### PR TITLE
Relax read-repair tolerate replica failures during read/write phases

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1920,6 +1920,13 @@ database::query_mutations(schema_ptr query_schema, const query::read_command& cm
     };
 
     try {
+        co_await utils::get_local_injector().inject("fail_mutation_query", [&s = query_schema] (auto& handler) -> future<> {
+            if (s->ks_name() != handler.get("ks_name") || s->cf_name() != handler.get("cf_name")) {
+                co_return;
+            }
+            throw std::runtime_error(format("injected failure in mutation_query for {}.{}", s->ks_name(), s->cf_name()));
+        });
+
         auto op = cf.read_in_progress();
 
         future<> f = make_ready_future<>();

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1408,71 +1408,6 @@ public:
     virtual void reply(locator::host_id ep) {};
 };
 
-// different mutation for each destination (for read repairs)
-class per_destination_mutation : public mutation_holder {
-    std::unordered_map<locator::host_id, lw_shared_ptr<const frozen_mutation>> _mutations;
-    dht::token _token;
-public:
-    per_destination_mutation(const std::unordered_map<locator::host_id, std::optional<mutation>>& mutations) {
-        for (auto&& m : mutations) {
-            lw_shared_ptr<const frozen_mutation> fm;
-            if (m.second) {
-                _schema = m.second.value().schema();
-                _token = m.second.value().token();
-                fm = make_lw_shared<const frozen_mutation>(freeze(m.second.value()));
-                _size += fm->representation().size();
-            }
-            _mutations.emplace(m.first, std::move(fm));
-        }
-    }
-    virtual bool store_hint(db::hints::manager& hm, locator::host_id hid, locator::effective_replication_map_ptr ermptr,
-            tracing::trace_state_ptr tr_state) override {
-        auto m = _mutations[hid];
-        if (m) {
-            return hm.store_hint(hid, _schema, std::move(m), tr_state);
-        } else {
-            return false;
-        }
-    }
-    virtual future<> apply_locally(storage_proxy& sp, storage_proxy::clock_type::time_point timeout,
-            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info,
-            const locator::effective_replication_map& erm) override {
-        const auto my_id = sp.my_host_id(erm);
-        auto m = _mutations[my_id];
-        if (m) {
-            tracing::trace(tr_state, "Executing a mutation locally");
-            return sp.mutate_locally(_schema, *m, std::move(tr_state), db::commitlog::force_sync::no, timeout, rate_limit_info);
-        }
-        return make_ready_future<>();
-    }
-    virtual future<> apply_remotely(storage_proxy& sp, locator::host_id ep, const host_id_vector_replica_set& forward,
-            storage_proxy::response_id_type response_id, storage_proxy::clock_type::time_point timeout,
-            tracing::trace_state_ptr tr_state, db::per_partition_rate_limit::info rate_limit_info, fencing_token fence) override {
-        auto m = _mutations[ep];
-        if (m) {
-            tracing::trace(tr_state, "Sending a mutation to /{}", ep);
-            return sp.remote().send_mutation(ep, timeout, tracing::make_trace_info(tr_state),
-                    *m, forward, sp.my_address(), sp.get_token_metadata_ptr()->get_my_id(), this_shard_id(),
-                    response_id, rate_limit_info, fence);
-        }
-        sp.got_response(response_id, ep, std::nullopt);
-        return make_ready_future<>();
-    }
-    virtual bool is_shared() override {
-        return false;
-    }
-    virtual void release_mutation() override {
-        for (auto&& m : _mutations) {
-            if (m.second) {
-                m.second.release();
-            }
-        }
-    }
-    dht::token& token() {
-        return _token;
-    }
-};
-
 class single_mutation_holder : public mutation_holder {
 protected:
     lw_shared_ptr<const frozen_mutation> _mutation;
@@ -3311,11 +3246,6 @@ struct batchlog_replay_mutation {
     mutation mut;
 };
 
-struct read_repair_mutation {
-    std::unordered_map<locator::host_id, std::optional<mutation>> value;
-    locator::effective_replication_map_ptr ermp;
-};
-
 struct read_repair_reconciled_write {
     mutation mut;
     locator::effective_replication_map_ptr ermp;
@@ -3339,13 +3269,6 @@ template <> struct fmt::formatter<service::hint_wrapper> : fmt::formatter<string
 template <> struct fmt::formatter<service::batchlog_replay_mutation> : fmt::formatter<string_view> {
     auto format(const service::batchlog_replay_mutation& h, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "batchlog_replay_mutation{{{}}}", h.mut);
-    }
-};
-
-template <>
-struct fmt::formatter<service::read_repair_mutation> : fmt::formatter<string_view> {
-    auto format(const service::read_repair_mutation& m, fmt::format_context& ctx) const {
-        return fmt::format_to(ctx.out(), "{}", m.value);
     }
 };
 
@@ -3870,21 +3793,6 @@ result<storage_proxy::response_id_type>
 storage_proxy::create_write_response_handler(const batchlog_replay_mutation& m, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options) {
     return create_write_response_handler_helper(m.mut.schema(), m.mut.token(), std::make_unique<shared_mutation>(m.mut), cl, type, tr_state,
             std::move(permit), allow_limit, is_cancellable::yes, std::move(options));
-}
-
-result<storage_proxy::response_id_type>
-storage_proxy::create_write_response_handler(const read_repair_mutation& mut, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options) {
-    host_id_vector_replica_set endpoints;
-    const auto& m = mut.value;
-    endpoints.reserve(m.size());
-    std::ranges::copy(m | std::views::keys, std::inserter(endpoints, endpoints.begin()));
-    auto mh = std::make_unique<per_destination_mutation>(m);
-
-    slogger.trace("creating write handler for read repair token: {} endpoint: {}", mh->token(), endpoints);
-    tracing::trace(tr_state, "Creating write handler for read repair token: {} endpoint: {}", mh->token(), endpoints);
-
-    // No rate limiting for read repair
-    return make_write_response_handler(std::move(mut.ermp), cl, type, std::move(mh), std::move(endpoints), host_id_vector_topology_change(), host_id_vector_topology_change(), std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no);
 }
 
 result<storage_proxy::response_id_type>
@@ -4848,20 +4756,6 @@ size_t storage_proxy::hint_to_dead_endpoints(std::unique_ptr<mutation_holder>& m
     } else {
         return 0;
     }
-}
-
-future<result<>> storage_proxy::schedule_repair(locator::effective_replication_map_ptr ermp, mutations_per_partition_key_map diffs, db::consistency_level cl, tracing::trace_state_ptr trace_state,
-                                        service_permit permit) {
-    if (diffs.empty()) {
-        return make_ready_future<result<>>(bo::success());
-    }
-    return mutate_internal(
-            diffs |
-                    std::views::values |
-                    std::views::transform([ermp] (auto& v) { return read_repair_mutation{std::move(v), ermp}; }) |
-                    // The transform above is destructive, materialize into a vector to make the range re-iterable.
-                    std::ranges::to<std::vector<read_repair_mutation>>()
-            , cl, std::move(trace_state), std::move(permit));
 }
 
 class abstract_read_resolver {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1473,17 +1473,16 @@ public:
     }
 };
 
-// same mutation for each destination
-class shared_mutation : public mutation_holder {
+class single_mutation_holder : public mutation_holder {
 protected:
     lw_shared_ptr<const frozen_mutation> _mutation;
 public:
-    explicit shared_mutation(frozen_mutation_and_schema&& fm_a_s)
+    explicit single_mutation_holder(frozen_mutation_and_schema&& fm_a_s)
             : _mutation(make_lw_shared<const frozen_mutation>(std::move(fm_a_s.fm))) {
         _size = _mutation->representation().size();
         _schema = std::move(fm_a_s.s);
     }
-    explicit shared_mutation(const mutation& m) : shared_mutation(frozen_mutation_and_schema{freeze(m), m.schema()}) {
+    explicit single_mutation_holder(const mutation& m) : single_mutation_holder(frozen_mutation_and_schema{freeze(m), m.schema()}) {
     }
     virtual bool store_hint(db::hints::manager& hm, locator::host_id hid, locator::effective_replication_map_ptr ermptr,
             tracing::trace_state_ptr tr_state) override {
@@ -1504,12 +1503,27 @@ public:
                 *_mutation, forward, sp.my_address(), sp.get_token_metadata_ptr()->get_my_id(), this_shard_id(),
                 response_id, rate_limit_info, fence);
     }
-    virtual bool is_shared() override {
-        return true;
-    }
     virtual void release_mutation() override {
         _mutation.release();
     }
+};
+
+// same mutation for each destination
+class shared_mutation : public single_mutation_holder {
+public:
+    using single_mutation_holder::single_mutation_holder;
+    bool is_shared() override {
+        return true;
+    }
+};
+
+// A full reconciled mutation used for read-repair writes.
+// is_shared() returns false so that read_repair_write() identifies
+// these writes for metrics and cross-DC forwarding classification.
+class read_repair_reconciled_mutation : public single_mutation_holder {
+public:
+    using single_mutation_holder::single_mutation_holder;
+    bool is_shared() override { return false; }
 };
 
 // shared mutation, but gets sent as a hint
@@ -1669,7 +1683,7 @@ public:
         return sp.remote().send_paxos_learn(ep, timeout, tracing::make_trace_info(tr_state),
                 *_proposal, forward, sp.my_address(), sp.get_token_metadata_ptr()->get_my_id(), this_shard_id(), response_id, fence);
     }
-    virtual bool is_shared() override {
+    bool is_shared() override {
         return true;
     }
     virtual void release_mutation() override {
@@ -2005,6 +2019,17 @@ public:
     }
     storage_proxy::write_stats& stats() {
         return _stats;
+    }
+    // For read-repair: count replicas that already hold the reconciled
+    // data as implicit acknowledgements toward the write CL.
+    void add_read_repair_implicit_acks(size_t nr) {
+        if (!nr) {
+            return;
+        }
+        SCYLLA_ASSERT(read_repair_write());
+        SCYLLA_ASSERT(_cl != db::consistency_level::EACH_QUORUM);
+        _total_endpoints += nr;
+        signal(nr);
     }
     friend storage_proxy;
 
@@ -3291,6 +3316,18 @@ struct read_repair_mutation {
     locator::effective_replication_map_ptr ermp;
 };
 
+struct read_repair_reconciled_write {
+    mutation mut;
+    locator::effective_replication_map_ptr ermp;
+    // Replicas whose mutation-data digest was missing or differed from the
+    // reconciled digest. They receive the full reconciled mutation.
+    lw_shared_ptr<const host_id_vector_replica_set> repair_targets;
+    // Replicas whose mutation-data digest already matched the reconciled digest.
+    // They do not receive a repair mutation, but count as immediate acks toward
+    // the original read CL.
+    size_t implicit_acks = 0;
+};
+
 }
 
 template <> struct fmt::formatter<service::hint_wrapper> : fmt::formatter<string_view> {
@@ -3848,6 +3885,18 @@ storage_proxy::create_write_response_handler(const read_repair_mutation& mut, db
 
     // No rate limiting for read repair
     return make_write_response_handler(std::move(mut.ermp), cl, type, std::move(mh), std::move(endpoints), host_id_vector_topology_change(), host_id_vector_topology_change(), std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no);
+}
+
+result<storage_proxy::response_id_type>
+storage_proxy::create_write_response_handler(const read_repair_reconciled_write& repair, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit, coordinator_mutate_options) {
+    auto r = make_write_response_handler(repair.ermp, cl, type,
+            std::make_unique<read_repair_reconciled_mutation>(repair.mut), *repair.repair_targets,
+            host_id_vector_topology_change{}, host_id_vector_topology_change{}, std::move(tr_state), get_stats(), std::move(permit), std::monostate(), is_cancellable::no);
+    if (!r) {
+        return r;
+    }
+    get_write_response_handler(r.value())->add_read_repair_implicit_acks(repair.implicit_acks);
+    return r;
 }
 
 result<storage_proxy::response_id_type>
@@ -5130,7 +5179,7 @@ class data_read_resolver : public abstract_read_resolver {
     query::short_read _is_short_read;
     std::vector<reply> _data_results;
     size_t _block_for;
-    mutations_per_partition_key_map _diffs;
+    utils::chunked_vector<mutation> _reconciled_mutations;
 private:
     void on_timeout() override {
         fail_request(read_timeout_exception(_schema->ks_name(), _schema->cf_name(), _cl, response_count(), _block_for, response_count() != 0));
@@ -5338,8 +5387,7 @@ private:
     }
 public:
     data_read_resolver(schema_ptr schema, db::consistency_level cl, size_t targets_count, size_t block_for, storage_proxy::clock_type::time_point timeout) : abstract_read_resolver(std::move(schema), cl, targets_count, timeout),
-    _block_for(block_for),
-    _diffs(10, partition_key::hashing(*_schema), partition_key::equality(*_schema)) {
+    _block_for(block_for) {
         _data_results.reserve(targets_count);
     }
     void add_mutate_data(locator::host_id from, foreign_ptr<lw_shared_ptr<reconcilable_result>> result) {
@@ -5487,46 +5535,9 @@ public:
         }
         _partition_count = reconciled_partitions.size();
 
-        bool has_diff = false;
-
-        // Сalculate differences: iterate over the versions from all the nodes and calculate the difference with the reconciled result.
-        for (auto z : std::views::zip(versions, reconciled_partitions)) {
-            const mutation& m = std::get<1>(z).mut;
-            for (const version& v : std::get<0>(z)) {
-                auto diff = v.par
-                          ? m.partition().difference(schema, (co_await unfreeze_gently(v.par->mut(), _schema)).partition())
-                          : mutation_partition(schema, m.partition());
-                std::optional<mutation> mdiff;
-                if (!diff.empty()) {
-                    has_diff = true;
-                    mdiff = mutation(_schema, m.decorated_key(), std::move(diff));
-                }
-                if (auto [it, added] = _diffs[m.key()].try_emplace(v.from, std::move(mdiff)); !added) {
-                    // A collision could happen only in 2 cases:
-                    // 1. We have 2 versions for the same node.
-                    // 2. `versions` (and or) `reconciled_partitions` are not unique per partition key.
-                    // Both cases are not possible unless there is a bug in the reconcilliation code.
-                    on_internal_error(slogger, fmt::format("Partition key conflict, key: {}, node: {}, table: {}.", m.key(), v.from, schema.ks_name()));
-                }
-                co_await coroutine::maybe_yield();
-            }
-        }
-
-        if (has_diff) {
-            if (got_incomplete_information(schema, cmd, original_row_limit, original_per_partition_limit,
-                                           original_partition_limit, reconciled_partitions, versions)) {
-                co_return std::nullopt;
-            }
-            // filter out partitions with empty diffs
-            for (auto it = _diffs.begin(); it != _diffs.end();) {
-                if (std::ranges::none_of(it->second | std::views::values, std::mem_fn(&std::optional<mutation>::operator bool))) {
-                    it = _diffs.erase(it);
-                } else {
-                    ++it;
-                }
-            }
-        } else {
-            _diffs.clear();
+        if (got_incomplete_information(schema, cmd, original_row_limit, original_per_partition_limit,
+                                       original_partition_limit, reconciled_partitions, versions)) {
+            co_return std::nullopt;
         }
 
         find_short_partitions(reconciled_partitions, versions, original_per_partition_limit, original_row_limit, original_partition_limit);
@@ -5548,13 +5559,34 @@ public:
             co_await coroutine::maybe_yield();
         }
 
+        // Store reconciled mutations for the repair write phase.
+        _reconciled_mutations.reserve(reconciled_partitions.size());
+        for (auto& m_a_rc : reconciled_partitions) {
+            _reconciled_mutations.push_back(std::move(m_a_rc.mut));
+        }
+
         co_return reconcilable_result(_total_live_count, std::move(vec), _is_short_read);
     }
     auto total_live_count() const {
         return _total_live_count;
     }
-    auto get_diffs_for_repair() {
-        return std::move(_diffs);
+    auto get_reconciled_mutations() {
+        return std::move(_reconciled_mutations);
+    }
+    // Compute a digest for each replica's mutation-data response.
+    // Must be called BEFORE resolve(), which destructively mutates _data_results.
+    future<std::unordered_map<locator::host_id, query::result_digest>>
+    get_reply_digests(const query::read_command& cmd, query::digest_algorithm da) {
+        std::unordered_map<locator::host_id, query::result_digest> digests;
+        digests.reserve(_data_results.size());
+        for (const auto& r : _data_results) {
+            auto qr = co_await to_data_query_result(
+                    *r.result, _schema, cmd.slice,
+                    cmd.get_row_limit(), cmd.partition_limit,
+                    query::result_options::only_digest(da));
+            digests.emplace(r.from, *qr.digest());
+        }
+        co_return digests;
     }
 };
 
@@ -5811,6 +5843,12 @@ protected:
                     on_read_resolved();
                     co_return;
                 }
+
+                // Compute per-replica digests. Must be called before resolve()
+                // which destructively sorts and mutates _data_results.
+                auto replica_digests = co_await data_resolver->get_reply_digests(
+                        *cmd, digest_algorithm(*_proxy));
+
                 auto rr_opt = co_await data_resolver->resolve(*cmd, original_row_limit(), original_per_partition_row_limit(), original_partition_limit()); // reconciliation happens here
 
                 // We generate a retry if at least one node reply with count live columns but after merge we have less
@@ -5826,32 +5864,57 @@ protected:
                     mlogger.trace("reconciled: {}", rr_opt->pretty_printer(_schema));
 
                     auto result = ::make_foreign(::make_lw_shared<query::result>(
-                            co_await to_data_query_result(std::move(*rr_opt), _schema, _cmd->slice, _cmd->get_row_limit(), _cmd->partition_limit)));
+                            co_await to_data_query_result(std::move(*rr_opt), _schema, _cmd->slice,
+                            _cmd->get_row_limit(), _cmd->partition_limit,
+                            query::result_options{query::result_request::result_and_digest,
+                                                  digest_algorithm(*_proxy)})));
                     qlogger.trace("reconciled: {}", result->pretty_printer(_schema, _cmd->slice));
 
-                    // Un-reverse mutations for reversed queries. When a mutation comes from a node in mixed-node cluster
-                    // it is reversed in make_mutation_data_request(). So we always deal here with reversed mutations for
-                    // reversed queries. No matter what format. Forward mutations are sent to spare replicas from reversing
-                    // them in the write-path.
-                    auto diffs = data_resolver->get_diffs_for_repair();
-                    if (_cmd->slice.is_reversed()) {
-                        for (auto&& [token, diff] : diffs) {
-                            for (auto&& [address, opt_mut] : diff) {
-                                if (opt_mut) {
-                                    opt_mut = reverse(std::move(opt_mut.value()));
-                                    co_await coroutine::maybe_yield();
-                                }
-                            }
+                    // Classify replicas by comparing digests.
+                    auto reconciled_digest = *result->digest();
+                    host_id_vector_replica_set repair_replicas;
+                    size_t implicit_acks = 0;
+                    for (auto& ep : _all_replicas) {
+                        auto it = replica_digests.find(ep);
+                        if (it != replica_digests.end() && it->second == reconciled_digest) {
+                            ++implicit_acks;
+                        } else {
+                            repair_replicas.push_back(ep);
                         }
                     }
 
-                    // wait for write to complete before returning result to prevent multiple concurrent read requests to
-                    // trigger repair multiple times and to prevent quorum read to return an old value, even after a quorum
-                    // another read had returned a newer value (but the newer value had not yet been sent to the other replicas)
+                    tracing::trace(_trace_state, "read-repair: {} replicas need repair, {} implicit acks",
+                                   repair_replicas.size(), implicit_acks);
+
+                    // Un-reverse reconciled mutations for reversed queries.
+                    auto reconciled_mutations = data_resolver->get_reconciled_mutations();
+                    if (_cmd->slice.is_reversed()) {
+                        for (auto& m : reconciled_mutations) {
+                            m = reverse(std::move(m));
+                            co_await coroutine::maybe_yield();
+                        }
+                    }
+
+                    utils::chunked_vector<read_repair_reconciled_write> repairs;
+                    repairs.reserve(reconciled_mutations.size());
+                    auto repair_targets = make_lw_shared<const host_id_vector_replica_set>(std::move(repair_replicas));
+                    for (auto& m : reconciled_mutations) {
+                        repairs.emplace_back(read_repair_reconciled_write{
+                                .mut = std::move(m),
+                                .ermp = _effective_replication_map_ptr,
+                                .repair_targets = repair_targets,
+                                .implicit_acks = implicit_acks,
+                        });
+                    }
+
                     // Waited on indirectly.
-                    (void)_proxy->schedule_repair(_effective_replication_map_ptr, std::move(diffs), _cl, _trace_state, _permit).then(utils::result_wrap([this, result = std::move(result)] () mutable {
-                        _result_promise.set_value(std::move(result));
-                        return make_ready_future<::result<>>(bo::success());
+                    (void)_proxy->mutate_prepare(std::move(repairs), _cl, db::write_type::SIMPLE, _trace_state, _permit,
+                            db::allow_per_partition_rate_limit::no, storage_proxy::coordinator_mutate_options{})
+                    .then(utils::result_wrap([this, result = std::move(result)] (storage_proxy::unique_response_handler_vector ids) mutable {
+                        return _proxy->mutate_begin(std::move(ids), _cl, _trace_state).then(utils::result_wrap([this, result = std::move(result)] () mutable {
+                            _result_promise.set_value(std::move(result));
+                            return make_ready_future<::result<>>(bo::success());
+                        }));
                     })).then_wrapped([this, exec] (future<::result<>>&& f) {
                         // All errors are handled, it's OK to discard the result.
                         (void)utils::result_try([&] {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6097,6 +6097,21 @@ static host_id_vector_replica_set filter_for_dc(db::consistency_level cl, const 
     return endpoints;
 }
 
+static void maybe_force_read_target(host_id_vector_replica_set& targets, const host_id_vector_replica_set& all_replicas) {
+    if (utils::get_local_injector().is_enabled("force_read_target")) {
+        auto params = utils::get_local_injector().get_injection_parameters("force_read_target");
+        auto it = params.find("host_id");
+        if (it != params.end()) {
+            auto forced_host = locator::host_id(utils::UUID(it->second));
+            auto in_all = std::find(all_replicas.begin(), all_replicas.end(), forced_host) != all_replicas.end();
+            auto in_targets = std::find(targets.begin(), targets.end(), forced_host) != targets.end();
+            if (in_all && !in_targets && !targets.empty()) {
+                targets.back() = forced_host;
+            }
+        }
+    }
+}
+
 result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw_shared_ptr<query::read_command> cmd,
         locator::effective_replication_map_ptr erm,
         schema_ptr schema,
@@ -6130,6 +6145,12 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
 
     slogger.trace("creating read executor for token {} with all: {} targets: {} rp decision: {}", token, all_replicas, target_replicas, repair_decision);
     tracing::trace(trace_state, "Creating read executor for token {} with all: {} targets: {} repair decision: {}", token, all_replicas, target_replicas, repair_decision);
+
+    // Error injection: force a specific host into the read targets.
+    // If the specified host is in all_replicas but was not selected
+    // as a target, replace the last target with it.
+    // This ensures deterministic read-repair behavior in tests.
+    maybe_force_read_target(target_replicas, all_replicas);
 
     // Throw UAE early if we don't have enough replicas.
     try {
@@ -6557,6 +6578,7 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
             }
 
             auto filtered_replicas = filter_for_dc(cl, erm->get_topology(), std::move(live_endpoints));
+            maybe_force_read_target(filtered_endpoints, filtered_replicas);
             exec.push_back(::make_shared<never_speculating_read_executor>(schema, cf.shared_from_this(), p, erm, cmd, std::move(range), cl, std::move(filtered_endpoints), std::move(filtered_replicas), trace_state, permit, std::monostate()));
             ranges_per_exec.emplace(exec.back().get(), std::move(merged_ranges));
         }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5563,6 +5563,9 @@ protected:
     host_id_vector_replica_set _targets;
     // Targets that were successfully used for a data or digest request
     host_id_vector_replica_set _used_targets;
+    // All live replicas for the token, filtered by DC for local CLs.
+    // Used during reconciliation to send mutation-data requests to all replicas.
+    host_id_vector_replica_set _all_replicas;
     promise<result<foreign_ptr<lw_shared_ptr<query::result>>>> _result_promise;
     tracing::trace_state_ptr _trace_state;
     lw_shared_ptr<replica::column_family> _cf;
@@ -5587,10 +5590,12 @@ public:
     abstract_read_executor(schema_ptr s, lw_shared_ptr<replica::column_family> cf, shared_ptr<storage_proxy> proxy,
             locator::effective_replication_map_ptr ermp,
             lw_shared_ptr<query::read_command> cmd, dht::partition_range pr, db::consistency_level cl, size_t block_for,
-            host_id_vector_replica_set targets, tracing::trace_state_ptr trace_state, service_permit permit, db::per_partition_rate_limit::info rate_limit_info) :
+            host_id_vector_replica_set targets, host_id_vector_replica_set all_replicas,
+            tracing::trace_state_ptr trace_state, service_permit permit, db::per_partition_rate_limit::info rate_limit_info) :
                            _schema(std::move(s)), _proxy(std::move(proxy))
                          , _effective_replication_map_ptr(std::move(ermp))
-                         , _cmd(std::move(cmd)), _partition_range(std::move(pr)), _cl(cl), _block_for(block_for), _targets(std::move(targets)), _trace_state(std::move(trace_state)),
+                         , _cmd(std::move(cmd)), _partition_range(std::move(pr)), _cl(cl), _block_for(block_for), _targets(std::move(targets)),
+                           _all_replicas(std::move(all_replicas)), _trace_state(std::move(trace_state)),
                            _cf(std::move(cf)), _permit(std::move(permit)), _rate_limit_info(rate_limit_info),
                            _native_reversed_queries_enabled(_proxy->features().native_reverse_queries) {
         _proxy->get_stats().reads++;
@@ -6010,9 +6015,11 @@ class never_speculating_read_executor : public abstract_read_executor {
 public:
     never_speculating_read_executor(schema_ptr s, lw_shared_ptr<replica::column_family> cf, shared_ptr<storage_proxy> proxy,
             locator::effective_replication_map_ptr ermp,
-            lw_shared_ptr<query::read_command> cmd, dht::partition_range pr, db::consistency_level cl, host_id_vector_replica_set targets, tracing::trace_state_ptr trace_state, service_permit permit,
+            lw_shared_ptr<query::read_command> cmd, dht::partition_range pr, db::consistency_level cl,
+            host_id_vector_replica_set targets, host_id_vector_replica_set all_replicas,
+            tracing::trace_state_ptr trace_state, service_permit permit,
             db::per_partition_rate_limit::info rate_limit_info) :
-                                        abstract_read_executor(std::move(s), std::move(cf), std::move(proxy), std::move(ermp), std::move(cmd), std::move(pr), cl, 0, std::move(targets), std::move(trace_state), std::move(permit), rate_limit_info) {
+                                        abstract_read_executor(std::move(s), std::move(cf), std::move(proxy), std::move(ermp), std::move(cmd), std::move(pr), cl, 0, std::move(targets), std::move(all_replicas), std::move(trace_state), std::move(permit), rate_limit_info) {
         _block_for = _targets.size();
     }
 };
@@ -6103,6 +6110,16 @@ public:
     }
 };
 
+// For DC-local consistency levels, return a copy of endpoints with only
+// local-DC members retained. For other CLs, return endpoints unchanged.
+static host_id_vector_replica_set filter_for_dc(db::consistency_level cl, const locator::topology& topo, host_id_vector_replica_set endpoints) {
+    if (is_datacenter_local(cl)) {
+        auto it = std::ranges::remove_if(endpoints, std::not_fn(topo.get_local_dc_filter())).begin();
+        endpoints.erase(it, endpoints.end());
+    }
+    return endpoints;
+}
+
 result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw_shared_ptr<query::read_command> cmd,
         locator::effective_replication_map_ptr erm,
         schema_ptr schema,
@@ -6129,6 +6146,10 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
     host_id_vector_replica_set target_replicas = filter_replicas_for_read(cl, *erm, all_replicas, preferred_endpoints, repair_decision,
             retry_type == speculative_retry::type::NONE ? nullptr : &extra_replica,
             _db.local().get_config().cache_hit_rate_read_balancing() ? &*cf : nullptr);
+
+    // For DC-local consistency levels, restrict all_replicas to the local DC
+    // so that reconciliation stays DC-local.
+    all_replicas = filter_for_dc(cl, erm->get_topology(), std::move(all_replicas));
 
     slogger.trace("creating read executor for token {} with all: {} targets: {} rp decision: {}", token, all_replicas, target_replicas, repair_decision);
     tracing::trace(trace_state, "Creating read executor for token {} with all: {} targets: {} repair decision: {}", token, all_replicas, target_replicas, repair_decision);
@@ -6165,7 +6186,7 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
     if (retry_type == speculative_retry::type::NONE || block_for == all_replicas.size()
             || (repair_decision == db::read_repair_decision::DC_LOCAL && is_datacenter_local(cl) && block_for == target_replicas.size())) {
         tracing::trace(trace_state, "Creating never_speculating_read_executor - speculative retry is disabled or there are no extra replicas to speculate with");
-        return ::make_shared<never_speculating_read_executor>(schema, cf, shared_from_this(), std::move(erm), cmd, std::move(partition_range), cl, std::move(target_replicas), std::move(trace_state), std::move(permit), rate_limit_info);
+        return ::make_shared<never_speculating_read_executor>(schema, cf, shared_from_this(), std::move(erm), cmd, std::move(partition_range), cl, std::move(target_replicas), std::move(all_replicas), std::move(trace_state), std::move(permit), rate_limit_info);
     }
 
     if (target_replicas.size() == all_replicas.size()) {
@@ -6173,7 +6194,7 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
         // We are going to contact every node anyway, so ask for 2 full data requests instead of 1, for redundancy
         // (same amount of requests in total, but we turn 1 digest request into a full blown data request).
         tracing::trace(trace_state, "always_speculating_read_executor (all targets)");
-        return ::make_shared<always_speculating_read_executor>(schema, cf, shared_from_this(), std::move(erm), cmd, std::move(partition_range), cl, block_for, std::move(target_replicas), std::move(trace_state), std::move(permit), rate_limit_info);
+        return ::make_shared<always_speculating_read_executor>(schema, cf, shared_from_this(), std::move(erm), cmd, std::move(partition_range), cl, block_for, std::move(target_replicas), std::move(all_replicas), std::move(trace_state), std::move(permit), rate_limit_info);
     }
 
     // RRD.NONE or RRD.DC_LOCAL w/ multiple DCs.
@@ -6182,7 +6203,7 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
         if (!extra_replica || (is_datacenter_local(cl) && !local_dc_filter(*extra_replica))) {
             slogger.trace("read executor no extra target to speculate");
             tracing::trace(trace_state, "Creating never_speculating_read_executor - there are no extra replicas to speculate with");
-            return ::make_shared<never_speculating_read_executor>(schema, cf, shared_from_this(), std::move(erm), cmd, std::move(partition_range), cl, std::move(target_replicas), std::move(trace_state), std::move(permit), rate_limit_info);
+            return ::make_shared<never_speculating_read_executor>(schema, cf, shared_from_this(), std::move(erm), cmd, std::move(partition_range), cl, std::move(target_replicas), std::move(all_replicas), std::move(trace_state), std::move(permit), rate_limit_info);
         } else {
             target_replicas.push_back(*extra_replica);
             slogger.trace("creating read executor with extra target {}", *extra_replica);
@@ -6192,10 +6213,10 @@ result<::shared_ptr<abstract_read_executor>> storage_proxy::get_read_executor(lw
 
     if (retry_type == speculative_retry::type::ALWAYS) {
         tracing::trace(trace_state, "Creating always_speculating_read_executor");
-        return ::make_shared<always_speculating_read_executor>(schema, cf, shared_from_this(), std::move(erm), cmd, std::move(partition_range), cl, block_for, std::move(target_replicas), std::move(trace_state), std::move(permit), rate_limit_info);
+        return ::make_shared<always_speculating_read_executor>(schema, cf, shared_from_this(), std::move(erm), cmd, std::move(partition_range), cl, block_for, std::move(target_replicas), std::move(all_replicas), std::move(trace_state), std::move(permit), rate_limit_info);
     } else {// PERCENTILE or CUSTOM.
         tracing::trace(trace_state, "Creating speculating_read_executor");
-        return ::make_shared<speculating_read_executor>(schema, cf, shared_from_this(), std::move(erm), cmd, std::move(partition_range), cl, block_for, std::move(target_replicas), std::move(trace_state), std::move(permit), rate_limit_info);
+        return ::make_shared<speculating_read_executor>(schema, cf, shared_from_this(), std::move(erm), cmd, std::move(partition_range), cl, block_for, std::move(target_replicas), std::move(all_replicas), std::move(trace_state), std::move(permit), rate_limit_info);
     }
 }
 
@@ -6558,7 +6579,8 @@ storage_proxy::query_partition_key_range_concurrent(storage_proxy::clock_type::t
                 throw;
             }
 
-            exec.push_back(::make_shared<never_speculating_read_executor>(schema, cf.shared_from_this(), p, erm, cmd, std::move(range), cl, std::move(filtered_endpoints), trace_state, permit, std::monostate()));
+            auto filtered_replicas = filter_for_dc(cl, erm->get_topology(), std::move(live_endpoints));
+            exec.push_back(::make_shared<never_speculating_read_executor>(schema, cf.shared_from_this(), p, erm, cmd, std::move(range), cl, std::move(filtered_endpoints), std::move(filtered_replicas), trace_state, permit, std::monostate()));
             ranges_per_exec.emplace(exec.back().get(), std::move(merged_ranges));
         }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -5129,10 +5129,11 @@ class data_read_resolver : public abstract_read_resolver {
     bool _all_reached_end = true;
     query::short_read _is_short_read;
     std::vector<reply> _data_results;
+    size_t _block_for;
     mutations_per_partition_key_map _diffs;
 private:
     void on_timeout() override {
-        fail_request(read_timeout_exception(_schema->ks_name(), _schema->cf_name(), _cl, response_count(), _targets_count, response_count() != 0));
+        fail_request(read_timeout_exception(_schema->ks_name(), _schema->cf_name(), _cl, response_count(), _block_for, response_count() != 0));
     }
     void on_failure(exceptions::coordinator_exception_container&& ex) override {
         // we will not need them any more
@@ -5336,7 +5337,8 @@ private:
         return got_incomplete_information_across_partitions(s, cmd, last_row, rp, versions, is_reversed);
     }
 public:
-    data_read_resolver(schema_ptr schema, db::consistency_level cl, size_t targets_count, storage_proxy::clock_type::time_point timeout) : abstract_read_resolver(std::move(schema), cl, targets_count, timeout),
+    data_read_resolver(schema_ptr schema, db::consistency_level cl, size_t targets_count, size_t block_for, storage_proxy::clock_type::time_point timeout) : abstract_read_resolver(std::move(schema), cl, targets_count, timeout),
+    _block_for(block_for),
     _diffs(10, partition_key::hashing(*_schema), partition_key::equality(*_schema)) {
         _data_results.reserve(targets_count);
     }
@@ -5344,23 +5346,37 @@ public:
         if (!_request_failed) {
             _max_live_count = std::max(result->row_count(), _max_live_count);
             _data_results.emplace_back(std::move(from), std::move(result));
-            if (_data_results.size() == _targets_count) {
-                _timeout.cancel();
-                _done_promise.set_value(bo::success());
-            }
+            maybe_resolve();
         }
     }
     void on_error(locator::host_id ep, error_kind kind) override {
-        switch (kind) {
-        case error_kind::RATE_LIMIT:
-            fail_request(exceptions::rate_limit_exception(_schema->ks_name(), _schema->cf_name(), db::operation_type::read, false));
-            break;
-        case error_kind::DISCONNECT:
-        case error_kind::FAILURE:
-            fail_request(read_failure_exception(_schema->ks_name(), _schema->cf_name(), _cl, response_count(), 1, _targets_count, response_count() != 0));
-            break;
+        ++_failed;
+        if (_failed > _targets_count - _block_for) {
+            switch (kind) {
+            case error_kind::RATE_LIMIT:
+                fail_request(exceptions::rate_limit_exception(_schema->ks_name(), _schema->cf_name(), db::operation_type::read, false));
+                break;
+            case error_kind::DISCONNECT:
+            case error_kind::FAILURE:
+                fail_request(read_failure_exception(_schema->ks_name(), _schema->cf_name(), _cl, response_count(), _failed, _block_for, response_count() != 0));
+                break;
+            }
+            return;
+        }
+
+        // We wait for every replica to either respond or fail. A tolerated
+        // failure may be the last outstanding target, completing the resolver.
+        maybe_resolve();
+    }
+private:
+    void maybe_resolve() {
+        // Resolve when every replica has either responded or failed.
+        if (!_request_failed && (_data_results.size() + _failed == _targets_count)) {
+            _timeout.cancel();
+            _done_promise.set_value(bo::success());
         }
     }
+public:
     uint32_t max_live_count() const {
         return _max_live_count;
     }
@@ -5765,15 +5781,19 @@ protected:
     virtual void adjust_targets_for_reconciliation() {}
     void reconcile(db::consistency_level cl, storage_proxy::clock_type::time_point timeout, lw_shared_ptr<query::read_command> cmd) {
         adjust_targets_for_reconciliation();
-        data_resolver_ptr data_resolver = ::make_shared<data_read_resolver>(_schema, cl, _targets.size(), timeout);
+        auto block_for = db::block_for(*_effective_replication_map_ptr, cl);
+        data_resolver_ptr data_resolver = ::make_shared<data_read_resolver>(_schema, cl, _all_replicas.size(), block_for, timeout);
         auto exec = shared_from_this();
 
         if (_proxy->features().empty_replica_mutation_pages) {
             cmd->slice.options.set<query::partition_slice::option::allow_mutation_read_page_without_live_row>();
         }
 
+        slogger.trace("read-repair reconcile: targets={} block_for={} for {}.{}",
+                _all_replicas.size(), block_for, _schema->ks_name(), _schema->cf_name());
+
         // Waited on indirectly.
-        make_mutation_data_requests(cmd, data_resolver, _targets.begin(), _targets.end(), timeout);
+        make_mutation_data_requests(cmd, data_resolver, _all_replicas.begin(), _all_replicas.end(), timeout);
 
         // Waited on indirectly.
         (void)data_resolver->done().then_wrapped([this, exec_ = std::move(exec), data_resolver_ = std::move(data_resolver), cmd_ = std::move(cmd), cl_ = cl, timeout_ = timeout] (future<result<>> f) mutable -> future<> {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -99,12 +99,9 @@ class client_state;
 class migration_manager;
 struct hint_wrapper;
 struct batchlog_replay_mutation;
-struct read_repair_mutation;
 struct read_repair_reconciled_write;
 
 using replicas_per_token_range = std::unordered_map<dht::token_range, std::vector<locator::host_id>>;
-using mutations_per_partition_key_map =
-        std::unordered_map<partition_key, std::unordered_map<locator::host_id, std::optional<mutation>>, partition_key::hashing, partition_key::equality>;
 
 struct query_partition_key_range_concurrent_result {
     std::vector<foreign_ptr<lw_shared_ptr<query::result>>> result;
@@ -387,7 +384,6 @@ private:
     result<response_id_type> create_write_response_handler(const mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     result<response_id_type> create_write_response_handler(const hint_wrapper&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     result<response_id_type> create_write_response_handler(const batchlog_replay_mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
-    result<response_id_type> create_write_response_handler(const read_repair_mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     result<response_id_type> create_write_response_handler(const read_repair_reconciled_write&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     result<response_id_type> create_write_response_handler(const std::tuple<lw_shared_ptr<paxos::proposal>, schema_ptr, shared_ptr<paxos_response_handler>, dht::token>& proposal,
             db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
@@ -475,7 +471,6 @@ private:
     future<result<unique_response_handler_vector>> mutate_prepare(Range&& mutations, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     future<result<>> mutate_begin(unique_response_handler_vector ids, db::consistency_level cl, tracing::trace_state_ptr trace_state, std::optional<clock_type::time_point> timeout_opt = { });
     future<result<>> mutate_end(future<result<>> mutate_result, utils::latency_counter, write_stats& stats, tracing::trace_state_ptr trace_state);
-    future<result<>> schedule_repair(locator::effective_replication_map_ptr ermp, mutations_per_partition_key_map diffs, db::consistency_level cl, tracing::trace_state_ptr trace_state, service_permit permit);
     bool need_throttle_writes() const;
     void unthrottle();
     void handle_read_error(std::variant<exceptions::coordinator_exception_container, std::exception_ptr> failure, bool range);
@@ -896,7 +891,6 @@ public:
     friend class view_update_backlog_broker;
     friend class paxos_response_handler;
     friend class mutation_holder;
-    friend class per_destination_mutation;
     friend class single_mutation_holder;
     friend class hint_mutation;
     friend class cas_mutation;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -100,6 +100,7 @@ class migration_manager;
 struct hint_wrapper;
 struct batchlog_replay_mutation;
 struct read_repair_mutation;
+struct read_repair_reconciled_write;
 
 using replicas_per_token_range = std::unordered_map<dht::token_range, std::vector<locator::host_id>>;
 using mutations_per_partition_key_map =
@@ -387,6 +388,7 @@ private:
     result<response_id_type> create_write_response_handler(const hint_wrapper&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     result<response_id_type> create_write_response_handler(const batchlog_replay_mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     result<response_id_type> create_write_response_handler(const read_repair_mutation&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
+    result<response_id_type> create_write_response_handler(const read_repair_reconciled_write&, db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     result<response_id_type> create_write_response_handler(const std::tuple<lw_shared_ptr<paxos::proposal>, schema_ptr, shared_ptr<paxos_response_handler>, dht::token>& proposal,
             db::consistency_level cl, db::write_type type, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, coordinator_mutate_options options);
     result<response_id_type> create_write_response_handler(const std::tuple<lw_shared_ptr<paxos::proposal>, schema_ptr, shared_ptr<paxos_response_handler>, dht::token, host_id_vector_replica_set>& meta,
@@ -895,7 +897,7 @@ public:
     friend class paxos_response_handler;
     friend class mutation_holder;
     friend class per_destination_mutation;
-    friend class shared_mutation;
+    friend class single_mutation_holder;
     friend class hint_mutation;
     friend class cas_mutation;
 };

--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -3,12 +3,13 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
-
+import asyncio
 import json
 import logging
 import pytest
 import random
 import time
+from enum import Enum
 from typing import TypeAlias, Any
 
 from cassandra.cluster import ConsistencyLevel, Session  # type: ignore
@@ -18,7 +19,7 @@ from cassandra.pool import Host  # type: ignore
 from test.pylib.util import wait_for_cql_and_get_hosts, execute_with_tracing
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, new_test_table
 
 
 logger = logging.getLogger(__name__)
@@ -341,3 +342,302 @@ async def test_read_repair_with_trace_logging(request, manager):
             found_read_repair |= "digest mismatch, starting read repair" == event.description
 
         assert found_read_repair
+
+
+class ReadRepairPhase(Enum):
+    READ = 1
+    WRITE = 2
+
+class QueryKind(Enum):
+    FORWARD = "forward"
+    REVERSED = "reversed"
+    RANGE = "range"
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.parametrize(
+    "failed_phase",
+    [
+        pytest.param(ReadRepairPhase.READ),
+        pytest.param(ReadRepairPhase.WRITE),
+    ]
+)
+@pytest.mark.parametrize(
+    "query_kind",
+    [
+        pytest.param(QueryKind.FORWARD, id="forward"),
+        pytest.param(QueryKind.REVERSED, id="reversed"),
+        pytest.param(QueryKind.RANGE, id="range"),
+    ]
+)
+async def test_read_repair_failure(manager: ManagerClient, failed_phase: ReadRepairPhase, query_kind: QueryKind):
+    cmdline = ["--hinted-handoff-enabled", "0", "--logger-log-level", "storage_proxy=trace"]
+    servers = await manager.servers_add(3, cmdline=cmdline, auto_rack_dc="dc1")
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    ks_opts = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        async with new_test_table(manager, ks, "pk bigint, ck bigint, c int, PRIMARY KEY (pk, ck)", " WITH speculative_retry = 'NONE'") as cf:
+
+            insert_stmt = cql.prepare(f"INSERT INTO {cf} (pk, ck, c) VALUES (?, ?, ?)")
+            insert_stmt.consistency_level = ConsistencyLevel.ONE
+
+            # Block writes on servers[0] so it becomes stale. servers[1] and servers[2]
+            # receive all writes and have up-to-date data.
+            cf_name = cf.split(".")[1]
+            await manager.api.enable_injection(servers[0].ip_addr, "database_apply", one_shot=False, parameters={"ks_name": ks, "cf_name": cf_name, "what": "throw"})
+            await asyncio.gather(*[cql.run_async(insert_stmt, (0, ck, ck)) for ck in range(0, 100)])
+            await manager.api.disable_injection(servers[0].ip_addr, "database_apply")
+
+            # Fail servers[1] (a fresh replica) during the read or write phase.
+            # servers[0] (stale) remains healthy and always participates in reads
+            # and receives repair writes.
+            match failed_phase:
+                case ReadRepairPhase.READ:
+                    await manager.api.enable_injection(servers[1].ip_addr, "fail_mutation_query", one_shot=False, parameters={"ks_name": ks, "cf_name": cf.split(".")[1]})
+                case ReadRepairPhase.WRITE:
+                    await manager.api.enable_injection(servers[1].ip_addr, "database_apply", one_shot=False, parameters={"ks_name": ks, "cf_name": cf.split(".")[1], "what": "throw"})
+
+            # Force servers[0] (stale) into every QUORUM read's target set.
+            # With RF=3 and 3 nodes, every node is a replica, but CL=QUORUM
+            # only selects 2. This injection ensures servers[0] is always
+            # selected, guaranteeing digest mismatch and read-repair on every read.
+            server0_host_id = await manager.get_host_id(servers[0].server_id)
+            for srv in servers:
+                await manager.api.enable_injection(srv.ip_addr, "force_read_target", one_shot=False, parameters={"host_id": server0_host_id})
+
+            # Open log files on all servers.
+            logs = []
+            for srv in servers:
+                log = await manager.server_open_log(srv.server_id)
+                logs.append(log)
+
+            # Read all 100 rows with CL=QUORUM. Each read includes servers[0] (stale),
+            # triggering read-repair. servers[1] may fail during read or write phase,
+            # but the read still succeeds and servers[0] gets repaired.
+            # After each read, verify that reconciliation was triggered.
+            #
+            # Build query list: range scan issues a single full-table query;
+            # forward/reversed issue per-row point queries.
+            match query_kind:
+                case QueryKind.RANGE:
+                    queries = [(f"SELECT * FROM {cf}", None)]
+                case QueryKind.REVERSED:
+                    queries = [(f"SELECT * FROM {cf} WHERE pk = 0 AND ck = {ck} ORDER BY ck DESC", ck) for ck in range(100)]
+                case QueryKind.FORWARD:
+                    queries = [(f"SELECT * FROM {cf} WHERE pk = 0 AND ck = {ck}", ck) for ck in range(100)]
+
+            for query, ck_filter in queries:
+                marks = [await log.mark() for log in logs]
+
+                resp = await cql.run_async(SimpleStatement(query, consistency_level=ConsistencyLevel.QUORUM))
+                if ck_filter is not None:
+                    assert resp
+                    assert resp[0] == (0, ck_filter, ck_filter)
+                else:
+                    assert len(resp) == 100, f"Expected 100 rows, got {len(resp)}"
+                    for row in resp:
+                        assert row == (0, row.ck, row.ck), f"Unexpected row: {row}"
+
+                reconciled = False
+                for log, mark in zip(logs, marks):
+                    if await log.grep("read-repair reconcile:", from_mark=mark):
+                        reconciled = True
+                        break
+                label = f"ck={ck_filter}" if ck_filter is not None else "range scan"
+                assert reconciled, f"No reconciliation triggered for {label}"
+
+            # Verify servers[0] has all rows via MUTATION_FRAGMENTS.
+            await manager.api.keyspace_flush(servers[0].ip_addr, ks)
+            rows = await cql.run_async(f"SELECT * FROM MUTATION_FRAGMENTS({ks}.{cf_name})", host=hosts[0])
+            live_cks = {row.ck for row in rows if row.partition_region == 2}
+            expected_cks = set(range(100))
+            assert live_cks == expected_cks, \
+                f"Expected all 100 rows repaired on servers[0], got {len(live_cks)}: missing {expected_cks - live_cks}"
+
+
+class TombstoneKind(Enum):
+    ROW = "row"
+    PARTITION = "partition"
+    CELL = "cell"
+    RANGE = "range"
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.parametrize(
+    "tombstone_kind",
+    [
+        pytest.param(TombstoneKind.ROW, id="row"),
+        pytest.param(TombstoneKind.PARTITION, id="partition"),
+        pytest.param(TombstoneKind.CELL, id="cell"),
+        pytest.param(TombstoneKind.RANGE, id="range"),
+    ]
+)
+async def test_read_repair_tombstone(manager: ManagerClient, tombstone_kind: TombstoneKind):
+    """Test that read-repair correctly propagates tombstones to stale replicas.
+
+    Setup: 3 nodes, RF=3. Insert 100 rows (pk=0 ck=0..49, pk=1 ck=0..49) with
+    CL=ALL so all nodes have the data. Then block writes on servers[0] and execute
+    deletes on the remaining nodes. servers[0] misses the deletes.
+
+    Read with CL=QUORUM triggers read-repair which should propagate the tombstones
+    to servers[0]. Verify via MUTATION_FRAGMENTS that the tombstones landed.
+    """
+    NUM_CKS = 50
+    DELETED_CKS = set(range(25))  # ck 0-24 deleted, ck 25-49 alive
+
+    cmdline = ["--hinted-handoff-enabled", "0"]
+    servers = await manager.servers_add(3, cmdline=cmdline, auto_rack_dc="dc1")
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    ks_opts = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        table_opts = " WITH speculative_retry = 'NONE'"
+        async with new_test_table(manager, ks, "pk bigint, ck bigint, c int, PRIMARY KEY (pk, ck)", table_opts) as cf:
+
+            # Step 1: Insert all rows with CL=ALL so every node has the data.
+            insert_stmt = cql.prepare(f"INSERT INTO {cf} (pk, ck, c) VALUES (?, ?, ?)")
+            insert_stmt.consistency_level = ConsistencyLevel.ALL
+            await asyncio.gather(*[
+                cql.run_async(insert_stmt, (pk, ck, ck))
+                for pk in (0, 1) for ck in range(NUM_CKS)
+            ])
+
+            # Step 2: Block writes on servers[0] and execute deletes.
+            # servers[0] misses these deletes and retains the original rows.
+            cf_name = cf.split(".")[1]
+            await manager.api.enable_injection(servers[0].ip_addr, "database_apply", one_shot=False,
+                                               parameters={"ks_name": ks, "cf_name": cf_name, "what": "throw"})
+
+            match tombstone_kind:
+                case TombstoneKind.ROW:
+                    delete_stmt = cql.prepare(f"DELETE FROM {cf} WHERE pk = ? AND ck = ?")
+                    delete_stmt.consistency_level = ConsistencyLevel.ONE
+                    await asyncio.gather(*[
+                        cql.run_async(delete_stmt, (pk, ck))
+                        for pk in (0, 1) for ck in DELETED_CKS
+                    ])
+                case TombstoneKind.PARTITION:
+                    # Delete only pk=0 entirely. pk=1 stays intact.
+                    await cql.run_async(SimpleStatement(
+                        f"DELETE FROM {cf} WHERE pk = 0",
+                        consistency_level=ConsistencyLevel.ONE))
+                case TombstoneKind.CELL:
+                    delete_stmt = cql.prepare(f"DELETE c FROM {cf} WHERE pk = ? AND ck = ?")
+                    delete_stmt.consistency_level = ConsistencyLevel.ONE
+                    await asyncio.gather(*[
+                        cql.run_async(delete_stmt, (pk, ck))
+                        for pk in (0, 1) for ck in DELETED_CKS
+                    ])
+                case TombstoneKind.RANGE:
+                    for pk in (0, 1):
+                        await cql.run_async(SimpleStatement(
+                            f"DELETE FROM {cf} WHERE pk = {pk} AND ck >= 0 AND ck < 25",
+                            consistency_level=ConsistencyLevel.ONE))
+
+            await manager.api.disable_injection(servers[0].ip_addr, "database_apply")
+
+            # Step 3: Force servers[0] into every QUORUM read's target set.
+            server0_host_id = await manager.get_host_id(servers[0].server_id)
+            for srv in servers:
+                await manager.api.enable_injection(srv.ip_addr, "force_read_target", one_shot=False,
+                                                   parameters={"host_id": server0_host_id})
+
+            # Step 4: Read each row and verify correct results.
+            # Read-repair triggers because servers[0] has stale data (no tombstones).
+            for pk in (0, 1):
+                for ck in range(NUM_CKS):
+                    resp = await cql.run_async(SimpleStatement(
+                        f"SELECT * FROM {cf} WHERE pk = {pk} AND ck = {ck}",
+                        consistency_level=ConsistencyLevel.QUORUM))
+
+                    is_deleted = _is_deleted(tombstone_kind, pk, ck, DELETED_CKS)
+
+                    if tombstone_kind == TombstoneKind.CELL and is_deleted:
+                        # Cell tombstone: row exists but column c is null.
+                        assert resp, f"pk={pk} ck={ck}: expected row with c=None"
+                        assert resp[0] == (pk, ck, None), f"pk={pk} ck={ck}: expected (pk, ck, None), got {resp[0]}"
+                    elif is_deleted:
+                        # Row/partition/range tombstone: row is gone.
+                        assert not resp, f"pk={pk} ck={ck}: expected no row, got {resp}"
+                    else:
+                        # Not deleted: row is live.
+                        assert resp, f"pk={pk} ck={ck}: expected live row"
+                        assert resp[0] == (pk, ck, ck), f"pk={pk} ck={ck}: expected (pk, ck, ck), got {resp[0]}"
+
+            # Step 5: Verify tombstones were propagated to servers[0] via MUTATION_FRAGMENTS.
+            await manager.api.keyspace_flush(servers[0].ip_addr, ks)
+            mf_rows = await cql.run_async(
+                f"SELECT * FROM MUTATION_FRAGMENTS({ks}.{cf_name})", host=hosts[0])
+
+            _verify_tombstones(mf_rows, tombstone_kind, NUM_CKS, DELETED_CKS)
+
+
+def _is_deleted(tombstone_kind: TombstoneKind, pk: int, ck: int, deleted_cks: set[int]) -> bool:
+    """Return True if this (pk, ck) should be deleted for the given tombstone kind."""
+    if tombstone_kind == TombstoneKind.PARTITION:
+        # Only pk=0 is deleted.
+        return pk == 0
+    return ck in deleted_cks
+
+
+def _verify_tombstones(mf_rows, tombstone_kind: TombstoneKind, num_cks: int, deleted_cks: set[int]):
+    """Verify MUTATION_FRAGMENTS on servers[0] shows tombstones were propagated."""
+
+    match tombstone_kind:
+        case TombstoneKind.ROW:
+            # For ck in deleted_cks, clustering rows should have a row tombstone.
+            for pk in (0, 1):
+                pk_rows = [r for r in mf_rows if r.pk == pk and r.partition_region == 2
+                           and r.mutation_fragment_kind == "clustering row"]
+                tombstoned_cks = set()
+                for row in pk_rows:
+                    metadata = json.loads(row.metadata)
+                    tombstone = metadata.get("tombstone")
+                    if tombstone:
+                        tombstoned_cks.add(row.ck)
+                assert tombstoned_cks >= deleted_cks, \
+                    f"pk={pk}: expected row tombstones for {deleted_cks}, got {tombstoned_cks}"
+
+        case TombstoneKind.PARTITION:
+            # pk=0 partition_start should have a non-empty tombstone.
+            pk0_starts = [r for r in mf_rows if r.pk == 0 and r.partition_region == 0]
+            assert pk0_starts, "pk=0: no partition_start found"
+            for ps in pk0_starts:
+                metadata = json.loads(ps.metadata)
+                assert metadata.get("tombstone"), \
+                    f"pk=0: expected partition tombstone, got {metadata}"
+            # pk=1 should NOT have a partition tombstone.
+            pk1_starts = [r for r in mf_rows if r.pk == 1 and r.partition_region == 0]
+            assert pk1_starts, "pk=1: no partition_start found"
+            for ps in pk1_starts:
+                metadata = json.loads(ps.metadata)
+                assert not metadata.get("tombstone"), \
+                    f"pk=1: unexpected partition tombstone: {metadata}"
+
+        case TombstoneKind.CELL:
+            # For ck in deleted_cks, column 'c' should have is_live: false.
+            for pk in (0, 1):
+                pk_rows = [r for r in mf_rows if r.pk == pk and r.partition_region == 2
+                           and r.mutation_fragment_kind == "clustering row"]
+                dead_cell_cks = set()
+                for row in pk_rows:
+                    metadata = json.loads(row.metadata)
+                    columns = metadata.get("columns", {})
+                    c_meta = columns.get("c", {})
+                    if c_meta and not c_meta.get("is_live", True):
+                        dead_cell_cks.add(row.ck)
+                assert dead_cell_cks >= deleted_cks, \
+                    f"pk={pk}: expected cell tombstones for {deleted_cks}, got {dead_cell_cks}"
+
+        case TombstoneKind.RANGE:
+            # For each pk, there should be range_tombstone_change fragments.
+            for pk in (0, 1):
+                rtc_rows = [r for r in mf_rows if r.pk == pk and r.partition_region == 2
+                            and r.mutation_fragment_kind == "range tombstone change"]
+                assert rtc_rows, \
+                    f"pk={pk}: expected range tombstone change fragments, found none"
+                # At minimum we expect one pair of range tombstone changes.
+                assert len(rtc_rows) >= 2, \
+                    f"pk={pk}: expected at least 2 range tombstone change fragments, got {len(rtc_rows)}"


### PR DESCRIPTION
Currently, the read-repair path is overly strict: if a single replica fails during reconciliation, either during the mutation-data read phase or during the repair write phase, the entire user read fails with ReadFailure — even when enough replicas responded to satisfy the consistency level.

This is unnecessarily harsh. A client asking for CL=QUORUM expects the read to succeed as long as a quorum of replicas responds.

**Example**: Consider RF=3, CL=QUORUM. Nodes:
```
A holds V=1 (ts=10, unacknowledged write)
B and C hold V=0 (ts=5)
```

The coordinator selects two targets for the digest phase. Both respond but there is a digest mismatch, so reconciliation begins: mutation data is collected, merged, and repair writes are sent back.

**Master**: Mutation data is collected from the two initial targets only — both must respond. The repair write computes per-host diffs and sends each replica only its missing data — the specific target must accept the write. A failure on either node during either phase causes the entire read to fail with ReadFailure.

**Patch**: Mutation data is collected from all live replicas, tolerating failures as long as QUORUM responds. The full reconciled result is sent only to stale replicas (identified by digest comparison). Up-to-date replicas count as implicit write acknowledgements, so failures are tolerated as long as QUORUM is satisfied.

Taking `Taking targets={A,B}, all_replicas={A,B,C}:`:

```
No Failure:
    Master: Reconcile A(V=1)+B(V=0) -> V=1. Write V=1 to B. Return V=1.
    Patch:  Reconcile A(V=1)+B(V=0)+C(V=0) -> V=1. Write V=1 to {B,C}.
            A's digest matches -> implicit ack. Return V=1.
Read to A fails:
    Master: ReadFailure.
    Patch:  Reconcile B(V=0)+C(V=0) -> V=0. All digests match -> no write.
            Return V=0. Valid: V=1 was never acknowledged at CL.
Read to B fails:
    Master: ReadFailure.
    Patch:  Reconcile A(V=1)+C(V=0) -> V=1. Write V=1 to {B,C}.
            A's digest matches -> implicit ack. Return V=1.
Write to B fails:
    Master: ReadFailure.
    Patch:  Write V=1 to {B,C}. B's failure tolerated (A implicit ack +
            C write ack satisfy QUORUM). Return V=1. After: A=1, B=0, C=1.
Write to B fails, C also fails:
    Master: ReadFailure.
    Patch:  ReadFailure (only A's implicit ack, below QUORUM).
```

This patch series makes both phases of read-repair tolerant of individual replica failures:

- **Read phase**: Mutation-data requests are sent to all live replicas (not just the initial targets). The resolver tolerates up to (all_replicas - block_for) failures, completing as soon as enough responses arrive to satisfy the consistency level (QUORUM).
- **Write phase**: Instead of computing per-host diffs and sending each replica only its missing data (which fails if the specific replica that needs repair is down), per-replica digests are compared against the reconciled digest. Replicas that already match are counted as implicit write acknowledgements. Only stale replicas receive the full reconciled mutation. For DC-local consistency levels, all operations stay within the local DC.

The series:

1. Store all live replicas on read executor
2. Reconcile read repair from all replicas
3. Write read repairs selectively by digest
4. Remove obsolete read-repair diff code
5. Add force_read_target error injection
6. Add fail_mutation_query error injection
7. Tests for read-repair failure tolerance and tombstone propagation

All 6 test_read_repair_failure variants (forward/reversed/range × READ/WRITE failure phase) fail on master with ReadFailure and pass with this series. The 4 test_read_repair_tombstone variants and test_read_repair_with_trace_logging pass both before and after.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-481

No backport required. It's an improvement for the current read-repair mechanism.