### PR TITLE
test.py: remove redundant pytest.mark.asyncio decorators

### DIFF
--- a/test/cluster/auth_cluster/test_attach_service_level_to_user.py
+++ b/test/cluster/auth_cluster/test_attach_service_level_to_user.py
@@ -13,7 +13,6 @@ from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.pylib.manager_client import ManagerClient
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
-@pytest.mark.asyncio
 async def test_attach_service_level_to_user(request, manager: ManagerClient):
     user = f"test_user_{unique_name()}"
 

--- a/test/cluster/auth_cluster/test_auth_after_reset.py
+++ b/test/cluster/auth_cluster/test_auth_after_reset.py
@@ -27,7 +27,6 @@ async def repeat_until_success(f):
 """
 Test if superuser is recreated after manual sstable delete (password reset procedure).
 """
-@pytest.mark.asyncio
 async def test_auth_after_reset(manager: ManagerClient) -> None:
     servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
     cql, _ = await manager.get_ready_cql(servers)

--- a/test/cluster/auth_cluster/test_auth_cache_metrics.py
+++ b/test/cluster/auth_cluster/test_auth_cache_metrics.py
@@ -12,7 +12,6 @@ from cassandra.auth import PlainTextAuthProvider
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_auth_cache_metrics(manager: ManagerClient):
     """
     Verify that auth cache metrics correctly track roles and permissions

--- a/test/cluster/auth_cluster/test_auth_no_quorum.py
+++ b/test/cluster/auth_cluster/test_auth_no_quorum.py
@@ -19,7 +19,6 @@ from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 Tests how cluster behaves when lost quorum. Ideally for operations with CL=1 live part of the
 cluster should still work but that's guaranteed only if auth data is replicated everywhere.
 """
-@pytest.mark.asyncio
 async def test_auth_no_quorum(manager: ManagerClient) -> None:
     config = {
         **auth_config,
@@ -60,7 +59,6 @@ async def test_auth_no_quorum(manager: ManagerClient) -> None:
 """
 Tests raft snapshot transfer of auth data.
 """
-@pytest.mark.asyncio
 async def test_auth_raft_snapshot_transfer(manager: ManagerClient) -> None:
     servers = await manager.servers_add(1, config=auth_config)
 

--- a/test/cluster/auth_cluster/test_auth_password_ensured.py
+++ b/test/cluster/auth_cluster/test_auth_password_ensured.py
@@ -27,7 +27,6 @@ async def repeat_if_host_unavailable(f):
 Test CQL is served only after superuser default password is created.
 After CQL is served, user is properily authenticated as superuser (not annonymous user)
 """
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
 async def test_auth_password_ensured(manager: ManagerClient) -> None:
     config = {

--- a/test/cluster/auth_cluster/test_connection_stage.py
+++ b/test/cluster/auth_cluster/test_connection_stage.py
@@ -64,7 +64,6 @@ def make_server_config(auth_type: str) -> dict:
     raise ValueError(f"Unknown auth_type: {auth_type!r}")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("auth_type", [
     "allow_all",
     "password",

--- a/test/cluster/auth_cluster/test_group0_batch_barrier.py
+++ b/test/cluster/auth_cluster/test_group0_batch_barrier.py
@@ -14,7 +14,6 @@ from test.pylib.util import unique_name, wait_for
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
 async def test_create_role_visible_on_all_nodes(manager: ManagerClient) -> None:
     """After CREATE ROLE returns, the role should be immediately visible
@@ -51,7 +50,6 @@ async def test_create_role_visible_on_all_nodes(manager: ManagerClient) -> None:
         )
 
 
-@pytest.mark.asyncio
 async def test_create_role_mixed_cluster(manager: ManagerClient,
                                                             scylla_2025_1: ScyllaVersionDescription) -> None:
     """Variant of test_create_role_visible_on_all_nodes that runs a mixed

--- a/test/cluster/auth_cluster/test_maintenance_socket.py
+++ b/test/cluster/auth_cluster/test_maintenance_socket.py
@@ -95,7 +95,6 @@ async def connect_with_credentials(ip: str, username: str, password: str, timeou
     return await wait_for(try_connect, time.time() + timeout)
 
 
-@pytest.mark.asyncio
 async def test_maintenance_socket(manager: ManagerClient, cql_clusters: CqlClusters):
     """
     Test that when connecting to the maintenance socket, the user has superuser permissions,
@@ -151,7 +150,6 @@ async def test_maintenance_socket(manager: ManagerClient, cql_clusters: CqlClust
     maintenance_session.execute("CREATE TABLE ks1.t2 (pk int PRIMARY KEY, val int);")
 
 
-@pytest.mark.asyncio
 async def test_no_default_superuser_exists_by_default(manager: ManagerClient, cql_clusters: CqlClusters):
     """
     Test that no 'cassandra' user exists when no default superuser is configured.
@@ -175,7 +173,6 @@ async def test_no_default_superuser_exists_by_default(manager: ManagerClient, cq
         pass
 
 
-@pytest.mark.asyncio
 async def test_no_default_superuser_maintenance_socket_ops(manager: ManagerClient, cql_clusters: CqlClusters):
     """
     Test that we can manage user roles via the maintenance socket.
@@ -266,7 +263,6 @@ async def test_no_default_superuser_maintenance_socket_ops(manager: ManagerClien
     await wait_for(check_role_dropped, time.time() + 60)
 
 
-@pytest.mark.asyncio
 async def test_maintenance_socket_grant_revoke(manager: ManagerClient, cql_clusters: CqlClusters):
     """
     Test that GRANT, REVOKE, and REVOKE ALL via the maintenance socket work correctly.

--- a/test/cluster/auth_cluster/test_permissions_removal_restart.py
+++ b/test/cluster/auth_cluster/test_permissions_removal_restart.py
@@ -13,7 +13,6 @@ from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_permissions_removal_and_restart(manager: ManagerClient) -> None:
     """Test that a node boots successfully when role_permissions contains a
     ghost row with role and resource set but the permissions column missing.

--- a/test/cluster/auth_cluster/test_prepared_metadata_id.py
+++ b/test/cluster/auth_cluster/test_prepared_metadata_id.py
@@ -141,7 +141,6 @@ def _prepare_and_execute(host: str, query: str) -> tuple[bytes, bool, int]:
             safe_driver_shutdown(cluster)
 
 
-@pytest.mark.asyncio
 async def test_prepared_list_metadata_ids(manager: ManagerClient) -> None:
     servers = await manager.running_servers()
     if servers:

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -25,7 +25,6 @@ from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 logger = logging.getLogger(__name__)
 DRIVER_SL_NAME = "driver"
 
-@pytest.mark.asyncio
 async def test_service_levels_snapshot(manager: ManagerClient):
     """
         Cluster with 3 nodes.
@@ -115,7 +114,6 @@ async def assert_connections_params(manager: ManagerClient, hosts, expect):
             assert param["timeout"] == expect[role]["timeout"]
             assert param["scheduling_group"]
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='cql server testing REST API is not supported in release mode')
 async def test_connections_parameters_auto_update(manager: ManagerClient, build_mode):
     servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
@@ -200,7 +198,6 @@ async def test_connections_parameters_auto_update(manager: ManagerClient, build_
     for cluster_conn in cluster_connections:
         safe_driver_shutdown(cluster_conn)
 
-@pytest.mark.asyncio
 async def test_service_level_cache_after_restart(manager: ManagerClient):
     servers = await manager.servers_add(1, config=auth_config, auto_rack_dc="dc1")
     cql = manager.get_cql()
@@ -227,7 +224,6 @@ async def test_service_level_cache_after_restart(manager: ManagerClient):
     result = await cql.run_async("SELECT workload_type FROM system.service_levels_v2")
     assert len(result) == 2 and result[0].workload_type == 'batch' and result[1].workload_type == 'batch'
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
 async def test_shares_check(manager: ManagerClient):
     srv = await manager.server_add(config={
@@ -256,7 +252,6 @@ async def test_shares_check(manager: ManagerClient):
     await cql.run_async(f"CREATE SERVICE LEVEL {sl2} WITH shares=500")
     await cql.run_async(f"ALTER SERVICE LEVEL {sl1} WITH shares=100")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
 async def test_service_levels_over_limit(manager: ManagerClient):
     srv = await manager.server_add(config={**auth_config,
@@ -284,7 +279,6 @@ async def test_service_levels_over_limit(manager: ManagerClient):
     await log.wait_for(f"service level \"{sls[-2]}\" will be effectively dropped to make scheduling group available to \"{sl_name}\", please consider removing a service level.", timeout=10, from_mark=mark)
 
 # Reproduces issue scylla-enterprise#4912
-@pytest.mark.asyncio
 async def test_service_level_metric_name_change(manager: ManagerClient) -> None:
     servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
     s = servers[0]
@@ -321,7 +315,6 @@ async def test_service_level_metric_name_change(manager: ManagerClient) -> None:
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
 # Reproduces scylladb/scylladb#24792.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injection is disabled in release mode')
 async def test_reload_service_levels_after_auth_service_is_stopped(manager: ManagerClient):
     config = {**auth_config, "error_injections_at_startup": ["reload_service_level_cache_after_auth_service_is_stopped"]}
@@ -329,7 +322,6 @@ async def test_reload_service_levels_after_auth_service_is_stopped(manager: Mana
     await manager.server_stop_gracefully(s1.server_id)
 
 # Reproduces scylladb/scylladb#26190
-@pytest.mark.asyncio
 async def test_service_level_reuse_name(manager: ManagerClient):
     servers = await manager.servers_add(1, config=auth_config, auto_rack_dc="dc1")
     cql = manager.get_cql()
@@ -354,7 +346,6 @@ async def test_service_level_reuse_name(manager: ManagerClient):
     cql = await create_sl_and_use(cql, sl2)
     cql = await create_sl_and_use(cql, sl1)
 
-@pytest.mark.asyncio
 async def test_driver_service_level(manager: ManagerClient) -> None:
     servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
 
@@ -386,7 +377,6 @@ async def test_driver_service_level(manager: ManagerClient) -> None:
     for host in hosts:
         assert len(await cql.run_async("LIST ALL SERVICE LEVELS", host=host)) == 0
 
-@pytest.mark.asyncio
 async def test_driver_service_creation_failure(manager: ManagerClient) -> None:
     servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
 
@@ -431,7 +421,6 @@ async def test_driver_service_creation_failure(manager: ManagerClient) -> None:
         service_level_names = [sl.service_level for sl in service_levels]
         assert "driver" not in service_level_names
 
-@pytest.mark.asyncio
 async def _verify_requests_count_metrics(manager, server, used_group, unused_group, func):
     number_of_requests = 1000
     # If the service level is changed, the scheduling group is changed in connection::process()
@@ -461,7 +450,6 @@ async def _verify_requests_count_metrics(manager, server, used_group, unused_gro
     assert requests_processed_by_used_group - initial_requests_processed_by_used_group >= expected_number_of_requests
     assert requests_processed_by_unused_group - initial_requests_processed_by_unused_group < expected_number_of_requests
 
-@pytest.mark.asyncio
 async def test_driver_service_level_not_used_for_user_queries(manager: ManagerClient) -> None:
     server = await manager.server_add(config=auth_config)
 
@@ -478,7 +466,6 @@ async def test_driver_service_level_not_used_for_user_queries(manager: ManagerCl
     func = lambda: cql.execute(f"SELECT * from system.peers")
     await _verify_requests_count_metrics(manager, server, 'sl:test', 'sl:driver', func)
 
-@pytest.mark.asyncio
 async def test_driver_service_level_used_for_driver_queries(manager: ManagerClient) -> None:
     server = await manager.server_add(config=auth_config)
 
@@ -508,7 +495,6 @@ async def test_driver_service_level_used_for_driver_queries(manager: ManagerClie
     await _verify_requests_count_metrics(manager, server, 'sl:driver', 'sl:test', func)
 
 # Reproduces scylladb/scylladb#26040
-@pytest.mark.asyncio
 async def test_anonymous_user(manager: ManagerClient) -> None:
     allow_all_config = {'authenticator':'AllowAllAuthenticator', 'authorizer':'AllowAllAuthorizer'}
     server = await manager.server_add(config=allow_all_config)
@@ -533,7 +519,6 @@ async def test_anonymous_user(manager: ManagerClient) -> None:
 
     assert False, f"None of clients use sl:default, rows={rows}"
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_per_service_level_cql_requests_serving(manager: ManagerClient) -> None:
     """Test that the per-service-level cql_requests_serving metric correctly

--- a/test/cluster/auth_cluster/test_service_levels_self_healing.py
+++ b/test/cluster/auth_cluster/test_service_levels_self_healing.py
@@ -35,7 +35,6 @@ def assert_service_levels(rows, expected):
         assert row.shares == shares
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode="release", reason="error injection is disabled in release mode")
 async def test_self_heals_service_levels_v1_after_restart(manager: ManagerClient, scale_timeout: callable):
     """Reproduces a raft-topology cluster created before service levels were initialized as v2."""

--- a/test/cluster/auth_cluster/test_startup_response.py
+++ b/test/cluster/auth_cluster/test_startup_response.py
@@ -17,7 +17,6 @@ from cassandra.auth import PlainTextAuthProvider
 from test.pylib.manager_client import ManagerClient, safe_driver_shutdown
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
-@pytest.mark.asyncio
 async def test_startup_no_auth_response(manager: ManagerClient, build_mode):
     """
     Test behavior when client hangs on startup auth response.

--- a/test/cluster/lwt/test_lwt_during_tablets_migration.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_migration.py
@@ -96,7 +96,6 @@ async def tablet_migration_ops(stop_event: asyncio.Event,
     logger.info("Completed tablet migration ops: %d/%d", migration_count, num_ops)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='debug mode is too slow for this test')
 async def test_multi_column_lwt_during_migration(manager: ManagerClient, scale_timeout):

--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -131,7 +131,6 @@ async def run_random_resizes(
     }
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='debug mode is too slow for this test')
 async def test_multi_column_lwt_during_split_merge(manager: ManagerClient, scale_timeout):

--- a/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
+++ b/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
@@ -293,7 +293,6 @@ async def run_random_resizes(
     }
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode("debug", "debug mode is too slow for this test")
 async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClient, scale_timeout):
 

--- a/test/cluster/mv/tablets/test_mv_tablets.py
+++ b/test/cluster/mv/tablets/test_mv_tablets.py
@@ -60,7 +60,6 @@ async def assert_one_tablet(cql, keyspace_name, table_or_view_name):
     assert len(rows) == 1
 
 
-@pytest.mark.asyncio
 async def test_tablet_mv_create(manager: ManagerClient):
     """A basic test for creating a materialized view on a table stored
        with tablets on a one-node cluster. We just create the view and
@@ -75,7 +74,6 @@ async def test_tablet_mv_create(manager: ManagerClient):
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk)")
 
 
-@pytest.mark.asyncio
 async def test_tablet_mv_simple(manager: ManagerClient):
     """A simple test for reading and writing a materialized view on a table
        stored with tablets on a one-node cluster. Because it's a one-node
@@ -94,7 +92,6 @@ async def test_tablet_mv_simple(manager: ManagerClient):
         # We used SYNCHRONOUS_UPDATES=TRUE, so the view should be updated:
         assert [(3,2)] == list(await cql.run_async(f"SELECT * FROM {ks}.tv WHERE c=3"))
 
-@pytest.mark.asyncio
 async def test_tablet_mv_simple_6node(manager: ManagerClient):
     """A simple reproducer for a bug of forgetting that the view table has a
        different tablet mapping from the base: Using the wrong tablet mapping
@@ -119,7 +116,6 @@ async def inject_error_on(manager, error_name, servers):
     errs = [manager.api.enable_injection(s.ip_addr, error_name, False) for s in servers]
     await asyncio.gather(*errs)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_alternator_lsi_consistency(manager: ManagerClient):
     """A reproducer for a bug where Alternator LSI was not using synchronous
@@ -197,7 +193,6 @@ async def test_tablet_alternator_lsi_consistency(manager: ManagerClient):
     )
     table.delete()
 
-@pytest.mark.asyncio
 async def test_tablet_si_create(manager: ManagerClient):
     """A basic test for creating a secondary index on a table stored
        with tablets on a one-node cluster. We just create the index and
@@ -226,7 +221,6 @@ async def test_tablet_lsi_create(manager: ManagerClient):
         await cql.run_async(f"CREATE INDEX my_idx ON {ks}.test((pk),c)")
         await cql.run_async(f"DROP INDEX {ks}.my_idx")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_cql_lsi(manager: ManagerClient):
     """A simple reproducer for issue #16371 where CQL LSI (local secondary
@@ -277,7 +271,6 @@ async def test_tablet_cql_lsi(manager: ManagerClient):
         # immediately after the previous INSERT returned.
         assert [(7,42)] == list(await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk=7 AND c=42"))
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_tablet_split(manager: ManagerClient):
     """A basic test for checking that tablet split works on MV tables.

--- a/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 #
 # RF needs to be smaller than the cluster size in order ensure appearance of
 # remote view updates.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='node replace needs to wait for tablet rebuild, which takes a lot of time in debug mode')
 async def test_mv_tablets_empty_ip(manager: ManagerClient):

--- a/test/cluster/mv/tablets/test_mv_tablets_merge.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_merge.py
@@ -15,7 +15,6 @@ from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_mv_merge_allowed(manager):
     """
     Test that tablet merge is allowed for materialized views and their base tables.

--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -23,7 +23,6 @@ from test.cluster.util import new_test_keyspace, wait_for
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.nightly
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):

--- a/test/cluster/mv/test_mv_admission_control.py
+++ b/test/cluster/mv/test_mv_admission_control.py
@@ -23,7 +23,6 @@ logger = logging.getLogger(__name__)
 # In the test, we create a table and perform a pair of writes to it. The
 # second write should fail due to admission control. We check that this
 # is indeed the error thrown.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_admission_control_exception(manager: ManagerClient) -> None:
     node_count = 2
@@ -60,7 +59,6 @@ async def test_mv_admission_control_exception(manager: ManagerClient) -> None:
 # are rejected by admission control and retried until they reach all replicas, instead
 # of succeeding just on the remaining replicas, reaching a quorum, but failing the
 # write on the slow node.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_retried_writes_reach_all_replicas(manager: ManagerClient) -> None:
     node_count = 4

--- a/test/cluster/mv/test_mv_backlog.py
+++ b/test/cluster/mv/test_mv_backlog.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 # In the test, we create a table and perform a write to it a couple of times
 # Each time, we check that a view update backlog on some shard increased
 # due to the write.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_view_backlog_increased_after_write(manager: ManagerClient) -> None:
     node_count = 2
@@ -52,7 +51,6 @@ async def test_view_backlog_increased_after_write(manager: ManagerClient) -> Non
 # This test reproduces issues #18461 and #18783
 # In the test, we create a table and perform a write to it that fills the view update backlog.
 # After a gossip round is performed, the following write should succeed.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_gossip_same_backlog(manager: ManagerClient) -> None:
     node_count = 2
@@ -96,7 +94,6 @@ async def test_gossip_same_backlog(manager: ManagerClient) -> None:
 # Finally, calculate ratios between the measured delays - the ratios should be
 # the same as ratios of the view_flow_control_delay_limit_in_ms parameter
 # that was set during the measurement.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_configurable_mv_control_flow_delay(manager: ManagerClient) -> None:
     node_count = 2

--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 #
 # For more context, see: https://github.com/scylladb/scylladb/issues/21232.
 # This test reproduces the issue in non-tablet mode.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='debug', reason='the test needs to do some work which takes too much time in debug mode')
 async def test_view_building_scheduling_group(manager: ManagerClient):
     # Note: The view building coordinator works in the gossiping scheduling group,
@@ -74,7 +73,6 @@ async def test_view_building_scheduling_group(manager: ManagerClient):
 
 # A sanity check test ensures that starting and shutting down Scylla when view building is
 # disabled is conducted properly and we don't run into any issues.
-@pytest.mark.asyncio
 async def test_start_scylla_with_view_building_disabled(manager: ManagerClient):
     server = await manager.server_add(config={"view_building": "false"})
     await manager.server_stop_gracefully(server_id=server.server_id)
@@ -87,7 +85,6 @@ async def test_start_scylla_with_view_building_disabled(manager: ManagerClient):
 # While view building is in progress, drop the index (which changes the schema
 # of the base table). The state of the view table corresponding to the index
 # may become inconsistent with the base table because they got detached.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_view_building_during_drop_index(manager: ManagerClient):
     server = await manager.server_add()
@@ -118,7 +115,6 @@ async def test_view_building_during_drop_index(manager: ManagerClient):
 # We restart the node in this state and verify that when it comes up the view building
 # is completed eventually and is correct.
 # Reproduces #22989
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_interrupt_view_build_shard_registration(manager: ManagerClient):
     cmdline = ['--smp=4']
@@ -163,7 +159,6 @@ async def test_interrupt_view_build_shard_registration(manager: ManagerClient):
 # which have different progress, we won't mistakenly decide that a view is built
 # even if a build step is empty due to resharding.
 # Reproduces https://github.com/scylladb/scylladb/issues/26523
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_empty_build_step_after_reshard(manager: ManagerClient):
     server = await manager.server_add(cmdline=['--smp', '1', '--logger-log-level', 'view=debug'])
@@ -206,7 +201,6 @@ async def test_empty_build_step_after_reshard(manager: ManagerClient):
 # they're most likely going to fail as well. Verify that that's the case.
 #
 # Reproduces scylladb/scylladb#26686.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_backoff_when_node_fails_task_rpc(manager: ManagerClient):
     """
@@ -315,7 +309,6 @@ async def test_backoff_when_node_fails_task_rpc(manager: ManagerClient):
 # Test that the view builder does not finish when some replica nodes are down,
 # and resumes correctly once they come back.
 # Migrated from dtest materialized_views_test.py::TestMaterializedViews::test_do_not_finish_view_building_with_hints
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_do_not_finish_view_builder_with_nodes_down(manager: ManagerClient):
     """Test that the view builder does not complete while replica nodes are down,

--- a/test/cluster/mv/test_mv_delete_partitions.py
+++ b/test/cluster/mv/test_mv_delete_partitions.py
@@ -56,7 +56,6 @@ async def insert_with_concurrency(cql, table, value_count, concurrency):
 # The "view_update_limit" error injections will cause the test to fail due to a failed
 # replica write if the view update limit is exceeded. If, thanks to throttling, we never
 # exceed the limit, the test will pass
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_delete_partition_rows_from_table_with_mv(manager: ManagerClient) -> None:
     node_count = 2
@@ -84,7 +83,6 @@ async def test_delete_partition_rows_from_table_with_mv(manager: ManagerClient) 
 # a partition in this case is expected to generate one view update for deleting
 # the corresponding view partition by a partition tombstone.
 # Reproduces #8199
-@pytest.mark.asyncio
 @pytest.mark.parametrize("permuted", [False, True])
 async def test_base_partition_deletion_with_metrics(manager: ManagerClient, permuted):
     server = await manager.server_add()
@@ -134,7 +132,6 @@ async def test_base_partition_deletion_with_metrics(manager: ManagerClient, perm
 # Perform a deletion of a base partition in a batch with deletion of individual rows. Verify the
 # partition is deleted correctly and that a single update is generated for the view for deleting
 # the whole partition, and no view updates for each row.
-@pytest.mark.asyncio
 async def test_base_partition_deletion_in_batch_with_delete_row_with_metrics(manager: ManagerClient):
     server = await manager.server_add()
     cql = manager.get_cql()

--- a/test/cluster/mv/test_mv_fail_building.py
+++ b/test/cluster/mv/test_mv_fail_building.py
@@ -15,7 +15,6 @@ from cassandra.query import SimpleStatement  # type: ignore
 # This test makes sure that even if the view building encounter errors, the view building is eventually finished
 # and the view is consistent with the base table.
 # Reproduces the scenario in #19261
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_fail_building(manager: ManagerClient) -> None:
     node_count = 3
@@ -46,7 +45,6 @@ async def test_mv_fail_building(manager: ManagerClient) -> None:
 # Test view build operations running during node shutdown and view drain.
 # Verify the drain order is correct and the view build doesn't fail with
 # database write failures.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_build_during_shutdown(manager: ManagerClient):
     server = await manager.server_add()

--- a/test/cluster/mv/test_mv_read_concurrency.py
+++ b/test/cluster/mv/test_mv_read_concurrency.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 # while concurrently running a small read workload on the other table.
 # The test fails if any of the reads times out.
 # Reproduces https://github.com/scylladb/scylladb/issues/8873
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_read_concurrency(manager: ManagerClient) -> None:
     node_count = 1
@@ -90,7 +89,6 @@ async def test_mv_read_concurrency(manager: ManagerClient) -> None:
 # an even larger number of writes causing view updates.
 # The test fails if Scylla aborts due to using too much memory.
 # Reproduces https://github.com/scylladb/scylladb/issues/15805
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_mv_read_memory(manager: ManagerClient) -> None:
     node_count = 1

--- a/test/cluster/mv/test_mv_staging.py
+++ b/test/cluster/mv/test_mv_staging.py
@@ -44,7 +44,6 @@ async def delete_table_sstables(manager: ManagerClient, server: ServerInfo, ks: 
             os.remove(path)
         break # break unconditionally here to remove only files in `table_dir`
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_staging_backlog_processed_after_restart(manager: ManagerClient):
     """

--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 # While the writes are in progress, we add then decommission a node in the cluster.
 # The test verifies that no node crashes as a result of the topology change combined
 # with the writes.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_topology_change(manager: ManagerClient):
     cfg = {'tablets_mode_for_new_keyspaces': 'disabled',
@@ -96,7 +95,6 @@ async def test_mv_topology_change(manager: ManagerClient):
 # With the parameter intranode=True it's the same except the tablet
 # is migrating between two shards on the same node.
 @pytest.mark.parametrize("intranode", [True, False])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_update_on_pending_replica(manager: ManagerClient, intranode):
     cfg = {'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -177,7 +175,6 @@ async def test_mv_update_on_pending_replica(manager: ManagerClient, intranode):
 # If the MV write handler is not completed after storing the hint, as in
 # issue #19529, it remains active until it timeouts, preventing topology changes
 # during this time.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='debug', reason='the test requires a short timeout for remove_node, but it is unpredictably slow in debug')
 async def test_mv_write_to_dead_node(manager: ManagerClient):
     servers = await manager.servers_add(4, property_file=[
@@ -251,7 +248,6 @@ async def test_mv_pairing_during_replace(manager: ManagerClient):
 # In this test we perform a write that generates a view update while the replication
 # factor of the keyspace is being changed and the corresponding base tablet finishes
 # the migration at a different time the view tablet does.
-@pytest.mark.asyncio
 @pytest.mark.parametrize("delayed_replica", ["base", "mv"])
 @pytest.mark.parametrize("altered_dc", ["dc1", "dc2"])
 # FIXME: The test relies on cross-rack tablet migrations. They're forbidden when the configuration option
@@ -326,7 +322,6 @@ async def test_mv_rf_change(manager: ManagerClient, delayed_replica: str, altere
     assert len(res) == 2
 
 # The same scenario as in the test above, but the RF change affects the first replica in a DC
-@pytest.mark.asyncio
 @pytest.mark.parametrize("delayed_replica", ["base", "mv"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_first_replica_in_dc(manager: ManagerClient, delayed_replica: str):
@@ -390,7 +385,6 @@ async def test_mv_first_replica_in_dc(manager: ManagerClient, delayed_replica: s
 # verify all expected rows appear in the MV eventually.
 # Checks for issues of view update generation during migration.
 # Reproduces #24292
-@pytest.mark.asyncio
 @pytest.mark.parametrize("migration_type", ["tablets_internode", "tablets_intranode", "vnodes"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_write_during_migration(manager: ManagerClient, migration_type: str):
@@ -483,7 +477,6 @@ async def test_mv_write_during_migration(manager: ManagerClient, migration_type:
 # on the topology coordinator, but the joining node is delayed in applying the group0 state.
 # The joining node receives base mutations from the other nodes to apply as the new replica,
 # and it also should generate view updates for them while in a joining state.
-@pytest.mark.asyncio
 async def test_mv_write_during_node_join(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'storage_service=debug', '--logger-log-level', 'raft_topology=debug']
     servers = await manager.servers_add(1, cmdline=cmdline)

--- a/test/cluster/mv/test_mv_with_tablets_restrictions.py
+++ b/test/cluster/mv/test_mv_with_tablets_restrictions.py
@@ -16,7 +16,6 @@ from test.pylib.manager_client import ManagerClient
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("rf_kind", ["numeric", "rack_list"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_create_mv_and_index_restrictions_in_tablet_keyspaces(manager: ManagerClient, rf_kind: str):
@@ -96,7 +95,6 @@ async def test_create_mv_and_index_restrictions_in_tablet_keyspaces(manager: Man
         await test_create_mv_or_index_with_rf(cql, schema_kind, 2, expected_error=expected_error)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("rf_kind", ["numeric", "rack_list"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_keyspace_rf_rack_restriction_with_mv_and_index(manager: ManagerClient, rf_kind: str):
@@ -176,7 +174,6 @@ async def test_alter_keyspace_rf_rack_restriction_with_mv_and_index(manager: Man
         await cql.run_async(f"DROP KEYSPACE {ks}")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_node_in_new_rack_restriction_with_mv(manager: ManagerClient):
     """
@@ -208,7 +205,6 @@ async def test_add_node_in_new_rack_restriction_with_mv(manager: ManagerClient):
 
 
 @pytest.mark.parametrize("op", ["remove", "decommission"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_remove_node_violating_rf_rack(manager: ManagerClient, op: str):
     """

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -51,7 +51,6 @@ async def take_snapshot_on_one_server(ks, server, manager, logger):
     return snap_name, sstables[server]
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("move_files", [False, True])
 async def test_simple_backup(manager: ManagerClient, object_storage, move_files):
     '''check that backing up a snapshot for a keyspace works'''
@@ -98,7 +97,6 @@ async def test_simple_backup(manager: ManagerClient, object_storage, move_files)
         assert len(res) == 1 and res[0][1].group(1) == 'bckp'
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("ne_parameter", [ "endpoint", "bucket", "snapshot" ])
 async def test_backup_with_non_existing_parameters(manager: ManagerClient, object_storage, ne_parameter):
     '''backup should fail if either of the parameters does not exist'''
@@ -132,7 +130,6 @@ async def test_backup_with_non_existing_parameters(manager: ManagerClient, objec
             assert status['error'] == 'std::invalid_argument (endpoint no-such-endpoint not found)'
 
 
-@pytest.mark.asyncio
 async def test_backup_endpoint_config_is_live_updateable(manager: ManagerClient, object_storage):
     '''backup should fail if the endpoint is invalid/inaccessible
        after updating the config, it should succeed'''
@@ -237,14 +234,12 @@ async def do_test_backup_abort(manager: ManagerClient, object_storage,
 
     await do_test_backup_helper(manager, object_storage, breakpoint_name, abort_and_check)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_backup_is_abortable(manager: ManagerClient, object_storage):
     '''check that backing up a snapshot for a keyspace works'''
     await do_test_backup_abort(manager, object_storage, breakpoint_name="backup_task_pause", min_files=0)
 
 
-@pytest.mark.asyncio
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_backup_is_abortable_in_s3_client(manager: ManagerClient, object_storage):
@@ -252,7 +247,6 @@ async def test_backup_is_abortable_in_s3_client(manager: ManagerClient, object_s
     await do_test_backup_abort(manager, object_storage, breakpoint_name="backup_task_pre_upload", min_files=0, max_files=1)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(("do_encrypt", "do_abort"), [(False, False), (False, True), (True, False)])
 async def test_simple_backup_and_restore(manager: ManagerClient, object_storage, tmpdir, do_encrypt, do_abort):
     '''check that restoring from backed up snapshot for a keyspace:table works'''
@@ -455,7 +449,6 @@ async def do_abort_restore(manager: ManagerClient, object_storage):
             failed |= final_status['state'] == 'failed'
         assert failed, "Expected at least one restore task to fail after aborting"
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_abort_restore_with_rpc_error(manager: ManagerClient, object_storage):
     await do_abort_restore(manager, object_storage)
@@ -661,7 +654,6 @@ class SSTablesOnObjectStorage:
         await asyncio.gather(*(do_restore_server(manager, logger, ks, cf, s, sstables, scope, primary_replica_only, prefix, self.object_storage) for s, sstables in sstables_per_server.items()))
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("topology", [
         topo(rf = 1, nodes = 3, racks = 1, dcs = 1),
         topo(rf = 3, nodes = 5, racks = 1, dcs = 1),
@@ -741,7 +733,6 @@ async def do_test_streaming_scopes(build_mode: str, manager: ManagerClient, topo
                 await check_streaming_directions(logger, servers, topology, host_ids, scope, pro, log_marks)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("topology", [
         topo(rf = 1, nodes = 3, racks = 1, dcs = 1),
         topo(rf = 2, nodes = 2, racks = 2, dcs = 1),
@@ -778,7 +769,6 @@ async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_s
         await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_vs_migration(build_mode: str, manager: ManagerClient, object_storage):
     '''Check that restore handles tablets migrating around'''
@@ -825,7 +815,6 @@ async def test_restore_tablets_vs_migration(build_mode: str, manager: ManagerCli
         await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_download_failure(build_mode: str, manager: ManagerClient, object_storage):
     '''Check that failure to download an sstable propagates back to API'''
@@ -859,7 +848,6 @@ async def test_restore_tablets_download_failure(build_mode: str, manager: Manage
         assert 'error' in status and 'Failed to download' in status['error']
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("target", ['coordinator', 'replica', 'api'])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: ManagerClient, object_storage, target):
@@ -911,7 +899,6 @@ async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: Ma
             await asyncio.wait_for(manager.api.wait_task(servers[1].ip_addr, tid), timeout=60)
 
 
-@pytest.mark.asyncio
 async def test_restore_with_non_existing_sstable(manager: ManagerClient, object_storage):
     '''Check that restore task fails well when given a non-existing sstable'''
 
@@ -936,7 +923,6 @@ async def test_restore_with_non_existing_sstable(manager: ManagerClient, object_
         assert 'error' in status and 'Not Found' in status['error']
 
 
-@pytest.mark.asyncio
 async def test_backup_broken_streaming(manager: ManagerClient, s3_storage):
     # Define configuration for the servers.
     objconf = s3_storage.create_endpoint_conf()
@@ -1018,7 +1004,6 @@ async def test_backup_broken_streaming(manager: ManagerClient, s3_storage):
         # just make sure we had partially contained sstables as well
         await log.wait_for("partially contained SSTables", timeout=10)
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("domain", ['rack', 'dc'])
 @pytest.mark.parametrize("scope_is_same", [True, False])
 async def test_restore_primary_replica(manager: ManagerClient, object_storage, domain, scope_is_same):

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize('replication_factor', [1, 3])
 @pytest.mark.parametrize('mode', ['normal', 'encrypted'])
-@pytest.mark.asyncio
 async def test_basic(manager: ManagerClient, object_storage, tmp_path, mode, replication_factor):
     '''verify ownership table is updated, and tables written to object storage can be read after scylla restarts.
     Parametrized over replication_factor to also verify RF=3 with multiple servers.'''
@@ -108,7 +107,6 @@ async def test_basic(manager: ManagerClient, object_storage, tmp_path, mode, rep
         rows = "\n".join(f"{row.table_id} {row.status}" for row in res)
         assert not rows, 'Unexpected entries in registry'
 
-@pytest.mark.asyncio
 async def test_garbage_collect(manager: ManagerClient, object_storage):
     '''verify ownership table is garbage-collected on boot'''
 
@@ -154,7 +152,6 @@ async def test_garbage_collect(manager: ManagerClient, object_storage):
                 assert not o.key.startswith(str(ent[2])), f'Sstable object not cleaned, found {o.key}'
 
 
-@pytest.mark.asyncio
 async def test_populate_from_quarantine(manager: ManagerClient, object_storage):
     '''verify sstables are populated from quarantine state'''
 
@@ -193,7 +190,6 @@ async def test_populate_from_quarantine(manager: ManagerClient, object_storage):
         assert have_res == rows, f'Unexpected table content: {have_res}'
 
 
-@pytest.mark.asyncio
 async def test_misconfigured_storage(manager: ManagerClient, object_storage):
     '''creating keyspace with unknown endpoint is not allowed'''
     # scylladb/scylladb#15074
@@ -216,7 +212,6 @@ async def test_misconfigured_storage(manager: ManagerClient, object_storage):
                       f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
 
 
-@pytest.mark.asyncio
 async def test_memtable_flush_retries(manager: ManagerClient, tmpdir, object_storage):
     '''verify that memtable flush doesn't crash in case storage access keys are incorrect'''
 
@@ -260,7 +255,6 @@ async def test_memtable_flush_retries(manager: ManagerClient, tmpdir, object_sto
         have_res = { x.name: x.value for x in res }
         assert have_res == dict(rows), f'Unexpected table content: {have_res}'
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('config_with_full_url', [True, False])
 async def test_get_object_store_endpoints(manager: ManagerClient, config_with_full_url):
     if config_with_full_url:
@@ -291,7 +285,6 @@ async def test_get_object_store_endpoints(manager: ManagerClient, config_with_fu
     assert json.loads(res[name]) == objconf[0]
 
 
-@pytest.mark.asyncio
 async def test_create_keyspace_after_config_update(manager: ManagerClient, object_storage):
     print('Trying to create a keyspace with an endpoint not configured in object_storage_endpoints should trip storage_manager::is_known_endpoint()')
     server = await manager.server_add()

--- a/test/cluster/random_failures/test_random_failures.py
+++ b/test/cluster/random_failures/test_random_failures.py
@@ -87,7 +87,6 @@ async def four_nodes_cluster(manager: ManagerClient) -> None:
 
 
 @pytest.mark.usefixtures("four_nodes_cluster")
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_random_failures(manager: ManagerClient,
                                random_tables: RandomTables,

--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -70,7 +70,6 @@ global_cmdline = ["--disk-space-monitor-normal-polling-interval-in-seconds", "1"
                   ]
 
 
-@pytest.mark.asyncio
 async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, hosts = await manager.get_ready_cql(servers)
@@ -122,7 +121,6 @@ async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Ca
                 await cql.run_async(SimpleStatement(next(wgen), consistency_level=ConsistencyLevel.ALL))
 
 
-@pytest.mark.asyncio
 async def test_autotoggle_compaction(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmdline = [*global_cmdline,
                "--logger-log-level", "compaction=debug"]
@@ -168,7 +166,6 @@ async def test_autotoggle_compaction(manager: ManagerClient, volumes_factory: Ca
                 await log.wait_for(rf"Major {ks}\.{table} .* Compacted .* sstables to .*", from_mark=mark)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_critical_utilization_during_decommission(manager: ManagerClient, volumes_factory: Callable) -> None:
     """
@@ -223,7 +220,6 @@ async def test_critical_utilization_during_decommission(manager: ManagerClient, 
 
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_reject_split_compaction(manager: ManagerClient, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
@@ -252,7 +248,6 @@ async def test_reject_split_compaction(manager: ManagerClient, volumes_factory: 
                     await log.wait_for(f"Split task .* for table {cf} .* stopped, reason: Compaction for {cf} was stopped due to: drain", from_mark=mark)
 
 
-@pytest.mark.asyncio
 async def test_split_compaction_not_triggered(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
            "--logger-log-level", "compaction=debug"]
@@ -286,7 +281,6 @@ async def test_split_compaction_not_triggered(manager: ManagerClient, volumes_fa
                     assert await s1_log.grep(f"compaction.*Split {cf}", from_mark=s1_mark) == []
 
 
-@pytest.mark.asyncio
 async def test_tablet_repair(manager: ManagerClient, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, _ = await manager.get_ready_cql(servers)
@@ -353,7 +347,6 @@ async def test_tablet_repair(manager: ManagerClient, volumes_factory: Callable) 
                 await manager.api.wait_task(servers[0].ip_addr, task_id)
 
 
-@pytest.mark.asyncio
 async def test_autotoggle_reject_incoming_migrations(manager: ManagerClient, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         await manager.disable_tablet_balancing()
@@ -413,7 +406,6 @@ async def test_autotoggle_reject_incoming_migrations(manager: ManagerClient, vol
                 mark, _ = await log.wait_for("Streaming for tablet migration .* successful", from_mark=mark)
 
 
-@pytest.mark.asyncio
 async def test_node_restart_while_tablet_split(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
            "--logger-log-level", "compaction=debug"]
@@ -481,7 +473,6 @@ async def test_node_restart_while_tablet_split(manager: ManagerClient, volumes_f
                 await assert_resize_task_info(table_id, lambda response: len(response) == 2 and all(r.resize_task_info is None for r in response))
 
 # Verify that new sstable produced by repair cannot be split, if disk utilization level is critical.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_repair_failure_on_split_rejection(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
@@ -567,7 +558,6 @@ global_cmdline_with_disabled_monitor = [
     "--schema-commitlog-segment-size-in-mb", "4",
     "--tablet-load-stats-refresh-interval-in-seconds", "1",
 ]
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_sstables_incrementally_released_during_streaming(manager: ManagerClient, volumes_factory: Callable) -> None:
     """
@@ -649,7 +639,6 @@ async def test_sstables_incrementally_released_during_streaming(manager: Manager
                     await decomm_task
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_load_and_stream_rejected_on_critical_disk(manager: ManagerClient, volumes_factory: Callable) -> None:
     """

--- a/test/cluster/tasks/test_node_ops_tasks.py
+++ b/test/cluster/tasks/test_node_ops_tasks.py
@@ -194,7 +194,6 @@ async def check_decommission_tasks_tree(manager: ManagerClient, tm: TaskManagerC
     vts_list = await get_new_virtual_tasks_list(tm, module_name, servers[0], previous_vts)
     return servers, previous_vts + [vts_list[0].task_id]
 
-@pytest.mark.asyncio
 async def test_node_ops_tasks_tree(manager: ManagerClient):
     """Test node ops task manager tasks."""
     module_name = "node_ops"
@@ -220,7 +219,6 @@ async def test_node_ops_tasks_tree(manager: ManagerClient):
         # live node for DROP KEYSPACE.
         await manager.driver_connect()
 
-@pytest.mark.asyncio
 async def test_node_ops_tasks_ttl(manager: ManagerClient):
     """Test node ops virtual tasks' ttl."""
     module_name = "node_ops"
@@ -230,7 +228,6 @@ async def test_node_ops_tasks_ttl(manager: ManagerClient):
     time.sleep(3)
     await get_new_virtual_tasks_statuses(tm, module_name, servers, [], expected_task_num=0)
 
-@pytest.mark.asyncio
 async def test_node_ops_task_wait(manager: ManagerClient):
     """Test node ops virtual task's wait."""
     async def _decommission(manager: ManagerClient, server: ServerInfo):

--- a/test/cluster/tasks/test_tablet_tasks.py
+++ b/test/cluster/tasks/test_tablet_tasks.py
@@ -80,7 +80,6 @@ async def check_and_abort_repair_task(manager: ManagerClient, tm: TaskManagerCli
 
     await asyncio.gather(wait_for_task(), abort_task())
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_task(manager: ManagerClient):
     module_name = "tablets"
@@ -97,7 +96,6 @@ async def test_tablet_repair_task(manager: ManagerClient):
 
     await asyncio.gather(repair_task(), check_and_abort_repair_task(manager, tm, servers, module_name, ks))
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_wait_with_table_drop(manager: ManagerClient):
     module_name = "tablets"
@@ -172,7 +170,6 @@ async def check_repair_task_list(tm: TaskManagerClient, servers: list[ServerInfo
 
         await tm.abort_task(servers[0].ip_addr, task0.task_id)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_task_list(manager: ManagerClient):
     module_name = "tablets"
@@ -196,7 +193,6 @@ async def test_tablet_repair_task_list(manager: ManagerClient):
 
     await asyncio.gather(run_repair(0, "test"), run_repair(1, "test2"), run_repair(2, "test3"), check_repair_task_list(tm, servers, module_name, ks))
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_wait(manager: ManagerClient):
     module_name = "tablets"
@@ -235,7 +231,6 @@ async def test_tablet_repair_wait(manager: ManagerClient):
 
     await asyncio.gather(wait_for_task(), merge_tablets())
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_task_children(manager: ManagerClient):
     module_name = "tablets"
@@ -292,7 +287,6 @@ async def prepare_migration_test(manager: ManagerClient):
 
     return (ks, servers, host_ids)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_task(manager: ManagerClient):
     module_name = "tablets"
@@ -327,7 +321,6 @@ async def test_tablet_migration_task(manager: ManagerClient):
     migration_dst = (host_ids[1], 0)
     await asyncio.gather(move_tablet(migration_src, migration_dst), check("migration"))
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_task_list(manager: ManagerClient):
     module_name = "tablets"
@@ -374,7 +367,6 @@ async def test_tablet_migration_task_list(manager: ManagerClient):
     await enable_injection(manager, servers, injection)
     await asyncio.gather(move_tablet(servers[0], migration_src, migration_dst), check_migration_task_list("migration"))
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_task_failed(manager: ManagerClient):
     module_name = "tablets"
@@ -415,7 +407,6 @@ async def test_tablet_migration_task_failed(manager: ManagerClient):
     dst = (src[0], 1 - src[1])
     await asyncio.gather(move_tablet(src, dst), check("intranode_migration", log, mark))
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_repair_task_info_is_none_when_no_running_repair(manager: ManagerClient):
     module_name = "tablets"
@@ -475,7 +466,6 @@ cmdline = ['--target-tablet-size-in-bytes', '30000', ]
 cmdline.extend(extra_scylla_cmdline_options)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_resize_task(manager: ManagerClient):
     module_name = "tablets"
@@ -516,7 +506,6 @@ async def test_tablet_resize_task(manager: ManagerClient):
         await wait_and_check_status(servers[0], "split", keyspace, table2)
         await wait_and_check_status(servers[0], "merge", keyspace, table1)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_resize_list(manager: ManagerClient):
     module_name = "tablets"
@@ -575,7 +564,6 @@ async def test_tablet_resize_list(manager: ManagerClient):
         await disable_injection(manager, servers, injection)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='debug mode is too time-sensitive')
 async def test_tablet_resize_revoked(manager: ManagerClient):
@@ -617,7 +605,6 @@ async def test_tablet_resize_revoked(manager: ManagerClient):
 
         await asyncio.gather(revoke_resize(log, mark), wait_for_task(task0.task_id))
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_task_sees_latest_state(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)

--- a/test/cluster/test_aggregation.py
+++ b/test/cluster/test_aggregation.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cancel_mapreduce(manager: ManagerClient):
     """

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -250,7 +250,6 @@ async def test_alternator_ttl_multinode_expiration(manager: ManagerClient, with_
         time.sleep(0.1)
     assert items == 0
 
-@pytest.mark.asyncio
 async def test_localnodes_broadcast_rpc_address(manager: ManagerClient):
     """Test that if the "broadcast_rpc_address" of a node is set, the
        "/localnodes" request returns not the node's internal IP address,
@@ -289,7 +288,6 @@ async def test_localnodes_broadcast_rpc_address(manager: ManagerClient):
                 break # done
             await asyncio.sleep(0.1)
 
-@pytest.mark.asyncio
 async def test_localnodes_drained_node(manager: ManagerClient):
     """Test that if in a cluster one node is brought down with "nodetool drain"
        a "/localnodes" request should NOT return that node. This test does
@@ -331,7 +329,6 @@ async def test_localnodes_drained_node(manager: ManagerClient):
     assert await wait_for(check_localnodes_one, time.time() + 60)
 
 
-@pytest.mark.asyncio
 async def test_localnodes_down_normal_node(manager: ManagerClient):
     """Test that if in a cluster one node reaches "normal" state and then
        brought down (so is now in "DN" state), a "/localnodes" request
@@ -374,7 +371,6 @@ async def test_localnodes_down_normal_node(manager: ManagerClient):
     assert await wait_for(check_localnodes_one, time.time() + 60)
 
 
-@pytest.mark.asyncio
 @pytest.mark.nightly
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_localnodes_joining_nodes(manager: ManagerClient):
@@ -430,7 +426,6 @@ async def test_localnodes_joining_nodes(manager: ManagerClient):
     except Exception as e:
         assert 'Failed to add server' in str(e)
 
-@pytest.mark.asyncio
 async def test_localnodes_multi_dc_multi_rack(manager: ManagerClient):
     """A test for /localnodes on a more general setup, with multiple DCs and
        multiple racks - an 8-node setup with two DCs, two racks in each, and
@@ -516,7 +511,6 @@ async def test_localnodes_multi_dc_multi_rack(manager: ManagerClient):
 # same one-node cluster with authentication and authorization enabled.
 # Here in this file we have the opportunity to create clusters with different
 # configurations, so we can check how these configuration settings affect RBAC.
-@pytest.mark.asyncio
 async def test_alternator_enforce_authorization_false(manager: ManagerClient):
     """A basic test for how Alternator authentication and authorization
        work when alternator_enfore_authorization is *false* (and CQL's
@@ -586,7 +580,6 @@ def get_secret_key(cql, user):
 
 #flaky, see https://github.com/scylladb/scylladb/issues/20135")
 @pytest.mark.unstable
-@pytest.mark.asyncio
 async def test_alternator_enforce_authorization_true(manager: ManagerClient):
     """A basic test for how Alternator authentication and authorization
        work when authentication and authorization is enabled in CQL, and
@@ -636,7 +629,6 @@ async def test_alternator_enforce_authorization_true(manager: ManagerClient):
     # We could further test how GRANT works, but this would be unnecessary
     # repeating of the tests in test/alternator/test_cql_rbac.py.
 
-@pytest.mark.asyncio
 async def test_index_in_rf_rack_valid_keyspace_does_not_require_rf_rack_flag(manager: ManagerClient):
     """
     Verify that creating a table with GSI or LSI and adding GSI to an existing table works
@@ -735,7 +727,6 @@ async def test_index_in_rf_rack_valid_keyspace_does_not_require_rf_rack_flag(man
         ]
     )
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_index_requires_rf_rack_valid_keyspace(manager: ManagerClient):
     """
@@ -840,7 +831,6 @@ async def test_index_requires_rf_rack_valid_keyspace(manager: ManagerClient):
             ]
         )
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_rf_rack_flag_enforces_rf_rack_validity(manager: ManagerClient):
     """
@@ -1155,7 +1145,6 @@ async def nodes_with_data(manager, ks, cf, host):
         return { await manager.api.get_host_id(entry['value']) for entry in j }
 
 @pytest.mark.parametrize("tablets", [True, False])
-@pytest.mark.asyncio
 async def test_zero_token_node_load_balancer(manager, tablets):
     """Test that a zero-token node (a.k.a. coordinator-only or proxy node),
        can be used as an Alternator server-side load balancer as proposed in
@@ -1279,7 +1268,6 @@ async def test_alternator_concurrent_rmw_same_partition_different_server(manager
         table.delete()
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alternator_invalid_shard_for_lwt(manager: ManagerClient):
     """
@@ -1395,7 +1383,6 @@ async def test_alternator_invalid_shard_for_lwt(manager: ManagerClient):
     stop_event.set()
     t.join()
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_deferred_stream_enablement_on_tablets(manager: ManagerClient):
     """Test that enabling Alternator Streams on a tablet table uses deferred

--- a/test/cluster/test_alternator_proxy_protocol.py
+++ b/test/cluster/test_alternator_proxy_protocol.py
@@ -204,7 +204,6 @@ async def alternator_proxy_server(manager: ManagerClient):
     yield (server, manager)
 
 
-@pytest.mark.asyncio
 async def test_alternator_proxy_protocol_basic(alternator_proxy_server):
     """Test that connections through the Alternator proxy protocol port work."""
     server, _ = alternator_proxy_server
@@ -222,7 +221,6 @@ async def test_alternator_proxy_protocol_basic(alternator_proxy_server):
     assert 'TableNames' in response, f"Expected TableNames in response: {response}"
 
 
-@pytest.mark.asyncio
 async def test_alternator_proxy_protocol_multiple_connections(alternator_proxy_server):
     """Test multiple connections with different source addresses."""
     server, _ = alternator_proxy_server
@@ -246,7 +244,6 @@ async def test_alternator_proxy_protocol_multiple_connections(alternator_proxy_s
         assert 'TableNames' in response, f"Expected TableNames in response for {fake_src_addr}: {response}"
 
 
-@pytest.mark.asyncio
 async def test_alternator_proxy_protocol_ssl_basic(alternator_proxy_server):
     """Test proxy protocol with TLS encryption."""
     server, _ = alternator_proxy_server
@@ -265,7 +262,6 @@ async def test_alternator_proxy_protocol_ssl_basic(alternator_proxy_server):
     assert 'TableNames' in response, f"Expected TableNames in response: {response}"
 
 
-@pytest.mark.asyncio
 async def test_alternator_regular_port_still_works(alternator_proxy_server):
     """Test that the regular Alternator port still works when proxy protocol ports are configured."""
     server, _ = alternator_proxy_server
@@ -281,7 +277,6 @@ async def test_alternator_regular_port_still_works(alternator_proxy_server):
     assert 'TableNames' in response, f"Expected TableNames in response: {response}"
 
 
-@pytest.mark.asyncio
 async def test_alternator_proxy_header_to_regular_port_fails(alternator_proxy_server):
     """Test that sending a proxy protocol header to the regular port fails.
 
@@ -303,7 +298,6 @@ async def test_alternator_proxy_header_to_regular_port_fails(alternator_proxy_se
         )
 
 
-@pytest.mark.asyncio
 async def test_alternator_no_proxy_header_to_proxy_port_fails(alternator_proxy_server):
     """Test that sending a request without proxy header to the proxy port fails.
 
@@ -324,7 +318,6 @@ async def test_alternator_no_proxy_header_to_proxy_port_fails(alternator_proxy_s
         )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("use_ssl", [False, True], ids=["http", "https"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alternator_proxy_protocol_address_in_system_clients(alternator_proxy_server, use_ssl):

--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -2102,7 +2102,6 @@ async def test_parallel_syslog_audit(manager: ManagerClient, helper_class):
     """Cluster must not fail when multiple queries are audited in parallel."""
     await CQLAuditTester(manager)._test_parallel_syslog_audit(helper_class)
 
-@pytest.mark.asyncio
 async def test_upgrade_preserves_ddl_audit_for_tables(
         manager: ManagerClient,
         scylla_2025_1: ScyllaVersionDescription,

--- a/test/cluster/test_automatic_cleanup.py
+++ b/test/cluster/test_automatic_cleanup.py
@@ -13,7 +13,6 @@ import asyncio
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_no_cleanup_when_unnecessary(manager: ManagerClient):
     """The test runs two bootstraps and checks that there is no cleanup in between.
        Then it runs a decommission and checks that cleanup runs automatically and then
@@ -72,7 +71,6 @@ async def test_no_cleanup_when_unnecessary(manager: ManagerClient):
     assert sum(len(x) for x in matches) == 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='debug', reason='dev is enough')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cleanup_waits_for_stale_writes(manager: ManagerClient):

--- a/test/cluster/test_bad_initial_token.py
+++ b/test/cluster/test_bad_initial_token.py
@@ -10,7 +10,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_bad_initial_token(manager: ManagerClient):
     # The validity of "initial_token" option is checked in the topology
     # coordinator, even if this is the first node being bootstrap, and triggers

--- a/test/cluster/test_batchlog_manager.py
+++ b/test/cluster/test_batchlog_manager.py
@@ -15,7 +15,6 @@ from test.cluster.util import new_test_keyspace, reconnect_driver, wait_for_cql_
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_batchlog_replay_while_a_node_is_down(manager: ManagerClient) -> None:
     """ Test that batchlog replay handles the case when a node is down while replaying a batch.
@@ -76,7 +75,6 @@ async def test_batchlog_replay_while_a_node_is_down(manager: ManagerClient) -> N
                 return True
         await wait_for(batchlog_empty, time.time() + 60)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_batchlog_replay_aborted_on_shutdown(manager: ManagerClient) -> None:
     """ Similar to the previous test, but also verifies that the batchlog replay is aborted on shutdown,
@@ -140,7 +138,6 @@ async def test_batchlog_replay_aborted_on_shutdown(manager: ManagerClient) -> No
                 return True
         await wait_for(batchlog_empty, time.time() + 60)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_batchlog_replay_includes_cdc(manager: ManagerClient) -> None:
     """ Test that when a batch is replayed from the batchlog, it includes CDC mutations.
@@ -203,7 +200,6 @@ async def test_batchlog_replay_includes_cdc(manager: ManagerClient) -> None:
         result2 = await cql.run_async(f"SELECT * FROM {cdc_table_name} WHERE key = 40 ALLOW FILTERING")
         assert len(result2) == 1, f"Expected 1 CDC mutation for key 40, got {len(result2)}"
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_mutations_for_dropped_table(manager: ManagerClient) -> None:
     """
@@ -292,7 +288,6 @@ async def test_drop_mutations_for_dropped_table(manager: ManagerClient) -> None:
 
         await wait_for(batchlog_empty, time.time() + 60)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("repair_cache", [True, False])
 async def test_batchlog_replay_failure_during_repair(manager: ManagerClient, repair_cache: bool) -> None:

--- a/test/cluster/test_blocked_bootstrap.py
+++ b/test/cluster/test_blocked_bootstrap.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.skip_not_implemented(reason="can't make it work with the new join procedure, without error recovery")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-@pytest.mark.asyncio
 async def test_blocked_bootstrap(manager: ManagerClient):
     """
     Scenario:

--- a/test/cluster/test_boot_nodes.py
+++ b/test/cluster/test_boot_nodes.py
@@ -9,7 +9,6 @@ import time
 import logging
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_boot(manager):
     rbno = True
     cfg = {'enable_repair_based_node_ops': rbno, 'num_tokens': 256}

--- a/test/cluster/test_bootstrap_with_quick_group0_join.py
+++ b/test/cluster/test_bootstrap_with_quick_group0_join.py
@@ -18,7 +18,6 @@ from test.pylib.util import wait_for
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_bootstrap_with_quick_group0_join(manager: ManagerClient):
     """Regression test for https://scylladb.atlassian.net/browse/SCYLLADB-959.

--- a/test/cluster/test_bti_index.py
+++ b/test/cluster/test_bti_index.py
@@ -34,7 +34,6 @@ async def get_sstable_files_for_server(data_dir, ks, cf):
     sstables = glob.glob(base_pattern)
     return sstables
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_bti_index_enable(manager: ManagerClient) -> None:
     cassandra_logger = logging.getLogger('cassandra')

--- a/test/cluster/test_cdc_generation_clearing.py
+++ b/test/cluster/test_cdc_generation_clearing.py
@@ -23,7 +23,6 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_generation_clearing(manager: ManagerClient):
     """Test that obsolete CDC generations are removed from CDC_GENERATIONS_V3 and TOPOLOGY.committed_cdc_generations
@@ -91,7 +90,6 @@ async def test_cdc_generation_clearing(manager: ManagerClient):
         await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
 
 
-@pytest.mark.asyncio
 async def test_unpublished_cdc_generations_arent_cleared(manager: ManagerClient):
     """Test that unpublished CDC generations aren't removed from CDC_GENERATIONS_V3 and
        TOPOLOGY.committed_cdc_generations regardless of their timestamps."""

--- a/test/cluster/test_cdc_generation_data.py
+++ b/test/cluster/test_cdc_generation_data.py
@@ -12,7 +12,6 @@ logger = logging.getLogger(__name__)
 The injection forces the topology coordinator to send CDC generation data in multiple parts,
 if it didn't the command size would go over commitlog segment size limit making it impossible to commit and apply the command.
 """
-@pytest.mark.asyncio
 async def test_send_data_in_parts(manager: ManagerClient):
     config = {
         'schema_commitlog_segment_size_in_mb': 2
@@ -37,7 +36,6 @@ async def test_send_data_in_parts(manager: ManagerClient):
         pytest.fail("No CDC generation data sent in parts was found")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_group0_apply_while_node_is_being_shutdown(manager: ManagerClient):
     # This a regression test for #24401.

--- a/test/cluster/test_cdc_generation_publishing.py
+++ b/test/cluster/test_cdc_generation_publishing.py
@@ -21,7 +21,6 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_generations_are_published(request, manager: ManagerClient):
     """Test that the CDC generation publisher eventually publishes committed CDC generations in the correct order."""
@@ -76,7 +75,6 @@ async def test_cdc_generations_are_published(request, manager: ManagerClient):
     logger.info(f"Timestamps after check_and_repair: {gen_timestamps}")
 
 
-@pytest.mark.asyncio
 async def test_multiple_unpublished_cdc_generations(request, manager: ManagerClient):
     """Test that the CDC generation publisher works correctly when there is more than one unpublished CDC generation."""
     query_gen_timestamps = SimpleStatement(

--- a/test/cluster/test_cdc_with_alter.py
+++ b/test/cluster/test_cdc_with_alter.py
@@ -16,7 +16,6 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_add_and_drop_column_with_cdc(manager: ManagerClient):
     """ Test writing to a table with CDC enabled while adding and dropping a column.
         In particular we are interested at the behavior when the schemas of the base table
@@ -74,7 +73,6 @@ async def test_add_and_drop_column_with_cdc(manager: ManagerClient):
         cdc_rows = await cql.run_async(f"SELECT COUNT(*) FROM {ks}.test_scylla_cdc_log")
         assert base_rows[0].count == cdc_rows[0].count, f"Base table rows: {base_rows[0].count}, CDC log rows: {cdc_rows[0].count}"
 
-@pytest.mark.asyncio
 async def test_cdc_compatible_schema(manager: ManagerClient):
     """
     Basic test that we can write to a table with CDC enabled when the schema of
@@ -110,7 +108,6 @@ async def test_cdc_compatible_schema(manager: ManagerClient):
         matches = await log.grep("has no CDC schema set")
         assert len(matches) == 0, "Found unexpected log messages indicating missing CDC schema"
 
-@pytest.mark.asyncio
 async def test_recreate_column_too_soon(manager: ManagerClient):
     """ Test that recreating a dropped column too soon fails with an appropriate error.
 
@@ -131,7 +128,6 @@ async def test_recreate_column_too_soon(manager: ManagerClient):
         with pytest.raises(Exception, match="a column with the same name was dropped too recently"):
             await cql.run_async(f"ALTER TABLE {ks}.test ADD dropped_col int")
 
-@pytest.mark.asyncio
 async def test_concurrent_writes_and_drop_column_with_cdc_preimage(manager: ManagerClient):
     """ Test concurrent writes and column drop with CDC preimage enabled.
 

--- a/test/cluster/test_cdc_with_tablets.py
+++ b/test/cluster/test_cdc_with_tablets.py
@@ -33,7 +33,6 @@ class CdcStreamState(IntEnum):
 # verifying that CDC streams for the table are created. Then we write to the table and verify
 # the CDC log entries are created in the table's streams.
 @pytest.mark.parametrize("with_alter", [pytest.param(False, id="create"), pytest.param(True, id="alter")])
-@pytest.mark.asyncio
 async def test_create_cdc_with_tablets(manager: ManagerClient, with_alter: bool):
     servers = await manager.servers_add(1)
     cql = manager.get_cql()
@@ -71,7 +70,6 @@ async def test_create_cdc_with_tablets(manager: ManagerClient, with_alter: bool)
 
 # Create tables with CDC and verify the CDC streams are removed from the
 # system tables when the tables or keyspaces are dropped.
-@pytest.mark.asyncio
 async def test_drop_table_and_drop_keyspace_removes_cdc_streams(manager: ManagerClient):
     servers = await manager.servers_add(1)
     cql = manager.get_cql()
@@ -105,7 +103,6 @@ async def test_drop_table_and_drop_keyspace_removes_cdc_streams(manager: Manager
 
 # Create a table with CDC, then disable CDC and drop the CDC log table, and create CDC again.
 # Verify streams are created and cleaned up correctly.
-@pytest.mark.asyncio
 async def test_drop_and_recreate_cdc(manager: ManagerClient):
     await manager.servers_add(1)
     cql = manager.get_cql()
@@ -169,7 +166,6 @@ async def validate_virtual_tables(manager, servers, cql, log_table_id, ks, table
 
 # Read CDC stream information from the virtual tables system.cdc_timestamps and system.cdc_streams
 # and verify it against the internal CDC tables.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_virtual_tables(manager: ManagerClient):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
@@ -209,7 +205,6 @@ async def test_cdc_virtual_tables(manager: ManagerClient):
         assert [] == await cql.run_async("SELECT * FROM system.cdc_streams")
         await validate_virtual_tables(manager, servers, cql, log_table_id, ks, 'test')
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_virtual_tables_with_multiple_cdc_tables(manager: ManagerClient):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
@@ -248,7 +243,6 @@ async def test_cdc_virtual_tables_with_multiple_cdc_tables(manager: ManagerClien
 # timestamp, and by applying the differences (closed / opened) in each timestamp, and verify we
 # get the same result.
 # Then trigger tablet merge and do the same, verifying streams are merged.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_stream_split_and_merge_basic(manager: ManagerClient):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
@@ -312,7 +306,6 @@ async def test_cdc_stream_split_and_merge_basic(manager: ManagerClient):
 # Test that base table writes and their corresponding CDC log writes are co-located on the same replica.
 # We create a 2-node cluster with RF=1, stop one node, and verify that the partitions available
 # on the alive node work correctly for both base table and CDC log.
-@pytest.mark.asyncio
 async def test_cdc_colocation(manager: ManagerClient):
     # Create 2-node cluster to test co-location
     servers = await manager.servers_add(2)
@@ -373,7 +366,6 @@ async def test_cdc_colocation(manager: ManagerClient):
 # Create a CDC table with short TTL, then split the tablets to create a new stream set,
 # and wait until the old streams are garbage collected and we have a single stream set again.
 # Verify the remaining stream set is equal to the most recent stream set.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cdc_stream_garbage_collection(manager: ManagerClient):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1, 'error_injections_at_startup': ['short_cdc_streams_gc_refresh_interval' ] }

--- a/test/cluster/test_change_ip.py
+++ b/test/cluster/test_change_ip.py
@@ -24,7 +24,6 @@ pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 
-@pytest.mark.asyncio
 async def test_change_two(manager, random_tables, build_mode):
     """Stop two nodes, change their IPs and start, check the cluster is
     functional"""

--- a/test/cluster/test_change_replication_factor_1_to_0.py
+++ b/test/cluster/test_change_replication_factor_1_to_0.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
         pytest.param(True, id="tablets", marks=[pytest.mark.skip_bug(reason="issue #20282"), pytest.mark.nightly]),
     ],
 )
-@pytest.mark.asyncio
 async def test_change_replication_factor_1_to_0(request: pytest.FixtureRequest, manager: ManagerClient, use_tablets: bool) -> None:
     CONFIG = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled" if use_tablets else "disabled"}
     logger.info("Creating a new cluster")
@@ -77,7 +76,6 @@ async def test_change_replication_factor_1_to_0(request: pytest.FixtureRequest, 
         pytest.param(True, id="tablets"),
     ],
 )
-@pytest.mark.asyncio
 async def test_change_replication_factor_1_to_0_and_decommission(request: pytest.FixtureRequest, manager: ManagerClient, use_tablets: bool) -> None:
     CONFIG = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled" if use_tablets else "disabled"}
     logger.info("Creating a new cluster")

--- a/test/cluster/test_change_rpc_address.py
+++ b/test/cluster/test_change_rpc_address.py
@@ -37,7 +37,6 @@ async def two_nodes_cluster(manager: ManagerClient) -> list[ServerNum]:
     return servers
 
 
-@pytest.mark.asyncio
 @pytest.mark.replication_factor(N_SERVERS)
 async def test_change_rpc_address(two_nodes_cluster: list[ServerNum],
                                   manager: ManagerClient,

--- a/test/cluster/test_client_routes.py
+++ b/test/cluster/test_client_routes.py
@@ -45,7 +45,6 @@ def generate_client_routes_entry(i):
         "alternator_https_port": 8004
     }
 
-@pytest.mark.asyncio
 async def test_client_routes(request, manager: ManagerClient):
     num_servers = 3
     cql = None
@@ -72,7 +71,6 @@ async def test_client_routes(request, manager: ManagerClient):
     await manager.api.client.delete("/v2/client-routes", host=running_server.ip_addr, json=[generate_client_routes_entry(0)])
     await wait_for_expected_client_routes_size(cql, num_servers)
 
-@pytest.mark.asyncio
 async def test_client_routes_node_restart(request, manager: ManagerClient):
     """
     This test verifies that a node receives updates if client routes were updated
@@ -90,7 +88,6 @@ async def test_client_routes_node_restart(request, manager: ManagerClient):
     cql = await manager.get_cql_exclusive(server_to_restart)
     await wait_for_expected_client_routes_size(cql, 1)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_client_routes_upgrade(request, manager: ManagerClient):
     """
@@ -135,7 +132,6 @@ async def test_client_routes_upgrade(request, manager: ManagerClient):
     await wait_for(client_routes_ready, time.time() + 60)
 
 
-@pytest.mark.asyncio
 async def test_client_routes_lost_quorum(request, manager: ManagerClient):
     """
     This test verifies that `/v2/client-routes` fails with a timeout if the Raft quorum cannot be reached.
@@ -195,7 +191,6 @@ async def wait_for_expected_event_num(expected_num, received_events):
         return None
     await wait_for(lambda: expected_event_num(expected_num), time.time() + 60)
 
-@pytest.mark.asyncio
 async def test_events(request, manager: ManagerClient, monkeypatch):
     """
     This test verifies client routes change events in the following steps:
@@ -234,7 +229,6 @@ async def test_events(request, manager: ManagerClient, monkeypatch):
     assert received_events[2]["connection_ids"] == [generate_connection_id(0)]
     assert received_events[2]["host_ids"] == [generate_host_id(0)]
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_client_routes_snapshot_transfer(request, manager: ManagerClient, monkeypatch):
     """
@@ -275,7 +269,6 @@ async def test_client_routes_snapshot_transfer(request, manager: ManagerClient, 
     assert received_events[0]["host_ids"] == [generate_host_id(1)]
     await log.wait_for("transfer snapshot: raft snapshot includes client_routes mutation")
 
-@pytest.mark.asyncio
 async def test_huge_event(request, manager: ManagerClient, monkeypatch):
     """
     This test verifies that an event can be sent to the driver even when it contains many host_ids and connection_ids.

--- a/test/cluster/test_cluster_features.py
+++ b/test/cluster/test_cluster_features.py
@@ -61,7 +61,6 @@ async def change_support_for_test_feature_and_restart(manager: ManagerClient, sr
     await asyncio.gather(*(manager.server_start(srv.server_id, expected_error) for srv in srvs))
 
 
-@pytest.mark.asyncio
 async def test_rolling_upgrade_happy_path(manager: ManagerClient) -> None:
     """Simulates an upgrade of a cluster by doing a rolling restart
        and marking the test-only feature as supported on restarted nodes.
@@ -94,7 +93,6 @@ async def test_rolling_upgrade_happy_path(manager: ManagerClient) -> None:
     await asyncio.gather(*(wait_for_feature(TEST_FEATURE_NAME, cql, h, time.time() + 60) for h in hosts))
 
 
-@pytest.mark.asyncio
 async def test_downgrade_after_partial_upgrade(manager: ManagerClient) -> None:
     """Simulates a partial upgrade of a cluster by enabling the test features
        in all nodes but one, then downgrading the upgraded nodes.
@@ -122,7 +120,6 @@ async def test_downgrade_after_partial_upgrade(manager: ManagerClient) -> None:
         assert TEST_FEATURE_NAME not in await get_supported_features(cql, host)
 
 
-@pytest.mark.asyncio
 async def test_joining_old_node_fails(manager: ManagerClient) -> None:
     """Upgrades the cluster to enable a new feature. Then, it first tries to
        add a new node without the feature, and then replace an existing node
@@ -156,7 +153,6 @@ async def test_joining_old_node_fails(manager: ManagerClient) -> None:
     await manager.server_start(new_server_info.server_id, expected_error="Feature check failed|received notification of being banned from the cluster from")
 
 
-@pytest.mark.asyncio
 async def test_downgrade_after_successful_upgrade_fails(manager: ManagerClient) -> None:
     """Upgrades the cluster to enable the test feature. Then, shuts down all nodes,
        disables support for the feature, then restarts all nodes. All nodes
@@ -182,7 +178,6 @@ async def test_downgrade_after_successful_upgrade_fails(manager: ManagerClient) 
 
 
 @pytest.mark.skip_bug(reason="issue #14194")
-@pytest.mark.asyncio
 async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerClient) -> None:
     """Upgrades all but one node in the cluster to enable the test feature.
        Then, the last one is shut down and removed via `nodetool removenode`.

--- a/test/cluster/test_commitlog.py
+++ b/test/cluster/test_commitlog.py
@@ -16,7 +16,6 @@ from test.pylib.random_tables import Column, TextType
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_reboot(request, manager: ManagerClient):
     # Check that commitlog provides durability in case of a node reboot.

--- a/test/cluster/test_commitlog_segment_data_resurrection.py
+++ b/test/cluster/test_commitlog_segment_data_resurrection.py
@@ -15,7 +15,6 @@ import json
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_pinned_cl_segment_doesnt_resurrect_data(manager: ManagerClient):
     """
         The tested scenario is as follows:

--- a/test/cluster/test_compaction_backpressure.py
+++ b/test/cluster/test_compaction_backpressure.py
@@ -17,7 +17,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_intranode_migration_not_blocked_by_backpressure(manager: ManagerClient):
     """

--- a/test/cluster/test_concurrent_schema.py
+++ b/test/cluster/test_concurrent_schema.py
@@ -21,7 +21,6 @@ pytestmark = pytest.mark.prepare_3_racks_cluster
 # How this repro works:
 # - Creates 20+20 tables to alter and 20 tables to index
 # - In parallel run 20 * create table, and drop/add column and index of previous 2 tables
-@pytest.mark.asyncio
 async def test_cassandra_issue_10250(random_tables):
     tables = random_tables
     # How many combinations of tables; original Cassandra issue repro had 20

--- a/test/cluster/test_config.py
+++ b/test/cluster/test_config.py
@@ -23,7 +23,6 @@ async def wait_for_config(manager, server, config_name, value):
         return None
     await wait_for(config_value_equal, deadline=time.time() + 60)
 
-@pytest.mark.asyncio
 async def test_non_liveupdatable_config(manager):
 
     server = await manager.server_add()

--- a/test/cluster/test_config_live_updates.py
+++ b/test/cluster/test_config_live_updates.py
@@ -6,7 +6,6 @@ import pytest
 from test.pylib.util import wait_for
 
 
-@pytest.mark.asyncio
 async def test_config_live_updates(manager):
     config = {
         "maintenance_socket": "ignore"  # bring back the default value

--- a/test/cluster/test_conflicting_keys_read_repair.py
+++ b/test/cluster/test_conflicting_keys_read_repair.py
@@ -18,7 +18,6 @@ from test.cluster.util import new_test_keyspace
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_read_repair_with_conflicting_hash_keys(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """
     Test that conflicting hash keys are handled correctly during read repair.

--- a/test/cluster/test_coordinator_queue_management.py
+++ b/test/cluster/test_coordinator_queue_management.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_coordinator_queue_management(manager: ManagerClient):
     """This test creates a 5 node cluster with 2 down nodes (A and B). After that it

--- a/test/cluster/test_counters_with_tablets.py
+++ b/test/cluster/test_counters_with_tablets.py
@@ -17,7 +17,6 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("migration_type", ["internode", "intranode"])
 async def test_counter_updates_during_tablet_migration(manager: ManagerClient, migration_type: str):
     """
@@ -94,7 +93,6 @@ async def test_counter_updates_during_tablet_migration(manager: ManagerClient, m
 
         assert actual_count == total_updates, f"Counter value mismatch: expected {total_updates}, got {actual_count}"
 
-@pytest.mark.asyncio
 async def test_counter_ids_reuse_in_single_rack(manager: ManagerClient):
     """
     Migrate a single counter tablet between 3 nodes in a single rack, performing counter updates on each node,
@@ -168,7 +166,6 @@ async def test_counter_ids_reuse_in_single_rack(manager: ManagerClient):
         assert len(counter_ids) >= 1, f"Expected at least 1 counter ID, but found none"
         assert len(counter_ids) <= 2, f"Expected at most 2 counter IDs, but found {len(counter_ids)}: {counter_ids}"
 
-@pytest.mark.asyncio
 async def test_counter_ids_multi_rack(manager: ManagerClient):
     """
     Test counter IDs with 3 nodes in 3 different racks with RF=3.

--- a/test/cluster/test_crash_coordinator_before_streaming.py
+++ b/test/cluster/test_crash_coordinator_before_streaming.py
@@ -18,7 +18,6 @@ from test.cluster.util import (check_token_ring_and_group0_consistency, wait_for
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_kill_coordinator_during_op(manager: ManagerClient, failure_detector_timeout: int, scale_timeout: callable) -> None:
     """ Kill coordinator with error injection while topology operation is running for cluster: decommission,

--- a/test/cluster/test_create_table_during_node_shutdown.py
+++ b/test/cluster/test_create_table_during_node_shutdown.py
@@ -9,7 +9,6 @@ from test.pylib.manager_client import ManagerClient
 from test.cluster.util import new_test_keyspace, reconnect_driver
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_create_table_notification_deadlock_with_shutdown(manager: ManagerClient):
     """

--- a/test/cluster/test_data_resurrection_after_cleanup.py
+++ b/test/cluster/test_data_resurrection_after_cleanup.py
@@ -15,7 +15,6 @@ import time
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_data_resurrection_after_cleanup(manager: ManagerClient):
     logger.info("Bootstrapping cluster")

--- a/test/cluster/test_data_resurrection_in_memtable.py
+++ b/test/cluster/test_data_resurrection_in_memtable.py
@@ -101,35 +101,30 @@ async def run_test_cache_tombstone_gc(manager: ManagerClient, statement_pairs: l
         check_data(host3, [])
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cache_tombstone_gc_partition_tombstone(manager: ManagerClient):
     await run_test_cache_tombstone_gc(manager,
                                       [("INSERT INTO {ks}.tbl (pk, ck, v) VALUES (0, 100, 999)", "DELETE FROM {ks}.tbl WHERE pk = 0")])
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cache_tombstone_gc_row_tombstone(manager: ManagerClient):
     await run_test_cache_tombstone_gc(manager,
                                       [("INSERT INTO {ks}.tbl (pk, ck, v) VALUES (0, 100, 999)", "DELETE FROM {ks}.tbl WHERE pk = 0 AND ck = 100")])
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cache_tombstone_gc_range_tombstone(manager: ManagerClient):
     await run_test_cache_tombstone_gc(manager,
                                       [("INSERT INTO {ks}.tbl (pk, ck, v) VALUES (0, 100, 999)", "DELETE FROM {ks}.tbl WHERE pk = 0 AND ck > 0 AND ck < 1000")])
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cache_tombstone_gc_cell_tombstone(manager: ManagerClient):
     await run_test_cache_tombstone_gc(manager,
                                       [("UPDATE {ks}.tbl SET v = 999 WHERE pk = 0 AND ck = 100", "DELETE v FROM {ks}.tbl WHERE pk = 0 AND ck = 100")])
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cache_tombstone_gc_cell_tombstone_and_row_tombstone(manager: ManagerClient):
     await run_test_cache_tombstone_gc(manager,

--- a/test/cluster/test_decommission.py
+++ b/test/cluster/test_decommission.py
@@ -13,7 +13,6 @@ from test.cluster.util import wait_for_token_ring_and_group0_consistency
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_decommissioned_node_cant_rejoin(request, manager: ManagerClient):
     # This a regression test for #17282.
 

--- a/test/cluster/test_decommission_kill_then_replace.py
+++ b/test/cluster/test_decommission_kill_then_replace.py
@@ -23,7 +23,6 @@ from test.pylib.util import wait_for_first_completed
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_decommission_kill_then_replace(manager: ManagerClient) -> None:
     """

--- a/test/cluster/test_deprecating_cluster_features.py
+++ b/test/cluster/test_deprecating_cluster_features.py
@@ -17,7 +17,6 @@ SUPPRESS_FEATURES = "suppress_features"
 ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY = "error_injections_at_startup"
 
 
-@pytest.mark.asyncio
 async def test_feature_deprecation_works(manager: ManagerClient) -> None:
     """Simulate a very old node which, long ago, has enabled some features,
        persisted them in system.scylla_local, and now some of them became
@@ -50,7 +49,6 @@ async def check_features_status(cql, features, enabled):
         assert check_feature(topology_features[0].supported_features, feature)
 
 
-@pytest.mark.asyncio
 async def test_features_suppress_works(manager: ManagerClient, build_mode) -> None:
     """ `suppress_features` error injection allows to revoke support for
         specified cluster features. It can be used to simulate upgrade process.

--- a/test/cluster/test_describe.py
+++ b/test/cluster/test_describe.py
@@ -21,7 +21,6 @@ import os
 # to 128 * 2^10 bytes.
 #
 # Reproducer for issue scylladb/scylladb#24018.
-@pytest.mark.asyncio
 async def test_large_create_statement(manager: ManagerClient):
     cmdline = ["--logger-log-level", "describe=trace"]
     srv = await manager.server_add(cmdline=cmdline)
@@ -54,7 +53,6 @@ async def test_large_create_statement(manager: ManagerClient):
             assert len(matches) == 0
 
 @pytest.mark.parametrize("mode", ["normal", "maintenance"])
-@pytest.mark.asyncio
 async def test_describe_cluster_sanity(manager: ManagerClient, mode: str):
     """
     Parametrized test that DESCRIBE CLUSTER returns correct cluster information

--- a/test/cluster/test_different_group0_ids.py
+++ b/test/cluster/test_different_group0_ids.py
@@ -9,7 +9,6 @@ from test.pylib.manager_client import ManagerClient
 import pytest
 
 
-@pytest.mark.asyncio
 async def test_different_group0_ids(manager: ManagerClient):
     """
     The test starts two single-node clusters (with different group0_ids). Node B (the

--- a/test/cluster/test_error_becoming_voter.py
+++ b/test/cluster/test_error_becoming_voter.py
@@ -17,7 +17,6 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_error_while_becoming_voter(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """
     Test that a node is starting successfully if while joining a cluster and becoming a voter, it

--- a/test/cluster/test_failure_after_group0_server_registration.py
+++ b/test/cluster/test_failure_after_group0_server_registration.py
@@ -12,7 +12,6 @@ from test.pylib.manager_client import ManagerClient
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_failure_after_group0_server_registration(manager: ManagerClient) -> None:
     """Test that a node shuts down cleanly when group0 startup fails after server registration.

--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -57,7 +57,6 @@ def all_hints_metrics(metrics: ScyllaMetrics) -> list[str]:
     return metrics.lines_by_prefix('scylla_hints_manager_')
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("tablets_enabled", [True, False])
 async def test_fence_writes(request, manager: ManagerClient, tablets_enabled: bool):
     cfg = {'tablets_mode_for_new_keyspaces' : 'enabled' if tablets_enabled else 'disabled'}
@@ -125,7 +124,6 @@ async def test_fence_writes(request, manager: ManagerClient, tablets_enabled: bo
     random_tables.drop_all()
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_fence_hints(request, manager: ManagerClient):
     logger.info("Bootstrapping cluster with three nodes")
@@ -216,7 +214,6 @@ async def test_fence_hints(request, manager: ManagerClient):
     random_tables.drop_all()
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_fence_lwt_during_bootstap(manager: ManagerClient):
     """
@@ -356,7 +353,6 @@ async def test_fence_lwt_during_bootstap(manager: ManagerClient):
         assert row.c == 2
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='dev mode is enough for this test')
 @pytest.mark.skip_mode(mode='debug', reason='dev mode is enough for this test')
 async def test_lwt_fencing_upgrade(manager: ManagerClient, scylla_2025_1: ScyllaVersionDescription, scylla_binary: Path):

--- a/test/cluster/test_global_ignore_nodes.py
+++ b/test/cluster/test_global_ignore_nodes.py
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 async def test_global_ignored_nodes_list(manager: ManagerClient, random_tables) -> None:
     """This test creates a 5 node cluster with two nodes down (A and B). It removes A while
        specifying B in ignored nodes list. Then is downs one more node and replaces it while

--- a/test/cluster/test_gossiper.py
+++ b/test/cluster/test_gossiper.py
@@ -10,7 +10,6 @@ import pytest
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 async def test_gossiper_endpoints(manager: ManagerClient) -> None:
     servers = await manager.running_servers()
     servers_ips = [await manager.get_host_ip(server.server_id) for server in servers]

--- a/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
+++ b/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
@@ -14,7 +14,6 @@ from test.cluster.util import get_coordinator_host
 from test.pylib.manager_client import ManagerClient
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_gossiper_empty_self_id_on_shadow_round(manager: ManagerClient):
     """

--- a/test/cluster/test_gossiper_orphan_remover.py
+++ b/test/cluster/test_gossiper_orphan_remover.py
@@ -16,7 +16,6 @@ from test.pylib.internal_types import ServerInfo
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_crashed_node_substitution(manager: ManagerClient):
     """Test that a node which crashed after starting gossip but before joining group0

--- a/test/cluster/test_gossiper_race.py
+++ b/test/cluster/test_gossiper_race.py
@@ -12,7 +12,6 @@ from test.cluster.util import get_coordinator_host
 from test.pylib.manager_client import ManagerClient
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_gossiper_race_on_decommission(manager: ManagerClient):
     """

--- a/test/cluster/test_guardrails.py
+++ b/test/cluster/test_guardrails.py
@@ -40,7 +40,6 @@ async def assert_creating_ks_fails(cql, query, ks_name):
         await cql.run_async(f"USE {ks_name}")
 
 
-@pytest.mark.asyncio
 async def test_default_rf(manager: ManagerClient):
     """
     As of now, the only RF guardrail enabled is a soft limit checking that RF >= 3. Not complying to this soft limit
@@ -64,7 +63,6 @@ async def test_default_rf(manager: ManagerClient):
     await create_ks_and_assert_warning(cql, query, ks_name, ["warn", "min", "replication", "factor", "3", "dc1", "2"])
 
 
-@pytest.mark.asyncio
 async def test_all_rf_limits(manager: ManagerClient):
     """
     There are 4 limits for RF: soft/hard min and soft/hard max limits. Breaking soft limits issues a warning,
@@ -103,7 +101,6 @@ async def test_all_rf_limits(manager: ManagerClient):
             await create_ks_and_assert_warning(cql, query, ks_name, [])
 
 
-@pytest.mark.asyncio
 async def test_invalid_write_cl_guardrail_config(manager: ManagerClient):
     """A node configured with invalid values for write_consistency_levels_warned
     and write_consistency_levels_disallowed should still start and respond to
@@ -126,7 +123,6 @@ async def test_invalid_write_cl_guardrail_config(manager: ManagerClient):
     rows = await cql.run_async("SELECT * FROM system.local")
     assert len(rows) == 1
 
-@pytest.mark.asyncio
 async def test_write_cl_default(manager: ManagerClient):
     """Test checks that the current implementation doesn't cause
     any warning nor failure for the default configuration."""

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -49,7 +49,6 @@ async def await_sync_point(client: TCPRESTClient, server_ip: IPAddress, sync_poi
             pytest.fail(f"Unexpected response from the server: {response}")
 
 # Write with RF=1 and CL=ANY to a dead node should write hints and succeed
-@pytest.mark.asyncio
 async def test_write_cl_any_to_dead_node_generates_hints(manager: ManagerClient):
     node_count = 2
     cmdline = ["--logger-log-level", "hints_manager=trace"]
@@ -89,7 +88,6 @@ async def test_write_cl_any_to_dead_node_generates_hints(manager: ManagerClient)
             # For dropping the keyspace
             await manager.server_start(servers[1].server_id)
 
-@pytest.mark.asyncio
 async def test_limited_concurrency_of_writes(manager: ManagerClient):
     """
     We want to verify that Scylla correctly limits the concurrency of writing hints to disk.
@@ -120,7 +118,6 @@ async def test_limited_concurrency_of_writes(manager: ManagerClient):
         # For dropping the keyspace
         await manager.server_start(node2.server_id)
 
-@pytest.mark.asyncio
 async def test_sync_point(manager: ManagerClient):
     """
     We want to verify that the sync point API is compliant with its design.
@@ -174,7 +171,6 @@ async def test_sync_point(manager: ManagerClient):
         assert await await_sync_point(manager.api.client, node1.ip_addr, sync_point1, 30)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_hints_consistency_during_decommission(manager: ManagerClient):
     """
@@ -260,7 +256,6 @@ async def test_hints_consistency_during_decommission(manager: ManagerClient):
         for i in range(100):
             assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = {i}")) == [(i + 1,)]
 
-@pytest.mark.asyncio
 async def test_hints_consistency_during_replace(manager: ManagerClient):
     """
     Reproducer for https://github.com/scylladb/scylladb/issues/24980
@@ -304,7 +299,6 @@ async def test_hints_consistency_during_replace(manager: ManagerClient):
         for i in range(100):
             assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = {i}")) == [(i + 1,)]
 
-@pytest.mark.asyncio
 async def test_draining_hints(manager: ManagerClient):
     """
     This test verifies that all hints are drained when a node is being decommissioned.
@@ -333,7 +327,6 @@ async def test_draining_hints(manager: ManagerClient):
         _ = tg.create_task(manager.decommission_node(s1.server_id, timeout=60))
         _ = tg.create_task(await_sync_point(manager.api.client, s1.ip_addr, sync_point, 60))
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_canceling_hint_draining(manager: ManagerClient):
     """
@@ -380,7 +373,6 @@ async def test_canceling_hint_draining(manager: ManagerClient):
     assert await await_sync_point(manager.api.client, s1.ip_addr, sync_point, 60)
     await s1_log.wait_for(f"Removed hint directory for {host_id2}")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_hint_to_pending(manager: ManagerClient):
     """
@@ -439,7 +431,6 @@ async def test_hint_to_pending(manager: ManagerClient):
 
         assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = 0")) == [(0,)]
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_hint_to_leaving_when_reducing_rf(manager: ManagerClient):
     '''

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -163,7 +163,6 @@ async def prepare_cluster_for_incremental_repair(manager, nr_keys = 100 , cmdlin
         logs.append(await manager.server_open_log(s.server_id))
     return servers, cql, hosts, ks, table_id, logs, repaired_keys,  unrepaired_keys, current_key, token
 
-@pytest.mark.asyncio
 async def test_tablet_repair_sstable_skipped_read_metrics(manager: ManagerClient):
     servers, cql, hosts, ks, table_id, logs, _, _, _, token = await prepare_cluster_for_incremental_repair(manager)
 
@@ -192,7 +191,6 @@ async def test_tablet_repair_sstable_skipped_read_metrics(manager: ManagerClient
     assert skipped_bytes3 > skipped_bytes2
     assert read_bytes3 > read_bytes2
 
-@pytest.mark.asyncio
 async def test_tablet_incremental_repair(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False, disable_flush_cache_time=True)
     token = -1
@@ -252,7 +250,6 @@ async def test_tablet_incremental_repair(manager: ManagerClient):
         assert len(disable) == 2
         assert len(enable) == 2
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_error(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
@@ -329,27 +326,21 @@ async def do_tablet_incremental_repair_and_ops(manager: ManagerClient, ops: str)
         assert len(sst_mark) == 1
         assert len(sst_skip) == 1
 
-@pytest.mark.asyncio
 async def test_tablet_incremental_repair_and_scrubsstables_abort(manager: ManagerClient):
     await do_tablet_incremental_repair_and_ops(manager, 'scrub_abort')
 
-@pytest.mark.asyncio
 async def test_tablet_incremental_repair_and_scrubsstables_validate(manager: ManagerClient):
     await do_tablet_incremental_repair_and_ops(manager, 'scrub_validate')
 
-@pytest.mark.asyncio
 async def test_tablet_incremental_repair_and_cleanup(manager: ManagerClient):
     await do_tablet_incremental_repair_and_ops(manager, 'cleanup')
 
-@pytest.mark.asyncio
 async def test_tablet_incremental_repair_and_upgradesstables(manager: ManagerClient):
     await do_tablet_incremental_repair_and_ops(manager, 'upgradesstables')
 
-@pytest.mark.asyncio
 async def test_tablet_incremental_repair_and_major(manager: ManagerClient):
     await do_tablet_incremental_repair_and_ops(manager, 'major')
 
-@pytest.mark.asyncio
 async def test_tablet_incremental_repair_and_minor(manager: ManagerClient):
     nr_keys = 100
     servers, cql, hosts, ks, table_id, logs, repaired_keys, unrepaired_keys, current_key, token = await prepare_cluster_for_incremental_repair(manager, nr_keys)
@@ -439,23 +430,19 @@ async def do_test_tablet_incremental_repair_with_split_and_merge(manager, do_spl
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
 @pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/24153")
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_with_split_and_merge(manager: ManagerClient):
     await do_test_tablet_incremental_repair_with_split_and_merge(manager, do_split=True, do_merge=True)
 
 @pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/24153")
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_with_split(manager: ManagerClient):
     await do_test_tablet_incremental_repair_with_split_and_merge(manager, do_split=True, do_merge=False)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_with_merge(manager: ManagerClient):
     await do_test_tablet_incremental_repair_with_split_and_merge(manager, do_split=False, do_merge=True)
 
-@pytest.mark.asyncio
 async def test_tablet_incremental_repair_existing_and_repair_produced_sstable(manager: ManagerClient):
     nr_keys = 100
     cmdline = ["--hinted-handoff-enabled", "0"]
@@ -479,7 +466,6 @@ async def test_tablet_incremental_repair_existing_and_repair_produced_sstable(ma
 
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_merge_higher_repaired_at_number(manager):
     nr_keys = 100
@@ -520,7 +506,6 @@ async def test_tablet_incremental_repair_merge_higher_repaired_at_number(manager
 
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_merge_correct_repaired_at_number_after_merge(manager):
     nr_keys = 100
@@ -592,17 +577,14 @@ async def do_test_tablet_incremental_repair_merge_error(manager, error):
 
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_merge_error_in_merge_finalization(manager):
     await do_test_tablet_incremental_repair_merge_error(manager, 'handle_tablet_resize_finalization_for_merge_error')
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_merge_error_in_merge_completion_fiber(manager):
     await do_test_tablet_incremental_repair_merge_error(manager, 'merge_completion_fiber_error')
 
-@pytest.mark.asyncio
 async def test_tablet_repair_with_incremental_option(manager: ManagerClient):
     servers, cql, hosts, ks, table_id, logs, _, _, _, token = await prepare_cluster_for_incremental_repair(manager)
     token = -1
@@ -647,7 +629,6 @@ async def test_tablet_repair_with_incremental_option(manager: ManagerClient):
         assert read1 < read2
     await do_repair_and_check('full', 1, rf'Starting tablet repair by API .* incremental_mode=full.*', check4)
 
-@pytest.mark.asyncio
 async def test_incremental_repair_tablet_time_metrics(manager: ManagerClient):
     servers, _, _, ks, _, _, _, _, _, token = await prepare_cluster_for_incremental_repair(manager)
     time1 = 0
@@ -663,7 +644,6 @@ async def test_incremental_repair_tablet_time_metrics(manager: ManagerClient):
     assert time2 > 0
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/26346
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_incremental_repair_finishes_when_tablet_skips_end_repair_stage(manager):
     servers = await manager.servers_add(3, auto_rack_dc="dc1")
@@ -688,7 +668,6 @@ async def test_incremental_repair_finishes_when_tablet_skips_end_repair_stage(ma
             await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
             await manager.api.wait_task(servers[0].ip_addr, task_id)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_incremental_repair_rejoin_do_tablet_operation(manager):
     cmdline = ['--logger-log-level', 'raft_topology=debug']
@@ -736,7 +715,6 @@ async def test_incremental_repair_rejoin_do_tablet_operation(manager):
                 await manager.api.disable_injection(s.ip_addr, "repair_finish_wait")
             await coord_log.wait_for("Finished tablet repair")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_incremental_retry_end_repair_stage(manager):
     config = {'tablet_load_stats_refresh_interval_in_seconds': 1}
@@ -786,7 +764,6 @@ async def test_incremental_retry_end_repair_stage(manager):
 # This test checks both tablet and vnode table. It tests the code path dealing
 # with appending sstables produced by repair to a list work correctly with
 # multishard writer when the shard count is different.
-@pytest.mark.asyncio
 @pytest.mark.parametrize("use_tablet", [False, True])
 async def test_repair_sigsegv_with_diff_shard_count(manager: ManagerClient, use_tablet):
     cmdline0 = [ '--smp', '2']
@@ -833,7 +810,6 @@ async def test_repair_sigsegv_with_diff_shard_count(manager: ManagerClient, use_
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/27365
 # Incremental repair vs table drop
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_table_drop_compaction_group_gone(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'repair=debug']
@@ -1128,7 +1104,6 @@ async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, to
         f"Wrongly promoted (first 10): {sorted(wrongly_promoted)[:10]}"
     return current_key
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: ManagerClient):
     cmdline = ['--hinted-handoff-enabled', '0']
@@ -1237,7 +1212,6 @@ async def _assert_key_deleted(cql, ks, key, hosts, *, msg=""):
         assert not rows, f"Key {key} unexpectedly visible on host {h} — data resurrection! {msg}"
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_no_resurrection_basic_ordering(manager: ManagerClient):
     """Verify that the ordering guarantee prevents premature tombstone GC.
@@ -1285,7 +1259,6 @@ async def test_tombstone_gc_no_resurrection_basic_ordering(manager: ManagerClien
     logger.info("test_tombstone_gc_no_resurrection_basic_ordering: PASSED")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_no_resurrection_hints_flush_failure(manager: ManagerClient):
     """Verify that repair_time stays at epoch when hints flush fails, so tombstones
@@ -1350,7 +1323,6 @@ async def test_tombstone_gc_no_resurrection_hints_flush_failure(manager: Manager
     logger.info("test_tombstone_gc_no_resurrection_hints_flush_failure: PASSED")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_no_resurrection_propagation_delay(manager: ManagerClient):
     """Verify the ordering guarantee when D arrives via hint flush just before repair.
@@ -1419,7 +1391,6 @@ async def test_tombstone_gc_no_resurrection_propagation_delay(manager: ManagerCl
     logger.info("test_tombstone_gc_no_resurrection_propagation_delay: PASSED")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_mv_optimization_safe_via_hints(manager: ManagerClient):
     """Verify the repaired-only tombstone GC optimization is safe for non-co-located MVs
@@ -1523,7 +1494,6 @@ async def test_tombstone_gc_mv_optimization_safe_via_hints(manager: ManagerClien
     logger.info("test_tombstone_gc_mv_optimization_safe_via_hints: PASSED")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_mv_safe_staging_processor_delay(manager: ManagerClient):
     """Verify no resurrection when the view-update-generator staging processor is delayed

--- a/test/cluster/test_initial_token.py
+++ b/test/cluster/test_initial_token.py
@@ -13,7 +13,6 @@ from test.cluster.conftest import cluster_con
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_initial_token(manager: ManagerClient) -> None:
     tokens = ["-9223372036854775808", "-4611686018427387904", "0", "4611686018427387904"]
     cfg1 = {'initial_token': f"{tokens[0]}, {tokens[1]}"}

--- a/test/cluster/test_ip_mappings.py
+++ b/test/cluster/test_ip_mappings.py
@@ -18,7 +18,6 @@ from cassandra.cluster import ConsistencyLevel, SimpleStatement
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_broken_bootstrap(manager: ManagerClient):
     server_a = await manager.server_add()
     server_b = await manager.server_add(start=False)
@@ -49,7 +48,6 @@ async def test_broken_bootstrap(manager: ManagerClient):
             assert response[0].b == i
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize('reuse_ip', [False, True])
 async def test_full_shutdown_during_replace(manager: ManagerClient, reuse_ip: bool):

--- a/test/cluster/test_keyspace_rf.py
+++ b/test/cluster/test_keyspace_rf.py
@@ -14,7 +14,6 @@ from test.cluster.conftest import cluster_con
 from test.cluster.util import create_new_test_keyspace, get_replication, get_replica_count
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("tablets_enabled", [True, False])
 @pytest.mark.parametrize("rf_rack_valid_keyspaces", [False, True])
 async def test_create_keyspace_with_default_replication_factor(manager: ManagerClient, tablets_enabled: bool, rf_rack_valid_keyspaces: bool):

--- a/test/cluster/test_left_node_notification.py
+++ b/test/cluster/test_left_node_notification.py
@@ -13,7 +13,6 @@ from test.cluster.util import check_token_ring_and_group0_consistency
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_left_node_notification(manager: ManagerClient) -> None:
     """
     Create a 3-node multi-DC cluster with 2 nodes in dc1 and 1 node in dc2.

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -17,7 +17,6 @@ from test.pylib.util import wait_for
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_property(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
@@ -39,7 +38,6 @@ async def test_property(manager: ManagerClient):
         with pytest.raises(ConfigurationException, match="The 'logstor' storage engine cannot be used with tables that have clustering columns"):
             await cql.run_async(f"CREATE TABLE {ks}.t_enabled (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH storage_engine = 'logstor'")
 
-@pytest.mark.asyncio
 async def test_config_option_consistency(manager: ManagerClient):
     """
     Test that logstor storage engine requires the experimental 'logstor' feature to be enabled.
@@ -56,7 +54,6 @@ async def test_config_option_consistency(manager: ManagerClient):
         with pytest.raises(ConfigurationException, match="The experimental feature 'logstor' must be enabled"):
             await cql.run_async(f"CREATE TABLE {ks}.t_logstor (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
 
-@pytest.mark.asyncio
 async def test_basic_write_and_read(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
@@ -100,7 +97,6 @@ async def test_basic_write_and_read(manager: ManagerClient):
         assert rows[0].pk == 1
         assert rows[0].v == {'a': 'apple', 'b': 'banana', 'c': 'cherry'}
 
-@pytest.mark.asyncio
 async def test_range_read(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
@@ -128,7 +124,6 @@ async def test_range_read(manager: ManagerClient):
         assert len(rows) == 3
         assert [row.tok for row in rows] == tokens[2:5]
 
-@pytest.mark.asyncio
 async def test_parallel_writes(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
@@ -147,7 +142,6 @@ async def test_parallel_writes(manager: ManagerClient):
             assert rows[0].pk == i
             assert rows[0].v == i + 1
 
-@pytest.mark.asyncio
 async def test_overwrites(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
@@ -167,7 +161,6 @@ async def test_overwrites(manager: ManagerClient):
         assert rows[0].pk == pk
         assert rows[0].v == 99
 
-@pytest.mark.asyncio
 async def test_parallel_big_writes(manager: ManagerClient):
     """
     Perform multiple writes in parallel with large values and validate to test segment switching.
@@ -193,7 +186,6 @@ async def test_parallel_big_writes(manager: ManagerClient):
             assert rows[0].pk == i
             assert rows[0].v == f"{i}-{large_value}"
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("fail_separator_flush", [False, True], ids=["normal", "fail_separator_flush"])
 async def test_recovery_basic(manager: ManagerClient, fail_separator_flush: bool):
@@ -280,7 +272,6 @@ async def test_recovery_basic(manager: ManagerClient, fail_separator_flush: bool
             assert rows[0].pk == pk, f"Key {pk} has wrong pk value"
             assert rows[0].v == expected_v, f"Key {pk} has wrong value after additional writes"
 
-@pytest.mark.asyncio
 async def test_recovery_with_segment_reuse(manager: ManagerClient):
     """
     Test recovery after segments have been compacted and reused.
@@ -347,7 +338,6 @@ async def test_recovery_with_segment_reuse(manager: ManagerClient):
             assert len(rows) == 1, f"Key {pk} not found after recovery"
             assert rows[0].v == expected_v, f"Key {pk} value mismatch after recovery"
 
-@pytest.mark.asyncio
 async def test_compaction(manager: ManagerClient):
     """
     Test log compaction by creating dead data and verifying space reclamation.
@@ -388,7 +378,6 @@ async def test_compaction(manager: ManagerClient):
             await manager.api.logstor_compaction(servers[0].ip_addr)
         await wait_for(segments_compacted, time.time() + 60)
 
-@pytest.mark.asyncio
 async def test_drop_table(manager: ManagerClient):
     """
     Test that DROP TABLE works properly with logstor tables.
@@ -451,7 +440,6 @@ async def test_drop_table(manager: ManagerClient):
             assert len(rows) == 1, f"Expected 1 row for key {i} in test2 after all operations, but got {len(rows)}"
             assert rows[0].v == value, f"Expected value of size {value_size} for key {i} in test2 after all operations, but got {len(rows[0].v)}"
 
-@pytest.mark.asyncio
 async def test_trigger_separator_flush(manager: ManagerClient):
     """
     Write to 2 tablets, one slower than the other.
@@ -491,7 +479,6 @@ async def test_trigger_separator_flush(manager: ManagerClient):
             value = f"value_{i}_" + ('x' * (value_size - 20))
             await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, '{value}')")
 
-@pytest.mark.asyncio
 async def test_tablet_split_trigger_by_size(manager: ManagerClient):
     """
     Test that a logstor table automatically splits tablets when the data size
@@ -543,7 +530,6 @@ async def test_tablet_split_trigger_by_size(manager: ManagerClient):
             assert len(rows) == 1, f"Key {i} not found after tablet split"
             assert rows[0].v == value, f"Wrong value for key {i} after tablet split"
 
-@pytest.mark.asyncio
 async def test_tablet_split_and_merge(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cmdline = [
@@ -606,7 +592,6 @@ async def test_tablet_split_and_merge(manager: ManagerClient):
 
         await check()
 
-@pytest.mark.asyncio
 async def test_tablet_migration(manager: ManagerClient):
     """
     Test tablet migration
@@ -642,7 +627,6 @@ async def test_tablet_migration(manager: ManagerClient):
             assert len(rows) == 1, f"Expected 1 row for key {i} after tablet migration, but got {len(rows)}"
             assert rows[0].v == f"{i}_{value}", f"Expected value '{i}_{value}' for key {i} after tablet migration, but got {rows[0].v}"
 
-@pytest.mark.asyncio
 async def test_tablet_intranode_migration(manager: ManagerClient):
     """
     Test tablet intranode migration
@@ -677,7 +661,6 @@ async def test_tablet_intranode_migration(manager: ManagerClient):
             assert len(rows) == 1, f"Expected 1 row for key {i} after tablet migration, but got {len(rows)}"
             assert rows[0].v == f"{i}_{value}", f"Expected value '{i}_{value}' for key {i} after tablet migration, but got {rows[0].v}"
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_with_compaction(manager: ManagerClient):
     """

--- a/test/cluster/test_long_join.py
+++ b/test/cluster/test_long_join.py
@@ -15,7 +15,6 @@ from test.pylib.util import wait_for
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_long_join(manager: ManagerClient) -> None:
     """The test checks that join works even if expiring entries are dropped
        between placement of the join request and its processing"""
@@ -29,7 +28,6 @@ async def test_long_join(manager: ManagerClient) -> None:
     await manager.api.message_injection(s1.ip_addr, inj)
     await asyncio.gather(task)
 
-@pytest.mark.asyncio
 async def test_long_join_drop_entries_on_bootstrapping(manager: ManagerClient) -> None:
     """The test checks that join works even if expiring entries are dropped
        on the joining node between placement of the join request and its processing"""

--- a/test/cluster/test_long_query_timeout_erm.py
+++ b/test/cluster/test_long_query_timeout_erm.py
@@ -15,7 +15,6 @@ import time
 
 logger = logging.getLogger(__name__)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-@pytest.mark.asyncio
 @pytest.mark.parametrize("query_type,should_wait_for_timeout,shutdown_nodes", [
     ("SELECT", True, True),
     ("SELECT_COUNT", False, False),
@@ -135,7 +134,6 @@ async def test_long_query_timeout_erm(request, manager: ManagerClient, query_typ
                 await query_future
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-@pytest.mark.asyncio
 @pytest.mark.parametrize("enable_tablets", [True, False])
 async def test_long_query_timeout_without_failure_erm(request, manager: ManagerClient, enable_tablets):
     """

--- a/test/cluster/test_lwt_semaphore.py
+++ b/test/cluster/test_lwt_semaphore.py
@@ -13,7 +13,6 @@ from cassandra.protocol import WriteTimeout
 from test.cluster.util import new_test_keyspace
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_cas_semaphore(manager):
     """ This is a regression test for scylladb/scylladb#19698 """

--- a/test/cluster/test_maintenance_mode.py
+++ b/test/cluster/test_maintenance_mode.py
@@ -24,7 +24,6 @@ from typing import TypeAlias
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_maintenance_mode(manager: ManagerClient):
     """
     The test checks that in maintenance mode server A is not available for other nodes and for clients.

--- a/test/cluster/test_major_compaction.py
+++ b/test/cluster/test_major_compaction.py
@@ -21,7 +21,6 @@ async def disable_autocompaction_across_keyspaces(manager: ManagerClient, server
     for ks in (*keyspace_list, "system", "system_schema"):
         await manager.api.disable_autocompaction(server_ip_addr, ks)
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("consider_only_existing_data", [True, False])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_major_compaction_consider_only_existing_data(manager: ManagerClient, consider_only_existing_data):
@@ -92,7 +91,6 @@ async def test_major_compaction_consider_only_existing_data(manager: ManagerClie
         for k in range(10):
             assert len(await cql.run_async(f"SELECT * FROM {ks}.{cf} WHERE pk = {k}")) == expected_count
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("compaction_flush_all_tables_before_major_seconds", [0, 2, 10])
 async def test_major_compaction_flush_all_tables(manager: ManagerClient, compaction_flush_all_tables_before_major_seconds):
     """
@@ -144,7 +142,6 @@ async def test_major_compaction_flush_all_tables(manager: ManagerClient, compact
         await check_all_table_flush_in_major_compaction(compaction_flush_all_tables_before_major_seconds == 2)
 
 # Testcase for https://github.com/scylladb/scylladb/issues/20197
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_shutdown_drain_during_compaction(manager: ManagerClient):
     """
@@ -199,7 +196,6 @@ async def test_shutdown_drain_during_compaction(manager: ManagerClient):
         await manager.server_start(server.server_id)
         await reconnect_driver(manager)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_compaction_strategy_during_compaction(manager: ManagerClient):
     """
@@ -244,7 +240,6 @@ async def test_alter_compaction_strategy_during_compaction(manager: ManagerClien
         await compaction_task
 
 # Testcase for https://github.com/scylladb/scylladb/issues/24501
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_disable_autocompaction_during_major_compaction(manager: ManagerClient):
     """

--- a/test/cluster/test_metadata_id.py
+++ b/test/cluster/test_metadata_id.py
@@ -23,7 +23,6 @@ async def create_server_and_cqls(manager, cqls_num):
 
     return tuple(create_cluster_connection() for _ in range(cqls_num))
 
-@pytest.mark.asyncio
 async def test_changed_prepared_statement_metadata_columns(manager):
     cql1, cql2, cql3 = await create_server_and_cqls(manager, cqls_num=3)
 
@@ -43,7 +42,6 @@ async def test_changed_prepared_statement_metadata_columns(manager):
             assert len(cql1.execute(prepared).one()) == 3
             assert len(cql2.execute(prepared2).one()) == 3
 
-@pytest.mark.asyncio
 async def test_changed_prepared_statement_metadata_types(manager):
     cql1, cql2, cql3 = await create_server_and_cqls(manager, cqls_num=3)
 
@@ -63,7 +61,6 @@ async def test_changed_prepared_statement_metadata_types(manager):
             assert len(cql1.execute(prepared).one()) == 2
             assert len(cql2.execute(prepared2).one()) == 2
 
-@pytest.mark.asyncio
 async def test_changed_prepared_statement_metadata_udt(manager):
     cql1, cql2, cql3 = await create_server_and_cqls(manager, cqls_num=3)
 

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -29,7 +29,6 @@ CONFIG = {"endpoint_snitch": "GossipingPropertyFileSnitch"}
 
 
 # Checks a cluster boot/operations in multi-dc environment with 5 nodes each in a separate DC
-@pytest.mark.asyncio
 async def test_multidc(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     logger.info("Creating a new cluster")
     for i in range(5):
@@ -51,7 +50,6 @@ cluster_config = [
 
 
 # Simple put-get test for 2 DC with a different amount of nodes and different replication factors
-@pytest.mark.asyncio
 @pytest.mark.parametrize("nodes_list, rf", cluster_config)
 async def test_putget_2dc_with_rf(
         request: pytest.FixtureRequest, manager: ManagerClient, nodes_list: list[int], rf: int
@@ -114,7 +112,6 @@ async def test_putget_2dc_with_rf(
             assert row[2] == f"value{i}"
 
 
-@pytest.mark.asyncio
 async def test_read_or_write_to_dc_with_rf_0_fails(request: pytest.FixtureRequest, manager: ManagerClient):
     """
     Verifies that operations using local consistency levels (LOCAL_QUORUM, LOCAL_ONE) fail
@@ -178,7 +175,6 @@ async def test_read_or_write_to_dc_with_rf_0_fails(request: pytest.FixtureReques
         assert_operation_fails_with_rf0_error(cl,
             f"INSERT INTO {ks}.{table_name} ({columns[0].name}, {columns[1].name}) VALUES ('k_fail_{i}', 'value_fail_{i}')")
 
-@pytest.mark.asyncio
 async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: ManagerClient):
     """
     This test verifies that creating and altering a keyspace keeps it RF-rack-valid.
@@ -326,7 +322,6 @@ async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: Man
     # RF = 1 is always OK!
     await alter_fail(ks3, [1, 1], 1, 2)
 
-@pytest.mark.asyncio
 async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
     """
     This test verifies that Scylla rejects RF-rack-invalid keyspaces
@@ -404,7 +399,6 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
         for task in [*valid_keyspaces, *invalid_keyspaces]:
             _ = tg.create_task(task)
 
-@pytest.mark.asyncio
 async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces(manager: ManagerClient):
     """
     This test verifies that starting a Scylla node fails when there's an RF-rack-invalid keyspace.
@@ -511,7 +505,6 @@ async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces(manager:
     await manager.server_update_config(s1.server_id, "rf_rack_valid_keyspaces", "true")
     await manager.server_start(s1.server_id)
 
-@pytest.mark.asyncio
 async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces_but_not_enforced(manager: ManagerClient):
     """
     When the configuration option `rf_rack_valid_keyspaces` is enabled and there is an RF-rack-invalid keyspace,
@@ -554,7 +547,6 @@ async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces_but_not_
 
     await log.wait_for(expected_pattern)
 
-@pytest.mark.asyncio
 async def test_restart_with_prefer_local(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     logger.info("Creating a new cluster")
     for i in range(3):
@@ -567,7 +559,6 @@ async def test_restart_with_prefer_local(request: pytest.FixtureRequest, manager
     await manager.server_stop_gracefully(s_info.server_id)
     await manager.server_start(s_info.server_id)
 
-@pytest.mark.asyncio
 async def test_warn_create_and_alter_rf_rack_invalid_ks(manager: ManagerClient):
     """
     When the configuration option `rf_rack_valid_keyspaces` is enabled, the user is not

--- a/test/cluster/test_mutation_schema_change.py
+++ b/test/cluster/test_mutation_schema_change.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 async def test_mutation_schema_change(manager, random_tables):
     """
         Cluster A, B, C
@@ -81,7 +80,6 @@ async def test_mutation_schema_change(manager, random_tables):
                                     execution_profile='whitelist')
 
 
-@pytest.mark.asyncio
 async def test_mutation_schema_change_restart(manager, random_tables):
     """
         Cluster A, B, C

--- a/test/cluster/test_mv.py
+++ b/test/cluster/test_mv.py
@@ -21,7 +21,6 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_not_implemented(reason="tombstone_gc repair mode is not supported yet for MVs due to #24816")
 async def test_mv_tombstone_gc_setting(manager):
     """
@@ -50,7 +49,6 @@ async def test_mv_tombstone_gc_setting(manager):
                 s = list(cql.execute(f"DESC {mv}"))[0].create_statement
                 assert "'mode': 'repair'" in s
 
-@pytest.mark.asyncio
 async def test_mv_tombstone_gc_not_inherited(manager):
     """
     Test that the tombstone_gc parameter set on a base table is NOT inherited

--- a/test/cluster/test_no_dc_rack_change.py
+++ b/test/cluster/test_no_dc_rack_change.py
@@ -11,7 +11,6 @@ from test.pylib.manager_client import ManagerClient
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_no_dc_rack_change(manager: ManagerClient) -> None:
     """
     Check that it is not possible to change node's DC or rack during restart.

--- a/test/cluster/test_no_removed_node_event_on_ip_change.py
+++ b/test/cluster/test_no_removed_node_event_on_ip_change.py
@@ -18,7 +18,6 @@ from test.cluster.conftest import cluster_con
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_no_removed_node_event_on_ip_change(manager: ManagerClient, caplog: pytest.LogCaptureFixture):
     logger.info("starting the first node (leader)")
     servers = [await manager.server_add()]

--- a/test/cluster/test_node_isolation.py
+++ b/test/cluster/test_node_isolation.py
@@ -20,7 +20,6 @@ from test.cluster.util import create_new_test_keyspace
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.nightly
 async def test_banned_node_notification(manager: ManagerClient, failure_detector_timeout) -> None:
     """Test that a node banned from the cluster get notification about been banned"""

--- a/test/cluster/test_node_ops_metrics.py
+++ b/test/cluster/test_node_ops_metrics.py
@@ -9,7 +9,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_bootstrap_removenode_metrics(manager):
     cfg = {'enable_repair_based_node_ops': True}
     servers = [await manager.server_add(config=cfg),

--- a/test/cluster/test_node_shutdown_waits_for_pending_requests.py
+++ b/test/cluster/test_node_shutdown_waits_for_pending_requests.py
@@ -15,7 +15,6 @@ from test.cluster.util import new_test_keyspace, reconnect_driver
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_node_shutdown_waits_for_pending_requests(manager: ManagerClient) -> None:
     """Reproducer for #16382"""

--- a/test/cluster/test_nodetool.py
+++ b/test/cluster/test_nodetool.py
@@ -70,7 +70,6 @@ async def validate_status_operation(result: str, live_eps: list, down_eps: list,
     assert lines[i] == ""
 
 
-@pytest.mark.asyncio
 async def test_zero_token_node_normal(manager: ManagerClient):
     zero_token_nodes = await manager.servers_add(servers_num=2, config={'join_ring': False})
 
@@ -115,7 +114,6 @@ async def test_zero_token_node_normal(manager: ManagerClient):
                                     host_id_map, config['num_tokens'])
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_zero_token_node_down_leaving(manager: ManagerClient):
     servers = await manager.running_servers()
@@ -161,7 +159,6 @@ async def test_zero_token_node_down_leaving(manager: ManagerClient):
     await task
 
 
-@pytest.mark.asyncio
 async def test_zero_token_node_down_normal(manager: ManagerClient):
     servers = await manager.running_servers()
 
@@ -197,7 +194,6 @@ async def test_zero_token_node_down_normal(manager: ManagerClient):
                                     host_id_map, config['num_tokens'])
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_regular_node_joining(manager: ManagerClient):
     servers = await manager.running_servers()

--- a/test/cluster/test_not_enough_token_owners.py
+++ b/test/cluster/test_not_enough_token_owners.py
@@ -12,7 +12,6 @@ from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.cluster.util import new_test_keyspace
 
 
-@pytest.mark.asyncio
 async def test_not_enough_token_owners(manager: ManagerClient):
     """
     Test that:

--- a/test/cluster/test_prepare_race.py
+++ b/test/cluster/test_prepare_race.py
@@ -12,7 +12,6 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_prepare_fails_if_cached_statement_is_invalidated_mid_prepare(manager: ManagerClient):
     server = await manager.server_add()

--- a/test/cluster/test_proxy_protocol.py
+++ b/test/cluster/test_proxy_protocol.py
@@ -326,7 +326,6 @@ async def proxy_server(manager: ManagerClient):
     yield (server, manager)
 
 
-@pytest.mark.asyncio
 async def test_proxy_protocol_basic(proxy_server):
     """
     Test that connections through the proxy protocol port correctly report
@@ -354,7 +353,6 @@ async def test_proxy_protocol_basic(proxy_server):
     assert opcode == 0x08, f"Expected RESULT opcode (0x08), got {hex(opcode)}"
 
 
-@pytest.mark.asyncio
 async def test_proxy_protocol_shard_aware(proxy_server):
     """
     Test that shard-aware proxy protocol port correctly uses the source port
@@ -417,7 +415,6 @@ async def test_proxy_protocol_shard_aware(proxy_server):
             await writer.wait_closed()
 
 
-@pytest.mark.asyncio
 async def test_proxy_protocol_multiple_connections(proxy_server):
     """
     Test that multiple connections through the proxy protocol port
@@ -447,7 +444,6 @@ async def test_proxy_protocol_multiple_connections(proxy_server):
         assert opcode == 0x08, f"Expected RESULT opcode for {fake_src_addr}, got {hex(opcode)}"
 
 
-@pytest.mark.asyncio
 async def test_proxy_protocol_port_preserved_in_system_clients(proxy_server):
     """
     Test that the source port from the proxy protocol header is correctly
@@ -498,7 +494,6 @@ async def test_proxy_protocol_port_preserved_in_system_clients(proxy_server):
         await writer.wait_closed()
 
 
-@pytest.mark.asyncio
 async def test_proxy_protocol_ssl_basic(proxy_server):
     """
     Test proxy protocol with TLS encryption.
@@ -524,7 +519,6 @@ async def test_proxy_protocol_ssl_basic(proxy_server):
     assert opcode == 0x08, f"Expected RESULT opcode (0x08), got {hex(opcode)}"
 
 
-@pytest.mark.asyncio
 async def test_proxy_protocol_ssl_shard_aware(proxy_server):
     """
     Test proxy protocol with TLS on the shard-aware port. We connect to all
@@ -624,7 +618,6 @@ async def test_proxy_protocol_ssl_shard_aware(proxy_server):
             ssl_sock.close()
 
 
-@pytest.mark.asyncio
 async def test_proxy_protocol_ssl_port_preserved(proxy_server):
     """
     Test that the source port from the proxy protocol header is correctly

--- a/test/cluster/test_query_rebounce.py
+++ b/test/cluster/test_query_rebounce.py
@@ -18,7 +18,6 @@ from test.cluster.util import new_test_keyspace
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_query_rebounce(manager: ManagerClient):
     """
     Issue https://github.com/scylladb/scylladb/issues/15465.

--- a/test/cluster/test_raft_cluster_features.py
+++ b/test/cluster/test_raft_cluster_features.py
@@ -15,37 +15,31 @@ from test.cluster import test_cluster_features
 import pytest
 
 
-@pytest.mark.asyncio
 async def test_rolling_upgrade_happy_path(manager: ManagerClient) -> None:
     await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_rolling_upgrade_happy_path(manager)
 
 
-@pytest.mark.asyncio
 async def test_downgrade_after_partial_upgrade(manager: ManagerClient) -> None:
     await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_downgrade_after_partial_upgrade(manager)
 
 
-@pytest.mark.asyncio
 async def test_joining_old_node_fails(manager: ManagerClient) -> None:
     await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_joining_old_node_fails(manager)
 
 
-@pytest.mark.asyncio
 async def test_downgrade_after_successful_upgrade_fails(manager: ManagerClient) -> None:
     await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_downgrade_after_successful_upgrade_fails(manager)
 
 
-@pytest.mark.asyncio
 async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerClient) -> None:
     await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_partial_upgrade_can_be_finished_with_removenode(manager)
 
 
-@pytest.mark.asyncio
 async def test_cannot_disable_cluster_feature_after_all_declare_support(manager: ManagerClient) -> None:
     """Upgrade all nodes to support the test cluster feature, but suppress
        the topology coordinator and prevent it from enabling the feature.

--- a/test/cluster/test_raft_ignore_nodes.py
+++ b/test/cluster/test_raft_ignore_nodes.py
@@ -59,7 +59,6 @@ async def make_servers(manager: ManagerClient, servers_num: int,
     return servers_ordered
 
 
-@pytest.mark.asyncio
 async def test_raft_replace_ignore_nodes(manager: ManagerClient, failure_detector_timeout) -> None:
     """Replace 3 dead nodes.
 
@@ -96,7 +95,6 @@ async def test_raft_replace_ignore_nodes(manager: ManagerClient, failure_detecto
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
 
-@pytest.mark.asyncio
 async def test_raft_remove_ignore_nodes(manager: ManagerClient) -> None:
     """Remove 3 dead nodes.
 

--- a/test/cluster/test_raft_no_quorum.py
+++ b/test/cluster/test_raft_no_quorum.py
@@ -34,7 +34,6 @@ async def update_group0_raft_op_timeout(server_id: ServerNum, manager: ManagerCl
         await manager.server_update_config(server_id, 'group0_raft_op_timeout_in_ms', timeout)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_cannot_add_new_node(manager: ManagerClient, raft_op_timeout: int) -> None:
@@ -88,7 +87,6 @@ async def test_cannot_add_new_node(manager: ManagerClient, raft_op_timeout: int)
     logger.info("done")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_quorum_lost_during_node_join(manager: ManagerClient, raft_op_timeout: int) -> None:
@@ -133,7 +131,6 @@ async def test_quorum_lost_during_node_join(manager: ManagerClient, raft_op_time
     await fourth_node_future
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_quorum_lost_during_node_join_response_handler(manager: ManagerClient, raft_op_timeout: int) -> None:
@@ -184,7 +181,6 @@ async def test_quorum_lost_during_node_join_response_handler(manager: ManagerCli
     await fourth_node_future
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_cannot_run_operations(manager: ManagerClient, raft_op_timeout: int) -> None:
@@ -234,7 +230,6 @@ async def test_cannot_run_operations(manager: ManagerClient, raft_op_timeout: in
     logger.info("done")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='dev mode is sufficient for this test')
 @pytest.mark.skip_mode(mode='debug', reason='dev mode is sufficient for this test')
 async def test_can_restart(manager: ManagerClient, raft_op_timeout: int) -> None:

--- a/test/cluster/test_raft_recovery_during_join.py
+++ b/test/cluster/test_raft_recovery_during_join.py
@@ -19,7 +19,6 @@ from test.cluster.util import check_system_topology_and_cdc_generations_v3_consi
         reconnect_driver, wait_for_cdc_generations_publishing
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_raft_recovery_during_join(manager: ManagerClient):
     """

--- a/test/cluster/test_raft_recovery_entry_loss.py
+++ b/test/cluster/test_raft_recovery_entry_loss.py
@@ -30,7 +30,6 @@ async def get_local_schema_version(cql: Session, h: Host) -> UUID:
     assert(rs)
     return rs[0].schema_version
 
-@pytest.mark.asyncio
 async def test_raft_recovery_entry_loss(manager: ManagerClient):
     """
     Test that the Raft-based recovery procedure works correctly if some committed group 0 entry has been permanently

--- a/test/cluster/test_raft_recovery_user_data.py
+++ b/test/cluster/test_raft_recovery_user_data.py
@@ -23,7 +23,6 @@ from test.cluster.util import check_system_topology_and_cdc_generations_v3_consi
         reconnect_driver, start_writes, wait_for_cdc_generations_publishing
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("remove_dead_nodes_with", ["remove", "replace"])
 async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes_with: str):
     """

--- a/test/cluster/test_raft_snapshot_request.py
+++ b/test/cluster/test_raft_snapshot_request.py
@@ -16,7 +16,6 @@ from test.cluster.util import reconnect_driver, trigger_snapshot, get_topology_c
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_raft_snapshot_request(manager: ManagerClient):
     cmdline = [
         '--logger-log-level', 'raft=trace',

--- a/test/cluster/test_raft_snapshot_truncation.py
+++ b/test/cluster/test_raft_snapshot_truncation.py
@@ -16,7 +16,6 @@ from test.pylib.rest_client import inject_error_one_shot
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_raft_snapshot_truncation(manager: ManagerClient):
     """
     Check that after snapshot creation, snapshot_trailing_size is taken into consideration,

--- a/test/cluster/test_raft_voters.py
+++ b/test/cluster/test_raft_voters.py
@@ -26,7 +26,6 @@ async def get_number_of_voters(manager: ManagerClient, srv: ServerInfo):
     return len([m for m in group0_members if m[1]])
 
 
-@pytest.mark.asyncio
 # Make sure the algorithm works with different cluster sizes.
 # (3, 1, 1) specifically checks that the largest DC doesn't get 2+ voters
 # and keep half or more of all voters, which would make losing that DC unsafe.
@@ -106,7 +105,6 @@ async def test_raft_voters_multidc_kill_dc(
     await read_barrier(manager.api, dc_servers[1][0].ip_addr)
 
 
-@pytest.mark.asyncio
 async def test_raft_limited_voters_retain_coordinator(manager: ManagerClient):
     """
     Test that the topology coordinator is retained as a voter when possible.

--- a/test/cluster/test_random_tables.py
+++ b/test/cluster/test_random_tables.py
@@ -14,7 +14,6 @@ pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 # Simple test of schema helper
-@pytest.mark.asyncio
 async def test_new_table(manager, random_tables):
     cql = manager.cql
     assert cql is not None
@@ -42,7 +41,6 @@ async def test_new_table(manager, random_tables):
 
 
 # Simple test of schema helper with alter
-@pytest.mark.asyncio
 async def test_alter_verify_schema(manager, random_tables):
     """Verify table schema"""
     cql = manager.cql
@@ -56,7 +54,6 @@ async def test_alter_verify_schema(manager, random_tables):
         await random_tables.verify_schema()
 
 
-@pytest.mark.asyncio
 async def test_new_table_insert_one(manager, random_tables):
     cql = manager.cql
     assert cql is not None
@@ -71,7 +68,6 @@ async def test_new_table_insert_one(manager, random_tables):
     assert list(res[0])[:2] == vals
 
 
-@pytest.mark.asyncio
 async def test_drop_column(manager, random_tables):
     """Drop a random column from a table"""
     cql = manager.cql
@@ -89,7 +85,6 @@ async def test_drop_column(manager, random_tables):
     await random_tables.verify_schema(table)
 
 
-@pytest.mark.asyncio
 async def test_add_index(random_tables):
     """Add and drop an index"""
     table = await random_tables.add_table(ncolumns=5)
@@ -99,7 +94,6 @@ async def test_add_index(random_tables):
     await random_tables.verify_schema(table)
 
 
-@pytest.mark.asyncio
 async def test_paged_result(manager, random_tables):
     """Test run_async with paged results"""
     cql = manager.cql

--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -183,7 +183,6 @@ incremental_repair_test_data = [pytest.param(row_tombstone_data, id="row-tombsto
 
 
 @pytest.mark.parametrize("data_class", incremental_repair_test_data)
-@pytest.mark.asyncio
 async def test_incremental_read_repair(data_class: DataClass, manager: ManagerClient):
     """Stress the incremental read repair logic
 
@@ -308,7 +307,6 @@ async def test_incremental_read_repair(data_class: DataClass, manager: ManagerCl
         check_rows(cql, host2, all_rows)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_read_repair_with_trace_logging(request, manager):
     logger.info("Creating a new cluster")

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -90,7 +90,6 @@ class SSTablesOnLocalStorage:
     async def restore(self, manager, sstables_per_server, prefix, ks, cf, scope, primary_replica_only, logger):
         await asyncio.gather(*(self.refresh_one(manager, s, ks, cf, sstables, scope, primary_replica_only) for s, sstables in sstables_per_server.items()))
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("topology", [
         topo(rf = 1, nodes = 3, racks = 1, dcs = 1),
         topo(rf = 3, nodes = 5, racks = 1, dcs = 1),

--- a/test/cluster/test_remove_alive_node.py
+++ b/test/cluster/test_remove_alive_node.py
@@ -10,7 +10,6 @@ import logging
 import pytest
 
 
-@pytest.mark.asyncio
 async def test_removing_alive_node_fails(manager: ManagerClient) -> None:
     """
     Test verifying that an attempt to remove an alive node fails as expected.

--- a/test/cluster/test_remove_rpc_client_with_pending_requests.py
+++ b/test/cluster/test_remove_rpc_client_with_pending_requests.py
@@ -17,7 +17,6 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_remove_rpc_client_with_pending_requests(request, manager: ManagerClient) -> None:
     # Regression test for #17445
 

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -36,7 +36,6 @@ async def get_injection_params(manager, node_ip, injection):
         return {}
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_enable_compacting_data_for_streaming_and_repair_live_update(manager):
     """
@@ -77,7 +76,6 @@ async def test_enable_compacting_data_for_streaming_and_repair_live_update(manag
     assert (await get_injection_params(manager, node1.ip_addr, "maybe_compact_for_streaming"))["compaction_enabled"] == "true"
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_for_streaming_and_repair(manager):
     """
@@ -153,7 +151,6 @@ async def test_tombstone_gc_for_streaming_and_repair(manager):
             "compaction_enabled": "true", "compaction_can_gc": "false"}
     check_nodes_have_data(True, True)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_repair_succeeds_with_unitialized_bm(manager):
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
@@ -216,17 +213,14 @@ async def do_batchlog_flush_in_repair(manager, cache_time_in_ms):
 
     logger.debug(f"Repair nr_repairs={nr_repairs} cache_time_in_ms={cache_time_in_ms} total_repair_duration={total_repair_duration}")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_batchlog_flush_in_repair_with_cache(manager):
     await do_batchlog_flush_in_repair(manager, 5000);
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_batchlog_flush_in_repair_without_cache(manager):
     await do_batchlog_flush_in_repair(manager, 0);
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_keyspace_drop_during_data_sync_repair(manager):
     cfg = {
@@ -242,7 +236,6 @@ async def test_keyspace_drop_during_data_sync_repair(manager):
 
     await manager.server_add(config=cfg)
 
-@pytest.mark.asyncio
 async def test_vnode_keyspace_describe_ring(manager: ManagerClient):
     cfg = {
         'tablets_mode_for_new_keyspaces': 'disabled',
@@ -287,7 +280,6 @@ async def test_vnode_keyspace_describe_ring(manager: ManagerClient):
             assert natural_endpoints == ring_endpoints, f"natural_endpoint mismatch describe_ring for {key=} {token=} {natural_endpoints=} {ring_endpoints=}"
 
 
-@pytest.mark.asyncio
 async def test_repair_timtestamp_difference(manager):
     cmdline = [ "--smp", "1", "--logger-log-level", "api=trace", "--hinted-handoff-enabled", "0" ]
     node1, node2 = await manager.servers_add(2, cmdline=cmdline, auto_rack_dc="dc1")
@@ -342,7 +334,6 @@ async def test_repair_timtestamp_difference(manager):
     logger.info("Checking timestamps after repair")
     await check({host1: update2_timestamp, host2: update2_timestamp})
 
-@pytest.mark.asyncio
 async def test_small_table_optimization_repair(manager):
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
 
@@ -357,7 +348,6 @@ async def test_small_table_optimization_repair(manager):
     assert len(rows) == 1
 
 
-@pytest.mark.asyncio
 async def test_repair_rejects_equal_start_and_end_token(manager):
     """Verify that repair rejects a request where startToken == endToken.
     When start == end, the wrapping range (T, T] covers the full token ring,

--- a/test/cluster/test_replace.py
+++ b/test/cluster/test_replace.py
@@ -20,7 +20,6 @@ from test.pylib.random_tables import RandomTables, Column, TextType
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_replace_different_ip(manager: ManagerClient, failure_detector_timeout) -> None:
     """Replace an existing node with new node using a different IP address"""
     servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout})
@@ -66,7 +65,6 @@ async def test_replace_different_ip(manager: ManagerClient, failure_detector_tim
         await wait_for(check_peers_and_gossiper, time.time() + 60)
         logger.info(f"server {s} system.peers and gossiper state is valid")
 
-@pytest.mark.asyncio
 async def test_replace_different_ip_using_host_id(manager: ManagerClient, failure_detector_timeout) -> None:
     """Replace an existing node with new node reusing the replaced node host id"""
     servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout})
@@ -75,7 +73,6 @@ async def test_replace_different_ip_using_host_id(manager: ManagerClient, failur
     await manager.server_add(replace_cfg)
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
-@pytest.mark.asyncio
 async def test_replace_reuse_ip(request, manager: ManagerClient, failure_detector_timeout) -> None:
     """Replace an existing node with new node using the same IP address"""
     servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout}, auto_rack_dc="dc1")
@@ -129,7 +126,6 @@ async def test_replace_reuse_ip(request, manager: ManagerClient, failure_detecto
     await manager.server_sees_other_server(servers[1].ip_addr, servers[0].ip_addr)
     await manager.server_sees_other_server(servers[2].ip_addr, servers[0].ip_addr)
 
-@pytest.mark.asyncio
 async def test_replace_reuse_ip_using_host_id(manager: ManagerClient, failure_detector_timeout) -> None:
     """Replace an existing node with new node using the same IP address and same host id"""
     servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout})

--- a/test/cluster/test_replace_alive_node.py
+++ b/test/cluster/test_replace_alive_node.py
@@ -11,7 +11,6 @@ import pytest
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 async def test_replacing_alive_node_fails(manager: ManagerClient) -> None:
     """Try replacing an alive node and check that it fails"""
     servers = await manager.running_servers()

--- a/test/cluster/test_replace_with_encryption.py
+++ b/test/cluster/test_replace_with_encryption.py
@@ -8,7 +8,6 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.scylla_cluster import ReplaceConfig
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("join_ring", [True, False])
 async def test_replace_with_encryption(manager: ManagerClient, join_ring):
     """Test that a node can be replaced if inter-dc encryption is enabled.

--- a/test/cluster/test_replace_with_same_ip_twice.py
+++ b/test/cluster/test_replace_with_same_ip_twice.py
@@ -13,7 +13,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_replace_with_same_ip_twice(manager: ManagerClient, failure_detector_timeout) -> None:
     logger.info("starting a cluster with two nodes")
     servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout})

--- a/test/cluster/test_rest_api_on_startup.py
+++ b/test/cluster/test_rest_api_on_startup.py
@@ -13,7 +13,6 @@ from test.pylib.rest_client import HTTPError
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_rest_api_on_startup(request, manager: ManagerClient):
 
     host = None

--- a/test/cluster/test_restart_cluster.py
+++ b/test/cluster/test_restart_cluster.py
@@ -17,7 +17,6 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_restart_cluster(manager: ManagerClient) -> None:
     """Test that cluster can restart fine after all nodes are stopped gracefully"""
     servers = await manager.servers_add(3)

--- a/test/cluster/test_resurrection.py
+++ b/test/cluster/test_resurrection.py
@@ -20,7 +20,6 @@ def disable_auto_compaction(ip_addr, ks_name, cf_name):
     if not ret.ok:
         raise RuntimeError(f'failed to disable autocompaction using {api_path}: {ret.text}')
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_resurrection_while_file_streaming(manager: ManagerClient):
     '''

--- a/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
+++ b/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
@@ -18,7 +18,6 @@ def verify_data(response, expected_data):
         pytest.fail("Length of response and expected data mismatch")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_reversed_queries_during_upgrade(manager: ManagerClient) -> None:
     """

--- a/test/cluster/test_rpc_compression.py
+++ b/test/cluster/test_rpc_compression.py
@@ -51,7 +51,6 @@ async def with_retries(test_once: typing.Callable[[], typing.Awaitable], timeout
             else:
                 break
 
-@pytest.mark.asyncio
 async def test_basic(manager: ManagerClient) -> None:
     """Tests basic functionality of internode compression.
     Also, tests that changing internode_compression_zstd_max_cpu_fraction from 0.0 to 1.0 enables zstd as expected.
@@ -92,7 +91,6 @@ async def test_basic(manager: ManagerClient) -> None:
 
         await with_retries(functools.partial(test_algo, "zstd", 0.25), timeout=600)
 
-@pytest.mark.asyncio
 async def test_dict_training(manager: ManagerClient) -> None:
     """Tests population of system.dicts with dicts trained on RPC traffic."""
     training_min_bytes = 128*1024
@@ -154,7 +152,6 @@ async def test_dict_training(manager: ManagerClient) -> None:
 
         await with_retries(test_once, timeout=600)
 
-@pytest.mark.asyncio
 async def test_external_dicts(manager: ManagerClient) -> None:
     """Tests internode compression with external dictionaries"""
     cfg = {
@@ -217,7 +214,6 @@ async def test_external_dicts(manager: ManagerClient) -> None:
         await with_retries(functools.partial(test_once, "lz4", 0.5), timeout=600)
 
 # Similar to test_external_dicts, but simpler.
-@pytest.mark.asyncio
 async def test_external_dicts_sanity(manager: ManagerClient) -> None:
     """Tests internode compression with external dictionaries, by spamming the same UPDATE statement."""
     cfg = {

--- a/test/cluster/test_select_from_mutation_fragments.py
+++ b/test/cluster/test_select_from_mutation_fragments.py
@@ -14,7 +14,6 @@ from test.cluster.util import new_test_keyspace
 from test.pylib.manager_client import ManagerClient
 
 
-@pytest.mark.asyncio
 async def test_sticky_coordinator_enforced(manager: ManagerClient) -> None:
     await manager.servers_add(2, cmdline=['--logger-log-level', 'paging=trace'], auto_rack_dc="dc1")
 

--- a/test/cluster/test_shutdown_hang.py
+++ b/test/cluster/test_shutdown_hang.py
@@ -20,7 +20,6 @@ from test.cluster.util import wait_for_token_ring_and_group0_consistency, new_te
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_hints_manager_shutdown_hang(manager: ManagerClient) -> None:
     """Reproducer for #8079"""

--- a/test/cluster/test_size_based_load_balancing.py
+++ b/test/cluster/test_size_based_load_balancing.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 GB = 1024 * 1024 * 1024
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_balance_empty_tablets(manager: ManagerClient):
 

--- a/test/cluster/test_snapshot.py
+++ b/test/cluster/test_snapshot.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 async def test_snapshot(manager, random_tables):
     """
         Cluster A, B, C

--- a/test/cluster/test_snapshot_with_tablets.py
+++ b/test/cluster/test_snapshot_with_tablets.py
@@ -63,7 +63,6 @@ async def prepare_write_workload(cql, table_name, flush=True, n: int = None):
     if flush:
         nodetool.flush(cql, table_name)
 
-@pytest.mark.asyncio
 async def test_snapshot_on_all_nodes(manager: ManagerClient):
     """
     Tests that a topology operation snapshot is done on all nodes,

--- a/test/cluster/test_sstable_cleanup_stop.py
+++ b/test/cluster/test_sstable_cleanup_stop.py
@@ -13,7 +13,6 @@ import asyncio
 import logging
 
 logger = logging.getLogger(__name__)
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cleanup_stop(manager: ManagerClient):
     logger.info("Bootstrapping cluster")

--- a/test/cluster/test_sstable_compression_config.py
+++ b/test/cluster/test_sstable_compression_config.py
@@ -30,7 +30,6 @@ def yaml_to_cmdline(config):
     return cmdline
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('cfg_source', ['yaml', 'cmdline'])
 async def test_chunk_size_negative(manager: ManagerClient, cfg_source: str):
     config = {
@@ -46,7 +45,6 @@ async def test_chunk_size_negative(manager: ManagerClient, cfg_source: str):
         await manager.server_add(cmdline=yaml_to_cmdline(config), expected_error=expected_error)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('cfg_source', ['yaml', 'cmdline'])
 async def test_chunk_size_beyond_max(manager: ManagerClient, cfg_source: str):
     config = {
@@ -62,7 +60,6 @@ async def test_chunk_size_beyond_max(manager: ManagerClient, cfg_source: str):
         await manager.server_add(cmdline=yaml_to_cmdline(config), expected_error=expected_error)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('cfg_source', ['yaml', 'cmdline'])
 async def test_chunk_size_not_power_of_two(manager: ManagerClient, cfg_source: str):
     config = {
@@ -79,7 +76,6 @@ async def test_chunk_size_not_power_of_two(manager: ManagerClient, cfg_source: s
         await manager.server_add(cmdline=yaml_to_cmdline(config), expected_error=expected_error)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('cfg_source', ['yaml', 'cmdline'])
 async def test_crc_check_chance_out_of_bounds(manager: ManagerClient, cfg_source: str):
     config = {
@@ -95,7 +91,6 @@ async def test_crc_check_chance_out_of_bounds(manager: ManagerClient, cfg_source
     else:
         await manager.server_add(cmdline=yaml_to_cmdline(config), expected_error=expected_error)
 
-@pytest.mark.asyncio
 async def test_default_compression_on_upgrade(manager: ManagerClient, scylla_2025_1: ScyllaVersionDescription, scylla_binary: Path):
     """
     Check that the default SSTable compression algorithm is:
@@ -148,7 +143,6 @@ async def test_default_compression_on_upgrade(manager: ManagerClient, scylla_202
     await create_table_and_check_compression(cql, "test_ks", "table_after_upgrade", "LZ4WithDictsCompressor", "after upgrade and feature enabled")
 
 
-@pytest.mark.asyncio
 async def test_alternator_tables_respect_compression_config(manager: ManagerClient):
     """
     Check that the default compression settings for all Alternator tables (base
@@ -234,7 +228,6 @@ async def test_alternator_tables_respect_compression_config(manager: ManagerClie
         table.delete()
 
 
-@pytest.mark.asyncio
 async def test_cql_base_tables_respect_compression_config(manager: ManagerClient):
     """
     Check that the default compression settings for CQL base tables are taken
@@ -265,7 +258,6 @@ async def test_cql_base_tables_respect_compression_config(manager: ManagerClient
         await cql.run_async(f"DROP KEYSPACE {ks}")
 
 
-@pytest.mark.asyncio
 async def test_cql_aux_tables_respect_compression_config(manager: ManagerClient):
     """
     Check that the default compression settings for CQL auxiliary tables

--- a/test/cluster/test_sstable_set.py
+++ b/test/cluster/test_sstable_set.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize("mode", ['vnode', 'tablet'])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-@pytest.mark.asyncio
 async def test_partitioned_sstable_set(manager: ManagerClient, mode):
     cfg = {
         'tablets_mode_for_new_keyspaces': 'enabled',

--- a/test/cluster/test_start_bootstrapped_with_invalid_seed.py
+++ b/test/cluster/test_start_bootstrapped_with_invalid_seed.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_bug(reason="Test is disabled due to scylladb/scylladb#28153")
 async def test_start_bootstrapped_with_invalid_seed(manager: ManagerClient):
     """

--- a/test/cluster/test_streaming_deadlock.py
+++ b/test/cluster/test_streaming_deadlock.py
@@ -16,7 +16,6 @@ from test.pylib.manager_client import ManagerClient
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 async def test_streaming_deadlock_removenode(request, manager: ManagerClient):
     # Force removenode to exercise range_streamer and not repair.
     # The bug is in the streaming, and when senders are on different nodes,

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -115,7 +115,6 @@ async def get_table_raft_group_id(manager: ManagerClient, ks: str, table: str):
     rows = await manager.get_cql().run_async(f"SELECT raft_group_id FROM system.tablets where table_id = {table_id}")
     return str(rows[0].raft_group_id)
 
-@pytest.mark.asyncio
 async def test_basic_write_read(manager: ManagerClient):
 
     logger.info("Bootstrapping cluster")
@@ -265,7 +264,6 @@ async def test_basic_write_read(manager: ManagerClient):
     # To check that the servers can be stopped gracefully. By default the test runner just kills them.
     await gather_safely(*[manager.server_stop_gracefully(s.server_id) for s in servers])
 
-@pytest.mark.asyncio
 async def test_multi_shard_write_read(manager: ManagerClient):
     """
     Verify that strongly consistent tables work correctly on non-shard-0.
@@ -301,7 +299,6 @@ async def test_multi_shard_write_read(manager: ManagerClient):
 
     await gather_safely(*[manager.server_stop_gracefully(s.server_id) for s in servers])
 
-@pytest.mark.asyncio
 async def test_sc_multishard_metadata_reads(manager: ManagerClient):
     """
     Verify that multi-shard reads of raft metadata for strongly-consistent tables work correctly.
@@ -388,7 +385,6 @@ async def test_sc_multishard_metadata_reads(manager: ManagerClient):
 
     await manager.server_stop_gracefully(server.server_id)
 
-@pytest.mark.asyncio
 async def test_sc_persistence_restart_with_smp_increase(manager: ManagerClient):
     """
     Verify that the metadata for strongly-consistent tables
@@ -440,7 +436,6 @@ async def test_sc_persistence_restart_with_smp_increase(manager: ManagerClient):
     await manager.server_stop_gracefully(server.server_id)
 
 
-@pytest.mark.asyncio
 async def test_sc_persistence_with_compaction(manager: ManagerClient):
     """
     Verify that compaction of system.raft_groups works correctly.
@@ -487,7 +482,6 @@ async def test_sc_persistence_with_compaction(manager: ManagerClient):
     await manager.server_stop_gracefully(server.server_id)
 
 
-@pytest.mark.asyncio
 async def test_sc_persistence_after_crash(manager: ManagerClient):
     """
     Verify that metadata for strongly-consistent tables is recovered
@@ -524,7 +518,6 @@ async def test_sc_persistence_after_crash(manager: ManagerClient):
 
     await manager.server_stop_gracefully(server.server_id)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_no_schema_when_apply_write(manager: ManagerClient):
     servers = await manager.servers_add(2, config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE, auto_rack_dc='my_dc')
@@ -569,7 +562,6 @@ async def test_no_schema_when_apply_write(manager: ManagerClient):
         assert row.c == 20
         assert row.new_col == 30
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_old_schema_when_apply_write(manager: ManagerClient):
     servers = await manager.servers_add(2, config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE, auto_rack_dc='my_dc')
@@ -612,7 +604,6 @@ async def test_old_schema_when_apply_write(manager: ManagerClient):
         assert row.c == 20
         assert row.new_col is None
 
-@pytest.mark.asyncio
 async def test_reject_user_provided_timestamps(manager: ManagerClient):
     """
     A simple validation test that makes sure that we don't accept
@@ -685,7 +676,6 @@ async def test_forward_cql_prepared_with_bound_values(manager: ManagerClient):
                 logger.info(f"Trace event: {event.description}")
                 assert "Prepared statement not found on target" not in event.description
 
-@pytest.mark.asyncio
 async def test_forward_cql_cache_invalidation(manager: ManagerClient):
     """
     Test that cql forwarding works after invalidation of prepared statement cache on schema changes.
@@ -794,7 +784,6 @@ async def test_forward_cql_exception_passthrough(manager: ManagerClient):
             await manager.api.message_injection(non_leader_replica_host.address, "wait_before_handling_forwarded_request")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode("release", "error injections aren't enabled in release mode")
 async def test_drop_table_during_insert(manager: ManagerClient):
     """Regression test for SCYLLADB-1450: node crashes when DROP TABLE races with
@@ -848,7 +837,6 @@ async def test_drop_table_during_insert(manager: ManagerClient):
         await manager.api.get_host_id(server.ip_addr)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_timed_out_queries(manager: ManagerClient):
     """
@@ -954,7 +942,6 @@ async def test_timed_out_queries(manager: ManagerClient):
                 await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (11, 13) USING TIMEOUT 100ms")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_queries_while_dropping_table(manager: ManagerClient):
     """
@@ -1028,7 +1015,6 @@ async def test_queries_while_dropping_table(manager: ManagerClient):
         await write_fut
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_queries_when_shutting_down(manager: ManagerClient):
     """
@@ -1146,7 +1132,6 @@ async def test_queries_when_shutting_down(manager: ManagerClient):
             await stop_fut
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_abort_forwarded_write_upon_shutdown(manager: ManagerClient):
     """
@@ -1308,7 +1293,6 @@ async def test_abort_state_machine_apply_after_dropping_table(manager: ManagerCl
         await log.wait_for(rf"apply\(\): execution for tablet \S+, group_id={group_id} aborted", from_mark=mark)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_bug(reason="SCYLLADB-1056")
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_abort_state_machine_apply_during_shutdown(manager: ManagerClient):

--- a/test/cluster/test_table_desc_read_barrier.py
+++ b/test/cluster/test_table_desc_read_barrier.py
@@ -15,7 +15,6 @@ from test.cluster.util import new_test_keyspace
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_table_desc_read_barrier(manager: ManagerClient) -> None:
     """

--- a/test/cluster/test_table_drop.py
+++ b/test/cluster/test_table_drop.py
@@ -9,7 +9,6 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_drop_table_during_streaming_receiver_side(manager: ManagerClient):
     servers = [await manager.server_add(config={
         'error_injections_at_startup': ['stream_mutation_fragments_table_dropped'],
@@ -18,7 +17,6 @@ async def test_drop_table_during_streaming_receiver_side(manager: ManagerClient)
         'tablets_mode_for_new_keyspaces': 'disabled'
     }) for _ in range(2)]
 
-@pytest.mark.asyncio
 async def test_drop_table_during_flush(manager: ManagerClient):
     servers = [await manager.server_add() for _ in range(2)]
 
@@ -31,7 +29,6 @@ async def test_drop_table_during_flush(manager: ManagerClient):
         await manager.api.keyspace_flush(servers[0].ip_addr, ks, "test")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_table_during_load_and_stream(manager: ManagerClient):
     """Verify that dropping a table while load_and_stream is in progress

--- a/test/cluster/test_tablet_repair_scheduler.py
+++ b/test/cluster/test_tablet_repair_scheduler.py
@@ -107,22 +107,18 @@ async def do_test_tablet_repair_progress_split_merge(manager: ManagerClient, do_
     await wait_task_progress(nr_tablets, nr_tablets)
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-@pytest.mark.asyncio
 async def test_tablet_repair_progress(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_split=False, do_merge=False)
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-@pytest.mark.asyncio
 async def test_tablet_repair_progress_split(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_split=True)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/26844")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_progress_merge(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_merge=True)
 
-@pytest.mark.asyncio
 async def test_tablet_manual_repair(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False, disable_flush_cache_time=True)
     token = -1
@@ -147,7 +143,6 @@ async def test_tablet_manual_repair(manager: ManagerClient):
 
     assert t2 > t1
 
-@pytest.mark.asyncio
 async def test_tombstone_gc_insert_flush(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False, disable_flush_cache_time=True)
     token = "all"
@@ -178,7 +173,6 @@ async def test_tombstone_gc_insert_flush(manager: ManagerClient):
         else:
             assert time.time() < deadline
 
-@pytest.mark.asyncio
 async def test_tablet_manual_repair_all_tokens(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False, disable_flush_cache_time=True)
     token = "all"
@@ -197,7 +191,6 @@ async def test_tablet_manual_repair_all_tokens(manager: ManagerClient):
         assert v != None
         assert v > now
 
-@pytest.mark.asyncio
 async def test_tablet_manual_repair_async(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False)
     token = "-1"
@@ -209,7 +202,6 @@ async def test_tablet_manual_repair_async(manager: ManagerClient):
     logging.info(f"{res=}")
     assert len(res) == 1
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_manual_repair_reject_parallel_requests(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=False)
@@ -238,7 +230,6 @@ async def test_tablet_manual_repair_reject_parallel_requests(manager: ManagerCli
     assert state.ok == 1
     assert state.error == 2
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_error_and_retry(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
@@ -249,7 +240,6 @@ async def test_tablet_repair_error_and_retry(manager: ManagerClient):
     await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", token)
     await inject_error_off(manager, "repair_tablet_fail_on_rpc_call", servers)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_error_not_finish(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
@@ -264,7 +254,6 @@ async def test_tablet_repair_error_not_finish(manager: ManagerClient):
         logger.info("Repair timeout as expected")
     await inject_error_off(manager, "repair_tablet_fail_on_rpc_call", servers)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_error_delete(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
@@ -308,7 +297,6 @@ def check_repairs(row_num_before: list[int], row_num_after: list[int], expected_
         else:
             assert val_before == row_num_after[i]
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("included_host_count", [2, 1, 0])
 async def test_tablet_repair_hosts_filter(manager: ManagerClient, included_host_count):
@@ -357,7 +345,6 @@ async def prepare_multi_dc_repair(manager) -> tuple[list[ServerInfo], CassandraS
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     return (servers, cql, hosts, ks, table_id)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("dcs_filter_and_res", [("DC1", [0, 1]), ("DC2", []), ("DC3", [])])
 async def test_tablet_repair_dcs_filter(manager: ManagerClient, dcs_filter_and_res):
@@ -387,7 +374,6 @@ async def test_tablet_repair_dcs_filter(manager: ManagerClient, dcs_filter_and_r
     row_num_after = [get_repair_row_from_disk(server) for server in servers]
     check_repairs(row_num_before, row_num_after, expected_repairs)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_hosts_and_dcs_filter(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await prepare_multi_dc_repair(manager)
@@ -417,7 +403,6 @@ async def test_tablet_repair_hosts_and_dcs_filter(manager: ManagerClient):
     row_num_after = [get_repair_row_from_disk(server) for server in servers]
     check_repairs(row_num_before, row_num_after, [0, 2])
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_multiple_rows(manager: ManagerClient):
     cmdline = ["--hinted-handoff-enabled", "0"]
@@ -485,12 +470,10 @@ async def run_tablet_repair_multiple_rows_merge(manager: ManagerClient, inject_e
     rows_query = [(r.pk, r.ck, r.data) for r in results]
     assert sorted(rows) == sorted(rows_query)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_multiple_rows_merge_fragments_nr(manager: ManagerClient):
     await run_tablet_repair_multiple_rows_merge(manager, "row_level_repair_max_fragments_nr", "10")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_multiple_rows_merge_fragments_size(manager: ManagerClient):
     await run_tablet_repair_multiple_rows_merge(manager, "row_level_repair_max_fragments_size", "1000")
@@ -507,7 +490,6 @@ async def config_auto_repair(manager, servers, ks, table, auto_repair_enabled, a
     else:
         raise NotImplementedError("Per-table auto-repair configuration is not supported yet.")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_auto_repair(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=True, disable_flush_cache_time=True)
@@ -564,7 +546,6 @@ async def check_has_repair_time(cql, hosts, table_id, timeout = 300):
         assert duration < timeout
         time.sleep(1)
 
-@pytest.mark.asyncio
 async def test_tablet_auto_repair_cfg_enable(manager: ManagerClient):
     cmdline = ["--auto-repair-enabled-default", "1",  "--auto-repair-threshold-default-in-seconds", "1"]
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, cmdline=cmdline, fast_stats_refresh=True, disable_flush_cache_time=True)
@@ -572,7 +553,6 @@ async def test_tablet_auto_repair_cfg_enable(manager: ManagerClient):
     await check_has_repair_time(cql, hosts[0:1], table_id)
 
 @pytest.mark.skip_not_implemented(reason="no per tablet support yet")
-@pytest.mark.asyncio
 async def test_tablet_auto_repair_cfg_disable_per_table_enable(manager: ManagerClient):
     cmdline = ["--auto-repair-enabled-default", "0",  "--auto-repair-threshold-default-in-seconds", "1"]
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, cmdline=cmdline, fast_stats_refresh=True, disable_flush_cache_time=True)
@@ -644,7 +624,6 @@ def verify_sort_order(plans):
                 is_sorted = False
     return is_sorted
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_user_and_auto_repair_priority(manager: ManagerClient):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, fast_stats_refresh=True, disable_flush_cache_time=True)

--- a/test/cluster/test_tablet_stats.py
+++ b/test/cluster/test_tablet_stats.py
@@ -14,7 +14,6 @@ from test.pylib.rest_client import read_barrier
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_load_stats_on_coordinator_failover(manager: ManagerClient):
     cfg = {
@@ -85,7 +84,6 @@ async def test_load_stats_on_coordinator_failover(manager: ManagerClient):
             break
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_load_stats_refresh_during_shutdown(manager: ManagerClient):
     """Verify that _tablet_load_stats_refresh is properly joined during

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -37,7 +37,6 @@ logger = logging.getLogger(__name__)
 # me-1-big-TOC.txt
 sstable_filename_glob = "??-*-???-*.*"
 
-@pytest.mark.asyncio
 async def test_tablet_replication_factor_enough_nodes(manager: ManagerClient):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
     # This test verifies that Scylla rejects creating a table if there are too few token-owning nodes.
@@ -60,7 +59,6 @@ async def test_tablet_replication_factor_enough_nodes(manager: ManagerClient):
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
 
-@pytest.mark.asyncio
 async def test_tablet_scaling_option_is_respected(manager: ManagerClient):
     # 32 is high enough to ensure we demand more tablets than the default choice.
     cfg = {'tablets_mode_for_new_keyspaces': 'enabled', 'tablets_initial_scale_factor': 32}
@@ -75,7 +73,6 @@ async def test_tablet_scaling_option_is_respected(manager: ManagerClient):
     assert len(tablets) == 64
 
 
-@pytest.mark.asyncio
 async def test_tablet_cannot_decommision_below_replication_factor(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -147,7 +144,6 @@ async def test_reshape_with_tablets(manager: ManagerClient):
 
 
 @pytest.mark.parametrize("direction", ["up", "down", "none"])
-@pytest.mark.asyncio
 async def test_tablet_rf_change(manager: ManagerClient, direction):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
     servers = await manager.servers_add(2, config=cfg, auto_rack_dc="dc1")
@@ -216,7 +212,6 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
             assert len(fragments[k]) == rf_to, f"Found mutations for {k} key on {fragments[k]} hosts, but expected only {rf_to} of them"
 
 
-@pytest.mark.asyncio
 async def test_tablet_mutation_fragments_unowned_partition(manager: ManagerClient):
     """Check that MUTATION_FRAGMENTS() queries handle the case when a partition
     not owned by the node is attempted to be read."""
@@ -246,7 +241,6 @@ async def test_tablet_mutation_fragments_unowned_partition(manager: ManagerClien
 # The test checks that describe_ring and range_to_address_map API return
 # information that's consistent with system.tablets contents
 @pytest.mark.parametrize("endpoint", ["describe_ring", "range_to_endpoint", "tokens_endpoint"])
-@pytest.mark.asyncio
 async def test_tablets_api_consistency(manager: ManagerClient, endpoint):
     servers = []
     servers += await manager.servers_add(2, property_file={'dc': f'dc1', 'rack': 'rack1'})
@@ -302,7 +296,6 @@ async def test_tablets_api_consistency(manager: ManagerClient, endpoint):
 # That provides us with a guarantee that the old and the new QUORUM overlap.
 # In this test, we verify that in a simple scenario with one DC. We explicitly disable
 # enforcing RF-rack-valid keyspaces to be able to perform more flexible alterations.
-@pytest.mark.asyncio
 async def test_singledc_alter_tablets_rf(manager: ManagerClient):
     await manager.server_add(config={"rf_rack_valid_keyspaces": "false", "enable_tablets": "true"}, property_file={"dc": "dc1", "rack": "r1"})
     cql = manager.get_cql()
@@ -326,7 +319,6 @@ async def test_singledc_alter_tablets_rf(manager: ManagerClient):
         with pytest.raises(InvalidRequest):
             await change_rf(0) # Trying to decrease the RF by more than 2 should fail.
 
-@pytest.mark.asyncio
 async def test_arbitrary_multi_rf_change_fails(manager: ManagerClient):
     config = {"rf_rack_valid_keyspaces": "false", "enable_tablets": "true", "tablet_load_stats_refresh_interval_in_seconds": 1}
     cmdline = ['--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
@@ -391,7 +383,6 @@ async def test_arbitrary_multi_rf_change_fails(manager: ManagerClient):
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1'], 'dc2': ['r4']}") as ks:
         await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1'], 'dc2': 0, 'dc3': ['r7']}}")
 
-@pytest.mark.asyncio
 async def test_alter_tablets_rf_dc_drop(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     config = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled"}
 
@@ -432,7 +423,6 @@ async def test_alter_tablets_rf_dc_drop(request: pytest.FixtureRequest, manager:
         await cql.run_async(f"alter keyspace {ks} with durable_writes = true")
         await check_rf(ks=ks, expected_dc1_rf=2, expected_dc2_rf=0)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_numeric_rf_to_rack_list_conversion(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     async def get_replication_options(ks: str, host, ip_addr):
@@ -536,7 +526,6 @@ async def test_numeric_rf_to_rack_list_conversion(request: pytest.FixtureRequest
     assert len(repl['dc2']) == 1
     assert repl['dc2'][0] == 'rack2a'
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_enforce_rack_list_option(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     async def get_replication_options(ks: str, host, ip_addr):
@@ -648,7 +637,6 @@ async def check_system_schema_keyspaces(manager, keyspace, replication, next_rep
     else:
         assert res[0].next_replication is None
 
-@pytest.mark.asyncio
 async def test_multi_rf_change_multi_dc_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """Test RF changes where each DC transitions only between 0 and N replicas."""
     config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
@@ -709,7 +697,6 @@ async def test_multi_rf_change_multi_dc_0_N(request: pytest.FixtureRequest, mana
         assert len(t.replicas) == 1
         assert t.replicas[0][0] in dc2_host_ids
 
-@pytest.mark.asyncio
 async def test_multi_rf_change_colocated_tables_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """Test RF changes with colocated tables where each DC transitions only between 0 and N replicas."""
     config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
@@ -756,7 +743,6 @@ async def test_multi_rf_change_colocated_tables_0_N(request: pytest.FixtureReque
     await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a']}, None)
     await check_replicas(1)
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("enforce_rack_list", ['false', 'true'])
 async def test_multi_rf_change_0_N(request: pytest.FixtureRequest, manager: ManagerClient, enforce_rack_list) -> None:
     config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
@@ -785,7 +771,6 @@ async def test_multi_rf_change_0_N(request: pytest.FixtureRequest, manager: Mana
         for r in replicas:
             assert len(r.replicas) == 2
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_multi_rf_increase_abort_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """Test aborting a 0->N RF increase (adding a new DC)."""
@@ -863,7 +848,6 @@ async def test_multi_rf_increase_abort_0_N(request: pytest.FixtureRequest, manag
         for rep in t.replicas:
             assert rep[0] in dc1_host_ids
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_multi_rf_decrease_abort_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """Test aborting an N->0 RF decrease (removing a DC). Abort should not be allowed."""
@@ -935,7 +919,6 @@ async def test_multi_rf_decrease_abort_0_N(request: pytest.FixtureRequest, manag
         for rep in t.replicas:
             assert rep[0] in dc1_host_ids
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """Test concurrent 0->N RF changes across multiple keyspaces."""
@@ -1022,7 +1005,6 @@ async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, ma
             for host_id in dc2_host_ids:
                 assert host_id in [r[0] for r in t.replicas]
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_multi_rf_increase_before_decrease_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """Test aborting an RF change that involves both 0->N increase and N->0 decrease across DCs."""
@@ -1110,7 +1092,6 @@ async def test_multi_rf_increase_before_decrease_0_N(request: pytest.FixtureRequ
             assert rep[0] in host_ids[0:3]
         assert all(host in [r[0] for r in t.replicas] for host in host_ids[0:3])
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_numeric_rf_to_rack_list_conversion_abort(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     async def get_replication_options(ks: str, host, ip_addr):
@@ -1174,7 +1155,6 @@ async def test_numeric_rf_to_rack_list_conversion_abort(request: pytest.FixtureR
     repl = await get_replication_options("ks1", host, servers[0].ip_addr)
     assert repl['dc1'] == '1'
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_failed_tablet_rebuild_is_retried(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     async def alter_keyspace(new_rf):
@@ -1224,7 +1204,6 @@ async def test_failed_tablet_rebuild_is_retried(request: pytest.FixtureRequest, 
 
     await alter_keyspace("'dc1': ['rack1a', 'rack1b', 'rack1c']")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_failed_tablet_rebuild_is_retried_on_alter(manager: ManagerClient) -> None:
     async def alter_keyspace(new_rf):
@@ -1270,7 +1249,6 @@ async def test_failed_tablet_rebuild_is_retried_on_alter(manager: ManagerClient)
 # Reproducer for https://github.com/scylladb/scylladb/issues/18110
 # Check that an existing cached read, will be cleaned up when the tablet it reads
 # from is migrated away.
-@pytest.mark.asyncio
 async def test_saved_readers_tablet_migration(manager: ManagerClient, build_mode):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
 
@@ -1341,7 +1319,6 @@ async def test_saved_readers_tablet_migration(manager: ManagerClient, build_mode
 #   6) tablet's update_effective_replication_map() is not refreshing tablet sstable set (for new tablet migrating in)
 #   7) so read on step 5 is not being able to find sstable set for tablet migrating in
 @pytest.mark.parametrize("with_cache", ['false', 'true'])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_read_of_pending_replica_during_migration(manager: ManagerClient, with_cache):
     logger.info("Bootstrapping cluster")
@@ -1410,7 +1387,6 @@ async def test_read_of_pending_replica_during_migration(manager: ManagerClient, 
 @pytest.mark.parametrize("tablets_mode_for_new_keyspaces", ["enabled", "disabled", "enforced"])
 @pytest.mark.parametrize("cql_tablets_params", ["enabled", "disabled", None])
 @pytest.mark.parametrize("replication_strategy", ["NetworkTopologyStrategy", "SimpleStrategy", "EverywhereStrategy", "LocalStrategy"])
-@pytest.mark.asyncio
 async def test_keyspace_creation_cql_vs_config_sanity(manager: ManagerClient, tablets_mode_for_new_keyspaces, cql_tablets_params, replication_strategy):
     cfg = {'tablets_mode_for_new_keyspaces': tablets_mode_for_new_keyspaces}
     server = await manager.server_add(config=cfg)
@@ -1459,7 +1435,6 @@ async def test_keyspace_creation_cql_vs_config_sanity(manager: ManagerClient, ta
         await cql.run_async(f"drop keyspace {ks}")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_streaming_with_unbuilt_view(manager: ManagerClient):
     """
@@ -1522,7 +1497,6 @@ async def test_tablet_streaming_with_unbuilt_view(manager: ManagerClient):
         rows = await cql.run_async(f"SELECT c from {ks}.mv1")
         assert len(list(rows)) == num_of_rows
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_streaming_with_staged_sstables(manager: ManagerClient):
     """
@@ -1613,7 +1587,6 @@ async def test_tablet_streaming_with_staged_sstables(manager: ManagerClient):
         rows = await cql.run_async(f"SELECT c from {ks}.mv1")
         assert len(list(rows)) == expected_num_of_rows
 
-@pytest.mark.asyncio
 async def test_orphaned_sstables_on_startup(manager: ManagerClient):
     """
     Reproducer for https://github.com/scylladb/scylladb/issues/18038
@@ -1667,7 +1640,6 @@ async def test_orphaned_sstables_on_startup(manager: ManagerClient):
     # Error thrown is of format : "Unable to load SSTable {sstable_name} : Storage wasn't found for tablet {tablet_id} of table {ks}.test"
     await manager.server_start(servers[0].server_id, expected_error="Storage wasn't found for tablet", expected_crash=True)
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
 async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: ManagerClient, with_zero_token_node: bool):
     """
@@ -1711,7 +1683,6 @@ async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: Manager
                                     ignore_dead_nodes=[replaced_host_id])
         await manager.server_add(replace_cfg=replace_cfg, property_file=node_to_remove.property_file())
 
-@pytest.mark.asyncio
 async def test_excludenode(manager: ManagerClient):
     """
     Verifies recovery scenario involving marking the node as excluded using excludenode.
@@ -1750,7 +1721,6 @@ async def test_excludenode(manager: ManagerClient):
         # Check that removenode succeeds on the node which is excluded
         await manager.remove_node(live_node.server_id, server_id=node_to_remove.server_id)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_excludenode_shrink_rf(manager: ManagerClient):
     """
@@ -1798,7 +1768,6 @@ async def test_excludenode_shrink_rf(manager: ManagerClient):
         repl = get_replication(cql, ks)
         assert 'dc2' not in repl or get_replica_count(repl.get('dc2', '0')) == 0
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
 async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_token_node: bool):
     """
@@ -1833,7 +1802,6 @@ async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_tok
         replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True)
         await manager.server_add(replace_cfg=replace_cfg, property_file=node_to_remove.property_file())
 
-@pytest.mark.asyncio
 @pytest.mark.nightly
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
 async def test_replace_with_no_normal_token_owners_in_dc(manager: ManagerClient, with_zero_token_node: bool):
@@ -1892,7 +1860,6 @@ async def test_replace_with_no_normal_token_owners_in_dc(manager: ManagerClient,
         # For dropping the keyspace
         await asyncio.gather(*[manager.server_start(node.server_id) for node in servers['dc2']])
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_keyspace_while_split(manager: ManagerClient):
 
@@ -1943,7 +1910,6 @@ async def test_drop_keyspace_while_split(manager: ManagerClient):
     await manager.api.message_injection(servers[0].ip_addr, "truncate_compaction_disabled_wait")
     await drop_ks_task
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_with_tablet_migration_cleanup(manager: ManagerClient):
 
@@ -1998,7 +1964,6 @@ async def test_drop_with_tablet_migration_cleanup(manager: ManagerClient):
         await drop_future
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_two_tablets_concurrent_repair_and_migration(manager: ManagerClient):
     injection = "repair_shard_repair_task_impl_do_repair_ranges"
@@ -2026,7 +1991,6 @@ async def test_two_tablets_concurrent_repair_and_migration(manager: ManagerClien
 
     await asyncio.gather(repair_task(), migration_task())
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_split_finalization_with_migrations(manager: ManagerClient):
     """
@@ -2106,7 +2070,6 @@ async def test_tablet_split_finalization_with_migrations(manager: ManagerClient)
     logger.info("Waiting for migrations to complete")
     await log.wait_for("Tablet load balancer did not make any plan", from_mark=migration_mark)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_two_tablets_concurrent_repair_and_migration_repair_writer_level(manager: ManagerClient):
     injection = "repair_writer_impl_create_writer_wait"
@@ -2210,16 +2173,13 @@ async def check_tablet_rebuild_with_repair(manager: ManagerClient, fail: bool):
             else:
                 assert res[0].count == 0
 
-@pytest.mark.asyncio
 async def test_tablet_rebuild(manager: ManagerClient):
     await check_tablet_rebuild_with_repair(manager, False)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_rebuild_failure(manager: ManagerClient):
     await check_tablet_rebuild_with_repair(manager, True)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_repair_with_invalid_session_id(manager: ManagerClient):
     injection = "handle_tablet_migration_repair_random_session"
@@ -2235,7 +2195,6 @@ async def test_repair_with_invalid_session_id(manager: ManagerClient):
     matches = [await log.grep(r"std::runtime_error \(Session not found", from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) > 0
 
-@pytest.mark.asyncio
 async def test_moving_replica_to_replica(manager: ManagerClient):
     """
     Verify that trying to move a tablet replica to a node that is already
@@ -2274,7 +2233,6 @@ async def test_moving_replica_to_replica(manager: ManagerClient):
             dst_shard=0,
             token=tablet_token)
 
-@pytest.mark.asyncio
 async def test_moving_replica_within_single_rack(manager: ManagerClient):
     """
     Verify that it's possible to move a tablet from a replica node to a node
@@ -2317,7 +2275,6 @@ async def test_moving_replica_within_single_rack(manager: ManagerClient):
         dst_shard=0,
         token=tablet_token)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_disabling_balancing_preempts_balancer(manager: ManagerClient):
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
@@ -2337,7 +2294,6 @@ async def test_disabling_balancing_preempts_balancer(manager: ManagerClient):
         await manager.disable_tablet_balancing()
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_table_creation_wakes_up_balancer(manager: ManagerClient):
     """
@@ -2371,7 +2327,6 @@ async def test_table_creation_wakes_up_balancer(manager: ManagerClient):
         await manager.api.message_injection(server.ip_addr, 'wait-before-topology-coordinator-goes-to-sleep')
         await log.wait_for('wait-after-topology-coordinator-gets-event: wait', from_mark=mark, timeout=5)
 
-@pytest.mark.asyncio
 async def test_multi_rf_increase_auto_abort_excluded_node(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """Test that an RF change is automatically aborted when a required rack has no available nodes.
 
@@ -2434,7 +2389,6 @@ async def test_multi_rf_increase_auto_abort_excluded_node(request: pytest.Fixtur
             assert len(t.replicas) == 1
             assert t.replicas[0][0] == dc1_host_id
 
-@pytest.mark.asyncio
 async def test_rf_extend_abort_with_down_node(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """Test that an RF extend is aborted when a required rack has a down (not excluded) node.
 

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -79,7 +79,6 @@ async def wait_for_valid_load_stats(cql, table_id, timeout=120):
 
         await asyncio.sleep(0.2)
 
-@pytest.mark.asyncio
 async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(manager: ManagerClient):
     """Test that you can create a table and insert and query data"""
 
@@ -152,7 +151,6 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
                 conn_logger.setLevel(logging.INFO)
 
 
-@pytest.mark.asyncio
 async def test_scans(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     servers = await manager.servers_add(3)
@@ -173,7 +171,6 @@ async def test_scans(manager: ManagerClient):
             assert r.c == r.pk
 
 
-@pytest.mark.asyncio
 async def test_table_drop_with_auto_snapshot(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cfg = { 'auto_snapshot': True }
@@ -193,7 +190,6 @@ async def test_table_drop_with_auto_snapshot(manager: ManagerClient):
     await cql.run_async("DROP KEYSPACE test;")
 
 
-@pytest.mark.asyncio
 async def test_topology_changes(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     servers = await manager.servers_add(3)
@@ -271,7 +267,6 @@ async def get_two_servers_to_move_tablet(manager: ManagerClient):
 
     return (servers, cql, s0_host_id, s1_host_id, replica, tablet_token, dst_shard, ks)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_streaming_rx_error_no_failed_message_with_fail_stream_plan(manager: ManagerClient):
     servers, cql, s0_host_id, s1_host_id, replica, tablet_token, dst_shard, ks = await get_two_servers_to_move_tablet(manager)
@@ -312,7 +307,6 @@ async def test_streaming_rx_error_no_failed_message_with_fail_stream_plan(manage
     rows = await cql.run_async(f"SELECT pk from {ks}.test")
     assert len(list(rows)) == 0
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_streaming_rx_error_no_failed_message_no_fail_stream_plan_hang(manager: ManagerClient):
     servers, cql, s0_host_id, s1_host_id, replica, tablet_token, dst_shard, ks = await get_two_servers_to_move_tablet(manager)
@@ -337,7 +331,6 @@ async def test_streaming_rx_error_no_failed_message_no_fail_stream_plan_hang(man
     except TimeoutError:
         logger.info("Migration timeout as expected")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_streaming_is_guarded_by_topology_guard(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
@@ -412,7 +405,6 @@ async def test_streaming_is_guarded_by_topology_guard(manager: ManagerClient):
         assert len(list(rows)) == 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_table_dropped_during_streaming(manager: ManagerClient):
     """
@@ -487,7 +479,6 @@ async def test_table_dropped_during_streaming(manager: ManagerClient):
         replica = await get_tablet_replica(manager, servers[0], ks, 'test2', tablet_token)
         assert replica == (s1_host_id, 0)
 
-@pytest.mark.asyncio
 async def test_tablet_cleanup(manager: ManagerClient):
     cmdline = ['--smp=2', '--commitlog-sync=batch']
 
@@ -558,7 +549,6 @@ async def test_tablet_cleanup(manager: ManagerClient):
         # Bonus: check that commitlog_cleanups doesn't have any garbage after restart.
         assert 0 == (await cql.run_async("SELECT COUNT(*) FROM system.commitlog_cleanups", host=hosts[0]))[0].count
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_cleanup_failure(manager: ManagerClient):
     cmdline = ['--smp=1']
@@ -613,7 +603,6 @@ async def test_tablet_cleanup_failure(manager: ManagerClient):
         logger.info("Guarantee source node of migration left no sstables undeleted")
         assert len(ssts) == 0
 
-@pytest.mark.asyncio
 async def test_tablet_resharding(manager: ManagerClient):
     cmdline = ['--smp=3']
     config = {'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -636,7 +625,6 @@ async def test_tablet_resharding(manager: ManagerClient):
         expected_error="Detected a tablet with invalid replica shard, reducing shard count with tablet-enabled tables is not yet supported. Replace the node instead.")
 
 @pytest.mark.parametrize("injection_error", ["foreach_compaction_group_wait", "major_compaction_wait"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_split(manager: ManagerClient, injection_error: str):
     logger.info("Bootstrapping cluster")
@@ -705,7 +693,6 @@ async def test_tablet_split(manager: ManagerClient, injection_error: str):
         await s1_log.wait_for(f"{injection_error}: released", from_mark=s1_mark)
         await compaction_task
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_correctness_of_tablet_split_finalization_after_restart(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
@@ -780,7 +767,6 @@ async def test_correctness_of_tablet_split_finalization_after_restart(manager: M
         await check()
 
 @pytest.mark.parametrize("injection_error", ["foreach_compaction_group_wait", "major_compaction_wait"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_concurrent_tablet_migration_and_major(manager: ManagerClient, injection_error):
     logger.info("Bootstrapping cluster")
@@ -836,7 +822,6 @@ async def test_concurrent_tablet_migration_and_major(manager: ManagerClient, inj
 
         await check()
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_concurrent_table_drop_and_major(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
@@ -923,7 +908,6 @@ def get_shard_that_has_tablets(tablet_count_per_shard: list[int]) -> int:
             return shard_id
     return -1
 
-@pytest.mark.asyncio
 async def test_tablet_count_metric_per_shard(manager: ManagerClient):
     # Given two running servers
     shards_count = 4
@@ -1110,7 +1094,6 @@ async def test_tablet_load_and_stream(manager: ManagerClient, primary_replica_on
 
     await asyncio.gather(*[cql.run_async(f"drop keyspace {i}") for i in [ks, ks2]])
 
-@pytest.mark.asyncio
 async def test_storage_service_api_uneven_ownership_keyspace_and_table_params_used(manager: ManagerClient):
     # Given two running servers
     shards_count = 4
@@ -1145,7 +1128,6 @@ async def test_storage_service_api_uneven_ownership_keyspace_and_table_params_us
 
             already_verified.add(actual_ip)
 
-@pytest.mark.asyncio
 async def test_tablet_storage_freeing(manager: ManagerClient):
     logger.info("Start first node")
     servers = [await manager.server_add()]
@@ -1186,7 +1168,6 @@ async def test_tablet_storage_freeing(manager: ManagerClient):
         size_after = await manager.server_get_sstables_disk_usage(servers[0].server_id, ks, "test")
         assert size_before * 0.33 < size_after < size_before * 0.66
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_schema_change_during_cleanup(manager: ManagerClient):
     logger.info("Start first node")
@@ -1228,7 +1209,6 @@ async def test_schema_change_during_cleanup(manager: ManagerClient):
         await cql.run_async(f"ALTER TABLE {ks}.test WITH gc_grace_seconds = 0;")
         await migration_task
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tombstone_gc_correctness_during_tablet_split(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
@@ -1379,7 +1359,6 @@ def verify_replicas_per_server(desc: str, expected_replicas_per_server: dict[Ser
     assert total == initial_tablets * rf
 
 
-@pytest.mark.asyncio
 async def test_decommission_rack_basic(manager: ManagerClient):
     """
     Test decommissioning of all nodes in a rack
@@ -1421,7 +1400,6 @@ async def test_decommission_rack_basic(manager: ManagerClient):
         tablet_count = await get_tablet_count_per_shard_for_hosts(manager, live_servers.values(), tables)
         verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
 
-@pytest.mark.asyncio
 async def test_decommission_rack_after_adding_new_rack(manager: ManagerClient):
     """
     Test decommissioning a rack, after a rack with new nodes is added
@@ -1474,7 +1452,6 @@ async def test_decommission_rack_after_adding_new_rack(manager: ManagerClient):
         tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers, tables)
         verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
 
-@pytest.mark.asyncio
 async def test_decommission_not_enough_racks(manager: ManagerClient):
     """
     Test that decommissioning a rack fails if the number of rack is
@@ -1517,7 +1494,6 @@ async def test_decommission_not_enough_racks(manager: ManagerClient):
         tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers.values(), tables)
         verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_cleanup_vs_snapshot_race(manager: ManagerClient):
     cmdline = ['--smp=1']
@@ -1558,7 +1534,6 @@ async def test_tablet_cleanup_vs_snapshot_race(manager: ManagerClient):
 # It's achieved by migrating a tablet away that contains the highest replay position of a shard,
 # so when drop/truncate happens, the highest replay position will be greater than all the data
 # found in the table (includes data in memtable).
-@pytest.mark.asyncio
 @pytest.mark.parametrize("operation", ['DROP TABLE', 'TRUNCATE'])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_table_and_truncate_after_migration(manager: ManagerClient, operation):
@@ -1599,7 +1574,6 @@ async def test_drop_table_and_truncate_after_migration(manager: ManagerClient, o
     await cql.run_async(f"{operation} {ks}.test")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("streaming_mode", ["sstables_during_snapshot", "sstables_after_snapshot", "logstor_after_snapshot"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_drop_table_during_streaming(manager: ManagerClient, streaming_mode: str):
@@ -1664,7 +1638,6 @@ async def test_drop_table_during_streaming(manager: ManagerClient, streaming_mod
         except HTTPError as e:
             logger.info("Tablet migration failed after drop as expected: %s", e.message)
 
-@pytest.mark.asyncio
 @pytest.mark.nightly
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_during_topology_change(manager: ManagerClient):
@@ -1700,7 +1673,6 @@ async def test_truncate_during_topology_change(manager: ManagerClient):
         assert rows[0].count == 0, "Table should be empty after truncation"
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/22040.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_concurrent_schema_change_with_compaction_completion(manager: ManagerClient):
     cmdline = ['--smp=2']
@@ -1738,7 +1710,6 @@ async def test_concurrent_schema_change_with_compaction_completion(manager: Mana
         await force_minor_compaction()
 
 # This is a test and reproducer for https://github.com/scylladb/scylladb/issues/24153
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_split_correctness_on_tablet_count_change(manager: ManagerClient):
     logger.info('Bootstrapping cluster')
@@ -2007,7 +1978,6 @@ async def test_update_load_stats_after_migration(manager: ManagerClient):
         assert leaving_replica[0] not in replica_hosts, "Leaving replica tablet size is not in load_stats any more"
         assert pending_replica[0] in replica_hosts, "Pending replica tablet size is in load_stats"
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_crash_on_missing_table_from_load_stats(manager: ManagerClient):
     logger.info('Bootstrapping cluster')
@@ -2045,7 +2015,6 @@ async def test_crash_on_missing_table_from_load_stats(manager: ManagerClient):
         await s0_log.wait_for('raft topology: Refreshed table load stats for all DC', from_mark=s0_mark)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablets_barrier_waits_for_replica_erms(manager: ManagerClient):
     """
@@ -2127,7 +2096,6 @@ async def test_tablets_barrier_waits_for_replica_erms(manager: ManagerClient):
         assert len(list(rows)) == 1
 
 # This is a test and reproducer for https://github.com/scylladb/scylladb/issues/26041
-@pytest.mark.asyncio
 @pytest.mark.parametrize("repair_before_split", [False, True])
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_split_and_incremental_repair_synchronization(manager: ManagerClient, repair_before_split: bool):
@@ -2217,7 +2185,6 @@ async def test_split_and_incremental_repair_synchronization(manager: ManagerClie
         hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
         await manager.servers_see_each_other(servers)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_split_and_intranode_synchronization(manager: ManagerClient):
     logger.info('Bootstrapping cluster')
@@ -2294,7 +2261,6 @@ async def test_split_and_intranode_synchronization(manager: ManagerClient):
         # Give enough time for split to happen in debug mode
         await wait_for(finished_splitting, time.time() + 120)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_split_stopped_on_shutdown(manager: ManagerClient):
     logger.info('Bootstrapping cluster')

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -51,7 +51,6 @@ async def wait_for_tablet_stage(manager, server, keyspace_name, table_name, toke
 # We create multiple views, some with the same partition key and some not, and
 # check that those views with the same partition key are co-located by reading
 # their tablet map from system.tablets and checking they have base_table set.
-@pytest.mark.asyncio
 async def test_base_view_colocation(manager: ManagerClient):
     cfg = {'enable_tablets': True}
     cmdline = [
@@ -98,7 +97,6 @@ async def test_base_view_colocation(manager: ManagerClient):
 # stop the other node, remaining only with the one node that should hold the
 # base and view tablets, and verify we can read both tables from this node.
 @pytest.mark.parametrize("move_table", ["base", "child"])
-@pytest.mark.asyncio
 async def test_move_tablet(manager: ManagerClient, move_table: str):
     cfg = {'enable_tablets': True}
     cmdline = [
@@ -166,7 +164,6 @@ async def test_move_tablet(manager: ManagerClient, move_table: str):
 # be split because it's co-located with the base table and their combined sizes are large enough.
 # We verify that the tablets of both tables are split, and the tables have the same tablet count.
 # Then delete some keys and verify the tablets of both tables are merged.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize(
     "with_merge",
@@ -299,7 +296,6 @@ async def test_tablet_split_and_merge(manager: ManagerClient, with_merge: bool):
 # While it's in some transition stage, we hold it and create a co-located view.
 # We verify we can continue read and write to both tables. Then we complete the
 # migration and verify everything continues to work as expected.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("wait_stage", [("streaming", "stream_tablet_wait"), ("cleanup", "cleanup_tablet_wait")])
 async def test_create_colocated_table_while_base_is_migrating(manager: ManagerClient, wait_stage):
@@ -387,7 +383,6 @@ async def test_create_colocated_table_while_base_is_migrating(manager: ManagerCl
 # 3. bring the node back up - it is now missing some data
 # 4. run tablet repair on the base table
 # 5. verify both the base table and the view contain the missing data on the node that was down
-@pytest.mark.asyncio
 @pytest.mark.skip_not_implemented(reason="tablet repair of colocated tables is not supported currently")
 async def test_repair_colocated_base_and_view(manager: ManagerClient):
     cfg = {'enable_tablets': True}
@@ -437,7 +432,6 @@ async def test_repair_colocated_base_and_view(manager: ManagerClient):
 
 # Verify the default tombstone GC mode for colocated tables is 'timeout',
 # and that altering it to 'repair' is not allowed.
-@pytest.mark.asyncio
 async def test_colocated_tables_gc_mode(manager: ManagerClient):
     servers = await manager.servers_add(3, auto_rack_dc="dc1")
     cql = manager.get_cql()

--- a/test/cluster/test_tablets_cql.py
+++ b/test/cluster/test_tablets_cql.py
@@ -17,7 +17,6 @@ from test.cluster.util import disable_schema_agreement_wait, parse_replication_o
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_dropped_tablets_keyspace(manager: ManagerClient) -> None:
     config = {
@@ -68,7 +67,6 @@ async def test_alter_dropped_tablets_keyspace(manager: ManagerClient) -> None:
     with pytest.raises(InvalidRequest, match=f"Can't ALTER keyspace {ks}, keyspace doesn't exist|Can't find a keyspace {ks}") as e:
         await task
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerClient) -> None:
     config = {

--- a/test/cluster/test_tablets_intranode.py
+++ b/test/cluster/test_tablets_intranode.py
@@ -22,7 +22,6 @@ import threading
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_intranode_migration(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
@@ -59,7 +58,6 @@ async def test_intranode_migration(manager: ManagerClient):
             assert r.c == r.pk
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_crash_during_intranode_migration(manager: ManagerClient):
     cmdline = [
@@ -111,7 +109,6 @@ async def test_crash_during_intranode_migration(manager: ManagerClient):
             assert r.c == r.pk
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_cross_shard_migration(manager: ManagerClient):
     """

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -44,7 +44,6 @@ async def inject_error_one_shot_on(manager, error_name, servers):
     await asyncio.gather(*errs)
 
 
-@pytest.mark.asyncio
 async def test_lwt(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cmdline = [
@@ -106,7 +105,6 @@ async def test_lwt(manager: ManagerClient):
     await manager.get_cql().run_async(f"DROP KEYSPACE \"{ks}\"")
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_during_migration(manager: ManagerClient):
     # Scenario:
@@ -207,7 +205,6 @@ async def test_lwt_during_migration(manager: ManagerClient):
         assert row.c == 2
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_state_is_preserved_on_tablet_migration(manager: ManagerClient):
     # Scenario:
@@ -299,7 +296,6 @@ async def test_lwt_state_is_preserved_on_tablet_migration(manager: ManagerClient
         assert row.c2 is None
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_no_lwt_with_tablets_feature(manager: ManagerClient):
     config = {
@@ -330,7 +326,6 @@ async def test_no_lwt_with_tablets_feature(manager: ManagerClient):
         assert res[0].val == 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_state_is_preserved_on_tablet_rebuild(manager: ManagerClient):
     # Scenario:
@@ -415,7 +410,6 @@ async def test_lwt_state_is_preserved_on_tablet_rebuild(manager: ManagerClient):
         assert row.c == 1
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_concurrent_base_table_recreation(manager: ManagerClient):
     # The test checks that the node doesn't crash when the base table is recreated
@@ -461,7 +455,6 @@ async def test_lwt_concurrent_base_table_recreation(manager: ManagerClient):
             await lwt_task
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_timeout_while_creating_paxos_state_table(manager: ManagerClient, build_mode):
@@ -498,7 +491,6 @@ async def test_lwt_timeout_while_creating_paxos_state_table(manager: ManagerClie
                              manager.server_start(servers[2].server_id))
 
 
-@pytest.mark.asyncio
 async def test_paxos_state_table_permissions(manager: ManagerClient):
     # This test checks permission handling for paxos state tables:
     #   * Only a superuser is allowed to access a paxos state table
@@ -592,7 +584,6 @@ async def test_paxos_state_table_permissions(manager: ManagerClient):
         cql = manager.get_cql()
 
 
-@pytest.mark.asyncio
 async def test_lwt_coordinator_shard(manager: ManagerClient):
     # The test checks that an LWT coordinator runs on a replica shard, and not on a 'default' (zero) shard.
     # Scenario:
@@ -645,7 +636,6 @@ async def test_lwt_coordinator_shard(manager: ManagerClient):
         assert "shard 1" in matches[0][0]
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='debug', reason='dev is enought: the test checks non-critical functionality')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_error_message_for_timeout_due_to_write_uncertainty(manager: ManagerClient):
@@ -706,7 +696,6 @@ async def test_error_message_for_timeout_due_to_write_uncertainty(manager: Manag
             await lwt_task
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='debug', reason='dev is enought')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_no_uncertainty_for_reads(manager: ManagerClient):
@@ -769,7 +758,6 @@ async def test_no_uncertainty_for_reads(manager: ManagerClient):
         assert row.c == 2
 
 
-@pytest.mark.asyncio
 async def test_lwts_for_special_tables(manager: ManagerClient):
     """
     SELECT commands with SERIAL consistency level are historically allowed for vnode-based views,
@@ -796,7 +784,6 @@ async def test_lwts_for_special_tables(manager: ManagerClient):
             await cql.run_async(SimpleStatement(f"SELECT * FROM {ks}.test_scylla_cdc_log WHERE \"cdc$stream_id\"=0xAB", consistency_level=ConsistencyLevel.SERIAL))
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_lwt_shutdown(manager: ManagerClient):
     """
@@ -871,7 +858,6 @@ async def test_lwt_shutdown(manager: ManagerClient):
         assert row.v == 2
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='debug', reason='dev is enough')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablets_merge_waits_for_lwt(manager: ManagerClient, scale_timeout):

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -33,7 +33,6 @@ async def disable_injection_on(manager, error_name, servers):
     await asyncio.gather(*errs)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_merge_simple(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
@@ -177,7 +176,6 @@ async def test_tablet_merge_simple(manager: ManagerClient):
         await check()
 
 # Multiple cycles of split and merge, with topology changes in parallel and RF > 1.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_split_and_merge_with_concurrent_topology_changes(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
@@ -323,7 +321,6 @@ async def test_tablet_split_and_merge_with_concurrent_topology_changes(manager: 
             await check()
 
 @pytest.mark.parametrize("racks", [2, 3])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_merge_cross_rack_migrations(manager: ManagerClient, racks):
     cmdline = ['--target-tablet-size-in-bytes', '30000',]
@@ -375,7 +372,6 @@ async def test_tablet_merge_cross_rack_migrations(manager: ManagerClient, racks)
     await wait_for(finished_merging, time.time() + 120)
 
 # Reproduces #23284
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_split_merge_with_many_tables(build_mode: str, manager: ManagerClient, racks = 2):
     cmdline = ['--smp', '4', '-m', '2G', '--target-tablet-size-in-bytes', '30000', '--max-task-backlog', '200', '--logger-log-level', 'load_balancer=debug']
@@ -440,7 +436,6 @@ async def test_tablet_split_merge_with_many_tables(build_mode: str, manager: Man
 
     await check_logs("after merge completion")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_missing_data(manager: ManagerClient):
 
@@ -508,7 +503,6 @@ async def test_missing_data(manager: ManagerClient):
 
         assert rec_count == len(pks), f"received {rec_count} records instead of {len(pks)} while querying server {server.server_id}; missing keys: {missing}"
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_merge_with_drop(manager: ManagerClient):
 
@@ -578,7 +572,6 @@ async def test_merge_with_drop(manager: ManagerClient):
         await drop_table_fut
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_background_merge_deadlock(manager: ManagerClient):
     """

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -32,7 +32,6 @@ async def await_api_task(task, allowed_exception: Optional[Type[Exception]]=None
 
 
 @pytest.mark.parametrize("action", ['move', 'add_replica', 'del_replica'])
-@pytest.mark.asyncio
 async def test_tablet_transition_sanity(manager: ManagerClient, action):
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -117,7 +116,6 @@ async def test_tablet_transition_sanity(manager: ManagerClient, action):
 
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
 @pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new", "cleanup", "cleanup_target", "end_migration", "revert_migration"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage, failure_detector_timeout):
     if fail_stage == 'cleanup' and fail_replica == 'destination':
@@ -273,7 +271,6 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
         # For dropping the keyspace after the node failure
         await reconnect_driver(manager)
 
-@pytest.mark.asyncio
 async def test_tablet_back_and_forth_migration(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -321,7 +318,6 @@ async def test_tablet_back_and_forth_migration(manager: ManagerClient):
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({3}, {3});")
         await assert_rows(3)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_staging_backlog_is_preserved_with_file_based_streaming(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
@@ -417,7 +413,6 @@ async def test_staging_backlog_is_preserved_with_file_based_streaming(manager: M
 
         await check(keys)
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("migration_stage_and_injection", [("cleanup", "cleanup_tablet_wait"), ("end_migration", "handle_tablet_migration_end_migration")], ids=["cleanup", "end_migration"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restart_leaving_replica_during_cleanup(manager: ManagerClient, migration_stage_and_injection):
@@ -502,7 +497,6 @@ async def test_restart_leaving_replica_during_cleanup(manager: ManagerClient, mi
         await wait_for(tablets_merged, time.time() + 60)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restart_in_cleanup_stage_after_cleanup(manager: ManagerClient):
     """

--- a/test/cluster/test_tablets_parallel_decommission.py
+++ b/test/cluster/test_tablets_parallel_decommission.py
@@ -26,7 +26,6 @@ async def count_requests_queued(manager: ManagerClient, coord_srv: ServerInfo, r
     return len(list(filter(lambda t: t['type'] == request_type, tasks)))
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_tablets_are_drained_in_parallel(manager: ManagerClient):
     """
@@ -85,7 +84,6 @@ async def test_tablets_are_drained_in_parallel(manager: ManagerClient):
         await decomm_task2
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("same_rack", [False, True])
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_tablets_are_rebuilt_in_parallel(manager: ManagerClient, same_rack):
@@ -161,7 +159,6 @@ async def test_tablets_are_rebuilt_in_parallel(manager: ManagerClient, same_rack
         await gather_safely(*tasks)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_decommission_can_be_canceled(manager: ManagerClient):
     """
@@ -238,7 +235,6 @@ async def test_decommission_can_be_canceled(manager: ManagerClient):
         assert load[decomm_hostid] == 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_decommission_is_rejected_when_another_one_is_still_pending(manager: ManagerClient):
     """
@@ -283,7 +279,6 @@ async def test_decommission_is_rejected_when_another_one_is_still_pending(manage
         await decomm_task
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_remove_is_canceled_if_there_is_node_down(manager: ManagerClient):
     """
@@ -320,7 +315,6 @@ async def test_remove_is_canceled_if_there_is_node_down(manager: ManagerClient):
             await manager.remove_node(coord_serv.server_id, servers[2].server_id)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_decommission_start_time_is_stable(manager: ManagerClient):
     """
@@ -367,7 +361,6 @@ async def test_decommission_start_time_is_stable(manager: ManagerClient):
         assert task2['start_time'] == task['start_time']
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_decommission_can_not_be_canceled_once_running(manager: ManagerClient):
     """
@@ -413,7 +406,6 @@ async def test_decommission_can_not_be_canceled_once_running(manager: ManagerCli
         assert load[decomm_hostid] == 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_decommission_fails_if_capacity_is_gone_during_draining(manager: ManagerClient):
     """
@@ -459,7 +451,6 @@ async def test_decommission_fails_if_capacity_is_gone_during_draining(manager: M
             await decomm_task
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
 async def test_node_lost_during_decommission_drain(manager: ManagerClient):
     """

--- a/test/cluster/test_tablets_removenode.py
+++ b/test/cluster/test_tablets_removenode.py
@@ -29,7 +29,6 @@ async def run_async_cl_all(cql, query: str):
     return await cql.run_async(stmt)
 
 
-@pytest.mark.asyncio
 async def test_removenode_with_coordinator_restart(manager: ManagerClient):
     """
     Verifies that removenode can proceed when the coordinator is restarted
@@ -61,7 +60,6 @@ async def test_removenode_with_coordinator_restart(manager: ManagerClient):
     await manager.remove_node(servers[1].server_id, servers[2].server_id)
 
 
-@pytest.mark.asyncio
 async def test_replace(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cmdline = [
@@ -142,7 +140,6 @@ async def test_replace(manager: ManagerClient):
     await check_ks(ks3)
 
 
-@pytest.mark.asyncio
 async def test_removenode(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cmdline = ['--logger-log-level', 'storage_service=trace']
@@ -205,7 +202,6 @@ async def test_removenode(manager: ManagerClient):
     await check()
 
 
-@pytest.mark.asyncio
 async def test_removenode_with_ignored_node(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cmdline = [

--- a/test/cluster/test_tls.py
+++ b/test/cluster/test_tls.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 async def test_upgrade_to_ssl(manager: ManagerClient) -> None:
     """Tests rolling upgrade/downgrade from non-SSL to SSL and back
     """

--- a/test/cluster/test_tombstone_gc.py
+++ b/test/cluster/test_tombstone_gc.py
@@ -26,7 +26,6 @@ def check_tombstone_gc_mode(cql, table, mode):
     assert f"'mode': '{mode}'" in s
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("rf", [1, 2])
 @pytest.mark.parametrize("tablets", [True, False])
 async def test_default_tombstone_gc(manager: ManagerClient, rf: int, tablets: bool):
@@ -38,7 +37,6 @@ async def test_default_tombstone_gc(manager: ManagerClient, rf: int, tablets: bo
             check_tombstone_gc_mode(cql, table, "repair")
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("rf", [1, 2])
 @pytest.mark.parametrize("tablets", [True, False])
 async def test_default_tombstone_gc_does_not_override(manager: ManagerClient, rf: int, tablets: bool):
@@ -51,7 +49,6 @@ async def test_default_tombstone_gc_does_not_override(manager: ManagerClient, rf
             check_tombstone_gc_mode(cql, table, "disabled")
 
 
-@pytest.mark.asyncio
 async def test_group0_tombstone_gc(manager: ManagerClient):
     """
     Regression test for #15607.
@@ -264,7 +261,6 @@ async def test_group0_tombstone_gc(manager: ManagerClient):
                 await delete_raft_group_data(first_group0_id, cql, h)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason="test only needs to run once - allowing only the 'dev' mode")
 @pytest.mark.skip_mode(mode='debug', reason="test only needs to run once - allowing only the 'dev' mode")
 async def test_group0_state_id_failure(manager: ManagerClient):
@@ -297,7 +293,6 @@ async def test_group0_state_id_failure(manager: ManagerClient):
     assert not matches, "The 'endpoint_state_map does not contain endpoint' warning appeared in the log"
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("tablets", (True, False))
 async def test_tombstone_gc_rf_one(manager: ManagerClient, tablets: bool):

--- a/test/cluster/test_topology_failure_recovery.py
+++ b/test/cluster/test_topology_failure_recovery.py
@@ -50,7 +50,6 @@ async def remove_error_on(manager: ManagerClient, error_name: str, servers: list
     await asyncio.gather(*errs)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
@@ -74,7 +73,6 @@ async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
         assert node.draining == False and node.excluded == False and node.status == 'NORMAL'
 
 
-@pytest.mark.asyncio
 @pytest.mark.prepare_3_nodes_cluster
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_topology_streaming_failure(request, manager: ManagerClient):

--- a/test/cluster/test_topology_ops.py
+++ b/test/cluster/test_topology_ops.py
@@ -18,7 +18,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("tablets_enabled", [True, False])
 async def test_topology_ops(request, manager: ManagerClient, tablets_enabled: bool):
     """Test basic topology operations using the topology coordinator."""

--- a/test/cluster/test_topology_ops_encrypted.py
+++ b/test/cluster/test_topology_ops_encrypted.py
@@ -18,7 +18,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("tablets_enabled", [True, False])
 async def test_topology_ops_encrypted(request, manager: ManagerClient, tablets_enabled: bool, tmp_path):
     """Test basic topology operations using the topology coordinator. But encrypted."""

--- a/test/cluster/test_topology_ops_with_rf_rack_valid.py
+++ b/test/cluster/test_topology_ops_with_rf_rack_valid.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("enforce", [True, False])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_node_in_new_rack_violating_rf_rack(manager: ManagerClient, enforce: bool):
     """
@@ -61,7 +60,6 @@ async def test_add_node_in_new_rack_violating_rf_rack(manager: ManagerClient, en
 
 @pytest.mark.parametrize("enforce", [True, False])
 @pytest.mark.parametrize("op", ["remove", "decommission"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_remove_node_violating_rf_rack(manager: ManagerClient, enforce: bool, op: str):
     """
@@ -122,7 +120,6 @@ async def test_remove_node_violating_rf_rack(manager: ManagerClient, enforce: bo
 
 
 @pytest.mark.parametrize("injection", ["before_bootstrap", "after_bootstrap"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_keyspace_creation_during_node_join(manager: ManagerClient, injection: str):
     """
@@ -231,7 +228,6 @@ async def test_keyspace_creation_during_node_join(manager: ManagerClient, inject
 
 
 @pytest.mark.parametrize("op", ["remove", "decommission"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_keyspace_creation_during_node_remove(manager: ManagerClient, op: str):
     """
@@ -299,7 +295,6 @@ async def test_keyspace_creation_during_node_remove(manager: ManagerClient, op: 
 
 
 @pytest.mark.parametrize("op", ["remove", "decommission"])
-@pytest.mark.asyncio
 async def test_remove_node_violating_rf_rack_with_rack_list(manager: ManagerClient, op: str):
     """
     Test removing a node when it would violate RF-rack constraints with explicit rack list.

--- a/test/cluster/test_topology_rejoin.py
+++ b/test/cluster/test_topology_rejoin.py
@@ -12,7 +12,6 @@ import pytest
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 async def test_start_after_sudden_stop(manager: ManagerClient, random_tables) -> None:
     """Tests a server can rejoin the cluster after being stopped suddenly"""
     servers = await manager.running_servers()

--- a/test/cluster/test_topology_remove_decom.py
+++ b/test/cluster/test_topology_remove_decom.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 async def test_remove_node_add_column(manager: ManagerClient, random_tables: RandomTables):
     """Add a node, remove an original node, add a column"""
     servers = await manager.running_servers()
@@ -37,7 +36,6 @@ async def test_remove_node_add_column(manager: ManagerClient, random_tables: Ran
     await random_tables.verify_schema()
 
 
-@pytest.mark.asyncio
 async def test_decommission_node_add_column(manager: ManagerClient, random_tables: RandomTables):
     """Add a node, remove an original node, add a column"""
     table = await random_tables.add_table(ncolumns=5)
@@ -70,7 +68,6 @@ async def test_decommission_node_add_column(manager: ManagerClient, random_table
     await random_tables.verify_schema()
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_bug(reason="Wait for @slow attribute, #11713")
 async def test_remove_node_with_concurrent_ddl(manager: ManagerClient, random_tables: RandomTables):
     stopped = False
@@ -132,14 +129,12 @@ async def test_remove_node_with_concurrent_ddl(manager: ManagerClient, random_ta
         await ddl_task
         logger.debug("ddl fiber done, finished")
 
-@pytest.mark.asyncio
 async def test_rebuild_node(manager: ManagerClient, random_tables: RandomTables):
     """rebuild a node"""
     servers = await manager.running_servers()
     await manager.rebuild_node(servers[0].server_id)
     await check_token_ring_and_group0_consistency(manager)
 
-@pytest.mark.asyncio
 async def test_concurrent_removenode_two_initiators_one_dead_node(manager: ManagerClient):
     servers = await manager.running_servers()
     assert len(servers) >= 3
@@ -154,7 +149,6 @@ async def test_concurrent_removenode_two_initiators_one_dead_node(manager: Manag
     else:
         raise Exception("concurrent removenode request should result in a failure, but unexpectedly succeeded")
 
-@pytest.mark.asyncio
 async def test_concurrent_removenode_one_initiator_two_dead_nodes(manager: ManagerClient):
     """
     Tests the execution flow in case of performing remove node
@@ -173,7 +167,6 @@ async def test_concurrent_removenode_one_initiator_two_dead_nodes(manager: Manag
     await asyncio.gather(*[manager.remove_node(servers[0].server_id, servers[2].server_id, ignore_dead=ignore_nodes),
             manager.remove_node(servers[0].server_id, servers[1].server_id, ignore_dead=ignore_nodes)])
 
-@pytest.mark.asyncio
 async def test_concurrent_removenode_two_initiators_two_dead_nodes(manager: ManagerClient):
     """
     Tests the execution flow in case of performing remove node
@@ -193,7 +186,6 @@ async def test_concurrent_removenode_two_initiators_two_dead_nodes(manager: Mana
     await asyncio.gather(*[manager.remove_node(servers[0].server_id, servers[2].server_id, ignore_dead=ignore_nodes),
             manager.remove_node(servers[3].server_id, servers[1].server_id, ignore_dead=ignore_nodes)])
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injection is not supported in release mode')
 async def test_decommission_left_token_ring_retry(manager: ManagerClient):
     """

--- a/test/cluster/test_topology_schema.py
+++ b/test/cluster/test_topology_schema.py
@@ -13,7 +13,6 @@ import pytest
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.asyncio
 async def test_topology_schema_changes(manager, random_tables):
     """Test schema consistency with restart, add, and sudden stop of servers"""
     table = await random_tables.add_table(ncolumns=5)

--- a/test/cluster/test_topology_smp.py
+++ b/test/cluster/test_topology_smp.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 
 
 # Checks basic functionality on the cluster with different values of the --smp parameter on the nodes.
-@pytest.mark.asyncio
 async def test_nodes_with_different_smp(request: FixtureRequest, manager: ManagerClient, build_mode) -> None:
     # In this test it's more convenient to start with a fresh cluster.
 

--- a/test/cluster/test_truncate_concurrent_writes.py
+++ b/test/cluster/test_truncate_concurrent_writes.py
@@ -19,7 +19,6 @@ import os
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_validate_truncate_with_concurrent_writes(manager: ManagerClient):
 
     # This test validates that all the data before a truncate started has been deleted,

--- a/test/cluster/test_truncate_with_drop.py
+++ b/test/cluster/test_truncate_with_drop.py
@@ -14,7 +14,6 @@ import pytest
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 async def test_truncation_on_drop(manager: ManagerClient):
     await manager.server_add()
     cql = manager.get_cql()
@@ -39,7 +38,6 @@ async def test_truncation_on_drop(manager: ManagerClient):
         row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM system.truncated where table_uuid={table_id}'))
         assert row[0].count == 0
 
-@pytest.mark.asyncio
 async def test_truncation_records_pruned_on_dirty_restart(manager: ManagerClient):
     server = await manager.server_add()
     cql = manager.get_cql()

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -18,7 +18,6 @@ import asyncio
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_while_migration(manager: ManagerClient):
 
@@ -70,7 +69,6 @@ async def get_raft_leader_and_log(manager: ManagerClient, servers):
     return (raft_leader, raft_leader_log)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_with_concurrent_drop(manager: ManagerClient):
 
@@ -121,7 +119,6 @@ async def test_truncate_with_concurrent_drop(manager: ManagerClient):
             await trunc_future
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_while_node_restart(manager: ManagerClient):
 
@@ -169,7 +166,6 @@ async def test_truncate_while_node_restart(manager: ManagerClient):
         assert row[0].count == 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_with_coordinator_crash(manager: ManagerClient):
 
@@ -215,7 +211,6 @@ async def test_truncate_with_coordinator_crash(manager: ManagerClient):
         assert row[0].count == 0
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_while_truncate_already_waiting(manager: ManagerClient):
 
@@ -264,7 +259,6 @@ async def test_truncate_while_truncate_already_waiting(manager: ManagerClient):
         assert row[0].count == 0
 
 # Reproduces https://github.com/scylladb/scylladb/issues/23771.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_replay_position_check_during_truncate(manager):
     logger.info("Bootstrapping cluster")
@@ -299,7 +293,6 @@ async def test_replay_position_check_during_truncate(manager):
         await s1_log.wait_for(f"database_truncate_wait: message received", from_mark=s1_mark)
         await truncate_task
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_parallel_truncate(manager: ManagerClient):
 
@@ -347,7 +340,6 @@ async def test_parallel_truncate(manager: ManagerClient):
         row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM {ks}.test1', consistency_level=ConsistencyLevel.ALL))
         assert row[0].count == 0
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_split_emitted_during_truncate(manager: ManagerClient):
     """Tests that truncation handles new compaction groups introduced by tablet

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -22,7 +22,6 @@ from cassandra.cluster import ConnectionException, NoHostAvailable  # type: igno
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """ Test a simultaneous topology change and write query during shutdown, which may cause the node to get stuck (see https://github.com/scylladb/scylladb/issues/23665).

--- a/test/cluster/test_uninitialized_conns_semaphore.py
+++ b/test/cluster/test_uninitialized_conns_semaphore.py
@@ -14,7 +14,6 @@ CQL_PORT = 9042
 SHARD_AWARE_PORT = 19042
 
 
-@pytest.mark.asyncio
 async def test_uninitialized_conns_sempahore_one(manager: ManagerClient):
     """Verify that CQL queries work when uninitialized_connections_semaphore_cpu_concurrency is set to 1."""
     config = {

--- a/test/cluster/test_vector_store.py
+++ b/test/cluster/test_vector_store.py
@@ -20,7 +20,6 @@ logger = logging.getLogger(__name__)
 # 
 # In this test, we check that creating a vector index without
 # rf_rack_valid_keyspaces being set is possible.
-@pytest.mark.asyncio
 async def test_vector_store_can_be_created_without_rf_rack_valid(manager: ManagerClient):
     # Explicitly disable the rf_rack_valid_keyspaces option.
     config = {"rf_rack_valid_keyspaces": False}

--- a/test/cluster/test_view_build_status.py
+++ b/test/cluster/test_view_build_status.py
@@ -58,7 +58,6 @@ async def wait_for_view_build_status(cql, ks_name, view_name, status, node_count
 # Create a materialized view and check that the view's build status
 # is stored in view_build_status_v2 and all nodes see all the other
 # node's statuses.
-@pytest.mark.asyncio
 async def test_view_build_status_v2_table(manager: ManagerClient):
     node_count = 3
     servers = await manager.servers_add(node_count)
@@ -78,7 +77,6 @@ async def test_view_build_status_v2_table(manager: ManagerClient):
 # The table system_distributed.view_build_status is set to be a virtual table reading
 # from system.view_build_status_v2, so verify that reading from each of them provides
 # the same output.
-@pytest.mark.asyncio
 async def test_view_build_status_virtual_table(manager: ManagerClient):
     node_count = 3
     servers = await manager.servers_add(node_count)
@@ -155,7 +153,6 @@ async def test_view_build_status_virtual_table(manager: ManagerClient):
 # Cluster with 3 nodes.
 # Create materialized views. Start new server and it should get a snapshot on bootstrap.
 # Stop 3 `old` servers and query the new server to validate if it has the same view build status.
-@pytest.mark.asyncio
 async def test_view_build_status_snapshot(manager: ManagerClient):
     servers = await manager.servers_add(3)
     cql, _ = await manager.get_ready_cql(servers)
@@ -191,7 +188,6 @@ async def test_view_build_status_snapshot(manager: ManagerClient):
 
 # Test that when removing a node from the cluster, we clean its rows from
 # the view build status table.
-@pytest.mark.asyncio
 async def test_view_build_status_cleanup_on_remove_node(manager: ManagerClient):
     node_count = 4
     servers = await manager.servers_add(node_count)
@@ -215,7 +211,6 @@ async def test_view_build_status_cleanup_on_remove_node(manager: ManagerClient):
 
 # Replace a node and verify that the view_build_status has rows for the new node and
 # no rows for the old node
-@pytest.mark.asyncio
 async def test_view_build_status_with_replace_node(manager: ManagerClient):
     node_count = 4
     servers = await manager.servers_add(node_count)
@@ -258,7 +253,6 @@ async def test_view_build_status_with_replace_node(manager: ManagerClient):
     await wait_for(node_rows_replaced, time.time() + 60)
 
 # Test that when removing the view, its build status is cleaned from the status table
-@pytest.mark.asyncio
 async def test_view_build_status_cleanup_on_drop_view(manager: ManagerClient):
     node_count = 4
     servers = await manager.servers_add(node_count)
@@ -273,7 +267,6 @@ async def test_view_build_status_cleanup_on_drop_view(manager: ManagerClient):
         await wait_for_view_build_status(cql, ks, "vt1", "SUCCESS", 0)
 
 # Test that when removing the view, its build status is cleaned from the status table
-@pytest.mark.asyncio
 async def test_view_build_status_extended_on_added_node(manager: ManagerClient):
     node_count = 4
     servers = await manager.servers_add(node_count)
@@ -288,7 +281,6 @@ async def test_view_build_status_extended_on_added_node(manager: ManagerClient):
         await wait_for_view_build_status(cql, ks, "vt1", "SUCCESS", node_count+1)
 
 # Test that when removing the view, its build status is cleaned from the status table
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_view_build_status_marked_started_on_node_added_during_building(manager: ManagerClient):
     node_count = 4

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -93,7 +93,6 @@ async def check_view_contents(cql: Session, ks: str, table: str, view: str, part
 ### TESTS ###
 #############
 
-@pytest.mark.asyncio
 async def test_build_no_data(manager: ManagerClient):
     node_count = 3
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[
@@ -109,7 +108,6 @@ async def test_build_no_data(manager: ManagerClient):
         await wait_for_view(cql, 'mv_cf_view', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
-@pytest.mark.asyncio
 async def test_build_one_view(manager: ManagerClient):
     node_count = 3
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[
@@ -127,7 +125,6 @@ async def test_build_one_view(manager: ManagerClient):
         await wait_for_view(cql, 'mv_cf_view', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
-@pytest.mark.asyncio
 async def test_build_filtered_view(manager: ManagerClient):
     node_count = 3
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers)
@@ -142,7 +139,6 @@ async def test_build_filtered_view(manager: ManagerClient):
         await check_view_contents(cql, ks, "tab", "mv_cf_view", partition_list=[1, 4, 9])
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_build_two_views(manager: ManagerClient):
     node_count = 3
@@ -172,7 +168,6 @@ async def test_build_two_views(manager: ManagerClient):
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
         await check_view_contents(cql, ks, "tab", "mv_cf_view2")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_add_view_while_build_in_progress(manager: ManagerClient):
     node_count = 3
@@ -206,7 +201,6 @@ async def test_add_view_while_build_in_progress(manager: ManagerClient):
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
         await check_view_contents(cql, ks, "tab", "mv_cf_view2")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_remove_some_view_while_build_in_progress(manager: ManagerClient):
     node_count = 3
@@ -235,7 +229,6 @@ async def test_remove_some_view_while_build_in_progress(manager: ManagerClient):
         await wait_for_view(cql, 'mv_cf_view1', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_abort_building_by_remove_view(manager: ManagerClient):
     node_count = 3
@@ -263,7 +256,6 @@ async def test_abort_building_by_remove_view(manager: ManagerClient):
         assert len(views) == 0
 
 @pytest.mark.parametrize("change", ["add", "rename"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_alter_base_schema_while_build_in_progress(manager: ManagerClient, change: str):
     node_count = 3
@@ -299,7 +291,6 @@ async def test_alter_base_schema_while_build_in_progress(manager: ManagerClient,
             await check_view_contents(cql, ks, "tab", "mv_cf_view", clustering_key="renamed_c")
 
 @pytest.mark.parametrize("change", ["increase", "decrease"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_change_rf_while_build_in_progress(manager: ManagerClient, change: str):
     if change == "increase":
@@ -341,7 +332,6 @@ async def test_change_rf_while_build_in_progress(manager: ManagerClient, change:
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
 @pytest.mark.parametrize("operation", ["add", "remove", "decommission", "replace"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_node_operation_during_view_building(manager: ManagerClient, operation: str):
     if operation == "remove" or operation == "decommission":
@@ -392,7 +382,6 @@ async def test_node_operation_during_view_building(manager: ManagerClient, opera
         await wait_for_view(cql, 'mv_cf_view', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_leader_change_while_building(manager: ManagerClient):
     node_count = 3
@@ -426,7 +415,6 @@ async def test_leader_change_while_building(manager: ManagerClient):
         await wait_for_view(cql, 'mv_cf_view1', node_count)
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
 
-@pytest.mark.asyncio
 @pytest.mark.xfail
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_while_building(manager: ManagerClient):
@@ -459,7 +447,6 @@ async def test_truncate_while_building(manager: ManagerClient):
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
 
 @pytest.mark.parametrize("view_action", ["finish_build", "drop_while_building"])
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_scylla_views_builds_in_progress(manager: ManagerClient, view_action):
     node_count = 3
@@ -506,7 +493,6 @@ async def test_scylla_views_builds_in_progress(manager: ManagerClient, view_acti
 
         await check_scylla_views_builds_in_progress(expect_zero_rows=True)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_view_building_while_tablet_streaming_fail(manager: ManagerClient):
     servers = [await manager.server_add(cmdline=cmdline_loggers)]
@@ -537,7 +523,6 @@ async def test_view_building_while_tablet_streaming_fail(manager: ManagerClient)
         await wait_for_view(cql, 'mv_cf_view', 2)
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_view_building_failure(manager: ManagerClient):
     node_count = 3
@@ -565,7 +550,6 @@ async def test_view_building_failure(manager: ManagerClient):
         await check_view_contents(cql, ks, "tab", "mv_cf_view")
 
 # Reproduces scylladb/scylladb#25912
-@pytest.mark.asyncio
 async def test_concurrent_tablet_migrations(manager: ManagerClient):
     """
     The test creates a situation where a single tablet is replicated across
@@ -669,7 +653,6 @@ async def assert_row_count_on_host(cql, host, ks, table, row_count):
 # Staging sstables are created by removing table's normal sstables and repairing it.
 # Then processing staging sstables is prevented using error injection and the tablet is
 # migrated to a new node, which will receive the staging sstables via file streaming.
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_file_streaming(manager: ManagerClient):
     node_count = 2
@@ -805,7 +788,6 @@ async def test_file_streaming(manager: ManagerClient):
 #   However after tablet merge, view building tasks of those sstables are merged into one task,
 #   but the map stays the same, so one sstable won't be processed
 #   because last token after tablet merge = last token of tablet2 before merge
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_staging_sstables_with_tablet_merge(manager: ManagerClient):
     node_count = 2
@@ -913,7 +895,6 @@ async def test_staging_sstables_with_tablet_merge(manager: ManagerClient):
         await assert_row_count_on_host(cql, new_hosts[0], ks, "mv", 1000)
         await manager.server_start(servers[1].server_id)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_migration_during_view_building(manager: ManagerClient):
     node_count = 1
@@ -944,7 +925,6 @@ async def test_tablet_migration_during_view_building(manager: ManagerClient):
         await wait_for_view(cql, 'mv_cf_view1', 2)
         await check_view_contents(cql, ks, "tab", "mv_cf_view1")
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_merge_during_view_building(manager: ManagerClient):
     node_count = 3
@@ -998,7 +978,6 @@ async def test_tablet_merge_during_view_building(manager: ManagerClient):
 #
 # We check that the observed bad behavior no longer occurs by checking that
 # the view_building_state_observer no longer prints warnings.
-@pytest.mark.asyncio
 async def test_all_good_on_node_restart(manager: ManagerClient):
     node_count = 2
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[
@@ -1024,7 +1003,6 @@ async def test_all_good_on_node_restart(manager: ManagerClient):
 # Test that view building does not trigger tombstone_warn_threshold warnings.
 # Uses a high tablet count (2048) to create many tasks, which produces many
 # tombstones when tasks are cleaned up. Verifies no warnings appear in logs.
-@pytest.mark.asyncio
 async def test_tombstone_warn_threshold(manager: ManagerClient):
     node_count = 1
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[
@@ -1054,7 +1032,6 @@ async def test_tombstone_warn_threshold(manager: ManagerClient):
 
 # Test that in presence of view update hints, view building will not be marked as finished
 # Migrated from dtest materialized_views_test.py::TestMaterializedViews::test_do_not_finish_view_building_with_hints
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_do_not_finish_view_building_with_hints(manager: ManagerClient):
     node_count = 3

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -147,7 +147,6 @@ async def verify_migration_status(manager: ManagerClient, server: ServerInfo,
                 raise
 
 
-@pytest.mark.asyncio
 async def test_migration(manager: ManagerClient):
     """Verify vnodes-to-tablets migration for a single table on a single-node cluster.
 
@@ -286,7 +285,6 @@ async def test_migration(manager: ManagerClient):
         await verify_migration_status(manager, server, ks, expected_status='tablets', expected_node_statuses={})
 
 
-@pytest.mark.asyncio
 async def test_migration_rollback(manager: ManagerClient):
     """Verify rollback of vnodes-to-tablets migration on a single-node cluster.
 
@@ -408,7 +406,6 @@ async def test_migration_rollback(manager: ManagerClient):
         await verify_data_integrity(cql, ks, "test", num_keys)
 
 
-@pytest.mark.asyncio
 async def test_migration_multinode(manager: ManagerClient):
     """Verify vnodes-to-tablets migration for a single table on a multi-node cluster with rolling restarts.
 
@@ -560,7 +557,6 @@ async def setup_single_node(manager: ManagerClient):
     return server, cql
 
 
-@pytest.mark.asyncio
 async def test_migration_nonexistent_keyspace(manager: ManagerClient):
     """Verify that migration APIs fail on a non-existent keyspace."""
     server, cql = await setup_single_node(manager)
@@ -573,7 +569,6 @@ async def test_migration_nonexistent_keyspace(manager: ManagerClient):
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, "ks")
 
 
-@pytest.mark.asyncio
 async def test_migration_already_tablets(manager: ManagerClient):
     """Verify that starting migration on a keyspace that already uses tablets fails."""
     server, cql = await setup_single_node(manager)
@@ -583,7 +578,6 @@ async def test_migration_already_tablets(manager: ManagerClient):
             await manager.api.create_vnode_tablet_migration(server.ip_addr, ks_tablets)
 
 
-@pytest.mark.asyncio
 async def test_migration_empty_keyspace(manager: ManagerClient):
     """Verify that starting migration on a keyspace with no tables fails."""
     server, cql = await setup_single_node(manager)
@@ -593,7 +587,6 @@ async def test_migration_empty_keyspace(manager: ManagerClient):
             await manager.api.create_vnode_tablet_migration(server.ip_addr, ks_empty)
 
 
-@pytest.mark.asyncio
 async def test_migration_finalize_without_migration(manager: ManagerClient):
     """Verify that finalizing migration without starting one first fails."""
     server, cql = await setup_single_node(manager)
@@ -604,7 +597,6 @@ async def test_migration_finalize_without_migration(manager: ManagerClient):
             await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks_vnodes)
 
 
-@pytest.mark.asyncio
 async def test_migration_upgrade_without_migration(manager: ManagerClient):
     """Verify that upgrading a node to tablets without an active migration fails."""
     server, cql = await setup_single_node(manager)
@@ -613,7 +605,6 @@ async def test_migration_upgrade_without_migration(manager: ManagerClient):
         await manager.api.upgrade_node_to_tablets(server.ip_addr)
 
 
-@pytest.mark.asyncio
 async def test_migration_overlapping_migrations(manager: ManagerClient):
     """Verify that starting a second migration while one is already in progress fails."""
     server, cql = await setup_single_node(manager)
@@ -634,7 +625,6 @@ async def test_migration_overlapping_migrations(manager: ManagerClient):
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks1)
 
 
-@pytest.mark.asyncio
 async def test_migration_finalize_before_upgrade(manager: ManagerClient):
     """Verify that finalizing migration before the node has finished upgrading fails."""
     server, cql = await setup_single_node(manager)
@@ -653,7 +643,6 @@ async def test_migration_finalize_before_upgrade(manager: ManagerClient):
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
 
 
-@pytest.mark.asyncio
 async def test_migration_task_not_abortable(manager: ManagerClient):
     """Verify that aborting a vnodes-to-tablets migration task via the task manager fails."""
     server, cql = await setup_single_node(manager)
@@ -679,7 +668,6 @@ async def test_migration_task_not_abortable(manager: ManagerClient):
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
 
 
-@pytest.mark.asyncio
 async def test_migration_wait_task(manager: ManagerClient):
     """Verify that the task manager "wait" API works for vnodes-to-tablets migration tasks.
 
@@ -743,7 +731,6 @@ async def test_migration_wait_task(manager: ManagerClient):
         assert wait_status.progress_completed == 1, f"Expected 1 upgraded node for completed migration, got {wait_status.progress_completed}"
 
 
-@pytest.mark.asyncio
 async def test_migration_multiple_keyspaces(manager: ManagerClient):
     """Verify that two keyspaces can be migrated from vnodes to tablets simultaneously."""
     num_shards = 3

--- a/test/cluster/test_write_query_during_cql_server_shutdown.py
+++ b/test/cluster/test_write_query_during_cql_server_shutdown.py
@@ -18,7 +18,6 @@ from cassandra.cluster import ConnectionException, NoHostAvailable  # type: igno
 
 logger = logging.getLogger(__name__)
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_write_query_during_cql_server_shutdown(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """

--- a/test/cluster/test_writes_to_previous_cdc_generations.py
+++ b/test/cluster/test_writes_to_previous_cdc_generations.py
@@ -41,7 +41,6 @@ async def wait_for_publishing_generations(cql: Session, servers: list[ServerInfo
     return gen_timestamps
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_writes_to_recent_previous_cdc_generations(request, manager: ManagerClient):
     """
@@ -90,7 +89,6 @@ async def test_writes_to_recent_previous_cdc_generations(request, manager: Manag
             await do_write(ts - 1)
 
 
-@pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='debug', reason='test requires nodes to be started quickly')
 async def test_writes_to_old_previous_cdc_generation(request, manager: ManagerClient):
     """

--- a/test/cluster/test_zero_token_nodes_multidc.py
+++ b/test/cluster/test_zero_token_nodes_multidc.py
@@ -16,7 +16,6 @@ from test.cluster.conftest import cluster_con
 from test.cluster.util import create_new_test_keyspace
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('zero_token_nodes', [1, 2])
 @pytest.mark.parametrize('rf_rack_valid_keyspaces', [False, True])
 async def test_zero_token_nodes_multidc_basic(manager: ManagerClient, zero_token_nodes: int, rf_rack_valid_keyspaces: bool):

--- a/test/cluster/test_zero_token_nodes_no_replication.py
+++ b/test/cluster/test_zero_token_nodes_no_replication.py
@@ -16,7 +16,6 @@ from test.cluster.conftest import cluster_con
 from test.cluster.util import create_new_test_keyspace
 
 
-@pytest.mark.asyncio
 async def test_zero_token_nodes_no_replication(manager: ManagerClient):
     """
     Test that zero-token nodes aren't replicas in all non-local replication strategies with and without tablets.

--- a/test/cluster/test_zero_token_nodes_topology_ops.py
+++ b/test/cluster/test_zero_token_nodes_topology_ops.py
@@ -15,7 +15,6 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import check_node_log_for_failed_mutations, start_writes
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize('tablets_enabled', [True, False])
 async def test_zero_token_nodes_topology_ops(manager: ManagerClient, tablets_enabled: bool):
     """


### PR DESCRIPTION
this pr remove redundant pytest.mark.asyncio decorators from tests

Fixes: SCYLLADB-1935
