### PR TITLE
db/schema_tables: don't emit empty view_building_tasks mutation on ALTER TABLE

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1863,8 +1863,12 @@ static void make_update_indices_mutations(
     }
 
     mutations.emplace_back(std::move(indices_mutation));
-    mutations.emplace_back(vb_mut_builder.build());
-    mutations.insert(mutations.end(), std::make_move_iterator(view_status_muts.begin()), std::make_move_iterator(view_status_muts.end()));
+    if (!vb_mut_builder.empty()) {
+        mutations.emplace_back(vb_mut_builder.build());
+    }
+    if (!view_status_muts.empty()) {
+        mutations.insert(mutations.end(), std::make_move_iterator(view_status_muts.begin()), std::make_move_iterator(view_status_muts.end()));
+    }
 }
 
 static void add_drop_column_to_mutations(schema_ptr table, const sstring& name, const schema::dropped_column& dc, api::timestamp_type timestamp, utils::chunked_vector<mutation>& mutations) {

--- a/db/view/view_building_task_mutation_builder.hh
+++ b/db/view/view_building_task_mutation_builder.hh
@@ -52,6 +52,9 @@ public:
     mutation build() {
         return std::move(_m);
     }
+    bool empty() const {
+        return _m.partition().empty();
+    }
 
 private:
     clustering_key get_ck(utils::UUID id);


### PR DESCRIPTION
After recent change (1a32ccd) `make_update_indices_mutations()` is unconditionally adding a mutation for `system.view_building_tasks`, even when no indices were being dropped.

In a mixed-version cluster, the older node may not have this table, causing the Raft schema applier to fail with 'Can't find a column family with UUID ...'.

This patch fixes the bug by emitting the mutation when indices are actually dropped (i.e., when the view building cleanup code path was entered).

Fixes: SCYLLADB-2026
Refs: scylladb#26557

scylladb#26557 wasn't backported, so this patch also doesn't need to be.