### PR TITLE
[DO NOT MERGE] test/cluster: use create_new_test_table to avoid AlreadyExists on retry

### DIFF
--- a/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
@@ -13,7 +13,7 @@ from cassandra.cluster import ConnectionException, NoHostAvailable  # type: igno
 
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 
 logger = logging.getLogger(__name__)
@@ -39,7 +39,7 @@ async def test_mv_tablets_empty_ip(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
+        await create_new_test_table(manager, ks, "pk int primary key, v int", table_name="t")
         await cql.run_async(f"CREATE materialized view {ks}.t_view AS select pk, v from {ks}.t where v is not null primary key (v, pk)")
 
         stop_event = asyncio.Event()

--- a/test/cluster/mv/test_mv_fail_building.py
+++ b/test/cluster/mv/test_mv_fail_building.py
@@ -7,7 +7,7 @@ import asyncio
 import pytest
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_view
-from test.cluster.util import new_test_keyspace, reconnect_driver
+from test.cluster.util import new_test_keyspace, reconnect_driver, create_new_test_table
 
 from cassandra.cluster import ConsistencyLevel  # type: ignore
 from cassandra.query import SimpleStatement  # type: ignore
@@ -53,7 +53,7 @@ async def test_mv_build_during_shutdown(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
+        await create_new_test_table(manager, ks, "pk int primary key, v int", table_name="t")
 
         for i in range(100):
             await cql.run_async(f"insert into {ks}.t (pk, v) values ({i}, {i+1})")

--- a/test/cluster/mv/test_mv_read_concurrency.py
+++ b/test/cluster/mv/test_mv_read_concurrency.py
@@ -10,7 +10,7 @@ import pytest
 import logging
 
 from test.pylib.util import wait_for_view
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 from cassandra import ReadTimeout, WriteTimeout
 
 logger = logging.getLogger(__name__)
@@ -37,8 +37,8 @@ async def test_mv_read_concurrency(manager: ManagerClient) -> None:
 
     cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (p int PRIMARY KEY, mvp int, v text)")
-        await cql.run_async(f"CREATE TABLE {ks}.tab2 (p int PRIMARY KEY, mvp int)")
+        await create_new_test_table(manager, ks, "p int PRIMARY KEY, mvp int, v text", table_name="tab")
+        await create_new_test_table(manager, ks, "p int PRIMARY KEY, mvp int", table_name="tab2")
         await cql.run_async(f"CREATE MATERIALIZED VIEW IF NOT EXISTS {ks}.mv AS SELECT p, mvp FROM {ks}.tab \
             WHERE p IS NOT NULL AND mvp IS NOT NULL PRIMARY KEY (mvp, p)")
         await wait_for_view(cql, 'mv', node_count)
@@ -109,7 +109,7 @@ async def test_mv_read_memory(manager: ManagerClient) -> None:
     cql, _ = await manager.get_ready_cql(servers)
     # Use just 1 tablet to make the test more predictable by running all view updates on the same shard
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (p int PRIMARY KEY, mvp int, v text)")
+        await create_new_test_table(manager, ks, "p int PRIMARY KEY, mvp int, v text", table_name="tab")
         await cql.run_async(f"CREATE MATERIALIZED VIEW IF NOT EXISTS {ks}.mv AS SELECT p, mvp FROM {ks}.tab \
             WHERE p IS NOT NULL AND mvp IS NOT NULL PRIMARY KEY (mvp, p)")
         await wait_for_view(cql, 'mv', node_count)

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -13,7 +13,7 @@ import time
 import random
 
 from test.pylib.manager_client import ManagerClient, ServerInfo
-from test.cluster.util import wait_for_cql_and_get_hosts, get_replication, new_test_keyspace
+from test.cluster.util import wait_for_cql_and_get_hosts, get_replication, new_test_keyspace, create_new_test_table
 from test.pylib.rest_client import read_barrier
 from test.pylib.util import unique_name, wait_all
 from cassandra.cluster import ConsistencyLevel
@@ -61,9 +61,9 @@ async def test_simple_backup(manager: ManagerClient, object_storage, move_files)
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
     server = await manager.server_add(config=cfg, cmdline=cmd)
     cql = manager.get_cql()
-    cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+        ks_table = await create_new_test_table(manager, ks, "name text primary key, value text")
+        cf = ks_table.split('.')[1]
         await asyncio.gather(*(cql.run_async(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('{name}', '{value}');") for name, value in [('0', 'zero'), ('1', 'one'), ('2', 'two')]))
         snap_name, files = await take_snapshot_on_one_server(ks, server, manager, logger)
         assert len(files) > 0
@@ -108,9 +108,9 @@ async def test_backup_with_non_existing_parameters(manager: ManagerClient, objec
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
     server = await manager.server_add(config=cfg, cmdline=cmd)
     cql = manager.get_cql()
-    cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+        ks_table = await create_new_test_table(manager, ks, "name text primary key, value text")
+        cf = ks_table.split('.')[1]
         await asyncio.gather(*(cql.run_async(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('{name}', '{value}');") for name, value in [('0', 'zero'), ('1', 'one'), ('2', 'two')]))
         backup_snap_name, files = await take_snapshot_on_one_server(ks, server, manager, logger)
         assert len(files) > 0
@@ -140,9 +140,9 @@ async def test_backup_endpoint_config_is_live_updateable(manager: ManagerClient,
     cmd = ['--logger-log-level', 'sstables_manager=debug']
     server = await manager.server_add(config=cfg, cmdline=cmd)
     cql = manager.get_cql()
-    cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+        ks_table = await create_new_test_table(manager, ks, "name text primary key, value text")
+        cf = ks_table.split('.')[1]
         await asyncio.gather(*(cql.run_async(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('{name}', '{value}');") for name, value in [('0', 'zero'), ('1', 'one'), ('2', 'two')]))
         snap_name, files = await take_snapshot_on_one_server(ks, server, manager, logger)
 
@@ -184,9 +184,9 @@ async def do_test_backup_helper(manager: ManagerClient, object_storage,
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
     server = (await manager.servers_add(num_servers, config=cfg, cmdline=cmd))[0]
     cql = manager.get_cql()
-    cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+        ks_table = await create_new_test_table(manager, ks, "name text primary key, value text")
+        cf = ks_table.split('.')[1]
         await asyncio.gather(*(cql.run_async(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('{name}', '{value}');") for name, value in [('0', 'zero'), ('1', 'one'), ('2', 'two')]))
         snap_name, files = await take_snapshot_on_one_server(ks, server, manager, logger)
 
@@ -274,9 +274,9 @@ async def test_simple_backup_and_restore(manager: ManagerClient, object_storage,
 
     # This test is sensitive not to share the bucket with any other test
     # that can run in parallel, so generate some unique name for the snapshot
-    cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+        ks_table = await create_new_test_table(manager, ks, "name text primary key, value text")
+        cf = ks_table.split('.')[1]
         await asyncio.gather(*(cql.run_async(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('{name}', '{value}');") for name, value in [('0', 'zero'), ('1', 'one'), ('2', 'two')]))
         snap_name, toc_names = await take_snapshot_on_one_server(ks, server, manager, logger)
 
@@ -381,11 +381,10 @@ async def do_abort_restore(manager: ManagerClient, object_storage):
     # Create keyspace, table, and fill data
     logger.info("Creating keyspace and table, then inserting data...")
 
-    table = 'test_cf'
     async with new_test_keyspace(manager,
             "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as keyspace:
-        create_table_query = f"CREATE TABLE {keyspace}.{table} (name text PRIMARY KEY, value text);"
-        await cql.run_async(create_table_query)
+        ks_table = await create_new_test_table(manager, keyspace, "name text PRIMARY KEY, value text")
+        table = ks_table.split('.')[1]
 
         insert_stmt = cql.prepare(f"INSERT INTO {keyspace}.{table} (name, value) VALUES (?, ?)")
         insert_stmt.consistency_level = ConsistencyLevel.ALL
@@ -699,18 +698,19 @@ async def do_test_streaming_scopes(build_mode: str, manager: ManagerClient, topo
     restored_min_tablet_counts = [original_min_tablet_count] if (build_mode == 'debug' or sstables_storage.object_storage is None) else [2, original_min_tablet_count, 10]
     
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {original_min_tablet_count}}};")
-        insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, value) VALUES (?, ?)")
+        ks_table = await create_new_test_table(manager, ks, "pk text primary key, value int", f" WITH tablets = {{'min_tablet_count': {original_min_tablet_count}}}")
+        cf = ks_table.split('.')[1]
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.{cf} (pk, value) VALUES (?, ?)")
         insert_stmt.consistency_level = ConsistencyLevel.ALL
         await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
 
         # validate replicas assertions hold on fresh dataset
-        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
+        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, cf)
 
         snap_name, sstables = await take_snapshot(ks, servers, manager, logger)
-        prefix = f'test/{snap_name}'
+        prefix = f'{cf}/{snap_name}'
 
-        await sstables_storage.save(manager, servers, snap_name, prefix, ks, 'test', logger)
+        await sstables_storage.save(manager, servers, snap_name, prefix, ks, cf, logger)
 
     for scope, pro, restored_min_tablet_count in itertools.product(scopes, pros, restored_min_tablet_counts):
         if scope == 'node' and pro == True:
@@ -723,16 +723,17 @@ async def do_test_streaming_scopes(build_mode: str, manager: ManagerClient, topo
             continue
 
         async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
-            await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {restored_min_tablet_count}}};")
+            ks_table = await create_new_test_table(manager, ks, "pk text primary key, value int", f" WITH tablets = {{'min_tablet_count': {restored_min_tablet_count}}}")
+            cf = ks_table.split('.')[1]
 
             log_marks = await mark_all_logs(manager, servers)
 
             logger.info(f'Loading {servers=} with {sstables=} scope={scope}')
             sstables_per_server = distribute_sstables(sstables, servers, topology, scope)
-            await sstables_storage.restore(manager, sstables_per_server, prefix, ks, 'test', scope, pro, logger)
+            await sstables_storage.restore(manager, sstables_per_server, prefix, ks, cf, scope, pro, logger)
             if pro:
-                await manager.api.tablet_repair(servers[0].ip_addr, ks, 'test', 'all', timeout=600)
-            await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
+                await manager.api.tablet_repair(servers[0].ip_addr, ks, cf, 'all', timeout=600)
+            await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, cf)
             if restored_min_tablet_count == original_min_tablet_count:
                 await check_streaming_directions(logger, servers, topology, host_ids, scope, pro, log_marks)
 
@@ -748,11 +749,10 @@ async def test_restore_with_non_existing_sstable(manager: ManagerClient, object_
            }
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
     server = await manager.server_add(config=cfg, cmdline=cmd)
-    cql = manager.get_cql()
     print('Create keyspace')
-    cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+        ks_table = await create_new_test_table(manager, ks, "name text primary key, value text")
+        cf = ks_table.split('.')[1]
         sstable_name = 'me-3gou_0fvw_4r94g2h8nw60b8ly4c-big-TOC.txt'
         tid = await manager.api.restore(server.ip_addr, ks, cf, object_storage.address, object_storage.bucket_name, 'no_such_prefix', [sstable_name])
         status = await manager.api.wait_task(server.ip_addr, tid)
@@ -780,12 +780,8 @@ async def test_backup_broken_streaming(manager: ManagerClient, s3_storage):
 
     async with new_test_keyspace(manager,
                                  "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as keyspace:
-        table = 'test_cf'
-        create_table_query = (
-            f"CREATE TABLE {keyspace}.{table} (name text PRIMARY KEY, value text) "
-            f"WITH tablets = {{'min_tablet_count': '16'}};"
-        )
-        cql.execute(create_table_query)
+        ks_table = await create_new_test_table(manager, keyspace, "name text PRIMARY KEY, value text", " WITH tablets = {'min_tablet_count': 16}")
+        table = ks_table.split('.')[1]
 
         expected_rows = 0
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -873,7 +869,6 @@ async def test_restore_primary_replica(manager: ManagerClient, object_storage, d
             scope = "all"
         expected_replicas = 1
 
-    cf = 'cf'
     keys = range(256)
     replication_str = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}"
 
@@ -883,7 +878,8 @@ async def test_restore_primary_replica(manager: ManagerClient, object_storage, d
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, replication_str) as ks:
-        cql.execute(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int );")
+        ks_table = await create_new_test_table(manager, ks, "pk text primary key, value int")
+        cf = ks_table.split('.')[1]
         stmt = cql.prepare(f"INSERT INTO {ks}.{cf} ( pk, value ) VALUES (?, ?)")
         stmt.consistency_level = ConsistencyLevel.ALL
         await asyncio.gather(*(cql.run_async(stmt, (str(k), k)) for k in keys))
@@ -897,7 +893,7 @@ async def test_restore_primary_replica(manager: ManagerClient, object_storage, d
         await asyncio.gather(*(do_backup(s, snap_name, prefix, ks, cf, object_storage, manager, logger) for s in servers))
 
     async with new_test_keyspace(manager, replication_str) as ks:
-        cql.execute(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int );")
+        await create_new_test_table(manager, ks, "pk text primary key, value int", table_name=cf)
 
         await asyncio.gather(*(do_restore_server(manager, logger, ks, cf, s, sstables[s], scope, True, prefix, object_storage) for s in servers))
 

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -11,7 +11,7 @@ from test.pylib.minio_server import MinioServer
 from cassandra.protocol import ConfigurationException
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import reconnect_driver
+from test.cluster.util import reconnect_driver, create_new_test_table
 from test.cluster.object_store.conftest import format_tuples, keyspace_options
 from test.cqlpy.rest_api import scylla_inject_error
 from test.cluster.test_config import wait_for_config
@@ -51,7 +51,7 @@ async def test_basic(manager: ManagerClient, object_storage, tmp_path, mode, rep
     workdir = await manager.server_get_workdir(servers[0].server_id)
     print(f'Create keyspace (storage server listening at {object_storage.address})')
     async with new_test_keyspace(manager, keyspace_options(object_storage, rf=replication_factor)) as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (name text PRIMARY KEY, value int);")
+        await create_new_test_table(manager, ks, "name text PRIMARY KEY, value int", table_name="test")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (name, value) VALUES ('{k}', {k});") for k in range(4)])
 
         assert not os.path.exists(os.path.join(workdir, f'data/{ks}')), "object storage backed keyspace has local directory created"
@@ -125,7 +125,7 @@ async def test_garbage_collect(manager: ManagerClient, object_storage):
 
     print(f'Create keyspace (storage server listening at {object_storage.address})')
     async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (name text PRIMARY KEY, value int);")
+        await create_new_test_table(manager, ks, "name text PRIMARY KEY, value int", table_name="test")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (name, value) VALUES ('{k}', {k});") for k in range(4)])
 
         await manager.api.flush_keyspace(server.ip_addr, ks)
@@ -168,7 +168,7 @@ async def test_populate_from_quarantine(manager: ManagerClient, object_storage):
 
     print(f'Create keyspace (storage server listening at {object_storage.address})')
     async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (name text PRIMARY KEY, value int);")
+        await create_new_test_table(manager, ks, "name text PRIMARY KEY, value int", table_name="test")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (name, value) VALUES ('{k}', {k});") for k in range(4)])
 
         res = cql.execute(f"SELECT * FROM {ks}.test;")
@@ -232,7 +232,7 @@ async def test_memtable_flush_retries(manager: ManagerClient, tmpdir, object_sto
     print(f'Create keyspace (storage server listening at {object_storage.address})')
 
     async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (name text PRIMARY KEY, value int);")
+        await create_new_test_table(manager, ks, "name text PRIMARY KEY, value int", table_name="test")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (name, value) VALUES ('{k}', {k});") for k in range(4)])
 
         res = cql.execute(f"SELECT * FROM {ks}.test;")

--- a/test/cluster/tasks/test_node_ops_tasks.py
+++ b/test/cluster/tasks/test_node_ops_tasks.py
@@ -12,7 +12,7 @@ from test.pylib.rest_client import InjectionHandler, inject_error_one_shot
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import wait_for
 from test.cluster.tasks.task_manager_client import TaskManagerClient
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 import asyncio
 import logging
@@ -204,7 +204,7 @@ async def test_node_ops_tasks_tree(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({1}, {1});")
         await cql.run_async(f"TRUNCATE {ks}.test;")
 

--- a/test/cluster/tasks/test_tablet_tasks.py
+++ b/test/cluster/tasks/test_tablet_tasks.py
@@ -14,7 +14,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.repair import create_table_insert_data_for_repair, get_tablet_task_id
 from test.pylib.rest_client import read_barrier
 from test.pylib.tablets import get_all_tablet_replicas
-from test.cluster.util import create_new_test_keyspace, new_test_keyspace, get_topology_coordinator, find_server_by_host_id
+from test.cluster.util import create_new_test_keyspace, new_test_keyspace, get_topology_coordinator, find_server_by_host_id, create_new_test_table
 from test.cluster.test_incremental_repair import trigger_tablet_merge
 from test.cluster.test_tablets2 import inject_error_on
 from test.cluster.tasks.task_manager_client import TaskManagerClient
@@ -182,8 +182,8 @@ async def test_tablet_repair_task_list(manager: ManagerClient):
     assert module_name in await tm.list_modules(servers[0].ip_addr), "tablets module wasn't registered"
 
     # Create other tables.
-    await cql.run_async(f"CREATE TABLE {ks}.test2 (pk int PRIMARY KEY, c int) WITH tombstone_gc = {{'mode':'repair'}};")
-    await cql.run_async(f"CREATE TABLE {ks}.test3 (pk int PRIMARY KEY, c int) WITH tombstone_gc = {{'mode':'repair'}};")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tombstone_gc = {{'mode':'repair'}}", table_name="test2")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tombstone_gc = {{'mode':'repair'}}", table_name="test3")
     keys = range(256)
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test2 (pk, c) VALUES ({k}, {k});") for k in keys])
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test3 (pk, c) VALUES ({k}, {k});") for k in keys])
@@ -285,7 +285,7 @@ async def prepare_migration_test(manager: ManagerClient):
     await manager.disable_tablet_balancing()
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
     await make_server()
 
     await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({1}, {1});")
@@ -490,8 +490,8 @@ async def test_tablet_resize_task(manager: ManagerClient):
     table1 = "test1"
     table2 = "test2"
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as keyspace:
-        await cql.run_async(f"CREATE TABLE {keyspace}.{table1} (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
-        await cql.run_async(f"CREATE TABLE {keyspace}.{table2} (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
+        await create_new_test_table(manager, keyspace, "pk int PRIMARY KEY, c blob", extra=" WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1", table_name=table1)
+        await create_new_test_table(manager, keyspace, "pk int PRIMARY KEY, c blob", extra=" WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1", table_name=table2)
 
         total_keys = 60
         keys = range(total_keys)
@@ -530,7 +530,7 @@ async def test_tablet_resize_list(manager: ManagerClient):
     cql = manager.get_cql()
     table1 = "test1"
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as keyspace:
-        await cql.run_async(f"CREATE TABLE {keyspace}.{table1} (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
+        await create_new_test_table(manager, keyspace, "pk int PRIMARY KEY, c blob", extra=" WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1", table_name=table1)
 
         total_keys = 60
         keys = range(total_keys)
@@ -590,7 +590,7 @@ async def test_tablet_resize_revoked(manager: ManagerClient):
     cql = manager.get_cql()
     table1 = "test1"
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as keyspace:
-        await cql.run_async(f"CREATE TABLE {keyspace}.{table1} (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
+        await create_new_test_table(manager, keyspace, "pk int PRIMARY KEY, c blob", extra=" WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1", table_name=table1)
 
         total_keys = 60
         keys = range(total_keys)

--- a/test/cluster/test_automatic_cleanup.py
+++ b/test/cluster/test_automatic_cleanup.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import new_test_keyspace, get_topology_version
+from test.cluster.util import new_test_keyspace, get_topology_version, create_new_test_table
 from cassandra import WriteFailure
 import pytest
 import logging
@@ -97,7 +97,7 @@ async def test_cleanup_waits_for_stale_writes(manager: ManagerClient):
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
         logger.info("Create table my_test_table")
-        await cql.run_async(f"CREATE TABLE {ks}.my_test_table (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="my_test_table")
 
         # Have a bootstrapping node hang in write_both_read_new
         logger.info("Add third node")

--- a/test/cluster/test_batchlog_manager.py
+++ b/test/cluster/test_batchlog_manager.py
@@ -10,7 +10,7 @@ import logging
 import time
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for
-from test.cluster.util import new_test_keyspace, reconnect_driver, wait_for_cql_and_get_hosts
+from test.cluster.util import new_test_keyspace, reconnect_driver, wait_for_cql_and_get_hosts, create_new_test_table
 
 
 logger = logging.getLogger(__name__)
@@ -36,7 +36,7 @@ async def test_batchlog_replay_while_a_node_is_down(manager: ManagerClient) -> N
     cql, hosts = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v int, PRIMARY KEY (key, c))")
+        await create_new_test_table(manager, ks, "key int, c int, v int, PRIMARY KEY (key, c)", table_name="tab")
 
         await asyncio.gather(*[manager.api.enable_injection(s.ip_addr, "storage_proxy_fail_remove_from_batchlog", one_shot=False) for s in servers])
 
@@ -98,7 +98,7 @@ async def test_batchlog_replay_aborted_on_shutdown(manager: ManagerClient) -> No
     cql, hosts = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v int, PRIMARY KEY (key, c))")
+        await create_new_test_table(manager, ks, "key int, c int, v int, PRIMARY KEY (key, c)", table_name="tab")
 
         await asyncio.gather(*[manager.api.enable_injection(s.ip_addr, "storage_proxy_fail_remove_from_batchlog", one_shot=False) for s in servers])
 
@@ -160,7 +160,7 @@ async def test_batchlog_replay_includes_cdc(manager: ManagerClient) -> None:
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks:
         # Create table with CDC enabled
-        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v int, PRIMARY KEY (key, c)) WITH cdc = {{'enabled': true}}")
+        await create_new_test_table(manager, ks, "key int, c int, v int, PRIMARY KEY (key, c)", extra=f" WITH cdc = {{'enabled': true}}", table_name="tab")
 
         # Enable error injection to make the batch fail after writing to batchlog
         await manager.api.enable_injection(servers[0].ip_addr, "storage_proxy_fail_remove_from_batchlog", one_shot=False)
@@ -252,7 +252,7 @@ async def test_drop_mutations_for_dropped_table(manager: ManagerClient) -> None:
         await asyncio.gather(*[manager.api.disable_injection(s.ip_addr, injection) for s in servers])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.my_table (pk int, ck int, v int, PRIMARY KEY (pk, ck))")
+        await create_new_test_table(manager, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)", table_name="my_table")
 
         # Make sure the mutations stay in the batchlog.
         await enable_injection("storage_proxy_fail_remove_from_batchlog")
@@ -351,7 +351,7 @@ async def test_batchlog_replay_failure_during_repair(manager: ManagerClient, rep
         return True if batchlog_row_count == 0 else None
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.my_table (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH tombstone_gc = {{'mode': 'repair', 'propagation_delay_in_seconds': '1'}} AND compaction = {{ 'class' : 'NullCompactionStrategy' }}")
+        await create_new_test_table(manager, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)", extra=f" WITH tombstone_gc = {{'mode': 'repair', 'propagation_delay_in_seconds': '1'}} AND compaction = {{ 'class' : 'NullCompactionStrategy' }}", table_name="my_table")
 
         await cql.run_async(f"BEGIN BATCH INSERT INTO {ks}.my_table (pk, ck, v) VALUES (0,0,0);"
                                 f"INSERT INTO {ks}.my_table (pk, ck, v) VALUES (1,1,1); APPLY BATCH")

--- a/test/cluster/test_cdc_with_alter.py
+++ b/test/cluster/test_cdc_with_alter.py
@@ -5,7 +5,7 @@
 #
 
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import new_test_keyspace, reconnect_driver
+from test.cluster.util import new_test_keyspace, reconnect_driver, create_new_test_table
 from cassandra.protocol import InvalidRequest
 
 import asyncio
@@ -29,7 +29,7 @@ async def test_add_and_drop_column_with_cdc(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}}", table_name="test")
 
         # sleep before CDC augmentation, because we want to have a write that starts with some base schema, and then
         # the table is altered while the write is in progress, and the CDC augmentation will use the new schema that
@@ -88,7 +88,7 @@ async def test_cdc_compatible_schema(manager: ManagerClient):
     log = await manager.server_open_log(servers[0].server_id)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}}", table_name="test")
 
         await cql.run_async(f"INSERT INTO {ks}.test(pk, v) VALUES(1, 10)")
         await cql.run_async(f"ALTER TABLE {ks}.test ADD a int")
@@ -124,7 +124,7 @@ async def test_recreate_column_too_soon(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int, dropped_col int) WITH cdc={{'enabled': true}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int, dropped_col int", extra=f" WITH cdc={{'enabled': true}}", table_name="test")
         await cql.run_async(f"ALTER TABLE {ks}.test DROP dropped_col")
 
         # recreating too soon
@@ -157,7 +157,7 @@ async def test_concurrent_writes_and_drop_column_with_cdc_preimage(manager: Mana
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int, dropped_col int) WITH cdc={{'enabled': true, 'preimage': 'full'}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int, dropped_col int", extra=f" WITH cdc={{'enabled': true, 'preimage': 'full'}}", table_name="test")
 
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, 0)") for pk in range(50)])
 

--- a/test/cluster/test_cdc_with_tablets.py
+++ b/test/cluster/test_cdc_with_tablets.py
@@ -11,7 +11,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
 from test.pylib.util import wait_for
 from test.pylib.tablets import get_tablet_count, get_base_table, get_tablet_replicas
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 import asyncio
 import logging
@@ -39,10 +39,10 @@ async def test_create_cdc_with_tablets(manager: ManagerClient, with_alter: bool)
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
         if with_alter:
-            await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int)")
+            await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", table_name="test")
             await cql.run_async(f"ALTER TABLE {ks}.test WITH cdc={{'enabled': true}}")
         else:
-            await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
+            await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}}", table_name="test")
 
         rows = await cql.run_async("SELECT * FROM system.cdc_streams_state")
         assert len(rows) == 2
@@ -76,13 +76,13 @@ async def test_drop_table_and_drop_keyspace_removes_cdc_streams(manager: Manager
     servers = await manager.servers_add(1)
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks1:
-        await cql.run_async(f"CREATE TABLE {ks1}.test1 (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
+        await create_new_test_table(manager, ks1, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}}", table_name="test1")
         rows = await cql.run_async("SELECT * FROM system.cdc_streams_state")
         assert len(rows) == 2
         rows = await cql.run_async("SELECT * FROM system.cdc_streams_history")
         assert len(rows) == 0
 
-        await cql.run_async(f"CREATE TABLE {ks1}.test2 (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
+        await create_new_test_table(manager, ks1, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}}", table_name="test2")
         rows = await cql.run_async("SELECT * FROM system.cdc_streams_state")
         assert len(rows) == 4
 
@@ -91,7 +91,7 @@ async def test_drop_table_and_drop_keyspace_removes_cdc_streams(manager: Manager
         assert len(rows) == 2
 
         async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks2:
-            await cql.run_async(f"CREATE TABLE {ks2}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
+            await create_new_test_table(manager, ks2, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}}", table_name="test")
             rows = await cql.run_async("SELECT * FROM system.cdc_streams_state")
             assert len(rows) == 4
 
@@ -110,7 +110,7 @@ async def test_drop_and_recreate_cdc(manager: ManagerClient):
     await manager.servers_add(1)
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test1 (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}}", table_name="test1")
         await cql.run_async(f"ALTER TABLE {ks}.test1 WITH cdc={{'enabled': false}}")
 
         # The CDC table still exists and streams are still present
@@ -180,7 +180,7 @@ async def test_cdc_virtual_tables(manager: ManagerClient):
         assert [] == await cql.run_async("SELECT * FROM system.cdc_timestamps")
         assert [] == await cql.run_async("SELECT * FROM system.cdc_streams")
 
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}}", table_name="test")
         log_table_id = await manager.get_table_id(ks, "test_scylla_cdc_log")
 
         await validate_virtual_tables(manager, servers, cql, log_table_id, ks, 'test')
@@ -218,7 +218,7 @@ async def test_cdc_virtual_tables_with_multiple_cdc_tables(manager: ManagerClien
     N = 3
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
         for i in range(N):
-            await cql.run_async(f"CREATE TABLE {ks}.test{i} (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
+            await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}}", table_name=f"test{i}")
 
         log_table_id = [await manager.get_table_id(ks, f"test{i}_scylla_cdc_log") for i in range(N)]
 
@@ -255,7 +255,7 @@ async def test_cdc_stream_split_and_merge_basic(manager: ManagerClient):
     servers = await manager.servers_add(1, config=cfg)
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}} AND tablets = {{'min_tablet_count': 2}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}} AND tablets = {{'min_tablet_count': 2}}", table_name="test")
 
         async def assert_streams_are_synchronized_with_tablets():
             tablet_count = await get_tablet_count(manager, servers[0], ks, 'test_scylla_cdc_log')
@@ -319,7 +319,7 @@ async def test_cdc_colocation(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 16}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true}}", table_name="test")
 
         # Insert diverse test data to ensure distribution across both nodes
         test_data = {}
@@ -380,7 +380,7 @@ async def test_cdc_stream_garbage_collection(manager: ManagerClient):
     servers = await manager.servers_add(1, config=cfg)
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true, 'ttl': 3600}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=f" WITH cdc={{'enabled': true, 'ttl': 3600}}", table_name="test")
 
         rows = await cql.run_async(f"SELECT toUnixTimestamp(timestamp) as ts FROM system.cdc_timestamps WHERE keyspace_name='{ks}' AND table_name='test'")
         assert len(rows) == 1

--- a/test/cluster/test_conflicting_keys_read_repair.py
+++ b/test/cluster/test_conflicting_keys_read_repair.py
@@ -12,7 +12,7 @@ from cassandra import ConsistencyLevel  # type: ignore
 from cassandra.query import SimpleStatement  # type: ignore
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 
 logger = logging.getLogger(__name__)
@@ -46,8 +46,7 @@ async def test_read_repair_with_conflicting_hash_keys(request: pytest.FixtureReq
     cql, _ = await manager.get_ready_cql(srvs)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};") as ks:
-        table = f"{ks}.t"
-        await cql.run_async(f"CREATE TABLE {table} (pk bigint PRIMARY KEY, c int);")
+        table = await create_new_test_table(manager, ks, "pk bigint PRIMARY KEY, c int", table_name="t")
 
         # Stop one of the nodes.
         await manager.server_stop_gracefully(srvs[0].server_id)

--- a/test/cluster/test_create_table_during_node_shutdown.py
+++ b/test/cluster/test_create_table_during_node_shutdown.py
@@ -24,7 +24,7 @@ async def test_create_table_notification_deadlock_with_shutdown(manager: Manager
         await manager.api.enable_injection(server.ip_addr, pause_in_notif_injection, one_shot=True)
 
         # Start creating the table asynchronously. it will wait at the injection point during the notification.
-        cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
+        cql.run_async(f"CREATE TABLE IF NOT EXISTS {ks}.t (pk int primary key, v int)")
 
         log = await manager.server_open_log(server.server_id)
         mark = await log.mark()

--- a/test/cluster/test_data_resurrection_after_cleanup.py
+++ b/test/cluster/test_data_resurrection_after_cleanup.py
@@ -6,7 +6,7 @@
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
-from test.cluster.util import new_test_keyspace, wait_for_token_ring_and_group0_consistency
+from test.cluster.util import new_test_keyspace, wait_for_token_ring_and_group0_consistency, create_new_test_table
 
 import pytest
 import asyncio
@@ -28,8 +28,7 @@ async def test_data_resurrection_after_cleanup(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};") as ks:
-        table = f"{ks}.test"
-        await cql.run_async(f"CREATE TABLE {table} (pk int PRIMARY KEY, c int) WITH gc_grace_seconds=0;")
+        table = await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=" WITH gc_grace_seconds=0", table_name="test")
 
         keys = range(256)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {table} (pk, c) VALUES ({k}, {k});") for k in keys])

--- a/test/cluster/test_data_resurrection_in_memtable.py
+++ b/test/cluster/test_data_resurrection_in_memtable.py
@@ -12,7 +12,7 @@ import time
 from cassandra.cluster import ConsistencyLevel  # type: ignore
 from cassandra.query import SimpleStatement  # type: ignore
 
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts, execute_with_tracing
 
@@ -47,10 +47,8 @@ async def run_test_cache_tombstone_gc(manager: ManagerClient, statement_pairs: l
     host1, host2, host3 = await wait_for_cql_and_get_hosts(cql, nodes, time.time() + 30)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = { 'enabled': true }") as ks:
-        cql.execute(f"CREATE TABLE {ks}.tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))"
-                    "     WITH speculative_retry = 'NONE'"
-                    "     AND tombstone_gc = {'mode': 'immediate', 'propagation_delay_in_seconds': 0}"
-                    "     AND compaction = {'class': 'NullCompactionStrategy'}")
+        table_extra = " WITH speculative_retry = 'NONE' AND tombstone_gc = {'mode': 'immediate', 'propagation_delay_in_seconds': 0} AND compaction = {'class': 'NullCompactionStrategy'}"
+        await create_new_test_table(manager, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)", extra=table_extra, table_name="tbl")
 
         for write_statement, delete_statement in statement_pairs:
             execute_with_tracing(cql, SimpleStatement(write_statement.format(ks=ks), consistency_level=ConsistencyLevel.ALL), log = True)

--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -13,7 +13,7 @@ from test.pylib.internal_types import ServerInfo
 from test.pylib.rest_client import ScyllaMetrics
 from cassandra.pool import Host # type: ignore # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement
-from test.cluster.util import new_test_keyspace, get_topology_version
+from test.cluster.util import new_test_keyspace, get_topology_version, create_new_test_table
 from test.pylib.scylla_cluster import ScyllaVersionDescription
 import pytest
 import logging
@@ -253,7 +253,7 @@ async def test_fence_lwt_during_bootstap(manager: ManagerClient):
     logger.info("Create a test keyspace")
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         logger.info("Create test table")
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         logger.info("Add the fourth server")
         servers += [await manager.server_add(property_file=property_file,
@@ -381,7 +381,7 @@ async def test_lwt_fencing_upgrade(manager: ManagerClient, scylla_2025_1: Scylla
     logger.info("Create a test keyspace")
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         logger.info("Create test table")
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES (1, 1)")
 
         update_stmt = cql.prepare(f"UPDATE {ks}.test SET c = ? WHERE pk = 1 IF c = ?")

--- a/test/cluster/test_guardrails.py
+++ b/test/cluster/test_guardrails.py
@@ -15,7 +15,7 @@ from cassandra.query import SimpleStatement
 from test.pylib.async_cql import _wrap_future
 from test.pylib.manager_client import ManagerClient, wait_for_cql_and_get_hosts
 from test.pylib.util import unique_name
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 logger = logging.getLogger(__name__)
 
@@ -135,7 +135,7 @@ async def test_write_cl_default(manager: ManagerClient):
     cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int)")
+        table = await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", table_name="t")
 
         all_cls = [ConsistencyLevel.ANY, ConsistencyLevel.ONE, ConsistencyLevel.LOCAL_ONE,
                 ConsistencyLevel.TWO, ConsistencyLevel.THREE, ConsistencyLevel.QUORUM,

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -20,7 +20,7 @@ from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import gather_safely, wait_for
 
 from test.cqlpy import nodetool
-from test.cluster.util import get_topology_coordinator, find_server_by_host_id, keyspace_has_tablets, new_test_keyspace, new_test_table
+from test.cluster.util import create_new_test_table, get_topology_coordinator, find_server_by_host_id, keyspace_has_tablets, new_test_keyspace, new_test_table
 
 
 logger = logging.getLogger(__name__)
@@ -103,8 +103,7 @@ async def test_limited_concurrency_of_writes(manager: ManagerClient):
 
     cql = await manager.get_cql_exclusive(node1)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
-        table = f"{ks}.t"
-        await cql.run_async(f"CREATE TABLE {table} (pk int primary key, v int)")
+        table = await create_new_test_table(manager, ks, "pk int primary key, v int", table_name="t")
 
         await manager.server_stop_gracefully(node2.server_id)
 
@@ -133,8 +132,7 @@ async def test_sync_point(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        table = f"{ks}.t"
-        await cql.run_async(f"CREATE TABLE {table} (pk int primary key, v int)")
+        table = await create_new_test_table(manager, ks, "pk int primary key, v int", table_name="t")
 
         await manager.server_stop_gracefully(node2.server_id)
         await manager.server_stop_gracefully(node3.server_id)
@@ -193,8 +191,7 @@ async def test_hints_consistency_during_decommission(manager: ManagerClient):
 
     logger.info("Creatting a keyspace with RF=1 and a table")
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = { 'enabled': false }") as ks:
-        table = f"{ks}.t"
-        await cql.run_async(f"CREATE TABLE {table} (pk int primary key, v int)")
+        table = await create_new_test_table(manager, ks, "pk int primary key, v int", table_name="t")
 
         logger.info("Stopping node 3")
         await manager.server_stop_gracefully(server3.server_id)
@@ -274,8 +271,7 @@ async def test_hints_consistency_during_replace(manager: ManagerClient):
     cql = await manager.get_cql_exclusive(servers[0])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        table = f"{ks}.t"
-        await cql.run_async(f"CREATE TABLE {table} (pk int primary key, v int)")
+        table = await create_new_test_table(manager, ks, "pk int primary key, v int", table_name="t")
 
         await manager.server_stop_gracefully(servers[2].server_id)
         await manager.others_not_see_server(servers[2].ip_addr)
@@ -401,8 +397,7 @@ async def test_hint_to_pending(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        table = f"{ks}.t"
-        await cql.run_async(f"CREATE TABLE {table} (pk int primary key, v int)")
+        table = await create_new_test_table(manager, ks, "pk int primary key, v int", table_name="t")
         replica = (await get_tablet_replicas(manager, servers[0], ks, "t", 0))[0]
         host_ids = [await manager.get_host_id(server.server_id) for server in servers]
         if replica[0] != host_ids[1]:
@@ -460,8 +455,7 @@ async def test_hint_to_leaving_when_reducing_rf(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r2', 'r3']}") as ks:
-        table = f"{ks}.t"
-        await cql.run_async(f"CREATE TABLE {table} (pk int primary key, v int) WITH tablets = {{'min_tablet_count': 1}};")
+        table = await create_new_test_table(manager, ks, "pk int primary key, v int", extra=" WITH tablets = {'min_tablet_count': 1}", table_name="t")
         host_ids = [await manager.get_host_id(server.server_id) for server in servers]
 
         # Stop the servers with replicas

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -8,7 +8,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.repair import load_tablet_sstables_repaired_at, load_tablet_repair_time, create_table_insert_data_for_repair
 from test.pylib.tablets import get_all_tablet_replicas
 from test.cluster.tasks.task_manager_client import TaskManagerClient
-from test.cluster.util import reconnect_driver, find_server_by_host_id, get_topology_coordinator, ensure_group0_leader_on, new_test_keyspace, new_test_table, trigger_stepdown, create_new_test_keyspace
+from test.cluster.util import reconnect_driver, find_server_by_host_id, get_topology_coordinator, ensure_group0_leader_on, new_test_keyspace, new_test_table, trigger_stepdown, create_new_test_keyspace, create_new_test_table
 from test.pylib.util import wait_for_cql_and_get_hosts
 
 from cassandra.query import ConsistencyLevel, SimpleStatement
@@ -797,7 +797,7 @@ async def test_repair_sigsegv_with_diff_shard_count(manager: ManagerClient, use_
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}} AND TABLETS = {{ 'enabled': {str(use_tablet).lower()} }}  ") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         async def write_with_cl_one(range_start, range_end):
             insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
@@ -897,8 +897,8 @@ async def _setup_table_for_race_window(manager, servers, cql):
     """
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', "
                   "'replication_factor': 3} AND tablets = {'initial': 2};")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) "
-                        f"WITH tombstone_gc = {{'mode':'repair'}};")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int",
+                               extra=" WITH tombstone_gc = {'mode':'repair'}", table_name="test")
 
     # Lower min_threshold to 2 so STCS fires as soon as two sstables appear in the
     # UNREPAIRED compaction view, making the race easy to trigger deterministically.

--- a/test/cluster/test_ip_mappings.py
+++ b/test/cluster/test_ip_mappings.py
@@ -12,7 +12,7 @@ from uuid import UUID
 from test.pylib.rest_client import inject_error_one_shot, read_barrier
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import gather_safely
-from test.cluster.util import disable_schema_agreement_wait, new_test_keyspace, reconnect_driver
+from test.cluster.util import disable_schema_agreement_wait, new_test_keyspace, reconnect_driver, create_new_test_table
 
 from cassandra.cluster import ConsistencyLevel, SimpleStatement
 
@@ -24,8 +24,7 @@ async def test_broken_bootstrap(manager: ManagerClient):
     server_b = await manager.server_add(start=False)
 
     async with new_test_keyspace(manager, "WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        table = f"{ks}.test"
-        await manager.cql.run_async(f"CREATE TABLE {table} (a int PRIMARY KEY, b int)")
+        table = await create_new_test_table(manager, ks, "a int PRIMARY KEY, b int", table_name="test")
         for i in range(100):
             await manager.cql.run_async(f"INSERT INTO {table} (a, b) VALUES ({i}, {i})")
         await inject_error_one_shot(manager.api, server_a.ip_addr, "crash-before-bootstrapping-node-added")
@@ -73,7 +72,7 @@ async def test_full_shutdown_during_replace(manager: ManagerClient, reuse_ip: bo
         async with new_test_keyspace(manager, """WITH REPLICATION = {'class': 'NetworkTopologyStrategy',
                                      'replication_factor': 3} AND tablets = {'enabled': false}""", host) as ks:
             table = f'{ks}.test'
-            await cql.run_async(f'CREATE TABLE {table} (a int PRIMARY KEY, b int)', host=host)
+            await cql.run_async(f'CREATE TABLE IF NOT EXISTS {table} (a int PRIMARY KEY, b int)', host=host)
 
             logger.info(f'Stopping {dead_server}')
             await manager.server_stop_gracefully(dead_server.server_id)

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -8,7 +8,7 @@ import asyncio
 import random
 import time
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 from cassandra.protocol import ConfigurationException
 import pytest
 import logging
@@ -25,8 +25,8 @@ async def test_property(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t_enabled (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
-        await cql.run_async(f"CREATE TABLE {ks}.t_disabled (pk int PRIMARY KEY, v int)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=" WITH storage_engine = 'logstor'", table_name="t_enabled")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", table_name="t_disabled")
 
         desc = await cql.run_async(f"DESCRIBE TABLE {ks}.t_enabled")
         logger.info(f"Table t_enabled description:\n{desc}")
@@ -37,7 +37,7 @@ async def test_property(manager: ManagerClient):
         assert "storage_engine = 'logstor'" not in desc[0].create_statement
 
         with pytest.raises(ConfigurationException, match="The 'logstor' storage engine cannot be used with tables that have clustering columns"):
-            await cql.run_async(f"CREATE TABLE {ks}.t_enabled (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH storage_engine = 'logstor'")
+            await create_new_test_table(manager, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)", extra=" WITH storage_engine = 'logstor'", table_name="t_enabled")
 
 @pytest.mark.asyncio
 async def test_config_option_consistency(manager: ManagerClient):
@@ -54,7 +54,7 @@ async def test_config_option_consistency(manager: ManagerClient):
     async with new_test_keyspace(manager, "") as ks:
         # Should fail because logstor feature is not enabled
         with pytest.raises(ConfigurationException, match="The experimental feature 'logstor' must be enabled"):
-            await cql.run_async(f"CREATE TABLE {ks}.t_logstor (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
+            await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=" WITH storage_engine = 'logstor'", table_name="t_logstor")
 
 @pytest.mark.asyncio
 async def test_basic_write_and_read(manager: ManagerClient):
@@ -67,7 +67,7 @@ async def test_basic_write_and_read(manager: ManagerClient):
 
         # test int value
 
-        await cql.run_async(f"CREATE TABLE {ks}.test_int (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=" WITH storage_engine = 'logstor'", table_name="test_int")
 
         await cql.run_async(f"INSERT INTO {ks}.test_int (pk, v) VALUES (1, 100)")
         await cql.run_async(f"INSERT INTO {ks}.test_int (pk, v) VALUES (2, 150)")
@@ -88,7 +88,7 @@ async def test_basic_write_and_read(manager: ManagerClient):
 
         # test frozen map value
 
-        await cql.run_async(f"CREATE TABLE {ks}.test_map (pk int PRIMARY KEY, v frozen<map<text, text>>) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v frozen<map<text, text>>", extra=" WITH storage_engine = 'logstor'", table_name="test_map")
 
         await cql.run_async(f"INSERT INTO {ks}.test_map (pk, v) VALUES (1, {{'a': 'apple', 'b': 'banana'}})")
         rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test_map WHERE pk = 1")
@@ -108,7 +108,7 @@ async def test_range_read(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=" WITH storage_engine = 'logstor'", table_name="test")
         for i in range(10):
             await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, {i*10})")
 
@@ -136,7 +136,7 @@ async def test_parallel_writes(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         # write to different keys in parallel
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, {i+1})") for i in range(100)])
@@ -155,7 +155,7 @@ async def test_overwrites(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         # write to a single key many times sequentially
         pk = 0
@@ -178,7 +178,7 @@ async def test_parallel_big_writes(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         # Create a large value of approximately 100KB, close to segment size
         large_value = 'x' * (100 * 1024)
@@ -217,7 +217,7 @@ async def test_recovery_basic(manager: ManagerClient, fail_separator_flush: bool
         await manager.api.enable_injection(servers[0].ip_addr, "fail_flush_separator_buffer", one_shot=False)
 
     async with new_test_keyspace(manager, "") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         # Create large values (~40KB each) to fill multiple segments
         value_size = 40 * 1024
@@ -307,7 +307,7 @@ async def test_recovery_with_segment_reuse(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         # Track the last value written to each key
         last_values = {}
@@ -358,7 +358,7 @@ async def test_compaction(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH tablets={'initial':1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         # write few segments with unique keys, then few segments with overwrites.
         # write large values so each write fills a single segment.
@@ -399,10 +399,10 @@ async def test_drop_table(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH tablets={'initial': 4}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test1 (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test1")
 
         # create another table that will not be dropped to verify it's not affected
-        await cql.run_async(f"CREATE TABLE {ks}.test2 (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test2")
 
         # write data to fill few segments
         value_size = 30 * 1024
@@ -420,7 +420,7 @@ async def test_drop_table(manager: ManagerClient):
             assert rows[0].v == value, f"Expected value of size {value_size} for key {i} in test2, but got {len(rows[0].v)}"
 
         # recreate the table and verify that old data is not visible
-        await cql.run_async(f"CREATE TABLE {ks}.test1 (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test1")
 
         for i in range(20):
             rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test1 WHERE pk = {i}")
@@ -473,7 +473,7 @@ async def test_trigger_separator_flush(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH tablets={'initial':2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         # Calculate how many writes needed to fill disk twice
         disk_size_bytes = disk_size_mb * 1024 * 1024
@@ -518,7 +518,7 @@ async def test_tablet_split_trigger_by_size(manager: ManagerClient):
     s0_log = await manager.server_open_log(servers[0].server_id)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         assert await get_tablet_count(manager, servers[0], ks, 'test') == 1
 
@@ -561,7 +561,7 @@ async def test_tablet_split_and_merge(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1 AND storage_engine='logstor';")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c blob", extra=" WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1 AND storage_engine='logstor'", table_name="test")
 
         total_keys = 10
         keys = range(total_keys)
@@ -620,7 +620,7 @@ async def test_tablet_migration(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets={'initial': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         nrows = 20
         value = 'x' * (30 * 1024)
@@ -656,7 +656,7 @@ async def test_tablet_intranode_migration(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets={'initial': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         nrows = 20
         value = 'x' * (30 * 1024)
@@ -712,7 +712,7 @@ async def test_tablet_migration_with_compaction(manager: ManagerClient):
     s1_log = await manager.server_open_log(s1.server_id)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets={'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=" WITH storage_engine = 'logstor'", table_name="test")
 
         value_size = 30 * 1024
         nrows = 20

--- a/test/cluster/test_lwt_semaphore.py
+++ b/test/cluster/test_lwt_semaphore.py
@@ -10,7 +10,7 @@ from test.pylib.rest_client import inject_error
 from test.pylib.util import wait_for_cql_and_get_hosts
 import pytest
 from cassandra.protocol import WriteTimeout
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 
 @pytest.mark.asyncio
@@ -22,8 +22,7 @@ async def test_cas_semaphore(manager):
     host = await wait_for_cql_and_get_hosts(manager.cql, {servers[0]}, time.time() + 60)
 
     async with new_test_keyspace(manager, "WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        table = f"{ks}.test"
-        await manager.cql.run_async(f"CREATE TABLE {table} (a int PRIMARY KEY, b int)")
+        table = await create_new_test_table(manager, ks, "a int PRIMARY KEY, b int", table_name="test")
 
         async with inject_error(manager.api, servers[0].ip_addr, 'cas_timeout_after_lock'):
             res = [manager.cql.run_async(f"INSERT INTO {table} (a) VALUES (0) IF NOT EXISTS", host=host[0]) for r in range(10)]

--- a/test/cluster/test_maintenance_mode.py
+++ b/test/cluster/test_maintenance_mode.py
@@ -14,7 +14,7 @@ from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.tablets import get_all_tablet_replicas
 from test.cluster.conftest import cluster_con
 from test.pylib.util import gather_safely, wait_for_cql_and_get_hosts
-from test.cluster.util import create_new_test_keyspace
+from test.cluster.util import create_new_test_keyspace, create_new_test_table
 
 import pytest
 import logging
@@ -69,8 +69,7 @@ async def test_maintenance_mode(manager: ManagerClient):
         rf_tag = "" if rf is None else f"rf{rf}"
         tablets_tag = "tablets" if tablets_enabled else "vnodes"
         table_suffix = f"{replication_strategy.lower()}_{rf_tag}_{tablets_tag}"
-        table = f"{ks}.{table_suffix}"
-        await cql.run_async(f"CREATE TABLE {table} (k int PRIMARY KEY, v int)")
+        table = await create_new_test_table(manager, ks, "k int PRIMARY KEY, v int", table_name=table_suffix)
         logger.info(f"Created table {table}")
 
         async def insert_one(cl: ConsistencyLevel):

--- a/test/cluster/test_major_compaction.py
+++ b/test/cluster/test_major_compaction.py
@@ -10,7 +10,7 @@ import asyncio
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
-from test.cluster.util import new_test_keyspace, reconnect_driver
+from test.cluster.util import new_test_keyspace, reconnect_driver, create_new_test_table
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ async def test_major_compaction_consider_only_existing_data(manager: ManagerClie
     cf = "test_consider_only_existing_data"
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY) WITH tombstone_gc = {{'mode': 'immediate'}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", extra=f" WITH tombstone_gc = {{'mode': 'immediate'}}", table_name=cf)
         await disable_autocompaction_across_keyspaces(manager, server.ip_addr, ks)
 
         logger.info("Populating table")
@@ -115,7 +115,7 @@ async def test_major_compaction_flush_all_tables(manager: ManagerClient, compact
     cf = "test_flush_all_tables"
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name=cf)
         await disable_autocompaction_across_keyspaces(manager, server.ip_addr, ks)
 
         logger.info("Populating table")
@@ -163,7 +163,7 @@ async def test_shutdown_drain_during_compaction(manager: ManagerClient):
     cf = "test_shutdown_drain_during_compaction"
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name=cf)
         await disable_autocompaction_across_keyspaces(manager, server.ip_addr, ks)
 
         logger.info("Populating table")
@@ -218,7 +218,7 @@ async def test_alter_compaction_strategy_during_compaction(manager: ManagerClien
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};") as ks:
         logger.info("Create table")
         cf = "t1"
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int, ck int, val int, PRIMARY KEY (pk, ck)) WITH compaction={{'class': 'TimeWindowCompactionStrategy'}}")
+        await create_new_test_table(manager, ks, "pk int, ck int, val int, PRIMARY KEY (pk, ck)", extra=f" WITH compaction={{'class': 'TimeWindowCompactionStrategy'}}", table_name=cf)
 
         logger.info("Inject error to pause compaction midway")
         injection_name="twcs_get_sstables_for_compaction"
@@ -265,7 +265,7 @@ async def test_disable_autocompaction_during_major_compaction(manager: ManagerCl
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         logger.info("Creating table")
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name=cf)
 
         logger.info("Populating table")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.{cf} (pk) VALUES ({k});") for k in range(100)])

--- a/test/cluster/test_not_enough_token_owners.py
+++ b/test/cluster/test_not_enough_token_owners.py
@@ -9,7 +9,7 @@ import time
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 
 @pytest.mark.asyncio
@@ -55,7 +55,7 @@ async def test_not_enough_token_owners(manager: ManagerClient):
     await wait_for_cql_and_get_hosts(cql, [server_a, server_c], time.time() + 60)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = { 'enabled': true }") as ks_name:
-        await cql.run_async(f'CREATE TABLE {ks_name}.tbl (pk int PRIMARY KEY, v int)')
+        await create_new_test_table(manager, ks_name, "pk int PRIMARY KEY, v int", table_name="tbl")
         await cql.run_async(f'INSERT INTO {ks_name}.tbl (pk, v) VALUES (1, 1)')
 
         # FIXME: Once scylladb/scylladb#16195 is fixed, we will have to replace the expected error message.

--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -18,7 +18,7 @@ from cassandra.pool import Host  # type: ignore
 from test.pylib.util import wait_for_cql_and_get_hosts, execute_with_tracing
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 
 logger = logging.getLogger(__name__)
@@ -207,8 +207,7 @@ async def test_incremental_read_repair(data_class: DataClass, manager: ManagerCl
     # contents. These assumptions are not held with tablets, which
     # distribute data among sstables differently than vnodes.
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = { 'enabled': true }") as ks:
-        table_schema = f"CREATE TABLE {ks}.tbl ({data_class.get_column_spec()}) WITH speculative_retry = 'NONE'"
-        cql.execute(table_schema)
+        await create_new_test_table(manager, ks, f"{data_class.get_column_spec()}", extra=" WITH speculative_retry = 'NONE'", table_name="tbl")
 
         total_rows = 100
         max_live_rows = 8
@@ -322,7 +321,7 @@ async def test_read_repair_with_trace_logging(request, manager):
     await wait_for_cql_and_get_hosts(cql, srvs, time.time() + 60)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk bigint, ck bigint, c int, PRIMARY KEY (pk, ck));")
+        await create_new_test_table(manager, ks, "pk bigint, ck bigint, c int, PRIMARY KEY (pk, ck)", table_name="t")
 
         await cql.run_async(f"INSERT INTO {ks}.t (pk, ck, c) VALUES (0, 0, 0)")
 

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -21,7 +21,7 @@ from test.pylib.minio_server import MinioServer
 from test.pylib.manager_client import ManagerClient
 from test.cluster.object_store.conftest import format_tuples
 from test.cluster.object_store.test_backup import topo, take_snapshot, do_test_streaming_scopes
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 from test.pylib.rest_client import read_barrier
 from test.pylib.util import unique_name, wait_for
 
@@ -117,7 +117,7 @@ async def test_refresh_deletes_uploaded_sstables(manager: ManagerClient):
     cf = 'cf'
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk text primary key, value int)")
+        await create_new_test_table(manager, ks, "pk text primary key, value int", table_name=cf)
         insert_stmt = cql.prepare(f"INSERT INTO {ks}.{cf} (pk, value) VALUES (?, ?)")
         insert_stmt.consistency_level = ConsistencyLevel.ALL
         keys = range(256)

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -17,7 +17,7 @@ from cassandra.query import SimpleStatement
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 
 logger = logging.getLogger(__name__)
@@ -251,7 +251,7 @@ async def test_vnode_keyspace_describe_ring(manager: ManagerClient):
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         keys = dict()
         cql = manager.get_cql()
-        await cql.run_async(f"CREATE TABLE {ks}.tbl (pk int PRIMARY KEY)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="tbl")
         for i in range(100):
             key = random.randint(-1000000000, 1000000000)
             await cql.run_async(f"INSERT into {ks}.tbl (pk) VALUES({key})")

--- a/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
+++ b/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
@@ -7,7 +7,7 @@ from itertools import zip_longest
 
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 
 def verify_data(response, expected_data):
@@ -31,7 +31,7 @@ async def test_reversed_queries_during_upgrade(manager: ManagerClient) -> None:
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int, ck1 int, ck2 int, PRIMARY KEY (pk, ck1, ck2));")
+        await create_new_test_table(manager, ks, "pk int, ck1 int, ck2 int, PRIMARY KEY (pk, ck1, ck2)", table_name="test")
 
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, ck1, ck2) VALUES ({k % 10}, {k % 3}, {k});") for k in range(100)])
 

--- a/test/cluster/test_size_based_load_balancing.py
+++ b/test/cluster/test_size_based_load_balancing.py
@@ -5,7 +5,7 @@
 #
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 from collections import defaultdict
 import pytest
 import logging
@@ -48,7 +48,7 @@ async def test_balance_empty_tablets(manager: ManagerClient):
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 16}") as ks:
         for table in ('t1', 't2', 't3'):
-            await cql.run_async(f'CREATE TABLE {ks}.{table} (pk int PRIMARY KEY, val text);')
+            await create_new_test_table(manager, ks, "pk int PRIMARY KEY, val text", table_name=table)
 
         servers.append(await manager.server_add(config=cfg_small, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'r1'}))
         small_host_id = await manager.get_host_id(servers[1].server_id)

--- a/test/cluster/test_sstable_cleanup_stop.py
+++ b/test/cluster/test_sstable_cleanup_stop.py
@@ -6,7 +6,7 @@
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
-from test.cluster.util import check_token_ring_and_group0_consistency, new_test_keyspace
+from test.cluster.util import check_token_ring_and_group0_consistency, new_test_keyspace, create_new_test_table
 
 import pytest
 import asyncio
@@ -26,8 +26,7 @@ async def test_cleanup_stop(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': 'false'};") as ks:
-        table = f"{ks}.test"
-        await cql.run_async(f"CREATE TABLE {table} (pk int PRIMARY KEY, c int);")
+        table = await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(100)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {table} (pk, c) VALUES ({k}, {k});") for k in keys])

--- a/test/cluster/test_sstable_set.py
+++ b/test/cluster/test_sstable_set.py
@@ -9,7 +9,7 @@ import time
 import logging
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.cluster.util import create_new_test_keyspace
+from test.cluster.util import create_new_test_keyspace, create_new_test_table
 
 logger = logging.getLogger(__name__)
 
@@ -33,10 +33,7 @@ async def test_partitioned_sstable_set(manager: ManagerClient, mode):
     else:
         ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': 'false'};")
 
-    cql.execute(f"""CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH compaction = {{
-        'class' : 'IncrementalCompactionStrategy',
-        'sstable_size_in_mb' : '0'
-    }}""")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=" WITH compaction = {'class' : 'IncrementalCompactionStrategy', 'sstable_size_in_mb' : '0'}", table_name="test")
 
     await manager.api.disable_autocompaction(server.ip_addr, ks)
 

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -8,7 +8,7 @@ from typing import Tuple
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import gather_safely, wait_for, Host
-from test.cluster.util import new_test_keyspace, new_test_table, reconnect_driver
+from test.cluster.util import new_test_keyspace, new_test_table, reconnect_driver, create_new_test_table
 from test.pylib.internal_types import HostID, ServerInfo
 from cassandra import InvalidRequest, ReadTimeout, WriteTimeout
 from cassandra.cluster import ConsistencyLevel
@@ -134,7 +134,7 @@ async def test_basic_write_read(manager: ManagerClient):
     logger.info("Creating a strongly-consistent keyspace")
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
         logger.info("Creating a table")
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         logger.info("Select raft group id for the tablet")
         group_id = await get_table_raft_group_id(manager, ks, 'test')
@@ -512,7 +512,7 @@ async def test_no_schema_when_apply_write(manager: ManagerClient):
         raise RuntimeError(f"Can't find host for host_id {host_id}")
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         # Drop incoming append entries from group0 (schema changes) on `servers[2]` after the table is created,
         # so strong consistency raft groups are created on the node but it won't receive next alter table mutations.
@@ -557,7 +557,7 @@ async def test_old_schema_when_apply_write(manager: ManagerClient):
         raise RuntimeError(f"Can't find host for host_id {host_id}")
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         group_id = await get_table_raft_group_id(manager, ks, 'test')
         leader_host_id = await wait_for_leader(manager, servers[0], group_id)
@@ -785,8 +785,7 @@ async def test_drop_table_during_insert(manager: ManagerClient):
         "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
         " AND tablets = {'initial': 1} AND consistency = 'global'",
     ) as ks:
-        table = f"{ks}.tbl"
-        await cql.run_async(f"CREATE TABLE {table} (pk int PRIMARY KEY, v int)")
+        table = await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", table_name="tbl")
 
         log = await manager.server_open_log(server.server_id)
         mark = await log.mark()
@@ -949,9 +948,7 @@ async def test_queries_while_dropping_table(manager: ManagerClient):
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
         table_name = "my_table"
-        table = f"{ks}.{table_name}"
-
-        await cql.run_async(f"CREATE TABLE {table} (pk int PRIMARY KEY, v int)")
+        table = await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", table_name=table_name)
         await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)")
 
         await gather_safely(*[
@@ -1244,9 +1241,7 @@ async def test_abort_state_machine_apply_after_dropping_table(manager: ManagerCl
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
         table_name = "my_table"
-        table = f"{ks}.{table_name}"
-
-        await cql.run_async(f"CREATE TABLE {table} (pk int PRIMARY KEY, v int)")
+        table = await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", table_name=table_name)
 
         group_id = await get_table_raft_group_id(manager, ks, table_name)
         leader_host_id = await wait_for_leader(manager, leader_server, group_id)
@@ -1310,9 +1305,7 @@ async def test_abort_state_machine_apply_during_shutdown(manager: ManagerClient)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
         table_name = "my_table"
-        table = f"{ks}.{table_name}"
-
-        await cql.run_async(f"CREATE TABLE {table} (pk int PRIMARY KEY, v int)")
+        table = await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", table_name=table_name)
 
         group_id = await get_table_raft_group_id(manager, ks, table_name)
         leader_host_id = await wait_for_leader(manager, leader_server, group_id)

--- a/test/cluster/test_table_drop.py
+++ b/test/cluster/test_table_drop.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import shutil
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import unique_name
 import pytest
@@ -26,7 +26,7 @@ async def test_drop_table_during_flush(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k%3});") for k in range(64)])
         await manager.api.keyspace_flush(servers[0].ip_addr, ks, "test")
 

--- a/test/cluster/test_tablet_repair_scheduler.py
+++ b/test/cluster/test_tablet_repair_scheduler.py
@@ -9,7 +9,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts, Host
 from test.pylib.repair import load_tablet_repair_time, create_table_insert_data_for_repair, create_table_insert_data_for_repair_multiple_rows, get_tablet_task_id, load_tablet_repair_task_infos
 from test.pylib.rest_client import inject_error_one_shot, read_barrier
-from test.cluster.util import create_new_test_keyspace
+from test.cluster.util import create_new_test_keyspace, create_new_test_table
 
 from cassandra.cluster import Session as CassandraSession
 from cassandra.query import SimpleStatement, ConsistencyLevel
@@ -350,7 +350,7 @@ async def prepare_multi_dc_repair(manager) -> tuple[list[ServerInfo], CassandraS
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', "
                   "'DC1': 2, 'DC2': 1} AND tablets = {'initial': 8};")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tombstone_gc = {{'mode':'repair'}};")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tombstone_gc = {{'mode':'repair'}}", table_name="test")
     keys = range(256)
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
     table_id = await manager.get_table_id(ks, "test")

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -17,7 +17,8 @@ from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from test.pylib.util import unique_name, wait_for, wait_for_first_completed
 from test.cluster.util import wait_for_cql_and_get_hosts, create_new_test_keyspace, new_test_keyspace, reconnect_driver, \
-    get_topology_coordinator, parse_replication_options, get_replication, get_replica_count, find_server_by_host_id
+    get_topology_coordinator, parse_replication_options, get_replication, get_replica_count, find_server_by_host_id, \
+    create_new_test_table
 from contextlib import nullcontext as does_not_raise
 import time
 import pytest
@@ -54,10 +55,10 @@ async def test_tablet_replication_factor_enough_nodes(manager: ManagerClient):
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 3}}") as ks:
         with pytest.raises(ConfigurationException, match=f"Datacenter {this_dc} doesn't have enough token-owning nodes"):
-            await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+            await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
 
         await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 2}}")
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
 
 @pytest.mark.asyncio
@@ -89,7 +90,7 @@ async def test_tablet_cannot_decommision_below_replication_factor(manager: Manag
     logger.info("Creating table")
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         logger.info("Populating table")
         keys = range(256)
@@ -119,7 +120,7 @@ async def test_reshape_with_tablets(manager: ManagerClient):
     cql = manager.get_cql()
     number_of_tablets = 2
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} and tablets = {{'initial': {number_of_tablets} }}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         logger.info("Disabling autocompaction for the table")
         await manager.api.disable_autocompaction(server.ip_addr, ks, "test")
@@ -231,7 +232,7 @@ async def test_tablet_mutation_fragments_unowned_partition(manager: ManagerClien
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         logger.info("Populating table")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in range(4)])
@@ -257,7 +258,7 @@ async def test_tablets_api_consistency(manager: ManagerClient, endpoint):
     cql = manager.get_cql()
     expected_tablet_count = 4
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH TABLETS = {{'min_tablet_count': {expected_tablet_count}, 'max_tablet_count': {expected_tablet_count}}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH TABLETS = {{'min_tablet_count': {expected_tablet_count}, 'max_tablet_count': {expected_tablet_count}}}", table_name="test")
 
 
         def columnar(lst):
@@ -770,7 +771,7 @@ async def test_multi_rf_change_0_N(request: pytest.FixtureRequest, manager: Mana
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b']} AND tablets = {'initial': 4}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="t")
         await asyncio.gather(*[cql.run_async(SimpleStatement(f"INSERT INTO {ks}.t (pk) VALUES ({k})", consistency_level=ConsistencyLevel.QUORUM)) for k in range(10)])
 
         await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': ['rack2a', 'rack2b']}}")
@@ -1285,7 +1286,7 @@ async def test_saved_readers_tablet_migration(manager: ManagerClient, build_mode
     async with new_test_keyspace(manager, "WITH"
                         " replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
                         " and tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int, ck int, c int, PRIMARY KEY (pk, ck));")
+        await create_new_test_table(manager, ks, "pk int, ck int, c int, PRIMARY KEY (pk, ck)", table_name="test")
 
         logger.info("Populating table")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, ck, c) VALUES (0, {k}, 0);") for k in range(128)])
@@ -1637,7 +1638,7 @@ async def test_orphaned_sstables_on_startup(manager: ManagerClient):
     logger.info("Create the test table, populate few rows and flush to disk")
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k%3});") for k in range(256)])
     await manager.api.keyspace_flush(servers[0].ip_addr, ks, "test")
     node0_workdir = await manager.server_get_workdir(servers[0].server_id)
@@ -1690,7 +1691,7 @@ async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: Manager
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1 } AND tablets = { 'initial': 1 }") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         node_to_remove = servers['dc1'][0]
         node_to_replace = servers['dc1'][1]
@@ -1729,8 +1730,8 @@ async def test_excludenode(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', "
-                                          "'dc1': ['rack1', 'rack2']} AND tablets = { 'initial': 8 }") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+                                           "'dc1': ['rack1', 'rack2']} AND tablets = { 'initial': 8 }") as ks:
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         live_node = servers[0]
         node_to_remove = servers[1]
@@ -1770,8 +1771,8 @@ async def test_excludenode_shrink_rf(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', "
-                                          "'dc1': 1, 'dc2': 1} AND tablets = { 'initial': 4 }") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+                                           "'dc1': 1, 'dc2': 1} AND tablets = { 'initial': 4 }") as ks:
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         # Stop the only node in dc2
         await manager.server_stop(dc2_server.server_id)
@@ -1812,7 +1813,7 @@ async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_tok
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1 } AND tablets = { 'initial': 1 }") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         node_to_remove = servers['dc1'][0]
         initiator_node = servers['dc2'][0]
@@ -1851,7 +1852,7 @@ async def test_replace_with_no_normal_token_owners_in_dc(manager: ManagerClient,
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1 } AND tablets = { 'initial': 1 }") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
         stmt.consistency_level = ConsistencyLevel.ALL
@@ -1909,7 +1910,7 @@ async def test_drop_keyspace_while_split(manager: ManagerClient):
 
     # create a table so that it has at least 2 tablets (and storage groups) per shard
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 4};")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
     await manager.api.disable_autocompaction(servers[0].ip_addr, ks)
 
@@ -1955,7 +1956,7 @@ async def test_drop_with_tablet_migration_cleanup(manager: ManagerClient):
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         # Create the table, insert data and flush
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 1}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=" WITH tablets = {'min_tablet_count': 1}", table_name="test")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in range(100)])
         await manager.api.flush_keyspace(server.ip_addr, ks)
 
@@ -2110,7 +2111,7 @@ async def test_two_tablets_concurrent_repair_and_migration_repair_writer_level(m
     ]
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, cmdline=cmdline)
 
-    await cql.run_async(f"CREATE TABLE {ks}.test2 (pk int PRIMARY KEY, c int) WITH tombstone_gc = {{'mode':'repair'}};")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=" WITH tombstone_gc = {'mode':'repair'}", table_name="test2")
 
     await manager.disable_tablet_balancing()
 
@@ -2162,7 +2163,7 @@ async def check_tablet_rebuild_with_repair(manager: ManagerClient, fail: bool):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
         keys = range(256)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
@@ -2324,7 +2325,7 @@ async def test_disabling_balancing_preempts_balancer(manager: ManagerClient):
         log = await manager.server_open_log(coord_srv.server_id)
         mark = await log.mark()
 
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
         await log.wait_for('Initiating tablet', from_mark=mark)
 
         # Should preempt balancing
@@ -2358,7 +2359,7 @@ async def test_table_creation_wakes_up_balancer(manager: ManagerClient):
         # Create a table, which should prevent the coordinator from sleeping
         await manager.api.enable_injection(server.ip_addr, 'wait-after-topology-coordinator-gets-event', one_shot=True)
         mark = await log.mark()
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         # Verify it didn't go to sleep. If it did, the wait for wakeup would be 30s on average,
         # up to stats refresh period, which is 60s. So use a small timeout.
@@ -2394,7 +2395,7 @@ async def test_multi_rf_increase_auto_abort_excluded_node(request: pytest.Fixtur
     dc1_host = (await wait_for_cql_and_get_hosts(cql, [dc1_server], time.time() + 30))[0]
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1']} AND tablets = {'initial': 4}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", table_name="t")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
 
         # Verify initial state: all replicas in dc1
@@ -2455,7 +2456,7 @@ async def test_rf_extend_abort_with_down_node(request: pytest.FixtureRequest, ma
     dc1_host = (await wait_for_cql_and_get_hosts(cql, [dc1_server], time.time() + 30))[0]
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1']} AND tablets = {'initial': 4}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v int", table_name="t")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
 
         # Stop dc2/rack1 node but do NOT exclude it

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -12,7 +12,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, HTTPError, read_barrier
 from test.pylib.util import wait_for_cql_and_get_hosts, unique_name, wait_for
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_count, TabletReplicas
-from test.cluster.util import reconnect_driver, create_new_test_keyspace, new_test_keyspace, get_topology_version
+from test.cluster.util import reconnect_driver, create_new_test_keyspace, new_test_keyspace, get_topology_version, create_new_test_table
 from test.cqlpy.cassandra_tests.validation.entities.secondary_index_test import dotestCreateAndDropIndex
 
 import pytest
@@ -105,7 +105,7 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 100}") as ks:
         # force s0 to catch up later from the snapshot and not the raft log
         await inject_error_one_shot_on(manager, 'raft_server_force_snapshot', not_s0)
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(10)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, 1);") for k in keys])
@@ -159,7 +159,7 @@ async def test_scans(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 8}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(100)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
@@ -200,7 +200,7 @@ async def test_topology_changes(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 32}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         logger.info("Populating table")
 
@@ -246,7 +246,7 @@ async def get_two_servers_to_move_tablet(manager: ManagerClient):
 
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
     servers.append(await manager.server_add(cmdline=cmdline))
 
@@ -352,7 +352,7 @@ async def test_streaming_is_guarded_by_topology_guard(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         servers.append(await manager.server_add(cmdline=cmdline))
 
@@ -427,8 +427,8 @@ async def test_table_dropped_during_streaming(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
-        await cql.run_async(f"CREATE TABLE {ks}.test2 (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test2")
 
         servers.append(await manager.server_add())
 
@@ -502,7 +502,7 @@ async def test_tablet_cleanup(manager: ManagerClient):
     await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     await manager.servers_see_each_other(servers)
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="test")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk) VALUES ({k});") for k in range(1000)])
 
         logger.info("Start second node")
@@ -575,7 +575,7 @@ async def test_tablet_cleanup_failure(manager: ManagerClient):
     await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     await manager.servers_see_each_other(servers)
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="test")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk) VALUES ({k});") for k in range(n_partitions)])
 
         await inject_error_one_shot_on(manager, "tablet_cleanup_failure", servers)
@@ -625,7 +625,7 @@ async def test_tablet_resharding(manager: ManagerClient):
     n_tablets = 32
     n_partitions = 1000
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY);")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="test")
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk) VALUES ({k});") for k in range(n_partitions)])
 
     await manager.server_stop_gracefully(server.server_id, timeout=120)
@@ -653,7 +653,7 @@ async def test_tablet_split(manager: ManagerClient, injection_error: str):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         # enough to trigger multiple splits with max size of 1024 bytes.
         keys = range(256)
@@ -726,7 +726,7 @@ async def test_correctness_of_tablet_split_finalization_after_restart(manager: M
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH compaction = {{'class': 'NullCompactionStrategy'}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH compaction = {{'class': 'NullCompactionStrategy'}}", table_name="test")
 
         # enough to trigger multiple splits with max size of 1024 bytes.
         keys = range(256)
@@ -791,7 +791,7 @@ async def test_concurrent_tablet_migration_and_major(manager: ManagerClient, inj
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(256)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
@@ -848,7 +848,7 @@ async def test_concurrent_table_drop_and_major(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(256)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
@@ -936,8 +936,8 @@ async def test_tablet_count_metric_per_shard(manager: ManagerClient):
     # When two tables are created
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.mytable1 (col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1));")
-        await cql.run_async(f"CREATE TABLE {ks}.mytable2 (col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1));")
+        await create_new_test_table(manager, ks, "col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1)", table_name="mytable1")
+        await create_new_test_table(manager, ks, "col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1)", table_name="mytable2")
 
         # Then tablet count metric for each shard depicts the actual state
         tables = { ks: ["mytable1", "mytable2"] }
@@ -948,7 +948,7 @@ async def test_tablet_count_metric_per_shard(manager: ManagerClient):
         await assert_tablet_count_metric_value_for_shards(manager, servers[1], expected_count_per_shard_for_host_1)
 
         # When third table is created
-        await cql.run_async(f"CREATE TABLE {ks}.mytable3 (col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1));")
+        await create_new_test_table(manager, ks, "col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1)", table_name="mytable3")
 
         # Then tablet count metric for each shard depicts the actual state
         tables = { ks: ["mytable1", "mytable2", "mytable3"] }
@@ -1028,7 +1028,7 @@ async def test_tablet_load_and_stream(manager: ManagerClient, primary_replica_on
         # Creates multiple tablets in the same shard
         ks_name = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}" \
                             f" AND tablets = {{ 'initial': {tablet_count} }};")
-        await cql.run_async(f"CREATE TABLE {ks_name}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks_name, "pk int PRIMARY KEY, c int", table_name="test")
         return ks_name
 
     ks = await create_table(5) # 5 is rounded up to next power-of-two
@@ -1120,7 +1120,7 @@ async def test_storage_service_api_uneven_ownership_keyspace_and_table_params_us
     # When table is created with initial tablets set to 1
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.mytable1 (col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1));")
+        await create_new_test_table(manager, ks, "col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1)", table_name="mytable1")
 
         # And when ownership for this table is queried
         actual_ownerships = await manager.api.get_ownership(servers[0].ip_addr, ks, "mytable1")
@@ -1157,7 +1157,7 @@ async def test_tablet_storage_freeing(manager: ManagerClient):
     n_tablets = 2
     n_partitions = 1000
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH compression = {{'sstable_compression': ''}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, v text", extra=f" WITH compression = {{'sstable_compression': ''}}", table_name="test")
         insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, v) VALUES (?, ?);")
         payload = "a"*10000
 
@@ -1197,7 +1197,7 @@ async def test_schema_change_during_cleanup(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         logger.info("Populating table")
 
@@ -1245,7 +1245,7 @@ async def test_tombstone_gc_correctness_during_tablet_split(manager: ManagerClie
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH gc_grace_seconds=0;")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=" WITH gc_grace_seconds=0", table_name="test")
 
         await manager.api.disable_autocompaction(servers[0].ip_addr, ks)
 
@@ -1345,7 +1345,7 @@ async def create_and_populate_table(manager: ManagerClient, rf: int = 3, initial
     cql = manager.get_cql()
     try:
         ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND tablets = {{'initial': {initial_tablets}}}")
-        await cql.run_async(f"CREATE TABLE {ks}.{table} (pk int PRIMARY KEY, c int)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name=table)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.{table} (pk, c) VALUES ({k}, 1);") for k in range(num_keys)])
         yield Context(ks, table, rf, initial_tablets, num_keys)
     finally:
@@ -1531,7 +1531,7 @@ async def test_tablet_cleanup_vs_snapshot_race(manager: ManagerClient):
     await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     await manager.servers_see_each_other(servers)
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="test")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk) VALUES ({k});") for k in range(n_partitions)])
 
         await inject_error_one_shot_on(manager, "tablet_cleanup_failure_post_deletion", servers)
@@ -1570,7 +1570,7 @@ async def test_drop_table_and_truncate_after_migration(manager: ManagerClient, o
 
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND TABLETS = {{'initial': 4}}")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
     await manager.api.disable_autocompaction(servers[0].ip_addr, ks)
 
@@ -1618,7 +1618,7 @@ async def test_drop_table_during_streaming(manager: ManagerClient, streaming_mod
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         table_opts = " WITH storage_engine = 'logstor'" if uses_logstor else ""
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c text){table_opts}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c text", extra=table_opts, table_name="test")
 
         for k in range(128):
             await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, '{k}')")
@@ -1674,7 +1674,7 @@ async def test_truncate_during_topology_change(manager: ManagerClient):
     servers = await manager.servers_add(3, config = { 'enable_tablets': True }, auto_rack_dc="dc1")
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (k int PRIMARY KEY, v int)")
+        await create_new_test_table(manager, ks, "k int PRIMARY KEY, v int", table_name="test")
 
         logger.info("Populating table")
         stmt = cql.prepare(f"INSERT INTO {ks}.test (k, v) VALUES (?, ?)")
@@ -1710,8 +1710,7 @@ async def test_concurrent_schema_change_with_compaction_completion(manager: Mana
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        table = f"{ks}.test"
-        await cql.run_async(f"CREATE TABLE {table} (a int PRIMARY KEY, b int);")
+        table = await create_new_test_table(manager, ks, "a int PRIMARY KEY, b int", table_name="test")
 
         stop_compaction = False
         async def background_compaction():
@@ -1761,7 +1760,7 @@ async def test_split_correctness_on_tablet_count_change(manager: ManagerClient):
     initial_tablets = 2
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': {initial_tablets}}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tablets = {{'min_tablet_count': {initial_tablets}}}", table_name="test")
 
         await manager.api.disable_autocompaction(server.ip_addr, ks, 'test')
 
@@ -1829,7 +1828,7 @@ async def test_tablet_load_and_stream_and_split_synchronization(manager: Manager
     initial_tablets = 1
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': {initial_tablets}}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tablets = {{'min_tablet_count': {initial_tablets}}}", table_name="test")
 
         keys = range(100)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
@@ -1919,7 +1918,7 @@ async def test_update_load_stats_after_rebuild(manager: ManagerClient):
         return await cql.run_async(f"SELECT * FROM system.tablet_sizes WHERE table_id = {table}")
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1']}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 1}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tablets = {{'min_tablet_count': 1}}", table_name="test")
 
         table_id = await manager.get_table_or_view_id(ks, 'test')
 
@@ -1974,7 +1973,7 @@ async def test_update_load_stats_after_migration(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1']}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 1}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tablets = {{'min_tablet_count': 1}}", table_name="test")
 
         table_id = await manager.get_table_or_view_id(ks, 'test')
 
@@ -2027,7 +2026,7 @@ async def test_crash_on_missing_table_from_load_stats(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         # Make sure load_stats has been refreshed and that the coordinator has cached load_stats
         table_id = await manager.get_table_or_view_id(ks, 'test')
@@ -2071,7 +2070,7 @@ async def test_tablets_barrier_waits_for_replica_erms(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         servers.append(await manager.server_add(cmdline=cmdline))
 
@@ -2149,7 +2148,7 @@ async def test_split_and_incremental_repair_synchronization(manager: ManagerClie
     initial_tablets = 2
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': {initial_tablets}}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tablets = {{'min_tablet_count': {initial_tablets}}}", table_name="test")
 
         # insert data
         pks = range(256)
@@ -2240,7 +2239,7 @@ async def test_split_and_intranode_synchronization(manager: ManagerClient):
     initial_tablets = 1
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': {initial_tablets}}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tablets = {{'min_tablet_count': {initial_tablets}}}", table_name="test")
 
         # insert data
         pks = range(256)
@@ -2316,7 +2315,7 @@ async def test_split_stopped_on_shutdown(manager: ManagerClient):
     initial_tablets = 2
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': {initial_tablets}}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tablets = {{'min_tablet_count': {initial_tablets}}}", table_name="test")
 
         await manager.api.disable_autocompaction(server.ip_addr, ks, 'test')
 

--- a/test/cluster/test_tablets_intranode.py
+++ b/test/cluster/test_tablets_intranode.py
@@ -8,7 +8,7 @@ from cassandra.cluster import Session, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts, start_writes
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 
 import pytest
@@ -38,7 +38,7 @@ async def test_intranode_migration(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         finish_writes = await start_writes(cql, ks, "test")
 
@@ -74,7 +74,7 @@ async def test_crash_during_intranode_migration(manager: ManagerClient):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 4}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         finish_writes = await start_writes(cql, ks, "test", ignore_errors=True)
 
@@ -141,7 +141,7 @@ async def test_cross_shard_migration(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         finish_writes = await start_writes(cql, ks, "test")
 

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -9,7 +9,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, read_barrier
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_count
 from test.pylib.util import wait_for
-from test.cluster.util import new_test_keyspace, create_new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_keyspace, create_new_test_table
 
 import pytest
 import asyncio
@@ -51,7 +51,7 @@ async def test_tablet_merge_simple(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c blob", extra=" WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1", table_name="test")
 
         # Initial average table size of 400k (1 tablet), so triggers some splits.
         total_keys = 200
@@ -198,7 +198,7 @@ async def test_tablet_split_and_merge_with_concurrent_topology_changes(manager: 
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c blob", extra=" WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1", table_name="test")
 
         async def perform_topology_ops():
             logger.info("Topology ops in background")
@@ -336,7 +336,7 @@ async def test_tablet_merge_cross_rack_migrations(manager: ManagerClient, racks)
 
     cql, _ = await manager.get_ready_cql(servers)
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND tablets = {{'initial': 1}}")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH compression = {{'sstable_compression': ''}};")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c blob", extra=f" WITH compression = {{'sstable_compression': ''}}", table_name="test")
 
     await inject_error_on(manager, "forbid_cross_rack_migration_attempt", servers)
 
@@ -389,9 +389,9 @@ async def test_tablet_split_merge_with_many_tables(build_mode: str, manager: Man
 
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND tablets = {{'initial': 1}}")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH compression = {{'sstable_compression': ''}};")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c blob", extra=f" WITH compression = {{'sstable_compression': ''}}", table_name="test")
     num_tables = 200 if build_mode != 'debug' else 20
-    await asyncio.gather(*[cql.run_async(f"CREATE TABLE {ks}.test{i} (pk int PRIMARY KEY, c blob);") for i in range(1, num_tables)])
+    await asyncio.gather(*[create_new_test_table(manager, ks, "pk int PRIMARY KEY, c blob", table_name=f"test{i}") for i in range(1, num_tables)])
 
     async def check_logs(when):
         for server in servers:
@@ -466,7 +466,7 @@ async def test_missing_data(manager: ManagerClient):
     inital_tablets = 32
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {inital_tablets}}}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         await manager.api.disable_autocompaction(server.ip_addr, ks, 'test')
 
@@ -534,7 +534,7 @@ async def test_merge_with_drop(manager: ManagerClient):
     initial_tablets = 32
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': {initial_tablets}}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tablets = {{'min_tablet_count': {initial_tablets}}}", table_name="test")
 
         await manager.api.disable_autocompaction(server.ip_addr, ks, 'test')
 
@@ -625,7 +625,7 @@ async def test_background_merge_deadlock(manager: ManagerClient):
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
 
     # Create a table which will go through 3 merge cycles.
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) with tablets = {{'min_tablet_count': 8}};")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" with tablets = {{'min_tablet_count': 8}}", table_name="test")
 
     await manager.api.enable_injection(servers[0].ip_addr, "merge_completion_fiber", one_shot=True)
     log = await manager.server_open_log(servers[0].server_id)

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -12,7 +12,7 @@ from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.skip_types import skip_env
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_info
 from test.pylib.util import start_writes
-from test.cluster.util import wait_for_cql_and_get_hosts, new_test_keyspace, reconnect_driver, wait_for
+from test.cluster.util import wait_for_cql_and_get_hosts, new_test_keyspace, reconnect_driver, wait_for, create_new_test_table
 import time
 import pytest
 import logging
@@ -56,7 +56,7 @@ async def test_tablet_transition_sanity(manager: ManagerClient, action):
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
         keys = range(256)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
 
@@ -144,7 +144,7 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(256)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
@@ -293,7 +293,7 @@ async def test_tablet_back_and_forth_migration(manager: ManagerClient):
     await manager.disable_tablet_balancing()
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
         await make_server()
 
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({1}, {1});")
@@ -441,7 +441,7 @@ async def test_restart_leaving_replica_during_cleanup(manager: ManagerClient, mi
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 8}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=" WITH tablets = {'min_tablet_count': 8}", table_name="test")
 
         total_keys = 10
         for pk in range(total_keys):
@@ -517,7 +517,7 @@ async def test_restart_in_cleanup_stage_after_cleanup(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 8}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=" WITH tablets = {'min_tablet_count': 8}", table_name="test")
 
         total_keys = 10
         for pk in range(total_keys):

--- a/test/cluster/test_tablets_parallel_decommission.py
+++ b/test/cluster/test_tablets_parallel_decommission.py
@@ -10,7 +10,7 @@ import time
 import pytest
 
 from test.cluster.tasks.task_manager_client import TaskManagerClient
-from test.cluster.util import get_coordinator_host, new_test_keyspace, ensure_group0_leader_on
+from test.cluster.util import get_coordinator_host, new_test_keyspace, ensure_group0_leader_on, create_new_test_table
 from test.pylib.internal_types import ServerInfo, IPAddress
 from test.pylib.manager_client import ManagerClient
 from test.pylib.scylla_cluster import gather_safely
@@ -50,7 +50,7 @@ async def test_tablets_are_drained_in_parallel(manager: ManagerClient):
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack1', 'rack2']} AND tablets = {'initial': 32};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="tab")
 
         coord_srv = await get_coordinator_host(manager)
         log = await manager.server_open_log(coord_srv.server_id) # group0 leader
@@ -120,7 +120,7 @@ async def test_tablets_are_rebuilt_in_parallel(manager: ManagerClient, same_rack
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack1', 'rack2']} AND tablets = {'initial': 32};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="tab")
 
         servers_to_remove = [servers[3], servers[4]]
         host_ids_to_remove = await gather_safely(*(manager.get_host_id(s.server_id) for s in servers_to_remove))
@@ -179,7 +179,7 @@ async def test_decommission_can_be_canceled(manager: ManagerClient):
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                         " 'dc1': ['rack1']} AND tablets = {'initial': 32};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="tab")
 
         coord_log = await manager.server_open_log(coord_serv.server_id) # group0 leader
         mark = await coord_log.mark()
@@ -263,7 +263,7 @@ async def test_decommission_is_rejected_when_another_one_is_still_pending(manage
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                         " 'dc1': ['rack1', 'rack2']} AND tablets = {'initial': 32};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="tab")
 
         coord_log = await manager.server_open_log(coord_serv.server_id) # group0 leader
         mark = await coord_log.mark()
@@ -311,7 +311,7 @@ async def test_remove_is_canceled_if_there_is_node_down(manager: ManagerClient):
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                         " 'dc1': ['rack1', 'rack2']} AND tablets = {'initial': 32};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="tab")
 
         await manager.server_stop_gracefully(servers[3].server_id)
         await manager.server_stop_gracefully(servers[2].server_id)
@@ -333,7 +333,7 @@ async def test_decommission_start_time_is_stable(manager: ManagerClient):
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack1']} AND tablets = {'initial': 32};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="tab")
 
         coord_serv = servers[0]
         coord_log = await manager.server_open_log(coord_serv.server_id) # group0 leader
@@ -380,7 +380,7 @@ async def test_decommission_can_not_be_canceled_once_running(manager: ManagerCli
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack1']} AND tablets = {'initial': 32};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="tab")
 
         coord_serv = servers[0]
         coord_log = await manager.server_open_log(coord_serv.server_id) # group0 leader
@@ -436,7 +436,7 @@ async def test_decommission_fails_if_capacity_is_gone_during_draining(manager: M
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack2']} AND tablets = {'initial': 32};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="tab")
 
         coord_serv = servers[0]
         coord_log = await manager.server_open_log(coord_serv.server_id) # group0 leader
@@ -482,7 +482,7 @@ async def test_node_lost_during_decommission_drain(manager: ManagerClient):
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack1']} AND tablets = {'initial': 32};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="tab")
 
         coord_serv = servers[0]
         coord_log = await manager.server_open_log(coord_serv.server_id) # group0 leader

--- a/test/cluster/test_tablets_removenode.py
+++ b/test/cluster/test_tablets_removenode.py
@@ -14,7 +14,7 @@ import logging
 
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import start_writes
-from test.cluster.util import create_new_test_keyspace, get_topology_coordinator
+from test.cluster.util import create_new_test_keyspace, get_topology_coordinator, create_new_test_table
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +45,7 @@ async def test_removenode_with_coordinator_restart(manager: ManagerClient):
     cql = manager.get_cql()
 
     ks1 = await create_keyspace(cql, 3, rf=1)
-    await cql.run_async(f"CREATE TABLE {ks1}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks1, "pk int PRIMARY KEY, c int", table_name="test")
 
     logger.info('Stopping a node to be removed')
     await manager.server_stop(servers[2].server_id)
@@ -75,17 +75,17 @@ async def test_replace(manager: ManagerClient):
     cql = manager.get_cql()
 
     ks1 = await create_keyspace(cql, 32, rf=1)
-    await cql.run_async(f"CREATE TABLE {ks1}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks1, "pk int PRIMARY KEY, c int", table_name="test")
 
     # We want RF=2 table to validate that quorum reads work after replacing node finishes
     # bootstrap which indicates that bootstrap waits for rebuilt.
     # Otherwise, some reads would fail to find a quorum.
     ks2 = await create_keyspace(cql, 32, rf=2)
-    await cql.run_async(f"CREATE TABLE {ks2}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks2, "pk int PRIMARY KEY, c int", table_name="test")
 
     ks3 = await create_keyspace(cql, 32, rf=3)
-    await cql.run_async(f"CREATE TABLE {ks3}.test (pk int PRIMARY KEY, c int);")
-    await cql.run_async(f"CREATE TABLE {ks3}.test2 (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks3, "pk int PRIMARY KEY, c int", table_name="test")
+    await create_new_test_table(manager, ks3, "pk int PRIMARY KEY, c int", table_name="test2")
 
     logger.info("Populating table")
 
@@ -156,15 +156,15 @@ async def test_removenode(manager: ManagerClient):
 
     # RF=1
     ks1 = await create_keyspace(cql, 32, rf=1)
-    await cql.run_async(f"CREATE TABLE {ks1}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks1, "pk int PRIMARY KEY, c int", table_name="test")
 
     # RF=2
     ks2 = await create_keyspace(cql, 32, rf=2)
-    await cql.run_async(f"CREATE TABLE {ks2}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks2, "pk int PRIMARY KEY, c int", table_name="test")
 
     # RF=3
     ks3 = await create_keyspace(cql, 32, rf=3)
-    await cql.run_async(f"CREATE TABLE {ks3}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks3, "pk int PRIMARY KEY, c int", table_name="test")
 
     logger.info("Populating table")
 
@@ -225,7 +225,7 @@ async def test_removenode_with_ignored_node(manager: ManagerClient):
     cql = manager.get_cql()
 
     ks = await create_keyspace(cql, 32, rf=3)
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+    await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
     logger.info("Populating table")
 

--- a/test/cluster/test_tls.py
+++ b/test/cluster/test_tls.py
@@ -6,7 +6,7 @@
 
 from test.pylib.manager_client import ManagerClient
 from cassandra.connection import ConnectionShutdown
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 
 import asyncio
 import logging
@@ -32,7 +32,7 @@ async def test_upgrade_to_ssl(manager: ManagerClient) -> None:
     servers = await manager.running_servers()
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY) WITH tombstone_gc = {{'mode': 'immediate'}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", extra=f" WITH tombstone_gc = {{'mode': 'immediate'}}", table_name=cf)
 
         async def update_config_and_restart(mode):
             for srv in servers:

--- a/test/cluster/test_topology_failure_recovery.py
+++ b/test/cluster/test_topology_failure_recovery.py
@@ -7,7 +7,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.internal_types import ServerInfo
 from test.pylib.rest_client import read_barrier
 from test.pylib.scylla_cluster import ReplaceConfig
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 import pytest
 import logging
 import asyncio
@@ -61,7 +61,7 @@ async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 32}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         await inject_error_on(manager, "stream_tablet_move_to_cleanup", servers)
 

--- a/test/cluster/test_truncate_concurrent_writes.py
+++ b/test/cluster/test_truncate_concurrent_writes.py
@@ -6,7 +6,7 @@
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, read_barrier
-from test.cluster.util import create_new_test_keyspace
+from test.cluster.util import create_new_test_keyspace, create_new_test_table
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
 import pytest
@@ -36,7 +36,7 @@ async def test_validate_truncate_with_concurrent_writes(manager: ManagerClient):
 
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}")
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int, ck int, val int, PRIMARY KEY(pk, ck));")
+    await create_new_test_table(manager, ks, "pk int, ck int, val int, PRIMARY KEY(pk, ck)", table_name="test")
 
     trunc_started_event = asyncio.Event()
     trunc_completed_event = asyncio.Event()

--- a/test/cluster/test_truncate_with_drop.py
+++ b/test/cluster/test_truncate_with_drop.py
@@ -6,7 +6,7 @@
 import logging
 import asyncio
 
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 from test.pylib.manager_client import ManagerClient
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
@@ -21,7 +21,7 @@ async def test_truncation_on_drop(manager: ManagerClient):
 
     # Create a keyspace
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
         table_id = await cql.run_async(f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 'test'")
         table_id = table_id[0].id
 
@@ -53,7 +53,7 @@ async def test_truncation_records_pruned_on_dirty_restart(manager: ManagerClient
     
     # Create a keyspace
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
         table_id = await cql.run_async(f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 'test'")
         table_id = table_id[0].id
 

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -8,7 +8,7 @@ from cassandra.protocol import InvalidRequest
 from cassandra.cluster import TruncateError
 from cassandra.policies import FallthroughRetryPolicy
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import get_topology_coordinator, new_test_keyspace
+from test.cluster.util import get_topology_coordinator, new_test_keyspace, create_new_test_table
 from test.pylib.tablets import get_all_tablet_replicas, get_tablet_count
 from test.pylib.util import wait_for_cql_and_get_hosts, wait_for
 import time
@@ -34,7 +34,7 @@ async def test_truncate_while_migration(manager: ManagerClient):
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(1024)
         await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
@@ -89,7 +89,7 @@ async def test_truncate_with_concurrent_drop(manager: ManagerClient):
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(1024)
         await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
@@ -138,7 +138,7 @@ async def test_truncate_while_node_restart(manager: ManagerClient):
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(1024)
         await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
@@ -185,7 +185,7 @@ async def test_truncate_with_coordinator_crash(manager: ManagerClient):
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(1024)
         await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
@@ -231,7 +231,7 @@ async def test_truncate_while_truncate_already_waiting(manager: ManagerClient):
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(1024)
         await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
@@ -275,7 +275,7 @@ async def test_replay_position_check_during_truncate(manager):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         keys = range(10)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
@@ -315,8 +315,8 @@ async def test_parallel_truncate(manager: ManagerClient):
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
-        await cql.run_async(f'CREATE TABLE {ks}.test1 (pk int PRIMARY KEY, c int);')
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test1")
 
         keys = range(1024)
         await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
@@ -377,7 +377,7 @@ async def test_split_emitted_during_truncate(manager: ManagerClient):
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 1}};")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH tablets = {{'min_tablet_count': 1}}", table_name="test")
 
         keys = range(10)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -13,7 +13,7 @@ from cassandra import ConsistencyLevel  # type: ignore
 from cassandra.query import SimpleStatement  # type: ignore
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.cluster.util import check_token_ring_and_group0_consistency, new_test_keyspace
+from test.cluster.util import check_token_ring_and_group0_consistency, new_test_keyspace, create_new_test_table
 from test.pylib.util import wait_for
 from test.cluster.test_tablets2 import inject_error_on
 from test.pylib.scylla_cluster import ReplaceConfig
@@ -48,7 +48,7 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
     cql, hosts = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
+        await create_new_test_table(manager, ks, "pk int primary key, v int", table_name="t")
         target_host = hosts[2]
         target_server = servers[2]
 

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -16,7 +16,7 @@ from test.pylib.tablets import get_tablet_count, get_all_tablet_replicas
 from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import new_test_keyspace, reconnect_driver
+from test.cluster.util import new_test_keyspace, reconnect_driver, create_new_test_table
 from test.cluster.tasks.task_manager_client import TaskManagerClient
 
 logger = logging.getLogger(__name__)
@@ -182,7 +182,7 @@ async def test_migration(manager: ManagerClient):
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': false}}") as ks:
         # Create the table with minor compaction disabled to ensure that Scylla
         # won't delete SSTables while we're checking them.
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH compaction = {{'class': 'IncrementalCompactionStrategy', 'enabled': false}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH compaction = {{'class': 'IncrementalCompactionStrategy', 'enabled': false}}", table_name="test")
 
         logger.info("Populating table in batches, flushing after each batch to produce multiple SSTables")
         stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
@@ -325,7 +325,7 @@ async def test_migration_rollback(manager: ManagerClient):
 
     logger.info("Creating keyspace and table with vnodes")
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': false}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH compaction = {{'class': 'IncrementalCompactionStrategy', 'enabled': false}}")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", extra=f" WITH compaction = {{'class': 'IncrementalCompactionStrategy', 'enabled': false}}", table_name="test")
 
         logger.info("Populating table in batches, flushing after each batch to produce multiple SSTables")
         stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
@@ -448,7 +448,7 @@ async def test_migration_multinode(manager: ManagerClient):
 
     logger.info(f"Creating keyspace and table with vnodes (RF={num_nodes})")
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {num_nodes}}} AND tablets = {{'enabled': false}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY, c int", table_name="test")
 
         logger.info(f"Populating table with {num_keys} rows at CL=QUORUM")
         insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
@@ -599,7 +599,7 @@ async def test_migration_finalize_without_migration(manager: ManagerClient):
     server, cql = await setup_single_node(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks_vnodes:
-        await cql.run_async(f"CREATE TABLE {ks_vnodes}.t (pk int PRIMARY KEY)")
+        await create_new_test_table(manager, ks_vnodes, "pk int PRIMARY KEY", table_name="t")
         with pytest.raises(HTTPError, match="does not have a tablet map"):
             await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks_vnodes)
 
@@ -619,12 +619,12 @@ async def test_migration_overlapping_migrations(manager: ManagerClient):
     server, cql = await setup_single_node(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks1:
-        await cql.run_async(f"CREATE TABLE {ks1}.t (pk int PRIMARY KEY)")
+        await create_new_test_table(manager, ks1, "pk int PRIMARY KEY", table_name="t")
         await manager.api.create_vnode_tablet_migration(server.ip_addr, ks1)
         await manager.api.upgrade_node_to_tablets(server.ip_addr)
 
         async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks2:
-            await cql.run_async(f"CREATE TABLE {ks2}.t (pk int PRIMARY KEY)")
+            await create_new_test_table(manager, ks2, "pk int PRIMARY KEY", table_name="t")
             with pytest.raises(HTTPError, match="Another migration is in progress"):
                 await manager.api.create_vnode_tablet_migration(server.ip_addr, ks2)
 
@@ -640,7 +640,7 @@ async def test_migration_finalize_before_upgrade(manager: ManagerClient):
     server, cql = await setup_single_node(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="t")
         await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
         await manager.api.upgrade_node_to_tablets(server.ip_addr)
 
@@ -659,7 +659,7 @@ async def test_migration_task_not_abortable(manager: ManagerClient):
     server, cql = await setup_single_node(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="t")
         await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
 
         tm = TaskManagerClient(manager.api)
@@ -690,7 +690,7 @@ async def test_migration_wait_task(manager: ManagerClient):
     server, cql = await setup_single_node(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY)")
+        await create_new_test_table(manager, ks, "pk int PRIMARY KEY", table_name="t")
 
         tm = TaskManagerClient(manager.api)
 
@@ -762,8 +762,8 @@ async def test_migration_multiple_keyspaces(manager: ManagerClient):
     logger.info("Creating two vnode keyspaces with tables")
     async with new_test_keyspace(manager, ks_opts) as ks1:
         async with new_test_keyspace(manager, ks_opts) as ks2:
-            await cql.run_async(f"CREATE TABLE {ks1}.t (pk int PRIMARY KEY, c int)")
-            await cql.run_async(f"CREATE TABLE {ks2}.t (pk int PRIMARY KEY, c int)")
+            await create_new_test_table(manager, ks1, "pk int PRIMARY KEY, c int", table_name="t")
+            await create_new_test_table(manager, ks2, "pk int PRIMARY KEY, c int", table_name="t")
 
             logger.info("Preparing both keyspaces for migration (creating tablet maps)")
             await manager.api.create_vnode_tablet_migration(server.ip_addr, ks1)

--- a/test/cluster/test_write_query_during_cql_server_shutdown.py
+++ b/test/cluster/test_write_query_during_cql_server_shutdown.py
@@ -12,7 +12,7 @@ from cassandra import ConsistencyLevel  # type: ignore
 from cassandra.query import SimpleStatement  # type: ignore
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_cql_and_get_hosts
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_table
 from test.cluster.test_tablets2 import inject_error_on
 from cassandra.cluster import ConnectionException, NoHostAvailable  # type: ignore
 
@@ -44,7 +44,7 @@ async def test_write_query_during_cql_server_shutdown(request: pytest.FixtureReq
     cql, hosts = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
+        await create_new_test_table(manager, ks, "pk int primary key, v int", table_name="t")
 
         await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 

--- a/test/cluster/test_zero_token_nodes_no_replication.py
+++ b/test/cluster/test_zero_token_nodes_no_replication.py
@@ -45,7 +45,7 @@ async def test_zero_token_nodes_no_replication(manager: ManagerClient):
                                     {{'class': '{replication_strategy}', 'replication_factor': 2}}
                                     AND tablets = {{ 'enabled': {str(tablets_enabled).lower()} }}""")
             ks_names.append(ks_name)
-            await cql_b.run_async(f'CREATE TABLE {ks_name}.tbl (pk int PRIMARY KEY, v int)')
+            await cql_b.run_async(f'CREATE TABLE IF NOT EXISTS {ks_name}.tbl (pk int PRIMARY KEY, v int)')
             for i in range(100):
                 insert_query = f'INSERT INTO {ks_name}.tbl (pk, v) VALUES ({i}, {i})'
                 if i % 2 == 0:

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -488,16 +488,13 @@ async def new_test_keyspace(manager: ManagerClient, opts, host=None):
         await manager.get_cql().run_async("DROP KEYSPACE IF EXISTS " + keyspace, host=host)
 
 previously_used_table_names = []
-@asynccontextmanager
-async def new_test_table(manager: ManagerClient, keyspace, schema, extra="", host=None, reuse_tables=True):
+async def create_new_test_table(manager: ManagerClient, keyspace, schema, extra="", host=None, reuse_tables=True):
     """
     A utility function for creating a new temporary table with a given schema.
     Because Scylla becomes slower when a huge number of uniquely-named tables
     are created and deleted (see https://github.com/scylladb/scylla/issues/7620)
     we keep here a list of previously used but now deleted table names, and
     reuse one of these names when possible.
-    This function can be used in a "async with", as:
-       async with create_table(cql, test_keyspace, '...') as table:
     """
     global previously_used_table_names
     if reuse_tables:
@@ -508,11 +505,22 @@ async def new_test_table(manager: ManagerClient, keyspace, schema, extra="", hos
         table_name = unique_name()
     table = keyspace + "." + table_name
     await manager.get_cql().run_async("CREATE TABLE " + table + "(" + schema + ")" + extra, host=host)
+    return table
+
+@asynccontextmanager
+async def new_test_table(manager: ManagerClient, keyspace, schema, extra="", host=None, reuse_tables=True):
+    """
+    A utility function for yielding a new temporary table with a given schema.
+    This function can be used in a "async with", as:
+       async with new_test_table(cql, test_keyspace, '...') as table:
+    """
+    table = await create_new_test_table(manager, keyspace, schema, extra, host, reuse_tables)
     try:
         yield table
     finally:
         await manager.get_cql().run_async("DROP TABLE " + table, host=host)
         if reuse_tables:
+            table_name = table.split('.')[1]
             previously_used_table_names.append(table_name)
 
 @asynccontextmanager

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -488,7 +488,7 @@ async def new_test_keyspace(manager: ManagerClient, opts, host=None):
         await manager.get_cql().run_async("DROP KEYSPACE IF EXISTS " + keyspace, host=host)
 
 previously_used_table_names = []
-async def create_new_test_table(manager: ManagerClient, keyspace, schema, extra="", host=None, reuse_tables=True):
+async def create_new_test_table(manager: ManagerClient, keyspace, schema, extra="", host=None, reuse_tables=True, table_name=None):
     """
     A utility function for creating a new temporary table with a given schema.
     Because Scylla becomes slower when a huge number of uniquely-named tables
@@ -497,12 +497,13 @@ async def create_new_test_table(manager: ManagerClient, keyspace, schema, extra=
     reuse one of these names when possible.
     """
     global previously_used_table_names
-    if reuse_tables:
-        if not previously_used_table_names:
-            previously_used_table_names.append(unique_name())
-        table_name = previously_used_table_names.pop()
-    else:
-        table_name = unique_name()
+    if not table_name:
+        if reuse_tables:
+            if not previously_used_table_names:
+                previously_used_table_names.append(unique_name())
+            table_name = previously_used_table_names.pop()
+        else:
+            table_name = unique_name()
     table = keyspace + "." + table_name
     await manager.get_cql().run_async(f"CREATE TABLE IF NOT EXISTS " + table + "(" + schema + ")" + extra, host=host)
     return table

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -504,7 +504,7 @@ async def create_new_test_table(manager: ManagerClient, keyspace, schema, extra=
     else:
         table_name = unique_name()
     table = keyspace + "." + table_name
-    await manager.get_cql().run_async("CREATE TABLE " + table + "(" + schema + ")" + extra, host=host)
+    await manager.get_cql().run_async(f"CREATE TABLE IF NOT EXISTS " + table + "(" + schema + ")" + extra, host=host)
     return table
 
 @asynccontextmanager
@@ -518,7 +518,7 @@ async def new_test_table(manager: ManagerClient, keyspace, schema, extra="", hos
     try:
         yield table
     finally:
-        await manager.get_cql().run_async("DROP TABLE " + table, host=host)
+        await manager.get_cql().run_async("DROP TABLE IF EXISTS " + table, host=host)
         if reuse_tables:
             table_name = table.split('.')[1]
             previously_used_table_names.append(table_name)


### PR DESCRIPTION
A Python driver bug causes in-flight CQL requests to be retried when connection pools are renewed during concurrent node bootstraps. This turns bare CREATE TABLE into a source of spurious AlreadyExists errors that fail tests.

Fix this by replacing bare CREATE TABLE with the create_new_test_table() helper (which uses IF NOT EXISTS) across 50 test files in test/cluster/.

Selection criteria — a CREATE TABLE was migrated only when ALL of:

1. It is actually-executed CQL (not in a comment or docstring).
2. It is expected to succeed (not inside pytest.raises or a try/except that catches the expected failure).
3. The session used is the shared pool session (get_cql()), not a pinned or exclusive session — pinned sessions cannot hit the pool-renewal retry path.
4. The statement is not fire-and-forget (no await-and-ignore pattern).
5. The same function does not also contain bare CREATE KEYSPACE, CREATE INDEX, CREATE MATERIALIZED VIEW, CREATE TYPE, CREATE ROLE, or CREATE FUNCTION — those need separate fixes and mixing partial idempotency in one function would be misleading.
6. The same function does not contain non-idempotent DML (e.g. counter increments) whose correctness depends on exactly-once execution.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1894
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1876

Fixes potential rare test failures on master. No backport required. Improvement.