### PR TITLE
vector: allow vector index on a table that had CDC in the past

### DIFF
--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -289,22 +289,6 @@ void vector_index::check_target(const schema& schema, const std::vector<::shared
     }
 }
 
-void vector_index::check_cdc_not_explicitly_disabled(const schema& schema) const {
-    auto cdc_options = schema.cdc_options();
-    if (cdc_options.is_enabled_set() && !cdc_options.enabled()) {
-        // If CDC is explicitly disabled by the user, we cannot create the vector index.
-        throw exceptions::invalid_request_exception(format(
-            "Cannot create the vector index when CDC is explicitly disabled.\n"
-                "Please enable CDC with the required parameters first.\n"
-                "CDC's TTL must be at least {} seconds (24 hours), "
-                "and the CDC's delta mode must be set to 'full' or postimage must be enabled "
-                "to enable Vector Search.\n"
-                "Check documentation on how to setup CDC's parameters - "
-                "https://docs.scylladb.com/manual/branch-2025.2/features/cdc/cdc-intro.html#cdc-parameters",
-                VS_TTL_SECONDS));
-    }
-}
-
 void vector_index::check_index_options(const cql3::statements::index_specific_prop_defs& properties) const {
     for (auto option: properties.get_raw_options()) {
         auto it = vector_index_options.find(option.first);
@@ -333,7 +317,6 @@ void vector_index::validate(const schema &schema, const cql3::statements::index_
     check_uses_tablets(schema, db);
     check_target(schema, targets);
     check_key_column_count(schema);
-    check_cdc_not_explicitly_disabled(schema);
     check_cdc_options(schema);
     check_index_options(properties);
 }

--- a/index/vector_index.hh
+++ b/index/vector_index.hh
@@ -44,7 +44,6 @@ public:
     static float get_oversampling(const index_options_map& properties);
     static sstring get_cql_similarity_function_name(const index_options_map& properties);
 private:
-    void check_cdc_not_explicitly_disabled(const schema& schema) const;
     void check_target(const schema& schema, const std::vector<::shared_ptr<cql3::statements::index_target>>& targets) const;
     void check_key_column_count(const schema& schema) const;
     void check_index_options(const cql3::statements::index_specific_prop_defs& properties) const;

--- a/test/cqlpy/test_vector_index.py
+++ b/test/cqlpy/test_vector_index.py
@@ -840,10 +840,9 @@ def test_sai_vector_index_with_source_model(cql, test_keyspace, scylla_only, ski
 #   * Preimage options can be freely toggled.
 #   * Disabling CDC is not allowed when a vector index already exists.
 #
-# We also verify that creating a vector index is forbidden
-# if CDC is enabled but uses invalid options or CDC is explicitly disabled
-# (set to false by the user), and allowed only when CDC is either undeclared
-# or configured to satisfy the minimal Vector Search requirements.
+# We also verify that creating a vector index is forbidden if CDC is enabled
+# but uses invalid options, and allowed when CDC is either not enabled or
+# configured to satisfy the minimal Vector Search requirements.
 ###############################################################################
 
 
@@ -949,17 +948,23 @@ def test_try_enable_vector_search_with_cdc_enabled(scylla_only, cql, test_keyspa
         assert create_index(cql, test_keyspace, table, "v")
 
 
-def test_try_enable_vector_search_with_cdc_disabled(scylla_only, cql, test_keyspace, skip_without_tablets):
+# Verify that if CDC was first enabled and then disabled, creating a vector
+# index is still allowed. A disabled CDC is treated the same as a table that
+# never had CDC enabled: the vector index auto-enables CDC in both cases.
+# Reproduces SCYLLADB-2005.
+def test_vector_search_after_enable_then_disable_cdc(scylla_only, cql, test_keyspace, skip_without_tablets):
     schema = "pk int primary key, v vector<float, 3>"
     with new_test_table(cql, test_keyspace, schema) as table:
-        # Disallow creating the vector index when CDC is explicitly disabled.
-        assert alter_cdc(cql, table, {'enabled': False, 'ttl': 172800, 'postimage' : True})
-        with pytest.raises(InvalidRequest, match="Cannot create the vector index when CDC is explicitly disabled."):
-            cql.execute(f"CREATE INDEX v_idx ON {table} (v) USING 'vector_index'")
-
-        # Allow creating the vector index when CDC is enabled again.
-        assert alter_cdc(cql, table, {'enabled': True})
-        assert create_index(cql, test_keyspace, table, "v")
+        # Enable CDC, then disable it again.
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled': True}}")
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled': False}}")
+        # Sanity check: check that it is allowed to enable CDC again after
+        # disabling it. And then disable it back again ;-)
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled': True}}")
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled': False}}")
+        # CDC is now off. Creating a vector index should succeed - it will
+        # auto-enable CDC just as it would on a table that never had CDC set.
+        cql.execute(f"CREATE INDEX v_idx ON {table} (v) USING 'vector_index'")
 
 # When a vector index is created on a table, writes to it should appear in the
 # CDC log, even though CDC was never explicitly enabled. This should be true


### PR DESCRIPTION
When creating a vector index, the code had one surprising (and wrong) check: If the CDC was "explicitly disabled", vector index refused to turn CDC back on and therefore refused to create the vector index.

But this means that if a table ever had CDC enabled, and then disabled, you could never create a vector index on it, even a year later. This makes no sense, and there is no reason for this limitation. In contrast, notice that it *is* allowed to renable CDC after it was disabled. The following sequence of commands does work:

    ALTER TABLE tbl WITH CDC = {'enabled': True}
    ALTER TABLE tbl WITH CDC = {'enabled': False}
    ALTER TABLE tbl WITH CDC = {'enabled': True}

And yet, the following sequence failed before this patch, claiming that CDC was "explicitly disabled":

    ALTER TABLE tbl WITH CDC = {'enabled': True}
    ALTER TABLE tbl WITH CDC = {'enabled': False}
    CREATE INDEX ind ON tbl (v) USING 'vector_index'

This patch fixes this bug. The vector index now treats CDC that is off the same as CDC that was never turned on. The code becomes simpler, because we no longer need to make this strange distinction of CDC that was never on, and one that was "explicitly disabled".

A test that enshrined the wrong buggy is deleted, and replaced by a new test for the fixed behavior.

Fixes SCYLLADB-2005.

I think this is a bug and so it makes sense to backport the fix.