### PR TITLE
schema: ensure group0_schema_version is set on boot

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -9,6 +9,7 @@
  */
 
 #include <algorithm>
+#include <random>
 #include <ranges>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/coroutine.hh>
@@ -1189,6 +1190,45 @@ future<> migration_manager::announce<topology_change>(utils::chunked_vector<muta
 future<group0_guard> migration_manager::start_group0_operation(std::optional<raft_timeout> timeout) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     return _group0_client.start_operation(_as, timeout.value_or(raft_timeout{}));
+}
+
+static thread_local std::default_random_engine random_engine{std::random_device{}()};
+
+future<> migration_manager::ensure_group0_schema_version_is_set() {
+    SCYLLA_ASSERT(this_shard_id() == 0);
+
+    while (true) {
+        auto version = co_await db::schema_tables::get_group0_schema_version(_sys_ks.local());
+        if (version) {
+            mlogger.info("group0_schema_version is already set to {}", *version);
+            co_return;
+        }
+
+        mlogger.info("group0_schema_version is not set, performing a dummy schema change to assign it");
+        auto guard = co_await start_group0_operation();
+
+        if (!guard.with_raft()) {
+            mlogger.info("Not in raft mode (e.g. RECOVERY), skipping group0_schema_version assignment");
+            co_return;
+        }
+
+        // Re-check after acquiring the guard, another node may have set it.
+        // start_group0_operation() performs a raft barrier, so any previously
+        // committed group0 changes are applied locally by this point.
+        version = co_await db::schema_tables::get_group0_schema_version(_sys_ks.local());
+        if (version) {
+            mlogger.info("group0_schema_version was set to {} while waiting for guard", *version);
+            co_return;
+        }
+
+        try {
+            co_await announce<schema_change>(utils::chunked_vector<mutation>{}, std::move(guard), "set group0_schema_version");
+            co_return;
+        } catch (const group0_concurrent_modification&) {
+            mlogger.info("Concurrent schema change detected while setting group0_schema_version, retrying");
+        }
+        co_await sleep_abortable(std::chrono::milliseconds(std::uniform_int_distribution<>(0, 500)(random_engine)), _as);
+    }
 }
 
 /**

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -146,6 +146,13 @@ public:
     //              `group0_raft_op_timeout_in_ms`, which defaults to one minute).
     future<group0_guard> start_group0_operation(std::optional<raft_timeout> timeout = std::nullopt);
 
+    // If group0_schema_version is not yet set in system.scylla_local
+    // (can happen if cluster was upgraded from pre-2024.2 and no schema
+    // change was performed since), perform a dummy schema change through
+    // group0 to assign it. This allows dropping the legacy schema version
+    // hashing code.
+    future<> ensure_group0_schema_version_is_set();
+
     // Apply a group 0 change.
     // The future resolves after the change is applied locally.
     // Parameters:

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2061,6 +2061,7 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
         }
 
         co_await _group0->finish_setup_after_join(*this, _qp, _migration_manager.local(), true);
+        co_await _migration_manager.local().ensure_group0_schema_version_is_set();
 
         // Initializes monitor only after updating local topology.
         start_tablet_split_monitor();
@@ -2263,6 +2264,7 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
 
     SCYLLA_ASSERT(_group0);
     co_await _group0->finish_setup_after_join(*this, _qp, _migration_manager.local(), false);
+    co_await _migration_manager.local().ensure_group0_schema_version_is_set();
     co_await _cdc_gens.local().after_join(std::move(cdc_gen_id));
 
     // Waited on during stop()


### PR DESCRIPTION
Starting from 2024.2, schema versions are assigned by group0 using raft state IDs instead of being calculated by hashing schema mutations with MD5. The assigned version is persisted in system.scylla_local as 'group0_schema_version'. When this value is present, it is used as the schema version; otherwise, the legacy calculate_schema_digest() hash is used as a fallback.

If a cluster was upgraded from a version before 2024.2 and no schema change was performed after the upgrade, group0_schema_version will never have been written, keeping the cluster permanently dependent on the legacy hashing code path. This prevents us from dropping that code.

Add migration_manager::ensure_group0_schema_version_is_set() which is called during join_cluster after finish_setup_after_join completes (in both the raft-topology and non-raft-topology paths). It checks whether group0_schema_version is set. If not, and the GROUP0_SCHEMA_VERSIONING feature is enabled, it performs a no-op schema change through group0 (announce with an empty mutation set). The announce() function automatically appends the group0_schema_version mutation, so this is sufficient to persist the version on all nodes via raft.

A double-check is performed: once before acquiring the group0 guard (to avoid unnecessary work), and once after (since start_group0_operation includes a raft barrier, ensuring any concurrently committed changes from other nodes are applied locally). This handles the case where multiple nodes restart simultaneously and race to set the version.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1884

Backport needed since we want to set group0 schema version on all supported versions so that it will be present during upgrade to versions newer than 2026.1.
