### PR TITLE
alternator: use per-DC RF capped to available racks/nodes

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -186,7 +186,7 @@ void executor::maybe_audit(
     }
 }
 
-static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type,
+static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, api::timestamp_type,
         const std::map<sstring, sstring>& tags_map, const gms::feature_service& feat, const db::tablets_mode_t::mode tablets_mode);
 
 static std::optional<unsigned> get_initial_tablet_count(const std::map<sstring, sstring>& tags_map,
@@ -1736,7 +1736,7 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
         auto group0_guard = co_await _mm.start_group0_operation();
         auto ts = group0_guard.write_timestamp();
         utils::chunked_vector<mutation> schema_mutations;
-        auto ksm = create_keyspace_metadata(keyspace_name, _proxy, _gossiper, ts, tags_map, _proxy.features(), tablets_mode);
+        auto ksm = create_keyspace_metadata(keyspace_name, _proxy, ts, tags_map, _proxy.features(), tablets_mode);
         locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets(), ksm->consistency_option());
         const auto& topo = _proxy.local_db().get_token_metadata().get_topology();
         auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params, topo);
@@ -4507,10 +4507,30 @@ future<executor::request_return_type> executor::describe_endpoints(client_state&
     co_return rjson::print(std::move(response));
 }
 
-static locator::replication_strategy_config_options get_network_topology_options(service::storage_proxy& sp, gms::gossiper& gossiper, int rf) {
+static locator::replication_strategy_config_options get_network_topology_options(service::storage_proxy& sp, std::string_view keyspace_name, bool use_tablets, int rf = 3) {
     locator::replication_strategy_config_options options;
-    for (const auto& dc : sp.get_token_metadata_ptr()->get_datacenter_racks_token_owners() | std::views::keys) {
-        options.emplace(dc, std::to_string(rf));
+    for (const auto& [dc, racks] : sp.get_token_metadata_ptr()->get_datacenter_racks_token_owners()) {
+        // For tablets, RF cannot exceed the number of racks in a DC.
+        // For vnodes, RF cannot exceed the number of nodes in a DC.
+        int capacity;
+        if (use_tablets) {
+            capacity = (int)racks.size();
+        } else {
+            capacity = 0;
+            for (const auto& [rack, owners] : racks) {
+                capacity += owners.size();
+            }
+        }
+        int dc_rf = rf;
+        if (dc_rf > capacity) {
+            dc_rf = capacity;
+            elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} in DC '{}' "
+                         "instead of the desired RF={} because it only has {} {}.",
+                         keyspace_name, dc_rf, dc, rf, capacity,
+                         use_tablets ? (capacity == 1 ? "rack" : "racks")
+                                     : (capacity == 1 ? "node" : "nodes"));
+        }
+        options.emplace(dc, std::to_string(dc_rf));
     }
     return options;
 }
@@ -4579,11 +4599,12 @@ static std::optional<unsigned> get_initial_tablet_count(const std::map<sstring, 
 
 // Create the metadata for the keyspace in which we put the alternator
 // table if it doesn't already exist.
-// Currently, we automatically configure the keyspace based on the number
-// of nodes in the cluster: A cluster with 3 or more live nodes, gets RF=3.
-// A smaller cluster (presumably, a test only), gets RF=1. The user may
-// manually create the keyspace to override this predefined behavior.
-static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type ts,
+// The replication factor for each DC is min(3, racks_in_dc) when using
+// tablets, or min(3, nodes_in_dc) when using vnodes. This means a small
+// cluster or DC gets a lower (possibly unsafe) RF, while a DC with 3 or
+// more racks/nodes gets the full RF=3. The user may manually create the
+// keyspace to override this predefined behavior.
+static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, api::timestamp_type ts,
             const std::map<sstring, sstring>& tags_map, const gms::feature_service& feat, const db::tablets_mode_t::mode tablets_mode) {
     auto initial_tablets = get_initial_tablet_count(tags_map, feat, tablets_mode);
     if (feat.tablets) {
@@ -4605,14 +4626,7 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
         }
     }
 
-    int endpoint_count = gossiper.num_endpoints();
-    int rf = 3;
-    if (endpoint_count < rf) {
-        rf = 1;
-        elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} because cluster only has {} nodes.",
-                     keyspace_name, rf, endpoint_count);
-    }
-    auto opts = get_network_topology_options(sp, gossiper, rf);
+    auto opts = get_network_topology_options(sp, keyspace_name, initial_tablets.has_value());
     cql3::statements::ks_prop_defs props;
     opts["class"] = sstring("NetworkTopologyStrategy");
     props.add_property(cql3::statements::ks_prop_defs::KW_REPLICATION, opts);

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -188,7 +188,7 @@ void executor::maybe_audit(
     }
 }
 
-static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type,
+static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, api::timestamp_type,
         const std::map<sstring, sstring>& tags_map, const gms::feature_service& feat, const db::tablets_mode_t::mode tablets_mode);
 
 static std::optional<unsigned> get_initial_tablet_count(const std::map<sstring, sstring>& tags_map,
@@ -1751,7 +1751,7 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
         auto group0_guard = co_await _mm.start_group0_operation();
         auto ts = group0_guard.write_timestamp();
         utils::chunked_vector<mutation> schema_mutations;
-        auto ksm = create_keyspace_metadata(keyspace_name, _proxy, _gossiper, ts, tags_map, _proxy.features(), tablets_mode);
+        auto ksm = create_keyspace_metadata(keyspace_name, _proxy, ts, tags_map, _proxy.features(), tablets_mode);
         locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets(), ksm->consistency_option());
         const auto& topo = _proxy.local_db().get_token_metadata().get_topology();
         auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params, topo);
@@ -4549,10 +4549,30 @@ future<executor::request_return_type> executor::describe_endpoints(client_state&
     co_return rjson::print(std::move(response));
 }
 
-static locator::replication_strategy_config_options get_network_topology_options(service::storage_proxy& sp, gms::gossiper& gossiper, int rf) {
+static locator::replication_strategy_config_options get_network_topology_options(service::storage_proxy& sp, std::string_view keyspace_name, bool use_tablets, int rf = 3) {
     locator::replication_strategy_config_options options;
-    for (const auto& dc : sp.get_token_metadata_ptr()->get_datacenter_racks_token_owners() | std::views::keys) {
-        options.emplace(dc, std::to_string(rf));
+    for (const auto& [dc, racks] : sp.get_token_metadata_ptr()->get_datacenter_racks_token_owners()) {
+        // For tablets, RF cannot exceed the number of racks in a DC.
+        // For vnodes, RF cannot exceed the number of nodes in a DC.
+        int capacity;
+        if (use_tablets) {
+            capacity = (int)racks.size();
+        } else {
+            capacity = 0;
+            for (const auto& [rack, owners] : racks) {
+                capacity += owners.size();
+            }
+        }
+        int dc_rf = rf;
+        if (dc_rf > capacity) {
+            dc_rf = capacity;
+            elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} in DC '{}' "
+                         "instead of the desired RF={} because it only has {} {}.",
+                         keyspace_name, dc_rf, dc, rf, capacity,
+                         use_tablets ? (capacity == 1 ? "rack" : "racks")
+                                     : (capacity == 1 ? "node" : "nodes"));
+        }
+        options.emplace(dc, std::to_string(dc_rf));
     }
     return options;
 }
@@ -4621,11 +4641,12 @@ static std::optional<unsigned> get_initial_tablet_count(const std::map<sstring, 
 
 // Create the metadata for the keyspace in which we put the alternator
 // table if it doesn't already exist.
-// Currently, we automatically configure the keyspace based on the number
-// of nodes in the cluster: A cluster with 3 or more live nodes, gets RF=3.
-// A smaller cluster (presumably, a test only), gets RF=1. The user may
-// manually create the keyspace to override this predefined behavior.
-static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type ts,
+// The replication factor for each DC is min(3, racks_in_dc) when using
+// tablets, or min(3, nodes_in_dc) when using vnodes. This means a small
+// cluster or DC gets a lower (possibly unsafe) RF, while a DC with 3 or
+// more racks/nodes gets the full RF=3. The user may manually create the
+// keyspace to override this predefined behavior.
+static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, api::timestamp_type ts,
             const std::map<sstring, sstring>& tags_map, const gms::feature_service& feat, const db::tablets_mode_t::mode tablets_mode) {
     auto initial_tablets = get_initial_tablet_count(tags_map, feat, tablets_mode);
     if (feat.tablets) {
@@ -4647,14 +4668,7 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
         }
     }
 
-    int endpoint_count = gossiper.num_endpoints();
-    int rf = 3;
-    if (endpoint_count < rf) {
-        rf = 1;
-        elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} because cluster only has {} nodes.",
-                     keyspace_name, rf, endpoint_count);
-    }
-    auto opts = get_network_topology_options(sp, gossiper, rf);
+    auto opts = get_network_topology_options(sp, keyspace_name, initial_tablets.has_value());
     cql3::statements::ks_prop_defs props;
     opts["class"] = sstring("NetworkTopologyStrategy");
     props.add_property(cql3::statements::ks_prop_defs::KW_REPLICATION, opts);

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -29,7 +29,7 @@ import threading
 import random
 import re
 
-from test.cluster.util import get_replication
+from test.cluster.util import get_replication, get_replica_count
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for
 from test.pylib.rest_client import inject_error
@@ -2084,4 +2084,57 @@ async def test_alternator_mtls_and_plain_http(manager: ManagerClient, tmp_path):
         alternator_bad.meta.client.list_tables()
 
 
+@pytest.mark.asyncio
+async def test_alternator_multidc_two_racks_three_racks(manager: ManagerClient):
+    """Verify that Alternator works correctly on a multi-DC cluster with
+       different number of racks in each DC. In this test we set up two DCs:
+       - DC1 has 2 nodes on 2 different racks
+       - DC2 has 3 nodes on 3 different racks
+    Create a table, write a bunch of rows, and read them back.
+    """
+    servers = await manager.servers_add(5, config=alternator_config, property_file=[
+        {'dc': 'dc1', 'rack': 'rack1'},
+        {'dc': 'dc1', 'rack': 'rack2'},
+        {'dc': 'dc2', 'rack': 'rack1'},
+        {'dc': 'dc2', 'rack': 'rack2'},
+        {'dc': 'dc2', 'rack': 'rack3'},
+    ])
 
+    alternator = get_alternator(servers[0].ip_addr)
+
+    table = alternator.create_table(
+        TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[
+            {'AttributeName': 'p', 'KeyType': 'HASH'},
+            {'AttributeName': 'c', 'KeyType': 'RANGE'},
+        ],
+        AttributeDefinitions=[
+            {'AttributeName': 'p', 'AttributeType': 'N'},
+            {'AttributeName': 'c', 'AttributeType': 'N'},
+        ])
+    table.meta.client.get_waiter('table_exists').wait(TableName=table.name)
+
+    try:
+        # Sanity check: verify the keyspace replication matches what we think it
+        # should be. In DC2 we can use RF=3 but in DC1 we can only use RF=2
+        ks = f'alternator_{table.name}'
+        repl = get_replication(manager.get_cql(), ks)
+        assert get_replica_count(repl['dc1']) == 2
+        assert get_replica_count(repl['dc2']) == 3
+
+        # Try to read and write a bunch of different partitions to verify that
+        # the cluster is working correctly.
+        N = 100
+        with table.batch_writer() as batch:
+            for i in range(N):
+                batch.put_item(Item={'p': i, 'c': i, 'val': f'value{i}'})
+
+        # Read back every row and verify the value
+        for i in range(N):
+            response = table.get_item(Key={'p': i, 'c': i}, ConsistentRead=True)
+            assert 'Item' in response
+            assert response['Item']['val'] == f'value{i}'
+    finally:
+        table.delete()
+        table.meta.client.get_waiter('table_not_exists').wait(TableName=table.name)

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -28,7 +28,7 @@ import threading
 import random
 import re
 
-from test.cluster.util import get_replication
+from test.cluster.util import get_replication, get_replica_count
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for
 from test.pylib.rest_client import inject_error
@@ -1517,6 +1517,61 @@ async def test_deferred_stream_enablement_on_tablets(manager: ManagerClient):
         # Shrinkage (streams disabled): must SUCCEED (16 -> 8).
         await set_tablet_target(ks, table.name, 8)
         await wait_for_tablet_count(table_id, 8)
+    finally:
+        table.delete()
+        table.meta.client.get_waiter('table_not_exists').wait(TableName=table.name)
+
+@pytest.mark.asyncio
+async def test_alternator_multidc_two_racks_three_racks(manager: ManagerClient):
+    """Verify that Alternator works correctly on a multi-DC cluster with
+       different number of racks in each DC. In this test we set up two DCs:
+       - DC1 has 2 nodes on 2 different racks
+       - DC2 has 3 nodes on 3 different racks
+    Create a table, write a bunch of rows, and read them back.
+    """
+    servers = await manager.servers_add(5, config=alternator_config, property_file=[
+        {'dc': 'dc1', 'rack': 'rack1'},
+        {'dc': 'dc1', 'rack': 'rack2'},
+        {'dc': 'dc2', 'rack': 'rack1'},
+        {'dc': 'dc2', 'rack': 'rack2'},
+        {'dc': 'dc2', 'rack': 'rack3'},
+    ])
+
+    alternator = get_alternator(servers[0].ip_addr)
+
+    table = alternator.create_table(
+        TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[
+            {'AttributeName': 'p', 'KeyType': 'HASH'},
+            {'AttributeName': 'c', 'KeyType': 'RANGE'},
+        ],
+        AttributeDefinitions=[
+            {'AttributeName': 'p', 'AttributeType': 'N'},
+            {'AttributeName': 'c', 'AttributeType': 'N'},
+        ])
+    table.meta.client.get_waiter('table_exists').wait(TableName=table.name)
+
+    try:
+        # Sanity check: verify the keyspace replication matches what we think it
+        # should be. In DC2 we can use RF=3 but in DC1 we can only use RF=2
+        ks = f'alternator_{table.name}'
+        repl = get_replication(manager.get_cql(), ks)
+        assert get_replica_count(repl['dc1']) == 2
+        assert get_replica_count(repl['dc2']) == 3
+
+        # Try to read and write a bunch of different partitions to verify that
+        # the cluster is working correctly.
+        N = 100
+        with table.batch_writer() as batch:
+            for i in range(N):
+                batch.put_item(Item={'p': i, 'c': i, 'val': f'value{i}'})
+
+        # Read back every row and verify the value
+        for i in range(N):
+            response = table.get_item(Key={'p': i, 'c': i}, ConsistentRead=True)
+            assert 'Item' in response
+            assert response['Item']['val'] == f'value{i}'
     finally:
         table.delete()
         table.meta.client.get_waiter('table_not_exists').wait(TableName=table.name)


### PR DESCRIPTION
Previously, Alternator created keyspaces with a global RF=3, reduced to 1 if the total node count was below 3. This was wrong in two ways:
1. In a multi-DC cluster, the RF was the same for all DCs regardless of how many racks/nodes each DC had, which could trigger an error when a DC has fewer racks than the requested RF (with tablets).
2. The node count check was global rather than per-DC.

Fix get_network_topology_options() to compute RF per DC:
- For tablets, DC RF = min(rf, number_of_racks_in_dc)
- For vnodes,  DC RF = min(rf, number_of_nodes_in_dc)

If the capacity forces a lower RF, a warning is logged indicating the DC name, the desired RF, and the actual RF used.

Also remove the now-unused 'gossiper' parameter from create_keyspace_metadata() and its forward declaration.

Add a test test_alternator_multidc_two_racks_three_racks that sets up a 5-node cluster spanning two DCs (dc1 with 2 racks, dc2 with 3 racks), creates a table, and verifies both the per-DC replication factors and basic read/write functionality.

Before this patch, the new test failed with an ugly InternalServerError:

    An error occurred (InternalServerError) when calling the CreateTable
    operation (reached max retries: 0): Internal server error:
    exceptions::configuration_exception (Replication factor 3 exceeds
    the number of racks (2) in dc dc1)