### PR TITLE
index: remove Chinese, Japanese, and Korean language analyzers

### DIFF
--- a/index/fulltext_index.cc
+++ b/index/fulltext_index.cc
@@ -23,7 +23,7 @@ namespace secondary_index {
 // This list corresponds to analyzers expected to be provided
 // by the backend search engine (Tantivy).
 static const std::vector<sstring> analyzer_values = {
-        "standard", "english", "german", "french", "spanish", "italian", "portuguese", "russian", "chinese", "japanese", "korean", "simple", "whitespace"};
+        "standard", "english", "german", "french", "spanish", "italian", "portuguese", "russian", "simple", "whitespace"};
 
 const static std::unordered_map<sstring, std::function<void(std::string_view, const sstring&, const sstring&)>> fulltext_index_options = {
         // 'analyzer' specifies the built-in text analyzer to use for tokenization.

--- a/test/cqlpy/test_fulltext_index.py
+++ b/test/cqlpy/test_fulltext_index.py
@@ -44,8 +44,7 @@ def test_create_fulltext_index_with_analyzer_option(cql, test_keyspace, scylla_o
     """All supported analyzer values should be accepted."""
     analyzers = [
         'standard', 'english', 'german', 'french', 'spanish', 'italian',
-        'portuguese', 'russian', 'chinese', 'japanese', 'korean',
-        'simple', 'whitespace',
+        'portuguese', 'russian', 'simple', 'whitespace',
     ]
     schema = 'p int primary key, content text'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -56,6 +55,22 @@ def test_create_fulltext_index_with_analyzer_option(cql, test_keyspace, scylla_o
                 f"WITH OPTIONS = {{'analyzer': '{analyzer}'}}"
             )
             cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
+
+
+def test_create_fulltext_index_with_cjk_analyzers_fails(cql, test_keyspace, scylla_only):
+    """CJK analyzers should be rejected. (VECTOR-672)"""
+    analyzers = [
+        'chinese', 'japanese', 'korean',
+    ]
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        for analyzer in analyzers:
+            index_name = unique_name()
+            with pytest.raises(InvalidRequest, match="Invalid value in option 'analyzer'"):
+                cql.execute(
+                    f"CREATE CUSTOM INDEX {index_name} ON {table}(content) USING 'fulltext_index' "
+                    f"WITH OPTIONS = {{'analyzer': '{analyzer}'}}"
+                )
 
 
 def test_create_fulltext_index_with_analyzer_case_insensitive(cql, test_keyspace, scylla_only):


### PR DESCRIPTION
Remove "chinese", "japanese", and "korean" from the list of accepted full-text search analyzer options. Exposing these options commits ScyllaDB to supporting them long-term — if we ever switch from one backend search engine to another, CJK analyzers are the most likely to lose out-of-the-box support, unlike the popular European languages that are broadly available across text analysis libraries.

Restrict the accepted set now, while FTS is still new, to avoid a future compatibility burden.

Fixes: VECTOR-672