### PR TITLE
tablet_allocator: use chunked_vector in cluster_resize_load to avoid oversized allocations

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -858,8 +858,8 @@ class load_balancer {
 
     struct cluster_resize_load {
         using table_id_and_size_desc = std::pair<table_id, table_size_desc>;
-        std::vector<table_id_and_size_desc> tables_need_resize;
-        std::vector<table_id_and_size_desc> tables_being_resized;
+        utils::chunked_vector<table_id_and_size_desc> tables_need_resize;
+        utils::chunked_vector<table_id_and_size_desc> tables_being_resized;
 
         static locator::resize_decision to_resize_decision(const table_size_desc& d) {
             return d.new_resize_decision;


### PR DESCRIPTION
In make_resize_plan(), the tables_need_resize vector in cluster_resize_load accumulates all tables that require a resize decision before the downstream heap-based logic selects the top-N most urgent ones to emit.

In clusters with thousands of tables and aggressive tablets-per-shard scaling (e.g., 5000 empty tables with scaling factors of 0.04-0.12), nearly all tables satisfy the merge condition (scaled target < current tablet count), causing the vector to grow to thousands of entries. With ~100 bytes per element, std::vector's doubling strategy triggers contiguous allocations exceeding 256KB, producing seastar oversized allocation warnings.

Replace std::vector with utils::chunked_vector in cluster_resize_load for both tables_need_resize and tables_being_resized. chunked_vector caps individual allocations at 128KB, splitting into multiple chunks when needed. For normal workloads (fewer than ~1300 resize candidates), behavior is identical to std::vector — single contiguous chunk, same performance.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1955

Improvement for a special case, no need to backport.

