### PR TITLE
packaging: fix 32-bit systemctl extracted in container image

### DIFF
--- a/dist/docker/redhat/build_docker.sh
+++ b/dist/docker/redhat/build_docker.sh
@@ -97,9 +97,7 @@ bcp LICENSE-ScyllaDB-Source-Available.md /licenses/
 
 run microdnf clean all
 run microdnf --setopt=tsflags=nodocs -y update
-run microdnf --setopt=tsflags=nodocs -y install hostname kmod procps-ng python3 python3-pip cpio
-# Extract only systemctl binary from systemd package to avoid installing the whole systemd in the container.
-run bash -rc "microdnf download systemd && rpm2cpio systemd-*.rpm | cpio -idmv ./usr/bin/systemctl && rm -rf systemd-*.rpm"
+run microdnf --setopt=tsflags=nodocs -y install hostname kmod procps-ng python3 python3-pip systemd
 run curl -L --output /etc/yum.repos.d/scylla.repo ${repo_file_url}
 run pip3 install --no-cache-dir --prefix /usr supervisor
 run bash -ec "echo LANG=C.UTF-8 > /etc/locale.conf"
@@ -108,8 +106,8 @@ run bash -ec "cat /scylla_bashrc >> /etc/bash.bashrc"
 run mkdir -p /var/log/scylla
 run chown -R scylla:scylla /var/lib/scylla
 run sed -i -e 's/^SCYLLA_ARGS=".*"$/SCYLLA_ARGS="--log-to-syslog 0 --log-to-stdout 1 --network-stack posix"/' /etc/sysconfig/scylla-server
-# Cleanup packages not needed in the final image and clean package manager cache to reduce image size.
-run bash -rc "microdnf remove -y cpio && microdnf clean all"
+# Cleanup package manager cache to reduce image size.
+run microdnf clean all
 
 run mkdir -p /opt/scylladb/supervisor
 run touch /opt/scylladb/SCYLLA-CONTAINER-FILE


### PR DESCRIPTION
## Summary

- The container image build script extracted only the `systemctl` binary from the systemd RPM via `rpm2cpio`, but this binary depends on `libsystemd-shared-252.so` which is not present in the image
- This causes `perftune.py` to fail when trying to restart `irqbalance` via `systemctl` on EKS nodes
- Replace the `rpm2cpio` extraction with a proper `microdnf install systemd`, which brings in `systemctl` and all its runtime dependencies

## Root cause

`microdnf download systemd` fetches both i686 and x86_64 RPMs. The glob `systemd-*.rpm` in `rpm2cpio` pipes both into `cpio`, extracting the 32-bit binary (which can't run due to missing `/lib/ld-linux.so.2`). Even with architecture pinned, the extracted binary still fails because `libsystemd-shared-252.so` is not installed in the image.

The only correct fix is to install the `systemd` package properly so that `systemctl` and its shared library dependency are both present.

## Verification

Built the full image using `build_docker.sh` with RPMs from `scylladb/scylla:2026.1.3`. Confirmed `systemctl --version` works in the resulting image:

```
systemd 252 (252-55.el9_7.9)
```

Test image available at `docker.io/czeslavo/scylla:2026.1.3-fix-systemctl`. Verified E2E on EKS with Operator.

Fixes: https://scylladb.atlassian.net/browse/OPERATOR-113