### PR TITLE
storage_service: cancel write handlers during drain to prevent shutdown deadlock

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1753,7 +1753,7 @@ public:
             register_cancellable();
         }
 
-        attach_to(_proxy->_write_handlers_gate);
+        attach_to(*_proxy->_write_handlers_gate);
     }
     void attach_to(gate& g) {
         _holders.push_back(g.hold());
@@ -7477,7 +7477,7 @@ void storage_proxy::on_down(const gms::inet_address& endpoint, locator::host_id 
 };
 
 future<> storage_proxy::drain_on_shutdown() {
-    co_await cancel_all_write_response_handlers();
+    co_await cancel_all_write_response_handlers(false);
     co_await _hints_resource_manager.stop();
 }
 
@@ -7501,12 +7501,23 @@ future<utils::chunked_vector<dht::token_range_endpoints>> storage_proxy::describ
     return locator::describe_ring(_db.local(), _remote->gossiper(), keyspace, include_only_local_dc);
 }
 
-future<> storage_proxy::cancel_all_write_response_handlers() {
-    auto f = _write_handlers_gate.close();
+future<> storage_proxy::cancel_all_write_response_handlers(bool allow_new) {
+    // Cancel all existing handlers. They are attached to the current gate.
     while (!_response_handlers.empty()) {
         _response_handlers.begin()->second->timeout_cb();
         co_await coroutine::maybe_yield();
     }
+    // Close the gate and wait for destruction of handlers still alive via
+    // external shared_ptr refs (e.g. background futures in send_to_live_endpoints).
+    auto f = _write_handlers_gate->close();
+    std::unique_ptr<gate> old_gate;
+    if (allow_new) {
+        // Swap in a fresh open gate so new handlers can be created.
+        // Keep the old gate alive (via old_gate) until the close future resolves.
+        old_gate = std::exchange(_write_handlers_gate, std::make_unique<gate>());
+    }
+    // If !allow_new, the closed gate stays in _write_handlers_gate — any
+    // subsequent handler creation will get gate_closed_exception.
     co_await std::move(f);
 }
 }

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -327,7 +327,7 @@ private:
     class cancellable_write_handlers_list;
     std::unique_ptr<cancellable_write_handlers_list> _cancellable_write_handlers_list;
 
-    gate _write_handlers_gate;
+    std::unique_ptr<gate> _write_handlers_gate = std::make_unique<gate>();
 
     /* This is a pointer to the shard-local part of the sharded cdc_service:
      * storage_proxy needs access to cdc_service to augment mutations.
@@ -577,7 +577,7 @@ public:
     bool is_me(gms::inet_address addr) const noexcept;
     bool is_me(const locator::effective_replication_map& erm, locator::host_id id) const noexcept;
 
-    future<> cancel_all_write_response_handlers();
+    future<> cancel_all_write_response_handlers(bool allow_new);
 
 private:
     bool only_me(const locator::effective_replication_map& erm, const host_id_vector_replica_set& replicas) const noexcept;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4473,7 +4473,10 @@ future<> storage_service::local_topology_barrier() {
         throw std::runtime_error("raft_topology_barrier_and_drain_fail_before injected exception");
     });
 
-    co_await utils::get_local_injector().inject("pause_before_barrier_and_drain", utils::wait_for_message(std::chrono::minutes(5)));
+    // share=false: each barrier_and_drain invocation needs its own message
+    // to proceed. Without this, a single message_injection call would release
+    // all past and future handlers sharing the same injection.
+    co_await utils::get_local_injector().inject("pause_before_barrier_and_drain", utils::wait_for_message(std::chrono::minutes(5), nullptr, false));
     if (_topology_state_machine._topology.tstate == topology::transition_state::write_both_read_old) {
         for (auto& n : _topology_state_machine._topology.transition_nodes) {
             if (!_address_map.find(locator::host_id{n.first.uuid()})) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2968,6 +2968,16 @@ future<> storage_service::do_drain() {
     // Need to stop transport before group0, otherwise RPCs may fail with raft_group_not_found.
     co_await stop_transport();
 
+    // Cancel write handlers on all shards so they release their ERMs
+    // (and the associated token_metadata versions). Without this,
+    // wait_for_group0_stop below may deadlock: the topology coordinator
+    // fiber calls barrier_and_drain which blocks in stale_versions_in_use()
+    // waiting for stale token_metadata versions held by write handlers
+    // whose MUTATION_DONE responses can no longer arrive (transport is stopped).
+    co_await _qp.proxy().container().invoke_on_all([] (storage_proxy& sp) {
+        return sp.cancel_all_write_response_handlers(true);
+    });
+
     // Drain view builder before group0, because the view builder uses group0 to coordinate view building.
     // Drain after transport is stopped, because view_builder::drain aborts view writes for user writes as well.
     co_await _view_builder.invoke_on_all(&db::view::view_builder::drain);

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -840,7 +840,11 @@ async def test_lwt_shutdown(manager: ManagerClient):
 
         logger.info("Start node shutdown")
         stop_task = asyncio.create_task(manager.server_stop_gracefully(s0.server_id))
-        await log.wait_for('Shutting down storage proxy RPC verbs')
+        # Wait for stop_transport to complete. After this, do_drain() will
+        # block in cancel_all_write_response_handlers() waiting for the
+        # paxos learn's background write handler to be released. The paxos
+        # store is still alive at this point.
+        await log.wait_for('Stop transport: done')
         assert len(await log.grep('Shutting down paxos store')) == 0
 
         logger.info("Trigger paxos_state_learn_after_mutate")

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -102,7 +102,19 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
         await manager.api.message_injection(server_to_pause.ip_addr, 'storage_proxy_write_response_pause')
 
         logger.info("Waiting for the shutdown to complete")
-        await shutdown_task
+        try:
+            await asyncio.wait_for(shutdown_task, timeout=15)
+        except asyncio.TimeoutError:
+            # Deadlock reproduced — shutdown hung because stale_versions_in_use
+            # blocks on the write handler holding a stale token_metadata version.
+            # We must explicitly kill the node here: the manager's _after_test
+            # handler waits up to 120s for all outstanding tasks (including
+            # the stuck stop_gracefully request) before teardown proceeds.
+            # Killing the process lets stop_gracefully's cmd.wait() return,
+            # which unblocks _after_test.
+            logger.info("Shutdown did not complete within the timeout, killing the node")
+            await manager.server_stop(target_server.server_id)
+            pytest.fail("Shutdown did not complete within 15s — deadlock reproduced")
 
         logger.info("Cancelling addnode task")
         add_last_node_task.cancel()

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -116,5 +116,5 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
             await manager.server_stop(target_server.server_id)
             pytest.fail("Shutdown did not complete within 15s — deadlock reproduced")
 
-        logger.info("Cancelling addnode task")
-        add_last_node_task.cancel()
+        logger.info("Waiting for addnode to complete")
+        await add_last_node_task

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -12,6 +12,7 @@ import time
 from cassandra import ConsistencyLevel  # type: ignore
 from cassandra.query import SimpleStatement  # type: ignore
 from test.pylib.manager_client import ManagerClient
+from test.pylib.internal_types import ServerInfo
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import check_token_ring_and_group0_consistency, new_test_keyspace
 from test.pylib.util import wait_for
@@ -23,19 +24,37 @@ from cassandra.cluster import ConnectionException, NoHostAvailable  # type: igno
 logger = logging.getLogger(__name__)
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(reason="SCYLLADB-1842")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
-    """ Test a simultaneous topology change and write query during shutdown, which may cause the node to get stuck (see https://github.com/scylladb/scylladb/issues/23665).
+    """ Test a simultaneous topology change and write query during shutdown,
+    which may cause the node to get stuck.
 
-     1. Create a keyspace with replication factor 3
-     2. Start 3 servers
-     3. Use error injection to pause the 3rd node on a topology change (`barrier_and_drain`)
-     4  Trigger a topology change by adding a new node to the cluster.
-     5. Make sure the topology change was paused on the node 3 (`barrier_and_drain`)
-     6. Now with error injection, make sure node 2 will pause before sending a write acknowledgment.
-     7. Send a write query to the node 3. (which already should be paused on the topology change operation)
-     8. The query should have completed, but one write to node 2 should be remaining, making write_response_handler block the topology change in node 3
-     9. Start node 3 shutdown. The shutdown should hang since the one of the replicas did not send the response and therefore the response write handler still holds the ERM.
+    The test runs twice on the same cluster:
+    - First with the target node being a non-coordinator (hangs in
+      uninit_messaging_service, see scylladb/scylladb#23665).
+    - Then with the target node being the topology coordinator (hangs in
+      do_drain -> wait_for_group0_stop, see SCYLLADB-1842).
+
+    Each run:
+     1. Enable pause_before_barrier_and_drain injection on the target.
+     2. Trigger a topology change by adding a new node to the cluster.
+     3. Wait for the first barrier_and_drain to hit the injection on
+        the target.
+     4. Pause write responses on all other running servers via injection.
+     5. Send a write with CL=ONE to the target node. It completes
+        immediately from the coordinator's local replica. The mutation
+        is still sent to other replicas whose responses are paused,
+        keeping the write_response_handler alive.
+     6. Release the first barrier_and_drain (the write handler's ERM
+        version is still current). Wait for the second
+        barrier_and_drain — by now topology_state_load has installed
+        a new token_metadata version, making the write handler's ERM
+        stale.
+     7. Start graceful shutdown of the target node.
+     8. Disable the injection to release all paused barrier_and_drain
+        handlers, then unblock the delayed write response.
+     9. Verify shutdown completes within 15s (deadlock = test failure).
     """
     logger.info("Creating a new cluster")
 
@@ -43,89 +62,130 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
         '--logger-log-level', 'debug_error_injection=debug',
     ]
 
-    servers = await manager.servers_add(3, auto_rack_dc="dc1", cmdline=cmdline)
+    await manager.servers_add(2, auto_rack_dc="dc1", cmdline=cmdline)
 
-    cql, hosts = await manager.get_ready_cql(servers)
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2};") as ks:
 
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
-        target_host = hosts[2]
-        target_server = servers[2]
+        # Preconditions: exactly 2 running nodes, RF=2, so both nodes
+        # are replicas for every partition. The target node is always a
+        # replica (local write satisfies CL=ONE) and the other node is
+        # always a replica (its paused response keeps the handler alive).
+        # The caller restores these preconditions between runs.
+        async def do_test(target_server: ServerInfo) -> ServerInfo:
+            """Run the test scenario. Returns the newly added server."""
+            other_server = next(s for s in running if s.server_id != target_server.server_id)
+            target_host = next(h for h in hosts
+                               if h.address == str(target_server.rpc_address))
 
-        # Make the target node stop before locking the ERM
-        logger.info(
-            f"Enabling injection 'pause_before_barrier_and_drain' on the target server {target_server}")
-        target_server_log = await manager.server_open_log(target_server.server_id)
-        await manager.api.enable_injection(target_server.ip_addr, "pause_before_barrier_and_drain", one_shot=False)
+            logger.info(
+                f"Enabling injection 'pause_before_barrier_and_drain' on the target server {target_server}")
+            target_server_log = await manager.server_open_log(target_server.server_id)
+            await manager.api.enable_injection(target_server.ip_addr, "pause_before_barrier_and_drain", one_shot=False)
 
-        async def do_add_node():
+            # Start adding a new node, causing a topology change that issues barrier_and_drain
             logger.info("Adding a node to the cluster")
-            try:
-                await manager.server_add(property_file={"dc": "dc1", "rack": servers[0].rack})
-            except Exception as exc:
-                logger.error(f"Failed to add a new node: {exc}")
+            add_last_node_task = asyncio.create_task(
+                manager.server_add(property_file={"dc": "dc1", "rack": running[0].rack}))
 
-        # Start adding a new node to the cluster, causing a topology change that will issue a barrier and drain
-        add_last_node_task = asyncio.create_task(do_add_node())
+            # Wait for the topology change to start
+            logger.info("Waiting for a topology change to start")
+            mark, _ = await target_server_log.wait_for("pause_before_barrier_and_drain: waiting for message")
 
-        # Wait for the topology change to start
-        logger.info("Waiting for a topology change to start")
-        mark, _ = await target_server_log.wait_for("pause_before_barrier_and_drain: waiting for message")
+            # Pause write responses on the other node so it keeps the
+            # write_response_handler alive on the target.
+            await inject_error_on(manager, "storage_proxy_write_response_pause", [other_server])
+            other_server_log = await manager.server_open_log(other_server.server_id)
 
-        # Now make sure responses on one of the replicas will be delayed
-        server_to_pause = servers[1]
-        await inject_error_on(manager, "storage_proxy_write_response_pause", [server_to_pause])
-        logger.info(
-            f"Pausing responses on one of the replicas {server_to_pause}")
-        paused_server_logs = await manager.server_open_log(server_to_pause.server_id)
+            # Send a write with CL=ONE so it completes from the coordinator's
+            # local replica without waiting for the paused server.
+            await cql.run_async(
+                SimpleStatement(f"insert into {ks}.t (pk, v) values ({32765}, {17777})",
+                                consistency_level=ConsistencyLevel.ONE),
+                host=target_host)
 
-        # Now send a write query to the target node that will be shut down.
-        await cql.run_async(f"insert into {ks}.t (pk, v) values ({32765}, {17777})", host=target_host)
+            # Make sure the other replica got the write request and is paused.
+            await other_server_log.wait_for("storage_proxy_write_response_pause: waiting for message")
 
-        # Make sure the node that's response is paused, got the write request.
-        await paused_server_logs.wait_for("storage_proxy_write_response_pause: waiting for message")
+            # Release the first barrier_and_drain — it completes because the write
+            # handler holds the current version (not stale yet).
+            await manager.api.message_injection(target_server.ip_addr, 'pause_before_barrier_and_drain')
 
-        # Release the first barrier_and_drain — it completes because the write
-        # handler holds the current version (not stale yet).
-        await manager.api.message_injection(target_server.ip_addr, 'pause_before_barrier_and_drain')
+            # Wait for the second barrier_and_drain. Between the first and second,
+            # topology_state_load installs a new token_metadata version. The write
+            # handler still holds the old version's ERM, which is now stale.
+            await target_server_log.wait_for("pause_before_barrier_and_drain: waiting for message", from_mark=mark)
 
-        # Wait for the second barrier_and_drain. Between the first and second,
-        # topology_state_load installs a new token_metadata version. The write
-        # handler still holds the old version's ERM, which is now stale.
-        await target_server_log.wait_for("pause_before_barrier_and_drain: waiting for message", from_mark=mark)
-
-        # Start shutdown of the query coordinator
-        async def do_shutdown():
+            # Start shutdown of the target node
             logger.info(f"Starting shutdown of node {target_server.server_id}")
-            await manager.server_stop_gracefully(target_server.server_id)
+            shutdown_task = asyncio.create_task(
+                manager.server_stop_gracefully(target_server.server_id))
 
-        shutdown_task = asyncio.create_task(do_shutdown())
+            # Wait for stop_transport to complete. At this point the local
+            # messaging service is shut down, so MUTATION_DONE from the other
+            # replica can no longer reach the coordinator — the write handler
+            # has no chance to complete naturally. Next we release the paused
+            # barrier_and_drain and unblock the write response. The
+            # barrier_and_drain handler calls stale_versions_in_use() which
+            # blocks until the stale ERM held by the write handler is released.
+            # The test verifies that shutdown succeeds because the fix
+            # forcefully cancels write handlers during storage_proxy shutdown,
+            # releasing the stale ERM and unblocking stale_versions_in_use().
+            await target_server_log.wait_for("Stop transport: done")
 
-        # Wait for the shutdown to start
-        await target_server_log.wait_for("Stop transport: done")
+            # Disable the injection. This releases the paused barrier_and_drain
+            # handler (and any subsequent ones that arrived during stop_transport)
+            # so they don't block uninit_messaging_service.
+            await manager.api.disable_injection(target_server.ip_addr, "pause_before_barrier_and_drain")
 
-        # Disable the injection. This releases the paused barrier_and_drain
-        # handler (and any subsequent ones that arrived during stop_transport)
-        # so they don't block uninit_messaging_service.
-        await manager.api.disable_injection(target_server.ip_addr, "pause_before_barrier_and_drain")
+            logger.info(f"Unblocking writes on the node {other_server}")
+            await manager.api.message_injection(other_server.ip_addr, 'storage_proxy_write_response_pause')
 
-        logger.info(f"Unblocking writes on the node {server_to_pause}")
-        await manager.api.message_injection(server_to_pause.ip_addr, 'storage_proxy_write_response_pause')
+            logger.info("Waiting for the shutdown to complete")
+            try:
+                await asyncio.wait_for(shutdown_task, timeout=15)
+            except asyncio.TimeoutError:
+                # Deadlock reproduced — shutdown hung because stale_versions_in_use
+                # blocks on the write handler holding a stale token_metadata version.
+                # Kill all servers including any being bootstrapped (stuck because
+                # the coordinator is dead). This unblocks the server-side addserver
+                # handler so _after_test doesn't wait 120s for it.
+                logger.info("Shutdown did not complete within the timeout, killing all servers")
+                for s in await manager.all_servers() + await manager.starting_servers():
+                    await manager.server_stop(s.server_id)
+                pytest.fail(f"Shutdown did not complete within 15s — deadlock reproduced"
+                            f" (target={target_server})")
 
-        logger.info("Waiting for the shutdown to complete")
-        try:
-            await asyncio.wait_for(shutdown_task, timeout=15)
-        except asyncio.TimeoutError:
-            # Deadlock reproduced — shutdown hung because stale_versions_in_use
-            # blocks on the write handler holding a stale token_metadata version.
-            # We must explicitly kill the node here: the manager's _after_test
-            # handler waits up to 120s for all outstanding tasks (including
-            # the stuck stop_gracefully request) before teardown proceeds.
-            # Killing the process lets stop_gracefully's cmd.wait() return,
-            # which unblocks _after_test.
-            logger.info("Shutdown did not complete within the timeout, killing the node")
-            await manager.server_stop(target_server.server_id)
-            pytest.fail("Shutdown did not complete within 15s — deadlock reproduced")
+            # Restart the target node before waiting for addnode — the addnode
+            # needs raft quorum which requires the target to be alive.
+            await manager.server_start(target_server.server_id)
 
-        logger.info("Waiting for addnode to complete")
-        await add_last_node_task
+            logger.info("Waiting for addnode to complete")
+            return await add_last_node_task
+
+        async def pick_target(is_coordinator: bool) -> ServerInfo:
+            coordinator_host_id = await get_topology_coordinator(manager)
+            for s in running:
+                hid = await manager.get_host_id(s.server_id)
+                if (hid == coordinator_host_id) == is_coordinator:
+                    return s
+            assert False, f"Could not find {'coordinator' if is_coordinator else 'non-coordinator'} among {running}"
+
+        # Run 1: target is a non-coordinator node
+        running = await manager.running_servers()
+        cql, hosts = await manager.get_ready_cql(running)
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
+        target_server = await pick_target(is_coordinator=False)
+        logger.info(f"=== Run 1: target={target_server} (non-coordinator) ===")
+        new_server = await do_test(target_server)
+
+        # Restore the cluster to its original state: decommission the added
+        # node. do_test already restarted the target. This keeps 2 nodes with
+        # RF=2, so both are replicas for every partition — same as run 1.
+        await manager.decommission_node(new_server.server_id)
+
+        # Run 2: target is the topology coordinator
+        running = await manager.running_servers()
+        cql, hosts = await manager.get_ready_cql(running)
+        target_server = await pick_target(is_coordinator=True)
+        logger.info(f"=== Run 2: target={target_server} (coordinator) ===")
+        await do_test(target_server)

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -56,7 +56,7 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
         logger.info(
             f"Enabling injection 'pause_before_barrier_and_drain' on the target server {target_server}")
         target_server_log = await manager.server_open_log(target_server.server_id)
-        await manager.api.enable_injection(target_server.ip_addr, "pause_before_barrier_and_drain", one_shot=True)
+        await manager.api.enable_injection(target_server.ip_addr, "pause_before_barrier_and_drain", one_shot=False)
 
         async def do_add_node():
             logger.info("Adding a node to the cluster")
@@ -70,7 +70,7 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
 
         # Wait for the topology change to start
         logger.info("Waiting for a topology change to start")
-        await target_server_log.wait_for("pause_before_barrier_and_drain: waiting for message")
+        mark, _ = await target_server_log.wait_for("pause_before_barrier_and_drain: waiting for message")
 
         # Now make sure responses on one of the replicas will be delayed
         server_to_pause = servers[1]
@@ -85,6 +85,15 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
         # Make sure the node that's response is paused, got the write request.
         await paused_server_logs.wait_for("storage_proxy_write_response_pause: waiting for message")
 
+        # Release the first barrier_and_drain — it completes because the write
+        # handler holds the current version (not stale yet).
+        await manager.api.message_injection(target_server.ip_addr, 'pause_before_barrier_and_drain')
+
+        # Wait for the second barrier_and_drain. Between the first and second,
+        # topology_state_load installs a new token_metadata version. The write
+        # handler still holds the old version's ERM, which is now stale.
+        await target_server_log.wait_for("pause_before_barrier_and_drain: waiting for message", from_mark=mark)
+
         # Start shutdown of the query coordinator
         async def do_shutdown():
             logger.info(f"Starting shutdown of node {target_server.server_id}")
@@ -95,8 +104,10 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
         # Wait for the shutdown to start
         await target_server_log.wait_for("Stop transport: done")
 
-        # Unpause the coordinator to make it now continue with `barrier_and_drain` shutdown
-        await manager.api.message_injection(target_server.ip_addr, 'pause_before_barrier_and_drain')
+        # Disable the injection. This releases the paused barrier_and_drain
+        # handler (and any subsequent ones that arrived during stop_transport)
+        # so they don't block uninit_messaging_service.
+        await manager.api.disable_injection(target_server.ip_addr, "pause_before_barrier_and_drain")
 
         logger.info(f"Unblocking writes on the node {server_to_pause}")
         await manager.api.message_injection(server_to_pause.ip_addr, 'storage_proxy_write_response_pause')

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -24,7 +24,6 @@ from cassandra.cluster import ConnectionException, NoHostAvailable  # type: igno
 logger = logging.getLogger(__name__)
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="SCYLLADB-1842")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """ Test a simultaneous topology change and write query during shutdown,

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -965,7 +965,7 @@ class ScyllaServer:
                                 "'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }")
                 session.execute("DROP KEYSPACE k")
 
-    async def shutdown_control_connection(self) -> None:
+    def shutdown_control_connection(self) -> None:
         """Shut down driver connection and notify socket"""
         if self.control_connection is not None:
             self.control_connection.shutdown()
@@ -975,14 +975,20 @@ class ScyllaServer:
             self.control_cluster = None
         self._cleanup_notify_socket()
 
-    @stop_event
-    @start_stop_lock
     async def stop(self) -> None:
         """Stop a running server. No-op if not running. Uses SIGKILL to
-        stop, so is not graceful. Waits for the process to exit before return."""
+        stop, so is not graceful. Waits for the process to exit before return.
+
+        This method intentionally does not acquire start_stop_lock so that it
+        can kill a server even while stop_gracefully() is blocked waiting for
+        the process to exit (e.g. the node is deadlocked). The concurrent
+        stop_gracefully() will unblock once the process dies from SIGKILL.
+        A local copy of self.cmd is used because there are await points after
+        which another coroutine (stop_gracefully) may set self.cmd to None."""
         self.logger.info("stopping %s in %s", self, self.workdir.name)
-        if not self.cmd:
-            await self.shutdown_control_connection()
+        cmd = self.cmd
+        if not cmd:
+            self.shutdown_control_connection()
             return
 
         # Dump the profile if exists and supported by the API.
@@ -993,25 +999,25 @@ class ScyllaServer:
             # since it is not part of the test functionality, allow
             # this step to fail unconditionally.
             pass
-        await self.shutdown_control_connection()
+        self.shutdown_control_connection()
 
-        if self.cmd.returncode is not None:
+        if cmd.returncode is not None:
             # process has already exited
-            if self.cmd.returncode != 0:
-                self.logger.error("%s exited with non-zero status code: %d", self, self.cmd.returncode)
+            if cmd.returncode != 0:
+                self.logger.error("%s exited with non-zero status code: %d", self, cmd.returncode)
             self.logger.info("stopped %s in %s", self, self.workdir.name)
             self.cmd = None
             return
 
         try:
-            self.cmd.kill()
+            cmd.kill()
         except ProcessLookupError:
-            # the process *might* exit after checking for self.cmd.returncode
-            # and before self.cmd.kill() call. this is unlikely, but should not
+            # the process *might* exit after checking for cmd.returncode
+            # and before cmd.kill() call. this is unlikely, but should not
             # be considered as a failure.
             pass
         else:
-            await self.cmd.wait()
+            await cmd.wait()
         finally:
             self.logger.info("stopped %s in %s", self, self.workdir.name)
             self.cmd = None
@@ -1025,7 +1031,7 @@ class ScyllaServer:
         if not self.cmd:
             return
 
-        await self.shutdown_control_connection()
+        self.shutdown_control_connection()
         try:
             self.cmd.terminate()
         except ProcessLookupError:

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -144,6 +144,7 @@ class error_injection {
         size_t received_message_count{0};
         size_t shared_read_message_count{0};
         size_t waiter_count{0};
+        bool disabled{false};
         condition_variable received_message_cv;
         error_injection_parameters parameters;
         sstring injection_name;
@@ -220,6 +221,9 @@ public:
                 ++_shared_data->waiter_count;
                 auto dec = defer([this] () noexcept { --_shared_data->waiter_count; });
                 co_await _shared_data->received_message_cv.wait(timeout, [&] {
+                    if (_shared_data->disabled) {
+                        return true;
+                    }
                     if (as) {
                         as->check();
                     }
@@ -401,14 +405,26 @@ public:
 
     void disable(const std::string_view& injection_name) {
         errinj_logger.debug("Disabling injection \"{}\"", injection_name);
-        _enabled.erase(injection_name);
-        if (auto it = _on_disable_callbacks.find(sstring(injection_name)); it != _on_disable_callbacks.end()) {
-            it->second();
+        auto it = _enabled.find(injection_name);
+        if (it != _enabled.end()) {
+            // Release any handlers currently waiting for messages on this
+            // injection. They hold a shared_ptr to the shared_data, so it
+            // stays alive after we erase the map entry.
+            it->second.shared_data->disabled = true;
+            it->second.shared_data->received_message_cv.broadcast();
+            _enabled.erase(it);
+        }
+        if (auto cb = _on_disable_callbacks.find(sstring(injection_name)); cb != _on_disable_callbacks.end()) {
+            cb->second();
         }
     }
 
     void disable_all() {
         errinj_logger.debug("Disabling all injections");
+        for (auto& [_, data] : _enabled) {
+            data.shared_data->disabled = true;
+            data.shared_data->received_message_cv.broadcast();
+        }
         auto was_enabled = std::move(_enabled);
         for (auto& [name, _] : was_enabled) {
             if (auto it = _on_disable_callbacks.find(sstring(name)); it != _on_disable_callbacks.end()) {

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -45,11 +45,16 @@ using error_injection_parameters = std::unordered_map<sstring, sstring>;
 // in class error_injection below). Parameters:
 // timeout - the timeout after which the pause is aborted
 // as (optional) - abort_source used to abort the pause
+// share - if true (default), injection handlers share received messages:
+//         every message can be received by all handlers (even if they start
+//         waiting in the future). If false, only one handler can receive a
+//         specific message; other handlers will wait for new messages.
 struct wait_for_message {
     std::chrono::milliseconds timeout;
-    abort_source* as = nullptr;
-    wait_for_message(std::chrono::milliseconds tmo) noexcept : timeout(tmo) {}
-    wait_for_message(std::chrono::milliseconds tmo, abort_source* a) noexcept : timeout(tmo), as(a) {}
+    abort_source* as;
+    bool share;
+    wait_for_message(std::chrono::milliseconds tmo, abort_source* a = nullptr, bool share_ = true) noexcept
+        : timeout(tmo), as(a), share(share_) {}
 };
 
 /**
@@ -552,7 +557,7 @@ public:
             errinj_logger.info("{}: waiting for message", name);
             co_await handler.wait_for_message(std::chrono::steady_clock::now() + wfm.timeout, wfm.as);
             errinj_logger.info("{}: message received", name);
-        });
+        }, wfm.share);
     }
 
     template <typename T = std::string_view>


### PR DESCRIPTION
### Summary
Fixes a shutdown deadlock where a node hangs because `stale_versions_in_use()` blocks on stale `token_metadata` versions held by write handlers whose `MUTATION_DONE` responses can never arrive (transport is already stopped).

Two manifestations depending on whether the shutting-down node is the topology coordinator:
- Coordinator: do_drain → wait_for_group0_stop deadlocks because the topology coordinator fiber is stuck in barrier_and_drain → stale_versions_in_use().
- Non-coordinator: ss::stop → uninit_messaging_service deadlocks because the barrier_and_drain RPC handler holds the gate open.

The non-coordinator case was fixed in PR #24714 (cancel all write requests on storage_proxy shutdown), but its test never actually failed — the write handler always captured the current token_metadata version because `pause_before_barrier_and_drain` used `one_shot=True,` so only the first `barrier_and_drain` was paused. The topology state hadn't advanced by that point, meaning the write handler's ERM version matched the current version and `stale_versions_in_use()` returned immediately. The coordinator case was not covered at all.

### Fix
Cancel all write response handlers on all shards right after `stop_transport()` in `do_drain()`. This releases their ERMs and the associated stale token_metadata versions, unblocking `stale_versions_in_use()`.

### Test changes
Fixed the test to ensure the write handler holds a stale version: use one_shot=False, let the first barrier_and_drain through (version still current), then wait for the second one (version now stale). Extended to cover both coordinator and non-coordinator shutdown on the same 2-node cluster.

Also includes supporting changes:
- error_injection: release wait_for_message waiters on disable() so the test can atomically unblock paused handlers
- error_injection: add non-shared mode to wait_for_message for per-invocation message semantics
- scylla_cluster.py: allow stop() to bypass start_stop_lock so SIGKILL works while stop_gracefully is blocked

Fixes: SCYLLADB-1842
Refs: scylladb/scylladb#23665

backports: SCYLLADB-1842 reported a failure in 2025.1, so we need to backport to all versions starting from 2025.1