### PR TITLE
database: add missing co_await on lock in create_local_system_table

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1142,7 +1142,7 @@ future<> database::create_local_system_table(
         cfg.memtable_scheduling_group = default_scheduling_group();
         cfg.memtable_to_cache_scheduling_group = default_scheduling_group();
     }
-    auto lock = get_tables_metadata().hold_write_lock();
+    auto lock = co_await get_tables_metadata().hold_write_lock();
     std::exception_ptr ex;
     try {
         add_column_family(ks, table, std::move(cfg), replica::database::is_new_cf::no);


### PR DESCRIPTION
The function database::create_local_system_table calls get_tables_metadata().hold_write_lock(), but does not co_await the returned future. Effectively, this code does not guarantee mutual exclusion because it does not wait for the lock to be acquired and does not guarantee that the lock is held long enough.

Fix this by adding the co_await that was missing.

Found by manual inspection. This code is not known to have caused any problems so far, but it's clearly wrong - hence the fix.

The issue was introduced in 1c5ec877a7bab5797aa6d5873cfc0abe621c7ef7, first released in 2025.4. Backports are needed to 2026.1 and 2026.2 as those are the maintained versions which contain the problematic code.

Fixes: SCYLLADB-1916