### PR TITLE
cql: atomic add/subtract operations with LWT

### DIFF
--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -10,12 +10,28 @@
 
 #include "cql3/constants.hh"
 #include "cql3/expr/evaluate.hh"
+#include "cql3/expr/expr-utils.hh"
+#include "types/concrete_types.hh"
 
 namespace cql3 {
 
+constants::setter::setter(const column_definition& column, expr::expression e)
+    : operation_skip_if_unset(column, std::move(e))
+    , _requires_read(_e && expr::find_in_expression<expr::column_value>(*_e, [](const expr::column_value& cv) {
+        // primary key columns are always available to an update, they don't
+        // require a read.
+        return !cv.col->is_primary_key();
+    }) != nullptr)
+{ }
+
 void
 constants::setter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
-    auto value = expr::evaluate(*_e, params._options);
+    auto value = _requires_read
+        ? params.evaluate_on_prefetched_row(
+            *_e,
+            m.key(),
+            column.is_static() ? clustering_key_prefix::make_empty() : prefix)
+        : expr::evaluate(*_e, params._options);
     execute(m, prefix, params, column, value.view());
 }
 
@@ -63,4 +79,6 @@ expr::expression
 constants::setter::prepare_new_value_for_broadcast_tables() const {
     return *_e;
 }
+
+
 }

--- a/cql3/constants.hh
+++ b/cql3/constants.hh
@@ -32,9 +32,20 @@ public:
 #endif
 public:
     class setter : public operation_skip_if_unset {
+        bool _requires_read;
     public:
-        using operation_skip_if_unset::operation_skip_if_unset;
+        setter(const column_definition& column, expr::expression e);
 
+        virtual bool requires_read() const override { return _requires_read; }
+        virtual bool requires_lwt() const override {
+            // An expression that requires reading a value from the row, e.g.,
+            // SET r = r + 1, requires LWT for atomicity and should not be allowed
+            // on non-LWT requests. In one special case, namely a list update
+            // "UPDATE t SET mylist[0] = 5 WHERE ...", we do allow reading the old
+            // row without LWT or atomicity - but this case is not handled by
+            // constants::setter so we don't need to support it here.
+            return _requires_read;
+        }
         virtual void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) override;
 
         static void execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, cql3::raw_value_view value);

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -75,6 +75,7 @@ static cql3::raw_value do_evaluate(const tuple_constructor&, const evaluation_in
 static cql3::raw_value do_evaluate(const collection_constructor&, const evaluation_inputs&);
 static cql3::raw_value do_evaluate(const usertype_constructor&, const evaluation_inputs&);
 static cql3::raw_value do_evaluate(const function_call&, const evaluation_inputs&);
+static cql3::raw_value do_evaluate(const unary_operator&, const evaluation_inputs&);
 
 namespace {
 
@@ -839,6 +840,9 @@ auto fmt::formatter<cql3::expr::expression::printer>::format(const cql3::expr::e
             },
             [&] (const temporary& t) {
                 out = fmt::format_to(out, "@temporary{}", t.index);
+            },
+            [&] (const unary_operator& uo) {
+                out = fmt::format_to(out, "({}{})", uo.op, to_printer(uo.operand));
             }
         }, pr.expr_to_print);
     return out;
@@ -972,6 +976,9 @@ bool recurse_until(const expression& e, const noncopyable_function<bool (const e
                 }
                 return false;
             },
+            [&] (const unary_operator& uo) {
+                return recurse_until(uo.operand, predicate_fun);
+            },
             [](LeafExpression auto const&) {
                 return false;
             }
@@ -1046,6 +1053,9 @@ expression search_and_replace(const expression& e,
                         .sub = recurse(s.sub),
                         .type = s.type,
                     };
+                },
+                [&] (const unary_operator& uo) -> expression {
+                    return unary_operator{uo.op, recurse(uo.operand)};
                 },
                 [&] (LeafExpression auto const& e) -> expression {
                     return e;
@@ -1452,6 +1462,51 @@ static
 cql3::raw_value
 do_evaluate(const temporary& t, const evaluation_inputs& inputs) {
     return inputs.temporaries[t.index];
+}
+
+static
+cql3::raw_value
+do_evaluate(const unary_operator& uo, const evaluation_inputs& inputs) {
+    // For now, this is do-nothing switch() supporting only the NEG operator.
+    // It will ask the compiler to warn us if we ever add a new type of unary
+    // operator and forget to update this function to handle it.
+    switch (uo.op) {
+    case unary_oper_t::NEG:
+        break;
+    }
+    raw_value operand_val = evaluate(uo.operand, inputs);
+    if (operand_val.is_null()) {
+        return raw_value::make_null();
+    }
+    const abstract_type& t = type_of(uo.operand)->without_reversed();
+    bytes result = operand_val.view().with_linearized([&](bytes_view bv) -> bytes {
+        return visit(t, make_visitor(
+            [&] <typename T> (const integer_type_impl<T>& itype) -> bytes {
+                T v = value_cast<T>(itype.deserialize(bv));
+                T res;
+                if (__builtin_sub_overflow(T(0), v, &res)) {
+                    throw exceptions::invalid_request_exception("Arithmetic negation overflow");
+                }
+                return serialized(res);
+            },
+            [&] <typename T> (const floating_type_impl<T>& ftype) -> bytes {
+                return serialized(-value_cast<T>(ftype.deserialize(bv)));
+            },
+            [&] (const varint_type_impl& vtype) -> bytes {
+                utils::multiprecision_int v = value_cast<utils::multiprecision_int>(vtype.deserialize(bv));
+                return serialized(-v);
+            },
+            [&] (const decimal_type_impl& dtype) -> bytes {
+                big_decimal v = value_cast<big_decimal>(dtype.deserialize(bv));
+                return serialized(-v);
+            },
+            [&] (const abstract_type& atype) -> bytes {
+                throw exceptions::invalid_request_exception(
+                    format("Arithmetic negation is not supported for type {}", atype.cql3_type_name()));
+            }
+        ));
+    });
+    return raw_value::make_value(managed_bytes(result));
 }
 
 cql3::raw_value evaluate(const expression& e, const evaluation_inputs& inputs) {
@@ -2031,6 +2086,9 @@ void fill_prepare_context(expression& e, prepare_context& ctx) {
         [](untyped_constant&) {},
         [](constant&) {},
         [](temporary&) {},
+        [&](unary_operator& uo) {
+            fill_prepare_context(uo.operand, ctx);
+        },
     }, e);
 }
 
@@ -2109,6 +2167,9 @@ type_of(const expression& e) {
                     return t;
                 },
             }, e.type);
+        },
+        [] (const unary_operator& uo) {
+            return type_of(uo.operand);
         },
         [] (const ExpressionElement auto& e) -> data_type {
             return e.type;
@@ -2407,6 +2468,9 @@ aggregation_depth(const cql3::expr::expression& e) {
         },
         [] (const usertype_constructor& uc) {
             return max_over_range(uc.elements | std::views::values);
+        },
+        [] (const unary_operator& uo) {
+            return aggregation_depth(uo.operand);
         }
     }, e);
 }
@@ -2496,6 +2560,10 @@ levellize_aggregation_depth(const cql3::expr::expression& e, unsigned desired_de
         [&] (usertype_constructor uc) -> expression {
             recurse_over_range(uc.elements | std::views::values);
             return uc;
+        },
+        [&] (unary_operator uo) -> expression {
+            recurse(uo.operand);
+            return uo;
         }
     }, e);
 }
@@ -2708,4 +2776,14 @@ std::string_view fmt::formatter<cql3::expr::oper_t>::to_string(const cql3::expr:
         return "-";
     }
     on_internal_error(cql3::expr::expr_logger, fmt::format("unexpected oper_t value {}", static_cast<int>(op)));
+}
+
+std::string_view fmt::formatter<cql3::expr::unary_oper_t>::to_string(const cql3::expr::unary_oper_t& op) {
+    using cql3::expr::unary_oper_t;
+
+    switch (op) {
+    case unary_oper_t::NEG:
+        return "-";
+    }
+    on_internal_error(cql3::expr::expr_logger, fmt::format("unexpected unary_oper_t value {}", static_cast<int>(op)));
 }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -21,11 +21,14 @@
 #include "cql3/selection/selection.hh"
 #include "cql3/util.hh"
 #include "index/secondary_index_manager.hh"
+#include "types/concrete_types.hh"
 #include "types/list.hh"
 #include "types/map.hh"
 #include "types/set.hh"
 #include "types/vector.hh"
 #include "utils/like_matcher.hh"
+#include "utils/big_decimal.hh"
+#include "utils/multiprecision_int.hh"
 #include "query/query-result-reader.hh"
 #include "types/user.hh"
 #include "cql3/functions/scalar_function.hh"
@@ -341,6 +344,8 @@ bool_or_null limits(const expression& lhs, oper_t op, null_handling_style null_h
                 }
             case oper_t::NOT_IN:
                 on_internal_error(expr_logger, "NOT IN operator on limits(), despite being rejected via !is_slice()");
+            case oper_t::ADD:
+                on_internal_error(expr_logger, "ADD operator on limits()");
             }
         }
     }
@@ -1092,6 +1097,61 @@ std::optional<bool> get_bool_value(const constant& constant_val) {
     return constant_val.view().deserialize<bool>(*boolean_type);
 }
 
+static raw_value arithmetic_add(const expression& lhs_expr, const expression& rhs_expr, const evaluation_inputs& inputs) {
+    raw_value lhs_val = evaluate(lhs_expr, inputs);
+    raw_value rhs_val = evaluate(rhs_expr, inputs);
+    if (lhs_val.is_null() || rhs_val.is_null()) {
+        // null plus anything is null:
+        return raw_value::make_null();
+    }
+    const abstract_type& t = type_of(lhs_expr)->without_reversed();
+    if (const abstract_type& rhs_t = type_of(rhs_expr)->without_reversed(); rhs_t != t) {
+        throw exceptions::invalid_request_exception(
+            format("Arithmetic ADD on different types ({} and {}) is not yet supported",
+                t.cql3_type_name(), rhs_t.cql3_type_name()));
+    }
+    bytes result = lhs_val.view().with_linearized([&](bytes_view lhs_bv) -> bytes {
+        return rhs_val.view().with_linearized([&](bytes_view rhs_bv) -> bytes {
+            return visit(t, make_visitor(
+                [&] <typename T> (const integer_type_impl<T>& itype) -> bytes {
+                    T l = value_cast<T>(itype.deserialize(lhs_bv));
+                    T r = value_cast<T>(itype.deserialize(rhs_bv));
+                    T res;
+                    if (__builtin_add_overflow(l, r, &res)) {
+                        throw exceptions::invalid_request_exception("Arithmetic ADD overflow");
+                    }
+                    return serialized(res);
+                },
+                [&] <typename T> (const floating_type_impl<T>& ftype) -> bytes {
+                    T l = value_cast<T>(ftype.deserialize(lhs_bv));
+                    T r = value_cast<T>(ftype.deserialize(rhs_bv));
+                    return serialized(l + r);
+                },
+                [&] (const varint_type_impl& vtype) -> bytes {
+                    utils::multiprecision_int l = value_cast<utils::multiprecision_int>(vtype.deserialize(lhs_bv));
+                    utils::multiprecision_int r = value_cast<utils::multiprecision_int>(vtype.deserialize(rhs_bv));
+                    return serialized(l + r);
+                },
+                [&] (const decimal_type_impl& dtype) -> bytes {
+                    // NOTE: This addition is susceptible to SCYLLADB-1576 - adding
+                    // two decimals with wildly different scales (e.g. 1 and
+                    // 1e100000000) can cause huge allocations and CPU usage.
+                    // This case should be caught and rejected in big_decimal's
+                    // implementation, not here.
+                    big_decimal l = value_cast<big_decimal>(dtype.deserialize(lhs_bv));
+                    big_decimal r = value_cast<big_decimal>(dtype.deserialize(rhs_bv));
+                    return serialized(l + r);
+                },
+                [&] (const abstract_type& atype) -> bytes {
+                    throw exceptions::invalid_request_exception(
+                        format("Arithmetic ADD is not supported for type {}", atype.cql3_type_name()));
+                }
+            ));
+        });
+    });
+    return raw_value::make_value(managed_bytes(result));
+}
+
 static
 cql3::raw_value do_evaluate(const binary_operator& binop, const evaluation_inputs& inputs) {
     if (binop.order == comparison_order::clustering) {
@@ -1101,6 +1161,8 @@ cql3::raw_value do_evaluate(const binary_operator& binop, const evaluation_input
     bool_or_null binop_result(false);
 
     switch (binop.op) {
+        case oper_t::ADD:
+            return arithmetic_add(binop.lhs, binop.rhs, inputs);
         case oper_t::EQ:
             binop_result = equal(binop.lhs, binop.rhs, inputs, binop.null_handling);
             break;
@@ -1952,7 +2014,11 @@ type_of(const expression& e) {
             return boolean_type;
         },
         [] (const binary_operator& e) {
-            // All our binary operators are relations
+            // Arithmetic operators return the type of their operands;
+            // all other (comparison) operators return boolean.
+            if (e.op == oper_t::ADD) {
+                return type_of(e.lhs);
+            }
             return boolean_type;
         },
         [] (const column_value& e) {
@@ -2582,6 +2648,8 @@ std::string_view fmt::formatter<cql3::expr::oper_t>::to_string(const cql3::expr:
         return "IS NOT";
     case oper_t::LIKE:
         return "LIKE";
+    case oper_t::ADD:
+        return "+";
     }
-    __builtin_unreachable();
+    on_internal_error(cql3::expr::expr_logger, fmt::format("unexpected oper_t value {}", static_cast<int>(op)));
 }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -346,6 +346,8 @@ bool_or_null limits(const expression& lhs, oper_t op, null_handling_style null_h
                 on_internal_error(expr_logger, "NOT IN operator on limits(), despite being rejected via !is_slice()");
             case oper_t::ADD:
                 on_internal_error(expr_logger, "ADD operator on limits()");
+            case oper_t::SUB:
+                on_internal_error(expr_logger, "SUB operator on limits()");
             }
         }
     }
@@ -1152,6 +1154,56 @@ static raw_value arithmetic_add(const expression& lhs_expr, const expression& rh
     return raw_value::make_value(managed_bytes(result));
 }
 
+static raw_value arithmetic_sub(const expression& lhs_expr, const expression& rhs_expr, const evaluation_inputs& inputs) {
+    raw_value lhs_val = evaluate(lhs_expr, inputs);
+    raw_value rhs_val = evaluate(rhs_expr, inputs);
+    if (lhs_val.is_null() || rhs_val.is_null()) {
+        // null minus anything is null:
+        return raw_value::make_null();
+    }
+    const abstract_type& t = type_of(lhs_expr)->without_reversed();
+    if (const abstract_type& rhs_t = type_of(rhs_expr)->without_reversed(); rhs_t != t) {
+        throw exceptions::invalid_request_exception(
+            format("Arithmetic SUB on different types ({} and {}) is not yet supported",
+                t.cql3_type_name(), rhs_t.cql3_type_name()));
+    }
+    bytes result = lhs_val.view().with_linearized([&](bytes_view lhs_bv) -> bytes {
+        return rhs_val.view().with_linearized([&](bytes_view rhs_bv) -> bytes {
+            return visit(t, make_visitor(
+                [&] <typename T> (const integer_type_impl<T>& itype) -> bytes {
+                    T l = value_cast<T>(itype.deserialize(lhs_bv));
+                    T r = value_cast<T>(itype.deserialize(rhs_bv));
+                    T res;
+                    if (__builtin_sub_overflow(l, r, &res)) {
+                        throw exceptions::invalid_request_exception("Arithmetic SUB overflow");
+                    }
+                    return serialized(res);
+                },
+                [&] <typename T> (const floating_type_impl<T>& ftype) -> bytes {
+                    T l = value_cast<T>(ftype.deserialize(lhs_bv));
+                    T r = value_cast<T>(ftype.deserialize(rhs_bv));
+                    return serialized(l - r);
+                },
+                [&] (const varint_type_impl& vtype) -> bytes {
+                    utils::multiprecision_int l = value_cast<utils::multiprecision_int>(vtype.deserialize(lhs_bv));
+                    utils::multiprecision_int r = value_cast<utils::multiprecision_int>(vtype.deserialize(rhs_bv));
+                    return serialized(l + (-r));
+                },
+                [&] (const decimal_type_impl& dtype) -> bytes {
+                    big_decimal l = value_cast<big_decimal>(dtype.deserialize(lhs_bv));
+                    big_decimal r = value_cast<big_decimal>(dtype.deserialize(rhs_bv));
+                    return serialized(l - r);
+                },
+                [&] (const abstract_type& atype) -> bytes {
+                    throw exceptions::invalid_request_exception(
+                        format("Arithmetic SUB is not supported for type {}", atype.cql3_type_name()));
+                }
+            ));
+        });
+    });
+    return raw_value::make_value(managed_bytes(result));
+}
+
 static
 cql3::raw_value do_evaluate(const binary_operator& binop, const evaluation_inputs& inputs) {
     if (binop.order == comparison_order::clustering) {
@@ -1163,6 +1215,8 @@ cql3::raw_value do_evaluate(const binary_operator& binop, const evaluation_input
     switch (binop.op) {
         case oper_t::ADD:
             return arithmetic_add(binop.lhs, binop.rhs, inputs);
+        case oper_t::SUB:
+            return arithmetic_sub(binop.lhs, binop.rhs, inputs);
         case oper_t::EQ:
             binop_result = equal(binop.lhs, binop.rhs, inputs, binop.null_handling);
             break;
@@ -2016,7 +2070,7 @@ type_of(const expression& e) {
         [] (const binary_operator& e) {
             // Arithmetic operators return the type of their operands;
             // all other (comparison) operators return boolean.
-            if (e.op == oper_t::ADD) {
+            if (e.op == oper_t::ADD || e.op == oper_t::SUB) {
                 return type_of(e.lhs);
             }
             return boolean_type;
@@ -2650,6 +2704,8 @@ std::string_view fmt::formatter<cql3::expr::oper_t>::to_string(const cql3::expr:
         return "LIKE";
     case oper_t::ADD:
         return "+";
+    case oper_t::SUB:
+        return "-";
     }
     on_internal_error(cql3::expr::expr_logger, fmt::format("unexpected oper_t value {}", static_cast<int>(op)));
 }

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -221,7 +221,7 @@ const column_value& get_subscripted_column(const subscript&);
 /// Only columns can be subscripted in CQL, so we can expect that the subscripted expression is a column_value.
 const column_value& get_subscripted_column(const expression&);
 
-enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, NOT_IN, CONTAINS, CONTAINS_KEY, IS_NOT, LIKE, ADD };
+enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, NOT_IN, CONTAINS, CONTAINS_KEY, IS_NOT, LIKE, ADD, SUB };
 
 /// Describes the nature of clustering-key comparisons.  Useful for implementing SCYLLA_CLUSTERING_BOUND.
 enum class comparison_order : char {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -57,6 +57,7 @@ struct allow_local_index_tag {};
 using allow_local_index = bool_class<allow_local_index_tag>;
 
 struct binary_operator;
+struct unary_operator;
 struct conjunction;
 struct column_value;
 struct subscript;
@@ -77,6 +78,7 @@ template <typename T>
 concept ExpressionElement
         = std::same_as<T, conjunction>
         || std::same_as<T, binary_operator>
+        || std::same_as<T, unary_operator>
         || std::same_as<T, column_value>
         || std::same_as<T, subscript>
         || std::same_as<T, unresolved_identifier>
@@ -97,6 +99,7 @@ template <typename Func>
 concept invocable_on_expression
         = std::invocable<Func, conjunction>
         && std::invocable<Func, binary_operator>
+        && std::invocable<Func, unary_operator>
         && std::invocable<Func, column_value>
         && std::invocable<Func, subscript>
         && std::invocable<Func, unresolved_identifier>
@@ -117,6 +120,7 @@ template <typename Func>
 concept invocable_on_expression_ref
         = std::invocable<Func, conjunction&>
         && std::invocable<Func, binary_operator&>
+        && std::invocable<Func, unary_operator&>
         && std::invocable<Func, column_value&>
         && std::invocable<Func, subscript&>
         && std::invocable<Func, unresolved_identifier&>
@@ -223,6 +227,9 @@ const column_value& get_subscripted_column(const expression&);
 
 enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, NOT_IN, CONTAINS, CONTAINS_KEY, IS_NOT, LIKE, ADD, SUB };
 
+/// The operator of a unary expression.
+enum class unary_oper_t { NEG };
+
 /// Describes the nature of clustering-key comparisons.  Useful for implementing SCYLLA_CLUSTERING_BOUND.
 enum class comparison_order : char {
     cql, ///< CQL order. (a,b)>(1,1) is equivalent to a>1 OR (a=1 AND b>1).
@@ -246,6 +253,15 @@ struct binary_operator {
     binary_operator(expression lhs, oper_t op, expression rhs, comparison_order order = comparison_order::cql);
 
     friend bool operator==(const binary_operator&, const binary_operator&) = default;
+};
+
+// A unary operation on an expression.
+// Currently only negation (unary_oper_t::NEG) for numeric types is supported.
+struct unary_operator {
+    unary_oper_t op;
+    expression operand;
+
+    friend bool operator==(const unary_operator&, const unary_operator&) = default;
 };
 
 // A conjunction of expressions separated by the AND keyword.
@@ -469,7 +485,8 @@ struct expression::impl final {
             conjunction, binary_operator, column_value, unresolved_identifier,
             column_mutation_attribute, function_call, cast, field_selection,
             bind_variable, untyped_constant, constant, tuple_constructor,
-            collection_constructor, usertype_constructor, subscript, temporary>;
+            collection_constructor, usertype_constructor, subscript, temporary,
+            unary_operator>;
     variant_type v;
     impl(variant_type v) : v(std::move(v)) {}
 };
@@ -602,4 +619,17 @@ struct fmt::formatter<cql3::expr::oper_t> {
 
 private:
     static std::string_view to_string(const cql3::expr::oper_t& op);
+};
+
+template <>
+struct fmt::formatter<cql3::expr::unary_oper_t> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const cql3::expr::unary_oper_t& op, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", to_string(op));
+    }
+
+private:
+    static std::string_view to_string(const cql3::expr::unary_oper_t& op);
 };

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -221,7 +221,7 @@ const column_value& get_subscripted_column(const subscript&);
 /// Only columns can be subscripted in CQL, so we can expect that the subscripted expression is a column_value.
 const column_value& get_subscripted_column(const expression&);
 
-enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, NOT_IN, CONTAINS, CONTAINS_KEY, IS_NOT, LIKE };
+enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, NOT_IN, CONTAINS, CONTAINS_KEY, IS_NOT, LIKE, ADD };
 
 /// Describes the nature of clustering-key comparisons.  Useful for implementing SCYLLA_CLUSTERING_BOUND.
 enum class comparison_order : char {

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1344,6 +1344,19 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             }
             return result;
         },
+        [&] (const unary_operator& uo) -> std::optional<expression> {
+            // Prepare the operand; unary_operator preserves its operand's type.
+            auto prepared_operand = try_prepare_expression(uo.operand, db, keyspace, schema_opt, receiver);
+            if (!prepared_operand) {
+                return std::nullopt;
+            }
+            unary_operator result{uo.op, std::move(*prepared_operand)};
+            // Constant folding: if the operand is fully known, evaluate now.
+            if (is<constant>(result.operand)) {
+                return constant(evaluate(result, query_options::DEFAULT), type_of(result.operand));
+            }
+            return result;
+        },
         [&] (const conjunction& conj) -> std::optional<expression> {
             return prepare_conjunction(conj, db, keyspace, schema_opt, receiver);
         },
@@ -1455,6 +1468,9 @@ test_assignment(const expression& expr, data_dictionary::database db, const sstr
         [&] (const binary_operator&) -> test_result {
             on_internal_error(expr_logger, "binary_operators are not yet reachable via test_assignment()");
         },
+        [&] (const unary_operator&) -> test_result {
+            on_internal_error(expr_logger, "unary_operators are not yet reachable via test_assignment()");
+        },
         [&] (const conjunction&) -> test_result {
             on_internal_error(expr_logger, "conjunctions are not yet reachable via test_assignment()");
         },
@@ -1548,6 +1564,9 @@ test_assignment_any_size_float_vector(const expression& expr) {
             return validate_assignment(value.type);
         },
         [&] (const binary_operator&) -> test_result {
+            return NOT_ASSIGNABLE;
+        },
+        [&] (const unary_operator&) -> test_result {
             return NOT_ASSIGNABLE;
         },
         [&] (const conjunction&) -> test_result {

--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -20,6 +20,7 @@
 #include "types/list.hh"
 #include "types/set.hh"
 #include "types/user.hh"
+#include "types/types.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
 
 namespace cql3 {
@@ -151,10 +152,19 @@ operation::addition::prepare(data_dictionary::database db, const sstring& keyspa
 
     auto ctype = dynamic_pointer_cast<const collection_type_impl>(receiver.type);
     if (!ctype) {
-        if (!receiver.is_counter()) {
-            throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name_as_text()));
+        if (receiver.is_counter()) {
+            return make_shared<constants::adder>(receiver, std::move(v));
         }
-        return make_shared<constants::adder>(receiver, std::move(v));
+        // Allow arithmetic on numeric non-counter columns in LWT updates
+        // (issue #10568). Build an expression that constants:setter will use.
+        if (receiver.type->is_arithmetic()) {
+            expr::expression arith_expr = expr::binary_operator(
+                expr::column_value{&receiver},
+                expr::oper_t::ADD,
+                v);
+            return make_shared<constants::setter>(receiver, std::move(arith_expr));
+        }
+        throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name_as_text()));
     } else if (!ctype->is_multi_cell()) {
         throw exceptions::invalid_request_exception(format("Invalid operation ({}) for frozen collection column {}", to_string(receiver), receiver.name_as_text()));
     }
@@ -184,12 +194,21 @@ shared_ptr<operation>
 operation::subtraction::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     auto ctype = dynamic_pointer_cast<const collection_type_impl>(receiver.type);
     if (!ctype) {
-        if (!receiver.is_counter()) {
-            throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name_as_text()));
+        if (receiver.is_counter()) {
+            auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
+            verify_no_aggregate_functions(v, "SET clause");
+            return make_shared<constants::subtracter>(receiver, std::move(v));
         }
-        auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
-        verify_no_aggregate_functions(v, "SET clause");
-        return make_shared<constants::subtracter>(receiver, std::move(v));
+        if (receiver.type->is_arithmetic()) {
+            auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
+            verify_no_aggregate_functions(v, "SET clause");
+            expr::expression arith_expr = expr::binary_operator(
+                expr::column_value{&receiver},
+                expr::oper_t::SUB,
+                v);
+            return make_shared<constants::setter>(receiver, std::move(arith_expr));
+        }
+        throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name_as_text()));
     }
     if (!ctype->is_multi_cell()) {
         throw exceptions::invalid_request_exception(

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -66,10 +66,30 @@ public:
     }
 
     /**
-    * @return whether the operation requires a read of the previous value to be executed
-    * (only lists setterByIdx, discard and discardByIdx requires that).
+    * @return whether the operation requires a read of the previous value to
+    * be executed. In traditional CQL only a few specific list operations
+    * perform read before the write, *non-atomically*:
+    *   - lists::setter_by_index (SET c[i] = v)
+    *   - lists::discarder (SET c = c - [v])
+    *   - lists::discarder_by_index (DELETE c[i])
+    *
+    * We're gradually adding ScyllaDB-only CQL extensions to allow additional
+    * expressions that need to read the old value of the row, e.g.,
+    * SET r = r + 1. The operations will set require_read() to true, but will
+    * also set requires_lwt() to true to require that this operation must be
+    * execute in an LWT update - and this will guarantee that so the read-
+    * modify-write operation is atomic.
     */
     virtual bool requires_read() const {
+        return false;
+    }
+
+    /**
+     * @return whether the operation is only valid in an LWT (conditional)
+     * update. For example, non-counter arithmetic (e.g. SET r = r + 1 on a
+     * regular column) requires LWT so that the read-modify-write is atomic.
+     */
+    virtual bool requires_lwt() const {
         return false;
     }
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -521,6 +521,9 @@ to_predicates(
                         [&] (const binary_operator&) -> std::vector<predicate> {
                             return cannot_solve(oper);
                         },
+                        [&] (const unary_operator&) -> std::vector<predicate> {
+                            return cannot_solve(oper);
+                        },
                         [&] (const conjunction&) -> std::vector<predicate> {
                             return cannot_solve(oper);
                         },
@@ -556,6 +559,9 @@ to_predicates(
                         },
                     }, oper.lhs);
                 },
+            [] (const unary_operator& uo) -> std::vector<predicate> {
+                return cannot_solve(uo);
+            },
             [] (const column_value& cv) -> std::vector<predicate> {
                 return cannot_solve(cv);
             },

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -40,6 +40,9 @@ selectable_processes_selection(const expr::expression& selectable) {
         [&] (const expr::binary_operator& conj) -> bool {
             on_internal_error(slogger, "no way to express 'SELECT a binop b' in the grammar yet");
         },
+        [&] (const expr::unary_operator&) -> bool {
+            on_internal_error(slogger, "no way to express 'SELECT unop a' in the grammar yet");
+        },
         [] (const expr::subscript&) -> bool {
             return true;
         },

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -761,6 +761,10 @@ void modification_statement::add_operation(::shared_ptr<operation> op) {
         }
     }
 
+    if (op->requires_lwt()) {
+        _requires_lwt = true;
+    }
+
     if (op->column.is_counter()) {
         auto is_raw_counter_shard_write = op->is_raw_counter_shard_write();
         if (_is_raw_counter_shard_write && _is_raw_counter_shard_write != is_raw_counter_shard_write) {

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -80,6 +80,9 @@ private:
     // True if any of update operations requires a prefetch.
     // Pre-computed during statement prepare.
     bool _requires_read = false;
+    // True if any of the update operations requires LWT (an IF condition) for
+    // atomicity, e.g. SET col = col + 1 on a non-counter column.
+    bool _requires_lwt = false;
     bool _if_not_exists = false;
     bool _if_exists = false;
 
@@ -185,6 +188,9 @@ public:
     // True if any of update operations of this statement requires
     // a prefetch of the old cell.
     bool requires_read() const { return _requires_read; }
+
+    // True if any of the update operations requires LWT for atomicity.
+    bool requires_lwt() const { return _requires_lwt; }
 
     // Columns used in this statement conditions or operations.
     const column_set& columns_to_read() const { return _columns_to_read; }

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -497,6 +497,10 @@ update_statement::prepare_internal(data_dictionary::database db, schema_ptr sche
     }
     prepare_conditions(db, *schema, ctx, *stmt);
     stmt->process_where_clause(db, _where_clause, ctx);
+    if (stmt->requires_lwt() && !stmt->has_conditions()) {
+        throw exceptions::invalid_request_exception(
+            "SET with a column expression (e.g. col = col + 1) requires an LWT condition (e.g., IF col != NULL or IF EXISTS) to ensure atomic read-before-write");
+    }
     return stmt;
 }
 

--- a/cql3/update_parameters.cc
+++ b/cql3/update_parameters.cc
@@ -63,6 +63,37 @@ update_parameters::prefetch_data::prefetch_data(schema_ptr schema)
     , schema(schema)
 { }
 
+cql3::raw_value
+update_parameters::evaluate_on_prefetched_row(
+        const expr::expression& e, const partition_key& pkey, const clustering_key& ckey) const {
+    if (_prefetched.selection == nullptr) {
+        // No prefetched data available. Normally we won't get here, the
+        // caller should have called evaluate() in this case, not this function
+        return expr::evaluate(e, expr::evaluation_inputs{.options = &_options});
+    }
+    auto pkey_bytes = pkey.explode();
+    auto ckey_bytes = ckey.explode();
+    auto row = _prefetched.find_row(pkey, ckey);
+    if (row == nullptr) {
+        // Row is absent: treat all column references as null (SQL null-
+        // propagation semantics).
+        std::vector<managed_bytes_opt> empty_cells(_prefetched.selection->get_column_count(), std::nullopt);
+        return expr::evaluate(e, expr::evaluation_inputs{
+            .partition_key = pkey_bytes,
+            .clustering_key = ckey_bytes,
+            .static_and_regular_columns = empty_cells,
+            .selection = _prefetched.selection.get(),
+            .options = &_options,
+        });
+    }
+    return expr::evaluate(e, expr::evaluation_inputs{
+        .partition_key = pkey_bytes,
+        .clustering_key = ckey_bytes,
+        .static_and_regular_columns = row->cells,
+        .selection = _prefetched.selection.get(),
+        .options = &_options,
+    });
+}
 
 const update_parameters::prefetch_data::row*
 update_parameters::prefetch_data::find_row(const partition_key& pkey, const clustering_key& ckey) const {

--- a/cql3/update_parameters.hh
+++ b/cql3/update_parameters.hh
@@ -168,6 +168,12 @@ public:
     std::optional<std::vector<std::pair<data_value, data_value>>>
     get_prefetched_list(const partition_key& pkey, const clustering_key& ckey, const column_definition& column) const;
 
+    // Evaluates expr against the prefetched row identified by (pkey, ckey).
+    // For efficiency, call this only when the expression references regular or
+    // static columns; for expressions that don't, call evaluate() directly.
+    cql3::raw_value evaluate_on_prefetched_row(
+        const expr::expression& expr, const partition_key& pkey, const clustering_key& ckey) const;
+
     static prefetch_data build_prefetch_data(schema_ptr schema, const query::result& query_result,
             const query::partition_slice& slice);
 };

--- a/docs/features/lwt.rst
+++ b/docs/features/lwt.rst
@@ -340,6 +340,38 @@ You can use lightweight transactions for any of the following activities:
 
       (8 rows)
 
+Arithmetic SET in a LWT update (ScyllaDB extension)
+----------------------------------------------------
+
+ScyllaDB allows ``SET col = col + value`` and ``SET col = col - value`` on
+non-counter numeric columns in a conditional ``UPDATE``. Because the statement
+is executed as an LWT, the read-modify-write is atomic: no separate read and
+no race condition. An ``IF`` condition is required; without it ScyllaDB
+rejects the statement.
+
+If the column is null, the arithmetic result is also null (standard SQL
+null-propagation semantics), so the column remains unset. To catch an
+uninitialized column, use an ``IF`` condition that checks the column directly
+(e.g. ``IF r != null``) rather than ``IF EXISTS``.
+
+.. code-block:: cql
+
+   -- Initialize a row, with numeric regular column r set to 0:
+   INSERT INTO mytable (pk, ck, r) VALUES (1, 1, 0) IF NOT EXISTS;
+
+   -- Increment r atomically:
+   UPDATE mytable SET r = r + 1 WHERE pk = 1 AND ck = 1 IF EXISTS;
+
+   -- Increment r atomically - and visibly fail if r was not initialized:
+   UPDATE mytable SET r = r + 1 WHERE pk = 1 AND ck = 1 IF r != null;
+
+   -- Decrement r by 5 only when the value is large enough:
+   UPDATE mytable SET r = r - 5 WHERE pk = 1 AND ck = 1 IF r >= 5;
+
+.. note::
+
+   This syntax is a ScyllaDB extension and is not supported by Apache Cassandra.
+
 Update a table using a LWT
 --------------------------
 

--- a/docs/kb/lwt-differences.rst
+++ b/docs/kb/lwt-differences.rst
@@ -12,12 +12,47 @@ How is it different?
 * For batch statement, ScyllaDB allows mixing `IF EXISTS`, `IF NOT EXISTS`, and other conditions for the same row.
 * Unlike Cassandra, ScyllaDB  uses per-core data partitioning, so the RPC  that is done to perform a transaction talks directly to the right core on a peer replica, avoiding the concurrency overhead. This is,  of course, true, if ScyllaDB’s own shard-aware driver is used - otherwise we  add an extra hop to the right core at the coordinator node.
 * ScyllaDB does not store  hints for lightweight transaction writes, since this is redundant as all such writes are already present in system.paxos table.
+* ScyllaDB supports arithmetic ``SET`` operations (``col = col + value`` and ``col = col - value``) on non-counter numeric columns inside LWT conditional updates. Cassandra does not support this syntax.
 
 
 More on :doc:`Lightweight Transactions (LWT) </features/lwt>`
 
 Additional Notes
 ================
+
+Arithmetic SET operations in LWT updates
+----------------------------------------
+
+ScyllaDB allows ``SET col = col + value`` and ``SET col = col - value`` on non-counter numeric
+columns inside a conditional ``UPDATE``. The Paxos read-modify-write cycle guarantees atomicity:
+the old value is read in the same transaction round, the arithmetic is applied, and the result
+is written — all without a separate read or a race condition.
+
+If the column is null, the arithmetic result is also null (standard SQL null-propagation
+semantics), so the column remains unset. To catch an uninitialized column, use an ``IF``
+condition that checks the column value (e.g. ``IF score != null``) rather than ``IF EXISTS``.
+
+This syntax is a ScyllaDB extension; Cassandra rejects it with an ``InvalidRequest`` error.
+An ``IF`` condition (``IF EXISTS`` or a column predicate) is required; omitting the ``IF``
+clause is rejected even in ScyllaDB, because without LWT atomicity the read-modify-write
+would not be safe.
+
+Example — atomic counter on a regular column:
+
+.. code-block:: cql
+
+   -- Initialize a row, with score=0
+   INSERT INTO mytable (pk, ck, score) VALUES (1, 1, 0) IF NOT EXISTS;
+
+   -- Increment atomically:
+   UPDATE mytable SET score = score + 1 WHERE pk = 1 AND ck = 1 IF EXISTS;
+
+   -- Increment only when score is already set (fails if score is null):
+   UPDATE mytable SET score = score + 1 WHERE pk = 1 AND ck = 1 IF score != null;
+
+   -- Decrement only when the value is large enough:
+   UPDATE mytable SET score = score - 5 WHERE pk = 1 AND ck = 1 IF score >= 5;
+
 
 Mixing LWT IF clauses in BATCH statements
 -----------------------------------------

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -5156,3 +5156,149 @@ BOOST_AUTO_TEST_CASE(evaluate_add_reversed_type) {
     raw_value result2 = evaluate(binary_operator(ck_col, oper_t::ADD, reversed_const), inputs);
     BOOST_REQUIRE_EQUAL(raw_to<int32_t>(result2, int32_type), 8);
 }
+
+// Helper: build a SUB binary_operator and evaluate it with no inputs (both sides are constants).
+static raw_value eval_sub(expression lhs, expression rhs) {
+    return evaluate(binary_operator(std::move(lhs), oper_t::SUB, std::move(rhs)), evaluation_inputs{});
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_sub_fixed_width_integers) {
+    // int (32-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(eval_sub(make_int_const(10), make_int_const(3)), int32_type), 7);
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(eval_sub(make_int_const(3), make_int_const(10)), int32_type), -7);
+
+    // tinyint (8-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int8_t>(eval_sub(make_tinyint_const(30), make_tinyint_const(10)), byte_type), int8_t(20));
+
+    // smallint (16-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int16_t>(eval_sub(make_smallint_const(300), make_smallint_const(100)), short_type), int16_t(200));
+
+    // bigint (64-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int64_t>(eval_sub(make_bigint_const(3'000'000'000LL), make_bigint_const(1'000'000'000LL)), long_type),
+                        int64_t(2'000'000'000LL));
+
+    // type_of a SUB expression is the type of the operands
+    expression sub_expr = binary_operator(make_int_const(5), oper_t::SUB, make_int_const(2));
+    BOOST_REQUIRE(type_of(sub_expr) == int32_type);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_sub_floating_point) {
+    // float (32-bit)
+    float float_result = raw_to<float>(eval_sub(make_float_const(4.0f), make_float_const(1.5f)), float_type);
+    BOOST_REQUIRE_CLOSE(float_result, 2.5f, 1e-5f);
+
+    // double (64-bit)
+    double double_result = raw_to<double>(eval_sub(make_double_const(5.0), make_double_const(1.25)), double_type);
+    BOOST_REQUIRE_CLOSE(double_result, 3.75, 1e-10);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_sub_varint) {
+    auto make_varint = [](int64_t v) -> constant {
+        return constant(raw_value::make_value(managed_bytes(varint_type->decompose(utils::multiprecision_int(v)))), varint_type);
+    };
+    auto result = eval_sub(make_varint(3000000000000LL), make_varint(1000000000000LL));
+    BOOST_REQUIRE_EQUAL(raw_to<utils::multiprecision_int>(result, varint_type), utils::multiprecision_int(2000000000000LL));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_sub_decimal) {
+    auto make_decimal = [](const char* s) -> constant {
+        return constant(raw_value::make_value(managed_bytes(decimal_type->decompose(big_decimal(s)))), decimal_type);
+    };
+    auto result = eval_sub(make_decimal("4.0"), make_decimal("1.5"));
+    BOOST_REQUIRE_EQUAL(raw_to<big_decimal>(result, decimal_type), big_decimal("2.5"));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_sub_null_propagation) {
+    constant null_int = constant::make_null(int32_type);
+    BOOST_REQUIRE_EQUAL(eval_sub(null_int, make_int_const(5)), raw_value::make_null());
+    BOOST_REQUIRE_EQUAL(eval_sub(make_int_const(5), null_int), raw_value::make_null());
+    BOOST_REQUIRE_EQUAL(eval_sub(null_int, null_int), raw_value::make_null());
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_sub_overflow) {
+    BOOST_REQUIRE_THROW(
+        eval_sub(make_int_const(std::numeric_limits<int32_t>::min()), make_int_const(1)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_sub(make_int_const(std::numeric_limits<int32_t>::max()), make_int_const(-1)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_sub(make_bigint_const(std::numeric_limits<int64_t>::min()), make_bigint_const(1)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_sub(make_tinyint_const(std::numeric_limits<int8_t>::min()), make_tinyint_const(1)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_sub(make_smallint_const(std::numeric_limits<int16_t>::min()), make_smallint_const(1)),
+        exceptions::invalid_request_exception);
+}
+
+// SUB has a key advantage over ADD+NEG: negating MININT overflows, so
+// -1 + (-MININT) would throw, but -1 - MININT = MAXINT is perfectly valid.
+BOOST_AUTO_TEST_CASE(evaluate_sub_minint) {
+    // int32: -1 - INT32_MIN = INT32_MAX (valid, but -1 + (-INT32_MIN) overflows)
+    BOOST_REQUIRE_EQUAL(
+        raw_to<int32_t>(eval_sub(make_int_const(-1), make_int_const(std::numeric_limits<int32_t>::min())), int32_type),
+        std::numeric_limits<int32_t>::max());
+
+    // int64: -1 - INT64_MIN = INT64_MAX
+    BOOST_REQUIRE_EQUAL(
+        raw_to<int64_t>(eval_sub(make_bigint_const(-1), make_bigint_const(std::numeric_limits<int64_t>::min())), long_type),
+        std::numeric_limits<int64_t>::max());
+
+    // int8: -1 - INT8_MIN = INT8_MAX
+    BOOST_REQUIRE_EQUAL(
+        raw_to<int8_t>(eval_sub(make_tinyint_const(-1), make_tinyint_const(std::numeric_limits<int8_t>::min())), byte_type),
+        std::numeric_limits<int8_t>::max());
+
+    // int16: -1 - INT16_MIN = INT16_MAX
+    BOOST_REQUIRE_EQUAL(
+        raw_to<int16_t>(eval_sub(make_smallint_const(-1), make_smallint_const(std::numeric_limits<int16_t>::min())), short_type),
+        std::numeric_limits<int16_t>::max());
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_sub_type_mismatch) {
+    BOOST_REQUIRE_THROW(
+        eval_sub(make_int_const(5), make_bigint_const(1)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_sub(make_float_const(1.0f), make_double_const(1.0)),
+        exceptions::invalid_request_exception);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_sub_non_numeric_type) {
+    BOOST_REQUIRE_THROW(
+        eval_sub(make_text_const("hello"), make_text_const("world")),
+        exceptions::invalid_request_exception);
+}
+
+// SUB binary_operator should print as "lhs - rhs"
+BOOST_AUTO_TEST_CASE(evaluate_sub_printer) {
+    expression sub_expr = binary_operator(make_int_const(10), oper_t::SUB, make_int_const(3));
+    BOOST_REQUIRE_EQUAL(expr_print(sub_expr), "10 - 3");
+}
+
+// Arithmetic SUB on a column with a reversed type (DESC clustering key) must work correctly.
+BOOST_AUTO_TEST_CASE(evaluate_sub_reversed_type) {
+    schema_ptr test_schema =
+        schema_builder("test_ks", "test_cf")
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("ck", reversed_type_impl::get_instance(int32_type), column_kind::clustering_key)
+            .build();
+
+    auto [inputs, inputs_data] = make_evaluation_inputs(test_schema, {
+        {"pk", make_int_raw(1)},
+        {"ck", make_int_raw(10)},
+    });
+
+    // ck - 3 should equal 7, regardless of the reversed type on ck
+    expression ck_col = column_value(test_schema->get_column_definition("ck"));
+    raw_value result = evaluate(binary_operator(ck_col, oper_t::SUB, make_int_const(3)), inputs);
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(result, int32_type), 7);
+}
+

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -5302,3 +5302,124 @@ BOOST_AUTO_TEST_CASE(evaluate_sub_reversed_type) {
     BOOST_REQUIRE_EQUAL(raw_to<int32_t>(result, int32_type), 7);
 }
 
+// Helper: evaluate a NEG unary_operator with a constant operand.
+static raw_value eval_neg(expression expr) {
+    return evaluate(unary_operator{unary_oper_t::NEG, std::move(expr)}, evaluation_inputs{});
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_neg_fixed_width_integers) {
+    // int (32-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(eval_neg(make_int_const(5)), int32_type), -5);
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(eval_neg(make_int_const(-7)), int32_type), 7);
+
+    // tinyint (8-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int8_t>(eval_neg(make_tinyint_const(10)), byte_type), int8_t(-10));
+
+    // smallint (16-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int16_t>(eval_neg(make_smallint_const(300)), short_type), int16_t(-300));
+
+    // bigint (64-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int64_t>(eval_neg(make_bigint_const(1'000'000'000LL)), long_type), int64_t(-1'000'000'000LL));
+
+    // type_of a NEG expression is the type of the operand
+    expression neg_expr = unary_operator{unary_oper_t::NEG, make_int_const(1)};
+    BOOST_REQUIRE(type_of(neg_expr) == int32_type);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_neg_floating_point) {
+    // float (32-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<float>(eval_neg(make_float_const(3.5f)), float_type), -3.5f);
+
+    // double (64-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<double>(eval_neg(make_double_const(-2.5)), double_type), 2.5);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_neg_varint) {
+    auto make_varint = [](int64_t v) -> constant {
+        return constant(raw_value::make_value(managed_bytes(varint_type->decompose(utils::multiprecision_int(v)))), varint_type);
+    };
+    BOOST_REQUIRE_EQUAL(
+        raw_to<utils::multiprecision_int>(eval_neg(make_varint(42)), varint_type),
+        utils::multiprecision_int(-42));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_neg_decimal) {
+    auto make_decimal = [](const char* s) -> constant {
+        return constant(raw_value::make_value(managed_bytes(decimal_type->decompose(big_decimal(s)))), decimal_type);
+    };
+    BOOST_REQUIRE_EQUAL(
+        raw_to<big_decimal>(eval_neg(make_decimal("3.14")), decimal_type),
+        big_decimal("-3.14"));
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_neg_null_propagation) {
+    // NEG(null) → null for any numeric type
+    BOOST_REQUIRE(eval_neg(constant::make_null(int32_type)).is_null());
+    BOOST_REQUIRE(eval_neg(constant::make_null(long_type)).is_null());
+    BOOST_REQUIRE(eval_neg(constant::make_null(float_type)).is_null());
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_neg_overflow) {
+    // Negating the minimum value of each signed integer type overflows
+    BOOST_REQUIRE_THROW(
+        eval_neg(make_int_const(std::numeric_limits<int32_t>::min())),
+        exceptions::invalid_request_exception);
+    BOOST_REQUIRE_THROW(
+        eval_neg(make_tinyint_const(std::numeric_limits<int8_t>::min())),
+        exceptions::invalid_request_exception);
+    BOOST_REQUIRE_THROW(
+        eval_neg(make_smallint_const(std::numeric_limits<int16_t>::min())),
+        exceptions::invalid_request_exception);
+    BOOST_REQUIRE_THROW(
+        eval_neg(make_bigint_const(std::numeric_limits<int64_t>::min())),
+        exceptions::invalid_request_exception);
+}
+
+// varint supports arbitrary precision, so negating INT64_MIN doesn't overflow.
+BOOST_AUTO_TEST_CASE(evaluate_neg_arbitrary_precision_no_overflow) {
+    utils::multiprecision_int min_val(std::numeric_limits<int64_t>::min());
+    constant c(raw_value::make_value(managed_bytes(varint_type->decompose(min_val))), varint_type);
+    BOOST_REQUIRE_EQUAL(
+        raw_to<utils::multiprecision_int>(eval_neg(c), varint_type),
+        -min_val);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_neg_non_numeric_type) {
+    BOOST_REQUIRE_THROW(
+        eval_neg(make_text_const("hello")),
+        exceptions::invalid_request_exception);
+
+    constant bool_const(raw_value::make_value(managed_bytes(boolean_type->decompose(true))), boolean_type);
+    BOOST_REQUIRE_THROW(
+        eval_neg(bool_const),
+        exceptions::invalid_request_exception);
+}
+
+// NEG unary_operator should print as "(-operand)"
+BOOST_AUTO_TEST_CASE(evaluate_neg_printer) {
+    expression neg_expr = unary_operator{unary_oper_t::NEG, make_int_const(3)};
+    BOOST_REQUIRE_EQUAL(expr_print(neg_expr), "(-3)");
+}
+
+// Arithmetic NEG on a column with a reversed type (DESC clustering key)
+// must work correctly, and not think reverse(int) is an unsupported type.
+BOOST_AUTO_TEST_CASE(evaluate_neg_reversed_type) {
+    // Schema with a DESC clustering key: equivalent to
+    // CREATE TABLE test_ks.test_cf (pk int, ck int, PRIMARY KEY (pk, ck)) WITH CLUSTERING ORDER BY (ck DESC);
+    schema_ptr test_schema =
+        schema_builder("test_ks", "test_cf")
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("ck", reversed_type_impl::get_instance(int32_type), column_kind::clustering_key)
+            .build();
+
+    auto [inputs, inputs_data] = make_evaluation_inputs(test_schema, {
+        {"pk", make_int_raw(1)},
+        {"ck", make_int_raw(5)},
+    });
+
+    // -ck should equal -5
+    expression ck_col = column_value(test_schema->get_column_definition("ck"));
+    expression neg_expr = unary_operator{unary_oper_t::NEG, ck_col};
+    raw_value result = evaluate(neg_expr, inputs);
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(result, int32_type), -5);
+}

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -25,6 +25,8 @@
 #include "test/lib/test_utils.hh"
 #include "cql3/expr/evaluate.hh"
 #include "cql3/expr/expr-utils.hh"
+#include "utils/big_decimal.hh"
+#include "utils/multiprecision_int.hh"
 
 using namespace cql3;
 using namespace cql3::expr;
@@ -4931,4 +4933,226 @@ BOOST_AUTO_TEST_CASE(test_levellize_aggregation_depth) {
     BOOST_REQUIRE_EQUAL(aggregation_depth(e2), 3);
     // Somewhat fragile, but easiest way to test entire structure
     BOOST_REQUIRE_EQUAL(fmt::format("{:debug}", e2), "foo.my_agg(system.sum(system.$$first$$(r)), system.$$first$$(system.$$first$$(TTL(r))))");
+}
+
+// Helper: build an ADD binary_operator and evaluate it with no inputs (both sides are constants).
+static raw_value eval_add(expression lhs, expression rhs) {
+    return evaluate(binary_operator(std::move(lhs), oper_t::ADD, std::move(rhs)), evaluation_inputs{});
+}
+
+// Helper: deserialize a raw_value of a given type back into the typed value.
+template <typename T>
+static T raw_to(const raw_value& v, const data_type& t) {
+    return v.view().deserialize<T>(*t);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_add_fixed_width_integers) {
+    // int (32-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(eval_add(make_int_const(3), make_int_const(4)), int32_type), 7);
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(eval_add(make_int_const(-10), make_int_const(3)), int32_type), -7);
+
+    // tinyint (8-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int8_t>(eval_add(make_tinyint_const(10), make_tinyint_const(20)), byte_type), int8_t(30));
+
+    // smallint (16-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int16_t>(eval_add(make_smallint_const(100), make_smallint_const(200)), short_type), int16_t(300));
+
+    // bigint (64-bit)
+    BOOST_REQUIRE_EQUAL(raw_to<int64_t>(eval_add(make_bigint_const(1'000'000'000LL), make_bigint_const(2'000'000'000LL)), long_type),
+                        int64_t(3'000'000'000LL));
+    BOOST_REQUIRE_EQUAL(raw_to<int64_t>(eval_add(make_bigint_const(-1), make_bigint_const(-1)), long_type), int64_t(-2));
+
+    // type_of an ADD expression is the type of the operands
+    expression add_expr = binary_operator(make_int_const(1), oper_t::ADD, make_int_const(2));
+    BOOST_REQUIRE(type_of(add_expr) == int32_type);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_add_floating_point) {
+    // float (32-bit)
+    float float_result = raw_to<float>(eval_add(make_float_const(1.5f), make_float_const(2.5f)), float_type);
+    BOOST_REQUIRE_CLOSE(float_result, 4.0f, 1e-5f);
+
+    // double (64-bit)
+    double double_result = raw_to<double>(eval_add(make_double_const(1.25), make_double_const(3.75)), double_type);
+    BOOST_REQUIRE_CLOSE(double_result, 5.0, 1e-10);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_add_varint) {
+    auto make_varint = [](int64_t v) -> constant {
+        return constant(raw_value::make_value(managed_bytes(varint_type->decompose(utils::multiprecision_int(v)))), varint_type);
+    };
+    auto result = eval_add(make_varint(1000000000000LL), make_varint(2000000000000LL));
+    auto expected = utils::multiprecision_int(3000000000000LL);
+    BOOST_REQUIRE_EQUAL(raw_to<utils::multiprecision_int>(result, varint_type), expected);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_add_decimal) {
+    auto make_decimal = [](const char* s) -> constant {
+        return constant(raw_value::make_value(managed_bytes(decimal_type->decompose(big_decimal(s)))), decimal_type);
+    };
+    auto result = eval_add(make_decimal("1.5"), make_decimal("2.5"));
+    big_decimal expected("4.0");
+    BOOST_REQUIRE_EQUAL(raw_to<big_decimal>(result, decimal_type), expected);
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_add_null_propagation) {
+    // null on either or both sides propagates to null
+    constant null_int = constant::make_null(int32_type);
+    BOOST_REQUIRE_EQUAL(eval_add(null_int, make_int_const(5)), raw_value::make_null());
+    BOOST_REQUIRE_EQUAL(eval_add(make_int_const(5), null_int), raw_value::make_null());
+    BOOST_REQUIRE_EQUAL(eval_add(null_int, null_int), raw_value::make_null());
+
+    constant null_bigint = constant::make_null(long_type);
+    BOOST_REQUIRE_EQUAL(eval_add(null_bigint, make_bigint_const(1)), raw_value::make_null());
+
+    constant null_float = constant::make_null(float_type);
+    BOOST_REQUIRE_EQUAL(eval_add(null_float, make_float_const(1.0f)), raw_value::make_null());
+}
+
+BOOST_AUTO_TEST_CASE(evaluate_add_overflow) {
+    // Fixed-width integers overflow with a clear exception
+    BOOST_REQUIRE_THROW(
+        eval_add(make_int_const(std::numeric_limits<int32_t>::max()), make_int_const(1)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_add(make_int_const(std::numeric_limits<int32_t>::min()), make_int_const(-1)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_add(make_bigint_const(std::numeric_limits<int64_t>::max()), make_bigint_const(1)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_add(make_tinyint_const(std::numeric_limits<int8_t>::max()), make_tinyint_const(1)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_add(make_smallint_const(std::numeric_limits<int16_t>::max()), make_smallint_const(1)),
+        exceptions::invalid_request_exception);
+}
+
+// varint and decimal support arbitrary precision and don't overflow when
+// going beyond the limits of int64 or double.
+BOOST_AUTO_TEST_CASE(evaluate_add_arbitrary_precision_no_overflow) {
+    auto make_varint = [](int64_t v) -> constant {
+        return constant(raw_value::make_value(managed_bytes(varint_type->decompose(utils::multiprecision_int(v)))), varint_type);
+    };
+    auto make_decimal = [](const char* s) -> constant {
+        return constant(raw_value::make_value(managed_bytes(decimal_type->decompose(big_decimal(s)))), decimal_type);
+    };
+
+    // varint: adding 1 to INT64_MAX must not overflow (result requires one extra bit)
+    auto big = constant(raw_value::make_value(managed_bytes(varint_type->decompose(
+            utils::multiprecision_int(std::numeric_limits<int64_t>::max())))), varint_type);
+    auto big_result = eval_add(big, make_varint(1));
+    utils::multiprecision_int expected_varint = utils::multiprecision_int(std::numeric_limits<int64_t>::max()) + 1;
+    BOOST_REQUIRE_EQUAL(raw_to<utils::multiprecision_int>(big_result, varint_type), expected_varint);
+
+    // decimal: adding 1 to a value above double's range (~1.8e308) is computed exactly
+    std::string large_str = "1" + std::string(309, '0'); // 10^309, well above DBL_MAX
+    std::string large_plus_one = large_str;
+    large_plus_one.back() = '1';
+    BOOST_REQUIRE_EQUAL(
+        raw_to<big_decimal>(eval_add(make_decimal(large_str.c_str()), make_decimal("1")), decimal_type),
+        big_decimal(large_plus_one.c_str()));
+}
+
+// The decimal type offers unlimited precision, but adding two numbers with
+// wildly different magnitudes - like 1 and 1e100000000 can require allocating
+// a huge number of digits, takes a huge amount of time and potentially
+// run out of memory. The expected behavior is to refuse this operation.
+// Reproduces SCYLLADB-1576.
+BOOST_AUTO_TEST_CASE(evaluate_add_large_magnitude) {
+    // SCYLLADB-1576: currently OOMs or churns CPU for a long time instead of
+    // throwing. Remove the next line when fixed.
+    return;
+
+    // 1e10000000 is stored compactly as (unscaled=1, scale=-100000000), but
+    // adding 1 to it forces alignment of decimal points, allocating 100 million
+    // digits and running out of memory.
+    auto make_decimal = [](const char* s) -> constant {
+        return constant(raw_value::make_value(managed_bytes(decimal_type->decompose(big_decimal(s)))), decimal_type);
+    };
+    BOOST_REQUIRE_THROW(
+        eval_add(make_decimal("1e100000000"), make_decimal("1")),
+        exceptions::invalid_request_exception);
+}
+
+// Adding two different numeric types is currently not supported and should
+// throw. If we implement this case in the future, this test will need to be
+// changed.
+BOOST_AUTO_TEST_CASE(evaluate_add_type_mismatch) {
+    BOOST_REQUIRE_THROW(
+        eval_add(make_int_const(1), make_bigint_const(1)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_add(make_float_const(1.0f), make_double_const(1.0)),
+        exceptions::invalid_request_exception);
+
+    BOOST_REQUIRE_THROW(
+        eval_add(make_int_const(1), make_float_const(1.0f)),
+        exceptions::invalid_request_exception);
+}
+
+// All tests above were on constants. Let's try a more complex expression with
+// non-constant subexpressions, like 1+(2+4) and (1+2)+4.
+BOOST_AUTO_TEST_CASE(evaluate_add_nested) {
+    // 1 + (2 + 4) == 7
+    expression inner = binary_operator(make_int_const(2), oper_t::ADD, make_int_const(4));
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(eval_add(make_int_const(1), inner), int32_type), 7);
+
+    // (1 + 2) + 4 == 7
+    expression outer = binary_operator(make_int_const(1), oper_t::ADD, make_int_const(2));
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(eval_add(outer, make_int_const(4)), int32_type), 7);
+}
+
+
+// ADD on non-numeric types should throw
+BOOST_AUTO_TEST_CASE(evaluate_add_non_numeric_type) {
+    BOOST_REQUIRE_THROW(
+        eval_add(make_text_const("hello"), make_text_const("world")),
+        exceptions::invalid_request_exception);
+
+    constant bool_const(raw_value::make_value(managed_bytes(boolean_type->decompose(true))), boolean_type);
+    BOOST_REQUIRE_THROW(
+        eval_add(bool_const, bool_const),
+        exceptions::invalid_request_exception);
+}
+
+// ADD binary_operator should print as "lhs + rhs"
+BOOST_AUTO_TEST_CASE(evaluate_add_printer) {
+    expression add_expr = binary_operator(make_int_const(3), oper_t::ADD, make_int_const(4));
+    BOOST_REQUIRE_EQUAL(expr_print(add_expr), "3 + 4");
+}
+
+// Arithmetic ADD on a column with a reversed type (DESC clustering key) must
+// work correctly, it should not consider int and reversed(int) to be different
+// types that cannot be added together.
+BOOST_AUTO_TEST_CASE(evaluate_add_reversed_type) {
+    // Schema with a DESC clustering key: equivalent to
+    // CREATE TABLE test_ks.test_cf (pk int, ck int, PRIMARY KEY (pk, ck)) WITH CLUSTERING ORDER BY (ck DESC);
+    schema_ptr test_schema =
+        schema_builder("test_ks", "test_cf")
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("ck", reversed_type_impl::get_instance(int32_type), column_kind::clustering_key)
+            .build();
+
+    auto [inputs, inputs_data] = make_evaluation_inputs(test_schema, {
+        {"pk", make_int_raw(1)},
+        {"ck", make_int_raw(5)},
+    });
+
+    // ck + 3 should equal 8, regardless of the reversed type on ck
+    expression ck_col = column_value(test_schema->get_column_definition("ck"));
+    expression add_expr = binary_operator(ck_col, oper_t::ADD, make_int_const(3));
+    raw_value result = evaluate(add_expr, inputs);
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(result, int32_type), 8);
+
+    // Also verify that both operands having reversed type works (reversed + reversed)
+    constant reversed_const(raw_value::make_value(managed_bytes(int32_type->decompose(int32_t(3)))),
+                            reversed_type_impl::get_instance(int32_type));
+    raw_value result2 = evaluate(binary_operator(ck_col, oper_t::ADD, reversed_const), inputs);
+    BOOST_REQUIRE_EQUAL(raw_to<int32_t>(result2, int32_type), 8);
 }

--- a/test/cqlpy/cassandra_tests/validation/operations/update_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/update_test.py
@@ -575,6 +575,6 @@ def testThatUpdatesWithEmptyInRestrictionDoNotCreateMutations(cql, test_keyspace
 
 def testAdderNonCounter(cql, test_keyspace):
     with create_table(cql, test_keyspace, f"(pk int PRIMARY KEY, a int, b text)") as table:
-        # if error ever includes "b" its safe to update this test
-        with pytest.raises(InvalidRequest, match=re.escape('Invalid operation (a = a + 1) for non counter column a')):
+        # Cassandra complains about column "a", Scylla about "b", both are fine
+        with pytest.raises(InvalidRequest, match='Invalid operation.* for non counter column'):
             execute(cql, table, "UPDATE %s SET a = a + 1, b = b + 'fail' WHERE pk = 1")

--- a/test/cqlpy/test_lwt.py
+++ b/test/cqlpy/test_lwt.py
@@ -10,7 +10,7 @@
 
 import re
 import pytest
-from cassandra.protocol import InvalidRequest
+from cassandra.protocol import InvalidRequest, SyntaxException
 
 from .util import new_test_table, unique_key_int
 
@@ -208,3 +208,254 @@ def test_lwt_insert_json_if_not_exists(cql, table1):
     # The following assert failed in #8682 (the INSERT was done despite the
     # row existing).
     assert list(cql.execute(f'SELECT * FROM {table1} WHERE p={p}')) == [(p, 1, None, 1)]
+
+# Test that the counter syntax SET i = i + 1 is not allowed on non-counter
+# columns. This prepares us to test the same thing for LWT updates, in the
+# next test.
+def test_counter_syntax_non_counter(cql, table1):
+    p = unique_key_int()
+    # Without an LWT condition, arithmetic on non-counter columns is rejected.
+    with pytest.raises(InvalidRequest):
+        cql.execute(f'UPDATE {table1} SET r = r + 1 WHERE p={p} AND c=1')
+    with pytest.raises(InvalidRequest):
+        cql.execute(f'UPDATE {table1} SET r = r - 1 WHERE p={p} AND c=1')
+
+# Test that arithmetic SET without an IF clause is rejected at prepare time,
+# not silently cached and only rejected at execution (in the previous test,
+# test_counter_syntax_non_counter, we tested execution).
+def test_counter_syntax_non_counter_prepare(cql, table1):
+    # PREPARE without IF clause must fail immediately, not succeed and then
+    # fail later at EXECUTE time.
+    with pytest.raises(InvalidRequest):
+        cql.prepare(f'UPDATE {table1} SET r = r + 1 WHERE p = ? AND c = ?')
+    with pytest.raises(InvalidRequest):
+        cql.prepare(f'UPDATE {table1} SET r = r - 1 WHERE p = ? AND c = ?')
+
+# Test that the counter syntax SET r = r + 1 IS allowed in an LWT update
+# on non-counter integer columns (issue #10568). This is a Scylla extension
+# (Cassandra rejects it). The underlying CAS mechanism reads the old value
+# and writes the incremented result atomically.
+def test_lwt_counter_syntax(cql, table1, scylla_only):
+    p = unique_key_int()
+    # Insert a row with r explicitly set to 0. Arithmetic on a null column
+    # is an error, so the column must have a value before using arithmetic SET.
+    cql.execute(f'INSERT INTO {table1} (p, c, r) VALUES ({p}, 1, 0)')
+    # Increment r from 0 to 1:
+    rs = list(cql.execute(f'UPDATE {table1} SET r = r + 1 WHERE p={p} AND c=1 IF EXISTS'))
+    assert len(rs) == 1 and rs[0].applied
+    assert list(cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1')) == [(1,)]
+    # Increment again by 3. r is now 1, so it will increment to 4:
+    rs = list(cql.execute(f'UPDATE {table1} SET r = r + 3 WHERE p={p} AND c=1 IF EXISTS'))
+    assert len(rs) == 1 and rs[0].applied
+    assert list(cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1')) == [(4,)]
+    # Subtraction also works, decrement r by 2 so it will go from 4 to 2. This
+    # time we'll use a condition on r itself, the condition is on r before the
+    # update.
+    rs = list(cql.execute(f'UPDATE {table1} SET r = r - 2 WHERE p={p} AND c=1 IF r = 4'))
+    assert len(rs) == 1 and rs[0].applied
+    assert list(cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1')) == [(2,)]
+    # Try a more sophisticated condition on the arithmetic operation:
+    # Decrement N from r, but only if r>=N. Try it for one N where it
+    # fails (3) and one where it succeeds (1).
+    rs = list(cql.execute(f'UPDATE {table1} SET r = r - 3 WHERE p={p} AND c=1 IF r >= 3'))
+    assert len(rs) == 1 and not rs[0].applied
+    assert list(cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1')) == [(2,)]
+    rs = list(cql.execute(f'UPDATE {table1} SET r = r - 1 WHERE p={p} AND c=1 IF r >= 1'))
+    assert len(rs) == 1 and rs[0].applied
+    assert list(cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1')) == [(1,)]
+
+# Arithmetic on a null just results in a null, so "r = r + 1" just does nothing
+# if r was never initialized - it is NOT caught as an error. This is how
+# expressions work in SQL, but can be considered a footgun; In contrast,
+# DynamoDB does throw an error when an expression uses an uninitialized
+# attribute.
+def test_lwt_counter_syntax_null_column(cql, table1, scylla_only):
+    p = unique_key_int()
+    cql.execute(f'INSERT INTO {table1} (p, c) VALUES ({p}, 1) IF NOT EXISTS')
+    # At this point, the row (p, 1) exists but has r is null.
+    rs = list(cql.execute(f'UPDATE {table1} SET r = r + 1 WHERE p={p} AND c=1 IF EXISTS'))
+    # The condition IF EXISTS was true (the row exists), so the LWT was applied.
+    assert len(rs) == 1 and rs[0].applied
+    # But the column r was not written: r + 1 where r is null results in null,
+    # so r should still be unset.
+    assert cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1').one().r is None
+
+    # Verify the same for subtraction:
+    rs = list(cql.execute(f'UPDATE {table1} SET r = r - 1 WHERE p={p} AND c=1 IF EXISTS'))
+    assert len(rs) == 1 and rs[0].applied
+    assert cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1').one().r is None
+
+    # We can achieve the same thing with a condition on r (r != null)
+    # instead of on the row (IF EXISTS). But the difference in this case is
+    # that a condition on r allows the user to catch an uninitialized r, by
+    # noticing that the LWT condition failed.
+    rs = list(cql.execute(f'UPDATE {table1} SET r = r + 1 WHERE p={p} AND c=1 IF r != null'))
+    assert len(rs) == 1 and not rs[0].applied
+    assert cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1').one().r is None
+    # After initializing r, the condition passes and the increment takes effect.
+    cql.execute(f'UPDATE {table1} SET r = 0 WHERE p={p} AND c=1')
+    rs = list(cql.execute(f'UPDATE {table1} SET r = r + 1 WHERE p={p} AND c=1 IF r != null'))
+    assert len(rs) == 1 and rs[0].applied
+    assert cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1').one().r == 1
+
+# Test that the LWT counter syntax is allowed for all numeric types, not just
+# integers. This is a Scylla extension (issue #10568).
+def test_lwt_counter_syntax_numeric_types(cql, test_keyspace, scylla_only):
+    # All CQL numeric types that should support arithmetic SET in LWT updates.
+    numeric_types = ['tinyint', 'smallint', 'int', 'bigint', 'varint', 'float', 'double', 'decimal']
+    # Build a table with one column per numeric type, all named col_<type>.
+    col_defs = ', '.join(f'col_{t} {t}' for t in numeric_types)
+    schema = f'p int PRIMARY KEY, {col_defs}'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        p = unique_key_int()
+        # Initialize all columns to 0; arithmetic requires a non-null value.
+        col_names = ', '.join(f'col_{t}' for t in numeric_types)
+        zero_vals = ', '.join(['0'] * len(numeric_types))
+        cql.execute(f'INSERT INTO {table} (p, {col_names}) VALUES ({p}, {zero_vals})')
+        for t in numeric_types:
+            col = f'col_{t}'
+            # Increment from 0 to 1 using IF EXISTS.
+            rs = list(cql.execute(f'UPDATE {table} SET {col} = {col} + 1 WHERE p = {p} IF EXISTS'))
+            assert len(rs) == 1 and rs[0].applied, f'increment from 0 failed for type {t}'
+            row = cql.execute(f'SELECT {col} FROM {table} WHERE p = {p}').one()
+            assert getattr(row, col) == 1, f'expected 1 after increment for type {t}, got {getattr(row, col)}'
+            # Increment again from 1 to 2.
+            rs = list(cql.execute(f'UPDATE {table} SET {col} = {col} + 1 WHERE p = {p} IF EXISTS'))
+            assert len(rs) == 1 and rs[0].applied, f'second increment failed for type {t}'
+            row = cql.execute(f'SELECT {col} FROM {table} WHERE p = {p}').one()
+            assert getattr(row, col) == 2, f'expected 2 after second increment for type {t}, got {getattr(row, col)}'
+            # Subtract 1 from 2, leaving 1.
+            rs = list(cql.execute(f'UPDATE {table} SET {col} = {col} - 1 WHERE p = {p} IF EXISTS'))
+            assert len(rs) == 1 and rs[0].applied, f'subtraction failed for type {t}'
+            row = cql.execute(f'SELECT {col} FROM {table} WHERE p = {p}').one()
+            assert getattr(row, col) == 1, f'expected 1 after subtraction for type {t}, got {getattr(row, col)}'
+
+# Currently, the syntax "SET r = p + 1" (different column on LHS and RHS) is
+# NOT allowed - the CQL grammar only allows "X = X +/- value", so mismatching
+# columns is a syntax error, regardless of whether the statement has an IF
+# clause. We may decide to allow this syntax in the future, in which case
+# this test should be changed - but for now we don't support it.
+def test_lwt_counter_syntax_mismatched_column(cql, table1):
+    p = unique_key_int()
+    # The grammar rejects r = p + 1 (p != r) as a SyntaxException.
+    with pytest.raises(SyntaxException, match='Only expressions of the form X = X'):
+        cql.execute(f'UPDATE {table1} SET r = p + 1 WHERE p={p} AND c=1 IF EXISTS')
+    with pytest.raises(SyntaxException, match='Only expressions of the form X = X'):
+        cql.execute(f'UPDATE {table1} SET r = p - 1 WHERE p={p} AND c=1 IF EXISTS')
+    # Also rejected without an IF clause:
+    with pytest.raises(SyntaxException, match='Only expressions of the form X = X'):
+        cql.execute(f'UPDATE {table1} SET r = p + 1 WHERE p={p} AND c=1')
+
+# We checked the LWT counter syntax SET r = r + 1 on regular columns, let's
+# check that it's *not* allowed for key columns: p and c are numeric but still
+# not allowed because they cannot be set by an UPDATE.
+def test_lwt_counter_forbidden_key_columns(cql, table1):
+    p = unique_key_int()
+    with pytest.raises(InvalidRequest, match='PRIMARY KEY'):
+        cql.execute(f'UPDATE {table1} SET p = p + 1 WHERE p={p} AND c=1 IF EXISTS')
+    with pytest.raises(InvalidRequest, match='PRIMARY KEY'):
+        cql.execute(f'UPDATE {table1} SET c = c + 1 WHERE p={p} AND c=1 IF EXISTS')
+
+# Test that the LWT counter syntax works in prepared statements, including
+# the operand coming from a bind variable.
+def test_lwt_counter_syntax_prepared(cql, table1, scylla_only):
+    p = unique_key_int()
+    cql.execute(f'INSERT INTO {table1} (p, c, r) VALUES ({p}, 1, 10)')
+    # Prepare a statement with a bind variable for the increment delta.
+    inc_stmt = cql.prepare(f'UPDATE {table1} SET r = r + ? WHERE p = ? AND c = ? IF EXISTS')
+    dec_stmt = cql.prepare(f'UPDATE {table1} SET r = r - ? WHERE p = ? AND c = ? IF EXISTS')
+    # Increment r by 5: 10 -> 15.
+    rs = list(cql.execute(inc_stmt, [5, p, 1]))
+    assert len(rs) == 1 and rs[0].applied
+    assert cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1').one().r == 15
+    # Decrement r by 3: 15 -> 12.
+    rs = list(cql.execute(dec_stmt, [3, p, 1]))
+    assert len(rs) == 1 and rs[0].applied
+    assert cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1').one().r == 12
+    # Execute the same prepared statement again with a different delta: 12 -> 17.
+    rs = list(cql.execute(inc_stmt, [5, p, 1]))
+    assert len(rs) == 1 and rs[0].applied
+    assert cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1').one().r == 17
+    # A failed condition leaves r unchanged.
+    rs = list(cql.execute(dec_stmt, [100, p, 999]))  # c=999 does not exist
+    assert len(rs) == 1 and not rs[0].applied
+    assert cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1').one().r == 17
+
+# Test that the LWT counter syntax (add and subtract) catches overflows and
+# underflows for fixed-width integer types (tinyint, smallint, int, bigint)
+# and doesn't allow them to wrap around.
+def test_lwt_counter_syntax_overflow(cql, test_keyspace, scylla_only):
+    # (type name, bits) for each fixed-width signed integer type.
+    integer_types = [
+        ('tinyint',  8),
+        ('smallint', 16),
+        ('int',      32),
+        ('bigint',   64),
+    ]
+    col_defs = ', '.join(f'col_{t} {t}' for t, _ in integer_types)
+    schema = f'p int PRIMARY KEY, {col_defs}'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        p = unique_key_int()
+        for t, bits in integer_types:
+            col = f'col_{t}'
+            max_val = 2**(bits-1) - 1
+            min_val = -(2**(bits-1))
+            # Incrementing past the maximum must be rejected, not wrap around.
+            cql.execute(f'UPDATE {table} SET {col} = {max_val} WHERE p = {p}')
+            with pytest.raises(InvalidRequest, match='overflow'):
+                cql.execute(f'UPDATE {table} SET {col} = {col} + 1 WHERE p = {p} IF {col} = {max_val}')
+            # Likewise, decrementing past the minimum must be rejected.
+            cql.execute(f'UPDATE {table} SET {col} = {min_val} WHERE p = {p}')
+            with pytest.raises(InvalidRequest, match='overflow'):
+                cql.execute(f'UPDATE {table} SET {col} = {col} - 1 WHERE p = {p} IF {col} = {min_val}')
+            # The subtraction -1 - MININT should *not* overflow, it has a valid
+            # result MAXINT. This forced us to implement a separate SUB
+            # operation, not just ADD and NEG (unary minus), because NEG on
+            # MININT overflows.
+            cql.execute(f'UPDATE {table} SET {col} = -1 WHERE p = {p}')
+            stmt = cql.prepare(f'UPDATE {table} SET {col} = {col} - ? WHERE p = ? IF {col} = -1')
+            cql.execute(stmt, [min_val, p])
+            assert cql.execute(f'SELECT {col} FROM {table} WHERE p = {p}').one()[0] == max_val
+
+# Test that adding a float literal (3.5) to an int column is rejected at
+# because 3.5 is not a valid integer value.
+def test_lwt_counter_syntax_float_on_integer(cql, table1, scylla_only):
+    p = unique_key_int()
+    cql.execute(f'INSERT INTO {table1} (p, c, r) VALUES ({p}, 1, 0)')
+    with pytest.raises(InvalidRequest, match='of type int'):
+        cql.execute(f'UPDATE {table1} SET r = r + 3.5 WHERE p={p} AND c=1 IF EXISTS')
+    with pytest.raises(InvalidRequest, match='of type int'):
+        cql.execute(f'UPDATE {table1} SET r = r - 3.5 WHERE p={p} AND c=1 IF EXISTS')
+    # Verify the type check is enforced at prepare time if 3.5 is a constant,
+    # or at execute time if 3.5 is a bind variable:
+    with pytest.raises(InvalidRequest, match='of type int'):
+        cql.prepare(f'UPDATE {table1} SET r = r + 3.5 WHERE p = ? AND c = ? IF EXISTS')
+    with pytest.raises(InvalidRequest, match='of type int'):
+        cql.prepare(f'UPDATE {table1} SET r = r - 3.5 WHERE p = ? AND c = ? IF EXISTS')
+    inc_stmt = cql.prepare(f'UPDATE {table1} SET r = r + ? WHERE p = ? AND c = ? IF EXISTS')
+    dec_stmt = cql.prepare(f'UPDATE {table1} SET r = r - ? WHERE p = ? AND c = ? IF EXISTS')
+    # When 3.5 is a bind variable, the Python driver catches the type mismatch
+    # itself before sending the request to Scylla, raising a TypeError.
+    # We don't intend the Python driver, but this check verifies that the
+    # server correctly told the driver which type it expects for the bind
+    # variable.
+    with pytest.raises(TypeError):
+        cql.execute(inc_stmt, [3.5, p, 1])
+    with pytest.raises(TypeError):
+        cql.execute(dec_stmt, [3.5, p, 1])
+
+# Test that trying to add "decimal" values with wildly different scales is
+# rejected with an error, not allowed to proceed with ridiculous amount of
+# CPU and memory usage. Reproduces SCYLLADB-1576.
+# This test needs to be skipped while SCYLLADB-1576 is not fixed, otherwise
+# it will cause the test suite to hang or crash.
+@pytest.mark.skip_bug(reason="SCYLLADB-1576: hangs or OOMs instead of rejecting")
+def test_lwt_counter_syntax_decimal_magnitude_difference(cql, test_keyspace, scylla_only):
+    # 1e100000000 is stored compactly as (unscaled=1, scale=-100000000), but
+    # adding 1 to it forces alignment of decimal points, potentially allocating
+    # 100 million digits and running out of memory.
+    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, d decimal') as table:
+        p = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (p, d) VALUES ({p}, 1e100000000)")
+        with pytest.raises(InvalidRequest):
+            cql.execute(f"UPDATE {table} SET d = d + 1 WHERE p = {p} IF EXISTS")

--- a/types/types.cc
+++ b/types/types.cc
@@ -774,6 +774,46 @@ bool abstract_type::is_counter() const {
     return visit(*this, visitor{});
 }
 
+bool abstract_type::is_arithmetic() const {
+    if (_kind == kind::reversed) {
+        return underlying_type()->is_arithmetic();
+    }
+    switch (_kind) {
+    case kind::byte:
+    case kind::short_kind:
+    case kind::int32:
+    case kind::long_kind:
+    case kind::varint:
+    case kind::decimal:
+    case kind::float_kind:
+    case kind::double_kind:
+        return true;
+    case kind::ascii:
+    case kind::boolean:
+    case kind::bytes:
+    case kind::counter:
+    case kind::date:
+    case kind::duration:
+    case kind::empty:
+    case kind::inet:
+    case kind::list:
+    case kind::map:
+    case kind::reversed:
+    case kind::set:
+    case kind::simple_date:
+    case kind::time:
+    case kind::timestamp:
+    case kind::timeuuid:
+    case kind::tuple:
+    case kind::user:
+    case kind::utf8:
+    case kind::uuid:
+    case kind::vector:
+        return false;
+    }
+    __builtin_unreachable();
+}
+
 bool abstract_type::is_collection() const {
     struct visitor {
         bool operator()(const reversed_type_impl& r) { return r.underlying_type()->is_collection(); }

--- a/types/types.hh
+++ b/types/types.hh
@@ -449,6 +449,9 @@ public:
     sstring to_string_impl(const data_value& v) const;
     bytes from_string(std::string_view text) const;
     bool is_counter() const;
+    /// True for numeric types that support arithmetic operations, including
+    /// integers and floating point of all sizes, decimal and varint.
+    bool is_arithmetic() const;
     bool is_string() const;
     bool is_collection() const;
     bool is_map() const { return _kind == kind::map; }


### PR DESCRIPTION
ScyllaDB has special counter columns for which atomic add/subtract operations like `SET a = a + 1` are allowed. Such operations have not been allowed on ordinary non-counter columns, as they would not be properly atomic - the read an the write are separate, and concurrent operations can have incorrect results.

This patch makes it allowed to use such atomic add/subtract operations in **LWT** statements. For example

	UPDATE ... SET a = a - 7 IF a > 0

or

	UPDATE ... SET a = a + 1 IF a != NULL

The row updated in the operation, and the updated column (`a`) should be initialized before the update. The example `SET a = a + 1 IF a != NULL` will fail the condition if `a` is not set. A different request `SET a = a + 1 IF EXISTS` will just leave `a` unset if it's unset (NULL + 1 is NULL, this is SQL's null propagation rules).

This add/subtract operations is allowed on any numeric (integer or floating point) column.

The ability of LWT to fetch the old values of a column and use it to calculate the new value has long been available in our internal CAS implementation - and has been in use for years in Alternator - but until this patch it was not exposed in CQL's LWT.

This series does not add new syntax to CQL - the "SET a = a + b" and "SET a = a - b"  syntax already existed for counters, and we just allow the same syntax for non- counters. However, the series does add a bit of machinery that will allow us to easily support more general expressions in the future. In particular, this series implements the addition, subtraction, and unary-minus operators for expressions, and adds the machinery needed to run **any** expression in "SET a = expr()", using existing row values fetched by LWT.

This is a new Scylla-only feature that does not exist in Cassandra.

Fixes #10568
Refs #22918 ("Support arithmetic operators"), SCYLLADB-1576 ("Decimal arithmetic operations OOM")

This is is a new feature, so normally would not be backported.