### PR TITLE
enable batch atomic deletion support for object storage sstables

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -30,6 +30,7 @@
 #include "schema/schema_builder.hh"
 #include "mutation/timestamp.hh"
 #include "utils/assert.hh"
+#include "utils/error_injection.hh"
 #include "utils/hashers.hh"
 #include "utils/log.hh"
 #include <seastar/core/enum.hh>
@@ -3502,6 +3503,8 @@ future<> system_keyspace::sstables_registry_batch_update_entry_status(table_id t
         auto& row = m.partition().clustered_row(*s, clustering_key::from_singular(*s, data_value(gen)));
         row.cells().apply(*status_cdef, atomic_cell::make_live(*status_cdef->type, ts, status_cdef->type->decompose(status)));
     }
+    utils::get_local_injector().inject("batch_update_entry_status_before_apply",
+            [] { throw std::runtime_error("batch_update_entry_status_before_apply"); });
     co_await apply_mutation(std::move(m));
 }
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3489,6 +3489,22 @@ future<> system_keyspace::sstables_registry_update_entry_status(table_id tid, lo
     co_await execute_cql(req, status, tid.id, node_owner.uuid(), gen).discard_result();
 }
 
+future<> system_keyspace::sstables_registry_batch_update_entry_status(table_id tid, locator::host_id node_owner, const std::vector<sstables::generation_type>& gens, sstring status) {
+    slogger.trace("Batch updating {} entries for {}.{} -> status={} in {}", gens.size(), tid, node_owner, status, SSTABLES_REGISTRY);
+    // Build a single mutation directly and batch all updates
+    // together to ensure atomicity, we touch a single partition.
+    auto s = sstables_registry();
+    auto ts = api::new_timestamp();
+    auto status_cdef = s->get_column_definition("status");
+    SCYLLA_ASSERT(status_cdef);
+    mutation m(s, partition_key::from_exploded(*s, {data_value(tid.id).serialize_nonnull(), data_value(node_owner.uuid()).serialize_nonnull()}));
+    for (auto& gen : gens) {
+        auto& row = m.partition().clustered_row(*s, clustering_key::from_singular(*s, data_value(gen)));
+        row.cells().apply(*status_cdef, atomic_cell::make_live(*status_cdef->type, ts, status_cdef->type->decompose(status)));
+    }
+    co_await apply_mutation(std::move(m));
+}
+
 future<> system_keyspace::sstables_registry_update_entry_state(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstables::sstable_state state) {
     static const auto req = format("UPDATE system.{} SET state = ? WHERE table_id = ? AND node_owner = ? AND generation = ?", SSTABLES_REGISTRY);
     auto new_state = sstables::state_to_dir(state);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -671,6 +671,7 @@ public:
 
     future<> sstables_registry_create_entry(table_id tid, locator::host_id node_owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
     future<> sstables_registry_update_entry_status(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstring status);
+    future<> sstables_registry_batch_update_entry_status(table_id tid, locator::host_id node_owner, const std::vector<sstables::generation_type>& gens, sstring status);
     future<> sstables_registry_update_entry_state(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstables::sstable_state state);
     future<> sstables_registry_delete_entry(table_id tid, locator::host_id node_owner, sstables::generation_type gen);
     using sstable_registry_entry_consumer = sstables::sstables_registry::entry_consumer;

--- a/db/system_keyspace_sstables_registry.hh
+++ b/db/system_keyspace_sstables_registry.hh
@@ -23,6 +23,10 @@ public:
         return _keyspace->sstables_registry_update_entry_status(tid, node_owner, gen, status);
     }
 
+    virtual seastar::future<> batch_update_entry_status(table_id tid, locator::host_id node_owner, const std::vector<sstables::generation_type>& gens, sstring status) override {
+        return _keyspace->sstables_registry_batch_update_entry_status(tid, node_owner, gens, status);
+    }
+
     virtual seastar::future<> update_entry_state(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstables::sstable_state state) override {
         return _keyspace->sstables_registry_update_entry_state(tid, node_owner, gen, state);
     }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4671,7 +4671,7 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
     }));
     rebuild_statistics();
 
-    co_await coroutine::parallel_for_each(per_cg_remove, [&] (auto& entry) {
+    co_await coroutine::parallel_for_each(per_cg_remove, [&] (auto& entry) -> future<> {
         auto& removed = entry.second;
         std::vector<sstables::shared_sstable> del;
         del.reserve(removed.size());
@@ -4682,7 +4682,15 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
             erase_sstable_cleanup_state(r.sst);
             del.emplace_back(std::move(r.sst));
         }
-        return delete_sstables_atomically(permit, std::move(del));
+        // Truncate may discard a large number of sstables. Deleting them all
+        // in a single atomic batch could produce an oversized mutation in the
+        // sstables registry.
+        // Split into chunks, FIXME: truncation is not expected to be atomic for now.
+        static constexpr size_t max_atomic_delete_chunk = 100;
+        for (auto chunk_view : del | std::views::chunk(max_atomic_delete_chunk)) {
+            auto chunk = chunk_view | std::views::as_rvalue | std::ranges::to<std::vector>();
+            co_await delete_sstables_atomically(permit, std::move(chunk));
+        }
     });
     co_return rp;
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3767,7 +3767,7 @@ utils::hashed_key sstable::make_hashed_key(const schema& s, const partition_key&
 }
 
 future<>
-sstable::unlink(storage::sync_dir sync) noexcept {
+sstable::unlink(const atomic_delete_context* ctx) noexcept {
     // Serialize with other calls to unlink or potentially ongoing mutations.
     auto lock = co_await get_units(_mutate_sem, 1);
     if (_unlinked) {
@@ -3777,7 +3777,7 @@ sstable::unlink(storage::sync_dir sync) noexcept {
     _unlinked = true;
     _on_delete(*this);
 
-    auto remove_fut = _storage->wipe(*this, sync);
+    auto remove_fut = _storage->wipe(*this, ctx);
 
     try {
         if (_cloned_to_sstable_filename) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -454,9 +454,9 @@ public:
 
     // Delete the sstable by unlinking all sstable files
     // Ignores all errors.
-    // Caller may pass sync_dir::no for batching multiple deletes in the same directory,
-    // and make sure the directory is sync'ed on or after the last call.
-    future<> unlink(storage::sync_dir sync = storage::sync_dir::yes) noexcept;
+    // When ctx is provided, it indicates the call is part of an atomic
+    // deletion sequence where atomic_delete_prepare has already been called.
+    future<> unlink(const atomic_delete_context* ctx = nullptr) noexcept;
 
     db::large_data_handler& get_large_data_handler() {
         return _large_data_handler;

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include "utils/log.hh"
+#include "utils/error_injection.hh"
 #include "sstables/sstables_manager.hh"
 #include "sstables/sstable_directory.hh"
 #include "sstables/sstables_registry.hh"
@@ -383,9 +384,15 @@ future<> sstables_manager::delete_atomically(std::vector<shared_sstable> ssts) {
     auto& storage = ssts.front()->get_storage();
     auto ctx = co_await storage.atomic_delete_prepare(ssts);
 
+    utils::get_local_injector().inject("delete_atomically_after_prepare",
+            [] { throw std::runtime_error("delete_atomically_after_prepare"); });
+
     co_await coroutine::parallel_for_each(ssts, [&ctx] (shared_sstable sst) {
         return sst->unlink(&ctx);
     });
+
+    utils::get_local_injector().inject("delete_atomically_after_unlink",
+            [] { throw std::runtime_error("delete_atomically_after_unlink"); });
 
     co_await storage.atomic_delete_complete(std::move(ctx));
 }

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -383,8 +383,8 @@ future<> sstables_manager::delete_atomically(std::vector<shared_sstable> ssts) {
     auto& storage = ssts.front()->get_storage();
     auto ctx = co_await storage.atomic_delete_prepare(ssts);
 
-    co_await coroutine::parallel_for_each(ssts, [] (shared_sstable sst) {
-        return sst->unlink(sstables::storage::sync_dir::no);
+    co_await coroutine::parallel_for_each(ssts, [&ctx] (shared_sstable sst) {
+        return sst->unlink(&ctx);
     });
 
     co_await storage.atomic_delete_complete(std::move(ctx));

--- a/sstables/sstables_registry.hh
+++ b/sstables/sstables_registry.hh
@@ -5,6 +5,7 @@
 
 #include "open_info.hh"
 
+#include <vector>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
 #include "locator/host_id.hh"
@@ -23,6 +24,7 @@ public:
     virtual future<> create_entry(table_id tid, locator::host_id node_owner, sstring status, sstable_state state, sstables::entry_descriptor desc) = 0;
     virtual future<> update_entry_status(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstring status) = 0;
     virtual future<> update_entry_state(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstables::sstable_state state) = 0;
+    virtual future<> batch_update_entry_status(table_id tid, locator::host_id node_owner, const std::vector<sstables::generation_type>& gens, sstring status) = 0;
     virtual future<> delete_entry(table_id tid, locator::host_id node_owner, sstables::generation_type gen) = 0;
     using entry_consumer = noncopyable_function<future<>(sstring status, sstables::sstable_state state, sstables::entry_descriptor desc)>;
     virtual future<> sstables_registry_list(table_id tid, locator::host_id node_owner, entry_consumer consumer) = 0;

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -849,7 +849,7 @@ future<> object_storage_base::change_state(const sstable& sst, sstable_state sta
     co_await sst.manager().sstables_registry().update_entry_state(owner(), sst.manager().get_local_host_id(), sst.generation(), state);
 }
 
-future<> object_storage_base::wipe(const sstable& sst, const atomic_delete_context*) noexcept {
+future<> object_storage_base::wipe(const sstable& sst, const atomic_delete_context* ctx) noexcept {
     // FIXME: unlike filesystem_storage::wipe, this implementation does not
     // catch exceptions from delete_object / sstables_registry calls and may
     // return an exceptional future, breaking the contract documented on
@@ -857,7 +857,9 @@ future<> object_storage_base::wipe(const sstable& sst, const atomic_delete_conte
     auto& sstables_registry = sst.manager().sstables_registry();
     auto node_owner = sst.manager().get_local_host_id();
 
-    co_await sstables_registry.update_entry_status(owner(), node_owner, sst.generation(), status_removing);
+    if (!ctx) {
+        co_await sstables_registry.update_entry_status(owner(), node_owner, sst.generation(), status_removing);
+    }
 
     co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
         co_await delete_object(make_object_name(sst, type));
@@ -866,8 +868,13 @@ future<> object_storage_base::wipe(const sstable& sst, const atomic_delete_conte
     co_await sstables_registry.delete_entry(owner(), node_owner, sst.generation());
 }
 
-future<atomic_delete_context> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>&) const {
-    // FIXME -- need atomicity, see #13567
+future<atomic_delete_context> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
+    std::vector<generation_type> gens;
+    gens.reserve(ssts.size());
+    for (auto& sst : ssts) {
+        gens.push_back(sst->generation());
+    }
+    co_await ssts.front()->manager().sstables_registry().batch_update_entry_status(owner(), ssts.front()->manager().get_local_host_id(), gens, status_removing);
     co_return atomic_delete_context{};
 }
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -93,7 +93,7 @@ public:
     virtual future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     virtual void open(sstable& sst) override;
-    virtual future<> wipe(const sstable& sst, sync_dir) noexcept override;
+    virtual future<> wipe(const sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept override;
     virtual future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) override;
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) override;
     future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
@@ -508,7 +508,8 @@ static inline fs::path parent_path(const sstring& fname) {
     return fs::canonical(fs::path(fname)).parent_path();
 }
 
-future<> filesystem_storage::wipe(const sstable& sst, sync_dir sync) noexcept {
+future<> filesystem_storage::wipe(const sstable& sst, const atomic_delete_context* ctx) noexcept {
+    auto sync = ctx ? sync_dir::no : sync_dir::yes;
     // We must be able to generate toc_filename()
     // in order to delete the sstable.
     // Running out of memory here will terminate.
@@ -665,7 +666,7 @@ public:
     future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     void open(sstable& sst) override;
-    future<> wipe(const sstable& sst, sync_dir) noexcept override;
+    future<> wipe(const sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept override;
     future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) override;
     future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) override;
     future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
@@ -848,7 +849,7 @@ future<> object_storage_base::change_state(const sstable& sst, sstable_state sta
     co_await sst.manager().sstables_registry().update_entry_state(owner(), sst.manager().get_local_host_id(), sst.generation(), state);
 }
 
-future<> object_storage_base::wipe(const sstable& sst, sync_dir) noexcept {
+future<> object_storage_base::wipe(const sstable& sst, const atomic_delete_context*) noexcept {
     // FIXME: unlike filesystem_storage::wipe, this implementation does not
     // catch exceptions from delete_object / sstables_registry calls and may
     // return an exceptional future, breaking the contract documented on

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -111,7 +111,7 @@ public:
     virtual void open(sstable& sst) = 0;
     // Must never return an exceptional future: implementations are expected
     // to catch and log any errors internally.
-    virtual future<> wipe(const sstable& sst, sync_dir) noexcept = 0;
+    virtual future<> wipe(const sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept = 0;
     virtual future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) = 0;
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) = 0;
     virtual future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const = 0;

--- a/test/cluster/object_store/test_atomic_delete.py
+++ b/test/cluster/object_store/test_atomic_delete.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import logging
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error_one_shot, inject_error
+from test.cluster.util import reconnect_driver, new_test_keyspace
+from test.cluster.object_store.conftest import keyspace_options
+
+logger = logging.getLogger(__name__)
+
+
+def make_server_config(object_storage):
+    objconf = object_storage.create_endpoint_conf()
+    return {
+        'enable_user_defined_functions': False,
+        'object_storage_endpoints': objconf,
+        'experimental_features': ['keyspace-storage-options'],
+    }
+
+async def populate_and_flush(cql, manager, server, ks, flushes, rows_per_flush=10):
+    """Insert rows and flush multiple times to create separate sstables."""
+    for i in range(flushes):
+        start = i * rows_per_flush
+        await asyncio.gather(*[
+            cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({start + k}, {start + k});")
+            for k in range(rows_per_flush)
+        ])
+        await manager.api.flush_keyspace(server.ip_addr, ks)
+
+async def get_registry_entries(cql, table_id):
+    """Return list of (status, generation) from sstables registry."""
+    res = cql.execute("SELECT * FROM system.sstables;")
+    return [(row.status, row.generation) for row in res if row.table_id == table_id]
+
+async def get_table_id(cql, ks, table='test'):
+    row = cql.execute(
+        f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = '{table}'"
+    ).one()
+    return row.id
+
+async def assert_registry_clean_after_restart(manager, server, table_id):
+    """Restart the server and verify all registry entries are 'sealed' after garbage_collect."""
+    await manager.server_restart(server.server_id)
+    cql = await reconnect_driver(manager)
+    entries = await get_registry_entries(cql, table_id)
+    for status, gen in entries:
+        assert status == 'sealed', f"Entry {gen} has status '{status}', expected 'sealed'"
+    logger.info("Registry entries after recovery: %d", len(entries))
+    return cql, entries
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_crash_after_compaction_prepare(manager: ManagerClient, object_storage):
+    """Error injection throws after atomic_delete_prepare marks input sstable
+    entries as 'removing' but before any S3 objects are actually deleted.
+
+    Verifies the atomicity property: all compaction input sstables are marked
+    'removing' together (none left in 'sealed' while others are 'removing').
+    On restart, garbage_collect cleans up the 'removing' entries and their
+    S3 objects, while the data remains readable from the compaction output.
+    """
+    cfg = make_server_config(object_storage)
+    server = await manager.server_add(config=cfg)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await populate_and_flush(cql, manager, server, ks, flushes=2)
+
+        table_id = await get_table_id(cql, ks)
+        entries_before = await get_registry_entries(cql, table_id)
+        sealed_before = {gen for status, gen in entries_before if status == 'sealed'}
+        logger.info("Registry entries before compaction: %d sealed", len(sealed_before))
+        assert len(sealed_before) >= 2, "Need at least 2 sstables for compaction"
+
+        # The injection throws after marking entries as 'removing' but before unlinking S3 objects.
+        # Compaction handles the error internally (the REST API does not propagate it), but the
+        # entries are left in 'removing' state with S3 objects still present.
+        await inject_error_one_shot(manager.api, server.ip_addr, "delete_atomically_after_prepare")
+        await manager.api.keyspace_compaction(server.ip_addr, ks)
+
+        # Verify atomicity of the batch status change: after the failed compaction, the input sstables
+        # should ALL be in 'removing' state. If some inputs were 'removing' and others still
+        # 'sealed', the batch wasn't atomic. Compaction outputs (new generations) are excluded.
+        entries_after_fail = await get_registry_entries(cql, table_id)
+        removing_from_original = sealed_before & {gen for status, gen in entries_after_fail if status == 'removing'}
+        still_sealed_from_original = sealed_before & {gen for status, gen in entries_after_fail if status == 'sealed'}
+        logger.info("After failed compaction: %d original entries now 'removing', %d still 'sealed'",
+                    len(removing_from_original), len(still_sealed_from_original))
+        assert len(removing_from_original) >= 2, \
+            f"Expected at least 2 original entries in 'removing', got {len(removing_from_original)}"
+        assert len(still_sealed_from_original) == 0, \
+            f"Atomicity violation: {len(still_sealed_from_original)} original entries still 'sealed' " \
+            f"while {len(removing_from_original)} are 'removing'"
+
+        cql, _ = await assert_registry_clean_after_restart(manager, server, table_id)
+
+        # Data should be readable from the compaction output sstables
+        res = cql.execute(f"SELECT count(*) FROM {ks}.test;")
+        count = res.one().count
+        logger.info("Row count after recovery: %d", count)
+        assert count == 20, f"Expected 20 rows after recovery, got {count}"
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_crash_after_compaction_unlink(manager: ManagerClient, object_storage):
+    """Error injection throws after S3 objects have been unlinked but before
+    atomic_delete_complete removes the registry entries.
+
+    On restart, garbage_collect should clean up the dangling 'removing'
+    entries. Data remains readable from the compaction output sstables.
+    """
+    cfg = make_server_config(object_storage)
+    server = await manager.server_add(config=cfg)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await populate_and_flush(cql, manager, server, ks, flushes=2)
+
+        table_id = await get_table_id(cql, ks)
+
+        # The injection throws after unlinks complete but before atomic_delete_complete.
+        # Compaction handles the error internally, but 'removing' entries whose S3 objects
+        # are already deleted remain in the registry.
+        await inject_error_one_shot(manager.api, server.ip_addr, "delete_atomically_after_unlink")
+        await manager.api.keyspace_compaction(server.ip_addr, ks)
+
+        cql, _ = await assert_registry_clean_after_restart(manager, server, table_id)
+
+        res = cql.execute(f"SELECT count(*) FROM {ks}.test;")
+        count = res.one().count
+        logger.info("Row count after recovery: %d", count)
+        assert count == 20, f"Expected 20 rows after recovery, got {count}"
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_crash_during_truncate(manager: ManagerClient, object_storage):
+    """Error injection throws in delete_atomically after atomic_delete_prepare
+    marks entries as 'removing' but before S3 objects are deleted.
+
+    On restart, garbage_collect cleans up the 'removing' registry entries.
+    """
+    cfg = make_server_config(object_storage)
+    server = await manager.server_add(config=cfg)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        # Create multiple sstables. Disable auto-compaction first so they don't get merged.
+        await manager.api.disable_autocompaction(server.ip_addr, ks)
+        await populate_and_flush(cql, manager, server, ks, flushes=5, rows_per_flush=1)
+
+        table_id = await get_table_id(cql, ks)
+        entries_before = await get_registry_entries(cql, table_id)
+        assert len(entries_before) >= 5, f"Expected at least 5 sstables, got {len(entries_before)}"
+
+        # The injection throws after marking sstables 'removing'. The error from
+        # delete_atomically is handled internally — truncate completes but leaves
+        # entries in 'removing' state.
+        async with inject_error(manager.api, server.ip_addr, "delete_atomically_after_prepare"):
+            await cql.run_async(f"TRUNCATE TABLE {ks}.test;")
+
+        await assert_registry_clean_after_restart(manager, server, table_id)
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_crash_before_batch_mutation_commits(manager: ManagerClient, object_storage):
+    """Error injection throws inside batch_update_entry_status BEFORE the
+    mutation is applied to the commitlog.
+
+    This is the complement to test_crash_after_compaction_prepare: together they
+    prove the atomicity guarantee of the batch mutation. If the mutation throws
+    before being committed, no entries should be marked 'removing' and all data
+    remains intact.
+    """
+    cfg = make_server_config(object_storage)
+    server = await manager.server_add(config=cfg)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await manager.api.disable_autocompaction(server.ip_addr, ks)
+        await populate_and_flush(cql, manager, server, ks, flushes=2)
+
+        table_id = await get_table_id(cql, ks)
+
+        # The injection throws before apply_mutation, so the batch mutation
+        # marking entries as 'removing' is never committed. Compaction handles
+        # the error internally — the REST API does not propagate it.
+        await inject_error_one_shot(manager.api, server.ip_addr, "batch_update_entry_status_before_apply")
+        await manager.api.keyspace_compaction(server.ip_addr, ks)
+
+        # Verify: no entries should be in 'removing' state since the mutation
+        # was never committed.
+        entries = await get_registry_entries(cql, table_id)
+        removing = {gen for status, gen in entries if status == 'removing'}
+        assert len(removing) == 0, f"Mutation should not have been committed, but found 'removing' entries: {removing}"
+        logger.info("After failed compaction: %d entries, none in 'removing' state", len(entries))
+
+        # All data should be readable.
+        res = cql.execute(f"SELECT count(*) FROM {ks}.test;")
+        count = res.one().count
+        logger.info("Row count after failed compaction: %d", count)
+        assert count == 20, f"Expected 20 rows, got {count}"

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -331,6 +331,11 @@ public:
         }
         co_return;
     }
+    virtual future<> batch_update_entry_status(table_id tid, locator::host_id node_owner, const std::vector<sstables::generation_type>& gens, sstring status) override {
+        for (auto& gen : gens) {
+            co_await update_entry_status(tid, node_owner, gen, status);
+        }
+    }
     virtual future<> update_entry_state(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstables::sstable_state state) override {
         auto it = _entries.find(key_type{tid, node_owner, gen});
         if (it != _entries.end()) {


### PR DESCRIPTION
This PR implements atomic batch deletion of SSTables by marking them all as `removing` (or none) in the `system.sstables` registry before deleting their S3 objects. 

Changes included here:
- a new `batch_update_entry_status` method on the sstables_registry interface that builds a single mutation with multiple clustering rows sharing the same partition key (table_id, node_owner).
- add optional atomic_delete_context* arg  to wipe() so it knows when to skip individual per-SSTable status updates (when the batch deletion path has already marked them as `removing`).
- object storage `atomic_delete_prepare()` now calls `batch_update_entry_status` to mark all compaction input SSTables as removing in one atomic operation
- TRUNCATE in `discard_sstables()` chunks deletions into groups of 100 to avoid building an oversized mutation in case the table is big.
- a few tests checking checking what happens if the node crashes at various stages of the atomic batch deletion or during truncate.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1001
