### PR TITLE
[Backport 2026.2] docs/cql: fix syntax errors in CQL examples

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -1017,11 +1017,11 @@ For example:
 
     CREATE TABLE customer_data (
         cust_id uuid,
-        cust_first-name text,
-        cust_last-name text,
+        "cust_first-name" text,
+        "cust_last-name" text,
         cust_phone text,
-        cust_get-sms text,
-        PRIMARY KEY (customer_id)
+        "cust_get-sms" text,
+        PRIMARY KEY (cust_id)
     ) WITH cdc = { 'enabled' : 'true', 'preimage' : 'true' };
 
 .. _cql-caching-options:

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -415,7 +415,7 @@ An empty list is allowed, and it's equivalent to numeric replication factor of 0
 .. code-block:: cql
 
   ALTER KEYSPACE Excelsior
-   WITH replication = { 'class' : 'NetworkTopologyStrategy', dc2' : []};
+   WITH replication = { 'class' : 'NetworkTopologyStrategy', 'dc2' : []};
 
 
 Altering from a rack list to a numeric replication factor is not supported.

--- a/docs/cql/dml/insert.rst
+++ b/docs/cql/dml/insert.rst
@@ -24,7 +24,8 @@ For example:
 
     INSERT INTO NerdMovies (movie, director, main_actor, year)
           VALUES ('Serenity', 'Joss Whedon', 'Nathan Fillion', 2005)
-          USING TTL 86400 IF NOT EXISTS;
+          IF NOT EXISTS
+          USING TTL 86400;
 
 The ``INSERT`` statement writes one or more columns for a given row in a table. Note that since a row is identified by
 its ``PRIMARY KEY``, at least the columns composing it must be specified. The list of columns to insert to must be

--- a/docs/cql/types.rst
+++ b/docs/cql/types.rst
@@ -507,7 +507,7 @@ For example::
 
   CREATE TABLE superheroes (
        name frozen<full_name> PRIMARY KEY,
-       home address
+       home frozen<address>
   );
 
 .. note::

--- a/test/cqlpy/test_name.py
+++ b/test/cqlpy/test_name.py
@@ -174,3 +174,20 @@ def test_column_name_500(cql, test_keyspace):
         pass
 
 # TODO: add tests for the allowed characters in a table name
+
+# Test that column names containing hyphens work when double-quoted.
+# Hyphens are not valid in unquoted identifiers (the '-' is parsed as
+# subtraction), but double-quoted identifiers can contain any character.
+def test_column_name_with_hyphen(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace,
+            'p int PRIMARY KEY, "my-col" text, "first-name" text') as tbl:
+        cql.execute(f'INSERT INTO {tbl} (p, "my-col", "first-name") VALUES (1, \'val\', \'Alice\')')
+        row = cql.execute(f'SELECT p, "my-col", "first-name" FROM {tbl} WHERE p = 1').one()
+        assert row.my_col == 'val'
+        assert row.first_name == 'Alice'
+
+# Test that unquoted column names with hyphens are rejected
+def test_column_name_unquoted_hyphen_rejected(cql, test_keyspace):
+    from cassandra.protocol import SyntaxException
+    with pytest.raises(SyntaxException):
+        cql.execute(f'CREATE TABLE {test_keyspace}.{unique_name()} (p int PRIMARY KEY, my-col text)')


### PR DESCRIPTION
## Summary

Fix 4 genuine CQL syntax errors in documentation examples, found by automated extraction and execution of doc code blocks against a live ScyllaDB instance.

### Fixes

- **insert.rst**: `USING TTL 86400 IF NOT EXISTS` → `IF NOT EXISTS USING TTL 86400` (wrong clause order produces syntax error)
- **ddl.rst**: Missing opening quote in ALTER KEYSPACE example (`dc2'` → `'dc2'`)
- **ddl.rst**: Hyphenated column names need double-quoting; also fix PRIMARY KEY referencing non-existent `customer_id` instead of `cust_id`
- **types.rst**: UDT `address` contains nested collections, so it must be `frozen<address>` when used as a column type

Parent PR: #29765

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2027