### PR TITLE
doc: label Migration from Vnodes to Tablets as experimental

### DIFF
--- a/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
+++ b/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
@@ -1,5 +1,5 @@
-Migrate a Keyspace from Vnodes to Tablets
-==========================================
+Migrate a Keyspace from Vnodes to Tablets :label-caution:`Experimental`
+=========================================================================
 
 This procedure describes how to migrate an existing keyspace from vnodes
 to tablets. Tablets are designed to be the long-term replacement for vnodes,
@@ -7,6 +7,9 @@ offering numerous benefits such as faster topology operations, automatic load
 balancing, automatic cleanups, and improved streaming performance. Migrating to
 tablets is strongly recommended. See :doc:`Data Distribution with Tablets </architecture/tablets/>`
 for details.
+
+ℹ️ This feature is experimental and will change in future releases, including
+the removal of current limitations.
 
 .. note::
 


### PR DESCRIPTION
The procedure to migrate a vnodes-based keyspace to tablets-based keyspace has been labeled as experimental.

Fixes SCYLLADB-1932

This PR should be backported to branch-2026.2 as the feature is experimental in version 2026.2