### PR TITLE
sstables_loader: fix missing include

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -16,6 +16,7 @@
 #include <seastar/coroutine/switch_to.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/rpc/rpc.hh>
+#include <seastar/util/short_streams.hh> 
 #include "sstables_loader.hh"
 #include "db/config.hh"
 #include "dht/auto_refreshing_sharder.hh"


### PR DESCRIPTION
Commit c97232b introduced use of `seastar::util::read_entire_stream()`, however it didn't included relevant header which is causing compilation error.

It probably went silently through CI because of precompiled headers.

Refs scylladb#28763

scylladb#28763 wasn't backported, so we also don't need to backport this.