### PR TITLE
tree: add missing -present to copyright headers

### DIFF
--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 ScyllaDB
+ * Copyright (C) 2017-present ScyllaDB
  */
 
 /*

--- a/audit/audit.hh
+++ b/audit/audit.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 ScyllaDB
+ * Copyright (C) 2017-present ScyllaDB
  */
 
 /*

--- a/audit/audit_cf_storage_helper.cc
+++ b/audit/audit_cf_storage_helper.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 ScyllaDB
+ * Copyright (C) 2017-present ScyllaDB
  */
 
 /*

--- a/audit/audit_cf_storage_helper.hh
+++ b/audit/audit_cf_storage_helper.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 ScyllaDB
+ * Copyright (C) 2017-present ScyllaDB
  */
 
 /*

--- a/audit/audit_composite_storage_helper.cc
+++ b/audit/audit_composite_storage_helper.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  */
 
 /*

--- a/audit/audit_composite_storage_helper.hh
+++ b/audit/audit_composite_storage_helper.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  */
 
 /*

--- a/audit/audit_syslog_storage_helper.cc
+++ b/audit/audit_syslog_storage_helper.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 ScyllaDB
+ * Copyright (C) 2017-present ScyllaDB
  */
 
 /*

--- a/audit/audit_syslog_storage_helper.hh
+++ b/audit/audit_syslog_storage_helper.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 ScyllaDB
+ * Copyright (C) 2017-present ScyllaDB
  */
 
 /*

--- a/audit/storage_helper.hh
+++ b/audit/storage_helper.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 ScyllaDB
+ * Copyright (C) 2017-present ScyllaDB
  */
 
 /*

--- a/auth/ldap_role_manager.cc
+++ b/auth/ldap_role_manager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2019-present ScyllaDB
  */
 
 /*

--- a/auth/ldap_role_manager.hh
+++ b/auth/ldap_role_manager.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2019-present ScyllaDB
  */
 
 /*

--- a/auth/saslauthd_authenticator.cc
+++ b/auth/saslauthd_authenticator.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 ScyllaDB
+ * Copyright (C) 2020-present ScyllaDB
  *
  * Modified by ScyllaDB
  */

--- a/auth/saslauthd_authenticator.hh
+++ b/auth/saslauthd_authenticator.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 ScyllaDB
+ * Copyright (C) 2020-present ScyllaDB
  *
  * Modified by ScyllaDB
  */

--- a/compaction/incremental_compaction_strategy.cc
+++ b/compaction/incremental_compaction_strategy.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2019-present ScyllaDB
  *
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */

--- a/compaction/incremental_compaction_strategy.hh
+++ b/compaction/incremental_compaction_strategy.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2019-present ScyllaDB
  *
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */

--- a/db/cache_tracker.hh
+++ b/db/cache_tracker.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 ScyllaDB
+ * Copyright (C) 2015-present ScyllaDB
  */
 
 /*

--- a/ent/encryption/azure_host.cc
+++ b/ent/encryption/azure_host.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/ent/encryption/azure_host.hh
+++ b/ent/encryption/azure_host.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/ent/encryption/azure_key_provider.cc
+++ b/ent/encryption/azure_key_provider.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/ent/encryption/azure_key_provider.hh
+++ b/ent/encryption/azure_key_provider.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/ent/encryption/encrypted_file_impl.cc
+++ b/ent/encryption/encrypted_file_impl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/encrypted_file_impl.hh
+++ b/ent/encryption/encrypted_file_impl.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 ScyllaDB
+ * Copyright (C) 2015-present ScyllaDB
  *
  */
 

--- a/ent/encryption/encryption.hh
+++ b/ent/encryption/encryption.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/encryption_config.cc
+++ b/ent/encryption/encryption_config.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 ScyllaDB
+ * Copyright (C) 2015-present ScyllaDB
  *
  */
 

--- a/ent/encryption/encryption_config.hh
+++ b/ent/encryption/encryption_config.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/encryption_exceptions.hh
+++ b/ent/encryption/encryption_exceptions.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 ScyllaDB
+ * Copyright (C) 2024-present ScyllaDB
  *
  */
 

--- a/ent/encryption/gcp_host.cc
+++ b/ent/encryption/gcp_host.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 ScyllaDB
+ * Copyright (C) 2024-present ScyllaDB
  *
  */
 

--- a/ent/encryption/gcp_host.hh
+++ b/ent/encryption/gcp_host.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 ScyllaDB
+ * Copyright (C) 2024-present ScyllaDB
  *
  */
 

--- a/ent/encryption/gcp_key_provider.cc
+++ b/ent/encryption/gcp_key_provider.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 ScyllaDB
+ * Copyright (C) 2024-present ScyllaDB
  *
  */
 

--- a/ent/encryption/gcp_key_provider.hh
+++ b/ent/encryption/gcp_key_provider.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 ScyllaDB
+ * Copyright (C) 2024-present ScyllaDB
  *
  */
 

--- a/ent/encryption/kmip_host.cc
+++ b/ent/encryption/kmip_host.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/kmip_host.hh
+++ b/ent/encryption/kmip_host.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/kmip_key_provider.cc
+++ b/ent/encryption/kmip_key_provider.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/kmip_key_provider.hh
+++ b/ent/encryption/kmip_key_provider.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/kms_host.cc
+++ b/ent/encryption/kms_host.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 ScyllaDB
+ * Copyright (C) 2022-present ScyllaDB
  *
  */
 

--- a/ent/encryption/kms_host.hh
+++ b/ent/encryption/kms_host.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 ScyllaDB
+ * Copyright (C) 2022-present ScyllaDB
  *
  */
 

--- a/ent/encryption/kms_key_provider.cc
+++ b/ent/encryption/kms_key_provider.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 ScyllaDB
+ * Copyright (C) 2022-present ScyllaDB
  *
  */
 

--- a/ent/encryption/kms_key_provider.hh
+++ b/ent/encryption/kms_key_provider.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 ScyllaDB
+ * Copyright (C) 2022-present ScyllaDB
  *
  */
 

--- a/ent/encryption/local_file_provider.cc
+++ b/ent/encryption/local_file_provider.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/local_file_provider.hh
+++ b/ent/encryption/local_file_provider.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/replicated_key_provider.cc
+++ b/ent/encryption/replicated_key_provider.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 ScyllaDB
+ * Copyright (C) 2015-present ScyllaDB
  *
  */
 

--- a/ent/encryption/replicated_key_provider.hh
+++ b/ent/encryption/replicated_key_provider.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 ScyllaDB
+ * Copyright (C) 2015-present ScyllaDB
  *
  */
 

--- a/ent/encryption/symmetric_key.cc
+++ b/ent/encryption/symmetric_key.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/symmetric_key.hh
+++ b/ent/encryption/symmetric_key.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 ScyllaDB
+ * Copyright (C) 2018-present ScyllaDB
  *
  */
 

--- a/ent/encryption/system_key.cc
+++ b/ent/encryption/system_key.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 ScyllaDB
+ * Copyright (C) 2015-present ScyllaDB
  *
  */
 

--- a/ent/encryption/system_key.hh
+++ b/ent/encryption/system_key.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 ScyllaDB
+ * Copyright (C) 2015-present ScyllaDB
  *
  */
 

--- a/ent/encryption/utils.cc
+++ b/ent/encryption/utils.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/ent/encryption/utils.hh
+++ b/ent/encryption/utils.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/ent/ldap/ldap_connection.cc
+++ b/ent/ldap/ldap_connection.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2019-present ScyllaDB
  */
 
 /*

--- a/ent/ldap/ldap_connection.hh
+++ b/ent/ldap/ldap_connection.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2019-present ScyllaDB
  */
 
 /*

--- a/mutation/range_tombstone_assembler.hh
+++ b/mutation/range_tombstone_assembler.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*

--- a/mutation/range_tombstone_change_generator.hh
+++ b/mutation/range_tombstone_change_generator.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*

--- a/mutation/range_tombstone_splitter.hh
+++ b/mutation/range_tombstone_splitter.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*

--- a/scripts/merge-compdb.py
+++ b/scripts/merge-compdb.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 ScyllaDB
+# Copyright (C) 2021-present ScyllaDB
 #
 
 #

--- a/sstables/partition_index_cache.hh
+++ b/sstables/partition_index_cache.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*

--- a/sstables/partition_index_cache_stats.hh
+++ b/sstables/partition_index_cache_stats.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 ScyllaDB
+ * Copyright (C) 2023-present ScyllaDB
  */
 
 /*

--- a/sstables/processing_result_generator.hh
+++ b/sstables/processing_result_generator.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*

--- a/test/alternator/test_backup.py
+++ b/test/alternator/test_backup.py
@@ -1,4 +1,4 @@
-# Copyright 2022 ScyllaDB
+# Copyright 2022-present ScyllaDB
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -1,4 +1,4 @@
-# Copyright 2021 ScyllaDB
+# Copyright 2021-present ScyllaDB
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 

--- a/test/boost/encrypted_file_test.cc
+++ b/test/boost/encrypted_file_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 ScyllaDB
+ * Copyright (C) 2016-present ScyllaDB
  */
 
 

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 ScyllaDB
+ * Copyright (C) 2016-present ScyllaDB
  */
 
 

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2019-present ScyllaDB
  *
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */

--- a/test/boost/sstable_compression_config_test.cc
+++ b/test/boost/sstable_compression_config_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  */
 
 /*

--- a/test/boost/symmetric_key_test.cc
+++ b/test/boost/symmetric_key_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 ScyllaDB
+ * Copyright (C) 2016-present ScyllaDB
  */
 
 

--- a/test/ldap/ldap_common.hh
+++ b/test/ldap/ldap_common.hh
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2015 ScyllaDB
+ * Copyright (C) 2015-present ScyllaDB
  */
 
 /*

--- a/test/ldap/ldap_connection_test.cc
+++ b/test/ldap/ldap_connection_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 ScyllaDB
+ * Copyright (C) 2019-present ScyllaDB
  */
 
 /*

--- a/test/ldap/role_manager_test.cc
+++ b/test/ldap/role_manager_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 ScyllaDB
+ * Copyright (C) 2017-present ScyllaDB
  */
 
 /*

--- a/test/ldap/saslauthd_authenticator_test.cc
+++ b/test/ldap/saslauthd_authenticator_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 ScyllaDB
+ * Copyright (C) 2020-present ScyllaDB
  */
 
 /*

--- a/test/perf/logalloc.cc
+++ b/test/perf/logalloc.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*

--- a/test/raft/future_set.hh
+++ b/test/raft/future_set.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*

--- a/test/raft/logical_timer.hh
+++ b/test/raft/logical_timer.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*

--- a/test/raft/ticker.hh
+++ b/test/raft/ticker.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*

--- a/utils/azure/identity/azure_cli_credentials.cc
+++ b/utils/azure/identity/azure_cli_credentials.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/azure/identity/azure_cli_credentials.hh
+++ b/utils/azure/identity/azure_cli_credentials.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/azure/identity/credentials.cc
+++ b/utils/azure/identity/credentials.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/azure/identity/credentials.hh
+++ b/utils/azure/identity/credentials.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/azure/identity/default_credentials.cc
+++ b/utils/azure/identity/default_credentials.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/azure/identity/default_credentials.hh
+++ b/utils/azure/identity/default_credentials.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/azure/identity/exceptions.hh
+++ b/utils/azure/identity/exceptions.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/azure/identity/managed_identity_credentials.cc
+++ b/utils/azure/identity/managed_identity_credentials.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/azure/identity/managed_identity_credentials.hh
+++ b/utils/azure/identity/managed_identity_credentials.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/azure/identity/service_principal_credentials.cc
+++ b/utils/azure/identity/service_principal_credentials.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/azure/identity/service_principal_credentials.hh
+++ b/utils/azure/identity/service_principal_credentials.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/entangled.hh
+++ b/utils/entangled.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 ScyllaDB
+ * Copyright (C) 2020-present ScyllaDB
  */
 
 /*

--- a/utils/lsa/weak_ptr.hh
+++ b/utils/lsa/weak_ptr.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 ScyllaDB
+ * Copyright (C) 2020-present ScyllaDB
  */
 
 /*

--- a/utils/rest/client.cc
+++ b/utils/rest/client.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/rest/client.hh
+++ b/utils/rest/client.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 ScyllaDB
+ * Copyright (C) 2025-present ScyllaDB
  *
  */
 

--- a/utils/sequential_producer.hh
+++ b/utils/sequential_producer.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*

--- a/utils/vle.hh
+++ b/utils/vle.hh
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 ScyllaDB
+ * Copyright (C) 2021-present ScyllaDB
  */
 
 /*


### PR DESCRIPTION
~2076 files used "Copyright (C) YYYY-present ScyllaDB" while ~88 files used "Copyright (C) YYYY ScyllaDB". This inconsistency leads to unnecessary code review discussions and gradual spread of the less common format.

Standardize all ScyllaDB copyright headers to use -present.

Fixes SCYLLADB-1984

No backport, just a cosmetic copyright header change.