### PR TITLE
alternator/ttl: clean up multi-DC FIXMEs

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -141,37 +141,46 @@ future<executor::request_return_type> executor::describe_time_to_live(client_sta
     co_return rjson::print(std::move(response));
 }
 
-// expiration_service is a sharded service responsible for cleaning up expired
-// items in all tables with per-item expiration enabled. Currently, this means
-// Alternator tables with TTL configured via an UpdateTimeToLive request.
+// expiration_service is a sharded service that cleans up expired items in all
+// tables with per-item expiration enabled. Currently, this includes Alternator
+// tables with TTL configured via UpdateTimeToLive and CQL tables using
+// per-row TTL.
 //
 // Here is a brief overview of how the expiration service works:
 //
-// An expiration thread on each shard periodically scans the items (i.e.,
-// rows) owned by this shard, looking for items whose chosen expiration-time
-// attribute indicates they are expired, and deletes those items.
-// The expiration-time "attribute" can be either an actual Scylla column
-// (must be numeric) or an Alternator "attribute" - i.e., an element in
-// the ATTRS_COLUMN_NAME map<utf8,bytes> column where the numeric expiration
-// time is encoded in DynamoDB's JSON encoding inside the bytes value.
-// To avoid scanning the same items RF times in RF replicas, only one node is
-// responsible for scanning a token range at a time. Normally, this is the
-// node owning this range as a "primary range" (the first node in the ring
-// with this range), but when this node is down, the secondary owner (the
-// second in the ring) may take over.
-// An expiration thread is responsible for all tables which need expiration
-// scans. Currently, the different tables are scanned sequentially (not in
-// parallel).
-// The expiration thread scans item using CL=QUORUM to ensures that it reads
-// a consistent expiration-time attribute. This means that the items are read
-// locally and in addition QUORUM-1 additional nodes (one additional node
-// when RF=3) need to read the data and send digests.
-// When the expiration thread decides that an item has expired and wants
-// to delete it, it does it using a CL=QUORUM write. This allows this
-// deletion to be visible for consistent (quorum) reads. The deletion,
-// like user deletions, will also appear on the CDC log and therefore
-// Alternator Streams if enabled - currently as ordinary deletes (the
-// userIdentity flag is currently missing this is issue #11523).
+// On each shard, an expiration thread periodically scans items (rows) owned by
+// that shard, checks their configured expiration-time attribute, and deletes
+// expired items. The expiration thread on each shard runs in a lower priority
+// (the streaming scheduling group), and scans all tables that require
+// expiration scans.
+//
+// The expiration-time attribute can be either:
+// 1) a real Scylla column (must be numeric), or
+// 2) an Alternator attribute stored in ATTRS_COLUMN_NAME (map<utf8, bytes>),
+//    where the numeric expiration time is encoded using DynamoDB JSON inside
+//    the bytes value.
+//
+// Scans and deletes are done with CL=LOCAL_QUORUM:
+// - Scans use LOCAL_QUORUM so expiration decisions are based on a consistent
+//   value (for RF=3, this means the scanning thread reads the local replica
+//   plus asking one additional replica for a digest).
+// - Deletes use LOCAL_QUORUM so they are visible to LOCAL_QUORUM readers.
+//
+// TTL deletions are also written to CDC as system-originated expiration
+// deletions (not user-initiated deletes): In Alternator Streams, these events
+// include userIdentity (with Type=Service). In CQL CDC, the cdc$operation of
+// these expirations are different from regular deletes - service_row_delete
+// and service_partition_delete instead of the regular row_delete and
+// partition_delete.
+//
+// To avoid scanning each item RF times, exactly one node scans a token range
+// at a time. Normally this is the global primary owner (first replica in ring
+// order). If that node is down, the global secondary owner (second replica)
+// may temporarily take over.
+//
+// "Primary"/"secondary" ownership here is global (cluster-wide), not per DC,
+// so each item is scanned once per cluster. Resulting deletes are replicated
+// to other DCs by normal replication.
 expiration_service::expiration_service(data_dictionary::database db, service::storage_proxy& proxy, gms::gossiper& g)
         : _db(db)
         , _proxy(proxy)
@@ -241,8 +250,8 @@ static bool is_expired(const rjson::value& expiration_time, gc_clock::time_point
 }
 
 // expire_item() expires an item - i.e., deletes it as appropriate for
-// expiration - with CL=QUORUM and (FIXME!) in a way Alternator Streams
-// understands it is an expiration event - not a user-initiated deletion.
+// expiration - with CL=LOCAL_QUORUM, and in a way Alternator Streams
+// understands is an expiration event - not a user-initiated deletion.
 static future<> expire_item(service::storage_proxy& proxy,
                             const service::query_state& qs,
                             const std::vector<managed_bytes_opt>& row,
@@ -298,6 +307,8 @@ static future<> expire_item(service::storage_proxy& proxy,
         db::allow_per_partition_rate_limit::no,
         false,
         cdc::per_request_options{
+            // tell Alternator Streams to report this deletion as a TTL
+            // expiration, not a user-initiated DeleteItem request.
             .is_system_originated = true,
         }
     );
@@ -385,15 +396,23 @@ static future<std::vector<std::pair<dht::token_range, locator::host_id>>> get_se
 // the tokens owned by it, so we want the secondary owner to take over its
 // primary ranges.
 //
-// FIXME: need to decide how to choose primary ranges in multi-DC setup!
-// We could call get_primary_ranges_within_dc() below instead of get_primary_ranges().
+// Multi-DC design choice: We use get_primary_ranges() (global primary) rather
+// than get_primary_ranges_within_dc() (DC-local primary). This means each
+// token range is scanned by exactly one node in the entire cluster - not once
+// per DC. Deletions done with CL=LOCAL_QUORUM are replicated to all DCs by
+// the normal replication mechanism. A known limitation is that if an entire DC
+// goes down, some token ranges may not be scanned promptly: if both the global
+// primary and global secondary for a range are in the same down DC, expiration
+// of items in that range will be delayed until the DC comes back up.
+//
 // NOTICE: Iteration currently starts from a random token range in order to improve
 // the chances of covering all ranges during a scan when restarts occur.
 // A more deterministic way would be to regularly persist the scanning state,
 // but that incurs overhead that we want to avoid if not needed.
 //
-// FIXME: Check if this algorithm is safe with tablet migration.
-// https://github.com/scylladb/scylladb/issues/16567
+// Note: this class is only used for the vnode path; the tablet path in
+// scan_table() is handled separately but follows the same multi-DC design
+// decisions described above.
 
 // ranges_holder_primary holds just the primary ranges themselves
 class ranges_holder_primary {
@@ -541,9 +560,6 @@ struct scan_ranges_context {
         tracing::trace_state_ptr trace_state;
         // NOTICE: empty_service_permit is used because the TTL service has fixed parallelism
         query_state_ptr = std::make_unique<service::query_state>(internal_client_state, trace_state, empty_service_permit());
-        // FIXME: What should we do on multi-DC? Will we run the expiration on the same ranges on all
-        // DCs or only once for each range? If the latter, we need to change the CLs in the
-        // scanner and deleter.
         db::consistency_level cl = db::consistency_level::LOCAL_QUORUM;
         query_options = std::make_unique<cql3::query_options>(cl, std::vector<cql3::raw_value>{});
         query_options = std::make_unique<cql3::query_options>(std::move(query_options), std::move(paging_state));
@@ -692,10 +708,12 @@ static future<> scan_table_ranges(
 // that this node is their first replica in the ring. Inside the node, each
 // shard "owns" subranges of the node's token ranges - according to the node's
 // sharding algorithm.
-// When a node goes down, the token ranges owned by it will not be scanned
-// and items in those token ranges will not expire, so in the future (FIXME)
-// this function should additionally work on token ranges whose primary owner
-// is down and this node is the range's secondary owner.
+// When a node goes down, the token ranges owned by it will not be scanned by
+// it, but this function also has each node take over scanning the token
+// ranges whose primary owner is down and this node is the range's secondary
+// owner. This is implemented below, separately, for both the tablets case
+// and the vnodes case (the latter using the <secondary> case of
+// ranges_holder_primary/ranges_holder_secondary above).
 // If the TTL (expiration-time scanning) feature is not enabled for this
 // table, scan_table() returns false without doing anything. Remember that the
 // TTL feature may be enabled later so this function will need to be called

--- a/test/cluster/test_ttl_row.py
+++ b/test/cluster/test_ttl_row.py
@@ -125,7 +125,7 @@ async def test_row_ttl_scheduling_group(manager: ManagerClient):
             # and get the CPU metrics again.
             timeout = time.time() + 60
             while time.time() < timeout:
-                time.sleep(0.5)
+                await asyncio.sleep(0.5)
                 ms_streaming_after, ms_statement_after, items_deleted = await get_cpu_metrics(manager)
                 if items_deleted - items_deleted_before == N:
                     break
@@ -202,7 +202,7 @@ async def test_row_ttl_multinode_expiration(manager: ManagerClient, with_down_no
             while time.time() < timeout:
                 if 0 == len(list(await cql.run_async(SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.QUORUM)))):
                     break
-                time.sleep(0.1)
+                await asyncio.sleep(0.1)
             assert 0 == len(list(await cql.run_async(SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.QUORUM))))
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
@@ -271,7 +271,7 @@ async def test_row_ttl_upgrade(manager: ManagerClient):
             # Maybe servers[2] didn't notice yet that servers[0] has been
             # upgraded. Try again.
             assert 'not yet supported by this cluster' in str(e)
-            time.sleep(0.1)
+            await asyncio.sleep(0.1)
     assert success
 
     # At this point, the TTL feature should work fully - if we write expired
@@ -285,7 +285,7 @@ async def test_row_ttl_upgrade(manager: ManagerClient):
     while time.time() < timeout:
         if 0 == len(list(await cql.run_async(SimpleStatement(f'SELECT p FROM ks.tbl2', consistency_level=ConsistencyLevel.QUORUM)))):
             break
-        time.sleep(0.1)
+        await asyncio.sleep(0.1)
     assert 0 == len(list(await cql.run_async(SimpleStatement(f'SELECT p FROM ks.tbl2', consistency_level=ConsistencyLevel.QUORUM))))
 
 
@@ -346,6 +346,114 @@ async def test_row_ttl_multi_dc(manager: ManagerClient):
                         success = False
                         break
                 if not success:
-                    time.sleep(0.1)
+                    await asyncio.sleep(0.1)
             for dc in range(2):
                 assert 0 == len(list(await cql_dc[dc].run_async(SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.LOCAL_QUORUM))))
+
+
+async def test_row_ttl_multi_dc_with_down_dc(manager: ManagerClient):
+    """Check that TTL expiration partially works in a multi-DC cluster when
+       one entire DC goes down.
+       Scylla's TTL scanner uses the global primary replica to decide which
+       node scans which token range, so each range is scanned by exactly one
+       node across the entire cluster. When DC2 is down, items whose global
+       primary is in DC1 continue to expire normally. Items whose global
+       primary and secondary are both in DC2 will not expire until DC2
+       comes back up - this is a known limitation described in issue #28614.
+       This test verifies that:
+       1. Some items DO expire while DC2 is down (those owned by DC1 primaries).
+       2. After DC2 restarts, all remaining items are eventually expired.
+
+       Note that this test does not enshrine the fact that some items do not
+       expire while DC2 is down. It allows for this possibility, but if one
+       day we'll decide to change the implementation to expire all items
+       even while one DC is down, this test will not fail. The important
+       thing that this test verifies some expiration work takes place even
+       while one DC is down, and when it comes back up, all items do expire.
+    """
+    config = {
+        'alternator_ttl_period_in_seconds': '0.5',
+    }
+    # Set up a cluster with 6 nodes - three nodes in three racks in each
+    # of two data centers.
+    futures = []
+    for dc in range(2):
+        for rack in range(3):
+            futures.append(manager.servers_add(1, config=config, property_file={'dc': f'dc{dc+1}', 'rack': f'rack{rack+1}'}))
+    servers = [x[0] for x in await asyncio.gather(*futures)]
+    # servers[0..2] are in dc1, servers[3..5] are in dc2
+    dc1_servers = servers[:3]
+    dc2_servers = servers[3:]
+    cql = manager.get_cql()
+    ksdef = "WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 }"
+    async with new_test_keyspace(manager, ksdef) as keyspace:
+        async with new_test_table(manager, keyspace, 'p int primary key, e bigint') as table:
+            # Insert 50 rows with expiration time 10 seconds in the past.
+            # Use CL=ALL to ensure data is present on all nodes before we
+            # stop DC2.
+            e = int(time.time()) - 10
+            stmt = cql.prepare(f'INSERT INTO {table} (p, e) VALUES (?, ?)')
+            stmt.consistency_level = ConsistencyLevel.ALL
+            await asyncio.gather(*[cql.run_async(stmt, [p, e]) for p in range(50)])
+
+            # We haven't yet enabled TTL, so all items should be present, in both DCs:
+            for dc in [await manager.get_cql_exclusive(dc1_servers[0]),
+                       await manager.get_cql_exclusive(dc2_servers[0])]:
+                assert 50 == len(list(await dc.run_async(
+                    SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.LOCAL_QUORUM))))
+
+            # Stop all three nodes of DC2.
+            for server in dc2_servers:
+                await manager.server_stop_gracefully(server.server_id)
+
+            # Enable TTL on column "e", while DC2 is down. This should cause
+            # the nodes in DC1 to start expiring items, but the nodes in DC2
+            # won't be able to do their usual expiration work until DC2 comes
+            # back up.
+            await cql.run_async(f'ALTER TABLE {table} TTL e')
+
+            # Connect exclusively to DC1, so we can read with LOCAL_QUORUM
+            # even while DC2 is down.
+            cql_dc1 = await manager.get_cql_exclusive(dc1_servers[0])
+
+            # With DC2 down, items whose global primary replica is in DC1
+            # should expire promptly. Wait to see at least some expire:
+            # With 50 partitions spread across all token ranges, approximately
+            # half of them are in primary ranges owned by DC1 so it is almost
+            # certain that some items will expire while DC2 is down.
+            timeout = time.time() + 120
+            while time.time() < timeout:
+                remaining = len(list(await cql_dc1.run_async(
+                    SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.LOCAL_QUORUM))))
+                if remaining < 50:
+                    break
+                await asyncio.sleep(0.1)
+            remaining_with_dc2_down = len(list(await cql_dc1.run_async(
+                SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.LOCAL_QUORUM))))
+            assert remaining_with_dc2_down < 50, "Expected some items to expire with DC2 down"
+
+            # Bring DC2 back up. Now all nodes can participate in TTL scanning
+            # again, so the remaining items (those whose global primary was in
+            # DC2) should also expire. Moreover, items already deleted on DC1
+            # should also be deleted from DC2 due to hints saved on the DC1
+            # nodes while DC2 was down.
+            for server in dc2_servers:
+                await manager.server_start(server.server_id)
+
+            # Connect exclusively to DC2 too, so we can verify with
+            # LOCAL_QUORUM that DC2's own replicas are empty as well.
+            cql_dc2 = await manager.get_cql_exclusive(dc2_servers[0])
+
+            timeout = time.time() + 120
+            while time.time() < timeout:
+                remaining_dc1 = len(list(await cql_dc1.run_async(
+                    SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.LOCAL_QUORUM))))
+                remaining_dc2 = len(list(await cql_dc2.run_async(
+                    SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.LOCAL_QUORUM))))
+                if remaining_dc1 == 0 and remaining_dc2 == 0:
+                    break
+                await asyncio.sleep(0.1)
+            assert 0 == len(list(await cql_dc1.run_async(
+                SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.LOCAL_QUORUM))))
+            assert 0 == len(list(await cql_dc2.run_async(
+                SimpleStatement(f'SELECT p FROM {table}', consistency_level=ConsistencyLevel.LOCAL_QUORUM))))


### PR DESCRIPTION
The TTL expiration scanner uses global primary ranges: each token range is scanned by exactly one node in the entire cluster. Reads and deletes use CL=LOCAL_QUORUM; the deletion is replicated to all DCs by normal replication. When a primary node is down, its secondary takes over.

This is a deliberate design choice trading absolute cross-DC consistency for performance (no redundant scans, no waiting for remote DCs). The known limitation is that if an entire DC is down and both the global primary and secondary for a range reside in that DC, expiration of those items is delayed until the DC recovers.

When this code was written, I wasn't sure about this approach and left several FIXMEs second-guessing it. Now that the design is confirmed reasonable (and tested by test_row_ttl_multi_dc), remove those FIXMEs and replace them with clear explanatory comments.

Also: the expire_item() comment was out of date, saying "FIXME!" regarding an Alternator Streams flag for expiration events, which was already implemented with is_system_originated=true. This FIXME is removed and a brief comment explaining this is added.

Finally, add test_row_ttl_multi_dc_with_down_dc to verify the known limitation: some items expire while an entire DC is down (those whose global primary is in a live DC), and all remaining items expire after the DC restarts.

Fixes #28614
