### PR TITLE
alternator: vector search and streams on the same table

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1898,6 +1898,20 @@ future<executor::request_return_type> executor::update_table(client_state& clien
             schema_builder builder(tab);
 
             rjson::value* stream_specification = rjson::find(request, "StreamSpecification");
+            rjson::value* gsi_updates = rjson::find(request, "GlobalSecondaryIndexUpdates");
+            rjson::value* vector_index_updates = rjson::find(request, "VectorIndexUpdates");
+            // DynamoDB rejects combining a GSI or vector index create/delete
+            // with a stream change in the same UpdateTable request. Check this
+            // early, before processing either, so that the error is consistent
+            // regardless of which individual operation would fail on its own.
+            if (stream_specification && stream_specification->IsObject()) {
+                if (gsi_updates && gsi_updates->IsArray() && gsi_updates->Size()) {
+                    co_return api_error::validation("You cannot create or delete index while changing stream status");
+                }
+                if (vector_index_updates && vector_index_updates->IsArray() && vector_index_updates->Size()) {
+                    co_return api_error::validation("You cannot create or delete index while changing stream status");
+                }
+            }
             if (stream_specification && stream_specification->IsObject()) {
                 empty_request = false;
                 if (add_stream_options(*stream_specification, builder, p.local(), tab->cdc_options())) {
@@ -1942,7 +1956,6 @@ future<executor::request_return_type> executor::update_table(client_state& clien
             // Support VectorIndexUpdates to add or delete a vector index,
             // similar to GlobalSecondaryIndexUpdates above. We handle this
             // before builder.build() so we can use builder directly.
-            rjson::value* vector_index_updates = rjson::find(request, "VectorIndexUpdates");
             if (vector_index_updates) {
                 if (!vector_index_updates->IsArray()) {
                     co_return api_error::validation("VectorIndexUpdates must be an array");
@@ -2066,7 +2079,6 @@ future<executor::request_return_type> executor::update_table(client_state& clien
             std::vector<view_ptr> new_views;
             std::vector<std::string> dropped_views;
 
-            rjson::value* gsi_updates = rjson::find(request, "GlobalSecondaryIndexUpdates");
             if (gsi_updates) {
                 if (!gsi_updates->IsArray()) {
                     co_return api_error::validation("GlobalSecondaryIndexUpdates must be an array");

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1334,6 +1334,52 @@ static void defer_enabling_streams_block_tablet_merges(schema_builder& builder) 
     builder.with_cdc_options(opts);
 }
 
+// When a table has both a vector index and Alternator Streams, the CDC log
+// must use delta_mode=full (not delta_mode=keys) so that the vector store can
+// read the full column data from CDC log entries. Alternator Streams' view type
+// (KEYS_ONLY, NEW_IMAGE, etc.) is determined by preimage/postimage settings,
+// not by delta_mode, so upgrading delta_mode to full does not affect what
+// streams return to clients.
+// This function upgrades delta_mode to full if needed. It is a no-op if
+// no CDC options are explicitly set, or if postimage is already enabled
+// (which also satisfies the vector store's requirements).
+static void upgrade_cdc_delta_for_vector_index(schema_builder& builder) {
+    auto& exts = builder.get_extensions();
+    auto it = exts.find(cdc::cdc_extension::NAME);
+    if (it == exts.end()) {
+        return; // No explicit CDC options; default delta_mode is already full
+    }
+    auto ext = dynamic_pointer_cast<cdc::cdc_extension>(it->second);
+    throwing_assert(ext);
+    auto opts = ext->get_options();
+    if (opts.postimage() || opts.get_delta_mode() == cdc::delta_mode::full) {
+        return; // Already satisfies vector store requirements
+    }
+    opts.set_delta_mode(cdc::delta_mode::full);
+    builder.with_cdc_options(opts);
+}
+
+// Symmetric to upgrade_cdc_delta_for_vector_index(): when the last vector
+// index is deleted, downgrade delta_mode from full back to keys (if it was
+// upgraded for the vector index and the stream no longer needs full).
+// This is a no-op if postimage is enabled (the stream was driving full delta
+// mode, not the vector index), or if delta is not currently full.
+static void downgrade_cdc_delta_after_vector_index_delete(schema_builder& builder) {
+    auto& exts = builder.get_extensions();
+    auto it = exts.find(cdc::cdc_extension::NAME);
+    if (it == exts.end()) {
+        return; // No explicit CDC options
+    }
+    auto ext = dynamic_pointer_cast<cdc::cdc_extension>(it->second);
+    throwing_assert(ext);
+    auto opts = ext->get_options();
+    if (opts.get_delta_mode() != cdc::delta_mode::full) {
+        return;
+    }
+    opts.set_delta_mode(cdc::delta_mode::keys);
+    builder.with_cdc_options(opts);
+}
+
 // Returns true if the given attribute name is already the target of any vector
 // index on the schema. Analogous to schema::has_index(), but looks up by the
 // indexed attribute name rather than the index name.
@@ -1656,6 +1702,16 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
     if (stream_specification && stream_specification->IsObject()) {
         if (executor::add_stream_options(*stream_specification, builder, _proxy)) {
             validate_cdc_log_name_length(builder.cf_name());
+            // If vector index was also enabled, it set up its desired CDC
+            // configuration before the code here overwrote it by its own
+            // desire. In that case we need to re-apply the vector index's
+            // minimum CDC requirements on top of the stream options. In
+            // particular, if the user enable streams with KEYS_ONLY we
+            // need to add delta_mode=full (because the vector store needs
+            // either delta_mode=full or postimage).
+            if (vector_indexes && vector_indexes->Size() > 0) {
+                upgrade_cdc_delta_for_vector_index(builder);
+            }
         }
     }
 
@@ -1916,11 +1972,35 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                 empty_request = false;
                 if (add_stream_options(*stream_specification, builder, p.local(), tab->cdc_options())) {
                     validate_cdc_log_name_length(builder.cf_name());
+                    // If the table already has a vector index, ensure CDC uses
+                    // delta_mode=full so the vector store can read full column
+                    // data (KEYS_ONLY streams would otherwise set delta_mode=keys).
+                    // Note: Alternator only uses secondary indexes for vector
+                    // search, so any non-empty indices() means a vector index.
+                    if (!tab->indices().empty()) {
+                        upgrade_cdc_delta_for_vector_index(builder);
+                    }
                     // On tablet tables, defer stream enablement and block
                     // tablet merges (see defer_enabling_streams_block_tablet_merges).
                     bool uses_tablets = p.local().local_db().find_keyspace(tab->ks_name()).get_replication_strategy().uses_tablets();
                     if (uses_tablets) {
                         defer_enabling_streams_block_tablet_merges(builder);
+                    }
+                } else {
+                    // Stream is being disabled. If the table has a vector index,
+                    // CDC will remain active for the vector store because
+                    // cdc::cdc_enabled() checks if there is a vector index. But
+                    // we need the CDC options to have enabled=false (CDC is
+                    // explicitly enabled) and delta_mode=full (vector store
+                    // requirement). is_vector_only_cdc() will return true
+                    // with this setting, so DescribeTable/ListStreams will
+                    // not show this CDC as a stream.
+                    if (!tab->indices().empty()) {
+                        cdc::options opts;
+                        opts.enabled(false);
+                        opts.set_delta_mode(cdc::delta_mode::full);
+                        opts.ttl(tab->cdc_options().ttl());
+                        builder.with_cdc_options(opts);
                     }
                 }
                 auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
@@ -2061,12 +2141,21 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                     index_options["dimensions"] = std::to_string(dimensions);
                     builder.with_index(index_metadata{index_name, index_options,
                             index_metadata_kind::custom, index_metadata::is_local_index(false)});
+                    // If the table already has CDC-enabled streams using
+                    // delta_mode=keys, upgrade to delta_mode=full so the vector
+                    // store can read full column data from the CDC log.
+                    upgrade_cdc_delta_for_vector_index(builder);
                 } else if (op == "Delete") {
                     if (!tab->has_index(index_name)) {
                         co_return api_error::resource_not_found(fmt::format(
                             "No vector index {} in table {}", index_name, tab->cf_name()));
                     }
                     builder.without_index(index_name);
+                    // If this was the last vector index, and delta=full was set
+                    // for the vector index's benefit, downgrade back to keys.
+                    if (tab->indices().size() == 1) {
+                        downgrade_cdc_delta_after_vector_index_delete(builder);
+                    }
                 } else {
                     // Update operation not yet supported, as we don't yet
                     // have any updatable properties of vector indexes.

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1612,12 +1612,13 @@ void executor::supplement_table_stream_info(rjson::value& descr, const schema& s
         rjson::add(descr, "LatestStreamArn", arn);
         rjson::add(descr, "LatestStreamLabel", rjson::from_string(stream_label(*log_schema)));
 
-        auto stream_desc = rjson::empty_object();
-        rjson::add(stream_desc, "StreamEnabled", opts.enabled());
-
-        stream_view_type mode = cdc_options_to_stream_view_type(opts);
-        rjson::add(stream_desc, "StreamViewType", mode);
-        rjson::add(descr, "StreamSpecification", std::move(stream_desc));
+        if (opts.enabled()) {
+            auto stream_desc = rjson::empty_object();
+            rjson::add(stream_desc, "StreamEnabled", true);
+            stream_view_type mode = cdc_options_to_stream_view_type(opts);
+            rjson::add(stream_desc, "StreamViewType", mode);
+            rjson::add(descr, "StreamSpecification", std::move(stream_desc));
+        }
     } else if (opts.enable_requested()) {
         // DynamoDB returns StreamEnabled=true in StreamSpecification even when
         // the stream status is ENABLING (not yet fully active). We mirror this

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -176,6 +176,35 @@ struct rapidjson::internal::TypeHelper<ValueType, alternator::stream_arn>
 
 namespace alternator {
 
+// Returns true if the CDC log table that we found NOT belong to an active
+// or disabled Stream, but rather from an active vector index, which also
+// uses CDC. See comments inline for the logic used by this function.
+static bool cdc_is_not_stream(const schema& base) {
+    if (base.cdc_options().enabled() || base.cdc_options().enable_requested()) {
+        // Stream is enabled right right now, or being enabled right now, so
+        // this cdc log definitely belongs to a stream, so return false.
+        return false;
+    }
+    if (!base.indices().empty()) {
+        // After the previous if(), Stream is not enabled right now, and there
+        // is a vector index, so definitely the CDC log we're seeing is for
+        // the vector index, so return true: This CDC log is NOT the CDC log
+        // of a disabled stream, but rather in current use by an active vector
+        // index.
+        // This case can be thought of as a limitation: It means that although
+        // we generally can list (with ListStreams and DescribeTable) streams
+        // which have been disabled, if a stream was disabled on a table with
+        // a vector index, we will not expose it as a disabled stream that can
+        // still be read. Had we done that, it would have been confusing -
+        // this stream is not really disabled, it's still being updated for
+        // the vector index, and the user will see in it continuing updates.
+        return true;
+    }
+    // If we're still here, this is a real disabled stream, and should be
+    // visible to the user as a disabled stream. So return false.
+    return false;
+}
+
 future<alternator::executor::request_return_type> alternator::executor::list_streams(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     _stats.api_operations.list_streams++;
 
@@ -246,10 +275,17 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
         // Use get_base_table instead of is_log_for_some_table because the
         // latter requires CDC to be enabled, but we want to list streams
         // that have been disabled but whose log table still exists (#7239).
-        if (cdc::get_base_table(db.real_database(), ks_name, cf_name)) {
+        auto bs = cdc::get_base_table(db.real_database(), ks_name, cf_name);
+        if (bs) {
+            // CDC may be enabled solely for a vector index, which is not a
+            // user-facing stream. Use cdc_is_not_stream() to detect this
+            // case (same check as in describe_stream).
+            if (cdc_is_not_stream(*bs)) {
+                continue;
+            }
             rjson::value new_entry = rjson::empty_object();
 
-            auto arn = stream_arn{ i->schema(), cdc::get_base_table(db.real_database(), *i->schema()) };
+            auto arn = stream_arn{ i->schema(), bs };
             rjson::add(new_entry, "StreamArn", arn);
             rjson::add(new_entry, "StreamLabel", rjson::from_string(stream_label(*s)));
             rjson::add(new_entry, "TableName", rjson::from_string(cdc::base_name(s->cf_name())));
@@ -841,9 +877,11 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
     auto& opts = bs->cdc_options();
 
     auto status = "DISABLED";
-    bool stream_disabled = !opts.enabled();
+    // CDC may be enabled solely for a vector index, which is not a user-
+    // facing stream. Use cdc_is_not_stream() to detect this case.
+    bool stream_disabled = !opts.enabled() || cdc_is_not_stream(*bs);
 
-    if (opts.enabled()) {
+    if (!stream_disabled) {
         if (!_cdc_metadata.streams_available()) {
             status = "ENABLING";
         } else {
@@ -1555,6 +1593,12 @@ bool executor::add_stream_options(const rjson::value& stream_specification, sche
 }
 
 void executor::supplement_table_stream_info(rjson::value& descr, const schema& schema, const service::storage_proxy& sp) {
+    // CDC might be enabled despite Streams not being enabled - it's also
+    // possible that a vector index enabled CDC. Use cdc_is_not_stream() to
+    // detect that case and skip reporting a user-facing stream.
+    if (cdc_is_not_stream(schema)) {
+        return;
+    }
     auto& opts = schema.cdc_options();
     // Report stream info when:
     //   1. Log table exists (covers both enabled and disabled-but-readable).

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -128,6 +128,10 @@ def run_vector_store_cmd(pid, dir):
         'VECTOR_STORE_SCYLLADB_URI': f'{ip}:9042',
         'VECTOR_STORE_SCYLLADB_USERNAME': 'cassandra',
         'VECTOR_STORE_SCYLLADB_PASSWORD_FILE': f'{dir}/.password',
+        # Use short poll intervals for faster test turnaround.
+        'VECTOR_STORE_CDC_FINE_SLEEP_INTERVAL': '100ms',
+        'VECTOR_STORE_CDC_SLEEP_INTERVAL': '1s',
+        'VECTOR_STORE_MONITOR_INDEXES_INTERVAL': '100ms',
     }
     global vector_store_executable # set by the code below
     cmd = [

--- a/test/alternator/test_gsi_updatetable.py
+++ b/test/alternator/test_gsi_updatetable.py
@@ -573,6 +573,29 @@ def test_gsi_updatetable_errors(dynamodb, table1):
                 { 'Delete': {  'IndexName': 'ind2' } }
             ])
 
+# Above in test_gsi_updatetable_errors we tested that a single UpdateTable
+# operation can't create or delete more than one GSI at a time. In general,
+# an UpdateTable operation should do just one change - of any kind. You're
+# also not allowed, for example, to create a GSI and enable streams.
+def test_gsi_updatetable_combined_with_streams(dynamodb, table1):
+    client = dynamodb.meta.client
+    gsi_ops = [
+        {'AttributeDefinitions': [{'AttributeName': 'x', 'AttributeType': 'S'}],
+         'GlobalSecondaryIndexUpdates': [{'Create': {'IndexName': 'ind',
+             'KeySchema': [{'AttributeName': 'x', 'KeyType': 'HASH'}],
+             'Projection': {'ProjectionType': 'ALL'}}}]},
+        {'GlobalSecondaryIndexUpdates': [{'Delete': {'IndexName': 'nonexistent'}}]},
+    ]
+    stream_specs = [
+        {'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},
+        {'StreamEnabled': False},
+    ]
+    for gsi_op in gsi_ops:
+        for stream_spec in stream_specs:
+            with pytest.raises(ClientError, match='ValidationException.*cannot create or delete index while changing stream status'):
+                client.update_table(TableName=table1.name,
+                    StreamSpecification=stream_spec, **gsi_op)
+
 # Whereas CreateTable rejects spurious entries in AttributeDefinitions
 # (entries which aren't used as a key of the table or any GSI or LSI),
 # as tested in test_table.py::test_create_table_spurious_attribute_definitions

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -2335,6 +2335,27 @@ def test_streams_disabled_stream(dynamodb, dynamodbstreams):
                 assert not 'NextShardIterator' in response
         assert nrecords == 1
 
+# Verify that streams of different StreamViewType can be disabled and still
+# be described reporting the expected type (rather than forgetting what was
+# its type).
+@pytest.mark.parametrize('stream_type', ['KEYS_ONLY', 'NEW_IMAGE', 'OLD_IMAGE', 'NEW_AND_OLD_IMAGES'])
+def test_streams_disabled_view_type(dynamodb, dynamodbstreams, stream_type):
+    with create_table_ss(dynamodb, dynamodbstreams, stream_type) as (table, arn):
+        disable_stream(dynamodbstreams, table)
+        # ListStreams should still list the disabled stream's ARN
+        arns = [s['StreamArn'] for s in dynamodbstreams.list_streams(TableName=table.name)['Streams']]
+        assert arn in arns
+        # DescribeStream should report DISABLED status and preserve the StreamViewType
+        desc = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
+        assert desc['StreamStatus'] == 'DISABLED'
+        assert desc['StreamViewType'] == stream_type
+        # DescribeTable doesn't list a StreamSpecification when the stream is
+        # disabled:
+        table_desc = table.meta.client.describe_table(TableName=table.name)['Table']
+        assert 'StreamSpecification' not in table_desc
+        # But it does still report the correct LatestStreamArn
+        assert table_desc['LatestStreamArn'] == arn
+
 # When streams are enabled for a table, we get a unique ARN which should be
 # unique but not change unless streams are eventually disabled for this table.
 # If this ARN changes unexpectedly, it can confuse existing readers who are

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -2268,7 +2268,7 @@ def test_vector_with_streams(vs, needs_vector_store, dynamodbstreams, cql, setup
                 break
             if time.monotonic() > stream_deadline:
                 pytest.fail('Timed out waiting for stream to become ENABLED')
-            time.sleep(0.5)
+            time.sleep(0.1)
         # Collect all shard "LATEST" iterators, handling multi-page DescribeStream.
         iterators = []
         while True:
@@ -2718,7 +2718,7 @@ def test_vector_with_old_image_stream(vs, needs_vector_store, dynamodbstreams, c
                 break
             if time.monotonic() > stream_deadline:
                 pytest.fail('Timed out waiting for stream to become ENABLED')
-            time.sleep(0.5)
+            time.sleep(0.1)
 
         # DescribeStream and DescribeTable must both report OLD_IMAGE.
         assert desc['StreamViewType'] == 'OLD_IMAGE'

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -2198,12 +2198,588 @@ def test_query_vectorsearch_queryvector_bad_number_string(table_vs, needs_vector
 # test yet, but I can write an xfailing test because we know what we
 # expect ALL_PROJECTED_ATTRIBUTES to return in that case.
 
-# TODO: test enabling vector index and Alternator Streams together, and
-# checking that Alternator Streams works as expected. Also we may need to
-# do something to avoid vector search's favorite parameters like TTL and
-# post-changes to take control - or vice versa we may get CDC which isn't
-# good enough for vector search.
-# Note that today, Alternator Streams only works with vnodes while vector
-# search doesn't work with vnodes - so we can't actually check this
-# combination! But we must check it when Alternator Streams finally supports
-# tablets.
+# Test enabling both vector index and Alternator Streams together on the same
+# table, and checking that both work as expected: New items appear in vector
+# search results and also in stream records.
+# This test focuses on streams with KEYS_ONLY view type, below we have
+# additional tests for other types - NEW_IMAGE and OLD_IMAGE.
+# Beyond just testing that the two features can coexist, we also want to
+# test different combinations and orders of how these features can be enabled
+# and later disabled, to check that at any time the situation with the
+# feature(s) enabled and the underlying CDC implementation is exactly as
+# we expect.
+# Three enablement orderings are tested via parametrize:
+# - both_at_creation: both vector index and Streams enabled in CreateTable.
+# - stream_then_vector: Streams enabled first, then vector index added.
+# - vector_then_stream: vector index enabled first, then Streams added.
+#   Note: a fourth way - adding both vector index and Streams by one
+#   UpdateTable request - is not allowed. This is checked in the next test
+#   (test_updatetable_vector_and_streams_same_request).
+# Additionally, we test two cases where we disable one of the features after
+# creating both, to check that the other continues working correctly:
+# - both_at_creation_then_disable_stream
+# - both_at_creation_then_disable_vector
+@pytest.mark.parametrize('setup_mode', [
+    'both_at_creation',
+    'stream_then_vector',
+    'vector_then_stream',
+    'both_at_creation_then_disable_stream',
+    'both_at_creation_then_disable_vector',
+])
+def test_vector_with_streams(vs, needs_vector_store, dynamodbstreams, cql, setup_mode):
+    vector_index_spec = {
+        'IndexName': 'vind',
+        'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+    }
+    # Note that the stream may ask for KEYS_ONLY, but the vector store's CDC
+    # needs deltas - both need to coexist on the same table.
+    stream_spec = {'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'}
+
+    create_kwargs = dict(
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+    )
+    if setup_mode.startswith('both_at_creation'):
+        create_kwargs['VectorIndexes'] = [vector_index_spec]
+        create_kwargs['StreamSpecification'] = stream_spec
+
+    with new_test_table(vs, **create_kwargs) as table:
+        if setup_mode == 'stream_then_vector':
+            # Enable Streams first, then add the vector index.
+            table.update(StreamSpecification=stream_spec)
+            table.update(VectorIndexUpdates=[{'Create': vector_index_spec}])
+        elif setup_mode == 'vector_then_stream':
+            # Enable the vector index first, then add the streams.
+            table.update(VectorIndexUpdates=[{'Create': vector_index_spec}])
+            table.update(StreamSpecification=stream_spec)
+
+        # Wait for the vector index to finish its initial prefill scan before
+        # writing, to ensure the later write is picked up via CDC, not prefill.
+        wait_for_vector_index_active(table, 'vind')
+
+        # Wait for the stream to become ENABLED:
+        streams_resp = dynamodbstreams.list_streams(TableName=table.name)
+        assert streams_resp['Streams']
+        arn = streams_resp['Streams'][0]['StreamArn']
+        stream_deadline = time.monotonic() + 60
+        while True:
+            desc = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
+            if desc.get('StreamStatus') == 'ENABLED':
+                break
+            if time.monotonic() > stream_deadline:
+                pytest.fail('Timed out waiting for stream to become ENABLED')
+            time.sleep(0.5)
+        # Collect all shard "LATEST" iterators, handling multi-page DescribeStream.
+        iterators = []
+        while True:
+            for shard in desc['Shards']:
+                shard_id = shard['ShardId']
+                iterators.append(dynamodbstreams.get_shard_iterator(
+                    StreamArn=arn, ShardId=shard_id,
+                    ShardIteratorType='LATEST')['ShardIterator'])
+            if 'LastEvaluatedShardId' not in desc:
+                break
+            desc = dynamodbstreams.describe_stream(
+                StreamArn=arn,
+                ExclusiveStartShardId=desc['LastEvaluatedShardId'])['StreamDescription']
+
+        # Confirm that DescribeTable and DescribeStream say that the vector
+        # index and stream are both enabled, with the expected KEYS_ONLY.
+        table_desc = table.meta.client.describe_table(TableName=table.name)['Table']
+        assert 'VectorIndexes' in table_desc
+        vector_indexes = table_desc.get('VectorIndexes')
+        assert len(vector_indexes) == 1
+        assert vector_indexes[0]['IndexName'] == 'vind'
+        assert 'StreamSpecification' in table_desc
+        stream_spec_desc = table_desc['StreamSpecification']
+        assert stream_spec_desc['StreamEnabled'] == True
+        assert stream_spec_desc['StreamViewType'] == 'KEYS_ONLY'
+
+        # Confirm with CQL DESCRIBE TABLE that the CDC is configured with
+        # delta=full, which is required for the vector index to work correctly
+        # (unless post-image is enabled, which it isn't)
+        ks = f'alternator_{table.name}'
+        create_stmt = cql.execute(f'DESCRIBE TABLE "{ks}"."{table.name}"').one().create_statement
+        assert "'delta': 'full'" in create_stmt
+        assert "'preimage': 'false'" in create_stmt
+        assert "'postimage': 'false'" in create_stmt
+
+        # Write an item with a vector. Both the vector store (via CDC) and
+        # Alternator Streams (also via CDC) should pick this up.
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': [1, 0, 0]})
+
+        # 1. Wait for the item to appear in vector search results.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]},
+                Limit=1,
+                Select='ALL_PROJECTED_ATTRIBUTES',
+            )
+            if result.get('Items') and result['Items'][0]['p'] == p:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail('Timed out waiting for item to appear in vector search results')
+            time.sleep(0.1)
+
+        # 2. Wait for the INSERT record to appear in Alternator Streams.
+        # We poll all shards until we see the record for key p.
+        # The retry loop isn't really necessary because if we found the
+        # item in vector search, we know it already appeared in CDC from where
+        # the vector index read.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        found_in_stream = False
+        while not found_in_stream:
+            new_iterators = []
+            for it in iterators:
+                response = dynamodbstreams.get_records(ShardIterator=it)
+                if 'NextShardIterator' in response:
+                    new_iterators.append(response['NextShardIterator'])
+                for record in response.get('Records', []):
+                    keys = record['dynamodb']['Keys']
+                    if keys.get('p', {}).get('S') == p and record['eventName'] == 'INSERT':
+                        found_in_stream = True
+                        # KEYS_ONLY stream must not include NewImage or OldImage
+                        # (which would contain the full item with 'v' etc.).
+                        assert 'NewImage' not in record['dynamodb']
+                        assert 'OldImage' not in record['dynamodb']
+            iterators = new_iterators
+            if not found_in_stream:
+                if time.monotonic() > deadline:
+                    pytest.fail('Timed out waiting for INSERT record to appear in Alternator Streams')
+                time.sleep(0.1)
+
+        if setup_mode == 'both_at_creation_then_disable_stream':
+            # Check that if we disable Streams now, DescribeTable/ListStreams
+            # say the stream no longer  exists, but DescribeTable says the
+            # vector index is still enabled, and moreover the vector index
+            # still works - if we write a new vector, we can eventually find
+            # it in a vector search.
+            table.update(StreamSpecification={'StreamEnabled': False})
+            # DescribeTable says stream is disabled, vector index is enabled
+            table_desc = table.meta.client.describe_table(TableName=table.name)['Table']
+            assert 'StreamSpecification' not in table_desc
+            assert 'VectorIndexes' in table_desc
+            assert len(table_desc['VectorIndexes']) == 1
+            assert table_desc['VectorIndexes'][0]['IndexName'] == 'vind'
+            # DescribeStream on the old stream ARN says the stream is gone
+            desc = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
+            assert desc['StreamStatus'] == 'DISABLED'
+            # ListStreams must no longer lists streams for this table.
+            list_resp = dynamodbstreams.list_streams(TableName=table.name)
+            assert not list_resp.get('Streams')
+            # Write a new item and verify the vector index still picks it up
+            p2 = random_string()
+            table.put_item(Item={'p': p2, 'v': [0, 1, 0]})
+            deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+            while True:
+                result = table.query(
+                    IndexName='vind',
+                    VectorSearch={'QueryVector': [0, 1, 0]},
+                    Limit=1,
+                    Select='ALL_PROJECTED_ATTRIBUTES',
+                )
+                if result.get('Items') and result['Items'][0]['p'] == p2:
+                    break
+                if time.monotonic() > deadline:
+                    pytest.fail('Timed out waiting for new item to appear in vector search after stream disabled')
+                time.sleep(0.1)
+        if setup_mode == 'both_at_creation_then_disable_vector':
+            # Delete the vector index. The stream should remain enabled.
+            table.update(VectorIndexUpdates=[{'Delete': {'IndexName': 'vind'}}])
+            # DescribeTable must no longer report VectorIndexes, but must
+            # still report StreamSpecification with KEYS_ONLY.
+            table_desc = table.meta.client.describe_table(TableName=table.name)['Table']
+            assert not table_desc.get('VectorIndexes')
+            assert 'StreamSpecification' in table_desc
+            assert table_desc['StreamSpecification']['StreamEnabled'] == True
+            assert table_desc['StreamSpecification']['StreamViewType'] == 'KEYS_ONLY'
+            # ListStreams must still list this table's stream, with the same ARN.
+            list_resp = dynamodbstreams.list_streams(TableName=table.name)
+            assert list_resp.get('Streams')
+            assert list_resp['Streams'][0]['StreamArn'] == arn
+
+            # Now that there's no longer a vector index, we no longer need
+            # delta=full which we needed while the vector index existed (and
+            # we confirmed above was set up). At this point, we need just what
+            # the Alternator KEYS_ONLY stream needs - this is delta=keys.
+            # So let's verify that we've gone back to delta=keys, or we'll be
+            # wasting performance.
+            ks = f'alternator_{table.name}'
+            create_stmt = cql.execute(f'DESCRIBE TABLE "{ks}"."{table.name}"').one().create_statement
+            assert "'delta': 'keys'" in create_stmt
+            assert "'preimage': 'false'" in create_stmt
+            assert "'postimage': 'false'" in create_stmt
+
+            # Write a new item and verify it still appears in the stream.
+            # Not only is Streams still enabled, we can actually continue to
+            # use the same iterators we had before to see new records.
+            p2 = random_string()
+            table.put_item(Item={'p': p2, 'v': [0, 1, 0]})
+            deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+            found_in_stream = False
+            while not found_in_stream:
+                new_iterators = []
+                for it in iterators:
+                    response = dynamodbstreams.get_records(ShardIterator=it)
+                    if 'NextShardIterator' in response:
+                        new_iterators.append(response['NextShardIterator'])
+                    for record in response.get('Records', []):
+                        keys = record['dynamodb']['Keys']
+                        if keys.get('p', {}).get('S') == p2 and record['eventName'] == 'INSERT':
+                            found_in_stream = True
+                            assert 'NewImage' not in record['dynamodb']
+                            assert 'OldImage' not in record['dynamodb']
+                iterators = new_iterators
+                if not found_in_stream:
+                    if time.monotonic() > deadline:
+                        pytest.fail('Timed out waiting for INSERT record in stream after vector index deleted')
+                    time.sleep(0.1)
+
+# Test that you can't change the Streams setup *and* vector indexes in one
+# UpdateTable call. We have the same test for streams and GSIs, in
+# test_gsi_updatetable.py::test_gsi_updatetable_combined_with_streams.
+def test_updatetable_vector_and_streams_same_request(vs):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        vector_ops = [
+            {'Create': {'IndexName': 'vind', 'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}},
+            {'Delete': {'IndexName': 'nonexistent'}},
+        ]
+        stream_specs = [
+            {'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'},
+            {'StreamEnabled': False},
+        ]
+        for vector_op in vector_ops:
+            for stream_spec in stream_specs:
+                with pytest.raises(ClientError, match='ValidationException.*cannot create or delete index while changing stream status'):
+                    table.update(
+                        VectorIndexUpdates=[vector_op],
+                        StreamSpecification=stream_spec)
+
+# Test special interactions of Streams with NEW_IMAGE, and vector index:
+# * When enabling vector index when streams with NEW_IMAGE was already
+#   enabled, things work - the vector search functions, stream returns new
+#   images as requested. DescribeStream knows we're in NEW_IMAGE.
+# * Enabling the vector index did not enable delta=full mode because NEW_IMAGE
+#   (postimage) is enough, and adding delta=full on top would be wasteful.
+# * After disabling the stream, the post-images are no longer needed, but
+#   CDC should continue to be enabled and switch to delta=full mode (the vector
+#   index default), and the vector index continues to get updated.
+@pytest.mark.parametrize('setup_mode', [
+    'stream_then_vector_then_disable_stream',
+    'stream_then_vector_then_disable_vector',
+])
+def test_vector_with_new_image_stream(vs, needs_vector_store, dynamodbstreams, cql, setup_mode):
+    stream_spec = {'StreamEnabled': True, 'StreamViewType': 'NEW_IMAGE'}
+    vector_index_spec = {
+        'IndexName': 'vind',
+        'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+    }
+
+    # Create the table with a NEW_IMAGE stream, then add the vector index.
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            StreamSpecification=stream_spec) as table:
+        table.update(VectorIndexUpdates=[{'Create': vector_index_spec}])
+        wait_for_vector_index_active(table, 'vind')
+
+        # Wait for the stream to become ENABLED.
+        streams_resp = dynamodbstreams.list_streams(TableName=table.name)
+        assert streams_resp['Streams']
+        arn = streams_resp['Streams'][0]['StreamArn']
+        stream_deadline = time.monotonic() + 60
+        while True:
+            desc = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
+            if desc.get('StreamStatus') == 'ENABLED':
+                break
+            if time.monotonic() > stream_deadline:
+                pytest.fail('Timed out waiting for stream to become ENABLED')
+            time.sleep(0.1)
+
+        # DescribeStream and DescribeTable must both report NEW_IMAGE
+        assert desc['StreamViewType'] == 'NEW_IMAGE'
+        table_desc = table.meta.client.describe_table(TableName=table.name)['Table']
+        assert table_desc['StreamSpecification']['StreamEnabled'] == True
+        assert table_desc['StreamSpecification']['StreamViewType'] == 'NEW_IMAGE'
+
+        # Check, using CQL DESCRIBE TABLE, that CDC is configured with
+        # postimage=true (for NEW_IMAGE) but delta=keys, not full - because
+        # the vector store can use the post image directly, so upgrading to
+        # delta=full is wasteful.
+        ks = f'alternator_{table.name}'
+        create_stmt = cql.execute(f'DESCRIBE TABLE "{ks}"."{table.name}"').one().create_statement
+        assert "'postimage': 'true'" in create_stmt
+        assert "'delta': 'keys'" in create_stmt
+
+        # Collect all shard LATEST iterators, that we'll use to read from
+        # the stream.
+        iterators = []
+        while True:
+            for shard in desc['Shards']:
+                iterators.append(dynamodbstreams.get_shard_iterator(
+                    StreamArn=arn, ShardId=shard['ShardId'],
+                    ShardIteratorType='LATEST')['ShardIterator'])
+            if 'LastEvaluatedShardId' not in desc:
+                break
+            desc = dynamodbstreams.describe_stream(
+                StreamArn=arn,
+                ExclusiveStartShardId=desc['LastEvaluatedShardId'])['StreamDescription']
+
+        # Write an item. Both vector store and stream should pick it up.
+        p1 = random_string()
+        item = {'p': p1, 'v': [1, 0, 0], 'x': 'hello'}
+        table.put_item(Item=item)
+
+        # Wait for the item to appear in vector search results.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1)
+            if result.get('Items') and result['Items'][0]['p'] == p1:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail('Timed out waiting for item to appear in vector search')
+            time.sleep(0.1)
+
+        # Wait for the INSERT record to appear in the stream.
+        # The stream must include NewImage (because StreamViewType=NEW_IMAGE)
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        found_in_stream = False
+        while not found_in_stream:
+            new_iterators = []
+            for it in iterators:
+                response = dynamodbstreams.get_records(ShardIterator=it)
+                if 'NextShardIterator' in response:
+                    new_iterators.append(response['NextShardIterator'])
+                for record in response.get('Records', []):
+                    keys = record['dynamodb']['Keys']
+                    if keys.get('p', {}).get('S') == p1 and record['eventName'] == 'INSERT':
+                        found_in_stream = True
+                        # NEW_IMAGE stream must include NewImage with the full item.
+                        assert 'NewImage' in record['dynamodb']
+                        deserializer = boto3.dynamodb.types.TypeDeserializer()
+                        new_image = {x:deserializer.deserialize(y) for (x,y) in record['dynamodb']['NewImage'].items()}
+                        assert new_image == item
+                        # No OldImage - we only asked for NEW_IMAGE and in
+                        # any case there was no previous item in this test.
+                        assert 'OldImage' not in record['dynamodb']
+            iterators = new_iterators
+            if not found_in_stream:
+                if time.monotonic() > deadline:
+                    pytest.fail('Timed out waiting for INSERT record in stream')
+                time.sleep(0.1)
+
+        if setup_mode == 'stream_then_vector_then_disable_stream':
+            # Now disable the stream. The vector index will remain enabled.
+            table.update(StreamSpecification={'StreamEnabled': False})
+
+            # Verify that DescribeTable and DescribeStream report the stream is
+            # really disabled, and DescribeTable still reports the vector index
+            # is enabled.
+            table_desc = table.meta.client.describe_table(TableName=table.name)['Table']
+            # Currently, when vector index is enabled, our implementation drops
+            # StreamSpecification entirely, it doesn't have it with enabled = false.
+            assert 'StreamSpecification' not in table_desc
+            assert 'VectorIndexes' in table_desc
+            assert len(table_desc['VectorIndexes']) == 1
+            assert table_desc['VectorIndexes'][0]['IndexName'] == 'vind'
+            # If we try to describe the old ARN of the stream, it should say it's disabled:
+            desc = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
+            assert desc['StreamStatus'] == 'DISABLED'
+            # Also check that ListStreams for this table doesn't return this stream
+            # (it's disabled, so it shouldn't appear as an active stream).
+            list_resp = dynamodbstreams.list_streams(TableName=table.name)
+            assert not list_resp.get('Streams')
+
+            # Check that CDC is still enabled, but post-image is off and
+            # delta=full (the vector index default):
+            create_stmt = cql.execute(f'DESCRIBE TABLE "{ks}"."{table.name}"').one().create_statement
+            assert "'postimage': 'false'" in create_stmt
+            assert "'delta': 'full'" in create_stmt
+
+            # Write a second item and verify the vector store still indexes it,
+            # so the remaining CDC is good enough for the vector store.
+            p2 = random_string()
+            table.put_item(Item={'p': p2, 'v': [0, 1, 0]})
+            deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+            while True:
+                result = table.query(IndexName='vind',
+                    VectorSearch={'QueryVector': [0, 1, 0]}, Limit=1)
+                if result.get('Items') and result['Items'][0]['p'] == p2:
+                    break
+                if time.monotonic() > deadline:
+                    pytest.fail('Timed out waiting for item to appear in vector search after stream disabled')
+                time.sleep(0.1)
+        if setup_mode == 'stream_then_vector_then_disable_vector':
+            # Now disable the vector index. The stream will remain enabled.
+            table.update(VectorIndexUpdates=[{'Delete': {'IndexName': 'vind'}}])
+
+            # Verify that DescribeTable and DescribeStream report the stream is
+            # still enabled, and DescribeTable no longer reports the vector index
+            # as enabled.
+            table_desc = table.meta.client.describe_table(TableName=table.name)['Table']
+            assert table_desc['StreamSpecification']['StreamEnabled'] == True
+            assert table_desc['StreamSpecification']['StreamViewType'] == 'NEW_IMAGE'
+            assert 'VectorIndexes' not in table_desc
+            # The old ARN of the stream is still usable and listed in ListStreams:
+            desc = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
+            assert desc['StreamStatus'] == 'ENABLED'
+            list_resp = dynamodbstreams.list_streams(TableName=table.name)
+            assert 'Streams' in list_resp
+            assert len(list_resp['Streams']) == 1
+            assert list_resp['Streams'][0]['StreamArn'] == arn
+            # Verify that CDC is still enabled, still has postimage and
+            # delta=keys which the stream still needs
+            create_stmt = cql.execute(f'DESCRIBE TABLE "{ks}"."{table.name}"').one().create_statement
+            assert "'postimage': 'true'" in create_stmt
+            assert "'delta': 'keys'" in create_stmt
+            # Write a second item and verify the stream still receives it.
+            # We continue with the same iterators we had before, which should
+            # still work because the stream is still enabled.
+            p2 = random_string()
+            item = {'p': p2, 'x': 'hello'}
+            table.put_item(Item=item)
+            deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+            found_in_stream = False
+            while not found_in_stream:
+                new_iterators = []
+                for it in iterators:
+                    response = dynamodbstreams.get_records(ShardIterator=it)
+                    if 'NextShardIterator' in response:
+                        new_iterators.append(response['NextShardIterator'])
+                    for record in response.get('Records', []):
+                        keys = record['dynamodb']['Keys']
+                        if keys.get('p', {}).get('S') == p2 and record['eventName'] == 'INSERT':
+                            found_in_stream = True
+                            # NEW_IMAGE stream must still include NewImage with the full item.
+                            assert 'NewImage' in record['dynamodb']
+                            deserializer = boto3.dynamodb.types.TypeDeserializer()
+                            new_image = {x: deserializer.deserialize(y) for (x, y) in record['dynamodb']['NewImage'].items()}
+                            assert new_image == item
+                iterators = new_iterators
+                if not found_in_stream:
+                    if time.monotonic() > deadline:
+                        pytest.fail('Timed out waiting for INSERT record in stream after vector disabled')
+                    time.sleep(0.1)
+
+# Test that enabling a vector index doesn't confuse Alternator to report that
+# this table has streams enabled. The vector index enables CDC internally
+# but this must not be mistaken for a user-facing stream: DescribeTable must
+# not show StreamSpecification, and ListStreams should not list any streams
+# for this table..
+def test_vectorindex_no_spurious_stream(table_vs, dynamodbstreams):
+    # DescribeTable must not report StreamSpecification for a table that only
+    # has a vector index (and no user-requested Alternator Stream).
+    table_desc = table_vs.meta.client.describe_table(TableName=table_vs.name)['Table']
+    assert 'StreamSpecification' not in table_desc
+    # ListStreams must not list any streams return this table.
+    list_resp = dynamodbstreams.list_streams(TableName=table_vs.name)
+    assert not list_resp.get('Streams')
+
+# Test special interactions of Streams with OLD_IMAGE, and vector index:
+# * When enabling a vector index after a stream with OLD_IMAGE was already
+#   enabled, things work - the vector search functions, stream returns old
+#   images as requested.
+# * DescribeTable, DescribeStream, and ListStreams know this stream exists
+#   and has OLD_IMAGE. This is despite the implementation detail that the
+#   vector index enabled delta=full on CDC (because pre-images aren't enough
+#   for it).
+def test_vector_with_old_image_stream(vs, needs_vector_store, dynamodbstreams, cql):
+    stream_spec = {'StreamEnabled': True, 'StreamViewType': 'OLD_IMAGE'}
+    vector_index_spec = {
+        'IndexName': 'vind',
+        'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+    }
+
+    # Create the table with an OLD_IMAGE stream, then add the vector index.
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            StreamSpecification=stream_spec) as table:
+        table.update(VectorIndexUpdates=[{'Create': vector_index_spec}])
+        wait_for_vector_index_active(table, 'vind')
+
+        # ListStreams must list this table's stream
+        streams_resp = dynamodbstreams.list_streams(TableName=table.name)
+        assert streams_resp['Streams']
+        assert len(streams_resp['Streams']) == 1
+        arn = streams_resp['Streams'][0]['StreamArn']
+
+        # Wait for the stream to become ENABLED.
+        stream_deadline = time.monotonic() + 60
+        while True:
+            desc = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
+            if desc.get('StreamStatus') == 'ENABLED':
+                break
+            if time.monotonic() > stream_deadline:
+                pytest.fail('Timed out waiting for stream to become ENABLED')
+            time.sleep(0.5)
+
+        # DescribeStream and DescribeTable must both report OLD_IMAGE.
+        assert desc['StreamViewType'] == 'OLD_IMAGE'
+        table_desc = table.meta.client.describe_table(TableName=table.name)['Table']
+        assert table_desc['StreamSpecification']['StreamEnabled'] == True
+        assert table_desc['StreamSpecification']['StreamViewType'] == 'OLD_IMAGE'
+
+        # Verify (using CQL DESCRIBE TABLE) that CDC is configured with preimage=true,
+        # postimage=false and delta=full (which the vector index needs when
+        # postimage=false)
+        ks = f'alternator_{table.name}'
+        create_stmt = cql.execute(f'DESCRIBE TABLE "{ks}"."{table.name}"').one().create_statement
+        assert "'preimage': 'full'" in create_stmt
+        assert "'postimage': 'false'" in create_stmt
+        assert "'delta': 'full'" in create_stmt
+
+        # Collect all shard LATEST iterators to prepare to read from the stream.
+        iterators = []
+        while True:
+            for shard in desc['Shards']:
+                iterators.append(dynamodbstreams.get_shard_iterator(
+                    StreamArn=arn, ShardId=shard['ShardId'],
+                    ShardIteratorType='LATEST')['ShardIterator'])
+            if 'LastEvaluatedShardId' not in desc:
+                break
+            desc = dynamodbstreams.describe_stream(
+                StreamArn=arn,
+                ExclusiveStartShardId=desc['LastEvaluatedShardId'])['StreamDescription']
+
+        # Write a first version of an item and wait for it to appear in vector search.
+        p = random_string()
+        item1 = {'p': p, 'v': [1, 0, 0], 'x': 'version1'}
+        table.put_item(Item=item1)
+
+        # Overwrite the item with a new version. The stream should eventually
+        # produce a record record with OldImage=item1 (the previous version)
+        # and no NewImage.
+        item2 = {'p': p, 'v': [1, 0, 0], 'x': 'version2'}
+        table.put_item(Item=item2)
+
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        found_oldimage = False
+        while not found_oldimage:
+            new_iterators = []
+            for it in iterators:
+                response = dynamodbstreams.get_records(ShardIterator=it)
+                if 'NextShardIterator' in response:
+                    new_iterators.append(response['NextShardIterator'])
+                for record in response.get('Records', []):
+                    keys = record['dynamodb']['Keys']
+                    if keys.get('p', {}).get('S') == p:
+                        # OLD_IMAGE stream must include OldImage with the previous item.
+                        if 'OldImage' in record['dynamodb']:
+                            found_oldimage = True
+                            deserializer = boto3.dynamodb.types.TypeDeserializer()
+                            old_image = {x: deserializer.deserialize(y) for (x, y) in record['dynamodb']['OldImage'].items()}
+                            assert old_image == item1
+                            # OLD_IMAGE must not include NewImage.
+                            assert 'NewImage' not in record['dynamodb']
+            iterators = new_iterators
+            if not found_oldimage:
+                if time.monotonic() > deadline:
+                    pytest.fail('Timed out waiting for MODIFY record in Alternator Streams')
+                time.sleep(0.1)


### PR DESCRIPTION
Previously, Alternator Streams was limited to vnodes only while Vector Search was limited to tablets only. This was fixed and now both features are supported on a table based on tablets (which today is the default for new tables).

But right now, trying to enable both streams (with KEYS_ONLY) and vector search on the same table doesn’t work.

*  If you enable streams (with KEYS_ONLY) and then vector search, enabling the vector search fails with InternalServerError, stating that “The CDC log must meet the minimal requirements of Vector Search. This means that the CDC's TTL must be at least 86400 seconds (24 hours), and the CDC's delta mode must be set to 'full' or postimage must be enabled.”
* If you enable vector search and then enable streams with KEYS_ONLY (or enable both at CreateTable time), no error is generated - but the vector store doesn’t seem to find anything. Perhaps the vector store can’t pick up the events because the streams code changed the CDC's configuration to not output deltas or post-images. 

The problem is that both the Alternator Streams and Vector Search features make use of CDC, and want to enable CDC in different ways with different parameters.

In this series we add extensive tests that check how the two features work together (they don't, before the fix), and then fix the bug. Fixing it in all the places was more difficult than I anticipated, but the result is very satisfying: The vector search and streams features are now completely independent, each can be enabled or disabled at will, and the user cannot be able to tell that under the hood both use the same ScyllaDB CDC mechanism.

Well, **almost completely** independent. There is one subtle interaction:

After we fixed #7239, you can disable a Stream and it remains visible and readable. But now, if a vector index is **also** enabled, we can't let the user continue to read the old stream - it won't really be an "old stream" any more - it will continue to be updated with new content that the vector store needs, something which shouldn't happen on a disabled stream. So in this specific case, the disabled stream will NOT be visible to the user.

Fixes SCYLLADB-1909
Fixes SCYLLADB-2051