### PR TITLE
commitlog: add v5 header feature flags with v4 replay support

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -118,8 +118,8 @@ db::commitlog::config db::commitlog::config::from_db_config(const db::config& cf
     return c;
 }
 
-db::commitlog::descriptor::descriptor(segment_id_type i, const std::string& fname_prefix, uint32_t v, sstring fname)
-        : _filename(std::move(fname)), id(i), ver(v), filename_prefix(fname_prefix) {
+db::commitlog::descriptor::descriptor(segment_id_type i, const std::string& fname_prefix, uint32_t v, descriptor::feature_flags flags, sstring fname)
+        : _filename(std::move(fname)), id(i), ver(v), filename_prefix(fname_prefix), _flags(flags) {
 }
 
 db::commitlog::descriptor::descriptor(replay_position p, const std::string& fname_prefix)
@@ -156,7 +156,7 @@ db::commitlog::descriptor::descriptor(const std::string& filename, const std::st
         segment_id_type id = std::stoull(m[3].str());
         uint32_t ver = std::stoul(m[2].str());
 
-        return descriptor(id, fname_prefix, ver, filename);
+        return descriptor(id, fname_prefix, ver, descriptor::feature_flags::none, filename);
     }()) {
 }
 
@@ -821,7 +821,8 @@ public:
     static constexpr size_t multi_entry_overhead_size = entry_overhead_size + sizeof(uint32_t);
     static constexpr size_t fragmented_entry_overhead_size = 4 * sizeof(uint32_t);
     static constexpr size_t segment_overhead_size = 2 * sizeof(uint32_t);
-    static constexpr size_t descriptor_header_size = 6 * sizeof(uint32_t);
+    static constexpr size_t descriptor_header_size = 8 * sizeof(uint32_t);    // magic + ver + id(2) + alignment + flags(2) + crc
+    static constexpr size_t descriptor_header_size_v4 = 6 * sizeof(uint32_t); // v4: magic + ver + id(2) + alignment + crc
     static constexpr uint32_t segment_magic = ('S'<<24) |('C'<< 16) | ('L' << 8) | 'C';
     static constexpr uint32_t multi_entry_size_magic = 0xffffffff;
     static constexpr uint32_t fragmented_entry_size_magic = 0xfffffffe;
@@ -831,6 +832,11 @@ public:
 
     // TODO : tune initial / default size
     static constexpr size_t default_size = 128 * 1024;
+
+    size_t active_header_size() const {
+        return _desc.ver == descriptor::segment_version_5
+            ? descriptor_header_size : descriptor_header_size_v4;
+    }
 
     segment(::shared_ptr<segment_manager> m, descriptor&& d, named_file&& f, size_t alignment)
             : _segment_manager(std::move(m)), _desc(std::move(d)), _file(std::move(f)),
@@ -1031,7 +1037,7 @@ public:
     std::tuple<size_t, size_t> buffer_usage_size(size_t s) const {
         auto overhead = segment_overhead_size;
         if (_file_pos == 0) {
-            overhead += descriptor_header_size;
+            overhead += active_header_size();
         }
 
         return {s + overhead, overhead};
@@ -1071,7 +1077,7 @@ public:
 
     bool buffer_is_empty() const {
         return buffer_position() <= segment_overhead_size
-                        || (_file_pos == 0 && buffer_position() <= (segment_overhead_size + descriptor_header_size));
+                        || (_file_pos == 0 && buffer_position() <= (segment_overhead_size + active_header_size()));
     }
     /**
      * Send any buffer contents to disk and get a new tmp buffer
@@ -1115,8 +1121,15 @@ public:
             crc.process<int32_t>(_desc.id & 0xffffffff);
             crc.process<int32_t>(_desc.id >> 32);
             crc.process<uint32_t>(uint32_t(_alignment));
+            if (_desc.ver == descriptor::segment_version_5) {
+                auto flags = static_cast<uint64_t>(_desc.flags());
+                write(out, flags);
+                crc.process(flags);
+                header_size = descriptor_header_size;
+            } else {
+                header_size = descriptor_header_size_v4;
+            }
             write(out, crc.checksum());
-            header_size = descriptor_header_size;
         }
 
         if (!termination) {
@@ -1584,7 +1597,7 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
         // more worst case
         auto size_with_meta_overhead = size_with_sector_overhead
             + (1 + size_with_sector_overhead/max_mutation_size) * (segment::entry_overhead_size + segment::fragmented_entry_overhead_size + segment::segment_overhead_size)
-            * (1 + size_with_sector_overhead/max_size) * segment::descriptor_header_size
+            * (1 + size_with_sector_overhead/max_size) * segment::descriptor_header_size  // conservative: uses v5 (max) size
             ;
         // this is not really true. We could have some space in current segment,
         // but again, lets be conservative.
@@ -1702,7 +1715,7 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
             auto get_segment = [&]() -> future<sseg_ptr> {
                 sseg_ptr s = co_await active_segment(timeout);
                 if (maybe_clear.empty() || maybe_clear.back().first.get() != s.get()) {
-                    if (s->position() > (segment::segment_overhead_size + segment::descriptor_header_size)) {
+                    if (s->position() > (segment::segment_overhead_size + s->active_header_size())) {
                         co_await s->sync(); // ensure file pos == restartable.
                     }
                     maybe_clear.emplace_back(s, s->file_position());
@@ -1803,7 +1816,7 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
                     avail = std::min(rem2, max_mutation_size) 
                         - segment::entry_overhead_size
                         - segment::fragmented_entry_overhead_size
-                        - (pos == 0 ? segment::descriptor_header_size : 0)
+                        - (pos == 0 ? s->active_header_size() : 0)
                         - segment::segment_overhead_size
                         ;
                 }
@@ -2424,7 +2437,9 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
 
 future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager::allocate_segment() {
     for (;;) {
-        descriptor d(next_id(), cfg.fname_prefix);
+        auto seg_ver = cfg.use_v5_header ? descriptor::segment_version_5 : descriptor::segment_version_4;
+        auto seg_flags = cfg.use_v5_header ? static_cast<descriptor::feature_flags>(cfg.features) : descriptor::feature_flags::none;
+        descriptor d(next_id(), cfg.fname_prefix, seg_ver, seg_flags);
         auto dst = filename(d);
         auto flags = open_flags::wo;
         if (cfg.use_o_dsync) {
@@ -3355,6 +3370,8 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
         size_t file_size = 0;
         size_t corrupt_size = 0;
         size_t alignment = 0;
+        // Populated by read_header; will be used by downstream consumers.
+        descriptor::feature_flags flags = descriptor::feature_flags::none;
         bool eof = false;
         bool header = true;
         bool failed = false;
@@ -3420,26 +3437,43 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
             stop();
         }
         future<> read_header() {
-            fragmented_temporary_buffer buf = co_await frag_reader.read_exactly(fin, segment::descriptor_header_size);
+            // Header layout:
+            //   v4: magic(4) + ver(4) + id(8) + alignment(4) + crc(4) = 24 bytes
+            //   v5: magic(4) + ver(4) + id(8) + alignment(4) + flags(8) + crc(4) = 32 bytes
+            //
+            // Read the common prefix (20 bytes) first to determine the version,
+            // then read the version-specific tail (4 for v4, 12 for v5).
+            static constexpr size_t common_size = sizeof(uint32_t) * 2 + sizeof(uint64_t) + sizeof(uint32_t);  // 20
+            fragmented_temporary_buffer common_buf = co_await frag_reader.read_exactly(fin, common_size);
 
-            if (buf.empty()) {
+            if (common_buf.empty()) {
                 eof = true;
                 co_return;
             }
 
-            // Will throw if we got eof
-            auto in = buf.get_istream();
+            auto in = common_buf.get_istream();
             auto magic = read<uint32_t>(in);
             auto ver = read<uint32_t>(in);
             auto id = read<uint64_t>(in);
             auto alignment = read<uint32_t>(in);
-            auto checksum = read<uint32_t>(in);
 
-            if (magic == 0 && ver == 0 && id == 0 && checksum == 0) {
-                // let's assume this was an empty (pre-allocated)
-                // file. just skip it.
+            if (magic == 0 && ver == 0 && id == 0 && alignment == 0) {
+                // Pre-allocated empty file.
                 co_return stop();
             }
+            if (magic != segment::segment_magic) {
+                throw invalid_segment_format();
+            }
+
+            size_t tail_size;
+            if (ver == descriptor::segment_version_5) {
+                tail_size = segment::descriptor_header_size - common_size;      // 12
+            } else if (ver == descriptor::segment_version_4) {
+                tail_size = segment::descriptor_header_size_v4 - common_size;   // 4
+            } else {
+                throw std::invalid_argument(fmt::format("Cannot replay commitlog segment with unsupported version {}", ver));
+            }
+
             if (id != d.id) {
                 // filename and id in file does not match.
                 // assume not valid/recycled.
@@ -3447,29 +3481,45 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
                 co_return;
             }
 
-            if (magic != segment::segment_magic) {
-                throw invalid_segment_format();
-            }
-            if (ver != descriptor::current_version) {
-                throw std::invalid_argument("Cannot replay old commitlog segments");
+            fragmented_temporary_buffer tail_buf = co_await frag_reader.read_exactly(fin, tail_size);
+            if (tail_buf.empty()) {
+                co_return stop();
             }
 
+            // Validate header checksum.
+            // CRC covers: ver + id + alignment [+ flags for v5].
             crc32_nbo crc;
             crc.process(ver);
             crc.process<int32_t>(id & 0xffffffff);
             crc.process<int32_t>(id >> 32);
             crc.process<uint32_t>(alignment);
 
-            auto cs = crc.checksum();
-            if (cs != checksum) {
+            auto tail_in = tail_buf.get_istream();
+            if (ver == descriptor::segment_version_5) {
+                auto flags_val = read<uint64_t>(tail_in);
+                crc.process(flags_val);
+                this->flags = static_cast<descriptor::feature_flags>(flags_val);
+            }
+
+            auto checksum = read<uint32_t>(tail_in);
+            if (crc.checksum() != checksum) {
                 throw header_checksum_error();
             }
 
+            this->alignment = alignment;
+
+            // Construct initial from common + tail. The initial buffer
+            // participates in the first sector's CRC computation.
+            auto header_size = common_size + tail_size;
+            auto vec = std::move(common_buf).release();
+            auto tail_vec = std::move(tail_buf).release();
+            for (auto&& v : tail_vec) {
+                vec.emplace_back(std::move(v));
+            }
+            this->initial = fragmented_temporary_buffer(std::move(vec), header_size);
+            this->pos = header_size;
             this->id = id;
             this->next = 0;
-            this->alignment = alignment;
-            this->initial = std::move(buf);
-            this->pos = this->initial.size_bytes();
         }
 
         future<fragmented_temporary_buffer> read_data(size_t size) {

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -122,6 +122,21 @@ public:
         std::optional<segment_id_type> base_segment_id;
 
         const db::extensions * extensions = nullptr;
+
+        // Whether to use the v5 header format (with feature flags field).
+        // Gated behind the strongly_consistent_tables cluster feature to
+        // ensure all nodes in the cluster support the new format before
+        // any node starts writing it.  Set once at startup; a node
+        // restart is required to activate so that v4 and v5 segments are
+        // never mixed within a single commitlog instance.
+        bool use_v5_header = false;
+
+        // Feature flags to set on newly created segments (as raw uint64_t).
+        // This allows enabling commitlog capabilities without bumping the
+        // header version for each new feature.  Only effective when
+        // use_v5_header is true.
+        // Use descriptor::feature_flags enum values.
+        uint64_t features = 0;
     };
 
     struct descriptor {
@@ -136,20 +151,39 @@ public:
         static inline constexpr uint32_t segment_version_2 = 2u;
         static inline constexpr uint32_t segment_version_3 = 3u;
         static inline constexpr uint32_t segment_version_4 = 4u;
-        static inline constexpr uint32_t current_version = segment_version_4;
+        // Version 5 introduces a feature flags field in the segment header.
+        // New commitlog capabilities should be represented by flags, so we do
+        // not need to bump the header version for each new feature.
+        static inline constexpr uint32_t segment_version_5 = 5u;
+        static inline constexpr uint32_t current_version = segment_version_5;
+
+        // Feature flags encoded as bits in a uint64_t field in the segment header.
+        enum class feature_flags : uint64_t {
+            none = 0,
+        };
 
         descriptor(descriptor&&) noexcept = default;
         descriptor(const descriptor&) = default;
-        descriptor(segment_id_type i, const std::string& fname_prefix, uint32_t v = current_version, sstring = {});
+        descriptor(segment_id_type i, const std::string& fname_prefix, uint32_t v = current_version, feature_flags flags = feature_flags::none, sstring = {});
         descriptor(replay_position p, const std::string& fname_prefix = FILENAME_PREFIX);
         descriptor(const std::string& filename, const std::string& fname_prefix = FILENAME_PREFIX);
 
         sstring filename() const;
         operator replay_position() const;
 
+        bool has_feature(feature_flags flag) const {
+            return (static_cast<uint64_t>(_flags) & static_cast<uint64_t>(flag)) != 0;
+        }
+
+        feature_flags flags() const {
+            return _flags;
+        }
+
         const segment_id_type id;
         const uint32_t ver;
         const std::string filename_prefix = FILENAME_PREFIX;
+    private:
+        feature_flags _flags = feature_flags::none;
     };
 
     commitlog(commitlog&&) noexcept;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -899,6 +899,13 @@ database::init_commitlog() {
     if (features().fragmented_commitlog_entries) {
         config.allow_fragmented_entries = true;
     }
+    // use_v5_header is set once at startup and remains fixed for the
+    // lifetime of the node.  A restart is required after the feature is
+    // enabled cluster-wide so that we never mix v4 and v5 segment headers
+    // within a single commitlog instance.
+    if (features().strongly_consistent_tables) {
+        config.use_v5_header = true;
+    }
     return db::commitlog::create_commitlog(config).then([this](db::commitlog&& log) {
         _commitlog = std::make_unique<db::commitlog>(std::move(log));
 

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -49,6 +49,7 @@
 #include "test/lib/key_utils.hh"
 #include "test/lib/test_utils.hh"
 #include "utils/checked-file-impl.hh"
+#include "utils/crc.hh"
 
 BOOST_AUTO_TEST_SUITE(commitlog_test)
 
@@ -1128,8 +1129,9 @@ SEASTAR_TEST_CASE(test_commitlog_entry_offsets) {
 
         auto rp = h.release();
 
-        // verify the first rp is at file offset 32 (file header + chunk header)
-        BOOST_CHECK_EQUAL(rp.pos, 24 + 8); // TODO: export these sizes for tests. 
+        // verify the first rp is at file offset 32 (file header 24 + chunk header 8)
+        // (v4 header since use_v5_header is not set by default)
+        BOOST_CHECK_EQUAL(rp.pos, 24 + 8); // TODO: export these sizes for tests.
 
         co_await log.sync_all_segments();
 
@@ -2407,6 +2409,238 @@ SEASTAR_TEST_CASE(test_commitlog_replay_segment_order) {
         // Check strictly ascending order.
         for (size_t i = 1; i < replayed_ids.size(); ++i) {
             BOOST_CHECK_GT(replayed_ids[i], replayed_ids[i - 1]);
+        }
+    });
+}
+
+
+static constexpr uint64_t test_feature_flag_bit = 1ULL << 17U;
+
+static future<uint64_t> read_segment_header_flags(sstring segment_path) {
+    auto f = co_await seastar::open_file_dma(segment_path, seastar::open_flags::ro);
+    auto buf = co_await f.dma_read_exactly<char>(0, align_up<size_t>(32, f.disk_read_dma_alignment()));
+    co_await f.close();
+
+    BOOST_REQUIRE_GE(buf.size(), 32u);
+    const auto* ptr = reinterpret_cast<const unsigned char*>(buf.get()) + 20;
+    uint64_t flags = 0;
+    for (size_t i = 0; i < sizeof(uint64_t); ++i) {
+        flags = (flags << 8) | ptr[i];
+    }
+    co_return flags;
+}
+
+SEASTAR_TEST_CASE(test_commitlog_feature_flags_default) {
+    commitlog::config cfg;
+    cfg.metrics_category_name = "commitlog";
+    cfg.use_v5_header = true;
+    return cl_test(cfg, [](commitlog& log) -> future<> {
+        auto uuid = make_table_id();
+        sstring tmp = "test data";
+
+        co_await log.add_mutation(uuid, tmp.size(), db::commitlog::force_sync::no, [&](db::commitlog::output& dst) {
+            dst.write(tmp.data(), tmp.size());
+        });
+
+        co_await log.sync_all_segments();
+
+        auto segments = log.get_active_segment_names();
+        BOOST_REQUIRE(!segments.empty());
+
+        for (auto& seg : segments) {
+            auto flags = co_await read_segment_header_flags(seg);
+            BOOST_CHECK_EQUAL(flags, 0u);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_commitlog_feature_flags_custom_bit_round_trip) {
+    commitlog::config cfg;
+    cfg.metrics_category_name = "commitlog";
+    cfg.use_v5_header = true;
+    cfg.features = test_feature_flag_bit;
+    return cl_test(cfg, [](commitlog& log) -> future<> {
+        auto uuid = make_table_id();
+        sstring tmp = "test data";
+
+        co_await log.add_mutation(uuid, tmp.size(), db::commitlog::force_sync::no, [&](db::commitlog::output& dst) {
+            dst.write(tmp.data(), tmp.size());
+        });
+
+        co_await log.sync_all_segments();
+
+        auto segments = log.get_active_segment_names();
+        BOOST_REQUIRE(!segments.empty());
+
+        for (auto& seg : segments) {
+            auto flags = co_await read_segment_header_flags(seg);
+            BOOST_CHECK_EQUAL(flags, test_feature_flag_bit);
+
+            bool replayed = false;
+            co_await db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX, [&](db::commitlog::buffer_and_replay_position) {
+                replayed = true;
+                return make_ready_future<>();
+            });
+            BOOST_CHECK(replayed);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(test_commitlog_feature_flags_has_feature) {
+    using ff = commitlog::descriptor::feature_flags;
+    constexpr auto bit_17 = static_cast<ff>(test_feature_flag_bit);
+    constexpr auto bit_18 = static_cast<ff>(1ULL << 18U);
+
+    commitlog::descriptor d1(1, commitlog::descriptor::FILENAME_PREFIX, commitlog::descriptor::current_version, bit_17);
+    BOOST_CHECK(d1.has_feature(bit_17));
+    BOOST_CHECK(!d1.has_feature(bit_18));
+
+    commitlog::descriptor d2(2, commitlog::descriptor::FILENAME_PREFIX, commitlog::descriptor::current_version, ff::none);
+    BOOST_CHECK(!d2.has_feature(bit_17));
+
+    return make_ready_future<>();
+}
+
+// Test backward-compat: construct a minimal v4-format segment file (24-byte
+// header + zero-filled data) and verify read_log_file handles it without
+// errors.  The zero-filled data is treated as EOF, so no entries are replayed.
+SEASTAR_TEST_CASE(test_commitlog_v4_segment_replay) {
+    tmpdir tmp;
+    auto dir = tmp.path().string();
+
+    // Use a fixed segment ID. The filename must match the v4 format:
+    // CommitLog-<ver>-<id>.log
+    constexpr uint64_t seg_id = 42;
+    constexpr uint32_t seg_ver = commitlog::descriptor::segment_version_4;
+    auto filename = fmt::format("{}/CommitLog-{}-{}.log",
+            dir, seg_ver, seg_id);
+
+    // Build a 24-byte v4 header: magic(4) + ver(4) + id(8) + alignment(4) + crc(4)
+    // All values are big-endian on disk.
+    constexpr uint32_t alignment = 4096;
+    constexpr uint32_t magic = ('S' << 24) | ('C' << 16) | ('L' << 8) | 'C';
+
+    // Compute CRC the same way commitlog.cc does (crc32_nbo: process_be).
+    utils::crc32 crc;
+    crc.process_be(seg_ver);
+    crc.process_be(static_cast<int32_t>(seg_id & 0xffffffff));
+    crc.process_be(static_cast<int32_t>(seg_id >> 32));
+    crc.process_be(alignment);
+    auto checksum = crc.get();
+
+    // Write the file: 24-byte header followed by zeros to fill one sector.
+    // DMA requires alignment, so write a full 4096-byte block.
+    auto buf = seastar::allocate_aligned_buffer<char>(alignment, alignment);
+    std::memset(buf.get(), 0, alignment);
+    auto* p = buf.get();
+    auto put = [p](size_t off, uint32_t val) {
+        auto v = seastar::net::hton(val);
+        std::memcpy(p + off, &v, sizeof(v));
+    };
+    auto put64 = [p](size_t off, uint64_t val) {
+        auto v = seastar::net::hton(val);
+        std::memcpy(p + off, &v, sizeof(v));
+    };
+
+    put(0, magic);
+    put(4, seg_ver);
+    put64(8, seg_id);
+    put(16, alignment);
+    put(20, checksum);
+    // Bytes 24..4083 are zero data (includes the chunk header which is
+    // all-zero, signalling EOF).
+    // Bytes 4084..4091: sector id (big-endian).
+    // Bytes 4092..4095: sector CRC.
+    // The sector CRC covers the entire sector except the trailing 4 CRC bytes:
+    // header(24) + zero-data(4060) + id(8) = 4092 bytes.
+    put64(alignment - 12, seg_id);  // sector id
+    {
+        utils::crc32 sector_crc;
+        sector_crc.process(reinterpret_cast<const uint8_t*>(p), alignment - 4);
+        put(alignment - 4, sector_crc.get());
+    }
+
+    auto f = co_await seastar::open_file_dma(filename,
+            seastar::open_flags::wo | seastar::open_flags::create);
+    co_await f.dma_write(0, p, alignment);
+    co_await f.close();
+
+    // Replay the v4 segment. No entries should be found.
+    bool replayed = false;
+    co_await db::commitlog::read_log_file(filename,
+            db::commitlog::descriptor::FILENAME_PREFIX,
+            [&](db::commitlog::buffer_and_replay_position) {
+                replayed = true;
+                return make_ready_future<>();
+            });
+    BOOST_CHECK(!replayed);
+}
+
+// Test that v4-format segments (written without use_v5_header) can be replayed
+// by code that has use_v5_header enabled — simulates an upgrade scenario where
+// old segments exist on disk when the feature flag becomes active.
+SEASTAR_TEST_CASE(test_commitlog_v4_to_v5_upgrade_replay) {
+    commitlog::config cfg;
+    cfg.metrics_category_name = "commitlog";
+    // Write in v4 mode (default).
+    return cl_test(cfg, [](commitlog& log) -> future<> {
+        auto uuid = make_table_id();
+        sstring tmp = "upgrade test data";
+
+        co_await log.add_mutation(uuid, tmp.size(), db::commitlog::force_sync::no, [&](db::commitlog::output& dst) {
+            dst.write(tmp.data(), tmp.size());
+        });
+
+        co_await log.sync_all_segments();
+
+        auto segments = log.get_active_segment_names();
+        BOOST_REQUIRE(!segments.empty());
+
+        // Replay the v4 segment — read_log_file handles v4 regardless of config.
+        for (auto& seg : segments) {
+            bool replayed = false;
+            co_await db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX,
+                    [&](db::commitlog::buffer_and_replay_position) {
+                        replayed = true;
+                        return make_ready_future<>();
+                    });
+            BOOST_CHECK(replayed);
+        }
+    });
+}
+
+// Test that v5-format segments can be replayed even when use_v5_header is not
+// set — simulates reading v5 segments after the feature flag is disabled or on
+// a node that hasn't enabled it yet (mixed cluster / rollback scenario).
+SEASTAR_TEST_CASE(test_commitlog_v5_replay_without_feature_flag) {
+    commitlog::config cfg;
+    cfg.metrics_category_name = "commitlog";
+    cfg.use_v5_header = true;
+    cfg.features = test_feature_flag_bit;
+    // Disable warning about segments left on disk — we intentionally leave them.
+    cfg.warn_about_segments_left_on_disk_after_shutdown = false;
+    return cl_test(cfg, [](commitlog& log) -> future<> {
+        auto uuid = make_table_id();
+        sstring data = "v5 segment data";
+
+        co_await log.add_mutation(uuid, data.size(), db::commitlog::force_sync::no, [&](db::commitlog::output& dst) {
+            dst.write(data.data(), data.size());
+        });
+        co_await log.sync_all_segments();
+
+        auto segments = log.get_active_segment_names();
+        BOOST_REQUIRE(!segments.empty());
+
+        // Replay the v5 segment — read_log_file handles v5 based on file
+        // content alone, independent of any config/feature flag.
+        for (auto& seg : segments) {
+            bool replayed = false;
+            co_await db::commitlog::read_log_file(seg, db::commitlog::descriptor::FILENAME_PREFIX,
+                    [&](db::commitlog::buffer_and_replay_position) {
+                        replayed = true;
+                        return make_ready_future<>();
+                    });
+            BOOST_CHECK(replayed);
         }
     });
 }


### PR DESCRIPTION
Add a single uint64_t feature flags field to the commitlog segment header (v5 format). Each bit represents an independently enabled commitlog capability, allowing future format extensions without bumping the header version for every new feature.

This is a prerequisite for commitlog-based raft persistence for tablet groups (https://github.com/scylladb/scylladb/pull/29005) which introduces variant-type entries in the commitlog - that capability will be represented as a flag bit rather than yet another
header version.

The v5 header layout extends v4 by inserting the 8-byte flags field before the CRC: magic(4) + ver(4) + id(8) + alignment(4) + flags(8) + crc(4) = 32 bytes. Writing v5 is gated behind the experimental strongly_consistent_tables cluster feature to ensure all nodes support the new format before any node produces it. Replay handles both v4 and
v5 segments reardless of configuration.

Fixes: SCYLLADB-1868
Backport: not needed, since this is a new feature. 