### PR TITLE
alternator: add S3 export python tests

### DIFF
--- a/alternator/export.hh
+++ b/alternator/export.hh
@@ -24,7 +24,6 @@ namespace alternator {
 // Call respective factory method below (`create_in_memory_sink_pipeline`) to construct.
 // Call `process()` method for each item (they might come in random order) - they will be serialized and written to the appropriate sink.
 // After all items are processed, call `flush_and_close()` to flush and finalize the pipeline - the call is mandatory, otherwise part of the data might not be written.
-// Calling `flush_and_close()` is required and needs to be done manually.
 // Calls to `process()` and `flush_and_close()` must be serialized, i.e. each call is allowed only after previous call's future is completed.
 struct export_pipeline_interface {
     // Invokes whole pipeline for a single item. The future will complete once item is processed.

--- a/test/alternator/test_export.py
+++ b/test/alternator/test_export.py
@@ -1,0 +1,1175 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+# Tests for the DynamoDB ExportTableToPointInTime, DescribeExport, and
+# ListExports APIs (part of SCYLLADB-1939).
+
+import base64
+import collections
+
+import pytest
+import boto3
+import time
+import uuid
+import json
+import hashlib
+import datetime
+import gzip
+import os
+import decimal
+
+from botocore.exceptions import ClientError
+from contextlib import contextmanager, ExitStack
+
+from test.alternator.util import is_aws, new_test_table
+
+# NOTE: tests here use `pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")` as xfail marker as the implementation is ongoing.
+# The tests will pass against AWS.
+
+# Helper to check if table is deleted.
+def is_table_deleted(dynamodb, table_name: str) -> bool:
+    try:
+        dynamodb.describe_table(TableName=table_name)
+        return False  # table still exists (or is in DELETING/ACTIVE/etc.)
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'ResourceNotFoundException':
+            return True
+        raise
+
+# Helper to get the table ARN from a table object.
+def get_table_arn(table):
+    desc = table.meta.client.describe_table(TableName=table.name)
+    return desc['Table']['TableArn']
+
+
+# Helper to create a unique S3 bucket name.
+def unique_bucket_name():
+    return f"alternator-export-test-{uuid.uuid4().hex[:12]}"
+
+
+# Create an S3 client using the same endpoint configuration as the DynamoDB
+# fixture where possible. On AWS, the default S3 client is used. On Scylla,
+# we will use MinIo (or something similar capable of pretending S3).
+# The code has branch to handle both cases, but the MinIo path is not covered as
+# Scylla implementation is not ready - it's here as a placeholder.
+def make_s3_client(dynamodb):
+    if is_aws(dynamodb):
+        return boto3.client('s3')
+    # Placeholder for MinIo configuration for local Scylla testing.
+    assert False, "MinIo S3 client configuration for local Scylla testing is not implemented yet"
+
+
+# Context manager that creates a uniquely-named S3 bucket and deletes it (including all objects) on exit.
+@contextmanager
+def new_s3_bucket(s3_client, bucket_name=None):
+    if bucket_name is None:
+        bucket_name = unique_bucket_name()
+    region = s3_client.meta.region_name
+    kwargs: dict = {'Bucket': bucket_name}
+    # us-east-1 does not accept a LocationConstraint - in other words if you want `us-east-1` bucket, you need to omit `LocationConstraint` entirely,
+    # in all other cases supply `LocationConstraint` - this is AWS quirk.
+    if region and region != 'us-east-1':
+        kwargs['CreateBucketConfiguration'] = {'LocationConstraint': region}
+    s3_client.create_bucket(**kwargs)
+    try:
+        yield bucket_name
+    finally:
+        # Delete all objects before deleting the bucket
+        paginator = s3_client.get_paginator('list_objects_v2')
+        for page in paginator.paginate(Bucket=bucket_name):
+            if 'Contents' in page:
+                s3_client.delete_objects(
+                    Bucket=bucket_name,
+                    Delete={'Objects': [{'Key': obj['Key']} for obj in page['Contents']]}
+                )
+        s3_client.delete_bucket(Bucket=bucket_name)
+
+
+# Helper: enable PITR on a table (required for ExportTableToPointInTime on
+# DynamoDB). Returns the client used.
+def enable_pitr(table, timeout=120):
+    client = table.meta.client
+
+    # We need to enable PITR on AWS, but not on scylla (in fact the call itself in scylla is not handled and will fail).
+    if not is_aws(table):
+        return client
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            client.update_continuous_backups(
+                TableName=table.name,
+                PointInTimeRecoverySpecification={'PointInTimeRecoveryEnabled': True}
+            )
+            break
+        except ClientError as e:
+            # After table creation there's a delay until PITR can be enabled (and then another delay
+            # until PITR is actually active) - the first delay is notified to the user by ContinuousBackupsUnavailableException
+            # exception. So we catch it here and try again.
+            if e.response['Error']['Code'] == 'ContinuousBackupsUnavailableException':
+                # This is run against AWS (see `if` above), which is slow, so no point in testing often
+                time.sleep(2)
+            else:
+                raise
+    else:
+        raise TimeoutError(f"UpdateContinuousBackups did not succeed on {table.name} within {timeout}s")
+    # Wait until PITR is actually active — there is a propagation delay on AWS.
+    while time.time() < deadline:
+        resp = client.describe_continuous_backups(TableName=table.name)
+        pitr = resp['ContinuousBackupsDescription'].get('PointInTimeRecoveryDescription', {})
+        if pitr.get('PointInTimeRecoveryStatus') == 'ENABLED':
+            return client
+        # This is run against AWS (see `if` above), which is slow, so no point in testing often
+        time.sleep(2)
+    raise TimeoutError(f"PITR did not become ENABLED on {table.name} within {timeout}s")
+
+
+# Helper: wait for an export to reach a terminal status (COMPLETED or FAILED).
+# My actual tests show export takes approximately 10-12 minutes on AWS hence hefty timeout.
+def wait_for_export(client, export_arn):
+    timeout = 60 * 60 if is_aws(client) else 60
+    sleep_time = 5 if is_aws(client) else 0.1
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        desc = client.describe_export(ExportArn=export_arn)['ExportDescription']
+        status = desc['ExportStatus']
+        if status in ('COMPLETED', 'FAILED'):
+            return desc
+        time.sleep(sleep_time)
+    raise TimeoutError(f"Export {export_arn} did not complete within {timeout}s")
+
+
+# ---------------------------------------------------------------------------
+# ExportTableToPointInTime tests
+# ---------------------------------------------------------------------------
+
+# Test that ExportTableToPointInTime starts an export and returns an
+# ExportDescription with expected fields.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_basic(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        response = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+        )
+        desc = response['ExportDescription']
+        assert 'ExportArn' in desc
+        assert desc['ExportStatus'] in ('IN_PROGRESS', 'COMPLETED')
+        assert desc['TableArn'] == table_arn
+        assert desc['S3Bucket'] == bucket
+
+        # Amazon returns an unique ClientToken in response, even if user did not supply one.
+        assert desc['ClientToken']
+
+        assert desc['ExportFormat'] == 'DYNAMODB_JSON'  # default format is DYNAMODB_JSON
+        assert 'ExportType' not in desc # default is FULL_EXPORT, but AWS does not return it in the response for some reason.
+        # Wait for completion and verify
+        final = wait_for_export(client, desc['ExportArn'])
+        assert final['ExportStatus'] == 'COMPLETED'
+        assert 'ExportType' not in final # default is FULL_EXPORT, but AWS does not return it in the response for some reason.
+
+
+# Test that ExportTableToPointInTime starts an export and then table is deleted,
+# after which ListExports should still return the export (with TableArn and TableId) and DescribeExport should still work.
+# This was run against Amazon and it seems they just return IN_PROGRESS after deleting the table and the S3 bucket.
+# We don't have to mark the progress as immediately FAILED in such situation.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_start_and_delete_table(dynamodb):
+    with new_test_table(dynamodb,
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+    ) as table:
+        client = enable_pitr(table)
+        table_arn = get_table_arn(table)
+        s3 = make_s3_client(dynamodb)
+
+        with new_s3_bucket(s3) as bucket:
+            response = client.export_table_to_point_in_time(
+                TableArn=table_arn,
+                S3Bucket=bucket,
+            )
+            desc = response['ExportDescription']
+            assert 'ExportArn' in desc
+            export_arn = desc['ExportArn']
+            assert desc['ExportStatus'] in ('IN_PROGRESS', 'COMPLETED')
+            assert desc['TableArn'] == table_arn
+            assert desc['S3Bucket'] == bucket
+            assert desc['ExportFormat'] == 'DYNAMODB_JSON'  # default format is DYNAMODB_JSON
+            assert 'ExportType' not in desc # default is FULL_EXPORT, but AWS does not return it in the response for some reason.
+
+    now = time.time()
+    while time.time() < now + 60:
+        if is_table_deleted(client, table.name):
+            break
+        time.sleep(2 if is_aws(client) else 0.1)
+    else:
+        assert False, f"Table {table.name} should be deleted after exiting the context manager"
+
+    # For some reason Amazon doesn't list the export in ListExports.
+    for ex in iterate_over_exports(client, table_arn):
+        if ex['ExportArn'] == export_arn:
+            assert False, f"Export {export_arn} found in list_exports"
+
+    desc = client.describe_export(ExportArn=export_arn)['ExportDescription']
+    assert desc['ExportArn'] == export_arn
+    assert desc['TableArn'] == table_arn
+    assert desc['S3Bucket'] == bucket
+    assert desc['ExportStatus'] in ('COMPLETED', 'FAILED')
+    assert 'StartTime' in desc
+    assert 'ExportFormat' in desc
+
+
+# Test that ExportTableToPointInTime starts an export and returns an
+# ExportDescription with expected fields. Wait for completion and verify that final description
+# is also valid.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_basic_with_export_type(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        response = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+            ExportType='FULL_EXPORT'
+        )
+        desc = response['ExportDescription']
+        assert 'ExportArn' in desc
+        assert desc['ExportStatus'] in ('IN_PROGRESS', 'COMPLETED')
+        assert desc['TableArn'] == table_arn
+        assert desc['S3Bucket'] == bucket
+        assert desc['ExportFormat'] == 'DYNAMODB_JSON'  # default format is DYNAMODB_JSON
+        assert desc['ExportType'] == 'FULL_EXPORT'
+        # Wait for completion and verify
+        final = wait_for_export(client, desc['ExportArn'])
+        assert final['ExportStatus'] == 'COMPLETED'
+        assert final['ExportType'] == 'FULL_EXPORT'
+
+
+def fetch_all_exported_items(s3, bucket):
+    result = {}
+    response = s3.list_objects_v2(Bucket=bucket)
+    objects = response.get('Contents', [])
+    while response.get('IsTruncated'):
+        response = s3.list_objects_v2(Bucket=bucket,
+                                      ContinuationToken=response['NextContinuationToken'])
+        objects.extend(response.get('Contents', []))
+    for obj in objects:
+        key = obj['Key']
+        # Strip the prefix to get the relative path
+        rel_path = key.lstrip('/')
+        parts = rel_path.split('/')
+        node = result
+        for part in parts[:-1]:
+            if part not in node:
+                node[part] = {}
+            node = node[part]
+        # Leaf: fetch content as bytes
+        content = s3.get_object(Bucket=bucket, Key=key)['Body'].read()
+        node[parts[-1]] = content
+    return result
+
+# Test that an export of a table with data completes.
+# Test will fetch S3 files and verify that they contain expected items and that manifest files are correct.
+# Test for ION will skip S3 file content verification for now until we get python ion library set up for testing -
+#   directory content will still be verified and as will be manifest files.
+# Test is parameterized to run with both supported export formats and with/without S3 prefix.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+@pytest.mark.parametrize('s3_prefix_value', [None, 'dira/dirb/dirc'])
+@pytest.mark.parametrize('export_format_value', ['DYNAMODB_JSON', 'ION'])
+def test_export_with_data_full(dynamodb, s3_prefix_value, export_format_value):
+    with new_test_table(dynamodb,
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+    ) as table:
+        # Insert some items
+        inserted_items_as_text = []
+
+        num_items = 10
+        for i in range(num_items):
+            table.put_item(Item={'p': f'item{i}',
+                                 'd01': f'value{i}',
+                                 'd02': (i + 10),
+                                 'd03': b"qwerty" + str(i).encode('utf-8'),
+                                 'd04': { 'a' + str(i), 'b' + str(i), 'c' + str(i) },
+                                 'd05': { decimal.Decimal(1.5 + i), decimal.Decimal(2.5 + i), decimal.Decimal(3.875 + i) },
+                                 'd06': { b'qwe' + str(i).encode('utf-8'), b'rty' + str(i).encode('utf-8'), b'abc' + str(i).encode('utf-8') },
+                                 'd07': { i:i - 10, i + 10: i - 20 },
+                                 'd08': { 'nested' + str(i): { 'v1' + str(i): 'v2' + str(i), 'v3' + str(i): 'v4' + str(i) } },
+                                 'd09': [ i + 5, 'qwerty' ],
+                                 'd10': None,
+                                 'd11': bool(i & 1 == 0),
+                                 })
+
+            # Note: sets are not ordered, so for text-based comparison we will sort them here.
+            # The same fields loaded from export files will be sorted as well.
+            item = {"Item":{
+                'p': { 'S':f'item{i}' },
+                'd01': { 'S':f'value{i}' },
+                'd02': { 'N':f'{i + 10}' },
+                'd03': { 'B': base64.b64encode(b'qwerty' + str(i).encode('utf-8')).decode('utf-8') },
+                'd04': { 'SS': list(sorted(( 'a' + str(i), 'b' + str(i), 'c' + str(i) )) ) },
+                'd05': { 'NS': list(sorted(( str(decimal.Decimal(1.5 + i)), str(decimal.Decimal(2.5 + i)), str(decimal.Decimal(3.875 + i)) )) ) },
+                'd06': { 'BS': list(sorted((
+                    base64.b64encode(b'qwe' + str(i).encode('utf-8')).decode('utf-8'),
+                    base64.b64encode(b'rty' + str(i).encode('utf-8')).decode('utf-8'),
+                    base64.b64encode(b'abc' + str(i).encode('utf-8')).decode('utf-8')
+                )) ) },
+                'd07': { 'M': { str(i): { 'N': str(i - 10) }, str(i + 10): { 'N': str(i - 20) } } },
+                'd08': { 'M': { 'nested' + str(i): { 'M': { 'v1' + str(i): { 'S': 'v2' + str(i) }, 'v3' + str(i): { 'S': 'v4' + str(i) } } } } },
+                'd09': { 'L': [ { 'N': str(i + 5) }, { 'S': 'qwerty' } ] },
+                'd10': { 'NULL': True },
+                'd11': { 'BOOL': bool(i & 1 == 0) },
+            }}
+
+            #  we insert items as text, because text lines can be sorted.
+            inserted_items_as_text.append(json.dumps(item, indent=None, sort_keys=True))
+
+        client = enable_pitr(table)
+        table_arn = get_table_arn(table)
+        s3 = make_s3_client(dynamodb)
+
+        with new_s3_bucket(s3) as bucket:
+            # Initialize an export
+            args = {}
+            if s3_prefix_value is not None:
+                args['S3Prefix'] = s3_prefix_value
+            response = client.export_table_to_point_in_time(
+                TableArn=table_arn,
+                S3Bucket=bucket,
+                ExportFormat=export_format_value,
+                **args
+            )
+
+
+            # Wait for a completion of the export (successful).
+            final = wait_for_export(client, response['ExportDescription']['ExportArn'])
+            assert final['ExportStatus'] == 'COMPLETED'
+            assert final['ItemCount'] == num_items
+
+            # Download all exported files as a in-memory dictionary representing a directory structure.
+            root_dir = downloaded_root_dir = fetch_all_exported_items(s3, bucket)
+
+            def simplify_downloaded_dir(dr):
+                for k, v in dr.items():
+                    if isinstance(v, dict):
+                        simplify_downloaded_dir(v)
+                    else:
+                        dr[k] = ''
+
+            if s3_prefix_value:
+                # Every entry must start with `s3_prefix_value`
+                for p in s3_prefix_value.split('/'):
+                    if p not in root_dir:
+                        # Something is wrong, so we will print whole tree for easier debugging.
+                        # since values in the tree contain a lot of data, which is not really useful,
+                        # we update all values to an empty string.
+                        simplify_downloaded_dir(downloaded_root_dir)
+                        assert p in root_dir, downloaded_root_dir
+                    root_dir = root_dir[p]
+            def get_content_by_path(pth):
+                if pth.startswith('/'):
+                    pth = pth[1:]
+                parts = pth.split('/')
+                node = downloaded_root_dir
+                for part in parts:
+                    assert part in node, f"Path {pth} not found in exported files"
+                    node = node[part]
+                assert type(node) is bytes, f"Path {pth} is expected to be a file but is a {type(node)}"
+                return node
+
+            # We're expecting this directory structure:
+            # AWSDynamoDB/<some-unique-str>/
+            #                    data/
+            #                         <unique-string>.json.gz # note - files might be empty
+            #                         <unique-string>.json.gz
+            #                         <unique-string>.json.gz
+            #                         <unique-string>.json.gz
+            #                         ...
+            #                    manifest-files.json
+            #                    manifest-files.md5
+            #                    manifest-summary.json
+            #                    manifest-summary.md5
+            #                    _started
+            # Note: this test was run against real AWS export and this structure was observed.
+
+            # Validate downloaded directory structure.
+
+            # Must start with `AWSDynamoDB`
+            assert set(root_dir.keys()) == { 'AWSDynamoDB' }
+            root_dir = root_dir['AWSDynamoDB']
+
+            # Next is some unique-str (randomly choosen by AWS) - there must be an single entry, so we just take it.
+            assert len(root_dir) == 1
+            root_dir = next(iter(root_dir.values()))
+
+            # Top level content directory (the one with `data` and `_started`)
+            assert set(root_dir.keys()) == { 'data', 'manifest-files.json', 'manifest-files.md5', 'manifest-summary.json', 'manifest-summary.md5', '_started' }
+
+            data_dir = root_dir['data']
+            items = []
+
+            # Helper to sort a field in a nested dictionary by a dot-separated path. This is used to sort sets (SS, NS, BS) before comparing exported items with inserted items.
+            # AWS will return sets in a random order.
+            def sort_field(obj, field_path):
+                field_list = field_path.split('.')
+                for f in field_list[:-1]:
+                    obj = obj.get(f, None)
+                    if type(obj) is not dict:
+                        # We will return here - something is wrong as we can't find our object
+                        # but the text comparison assert will fail as well and printed object there should be easier to decipher.
+                        return
+                val = obj[field_list[-1]]
+                if type(val) is list:
+                    val = list(sorted(val))
+                    obj[field_list[-1]] = val
+
+            # There might be any number of files and some of them might be empty, we need to read them all to verify that they contain the expected items.
+            # We also need to count items in each file to verify manifest file later on.
+            item_count_map = collections.defaultdict(int)
+            for data_file, data_file_content in data_dir.items():
+                # For now we validate content file only for json format.
+                if export_format_value == 'DYNAMODB_JSON':
+                    # Decipher and read file with items. Insert read items into `items` list and count them in `item_count_map`.
+                    assert data_file.endswith('.json.gz')
+
+                    content = gzip.decompress(data_file_content).decode('utf-8')
+                    for line in content.splitlines():
+                        line = line.strip()
+                        js = json.loads(line)
+                        # Note: sets are not ordered, so we will sort them here before text comparison.
+                        sort_field(js, 'Item.d04.SS')
+                        sort_field(js, 'Item.d05.NS')
+                        sort_field(js, 'Item.d06.BS')
+
+                        items.append(json.dumps(js, indent=None, sort_keys=True))
+                        item_count_map[data_file] += 1
+                else:
+                    assert data_file.endswith('.ion.gz')
+
+
+            # We've read all files with data content, so `items` should contain all items exported and `item_count_map` should contain count of items in each file
+            # (that will be checked later).
+            # For now we validate content file only for json format.
+            if export_format_value == 'DYNAMODB_JSON':
+                # we assert with message here, as pytest will shorten output of `items` and `inserted_items_as_text` if the assert fails and even `-vv` sometimes doesn't help.
+                assert set(items) == set(inserted_items_as_text), f"items1: {list(sorted(items))}\nitems2: {list(sorted(inserted_items_as_text))}"
+
+            def calculate_md5(content):
+                h = hashlib.md5()
+                if type(content) is str:
+                    content = content.encode('utf-8')
+                h.update(content)
+                return base64.b64encode(h.digest())
+
+            # Verify two main manifest files in `data` directory (each has their own md5 file).
+            for path1, path2 in (
+                ('manifest-files.json', 'manifest-files.md5'),
+                ('manifest-summary.json', 'manifest-summary.md5'),
+            ):
+                expected_md5 = root_dir[path2].strip()
+                calculated_md5 = calculate_md5(root_dir[path1])
+                assert calculated_md5 == expected_md5, f"{calculated_md5} != {expected_md5} for file {path1}"
+
+            # Verify main manifest files content.
+            manifest_files_json = root_dir['manifest-files.json'].decode('utf-8')
+            total_real_item_count = 0
+            for line in manifest_files_json.splitlines():
+                js = json.loads(line.strip())
+                assert 'itemCount' in js
+                assert 'dataFileS3Key' in js
+                assert 'etag' in js
+                assert 'md5Checksum' in js
+
+                # Path to the data file seems to be relative from bucket root and should start with `<optionally s3_prefix_value/>AWSDynamoDB/`.
+                # The path itself is verified by the call to `get_content_by_path` later on.
+                p = js['dataFileS3Key']
+                if s3_prefix_value is None:
+                    assert p.startswith('AWSDynamoDB/')
+                else:
+                    t = s3_prefix_value + ('' if s3_prefix_value.endswith('/') else '/')
+                    assert p.startswith(t + 'AWSDynamoDB/')
+
+                # We counted items in each file while reading them, now we verify that the count matches the manifest file.
+                # This is done only for json export format.
+                if export_format_value == 'DYNAMODB_JSON':
+                    real_item_count = item_count_map[p.split('/')[-1]]
+                    assert js['itemCount'] == real_item_count
+                    total_real_item_count += real_item_count
+                assert js['etag']
+
+                # There is md5 file for each data file, we verify that the md5 in manifest matches the calculated md5 of the downloaded file.
+                md5_checksum = js['md5Checksum'].encode('utf-8')
+                assert md5_checksum
+                calculated_md5 = calculate_md5(get_content_by_path(p))
+                assert calculated_md5 == md5_checksum, f"{calculated_md5} != {md5_checksum} for file {p}"
+
+            # Verify total item count in manifest files matches the number of items inserted into the table.
+            # We count items only with json export format.
+            if export_format_value == 'DYNAMODB_JSON':
+                assert total_real_item_count == num_items
+
+            # Read and verify manifest-summary.json file.
+            manifest_summary_json = root_dir['manifest-summary.json'].decode('utf-8')
+            manifest_summary = json.loads(manifest_summary_json)
+            assert 'version' in manifest_summary
+            assert 'exportArn' in manifest_summary
+            assert manifest_summary['exportArn'] == final['ExportArn']
+            assert 'startTime' in manifest_summary
+            assert 'endTime' in manifest_summary
+
+            start_time = datetime.datetime.fromisoformat(manifest_summary['startTime'])
+            end_time = datetime.datetime.fromisoformat(manifest_summary['endTime'])
+            assert start_time < end_time
+            # This is only few items on test instance, so 1h seems reasonable.
+            assert end_time - start_time < datetime.timedelta(hours=1)
+
+            assert 'tableArn' in manifest_summary
+            assert manifest_summary['tableArn'] == table_arn
+
+            assert 'tableId' in manifest_summary
+            assert 'exportTime' in manifest_summary
+
+            export_time = datetime.datetime.fromisoformat(manifest_summary['exportTime'])
+
+            # The export time should be close to the start time (certainly within a day, but let's be more strict and require it to be within an hour).
+            # It's unclear if export_time must be before (or equal) to start_time, so we don't check it.
+            assert start_time - export_time < datetime.timedelta(hours=1)
+
+            assert 's3Bucket' in manifest_summary
+            assert manifest_summary['s3Bucket'] == bucket
+
+            assert 's3Prefix' in manifest_summary
+            assert 's3SseAlgorithm' in manifest_summary
+            assert 's3SseKmsKeyId' in manifest_summary
+            assert 'manifestFilesS3Key' in manifest_summary
+            assert get_content_by_path(manifest_summary['manifestFilesS3Key']) == root_dir['manifest-files.json']
+
+            assert 'billedSizeBytes' in manifest_summary
+            assert manifest_summary['billedSizeBytes'] >= 0
+
+            assert 'itemCount' in manifest_summary
+            assert manifest_summary['itemCount'] == num_items
+
+            assert 'outputFormat' in manifest_summary
+            assert manifest_summary['outputFormat'] == export_format_value
+
+# Test that sending the same ClientToken twice returns the same export.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_client_token_idempotent(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+
+    with new_s3_bucket(s3) as bucket:
+        resp1 = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+            ClientToken=token,
+        )
+        resp2 = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+            ClientToken=token,
+        )
+        assert resp1['ExportDescription']['ExportArn'] == resp2['ExportDescription']['ExportArn']
+        assert resp1['ExportDescription']['ClientToken'] == resp2['ExportDescription']['ClientToken'] == token
+        wait_for_export(client, resp1['ExportDescription']['ExportArn'])
+
+
+# Following tests check idempotency of export with respect to ClientToken - they verify that
+# if we change some parameter of the export but keep the same ClientToken,
+# the second call will fail with ExportConflictException.
+# Note: we postpone test for `S3SseKmsKeyId` (due to complexity of setting up KMS)
+
+# Test that trying to export a different table reusing the same client token fails with ExportConflictException.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_client_token_changed_export_format(dynamodb, test_table_s, test_table_s_2):
+    client1 = enable_pitr(test_table_s)
+    table_arn1 = get_table_arn(test_table_s)
+    client2 = enable_pitr(test_table_s_2)
+    table_arn2 = get_table_arn(test_table_s_2)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+
+    with new_s3_bucket(s3) as bucket:
+        client1.export_table_to_point_in_time(
+            TableArn=table_arn1,
+            S3Bucket=bucket,
+            ExportFormat='DYNAMODB_JSON',
+            ClientToken=token,
+        )
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            client2.export_table_to_point_in_time(
+                TableArn=table_arn2,
+                S3Bucket=bucket,
+                ExportFormat='DYNAMODB_JSON',
+                ClientToken=token,
+                )
+
+
+# Test that trying to export the table twice using the same client token but changing some parameter value fails with ExportConflictException.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+@pytest.mark.parametrize("param_values", [
+    ('ExportFormat', 'DYNAMODB_JSON', 'ION'),
+    ('S3Bucket', unique_bucket_name(), unique_bucket_name() + 'A' ),
+    ('S3BucketOwner', None, '000000000000'),
+    ('S3Prefix', None, 'prefix' ),
+    ('S3SseAlgorithm', 'AES256', 'KMS'),
+])
+def test_export_client_token_some_value_changed(dynamodb, test_table_s, param_values):
+    client1 = enable_pitr(test_table_s)
+    table_arn1 = get_table_arn(test_table_s)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+    param_name, first_param_value, second_param_value = param_values
+
+    with new_s3_bucket(s3, bucket_name=(first_param_value if param_name == 'S3Bucket' else None)) as bucket:
+        kwargs = {
+            'S3Bucket': bucket,
+        }
+        kwargs[param_name] = first_param_value
+        client1.export_table_to_point_in_time(
+            TableArn=table_arn1,
+            ClientToken=token,
+            **kwargs
+        )
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            kwargs = {
+                'S3Bucket': bucket,
+            }
+            kwargs[param_name] = second_param_value
+            client1.export_table_to_point_in_time(
+                TableArn=table_arn1,
+                ClientToken=token,
+                **kwargs
+            )
+
+
+# Test that setting fields to unsupported, weird values fail with consistent error.
+# (<exception name>, <field name>, <error text>, <value>)
+# exception name - Name of the exception, that should be raised
+# field name - Name of the field that should be set to an invalid value
+# error text - Text of the error message that should be raised
+# value - value that should be set to the field. If None, the field will be not set at all.
+# Both <exception name> and <error text> are must appear in the error message, first <exception name>, then (after possibly some text) <error text>.
+# We can't add ExportArn field testing here - boto3 raises strange exception (looks like a bug in boto3).
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+@pytest.mark.parametrize('exception_field_error_and_value', [
+    ('ValidationException', 'ExportType', 'exportType', 'QWERTY'),
+    ('ValidationException', 'ExportType', 'exportType', ''),
+    ('ValidationException', 'ClientToken', 'clientToken', ''),
+    ('ValidationException', 'ExportFormat', 'exportFormat', ''),
+    ('ValidationException', 'ExportFormat', 'exportFormat', 'QWERTY'),
+    ('InvalidExportTimeException', 'ExportTime', 'Export Time', -1),
+    ('ValidationException', 'S3Prefix', 's3Prefix', ''),
+    ('ValidationException', 'S3Prefix', 's3Prefix', '\t'),
+    ('ValidationException', 'S3Bucket', 's3Bucket', ''),
+    ('ValidationException', 'S3Bucket', 's3Bucket', None),
+    ('ValidationException', 'S3Bucket', 's3Bucket', '\t'),
+    ('ValidationException', 'TableArn', 'TableArn', None),
+    ('ValidationException', 'TableArn', 'TableArn', ''),
+    ('ValidationException', 'TableArn', 'tableArn', '\t'),
+    ('ValidationException', 'TableArn', 'tableArn', 'QWERTY'),
+    ('ValidationException', 'S3BucketOwner', 's3BucketOwner', ''),
+    ('ValidationException', 'S3BucketOwner', 's3BucketOwner', 'QWERTY'),
+    ('ValidationException', 'S3SseAlgorithm', 's3SseAlgorithm', ''),
+    ('ValidationException', 'S3SseAlgorithm', 's3SseAlgorithm', 'QWERTY'),
+])
+def test_export_setting_fields_to_weird_values_or_skipping_fail(dynamodb, test_table_s, exception_field_error_and_value):
+    client = enable_pitr(test_table_s)
+    table_arn = get_table_arn(test_table_s)
+    exception, field, error, value = exception_field_error_and_value
+    with pytest.raises(ClientError, match=f'{exception}.*{error}'):
+        kw = {
+            'TableArn': table_arn,
+            'S3Bucket': unique_bucket_name()
+        }
+        kw[field] = value
+        client.export_table_to_point_in_time(**{ k:v for k, v in kw.items() if v is not None })
+
+
+# The same as test_export_setting_fields_to_weird_values_or_skipping_fail but only for S3SseKmsKeyId field
+# as it requires S3SseAlgorithm to be set
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+@pytest.mark.parametrize('exception_field_error_and_value', [
+    ('ValidationException', 'S3SseKmsKeyId', 's3SseKmsKeyId', ''),
+])
+def test_export_setting_fields_to_weird_values_or_skipping_fail_for_S3SseKmsKeyId(dynamodb, test_table_s, exception_field_error_and_value):
+    client = enable_pitr(test_table_s)
+    table_arn = get_table_arn(test_table_s)
+    exception, field, error, value = exception_field_error_and_value
+    with pytest.raises(ClientError, match=f'{exception}.*{error}'):
+        kw = {
+            'TableArn': table_arn,
+            'S3Bucket': 'my-bucket',
+            'S3SseAlgorithm': 'KMS',
+        }
+        kw[field] = value
+        client.export_table_to_point_in_time(**{ k:v for k, v in kw.items() if v is not None })
+
+
+# Test that trying to export the table with incremental export specifications times (ExportFromTime and ExportToTime) too close to each other -
+# (less than 15 minutes) - should fail with InvalidExportTimeException
+@pytest.mark.xfail(reason="Not yet implemented on Scylla")
+def test_export_incremental_export_time_too_close(dynamodb, test_table_s):
+    client1 = enable_pitr(test_table_s)
+    table_arn1 = get_table_arn(test_table_s)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+    export_time = int(datetime.datetime.now().timestamp())
+    with new_s3_bucket(s3) as bucket:
+        with pytest.raises(ClientError, match='InvalidExportTimeException.*Difference between export period'):
+            client1.export_table_to_point_in_time(
+                TableArn=table_arn1,
+                S3Bucket=bucket,
+                ClientToken=token,
+                ExportType='INCREMENTAL_EXPORT',
+                IncrementalExportSpecification={
+                    'ExportFromTime': export_time - 2,
+                    'ExportToTime': export_time,
+                    'ExportViewType': 'NEW_IMAGE',
+                }
+            )
+
+
+# Test that trying to export the table twice using the same client token but different IncrementalExportSpecification fails with ExportConflictException.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_client_token_changed_incremental_export_spec_fields(dynamodb, test_table_s, test_table_s_2):
+    client1 = enable_pitr(test_table_s)
+    table_arn1 = get_table_arn(test_table_s)
+    client2 = enable_pitr(test_table_s_2)
+    table_arn2 = get_table_arn(test_table_s_2)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+    export_time = int(datetime.datetime.now().timestamp())
+    min_export_time_diff = 1
+
+    if is_aws(client1):
+        min_export_time_diff = 15 * 60
+        # Amazon requires from and to times to be at least 15 minutes apart and we can't set to time in the future, so we need to wait.
+        time.sleep(min_export_time_diff + 1)
+
+    with new_s3_bucket(s3) as bucket:
+        client1.export_table_to_point_in_time(
+            TableArn=table_arn1,
+            S3Bucket=bucket,
+            ClientToken=token,
+            ExportType='INCREMENTAL_EXPORT',
+            IncrementalExportSpecification={
+                'ExportFromTime': export_time,
+                'ExportToTime': export_time + min_export_time_diff + 1,
+                'ExportViewType': 'NEW_IMAGE',
+            }
+        )
+        # ExportFromTime is different
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            client2.export_table_to_point_in_time(
+                TableArn=table_arn1,
+                S3Bucket=bucket,
+                ClientToken=token,
+                ExportType='INCREMENTAL_EXPORT',
+                IncrementalExportSpecification={
+                    'ExportFromTime': export_time + 1,
+                    'ExportToTime': export_time + min_export_time_diff + 1,
+                    'ExportViewType': 'NEW_IMAGE',
+                }
+            )
+
+        # ExportToTime is different
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            client2.export_table_to_point_in_time(
+                TableArn=table_arn1,
+                S3Bucket=bucket,
+                ClientToken=token,
+                ExportType='INCREMENTAL_EXPORT',
+                IncrementalExportSpecification={
+                    'ExportFromTime': export_time,
+                    'ExportToTime': export_time + min_export_time_diff,
+                    'ExportViewType': 'NEW_IMAGE',
+                }
+            )
+
+        # ExportViewType is different
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            client2.export_table_to_point_in_time(
+                TableArn=table_arn1,
+                S3Bucket=bucket,
+                ClientToken=token,
+                ExportType='INCREMENTAL_EXPORT',
+                IncrementalExportSpecification={
+                    'ExportFromTime': export_time + 1,
+                    'ExportToTime': export_time + min_export_time_diff + 1,
+                    'ExportViewType': 'NEW_AND_OLD_IMAGES',
+                }
+            )
+
+
+# Test that starts two exports on the same table (no ClientToken)
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_two_exports_without_client_token(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        resp1 = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket
+        )
+        resp2 = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket
+        )
+        assert resp1['ExportDescription']['ExportArn'] != resp2['ExportDescription']['ExportArn']
+        wait_for_export(client, resp1['ExportDescription']['ExportArn'])
+        wait_for_export(client, resp2['ExportDescription']['ExportArn'])
+
+
+# Test that trying to export from two tables using the same client token fails.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_client_token_doesnt_work_on_two_tables(dynamodb, test_table_s, test_table_s_2):
+    client1 = enable_pitr(test_table_s)
+    table_arn1 = get_table_arn(test_table_s)
+    client2 = enable_pitr(test_table_s_2)
+    table_arn2 = get_table_arn(test_table_s_2)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+
+    with new_s3_bucket(s3) as bucket:
+        client1.export_table_to_point_in_time(
+            TableArn=table_arn1,
+            S3Bucket=bucket,
+            ClientToken=token,
+        )
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            client2.export_table_to_point_in_time(
+                TableArn=table_arn2,
+                S3Bucket=bucket,
+                ClientToken=token,
+            )
+
+# Test that exporting a nonexistent table returns TableNotFoundException.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_nonexistent_table(dynamodb, test_table_s):
+    client = dynamodb.meta.client
+    s3 = make_s3_client(dynamodb)
+    region = dynamodb.meta.client.meta.region_name
+    table_arn = get_table_arn(test_table_s)
+    account_id = table_arn.split(':')[4]
+    fake_arn = f'arn:aws:dynamodb:{region}:{account_id}:table/nonexistent_table_xyz'
+
+    with pytest.raises(ClientError, match='TableNotFoundException.*Table not found'):
+        client.export_table_to_point_in_time(
+            TableArn=fake_arn,
+            S3Bucket=unique_bucket_name(),
+        )
+
+
+# Test that exporting to a nonexistent S3 bucket fails.
+# This one is little different, as - it seems - DynamoDB actually accepts nonexistent bucket and starts the export,
+# returns the FAILED and an error message later on.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_nonexistent_bucket(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    fake_bucket = unique_bucket_name()
+
+    response = client.export_table_to_point_in_time(
+        TableArn=table_arn,
+        S3Bucket=fake_bucket,
+    )
+
+    export_arn = response['ExportDescription']['ExportArn']
+
+    desc = wait_for_export(client, export_arn)
+    assert desc['ExportArn'] == export_arn
+    assert desc['TableArn'] == table_arn
+    assert desc['S3Bucket'] == fake_bucket
+    assert desc['ExportStatus'] == 'FAILED'
+    assert desc['FailureCode'] == 'S3NoSuchBucket'
+    assert 'bucket does not exist' in desc['FailureMessage']
+
+    for ex in iterate_over_exports(client, table_arn):
+        if ex['ExportArn'] == export_arn:
+            assert ex['ExportStatus'] == 'FAILED'
+            break
+    else:
+        assert False, f"Export {export_arn} not found in list_exports"
+
+
+# Test that failed export that didn't start doesn't reserve ClientToken
+# and thus the same ClientToken can be used again for a new export.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_failed_does_not_reserve_client_token(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+
+    with pytest.raises(ClientError, match='ValidationException.*s3Bucket.*failed'):
+        client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket='',
+            ClientToken=token,
+        )
+
+    # We don't care about export result here, we just want to verify that ClientToken can be passed again to start a new export
+    # (the call did not raise an exception).
+    with new_s3_bucket(s3) as bucket:
+        client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+            ClientToken=token,
+        )
+
+# ---------------------------------------------------------------------------
+# DescribeExport tests
+# ---------------------------------------------------------------------------
+
+# Test that DescribeExport returns the full ExportDescription for a
+# known export.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_describe_export(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        response = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+        )
+        export_arn = response['ExportDescription']['ExportArn']
+
+        desc = client.describe_export(ExportArn=export_arn)['ExportDescription']
+        assert desc['ExportArn'] == export_arn
+        assert desc['TableArn'] == table_arn
+        assert desc['S3Bucket'] == bucket
+        assert desc['ExportStatus'] in ('IN_PROGRESS', 'COMPLETED')
+        assert 'StartTime' in desc
+        assert 'ExportFormat' in desc
+
+        wait_for_export(client, export_arn)
+
+        # this should return description with ExportStatus=COMPLETED and additional fields like EndTime, ExportManifest, ItemCount, BilledSizeBytes etc.
+        desc = client.describe_export(ExportArn=export_arn)['ExportDescription']
+        assert desc['ExportStatus'] == 'COMPLETED'
+        assert desc['ExportArn'] == export_arn
+        assert desc['TableArn'] == table_arn
+        assert 'EndTime' in desc
+        assert 'ExportManifest' in desc
+        assert 'ItemCount' in desc
+        assert 'BilledSizeBytes' in desc
+
+
+# Test that DescribeExport with a non-existent ARN returns ValidationException.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_describe_export_nonexistent(dynamodb, test_table_s):
+    client = dynamodb.meta.client
+    region = dynamodb.meta.client.meta.region_name
+    table_arn = get_table_arn(test_table_s)
+    account_id = table_arn.split(':')[4]
+    fake_arn = f'arn:aws:dynamodb:{region}:{account_id}:table/nonexistent_table_xyz'
+    with pytest.raises(ClientError, match='ValidationException.*Invalid Export ARN'):
+        client.describe_export(ExportArn=fake_arn)
+
+
+
+# Test that DescribeExport with a incorrect ARN returns ValidationException.
+# Note: this one is a bit tricky - AWS probably doesn't check for `arn:` prefix and we fail
+# on the same ValidationException as `test_describe_export_nonexistent` test.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+@pytest.mark.parametrize('fake_arn_error', [
+    ('qwerty:aws:dynamodb:us-east-1:000000000000:table/nonexistent_table_xyz', 'ValidationException.*Invalid Export ARN'),
+    ('arn:qwerty:dynamodb:us-east-1:000000000000:table/nonexistent_table_xyz', 'AccessDeniedException'),
+    ('arn:aws:qwerty:us-east-1:000000000000:table/nonexistent_table_xyz', 'AccessDeniedException'),
+    ('arn:aws:dynamodb:qwerty:000000000000:table/nonexistent_table_xyz', 'AccessDeniedException'),
+    ('arn:aws:dynamodb:us-east-1:qwerty:table/nonexistent_table_xyz', 'AccessDeniedException'),
+])
+def test_describe_export_incorrect_arns(dynamodb, fake_arn_error):
+    client = dynamodb.meta.client
+    fake_arn, error = fake_arn_error
+    with pytest.raises(ClientError, match=error):
+        client.describe_export(ExportArn=fake_arn)
+
+
+# ---------------------------------------------------------------------------
+# ListExports tests
+# ---------------------------------------------------------------------------
+
+# Test that ListExports returns an ExportSummaries list. In our case it must be empty
+# as we use it on a freshly created table.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_empty(dynamodb):
+    with new_test_table(dynamodb,
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+    ) as table:
+        client = table.meta.client
+        table_arn = get_table_arn(table)
+        response = client.list_exports(TableArn=table_arn)
+        assert 'ExportSummaries' in response
+        # The list should be empty for a freshly-created table
+        assert len(response['ExportSummaries']) == 0
+
+
+def iterate_over_exports(client, table_arn = None, max_results = None):
+    kwargs = {}
+    if table_arn is not None:
+        kwargs['TableArn'] = table_arn
+    if max_results is not None:
+        kwargs['MaxResults'] = max_results
+
+    while True:
+        response = client.list_exports(**kwargs)
+        results = response.get('ExportSummaries', ())
+        if max_results is not None:
+            assert len(results) <= max_results
+        yield from results
+
+        next_token = response.get('NextToken', None)
+        if not next_token:
+            break
+
+        kwargs['NextToken'] = response['NextToken']
+
+
+# Test that after starting an export, ListExports includes it.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_contains_export(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        response = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+        )
+        export_arn = response['ExportDescription']['ExportArn']
+
+        for e in iterate_over_exports(client, table_arn):
+            if e['ExportArn'] == export_arn:
+                break
+        else:
+            pytest.fail(f"Export {export_arn} not found in ListExports for table {table_arn}")
+
+
+# Test that ListExports without a TableArn filter returns results.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_no_table_filter(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        response = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+        )
+        export_arn = response['ExportDescription']['ExportArn']
+
+        # ListExports without TableArn should still include our export
+        for e in iterate_over_exports(client):
+            if e['ExportArn'] == export_arn:
+                break
+        else:
+            pytest.fail(f"Export {export_arn} not found in ListExports without TableArn filter")
+
+
+# Test that ListExports pagination via MaxResults and NextToken works.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_pagination(dynamodb):
+    max_tables = 10
+
+    created_tables = []
+    with ExitStack() as created_tables_context_manager:
+        for _ in range(max_tables):
+            created_tables.append(
+                created_tables_context_manager.enter_context(new_test_table(dynamodb,
+                    KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]))
+            )
+
+        export_arns = []
+        # Start multiple exports to the same bucket with different prefixes
+        # Note: we intentionally use the fake bucket, as it starts the export,
+        # but fails it almost immediately, drastically reducing test runtime.
+        # The exports will still be present in ListExports results (with status FAILED),
+        # which is enough for testing pagination.
+        for table in created_tables:
+            client = enable_pitr(table)
+            table_arn = get_table_arn(table)
+            resp = client.export_table_to_point_in_time(
+                TableArn=table_arn,
+                S3Bucket=unique_bucket_name(),
+                S3Prefix=f'prefix-{uuid.uuid4()}',
+                ClientToken=str(uuid.uuid4()),
+            )
+            export_arns.append(resp['ExportDescription']['ExportArn'])
+
+        # List with max_results set to 4, so we get some pagination.
+        all_arns_by_table = collections.defaultdict(list)
+        all_arns = set()
+        for summary in iterate_over_exports(client, max_results=4):
+            assert 'ExportArn' in summary
+            sm = summary["ExportArn"]
+            all_arns.add(sm)
+
+            # It seems ARNS are reversed (newest first), but only for the same table
+            x = sm.find('/export/')
+            assert x >= 0, sm
+            arn_up_to_table = sm[:x]
+            t = all_arns_by_table[arn_up_to_table]
+            assert not t or summary['ExportArn'] < t[-1], (sm, t)
+            t.append(sm)
+
+        # we're not filtering, so we will get more stuff in the list, but at least all our exports should be there
+        assert len(export_arns) <= len(all_arns)
+        assert set(export_arns).issubset(set(all_arns))
+
+
+# Test that ExportSummary from ListExports contains the expected
+# fields: ExportArn, ExportStatus, ExportType.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_summary_fields(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        resp = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+        )
+        export_arn = resp['ExportDescription']['ExportArn']
+        wait_for_export(client, export_arn)
+
+        for summary in iterate_over_exports(client, table_arn):
+            if summary['ExportArn'] == export_arn:
+                assert 'ExportArn' in summary
+                assert 'ExportStatus' in summary
+                assert summary['ExportStatus'] == 'COMPLETED'
+                assert 'ExportType' in summary
+                assert summary['ExportType'] == 'FULL_EXPORT'
+                break
+        else:
+            pytest.fail(f"Export {export_arn} not found in ListExports for table {table_arn}")

--- a/test/alternator/test_export.py
+++ b/test/alternator/test_export.py
@@ -1,0 +1,1225 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+# Tests for the DynamoDB ExportTableToPointInTime, DescribeExport, and
+# ListExports APIs (part of SCYLLADB-1939).
+
+import base64
+import collections
+import logging
+from urllib import response
+
+import pytest
+import boto3
+import time
+import uuid
+import json
+import hashlib
+import datetime
+import gzip
+import decimal
+
+from botocore.exceptions import ClientError
+from contextlib import contextmanager, ExitStack
+
+from test.alternator.util import is_aws, new_test_table
+
+# NOTE: tests here use `pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")` as xfail marker as the implementation is ongoing.
+# The tests will pass against AWS.
+
+# Helper to check if table is deleted.
+def is_table_deleted(dynamodb, table_name: str) -> bool:
+    try:
+        dynamodb.describe_table(TableName=table_name)
+        return False  # table still exists (or is in DELETING/ACTIVE/etc.)
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'ResourceNotFoundException':
+            return True
+        raise
+
+# Helper to get the table ARN from a table object.
+def get_table_arn(table):
+    desc = table.meta.client.describe_table(TableName=table.name)
+    return desc['Table']['TableArn']
+
+
+# Helper to create a unique S3 bucket name.
+def unique_bucket_name():
+    return f"alternator-export-test-{uuid.uuid4().hex[:12]}"
+
+
+# Create an S3 client using the same endpoint configuration as the DynamoDB
+# fixture where possible. On AWS, the default S3 client is used. On Scylla,
+# we will use MinIo (or something similar capable of pretending S3).
+# The code has branch to handle both cases, but the MinIo path is not covered as
+# Scylla implementation is not ready - it's here as a placeholder.
+def make_s3_client(dynamodb):
+    if is_aws(dynamodb):
+        return boto3.client('s3')
+    # Placeholder for MinIo configuration for local Scylla testing.
+    assert False, "MinIo S3 client configuration for local Scylla testing is not implemented yet"
+
+
+# Attach an explicit Deny on PutObject so an in-progress DynamoDB export
+# cannot recreate objects while we purge the bucket. Delete/List are left
+# alone, so cleanup still works with our own credentials.
+def block_bucket_writes_on_s3(s3_client, bucket_name):
+    policy = {
+        'Version': '2012-10-17',
+        'Statement': [{
+            'Sid': 'BlockWrites',
+            'Effect': 'Deny',
+            'Principal': '*',
+            'Action': ['s3:PutObject', 's3:PutObjectAcl'],
+            'Resource': f'arn:aws:s3:::{bucket_name}/*',
+        }],
+    }
+    s3_client.put_bucket_policy(Bucket=bucket_name, Policy=json.dumps(policy))
+
+# Context manager that creates a uniquely-named S3 bucket and deletes it (including all objects) on exit.
+@contextmanager
+def new_s3_bucket(s3_client, bucket_name=None):
+    if bucket_name is None:
+        bucket_name = unique_bucket_name()
+    region = s3_client.meta.region_name
+    kwargs: dict = {'Bucket': bucket_name}
+    # us-east-1 does not accept a LocationConstraint - in other words if you want `us-east-1` bucket, you need to omit `LocationConstraint` entirely,
+    # in all other cases supply `LocationConstraint` - this is AWS quirk.
+    if region and region != 'us-east-1':
+        kwargs['CreateBucketConfiguration'] = {'LocationConstraint': region}
+    s3_client.create_bucket(**kwargs)
+    try:
+        yield bucket_name
+    finally:
+        # We will try hard to cleanup on AWS (leftovers are costly)
+        # We don't care for local (Minio or similar) - cleanup is not critical there.
+        if is_aws(s3_client):
+            # An export may still be running and writing into this bucket; deny
+            # further writes first so the purge below cannot race with it.
+            try:
+                block_bucket_writes_on_s3(s3_client, bucket_name)
+            except ClientError as ce:
+                logging.error("Failed to block bucket writes on S3 for bucket %s: %s", bucket_name, ce)
+                # Not yet fatal - fall through to the retry loop below.
+
+            # Delete all objects before deleting the bucket
+            deadline = time.time() + 60 # 60-second timeout for bucket deletion
+            while time.time() < deadline:
+                paginator = s3_client.get_paginator('list_objects_v2')
+                for page in paginator.paginate(Bucket=bucket_name):
+                    if 'Contents' in page:
+                        s3_client.delete_objects(
+                            Bucket=bucket_name,
+                            Delete={'Objects': [{'Key': obj['Key']} for obj in page['Contents']]}
+                        )
+                try:
+                    s3_client.delete_bucket(Bucket=bucket_name)
+                    break
+                except ClientError as ce:
+                    if ce.response['Error']['Code'] != 'BucketNotEmpty':
+                        raise
+                    time.sleep(2)
+            else:
+                assert False, f"Failed to delete S3 bucket {bucket_name} within the timeout of 1 minute"
+
+# Helper: enable PITR on a table (required for ExportTableToPointInTime on
+# DynamoDB). Returns the client used.
+def enable_pitr(table, timeout=120):
+    client = table.meta.client
+
+    # We need to enable PITR on AWS, but not on scylla (in fact the call itself in scylla is not handled and will fail).
+    if not is_aws(table):
+        return client
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            client.update_continuous_backups(
+                TableName=table.name,
+                PointInTimeRecoverySpecification={'PointInTimeRecoveryEnabled': True}
+            )
+            break
+        except ClientError as e:
+            # After table creation there's a delay until PITR can be enabled (and then another delay
+            # until PITR is actually active) - the first delay is notified to the user by ContinuousBackupsUnavailableException
+            # exception. So we catch it here and try again.
+            if e.response['Error']['Code'] == 'ContinuousBackupsUnavailableException':
+                # This is run against AWS (see `if` above), which is slow, so no point in testing often
+                time.sleep(2)
+            else:
+                raise
+    else:
+        raise TimeoutError(f"UpdateContinuousBackups did not succeed on {table.name} within {timeout}s")
+    # Wait until PITR is actually active — there is a propagation delay on AWS.
+    while time.time() < deadline:
+        resp = client.describe_continuous_backups(TableName=table.name)
+        pitr = resp['ContinuousBackupsDescription'].get('PointInTimeRecoveryDescription', {})
+        if pitr.get('PointInTimeRecoveryStatus') == 'ENABLED':
+            return client
+        # This is run against AWS (see `if` above), which is slow, so no point in testing often
+        time.sleep(2)
+    raise TimeoutError(f"PITR did not become ENABLED on {table.name} within {timeout}s")
+
+
+# Helper: wait for an export to reach a terminal status (COMPLETED or FAILED).
+# My actual tests show export takes approximately 10-12 minutes on AWS hence hefty timeout.
+def wait_for_export(client, export_arn):
+    timeout = 60 * 60 if is_aws(client) else 60
+    sleep_time = 5 if is_aws(client) else 0.1
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        desc = client.describe_export(ExportArn=export_arn)['ExportDescription']
+        status = desc['ExportStatus']
+        if status in ('COMPLETED', 'FAILED'):
+            return desc
+        time.sleep(sleep_time)
+    raise TimeoutError(f"Export {export_arn} did not complete within {timeout}s")
+
+
+# ---------------------------------------------------------------------------
+# ExportTableToPointInTime tests
+# ---------------------------------------------------------------------------
+
+# Test that ExportTableToPointInTime starts an export and returns an
+# ExportDescription with expected fields.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_basic(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        response = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+        )
+        desc = response['ExportDescription']
+        assert 'ExportArn' in desc
+        assert desc['ExportStatus'] in ('IN_PROGRESS', 'COMPLETED')
+        assert desc['TableArn'] == table_arn
+        assert desc['S3Bucket'] == bucket
+
+        # Amazon returns an unique ClientToken in response, even if user did not supply one.
+        assert desc['ClientToken']
+
+        assert desc['ExportFormat'] == 'DYNAMODB_JSON'  # default format is DYNAMODB_JSON
+        assert 'ExportType' not in desc # default is FULL_EXPORT, but AWS does not return it in the response for some reason.
+        # Wait for completion and verify
+        final = wait_for_export(client, desc['ExportArn'])
+        assert final['ExportStatus'] == 'COMPLETED'
+        assert 'ExportType' not in final # default is FULL_EXPORT, but AWS does not return it in the response for some reason.
+
+
+# Test that ExportTableToPointInTime starts an export and then table is deleted,
+# after which ListExports will not return the export (with TableArn and TableId), but DescribeExport will work.
+# Amazon seems to delete the table asynchronously - after the delete request, the table exists for some time and export still goes on
+# (IN_PROGRESS status). Once the table gets actually deleted the export status (asynchronously) goes to FAILED / COMPLETED.
+# Note, that it's theoritically possible in this test to complete an export before the table actually gets deleted.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_start_and_delete_table(dynamodb):
+    s3 = make_s3_client(dynamodb)
+    with new_s3_bucket(s3) as bucket:
+        with new_test_table(dynamodb,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+        ) as table:
+            client = enable_pitr(table)
+            table_arn = get_table_arn(table)
+
+            response = client.export_table_to_point_in_time(
+                TableArn=table_arn,
+                S3Bucket=bucket,
+            )
+            desc = response['ExportDescription']
+            assert 'ExportArn' in desc
+            export_arn = desc['ExportArn']
+            assert desc['ExportStatus'] in ('IN_PROGRESS', 'COMPLETED')
+            assert desc['TableArn'] == table_arn
+            assert desc['S3Bucket'] == bucket
+            assert desc['ExportFormat'] == 'DYNAMODB_JSON'  # default format is DYNAMODB_JSON
+            assert 'ExportType' not in desc # default is FULL_EXPORT, but AWS does not return it in the response for some reason.
+
+        now = time.time()
+        while time.time() < now + 60:
+            if is_table_deleted(client, table.name):
+                break
+            time.sleep(2 if is_aws(client) else 0.1)
+        else:
+            assert False, f"Table {table.name} should be deleted after exiting the context manager"
+
+        # For some reason Amazon doesn't list the export in ListExports.
+        for ex in iterate_over_exports(client, table_arn):
+            if ex['ExportArn'] == export_arn:
+                assert False, f"Export {export_arn} found in list_exports"
+
+        desc = client.describe_export(ExportArn=export_arn)['ExportDescription']
+        assert desc['ExportArn'] == export_arn
+        assert desc['TableArn'] == table_arn
+        assert desc['S3Bucket'] == bucket
+        # We might be fast enough here to still get IN_PROGRESS (rare, but happens)
+        assert desc['ExportStatus'] in ('IN_PROGRESS', 'COMPLETED', 'FAILED')
+        assert 'StartTime' in desc
+        assert 'ExportFormat' in desc
+
+
+# Test that ExportTableToPointInTime starts an export and returns an
+# ExportDescription with expected fields. Wait for completion and verify that final description
+# is also valid.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_basic_with_export_type(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        response = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+            ExportType='FULL_EXPORT'
+        )
+        desc = response['ExportDescription']
+        assert 'ExportArn' in desc
+        assert desc['ExportStatus'] in ('IN_PROGRESS', 'COMPLETED')
+        assert desc['TableArn'] == table_arn
+        assert desc['S3Bucket'] == bucket
+        assert desc['ExportFormat'] == 'DYNAMODB_JSON'  # default format is DYNAMODB_JSON
+        assert desc['ExportType'] == 'FULL_EXPORT'
+        # Wait for completion and verify
+        final = wait_for_export(client, desc['ExportArn'])
+        assert final['ExportStatus'] == 'COMPLETED'
+        assert final['ExportType'] == 'FULL_EXPORT'
+
+
+def fetch_all_exported_items(s3, bucket):
+    result = {}
+    response = s3.list_objects_v2(Bucket=bucket)
+    objects = response.get('Contents', [])
+    while response.get('IsTruncated'):
+        response = s3.list_objects_v2(Bucket=bucket,
+                                      ContinuationToken=response['NextContinuationToken'])
+        objects.extend(response.get('Contents', []))
+    for obj in objects:
+        key = obj['Key']
+        # Strip the prefix to get the relative path
+        rel_path = key.lstrip('/')
+        parts = rel_path.split('/')
+        node = result
+        for part in parts[:-1]:
+            if part not in node:
+                node[part] = {}
+            node = node[part]
+        # Leaf: fetch content as bytes
+        content = s3.get_object(Bucket=bucket, Key=key)['Body'].read()
+        node[parts[-1]] = content
+    return result
+
+# Test that an export of a table with data completes.
+# Test will fetch S3 files and verify that they contain expected items and that manifest files are correct.
+# Test for ION will skip S3 file content verification for now until we get python ion library set up for testing -
+#   directory content will still be verified and as will be manifest files.
+# Test is parameterized to run with both supported export formats and with/without S3 prefix.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+@pytest.mark.parametrize('s3_prefix_value', [None, 'dira/dirb/dirc'])
+@pytest.mark.parametrize('export_format_value', ['DYNAMODB_JSON', 'ION'])
+def test_export_with_data_full(dynamodb, s3_prefix_value, export_format_value):
+    with new_test_table(dynamodb,
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+    ) as table:
+        # Insert some items
+        inserted_items_as_text = []
+
+        num_items = 10
+        for i in range(num_items):
+            table.put_item(Item={'p': f'item{i}',
+                                 'd01': f'value{i}',
+                                 'd02': (i + 10),
+                                 'd03': b"qwerty" + str(i).encode('utf-8'),
+                                 'd04': { 'a' + str(i), 'b' + str(i), 'c' + str(i) },
+                                 'd05': { decimal.Decimal(1.5 + i), decimal.Decimal(2.5 + i), decimal.Decimal(3.875 + i) },
+                                 'd06': { b'qwe' + str(i).encode('utf-8'), b'rty' + str(i).encode('utf-8'), b'abc' + str(i).encode('utf-8') },
+                                 'd07': { str(i):i - 10, str(i + 10): i - 20 },
+                                 'd08': { 'nested' + str(i): { 'v1' + str(i): 'v2' + str(i), 'v3' + str(i): 'v4' + str(i) } },
+                                 'd09': [ i + 5, 'qwerty' ],
+                                 'd10': None,
+                                 'd11': bool(i & 1 == 0),
+                                 })
+
+            # Note: sets are not ordered, so for text-based comparison we will sort them here.
+            # The same fields loaded from export files will be sorted as well.
+            item = {"Item":{
+                'p': { 'S':f'item{i}' },
+                'd01': { 'S':f'value{i}' },
+                'd02': { 'N':f'{i + 10}' },
+                'd03': { 'B': base64.b64encode(b'qwerty' + str(i).encode('utf-8')).decode('utf-8') },
+                'd04': { 'SS': list(sorted(( 'a' + str(i), 'b' + str(i), 'c' + str(i) )) ) },
+                'd05': { 'NS': list(sorted(( str(decimal.Decimal(1.5 + i)), str(decimal.Decimal(2.5 + i)), str(decimal.Decimal(3.875 + i)) )) ) },
+                'd06': { 'BS': list(sorted((
+                    base64.b64encode(b'qwe' + str(i).encode('utf-8')).decode('utf-8'),
+                    base64.b64encode(b'rty' + str(i).encode('utf-8')).decode('utf-8'),
+                    base64.b64encode(b'abc' + str(i).encode('utf-8')).decode('utf-8')
+                )) ) },
+                'd07': { 'M': { str(i): { 'N': str(i - 10) }, str(i + 10): { 'N': str(i - 20) } } },
+                'd08': { 'M': { 'nested' + str(i): { 'M': { 'v1' + str(i): { 'S': 'v2' + str(i) }, 'v3' + str(i): { 'S': 'v4' + str(i) } } } } },
+                'd09': { 'L': [ { 'N': str(i + 5) }, { 'S': 'qwerty' } ] },
+                'd10': { 'NULL': True },
+                'd11': { 'BOOL': bool(i & 1 == 0) },
+            }}
+
+            #  we insert items as text, because text lines can be sorted.
+            inserted_items_as_text.append(json.dumps(item, indent=None, sort_keys=True))
+
+        client = enable_pitr(table)
+        table_arn = get_table_arn(table)
+        s3 = make_s3_client(dynamodb)
+
+        with new_s3_bucket(s3) as bucket:
+            # Initialize an export
+            args = {}
+            if s3_prefix_value is not None:
+                args['S3Prefix'] = s3_prefix_value
+            response = client.export_table_to_point_in_time(
+                TableArn=table_arn,
+                S3Bucket=bucket,
+                ExportFormat=export_format_value,
+                **args
+            )
+
+
+            # Wait for a completion of the export (successful).
+            final = wait_for_export(client, response['ExportDescription']['ExportArn'])
+            assert final['ExportStatus'] == 'COMPLETED'
+            assert final['ItemCount'] == num_items
+
+            # Download all exported files as a in-memory dictionary representing a directory structure.
+            root_dir = downloaded_root_dir = fetch_all_exported_items(s3, bucket)
+
+            def simplify_downloaded_dir(dr):
+                for k, v in dr.items():
+                    if isinstance(v, dict):
+                        simplify_downloaded_dir(v)
+                    else:
+                        dr[k] = ''
+
+            if s3_prefix_value:
+                # Every entry must start with `s3_prefix_value`
+                for p in s3_prefix_value.split('/'):
+                    if p not in root_dir:
+                        # Something is wrong, so we will print whole tree for easier debugging.
+                        # since values in the tree contain a lot of data, which is not really useful,
+                        # we update all values to an empty string.
+                        simplify_downloaded_dir(downloaded_root_dir)
+                        assert p in root_dir, downloaded_root_dir
+                    root_dir = root_dir[p]
+            def get_content_by_path(pth):
+                if pth.startswith('/'):
+                    pth = pth[1:]
+                parts = pth.split('/')
+                node = downloaded_root_dir
+                for part in parts:
+                    assert part in node, f"Path {pth} not found in exported files"
+                    node = node[part]
+                assert type(node) is bytes, f"Path {pth} is expected to be a file but is a {type(node)}"
+                return node
+
+            # We're expecting this directory structure:
+            # AWSDynamoDB/<some-unique-str>/
+            #                    data/
+            #                         <unique-string>.json.gz # note - files might be empty
+            #                         <unique-string>.json.gz
+            #                         <unique-string>.json.gz
+            #                         <unique-string>.json.gz
+            #                         ...
+            #                    manifest-files.json
+            #                    manifest-files.md5
+            #                    manifest-summary.json
+            #                    manifest-summary.md5
+            #                    _started
+            # Note: this test was run against real AWS export and this structure was observed.
+
+            # Validate downloaded directory structure.
+
+            # Must start with `AWSDynamoDB`
+            assert set(root_dir.keys()) == { 'AWSDynamoDB' }
+            root_dir = root_dir['AWSDynamoDB']
+
+            # Next is some unique-str (randomly choosen by AWS) - there must be an single entry, so we just take it.
+            assert len(root_dir) == 1
+            root_dir = next(iter(root_dir.values()))
+
+            # Top level content directory (the one with `data` and `_started`)
+            assert set(root_dir.keys()) == { 'data', 'manifest-files.json', 'manifest-files.md5', 'manifest-summary.json', 'manifest-summary.md5', '_started' }
+
+            data_dir = root_dir['data']
+            items = []
+
+            # Helper to sort a field in a nested dictionary by a dot-separated path. This is used to sort sets (SS, NS, BS) before comparing exported items with inserted items.
+            # AWS will return sets in a random order.
+            def sort_field(obj, field_path):
+                field_list = field_path.split('.')
+                for f in field_list[:-1]:
+                    obj = obj.get(f, None)
+                    if type(obj) is not dict:
+                        # We will return here - something is wrong as we can't find our object
+                        # but the text comparison assert will fail as well and printed object there should be easier to decipher.
+                        return
+                val = obj[field_list[-1]]
+                if type(val) is list:
+                    val = list(sorted(val))
+                    obj[field_list[-1]] = val
+
+            # There might be any number of files and some of them might be empty, we need to read them all to verify that they contain the expected items.
+            # We also need to count items in each file to verify manifest file later on.
+            item_count_map = collections.defaultdict(int)
+            for data_file, data_file_content in data_dir.items():
+                # For now we validate content file only for json format.
+                if export_format_value == 'DYNAMODB_JSON':
+                    # Decipher and read file with items. Insert read items into `items` list and count them in `item_count_map`.
+                    assert data_file.endswith('.json.gz')
+
+                    content = gzip.decompress(data_file_content).decode('utf-8')
+                    for line in content.splitlines():
+                        line = line.strip()
+                        js = json.loads(line)
+                        # Note: sets are not ordered, so we will sort them here before text comparison.
+                        sort_field(js, 'Item.d04.SS')
+                        sort_field(js, 'Item.d05.NS')
+                        sort_field(js, 'Item.d06.BS')
+
+                        items.append(json.dumps(js, indent=None, sort_keys=True))
+                        item_count_map[data_file] += 1
+                else:
+                    assert data_file.endswith('.ion.gz')
+
+
+            # We've read all files with data content, so `items` should contain all items exported and `item_count_map` should contain count of items in each file
+            # (that will be checked later).
+            # For now we validate content file only for json format.
+            if export_format_value == 'DYNAMODB_JSON':
+                # we assert with message here, as pytest will shorten output of `items` and `inserted_items_as_text` if the assert fails and even `-vv` sometimes doesn't help.
+                assert set(items) == set(inserted_items_as_text), f"items1: {list(sorted(items))}\nitems2: {list(sorted(inserted_items_as_text))}"
+
+            def calculate_md5(content):
+                h = hashlib.md5()
+                if type(content) is str:
+                    content = content.encode('utf-8')
+                h.update(content)
+                return base64.b64encode(h.digest())
+
+            # Verify two main manifest files in `data` directory (each has their own md5 file).
+            for path1, path2 in (
+                ('manifest-files.json', 'manifest-files.md5'),
+                ('manifest-summary.json', 'manifest-summary.md5'),
+            ):
+                expected_md5 = root_dir[path2].strip()
+                calculated_md5 = calculate_md5(root_dir[path1])
+                assert calculated_md5 == expected_md5, f"{calculated_md5} != {expected_md5} for file {path1}"
+
+            # Verify main manifest files content.
+            manifest_files_json = root_dir['manifest-files.json'].decode('utf-8')
+            total_real_item_count = 0
+            for line in manifest_files_json.splitlines():
+                js = json.loads(line.strip())
+                assert 'itemCount' in js
+                assert 'dataFileS3Key' in js
+                assert 'etag' in js
+                assert 'md5Checksum' in js
+
+                # Path to the data file seems to be relative from bucket root and should start with `<optionally s3_prefix_value/>AWSDynamoDB/`.
+                # The path itself is verified by the call to `get_content_by_path` later on.
+                p = js['dataFileS3Key']
+                if s3_prefix_value is None:
+                    assert p.startswith('AWSDynamoDB/')
+                else:
+                    t = s3_prefix_value + ('' if s3_prefix_value.endswith('/') else '/')
+                    assert p.startswith(t + 'AWSDynamoDB/')
+
+                # We counted items in each file while reading them, now we verify that the count matches the manifest file.
+                # This is done only for json export format.
+                if export_format_value == 'DYNAMODB_JSON':
+                    real_item_count = item_count_map[p.split('/')[-1]]
+                    assert js['itemCount'] == real_item_count
+                    total_real_item_count += real_item_count
+                assert js['etag']
+
+                # There is md5 file for each data file, we verify that the md5 in manifest matches the calculated md5 of the downloaded file.
+                md5_checksum = js['md5Checksum'].encode('utf-8')
+                assert md5_checksum
+                calculated_md5 = calculate_md5(get_content_by_path(p))
+                assert calculated_md5 == md5_checksum, f"{calculated_md5} != {md5_checksum} for file {p}"
+
+            # Verify total item count in manifest files matches the number of items inserted into the table.
+            # We count items only with json export format.
+            if export_format_value == 'DYNAMODB_JSON':
+                assert total_real_item_count == num_items
+
+            # Read and verify manifest-summary.json file.
+            manifest_summary_json = root_dir['manifest-summary.json'].decode('utf-8')
+            manifest_summary = json.loads(manifest_summary_json)
+            assert 'version' in manifest_summary
+            assert 'exportArn' in manifest_summary
+            assert manifest_summary['exportArn'] == final['ExportArn']
+            assert 'startTime' in manifest_summary
+            assert 'endTime' in manifest_summary
+
+            start_time = datetime.datetime.fromisoformat(manifest_summary['startTime'])
+            end_time = datetime.datetime.fromisoformat(manifest_summary['endTime'])
+            assert start_time < end_time
+            # This is only few items on test instance, so 1h seems reasonable.
+            assert end_time - start_time < datetime.timedelta(hours=1)
+
+            assert 'tableArn' in manifest_summary
+            assert manifest_summary['tableArn'] == table_arn
+
+            assert 'tableId' in manifest_summary
+            assert 'exportTime' in manifest_summary
+
+            export_time = datetime.datetime.fromisoformat(manifest_summary['exportTime'])
+
+            # The export time should be close to the start time (certainly within a day, but let's be more strict and require it to be within an hour).
+            # It's unclear if export_time must be before (or equal) to start_time, so we don't check it.
+            assert start_time - export_time < datetime.timedelta(hours=1)
+
+            assert 's3Bucket' in manifest_summary
+            assert manifest_summary['s3Bucket'] == bucket
+
+            assert 's3Prefix' in manifest_summary
+            assert 's3SseAlgorithm' in manifest_summary
+            assert 's3SseKmsKeyId' in manifest_summary
+            assert 'manifestFilesS3Key' in manifest_summary
+            assert get_content_by_path(manifest_summary['manifestFilesS3Key']) == root_dir['manifest-files.json']
+
+            assert 'billedSizeBytes' in manifest_summary
+            assert manifest_summary['billedSizeBytes'] >= 0
+
+            assert 'itemCount' in manifest_summary
+            assert manifest_summary['itemCount'] == num_items
+
+            assert 'outputFormat' in manifest_summary
+            assert manifest_summary['outputFormat'] == export_format_value
+
+# Test that sending the same ClientToken twice returns the same export.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_client_token_idempotent(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+
+    with new_s3_bucket(s3) as bucket:
+        resp1 = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+            ClientToken=token,
+        )
+        resp2 = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+            ClientToken=token,
+        )
+        assert resp1['ExportDescription']['ExportArn'] == resp2['ExportDescription']['ExportArn']
+        assert resp1['ExportDescription']['ClientToken'] == resp2['ExportDescription']['ClientToken'] == token
+
+
+# Following tests check idempotency of export with respect to ClientToken - they verify that
+# if we change some parameter of the export but keep the same ClientToken,
+# the second call will fail with ExportConflictException.
+# Note: we postpone test for `S3SseKmsKeyId` (due to complexity of setting up KMS)
+
+# Test that trying to export a different table reusing the same client token fails with ExportConflictException.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_client_token_changed_export_format(dynamodb, test_table_s, test_table_s_2):
+    client1 = enable_pitr(test_table_s)
+    table_arn1 = get_table_arn(test_table_s)
+    client2 = enable_pitr(test_table_s_2)
+    table_arn2 = get_table_arn(test_table_s_2)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+
+    with new_s3_bucket(s3) as bucket:
+        client1.export_table_to_point_in_time(
+            TableArn=table_arn1,
+            S3Bucket=bucket,
+            ExportFormat='DYNAMODB_JSON',
+            ClientToken=token,
+        )
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            client2.export_table_to_point_in_time(
+                TableArn=table_arn2,
+                S3Bucket=bucket,
+                ExportFormat='ION',
+                ClientToken=token,
+                )
+
+
+# Test that trying to export the table twice using the same client token but changing some parameter value fails with ExportConflictException.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+@pytest.mark.parametrize("param_values", [
+    ('ExportFormat', 'DYNAMODB_JSON', 'ION'),
+    ('S3Bucket', unique_bucket_name(), unique_bucket_name() + 'a' ),
+    ('S3BucketOwner', None, '000000000000'),
+    ('S3Prefix', None, 'prefix' ),
+    ('S3SseAlgorithm', 'AES256', 'KMS'),
+])
+def test_export_client_token_some_value_changed(dynamodb, test_table_s, param_values):
+    client1 = enable_pitr(test_table_s)
+    table_arn1 = get_table_arn(test_table_s)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+    param_name, first_param_value, second_param_value = param_values
+
+    with new_s3_bucket(s3, bucket_name=(first_param_value if param_name == 'S3Bucket' else None)) as bucket:
+        kwargs = {
+            'S3Bucket': bucket,
+        }
+        kwargs[param_name] = first_param_value
+        client1.export_table_to_point_in_time(
+            TableArn=table_arn1,
+            ClientToken=token,
+            **kwargs
+        )
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            kwargs = {
+                'S3Bucket': bucket,
+            }
+            kwargs[param_name] = second_param_value
+            client1.export_table_to_point_in_time(
+                TableArn=table_arn1,
+                ClientToken=token,
+                **kwargs
+            )
+
+
+# Test that setting fields to unsupported, weird values fail with consistent error.
+# (<exception name>, <field name>, <error text>, <value>)
+# exception name - Name of the exception, that should be raised
+# field name - Name of the field that should be set to an invalid value
+# error text - Text of the error message that should be raised
+# value - value that should be set to the field. If None, the field will be not set at all.
+# Both <exception name> and <error text> are must appear in the error message, first <exception name>, then (after possibly some text) <error text>.
+# We can't add ExportArn field testing here - boto3 raises strange exception (looks like a bug in boto3).
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+@pytest.mark.parametrize('exception_field_error_and_value', [
+    ('ValidationException', 'ExportType', 'exportType', 'QWERTY'),
+    ('ValidationException', 'ExportType', 'exportType', ''),
+    ('ValidationException', 'ClientToken', 'clientToken', ''),
+    ('ValidationException', 'ExportFormat', 'exportFormat', ''),
+    ('ValidationException', 'ExportFormat', 'exportFormat', 'QWERTY'),
+    ('InvalidExportTimeException', 'ExportTime', 'Export Time', -1),
+    ('ValidationException', 'S3Prefix', 's3Prefix', ''),
+    ('ValidationException', 'S3Prefix', 's3Prefix', '\t'),
+    ('ValidationException', 'S3Bucket', 's3Bucket', ''),
+    ('ValidationException', 'S3Bucket', 's3Bucket', None),
+    ('ValidationException', 'S3Bucket', 's3Bucket', '\t'),
+    ('ValidationException', 'TableArn', 'TableArn', None),
+    ('ValidationException', 'TableArn', 'TableArn', ''),
+    ('ValidationException', 'TableArn', 'tableArn', '\t'),
+    ('ValidationException', 'TableArn', 'tableArn', 'QWERTY'),
+    ('ValidationException', 'S3BucketOwner', 's3BucketOwner', ''),
+    ('ValidationException', 'S3BucketOwner', 's3BucketOwner', 'QWERTY'),
+    ('ValidationException', 'S3SseAlgorithm', 's3SseAlgorithm', ''),
+    ('ValidationException', 'S3SseAlgorithm', 's3SseAlgorithm', 'QWERTY'),
+])
+def test_export_setting_fields_to_weird_values_or_skipping_fail(dynamodb, test_table_s, exception_field_error_and_value):
+    client = enable_pitr(test_table_s)
+    table_arn = get_table_arn(test_table_s)
+    exception, field, error, value = exception_field_error_and_value
+    with pytest.raises(ClientError, match=f'{exception}.*{error}'):
+        kw = {
+            'TableArn': table_arn,
+            'S3Bucket': unique_bucket_name()
+        }
+        kw[field] = value
+        client.export_table_to_point_in_time(**{ k:v for k, v in kw.items() if v is not None })
+
+
+# The same as test_export_setting_fields_to_weird_values_or_skipping_fail but only for S3SseKmsKeyId field
+# as it requires S3SseAlgorithm to be set
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+@pytest.mark.parametrize('exception_field_error_and_value', [
+    ('ValidationException', 'S3SseKmsKeyId', 's3SseKmsKeyId', ''),
+])
+def test_export_setting_fields_to_weird_values_or_skipping_fail_for_S3SseKmsKeyId(dynamodb, test_table_s, exception_field_error_and_value):
+    client = enable_pitr(test_table_s)
+    table_arn = get_table_arn(test_table_s)
+    exception, field, error, value = exception_field_error_and_value
+    with pytest.raises(ClientError, match=f'{exception}.*{error}'):
+        kw = {
+            'TableArn': table_arn,
+            'S3Bucket': 'my-bucket',
+            'S3SseAlgorithm': 'KMS',
+        }
+        kw[field] = value
+        client.export_table_to_point_in_time(**{ k:v for k, v in kw.items() if v is not None })
+
+
+# Test that trying to export the table with incremental export specifications times (ExportFromTime and ExportToTime) too close to each other -
+# (less than 15 minutes) - should fail with InvalidExportTimeException
+@pytest.mark.xfail(reason="Not yet implemented on Scylla")
+def test_export_incremental_export_time_too_close(dynamodb, test_table_s):
+    client1 = enable_pitr(test_table_s)
+    table_arn1 = get_table_arn(test_table_s)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+    export_time = int(datetime.datetime.now().timestamp())
+    with new_s3_bucket(s3) as bucket:
+        with pytest.raises(ClientError, match='InvalidExportTimeException.*Difference between export period'):
+            client1.export_table_to_point_in_time(
+                TableArn=table_arn1,
+                S3Bucket=bucket,
+                ClientToken=token,
+                ExportType='INCREMENTAL_EXPORT',
+                IncrementalExportSpecification={
+                    'ExportFromTime': export_time - 2,
+                    'ExportToTime': export_time,
+                    'ExportViewType': 'NEW_IMAGE',
+                }
+            )
+
+
+# Test that trying to export the table twice using the same client token but different IncrementalExportSpecification fails with ExportConflictException.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_client_token_changed_incremental_export_spec_fields(dynamodb, test_table_s, test_table_s_2):
+    client1 = enable_pitr(test_table_s)
+    table_arn1 = get_table_arn(test_table_s)
+    client2 = enable_pitr(test_table_s_2)
+    table_arn2 = get_table_arn(test_table_s_2)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+    export_time = int(datetime.datetime.now().timestamp())
+    min_export_time_diff = 1
+
+    if is_aws(client1):
+        min_export_time_diff = 15 * 60
+        # Amazon requires from and to times to be at least 15 minutes apart and we can't set to time in the future, so we need to wait.
+        time.sleep(min_export_time_diff + 1)
+
+    with new_s3_bucket(s3) as bucket:
+        client1.export_table_to_point_in_time(
+            TableArn=table_arn1,
+            S3Bucket=bucket,
+            ClientToken=token,
+            ExportType='INCREMENTAL_EXPORT',
+            IncrementalExportSpecification={
+                'ExportFromTime': export_time,
+                'ExportToTime': export_time + min_export_time_diff + 1,
+                'ExportViewType': 'NEW_IMAGE',
+            }
+        )
+        # ExportFromTime is different
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            client2.export_table_to_point_in_time(
+                TableArn=table_arn1,
+                S3Bucket=bucket,
+                ClientToken=token,
+                ExportType='INCREMENTAL_EXPORT',
+                IncrementalExportSpecification={
+                    'ExportFromTime': export_time + 1,
+                    'ExportToTime': export_time + min_export_time_diff + 1,
+                    'ExportViewType': 'NEW_IMAGE',
+                }
+            )
+
+        # ExportToTime is different
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            client2.export_table_to_point_in_time(
+                TableArn=table_arn1,
+                S3Bucket=bucket,
+                ClientToken=token,
+                ExportType='INCREMENTAL_EXPORT',
+                IncrementalExportSpecification={
+                    'ExportFromTime': export_time,
+                    'ExportToTime': export_time + min_export_time_diff,
+                    'ExportViewType': 'NEW_IMAGE',
+                }
+            )
+
+        # ExportViewType is different
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            client2.export_table_to_point_in_time(
+                TableArn=table_arn1,
+                S3Bucket=bucket,
+                ClientToken=token,
+                ExportType='INCREMENTAL_EXPORT',
+                IncrementalExportSpecification={
+                    'ExportFromTime': export_time,
+                    'ExportToTime': export_time + min_export_time_diff + 1,
+                    'ExportViewType': 'NEW_AND_OLD_IMAGES',
+                }
+            )
+
+
+# Test that starts two exports on the same table (no ClientToken)
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_two_exports_without_client_token(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        resp1 = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket
+        )
+        resp2 = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket
+        )
+        assert resp1['ExportDescription']['ExportArn'] != resp2['ExportDescription']['ExportArn']
+
+
+# Test that trying to export from two tables using the same client token fails.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_client_token_doesnt_work_on_two_tables(dynamodb, test_table_s, test_table_s_2):
+    client1 = enable_pitr(test_table_s)
+    table_arn1 = get_table_arn(test_table_s)
+    client2 = enable_pitr(test_table_s_2)
+    table_arn2 = get_table_arn(test_table_s_2)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+
+    with new_s3_bucket(s3) as bucket:
+        client1.export_table_to_point_in_time(
+            TableArn=table_arn1,
+            S3Bucket=bucket,
+            ClientToken=token,
+        )
+        with pytest.raises(ClientError, match='ExportConflictException.*Duplicate request detected'):
+            client2.export_table_to_point_in_time(
+                TableArn=table_arn2,
+                S3Bucket=bucket,
+                ClientToken=token,
+            )
+
+# Test that exporting a nonexistent table returns TableNotFoundException.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_nonexistent_table(dynamodb, test_table_s):
+    client = dynamodb.meta.client
+    s3 = make_s3_client(dynamodb)
+    region = dynamodb.meta.client.meta.region_name
+    table_arn = get_table_arn(test_table_s)
+    account_id = table_arn.split(':')[4]
+    fake_arn = f'arn:aws:dynamodb:{region}:{account_id}:table/nonexistent_table_xyz'
+
+    with pytest.raises(ClientError, match='TableNotFoundException.*Table not found'):
+        client.export_table_to_point_in_time(
+            TableArn=fake_arn,
+            S3Bucket=unique_bucket_name(),
+        )
+
+
+# Test that exporting to a nonexistent S3 bucket fails.
+# This one is little different, as - it seems - DynamoDB actually accepts nonexistent bucket and starts the export,
+# returns the FAILED and an error message later on.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_nonexistent_bucket(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    fake_bucket = unique_bucket_name()
+
+    response = client.export_table_to_point_in_time(
+        TableArn=table_arn,
+        S3Bucket=fake_bucket,
+    )
+
+    export_arn = response['ExportDescription']['ExportArn']
+
+    desc = wait_for_export(client, export_arn)
+    assert desc['ExportArn'] == export_arn
+    assert desc['TableArn'] == table_arn
+    assert desc['S3Bucket'] == fake_bucket
+    assert desc['ExportStatus'] == 'FAILED'
+    assert desc['FailureCode'] == 'S3NoSuchBucket'
+    assert 'bucket does not exist' in desc['FailureMessage']
+
+    for ex in iterate_over_exports(client, table_arn):
+        if ex['ExportArn'] == export_arn:
+            assert ex['ExportStatus'] == 'FAILED'
+            break
+    else:
+        assert False, f"Export {export_arn} not found in list_exports"
+
+
+# Test that failed export that didn't start doesn't reserve ClientToken
+# and thus the same ClientToken can be used again for a new export.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_export_failed_does_not_reserve_client_token(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+    token = str(uuid.uuid4())
+
+    with pytest.raises(ClientError, match='ValidationException.*s3Bucket.*failed'):
+        client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket='',
+            ClientToken=token,
+        )
+
+    # We don't care about export result here, we just want to verify that ClientToken can be passed again to start a new export
+    # (the call did not raise an exception).
+    with new_s3_bucket(s3) as bucket:
+        client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+            ClientToken=token,
+        )
+
+# ---------------------------------------------------------------------------
+# DescribeExport tests
+# ---------------------------------------------------------------------------
+
+# Test that DescribeExport returns the full ExportDescription for a
+# known export.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_describe_export(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        response = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+        )
+        export_arn = response['ExportDescription']['ExportArn']
+
+        desc = client.describe_export(ExportArn=export_arn)['ExportDescription']
+        assert desc['ExportArn'] == export_arn
+        assert desc['TableArn'] == table_arn
+        assert desc['S3Bucket'] == bucket
+        assert desc['ExportStatus'] in ('IN_PROGRESS', 'COMPLETED')
+        assert 'StartTime' in desc
+        assert 'ExportFormat' in desc
+
+        wait_for_export(client, export_arn)
+
+        # this should return description with ExportStatus=COMPLETED and additional fields like EndTime, ExportManifest, ItemCount, BilledSizeBytes etc.
+        desc = client.describe_export(ExportArn=export_arn)['ExportDescription']
+        assert desc['ExportStatus'] == 'COMPLETED'
+        assert desc['ExportArn'] == export_arn
+        assert desc['TableArn'] == table_arn
+        assert 'EndTime' in desc
+        assert 'ExportManifest' in desc
+        assert 'ItemCount' in desc
+        assert 'BilledSizeBytes' in desc
+
+
+# Test that DescribeExport with a non-existent ARN returns ValidationException.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_describe_export_nonexistent(dynamodb, test_table_s):
+    client = dynamodb.meta.client
+    region = dynamodb.meta.client.meta.region_name
+    table_arn = get_table_arn(test_table_s)
+    account_id = table_arn.split(':')[4]
+    fake_arn = f'arn:aws:dynamodb:{region}:{account_id}:table/nonexistent_table_xyz'
+    with pytest.raises(ClientError, match='ValidationException.*Invalid Export ARN'):
+        client.describe_export(ExportArn=fake_arn)
+
+
+
+# Test that DescribeExport with a incorrect ARN returns ValidationException.
+# Note: this one is a bit tricky - AWS probably doesn't check for `arn:` prefix and we fail
+# on the same ValidationException as `test_describe_export_nonexistent` test.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+@pytest.mark.parametrize('fake_arn_error', [
+    ('qwerty:aws:dynamodb:us-east-1:000000000000:table/nonexistent_table_xyz', 'ValidationException.*Invalid Export ARN'),
+    ('arn:qwerty:dynamodb:us-east-1:000000000000:table/nonexistent_table_xyz', 'AccessDeniedException'),
+    ('arn:aws:qwerty:us-east-1:000000000000:table/nonexistent_table_xyz', 'AccessDeniedException'),
+    ('arn:aws:dynamodb:qwerty:000000000000:table/nonexistent_table_xyz', 'AccessDeniedException'),
+    ('arn:aws:dynamodb:us-east-1:qwerty:table/nonexistent_table_xyz', 'AccessDeniedException'),
+])
+def test_describe_export_incorrect_arns(dynamodb, fake_arn_error):
+    client = dynamodb.meta.client
+    fake_arn, error = fake_arn_error
+    with pytest.raises(ClientError, match=error):
+        client.describe_export(ExportArn=fake_arn)
+
+
+# ---------------------------------------------------------------------------
+# ListExports tests
+# ---------------------------------------------------------------------------
+
+# Test that ListExports returns an ExportSummaries list. In our case it must be empty
+# as we use it on a freshly created table.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_empty(dynamodb):
+    with new_test_table(dynamodb,
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+    ) as table:
+        client = table.meta.client
+        table_arn = get_table_arn(table)
+        response = client.list_exports(TableArn=table_arn)
+        assert 'ExportSummaries' in response
+        # The list should be empty for a freshly-created table
+        assert len(response['ExportSummaries']) == 0
+
+
+def iterate_over_exports(client, table_arn = None, max_results = None):
+    kwargs = {}
+    if table_arn is not None:
+        kwargs['TableArn'] = table_arn
+    if max_results is not None:
+        kwargs['MaxResults'] = max_results
+
+    while True:
+        response = client.list_exports(**kwargs)
+        results = response.get('ExportSummaries', ())
+        if max_results is not None:
+            assert len(results) <= max_results
+        yield from results
+
+        next_token = response.get('NextToken', None)
+        if not next_token:
+            break
+
+        kwargs['NextToken'] = response['NextToken']
+
+
+# Test that sending an invalid NextToken to ListExports results in an error.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_invalid_next_token(dynamodb):
+    with pytest.raises(ClientError, match='ValidationException.*ListExports'):
+        try:
+            dynamodb.meta.client.list_exports(NextToken='0123456789abcdef' * 16)
+        except ClientError as e:
+            response = e.response
+            assert response['ResponseMetadata']['HTTPStatusCode'] == 400
+            raise
+
+
+# Test that after starting an export, ListExports includes it.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_contains_export(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        response = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+        )
+        export_arn = response['ExportDescription']['ExportArn']
+
+        for e in iterate_over_exports(client, table_arn):
+            if e['ExportArn'] == export_arn:
+                break
+        else:
+            pytest.fail(f"Export {export_arn} not found in ListExports for table {table_arn}")
+
+
+# Test that ListExports without a TableArn filter returns results.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_no_table_filter(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        response = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+        )
+        export_arn = response['ExportDescription']['ExportArn']
+
+        # ListExports without TableArn should still include our export
+        for e in iterate_over_exports(client):
+            if e['ExportArn'] == export_arn:
+                break
+        else:
+            pytest.fail(f"Export {export_arn} not found in ListExports without TableArn filter")
+
+
+# Test that ListExports pagination via MaxResults and NextToken works.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_pagination(dynamodb):
+    max_tables = 5
+    exports_per_table = 2
+
+    created_tables = []
+    with ExitStack() as created_tables_context_manager:
+        for _ in range(max_tables):
+            created_tables.append(
+                created_tables_context_manager.enter_context(new_test_table(dynamodb,
+                    KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]))
+            )
+
+        export_arns = []
+        # Start multiple exports to the same bucket with different prefixes
+        # Note: we intentionally use the fake bucket, as it starts the export,
+        # but fails it almost immediately, drastically reducing test runtime.
+        # The exports will still be present in ListExports results (with status FAILED),
+        # which is enough for testing pagination.
+        for table in created_tables:
+            client = enable_pitr(table)
+            table_arn = get_table_arn(table)
+            for _ in range(exports_per_table):
+                resp = client.export_table_to_point_in_time(
+                    TableArn=table_arn,
+                    S3Bucket=unique_bucket_name(),
+                    S3Prefix=f'prefix-{uuid.uuid4()}',
+                    ClientToken=str(uuid.uuid4()),
+                )
+                export_arns.append(resp['ExportDescription']['ExportArn'])
+
+        # List with max_results set to 4, so we get some pagination.
+        all_arns_by_table = collections.defaultdict(list)
+        all_arns = set()
+        for summary in iterate_over_exports(client, max_results=4):
+            assert 'ExportArn' in summary
+            sm = summary["ExportArn"]
+            all_arns.add(sm)
+
+            # It seems ARNS are reversed (newest first), but only for the same table
+            x = sm.find('/export/')
+            assert x >= 0, sm
+            arn_up_to_table = sm[:x]
+            t = all_arns_by_table[arn_up_to_table]
+            assert not t or summary['ExportArn'] < t[-1], (sm, t)
+            t.append(sm)
+
+        # we're not filtering, so we will get more stuff in the list, but at least all our exports should be there
+        assert len(export_arns) <= len(all_arns)
+        assert set(export_arns).issubset(set(all_arns))
+
+
+# Test that ExportSummary from ListExports contains the expected
+# fields: ExportArn, ExportStatus, ExportType.
+@pytest.mark.xfail(reason="Not yet implemented on Scylla and MinIO is not started")
+def test_list_exports_summary_fields(dynamodb, test_table_s):
+    table = test_table_s
+    client = enable_pitr(table)
+    table_arn = get_table_arn(table)
+    s3 = make_s3_client(dynamodb)
+
+    with new_s3_bucket(s3) as bucket:
+        resp = client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket=bucket,
+        )
+        export_arn = resp['ExportDescription']['ExportArn']
+        wait_for_export(client, export_arn)
+
+        for summary in iterate_over_exports(client, table_arn):
+            if summary['ExportArn'] == export_arn:
+                assert 'ExportArn' in summary
+                assert 'ExportStatus' in summary
+                assert summary['ExportStatus'] == 'COMPLETED'
+                assert 'ExportType' in summary
+                assert summary['ExportType'] == 'FULL_EXPORT'
+                break
+        else:
+            pytest.fail(f"Export {export_arn} not found in ListExports for table {table_arn}")

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -230,7 +230,13 @@ def client_no_transform(client):
         client.meta.events = old_events
 
 def is_aws(dynamodb):
-    return dynamodb.meta.client._endpoint.host.endswith('.amazonaws.com')
+    try:
+        # Let's try first if dynamodb represents a client object
+        # `Client` object has `_endpoint.host` attribute, which we check for amazon domain
+        return dynamodb._endpoint.host.endswith('.amazonaws.com')
+    except AttributeError:
+        # If not, it must be a resource (table for example), which has meta.client object, which has the _endpoint.host attribute.
+        return dynamodb.meta.client._endpoint.host.endswith('.amazonaws.com')
 
 # Return the AWS region name, or the Scylla data center name.
 def get_region(dynamodb):

--- a/test/boost/alternator_export_test.cc
+++ b/test/boost/alternator_export_test.cc
@@ -10,6 +10,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include "alternator/export.hh"
+#include "utils/rjson.hh"
 #include <string>
 #include <vector>
 #include <span>


### PR DESCRIPTION
Add conformance tests for Alterantor Export to S3 feature. The tests cover Amazon's specification and will validate user-facing behaviour of our implementation, including error reporting. Tests were run against Amazon and all pass.

Since the implementation of S3 export is in progress, the tests are marked with `xfail` pytest mark. You might need to add `--runxfail` if you want to run them.

Refs: SCYLLADB-1370
Fixes: SCYLLADB-1939

Backport: none - new feature.