### PR TITLE
test/test_mv_building: ensure nodes see each other after restart

### DIFF
--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -328,6 +328,9 @@ async def test_do_not_finish_view_builder_with_nodes_down(manager: ManagerClient
         {"dc": "dc1", "rack": "r1"},
         {"dc": "dc1", "rack": "r2"},
         {"dc": "dc1", "rack": "r3"},
+    ], cmdline=[
+        '--logger-log-level', 'storage_proxy=debug',
+        '--logger-log-level', 'cql_server=debug',
     ])
     cql, _ = await manager.get_ready_cql(servers)
 
@@ -376,6 +379,8 @@ async def test_do_not_finish_view_builder_with_nodes_down(manager: ManagerClient
         logger.info("Restarting nodes 2 and 3")
         await manager.server_start(servers[1].server_id)
         await manager.server_start(servers[2].server_id)
+        await manager.servers_see_each_other(servers)
+        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
         logger.info("Waiting for the view builder to complete")
         await wait_for_view(cql, 'mv_cf_view', node_count)


### PR DESCRIPTION
In SCYLLADB-2058 we observed a timeout exception while querying the base
table after restarting nodes 2 and 3.
Unfortunately, logs don't give us much useful information about the root cause.

This patch adds basic checks that nodes see each other after the restart and that the cql connection sees restarted node.
It doesn't guarantee that the error won't occur again - in logs from SCYLLADB-2058 we see that each node sees other via gossip after part of the cluster is restarted.

In case the error will occur again, this commit also increases logging level of `cql_server` and `storage_proxy`.

Refs SCYLLADB-2058

The test is present in 2026.2, the patch should be backported to this version.