### PR TITLE
[Backport 2026.1] test: fix flaky test_incremental_repair_race_window_promotes_unrepaired_data

### DIFF
--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -9,7 +9,7 @@ from test.cluster.conftest import skip_mode
 from test.pylib.repair import load_tablet_sstables_repaired_at, create_table_insert_data_for_repair
 from test.pylib.tablets import get_all_tablet_replicas
 from test.cluster.tasks.task_manager_client import TaskManagerClient
-from test.cluster.util import reconnect_driver, find_server_by_host_id, get_topology_coordinator, new_test_keyspace, new_test_table, trigger_stepdown
+from test.cluster.util import reconnect_driver, find_server_by_host_id, get_topology_coordinator, ensure_group0_leader_on, new_test_keyspace, new_test_table, trigger_stepdown
 
 from cassandra.query import ConsistencyLevel
 
@@ -965,8 +965,18 @@ async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: 
         await manager.api.flush_keyspace(s.ip_addr, ks)
     current_key += 10
 
+    # Ensure servers[1] is not the topology coordinator.  If the coordinator is
+    # restarted, the Raft leader dies, a new election occurs, and the new
+    # coordinator re-initiates tablet repair -- flushing memtables on all replicas
+    # and marking post-repair data as repaired.  That legitimate re-repair masks
+    # the compaction-merge bug this test detects.
     coord = await get_topology_coordinator(manager)
     coord_serv = await find_server_by_host_id(manager, servers, coord)
+    if coord_serv == servers[1]:
+        other = next(s for s in servers if s != servers[1])
+        await ensure_group0_leader_on(manager, other)
+        coord = await get_topology_coordinator(manager)
+        coord_serv = await find_server_by_host_id(manager, servers, coord)
     coord_log = await manager.server_open_log(coord_serv.server_id)
     coord_mark = await coord_log.mark()
 

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -980,18 +980,27 @@ async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: 
     )
     task_id = repair_response['tablet_task_id']
 
-    # "Finished tablet repair" is logged once per tablet after mark_sstable_as_repaired()
-    # has completed on all replicas for that tablet.  With tablets=2 the coordinator logs
-    # this message twice (once per tablet).  We must wait for BOTH before writing
-    # post-repair keys; waiting for only the first leaves the second tablet's repair in
-    # progress, which can flush the memtable and mark newly-flushed sstables as repaired,
-    # contaminating servers[0] and servers[2] with post-repair data in repaired sstables.
+    # The topology coordinator logs "Finished tablet repair host=..." once per tablet
+    # after mark_sstable_as_repaired() has completed on all replicas for that tablet.
+    # With tablets=2, the coordinator logs this message twice (once per tablet).
+    # We must wait for BOTH before writing post-repair keys; waiting for only the
+    # first leaves the second tablet's repair in progress, which can flush the
+    # memtable and mark newly-flushed sstables as repaired, contaminating servers[0]
+    # and servers[2] with post-repair data in repaired sstables.
+    #
+    # IMPORTANT: We match "Finished tablet repair host=" specifically to avoid
+    # matching the repair module's "Finished tablet repair for table=..." message
+    # (repair/repair.cc), which is also logged on this node when the coordinator
+    # happens to be a repair replica.  Both messages appear for the same tablet,
+    # so the generic "Finished tablet repair" pattern would consume two messages
+    # for one tablet and miss the second tablet entirely.
+    #
     # After both tablets complete, S1 is fully rewritten as S1'(repaired_at=2,
-    # being_repaired=null) on every replica, but sstables_repaired_at in system.tablets is
+    # being_repaired=session_id) on every replica, but sstables_repaired_at in system.tablets is
     # still 1, so is_repaired(1, S1'{repaired_at=2}) == false and S1' lands in the
     # UNREPAIRED compaction view on every replica. The race window is now open.
-    pos, _ = await coord_log.wait_for("Finished tablet repair", from_mark=coord_mark)
-    await coord_log.wait_for("Finished tablet repair", from_mark=pos)
+    pos, _ = await coord_log.wait_for("Finished tablet repair host=", from_mark=coord_mark)
+    await coord_log.wait_for("Finished tablet repair host=", from_mark=pos)
 
     # --- Race window is open ---
     # Write post-repair keys 20-29.  All nodes receive the writes into their memtables

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -9,7 +9,7 @@ from test.cluster.conftest import skip_mode
 from test.pylib.repair import load_tablet_sstables_repaired_at, create_table_insert_data_for_repair
 from test.pylib.tablets import get_all_tablet_replicas
 from test.cluster.tasks.task_manager_client import TaskManagerClient
-from test.cluster.util import reconnect_driver, find_server_by_host_id, get_topology_coordinator, ensure_group0_leader_on, new_test_keyspace, new_test_table, trigger_stepdown
+from test.cluster.util import reconnect_driver, find_server_by_host_id, get_topology_coordinator, ensure_group0_leader_on, create_new_test_keyspace, new_test_keyspace, new_test_table, trigger_stepdown
 
 from cassandra.query import ConsistencyLevel
 
@@ -932,12 +932,24 @@ async def test_tablet_incremental_repair_table_drop_compaction_group_gone(manage
 # affected replica but process the UNREPAIRED sstable on the others, so the classification
 # divergence is never corrected. In tombstone scenarios this enables premature tombstone GC
 # on the affected replica leading to data resurrection.
-@pytest.mark.asyncio
-@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: ManagerClient):
-    cmdline = ['--hinted-handoff-enabled', '0']
-    servers, cql, hosts, ks, table_id, logs, _, _, current_key, token = \
-        await prepare_cluster_for_incremental_repair(manager, nr_keys=10, cmdline=cmdline, tablets=2)
+class _LeadershipTransferred(Exception):
+    """Raised when leadership transferred to servers[1] during the test, requiring a retry."""
+    pass
+
+async def _setup_table_for_race_window(manager, servers, cql):
+    """Create a fresh keyspace+table with incremental repair setup for the race window test.
+
+    Creates a new keyspace (unique name each call), creates the table with
+    tombstone_gc=repair and STCS min_threshold=2, inserts keys 0-9 as baseline,
+    runs repair 1 (sstables_repaired_at=1), then inserts keys 10-19 (subject
+    of repair 2) and flushes all nodes.
+
+    Returns (ks, current_key) where current_key is 20.
+    """
+    ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', "
+                  "'replication_factor': 3} AND tablets = {'initial': 2};")
+    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) "
+                        f"WITH tombstone_gc = {{'mode':'repair'}};")
 
     # Lower min_threshold to 2 so STCS fires as soon as two sstables appear in the
     # UNREPAIRED compaction view, making the race easy to trigger deterministically.
@@ -946,25 +958,35 @@ async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: 
         f"{{'class': 'SizeTieredCompactionStrategy', 'min_threshold': 2, 'max_threshold': 4}}"
     )
 
+    # Insert keys 0-9 (baseline for repair 1).
+    keys = list(range(0, 10))
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k})") for k in keys])
+
     # Disable autocompaction everywhere so we control exactly when compaction runs.
     for s in servers:
         await manager.api.disable_autocompaction(s.ip_addr, ks, 'test')
 
-    scylla_path = await manager.server_get_exe(servers[0].server_id)
-
     # Repair 1: establishes sstables_repaired_at=1 on all nodes.
-    # Keys 0-9 (inserted by prepare_cluster_for_incremental_repair) end up in
-    # S0'(repaired_at=1) on all nodes.
-    await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", token, incremental_mode='incremental')
+    # Keys 0-9 end up in S0'(repaired_at=1) on all nodes.
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", 'all', incremental_mode='incremental')
 
-    # Insert keys 10-19 and flush on all nodes → S1(repaired_at=0).
+    # Insert keys 10-19 and flush on all nodes -> S1(repaired_at=0).
     # These will be the subject of repair 2.
-    repair2_keys = list(range(current_key, current_key + 10))
+    repair2_keys = list(range(10, 20))
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k})") for k in repair2_keys])
     for s in servers:
         await manager.api.flush_keyspace(s.ip_addr, ks)
-    current_key += 10
 
+    return ks, 20
+
+async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, token, scylla_path, current_key):
+    """Core logic for test_incremental_repair_race_window_promotes_unrepaired_data.
+
+    Returns the next current_key value.
+    Raises _LeadershipTransferred if the topology coordinator changes or if a
+    residual re-repair is detected, signalling the caller to retry with a fresh
+    keyspace.
+    """
     # Ensure servers[1] is not the topology coordinator.  If the coordinator is
     # restarted, the Raft leader dies, a new election occurs, and the new
     # coordinator re-initiates tablet repair -- flushing memtables on all replicas
@@ -1010,7 +1032,7 @@ async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: 
     # still 1, so is_repaired(1, S1'{repaired_at=2}) == false and S1' lands in the
     # UNREPAIRED compaction view on every replica. The race window is now open.
     pos, _ = await coord_log.wait_for("Finished tablet repair host=", from_mark=coord_mark)
-    await coord_log.wait_for("Finished tablet repair host=", from_mark=pos)
+    post_marks_pos, _ = await coord_log.wait_for("Finished tablet repair host=", from_mark=pos)
 
     # --- Race window is open ---
     # Write post-repair keys 20-29.  All nodes receive the writes into their memtables
@@ -1040,6 +1062,29 @@ async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: 
     await manager.server_start(target.server_id)
     await manager.servers_see_each_other(servers)
 
+    # Check if leadership transferred during the restart.  Any coordinator
+    # change (not just to servers[1]) can trigger a residual re-repair that
+    # flushes memtables on all replicas and marks post-repair data as repaired,
+    # masking the bug this test detects.
+    new_coord = await get_topology_coordinator(manager)
+    if new_coord != coord:
+        await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
+        await manager.api.wait_task(servers[0].ip_addr, task_id)
+        raise _LeadershipTransferred(
+            f"topology coordinator changed from {coord} to {new_coord} after restart")
+
+    # Even without a coordinator change, check if the coordinator initiated a
+    # residual re-repair (e.g. after seeing tablets stuck in the repair stage
+    # following the topology restart).  Such a re-repair flushes memtables on
+    # all replicas and contaminates the repaired set with post-repair data.
+    rerepair_matches = await coord_log.grep("Initiating tablet repair host=", from_mark=post_marks_pos)
+    if rerepair_matches:
+        logger.warning(f"Coordinator initiated residual re-repair post-restart: {rerepair_matches[0][1]}")
+        await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
+        await manager.api.wait_task(servers[0].ip_addr, task_id)
+        raise _LeadershipTransferred(
+            "coordinator initiated residual re-repair after restart")
+
     # Poll until compaction has produced F(repaired_at=2) containing post-repair keys,
     # confirming that the bug was triggered (S1' and E merged during the race window).
     deadline = time.time() + 60
@@ -1053,16 +1098,32 @@ async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: 
                     break
         if compaction_ran:
             break
+        # Check for residual re-repair during the polling window.
+        rerepair_matches = await coord_log.grep("Initiating tablet repair host=", from_mark=post_marks_pos)
+        if rerepair_matches:
+            logger.warning(f"Coordinator initiated residual re-repair during poll: {rerepair_matches[0][1]}")
+            await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
+            await manager.api.wait_task(servers[0].ip_addr, task_id)
+            raise _LeadershipTransferred(
+                "coordinator initiated residual re-repair during compaction poll")
         await asyncio.sleep(1)
 
     # --- Release the race window ---
     await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
     await manager.api.wait_task(servers[0].ip_addr, task_id)
 
+    # Final re-repair check after injection release: the coordinator may have
+    # queued a re-repair that only executes once the injection is lifted.
+    rerepair_matches = await coord_log.grep("Initiating tablet repair host=", from_mark=post_marks_pos)
+    if rerepair_matches:
+        logger.warning(f"Coordinator initiated residual re-repair after injection release: {rerepair_matches[0][1]}")
+        raise _LeadershipTransferred(
+            "coordinator initiated residual re-repair after injection release")
+
     if not compaction_ran:
         logger.warning("Compaction did not merge S1' and E after restart during the race window; "
                        "the bug was not triggered.  Skipping assertion.")
-        return
+        return current_key
 
     # Flush servers[0] and servers[2] AFTER the race window closes so their post-repair
     # keys land in G(repaired_at=0): correctly classified as UNREPAIRED.
@@ -1093,8 +1154,9 @@ async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: 
                 f"servers[1]={len(repaired_keys_1 & post_repair_key_set)}, "
                 f"servers[2]={len(repaired_keys_2 & post_repair_key_set)}")
 
-    # servers[0] and servers[2] flushed post-repair keys after the race window closed,
-    # so those keys are in G(repaired_at=0) → correctly UNREPAIRED.
+    # servers[0] and servers[2] were never restarted and the coordinator stayed
+    # alive throughout, so no re-repair could have flushed their memtables.
+    # Post-repair keys must NOT appear in repaired sstables on these servers.
     assert not (repaired_keys_0 & post_repair_key_set), \
         f"servers[0] should not have post-repair keys in repaired sstables, " \
         f"got: {repaired_keys_0 & post_repair_key_set}"
@@ -1115,3 +1177,32 @@ async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: 
         f"on servers[1] after restart lost the being_repaired markers during the race window. " \
         f"They are UNREPAIRED on servers[0] and servers[2] (classification divergence). " \
         f"Wrongly promoted (first 10): {sorted(wrongly_promoted)[:10]}"
+    return current_key
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: ManagerClient):
+    cmdline = ['--hinted-handoff-enabled', '0']
+    servers, cql, hosts, _, _, _, _, _, _, _ = \
+        await prepare_cluster_for_incremental_repair(manager, nr_keys=10, cmdline=cmdline, tablets=2)
+
+    scylla_path = await manager.server_get_exe(servers[0].server_id)
+
+    ks, current_key = await _setup_table_for_race_window(manager, servers, cql)
+
+    # If leadership transfers or a residual re-repair is triggered between our
+    # coordinator check and the restart, the coordinator change masks the bug.
+    # Detect and retry with a fresh keyspace.
+    max_attempts = 5
+    for attempt in range(1, max_attempts + 1):
+        try:
+            current_key = await _do_race_window_promotes_unrepaired_data(
+                manager, servers, cql, ks, 'all', scylla_path, current_key)
+            return
+        except _LeadershipTransferred as e:
+            logger.warning(f"Attempt {attempt}/{max_attempts}: {e}.  Retrying.")
+            ks, current_key = await _setup_table_for_race_window(manager, servers, cql)
+
+    pytest.fail(f"Leadership kept transferring to servers[1] after {max_attempts} attempts; "
+                "could not run the test without coordinator interference.")
+


### PR DESCRIPTION
The test waited for two "Finished tablet repair" log messages on the
coordinator, expecting one per tablet.  But there are two log sources
that emit messages matching this pattern:

  repair module (repair/repair.cc:2329):
    "Finished tablet repair for table=..."
  topology coordinator (topology_coordinator.cc:2083):
    "Finished tablet repair host=..."

When the coordinator is also a repair replica (always the case with
RF=3 and 3 nodes), both messages appear in the coordinator log for the
same tablet within 1ms of each other.  The test consumed both, thinking
both tablets were done, while the second tablet repair was still running.

From the CI failure logs:

  04:08:09.658 Found: repair[...]: Finished tablet repair for table=...
    global_tablet_id=e42fd650-3542-11f1-9756-85403784a622:0
  04:08:09.660 Found: raft_topology - Finished tablet repair host=...
    tablet=e42fd650-3542-11f1-9756-85403784a622:0

Both messages are for tablet :0.  Tablet :1 repair had not finished yet.

The test then wrote keys 20-29 while the second tablet repair was still
in progress.  That repair flushed the memtable (via
prepare_sstables_for_incremental_repair), including keys 20-29 in the
repair scan, and mark_sstable_as_repaired set repaired_at=2 on the
resulting sstable.  This caused the assertion failure on servers[0]:
  "should not have post-repair keys in repaired sstables, got:
   {20, 21, 22, 23, 24, 25, 26, 27, 28, 29}"

Fix by matching "Finished tablet repair host=" which is unique to the
topology coordinator message and avoids the ambiguity.

Also fix an incorrect comment that said being_repaired=null when at that
point in the test being_repaired is still set to the session_id (the
delay_end_repair_update injection prevents end_repair from running).

Fixes: [SCYLLADB-1478](https://scylladb.atlassian.net/browse/SCYLLADB-1478)

Closes https://github.com/scylladb/scylladb/pull/29444

(cherry picked from commit https://github.com/scylladb/scylladb/commit/ebdfa10c8f09983721224f5083f3689272828f33)
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1903

[SCYLLADB-1478]: https://scylladb.atlassian.net/browse/SCYLLADB-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ