### PR TITLE
schema: ensure committed_by_group0 is set for all non-system tables o…

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -9,7 +9,9 @@
  */
 
 #include <algorithm>
+#include <random>
 #include <ranges>
+#include <set>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -994,6 +996,98 @@ future<> migration_manager::announce<topology_change>(utils::chunked_vector<muta
 future<group0_guard> migration_manager::start_group0_operation(std::optional<raft_timeout> timeout) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     return _group0_client.start_operation(_as, timeout.value_or(raft_timeout{}));
+}
+
+static thread_local std::default_random_engine random_engine{std::random_device{}()};
+
+future<> migration_manager::ensure_committed_by_group0() {
+    SCYLLA_ASSERT(this_shard_id() == 0);
+
+    // Find non-system tables where committed_by_group0 is not true in scylla_tables.
+    // This includes tables that have no row in scylla_tables at all (very old tables).
+    auto find_tables_missing_flag = [this]() -> future<std::vector<std::pair<sstring, sstring>>> {
+        // Collect all non-system tables with committed_by_group0 = true from scylla_tables
+        auto rs = co_await db::system_keyspace::query(
+            _storage_proxy.get_db(), db::schema_tables::NAME, db::schema_tables::v3::SCYLLA_TABLES);
+        std::set<std::pair<sstring, sstring>> already_committed;
+        for (auto& row : rs->rows()) {
+            auto ks_name = row.get_nonnull<sstring>("keyspace_name");
+            if (is_system_keyspace(ks_name)) {
+                continue;
+            }
+            auto committed = row.get<bool>("committed_by_group0");
+            if (committed && *committed) {
+                auto table_name = row.get_nonnull<sstring>("table_name");
+                already_committed.emplace(std::move(ks_name), std::move(table_name));
+            }
+        }
+
+        // Now find all non-system tables in-memory that are not in the committed set
+        std::vector<std::pair<sstring, sstring>> result;
+        auto db = _storage_proxy.data_dictionary();
+        for (auto& ks : db.get_all_keyspaces()) {
+            if (is_system_keyspace(ks)) {
+                continue;
+            }
+            for (auto& [name, schema] : db.find_keyspace(ks).metadata()->cf_meta_data()) {
+                if (!already_committed.contains({ks, name})) {
+                    result.emplace_back(ks, name);
+                }
+            }
+        }
+        co_return result;
+    };
+
+    auto tables = co_await find_tables_missing_flag();
+    if (tables.empty()) {
+        mlogger.info("All non-system tables have committed_by_group0 set");
+        co_return;
+    }
+
+    mlogger.info("Found {} table(s) missing committed_by_group0, performing fixup", tables.size());
+
+    while (true) {
+        auto guard = co_await start_group0_operation();
+
+        // Re-check after raft barrier — another node may have fixed it.
+        tables = co_await find_tables_missing_flag();
+        if (tables.empty()) {
+            mlogger.info("All tables now have committed_by_group0 set (fixed by another node)");
+            co_return;
+        }
+
+        auto timestamp = guard.write_timestamp();
+        auto db = _storage_proxy.data_dictionary();
+        auto scylla_tables_schema = db::schema_tables::scylla_tables();
+        utils::chunked_vector<mutation> mutations;
+
+        for (auto& [ks_name, table_name] : tables) {
+            try {
+                auto s = db.find_schema(ks_name, table_name);
+                auto pkey = partition_key::from_singular(*scylla_tables_schema, ks_name);
+                auto ckey = clustering_key::from_singular(*scylla_tables_schema, table_name);
+                mutation m(scylla_tables_schema, pkey);
+                m.set_clustered_cell(ckey, "version", s->version().uuid(), timestamp);
+                // committed_by_group0 will be stamped by add_committed_by_group0_flag() in announce()
+                mutations.emplace_back(std::move(m));
+            } catch (const data_dictionary::no_such_column_family&) {
+                mlogger.debug("Table {}.{} not found (dropped concurrently?), skipping", ks_name, table_name);
+            }
+        }
+
+        if (mutations.empty()) {
+            co_return;
+        }
+
+        mlogger.info("Setting committed_by_group0 for {} table(s)", mutations.size());
+        try {
+            co_await announce<schema_change>(std::move(mutations), std::move(guard), "ensure committed_by_group0");
+            co_return;
+        } catch (const group0_concurrent_modification&) {
+            mlogger.info("Concurrent schema change detected while setting committed_by_group0, retrying");
+        }
+        co_await sleep_abortable(std::chrono::milliseconds(std::uniform_int_distribution<>(0, 500)(random_engine)), _as);
+    }
 }
 
 /**

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -113,6 +113,14 @@ public:
     //              `group0_raft_op_timeout_in_ms`, which defaults to one minute).
     future<group0_guard> start_group0_operation(std::optional<raft_timeout> timeout = std::nullopt);
 
+    // Ensure all non-system tables have committed_by_group0 = true in
+    // system_schema.scylla_tables. Tables created before the
+    // GROUP0_SCHEMA_VERSIONING feature was enabled will have this column
+    // as null, causing their version to be deleted by maybe_delete_schema_version()
+    // and forcing hash-based version computation. This fixup stamps them
+    // so we can eventually remove the legacy hashing code.
+    future<> ensure_committed_by_group0();
+
     // Apply a group 0 change.
     // The future resolves after the change is applied locally.
     // Parameters:

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1730,6 +1730,8 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
         throw std::runtime_error(err);
     }
 
+    co_await _migration_manager.local().ensure_committed_by_group0();
+
     // Initializes monitor only after updating local topology.
     start_tablet_split_monitor();
 

--- a/test/cluster/test_ensure_committed_by_group0.py
+++ b/test/cluster/test_ensure_committed_by_group0.py
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""
+Test that ensure_committed_by_group0() fixes tables missing the flag on boot.
+"""
+import pytest
+import logging
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_ensure_committed_by_group0(manager: ManagerClient):
+    """Tables with committed_by_group0 = null or false get fixed on restart."""
+    servers = await manager.servers_add(1)
+    (cql, _) = await manager.get_ready_cql(servers)
+
+    await cql.run_async("CREATE KEYSPACE ks WITH replication = "
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+    await cql.run_async("CREATE TABLE ks.tbl_null (pk int PRIMARY KEY)")
+    await cql.run_async("CREATE TABLE ks.tbl_false (pk int PRIMARY KEY)")
+
+    # Verify both have committed_by_group0 = true initially
+    for tbl in ['tbl_null', 'tbl_false']:
+        rows = await cql.run_async(
+            f"SELECT committed_by_group0 FROM system_schema.scylla_tables "
+            f"WHERE keyspace_name = 'ks' AND table_name = '{tbl}'")
+        assert rows[0].committed_by_group0 == True
+
+    # Simulate pre-group0 table (null) and recovery-mode table (false)
+    await cql.run_async(
+        "DELETE committed_by_group0 FROM system_schema.scylla_tables "
+        "WHERE keyspace_name = 'ks' AND table_name = 'tbl_null'")
+    await cql.run_async(
+        "UPDATE system_schema.scylla_tables SET committed_by_group0 = false "
+        "WHERE keyspace_name = 'ks' AND table_name = 'tbl_false'")
+
+    # Restart — ensure_committed_by_group0() should fix both on boot
+    await manager.server_restart(servers[0].server_id)
+    (cql, _) = await manager.get_ready_cql(servers)
+
+    # Verify fixup happened for both tables
+    for tbl in ['tbl_null', 'tbl_false']:
+        rows = await cql.run_async(
+            f"SELECT committed_by_group0 FROM system_schema.scylla_tables "
+            f"WHERE keyspace_name = 'ks' AND table_name = '{tbl}'")
+        assert rows[0].committed_by_group0 == True, \
+            f"committed_by_group0 not fixed for {tbl}"


### PR DESCRIPTION
…n boot

Tables created before the GROUP0_SCHEMA_VERSIONING feature was enabled have committed_by_group0 = null in system_schema.scylla_tables. This causes maybe_delete_schema_version() to delete their version cell, forcing the legacy hash-based schema version computation path.

Add ensure_committed_by_group0() which runs on boot and fixes up any non-system tables where committed_by_group0 is not true (null or false):

1. Queries system_schema.scylla_tables for rows where committed_by_group0 is null or false, skipping system keyspaces (system, system_schema).
2. Takes a group0 guard
3. Re-checks after the raft barrier in case another node already fixed it.
4. For each table needing fixup, creates a mutation writing the version cell (from the in-memory schema). The committed_by_group0 = true flag is stamped by add_committed_by_group0_flag() inside announce().
5. Announces via raft group0.
6. Retries with a small random delay on group0_concurrent_modification.

On other nodes, schema_applier will detect these as "altered" tables (scylla_tables mutation changed), but since the actual table definition is unchanged, update_column_family is effectively a no-op.

This is a prerequisite for eventually removing the legacy hash-based schema versioning code path.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2072

Need to backport to TSL version to be able to drop the code earlier.