### PR TITLE
[Backport 2025.1] reader_concurrency_semaphore: fix leak workaround

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1027,8 +1027,8 @@ void reader_concurrency_semaphore::signal(const resources& r) noexcept {
         on_internal_error_noexcept(rcslog,
                 format("reader_concurrency_semaphore::signal(): semaphore {} detected resource leak, available {} exceeds initial {}", _name,
                         _resources, _initial_resources));
-        _resources.count = std::max(_resources.count, _initial_resources.count);
-        _resources.memory = std::max(_resources.memory, _initial_resources.memory);
+        _resources.count = std::min(_resources.count, _initial_resources.count);
+        _resources.memory = std::min(_resources.memory, _initial_resources.memory);
     }
     maybe_wake_execution_loop();
 }


### PR DESCRIPTION
The backport to 2025.1 was never created automatically after https://github.com/scylladb/scylladb/pull/29196 and https://github.com/scylladb/scylladb/pull/29490 were closed. Therefore, I created it manually.

===

`e4da0afb8d5491bf995cbd1d7a7efb966c79ac34` introduces a protection against resources that are "made up" of thin air to `reader_concurrency_semaphore`. If there are more `_resources` than the `_initial_resources`, it means there is a negative leak, and `on_internal_error_noexcept` is called. In addition to it, `_resources` is set to `std::max(_resources, _initial_resources)`.

However, the commit message of `e4da0afb8d5491bf995cbd1d7a7efb966c79ac34` states the opposite: "The detection also clamps the _resources to _initial_resources, to prevent any damage".

Before this commit, the protection mechanism doesn't clamp `_resources` to `_initial_resources` but instead keeps `_resources` high, possibly even indefinitely growing. This commit changes `std::max` to `std::min` to make the code behave as intended.

Fixes: SCYLLADB-1014
Refs: SCYLLADB-163

Closes scylladb/scylladb#28982

(cherry picked from commit 9247dff8c25ff57fa900f42d923f77931af707f7)

Closes scylladb/scylladb#28988

Closes scylladb/scylladb#29196
