### PR TITLE
sstables: include SSTable filename in Stats metadata error messages

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1319,11 +1319,11 @@ future<> sstable::validate_index_digest() const {
 void sstable::validate_min_max_metadata() {
     auto entry = _components->statistics.contents.find(metadata_type::Stats);
     if (entry == _components->statistics.contents.end()) {
-        throw std::runtime_error("Stats metadata not available");
+        throw std::runtime_error(fmt::format("Stats metadata not available for SSTable {}", get_filename()));
     }
     auto& p = entry->second;
     if (!p) {
-        throw std::runtime_error("Statistics is malformed");
+        throw std::runtime_error(fmt::format("Statistics is malformed for SSTable {}", get_filename()));
     }
 
     stats_metadata& s = *static_cast<stats_metadata *>(p.get());

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -49,6 +49,7 @@
 #include "sstables/file_size_stats.hh"
 
 #include <seastar/util/optimized_optional.hh>
+#include <fmt/format.h>
 
 class sstable_assertions;
 class cached_file;
@@ -975,11 +976,11 @@ public:
     const stats_metadata& get_stats_metadata() const {
         auto entry = _components->statistics.contents.find(metadata_type::Stats);
         if (entry == _components->statistics.contents.end()) {
-            throw std::runtime_error("Stats metadata not available");
+            throw std::runtime_error(fmt::format("Stats metadata not available for SSTable {}", get_filename()));
         }
         auto& p = entry->second;
         if (!p) {
-            throw std::runtime_error("Statistics is malformed");
+            throw std::runtime_error(fmt::format("Statistics is malformed for SSTable {}", get_filename()));
         }
         const stats_metadata& s = *static_cast<stats_metadata *>(p.get());
         return s;

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3425,3 +3425,32 @@ SEASTAR_TEST_CASE(test_non_full_and_empty_row_keys) {
         }
     });
 }
+
+SEASTAR_TEST_CASE(test_stats_metadata_error_includes_filename) {
+    return test_env::do_with_async([] (test_env& env) {
+        for (const auto version : writable_sstable_versions) {
+            auto s = schema_builder("ks", "cf")
+                    .with_column("pk", utf8_type, column_kind::partition_key)
+                    .with_column("v", int32_type)
+                    .build();
+            auto sst_gen = env.make_sst_factory(s, version);
+            auto key = partition_key::from_exploded(*s, {to_bytes("key1")});
+
+            mutation m(s, key);
+            m.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("v"),
+                                 make_atomic_cell(int32_type, int32_type->decompose(1)));
+            auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
+
+            // Verify get_stats_metadata() works normally
+            BOOST_REQUIRE_NO_THROW(sst->get_stats_metadata());
+
+            // Erase Stats from the loaded statistics to simulate corruption
+            sstables::test(sst)._statistics().contents.erase(metadata_type::Stats);
+
+            // Now get_stats_metadata() should throw with the filename in the message
+            auto filename = fmt::to_string(sst->get_filename());
+            BOOST_REQUIRE_EXCEPTION(sst->get_stats_metadata(), std::runtime_error,
+                exception_predicate::message_contains(filename));
+        }
+    });
+}

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -46,6 +46,10 @@ public:
         return _sst->_components->summary;
     }
 
+    statistics& _statistics() {
+        return _sst->_components->statistics;
+    }
+
     std::unique_ptr<index_reader> make_index_reader(reader_permit permit) {
         return std::make_unique<index_reader>(_sst, std::move(permit));
     }


### PR DESCRIPTION
When Stats metadata is not available or malformed, include the SSTable
filename in the error message to help operators identify which SSTable
files need attention during startup failures.

Fixes: https://github.com/scylladb/scylla-enterprise/issues/5439
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
AI-assisted: yes
Backport: no, benign improvement