### PR TITLE
test: fix use-after-free in start_docker_service retry path

### DIFF
--- a/test/lib/proc_utils.cc
+++ b/test/lib/proc_utils.cc
@@ -185,8 +185,8 @@ future<std::tuple<tests::proc::process_fixture, int>> tests::proc::start_docker_
     std::string_view image,
     parse_service_callback stdout_parse,
     parse_service_callback stderr_parse,
-    const std::vector<std::string>& docker_args,
-    const std::vector<std::string>& image_args,
+    std::vector<std::string> docker_args,
+    std::vector<std::string> image_args,
     int service_port)
 {
     std::string container_name;

--- a/test/lib/proc_utils.hh
+++ b/test/lib/proc_utils.hh
@@ -73,8 +73,8 @@ namespace tests::proc {
         std::string_view image,
         parse_service_callback stdout_parse = {},
         parse_service_callback stderr_parse = {},
-        const std::vector<std::string>& docker_args = {},
-        const std::vector<std::string>& image_args = {},
+        std::vector<std::string> docker_args = {},
+        std::vector<std::string> image_args = {},
         int service_port = 0
     );
 }


### PR DESCRIPTION
`start_docker_service` is a coroutine that took `docker_args` and `image_args` by `const&`. Its caller `start_fake_gcs_server` is a regular function that passes temporaries (initializer lists) and immediately returns a future. The temporaries are destroyed when the caller returns, leaving the coroutine holding dangling references.

### Problem

On the first loop iteration this works by luck (memory not yet reused), but on retry (after "address already in use") `params.append_range(image_args)` reads freed memory — use-after-free that manifests as `std::bad_alloc` or `broken_promise` in non-sanitizer builds.

ASan (debug build) confirms:
```
AddressSanitizer: heap-use-after-free on address ... at pc ...
  #7 in tests::proc::start_docker_service(...) test/lib/proc_utils.cc:225
```

### Changes

Change `docker_args` and `image_args` parameters from `const std::vector<std::string>&` to `std::vector<std::string>` (by value), so the coroutine frame owns the vectors for its entire lifetime including retries.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2003

Backport to 2026.2 needed — this is a bug fix for a flaky test that affects CI stability.