### PR TITLE
test/cluster/test_keyspace_rf: extend test_create_keyspace_with_default_replication_factor for tablets rack lists

### DIFF
--- a/test/cluster/test_keyspace_rf.py
+++ b/test/cluster/test_keyspace_rf.py
@@ -5,6 +5,7 @@
 #
 import pytest
 import logging
+from collections import defaultdict
 
 from cassandra.policies import WhiteListRoundRobinPolicy
 from cassandra.protocol import ConfigurationException
@@ -17,7 +18,7 @@ from test.cluster.util import create_new_test_keyspace, get_replication, get_rep
 @pytest.mark.asyncio
 @pytest.mark.parametrize("tablets_enabled", [True, False])
 @pytest.mark.parametrize("rf_rack_valid_keyspaces", [False, True])
-async def test_create_keyspace_with_default_replication_factor(manager: ManagerClient, tablets_enabled: bool, rf_rack_valid_keyspaces: bool):
+async def test_create_keyspace_with_default_replication_factor(manager: ManagerClient, tablets_enabled: bool, rf_rack_valid_keyspaces: bool, build_mode):
     def get_pf(dc: str, rack: str) -> dict:
         return {'dc': dc, 'rack': rack}
 
@@ -26,6 +27,8 @@ async def test_create_keyspace_with_default_replication_factor(manager: ManagerC
         'rf_rack_valid_keyspaces': rf_rack_valid_keyspaces
     }
     zero_token_cfg = normal_cfg | {'join_ring': False}
+
+    expected_rf = defaultdict(set)
 
     logging.info("Adding the dc1/r1/s1 server")
     server = await manager.server_add(config=normal_cfg, property_file=get_pf("dc1", "r1"))
@@ -36,11 +39,24 @@ async def test_create_keyspace_with_default_replication_factor(manager: ManagerC
     logging.info("Adding dc1/r2 rack server")
     await manager.server_add(config=normal_cfg, property_file=get_pf("dc1", "r2"))
 
+    expected_rf["dc1"] = {"r1", "r2"}
+
     logging.info("Adding dc2/r1 rack server")
     await manager.server_add(config=normal_cfg, property_file=get_pf("dc2", "r1"))
 
     logging.info("Adding dc2/r2 rack server")
     await manager.server_add(config=normal_cfg, property_file=get_pf("dc2", "r2"))
+
+    expected_rf["dc2"] = {"r1", "r2"}
+
+    if build_mode != "debug":
+        logging.info("Adding dc2/r3 rack server")
+        await manager.server_add(config=normal_cfg, property_file=get_pf("dc2", "r3"))
+
+        logging.info("Adding dc2/r4 rack server")
+        await manager.server_add(config=normal_cfg, property_file=get_pf("dc2", "r4"))
+
+        expected_rf["dc2"] |= {"r3", "r4"}
 
     if rf_rack_valid_keyspaces == False:
         logging.info("Adding dc3/rz1 rack server as zero-token")
@@ -49,6 +65,19 @@ async def test_create_keyspace_with_default_replication_factor(manager: ManagerC
         logging.info("Adding dc3/rz2 rack server as zero-token")
         await manager.server_add(config=zero_token_cfg, property_file=get_pf("dc3", "r2"))
 
+    def verify_rf(cql, ks_name: str):
+        rep = get_replication(cql, ks_name)
+        assert len(rep) == 3
+        assert rep['class'] == 'org.apache.cassandra.locator.NetworkTopologyStrategy'
+
+        def verify_dc_rf(dc: str):
+            assert get_replica_count(rep[dc]) == len(expected_rf[dc])
+            if tablets_enabled and rf_rack_valid_keyspaces:
+                assert set(rep[dc]) == expected_rf[dc]
+
+        verify_dc_rf('dc1')
+        verify_dc_rf('dc2')
+
     cql = cluster_con([server.ip_addr], 9042, False,
                         load_balancing_policy=WhiteListRoundRobinPolicy([server.ip_addr])).connect()
 
@@ -56,11 +85,7 @@ async def test_create_keyspace_with_default_replication_factor(manager: ManagerC
     ks_name = await create_new_test_keyspace(cql, f"""WITH replication =
                                                 {{'class': 'NetworkTopologyStrategy'}}
                                                 AND tablets = {{ 'enabled': {str(tablets_enabled).lower()} }}""")
-    rep = get_replication(cql, ks_name)
-    assert len(rep) == 3
-    assert rep['class'] == 'org.apache.cassandra.locator.NetworkTopologyStrategy'
-    assert get_replica_count(rep['dc1']) == 2
-    assert get_replica_count(rep['dc2']) == 2
+    verify_rf(cql, ks_name)
 
     logging.info("Try to create SimpleStrategy keyspace with default replication factor")
     with pytest.raises(ConfigurationException, match="SimpleStrategy requires a replication_factor strategy option."):
@@ -72,8 +97,4 @@ async def test_create_keyspace_with_default_replication_factor(manager: ManagerC
     ks_name = await create_new_test_keyspace(cql, f"""WITH replication =
                                                 {{}}
                                                 AND tablets = {{ 'enabled': {str(tablets_enabled).lower()} }}""")
-    rep = get_replication(cql, ks_name)
-    assert len(rep) == 3
-    assert rep['class'] == 'org.apache.cassandra.locator.NetworkTopologyStrategy'
-    assert get_replica_count(rep['dc1']) == 2
-    assert get_replica_count(rep['dc2']) == 2
+    verify_rf(cql, ks_name)


### PR DESCRIPTION
Add more racks to dc2 to verify that the default replication factor covers all available racks (rather than e.g. limited to 3).

With tablets and rf_rack_valid_keyspaces, verify also the automatically selected rack list.

--

* Improvement, no backport needed
