### PR TITLE
audit/alternator: filter batch audit entries by selected tables

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -169,11 +169,15 @@ void executor::maybe_audit(
     std::string_view table_name,
     std::string_view operation_name,
     const rjson::value& request,
-    std::optional<db::consistency_level> cl)
+    std::optional<db::consistency_level> cl,
+    std::optional<audit::audit_table_set> alternator_batch_tables)
 {
-    if (_audit.local_is_initialized() && _audit.local().will_log(category, ks_name, table_name)) {
+    if (_audit.local_is_initialized() && (alternator_batch_tables || _audit.local().will_log(category, ks_name, table_name))) {
         audit_info = std::make_unique<audit::audit_info_alternator>(
             category, sstring(ks_name), sstring(table_name), cl);
+        if (alternator_batch_tables) {
+            audit_info->set_alternator_batch_tables(std::move(*alternator_batch_tables));
+        }
         // FIXME: rjson::print(request) serializes the entire JSON request body, which
         // can be up to 16 MB for BatchWriteItem.
         audit_info->set_query_string(sstring(rjson::print(request)), sstring(operation_name));
@@ -3415,10 +3419,10 @@ future<> executor::do_batch_write(
     }
 }
 
-sstring print_names_for_audit(const std::set<sstring>& names) {
+sstring print_names_for_audit(const audit::audit_table_set& names) {
     sstring res;
     // Might have been useful to loop twice, with the 1st loop learning the total size of the names for the res to then reserve()
-    for(const auto& name : names) {
+    for (const auto& [_, name] : names) {
         if (!res.empty()) {
             res += "|";
         }
@@ -3458,7 +3462,7 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
     // For each table, we need its stats and schema.
     std::vector<std::pair<lw_shared_ptr<stats>, schema_ptr>> per_table_wcu;
 
-    std::set<sstring> audited_table_names;
+    audit::audit_table_set audited_table_names;
     bool only_audited_tables = true;
     bool should_audit = _audit.local_is_initialized() && _audit.local().will_log(audit::statement_category::DML);
     mutation_builders.reserve(request_items.MemberCount());
@@ -3472,7 +3476,7 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
         tracing::add_alternator_table_name(trace_state, schema->cf_name());
         if (should_audit) {
             if (_audit.local().will_log(audit::statement_category::DML, schema->ks_name(), schema->cf_name())) {
-                audited_table_names.insert(schema->cf_name());
+                audited_table_names.emplace(schema->ks_name(), schema->cf_name());
             } else {
                 only_audited_tables = false;
             }
@@ -3599,8 +3603,9 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
             // Filter out non-audited tables from the request body for privacy
             filter_batch_request_items_by_tbl_name(request, audited_table_names);
         }
+        auto audit_table_names = print_names_for_audit(audited_table_names);
         maybe_audit(audit_info, audit::statement_category::DML, "",
-                    print_names_for_audit(audited_table_names), "BatchWriteItem", request, db::consistency_level::LOCAL_QUORUM);
+                    audit_table_names, "BatchWriteItem", request, db::consistency_level::LOCAL_QUORUM, std::move(audited_table_names));
     }
     co_return rjson::print(std::move(ret));
 }

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3458,9 +3458,8 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
     // For each table, we need its stats and schema.
     std::vector<std::pair<lw_shared_ptr<stats>, schema_ptr>> per_table_wcu;
 
-    std::set<sstring> table_names; // for auditing
-    // FIXME: will_log() here doesn't pass keyspace/table, so keyspace-level audit
-    // filtering is bypassed — a batch spanning multiple tables is audited as a whole.
+    std::set<sstring> audited_table_names;
+    bool only_audited_tables = true;
     bool should_audit = _audit.local_is_initialized() && _audit.local().will_log(audit::statement_category::DML);
     mutation_builders.reserve(request_items.MemberCount());
     per_table_wcu.reserve(request_items.MemberCount());
@@ -3472,7 +3471,11 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
         per_table_stats->api_operations.batch_write_item_histogram.add(it->value.Size());
         tracing::add_alternator_table_name(trace_state, schema->cf_name());
         if (should_audit) {
-            table_names.insert(schema->cf_name());
+            if (_audit.local().will_log(audit::statement_category::DML, schema->ks_name(), schema->cf_name())) {
+                audited_table_names.insert(schema->cf_name());
+            } else {
+                only_audited_tables = false;
+            }
         }
 
         std::unordered_set<primary_key, primary_key_hash, primary_key_equal> used_keys(
@@ -3591,8 +3594,14 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
     for (const auto& w : per_table_wcu) {
         w.first->api_operations.batch_write_item_latency.mark(duration);
     }
-    maybe_audit(audit_info, audit::statement_category::DML, "",
-                print_names_for_audit(table_names), "BatchWriteItem", request, db::consistency_level::LOCAL_QUORUM);
+    if (!audited_table_names.empty()) {
+        if (!only_audited_tables) {
+            // Filter out non-audited tables from the request body for privacy
+            filter_batch_request_items_by_tbl_name(request, audited_table_names);
+        }
+        maybe_audit(audit_info, audit::statement_category::DML, "",
+                    print_names_for_audit(audited_table_names), "BatchWriteItem", request, db::consistency_level::LOCAL_QUORUM);
+    }
     co_return rjson::print(std::move(ret));
 }
 

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -183,7 +183,8 @@ private:
                      std::string_view table_name,
                      std::string_view operation_name,
                      const rjson::value& request,
-                     std::optional<db::consistency_level> cl = std::nullopt);
+                     std::optional<db::consistency_level> cl = std::nullopt,
+                     std::optional<audit::audit_table_set> alternator_batch_tables = std::nullopt);
 
     future<rjson::value> fill_table_description(schema_ptr schema, table_status tbl_status, service::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit);
     future<executor::request_return_type> create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, bool enforce_authorization,
@@ -228,6 +229,6 @@ struct arn_parts {
 //    if not empty - postfix value must start with expected_postfix, but might be longer
 arn_parts parse_arn(std::string_view arn, std::string_view arn_field_name, std::string_view type_name, std::string_view expected_postfix);
 
-// The format is ks1|ks2|ks3... and table1|table2|table3...
-sstring print_names_for_audit(const std::set<sstring>& names);
+// The format is table1|table2|table3...
+sstring print_names_for_audit(const audit::audit_table_set& names);
 }

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1959,7 +1959,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     // from one of the operations will be returned.
     bool some_succeeded = false;
     std::exception_ptr eptr;
-    std::set<sstring> audited_table_names;
+    audit::audit_table_set audited_table_names;
     bool only_audited_tables = true;
     bool should_audit = _audit.local_is_initialized() && _audit.local().will_log(audit::statement_category::QUERY);
     rjson::value response = rjson::empty_object();
@@ -1972,7 +1972,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
         std::string table = rs.schema->cf_name();
         if (should_audit) {
             if (_audit.local().will_log(audit::statement_category::QUERY, rs.schema->ks_name(), table)) {
-                audited_table_names.insert(table);
+                audited_table_names.emplace(rs.schema->ks_name(), table);
             } else {
                 only_audited_tables = false;
             }
@@ -2038,8 +2038,9 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
             // Filter out non-audited tables from the request body for privacy
             filter_batch_request_items_by_tbl_name(request, audited_table_names);
         }
+        auto audit_table_names = print_names_for_audit(audited_table_names);
         maybe_audit(audit_info, audit::statement_category::QUERY, "",
-                    print_names_for_audit(audited_table_names), "BatchGetItem", request, db::consistency_level::ANY);
+                    audit_table_names, "BatchGetItem", request, db::consistency_level::ANY, std::move(audited_table_names));
     }
     if (!some_succeeded && eptr) {
         co_await coroutine::return_exception_ptr(std::move(eptr));

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1959,9 +1959,8 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     // from one of the operations will be returned.
     bool some_succeeded = false;
     std::exception_ptr eptr;
-    std::set<sstring> table_names; // for auditing
-    // FIXME: will_log() here doesn't pass keyspace/table, so keyspace-level audit
-    // filtering is bypassed — a batch spanning multiple tables is audited as a whole.
+    std::set<sstring> audited_table_names;
+    bool only_audited_tables = true;
     bool should_audit = _audit.local_is_initialized() && _audit.local().will_log(audit::statement_category::QUERY);
     rjson::value response = rjson::empty_object();
     rjson::add(response, "Responses", rjson::empty_object());
@@ -1972,7 +1971,11 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
         const table_requests& rs = requests[i];
         std::string table = rs.schema->cf_name();
         if (should_audit) {
-            table_names.insert(table);
+            if (_audit.local().will_log(audit::statement_category::QUERY, rs.schema->ks_name(), table)) {
+                audited_table_names.insert(table);
+            } else {
+                only_audited_tables = false;
+            }
         }
         for (const auto& [_, cks] : rs.requests) {
             auto& fut = *fut_it;
@@ -2030,8 +2033,14 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     // but the audit entry records a single CL for the whole batch. We use ANY as a
     // placeholder to indicate "mixed / not applicable".
     // FIXME: Auditing is executed only for a complete success
-    maybe_audit(audit_info, audit::statement_category::QUERY, "",
-                print_names_for_audit(table_names), "BatchGetItem", request, db::consistency_level::ANY);
+    if (!audited_table_names.empty()) {
+        if (!only_audited_tables) {
+            // Filter out non-audited tables from the request body for privacy
+            filter_batch_request_items_by_tbl_name(request, audited_table_names);
+        }
+        maybe_audit(audit_info, audit::statement_category::QUERY, "",
+                    print_names_for_audit(audited_table_names), "BatchGetItem", request, db::consistency_level::ANY);
+    }
     if (!some_succeeded && eptr) {
         co_await coroutine::return_exception_ptr(std::move(eptr));
     }

--- a/alternator/executor_util.cc
+++ b/alternator/executor_util.cc
@@ -556,12 +556,12 @@ body_writer make_streamed(rjson::value&& value) {
     };
 }
 
-void filter_batch_request_items_by_tbl_name(rjson::value& request, const std::set<sstring>& tbl_name_filter) {
+void filter_batch_request_items_by_tbl_name(rjson::value& request, const audit::audit_table_set& tbl_name_filter) {
     rjson::value& items = request["RequestItems"];
     for (auto it = items.MemberBegin(); it != items.MemberEnd(); ) {
         auto table_name = rjson::to_string_view(it->name);
         auto found = std::ranges::any_of(tbl_name_filter, [table_name] (const auto& table) {
-            return table == table_name;
+            return table.second == table_name;
         });
         if (!found) {
             it = items.EraseMember(it);

--- a/alternator/executor_util.cc
+++ b/alternator/executor_util.cc
@@ -556,4 +556,19 @@ body_writer make_streamed(rjson::value&& value) {
     };
 }
 
+void filter_batch_request_items_by_tbl_name(rjson::value& request, const std::set<sstring>& tbl_name_filter) {
+    rjson::value& items = request["RequestItems"];
+    for (auto it = items.MemberBegin(); it != items.MemberEnd(); ) {
+        auto table_name = rjson::to_string_view(it->name);
+        auto found = std::ranges::any_of(tbl_name_filter, [table_name] (const auto& table) {
+            return table == table_name;
+        });
+        if (!found) {
+            it = items.EraseMember(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
 } // namespace alternator

--- a/alternator/executor_util.hh
+++ b/alternator/executor_util.hh
@@ -17,6 +17,7 @@
 
 #include <map>
 #include <optional>
+#include <set>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -217,6 +218,10 @@ schema_ptr get_table_from_batch_request(const service::storage_proxy& proxy, con
 /// Returns (or lazily creates) the per-table stats object for the given schema.
 /// If the table has been deleted, returns a temporary stats object.
 lw_shared_ptr<stats> get_stats_from_schema(service::storage_proxy& sp, const schema& schema);
+
+/// Filter tables from a batch request's "RequestItems" JSON
+/// object. Removes members whose key is not in `tbl_name_filter`.
+void filter_batch_request_items_by_tbl_name(rjson::value& request, const std::set<sstring>& tbl_name_filter);
 
 /// Writes one item's attributes into `item` from the given selection result
 /// row. If include_all_embedded_attributes is true, all attributes from the

--- a/alternator/executor_util.hh
+++ b/alternator/executor_util.hh
@@ -32,6 +32,7 @@
 #include "auth/permission.hh"
 #include "alternator/stats.hh"
 #include "alternator/attribute_path.hh"
+#include "audit/audit.hh"
 #include "utils/managed_bytes.hh"
 
 namespace query { class partition_slice; class result; }
@@ -221,7 +222,7 @@ lw_shared_ptr<stats> get_stats_from_schema(service::storage_proxy& sp, const sch
 
 /// Filter tables from a batch request's "RequestItems" JSON
 /// object. Removes members whose key is not in `tbl_name_filter`.
-void filter_batch_request_items_by_tbl_name(rjson::value& request, const std::set<sstring>& tbl_name_filter);
+void filter_batch_request_items_by_tbl_name(rjson::value& request, const audit::audit_table_set& tbl_name_filter);
 
 /// Writes one item's attributes into `item` from the given selection result
 /// row. If include_all_embedded_attributes is true, all attributes from the

--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -10,6 +10,7 @@
 #include "audit/audit.hh"
 #include "audit/audit_rule.hh"
 #include "audit/preprocessed_audit_rules.hh"
+#include "utils/rjson.hh"
 #include "db/config.hh"
 #include "cql3/cql_statement.hh"
 #include "cql3/query_processor.hh"
@@ -335,15 +336,26 @@ future<> audit::log(const audit_info& audit_info, const service::client_state& c
     if (!_preprocessed_rules.rules().empty() && client_state.user() && client_state.user()->name) {
         role = *client_state.user()->name;
     }
-    auto sinks = sinks_for(audit_info, role);
-    if (!sinks) {
-        return make_ready_future<>();
-    }
     thread_local static sstring no_username("undefined");
     static const sstring anonymous_username("anonymous");
     const sstring& username = client_state.user() ? client_state.user()->name.value_or(anonymous_username) : no_username;
     socket_address client_ip = client_state.get_client_address().addr();
     socket_address node_ip = _token_metadata.get()->get_topology().my_address().addr();
+    if (audit_info.alternator_batch_tables()) {
+        return log_alternator_batch(audit_info, role, node_ip, client_ip, cl, username, error);
+    }
+    auto sinks = sinks_for(audit_info, role);
+    if (!sinks) {
+        return make_ready_future<>();
+    }
+    return log_with_sinks(sinks, audit_info, node_ip, client_ip, cl, username, error);
+}
+
+future<> audit::log_with_sinks(audit_sink_set sinks, const audit_info& audit_info, socket_address node_ip, socket_address client_ip,
+        std::optional<db::consistency_level> cl, const sstring& username, bool error) {
+    if (!sinks) {
+        return make_ready_future<>();
+    }
     if (!_storage_started) {
         on_internal_error_noexcept(logger, fmt::format("Audit log dropped (storage not ready): node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {}",
             node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
@@ -370,6 +382,82 @@ future<> audit::log(const audit_info& audit_info, const service::client_state& c
                     node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
                     audit_info.query(), client_ip, audit_info.table(), username, ep);
             }
+    });
+}
+
+static sstring print_alternator_table_names(const audit_table_set& tables) {
+    sstring res;
+    for (const auto& [_, table] : tables) {
+        if (!res.empty()) {
+            res += "|";
+        }
+        res += table;
+    }
+    return res;
+}
+
+static sstring print_filtered_alternator_batch_query(const audit_info& audit_info, const audit_table_set& tables) {
+    // Alternator audit query strings are built by audit_info::set_query_string()
+    // as "<operation>|<serialized request JSON>".
+    auto sep = audit_info.query().find('|');
+    if (sep == sstring::npos) {
+        return audit_info.query();
+    }
+    auto operation = audit_info.query().substr(0, sep);
+    try {
+        auto request = rjson::parse(std::string_view(audit_info.query()).substr(sep + 1));
+        auto& request_items = request["RequestItems"];
+        for (auto it = request_items.MemberBegin(); it != request_items.MemberEnd(); ) {
+            std::string_view table_name = rjson::to_string_view(it->name);
+            auto found = std::ranges::any_of(tables, [table_name] (const auto& table) {
+                return table.second == table_name;
+            });
+            if (!found) {
+                it = request_items.EraseMember(it);
+            } else {
+                ++it;
+            }
+        }
+        return operation + "|" + rjson::print(request);
+    } catch (...) {
+        // Do not fall back to the unfiltered query: it may contain data for
+        // tables that do not match this audit sink.
+        return operation + "|<batch audit request omitted: unexpected audit query format>";
+    }
+}
+
+void add_alternator_batch_sink_tables(std::vector<std::pair<audit_sink, audit_table_set>>& sink_tables,
+        audit_sink sink, const std::pair<sstring, sstring>& table) {
+    auto it = std::ranges::find_if(sink_tables, [sink] (const auto& entry) {
+        return entry.first == sink;
+    });
+    if (it == sink_tables.end()) {
+        sink_tables.emplace_back(sink, audit_table_set{table});
+    } else {
+        it->second.insert(table);
+    }
+}
+
+future<> audit::log_alternator_batch(const audit_info& ai, std::string_view role, socket_address node_ip, socket_address client_ip,
+        std::optional<db::consistency_level> cl, const sstring& username, bool error) {
+    std::vector<std::pair<audit_sink, audit_table_set>> sink_tables;
+    for (const auto& table : *ai.alternator_batch_tables()) {
+        auto sinks = sinks_for_table(ai.category(), table.first, table.second, role);
+        for (auto sink : sinks) {
+            add_alternator_batch_sink_tables(sink_tables, sink, table);
+        }
+    }
+
+    return do_with(std::move(sink_tables), [this, &ai, node_ip, client_ip, cl, &username, error] (auto& sink_tables) {
+        return do_for_each(sink_tables, [this, &ai, node_ip, client_ip, cl, &username, error] (const auto& entry) {
+            return do_with(::audit::audit_info(ai.category(), sstring(ai.keyspace()), print_alternator_table_names(entry.second), false),
+                    [this, &ai, node_ip, client_ip, cl, &username, error, &entry] (::audit::audit_info& filtered_info) {
+                filtered_info.set_query_string(print_filtered_alternator_batch_query(ai, entry.second));
+                audit_sink_set sinks;
+                sinks.set(entry.first);
+                return log_with_sinks(sinks, filtered_info, node_ip, client_ip, cl, username, error);
+            });
+        });
     });
 }
 
@@ -469,6 +557,24 @@ audit_sink_set audit::sinks_for(const audit_info& audit_info, std::string_view r
     return result;
 }
 
+audit_sink_set audit::sinks_for_table(statement_category category, std::string_view keyspace, std::string_view table, std::string_view role) const {
+    audit_sink_set result;
+    if (_audited_categories.contains(category)
+            && (keyspace.empty()
+                || _audited_keyspaces.find(keyspace) != _audited_keyspaces.cend()
+                || should_log_table(keyspace, table)
+                || category == statement_category::AUTH
+                || category == statement_category::ADMIN
+                || category == statement_category::DCL)) {
+        result.add(_audit_sinks);
+    }
+
+    if (!_preprocessed_rules.rules().empty()) {
+        result.add(_preprocessed_rules.matching_sinks(category, keyspace, table, role));
+    }
+    return result;
+}
+
 audit_sink_set audit::sinks_for_login(const sstring& username) const {
     audit_sink_set result;
     if (_audited_categories.contains(statement_category::AUTH)) {
@@ -493,7 +599,8 @@ bool audit::rules_may_log(statement_category cat, std::string_view keyspace, std
         if (!matches_category(rule, cat)) {
             continue;
         }
-        // If keyspace is empty (e.g., alternator batch), skip table matching and assume the rule may log.
+        // If keyspace is empty (e.g., global operations with no table), skip
+        // table matching and assume the rule may log.
         if (!is_table_scoped_category(cat) || keyspace.empty() || matches_table(rule, keyspace, table)) {
             return true;
         }

--- a/audit/audit.hh
+++ b/audit/audit.hh
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <optional>
+#include <set>
 
 namespace db {
 
@@ -56,6 +57,8 @@ namespace audit {
 
 extern logging::logger logger;
 
+using audit_table_set = std::set<std::pair<sstring, sstring>>;
+
 class audit_exception : public std::exception {
     sstring _what;
 public:
@@ -74,6 +77,7 @@ protected:
     sstring _table;
     sstring _query;
     bool _batch; // used only for unpacking batches in CQL, not relevant for Alternator
+    std::optional<audit_table_set> _alternator_batch_tables;
 public:
     audit_info(statement_category cat, sstring keyspace, sstring table, bool batch)
         : _category(cat)
@@ -96,6 +100,10 @@ public:
     const sstring& keyspace() const { return _keyspace; }
     const sstring& table() const { return _table; }
     const sstring& query() const { return _query; }
+    void set_alternator_batch_tables(audit_table_set tables) {
+        _alternator_batch_tables = std::move(tables);
+    }
+    const std::optional<audit_table_set>& alternator_batch_tables() const { return _alternator_batch_tables; }
     sstring category_string() const;
     statement_category category() const { return _category; }
     bool batch() const { return _batch; }
@@ -160,6 +168,7 @@ private:
 
     bool should_log_table(std::string_view keyspace, std::string_view name) const;
     bool rules_may_log(statement_category cat, std::string_view keyspace, std::string_view table) const;
+    audit_sink_set sinks_for_table(statement_category category, std::string_view keyspace, std::string_view table, std::string_view role) const;
     audit_sink_set sinks_for(const audit_info& audit_info, std::string_view role) const;
     audit_sink_set sinks_for_login(const sstring& username) const;
     future<> write_to_storage(audit_sink_set sinks,
@@ -174,6 +183,10 @@ private:
                                     socket_address node_ip,
                                     socket_address client_ip,
                                     bool error);
+    future<> log_with_sinks(audit_sink_set sinks, const audit_info& audit_info, socket_address node_ip, socket_address client_ip,
+            std::optional<db::consistency_level> cl, const sstring& username, bool error);
+    future<> log_alternator_batch(const audit_info& audit_info, std::string_view role, socket_address node_ip, socket_address client_ip,
+            std::optional<db::consistency_level> cl, const sstring& username, bool error);
     future<> rebuild_rules();
 public:
     static seastar::sharded<audit>& audit_instance() {

--- a/audit/audit_rule.cc
+++ b/audit/audit_rule.cc
@@ -203,7 +203,7 @@ bool matches_rule(const audit_rule& rule, statement_category category,
                   std::string_view keyspace, std::string_view table,
                   std::string_view role) {
     return matches_category(rule, category)
-        && (is_table_scoped_category(category) ? (keyspace.empty() || matches_table(rule, keyspace, table)) : true)
+        && (!is_table_scoped_category(category) || keyspace.empty() || matches_table(rule, keyspace, table))
         && matches_role(rule, role);
 }
 

--- a/audit/preprocessed_audit_rules.cc
+++ b/audit/preprocessed_audit_rules.cc
@@ -159,8 +159,7 @@ audit_sink_set preprocessed_audit_rules::matching_sinks(statement_category categ
 
     if (!table_scoped || keyspace.empty()) {
         // Table-independent categories (AUTH, ADMIN, DCL) or operations with
-        // empty keyspace (e.g., batch operations spanning multiple tables):
-        // only role matching matters.
+        // empty keyspace: only role matching matters.
         return collect_sinks(role_it->second, category);
     }
 

--- a/docs/operating-scylla/security/auditing.rst
+++ b/docs/operating-scylla/security/auditing.rst
@@ -77,8 +77,9 @@ Auditing Alternator Requests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When auditing is enabled, Alternator (DynamoDB-compatible API) requests are audited using the same
-backends and the same filtering configuration (``audit_categories``, ``audit_keyspaces``,
-``audit_tables``) as CQL operations. No additional configuration is needed.
+backends and filtering configuration as CQL operations. There are no separate Alternator audit settings.
+The filtering configuration includes ``audit_categories``, ``audit_keyspaces``, ``audit_tables``,
+and, for operations with table context, ``audit_rules``.
 
 Both successful and failed Alternator requests are audited.
 
@@ -142,11 +143,25 @@ For example, to audit an Alternator table called ``my_table_name`` use either of
 **Global and batch operations**: Some Alternator operations are not scoped to a single table:
 
 * ``ListTables`` and ``DescribeEndpoints`` have no associated keyspace or table.
-* ``BatchWriteItem`` and ``BatchGetItem`` may span multiple tables.
+  These operations are logged whenever their category matches ``audit_categories``, regardless of
+  ``audit_keyspaces`` or ``audit_tables`` filters. Their ``keyspace_name`` field is empty.
+* ``BatchWriteItem`` and ``BatchGetItem`` may span multiple tables. Therefore, the audit log
+  entries for these operations have the ``keyspace_name`` field empty. These operations still
+  match each table in the batch against ``audit_keyspaces``, ``audit_tables``, and table-qualified
+  ``audit_rules`` filters. The ``table_name`` field in the audit entry contains only the audited
+  tables, listed in pipe-separated (``|``) format. The JSON request in the audit entry's
+  ``operation`` field is also stripped of entries belonging to non-audited tables, so that data
+  from these tables is not leaked into audit records. If none of the tables in a batch match the
+  audit filter, no audit entry is produced for that batch operation. When different tables in a
+  batch match different audit sinks, each sink receives at most one audit entry with the tables
+  matching that sink.
 
-These operations are logged whenever their category matches ``audit_categories``, regardless of
-``audit_keyspaces`` or ``audit_tables`` filters. Their ``keyspace_name`` field is empty, and for
-batch operations the ``table_name`` field contains a pipe-separated (``|``) list of all involved table names.
+For example, given ``audit_tables: "alternator.my_table"`` or an ``audit_rules`` entry whose
+``qualified_table_names`` match only ``alternator_my_table.*``, and a single ``BatchWriteItem`` that
+targets both ``my_table`` and ``other_table``, the resulting audit entry will list only
+``my_table`` in its ``table_name`` field -- ``other_table`` is filtered out. Also, the contents of
+the JSON request body for ``other_table`` will not be present in the audit entry. If the same
+``BatchWriteItem`` targeted only ``other_table``, no audit entry would be produced at all.
 
 **DynamoDB Streams operations**: For streams-related operations (``DescribeStream``, ``GetShardIterator``,
 ``GetRecords``), the ``table_name`` field contains the base table name and the CDC log table name
@@ -388,9 +403,6 @@ Additional Resources
 * :doc:`Authorization</operating-scylla/security/authorization>` 
 
 * :doc:`Authentication</operating-scylla/security/authentication>` 
-
-
-
 
 
 

--- a/test/alternator/test_audit.py
+++ b/test/alternator/test_audit.py
@@ -162,6 +162,11 @@ def _assert_no_audit_entries_for(rows, ks_name=None, table_name=None, category=N
         f"category={category}, but found {len(matching)}: {_simplify_rows(matching)}")
 
 
+def _assert_audit_operation_excludes(row, excluded_fragments):
+    for fragment in excluded_fragments:
+        assert fragment not in row.operation, f"Unexpected substring '{fragment}' found in operation {row.operation}"
+
+
 # system.config stores values as JSON-encoded strings with surrounding quotes.
 # Strip them so that writing back via a parameterized UPDATE doesn't double-quote.
 def _strip_config_quotes(val):
@@ -196,7 +201,7 @@ def alternator_audit_enabled(cql):
         ("ADMIN,AUTH,QUERY,DML,DDL,DCL",),
     )
     yield
-    # Restore previous values of "audit_categories", "audit_keyspaces" in the system.config table and verify the restoration
+    # Restore previous values of audit config keys in the system.config table and verify the restoration
     for name in names:
         if name in original_config_vals:
             original_val = get_original_config_vals(name, "")
@@ -354,6 +359,120 @@ def test_audit_query_batch_operations(dynamodb, cql, alternator_audit_enabled):
         # Each individual Alternator call above must be audited.
         new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
         _assert_audit_entries(new_rows, expected, table_name=table.name)
+
+
+# Test that BatchWriteItem respects audit_tables filtering.
+# When audit_tables is set to a specific table, batch operations should only
+# log entries for that table. A batch touching only non-audited tables should
+# produce no audit entry at all. A batch touching both audited and non-audited
+# tables should only include the audited table in the log entry.
+def test_audit_batch_write_item_respects_table_filter(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table_a:
+        with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table_b:
+            ks_a = f"alternator_{table_a.name}"
+            # Only audit table_a via audit_tables.
+            cql.execute("UPDATE system.config SET value=%s WHERE name='audit_tables'",
+                        (f"alternator.{table_a.name}",))
+            cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", ("",))
+            client = table_a.meta.client
+
+            # --- Batch 1: only table_a (audited) ---
+            before_rows = _get_audit_log_rows(cql)
+            client.batch_write_item(RequestItems={
+                table_a.name: [{"PutRequest": {"Item": {"p": "pk_a"}}}]
+            })
+            new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+            _assert_audit_entries(new_rows, [
+                ("DML", "LOCAL_QUORUM", False, "", table_a.name,
+                 ["BatchWriteItem", "pk_a"]),
+            ], table_name=table_a.name)
+
+            # --- Batch 2: only table_b (not audited) ---
+            # Send a fence PutItem to table_a right after so we can wait for
+            # a known entry and then safely assume table_b produced nothing.
+            before_rows = _get_audit_log_rows(cql)
+            client.batch_write_item(RequestItems={
+                table_b.name: [{"PutRequest": {"Item": {"p": "pk_b"}}}]
+            })
+            table_a.put_item(Item={"p": "pk_fence"})
+            new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+            _assert_audit_entries(new_rows, [
+                ("DML", "LOCAL_QUORUM", False, ks_a, table_a.name,
+                 ["PutItem", "pk_fence"]),
+            ], ks_name=ks_a, table_name=table_a.name)
+            _assert_no_audit_entries_for(new_rows, table_name=table_b.name, category="DML")
+
+            # --- Batch 3: both tables (only table_a should appear) ---
+            before_rows = _get_audit_log_rows(cql)
+            client.batch_write_item(RequestItems={
+                table_a.name: [{"PutRequest": {"Item": {"p": "pk_a"}}}],
+                table_b.name: [{"PutRequest": {"Item": {"p": "pk_b"}}}],
+            })
+            new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+            _assert_audit_entries(new_rows, [
+                ("DML", "LOCAL_QUORUM", False, "", table_a.name,
+                 ["BatchWriteItem", "pk_a"]),
+            ], table_name=table_a.name)
+            _assert_no_audit_entries_for(new_rows, table_name=table_b.name, category="DML")
+            _assert_audit_operation_excludes(new_rows[0], [table_b.name, "pk_b"])
+
+
+# Test that BatchGetItem respects audit_tables filtering.
+# This mirrors test_audit_batch_write_item_respects_table_filter for QUERY
+# batches: only audited tables should appear in the audit row, and the JSON
+# request stored in the operation field should not contain non-audited tables.
+def test_audit_batch_get_item_respects_table_filter(dynamodb, cql, alternator_audit_enabled):
+    with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table_a:
+        with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table_b:
+            table_a.put_item(Item={"p": "pk_a"})
+            table_b.put_item(Item={"p": "pk_b"})
+
+            ks_a = f"alternator_{table_a.name}"
+            # Only audit table_a via audit_tables.
+            cql.execute("UPDATE system.config SET value=%s WHERE name='audit_tables'",
+                        (f"alternator.{table_a.name}",))
+            cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", ("",))
+            client = table_a.meta.client
+
+            # --- Batch 1: only table_a (audited) ---
+            before_rows = _get_audit_log_rows(cql)
+            client.batch_get_item(RequestItems={
+                table_a.name: {"Keys": [{"p": "pk_a"}]}
+            })
+            new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+            _assert_audit_entries(new_rows, [
+                ("QUERY", "ANY", False, "", table_a.name,
+                 ["BatchGetItem", "pk_a"]),
+            ], table_name=table_a.name)
+
+            # --- Batch 2: only table_b (not audited) ---
+            # Send a fence GetItem to table_a right after so we can wait for
+            # a known entry and then safely assume table_b produced nothing.
+            before_rows = _get_audit_log_rows(cql)
+            client.batch_get_item(RequestItems={
+                table_b.name: {"Keys": [{"p": "pk_b"}]}
+            })
+            table_a.get_item(Key={"p": "pk_a"})
+            new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+            _assert_audit_entries(new_rows, [
+                ("QUERY", "LOCAL_ONE", False, ks_a, table_a.name,
+                 ["GetItem", "pk_a"]),
+            ], ks_name=ks_a, table_name=table_a.name)
+            _assert_no_audit_entries_for(new_rows, table_name=table_b.name, category="QUERY")
+
+            # --- Batch 3: both tables (only table_a should appear) ---
+            before_rows = _get_audit_log_rows(cql)
+            client.batch_get_item(RequestItems={
+                table_a.name: {"Keys": [{"p": "pk_a"}]},
+                table_b.name: {"Keys": [{"p": "pk_b"}]},
+            })
+            new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
+            _assert_audit_entries(new_rows, [
+                ("QUERY", "ANY", False, "", table_a.name,
+                 ["BatchGetItem", "pk_a"]),
+            ], table_name=table_a.name)
+            _assert_no_audit_entries_for(new_rows, table_name=table_b.name, category="QUERY")
+            _assert_audit_operation_excludes(new_rows[0], [table_b.name, "pk_b"])
 
 
 # Test auditing of DDL operations: CreateTable, UpdateTable (with GSI),
@@ -607,8 +726,8 @@ def test_audit_keyspace_filtering(dynamodb, cql, alternator_audit_enabled):
             table_b.put_item(Item={"p": "pk_b"})
             table_b.get_item(Key={"p": "pk_b"})
             # Positive: PutItem on table_a (correct keyspace) — should be logged.
-            table_a.put_item(Item={"p": "pk_a"})
-            expected = [("DML", "LOCAL_QUORUM", False, ks_a, table_a.name, ["PutItem", "pk_a"])]
+            table_a.put_item(Item={"p": "canary_a"})
+            expected = [("DML", "LOCAL_QUORUM", False, ks_a, table_a.name, ["PutItem", "canary_a"])]
             new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
             _assert_audit_entries(new_rows, expected, ks_a, table_a.name)
             _assert_no_audit_entries_for(new_rows, ks_name=ks_b)
@@ -624,8 +743,9 @@ def test_audit_keyspace_filtering(dynamodb, cql, alternator_audit_enabled):
 def test_audit_error_entry(dynamodb, cql, alternator_audit_enabled):
     with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table:
         ks_name = f"alternator_{table.name}"
-        # Insert data so the successful GetItem has something to return.
+        # Insert data so the GetItems have something to return.
         table.put_item(Item={"p": "pk_0"})
+        table.put_item(Item={"p": "canary_0"})
         cql.execute("UPDATE system.config SET value=%s WHERE name='audit_keyspaces'", (ks_name,))
         before_rows = _get_audit_log_rows(cql)
         # Negative operation: GetItem with an extra key attribute beyond the schema.
@@ -634,10 +754,10 @@ def test_audit_error_entry(dynamodb, cql, alternator_audit_enabled):
         with pytest.raises(ClientError, match='ValidationException'):
             table.get_item(Key={"p": "pk_0", "bogus": "junk"})
         # Positive operation: normal GetItem — should succeed and produce error=False entry.
-        table.get_item(Key={"p": "pk_0"})
+        table.get_item(Key={"p": "canary_0"})
         expected = [
             ("QUERY", "LOCAL_ONE", True, ks_name, table.name, ["GetItem", "pk_0", "bogus"]),
-            ("QUERY", "LOCAL_ONE", False, ks_name, table.name, ["GetItem", "pk_0"]),
+            ("QUERY", "LOCAL_ONE", False, ks_name, table.name, ["GetItem", "canary_0"]),
         ]
         new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=2)
         _assert_audit_entries(new_rows, expected, ks_name, table.name)
@@ -691,8 +811,8 @@ def test_audit_tables_filtering(dynamodb, cql, alternator_audit_enabled):
             # Negative: PutItem on table_b — should NOT be logged.
             table_b.put_item(Item={"p": "pk_b"})
             # Positive canary: PutItem on table_a — should be logged.
-            table_a.put_item(Item={"p": "pk_a"})
-            expected = [("DML", "LOCAL_QUORUM", False, ks_a, table_a.name, ["PutItem", "pk_a"])]
+            table_a.put_item(Item={"p": "canary_a"})
+            expected = [("DML", "LOCAL_QUORUM", False, ks_a, table_a.name, ["PutItem", "canary_a"])]
             new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=1)
             _assert_audit_entries(new_rows, expected, ks_a, table_a.name)
             _assert_no_audit_entries_for(new_rows, ks_name=ks_b)
@@ -730,11 +850,10 @@ def test_audit_rules_basic_filtering(dynamodb, cql, alternator_audit_enabled):
             _assert_no_audit_entries_for(new_rows, ks_name=ks_b)
 
 
-# Cross-table batch operations pass empty keyspace to the audit path,
-# bypassing qualified_table_names filtering in audit_rules. Verify that a
-# BatchWriteItem is logged even when the rule only targets one of the
-# batch's tables.
-def test_audit_rules_batch_bypass(dynamodb, cql, alternator_audit_enabled):
+# Verify that Alternator's cross-table batch operations respect audit_rules filtering:
+# only matching tables are recorded, and non-matching table data is not
+# leaked into the audit operation text.
+def test_audit_rules_batch_filtering(dynamodb, cql, alternator_audit_enabled):
     with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table_a:
         with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table_b:
             ks_a = f"alternator_{table_a.name}"
@@ -746,17 +865,35 @@ def test_audit_rules_batch_bypass(dynamodb, cql, alternator_audit_enabled):
                                     "qualified_table_names": [f"{ks_a}.*"], "roles": ["*"]}])
             before_rows = _get_audit_log_rows(cql)
 
-            # Batch spanning two tables — logged regardless of qualified_table_names
-            # because the empty keyspace bypasses the table filter in the rule.
+            # Batch spanning two tables. The rule matches only table_a, so the
+            # audit row should include only table_a and its request body.
             client.batch_write_item(RequestItems={
                 table_a.name: [{"PutRequest": {"Item": {"p": "batch_a"}}}],
                 table_b.name: [{"PutRequest": {"Item": {"p": "batch_b"}}}],
             })
 
             expected = [
-                ("DML", "LOCAL_QUORUM", False, "", f"{table_a.name}|{table_b.name}", ["BatchWriteItem"]),
+                ("DML", "LOCAL_QUORUM", False, "", table_a.name, ["BatchWriteItem", "batch_a"]),
             ]
             new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
             _assert_audit_entries(new_rows, expected)
-            _assert_no_audit_entries_for(new_rows, ks_name=f"alternator_{table_a.name}")
-            _assert_no_audit_entries_for(new_rows, ks_name=f"alternator_{table_b.name}")
+            _assert_no_audit_entries_for(new_rows, table_name=table_b.name, category="DML")
+            _assert_audit_operation_excludes(new_rows[0], [table_b.name, "batch_b"])
+
+            # Batch touching only non-matching tables should not produce a batch
+            # audit entry. Use a matching PutItem canary so the test can wait for
+            # a known audit row before checking the negative case.
+            before_rows = _get_audit_log_rows(cql)
+            client.batch_write_item(RequestItems={
+                table_b.name: [{"PutRequest": {"Item": {"p": "batch_b_only"}}}],
+            })
+            table_a.put_item(Item={"p": "canary_a"})
+
+            expected = [
+                ("DML", "LOCAL_QUORUM", False, ks_a, table_a.name, ["PutItem", "canary_a"]),
+            ]
+            new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=len(expected))
+            _assert_audit_entries(new_rows, expected, ks_name=ks_a, table_name=table_a.name)
+            _assert_no_audit_entries_for(new_rows, table_name=table_b.name, category="DML")
+            for row in new_rows:
+                _assert_audit_operation_excludes(row, [table_b.name, "batch_b_only"])

--- a/test/boost/audit_rule_test.cc
+++ b/test/boost/audit_rule_test.cc
@@ -47,6 +47,13 @@ bool role_matches(const sstring& pattern, const sstring& name) {
 
 } // anonymous namespace
 
+namespace audit {
+
+void add_alternator_batch_sink_tables(std::vector<std::pair<audit_sink, audit_table_set>>& sink_tables,
+        audit_sink sink, const std::pair<sstring, sstring>& table);
+
+}
+
 BOOST_AUTO_TEST_CASE(test_parse_audit_rules_json) {
     auto rules = audit::parse_audit_rules_from_json(R"([
         {"sinks":["table"],"categories":["DML","DDL"],"qualified_table_names":["ks.t1"],"roles":["admin"]},
@@ -263,7 +270,7 @@ BOOST_AUTO_TEST_CASE(test_rule_matching_and_sinks) {
     BOOST_CHECK(!audit::matches_rule(rule, audit::statement_category::DML, "ks", "t2", "admin_read"));
     BOOST_CHECK(!audit::matches_rule(rule, audit::statement_category::DML, "ks", "t1", "viewer"));
 
-    // DML with empty keyspace (alternator batch operations) bypasses table matching.
+    // DML with empty keyspace bypasses table matching.
     BOOST_CHECK(audit::matches_rule(rule, audit::statement_category::DML, "", "tbl1|tbl2", "admin_read"));
     BOOST_CHECK(!audit::matches_rule(rule, audit::statement_category::DML, "", "tbl1|tbl2", "viewer"));
 
@@ -308,7 +315,7 @@ SEASTAR_THREAD_TEST_CASE(test_preprocessed_rules_match_fast_and_slow_paths) {
     BOOST_CHECK(ddl_sinks.contains(audit::audit_sink::syslog));
     BOOST_CHECK(!ddl_sinks.contains(audit::audit_sink::table));
 
-    // DML with empty keyspace (alternator batch operations) bypasses table matching.
+    // DML with empty keyspace bypasses table matching.
     // Known role (fast path):
     BOOST_CHECK(rules.matching_sinks(audit::statement_category::DML, "", "tbl1|tbl2", "admin_read").contains(audit::audit_sink::table));
     BOOST_CHECK(!rules.matching_sinks(audit::statement_category::DML, "", "tbl1|tbl2", "viewer"));
@@ -353,4 +360,20 @@ SEASTAR_THREAD_TEST_CASE(test_preprocessed_empty_rules_skip_cache) {
     rules.refresh_rules({make_rule({"table"}, {"DML"}, {"ks.*"}, {"*"})}).get();
     BOOST_CHECK(rules.matching_sinks(audit::statement_category::DML, "ks", "t1", "alice"));
     BOOST_CHECK(rules.matching_sinks(audit::statement_category::DML, "ks", "t3", "charlie"));
+}
+
+BOOST_AUTO_TEST_CASE(test_alternator_batch_sink_tables_aggregate_per_sink) {
+    std::vector<std::pair<audit::audit_sink, audit::audit_table_set>> sink_tables;
+    audit::add_alternator_batch_sink_tables(sink_tables, audit::audit_sink::table, {"ks", "table_only"});
+    audit::add_alternator_batch_sink_tables(sink_tables, audit::audit_sink::table, {"ks", "both_sinks"});
+    audit::add_alternator_batch_sink_tables(sink_tables, audit::audit_sink::syslog, {"ks", "both_sinks"});
+
+    BOOST_REQUIRE_EQUAL(sink_tables.size(), 2u);
+    BOOST_CHECK(sink_tables[0].first == audit::audit_sink::table);
+    BOOST_CHECK_EQUAL(sink_tables[0].second.size(), 2u);
+    BOOST_CHECK(sink_tables[0].second.contains({"ks", "table_only"}));
+    BOOST_CHECK(sink_tables[0].second.contains({"ks", "both_sinks"}));
+    BOOST_CHECK(sink_tables[1].first == audit::audit_sink::syslog);
+    BOOST_CHECK_EQUAL(sink_tables[1].second.size(), 1u);
+    BOOST_CHECK(sink_tables[1].second.contains({"ks", "both_sinks"}));
 }


### PR DESCRIPTION
## Summary

BatchWriteItem and BatchGetItem were audited whenever their category (DML/QUERY) matched, before checking the tables in the batch against table-scoped audit filters. For batch-heavy workloads this could produce many unnecessary audit entries, degrading performance and consuming storage.

This series makes Alternator batch auditing select tables before creating the audit row. Each table touched by the batch is checked against the configured filters, including `audit_keyspaces`, `audit_tables`, and `audit_rules` qualified table filters. Only matching tables are recorded in `table_name`; if no table matches, no batch audit row is produced.

For mixed batches, the serialized JSON request stored in the audit `operation` field is also filtered so entries belonging to non-matching tables are not logged. This prevents data from non-audited tables from leaking into audit records.

The audit core routes Alternator batch rows by the selected real keyspace/table pairs while preserving the existing empty `keyspace_name` and pipe-separated `table_name` representation. When different tables in one batch match different sinks, each sink receives at most one audit row containing only the tables matching that sink.

Generic empty-keyspace `audit_rules` behavior remains unchanged outside Alternator batch selected-table routing.

Fixes SCYLLADB-1912
Refs SCYLLADB-1430

The performance issue fixed by this PR can affect 2026.2, however this PR relies already on SCYLLADB-1430 which is not present in 2026.2. So let's not backport there and target 2026.3.