### PR TITLE
transport: report host id in SUPPORTED

### DIFF
--- a/docs/dev/protocol-extensions.md
+++ b/docs/dev/protocol-extensions.md
@@ -50,6 +50,17 @@ policy, timeouts, and other configuration.
 Such data should be sent in `CLIENT_OPTIONS` key, as JSON. The recommended
 structure of this JSON will be decided in the future.
 
+## Host ID discovery
+
+The `SCYLLA_HOST_ID` option in the SUPPORTED response contains the host ID of
+the node that accepted the connection, formatted as a UUID string. This is the
+same value exposed as `host_id` in the connected node's `system.local` row.
+
+This option lets drivers identify the connected node during protocol
+initialization without issuing an additional `system.local` query. It is an
+informational option returned by the server; clients do not send
+`SCYLLA_HOST_ID` in STARTUP.
+
 ## Intranode sharding
 
 This extension allows the driver to discover how Scylla internally

--- a/test/cqlpy/test_protocol_exceptions.py
+++ b/test/cqlpy/test_protocol_exceptions.py
@@ -4,12 +4,14 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 
 from cassandra.cluster import NoHostAvailable
+from cassandra.connection import Connection
 from contextlib import contextmanager
 import pytest
 import re
 import requests
 import socket
 import struct
+from unittest import mock
 from test.cqlpy import nodetool
 from test.cqlpy.util import cql_session
 from test.pylib.skip_types import skip_env
@@ -361,3 +363,26 @@ def test_no_protocol_exceptions(scylla_only, no_ssl, debug_exceptions_logging, h
 
     cpp_exception_metrics_after = get_cpp_exceptions_metrics(host)
     assert cpp_exception_metrics_after - cpp_exception_metrics_before <= cpp_exception_threshold, "Expected C++ protocol errors to not increase"
+
+# Regression test for GitHub issue #27452.
+def test_supported_includes_host_id(scylla_only, no_ssl, cql, host, request):
+    expected_host_id = str(cql.execute("SELECT host_id FROM system.local WHERE key = 'local'").one()[0])
+    captured_supported = {}
+    original_handle = Connection._handle_options_response
+
+    def _capture_supported(self, options_response):
+        if hasattr(options_response, "options"):
+            captured_supported.update(options_response.options)
+        return original_handle(self, options_response)
+
+    with mock.patch.object(Connection, "_handle_options_response", _capture_supported):
+        with cql_session(
+                host=host,
+                port=request.config.getoption("--port"),
+                is_ssl=False,
+                username=request.config.getoption("--auth_username") or "cassandra",
+                password=request.config.getoption("--auth_password") or "cassandra",
+        ):
+            pass
+
+    assert captured_supported["SCYLLA_HOST_ID"] == [expected_host_id]

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1979,6 +1979,8 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int
     // CLIENT_OPTIONS value is a JSON string that can be used to pass client-specific configuration,
     // e.g. CQL driver configuration.
     opts.insert({"CLIENT_OPTIONS", ""});
+    // Let drivers identify the connected node without an extra system.local query.
+    opts.insert({"SCYLLA_HOST_ID", _server._gossiper.my_host_id().to_sstring()});
     if (_server._config.allow_shard_aware_drivers) {
         opts.insert({"SCYLLA_SHARD", format("{:d}", this_shard_id())});
         opts.insert({"SCYLLA_NR_SHARDS", format("{:d}", smp::count)});


### PR DESCRIPTION
Currently driver creates network layout (node IP addresses and ports) from `system.local`, `system.peers`, `system.client_routes` and then runs on assumption that this network layout is correct.
It does not check if it is.
If, for example it happens so that node ip/port (say on proxy) will not match what driver calculated it will go unnoticed.

The goal of this feature is to provide driver host-id on SUPPORTED frame, so that it would know which node it connected to and could make decision wether keep connection or drop it.

## Summary
- add `SCYLLA_HOST_ID` to the CQL `SUPPORTED` response
- add a regression test that hooks the Python driver handshake and verifies the reported host id

## Verification
- `python3.12 -m py_compile test/cqlpy/test_protocol_exceptions.py`
- syntax-only compile of `transport/server.cc` with the repo toolchain flags inside `dbuild`

Refs #27452 and https://scylladb.atlassian.net/browse/DRIVER-610
Backport: None