### PR TITLE
alternator: make RF on new tables configurable

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -141,7 +141,10 @@ extern const sstring SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANG
 // Setting this tag to any non-numeric value (e.g., an empty string or the
 // word "none") will ask to disable tablets.
 static constexpr auto INITIAL_TABLETS_TAG_KEY = "system:initial_tablets";
-
+// Setting this tag with a numeric value on a table being created will
+// determine its replication factor (in each DC), instead of the default
+// (RF=3 on clusters with 3 or more nodes, RF=1 on smaller clusters).
+static constexpr auto REPLICATION_FACTOR_TAG_KEY = "system:replication_factor";
 
 enum class table_status {
     active = 0,
@@ -1013,18 +1016,25 @@ void rmw_operation::set_default_write_isolation(std::string_view value) {
 // Alternator uses tags whose keys start with the "system:" prefix for
 // internal purposes. Those should not be readable by ListTagsOfResource,
 // nor writable with TagResource or UntagResource (see #24098).
-// Only a few specific system tags, currently only "system:write_isolation"
-// and "system:initial_tablets", are deliberately intended to be set and read
-// by the user, so are not considered "internal".
+// Only a few specific system tags, currently only "system:write_isolation",
+// "system:initial_tablets", and "system:replication_factor", are deliberately
+// intended to be set and read by the user, so are not considered "internal".
 static bool tag_key_is_internal(std::string_view tag_key) {
     return tag_key.starts_with("system:")
         && tag_key != rmw_operation::WRITE_ISOLATION_TAG_KEY
-        && tag_key != INITIAL_TABLETS_TAG_KEY;
+        && tag_key != INITIAL_TABLETS_TAG_KEY
+        && tag_key != REPLICATION_FACTOR_TAG_KEY;
 }
 
-enum class update_tags_action { add_tags, delete_tags };
+// "add_tags_initial" is used when adding tags while the table is being created
+// (CreateTable). "add_tags" is used for subsequent tag updates (TagResource),
+// and "delete_tags" is used for removing tags (UntagResource).
+// The main distinction between "add_tags" and "add_tags_initial" is to let us
+// permit setting some tags when the table is being created, but forbid
+// changing these tags later.
+enum class update_tags_action { add_tags, add_tags_initial, delete_tags };
 static void update_tags_map(const rjson::value& tags, std::map<sstring, sstring>& tags_map, update_tags_action action) {
-    if (action == update_tags_action::add_tags) {
+    if (action == update_tags_action::add_tags || action == update_tags_action::add_tags_initial) {
         for (auto it = tags.Begin(); it != tags.End(); ++it) {
             if (!it->IsObject()) {
                 throw api_error::validation("invalid tag object");
@@ -1049,6 +1059,19 @@ static void update_tags_map(const rjson::value& tags, std::map<sstring, sstring>
             if (tag_key_is_internal(tag_key)) {
                 throw api_error::validation(fmt::format("Tag key '{}' is reserved for internal use", tag_key));
             }
+            // system:replication_factor only takes effect during CreateTable.
+            // On subsequent tag updates (add_tags, not add_tags_initial), only
+            // allow setting it to the same value it already has (a no-op);
+            // reject any attempt to change it or introduce it on an existing table.
+            if (action == update_tags_action::add_tags && tag_key == REPLICATION_FACTOR_TAG_KEY) {
+                auto existing = tags_map.find(sstring(tag_key));
+                if (existing == tags_map.end() || existing->second != sstring(tag_value)) {
+                    throw api_error::validation(fmt::format(
+                        "Tag '{}' can only be set during CreateTable and cannot be changed afterwards",
+                        REPLICATION_FACTOR_TAG_KEY));
+                }
+                continue; // same value - silently allow
+            }
             // Note tag values are limited similarly to tag keys, but have a
             // longer length limit, and *can* be empty.
             if (tag_value.size() > 256) {
@@ -1064,6 +1087,11 @@ static void update_tags_map(const rjson::value& tags, std::map<sstring, sstring>
             auto tag_key = rjson::to_string_view(*it);
             if (tag_key_is_internal(tag_key)) {
                 throw api_error::validation(fmt::format("Tag key '{}' is reserved for internal use", tag_key));
+            }
+            if (tag_key == REPLICATION_FACTOR_TAG_KEY) {
+                throw api_error::validation(fmt::format(
+                    "Tag '{}' can only be set during CreateTable and cannot be changed afterwards",
+                    REPLICATION_FACTOR_TAG_KEY));
             }
             tags_map.erase(sstring(tag_key));
         }
@@ -1694,7 +1722,7 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
     const rjson::value* tags = rjson::find(request, "Tags");
     std::map<sstring, sstring> tags_map;
     if (tags && tags->IsArray()) {
-        update_tags_map(*tags, tags_map, update_tags_action::add_tags);
+        update_tags_map(*tags, tags_map, update_tags_action::add_tags_initial);
     }
     if (bm.provisioned) {
         tags_map[RCU_TAG_KEY] = std::to_string(bm.rcu);
@@ -4605,12 +4633,52 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
         }
     }
 
-    int endpoint_count = gossiper.num_endpoints();
-    int rf = 3;
-    if (endpoint_count < rf) {
-        rf = 1;
-        elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} because cluster only has {} nodes.",
-                     keyspace_name, rf, endpoint_count);
+    // The system:replication_factor tag allows overriding the default RF per DC.
+    int rf;
+    auto rf_tag_it = tags_map.find(REPLICATION_FACTOR_TAG_KEY);
+    if (rf_tag_it != tags_map.end()) {
+        const auto& s = rf_tag_it->second;
+        int requested_rf = 0;
+        auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), requested_rf);
+        if (ec != std::errc{} || ptr != s.data() + s.size() || requested_rf < 1) {
+            throw api_error::validation(fmt::format("Tag {} value must be a positive integer", REPLICATION_FACTOR_TAG_KEY));
+        }
+        // Validate the requested RF against the topology constraints that
+        // the downstream DDL code would enforce, to produce a user-friendly
+        // ValidationException instead of an InternalServerError:
+        // - With tablets, expand_to_racks() in ks_prop_defs.cc enforces
+        //   RF <= rack count per DC.
+        // - With vnodes, check_enough_endpoints() in network_topology_strategy.cc
+        //   enforces RF <= node count per DC.
+        for (const auto& [dc, racks] : sp.get_token_metadata_ptr()->get_datacenter_racks_token_owners()) {
+            if (initial_tablets) {
+                int num_racks = static_cast<int>(racks.size());
+                if (requested_rf > num_racks) {
+                    throw api_error::validation(fmt::format(
+                        "Tag {} value {} exceeds the number of racks ({}) in datacenter {}",
+                        REPLICATION_FACTOR_TAG_KEY, requested_rf, num_racks, dc));
+                }
+            } else {
+                int num_nodes = 0;
+                for (const auto& [rack, hosts] : racks) {
+                    num_nodes += static_cast<int>(hosts.size());
+                }
+                if (requested_rf > num_nodes) {
+                    throw api_error::validation(fmt::format(
+                        "Tag {} value {} exceeds the number of nodes ({}) in datacenter {}",
+                        REPLICATION_FACTOR_TAG_KEY, requested_rf, num_nodes, dc));
+                }
+            }
+        }
+        rf = requested_rf;
+    } else {
+        int endpoint_count = gossiper.num_endpoints();
+        rf = 3;
+        if (endpoint_count < rf) {
+            rf = 1;
+            elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} because cluster only has {} nodes.",
+                         keyspace_name, rf, endpoint_count);
+        }
     }
     auto opts = get_network_topology_options(sp, gossiper, rf);
     cql3::statements::ks_prop_defs props;

--- a/docs/alternator/new-apis.md
+++ b/docs/alternator/new-apis.md
@@ -207,3 +207,27 @@ in the CreateTable operation. The value of this tag can be:
 The `system:initial_tablets` tag only has any effect while creating
 a new table with CreateTable - changing it later has no effect.
 
+## Replication factor
+
+By default, Alternator creates each table's keyspace with a replication
+factor (RF) of 3 in each datacenter, or RF=1 when the cluster has fewer
+than 3 nodes. The replication factor controls how many copies of each row
+are stored across the cluster.
+
+To override this default for a specific table, set the
+`system:replication_factor` tag to a positive integer in the CreateTable
+operation. For example, on a cluster with 5 racks you might set this tag
+to `5` so that each rack holds a full replica of the data.
+
+The value must be a positive integer. The maximum allowed RF depends on
+the table's replication mode: for tables using tablets (the default), RF
+must not exceed the number of racks in any datacenter; for tables using
+vnodes, RF must not exceed the number of nodes in any datacenter.
+Exceeding the limit causes a `ValidationException`.
+
+The `system:replication_factor` tag can only be set during CreateTable.
+Attempting to add, change, or remove it via TagResource or UntagResource
+after the table has been created will result in a `ValidationException`.
+Support for changing a table's replication factor after creation may be
+added in a future version.
+

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -28,7 +28,7 @@ import threading
 import random
 import re
 
-from test.cluster.util import get_replication
+from test.cluster.util import get_replication, get_replica_count
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for
 from test.pylib.rest_client import inject_error
@@ -1520,3 +1520,199 @@ async def test_deferred_stream_enablement_on_tablets(manager: ManagerClient):
     finally:
         table.delete()
         table.meta.client.get_waiter('table_not_exists').wait(TableName=table.name)
+
+async def test_alternator_rf_on_5_racks(manager: ManagerClient):
+    """Test that when an Alternator cluster is started with 5 nodes each on a
+       separate rack, the RF on the keyspace created for a new Alternator table
+       is correct:
+       - By default (no tag), RF=3 regardless of the number of racks.
+       - When the system:replication_factor tag is set to 5, RF=5 (one replica
+         per rack, so each rack holds a full copy of the data).
+       - Similarly, system:replication_factor = 1 is also allowed.
+       - When the system:replication_factor tag is set to 6 (more than the
+         number of nodes or racks), CreateTable fails with a ValidationException.
+    """
+    # Start 5 nodes in dc1, each in its own rack (rack1...rack5), one node per rack.
+    servers = await manager.servers_add(5, config=alternator_config, auto_rack_dc='dc1')
+    alternator = get_alternator(servers[0].ip_addr)
+    cql = manager.get_cql()
+    for (tags, expected_rf) in [
+        ([], 3),
+        ([{'Key': 'system:replication_factor', 'Value': '1'}], 1),
+        ([{'Key': 'system:replication_factor', 'Value': '5'}], 5),
+    ]:
+        table = alternator.create_table(TableName=unique_table_name(),
+            Tags=tags,
+            BillingMode='PAY_PER_REQUEST',
+            KeySchema=[
+                {'AttributeName': 'p', 'KeyType': 'HASH'},
+            ],
+            AttributeDefinitions=[
+                {'AttributeName': 'p', 'AttributeType': 'N'},
+            ])
+        try:
+            ks = f'alternator_{table.name}'
+            repl = get_replication(cql, ks)
+            assert 'dc1' in repl
+            assert get_replica_count(repl['dc1']) == expected_rf
+        finally:
+            table.delete()
+    # RF=6 exceeds the number of racks (5) in dc1, so CreateTable should fail.
+    with pytest.raises(ClientError, match='ValidationException.*system:replication_factor.*number of racks'):
+        alternator.create_table(TableName=unique_table_name(),
+            Tags=[{'Key': 'system:replication_factor', 'Value': '6'}],
+            BillingMode='PAY_PER_REQUEST',
+            KeySchema=[
+                {'AttributeName': 'p', 'KeyType': 'HASH'},
+            ],
+            AttributeDefinitions=[
+                {'AttributeName': 'p', 'AttributeType': 'N'},
+            ])
+    # Non-integer, non-positive, and partially-numeric values must be rejected
+    # with a ValidationException. In particular, "5abc" must not be silently
+    # accepted as 5.
+    for bad_rf in ['abc', '5abc', '5.0', '5e1', '0', '-1']:
+        with pytest.raises(ClientError, match='ValidationException.*system:replication_factor.*positive integer'):
+            alternator.create_table(TableName=unique_table_name(),
+                Tags=[{'Key': 'system:replication_factor', 'Value': bad_rf}],
+                BillingMode='PAY_PER_REQUEST',
+                KeySchema=[
+                    {'AttributeName': 'p', 'KeyType': 'HASH'},
+                ],
+                AttributeDefinitions=[
+                    {'AttributeName': 'p', 'AttributeType': 'N'},
+                ])
+
+async def test_alternator_replication_factor_tag_immutable(manager: ManagerClient):
+    """Test that the system:replication_factor tag cannot be added or changed
+    after a table is created via TagResource/UntagResource.
+
+    Currently, changing this tag after table creation has no effect on the
+    actual replication factor. To avoid silently accepting a tag change that
+    does nothing, we reject such changes with a ValidationException.
+
+    As explained in issue #5092, eventually we should implement support for
+    changing the RF of an existing table (which is fairly easy, actually,
+    already implemented for CQL's ALTER TABLE). At that point this restriction
+    would be lifted and the tag change would trigger an actual RF update - and
+    this test will need to be rewritten to check the correct operation of that RF
+    change. Until then, rejecting the change is the safest behaviour so the user
+    knows it is not yet supported.
+    """
+    # A single node is sufficient for this test.
+    servers = await manager.servers_add(1, config=alternator_config)
+    alternator = get_alternator(servers[0].ip_addr)
+
+    def make_table(tags):
+        return alternator.create_table(
+            TableName=unique_table_name(),
+            Tags=tags,
+            BillingMode='PAY_PER_REQUEST',
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N'}],
+        )
+
+    # Table created without the tag: adding it afterwards must fail.
+    table_no_tag = make_table([])
+    try:
+        with pytest.raises(ClientError, match='ValidationException.*system:replication_factor'):
+            table_no_tag.meta.client.tag_resource(
+                ResourceArn=table_no_tag.meta.client.describe_table(
+                    TableName=table_no_tag.name)['Table']['TableArn'],
+                Tags=[{'Key': 'system:replication_factor', 'Value': '1'}],
+            )
+    finally:
+        table_no_tag.delete()
+
+    # Table created with the tag set to '1':
+    table_rf1 = make_table([{'Key': 'system:replication_factor', 'Value': '1'}])
+    try:
+        arn = table_rf1.meta.client.describe_table(
+            TableName=table_rf1.name)['Table']['TableArn']
+        # Changing the value (1 -> 2) must fail.
+        with pytest.raises(ClientError, match='ValidationException.*system:replication_factor'):
+            table_rf1.meta.client.tag_resource(
+                ResourceArn=arn,
+                Tags=[{'Key': 'system:replication_factor', 'Value': '2'}],
+            )
+        # "Changing" to the same value (1 -> 1) must succeed (it is a no-op).
+        table_rf1.meta.client.tag_resource(
+            ResourceArn=arn,
+            Tags=[{'Key': 'system:replication_factor', 'Value': '1'}],
+        )
+        # Deleting the tag must also fail.
+        with pytest.raises(ClientError, match='ValidationException.*system:replication_factor'):
+            table_rf1.meta.client.untag_resource(
+                ResourceArn=arn,
+                TagKeys=['system:replication_factor'],
+            )
+    finally:
+        table_rf1.delete()
+
+async def test_alternator_rf_exceeds_racks_or_nodes(manager: ManagerClient):
+    """Test the RF constraints on a 6-node, 3-rack cluster (2 nodes per rack):
+       - RF=4 with vnodes: exceeds the rack count (3) but not the node count (6),
+         so it should succeed - NetworkTopologyStrategy handles RF > rack count
+         by placing multiple replicas per rack.
+       - RF=4 with tablets: fails because tablets enforce RF <= rack count (3).
+       - RF=7 with vnodes: exceeds the node count (6), so it fails even for vnodes.
+    """
+    # Start 6 nodes in dc1, 2 nodes per rack (rack1, rack2, rack3).
+    servers = await manager.servers_add(6, config=alternator_config, property_file=[
+        {'dc': 'dc1', 'rack': 'rack1'},
+        {'dc': 'dc1', 'rack': 'rack1'},
+        {'dc': 'dc1', 'rack': 'rack2'},
+        {'dc': 'dc1', 'rack': 'rack2'},
+        {'dc': 'dc1', 'rack': 'rack3'},
+        {'dc': 'dc1', 'rack': 'rack3'},
+    ])
+    alternator = get_alternator(servers[0].ip_addr)
+    cql = manager.get_cql()
+    # RF=4 with vnodes: exceeds the number of racks (3) but not nodes (6) - should succeed.
+    table = alternator.create_table(TableName=unique_table_name(),
+        Tags=[
+            {'Key': 'system:replication_factor', 'Value': '4'},
+            {'Key': 'system:initial_tablets', 'Value': 'none'},
+        ],
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[
+            {'AttributeName': 'p', 'KeyType': 'HASH'},
+        ],
+        AttributeDefinitions=[
+            {'AttributeName': 'p', 'AttributeType': 'N'},
+        ])
+    try:
+        ks = f'alternator_{table.name}'
+        repl = get_replication(cql, ks)
+        assert 'dc1' in repl
+        assert get_replica_count(repl['dc1']) == 4
+    finally:
+        table.delete()
+    # RF=4 with tablets: tablets enforce RF <= rack count (3), so this should fail.
+    with pytest.raises(ClientError, match='ValidationException.*system:replication_factor.*number of racks'):
+        alternator.create_table(TableName=unique_table_name(),
+            Tags=[
+                {'Key': 'system:replication_factor', 'Value': '4'},
+                {'Key': 'system:initial_tablets', 'Value': '1'},
+            ],
+            BillingMode='PAY_PER_REQUEST',
+            KeySchema=[
+                {'AttributeName': 'p', 'KeyType': 'HASH'},
+            ],
+            AttributeDefinitions=[
+                {'AttributeName': 'p', 'AttributeType': 'N'},
+            ])
+    # RF=7 with vnodes: exceeds the number of nodes (6), so CreateTable should fail even for vnodes.
+    with pytest.raises(ClientError, match='ValidationException.*system:replication_factor.*number of nodes'):
+        alternator.create_table(TableName=unique_table_name(),
+            Tags=[
+                {'Key': 'system:replication_factor', 'Value': '7'},
+                {'Key': 'system:initial_tablets', 'Value': 'none'},
+            ],
+            BillingMode='PAY_PER_REQUEST',
+            KeySchema=[
+                {'AttributeName': 'p', 'KeyType': 'HASH'},
+            ],
+            AttributeDefinitions=[
+                {'AttributeName': 'p', 'AttributeType': 'N'},
+            ])


### PR DESCRIPTION
Before this patch, new Alternator tables are *always* created with RF=3 (unless the cluster has fewer than three nodes, when RF=1 is used).

Some users have requested the ability to use a different RF. For example, on a cluster with 5 racks, a user might want to use RF=5 so that each rack contains a replica - so clients on each rack will have access to a local replica.

So this patch adds the ability to set a tag "system:replication_factor" to the desired replication factor of the new table. It can be an integer between 1 and the minimum number of racks per DC (for tablets) or minimum number of nodes per DC (if the non-default vnodes are requested).

If the tag is not provided, the default is still RF=3 regardless of the number of racks.

Currently, setting system:replication_factor only matters during the CreateTable - changing it later has no effect. We can in the future change this, so that changing system:replication_factor will actively change the replication factor. However, this feature is not implemented in this patch.

This patch includes the feature, tests (that RF can be controlled as expected, and allowed RF values on both tablets and vnodes), and also documentation.

Note that this patch only allows changing RF, not CL of operations: Writes continue to use LOCAL_QUORUM and LOCAL_SERIAL and reads continue to use LOCAL_QUORUM or LOCAL_ONE, as these consistently levels continue to make sense for different RFs.

Refs #5092. (we do not mark "Fixes" because we are still missing the ability to change the table's RF after it already exists).