### PR TITLE
storage_service: smooth effective_capacity to prevent load balancer oscillations

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1785,6 +1785,12 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Sets the maximum difference in percentages between the most loaded and least loaded nodes, below which the load balancer considers nodes balanced.")
     , minimal_tablet_size_for_balancing(this, "minimal_tablet_size_for_balancing", liveness::LiveUpdate, value_status::Used, service::default_target_tablet_size / 100,
         "Sets the minimal tablet size for the load balancer. For any tablet smaller than this, the balancer will use this size instead of the actual tablet size.")
+    , effective_capacity_rise_decay_period_in_seconds(this, "effective_capacity_rise_decay_period_in_seconds", liveness::LiveUpdate, value_status::Used, 300,
+        "Time constant (in seconds) for smoothing rising effective_capacity reported to the load balancer. "
+        "Decreases in capacity are reported immediately, while increases are damped with an exponential "
+        "moving average using this decay period, chosen larger than the fluctuation/tablet-migration time "
+        "scale. This prevents load balancer oscillations caused by fluctuations in available disk space "
+        "without ever overestimating capacity. Set to 0 to disable smoothing.")
     /**
     * @Group Ungrouped properties
     */

--- a/db/config.hh
+++ b/db/config.hh
@@ -660,6 +660,7 @@ public:
     named_value<bool> force_capacity_based_balancing;
     named_value<float> size_based_balance_threshold_percentage;
     named_value<uint64_t> minimal_tablet_size_for_balancing;
+    named_value<uint32_t> effective_capacity_rise_decay_period_in_seconds;
 
     named_value<double> background_writer_scheduling_quota;
     named_value<bool> auto_adjust_flush_quota;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -28,6 +28,7 @@
 #include "service/session.hh"
 #include "dht/boot_strapper.hh"
 #include <chrono>
+#include <cmath>
 #include <exception>
 #include <optional>
 #include <fmt/ranges.h>
@@ -6174,10 +6175,41 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
         for (const auto& ts : tablet_sizes_per_shard) {
             sum_tablet_sizes += ts.size;
         }
-        tls.effective_capacity = si.available + sum_tablet_sizes;
+        uint64_t new_effective_capacity = si.available + sum_tablet_sizes;
+
+        const auto decay_period = std::chrono::seconds(
+                _db.local().get_config().effective_capacity_rise_decay_period_in_seconds());
+        tls.effective_capacity = smooth_effective_capacity(new_effective_capacity, decay_period);
     }
 
     co_return std::move(load_stats);
+}
+
+uint64_t storage_service::smooth_effective_capacity(uint64_t new_value,
+        std::chrono::seconds decay_period, lowres_clock::time_point now) {
+    if (!_smoothed_effective_capacity || decay_period.count() == 0) {
+        _smoothed_effective_capacity = new_value;
+        _last_capacity_sample_time = now;
+        return new_value;
+    }
+    if (new_value <= *_smoothed_effective_capacity) {
+        // Report decreases immediately: never overestimate available capacity.
+        _smoothed_effective_capacity = new_value;
+    } else {
+        // Dampen increases with an exponential moving average over the real
+        // elapsed time since the previous sample (samples are pulled by the
+        // topology coordinator at an irregular cadence).
+        // alpha = 1 - exp(-dt / decay_period), same form as utils::moving_average.
+        const double dt = std::chrono::duration_cast<std::chrono::duration<double>>(
+                now - _last_capacity_sample_time).count();
+        const double period = std::chrono::duration_cast<std::chrono::duration<double>>(
+                decay_period).count();
+        const double alpha = dt <= 0 ? 0.0 : 1.0 - std::exp(-dt / period);
+        const double prev = double(*_smoothed_effective_capacity);
+        _smoothed_effective_capacity = uint64_t(prev + alpha * (double(new_value) - prev) + 0.5);
+    }
+    _last_capacity_sample_time = now;
+    return *_smoothed_effective_capacity;
 }
 
 future<> storage_service::transit_tablet(table_id table, dht::token token, noncopyable_function<std::tuple<utils::chunked_vector<canonical_mutation>, sstring>(const locator::tablet_map&, api::timestamp_type)> prepare_mutations) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -32,6 +32,7 @@
 #include "dht/token_range_endpoints.hh"
 #include "gms/application_state.hh"
 #include <seastar/core/semaphore.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/gate.hh>
 #include "replica/database_fwd.hh"
 #include "streaming/stream_reason.hh"
@@ -1087,6 +1088,14 @@ private:
 
     utils::disk_space_monitor* _disk_space_monitor; // != nullptr only on shard0.
 
+    // State for asymmetric time-decay smoothing of effective_capacity.
+    // Capacity decreases are reported immediately, while increases are damped
+    // with an exponential moving average. This prevents load balancer
+    // oscillations caused by fluctuations in available disk space without ever
+    // overestimating capacity.
+    std::optional<uint64_t> _smoothed_effective_capacity;
+    lowres_clock::time_point _last_capacity_sample_time;
+
     strong_consistency::groups_manager& _groups_manager;
 
 public:
@@ -1098,6 +1107,19 @@ public:
     future<std::vector<std::byte>> train_dict(utils::chunked_vector<temporary_buffer<char>> sample);
     future<> publish_new_sstable_dict(table_id, std::span<const std::byte>, service::raft_group0_client&);
     void set_train_dict_callback(decltype(_train_dict));
+
+    /// Smooth effective_capacity to prevent load-balancer oscillations.
+    /// Capacity decreases are reported immediately; increases are damped with
+    /// an exponential moving average whose time constant is \p decay_period,
+    /// computed from the real elapsed time since the previous sample.
+    ///
+    /// \param new_value     newly measured capacity
+    /// \param decay_period  EWMA time constant (0 disables smoothing)
+    /// \param now           current time (injectable for testing)
+    /// \returns smoothed capacity value
+    uint64_t smooth_effective_capacity(uint64_t new_value,
+            std::chrono::seconds decay_period,
+            lowres_clock::time_point now = lowres_clock::now());
     seastar::future<> notify_client_routes_change(const client_routes_service::client_route_keys& client_route_keys);
 
     // Alters the given table's min/max tablet count hints. Only the engaged

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -7973,4 +7973,113 @@ SEASTAR_TEST_CASE(test_load_stats_split_ready_invalidation) {
     return make_ready_future<>();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_effective_capacity_smoothing) {
+    // Verifies storage_service::smooth_effective_capacity(): capacity
+    // decreases are reported immediately, while increases are damped with a
+    // time-decay (EWMA) filter to prevent load balancer oscillations without
+    // ever overestimating capacity.
+    do_with_cql_env_thread([] (cql_test_env& e) {
+        auto& ss = e.get_storage_service().local();
+
+        const auto period = std::chrono::seconds(300);
+        const uint64_t base = 1'000'000'000; // 1 GB
+        lowres_clock::time_point t0{};
+
+        // First call: no cached value, should accept new value verbatim.
+        auto result = ss.smooth_effective_capacity(base, period, t0);
+        BOOST_REQUIRE_EQUAL(result, base);
+
+        // A decrease is reported immediately and fully, regardless of dt.
+        uint64_t drop = base - base / 100; // -1%
+        result = ss.smooth_effective_capacity(drop, period, t0 + std::chrono::seconds(1));
+        BOOST_REQUIRE_EQUAL(result, drop);
+
+        // Even a tiny decrease is applied immediately.
+        result = ss.smooth_effective_capacity(drop - 1, period, t0 + std::chrono::seconds(2));
+        BOOST_REQUIRE_EQUAL(result, drop - 1);
+
+        // An increase with dt == period reaches ~63.2% (1 - 1/e) of the gap.
+        {
+            uint64_t prev = drop - 1;
+            uint64_t target = prev + 100'000'000; // +100 MB
+            auto now = t0 + std::chrono::seconds(2) + period;
+            result = ss.smooth_effective_capacity(target, period, now);
+            double expected = prev + (1.0 - std::exp(-1.0)) * (target - prev);
+            BOOST_REQUIRE_LT(result, target); // damped, not snapped
+            BOOST_REQUIRE_GT(result, prev);
+            BOOST_REQUIRE_CLOSE(double(result), expected, 0.01);
+        }
+
+        // Reset to a known state for the remaining sub-cases.
+        result = ss.smooth_effective_capacity(base, period, t0 + std::chrono::hours(1));
+        BOOST_REQUIRE_EQUAL(result, base); // drop below current -> immediate
+
+        // An increase with dt much smaller than the period moves only a small
+        // fraction toward the target.
+        {
+            uint64_t target = base + 200'000'000;
+            auto now = t0 + std::chrono::hours(1) + std::chrono::seconds(3);
+            result = ss.smooth_effective_capacity(target, period, now);
+            double alpha = 1.0 - std::exp(-3.0 / 300.0);
+            double expected = base + alpha * (target - base);
+            BOOST_REQUIRE_CLOSE(double(result), expected, 0.01);
+            // Moved less than 2% of the way.
+            BOOST_REQUIRE_LT(result - base, (target - base) / 50);
+        }
+
+        // Convergence: repeated large steps of dt == period converge to target.
+        {
+            uint64_t target = base + 500'000'000;
+            auto now = t0 + std::chrono::hours(2);
+            for (int i = 0; i < 50; ++i) {
+                now += period;
+                result = ss.smooth_effective_capacity(target, period, now);
+            }
+            // After 50 time constants the value is effectively at the target.
+            BOOST_REQUIRE_CLOSE(double(result), double(target), 0.001);
+        }
+
+        // Irregular cadence: one step of 2*period advances more than a single
+        // step of period would (time-proportional response, not per-call).
+        {
+            uint64_t start = ss.smooth_effective_capacity(0, period, t0 + std::chrono::hours(3));
+            // Above forced an immediate drop to 0; now rise with a big gap.
+            uint64_t target = 1'000'000'000;
+            auto now = t0 + std::chrono::hours(3) + 2 * period;
+            uint64_t r_double = ss.smooth_effective_capacity(target, period, now);
+            double alpha2 = 1.0 - std::exp(-2.0);
+            double expected2 = start + alpha2 * (target - start);
+            BOOST_REQUIRE_CLOSE(double(r_double), expected2, 0.01);
+        }
+
+        // Oscillating input settles near the trough (never overestimates):
+        // alternating rise/drop keeps the reported value pinned to the low
+        // envelope because drops apply immediately and rises lag.
+        {
+            uint64_t low = 800'000'000;
+            uint64_t high = 1'000'000'000;
+            auto now = t0 + std::chrono::hours(4);
+            // Establish the low as the current value.
+            ss.smooth_effective_capacity(low, period, now);
+            for (int i = 0; i < 20; ++i) {
+                now += std::chrono::seconds(30); // dt << period
+                ss.smooth_effective_capacity(high, period, now); // small rise
+                now += std::chrono::seconds(30);
+                result = ss.smooth_effective_capacity(low, period, now); // full drop
+            }
+            // The reported value tracks the low, never drifting up to high.
+            BOOST_REQUIRE_EQUAL(result, low);
+        }
+
+        // decay_period == 0 disables smoothing entirely.
+        {
+            auto now = t0 + std::chrono::hours(5);
+            result = ss.smooth_effective_capacity(base, std::chrono::seconds(0), now);
+            BOOST_REQUIRE_EQUAL(result, base);
+            result = ss.smooth_effective_capacity(base + 123, std::chrono::seconds(0), now);
+            BOOST_REQUIRE_EQUAL(result, base + 123);
+        }
+    }).get();
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
service/storage_service: smooth effective_capacity to prevent load balancer oscillations

Problem
=======

The tablet size-based load balancer distributes tablets across nodes based
on each node's reported effective_capacity (available disk space plus the
size of the tablets already stored on the node). This value is measured
from the filesystem and reported to the topology coordinator, which pulls
it via RPC at an irregular cadence (tablet_load_stats_refresh_interval_in_seconds,
default 60s, plus additional event-triggered refreshes).

The raw available-space measurement fluctuates continuously due to normal
filesystem activity (compaction consuming and releasing space, commitlog,
temporary files, etc.). Because the balancer compares capacities between
nodes, these fluctuations cause it to perceive a moving imbalance and
migrate tablets back and forth, i.e. the disk capacities oscillate and the
balancer never settles.

Approach
========

Rather than filtering out only small fluctuations, this change applies an
asymmetric time-decay (exponential moving average) filter to the reported
effective_capacity:

  - Decreases are reported immediately and in full. The balancer therefore
    never overestimates a node's available capacity and stays safe under
    disk pressure.

  - Increases are damped with an exponential moving average whose time
    constant (decay period) is chosen larger than the fluctuation period
    and the tablet migration time. The EWMA weight is computed from the
    real elapsed wall-clock time between samples:

        alpha = 1 - exp(-dt / decay_period)

    Computing alpha from the actual elapsed time (rather than per call) is
    necessary because the coordinator pulls the stats at an irregular rate;
    a fixed per-call weight would distort the effective time constant.

This behaves like a "soft minimum": it tracks drops instantly and relaxes
upward only gradually. As a low-pass filter it attenuates fluctuations that
are faster than the migration frequency while allowing genuine capacity
changes to propagate. Recovery after a transient dip is smooth, with no
step artifacts.

Why not a dead-band (relative threshold) filter
===============================================

An earlier version of this fix suppressed reporting until the value changed
by more than a fixed relative threshold (e.g. 0.5%). That approach has two
weaknesses:

  1. It relocates the error between nodes rather than removing it. Each
     node's reported value can lag reality by up to the threshold, and two
     nodes with the same true capacity can be reported as differing by up
     to twice the threshold. The balancer may then act on an imbalance that
     the filter itself manufactured.

  2. It does not dampen oscillations whose amplitude exceeds the threshold:
     every sample passes the filter and snaps through, so no smoothing
     happens exactly when it is most needed.

The asymmetric time-decay filter avoids both problems. Its residual
cross-node bias is one-directional (all nodes drop fast and rise slowly),
so it does not fabricate a peer imbalance, and it genuinely attenuates
high-amplitude oscillations by frequency.

Configuration
=============

A new live-updatable parameter controls the behaviour:

  effective_capacity_rise_decay_period_in_seconds (default 300)

Set to 0 to disable smoothing entirely.

Testing
=======

test/boost/tablets_test.cc adds test_effective_capacity_smoothing, which
injects synthetic timestamps to verify: immediate application of decreases,
EWMA damping of increases at dt == period (~63% of the gap) and dt << period,
convergence over many periods, correct time-proportional response for an
irregular sample cadence, settling near the trough for oscillating input
(no overestimation), and the decay_period=0 bypass.

Fixes: SCYLLADB-3016
Fixes: SCYLLADB-1717
Fixes: SCYLLADB-3152

This is an improvement, and does not need to be backported.