### PR TITLE
cql: preserve tablet routing source without IDL changes

### DIFF
--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -39,6 +39,21 @@ using coordinator_result = exceptions::coordinator_result<T>;
 
 bool is_internal_keyspace(std::string_view name);
 
+namespace {
+
+std::optional<locator::tablet_replica> tablet_routing_source_replica(const service::client_state& client_state, const locator::effective_replication_map& erm) {
+    auto source_shard = client_state.get_tablet_routing_source_shard();
+    if (!source_shard) {
+        return std::nullopt;
+    }
+    return locator::tablet_replica{
+        client_state.get_tablet_routing_source_host().value_or(erm.get_token_metadata().get_my_id()),
+        *source_shard,
+    };
+}
+
+}
+
 namespace cql3 {
 
 namespace statements {
@@ -314,7 +329,7 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
         auto&& table = s->table();
         if (_may_use_token_aware_routing && table.uses_tablets() && qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
             auto erm = table.get_effective_replication_map();
-            auto tablet_info = erm->check_locality(token);
+            auto tablet_info = erm->check_locality(token, tablet_routing_source_replica(qs.get_client_state(), *erm));
             if (tablet_info.has_value()) {
                 result->add_tablet_info(tablet_info->tablet_replicas, tablet_info->token_range);
             }
@@ -441,19 +456,21 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
             );
     }
 
-    std::optional<locator::tablet_routing_info> tablet_info = locator::tablet_routing_info{locator::tablet_replica_set(), std::pair<dht::token, dht::token>()};
+    std::optional<locator::tablet_routing_info> tablet_info;
 
     auto&& table = s->table();
     if (_may_use_token_aware_routing && table.uses_tablets() && qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
         auto erm = table.get_effective_replication_map();
-        tablet_info = erm->check_locality(token);
+        tablet_info = erm->check_locality(token, tablet_routing_source_replica(qs.get_client_state(), *erm));
     }
 
     return qp.proxy().cas(s, std::move(cas_shard), *request_ptr, request->read_command(qp), request->key(),
             {read_timeout, qs.get_permit(), qs.get_client_state(), qs.get_trace_state()},
-            std::move(cl_for_paxos).assume_value(), cl_for_learn, statement_timeout, cas_timeout).then([this, request = std::move(request), tablet_replicas = std::move(tablet_info->tablet_replicas), token_range = tablet_info->token_range] (bool is_applied) {
+            std::move(cl_for_paxos).assume_value(), cl_for_learn, statement_timeout, cas_timeout).then([this, request = std::move(request), tablet_info = std::move(tablet_info)] (bool is_applied) mutable {
         auto result = request->build_cas_result_set(_metadata, _columns_of_cas_result_set, is_applied);
-        result->add_tablet_info(tablet_replicas, token_range);
+        if (tablet_info.has_value()) {
+            result->add_tablet_info(std::move(tablet_info->tablet_replicas), tablet_info->token_range);
+        }
         return result;
     });
 }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -68,6 +68,21 @@ using coordinator_result = cql3::statements::select_statement::coordinator_resul
 
 bool is_internal_keyspace(std::string_view name);
 
+namespace {
+
+std::optional<locator::tablet_replica> tablet_routing_source_replica(const service::client_state& client_state, const locator::effective_replication_map& erm) {
+    auto source_shard = client_state.get_tablet_routing_source_shard();
+    if (!source_shard) {
+        return std::nullopt;
+    }
+    return locator::tablet_replica{
+        client_state.get_tablet_routing_source_host().value_or(erm.get_token_metadata().get_my_id()),
+        *source_shard,
+    };
+}
+
+}
+
 namespace cql3 {
 
 namespace statements {
@@ -491,7 +506,7 @@ select_statement::do_execute(query_processor& qp,
             token = key_ranges[0].start()->value().as_decorated_key().token();
 
             auto erm = table.get_effective_replication_map();
-            tablet_info = erm->check_locality(token);
+            tablet_info = erm->check_locality(token, tablet_routing_source_replica(state.get_client_state(), *erm));
         }
     }
 

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -112,7 +112,7 @@ host_id_vector_replica_set vnode_effective_replication_map::get_replicas_for_rea
     return *endpoints | std::ranges::to<host_id_vector_replica_set>();
 }
 
-std::optional<tablet_routing_info> vnode_effective_replication_map::check_locality(const token& token) const {
+std::optional<tablet_routing_info> vnode_effective_replication_map::check_locality(const token&, std::optional<tablet_replica>) const {
     return {};
 }
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -306,7 +306,10 @@ public:
     /// replaced but not yet rebuilt.
     virtual host_id_vector_replica_set get_replicas(const token& search_token, bool is_vnode = false) const = 0;
 
-    virtual std::optional<tablet_routing_info> check_locality(const token& token) const = 0;
+    std::optional<tablet_routing_info> check_locality(const token& token) const {
+        return check_locality(token, std::nullopt);
+    }
+    virtual std::optional<tablet_routing_info> check_locality(const token& token, std::optional<tablet_replica> source_replica) const = 0;
 
 
     /// Returns true if there are any pending ranges for this endpoint.
@@ -498,7 +501,7 @@ public: // effective_replication_map
     host_id_vector_topology_change get_pending_replicas(const token& search_token) const override;
     host_id_vector_replica_set get_replicas_for_reading(const token& token, bool is_vnode = false) const override;
     host_id_vector_replica_set get_replicas(const token& search_token, bool is_vnode = false) const override;
-    std::optional<tablet_routing_info> check_locality(const token& token) const override;
+    std::optional<tablet_routing_info> check_locality(const token& token, std::optional<tablet_replica> source_replica) const override;
     bool has_pending_ranges(locator::host_id endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
     const dht::sharder& get_sharder(const schema& s) const override;
@@ -610,7 +613,7 @@ public:
     host_id_vector_topology_change get_pending_replicas(const token& search_token) const override;
     host_id_vector_replica_set get_replicas_for_reading(const token& token, bool is_vnode = false) const override;
     host_id_vector_replica_set get_replicas(const token& search_token, bool is_vnode = false) const override;
-    std::optional<tablet_routing_info> check_locality(const token& token) const override;
+    std::optional<tablet_routing_info> check_locality(const token& token, std::optional<tablet_replica> source_replica) const override;
     bool has_pending_ranges(locator::host_id endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
     const dht::sharder& get_sharder(const schema& s) const override;

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -61,7 +61,7 @@ host_id_vector_replica_set local_effective_replication_map::get_replicas(const t
     return _replica_set;
 }
 
-std::optional<tablet_routing_info> local_effective_replication_map::check_locality(const token& token) const {
+std::optional<tablet_routing_info> local_effective_replication_map::check_locality(const token&, std::optional<tablet_replica>) const {
     return std::nullopt;
 }
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1474,12 +1474,11 @@ public:
         return get_for_reading_helper(search_token);
     }
 
-    std::optional<tablet_routing_info> check_locality(const token& search_token) const override {
+    std::optional<tablet_routing_info> check_locality(const token& search_token, std::optional<tablet_replica> source_replica) const override {
         auto&& tablets = get_tablet_map();
         auto tid = tablets.get_tablet_id(search_token);
         auto&& info = tablets.get_tablet_info(tid);
-        auto host = get_token_metadata().get_my_id();
-        auto shard = this_shard_id();
+        auto source = source_replica.value_or(tablet_replica{get_token_metadata().get_my_id(), this_shard_id()});
 
         auto make_tablet_routing_info = [&] {
             dht::token first_token;
@@ -1493,17 +1492,13 @@ public:
         };
 
         for (auto&& r : info.replicas) {
-            if (r.host == host) {
-                if (r.shard == shard) {
-                    return std::nullopt; // routed correctly
-                } else {
-                    return make_tablet_routing_info();
-                }
+            if (r == source) {
+                return std::nullopt; // routed correctly
             }
         }
 
         auto tinfo = tablets.get_tablet_transition_info(tid);
-        if (tinfo && tinfo->pending_replica && tinfo->pending_replica->host == host && tinfo->pending_replica->shard == shard) {
+        if (tinfo && tinfo->pending_replica && *tinfo->pending_replica == source) {
             return std::nullopt; // routed correctly
         }
 

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -19,6 +19,7 @@
 #include "auth/authenticator.hh"
 #include "auth/permission.hh"
 #include "client_data.hh"
+#include "locator/host_id.hh"
 
 #include "transport/cql_protocol_extension.hh"
 #include "service/qos/service_level_controller.hh"
@@ -97,6 +98,8 @@ private:
             , _timeout_config(cs->_timeout_config)
             , _as(as)
             , _enabled_protocol_extensions(cs->_enabled_protocol_extensions)
+            , _tablet_routing_source_host(cs->_tablet_routing_source_host)
+            , _tablet_routing_source_shard(cs->_tablet_routing_source_shard)
     {}
     friend client_state_for_another_shard;
 private:
@@ -505,6 +508,12 @@ public:
 private:
 
     cql_transport::cql_protocol_extension_enum_set _enabled_protocol_extensions;
+    // Host and shard where the current CQL request entered the coordinator.
+    // Local shard bounces copy this state; node-forwarded requests restore it
+    // from RPC client metadata so tablet routing feedback is based on the
+    // client's routing decision, not on the post-bounce execution shard.
+    std::optional<locator::host_id> _tablet_routing_source_host;
+    std::optional<unsigned> _tablet_routing_source_shard;
 
 public:
 
@@ -519,7 +528,24 @@ public:
     void set_protocol_extensions(cql_transport::cql_protocol_extension_enum_set exts) {
         _enabled_protocol_extensions = std::move(exts);
     }
+
+    void set_tablet_routing_source(locator::host_id host, unsigned shard) noexcept {
+        _tablet_routing_source_host = host;
+        _tablet_routing_source_shard = shard;
+    }
+
+    void set_tablet_routing_source_shard(unsigned shard) noexcept {
+        _tablet_routing_source_host = std::nullopt;
+        _tablet_routing_source_shard = shard;
+    }
+
+    std::optional<locator::host_id> get_tablet_routing_source_host() const noexcept {
+        return _tablet_routing_source_host;
+    }
+
+    std::optional<unsigned> get_tablet_routing_source_shard() const noexcept {
+        return _tablet_routing_source_shard;
+    }
 };
 
 }
-

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -7,6 +7,8 @@
  */
 
 
+#include <initializer_list>
+
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 
@@ -4890,7 +4892,6 @@ SEASTAR_TEST_CASE(test_select_serial_consistency) {
     }, std::move(cfg));
 }
 
-
 SEASTAR_TEST_CASE(test_range_deletions_for_specific_column) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         cquery_nofail(e, "CREATE TABLE t (pk int, ck int, col text, PRIMARY KEY(pk, ck))");
@@ -6113,6 +6114,114 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_select) {
             });
         }).get();
     }, tablet_cql_test_config());
+}
+
+SEASTAR_TEST_CASE(test_tablet_routing_feedback_uses_source_host) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        e.execute_cql("create keyspace ks_tablet with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} and tablets = {'initial': 8};").get();
+        e.execute_cql("create table ks_tablet.test_tablet (pk int, ck int, v int, PRIMARY KEY (pk, ck));").get();
+        e.execute_cql("insert into ks_tablet.test_tablet (pk, ck, v) VALUES (1, 2, 3);").get();
+
+        auto select = e.prepare("select pk, ck, v FROM ks_tablet.test_tablet WHERE pk = ?;").get();
+        std::vector<cql3::raw_value> raw_values;
+        raw_values.emplace_back(cql3::raw_value::make_value(int32_type->decompose(int32_t{1})));
+
+        const auto sptr = e.local_db().find_schema("ks_tablet", "test_tablet");
+        auto pk = partition_key::from_singular(*sptr, int32_t(1));
+        auto token = dht::get_token(*sptr, pk.view());
+        unsigned local_shard = sptr->table().shard_for_reads(token);
+        auto foreign_host = locator::host_id(utils::UUID_gen::get_time_UUID());
+
+        smp::submit_to(local_shard, [&] {
+            return seastar::async([&] {
+                e.local_client_state().set_tablet_routing_source(foreign_host, this_shard_id());
+                auto result = e.execute_prepared(select, raw_values).get();
+                BOOST_REQUIRE(has_tablet_routing(result));
+            });
+        }).get();
+    }, tablet_cql_test_config());
+}
+
+SEASTAR_TEST_CASE(test_sending_tablet_info_for_forwarded_serial_and_lwt) {
+    BOOST_REQUIRE_GT(smp::count, 1u);
+
+    auto cfg = tablet_cql_test_config();
+    cfg.initial_tablets = 8;
+    cfg.need_remote_proxy = true;
+
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        e.execute_cql("create table test_tablet (pk int, ck int, v int, PRIMARY KEY (pk, ck));").get();
+
+        for (int32_t pk = 1; pk <= 8; ++pk) {
+            e.execute_cql(format("insert into test_tablet (pk, ck, v) values ({}, 1, 2);", pk)).get();
+        }
+
+        const auto schema = e.local_db().find_schema("ks", "test_tablet");
+
+        auto raw_values = [] (std::initializer_list<int32_t> values) {
+            std::vector<cql3::raw_value> result;
+            result.reserve(values.size());
+            for (auto value : values) {
+                result.emplace_back(cql3::raw_value::make_value(int32_type->decompose(value)));
+            }
+            return result;
+        };
+
+        auto shard_for_pk = [&] (int32_t pk) {
+            auto key = partition_key::from_singular(*schema, pk);
+            return schema->table().shard_for_reads(dht::get_token(*schema, key.view()));
+        };
+
+        struct tablet_query_result {
+            bool has_tablet_info;
+            std::optional<unsigned> bounce_shard;
+        };
+
+        auto execute_prepared_once_on_shard = [&] (unsigned shard, unsigned source_shard,
+                const cql3::prepared_cache_key_type& id, std::vector<cql3::raw_value> values,
+                db::consistency_level cl) {
+            return smp::submit_to(shard, [&e, &id, values = std::move(values), cl, source_shard] () mutable {
+                return seastar::async([&e, &id, values = std::move(values), cl, source_shard] () mutable {
+                    e.local_client_state().set_tablet_routing_source_shard(source_shard);
+                    auto result = e.execute_prepared(id, std::move(values), cl).get();
+                    if (auto bounce = result->as_bounce()) {
+                        return tablet_query_result{false, bounce->target_shard()};
+                    }
+                    return tablet_query_result{has_tablet_routing(result), std::nullopt};
+                });
+            }).get();
+        };
+
+        auto execute_prepared_from_source_shard = [&] (unsigned source_shard,
+                const cql3::prepared_cache_key_type& id, std::vector<cql3::raw_value> values,
+                db::consistency_level cl) {
+            auto result = execute_prepared_once_on_shard(source_shard, source_shard, id, values, cl);
+            if (result.bounce_shard) {
+                result = execute_prepared_once_on_shard(*result.bounce_shard, source_shard, id, std::move(values), cl);
+            }
+            return result.has_tablet_info;
+        };
+
+        auto require_token_aware_prepared = [&] (std::string_view name,
+                const cql3::prepared_cache_key_type& id, auto make_values, int32_t local_pk,
+                int32_t foreign_pk, db::consistency_level cl) {
+            auto local_shard = shard_for_pk(local_pk);
+            BOOST_REQUIRE_MESSAGE(!execute_prepared_from_source_shard(local_shard, id, make_values(local_pk), cl),
+                    format("{} got tablet info on owning shard {}", name, local_shard));
+
+            auto foreign_shard = (shard_for_pk(foreign_pk) + 1) % smp::count;
+            BOOST_REQUIRE_MESSAGE(execute_prepared_from_source_shard(foreign_shard, id, make_values(foreign_pk), cl),
+                    format("{} did not get tablet info from foreign shard {}", name, foreign_shard));
+        };
+
+        auto select_prepared = e.prepare("select pk, ck, v from ks.test_tablet where pk = ? and ck = ?;").get();
+        auto update_lwt_if_v = e.prepare("update ks.test_tablet set v = ? where pk = ? and ck = ? if v = ?;").get();
+
+        require_token_aware_prepared("SELECT_SERIAL_PREPARED", select_prepared,
+                [&] (int32_t pk) { return raw_values({pk, 1}); }, 1, 2, db::consistency_level::SERIAL);
+        require_token_aware_prepared("UPDATE_LWT_IF_VAL", update_lwt_if_v,
+                [&] (int32_t pk) { return raw_values({4, pk, 1, 2}); }, 3, 4, db::consistency_level::ONE);
+    }, std::move(cfg));
 }
 
 // check if create statements emit schema change event properly

--- a/test/cluster/test_tablet_routing_payload.py
+++ b/test/cluster/test_tablet_routing_payload.py
@@ -1,0 +1,340 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import socket
+import struct
+from dataclasses import dataclass
+
+import pytest
+from cassandra import ConsistencyLevel
+
+from test.cluster.lwt.lwt_common import get_token_for_pk
+from test.cluster.util import new_test_keyspace
+from test.pylib.internal_types import ServerInfo
+from test.pylib.manager_client import ManagerClient
+from test.pylib.tablets import get_tablet_replicas
+
+CQL_VERSION = 0x04
+CQL_RESPONSE_VERSION = 0x84
+
+OP_ERROR = 0x00
+OP_STARTUP = 0x01
+OP_READY = 0x02
+OP_OPTIONS = 0x05
+OP_SUPPORTED = 0x06
+OP_RESULT = 0x08
+OP_PREPARE = 0x09
+OP_EXECUTE = 0x0A
+
+FLAG_CUSTOM_PAYLOAD = 0x04
+FLAG_WARNING = 0x08
+
+RESULT_PREPARED = 0x0004
+TABLETS_ROUTING_V1_PAYLOAD = "tablets-routing-v1"
+SHARD_AWARE_PORT = 19042
+
+
+@dataclass
+class CqlFrame:
+    flags: int
+    stream: int
+    opcode: int
+    body: bytes
+
+
+def _write_string(value: str) -> bytes:
+    encoded = value.encode("utf-8")
+    return struct.pack("!H", len(encoded)) + encoded
+
+
+def _write_long_string(value: str) -> bytes:
+    encoded = value.encode("utf-8")
+    return struct.pack("!I", len(encoded)) + encoded
+
+
+def _write_string_map(values: dict[str, str]) -> bytes:
+    body = bytearray(struct.pack("!H", len(values)))
+    for key, value in values.items():
+        body.extend(_write_string(key))
+        body.extend(_write_string(value))
+    return bytes(body)
+
+
+def _write_int_value(value: int) -> bytes:
+    encoded = struct.pack("!i", value)
+    return struct.pack("!i", len(encoded)) + encoded
+
+
+def _write_query_parameters(consistency: int, values: list[int] | None = None) -> bytes:
+    body = bytearray(struct.pack("!H", consistency))
+    if values is None:
+        body.append(0x00)
+        return bytes(body)
+
+    body.append(0x01)  # VALUES
+    body.extend(struct.pack("!H", len(values)))
+    for value in values:
+        body.extend(_write_int_value(value))
+    return bytes(body)
+
+
+def _read_string(body: bytes, pos: int) -> tuple[str, int]:
+    size = struct.unpack_from("!H", body, pos)[0]
+    pos += 2
+    value = body[pos:pos + size].decode("utf-8")
+    pos += size
+    return value, pos
+
+
+def _read_string_list(body: bytes, pos: int) -> tuple[list[str], int]:
+    size = struct.unpack_from("!H", body, pos)[0]
+    pos += 2
+    values = []
+    for _ in range(size):
+        value, pos = _read_string(body, pos)
+        values.append(value)
+    return values, pos
+
+
+def _read_string_multimap(body: bytes) -> dict[str, list[str]]:
+    pos = 0
+    size = struct.unpack_from("!H", body, pos)[0]
+    pos += 2
+    values = {}
+    for _ in range(size):
+        key, pos = _read_string(body, pos)
+        value_count = struct.unpack_from("!H", body, pos)[0]
+        pos += 2
+        key_values = []
+        for _ in range(value_count):
+            value, pos = _read_string(body, pos)
+            key_values.append(value)
+        values[key] = key_values
+    return values
+
+
+def _read_short_bytes(body: bytes, pos: int) -> tuple[bytes, int]:
+    size = struct.unpack_from("!H", body, pos)[0]
+    pos += 2
+    value = body[pos:pos + size]
+    pos += size
+    return value, pos
+
+
+def _read_string_bytes_map(body: bytes, pos: int) -> tuple[dict[str, bytes], int]:
+    size = struct.unpack_from("!H", body, pos)[0]
+    pos += 2
+    values = {}
+    for _ in range(size):
+        key, pos = _read_string(body, pos)
+        value_size = struct.unpack_from("!i", body, pos)[0]
+        pos += 4
+        assert value_size >= 0
+        values[key] = body[pos:pos + value_size]
+        pos += value_size
+    return values, pos
+
+
+async def _read_frame(reader: asyncio.StreamReader) -> CqlFrame:
+    header = await reader.readexactly(9)
+    version, flags, stream, opcode, body_len = struct.unpack("!BBhBI", header)
+    assert version == CQL_RESPONSE_VERSION
+    body = await reader.readexactly(body_len)
+    return CqlFrame(flags=flags, stream=stream, opcode=opcode, body=body)
+
+
+def _frame_body_start(frame: CqlFrame) -> int:
+    pos = 0
+    if frame.flags & FLAG_WARNING:
+        _warnings, pos = _read_string_list(frame.body, pos)
+    if frame.flags & FLAG_CUSTOM_PAYLOAD:
+        _payload, pos = _read_string_bytes_map(frame.body, pos)
+    return pos
+
+
+def _custom_payload(frame: CqlFrame) -> dict[str, bytes]:
+    if not frame.flags & FLAG_CUSTOM_PAYLOAD:
+        return {}
+    pos = 0
+    if frame.flags & FLAG_WARNING:
+        _warnings, pos = _read_string_list(frame.body, pos)
+    payload, _pos = _read_string_bytes_map(frame.body, pos)
+    return payload
+
+
+def _cql_error(frame: CqlFrame) -> str:
+    code = struct.unpack_from("!i", frame.body, 0)[0]
+    message, _pos = _read_string(frame.body, 4)
+    return f"CQL error {code}: {message}"
+
+
+class RawCqlClient:
+    def __init__(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        self._reader = reader
+        self._writer = writer
+        self._stream = 0
+
+    async def close(self) -> None:
+        self._writer.close()
+        await self._writer.wait_closed()
+
+    async def send(self, opcode: int, body: bytes = b"") -> CqlFrame:
+        self._stream += 1
+        frame = struct.pack("!BBhBI", CQL_VERSION, 0, self._stream, opcode, len(body)) + body
+        self._writer.write(frame)
+        await self._writer.drain()
+        response = await asyncio.wait_for(_read_frame(self._reader), timeout=100.0)
+        if response.opcode == OP_ERROR:
+            raise AssertionError(_cql_error(response))
+        return response
+
+    async def options(self) -> dict[str, list[str]]:
+        response = await self.send(OP_OPTIONS)
+        assert response.opcode == OP_SUPPORTED
+        return _read_string_multimap(response.body)
+
+    async def startup(self) -> None:
+        response = await self.send(OP_STARTUP, _write_string_map({
+            "CQL_VERSION": "3.0.0",
+            "TABLETS_ROUTING_V1": "",
+        }))
+        assert response.opcode == OP_READY
+
+    async def prepare(self, query: str) -> bytes:
+        response = await self.send(OP_PREPARE, _write_long_string(query))
+        assert response.opcode == OP_RESULT
+        pos = _frame_body_start(response)
+        result_kind = struct.unpack_from("!i", response.body, pos)[0]
+        pos += 4
+        assert result_kind == RESULT_PREPARED
+        prepared_id, _pos = _read_short_bytes(response.body, pos)
+        return prepared_id
+
+    async def execute(self, prepared_id: bytes, values: list[int], consistency: int = ConsistencyLevel.ONE) -> CqlFrame:
+        body = bytearray()
+        body.extend(struct.pack("!H", len(prepared_id)))
+        body.extend(prepared_id)
+        body.extend(_write_query_parameters(consistency, values))
+        response = await self.send(OP_EXECUTE, bytes(body))
+        assert response.opcode == OP_RESULT
+        return response
+
+
+async def _open_connection(host: str, port: int) -> RawCqlClient:
+    reader, writer = await asyncio.open_connection(host, port)
+    return RawCqlClient(reader, writer)
+
+
+async def _open_shard_aware_connection(host: str, port: int, shard: int, nr_shards: int) -> RawCqlClient:
+    loop = asyncio.get_running_loop()
+    last_error: Exception | None = None
+    first_port = 20000 + shard
+    for local_port in range(first_port, 60000, nr_shards):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.setblocking(False)
+        try:
+            sock.bind(("127.0.0.1", local_port))
+            await loop.sock_connect(sock, (host, port))
+            reader, writer = await asyncio.open_connection(sock=sock)
+            return RawCqlClient(reader, writer)
+        except OSError as exc:
+            last_error = exc
+            sock.close()
+    raise RuntimeError(f"Could not open shard-aware connection to shard {shard}") from last_error
+
+
+async def _supported_options(host: str, port: int) -> dict[str, list[str]]:
+    client = await _open_connection(host, port)
+    try:
+        return await client.options()
+    finally:
+        await client.close()
+
+
+async def _connect_to_shard(host: str, port: int, shard: int, nr_shards: int) -> RawCqlClient:
+    client = await _open_shard_aware_connection(host, port, shard, nr_shards)
+    try:
+        options = await client.options()
+        assert int(options["SCYLLA_SHARD"][0]) == shard
+        await client.startup()
+        return client
+    except Exception:
+        await client.close()
+        raise
+
+
+async def _prepared_response_has_tablet_info(
+        manager: ManagerClient,
+        server: ServerInfo,
+        shard_aware_port: int,
+        nr_shards: int,
+        keyspace: str,
+        query: str,
+        values: list[int],
+        pk: int,
+        consistency: int = ConsistencyLevel.ONE) -> bool:
+    token = await get_token_for_pk(manager.get_cql(), keyspace, "test_tablet", pk)
+    replicas = await get_tablet_replicas(manager, server, keyspace, "test_tablet", token)
+    assert replicas
+    owning_shard = replicas[0][1]
+    wrong_shard = (owning_shard + 1) % nr_shards
+
+    client = await _connect_to_shard(str(server.rpc_address), shard_aware_port, wrong_shard, nr_shards)
+    try:
+        prepared_id = await client.prepare(query)
+        response = await client.execute(prepared_id, values, consistency)
+        return TABLETS_ROUTING_V1_PAYLOAD in _custom_payload(response)
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_tablet_routing_payload_for_lwt_and_serial_from_wrong_shard(manager: ManagerClient) -> None:
+    """
+    Reproduces #29874 at the protocol boundary: LWT/SERIAL responses should carry
+    TABLETS_ROUTING_V1 feedback when the request entered on a wrong tablet shard.
+    """
+    servers = await manager.servers_add(1, config={
+        "tablets_mode_for_new_keyspaces": "enabled",
+        "native_shard_aware_transport_port": SHARD_AWARE_PORT,
+    }, cmdline=["--smp", "2"])
+    server = servers[0]
+    cql = manager.get_cql()
+
+    options = await _supported_options(str(server.rpc_address), manager.port)
+    assert "TABLETS_ROUTING_V1" in options
+    nr_shards = int(options["SCYLLA_NR_SHARDS"][0])
+    assert nr_shards > 1
+    shard_aware_port = int(options.get("SCYLLA_SHARD_AWARE_PORT", [SHARD_AWARE_PORT])[0])
+
+    missing_payload = []
+    async with new_test_keyspace(
+            manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 8}") as keyspace:
+        await cql.run_async(f"CREATE TABLE {keyspace}.test_tablet (pk int, ck int, v int, PRIMARY KEY (pk, ck));")
+        for pk in range(1, 21):
+            await cql.run_async(f"INSERT INTO {keyspace}.test_tablet (pk, ck, v) VALUES ({pk}, 1, 2);")
+
+        select_query = f"SELECT pk, ck, v FROM {keyspace}.test_tablet WHERE pk = ? AND ck = ?"
+        regular_has_payload = await _prepared_response_has_tablet_info(
+            manager, server, shard_aware_port, nr_shards, keyspace, select_query, [1, 1], pk=1)
+        assert regular_has_payload
+
+        cases: list[tuple[str, str, list[int], int, int]] = [
+            ("SELECT_SERIAL_PREPARED", select_query, [2, 1], 2, ConsistencyLevel.SERIAL),
+            ("UPDATE_LWT_IF_VAL",
+             f"UPDATE {keyspace}.test_tablet SET v = ? WHERE pk = ? AND ck = ? IF v = ?",
+             [4, 3, 1, 2], 3, ConsistencyLevel.ONE),
+        ]
+
+        for name, query, values, pk, consistency in cases:
+            has_payload = await _prepared_response_has_tablet_info(
+                manager, server, shard_aware_port, nr_shards, keyspace, query, values, pk, consistency)
+            if not has_payload:
+                missing_payload.append(name)
+
+    assert not missing_payload, f"missing tablet routing payload for {missing_payload}"

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -399,22 +399,24 @@ void cql_server::init_messaging_service() {
     ser::forward_cql_rpc_verbs::register_forward_cql_execute(&_ms,
         [this](const rpc::client_info& cinfo, rpc::opt_time_point timeout, unsigned shard, forward_cql_execute_request req) -> future<forward_cql_execute_response> {
             auto src_host = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-            clogger.trace("Handling forwarded CQL request from {} on shard {}", src_host, shard);
+            auto src_shard = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+            clogger.trace("Handling forwarded CQL request from {} shard {} on shard {}", src_host, src_shard, shard);
 
             co_await utils::get_local_injector().inject("wait_before_handling_forwarded_request", utils::wait_for_message(60s));
 
-            co_return co_await container().invoke_on(shard, [src_host, req = std::move(req)] (cql_server& shard_svc) mutable -> future<forward_cql_execute_response> {
+            co_return co_await container().invoke_on(shard, [src_host, src_shard, req = std::move(req)] (cql_server& shard_svc) mutable -> future<forward_cql_execute_response> {
                 service::client_state cs(shard_svc._auth_service,
                     &shard_svc._sl_controller,
                     std::move(req.client_state),
                     &shard_svc._abort_source);
+                cs.set_tablet_routing_source(src_host, src_shard);
                 tracing::trace_state_ptr trace_state_ptr;
                 if (req.trace_info) {
                     trace_state_ptr = tracing::tracing::get_local_tracing_instance().create_session(*req.trace_info);
                     tracing::begin(trace_state_ptr);
                 }
                 service::query_state qs(cs, trace_state_ptr, empty_service_permit());
-                tracing::trace(qs.get_trace_state(), "Handling forwarded CQL request from {} on shard {}", src_host, this_shard_id());
+                tracing::trace(qs.get_trace_state(), "Handling forwarded CQL request from {} shard {} on shard {}", src_host, src_shard, this_shard_id());
 
                 auto f = co_await coroutine::as_future(shard_svc.handle_forward_execute(qs, req));
                 if (f.failed()) {
@@ -1856,6 +1858,11 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
     } (opcode);
 
     co_await utils::get_local_injector().inject("transport_cql_request_pause", utils::wait_for_message(60s));
+
+    if (!client_state.get_tablet_routing_source_host() || !client_state.get_tablet_routing_source_shard()) {
+        auto my_host_id = _query_processor.local().proxy().get_token_metadata_ptr()->get_topology().my_host_id();
+        client_state.set_tablet_routing_source(my_host_id, this_shard_id());
+    }
 
     bool init_trace = (bool)!bounced; // If the request was bounced, we already started the trace in the handler
     auto msg = co_await coroutine::try_future(process_fn(client_state, _query_processor, in, stream,


### PR DESCRIPTION
This keeps tablet routing feedback based on where the CQL request entered, while avoiding forwarded_client_state IDL changes.

Changes:
- track the tablet routing source in client_state for local requests and shard bounces
- restore the source for node-forwarded CQL from RPC client metadata
- use the recorded source in regular, SERIAL, and LWT tablet locality checks
- add boost and cluster coverage for wrong-shard SERIAL/LWT tablet feedback

Testing:
- Not run locally: repo-ci fast validation cannot start because .github/workflows/call_jira_sync.yml has multiple YAML documents and repo-ci fails while relearning.