### PR TITLE
raft/server: introduce server::handle to prevent abort races on async operations

### DIFF
--- a/api/raft.cc
+++ b/api/raft.cc
@@ -133,9 +133,9 @@ void set_raft(http_context&, httpd::routes& r, sharded<service::raft_group_regis
 
         if (req->get_query_param("group_id").empty()) {
             // Stepdown on group 0 by default
-            co_await raft_gr.invoke_on(0, [timeout_dur] (service::raft_group_registry& raft_gr) {
+            co_await raft_gr.invoke_on(0, [timeout_dur] (service::raft_group_registry& raft_gr) -> future<> {
                 apilog.info("Triggering stepdown for group0");
-                return raft_gr.group0().stepdown(timeout_dur);
+                co_await raft_gr.get_group0()->stepdown(timeout_dur);
             });
             co_return json_void{};
         }
@@ -150,7 +150,7 @@ void set_raft(http_context&, httpd::routes& r, sharded<service::raft_group_regis
 
             found_srv = true;
             apilog.info("Triggering stepdown for group {}", gid);
-            co_await srv->stepdown(timeout_dur);
+            co_await raft_gr.get_server_handle(gid)->stepdown(timeout_dur);
         });
 
         if (!found_srv) {

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -1043,7 +1043,7 @@ public:
         while (!_raft_gr.local().group0().current_leader()) {
             abort_on_expiry aoe(permit.timeout());
             reader_permit::awaits_guard ag(permit);
-            co_await _raft_gr.local().group0().read_barrier(&aoe.abort_source());
+            co_await _raft_gr.local().get_group0()->read_barrier(&aoe.abort_source());
         }
 
         co_return _raft_gr.local().group0().current_leader();

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -105,6 +105,7 @@ public:
     future<entry_id> add_entry_on_leader(command command, seastar::abort_source* as);
     void register_metrics() override;
     size_t max_command_size() const override;
+    handle get_handle() override;
 private:
     seastar::condition_variable _events;
 
@@ -327,6 +328,8 @@ private:
     future<> wait_for_next_tick(seastar::abort_source* as);
 
 
+    seastar::named_gate _shutdown_gate;
+
     seastar::named_gate _do_on_leader_gate;
     // Call a function on a current leader until it returns stop_iteration::yes.
     // Handles aborts and leader changes, adds a delay between
@@ -347,7 +350,9 @@ server_impl::server_impl(server_id uuid, std::unique_ptr<rpc> rpc,
         seastar::shared_ptr<failure_detector> failure_detector, server::configuration config) :
                     _rpc(std::move(rpc)), _state_machine(std::move(state_machine)),
                     _persistence(std::move(persistence)), _failure_detector(failure_detector),
-                    _id(uuid), _config(config), _do_on_leader_gate("raft::server_impl::do_on_leader_gate")
+                    _id(uuid), _config(config),
+                    _shutdown_gate("raft::server_impl::shutdown_gate"),
+                    _do_on_leader_gate("raft::server_impl::do_on_leader_gate")
 {
     set_rpc_server(_rpc.get());
     if (_config.snapshot_threshold_log_size > _config.max_log_size) {
@@ -1613,17 +1618,54 @@ future<> server_impl::abort(sstring reason) {
     _is_alive = false;
     _aborted = std::move(reason);
     logger.trace("[{}]: abort() called", _id);
+
+    // Stop FSM and break condition variables to cause io_fiber and
+    // applier_fiber to exit. These internal fibers don't hold shutdown gate
+    // handles, so we can safely wait for them before closing the gate.
     _fsm->stop();
     _events.broken();
     _snapshot_desc_idx_changed.broken();
-
-    // IO and applier fibers may update waiters and start new snapshot
-    // transfers, so abort them first
     _apply_entries.abort(std::make_exception_ptr(stop_apply_fiber()));
     co_await seastar::when_all_succeed(std::move(_io_status), std::move(_applier_status)).discard_result();
 
-    // Start RPC abort before aborting snapshot applications or destroying entry waiters.
-    // After calling `_rpc->abort()` no new snapshot applications should be started or new waiters created
+    // Now that internal fibers have stopped, break all promises that
+    // handle-holding callers may be waiting on. This allows them to observe
+    // the abort and release their handles so the shutdown gate can close.
+    if (_state_change_promise) {
+        _state_change_promise->set_exception(stopped_error(*_aborted));
+    }
+    if (_leader_promise) {
+        _leader_promise->set_exception(stopped_error(*_aborted));
+    }
+    if (_tick_promise) {
+        _tick_promise->set_exception(stopped_error(*_aborted));
+    }
+    for (auto& ac: _awaited_commits) {
+        ac.second.done.set_exception(stopped_error(*_aborted));
+    }
+    _awaited_commits.clear();
+    for (auto& aa: _awaited_applies) {
+        aa.second.done.set_exception(stopped_error(*_aborted));
+    }
+    _awaited_applies.clear();
+    if (_non_joint_conf_commit_promise) {
+        std::exchange(_non_joint_conf_commit_promise, std::nullopt)->promise.set_exception(stopped_error(*_aborted));
+    }
+    for (auto& r: _reads) {
+        r.promise.set_value(raft::not_a_leader{server_id{}});
+    }
+    _reads.clear();
+    for (auto& i : _awaited_indexes) {
+        i.second.promise.set_exception(stopped_error(*_aborted));
+    }
+    _awaited_indexes.clear();
+
+    // Close the shutdown gate. All waiters have been signaled, so
+    // handle holders can observe the abort and release their handles.
+    co_await _shutdown_gate.close();
+
+    // Start RPC abort before aborting snapshot applications.
+    // After calling `_rpc->abort()` no new snapshot applications should be started
     // (see `rpc::abort()` comment and `_aborted` flag).
     auto abort_rpc = _rpc->abort();
     auto abort_sm = _state_machine->abort();
@@ -1635,45 +1677,7 @@ future<> server_impl::abort(sstring reason) {
         f.set_exception(std::runtime_error("Snapshot application aborted"));
     }
 
-    // Destroy entry waiters before waiting for `abort_rpc`,
-    // since the RPC implementation may wait for forwarded `modify_config` calls to finish
-    // (and `modify_config` does not finish until the configuration entry is committed or an error occurs).
-    for (auto& ac: _awaited_commits) {
-        ac.second.done.set_exception(stopped_error(*_aborted));
-    }
-    for (auto& aa: _awaited_applies) {
-        aa.second.done.set_exception(stopped_error(*_aborted));
-    }
-    _awaited_commits.clear();
-    _awaited_applies.clear();
-    if (_non_joint_conf_commit_promise) {
-        std::exchange(_non_joint_conf_commit_promise, std::nullopt)->promise.set_exception(stopped_error(*_aborted));
-    }
-
-    // Complete all read attempts with not_a_leader
-    for (auto& r: _reads) {
-        r.promise.set_value(raft::not_a_leader{server_id{}});
-    }
-    _reads.clear();
-
-    // Abort all read_barriers with an exception
-    for (auto& i : _awaited_indexes) {
-        i.second.promise.set_exception(stopped_error(*_aborted));
-    }
-    _awaited_indexes.clear();
-
     co_await seastar::when_all_succeed(std::move(abort_rpc), std::move(abort_sm), std::move(abort_persistence)).discard_result();
-
-    if (_leader_promise) {
-        _leader_promise->set_exception(stopped_error(*_aborted));
-    }
-    if (_tick_promise) {
-        _tick_promise->set_exception(stopped_error(*_aborted));
-    }
-
-    if (_state_change_promise) {
-        _state_change_promise->set_exception(stopped_error(*_aborted));
-    }
 
     abort_snapshot_transfers();
 
@@ -1925,6 +1929,11 @@ future<> server_impl::stepdown(logical_clock::duration timeout) {
 
 size_t server_impl::max_command_size() const {
     return _config.max_command_size;
+}
+
+server::handle server_impl::get_handle() {
+    check_not_aborted();
+    return handle(*this, _shutdown_gate.hold());
 }
 
 std::unique_ptr<server> create_server(server_id uuid, std::unique_ptr<rpc> rpc,

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -7,6 +7,7 @@
  */
 #pragma once
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
 #include "raft.hh"
 
 namespace raft {
@@ -19,6 +20,26 @@ enum class wait_type {
 // A single uniquely identified participant of a Raft group.
 class server {
 public:
+    // RAII handle to a raft server that holds the server's shutdown gate
+    // open, preventing the server from being fully aborted while the handle
+    // exists. This protects against races between async operations on the
+    // server (e.g. read_barrier) and the server being aborted concurrently.
+    class handle {
+        server& _server;
+        seastar::gate::holder _holder;
+    public:
+        handle(server& s, seastar::gate::holder h) noexcept
+                : _server(s), _holder(std::move(h)) {}
+        server& operator*() const { return _server; }
+        server* operator->() const { return &_server; }
+    };
+
+    // Returns a handle that holds the server's shutdown gate open.
+    // The caller must keep the handle alive for the duration of any
+    // async operation on this server.
+    // Throws seastar::gate_closed_exception if the server is being shut down.
+    virtual handle get_handle() = 0;
+
     struct configuration {
         // automatically snapshot state machine after applying
         // this number of entries

--- a/service/raft/group0_voter_handler.cc
+++ b/service/raft/group0_voter_handler.cc
@@ -491,6 +491,9 @@ future<> group0_voter_handler::update_nodes(
         co_return co_await _group0.modify_voters({}, nodes_removed, as);
     }
 
+    // Plain reference is sufficient here since raft_server is only used
+    // synchronously below (not held across co_await). If it were used
+    // across async calls, get_group0_server() should be used instead.
     auto& raft_server = _group0.group0_server();
 
     const auto& leader_id = raft_server.current_leader();

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -239,10 +239,19 @@ public:
         return _client;
     }
 
-    // Return an instance of group 0. Valid only on shard 0,
-    // after boot/upgrade is complete
+    // Return a reference to group 0 server. Valid only on shard 0,
+    // after boot/upgrade is complete.
     raft::server& group0_server() {
         return _raft_gr.group0();
+    }
+
+    // Return a handle to group 0 server. Valid only on shard 0,
+    // after boot/upgrade is complete.
+    // The handle holds the server's shutdown gate open,
+    // preventing the server from being aborted while the handle exists.
+    // Use this variant when the server reference is held across async calls.
+    raft::server::handle get_group0_server() {
+        return _raft_gr.get_group0();
     }
 
     // Returns a wrapper for the group0_server() with timeouts support.

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -219,7 +219,7 @@ future<> raft_group0_client::add_entry_unguarded(group0_command group0_cmd, seas
 
     // Command is not retried, because for now it's not idempotent.
     try {
-        co_await _raft_gr.group0().add_entry(cmd, raft::wait_type::applied, as);
+        co_await _raft_gr.get_group0()->add_entry(cmd, raft::wait_type::applied, as);
     } catch (const raft::not_a_leader& e) {
         // This should not happen since follower-to-leader entry forwarding is enabled in group 0.
         // Just fail the operation by propagating the error.

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -314,6 +314,10 @@ raft::server& raft_group_registry::get_server(raft::group_id gid) {
     return *ptr;
 }
 
+raft::server::handle raft_group_registry::get_server_handle(raft::group_id gid) {
+    return get_server(gid).get_handle();
+}
+
 raft_server_with_timeouts raft_group_registry::get_server_with_timeouts(raft::group_id gid) {
     auto& group_server = server_for_group(gid);
     if (!group_server.server.get()) {
@@ -344,6 +348,13 @@ raft::server& raft_group_registry::group0() {
         on_internal_error(rslog, "group0(): _group0_id not present");
     }
     return get_server(*_group0_id);
+}
+
+raft::server::handle raft_group_registry::get_group0() {
+    if (!_group0_id) {
+        on_internal_error(rslog, "get_group0(): _group0_id not present");
+    }
+    return get_server_handle(*_group0_id);
 }
 
 raft::group_id raft_group_registry::group0_id() const {
@@ -461,6 +472,7 @@ namespace {
 raft_server_with_timeouts::raft_server_with_timeouts(raft_server_for_group& group_server, shared_ptr<raft::failure_detector> fd)
     : _group_server(group_server)
     , _fd(fd)
+    , _handle(group_server.server->get_handle())
 {
 }
 

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -84,6 +84,7 @@ class raft_operation_timeout_error : public std::runtime_error {
 class raft_server_with_timeouts {
     raft_server_for_group& _group_server;
     shared_ptr<raft::failure_detector> _fd;
+    raft::server::handle _handle;
 
     template <std::invocable<abort_source*> Op>
     std::invoke_result_t<Op, abort_source*>
@@ -160,6 +161,12 @@ public:
     // there is no such group.
     raft::server& get_server(raft::group_id gid);
 
+    // Returns a handle to the server for the given group id.
+    // The handle holds the server's shutdown gate open, preventing
+    // the server from being aborted while the handle exists.
+    // Throws raft_group_not_found if there is no such group.
+    raft::server::handle get_server_handle(raft::group_id gid);
+
     // Returns a server with timeouts support for group by group id.
     // Throws exception if there is no such group.
     raft_server_with_timeouts get_server_with_timeouts(raft::group_id gid);
@@ -171,9 +178,16 @@ public:
     // Returns the list of all Raft groups on this shard by their IDs.
     std::vector<raft::group_id> all_groups() const;
 
-    // Return an instance of group 0. Valid only on shard 0,
-    // after boot/upgrade is complete
+    // Return a reference to group 0 server. Valid only on shard 0,
+    // after boot/upgrade is complete.
     raft::server& group0();
+
+    // Return a handle to group 0 server. Valid only on shard 0,
+    // after boot/upgrade is complete.
+    // The handle holds the server's shutdown gate open,
+    // preventing the server from being aborted while the handle exists.
+    // Use this variant when the server reference is held across async calls.
+    raft::server::handle get_group0();
     raft::group_id group0_id() const;
 
     // Return an instance of group 0 server with timeouts support. Valid only on shard 0,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4888,8 +4888,7 @@ future<tablet_operation_result> storage_service::do_tablet_operation(locator::gl
                                               std::function<future<tablet_operation_result>(locator::tablet_metadata_guard&)> op) {
     // The coordinator may not execute global token metadata barrier before triggering the operation, so we need
     // a barrier here to see the token metadata which is at least as recent as that of the sender.
-    auto& raft_server = _group0->group0_server();
-    co_await raft_server.read_barrier(&_group0_as);
+    co_await _group0->get_group0_server()->read_barrier(&_group0_as);
 
     if (_tablet_ops.contains(tablet)) {
         rtlogger.debug("{} retry joining with existing session for tablet {}", op_name, tablet);
@@ -5714,7 +5713,7 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
     }
 
     // Refresh is triggered after table creation, need to make sure we see the new tablets.
-    co_await _group0->group0_server().read_barrier(&_group0_as);
+    co_await _group0->get_group0_server()->read_barrier(&_group0_as);
 
     using table_ids_t = std::unordered_set<table_id>;
     const auto table_ids = co_await std::invoke([this] () -> future<table_ids_t> {
@@ -5922,7 +5921,7 @@ future<> storage_service::await_topology_quiesced() {
         co_return;
     }
 
-    co_await _group0->group0_server().read_barrier(&_group0_as);
+    co_await _group0->get_group0_server()->read_barrier(&_group0_as);
     co_await _topology_state_machine.await_not_busy();
 }
 
@@ -5936,7 +5935,7 @@ future<bool> storage_service::verify_topology_quiesced(token_metadata::version_t
         });
     }
 
-    co_await _group0->group0_server().read_barrier(&_group0_as);
+    co_await _group0->get_group0_server()->read_barrier(&_group0_as);
     co_return _topology_state_machine._topology.version == expected_version && !_topology_state_machine._topology.is_busy();
 }
 

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -383,7 +383,10 @@ void groups_manager::update(token_metadata_ptr new_tm) {
         state.server_control_op = futurize_invoke([&state, this, tablet, id, new_tm](this auto) -> future<> {
             co_await state.server_control_op.get_future();
             co_await start_raft_group(tablet, id, std::move(new_tm));
-            state.server = &_raft_gr.get_server(id);
+            state.server = _raft_gr.find_server(id);
+            if (!state.server) {
+                on_internal_error(logger, format("update(): no server for group {}", id));
+            }
             state.leader_info_updater = leader_info_updater(state, tablet, id);
 
             // We want to make sure the server is ready to serve requests before

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -206,7 +206,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 try {
                     rtlogger.debug("topology coordinator fiber removing {}"
                                   " from raft since they are in `left` state", to_remove);
-                    co_await _group0.group0_server().modify_config({}, to_remove, &_as);
+                    co_await _group0.get_group0_server()->modify_config({}, to_remove, &_as);
                 } catch (const raft::commit_status_unknown&) {
                     rtlogger.warn("topology coordinator fiber got commit_status_unknown status"
                                   " while removing {} from raft", to_remove);
@@ -4645,7 +4645,7 @@ future<> topology_coordinator::rollback_current_topology_op(group0_guard&& guard
             // The node was removed already. We need to add it back. Lets do it as non voter.
             // If it ever boots again it will make itself a voter.
             release_node(std::move(node));
-            co_await _group0.group0_server().modify_config({raft::config_member{{id, {}}, raft::is_voter::no}}, {}, &_as);
+            co_await _group0.get_group0_server()->modify_config({raft::config_member{{id, {}}, raft::is_voter::no}}, {}, &_as);
             node = retake_node(co_await start_operation(), id);
         }
             [[fallthrough]];


### PR DESCRIPTION
## Summary

- Introduce `raft::server::handle`, a RAII type that holds the server's shutdown gate open, preventing the server from being fully aborted while async operations (e.g. `read_barrier`, `add_entry`, `modify_config`) are in flight.
- Add `get_group0()` / `get_group0_server()` / `get_server_handle()` accessors that return handles, alongside the existing `group0()` / `group0_server()` / `get_server()` which continue to return plain references for short-lived synchronous use.
- Update all callers that hold a server reference across coroutine suspension points to use the handle variants.
- Split out an unrelated defensive fix in `groups_manager::update` to use `find_server` with null check.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2071

---

- Backport is not required due to the intrusiveness of the fix vs. the rarity of the bug it fixes and the severity as it happens on the shutdown path.