### PR TITLE
cql: fix missing TABLETS_ROUTING_V1 payload after CAS shard bounce

### DIFF
--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -314,7 +314,7 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
         auto&& table = s->table();
         if (_may_use_token_aware_routing && table.uses_tablets() && qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
             auto erm = table.get_effective_replication_map();
-            auto tablet_info = erm->check_locality(token);
+            auto tablet_info = erm->check_locality(token, qs.get_client_state().get_original_shard());
             if (tablet_info.has_value()) {
                 result->add_tablet_info(tablet_info->tablet_replicas, tablet_info->token_range);
             }
@@ -446,7 +446,7 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
     auto&& table = s->table();
     if (_may_use_token_aware_routing && table.uses_tablets() && qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
         auto erm = table.get_effective_replication_map();
-        tablet_info = erm->check_locality(token);
+        tablet_info = erm->check_locality(token, qs.get_client_state().get_original_shard());
     }
 
     return qp.proxy().cas(s, std::move(cas_shard), *request_ptr, request->read_command(qp), request->key(),

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -316,7 +316,7 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
             auto erm = table.get_effective_replication_map();
             auto tablet_info = erm->check_locality(token, qs.get_client_state().get_original_shard());
             if (tablet_info.has_value()) {
-                result->add_tablet_info(tablet_info->tablet_replicas, tablet_info->token_range);
+                result->add_tablet_info(std::move(*tablet_info));
             }
         }
     }
@@ -454,7 +454,7 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
             std::move(cl_for_paxos).assume_value(), cl_for_learn, statement_timeout, cas_timeout).then([this, request = std::move(request), tablet_info = std::move(tablet_info)] (bool is_applied) mutable {
         auto result = request->build_cas_result_set(_metadata, _columns_of_cas_result_set, is_applied);
         if (tablet_info) {
-            result->add_tablet_info(std::move(tablet_info->tablet_replicas), tablet_info->token_range);
+            result->add_tablet_info(std::move(*tablet_info));
         }
         return result;
     });

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -441,7 +441,7 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
             );
     }
 
-    std::optional<locator::tablet_routing_info> tablet_info = locator::tablet_routing_info{locator::tablet_replica_set(), std::pair<dht::token, dht::token>()};
+    std::optional<locator::tablet_routing_info> tablet_info;
 
     auto&& table = s->table();
     if (_may_use_token_aware_routing && table.uses_tablets() && qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
@@ -451,9 +451,11 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
 
     return qp.proxy().cas(s, std::move(cas_shard), *request_ptr, request->read_command(qp), request->key(),
             {read_timeout, qs.get_permit(), qs.get_client_state(), qs.get_trace_state()},
-            std::move(cl_for_paxos).assume_value(), cl_for_learn, statement_timeout, cas_timeout).then([this, request = std::move(request), tablet_replicas = std::move(tablet_info->tablet_replicas), token_range = tablet_info->token_range] (bool is_applied) {
+            std::move(cl_for_paxos).assume_value(), cl_for_learn, statement_timeout, cas_timeout).then([this, request = std::move(request), tablet_info = std::move(tablet_info)] (bool is_applied) mutable {
         auto result = request->build_cas_result_set(_metadata, _columns_of_cas_result_set, is_applied);
-        result->add_tablet_info(tablet_replicas, token_range);
+        if (tablet_info) {
+            result->add_tablet_info(std::move(tablet_info->tablet_replicas), tablet_info->token_range);
+        }
         return result;
     });
 }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -491,7 +491,7 @@ select_statement::do_execute(query_processor& qp,
             token = key_ranges[0].start()->value().as_decorated_key().token();
 
             auto erm = table.get_effective_replication_map();
-            tablet_info = erm->check_locality(token);
+            tablet_info = erm->check_locality(token, state.get_client_state().get_original_shard());
         }
     }
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -527,8 +527,8 @@ select_statement::do_execute(query_processor& qp,
         return f;
     }
 
-    return f.then([tablet_replicas = std::move(tablet_info->tablet_replicas), token_range = tablet_info->token_range] (auto res) mutable {
-        res->add_tablet_info(std::move(tablet_replicas), token_range);
+    return f.then([tablet_info = std::move(*tablet_info)] (auto res) mutable {
+        res->add_tablet_info(std::move(tablet_info));
         return res;
     });
 }

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -34,6 +34,7 @@
 #include "cdc/cdc_partitioner.hh"
 #include "view_info.hh"
 #include "replica/database.hh"
+#include "replica/tablets.hh"
 #include "lang/manager.hh"
 #include "db/system_keyspace.hh"
 #include "compaction/compaction_manager.hh"

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -112,7 +112,7 @@ host_id_vector_replica_set vnode_effective_replication_map::get_replicas_for_rea
     return *endpoints | std::ranges::to<host_id_vector_replica_set>();
 }
 
-std::optional<tablet_routing_info> vnode_effective_replication_map::check_locality(const token& token) const {
+std::optional<tablet_routing_info> vnode_effective_replication_map::check_locality(const token&, unsigned) const {
     return {};
 }
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -306,7 +306,13 @@ public:
     /// replaced but not yet rebuilt.
     virtual host_id_vector_replica_set get_replicas(const token& search_token, bool is_vnode = false) const = 0;
 
-    virtual std::optional<tablet_routing_info> check_locality(const token& token) const = 0;
+    /// Checks whether the request was routed to the correct tablet replica.
+    /// \param token       the partition token
+    /// \param original_shard the shard where the CQL request originally entered the node;
+    ///                    after an internal CAS shard bounce this differs from this_shard_id()
+    /// \returns nullopt if routed correctly, otherwise the tablet routing info
+    ///          so the client can learn the correct tablet map
+    virtual std::optional<tablet_routing_info> check_locality(const token& token, unsigned original_shard) const = 0;
 
 
     /// Returns true if there are any pending ranges for this endpoint.
@@ -498,7 +504,7 @@ public: // effective_replication_map
     host_id_vector_topology_change get_pending_replicas(const token& search_token) const override;
     host_id_vector_replica_set get_replicas_for_reading(const token& token, bool is_vnode = false) const override;
     host_id_vector_replica_set get_replicas(const token& search_token, bool is_vnode = false) const override;
-    std::optional<tablet_routing_info> check_locality(const token& token) const override;
+    std::optional<tablet_routing_info> check_locality(const token& token, unsigned original_shard) const override;
     bool has_pending_ranges(locator::host_id endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
     const dht::sharder& get_sharder(const schema& s) const override;
@@ -610,7 +616,7 @@ public:
     host_id_vector_topology_change get_pending_replicas(const token& search_token) const override;
     host_id_vector_replica_set get_replicas_for_reading(const token& token, bool is_vnode = false) const override;
     host_id_vector_replica_set get_replicas(const token& search_token, bool is_vnode = false) const override;
-    std::optional<tablet_routing_info> check_locality(const token& token) const override;
+    std::optional<tablet_routing_info> check_locality(const token& token, unsigned original_shard) const override;
     bool has_pending_ranges(locator::host_id endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
     const dht::sharder& get_sharder(const schema& s) const override;

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -61,7 +61,7 @@ host_id_vector_replica_set local_effective_replication_map::get_replicas(const t
     return _replica_set;
 }
 
-std::optional<tablet_routing_info> local_effective_replication_map::check_locality(const token& token) const {
+std::optional<tablet_routing_info> local_effective_replication_map::check_locality(const token&, unsigned) const {
     return std::nullopt;
 }
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1474,12 +1474,11 @@ public:
         return get_for_reading_helper(search_token);
     }
 
-    std::optional<tablet_routing_info> check_locality(const token& search_token) const override {
+    std::optional<tablet_routing_info> check_locality(const token& search_token, unsigned original_shard) const override {
         auto&& tablets = get_tablet_map();
         auto tid = tablets.get_tablet_id(search_token);
         auto&& info = tablets.get_tablet_info(tid);
         auto host = get_token_metadata().get_my_id();
-        auto shard = this_shard_id();
 
         auto make_tablet_routing_info = [&] {
             dht::token first_token;
@@ -1494,7 +1493,7 @@ public:
 
         for (auto&& r : info.replicas) {
             if (r.host == host) {
-                if (r.shard == shard) {
+                if (r.shard == original_shard) {
                     return std::nullopt; // routed correctly
                 } else {
                     return make_tablet_routing_info();
@@ -1503,7 +1502,7 @@ public:
         }
 
         auto tinfo = tablets.get_tablet_transition_info(tid);
-        if (tinfo && tinfo->pending_replica && tinfo->pending_replica->host == host && tinfo->pending_replica->shard == shard) {
+        if (tinfo && tinfo->pending_replica && tinfo->pending_replica->host == host && tinfo->pending_replica->shard == original_shard) {
             return std::nullopt; // routed correctly
         }
 

--- a/main.cc
+++ b/main.cc
@@ -32,6 +32,7 @@
 #include "supervisor.hh"
 #include "timeout_config.hh"
 #include "replica/database.hh"
+#include "replica/tablets.hh"
 #include <seastar/core/reactor.hh>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/sharded.hh>

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -97,6 +97,7 @@ private:
             , _timeout_config(cs->_timeout_config)
             , _as(as)
             , _enabled_protocol_extensions(cs->_enabled_protocol_extensions)
+            , _original_shard(cs->_original_shard)
     {}
     friend client_state_for_another_shard;
 private:
@@ -506,6 +507,10 @@ private:
 
     cql_transport::cql_protocol_extension_enum_set _enabled_protocol_extensions;
 
+    // The shard where the current CQL request originally entered the node.
+    // After an internal CAS shard bounce this differs from this_shard_id().
+    unsigned _original_shard = this_shard_id();
+
 public:
 
     bool is_protocol_extension_set(cql_transport::cql_protocol_extension ext) const {
@@ -518,6 +523,10 @@ public:
 
     void set_protocol_extensions(cql_transport::cql_protocol_extension_enum_set exts) {
         _enabled_protocol_extensions = std::move(exts);
+    }
+
+    unsigned get_original_shard() const noexcept {
+        return _original_shard;
     }
 };
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -54,6 +54,8 @@
 #include "sstables/sstables.hh"
 #include "replica/distributed_loader.hh"
 #include "compaction/compaction_manager.hh"
+#include "service/query_state.hh"
+#include "service_permit.hh"
 
 
 BOOST_AUTO_TEST_SUITE(cql_query_test)
@@ -6113,6 +6115,91 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_select) {
             });
         }).get();
     }, tablet_cql_test_config());
+}
+
+// Regression test for scylladb/scylladb#29874:
+// After an internal CAS shard bounce, TABLETS_ROUTING_V1 payload must still
+// be returned when the client originally routed to the wrong shard.
+//
+// The test simulates what the transport layer does during a CAS shard bounce:
+// 1. The request arrives on shard X (the "foreign" shard, not owning the tablet).
+// 2. The LWT statement detects the wrong shard and returns a bounce to shard Y
+//    (the tablet shard).
+// 3. The transport layer transfers client_state from X to Y via
+//    client_state_for_another_shard, preserving _original_shard = X.
+// 4. The statement re-executes on shard Y. check_locality() compares against
+//    _original_shard (X, wrong) rather than this_shard_id() (Y, correct),
+//    so it returns tablet routing info.
+//
+// We arrange the test so that the test thread's shard is the "foreign" shard
+// (not the tablet shard). This way local_client_state() belongs to the current
+// shard, and move_to_other_shard() is called on the owning shard.
+SEASTAR_TEST_CASE(test_tablet_routing_info_after_cas_shard_bounce) {
+    BOOST_REQUIRE_GT(smp::count, 1u);
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        e.execute_cql("create keyspace ks_tablet with replication = "
+            "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+            "and tablets = {'initial': 1};").get();
+
+        // Create dummy tables until the next table's single tablet lands on
+        // a shard other than ours. Each dummy table occupies one shard in the
+        // load balancer, so after at most smp::count dummies shard 0 (or
+        // whichever shard we're on) is no longer the least loaded.
+        schema_ptr schema;
+        unsigned tablet_shard;
+        for (unsigned i = 0; ; ++i) {
+            BOOST_REQUIRE_MESSAGE(i <= smp::count, "Could not place tablet on a foreign shard");
+            auto tbl = format("tbl_{}", i);
+            e.execute_cql(format("create table ks_tablet.{} (pk int PRIMARY KEY, v int);", tbl)).get();
+            schema = e.local_db().find_schema("ks_tablet", tbl);
+            auto pk = partition_key::from_singular(*schema, int32_t(1));
+            tablet_shard = schema->table().shard_for_reads(dht::get_token(*schema, pk.view()));
+            if (tablet_shard != this_shard_id()) {
+                break;
+            }
+        }
+
+        e.execute_cql(format("insert into ks_tablet.{} (pk, v) VALUES (1, 1);", schema->cf_name())).get();
+        const auto lwt_id = e.prepare(format("update ks_tablet.{} set v = ? where pk = ? if v = ?;", schema->cf_name())).get();
+
+        // Execute LWT on this shard (the foreign shard). Expect a bounce.
+        {
+            auto raw_val = [] (int32_t v) { return cql3::raw_value::make_value(int32_type->decompose(v)); };
+            const auto result = e.execute_prepared(lwt_id, {raw_val(2), raw_val(1), raw_val(1)}).get();
+            BOOST_REQUIRE(result->as_bounce());
+            BOOST_REQUIRE_EQUAL(result->as_bounce()->target_shard(), tablet_shard);
+        }
+
+        // Simulate the transport-layer bounce: transfer client_state from
+        // this shard (foreign, owning the client_state) to the tablet shard.
+        // client_state_for_another_shard preserves _original_shard = this shard.
+        const auto gcs = e.local_client_state().move_to_other_shard();
+
+        smp::submit_to(tablet_shard, [&] {
+            return seastar::async([&] {
+                auto cs = gcs.get();
+                auto qs = ::make_shared<service::query_state>(cs, empty_service_permit());
+                const auto prepared = e.local_qp().get_prepared(lwt_id);
+                BOOST_REQUIRE(prepared);
+
+                const auto options = e.local_qp().make_internal_options(prepared, 
+                    {data_value(2), data_value(1), data_value(1)},
+                    db::consistency_level::ONE);
+
+                auto res = e.local_qp().execute_prepared_without_checking_exception_message(
+                    *qs, prepared->statement, options,
+                    std::move(prepared), lwt_id, false).get();
+                res = cql_transport::messages::propagate_exception_as_future(
+                    std::move(res)).get();
+
+                BOOST_REQUIRE(has_tablet_routing(res));
+            });
+        }).get();
+    }, [] {
+        auto cfg = tablet_cql_test_config();
+        cfg.need_remote_proxy = true;
+        return cfg;
+    }());
 }
 
 // check if create statements emit schema change event properly

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -57,6 +57,7 @@
 #include "db/view/node_view_update_backlog.hh"
 #include "db/view/view_update_generator.hh"
 #include "replica/distributed_loader.hh"
+#include "replica/tablets.hh"
 // TODO: remove (#293)
 #include "message/messaging_service.hh"
 #include "gms/gossiper.hh"

--- a/transport/messages/result_message.cc
+++ b/transport/messages/result_message.cc
@@ -9,10 +9,21 @@
 
 #include "result_message.hh"
 #include "cql3/cql_statement.hh"
+#include "replica/tablets.hh"
+#include "types/tuple.hh"
 #include <seastar/core/format.hh>
 #include <fmt/std.h>
 
 namespace cql_transport::messages {
+
+void result_message::add_tablet_info(locator::tablet_routing_info info) {
+    auto replicas_values = make_list_value(replica::get_replica_set_type(), replica::replicas_to_data_value(info.tablet_replicas));
+    auto v1 = data_value(dht::token::to_int64(info.token_range.first));
+    auto v2 = data_value(dht::token::to_int64(info.token_range.second));
+
+    auto tablets_routing = make_tuple_value(replica::get_tablet_info_type(), {v1, v2, replicas_values});
+    add_custom_payload("tablets-routing-v1", tablets_routing.serialize_nonnull());
+}
 
 std::ostream& operator<<(std::ostream& os, const result_message::void_message& msg) {
     fmt::print(os, "{{result_message::void}}");

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -14,8 +14,6 @@
 
 #include "seastarx.hh"
 #include "locator/tablets.hh"
-#include "replica/tablets.hh"
-#include "types/tuple.hh"
 
 namespace cql_transport {
 namespace messages {
@@ -56,16 +54,7 @@ public:
         _custom_payload.value()[key] = value;
     }
 
-    void add_tablet_info(locator::tablet_replica_set tablet_replicas, std::pair<dht::token, dht::token> token_range) {
-        if (!tablet_replicas.empty()) {
-            auto replicas_values = make_list_value(replica::get_replica_set_type(), replica::replicas_to_data_value(tablet_replicas));
-            auto v1 = data_value(dht::token::to_int64(token_range.first));
-            auto v2 = data_value(dht::token::to_int64(token_range.second));
-
-            auto tablets_routing = make_tuple_value(replica::get_tablet_info_type(), {v1, v2, replicas_values});
-            this->add_custom_payload("tablets-routing-v1", tablets_routing.serialize_nonnull());
-        }
-    }
+    void add_tablet_info(locator::tablet_routing_info info);
 
     const std::optional<std::unordered_map<sstring, bytes>>& custom_payload() const {
         return _custom_payload;


### PR DESCRIPTION
After an internal CAS shard bounce, check_locality() was evaluating
against this_shard_id() of the post-bounce shard — which is the correct
tablet shard — so it returned nullopt, and LWT/SERIAL responses omitted
the tablets-routing-v1 custom payload. The client never learned the
correct tablet map.

Fix by recording the original entry shard in client_state (initialized
to this_shard_id() at construction, preserved across shard bounces via
client_state_for_another_shard) and passing it to check_locality() so
it compares against the client's actual routing decision.

No host_id tracking or forwarded_client_state IDL changes are needed
because CAS shard bounces are always intra-node.

Fixes SCYLLADB-2041

backport: need to backport to all versions with LWT over tablets