### PR TITLE
test/cluster: fix race where sd_notify fires before setting control_connection

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -975,8 +975,14 @@ class ScyllaServer:
                 # Only poll CQL/Alternator until they are known to be up.
                 # Once CQL_ALTERNATOR_QUERIED is reached, skip the poll to avoid
                 # repeatedly recreating driver connections while waiting for sd_notify.
-                if server_up_state < ServerUpState.CQL_ALTERNATOR_QUERIED:
-                    server_up_state = await self.get_cql_alternator_up_state() or server_up_state
+                if server_up_state < expected_server_up_state and server_up_state < ServerUpState.CQL_ALTERNATOR_QUERIED:
+                    if state := await self.get_cql_alternator_up_state():
+                        server_up_state = state
+                    else:
+                        # Don't check SERVING state until we successfully setup the connections
+                        await asyncio.sleep(sleep_interval)
+                        continue
+
                 # Check for SERVING state via sd_notify. This is authoritative: Scylla sends
                 # STATUS=serving once all configured listeners are ready, and
                 # STATUS=entering maintenance mode once the maintenance socket is ready.


### PR DESCRIPTION
If we fail to setup the control_connection in get_cql_alternator_up_state() we expect to retry before starting running tests. Instead, currently we may still start the test if we get the SERVING notification just after the failed check. This is particularly likely in alternator tests, where before checking the SERVING notification we may still try to setup the alternator connection even if we failed to setup control_connection.

We fix this by only proceeding to the SERVING check when `get_cql_alternator_up_state()` returns a non-None state and retrying otherwise.

Fixes: SCYLLADB-2065
