### PR TITLE
Memtable large data guardrail

### DIFF
--- a/db/large_data_cache_tracker.hh
+++ b/db/large_data_cache_tracker.hh
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <unordered_map>
+#include "bytes.hh"
+#include "schema/schema_fwd.hh"
+#include "utils/hash.hh"
+#include "utils/updateable_value.hh"
+#include "utils/small_vector.hh"
+
+class schema;
+class rows_entry;
+class column_definition;
+class atomic_cell_or_collection;
+
+namespace db {
+
+struct row_key {
+    bytes pk;
+    bytes ck;
+    bool operator==(const row_key&) const = default;
+    struct hash {
+        size_t operator()(const row_key& k) const noexcept;
+    };
+};
+
+struct collection_key {
+    bytes pk;
+    bytes ck;
+    column_id col;
+    bool operator==(const collection_key&) const = default;
+    struct hash {
+        size_t operator()(const collection_key& k) const noexcept;
+    };
+};
+
+using memtable_row_cache = std::unordered_map<row_key, uint64_t, row_key::hash>;
+using memtable_collection_cache = std::unordered_map<collection_key, uint64_t, collection_key::hash>;
+
+struct guardrail_config {
+    // Partition thresholds (replica-side only — checked via SSTable metadata index)
+    utils::updateable_value<uint32_t> partition_size_fail_threshold_mb;
+    utils::updateable_value<uint32_t> partition_size_warn_threshold_mb;
+    utils::updateable_value<uint32_t> rows_count_fail_threshold;
+    utils::updateable_value<uint32_t> rows_count_warn_threshold;
+    // Row thresholds (shared: replica checks on-disk size, coordinator checks mutation memory)
+    utils::updateable_value<uint32_t> row_size_fail_threshold_mb;
+    utils::updateable_value<uint32_t> row_size_warn_threshold_mb;
+    // Collection thresholds (shared: replica checks SSTable metadata, coordinator checks mutation)
+    utils::updateable_value<uint32_t> collection_elements_fail_threshold;
+    utils::updateable_value<uint32_t> collection_elements_warn_threshold;
+    // Cell thresholds (coordinator-side only — checked from mutation content)
+    utils::updateable_value<uint32_t> cell_size_fail_threshold_mb;
+    utils::updateable_value<uint32_t> cell_size_warn_threshold_mb;
+};
+
+// Tracker for mutation_partition_v2::apply_monotonically().
+// Populates the memtable-level row/collection caches after each row
+// merge so that subsequent writes to the same row can be rejected
+// by the guardrail before an SSTable flush.
+class large_data_cache_tracker {
+public:
+    large_data_cache_tracker(guardrail_config& cfg,
+            memtable_row_cache& row_cache,
+            memtable_collection_cache& collection_cache) noexcept
+        : _cfg(cfg), _row_cache(row_cache), _collection_cache(collection_cache) {}
+
+    void set_partition_key(bytes pk) noexcept { _pk_bytes = std::move(pk); }
+    void on_row_merged(const schema& s, const rows_entry& row) noexcept;
+    void on_collection_merged(const column_definition& cdef,
+            const atomic_cell_or_collection& merged_cell) noexcept;
+
+private:
+    struct pending_collection {
+        column_id id;
+        uint32_t count;
+    };
+
+    guardrail_config& _cfg;
+    memtable_row_cache& _row_cache;
+    memtable_collection_cache& _collection_cache;
+    bytes _pk_bytes;
+    utils::small_vector<pending_collection, 4> _pending_collections;
+};
+
+} // namespace db

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -15,6 +15,8 @@
 #include "keys/keys.hh"
 #include "mutation/mutation_partition.hh"
 #include "mutation/atomic_cell.hh"
+#include "mutation/mutation_partition_v2.hh"
+#include "mutation/atomic_cell_or_collection.hh"
 #include "mutation/collection_mutation.hh"
 #include "replica/exceptions.hh"
 #include "exceptions/exceptions.hh"
@@ -25,6 +27,20 @@
 static logging::logger large_data_logger("large_data");
 
 namespace db {
+
+size_t row_key::hash::operator()(const row_key& k) const noexcept {
+    return utils::hash_combine(
+        std::hash<bytes_view>{}(bytes_view(k.pk)),
+        std::hash<bytes_view>{}(bytes_view(k.ck)));
+}
+
+size_t collection_key::hash::operator()(const collection_key& k) const noexcept {
+    return utils::hash_combine(
+        utils::hash_combine(
+            std::hash<bytes_view>{}(bytes_view(k.pk)),
+            std::hash<bytes_view>{}(bytes_view(k.ck))),
+        std::hash<column_id>{}(k.col));
+}
 
 namespace {
 constexpr uint64_t MB = 1024 * 1024;
@@ -189,8 +205,15 @@ void large_data_guardrail::register_sstable(sstables::shared_sstable sst) {
     _index.register_sstable(std::move(sst));
 }
 
+void large_data_guardrail::on_flush() {
+    _memtable_row_cache.clear();
+    _memtable_collection_cache.clear();
+}
+
 void large_data_guardrail::rebuild(const std::unordered_set<sstables::shared_sstable>& sstables) {
     _index.rebuild(sstables);
+    _memtable_row_cache.clear();
+    _memtable_collection_cache.clear();
 }
 
 void large_data_guardrail::check(const schema& s, const mutation_partition& mp,
@@ -239,14 +262,21 @@ void large_data_guardrail::check_rows_and_collections(const schema& s, bytes_vie
 
 void large_data_guardrail::check_row_size(const schema& s, bytes_view pk_bytes, partition_key_view pk,
         bytes_view ck_bytes, const clustering_key_prefix* ck) const {
-    auto row_size = _index.lookup_row(pk_bytes, ck_bytes);
-    if (!row_size) [[likely]] {
+    const uint64_t fail = uint64_t(_cfg.row_size_fail_threshold_mb()) * MB;
+    const uint64_t warn = uint64_t(_cfg.row_size_warn_threshold_mb()) * MB;
+    auto row_size_opt = _index.lookup_row(pk_bytes, ck_bytes);
+    uint64_t row_size = row_size_opt.value_or(0);
+    if (ck) {
+        auto it = _memtable_row_cache.find(row_key{bytes(pk_bytes), bytes(ck_bytes)});
+        if (it != _memtable_row_cache.end()) {
+            row_size = std::max(row_size, it->second);
+        }
+    }
+    if (row_size == 0) [[likely]] {
         return;
     }
-    enforce_threshold<guardrail_source::replica>(s, *row_size,
-        uint64_t(_cfg.row_size_fail_threshold_mb()) * MB,
-        uint64_t(_cfg.row_size_warn_threshold_mb()) * MB,
-        "row size",
+    enforce_threshold<guardrail_source::replica>(s, row_size,
+        fail, warn, "row size",
         [&] { return seastar::format("clustering_key={}",
             ck ? seastar::format("{}", ck->with_schema(s)) : sstring()); });
 }
@@ -258,11 +288,19 @@ void large_data_guardrail::check_collection_element_count(const schema& s, bytes
         return;
     }
     auto col_bytes = to_bytes(cdef.name_as_text());
-    auto count = _index.lookup_collection(pk_bytes, ck_bytes, bytes_view(col_bytes));
-    if (!count) [[likely]] {
+    auto count_opt = _index.lookup_collection(pk_bytes, ck_bytes, bytes_view(col_bytes));
+    uint64_t count = count_opt.value_or(0);
+    if (ck) {
+        auto it = _memtable_collection_cache.find(
+            collection_key{bytes(pk_bytes), bytes(ck_bytes), cdef.id});
+        if (it != _memtable_collection_cache.end()) {
+            count = std::max(count, it->second);
+        }
+    }
+    if (count == 0) [[likely]] {
         return;
     }
-    enforce_threshold<guardrail_source::replica>(s, *count,
+    enforce_threshold<guardrail_source::replica>(s, count,
         uint64_t(_cfg.collection_elements_fail_threshold()),
         uint64_t(_cfg.collection_elements_warn_threshold()),
         "collection element count",
@@ -327,6 +365,81 @@ void large_data_guardrail::check_coordinator(const schema& s, const mutation_par
             check_collection(cdef, cell);
         });
     }
+}
+
+void large_data_cache_tracker::on_row_merged(const schema& s, const rows_entry& row) noexcept {
+    try {
+        constexpr uint64_t MB = 1024 * 1024;
+        const uint64_t row_warn = uint64_t(_cfg.row_size_warn_threshold_mb()) * MB;
+        const uint64_t row_fail = uint64_t(_cfg.row_size_fail_threshold_mb()) * MB;
+
+        auto ck_bytes = row.key().view().representation().linearize();
+
+        if (row_warn > 0 || row_fail > 0) {
+            size_t row_size = row.memory_usage(s);
+            uint64_t threshold = row_warn > 0 ? row_warn : row_fail;
+            if (row_size >= threshold) {
+                _row_cache.insert_or_assign(row_key{_pk_bytes, ck_bytes}, row_size);
+            }
+        }
+
+        // Flush buffered collection observations from on_collection_merged().
+        for (auto& pc : _pending_collections) {
+            _collection_cache.insert_or_assign(
+                collection_key{_pk_bytes, ck_bytes, pc.id}, pc.count);
+        }
+        _pending_collections.clear();
+    } catch (...) {
+        // noexcept: a failure here only means the memtable-level cache is not
+        // updated, so a large row may slip past the guardrail until the next
+        // SSTable flush rebuilds the on-disk index.
+        large_data_logger.warn("Failed to update memtable-level large-row cache; "
+            "large rows may slip past the guardrail until the next SSTable flush: {}",
+            std::current_exception());
+        _pending_collections.clear();
+    }
+}
+
+void large_data_cache_tracker::on_collection_merged(const column_definition& cdef,
+        const atomic_cell_or_collection& merged_cell) noexcept {
+    try {
+        const uint64_t coll_warn = uint64_t(_cfg.collection_elements_warn_threshold());
+        const uint64_t coll_fail = uint64_t(_cfg.collection_elements_fail_threshold());
+
+        if (coll_warn == 0 && coll_fail == 0) {
+            return;
+        }
+
+        auto cmv = merged_cell.as_collection_mutation();
+        uint32_t count = cmv.size();
+        uint64_t threshold = coll_warn > 0 ? coll_warn : coll_fail;
+        if (count >= threshold) {
+            _pending_collections.push_back({cdef.id, count});
+        }
+    } catch (...) {
+        // noexcept: see on_row_merged().  A failure here only means a large
+        // collection may slip past the guardrail until the next SSTable flush.
+        large_data_logger.warn("Failed to record collection size for memtable-level "
+            "large-collection cache; large collections may slip past the guardrail "
+            "until the next SSTable flush: {}", std::current_exception());
+    }
+}
+
+large_data_cache_tracker* large_data_guardrail::get_memtable_cache_tracker(const schema& s,
+        partition_key_view pk) {
+    constexpr uint64_t MB = 1024 * 1024;
+    const uint64_t row_warn = uint64_t(_cfg.row_size_warn_threshold_mb()) * MB;
+    const uint64_t row_fail = uint64_t(_cfg.row_size_fail_threshold_mb()) * MB;
+    const uint64_t coll_warn = uint64_t(_cfg.collection_elements_warn_threshold());
+    const uint64_t coll_fail = uint64_t(_cfg.collection_elements_fail_threshold());
+
+    if (row_warn == 0 && row_fail == 0 && coll_warn == 0 && coll_fail == 0) {
+        return nullptr;
+    }
+
+    auto sst_key = sstables::key::from_partition_key(s, pk);
+    _tracker.set_partition_key(sst_key.get_bytes());
+    return &_tracker;
 }
 
 sstring large_data_handler::sst_filename(const sstables::sstable& sst) {

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -23,6 +23,7 @@
 #include "utils/hash.hh"
 #include "utils/updateable_value.hh"
 #include "utils/pluggable.hh"
+#include "db/large_data_cache_tracker.hh"
 
 namespace sstables {
 class sstable;
@@ -114,23 +115,6 @@ private:
     record_set<record_type::collection> _collections;
 };
 
-struct guardrail_config {
-    // Partition thresholds (replica-side only — checked via SSTable metadata index)
-    utils::updateable_value<uint32_t> partition_size_fail_threshold_mb;
-    utils::updateable_value<uint32_t> partition_size_warn_threshold_mb;
-    utils::updateable_value<uint32_t> rows_count_fail_threshold;
-    utils::updateable_value<uint32_t> rows_count_warn_threshold;
-    // Row thresholds (shared: replica checks on-disk size, coordinator checks mutation memory)
-    utils::updateable_value<uint32_t> row_size_fail_threshold_mb;
-    utils::updateable_value<uint32_t> row_size_warn_threshold_mb;
-    // Collection thresholds (shared: replica checks SSTable metadata, coordinator checks mutation)
-    utils::updateable_value<uint32_t> collection_elements_fail_threshold;
-    utils::updateable_value<uint32_t> collection_elements_warn_threshold;
-    // Cell thresholds (coordinator-side only — checked from mutation content)
-    utils::updateable_value<uint32_t> cell_size_fail_threshold_mb;
-    utils::updateable_value<uint32_t> cell_size_warn_threshold_mb;
-};
-
 // Each replica::table holds a shared_ptr to either a real guardrail or a
 // noop.  The guardrail owns the per-table large_data_record_index, so
 // noop tables pay no index-maintenance cost.
@@ -149,6 +133,16 @@ public:
     // (cell value sizes, row memory usage, collection element counts).
     virtual void check_coordinator(const schema& s, const mutation_partition& mp,
             partition_key_view pk) const = 0;
+    // Returns a tracker to pass to partition_entry::apply(), or nullptr
+    // when no memtable-level tracking is needed.  The returned pointer
+    // remains valid until the next call to get_memtable_cache_tracker() or
+    // until this guardrail is destroyed.
+    virtual large_data_cache_tracker* get_memtable_cache_tracker(const schema& s,
+            partition_key_view pk) = 0;
+    // Called after a memtable flush completes and new SSTables are registered.
+    // Clears memtable-level caches whose data is now captured in the SSTable
+    // index, preventing unbounded cache growth.
+    virtual void on_flush() = 0;
     virtual void register_sstable(sstables::shared_sstable sst) = 0;
     virtual void rebuild(const std::unordered_set<sstables::shared_sstable>& sstables) = 0;
 };
@@ -163,6 +157,9 @@ public:
             partition_key_view) const override {}
     void check_coordinator(const schema&, const mutation_partition&,
             partition_key_view) const override {}
+    large_data_cache_tracker* get_memtable_cache_tracker(const schema&,
+            partition_key_view) override { return nullptr; }
+    void on_flush() override {}
     void register_sstable(sstables::shared_sstable) override {}
     void rebuild(const std::unordered_set<sstables::shared_sstable>&) override {}
 };
@@ -170,12 +167,16 @@ public:
 class large_data_guardrail final : public large_data_guardrail_base {
 public:
     explicit large_data_guardrail(guardrail_config cfg) noexcept
-        : _cfg(std::move(cfg)) {}
+        : _cfg(std::move(cfg))
+        , _tracker(_cfg, _memtable_row_cache, _memtable_collection_cache) {}
 
     void check(const schema& s, const mutation_partition& mp,
             partition_key_view pk) const override;
     void check_coordinator(const schema& s, const mutation_partition& mp,
             partition_key_view pk) const override;
+    large_data_cache_tracker* get_memtable_cache_tracker(const schema& s,
+            partition_key_view pk) override;
+    void on_flush() override;
     void register_sstable(sstables::shared_sstable sst) override;
     void rebuild(const std::unordered_set<sstables::shared_sstable>& sstables) override;
 
@@ -190,6 +191,9 @@ private:
 
     guardrail_config _cfg;
     large_data_record_index _index;
+    mutable memtable_row_cache _memtable_row_cache;
+    mutable memtable_collection_cache _memtable_collection_cache;
+    large_data_cache_tracker _tracker;
 };
 
 class large_data_handler {

--- a/mutation/converting_mutation_partition_applier.cc
+++ b/mutation/converting_mutation_partition_applier.cc
@@ -33,15 +33,17 @@ converting_mutation_partition_applier::upgrade_cell(const abstract_type& new_typ
 }
 
 void
-converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, atomic_cell_view cell) {
+converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, atomic_cell_view cell,
+        db::large_data_cache_tracker* tracker) {
     if (!is_compatible(new_def, old_type, kind) || cell.timestamp() <= new_def.dropped_at()) {
         return;
     }
-    dst.apply(new_def, upgrade_cell(*new_def.type, old_type, cell));
+    dst.apply(new_def, upgrade_cell(*new_def.type, old_type, cell), {}, tracker);
 }
 
 void
-converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, collection_mutation_view cell) {
+converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, collection_mutation_view cell,
+        db::large_data_cache_tracker* tracker) {
     if (!is_compatible(new_def, old_type, kind)) {
         return;
     }
@@ -84,7 +86,7 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
     ));
 
     if (!new_view.empty()) {
-        dst.apply(new_def, std::move(new_view).finish());
+        dst.apply(new_def, std::move(new_view).finish(), {}, tracker);
     }
 }
 
@@ -163,10 +165,11 @@ converting_mutation_partition_applier::accept_row_cell(column_id id, collection_
 }
 
 void
-converting_mutation_partition_applier::append_cell(row& dst, column_kind kind, const column_definition& new_def, const column_definition& old_def, const atomic_cell_or_collection& cell) {
+converting_mutation_partition_applier::append_cell(row& dst, column_kind kind, const column_definition& new_def, const column_definition& old_def, const atomic_cell_or_collection& cell,
+        db::large_data_cache_tracker* tracker) {
     if (new_def.is_atomic()) {
-        accept_cell(dst, kind, new_def, *old_def.type, cell.as_atomic_cell(old_def));
+        accept_cell(dst, kind, new_def, *old_def.type, cell.as_atomic_cell(old_def), tracker);
     } else {
-        accept_cell(dst, kind, new_def, *old_def.type, cell.as_collection_mutation());
+        accept_cell(dst, kind, new_def, *old_def.type, cell.as_collection_mutation(), tracker);
     }
 }

--- a/mutation/converting_mutation_partition_applier.hh
+++ b/mutation/converting_mutation_partition_applier.hh
@@ -20,6 +20,7 @@ class deletable_row;
 class column_definition;
 class abstract_type;
 class atomic_cell_or_collection;
+namespace db { class large_data_cache_tracker; }
 
 // Mutation partition visitor which applies visited data into
 // existing mutation_partition. The visited data may be of a different schema.
@@ -34,8 +35,11 @@ private:
     static bool is_compatible(const column_definition& new_def, const abstract_type& old_type, column_kind kind);
     static atomic_cell upgrade_cell(const abstract_type& new_type, const abstract_type& old_type, atomic_cell_view cell,
                                     atomic_cell::collection_member cm = atomic_cell::collection_member::no);
-    static void accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, atomic_cell_view cell);
-    static void accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, collection_mutation_view cell);public:
+    static void accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, atomic_cell_view cell,
+            db::large_data_cache_tracker* tracker = nullptr);
+    static void accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, collection_mutation_view cell,
+            db::large_data_cache_tracker* tracker = nullptr);
+public:
     converting_mutation_partition_applier(
             const column_mapping& visited_column_mapping,
             const schema& target_schema,
@@ -52,5 +56,6 @@ private:
 
     // Appends the cell to dst upgrading it to the new schema.
     // Cells must have monotonic names.
-    static void append_cell(row& dst, column_kind kind, const column_definition& new_def, const column_definition& old_def, const atomic_cell_or_collection& cell);
+    static void append_cell(row& dst, column_kind kind, const column_definition& new_def, const column_definition& old_def, const atomic_cell_or_collection& cell,
+            db::large_data_cache_tracker* tracker = nullptr);
 };

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -11,6 +11,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include "mutation_partition.hh"
+#include "db/large_data_cache_tracker.hh"
 #include "keys/clustering_interval_set.hh"
 #include "converting_mutation_partition_applier.hh"
 #include "partition_builder.hh"
@@ -1052,26 +1053,26 @@ void deletable_row::apply(const schema& our_schema, const schema& their_schema, 
     apply_monotonically(our_schema, their_schema, src);
 }
 
-void deletable_row::apply_monotonically(const schema& s, deletable_row&& src) {
-    _cells.apply_monotonically(s, column_kind::regular_column, std::move(src._cells));
+void deletable_row::apply_monotonically(const schema& s, deletable_row&& src, db::large_data_cache_tracker* tracker) {
+    _cells.apply_monotonically(s, column_kind::regular_column, std::move(src._cells), tracker);
     _marker.apply(src._marker);
     _deleted_at.apply(src._deleted_at, _marker);
 }
 
-void deletable_row::apply_monotonically(const schema& s, const deletable_row& src) {
-    _cells.apply_monotonically(s, column_kind::regular_column, src._cells);
+void deletable_row::apply_monotonically(const schema& s, const deletable_row& src, db::large_data_cache_tracker* tracker) {
+    _cells.apply_monotonically(s, column_kind::regular_column, src._cells, tracker);
     _marker.apply(src._marker);
     _deleted_at.apply(src._deleted_at, _marker);
 }
 
-void deletable_row::apply_monotonically(const schema& our_schema, const schema& their_schema, deletable_row&& src) {
-    _cells.apply_monotonically(our_schema, their_schema, column_kind::regular_column, std::move(src._cells));
+void deletable_row::apply_monotonically(const schema& our_schema, const schema& their_schema, deletable_row&& src, db::large_data_cache_tracker* tracker) {
+    _cells.apply_monotonically(our_schema, their_schema, column_kind::regular_column, std::move(src._cells), tracker);
     _marker.apply(src._marker);
     _deleted_at.apply(src._deleted_at, _marker);
 }
 
-void deletable_row::apply_monotonically(const schema& our_schema, const schema& their_schema, const deletable_row& src) {
-    _cells.apply_monotonically(our_schema, their_schema, column_kind::regular_column, src._cells);
+void deletable_row::apply_monotonically(const schema& our_schema, const schema& their_schema, const deletable_row& src, db::large_data_cache_tracker* tracker) {
+    _cells.apply_monotonically(our_schema, their_schema, column_kind::regular_column, src._cells, tracker);
     _marker.apply(src._marker);
     _deleted_at.apply(src._deleted_at, _marker);
 }
@@ -1134,7 +1135,8 @@ mutation_partition mutation_partition::sliced(const schema& s, const query::clus
 static
 void
 apply_monotonically(const column_definition& def, cell_and_hash& dst,
-                    atomic_cell_or_collection& src, cell_hash_opt src_hash) {
+        atomic_cell_or_collection& src, cell_hash_opt src_hash,
+        db::large_data_cache_tracker* tracker = nullptr) {
     if (def.is_atomic()) {
         if (def.is_counter()) {
             counter_cell_view::apply(def, dst.cell, src); // FIXME: Optimize
@@ -1147,18 +1149,23 @@ apply_monotonically(const column_definition& def, cell_and_hash& dst,
     } else {
         dst.cell = merge(*def.type, dst.cell.as_collection_mutation(), src.as_collection_mutation());
         dst.hash = { };
+        if (tracker) {
+            tracker->on_collection_merged(def, dst.cell);
+        }
     }
 }
 
 void
-row::apply(const column_definition& column, const atomic_cell_or_collection& value, cell_hash_opt hash) {
+row::apply(const column_definition& column, const atomic_cell_or_collection& value, cell_hash_opt hash,
+        db::large_data_cache_tracker* tracker) {
     auto tmp = value.copy(*column.type);
-    apply_monotonically(column, std::move(tmp), std::move(hash));
+    apply_monotonically(column, std::move(tmp), std::move(hash), tracker);
 }
 
 void
-row::apply(const column_definition& column, atomic_cell_or_collection&& value, cell_hash_opt hash) {
-    apply_monotonically(column, std::move(value), std::move(hash));
+row::apply(const column_definition& column, atomic_cell_or_collection&& value, cell_hash_opt hash,
+        db::large_data_cache_tracker* tracker) {
+    apply_monotonically(column, std::move(value), std::move(hash), tracker);
 }
 
 template<typename Func>
@@ -1171,7 +1178,8 @@ void row::consume_with(Func&& func) {
 }
 
 void
-row::apply_monotonically(const column_definition& column, atomic_cell_or_collection&& value, cell_hash_opt hash) {
+row::apply_monotonically(const column_definition& column, atomic_cell_or_collection&& value, cell_hash_opt hash,
+        db::large_data_cache_tracker* tracker) {
     static_assert(std::is_nothrow_move_constructible<atomic_cell_or_collection>::value
                   && std::is_nothrow_move_assignable<atomic_cell_or_collection>::value,
                   "noexcept required for atomicity");
@@ -1185,7 +1193,7 @@ row::apply_monotonically(const column_definition& column, atomic_cell_or_collect
         _cells.emplace(id, std::move(value), std::move(hash));
         _size++;
     } else {
-        ::apply_monotonically(column, *cah, value, std::move(hash));
+        ::apply_monotonically(column, *cah, value, std::move(hash), tracker);
     }
 }
 
@@ -1554,46 +1562,46 @@ void row::apply(const schema& our_schema, const schema& their_schema, column_kin
     apply_monotonically(our_schema, their_schema, kind, other);
 };
 
-void row::apply_monotonically(const schema& s, column_kind kind, row&& other) {
+void row::apply_monotonically(const schema& s, column_kind kind, row&& other, db::large_data_cache_tracker* tracker) {
     if (other.empty()) {
         return;
     }
     other.consume_with([&] (column_id id, cell_and_hash& c_a_h) {
-        apply_monotonically(s.column_at(kind, id), std::move(c_a_h.cell), std::move(c_a_h.hash));
+        apply_monotonically(s.column_at(kind, id), std::move(c_a_h.cell), std::move(c_a_h.hash), tracker);
     });
 }
 
-void row::apply_monotonically(const schema& s, column_kind kind, const row& other) {
+void row::apply_monotonically(const schema& s, column_kind kind, const row& other, db::large_data_cache_tracker* tracker) {
     if (other.empty()) {
         return;
     }
     other.for_each_cell([&] (column_id id, const cell_and_hash& c_a_h) {
-        apply(s.column_at(kind, id), c_a_h.cell, c_a_h.hash);
+        apply(s.column_at(kind, id), c_a_h.cell, c_a_h.hash, tracker);
     });
 }
 
-void row::apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind kind, row&& other) {
+void row::apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind kind, row&& other, db::large_data_cache_tracker* tracker) {
     if (our_schema.version() == their_schema.version()) {
-        return apply_monotonically(our_schema, kind, std::move(other));
+        return apply_monotonically(our_schema, kind, std::move(other), tracker);
     }
     other.consume_with([&] (column_id id, cell_and_hash& c_a_h) {
         const column_definition& their_col = their_schema.column_at(kind, id);
         const column_definition* our_col = our_schema.get_column_definition(their_col.name());
         if (our_col) {
-            converting_mutation_partition_applier::append_cell(*this, kind, *our_col, their_col, c_a_h.cell);
+            converting_mutation_partition_applier::append_cell(*this, kind, *our_col, their_col, c_a_h.cell, tracker);
         }
     });
 }
 
-void row::apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind kind, const row& other) {
+void row::apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind kind, const row& other, db::large_data_cache_tracker* tracker) {
     if (our_schema.version() == their_schema.version()) {
-        return apply_monotonically(our_schema, kind, other);
+        return apply_monotonically(our_schema, kind, other, tracker);
     }
     other.for_each_cell([&] (column_id id, const cell_and_hash& c_a_h) {
         const column_definition& their_col = their_schema.column_at(kind, id);
         const column_definition* our_col = our_schema.get_column_definition(their_col.name());
         if (our_col) {
-            converting_mutation_partition_applier::append_cell(*this, kind, *our_col, their_col, c_a_h.cell);
+            converting_mutation_partition_applier::append_cell(*this, kind, *our_col, their_col, c_a_h.cell, tracker);
         }
     });
 }

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -38,6 +38,7 @@
 class mutation_fragment;
 class mutation_partition_view;
 class mutation_partition_visitor;
+namespace db { class large_data_cache_tracker; }
 
 namespace query {
     class clustering_key_filter_ranges;
@@ -166,14 +167,17 @@ public:
 
     // Merges cell's value into the row.
     // Weak exception guarantees.
-    void apply(const column_definition& column, const atomic_cell_or_collection& cell, cell_hash_opt hash = cell_hash_opt());
+    void apply(const column_definition& column, const atomic_cell_or_collection& cell, cell_hash_opt hash = cell_hash_opt(),
+            db::large_data_cache_tracker* tracker = nullptr);
 
     // Merges cell's value into the row.
     // Weak exception guarantees.
-    void apply(const column_definition& column, atomic_cell_or_collection&& cell, cell_hash_opt hash = cell_hash_opt());
+    void apply(const column_definition& column, atomic_cell_or_collection&& cell, cell_hash_opt hash = cell_hash_opt(),
+            db::large_data_cache_tracker* tracker = nullptr);
 
     // Monotonic exception guarantees. In case of exception the sum of cell and this remains the same as before the exception.
-    void apply_monotonically(const column_definition& column, atomic_cell_or_collection&& cell, cell_hash_opt hash = cell_hash_opt());
+    void apply_monotonically(const column_definition& column, atomic_cell_or_collection&& cell, cell_hash_opt hash = cell_hash_opt(),
+            db::large_data_cache_tracker* tracker = nullptr);
 
     // Adds cell to the row. The column must not be already set.
     void append_cell(column_id id, atomic_cell_or_collection cell);
@@ -185,10 +189,10 @@ public:
     void apply(const schema& our_schema, const schema& their_schema, column_kind kind, row&& other);
 
     // Monotonic exception guarantees
-    void apply_monotonically(const schema&, column_kind, row&& src);
-    void apply_monotonically(const schema&, column_kind, const row& src);
-    void apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind, row&& src);
-    void apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind, const row& src);
+    void apply_monotonically(const schema&, column_kind, row&& src, db::large_data_cache_tracker* tracker = nullptr);
+    void apply_monotonically(const schema&, column_kind, const row& src, db::large_data_cache_tracker* tracker = nullptr);
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind, row&& src, db::large_data_cache_tracker* tracker = nullptr);
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind, const row& src, db::large_data_cache_tracker* tracker = nullptr);
 
     // Expires cells based on query_time. Expires tombstones based on gc_before
     // and max_purgeable. Removes cells covered by tomb.
@@ -404,15 +408,15 @@ public:
     }
 
     // Monotonic exception guarantees
-    void apply_monotonically(const schema& s, column_kind kind, row&& src) {
+    void apply_monotonically(const schema& s, column_kind kind, row&& src, db::large_data_cache_tracker* tracker = nullptr) {
         if (src.empty()) {
             return;
         }
-        maybe_create().apply_monotonically(s, kind, std::move(src));
+        maybe_create().apply_monotonically(s, kind, std::move(src), tracker);
     }
 
     // Monotonic exception guarantees
-    void apply_monotonically(const schema& s, column_kind kind, lazy_row&& src) {
+    void apply_monotonically(const schema& s, column_kind kind, lazy_row&& src, db::large_data_cache_tracker* tracker = nullptr) {
         if (src.empty()) {
             return;
         }
@@ -420,15 +424,15 @@ public:
             _row = std::move(src._row);
             return;
         }
-        get_existing().apply_monotonically(s, kind, std::move(src.get_existing()));
+        get_existing().apply_monotonically(s, kind, std::move(src.get_existing()), tracker);
     }
 
     // Monotonic exception guarantees
-    void apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind kind, lazy_row&& src) {
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, column_kind kind, lazy_row&& src, db::large_data_cache_tracker* tracker = nullptr) {
         if (src.empty()) {
             return;
         }
-        maybe_create().apply_monotonically(our_schema, their_schema, kind, std::move(src.get_existing()));
+        maybe_create().apply_monotonically(our_schema, their_schema, kind, std::move(src.get_existing()), tracker);
     }
 
     // Expires cells based on query_time. Expires tombstones based on gc_before
@@ -878,10 +882,10 @@ public:
     void apply(const schema& our_schema, const schema& their_schema, const deletable_row& src);
     void apply(const schema& our_schema, const schema& their_schema, deletable_row&& src);
 
-    void apply_monotonically(const schema&, deletable_row&& src);
-    void apply_monotonically(const schema&, const deletable_row& src);
-    void apply_monotonically(const schema& our_schema, const schema& their_schema, deletable_row&& src);
-    void apply_monotonically(const schema& our_schema, const schema& their_schema, const deletable_row& src);
+    void apply_monotonically(const schema&, deletable_row&& src, db::large_data_cache_tracker* tracker = nullptr);
+    void apply_monotonically(const schema&, const deletable_row& src, db::large_data_cache_tracker* tracker = nullptr);
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, deletable_row&& src, db::large_data_cache_tracker* tracker = nullptr);
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, const deletable_row& src, db::large_data_cache_tracker* tracker = nullptr);
 public:
     row_tombstone deleted_at() const { return _deleted_at; }
     api::timestamp_type created_at() const { return _marker.timestamp(); }
@@ -1020,11 +1024,11 @@ public:
     void apply(row_tombstone t) {
         _row.apply(t);
     }
-    void apply_monotonically(const schema& s, rows_entry&& e) {
-        _row.apply_monotonically(s, std::move(e._row));
+    void apply_monotonically(const schema& s, rows_entry&& e, db::large_data_cache_tracker* tracker = nullptr) {
+        _row.apply_monotonically(s, std::move(e._row), tracker);
     }
-    void apply_monotonically(const schema& our_schema, const schema& their_schema, rows_entry&& e) {
-        _row.apply_monotonically(our_schema, their_schema, std::move(e._row));
+    void apply_monotonically(const schema& our_schema, const schema& their_schema, rows_entry&& e, db::large_data_cache_tracker* tracker = nullptr) {
+        _row.apply_monotonically(our_schema, their_schema, std::move(e._row), tracker);
     }
     bool empty() const {
         return _row.empty();

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -10,6 +10,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include "mutation_partition_v2.hh"
+#include "db/large_data_cache_tracker.hh"
 #include "keys/clustering_interval_set.hh"
 #include "converting_mutation_partition_applier.hh"
 #include "partition_builder.hh"
@@ -115,7 +116,8 @@ void mutation_partition_v2::apply(const schema& s, mutation_partition_v2&& p, ca
 }
 
 stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, const schema& p_s, mutation_partition_v2&& p, cache_tracker* tracker,
-        mutation_application_stats& app_stats, preemption_check need_preempt, apply_resume& res, is_evictable evictable) {
+        mutation_application_stats& app_stats, preemption_check need_preempt, apply_resume& res, is_evictable evictable,
+        db::large_data_cache_tracker* ld_tracker) {
 #ifdef SEASTAR_DEBUG
     SCYLLA_ASSERT(_schema_version == s.version());
     SCYLLA_ASSERT(p._schema_version == p_s.version());
@@ -471,9 +473,9 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, const
                             (i->range_tombstone() + i->row().deleted_at().regular());
                 memory::on_alloc_point();
                 if (same_schema) [[likely]] {
-                    i->apply_monotonically(s, std::move(src_e));
+                    i->apply_monotonically(s, std::move(src_e), ld_tracker);
                 } else {
-                    i->apply_monotonically(s, p_s, std::move(src_e));
+                    i->apply_monotonically(s, p_s, std::move(src_e), ld_tracker);
                 }
             }
             ++app_stats.row_hits;
@@ -484,6 +486,9 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, const
             this_sentinel = std::move(s2);
         }
         // All operations above up to each insert_before() must be noexcept.
+        if (ld_tracker && !lb_i->dummy()) {
+            ld_tracker->on_row_merged(s, *lb_i);
+        }
         if (prev_compacted && lb_i != _rows.begin()) {
             maybe_drop(s, tracker, std::prev(lb_i), app_stats);
         }

--- a/mutation/mutation_partition_v2.hh
+++ b/mutation/mutation_partition_v2.hh
@@ -14,6 +14,8 @@
 
 #include <ranges>
 
+namespace db { class large_data_cache_tracker; }
+
 #ifdef SEASTAR_DEBUG
 #include "utils/assert.hh"
 #endif
@@ -196,7 +198,8 @@ public:
     // If is_preemptible::yes is passed, apply_resume must also be passed,
     // same instance each time until stop_iteration::yes is returned.
     stop_iteration apply_monotonically(const schema& this_schema, const schema& p_schema, mutation_partition_v2&& p,
-            cache_tracker*, mutation_application_stats& app_stats, preemption_check, apply_resume&, is_evictable);
+            cache_tracker*, mutation_application_stats& app_stats, preemption_check, apply_resume&, is_evictable,
+            db::large_data_cache_tracker* ld_tracker = nullptr);
 
     // Converts partition to the new schema. When succeeds the partition should only be accessed
     // using the new schema.

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -416,8 +416,8 @@ partition_version& partition_entry::add_version(const schema& s, cache_tracker* 
 }
 
 void partition_entry::apply(logalloc::region& r, mutation_cleaner& cleaner, const schema& s, const mutation_partition_v2& mp, const schema& mp_schema,
-        mutation_application_stats& app_stats) {
-    apply(r, cleaner, s, mutation_partition_v2(mp_schema, mp), mp_schema, app_stats);
+        mutation_application_stats& app_stats, db::large_data_cache_tracker* tracker) {
+    apply(r, cleaner, s, mutation_partition_v2(mp_schema, mp), mp_schema, app_stats, tracker);
 }
 
 void partition_entry::apply(logalloc::region& r,
@@ -425,14 +425,15 @@ void partition_entry::apply(logalloc::region& r,
            const schema& s,
            const mutation_partition& mp,
            const schema& mp_schema,
-           mutation_application_stats& app_stats) {
+           mutation_application_stats& app_stats,
+           db::large_data_cache_tracker* tracker) {
     auto mp_v1 = mutation_partition(mp_schema, mp);
     mp_v1.make_fully_continuous();
-    apply(r, c, s, mutation_partition_v2(mp_schema, std::move(mp_v1)), mp_schema, app_stats);
+    apply(r, c, s, mutation_partition_v2(mp_schema, std::move(mp_v1)), mp_schema, app_stats, tracker);
 }
 
 void partition_entry::apply(logalloc::region& r, mutation_cleaner& cleaner, const schema& s, mutation_partition_v2&& mp, const schema& mp_schema,
-        mutation_application_stats& app_stats) {
+        mutation_application_stats& app_stats, db::large_data_cache_tracker* tracker) {
     // A note about app_stats: it may happen that mp has rows that overwrite other rows
     // in older partition_version. Those overwrites will be counted when their versions get merged.
     if (s.version() != mp_schema.version()) {
@@ -450,7 +451,8 @@ void partition_entry::apply(logalloc::region& r, mutation_cleaner& cleaner, cons
                       app_stats,
                       default_preemption_check(),
                       res,
-                      is_evictable::no) == stop_iteration::yes) {
+                      is_evictable::no,
+                      tracker) == stop_iteration::yes) {
                 current_allocator().destroy(new_version);
                 return;
             } else {

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -20,6 +20,8 @@
 
 class static_row;
 
+namespace db { class large_data_cache_tracker; }
+
 // This is MVCC implementation for mutation_partitions.
 //
 // See docs/dev/mvcc.md for important design information.
@@ -601,21 +603,24 @@ public:
                const schema& s,
                const mutation_partition_v2& mp,
                const schema& mp_schema,
-               mutation_application_stats& app_stats);
+               mutation_application_stats& app_stats,
+               db::large_data_cache_tracker* tracker = nullptr);
 
     void apply(logalloc::region&,
                mutation_cleaner&,
                const schema& s,
                mutation_partition_v2&& mp,
                const schema& mp_schema,
-               mutation_application_stats& app_stats);
+               mutation_application_stats& app_stats,
+               db::large_data_cache_tracker* tracker = nullptr);
 
     void apply(logalloc::region&,
                mutation_cleaner&,
                const schema& s,
                const mutation_partition& mp,
                const schema& mp_schema,
-               mutation_application_stats& app_stats);
+               mutation_application_stats& app_stats,
+               db::large_data_cache_tracker* tracker = nullptr);
 
     // Adds mutation_partition represented by "pe" to the one represented
     // by this entry.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1033,10 +1033,10 @@ public:
     // Applies given mutation to this column family
     // The mutation is always upgraded to current schema.
     void apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_handle&& h = {}) {
-        do_apply(compaction_group_for_key(m.key(), m_schema), std::move(h), m, m_schema, *db::noop_large_data_guardrail::instance());
+        do_apply(compaction_group_for_key(m.key(), m_schema), std::move(h), m, m_schema, *_large_data_guardrail, _large_data_guardrail->get_memtable_cache_tracker(*m_schema, m.key()));
     }
     void apply(const mutation& m, db::rp_handle&& h = {}) {
-        do_apply(compaction_group_for_token(m.token()), std::move(h), m);
+        do_apply(compaction_group_for_token(m.token()), std::move(h), m, _large_data_guardrail->get_memtable_cache_tracker(*m.schema(), m.key()));
     }
 
     future<> apply(const frozen_mutation& m, schema_ptr m_schema, db::rp_handle&& h,

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -787,12 +787,12 @@ memtable::apply(memtable& mt, reader_permit permit) {
 }
 
 void
-memtable::apply(const mutation& m, db::rp_handle&& h) {
-    with_allocator(allocator(), [this, &m] {
+memtable::apply(const mutation& m, db::large_data_cache_tracker* tracker, db::rp_handle&& h) {
+    with_allocator(allocator(), [this, &m, tracker] {
         _table_shared_data.allocating_section(*this, [&, this] {
             auto& p = find_or_create_partition(m.decorated_key());
             _stats_collector.update(*m.schema(), m.partition());
-            p.apply(region(), cleaner(), *_schema, m.partition(), *m.schema(), _table_stats.memtable_app_stats);
+            p.apply(region(), cleaner(), *_schema, m.partition(), *m.schema(), _table_stats.memtable_app_stats, tracker);
         });
     });
     update(std::move(h));
@@ -800,8 +800,9 @@ memtable::apply(const mutation& m, db::rp_handle&& h) {
 
 void
 memtable::apply(const frozen_mutation& m, const schema_ptr& m_schema,
-                const db::large_data_guardrail_base& guardrails, db::rp_handle&& h) {
-    with_allocator(allocator(), [this, &m, &m_schema, &guardrails] {
+        const db::large_data_guardrail_base& guardrails, db::large_data_cache_tracker* tracker,
+        db::rp_handle&& h) {
+    with_allocator(allocator(), [this, &m, &m_schema, &guardrails, tracker] {
         _table_shared_data.allocating_section(*this, [&, this] {
             mutation_partition mp(*m_schema);
             partition_builder pb(*m_schema, mp);
@@ -809,7 +810,7 @@ memtable::apply(const frozen_mutation& m, const schema_ptr& m_schema,
             guardrails.check(*m_schema, mp, m.key());
             auto& p = find_or_create_partition_slow(m.key());
             _stats_collector.update(*m_schema, mp);
-            p.apply(region(), cleaner(), *_schema, std::move(mp), *m_schema, _table_stats.memtable_app_stats);
+            p.apply(region(), cleaner(), *_schema, mp, *m_schema, _table_stats.memtable_app_stats, tracker);
         });
     });
     update(std::move(h));

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -236,11 +236,14 @@ public:
     future<> apply(memtable&, reader_permit);
     // Applies mutation to this memtable.
     // The mutation is upgraded to current schema.
-    void apply(const mutation& m, db::rp_handle&& = {});
+    void apply(const mutation& m, db::large_data_cache_tracker* tracker, db::rp_handle&& = {});
+    void apply(const mutation& m, db::rp_handle&& h = {}) {
+        apply(m, nullptr, std::move(h));
+    }
     void apply(const frozen_mutation& m, const schema_ptr& m_schema,
-               const db::large_data_guardrail_base& guardrails, db::rp_handle&& = {});
+               const db::large_data_guardrail_base& guardrails, db::large_data_cache_tracker* tracker, db::rp_handle&& h = {});
     void apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_handle&& h = {}) {
-        apply(m, m_schema, *db::noop_large_data_guardrail::instance(), std::move(h));
+        apply(m, m_schema, *db::noop_large_data_guardrail::instance(), nullptr, std::move(h));
     }
     void evict_entry(memtable_entry& e, mutation_cleaner& cleaner) noexcept;
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2060,6 +2060,7 @@ table::try_flush_memtable_to_sstable(compaction_group& cg, lw_shared_ptr<memtabl
         for (const auto& sst : newtabs) {
             _large_data_guardrail->register_sstable(sst);
         }
+        _large_data_guardrail->on_flush();
 
         co_await utils::get_local_injector().inject("replica_post_flush_after_update_cache", [this] (auto& handler) -> future<> {
             const auto this_table_name = format("{}.{}", _schema->ks_name(), _schema->cf_name());
@@ -5033,11 +5034,11 @@ future<> table::apply(const mutation& m, db::rp_handle&& h, db::timeout_clock::t
     }
 
     return dirty_memory_region_group().run_when_memory_available([this, &m, h = std::move(h), &cg, holder = std::move(holder)] () mutable {
-        do_apply(cg, std::move(h), m);
+        do_apply(cg, std::move(h), m, _large_data_guardrail->get_memtable_cache_tracker(*m.schema(), m.key()));
     }, timeout);
 }
 
-template void table::do_apply(compaction_group& cg, db::rp_handle&&, const mutation&);
+template void table::do_apply(compaction_group& cg, db::rp_handle&&, const mutation&, db::large_data_cache_tracker*&&);
 
 future<> table::apply(const frozen_mutation& m, schema_ptr m_schema, db::rp_handle&& h,
                       db::timeout_clock::time_point timeout, shared_ptr<db::large_data_guardrail_base> guardrails) {
@@ -5054,11 +5055,11 @@ future<> table::apply(const frozen_mutation& m, schema_ptr m_schema, db::rp_hand
     }
 
     return dirty_memory_region_group().run_when_memory_available([this, &m, m_schema = std::move(m_schema), h = std::move(h), &cg, holder = std::move(holder), guardrails = std::move(guardrails)]() mutable {
-        do_apply(cg, std::move(h), m, m_schema, *guardrails);
+        do_apply(cg, std::move(h), m, m_schema, *guardrails, _large_data_guardrail->get_memtable_cache_tracker(*m_schema, m.key()));
     }, timeout);
 }
 
-template void table::do_apply(compaction_group& cg, db::rp_handle&&, const frozen_mutation&, const schema_ptr&, const db::large_data_guardrail_base&);
+template void table::do_apply(compaction_group& cg, db::rp_handle&&, const frozen_mutation&, const schema_ptr&, const db::large_data_guardrail_base&, db::large_data_cache_tracker*&&);
 
 future<>
 write_memtable_to_sstable(mutation_reader reader,

--- a/test/cqlpy/test_coordinator_guardrail_large_cell.py
+++ b/test/cqlpy/test_coordinator_guardrail_large_cell.py
@@ -31,14 +31,14 @@ def all_tests_are_scylla_only(scylla_only):
     pass
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def test_table(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
                         " WITH large_data_guardrails_enabled = true") as table:
         yield table
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def test_table_with_static(cql, test_keyspace):
     with new_test_table(
         cql,

--- a/test/cqlpy/test_coordinator_guardrail_large_collection.py
+++ b/test/cqlpy/test_coordinator_guardrail_large_collection.py
@@ -31,14 +31,14 @@ def all_tests_are_scylla_only(scylla_only):
     pass
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def test_table_set(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v set<int>",
                         " WITH large_data_guardrails_enabled = true") as table:
         yield table
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def test_table_with_static(cql, test_keyspace):
     with new_test_table(
         cql,

--- a/test/cqlpy/test_coordinator_guardrail_large_row.py
+++ b/test/cqlpy/test_coordinator_guardrail_large_row.py
@@ -31,14 +31,14 @@ def all_tests_are_scylla_only(scylla_only):
     pass
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def test_table(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
                         " WITH large_data_guardrails_enabled = true") as table:
         yield table
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def test_table_with_static(cql, test_keyspace):
     with new_test_table(
         cql,

--- a/test/cqlpy/test_large_data_guardrail.py
+++ b/test/cqlpy/test_large_data_guardrail.py
@@ -346,9 +346,17 @@ def test_collection_rejects_after_flush(cql, test_keyspace):
         schema = "pk int, ck int, s set<int>, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
-            build_large_collection(cql, tbl, pk=1, ck=0, num_elements=60)
-            nodetool.flush(cql, tbl)
+            # Build element-by-element (each UPDATE adds 1 element, so
+            # future coordinator-side guardrails won't reject).  Disable
+            # the fail threshold during setup to prevent memtable-level
+            # rejection while the collection grows past the limit.
+            with config_value_context(cql,
+                    'large_collection_elements_fail_threshold', '0'):
+                build_large_collection(cql, tbl, pk=1, ck=0, num_elements=60)
+                nodetool.flush(cql, tbl)
 
+            # Fail threshold restored to 50.  SSTable index has the
+            # 60-element collection, memtable cache was cleared by flush.
             insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, s) VALUES (?, ?, ?)")
             with pytest.raises(WriteFailure, match=REJECT_COLLECTION_RE):
                 cql.execute(insert, [1, 0, {0}])
@@ -622,10 +630,14 @@ def test_each_guardrail_rejects_independently(cql, test_keyspace):
             cql.execute(insert_v2, [2, 0, bytes(600 * 1024)])
 
             # pk=3: 60-element collection; row and partition tiny.
-            update_s = cql.prepare(
-                f"UPDATE {tbl} SET s = s + ? WHERE pk = ? AND ck = ?")
-            for i in range(60):
-                cql.execute(update_s, [{i}, 3, 0])
+            # Build element-by-element.  Disable the collection fail
+            # threshold during setup to prevent memtable-level rejection.
+            with config_value_context(cql,
+                    'large_collection_elements_fail_threshold', '0'):
+                update_s = cql.prepare(
+                    f"UPDATE {tbl} SET s = s + ? WHERE pk = ? AND ck = ?")
+                for i in range(60):
+                    cql.execute(update_s, [{i}, 3, 0])
 
             nodetool.flush(cql, tbl)
 

--- a/test/cqlpy/test_large_data_guardrail.py
+++ b/test/cqlpy/test_large_data_guardrail.py
@@ -661,3 +661,128 @@ def test_each_guardrail_rejects_independently(cql, test_keyspace):
             cql.execute(insert_v1, [3, 0, b"\x00"])
             # Different CK in pk=3 succeeds.
             cql.execute(insert_s, [3, 99, {999}])
+
+
+# ---------------------------------------------------------------------------
+# Memtable-level detection — row size
+# ---------------------------------------------------------------------------
+
+
+def test_row_size_rejects_from_memtable(cql, test_keyspace):
+    """A row exceeding the hard limit in the memtable (no flush) must be
+    rejected on the next write to the same (pk, ck)."""
+    with ExitStack() as cfg:
+        cfg.enter_context(config_value_context(cql,
+            'compaction_large_row_warning_threshold_mb', '1'))
+        cfg.enter_context(config_value_context(cql,
+            'large_row_fail_threshold_mb', '1'))
+
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
+        with new_test_table(cql, test_keyspace, schema,
+                extra=" WITH large_data_guardrails_enabled = true") as tbl:
+            # First write succeeds (large_data_cache_tracker caches the size).
+            make_large_row(cql, tbl, pk=1, ck=0,
+                           value_size_bytes=1200 * 1024)
+
+            # No flush — memtable cache must trigger rejection.
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
+            with pytest.raises(WriteFailure, match=REJECT_ROW_RE):
+                cql.execute(insert, [1, 0, b"\x00"])
+
+            # Different CK succeeds.
+            cql.execute(insert, [1, 99, b"\x00"])
+            # Different partition succeeds.
+            cql.execute(insert, [2, 0, b"\x00"])
+
+
+def test_row_size_warns_from_memtable(cql, test_keyspace, logfile):
+    """A row above the soft limit in the memtable (no flush) must produce
+    a warning on the next write to the same row."""
+    with ExitStack() as cfg:
+        cfg.enter_context(config_value_context(cql,
+            'compaction_large_row_warning_threshold_mb', '1'))
+        cfg.enter_context(config_value_context(cql,
+            'large_row_fail_threshold_mb', '10'))
+
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
+        with new_test_table(cql, test_keyspace, schema,
+                extra=" WITH large_data_guardrails_enabled = true") as tbl:
+            make_large_row(cql, tbl, pk=1, ck=0,
+                           value_size_bytes=1200 * 1024)
+
+            # No flush — memtable cache should trigger a warning.
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
+            cql.execute(insert, [1, 0, b"\x00"])
+
+            wait_for_log(logfile, WARN_RE, timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Memtable-level detection — collection element count
+# ---------------------------------------------------------------------------
+
+
+def test_collection_rejects_from_memtable(cql, test_keyspace):
+    """A collection exceeding the element-count hard limit in the memtable
+    (no flush) must be rejected on a subsequent write to the same (pk, ck).
+    The set is grown across two sub-threshold writes so each passes the
+    coordinator-side guardrail; a fresh insert is not a merge, so it does not
+    cache the collection, but the merge of the second write into the memtable
+    row caches the combined count.  The third write is then rejected."""
+    with ExitStack() as cfg:
+        cfg.enter_context(config_value_context(cql,
+            'compaction_collection_elements_count_warning_threshold', '50'))
+        cfg.enter_context(config_value_context(cql,
+            'large_collection_elements_fail_threshold', '50'))
+
+        schema = "pk int, ck int, s set<int>, PRIMARY KEY (pk, ck)"
+        with new_test_table(cql, test_keyspace, schema,
+                extra=" WITH large_data_guardrails_enabled = true") as tbl:
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, s) VALUES (?, ?, ?)")
+            update = cql.prepare(f"UPDATE {tbl} SET s = s + ? WHERE pk = ? AND ck = ?")
+            # Write 1: create the row with 30 elements (< 50) — passes the
+            # coordinator guardrail; a fresh row is not a merge, so the
+            # collection is not cached yet.
+            cql.execute(update, [set(range(30)), 1, 0])
+            # Write 2: add 30 more (< 50 in this mutation) — passes the
+            # coordinator guardrail, but the merge into the memtable row
+            # produces a 60-element set that on_collection_merged caches.
+            cql.execute(update, [set(range(30, 60)), 1, 0])
+
+            # Write 3: check() finds the cached count → rejected.
+            with pytest.raises(WriteFailure, match=REJECT_COLLECTION_RE):
+                cql.execute(update, [{998}, 1, 0])
+
+            # Different CK succeeds.
+            cql.execute(insert, [1, 99, {0}])
+            # Different partition succeeds.
+            cql.execute(insert, [2, 0, {0}])
+
+
+def test_collection_warns_from_memtable(cql, test_keyspace, logfile):
+    """A collection above the soft limit in the memtable (no flush) must
+    produce a warning on a subsequent write to the same (pk, ck).
+    The set is grown across two sub-threshold writes so the coordinator-side
+    guardrail never warns; the merge of the second write caches the count,
+    and the third write triggers the memtable-level warning."""
+    with ExitStack() as cfg:
+        cfg.enter_context(config_value_context(cql,
+            'compaction_collection_elements_count_warning_threshold', '50'))
+        cfg.enter_context(config_value_context(cql,
+            'large_collection_elements_fail_threshold', '10000'))
+
+        schema = "pk int, ck int, s set<int>, PRIMARY KEY (pk, ck)"
+        with new_test_table(cql, test_keyspace, schema,
+                extra=" WITH large_data_guardrails_enabled = true") as tbl:
+            update = cql.prepare(f"UPDATE {tbl} SET s = s + ? WHERE pk = ? AND ck = ?")
+            # Write 1: create the row with 30 elements (< 50) — coordinator
+            # does not warn; a fresh row is not a merge, so it is not cached.
+            cql.execute(update, [set(range(30)), 1, 0])
+            # Write 2: add 30 more (< 50 in this mutation) — coordinator does
+            # not warn, but the merge caches the combined 60-element count.
+            cql.execute(update, [set(range(30, 60)), 1, 0])
+
+            # Write 3: check() finds the cached count → memtable warning.
+            cql.execute(update, [{998}, 1, 0])
+
+            wait_for_log(logfile, WARN_RE, timeout=5)


### PR DESCRIPTION
Replica-side large data guardrails only detected oversized rows and collections after an SSTable flush. This meant that a large row or collection written to the memtable would not be rejected until the memtable was flushed and the SSTable large-data index was populated. For workloads with infrequent flushes, this could allow many writes to accumulate before any guardrail fires.

Introduce a large_data_cache_tracker that hooks into mutation_partition_v2::apply_monotonically() to cache row sizes and collection element counts directly in the memtable path. On subsequent writes to the same (pk, ck), the guardrail's check() method consults these caches alongside the SSTable index, enabling rejection or warning without requiring a flush.

Backport is not required

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1825