### PR TITLE
alternator: start S3 export implementation

### DIFF
--- a/alternator/CMakeLists.txt
+++ b/alternator/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(alternator
     ttl.cc
     parsed_expression_cache.cc
     http_compression.cc
+    export.cc
     ${cql_grammar_srcs})
 target_include_directories(alternator
   PUBLIC

--- a/alternator/export.cc
+++ b/alternator/export.cc
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include "alternator/export.hh"
+#include <seastar/core/coroutine.hh>
+#include "utils/rjson.hh"
+#include <algorithm>
+#include <string>
+#include <string_view>
+
+namespace alternator {
+
+// Interfaces for `sink` / `source` pipelines.
+// The `sink` pipeline consists of 3 stages:
+//   - formatter (see `export_pipeline_interface` interface in header) - serializes rjson::value as-is to simple binary format (JSON lines, Ion, CSV are required by Amazon specs),
+//   - compressor - optionally compresses the data - Amazon S3 requires support for gzip compression,
+//   - writer - writes the data to the storage (e.g. S3 or in-memory).
+// After construction user is expected to call `export_pipeline_interface::process()` with an item to export,
+// which will call a compressor and a writer for that item. After that the future will complete and user is free to call
+// `export_pipeline_interface::process()` with another item.
+
+struct storage_sink_interface {
+    virtual seastar::future<> write(std::span<const std::byte>) = 0;
+    virtual seastar::future<> flush_and_close() = 0;
+    virtual ~storage_sink_interface() = default;
+};
+
+struct compression_interface {
+    virtual seastar::future<> compress(std::span<const std::byte>) = 0;
+    virtual seastar::future<> flush_and_close() = 0;
+    virtual ~compression_interface() = default;
+};
+
+// The `source` pipeline consists of 3 stages:
+//   - reader (see `import_pipeline_interface` interface in header) - reads the data from the storage (e.g. S3 or in-memory).
+//   - decompressor - optionally decompresses the data - Amazon S3 requires support for gzip compression,
+//   - parser - deserializes binary data to rjson::value as-is (JSON lines, Ion, CSV are required by Amazon specs),
+// After pipeline construction (see `create_**` family of factory functions in header `export.hh`) user is expected to
+// call `import_pipeline_interface::read()`. This will read some data from the source and
+// call `decompression_interface::decompress()` with it, which will - optionally - decompress it,
+// then call `parsing_interface::parse()` with the decompressed data. The parser invokes the `on_item` (passed to the pipeline factory function) callback
+// for each parsed item.
+struct parsing_interface {
+    virtual seastar::future<> parse(std::span<const std::byte>) = 0;
+    virtual seastar::future<> flush_and_close() = 0;
+    virtual ~parsing_interface() = default;
+};
+
+struct decompression_interface {
+    virtual seastar::future<> decompress(std::span<const std::byte>) = 0;
+    virtual seastar::future<> flush_and_close() = 0;
+    virtual ~decompression_interface() = default;
+};
+
+// In memory sink - stores data to a caller owned in_memory_test_storage buffer object.
+// Single threaded, single "file" use only. Caller must ensure in_memory_test_storage object lives long enough.
+class in_memory_storage_sink : public storage_sink_interface {
+    in_memory_test_storage& _storage;
+public:
+    explicit in_memory_storage_sink(in_memory_test_storage& storage)
+        : _storage(storage) {}
+
+    seastar::future<> write(std::span<const std::byte> data) override {
+        _storage.append(data);
+        co_return;
+    }
+
+    seastar::future<> flush_and_close() override {
+        _storage.flush_write();
+        co_return;
+    }
+};
+
+// No compression compressor - passes data further down the pipeline.
+class noop_compressor : public compression_interface {
+    std::unique_ptr<storage_sink_interface> _sink;
+
+public:
+    noop_compressor(std::unique_ptr<storage_sink_interface> sink) : _sink(std::move(sink)) {}
+
+    seastar::future<> compress(std::span<const std::byte> data) override {
+        co_await _sink->write(data);
+    }
+
+    seastar::future<> flush_and_close() override {
+        co_await _sink->flush_and_close();
+    }
+};
+
+// Formatter that converts rjson::value item to single JSON line and passes it to the compressor.
+// The line is terminated with a newline character, so that the source pipeline can parse it line by line.
+class json_formatter : public export_pipeline_interface {
+    std::unique_ptr<compression_interface> _sink;
+public:
+    json_formatter(std::unique_ptr<compression_interface> sink) : _sink(std::move(sink)) {}
+
+    seastar::future<> process(const rjson::value &item) override {
+        // TODO(rcybulski): this is extremely slow and naive - we need a streaming version of `rjson::print` here.
+        auto line = rjson::print(item);
+        line += "\n";
+        co_await _sink->compress(std::as_bytes(std::span<const char>(line)));
+    }
+
+    seastar::future<> flush_and_close() override {
+        co_await _sink->flush_and_close();
+    }
+};
+
+// In memory source object - reads data from a caller owned in_memory_test_storage buffer object and
+// feeds it through a decompressor and parsing pipeline, which parses each line back into an rjson::value, and invokes the on_item callback.
+// Single threaded, single "file" use only. Caller must ensure in_memory_test_storage object lives long enough, and that on_item callback remains valid until flush_and_close() is called.
+// Due to a low chunk size this is test only class.
+class in_memory_source : public import_pipeline_interface {
+    in_memory_test_storage& _storage;
+    std::unique_ptr<decompression_interface> _decompressor;
+public:
+    in_memory_source(in_memory_test_storage& storage,
+                     std::unique_ptr<decompression_interface> decompressor)
+        : _storage(storage)
+        , _decompressor(std::move(decompressor)) {}
+
+    seastar::future<> read() override {
+        auto data = _storage.data();
+        auto* ptr = reinterpret_cast<const char*>(data.data());
+        constexpr size_t chunk_size = 16;
+        // We feed the data in small chunks here to test the pipeline.
+        size_t position = 0;
+        while(position < data.size()) {
+            auto n = std::min(chunk_size, data.size() - position);
+            co_await _decompressor->decompress(std::as_bytes(std::span<const char>(ptr + position, n)));
+            position += n;
+        }
+    }
+
+    seastar::future<> flush_and_close() override {
+        _storage.flush_read();
+        return _decompressor->flush_and_close();
+    }
+};
+
+// No compression decompressor - passes data further up the pipeline.
+class noop_decompressor : public decompression_interface {
+    std::unique_ptr<parsing_interface> _parser;
+public:
+    noop_decompressor(std::unique_ptr<parsing_interface> parser) : _parser(std::move(parser)) {}
+
+    seastar::future<> decompress(std::span<const std::byte> data) override {
+        co_await _parser->parse(data);
+    }
+
+    seastar::future<> flush_and_close() override {
+        co_await _parser->flush_and_close();
+    }
+};
+
+// Json parser that accumulates incoming data until it sees a newline character,
+// then parses the accumulated line as JSON and invokes the on_item callback with the parsed rjson::value.
+// The last line is parsed and sent to callback even if it doesn't end with a newline.
+class json_parser : public parsing_interface {
+    std::function<seastar::future<>(rjson::value)> _on_item;
+    std::string _buffer;
+public:
+    json_parser(std::function<seastar::future<>(rjson::value)> on_item) : _on_item(std::move(on_item)) {}
+    seastar::future<> parse(std::span<const std::byte> data) override {
+        auto sv = std::string_view(reinterpret_cast<const char*>(data.data()), data.size());
+        size_t pos = 0;
+        while (pos < sv.size()) {
+            auto nl = sv.find('\n', pos);
+            if (nl == std::string_view::npos) {
+                _buffer.append(sv.substr(pos));
+                break;
+            }
+            _buffer.append(sv.substr(pos, nl - pos));
+            if (!_buffer.empty()) {
+                co_await _on_item(rjson::parse(_buffer));
+                _buffer.clear();
+            }
+            pos = nl + 1;
+        }
+    }
+
+    seastar::future<> flush_and_close() override {
+        if (!_buffer.empty()) {
+            // Process any remaining data as a final line (even if it doesn't end with a newline).
+            co_await _on_item(rjson::parse(_buffer));
+            _buffer.clear();
+        }
+        co_return;
+    }
+};
+
+// Factory function to create in-memory sink pipeline for testing (no compression, JSON formatter).
+std::unique_ptr<export_pipeline_interface> create_in_memory_sink_pipeline(in_memory_test_storage& storage) {
+    auto sink = std::make_unique<in_memory_storage_sink>(storage);
+    auto compressor = std::make_unique<noop_compressor>(std::move(sink));
+    return std::make_unique<json_formatter>(std::move(compressor));
+}
+
+// Factory function to create in-memory source pipeline for testing (no compression, JSON parser).
+std::unique_ptr<import_pipeline_interface> create_in_memory_source_pipeline(in_memory_test_storage& storage, std::function<seastar::future<>(rjson::value)> on_item) {
+    auto parser = std::make_unique<json_parser>(std::move(on_item));
+    auto decompressor = std::make_unique<noop_decompressor>(std::move(parser));
+    return std::make_unique<in_memory_source>(storage, std::move(decompressor));
+}
+
+} // namespace alternator

--- a/alternator/export.hh
+++ b/alternator/export.hh
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <span>
+#include <vector>
+#include <seastar/core/future.hh>
+#include "utils/rjson.hh"
+
+namespace alternator {
+
+// An interface encapsulating write (sink) pipeline for exporting data. Is used to implement DynamoDB export api (ExportTableToPointInTime call).
+// The pipeline is a multistage processing unit, which takes `rjson::value` item (of any content), serializes it as-is and writes it depending on the configuration.
+// Currently supporting only test-only in-memory pipeline, serializing to raw text JSON lines. In the future we will add support for S3, compression and different formats (e.g. Ion, CSV).
+// Call respective factory method below (`create_in_memory_sink_pipeline`) to construct.
+// Call `process()` method for each item (they might come in random order) - they will be serialized and written to the appropriate sink.
+// After all items are processed, call `flush_and_close()` to flush and finalize the pipeline - the call is mandatory, otherwise part of the data might not be written.
+// Calling `flush_and_close()` is required and needs to be done manually.
+// Calls to `process()` and `flush_and_close()` must be serialized, i.e. each call is allowed only after previous call's future is completed.
+struct export_pipeline_interface {
+    // Invokes whole pipeline for a single item. The future will complete once item is processed.
+    // This doesn't mean the item hit external storage, but you're free to process another item.
+    // Call to `process()` is allowed only after previous call to `process()` or `flush_and_close()` future is completed.
+    // Caller is responsible for ensuring `item` is kept alive until the future is completed.
+    virtual seastar::future<> process(const rjson::value &item) = 0;
+
+    // Flushes and closes the pipeline. The future will complete once all items are flushed and pipeline is finalized.
+    // Do not call process() after calling flush_and_close().
+    virtual seastar::future<> flush_and_close() = 0;
+
+    virtual ~export_pipeline_interface() = default;
+};
+
+// An interface encapsulating read (source) pipeline. This mirrors write (sink) pipeline - what sink pipeline can produce, source pipeline will consume.
+// This will be used in future for DynamoDB import api (ImportTable call).
+// Added currently for testing purposes - so we have a consistent way to read exported data without relying on connection to S3 / DynamoDB.
+// Call respective factory method below (`create_in_memory_source_pipeline`) to construct.
+// Call `read()` (only once!) method to start reading the data - it will read all data, pass it through the decompressor and parser
+// and call the callback provided to the factory function for each parsed item. The pipeline will wait
+// for each callback's future to complete before processing the next item.
+// After all data is read (the future from `read()` call completes), call `flush_and_close()` to flush and finalize the pipeline.
+// Calling `flush_and_close()` is required and needs to be done manually.
+struct import_pipeline_interface {
+    // Reads all available data from the source, feeds it through the decompression and parsing pipeline,
+    // and invokes the on_item callback (passed to the pipeline constructor function) for each parsed item.
+    // The future completes after source is exhausted.
+    // Note: you still need to call `flush_and_close()` to finalize the pipeline - there might be some remaining data to process.
+    virtual seastar::future<> read() = 0;
+
+    // Flushes and closes the pipeline. The future will complete once all remaining, already read data is processed, flushed and pipeline is finalized.
+    // The call doesn't read additional data.
+    // Do not call read() after calling flush_and_close().
+    virtual seastar::future<> flush_and_close() = 0;
+
+    virtual ~import_pipeline_interface() = default;
+};
+
+// Simple in-memory byte buffer used for testing the export pipeline without actual S3 or compression.
+// Represents content of single file. Allows both exporting and importing data.
+class in_memory_test_storage {
+    std::vector<std::byte> _data;
+    bool _read_flushed = false;
+    bool _write_flushed = false;
+public:
+    void append(std::span<const std::byte> bytes) {
+        _data.insert(_data.end(), bytes.begin(), bytes.end());
+    }
+    std::span<const std::byte> data() const { return _data; }
+
+    // for testing calling `flush` methods - pipeline will call those methods when flush / flush_and_close is called, and we want to verify that.
+    void flush_read() { _read_flushed = true; }
+    void flush_write() { _write_flushed = true; }
+    bool is_read_flushed() const { return _read_flushed; }
+    bool is_write_flushed() const { return _write_flushed; }
+};
+
+// Create in-memory sink pipeline for a single file
+// You should not use the same in_memory_test_storage object for sink and source pipeline simultaneously -
+// you need to complete sink pipeline first, then create and run source pipeline.
+std::unique_ptr<export_pipeline_interface> create_in_memory_sink_pipeline(in_memory_test_storage&);
+
+// Create in-memory source pipeline for a single file
+// You should not use the same in_memory_test_storage object for sink and source pipeline simultaneously -
+// you need to complete sink pipeline first, then create and run source pipeline.
+std::unique_ptr<import_pipeline_interface> create_in_memory_source_pipeline(in_memory_test_storage &, std::function<seastar::future<>(rjson::value)> on_item);
+
+} // namespace alternator

--- a/configure.py
+++ b/configure.py
@@ -532,6 +532,7 @@ scylla_tests = set([
     'test/boost/advanced_rpc_compressor_test',
     'test/boost/allocation_strategy_test',
     'test/boost/alternator_unit_test',
+    'test/boost/alternator_export_test',
     'test/boost/anchorless_list_test',
     'test/boost/auth_passwords_test',
     'test/boost/audit_rule_test',
@@ -1473,7 +1474,8 @@ alternator = [
        'alternator/auth.cc',
        'alternator/streams.cc',
        'alternator/ttl.cc',
-       'alternator/http_compression.cc'
+       'alternator/http_compression.cc',
+       'alternator/export.cc'
 ]
 
 idls = ['idl/gossip_digest.idl.hh',

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -6,6 +6,9 @@ add_scylla_test(advanced_rpc_compressor_test
   KIND SEASTAR)
 add_scylla_test(allocation_strategy_test
   KIND BOOST)
+add_scylla_test(alternator_export_test
+  KIND SEASTAR
+  LIBRARIES alternator)
 add_scylla_test(alternator_unit_test
   KIND SEASTAR
   LIBRARIES alternator)

--- a/test/boost/alternator_export_test.cc
+++ b/test/boost/alternator_export_test.cc
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include "test/lib/scylla_test_case.hh"
+
+#include <seastar/core/coroutine.hh>
+#include "alternator/export.hh"
+#include <string>
+#include <vector>
+#include <span>
+
+SEASTAR_TEST_CASE(test_in_memory_roundtrip_single_item) {
+    auto storage = alternator::in_memory_test_storage();
+    auto sink = alternator::create_in_memory_sink_pipeline(storage);
+
+    auto item = rjson::parse("{\"key\": \"value\"}");
+    co_await sink->process(item);
+    co_await sink->flush_and_close();
+
+    BOOST_CHECK(storage.is_write_flushed());
+
+    std::vector<rjson::value> received;
+    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+        received.push_back(std::move(v));
+        co_return;
+    });
+    co_await source->read();
+    co_await source->flush_and_close();
+
+    BOOST_CHECK(storage.is_read_flushed());
+    BOOST_REQUIRE_EQUAL(received.size(), 1u);
+    BOOST_CHECK_EQUAL(rjson::print(received[0]), rjson::print(item));
+}
+
+SEASTAR_TEST_CASE(test_in_memory_line_without_newline) {
+    auto storage = alternator::in_memory_test_storage();
+    std::string line = "{\"key\": \"value\"}"; // Note: no newline at the end
+    storage.append(std::as_bytes(std::span<const char>(line)));
+
+    std::vector<rjson::value> received;
+    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+        received.push_back(std::move(v));
+        co_return;
+    });
+    co_await source->read();
+    co_await source->flush_and_close();
+
+    BOOST_CHECK(storage.is_read_flushed());
+    BOOST_REQUIRE_EQUAL(received.size(), 1u);
+    BOOST_CHECK_EQUAL(rjson::print(received[0]), rjson::print(rjson::parse(line)));
+}
+
+SEASTAR_TEST_CASE(test_in_memory_roundtrip_multiple_items) {
+    auto storage = alternator::in_memory_test_storage();
+    auto sink = alternator::create_in_memory_sink_pipeline(storage);
+
+    auto item1 = rjson::parse("{\"id\": 1, \"name\": \"alice\"}");
+    auto item2 = rjson::parse("{\"id\": 2, \"name\": \"bob\"}");
+    auto item3 = rjson::parse("{\"id\": 3, \"name\": \"charlie\"}");
+    co_await sink->process(item1);
+    co_await sink->process(item2);
+    co_await sink->process(item3);
+    co_await sink->flush_and_close();
+
+    std::vector<rjson::value> received;
+    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+        received.push_back(std::move(v));
+        co_return;
+    });
+    co_await source->read();
+    co_await source->flush_and_close();
+
+    BOOST_REQUIRE_EQUAL(received.size(), 3u);
+    BOOST_CHECK_EQUAL(rjson::print(received[0]), rjson::print(item1));
+    BOOST_CHECK_EQUAL(rjson::print(received[1]), rjson::print(item2));
+    BOOST_CHECK_EQUAL(rjson::print(received[2]), rjson::print(item3));
+}
+
+SEASTAR_TEST_CASE(test_in_memory_roundtrip_nested_json) {
+    auto storage = alternator::in_memory_test_storage();
+    auto sink = alternator::create_in_memory_sink_pipeline(storage);
+
+    auto item = rjson::parse("{\"nested\": {\"array\": [1, 2, 3], \"obj\": {\"a\": true}}}");
+    co_await sink->process(item);
+    co_await sink->flush_and_close();
+
+    std::vector<rjson::value> received;
+    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+        received.push_back(std::move(v));
+        co_return;
+    });
+    co_await source->read();
+    co_await source->flush_and_close();
+
+    BOOST_REQUIRE_EQUAL(received.size(), 1u);
+    BOOST_CHECK_EQUAL(rjson::print(received[0]), rjson::print(item));
+}
+
+SEASTAR_TEST_CASE(test_in_memory_roundtrip_empty_storage) {
+    auto storage = alternator::in_memory_test_storage();
+
+    std::vector<rjson::value> received;
+    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+        received.push_back(std::move(v));
+        co_return;
+    });
+    co_await source->read();
+    co_await source->flush_and_close();
+
+    BOOST_CHECK(storage.is_read_flushed());
+    BOOST_CHECK(received.empty());
+}
+
+// Test that special characters in JSON strings are properly escaped and unescaped during export/import roundtrip,
+// especially end of line character, which has additional meaning as item separator.
+SEASTAR_TEST_CASE(test_in_memory_roundtrip_special_characters) {
+    auto storage = alternator::in_memory_test_storage();
+    auto sink = alternator::create_in_memory_sink_pipeline(storage);
+
+    auto item1 = rjson::parse("{\"msg\": \"hello\\nworld\\t\\\"quoted1\\\"\"}");
+    auto item2 = rjson::parse("{\"msg\": \"hello\\nworld\\t\\\"quoted2\\\"\"}");
+
+    co_await sink->process(item1);
+    co_await sink->process(item2);
+    co_await sink->flush_and_close();
+
+    std::vector<rjson::value> received;
+    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+        received.push_back(std::move(v));
+        co_return;
+    });
+    co_await source->read();
+    co_await source->flush_and_close();
+
+    BOOST_REQUIRE_EQUAL(received.size(), 2u);
+    BOOST_CHECK_EQUAL(rjson::print(received[0]), rjson::print(item1));
+    BOOST_CHECK_EQUAL(rjson::print(received[1]), rjson::print(item2));
+}


### PR DESCRIPTION
Add a starting commit for S3 export implementation. The implementation is splited across several PR and will be divided into three main sections:
- sink - takes a row representation (as `rjson::value`), processes it and stores it into it's final destination (we add `source` part as well, to simplify debugging),
- scan - produces content of the table as single `rjson::value` object for each row (in random order, but not repeating),
- orchestration - the logic that constructs sink / scan objects and manage them.

This patch lays groundwork for `sink` phase. The patch adds:
- new file export.cc / export.hh, which will contain export related implementations,
- new test file alternator_export_test.cc - for tests related to export,
- changes to CMakeFiles.txt / configure.py to accomodate new files,
- public `export_pipeline_interface` / `import_pipeline_interface` - interfaces ecapsulating `sink` / `source` pipelines (we add import for testing purposes),
- public `in_memory_test_storage` class - debug helper, which will allow `sink` pipeline to write into in-memory object, reducing need for AWS / MinIO services and improving test performance (we add it to export.hh, because we keep most parts of the pipeline private, which means the factory for `in_memory_test_storage` must be in `export.cc`, which means `in_memory_test_storage` definition should be here as well - otherwise we will have to include header from test module),
- `create_in_memory_sink_pipeline` / `create_in_memory_source_pipeline` functions - factory functions for constructing `sink` / `source` pipelines. Currently only capable of creating in-memory json-backed simple pipelines, will be extended, once support for compression and other formats comes in,
- tests for pipelines and `in_memory_test_storage` class.

Refs: SCYLLADB-1370
Fixes: SCYLLADB-1879

Backport: none - new feature.