### PR TITLE
test.py: fix issue that C++ tests' logs are deleted

### DIFF
--- a/test/pylib/cpp/base.py
+++ b/test/pylib/cpp/base.py
@@ -222,7 +222,7 @@ class CppTestCase(pytest.Item):
             print('\n'.join(lines))
             print("=" * 70 + "\n")
 
-        if not self.config.getoption("--save-log-on-success"):
+        if not self.config.getoption("--save-log-on-success") and not failures:
             output.unlink(missing_ok=True)
 
         if failures:


### PR DESCRIPTION
Add skipping deletion of the log file in case of the fail in C++ tests.

Framework fix, no backport.