### PR TITLE
[DO NOT REVIEW] cql3: enable paging with auto-depagination for internal CQL queries

### DIFF
--- a/auth/cache.cc
+++ b/auth/cache.cc
@@ -153,7 +153,7 @@ future<lw_shared_ptr<cache::role_record>> cache::fetch_role(const role_name_t& r
     };
     // roles
     {
-        static const sstring q = format("SELECT * FROM {}.{} WHERE role = ?", db::system_keyspace::NAME, meta::roles_table::name);
+        static const sstring q = format("SELECT * FROM {}.{} WHERE role = ? LIMIT 1", db::system_keyspace::NAME, meta::roles_table::name);
         auto rs = co_await fetch(q);
         if (!rs->empty()) {
             auto& r = rs->one();

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -61,7 +61,7 @@ default_authorizer::authorize(const role_or_anonymous& maybe_role, const resourc
         co_return permissions::NONE;
     }
 
-    const sstring query = seastar::format("SELECT {} FROM {}.{} WHERE {} = ? AND {} = ?",
+    const sstring query = seastar::format("SELECT {} FROM {}.{} WHERE {} = ? AND {} = ? LIMIT 1",
             PERMISSIONS_NAME,
             db::system_keyspace::NAME,
             PERMISSIONS_CF,

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -269,7 +269,7 @@ future<std::optional<sstring>> password_authenticator::get_password_hash(std::st
     // obsolete prepared statements pretty quickly.
     // Rely on query processing caching statements instead, and lets assume
     // that a map lookup string->statement is not gonna kill us much.
-    const sstring query = seastar::format("SELECT {} FROM {}.{} WHERE {} = ?",
+    const sstring query = seastar::format("SELECT {} FROM {}.{} WHERE {} = ? LIMIT 1",
                 SALTED_HASH,
                 db::system_keyspace::NAME,
                 meta::roles_table::name,

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1056,7 +1056,64 @@ query_processor::execute_with_params(
     auto statement = p->statement;
 
     auto msg = co_await coroutine::try_future(execute_maybe_with_guard(query_state, std::move(statement), opts, &query_processor::do_execute_with_params));
-    co_return ::make_shared<untyped_result_set>(msg);
+
+    // Check if there are more pages. If so, loop and collect all pages.
+    auto has_more = [](const ::shared_ptr<result_message>& msg) -> bool {
+        if (!msg) {
+            return false;
+        }
+        class paging_visitor : public result_message::visitor_base {
+        public:
+            bool more = false;
+            void visit(const result_message::rows& rmrs) override {
+                auto& rs = rmrs.rs();
+                more = rs.get_metadata().paging_state()
+                    && rs.get_metadata().flags().contains<cql3::metadata::flag::HAS_MORE_PAGES>();
+            }
+        };
+        paging_visitor v;
+        msg->accept(v);
+        return v.more;
+    };
+
+    if (!has_more(msg)) {
+        // Common case: single page or no results. No overhead.
+        co_return ::make_shared<untyped_result_set>(msg);
+    }
+
+    // Multiple pages: collect all result_messages and build a combined result.
+    // Reuse the same prepared statement from the first page to preserve
+    // cache_internal semantics (the caller may have used cache_internal::no).
+    std::vector<::shared_ptr<result_message>> pages;
+    pages.push_back(msg);
+
+    auto stmt = p->statement;
+    auto current_opts = std::make_unique<query_options>(std::move(opts));
+
+    while (has_more(pages.back())) {
+        // Extract paging state from the last page and create new options.
+        class state_visitor : public result_message::visitor_base {
+        public:
+            lw_shared_ptr<service::pager::paging_state> paging;
+            void visit(const result_message::rows& rmrs) override {
+                auto& rs = rmrs.rs();
+                if (rs.get_metadata().paging_state()) {
+                    paging = make_lw_shared<service::pager::paging_state>(*rs.get_metadata().paging_state());
+                }
+            }
+        };
+        state_visitor sv;
+        pages.back()->accept(sv);
+
+        current_opts = std::make_unique<query_options>(std::move(current_opts), std::move(sv.paging));
+
+        // Execute subsequent pages through the same guarded/try_future path as page 1.
+        auto next_msg = co_await coroutine::try_future(
+            execute_maybe_with_guard(query_state, stmt, *current_opts, &query_processor::do_execute_with_params));
+        pages.push_back(std::move(next_msg));
+    }
+
+    co_return ::make_shared<untyped_result_set>(std::move(pages));
 }
 
 future<::shared_ptr<result_message>>

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -530,7 +530,7 @@ public:
             const statements::prepared_statement::checked_weak_ptr& p,
             const std::vector<data_value_or_unset>& values,
             db::consistency_level,
-            int32_t page_size = -1,
+            int32_t page_size = 1000,
             service::node_local_only node_local_only = service::node_local_only::no) const;
 
     enum class write_consistency_guardrail_state { NONE, WARN, FAIL };

--- a/cql3/untyped_result_set.cc
+++ b/cql3/untyped_result_set.cc
@@ -141,6 +141,32 @@ cql3::untyped_result_set::untyped_result_set(const schema& s, foreign_ptr<lw_sha
     query::result_view::consume(*qres, slice, vv);
 }
 
+cql3::untyped_result_set::untyped_result_set(std::vector<::shared_ptr<result_message>> pages)
+    : _storage(std::move(pages))
+{
+    auto& msgs = std::get<std::vector<::shared_ptr<result_message>>>(_storage);
+    for (auto& msg : msgs) {
+        if (!msg) {
+            continue;
+        }
+        class meta_visitor : public result_message::visitor_base {
+        public:
+            const cql3::result* res = nullptr;
+            void visit(const result_message::rows& rmrs) override {
+                res = &rmrs.rs();
+            }
+        };
+        meta_visitor mv;
+        msg->accept(mv);
+        if (mv.res) {
+            if (!_index) {
+                _index = make_index(mv.res->get_metadata());
+            }
+            mv.res->visit(visitor{_rows, mv.res->get_metadata(), *_index});
+        }
+    }
+}
+
 cql3::untyped_result_set::~untyped_result_set() = default;
 
 const cql3::untyped_result_set_row& cql3::untyped_result_set::one() const {

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -160,6 +160,9 @@ public:
 
     untyped_result_set(::shared_ptr<cql_transport::messages::result_message>);
     untyped_result_set(const schema&, foreign_ptr<lw_shared_ptr<query::result>>, const cql3::selection::selection&, const query::partition_slice&);
+    /// Construct from multiple pages of results (auto-depagination).
+    /// All result messages must come from the same query (identical metadata).
+    untyped_result_set(std::vector<::shared_ptr<cql_transport::messages::result_message>> pages);
     untyped_result_set(untyped_result_set&&) = default;
     ~untyped_result_set();
 
@@ -191,6 +194,7 @@ private:
     using storage = std::variant<std::monostate
         , ::shared_ptr<cql_transport::messages::result_message>
         , qr_tuple
+        , std::vector<::shared_ptr<cql_transport::messages::result_message>>
     >;
     struct visitor;
 

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -335,7 +335,7 @@ system_distributed_keyspace::cdc_desc_exists(
 
     // At this point replicas know the schema, we can perform the actual read...
     co_return co_await _qp.execute_internal(
-            format("SELECT time FROM {}.{} WHERE key = ? AND time = ?", NAME, CDC_TIMESTAMPS),
+            format("SELECT time FROM {}.{} WHERE key = ? AND time = ? LIMIT 1", NAME, CDC_TIMESTAMPS),
             quorum_if_many(ctx.num_token_owners),
             internal_distributed_query_state(),
             { CDC_TIMESTAMPS_KEY, streams_ts },

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1342,7 +1342,7 @@ schema_ptr system_keyspace::client_routes() {
 }
 
 future<system_keyspace::local_info> system_keyspace::load_local_info() {
-    auto msg = co_await execute_cql(format("SELECT host_id, cluster_name, data_center, rack FROM system.{} WHERE key=?", LOCAL), sstring(LOCAL));
+    auto msg = co_await execute_cql(format("SELECT host_id, cluster_name, data_center, rack FROM system.{} WHERE key=? LIMIT 1", LOCAL), sstring(LOCAL));
 
     local_info ret;
     if (!msg->empty()) {
@@ -2538,7 +2538,7 @@ future<> system_keyspace::get_repair_task(tasks::task_id task_uuid, repair_task_
 }
 
 future<gms::generation_type> system_keyspace::increment_and_get_generation() {
-    auto req = format("SELECT gossip_generation FROM system.{} WHERE key='{}'", LOCAL, LOCAL);
+    auto req = format("SELECT gossip_generation FROM system.{} WHERE key='{}' LIMIT 1", LOCAL, LOCAL);
     auto rs = co_await _qp.execute_internal(req, cql3::query_processor::cache_internal::yes);
     gms::generation_type generation;
     if (rs->empty() || !rs->one().has("gossip_generation")) {
@@ -3732,7 +3732,7 @@ future<std::vector<sstring>> system_keyspace::query_all_dict_names() const {
 }
 
 future<netw::shared_dict> system_keyspace::query_dict(std::string_view name) const {
-    static sstring query = format("SELECT * FROM {}.{} WHERE name = ?;", NAME, DICTS);
+    static sstring query = format("SELECT * FROM {}.{} WHERE name = ? LIMIT 1;", NAME, DICTS);
     auto result_set = co_await _qp.execute_internal(
         query, db::consistency_level::ONE, internal_system_query_state(), {name}, cql3::query_processor::cache_internal::yes);
     if (!result_set->empty()) {
@@ -3753,7 +3753,7 @@ future<netw::shared_dict> system_keyspace::query_dict(std::string_view name) con
 }
 
 future<std::optional<db_clock::time_point>> system_keyspace::query_dict_timestamp(std::string_view name) const {
-    static sstring query = format("SELECT timestamp FROM {}.{} WHERE name = ?;", NAME, DICTS);
+    static sstring query = format("SELECT timestamp FROM {}.{} WHERE name = ? LIMIT 1;", NAME, DICTS);
     auto result_set = co_await _qp.execute_internal(
         query, db::consistency_level::ONE, internal_system_query_state(), {name}, cql3::query_processor::cache_internal::yes);
     if (!result_set->empty()) {

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -984,7 +984,7 @@ static future<>
 do_update_tablet_metadata_rows(replica::database& db, cql3::query_processor& qp, tablet_map& tmap, const tablet_metadata_change_hint::table_hint& hint) {
     for (const auto token : hint.tokens) {
         auto res = co_await qp.execute_internal(
-                "select * from system.tablets where table_id = ? and last_token = ?",
+                "select * from system.tablets where table_id = ? and last_token = ? LIMIT 1",
                 db::consistency_level::ONE,
                 {data_value(hint.table_id.uuid()), data_value(dht::token::to_int64(token))},
                 cql3::query_processor::cache_internal::yes);
@@ -1166,7 +1166,7 @@ future<std::optional<tablet_transition_stage>> read_tablet_transition_stage(cql3
     if (auto base_table = co_await read_base_table(qp, tid)) {
         tid = *base_table;
     }
-    auto rs = co_await qp.execute_internal("select stage from system.tablets where table_id = ? and last_token = ?",
+    auto rs = co_await qp.execute_internal("select stage from system.tablets where table_id = ? and last_token = ? LIMIT 1",
             {tid.uuid(), dht::token::to_int64(last_token)}, cql3::query_processor::cache_internal::no);
     if (rs->empty() || !rs->one().has("stage")) {
         co_return std::nullopt;

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -446,8 +446,11 @@ static future<cql3::untyped_result_set> do_execute_cql_with_timeout(sstring req,
             on_internal_error(paxos_state::logger, "prepared statement is null");
         }
     }
+    // Use page_size=1 so these queries count as paged reads in metrics.
+    // LIMIT 1 in the query causes may_need_paging() to short-circuit to false
+    // (row_limit <= 1), avoiding pager allocation overhead entirely.
     const auto qo = qp.make_internal_options(ps_ptr, values, db::consistency_level::ONE,
-        1000, service::node_local_only::yes);
+        1, service::node_local_only::yes);
     const auto st = ps_ptr->statement;
 
     const auto result_ptr = co_await st->execute(qp, qs, qo, std::nullopt);
@@ -530,7 +533,7 @@ future<paxos_state> paxos_store::load_paxos_state(partition_key_view key, schema
     // FIXME: we need execute_cql_with_now()
     (void)now;
     const auto results = co_await execute_cql_with_timeout(
-        format("SELECT * FROM \"{}\".\"{}\" WHERE row_key = ?{}", 
+        format("SELECT * FROM \"{}\".\"{}\" WHERE row_key = ?{} LIMIT 1", 
             state_schema->ks_name(), state_schema->cf_name(), 
             paxos_state_cf_filter(*s, *state_schema)
         ),

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -447,7 +447,7 @@ static future<cql3::untyped_result_set> do_execute_cql_with_timeout(sstring req,
         }
     }
     const auto qo = qp.make_internal_options(ps_ptr, values, db::consistency_level::ONE,
-        -1, service::node_local_only::yes);
+        1000, service::node_local_only::yes);
     const auto st = ps_ptr->statement;
 
     const auto result_ptr = co_await st->execute(qp, qs, qo, std::nullopt);

--- a/service/qos/qos_common.cc
+++ b/service/qos/qos_common.cc
@@ -241,7 +241,7 @@ future<qos::service_levels_info> get_service_levels(cql3::query_processor& qp, s
 }
 
 future<service_levels_info> get_service_level(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name, sstring service_level_name, db::consistency_level cl) {
-    sstring prepared_query = seastar::format("SELECT {} FROM {}.{} WHERE service_level = ?;", get_columns(qp, ks_name, cf_name), ks_name, cf_name);
+    sstring prepared_query = seastar::format("SELECT {} FROM {}.{} WHERE service_level = ? LIMIT 1;", get_columns(qp, ks_name, cf_name), ks_name, cf_name);
     auto result_set = co_await  qp.execute_internal(prepared_query, cl, qos_query_state(), {service_level_name}, cql3::query_processor::cache_internal::yes);
 
     qos::service_levels_info service_levels;

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -125,7 +125,7 @@ future<raft::snapshot_descriptor> raft_sys_table_storage::load_snapshot_descript
     utils::UUID snapshot_id = id_row.get_as<utils::UUID>("snapshot_id");
 
     // Fetch raft log index and term for the latest snapshot descriptor
-    static const auto load_snp_info_cql = format("SELECT idx, term FROM system.{} WHERE group_id = ?",
+    static const auto load_snp_info_cql = format("SELECT idx, term FROM system.{} WHERE group_id = ? LIMIT 1",
         db::system_keyspace::RAFT_SNAPSHOTS);
     ::shared_ptr<cql3::untyped_result_set> snp_rs = co_await _qp.execute_internal(load_snp_info_cql, {_group_id.id}, cql3::query_processor::cache_internal::yes);
     // Should be only one matching row, since each individual server can only

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -132,7 +132,7 @@ future<raft::snapshot_descriptor> raft_groups_storage::load_snapshot_descriptor(
     utils::UUID snapshot_id = id_row.get_as<utils::UUID>("snapshot_id");
 
     // Fetch raft log index and term for the latest snapshot descriptor
-    static const auto load_snp_info_cql = format("SELECT idx, term FROM system.{} WHERE shard = ? AND group_id = ?",
+    static const auto load_snp_info_cql = format("SELECT idx, term FROM system.{} WHERE shard = ? AND group_id = ? LIMIT 1",
         db::system_keyspace::RAFT_GROUPS_SNAPSHOTS);
     ::shared_ptr<cql3::untyped_result_set> snp_rs = co_await _qp.execute_internal(load_snp_info_cql, {int16_t(_shard), _group_id.id}, cql3::query_processor::cache_internal::yes);
     // Should be only one matching row, since each individual server can only


### PR DESCRIPTION
## Summary

- Internal CQL queries via `execute_internal`/`execute_with_params` used `page_size=-1` (no paging), causing them to inflate the non-paged reads metric — confusing for users.
- Changed the default `page_size` in `make_internal_options` from `-1` to `1000`.
- To avoid silent truncation, `execute_with_params` now **auto-depaginates**: if results span multiple pages, it loops collecting all pages and merges them into a single `untyped_result_set`.
- For the common case (results fit in one page), there is **zero overhead** — we just check a flag and return immediately.
- A new `untyped_result_set` constructor accepts a vector of `result_message`s (one per page) and combines all rows.

## Affected internal queries (~17 SELECT queries that could return multiple rows)

- `auth/default_authorizer.cc` — role_permissions scans
- `auth/standard_role_manager.cc`, `auth/password_authenticator.cc` — superuser scans
- `service/raft/raft_sys_table_storage.cc`, `service/strong_consistency/raft_groups_storage.cc` — raft log/config
- `db/system_distributed_keyspace.cc` — CDC timestamps/descriptors
- `db/schema_tables.cc` — column mappings
- `replica/tablets.cc`, `service/storage_service.cc` — tablet queries
- `service/raft/raft_group0.cc` — discovery peers
- `service/qos/qos_common.cc` — service levels
- `db/system_keyspace.cc` — dict names

Closes #7415
Refs: https://scylladb.atlassian.net/browse/SCYLLADB-1944