### PR TITLE
fix: raise scylla-helper.slice CPUWeight to prevent node_exporter timeouts

### DIFF
--- a/dist/common/systemd/scylla-helper.slice
+++ b/dist/common/systemd/scylla-helper.slice
@@ -7,7 +7,7 @@ MemoryAccounting=true
 IOAccounting=true
 CPUAccounting=true
 
-CPUWeight=10
+CPUWeight=100
 IOWeight=10
 
 # MemoryHigh is the throttle point


### PR DESCRIPTION
Under heavy load on 2-vCPU instances, node_exporter gets starved of CPU cycles due to the 1:100 CPUWeight ratio between scylla-helper.slice (10) and scylla-server.slice (1000). This causes scrape timeouts and false-positive InstanceDown alerts.

This change raises scylla-helper.slice CPUWeight from 10 to 100, giving helper services a 1:10 ratio instead. This ensures node_exporter can respond to Prometheus scrapes even under maximum Scylla load.

Changes:
- dist/common/systemd/scylla-helper.slice: CPUWeight 10 → 100

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-781

cc: @d-helios @adambabik 