### PR TITLE
Introduce auth::config to decouple auth modules from db::config

### DIFF
--- a/auth/certificate_authenticator.cc
+++ b/auth/certificate_authenticator.cc
@@ -9,6 +9,7 @@
 
 #include "auth/certificate_authenticator.hh"
 #include "auth/cache.hh"
+#include "auth/config.hh"
 
 #include <boost/regex.hpp>
 #include <fmt/ranges.h>
@@ -17,7 +18,6 @@
 #include "utils/error_injection.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "cql3/query_processor.hh"
-#include "db/config.hh"
 
 
 static logging::logger clogger("certificate_authenticator");
@@ -32,10 +32,9 @@ enum class auth::certificate_authenticator::query_source {
     subject, altname
 };
 
-auth::certificate_authenticator::certificate_authenticator(cql3::query_processor& qp, ::service::raft_group0_client&, ::service::migration_manager&, auth::cache&)
+auth::certificate_authenticator::certificate_authenticator(cql3::query_processor& qp, ::service::raft_group0_client&, ::service::migration_manager&, auth::cache&, const config& cfg)
     : _queries([&] {
-        auto& conf = qp.db().get_config();
-        auto queries = conf.auth_certificate_role_queries();
+        auto& queries = cfg.auth_certificate_role_queries;
 
         if (queries.empty()) {
             throw std::invalid_argument("No role extraction queries specified.");
@@ -47,7 +46,7 @@ auth::certificate_authenticator::certificate_authenticator(cql3::query_processor
             // first, check for any invalid config keys
             if (map.size() == 2) {
                 try {
-                    auto& source = map.at(cfg_source_attr);
+                    sstring source = map.at(cfg_source_attr);
                     std::string query = map.at(cfg_query_attr);
 
                     std::transform(source.begin(), source.end(), source.begin(), ::toupper);

--- a/auth/certificate_authenticator.hh
+++ b/auth/certificate_authenticator.hh
@@ -26,12 +26,13 @@ class raft_group0_client;
 namespace auth {
 
 class cache;
+struct config;
 
 class certificate_authenticator : public authenticator {
     enum class query_source;
     std::vector<std::pair<query_source, boost::regex>> _queries;
 public:
-    certificate_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, cache&);
+    certificate_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, cache&, const config&);
     ~certificate_authenticator();
 
     future<> start() override;

--- a/auth/common.cc
+++ b/auth/common.cc
@@ -32,10 +32,6 @@ constinit const std::string_view AUTH_PACKAGE_NAME("org.apache.cassandra.auth.")
 
 static logging::logger auth_log("auth");
 
-std::string default_superuser(cql3::query_processor& qp) {
-    return qp.db().get_config().auth_superuser_name();
-}
-
 // Func must support being invoked more than once.
 future<> do_after_system_ready(seastar::abort_source& as, seastar::noncopyable_function<future<>()> func) {
     struct empty_state { };

--- a/auth/common.hh
+++ b/auth/common.hh
@@ -45,8 +45,6 @@ constexpr std::string_view PERMISSIONS_CF = "role_permissions";
 constexpr std::string_view ROLE_MEMBERS_CF = "role_members";
 constexpr std::string_view ROLE_ATTRIBUTES_CF = "role_attributes";
 
-std::string default_superuser(cql3::query_processor& qp);
-
 template <class Task>
 future<> once_among_shards(Task&& f) {
     if (this_shard_id() == 0u) {

--- a/auth/config.hh
+++ b/auth/config.hh
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <seastar/core/sstring.hh>
+
+#include "utils/updateable_value.hh"
+
+namespace auth {
+
+struct config {
+    std::string auth_superuser_name;
+    std::string auth_superuser_salted_password;
+    seastar::sstring saslauthd_socket_path;
+    std::vector<std::unordered_map<seastar::sstring, seastar::sstring>> auth_certificate_role_queries;
+    seastar::sstring ldap_url_template;
+    seastar::sstring ldap_attr_role;
+    seastar::sstring ldap_bind_dn;
+    seastar::sstring ldap_bind_passwd;
+    utils::updateable_value<uint32_t> permissions_update_interval_in_ms;
+};
+
+}

--- a/auth/ldap_role_manager.cc
+++ b/auth/ldap_role_manager.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "common.hh"
+#include "auth/config.hh"
 #include "cql3/query_processor.hh"
 #include "exceptions/exceptions.hh"
 #include "seastarx.hh"
@@ -213,8 +214,8 @@ ldap_role_manager::ldap_role_manager(
         std::string_view query_template, std::string_view target_attr, std::string_view bind_name, std::string_view bind_password,
         uint32_t permissions_update_interval_in_ms,
         utils::observer<uint32_t>  permissions_update_interval_in_ms_observer,
-        cql3::query_processor& qp, ::service::raft_group0_client& rg0c, ::service::migration_manager& mm, cache& cache)
-        : _std_mgr(qp, rg0c, mm, cache), _group0_client(rg0c), _query_template(query_template), _target_attr(target_attr), _bind_name(bind_name)
+        cql3::query_processor& qp, ::service::raft_group0_client& rg0c, ::service::migration_manager& mm, cache& cache, const config& cfg)
+        : _std_mgr(qp, rg0c, mm, cache, cfg), _group0_client(rg0c), _query_template(query_template), _target_attr(target_attr), _bind_name(bind_name)
         , _bind_password(bind_password)
         , _permissions_update_interval_in_ms(permissions_update_interval_in_ms)
         , _permissions_update_interval_in_ms_observer(std::move(permissions_update_interval_in_ms_observer))
@@ -223,18 +224,19 @@ ldap_role_manager::ldap_role_manager(
         , _cache_pruner(make_ready_future<>()) {
 }
 
-ldap_role_manager::ldap_role_manager(cql3::query_processor& qp, ::service::raft_group0_client& rg0c, ::service::migration_manager& mm, cache& cache)
+ldap_role_manager::ldap_role_manager(cql3::query_processor& qp, ::service::raft_group0_client& rg0c, ::service::migration_manager& mm, cache& cache, const config& cfg)
     : ldap_role_manager(
-            qp.db().get_config().ldap_url_template(),
-            qp.db().get_config().ldap_attr_role(),
-            qp.db().get_config().ldap_bind_dn(),
-            qp.db().get_config().ldap_bind_passwd(),
-            qp.db().get_config().permissions_update_interval_in_ms(),
-            qp.db().get_config().permissions_update_interval_in_ms.observe([this] (const uint32_t& v) { _permissions_update_interval_in_ms = v; }),
+            cfg.ldap_url_template,
+            cfg.ldap_attr_role,
+            cfg.ldap_bind_dn,
+            cfg.ldap_bind_passwd,
+            cfg.permissions_update_interval_in_ms(),
+            cfg.permissions_update_interval_in_ms.observe([this] (const uint32_t& v) { _permissions_update_interval_in_ms = v; }),
             qp,
             rg0c,
             mm,
-            cache) {
+            cache,
+            cfg) {
 }
 
 std::string_view ldap_role_manager::qualified_java_name() const noexcept {

--- a/auth/ldap_role_manager.hh
+++ b/auth/ldap_role_manager.hh
@@ -19,6 +19,8 @@
 
 namespace auth {
 
+struct config;
+
 /// Queries an LDAP server for roles.
 ///
 /// Since LDAP grants and revokes roles, calling grant() and revoke() is disallowed.
@@ -54,11 +56,12 @@ class ldap_role_manager : public role_manager {
             cql3::query_processor& qp, ///< Passed to standard_role_manager.
             ::service::raft_group0_client& rg0c, ///< Passed to standard_role_manager.
             ::service::migration_manager& mm, ///< Passed to standard_role_manager.
-            cache& cache ///< Passed to standard_role_manager.
+            cache& cache, ///< Passed to standard_role_manager.
+            const config& cfg ///< Auth configuration.
     );
 
-    /// Retrieves LDAP configuration entries from qp and invokes the other constructor.
-    ldap_role_manager(cql3::query_processor& qp, ::service::raft_group0_client& rg0c, ::service::migration_manager& mm, cache& cache);
+    /// Retrieves LDAP configuration entries from cfg and invokes the other constructor.
+    ldap_role_manager(cql3::query_processor& qp, ::service::raft_group0_client& rg0c, ::service::migration_manager& mm, cache& cache, const config& cfg);
 
     /// Thrown when query-template parsing fails.
     struct url_error : public std::runtime_error {

--- a/auth/maintenance_socket_role_manager.cc
+++ b/auth/maintenance_socket_role_manager.cc
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <string_view>
 #include "auth/cache.hh"
+#include "auth/config.hh"
 #include "cql3/description.hh"
 #include "utils/log.hh"
 #include "utils/on_internal_error.hh"
@@ -29,7 +30,7 @@ future<> maintenance_socket_role_manager::ensure_role_operations_are_enabled() {
         on_internal_error(log, "role operations are already enabled");
     }
 
-    _std_mgr.emplace(_qp, _group0_client, _migration_manager, _cache);
+    _std_mgr.emplace(_qp, _group0_client, _migration_manager, _cache, _cfg);
     return _std_mgr->start();
 }
 
@@ -44,11 +45,13 @@ maintenance_socket_role_manager::maintenance_socket_role_manager(
         cql3::query_processor& qp,
         ::service::raft_group0_client& rg0c,
         ::service::migration_manager& mm,
-        cache& c)
+        cache& c,
+        const config& cfg)
     : _qp(qp)
     , _group0_client(rg0c)
     , _migration_manager(mm)
     , _cache(c)
+    , _cfg(cfg)
     , _std_mgr(std::nullopt)
     , _is_maintenance_mode(false) {
 }

--- a/auth/maintenance_socket_role_manager.hh
+++ b/auth/maintenance_socket_role_manager.hh
@@ -25,6 +25,8 @@ class raft_group0_client;
 
 namespace auth {
 
+struct config;
+
 // This role manager is used by the maintenance socket. It has disabled all role management operations
 // in maintenance mode. In normal mode it delegates all operations to a standard_role_manager,
 // which is created on demand when the node joins the cluster.
@@ -33,6 +35,7 @@ class maintenance_socket_role_manager final : public role_manager {
     ::service::raft_group0_client& _group0_client;
     ::service::migration_manager& _migration_manager;
     cache& _cache;
+    const config& _cfg;
     std::optional<standard_role_manager> _std_mgr;
     bool _is_maintenance_mode;
 
@@ -44,7 +47,7 @@ public:
     // In the meantime all role management operations will fail.
     future<> ensure_role_operations_are_enabled() override;
 
-    maintenance_socket_role_manager(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, cache&);
+    maintenance_socket_role_manager(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, cache&, const config&);
 
     virtual std::string_view qualified_java_name() const noexcept override;
 

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -21,13 +21,13 @@
 #include "auth/authenticated_user.hh"
 #include "auth/authentication_options.hh"
 #include "auth/common.hh"
+#include "auth/config.hh"
 #include "auth/passwords.hh"
 #include "auth/roles-metadata.hh"
 #include "cql3/untyped_result_set.hh"
 #include "utils/log.hh"
 #include "service/migration_manager.hh"
 #include "cql3/query_processor.hh"
-#include "db/config.hh"
 #include "db/system_keyspace.hh"
 
 namespace auth {
@@ -43,11 +43,13 @@ static thread_local auto rng_for_salt = std::default_random_engine(std::random_d
 password_authenticator::~password_authenticator() {
 }
 
-password_authenticator::password_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm, cache& cache)
+password_authenticator::password_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm, cache& cache, const config& cfg)
     : _qp(qp)
     , _group0_client(g0)
     , _migration_manager(mm)
     , _cache(cache)
+    , _superuser_name(cfg.auth_superuser_name)
+    , _superuser_salted_password(cfg.auth_superuser_salted_password)
     , _stopped(make_ready_future<>()) 
 {}
 
@@ -65,7 +67,7 @@ sstring password_authenticator::update_row_query() const {
 
 future<> password_authenticator::maybe_create_default_password() {
     auto needs_password = [this] () -> future<bool> {
-        if (default_superuser(_qp).empty()) {
+        if (_superuser_name.empty()) {
             co_return false;
         }
         const sstring query = seastar::format("SELECT * FROM {}.{} WHERE is_superuser = true ALLOW FILTERING", db::system_keyspace::NAME, meta::roles_table::name);
@@ -78,7 +80,7 @@ future<> password_authenticator::maybe_create_default_password() {
         bool has_default = false;
         bool has_superuser_with_password = false;
         for (auto& result : *results) {
-            if (result.get_as<sstring>(meta::roles_table::role_col_name) == default_superuser(_qp)) {
+            if (result.get_as<sstring>(meta::roles_table::role_col_name) == _superuser_name) {
                 has_default = true;
             }
             if (has_salted_hash(result)) {
@@ -99,12 +101,12 @@ future<> password_authenticator::maybe_create_default_password() {
         co_return;
     }
     // Set default superuser's password.
-    std::string salted_pwd(_qp.db().get_config().auth_superuser_salted_password());
+    std::string salted_pwd(_superuser_salted_password);
     if (salted_pwd.empty()) {
         co_return;
     }
     const auto update_query = update_row_query();
-    co_await collect_mutations(_qp, batch, update_query, {salted_pwd, default_superuser(_qp)});
+    co_await collect_mutations(_qp, batch, update_query, {salted_pwd, sstring(_superuser_name)});
     co_await std::move(batch).commit(_group0_client, _as, get_raft_timeout());
     plogger.info("Created default superuser authentication record.");
 }

--- a/auth/password_authenticator.hh
+++ b/auth/password_authenticator.hh
@@ -18,10 +18,6 @@
 #include "auth/cache.hh"
 #include "service/raft/raft_group0_client.hh"
 
-namespace db {
-    class config;
-}
-
 namespace cql3 {
 
 class query_processor;
@@ -34,6 +30,8 @@ class migration_manager;
 
 namespace auth {
 
+struct config;
+
 extern const std::string_view password_authenticator_name;
 
 class password_authenticator : public authenticator {
@@ -41,6 +39,8 @@ class password_authenticator : public authenticator {
     ::service::raft_group0_client& _group0_client;
     ::service::migration_manager& _migration_manager;
     cache& _cache;
+    std::string _superuser_name;
+    std::string _superuser_salted_password;
     future<> _stopped;
     abort_source _as;
     shared_promise<> _superuser_created_promise;
@@ -48,7 +48,7 @@ class password_authenticator : public authenticator {
     constexpr static auth::passwords::scheme _scheme = passwords::scheme::sha_512;
 
 public:
-    password_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, cache&);
+    password_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, cache&, const config&);
 
     ~password_authenticator();
 

--- a/auth/saslauthd_authenticator.cc
+++ b/auth/saslauthd_authenticator.cc
@@ -17,9 +17,9 @@
 #include <seastar/net/socket_defs.hh>
 #include <seastar/util/log.hh>
 #include <system_error>
+#include "auth/config.hh"
 #include "common.hh"
 #include "cql3/query_processor.hh"
-#include "db/config.hh"
 #include "utils/log.hh"
 #include "seastarx.hh"
 
@@ -27,8 +27,8 @@ namespace auth {
 
 static logging::logger mylog("saslauthd_authenticator");
 
-saslauthd_authenticator::saslauthd_authenticator(cql3::query_processor& qp, ::service::raft_group0_client&, ::service::migration_manager&, cache&)
-    : _socket_path(qp.db().get_config().saslauthd_socket_path())
+saslauthd_authenticator::saslauthd_authenticator(cql3::query_processor& qp, ::service::raft_group0_client&, ::service::migration_manager&, cache&, const config& cfg)
+    : _socket_path(cfg.saslauthd_socket_path)
 {}
 
 future<> saslauthd_authenticator::start() {

--- a/auth/saslauthd_authenticator.hh
+++ b/auth/saslauthd_authenticator.hh
@@ -24,12 +24,14 @@ class raft_group0_client;
 
 namespace auth {
 
+struct config;
+
 /// Delegates authentication to saslauthd.  When this class is asked to authenticate, it passes the credentials
 /// to saslauthd, gets its response, and allows or denies authentication based on that response.
 class saslauthd_authenticator : public authenticator {
     sstring _socket_path; ///< Path to the domain socket on which saslauthd is listening.
 public:
-    saslauthd_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, cache&);
+    saslauthd_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, cache&, const config&);
 
     future<> start() override;
 

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -859,11 +859,11 @@ role_manager_factory make_role_manager_factory(
 
     if (boost::iequals(short_name, "CassandraRoleManager")) {
         return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
-            return std::make_unique<standard_role_manager>(qp.local(), g0, mm.local(), auth_cache.local());
+            return std::make_unique<standard_role_manager>(qp.local(), g0, mm.local(), auth_cache.local(), cfg);
         };
     } else if (boost::iequals(short_name, "LDAPRoleManager")) {
         return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
-            return std::make_unique<ldap_role_manager>(qp.local(), g0, mm.local(), auth_cache.local());
+            return std::make_unique<ldap_role_manager>(qp.local(), g0, mm.local(), auth_cache.local(), cfg);
         };
     }
     throw std::invalid_argument(fmt::format("Unknown role manager: {}", name));
@@ -891,7 +891,7 @@ role_manager_factory make_maintenance_socket_role_manager_factory(
         sharded<::service::migration_manager>& mm,
         sharded<cache>& auth_cache) {
     return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
-        return std::make_unique<maintenance_socket_role_manager>(qp.local(), g0, mm.local(), auth_cache.local());
+        return std::make_unique<maintenance_socket_role_manager>(qp.local(), g0, mm.local(), auth_cache.local(), cfg);
     };
 }
 

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -104,17 +104,17 @@ service::service(
         authorizer_factory authorizer_factory,
         authenticator_factory authenticator_factory,
         role_manager_factory role_manager_factory,
+        config cfg,
         maintenance_socket_enabled used_by_maintenance_socket,
         cache& cache)
-            : service(
-                      cache,
-                      qp,
-                      g0,
-                      authorizer_factory(),
-                      authenticator_factory(),
-                      role_manager_factory(),
-                      used_by_maintenance_socket) {
-}
+            : _cache(cache)
+            , _qp(qp)
+            , _group0_client(g0)
+            , _cfg(std::move(cfg))
+            , _authorizer(authorizer_factory())
+            , _authenticator(authenticator_factory(_cfg))
+            , _role_manager(role_manager_factory(_cfg))
+            , _used_by_maintenance_socket(used_by_maintenance_socket) {}
 
 future<> service::create_legacy_keyspace_if_missing(::service::migration_manager& mm) const {
     SCYLLA_ASSERT(this_shard_id() == 0); // once_among_shards makes sure a function is executed on shard 0 only
@@ -369,7 +369,7 @@ future<std::vector<cql3::description>> service::describe_roles(bool with_hashed_
 
     const bool authenticator_uses_password_hashes = _authenticator->uses_password_hashes();
 
-    const auto default_su = cql3::util::maybe_quote(default_superuser(_qp));
+    const auto default_su = cql3::util::maybe_quote(_cfg.auth_superuser_name);
 
     auto produce_create_statement = [&default_su, with_hashed_passwords] (const sstring& formatted_role_name,
             const std::optional<sstring>& maybe_hashed_password, bool can_login, bool is_superuser) {
@@ -826,23 +826,23 @@ authenticator_factory make_authenticator_factory(
     std::string_view short_name = get_short_name(name);
 
     if (boost::iequals(short_name, "AllowAllAuthenticator")) {
-        return [&qp, &g0, &mm, &auth_cache] {
+        return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
             return std::make_unique<allow_all_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
         };
     } else if (boost::iequals(short_name, "PasswordAuthenticator")) {
-        return [&qp, &g0, &mm, &auth_cache] {
+        return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
             return std::make_unique<password_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
         };
     } else if (boost::iequals(short_name, "CertificateAuthenticator")) {
-        return [&qp, &g0, &mm, &auth_cache] {
+        return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
             return std::make_unique<certificate_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
         };
     } else if (boost::iequals(short_name, "SaslauthdAuthenticator")) {
-        return [&qp, &g0, &mm, &auth_cache] {
+        return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
             return std::make_unique<saslauthd_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
         };
     } else if (boost::iequals(short_name, "TransitionalAuthenticator")) {
-        return [&qp, &g0, &mm, &auth_cache] {
+        return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
             return std::make_unique<transitional_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
         };
     }
@@ -858,11 +858,11 @@ role_manager_factory make_role_manager_factory(
     std::string_view short_name = get_short_name(name);
 
     if (boost::iequals(short_name, "CassandraRoleManager")) {
-        return [&qp, &g0, &mm, &auth_cache] {
+        return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
             return std::make_unique<standard_role_manager>(qp.local(), g0, mm.local(), auth_cache.local());
         };
     } else if (boost::iequals(short_name, "LDAPRoleManager")) {
-        return [&qp, &g0, &mm, &auth_cache] {
+        return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
             return std::make_unique<ldap_role_manager>(qp.local(), g0, mm.local(), auth_cache.local());
         };
     }
@@ -874,7 +874,7 @@ authenticator_factory make_maintenance_socket_authenticator_factory(
         ::service::raft_group0_client& g0,
         sharded<::service::migration_manager>& mm,
         sharded<cache>& auth_cache) {
-    return [&qp, &g0, &mm, &auth_cache] {
+    return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
         return std::make_unique<maintenance_socket_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
     };
 }
@@ -890,7 +890,7 @@ role_manager_factory make_maintenance_socket_role_manager_factory(
         ::service::raft_group0_client& g0,
         sharded<::service::migration_manager>& mm,
         sharded<cache>& auth_cache) {
-    return [&qp, &g0, &mm, &auth_cache] {
+    return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
         return std::make_unique<maintenance_socket_role_manager>(qp.local(), g0, mm.local(), auth_cache.local());
     };
 }

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -831,19 +831,19 @@ authenticator_factory make_authenticator_factory(
         };
     } else if (boost::iequals(short_name, "PasswordAuthenticator")) {
         return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
-            return std::make_unique<password_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
+            return std::make_unique<password_authenticator>(qp.local(), g0, mm.local(), auth_cache.local(), cfg);
         };
     } else if (boost::iequals(short_name, "CertificateAuthenticator")) {
         return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
-            return std::make_unique<certificate_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
+            return std::make_unique<certificate_authenticator>(qp.local(), g0, mm.local(), auth_cache.local(), cfg);
         };
     } else if (boost::iequals(short_name, "SaslauthdAuthenticator")) {
         return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
-            return std::make_unique<saslauthd_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
+            return std::make_unique<saslauthd_authenticator>(qp.local(), g0, mm.local(), auth_cache.local(), cfg);
         };
     } else if (boost::iequals(short_name, "TransitionalAuthenticator")) {
         return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
-            return std::make_unique<transitional_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
+            return std::make_unique<transitional_authenticator>(qp.local(), g0, mm.local(), auth_cache.local(), cfg);
         };
     }
     throw std::invalid_argument(fmt::format("Unknown authenticator: {}", name));
@@ -875,7 +875,7 @@ authenticator_factory make_maintenance_socket_authenticator_factory(
         sharded<::service::migration_manager>& mm,
         sharded<cache>& auth_cache) {
     return [&qp, &g0, &mm, &auth_cache] (const config& cfg) {
-        return std::make_unique<maintenance_socket_authenticator>(qp.local(), g0, mm.local(), auth_cache.local());
+        return std::make_unique<maintenance_socket_authenticator>(qp.local(), g0, mm.local(), auth_cache.local(), cfg);
     };
 }
 

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -30,6 +30,7 @@
 #include "utils/observable.hh"
 #include "utils/serialized_action.hh"
 #include "service/maintenance_mode.hh"
+#include "auth/config.hh"
 
 namespace cql3 {
 class query_processor;
@@ -45,8 +46,8 @@ class role_or_anonymous;
 
 /// Factory function types for creating auth module instances on each shard.
 using authorizer_factory = std::function<std::unique_ptr<authorizer>()>;
-using authenticator_factory = std::function<std::unique_ptr<authenticator>()>;
-using role_manager_factory = std::function<std::unique_ptr<role_manager>()>;
+using authenticator_factory = std::function<std::unique_ptr<authenticator>(const config&)>;
+using role_manager_factory = std::function<std::unique_ptr<role_manager>(const config&)>;
 
 ///
 /// Due to poor (in this author's opinion) decisions of Apache Cassandra, certain choices of one role-manager,
@@ -77,6 +78,8 @@ class service final : public seastar::peering_sharded_service<service> {
     cql3::query_processor& _qp;
 
     ::service::raft_group0_client& _group0_client;
+
+    config _cfg;
 
     authorizer::ptr_type _authorizer;
 
@@ -109,6 +112,7 @@ public:
             authorizer_factory,
             authenticator_factory,
             role_manager_factory,
+            config,
             maintenance_socket_enabled,
             cache&);
 

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -21,6 +21,7 @@
 #include <seastar/core/thread.hh>
 
 #include "auth/common.hh"
+#include "auth/config.hh"
 #include "auth/role_manager.hh"
 #include "auth/roles-metadata.hh"
 #include "cql3/query_processor.hh"
@@ -70,11 +71,12 @@ static bool has_can_login(const cql3::untyped_result_set_row& row) {
     return row.has("can_login") && !(boolean_type->deserialize(row.get_blob_unfragmented("can_login")).is_null());
 }
 
-standard_role_manager::standard_role_manager(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm, cache& cache)
+standard_role_manager::standard_role_manager(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm, cache& cache, const config& cfg)
     : _qp(qp)
     , _group0_client(g0)
     , _migration_manager(mm)
     , _cache(cache)
+    , _superuser_name(cfg.auth_superuser_name)
     , _stopped(make_ready_future<>())
 {}
 
@@ -91,7 +93,7 @@ const resource_set& standard_role_manager::protected_resources() const {
 }
 
 future<> standard_role_manager::maybe_create_default_role() {
-    if (default_superuser(_qp).empty()) {
+    if (_superuser_name.empty()) {
         co_return;
     }
     auto has_superuser = [this] () -> future<bool> {
@@ -122,9 +124,9 @@ future<> standard_role_manager::maybe_create_default_role() {
             db::system_keyspace::NAME,
             meta::roles_table::name,
             meta::roles_table::role_col_name);
-    co_await collect_mutations(_qp, batch, insert_query, {default_superuser(_qp)});
+    co_await collect_mutations(_qp, batch, insert_query, {sstring(_superuser_name)});
     co_await std::move(batch).commit(_group0_client, _as, get_raft_timeout());
-    log.info("Created default superuser role '{}'.", default_superuser(_qp));
+    log.info("Created default superuser role '{}'.", _superuser_name);
 }
 
 future<> standard_role_manager::maybe_create_default_role_with_retries() {

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -33,17 +33,20 @@ class migration_manager;
 
 namespace auth {
 
+struct config;
+
 class standard_role_manager final : public role_manager {
     cql3::query_processor& _qp;
     ::service::raft_group0_client& _group0_client;
     ::service::migration_manager& _migration_manager;
     cache& _cache;
+    std::string _superuser_name;
     future<> _stopped;
     abort_source _as;
     shared_promise<> _superuser_created_promise;
 
 public:
-    standard_role_manager(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, cache&);
+    standard_role_manager(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&, cache&, const config&);
 
     virtual std::string_view qualified_java_name() const noexcept override;
 

--- a/auth/transitional.cc
+++ b/auth/transitional.cc
@@ -10,6 +10,7 @@
 
 #include "auth/transitional.hh"
 #include "auth/authenticated_user.hh"
+#include "auth/config.hh"
 #include "auth/default_authorizer.hh"
 #include "auth/password_authenticator.hh"
 #include "auth/permission.hh"
@@ -17,8 +18,8 @@
 
 namespace auth {
 
-transitional_authenticator::transitional_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm, cache& cache)
-        : transitional_authenticator(std::make_unique<password_authenticator>(qp, g0, mm, cache)) {
+transitional_authenticator::transitional_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm, cache& cache, const config& cfg)
+        : transitional_authenticator(std::make_unique<password_authenticator>(qp, g0, mm, cache, cfg)) {
 }
 
 transitional_authenticator::transitional_authenticator(std::unique_ptr<authenticator> a)

--- a/auth/transitional.hh
+++ b/auth/transitional.hh
@@ -25,6 +25,8 @@ class migration_manager;
 
 namespace auth {
 
+struct config;
+
 ///
 /// Transitional authenticator that allows anonymous access when credentials are not provided
 /// or authentication fails. Used for migration scenarios.
@@ -33,7 +35,7 @@ class transitional_authenticator : public authenticator {
     std::unique_ptr<authenticator> _authenticator;
 
 public:
-    transitional_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm, cache& cache);
+    transitional_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm, cache& cache, const config& cfg);
     transitional_authenticator(std::unique_ptr<authenticator> a);
 
     virtual future<> start() override;

--- a/main.cc
+++ b/main.cc
@@ -61,6 +61,7 @@
 #include "utils/directories.hh"
 #include "debug.hh"
 #include "auth/common.hh"
+#include "auth/config.hh"
 #include "init.hh"
 #include "release.hh"
 #include "repair/repair.hh"
@@ -2185,12 +2186,27 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             std::any stop_maintenance_auth_service;
             std::any stop_maintenance_cql;
 
+            auto make_auth_cfg = [&] {
+                return auth::config {
+                    .auth_superuser_name = cfg->auth_superuser_name(),
+                    .auth_superuser_salted_password = cfg->auth_superuser_salted_password(),
+                    .saslauthd_socket_path = cfg->saslauthd_socket_path(),
+                    .auth_certificate_role_queries = cfg->auth_certificate_role_queries(),
+                    .ldap_url_template = cfg->ldap_url_template(),
+                    .ldap_attr_role = cfg->ldap_attr_role(),
+                    .ldap_bind_dn = cfg->ldap_bind_dn(),
+                    .ldap_bind_passwd = cfg->ldap_bind_passwd(),
+                    .permissions_update_interval_in_ms = cfg->permissions_update_interval_in_ms,
+                };
+            };
+
             if (cfg->maintenance_socket() != "ignore") {
                 checkpoint(stop_signal, "starting maintenance auth service");
                 maintenance_auth_service.start(std::ref(qp), std::ref(group0_client),
                         auth::make_maintenance_socket_authorizer_factory(qp),
                         auth::make_maintenance_socket_authenticator_factory(qp, group0_client, mm, auth_cache),
                         auth::make_maintenance_socket_role_manager_factory(qp, group0_client, mm, auth_cache),
+                        sharded_parameter(make_auth_cfg),
                         maintenance_socket_enabled::yes, std::ref(auth_cache)).get();
 
                 cql_maintenance_server_ctl.emplace(maintenance_auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, messaging, timeout_cfg, *cfg, maintenance_cql_sg_stats_key, maintenance_socket_enabled::yes, dbcfg.statement_scheduling_group);
@@ -2464,6 +2480,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     auth::make_authorizer_factory(cfg->authorizer(), qp),
                     auth::make_authenticator_factory(cfg->authenticator(), qp, group0_client, mm, auth_cache),
                     auth::make_role_manager_factory(cfg->role_manager(), qp, group0_client, mm, auth_cache),
+                    sharded_parameter(make_auth_cfg),
                     maintenance_socket_enabled::no, std::ref(auth_cache)).get();
 
             std::any stop_auth_service;

--- a/test/boost/role_manager_test.cc
+++ b/test/boost/role_manager_test.cc
@@ -9,6 +9,7 @@
 #include <fmt/ranges.h>
 
 #include "auth/standard_role_manager.hh"
+#include "auth/config.hh"
 
 #include "service/raft/raft_group0_client.hh"
 #undef SEASTAR_TESTING_MAIN
@@ -24,7 +25,7 @@ auto make_manager(cql_test_env& env) {
         std::default_delete<auth::standard_role_manager>()(m);
     };
     return std::unique_ptr<auth::standard_role_manager, decltype(stop_role_manager)>(
-            new auth::standard_role_manager(env.local_qp(), env.get_raft_group0_client(), env.migration_manager().local(), env.auth_cache().local()),
+            new auth::standard_role_manager(env.local_qp(), env.get_raft_group0_client(), env.migration_manager().local(), env.auth_cache().local(), auth::config{}),
             std::move(stop_role_manager));
 }
 

--- a/test/ldap/role_manager_test.cc
+++ b/test/ldap/role_manager_test.cc
@@ -7,6 +7,7 @@
  */
 
 #include "auth/common.hh"
+#include "auth/config.hh"
 #include "auth/standard_role_manager.hh"
 #include "auth/ldap_role_manager.hh"
 #include "auth/password_authenticator.hh"
@@ -30,7 +31,7 @@ auto make_manager(cql_test_env& env) {
         std::default_delete<auth::standard_role_manager>()(m);
     };
     return std::unique_ptr<auth::standard_role_manager, decltype(stop_role_manager)>(
-            new auth::standard_role_manager(env.local_qp(), env.get_raft_group0_client(),  env.migration_manager().local(), env.auth_cache().local()),
+            new auth::standard_role_manager(env.local_qp(), env.get_raft_group0_client(),  env.migration_manager().local(), env.auth_cache().local(), auth::config{}),
             std::move(stop_role_manager));
 }
 
@@ -290,7 +291,7 @@ auto make_ldap_manager(cql_test_env& env, sstring query_template = default_query
     return std::unique_ptr<auth::ldap_role_manager, decltype(stop_role_manager)>(
             new auth::ldap_role_manager(query_template, /*target_attr=*/"cn", manager_dn, manager_password,
                     env.db_config().permissions_update_interval_in_ms(), env.db_config().permissions_update_interval_in_ms.observe([] (const uint32_t& v) {}),
-                    env.local_qp(), env.get_raft_group0_client(), env.migration_manager().local(), env.auth_cache().local()),
+                    env.local_qp(), env.get_raft_group0_client(), env.migration_manager().local(), env.auth_cache().local(), auth::config{}),
         std::move(stop_role_manager));
 }
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1145,10 +1145,24 @@ private:
             startlog.info("Verifying that all of the keyspaces are RF-rack-valid");
             _db.local().check_rf_rack_validity(_token_metadata.local().get());
 
+            auto make_auth_cfg = [&] {
+                return auth::config {
+                    .auth_superuser_name = cfg->auth_superuser_name(),
+                    .auth_superuser_salted_password = cfg->auth_superuser_salted_password(),
+                    .saslauthd_socket_path = cfg->saslauthd_socket_path(),
+                    .auth_certificate_role_queries = cfg->auth_certificate_role_queries(),
+                    .ldap_url_template = cfg->ldap_url_template(),
+                    .ldap_attr_role = cfg->ldap_attr_role(),
+                    .ldap_bind_dn = cfg->ldap_bind_dn(),
+                    .ldap_bind_passwd = cfg->ldap_bind_passwd(),
+                    .permissions_update_interval_in_ms = cfg->permissions_update_interval_in_ms,
+                };
+            };
             _auth_service.start(std::ref(_qp), std::ref(group0_client),
                     auth::make_authorizer_factory(cfg->authorizer(), _qp),
                     auth::make_authenticator_factory(cfg->authenticator(), _qp, group0_client, _mm, _auth_cache),
                     auth::make_role_manager_factory(cfg->role_manager(), _qp, group0_client, _mm, _auth_cache),
+                    sharded_parameter(make_auth_cfg),
                     maintenance_socket_enabled::no, std::ref(_auth_cache)).get();
 
             _auth_service.invoke_on_all([this] (auth::service& auth) {


### PR DESCRIPTION
Auth modules (authenticators, role managers, and auth::service) access their configuration options by reaching into db::config through the query processor. This abuses database as proxy object to get configuration.

This series introduces a dedicated auth::config struct that carries the configuration options used by auth modules.The config is populated in main.cc and delivered to each shard via sharded_parameter. This makes auth service conform to the overall design, where db::config is split into smaller per-service configs on start, thus decoupling individual components/services from global configuration.

Cleaning components dependencies, not backporting.