### PR TITLE
test/pylib: test/pylib: Cached Scylla package resolver

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -34,6 +34,7 @@ from test.pylib.rest_client import ScyllaRESTAPIClient, HTTPError
 from test.pylib.util import LogPrefixAdapter, read_last_line, gather_safely, get_xdist_worker_id, scale_timeout_by_mode
 from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
+from test.pylib.version_fetch_utils import fetch_and_install_scylla_version
 from functools import partial
 import aiohttp
 import aiohttp.web
@@ -213,79 +214,22 @@ def get_current_version_description(path: str) -> ScyllaVersionDescription:
         ]
     )
 
-@asynccontextmanager
-async def with_file_lock(lock_path: pathlib.Path) -> AsyncIterator[None]:
-    with open(lock_path, 'w') as f:
-        try:
-            await asyncio.to_thread(fcntl.flock, f, fcntl.LOCK_EX)
-            yield
-        finally:
-            await asyncio.to_thread(fcntl.flock, f, fcntl.LOCK_UN)
 
 async def get_scylla_2025_1_executable(build_mode: str) -> str:
-    async def run_process(cmd, **kwargs):
-        proc = await asyncio.create_subprocess_exec(
-            *cmd, stderr=asyncio.subprocess.PIPE, **kwargs)
-        _, stderr = await proc.communicate()
-        if proc.returncode != 0:
-            raise RuntimeError(
-                f"Command {cmd} failed with exit code {proc.returncode}: {stderr.decode(errors='replace').strip()}"
-            )
-
     is_debug = build_mode == 'debug' or build_mode == 'sanitize'
-    package = "scylla-debug" if is_debug else "scylla"
+    package = "debug" if is_debug else ""
     arch = platform.machine()
-    url = f'https://downloads.scylladb.com/downloads/scylla/relocatable/scylladb-2025.1/{package}-2025.1.12-0.20260329.1d372670365f.{arch}.tar.gz'
+    return fetch_and_install_scylla_version(2025, 1, arch=arch, pack=package)
 
-    return await get_scylla_executable(url)
-
-async def get_scylla_executable(url: str) -> str:
-    async def run_process(cmd, **kwargs):
-        proc = await asyncio.create_subprocess_exec(*cmd, **kwargs)
-        await proc.communicate()
-        assert proc.returncode == 0
-    archive_filename = urllib.parse.urlparse(url).path.split("/")[-1]
-
-    xdg_cache_dir = pathlib.Path(os.getenv("XDG_CACHE_HOME", str(pathlib.Path.home() / ".cache")))
-    cache_dir = (xdg_cache_dir / "scylladb" / "test.py" / archive_filename)
-    cache_dir.mkdir(exist_ok=True, parents=True)
-
-    archive_path = cache_dir/archive_filename
-    unpack_dir = cache_dir/"unpacked"
-    install_dir = cache_dir/"installed"
-
-    lock_file = cache_dir / "lock"
-    downloaded_marker = cache_dir / "downloaded.success"
-    unpacked_marker = cache_dir / "unpacked.success"
-    installed_marker = cache_dir / "installed.success"
-
-    async with with_file_lock(lock_file):
-        if not installed_marker.exists():
-            if not unpacked_marker.exists():
-                if not downloaded_marker.exists():
-                    archive_path.unlink(missing_ok=True)
-                    await run_process(["curl", "--retry", "40", "--retry-max-time", "60", "--fail", "--silent", "--show-error", "--retry-all-errors", "--output", archive_path, url])
-                    downloaded_marker.touch()
-                shutil.rmtree(unpack_dir, ignore_errors=True)
-                unpack_dir.mkdir(exist_ok=True, parents=True)
-                await run_process(["tar", "--no-same-owner", "-xf", archive_path], cwd=unpack_dir)
-                unpacked_marker.touch()
-            shutil.rmtree(install_dir, ignore_errors=True)
-            install_dir.mkdir(exist_ok=True, parents=True)
-            await run_process(["bash", "./install.sh", "--without-systemd", "--nonroot", "--prefix", install_dir], cwd=unpack_dir/"scylla")
-            installed_marker.touch()
-
-    return str(install_dir/"bin"/"scylla")
 
 async def get_scylla_2025_1_description(build_mode: str) -> ScyllaVersionDescription:
-    path = await get_scylla_2025_1_executable(build_mode)
     # Note: 2025.1 is the oldest version which participates in upgrade tests in test.py,
     # so the added version-specific config is naturally empty.
     #
     # SCYLLA_CMDLINE_OPTIONS is the 2025.1 baseline, and newer versions add their
     # own version-specific config.
     return ScyllaVersionDescription(
-        path=path,
+        path=str(await get_scylla_2025_1_executable(build_mode)),
         config={},
         argv=[],
     )

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -34,7 +34,7 @@ from test.pylib.resource_gather import get_resource_gather, setup_cgroup
 from test.pylib.s3_proxy import S3ProxyServer
 from test.pylib.s3_server_mock import MockS3Server
 from test.pylib.util import LogPrefixAdapter, get_xdist_worker_id
-from test.pylib.scylla_cluster import get_scylla_executable
+from test.pylib.version_fetch_utils import fetch_and_install_scylla_version
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
     from typing import Any, List
@@ -629,6 +629,6 @@ async def get_testpy_test(path: pathlib.Path, options: argparse.Namespace, mode:
     if getattr(options, "exe_path", False):
         suite.scylla_exe = options.exe_path
     elif getattr(options, "exe_url", False):
-        suite.scylla_exe = await get_scylla_executable(options.exe_url)
+        suite.scylla_exe = fetch_and_install_scylla_version(url=options.exe_url)
     await suite.add_test(shortname=str(path.relative_to(suite.suite_path).with_suffix("")), casename=None)
     return suite.tests[-1]

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -11,7 +11,6 @@ import threading
 import time
 import asyncio
 import logging
-import pathlib
 import os
 import universalasync
 from collections.abc import Awaitable, Callable, Coroutine

--- a/test/pylib/version_fetch_utils.py
+++ b/test/pylib/version_fetch_utils.py
@@ -1,0 +1,309 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import boto3
+import urllib.error
+import urllib.request
+from botocore import UNSIGNED
+from botocore.config import Config
+from packaging.version import Version
+from pathlib import Path
+import time
+import re
+import subprocess
+import fcntl
+import shutil
+import tarfile
+import os
+from contextlib import contextmanager
+
+from typing import Optional, List, Iterator
+
+def _list_scylla_release_entries(bucket: str, prefix: str, pack: str = "") -> list[str]:
+    """
+    List Scylla release entries directly under an S3 prefix.
+    The S3 listing is paginated and limited to one prefix level. Returned entries
+    have the requested prefix and trailing slash removed, and are filtered to
+    Scylla/ScyllaDB release names matching the requested package type (`pack`).
+    """
+    if not prefix.endswith("/"):
+        prefix = f"{prefix}/"
+
+    pack_part = rf"{re.escape(pack)}-" if pack else ""    
+    pattern = re.compile(rf"^scylla(?:db)?-{pack_part}\d{{4}}\.\d+(?:\.\d+)?(?:/|$|[~.-])")
+
+    s3 = boto3.client("s3", region_name="us-east-1", config=Config(signature_version=UNSIGNED))
+
+    files = []
+    folders = []
+    continuation_token = None
+    while True:
+        kwargs = {"Bucket": bucket, "Prefix": prefix, "Delimiter": "/"}
+        if continuation_token:
+            kwargs["ContinuationToken"] = continuation_token
+        resp = s3.list_objects_v2(**kwargs)
+        files += resp.get("Contents", [])
+        folders += resp.get("CommonPrefixes", [])
+        if not resp.get("IsTruncated"):
+            break
+        continuation_token = resp.get("NextContinuationToken")
+        if not continuation_token:
+            break
+
+    objs = [f["Key"].removeprefix(prefix) for f in files] if files else [f["Prefix"].removeprefix(prefix) for f in folders]
+    return [o.rstrip("/") for o in objs if pattern.match(o)]
+
+
+def _version_key(v: str, pack: str = "") -> str:
+    """
+    Extract the sortable version component from a Scylla release entry or archive name.
+    The `pack` argument identifies the archive-name structure, so the function knows
+    where to find the version component: after `scylla-` for default archives, or
+    after `scylla-<pack>-` for package variants such as `dev` and `debug`.
+    For example:
+    `scylla-2026.1.0-...` with `pack=""` returns `2026.1.0-...`.
+    `scylla-dev-2026.1.0-...` with `pack="dev"` returns `2026.1.0-...`.
+    `scylla-debug-2026.1.0-...` with `pack="debug"` returns `2026.1.0-...`.
+    The returned version is normalized for `packaging.version.Version` sorting by
+    converting release-candidate versions from `~rc` to `rc`.
+    """
+    if not pack:
+        v = v.rstrip("/").split("-", 2)[1]  # name-version-postfix or name-version
+    else:
+        v = v.rstrip("/").split("-", 3)[2]  # name-pack-postfix    
+    v = v.replace("~rc", "rc")
+    return v
+
+
+def _version_matches(v: str, match_pattern: str) -> bool:
+    return v == match_pattern or v.startswith(f"{match_pattern}.") or v.startswith(f"{match_pattern}rc")
+
+
+def _get_latest_ver(objs: List[str], match_pattern: Optional[str] = None, pack: str = None) -> Optional[str]:
+    sorted_vers = [_version_key(o, pack) for o in objs]
+    if match_pattern:
+        sorted_vers = [v for v in sorted_vers if _version_matches(v, match_pattern)]
+    sorted_vers.sort(key=Version)
+    return sorted_vers[-1] if sorted_vers else None
+
+
+def _get_version_url(major: Optional[int] = None, minor: Optional[int] = None,
+                     patch: Optional[int] = None, rc: Optional[int] = None, 
+                     arch: str = "x86_64", pack: str = "") -> Optional[str]:
+    """
+    Resolve the download URL for a Scylla relocatable package.
+    The lookup walks the Scylla downloads S3 bucket in two stages: first selecting
+    the matching release directory from `major` and `minor`, then selecting the
+    matching package artifact from `patch`, `rc`, `arch`, and `pack`. Missing version
+    components are resolved to the latest available match. Returns the full HTTPS URL
+    for the selected artifact, or `None` if no matching package is found.
+    """
+
+    bucket_url = "downloads.scylladb.com"
+    prefix_url = "downloads/scylla/relocatable"
+
+    if major is None:
+        ver = _get_latest_ver(_list_scylla_release_entries(bucket_url, prefix_url))
+    elif minor is None:
+        ver = _get_latest_ver(_list_scylla_release_entries(bucket_url, prefix_url), f"{major}")
+    else:
+        ver = f"{major}.{minor}"
+
+    if ver is None:
+        return None
+
+    prefix_url = f"{prefix_url}/scylladb-{ver}/"
+    objs = _list_scylla_release_entries(bucket_url, prefix_url, pack)
+    if patch is None:
+        ver = _get_latest_ver(objs, ver, pack)
+    elif rc is None:
+        ver = _get_latest_ver(objs, f"{ver}.{patch}", pack)
+    else:
+        ver = f"{ver}.{patch}rc{rc}"
+
+    if ver is None:
+        return None
+
+    filtered = [o for o in objs if _version_key(o, pack) == ver and f".{arch}." in o]
+
+    return f"https://{bucket_url}/{prefix_url}{filtered[0]}" if filtered else None
+
+
+def get_file_name_and_url_from_url(major: Optional[int] = None, minor: Optional[int] = None,
+                                   patch: Optional[int] = None, rc: Optional[int] = None, 
+                                   arch: str = "x86_64", pack: str = "", url: str = None):
+    """
+    Resolve the download URL and file name for a Scylla package.
+    If `url` is provided, it is used directly. Otherwise, the URL is resolved from
+    the requested `major`, `minor`, `patch`, `rc`, `arch`, and `pack` values, using
+    the latest available value for any missing version component. If `rc` is
+    provided, `patch` is treated as 0. Returns `(url, file_name)` on success, or
+    `(None, None)` if no matching URL can be resolved.
+    Args:
+        major: ScyllaDB major version to fetch.
+        minor: ScyllaDB minor version to fetch.
+        patch: ScyllaDB patch version to fetch.
+        rc: Release-candidate number, if fetching an RC build.
+        arch: Target architecture of the archive.
+        pack: Package/build variant to resolve. Use an empty string for the default
+              archive name (`scylla-<version>-...`), or a variant such as `"dev"` or
+              `"debug"` for archive names like `scylla-dev-<version>-...` and
+              `scylla-debug-<version>-...`.
+        url: Direct archive URL to fetch instead of resolving one from version parts.
+             If `url` is provided, it is downloaded directly. Otherwise, the version URL is
+             resolved from the requested `major`, `minor`, `patch`, `rc`, `arch`, and `pack`
+             components, using the latest available value for any missing component.
+    """
+
+    if rc is not None:
+        patch = 0
+
+    if not url:
+        url = _get_version_url(major, minor, patch, rc, arch, pack)
+    
+    return (url, url.rsplit("/", 1)[-1]) if url else (None, None)
+
+
+def download_scylla_version(major: Optional[int] = None, minor: Optional[int] = None,
+                            patch: Optional[int] = None, rc: Optional[int] = None,
+                            arch: str = "x86_64", pack: str = "", 
+                            output_dir: str | Path = ".", url: str = None, 
+                            retry: int = 1) -> Optional[Path]:
+    """
+    Download a Scylla package matching the requested version components.
+    If `url` is provided, it is downloaded directly. Otherwise, the version URL is
+    resolved from the requested `major`, `minor`, `patch`, and `rc` components,
+    using the latest available value for any missing component. If `rc` is provided,
+    `patch` is treated as 0. Returns the path to the downloaded file on success, or
+    `None` if no matching version is found or the download fails after all retries.
+    Args:
+        major: ScyllaDB major version to fetch.
+        minor: ScyllaDB minor version to fetch.
+        patch: ScyllaDB patch version to fetch.
+        rc: Release-candidate number, if fetching an RC build.
+        arch: Target architecture of the archive.
+        pack: Package/build variant to resolve. Use an empty string for the default
+              archive name (`scylla-<version>-...`), or a variant such as `"dev"` or
+              `"debug"` for archive names like `scylla-dev-<version>-...` and
+              `scylla-debug-<version>-...`.
+        url: Direct archive URL to fetch instead of resolving one from version parts.
+             If `url` is provided, it is downloaded directly. Otherwise, the version URL is
+             resolved from the requested `major`, `minor`, `patch`, `rc`, `arch`, and `pack`
+             components, using the latest available value for any missing component.
+    """
+
+    KB = 1024 * 1024
+
+    if rc is not None:
+        patch = 0
+
+    if not url:
+        url = _get_version_url(major, minor, patch, rc, arch, pack)
+        if url is None:
+            return None
+
+    output_path = Path(output_dir) / url.rsplit("/", 1)[-1]
+
+    for i in range(retry):
+        try:
+            with urllib.request.urlopen(url, timeout=60) as response:
+                if response.status == 200:
+                    with output_path.open("wb") as f:
+                        while chunk := response.read(KB):
+                            f.write(chunk)
+                    return output_path
+                if i == retry - 1:
+                    return None
+                time.sleep(1)
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, OSError):
+            if i == retry - 1:
+                return None
+            time.sleep(1)
+    return None
+
+
+@contextmanager
+def with_file_lock(lock_path: Path) -> Iterator[None]:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def extract_tar_no_same_owner(archive_path: Path, unpack_dir: Path) -> None:
+    with tarfile.open(archive_path, "r:*") as archive:
+        archive.extractall(path=unpack_dir, filter="data")            
+
+
+def fetch_and_install_scylla_version(major: Optional[int] = None, minor: Optional[int] = None,
+                                     patch: Optional[int] = None, rc: Optional[int] = None,
+                                     arch: str = "x86_64", pack: str = "", 
+                                     url: str = None) -> Path:
+    """Fetch, cache, unpack, and install a ScyllaDB release archive.
+    The archive is resolved from either the supplied version components or a direct
+    URL, then cached under XDG_CACHE_HOME, or ~/.cache if XDG_CACHE_HOME is unset.
+    Download, unpack, and install steps are guarded by marker files so repeated
+    calls reuse the existing installation. A file lock prevents concurrent callers
+    from modifying the same cached archive directory at the same time.
+    Args:
+        major: ScyllaDB major version to fetch.
+        minor: ScyllaDB minor version to fetch.
+        patch: ScyllaDB patch version to fetch.
+        rc: Release-candidate number, if fetching an RC build.
+        arch: Target architecture of the archive.
+        pack: Package/build variant to resolve. Use an empty string for the default
+              archive name (`scylla-<version>-...`), or a variant such as `"dev"` or
+              `"debug"` for archive names like `scylla-dev-<version>-...` and
+              `scylla-debug-<version>-...`.
+        url: Direct archive URL to fetch instead of resolving one from version parts.
+             If `url` is provided, it is downloaded directly. Otherwise, the version URL is
+             resolved from the requested `major`, `minor`, `patch`, `rc`, `arch`, and `pack`
+             components, using the latest available value for any missing component.
+    Returns:
+        Path to the installed ScyllaDB binary.
+    Raises:
+        RuntimeError: If the archive name cannot be resolved or the archive cannot be downloaded.
+        subprocess.CalledProcessError: If the ScyllaDB install script fails.
+    """
+    xdg_cache_dir = Path(os.getenv("XDG_CACHE_HOME", str(Path.home() / ".cache")))
+    archive_url, archive_name = get_file_name_and_url_from_url(major, minor, patch, rc, arch, pack, url)
+    if not archive_name: 
+        raise RuntimeError(f"couldnt get archive name for major: {major}, minor: {minor}," 
+                           f" patch: {patch}, rc: {rc}, arch: {arch}, pack: {pack}, url: {url}")
+    cache_dir = (xdg_cache_dir / "scylladb" / "test.py" / archive_name)
+    cache_dir.mkdir(exist_ok=True, parents=True)
+
+    archive_path = cache_dir/archive_name
+    unpack_dir = cache_dir/"unpacked"
+    install_dir = cache_dir/"installed"
+
+    lock_file = cache_dir / "lock"
+    downloaded_marker = cache_dir / "downloaded.success"
+    unpacked_marker = cache_dir / "unpacked.success"
+    installed_marker = cache_dir / "installed.success"
+
+    with with_file_lock(lock_file):
+        if not installed_marker.exists():
+            if not unpacked_marker.exists():
+                if not downloaded_marker.exists():
+                    archive_path.unlink(missing_ok=True)
+                    archive_path = download_scylla_version(url=archive_url, output_dir=cache_dir, retry=40)
+                    if archive_path is None:
+                        raise RuntimeError(f"Couldnt download Scylla archive: {archive_url}")
+                    downloaded_marker.touch()
+                shutil.rmtree(unpack_dir, ignore_errors=True)
+                unpack_dir.mkdir(exist_ok=True, parents=True)
+                extract_tar_no_same_owner(archive_path, unpack_dir)
+                unpacked_marker.touch()
+            shutil.rmtree(install_dir, ignore_errors=True)
+            install_dir.mkdir(exist_ok=True, parents=True)
+            subprocess.run(["bash", "./install.sh", "--without-systemd", "--nonroot", "--prefix", str(install_dir)], cwd=unpack_dir/"scylla", check=True)
+            installed_marker.touch()
+
+    return install_dir/"bin"/"scylla"

--- a/test/pylib_test/test_fetch_version_utils.py
+++ b/test/pylib_test/test_fetch_version_utils.py
@@ -1,0 +1,265 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import pytest
+import test.pylib.version_fetch_utils as vfu
+
+def test_list_scylla_release_entries_prefers_files_when_files_exist(monkeypatch):
+    class FakeS3Client:
+        def __init__(self):
+            self.calls = []
+
+        def list_objects_v2(self, **kwargs):
+            self.calls.append(kwargs)
+            prefix = kwargs["Prefix"]
+            return {
+                "Contents": [
+                    {"Key": f"{prefix}scylla-2026.1.0-0.20260125.f94296e0ae43.x86_64.tar.gz"},
+                    {"Key": f"{prefix}not-a-scylla-object.txt"}],
+                "CommonPrefixes": [
+                    {"Prefix": f"{prefix}scylladb-2026.1/"},
+                    {"Prefix": f"{prefix}other/"}]
+            }
+
+    fake_s3 = FakeS3Client()
+
+    def fake_client(service_name, region_name, config):
+        assert service_name == "s3"
+        assert region_name == "us-east-1"
+        return fake_s3
+
+    monkeypatch.setattr(vfu.boto3, "client", fake_client)
+
+    assert vfu._list_scylla_release_entries("downloads.scylladb.com", "downloads/scylla/relocatable") == [
+        "scylla-2026.1.0-0.20260125.f94296e0ae43.x86_64.tar.gz"]
+    assert fake_s3.calls == [{
+            "Bucket": "downloads.scylladb.com",
+            "Prefix": "downloads/scylla/relocatable/",
+            "Delimiter": "/",}]
+    
+
+def test_list_scylla_release_entries_returns_folders_when_no_files_exist(monkeypatch):
+    class FakeS3Client:
+        def list_objects_v2(self, **kwargs):
+            prefix = kwargs["Prefix"]
+            return {
+                "CommonPrefixes": [
+                    {"Prefix": f"{prefix}scylladb-2025.1/"},
+                    {"Prefix": f"{prefix}scylladb-2026.1/"},
+                    {"Prefix": f"{prefix}other/"}]}
+
+    monkeypatch.setattr(vfu.boto3, "client", lambda *args, **kwargs: FakeS3Client())
+
+    assert vfu._list_scylla_release_entries("downloads.scylladb.com", "downloads/scylla/relocatable") == [
+        "scylladb-2025.1", "scylladb-2026.1"]
+
+
+def test_list_scylla_release_entries_reads_all_pages(monkeypatch):
+    class FakeS3Client:
+        def __init__(self):
+            self.calls = []
+
+        def list_objects_v2(self, **kwargs):
+            self.calls.append(kwargs)
+            prefix = kwargs["Prefix"]
+            if "ContinuationToken" not in kwargs:
+                return {
+                    "IsTruncated": True,
+                    "NextContinuationToken": "next-page",
+                    "Contents": [{
+                        "Key": f"{prefix}scylla-2026.1.0-0.20260125.f94296e0ae43.x86_64.tar.gz"}]}
+            return {
+                "IsTruncated": False,
+                "Contents": [
+                    {"Key": f"{prefix}scylla-2026.1.1-0.20260301.f94296e0ae43.x86_64.tar.gz"}]}
+
+    fake_s3 = FakeS3Client()
+
+    monkeypatch.setattr(vfu.boto3, "client", lambda *args, **kwargs: fake_s3)
+
+    assert vfu._list_scylla_release_entries("downloads.scylladb.com", "downloads/scylla/relocatable/scylladb-2026.1/") == [
+        "scylla-2026.1.0-0.20260125.f94296e0ae43.x86_64.tar.gz", "scylla-2026.1.1-0.20260301.f94296e0ae43.x86_64.tar.gz"]
+    assert fake_s3.calls[1]["ContinuationToken"] == "next-page"
+
+
+def test_get_latest_ver_prefers_latest_release_over_rc():
+    objs = ["scylla-2026.1.0~rc0-0.20260125.f94296e0ae43.x86_64.tar.gz",
+            "scylla-2026.1.0-0.20260201.f94296e0ae43.x86_64.tar.gz",
+            "scylla-2026.1.1-0.20260301.f94296e0ae43.x86_64.tar.gz",
+            "scylla-2026.2.0-0.20260401.f94296e0ae43.x86_64.tar.gz"]
+
+    assert vfu._get_latest_ver(objs, "2026.1") == "2026.1.1"
+
+
+def test_get_latest_ver_does_not_match_partial_minor_version():
+    objs = ["scylla-2026.1.1-0.20260301.f94296e0ae43.x86_64.tar.gz",
+            "scylla-2026.10.0-0.20260401.f94296e0ae43.x86_64.tar.gz"]
+
+    assert vfu._get_latest_ver(objs, "2026.1") == "2026.1.1"
+
+
+def test_get_latest_ver_handles_version_directories():
+    assert (vfu._get_latest_ver(["scylladb-2025.1", "scylladb-2026.1", "scylladb-2024.2"]) == "2026.1")
+
+
+def test_get_version_url_selects_latest_matching_arch(monkeypatch):
+    def fake_list_scylla_release_entries(bucket, prefix, pack=""):
+        assert bucket == "downloads.scylladb.com"
+        assert prefix == "downloads/scylla/relocatable/scylladb-2026.1/"
+        assert pack == ""
+        return ["scylla-2026.1.0~rc0-0.20260125.f94296e0ae43.x86_64.tar.gz",
+                "scylla-2026.1.0-0.20260201.f94296e0ae43.aarch64.tar.gz",
+                "scylla-2026.1.1-0.20260301.f94296e0ae43.x86_64.tar.gz"]
+
+    monkeypatch.setattr(vfu, "_list_scylla_release_entries", fake_list_scylla_release_entries)
+
+    assert vfu._get_version_url(major=2026, minor=1, arch="x86_64") == (
+        "https://downloads.scylladb.com/downloads/scylla/relocatable/scylladb-2026.1/"
+        "scylla-2026.1.1-0.20260301.f94296e0ae43.x86_64.tar.gz")
+
+
+def test_get_version_url_supports_rc_zero(monkeypatch):
+    def fake_list_scylla_release_entries(bucket, prefix, pack=""):
+        assert bucket == "downloads.scylladb.com"
+        assert prefix == "downloads/scylla/relocatable/scylladb-2026.1/"
+        assert pack == ""
+        return ["scylla-2026.1.0~rc0-0.20260125.f94296e0ae43.aarch64.tar.gz",
+                "scylla-2026.1.0-0.20260201.f94296e0ae43.aarch64.tar.gz"]
+
+    monkeypatch.setattr(vfu, "_list_scylla_release_entries", fake_list_scylla_release_entries)
+
+    assert vfu._get_version_url(major=2026, minor=1, patch=0, rc=0, arch="aarch64") == (
+        "https://downloads.scylladb.com/downloads/scylla/relocatable/scylladb-2026.1/"
+        "scylla-2026.1.0~rc0-0.20260125.f94296e0ae43.aarch64.tar.gz")
+
+
+def test_get_version_url_exact_release_does_not_select_rc(monkeypatch):
+    def fake_list_scylla_release_entries(bucket, prefix, pack=""):
+        assert bucket == "downloads.scylladb.com"
+        assert prefix == "downloads/scylla/relocatable/scylladb-2026.1/"
+        assert pack == ""
+        return ["scylla-2026.1.0~rc0-0.20260125.f94296e0ae43.x86_64.tar.gz",
+                "scylla-2026.1.0-0.20260201.f94296e0ae43.x86_64.tar.gz"]
+
+    monkeypatch.setattr(
+        vfu, "_list_scylla_release_entries", fake_list_scylla_release_entries
+    )
+
+    assert vfu._get_version_url(major=2026, minor=1, patch=0, arch="x86_64") == (
+        "https://downloads.scylladb.com/downloads/scylla/relocatable/scylladb-2026.1/"
+        "scylla-2026.1.0-0.20260201.f94296e0ae43.x86_64.tar.gz")
+
+
+def test_download_scylla_version_streams_to_output_dir(monkeypatch, tmp_path):
+    url = "https://downloads.scylladb.com/downloads/scylla/relocatable/scylladb-2026.1/scylla-2026.1.0-0.20260201.f94296e0ae43.x86_64.tar.gz"
+    calls = []
+
+    class FakeResponse:
+        def __init__(self):
+            self.status = 200
+            self.chunks = [b"abc", b"def", b""]
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def read(self, chunk_size):
+            assert chunk_size == 1024 * 1024
+            return self.chunks.pop(0)
+
+    def fake_get_version_url(*args, **kwargs):
+        return url
+
+    def fake_urlopen(request_url, timeout):
+        calls.append(request_url)
+        assert timeout == 60
+        return FakeResponse()
+
+    monkeypatch.setattr(vfu, "_get_version_url", fake_get_version_url)
+    monkeypatch.setattr(vfu.urllib.request, "urlopen", fake_urlopen)
+
+    path = vfu.download_scylla_version(major=2026, minor=1, output_dir=tmp_path)
+
+    assert path == tmp_path / "scylla-2026.1.0-0.20260201.f94296e0ae43.x86_64.tar.gz"
+    assert path.read_bytes() == b"abcdef"
+    assert calls == [url]
+
+
+def test_download_scylla_version_returns_none_when_no_version(monkeypatch, tmp_path):
+    
+    def fake_get_version_url(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(vfu, "_get_version_url", fake_get_version_url)
+    monkeypatch.setattr(vfu.urllib.request, "urlopen",
+                        lambda *args, **kwargs: pytest.fail("unexpected download"))
+
+    assert vfu.download_scylla_version(output_dir=tmp_path) is None
+
+
+def test_get_file_name_and_url_from_url_uses_direct_url():
+    url = "https://example.com/path/scylla.tar.gz"
+    assert vfu.get_file_name_and_url_from_url(url=url) == (url, "scylla.tar.gz")
+
+
+def test_get_file_name_and_url_from_url_supports_rc_zero(monkeypatch):
+    calls = []
+
+    def fake_get_version_url(major, minor, patch, rc, arch, pack):
+        calls.append((major, minor, patch, rc, arch, pack))
+        return "https://example.com/scylla-2026.1.0~rc0.x86_64.tar.gz"
+
+    monkeypatch.setattr(vfu, "_get_version_url", fake_get_version_url)
+
+    assert vfu.get_file_name_and_url_from_url(2026, 1, rc=0) == (
+        "https://example.com/scylla-2026.1.0~rc0.x86_64.tar.gz",
+        "scylla-2026.1.0~rc0.x86_64.tar.gz")
+    assert calls == [(2026, 1, 0, 0, "x86_64", "")]
+
+
+def test_download_scylla_version_retries_after_url_error(monkeypatch, tmp_path):
+    url = "https://example.com/scylla.tar.gz"
+    calls = []
+    class FakeResponse:
+        status = 200
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+        def read(self, chunk_size):
+            return b"data" if not hasattr(self, "done") else b""
+        
+    def fake_urlopen(request_url, timeout):
+        calls.append(request_url)
+        if len(calls) == 1:
+            raise vfu.urllib.error.URLError("temporary failure")
+        response = FakeResponse()
+        response.done = False
+
+        def read(chunk_size):
+            if response.done:
+                return b""
+            response.done = True
+            return b"data"
+        response.read = read
+        return response
+    
+    monkeypatch.setattr(vfu.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(vfu.urllib.request, "urlopen", fake_urlopen)
+
+    path = vfu.download_scylla_version(url=url, output_dir=tmp_path, retry=2)
+
+    assert path == tmp_path / "scylla.tar.gz"
+    assert path.read_bytes() == b"data"
+    assert calls == [url, url]
+
+def test_with_file_lock_creates_parent_and_runs_body(tmp_path):
+    lock_path = tmp_path / "locks" / "scylla.lock"
+    with vfu.with_file_lock(lock_path):
+        assert lock_path.exists()
+    assert lock_path.exists()


### PR DESCRIPTION
This series adds a shared helper for resolving, downloading, unpacking, and
installing Scylla relocatable packages for test.py.

The first patch introduces `version_fetch_utils`, which can resolve public
Scylla artifacts from the downloads bucket by version, architecture, package
variant, or direct URL. It also centralizes the local cache/install flow using
retry handling, marker files, and file locking so repeated or concurrent test
runs can safely reuse an existing installation.

The second patch wires this helper into the existing Scylla executable setup
paths. This removes the hard-coded 2025.1 package URL and replaces the local
download/unpack/install logic in `scylla_cluster.py` with the shared resolver.
It also makes `--exe-url` use the same cached installer path.
Together, these changes make upgrade-test executable selection less brittle,
avoid duplicated install logic, and provide a reusable foundation for fetching
other Scylla versions in test.py.