### PR TITLE
[Backport 2025.1] Fix for auth version change during node startup

### DIFF
--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -122,7 +122,7 @@ future<> password_authenticator::migrate_legacy_metadata() const {
 }
 
 future<> password_authenticator::legacy_create_default_if_missing() {
-    const auto exists = co_await default_role_row_satisfies(_qp, &has_salted_hash, _superuser);
+    const auto exists = co_await legacy::default_role_row_satisfies(_qp, &has_salted_hash, _superuser);
     if (exists) {
         co_return;
     }
@@ -214,7 +214,7 @@ future<> password_authenticator::start() {
                 if (legacy_mode(_qp)) {
                     _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get();
 
-                    if (any_nondefault_role_row_satisfies(_qp, &has_salted_hash, _superuser).get()) {
+                    if (legacy::any_nondefault_role_row_satisfies(_qp, &has_salted_hash, _superuser).get()) {
                         if (legacy_metadata_exists()) {
                             plogger.warn("Ignoring legacy authentication metadata since nondefault data already exist.");
                         }
@@ -233,10 +233,21 @@ future<> password_authenticator::start() {
         });
 
         if (legacy_mode(_qp)) {
+            static const sstring create_roles_query = fmt::format(
+                    "CREATE TABLE {}.{} ("
+                    "  {} text PRIMARY KEY,"
+                    "  can_login boolean,"
+                    "  is_superuser boolean,"
+                    "  member_of set<text>,"
+                    "  salted_hash text"
+                    ")",
+                    meta::legacy::AUTH_KS,
+                    meta::roles_table::name,
+                    meta::roles_table::role_col_name);
             return create_legacy_metadata_table_if_missing(
                     meta::roles_table::name,
                     _qp,
-                    meta::roles_table::creation_query(),
+                    create_roles_query,
                     _migration_manager);
         }
         return make_ready_future<>();

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -101,7 +101,11 @@ future<> password_authenticator::migrate_legacy_metadata() const {
         return do_for_each(*results, [this](const cql3::untyped_result_set_row& row) {
             auto username = row.get_as<sstring>("username");
             auto salted_hash = row.get_as<sstring>(SALTED_HASH);
-            static const auto query = update_row_query();
+            static const auto query = seastar::format("UPDATE {}.{} SET {} = ? WHERE {} = ?",
+                    meta::legacy::AUTH_KS,
+                    meta::roles_table::name,
+                    SALTED_HASH,
+                    meta::roles_table::role_col_name);
             return _qp.execute_internal(
                     query,
                     consistency_for_user(username),
@@ -118,7 +122,6 @@ future<> password_authenticator::migrate_legacy_metadata() const {
 }
 
 future<> password_authenticator::legacy_create_default_if_missing() {
-    SCYLLA_ASSERT(legacy_mode(_qp));
     const auto exists = co_await default_role_row_satisfies(_qp, &has_salted_hash, _superuser);
     if (exists) {
         co_return;
@@ -127,7 +130,11 @@ future<> password_authenticator::legacy_create_default_if_missing() {
     if (salted_pwd.empty()) {
         salted_pwd = passwords::hash(DEFAULT_USER_PASSWORD, rng_for_salt);
     }
-    const auto query = update_row_query();
+    const auto query = seastar::format("UPDATE {}.{} SET {} = ? WHERE {} = ?",
+            meta::legacy::AUTH_KS,
+            meta::roles_table::name,
+            SALTED_HASH,
+            meta::roles_table::role_col_name);
     co_await _qp.execute_internal(
             query,
             db::consistency_level::QUORUM,

--- a/auth/roles-metadata.cc
+++ b/auth/roles-metadata.cc
@@ -47,7 +47,7 @@ future<bool> default_role_row_satisfies(
         std::function<bool(const cql3::untyped_result_set_row&)> p,
         std::optional<std::string> rolename) {
     const sstring query = seastar::format("SELECT * FROM {}.{} WHERE {} = ?",
-            get_auth_ks_name(qp),
+            meta::legacy::AUTH_KS,
             meta::roles_table::name,
             meta::roles_table::role_col_name);
 
@@ -68,7 +68,7 @@ future<bool> any_nondefault_role_row_satisfies(
         cql3::query_processor& qp,
         std::function<bool(const cql3::untyped_result_set_row&)> p,
         std::optional<std::string> rolename) {
-    const sstring query = seastar::format("SELECT * FROM {}.{}", get_auth_ks_name(qp), meta::roles_table::name);
+    const sstring query = seastar::format("SELECT * FROM {}.{}", meta::legacy::AUTH_KS, meta::roles_table::name);
 
     auto results = co_await qp.execute_internal(query, db::consistency_level::QUORUM
         , internal_distributed_query_state(), cql3::query_processor::cache_internal::no

--- a/auth/roles-metadata.hh
+++ b/auth/roles-metadata.hh
@@ -27,15 +27,15 @@ namespace meta {
 
 namespace roles_table {
 
-std::string_view creation_query();
-
 constexpr std::string_view name{"roles", 5};
 
 constexpr std::string_view role_col_name{"role", 4};
 
-}
+} // namespace roles_table
 
-}
+} // namespace meta
+
+namespace legacy {
 
 ///
 /// Check that the default role satisfies a predicate, or `false` if the default role does not exist.
@@ -55,4 +55,6 @@ future<bool> any_nondefault_role_row_satisfies(
         std::optional<std::string> rolename = {}
         );
 
-}
+} // namespace legacy
+
+} // namespace auth

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -181,14 +181,13 @@ future<> standard_role_manager::create_legacy_metadata_tables_if_missing() const
 }
 
 future<> standard_role_manager::legacy_create_default_role_if_missing() {
-    SCYLLA_ASSERT(legacy_mode(_qp));
     try {
         const auto exists = co_await default_role_row_satisfies(_qp, &has_can_login, _superuser);
         if (exists) {
             co_return;
         }
         const sstring query = seastar::format("INSERT INTO {}.{} ({}, is_superuser, can_login) VALUES (?, true, true)",
-                get_auth_ks_name(_qp),
+                meta::legacy::AUTH_KS,
                 meta::roles_table::name,
                 meta::roles_table::role_col_name);
         co_await _qp.execute_internal(
@@ -283,7 +282,7 @@ future<> standard_role_manager::migrate_legacy_metadata() {
                     std::move(config),
                     ::service::group0_batch::unused(),
                     [this](const auto& name, const auto& config, auto& mc) {
-                return create_or_replace(name, config, mc);
+                return create_or_replace(meta::legacy::AUTH_KS, name, config, mc);
             });
         }).finally([results] {});
     }).then([] {
@@ -344,12 +343,12 @@ future<> standard_role_manager::ensure_superuser_is_created() {
     return _superuser_created_promise.get_shared_future();
 }
 
-future<> standard_role_manager::create_or_replace(std::string_view role_name, const role_config& c, ::service::group0_batch& mc) {
+future<> standard_role_manager::create_or_replace(std::string_view auth_ks_name, std::string_view role_name, const role_config& c, ::service::group0_batch& mc) {
     const sstring query = seastar::format("INSERT INTO {}.{} ({}, is_superuser, can_login) VALUES (?, ?, ?)",
-            get_auth_ks_name(_qp),
+            auth_ks_name,
             meta::roles_table::name,
             meta::roles_table::role_col_name);
-    if (legacy_mode(_qp)) {
+    if (auth_ks_name == meta::legacy::AUTH_KS) {
         co_await _qp.execute_internal(
                 query,
                 consistency_for_role(role_name),
@@ -368,7 +367,7 @@ standard_role_manager::create(std::string_view role_name, const role_config& c, 
             throw role_already_exists(role_name);
         }
 
-        return create_or_replace(role_name, c, mc);
+        return create_or_replace(get_auth_ks_name(_qp), role_name, c, mc);
     });
 }
 

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -49,22 +49,11 @@ constexpr std::string_view name{"role_members" , 12};
 }
 
 namespace role_attributes_table {
+
 constexpr std::string_view name{"role_attributes", 15};
 
-static std::string_view creation_query() noexcept {
-    static const sstring instance = seastar::format(
-            "CREATE TABLE {}.{} ("
-            "  role text,"
-            "  name text,"
-            "  value text,"
-            "  PRIMARY KEY(role, name)"
-            ")",
-            meta::legacy::AUTH_KS,
-            name);
+}
 
-    return instance;
-}
-}
 }
 
 static logging::logger log("standard_role_manager");
@@ -152,6 +141,17 @@ const resource_set& standard_role_manager::protected_resources() const {
 }
 
 future<> standard_role_manager::create_legacy_metadata_tables_if_missing() const {
+    static const sstring create_roles_query = fmt::format(
+            "CREATE TABLE {}.{} ("
+            "  {} text PRIMARY KEY,"
+            "  can_login boolean,"
+            "  is_superuser boolean,"
+            "  member_of set<text>,"
+            "  salted_hash text"
+            ")",
+            meta::legacy::AUTH_KS,
+            meta::roles_table::name,
+            meta::roles_table::role_col_name);
     static const sstring create_role_members_query = fmt::format(
             "CREATE TABLE {}.{} ("
             "  role text,"
@@ -160,13 +160,20 @@ future<> standard_role_manager::create_legacy_metadata_tables_if_missing() const
             ")",
             meta::legacy::AUTH_KS,
             meta::role_members_table::name);
-
-
+    static const sstring create_role_attributes_query = seastar::format(
+            "CREATE TABLE {}.{} ("
+            "  role text,"
+            "  name text,"
+            "  value text,"
+            "  PRIMARY KEY(role, name)"
+            ")",
+            meta::legacy::AUTH_KS,
+            meta::role_attributes_table::name);
     return when_all_succeed(
             create_legacy_metadata_table_if_missing(
                     meta::roles_table::name,
                     _qp,
-                    meta::roles_table::creation_query(),
+                    create_roles_query,
                     _migration_manager),
             create_legacy_metadata_table_if_missing(
                     meta::role_members_table::name,
@@ -176,13 +183,13 @@ future<> standard_role_manager::create_legacy_metadata_tables_if_missing() const
             create_legacy_metadata_table_if_missing(
                     meta::role_attributes_table::name,
                     _qp,
-                    meta::role_attributes_table::creation_query(),
+                    create_role_attributes_query,
                     _migration_manager)).discard_result();
 }
 
 future<> standard_role_manager::legacy_create_default_role_if_missing() {
     try {
-        const auto exists = co_await default_role_row_satisfies(_qp, &has_can_login, _superuser);
+        const auto exists = co_await legacy::default_role_row_satisfies(_qp, &has_can_login, _superuser);
         if (exists) {
             co_return;
         }
@@ -307,7 +314,7 @@ future<> standard_role_manager::start() {
                 }
                 co_await _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as);
 
-                if (co_await any_nondefault_role_row_satisfies(_qp, &has_can_login)) {
+                if (co_await legacy::any_nondefault_role_row_satisfies(_qp, &has_can_login)) {
                     if (legacy_metadata_exists()) {
                         log.warn("Ignoring legacy user metadata since nondefault roles already exist.");
                     }

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -100,7 +100,7 @@ private:
     future<> maybe_create_default_role();
     future<> maybe_create_default_role_with_retries();
 
-    future<> create_or_replace(std::string_view role_name, const role_config&, ::service::group0_batch&);
+    future<> create_or_replace(std::string_view auth_ks_name, std::string_view role_name, const role_config&, ::service::group0_batch&);
 
     future<> legacy_modify_membership(std::string_view role_name, std::string_view grantee_name, membership_change);
 


### PR DESCRIPTION
## Summary

Before this patch we may trigger SCYLLA_ASSERT(legacy_mode(_qp)).
That's because some auth startup is done in the background
and assumes that auth version doesn't change in the middle
of the startup. But topology coordinator may decide to do
the migration at any time, regadless if auth service is
fully started on all nodes.

This change makes sure that in legacy startup flow we'll
always use old auth-v1 keyspace and therefore auth version
change in the middle won't negatively affect the flow.

Crash seen in dtest-release during upgrade from 2024.1 to 2025.1:
```
auth/standard_role_manager.cc:184: Assertion `legacy_mode(_qp)' failed.
```

Fixes SCYLLADB-1918
Refs SCYLLADB-1195

(cherry picked from commit 793a64a50e6492307db9f488b1e90fb977c72aa8)

Parent PR: #25949