### PR TITLE
Update seastar submodule

### DIFF
--- a/db/hints/internal/hint_storage.cc
+++ b/db/hints/internal/hint_storage.cc
@@ -149,7 +149,7 @@ future<> rebalance_segments_for(const sstring& ep, size_t segments_per_shard,
             // Don't move the file to the same location. It's pointless.
             if (*seg_path_it != seg_new_path) {
                 manager_logger.trace("going to move: {} -> {}", *seg_path_it, seg_new_path);
-                co_await io_check(rename_file, seg_path_it->native(), seg_new_path.native());
+                co_await io_check(rename_file, seg_path_it->native(), seg_new_path.native(), rename_flags::none);
             } else {
                 manager_logger.trace("skipping: {}", *seg_path_it);
             }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -684,7 +684,7 @@ future<sstring> sstable_directory::create_pending_deletion_log(opened_directory&
         }
 
             // Once flushed and closed, the temporary log file can be renamed.
-            io_check(rename_file, tmp_pending_delete_log, pending_delete_log).get();
+            io_check(rename_file, tmp_pending_delete_log, pending_delete_log, rename_flags::none).get();
 
             // Guarantee that the changes above reached the disk.
             base_dir.sync(general_disk_error_handler).get();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3572,7 +3572,7 @@ future<sstring> make_toc_temporary(sstring sstable_toc_name, storage::sync_dir s
     sstlog.debug("Removing by TOC name: {}", sstable_toc_name);
     if (co_await sstable_io_check(sstable_write_error_handler, file_exists, sstable_toc_name)) {
         // If new_toc_name exists it will be atomically replaced.  See rename(2)
-        co_await sstable_io_check(sstable_write_error_handler, rename_file, sstable_toc_name, new_toc_name);
+        co_await sstable_io_check(sstable_write_error_handler, rename_file, sstable_toc_name, new_toc_name, rename_flags::none);
         if (sync) {
             co_await sstable_io_check(sstable_write_error_handler, sync_directory, parent_path(new_toc_name));
         }

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -162,7 +162,7 @@ static future<file> open_sstable_component_file_non_checked(std::string_view nam
 }
 
 future<> filesystem_storage::rename_new_file(const sstable& sst, sstring from_name, sstring to_name) const {
-    return sst.sstable_write_io_check(rename_file, from_name, to_name).handle_exception([from_name, to_name] (std::exception_ptr ep) {
+    return sst.sstable_write_io_check(rename_file, from_name, to_name, rename_flags::none).handle_exception([from_name, to_name] (std::exception_ptr ep) {
         sstlog.error("Could not rename SSTable component {} to {}. Found exception: {}", from_name, to_name, ep);
         return make_exception_future<>(ep);
     });
@@ -243,7 +243,7 @@ future<> filesystem_storage::seal(const sstable& sst) {
     // Guarantee that every component of this sstable reached the disk.
     co_await _dir.sync(sst._write_error_handler);
     // Rename TOC because it's no longer temporary.
-    co_await sst.sstable_write_io_check(rename_file, fmt::to_string(sst.filename(component_type::TemporaryTOC)), fmt::to_string(sst.filename(component_type::TOC)));
+    co_await sst.sstable_write_io_check(rename_file, fmt::to_string(sst.filename(component_type::TemporaryTOC)), fmt::to_string(sst.filename(component_type::TOC)), rename_flags::none);
     co_await _dir.sync(sst._write_error_handler);
     // If this point was reached, sstable should be safe in disk.
     sstlog.debug("SSTable with generation {} of {}.{} was sealed successfully.", sst._generation, sst._schema->ks_name(), sst._schema->cf_name());
@@ -400,7 +400,7 @@ future<> filesystem_storage::create_links_common(const sstable& sst, sstring dst
         // Now that the source sstable is linked to new_dir, mark the source links for
         // deletion by leaving a TemporaryTOC file in the source directory.
         auto src_temp_toc = filename(sst, _dir.native(), sst._generation, component_type::TemporaryTOC);
-        co_await sst.sstable_write_io_check(rename_file, std::move(dst_temp_toc), std::move(src_temp_toc));
+        co_await sst.sstable_write_io_check(rename_file, std::move(dst_temp_toc), std::move(src_temp_toc), rename_flags::none);
         co_await _dir.sync(sst._write_error_handler);
     } else if (!leave_unsealed) {
         // Now that the source sstable is linked to dir, remove

--- a/test/boost/aws_error_injection_test.cc
+++ b/test/boost/aws_error_injection_test.cc
@@ -47,7 +47,7 @@ static s3::endpoint_config_ptr make_minio_config() {
 }
 
 static void register_policy(const std::string& key, failure_policy policy) {
-    auto cln = http::experimental::client(socket_address(net::inet_address(get_address()), get_port()));
+    auto cln = http::client(socket_address(net::inet_address(get_address()), get_port()));
     auto close_client = deferred_close(cln);
     auto req = http::request::make("PUT", get_address(), "/");
     req._headers["Content-Length"] = "0";

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -1640,7 +1640,7 @@ SEASTAR_FIXTURE_TEST_CASE(test_azure_network_error, fake_azure, *check_azure_moc
 }
 
 static future<> configure_azure_mock_server(const std::string& host, const unsigned int port, const std::string& service, const std::string& error_type, int repeat) {
-    auto cln = http::experimental::client(socket_address(net::inet_address(host), uint16_t(port)));
+    auto cln = http::client(socket_address(net::inet_address(host), uint16_t(port)));
     auto close_client = deferred_close(cln);
     auto req = http::request::make("POST", host, "/config/error");
     req._headers["Content-Length"] = "0";

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -45,7 +45,7 @@ using namespace std::chrono_literals;
 // Retry strategy for tests: same retryability logic as the default AWS
 // strategy but with a fixed 1ms delay between retries instead of
 // exponential backoff, to keep tests fast.
-class test_retry_strategy : public seastar::http::experimental::retry_strategy {
+class test_retry_strategy : public seastar::http::retry_strategy {
     unsigned _max_retries;
 
 public:
@@ -66,7 +66,7 @@ public:
     }
 };
 
-static std::unique_ptr<seastar::http::experimental::retry_strategy> make_test_retry_strategy() {
+static std::unique_ptr<seastar::http::retry_strategy> make_test_retry_strategy() {
     return std::make_unique<test_retry_strategy>();
 }
 

--- a/test/perf/perf_alternator.cc
+++ b/test/perf/perf_alternator.cc
@@ -57,14 +57,14 @@ std::ostream& operator<<(std::ostream& os, const test_config& cfg) {
            << "}";
 }
 
-static http::experimental::client get_client(const test_config& c, int port = 0) {
+static http::client get_client(const test_config& c, int port = 0) {
     if (port == 0) {
         port = c.port;
     }
-    return http::experimental::client(socket_address(net::inet_address(c.remote_host), port));
+    return http::client(socket_address(net::inet_address(c.remote_host), port));
 }
 
-static future<> make_request(http::experimental::client& cli, sstring operation, sstring body) {
+static future<> make_request(http::client& cli, sstring operation, sstring body) {
     auto req = http::request::make("POST", "localhost", "/");
     req._headers["X-Amz-Target:"] = "DynamoDB_20120810." + operation;
     req.write_body("application/x-amz-json-1.0", std::move(body));
@@ -95,7 +95,7 @@ static void wait_for_alternator(const test_config& c, abort_source& as) {
     throw std::runtime_error("Timed out waiting for alternator port to become ready");
 }
 
-static void delete_alternator_table(http::experimental::client& cli) {
+static void delete_alternator_table(http::client& cli) {
     try {
         make_request(cli, "DeleteTable", R"({"TableName": "workloads_test"})").get();
     } catch(...) {
@@ -103,7 +103,7 @@ static void delete_alternator_table(http::experimental::client& cli) {
     }
 }
 
-static void create_alternator_table(http::experimental::client& cli) {
+static void create_alternator_table(http::client& cli) {
     delete_alternator_table(cli); // cleanup in case of leftovers
     make_request(cli, "CreateTable", R"(
         {
@@ -131,7 +131,7 @@ static void create_alternator_table(http::experimental::client& cli) {
     )").get();
 }
 
-static void create_alternator_table_with_gsi(http::experimental::client& cli) {
+static void create_alternator_table_with_gsi(http::client& cli) {
     delete_alternator_table(cli); // cleanup in case of leftovers
     make_request(cli, "CreateTable", R"(
         {
@@ -251,7 +251,7 @@ static constexpr auto update_item_suffix = R"(
     }}
 )";
 
-static future<> update_item(const test_config& _, http::experimental::client& cli, uint64_t seq) {
+static future<> update_item(const test_config& _, http::client& cli, uint64_t seq) {
     auto prefix = format(R"({{
             "TableName": "workloads_test",
             "Key": {{
@@ -266,7 +266,7 @@ static future<> update_item(const test_config& _, http::experimental::client& cl
     return make_request(cli, "UpdateItem", prefix + seastar::format(update_item_suffix, ""));
 }
 
-static future<> update_item_gsi(const test_config& _, http::experimental::client& cli, uint64_t seq) {
+static future<> update_item_gsi(const test_config& _, http::client& cli, uint64_t seq) {
     auto prefix = format(R"({{
             "TableName": "workloads_test",
             "Key": {{
@@ -300,7 +300,7 @@ static future<> update_item_gsi(const test_config& _, http::experimental::client
     return make_request(cli, "UpdateItem", prefix);
 }
 
-static future<> update_item_rmw(const test_config& _, http::experimental::client& cli, uint64_t seq) {
+static future<> update_item_rmw(const test_config& _, http::client& cli, uint64_t seq) {
     auto prefix = format(R"({{
             "TableName": "workloads_test",
             "Key": {{
@@ -328,7 +328,7 @@ static future<> update_item_rmw(const test_config& _, http::experimental::client
                         format(update_item_suffix, condition_attribute_values));
 }
 
-static future<> get_item(const test_config& _, http::experimental::client& cli, uint64_t seq) {
+static future<> get_item(const test_config& _, http::client& cli, uint64_t seq) {
     auto body = format(R"({{
         "TableName": "workloads_test",
         "Key": {{
@@ -346,7 +346,7 @@ static future<> get_item(const test_config& _, http::experimental::client& cli, 
     co_await make_request(cli, "GetItem", std::move(body));
 }
 
-static future<> scan(const test_config& c, http::experimental::client& cli, uint64_t seq) {
+static future<> scan(const test_config& c, http::client& cli, uint64_t seq) {
     // This uses "parallel scan" feature, see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan
     auto body = format(R"({{
         "TableName": "workloads_test",
@@ -367,7 +367,7 @@ static void flush_table(const test_config& c) {
     cli.close().get();
 }
 
-static void create_partitions(const test_config& c, http::experimental::client& cli) {
+static void create_partitions(const test_config& c, http::client& cli) {
     std::cout << "Creating " << c.partitions << " partitions..." << std::endl;
     for (unsigned seq = 0; seq < c.partitions; ++seq) {
         update_item(c, cli, seq).get();
@@ -379,7 +379,7 @@ static void create_partitions(const test_config& c, http::experimental::client& 
 }
 
 auto make_client_pool(const test_config& c) {
-    std::vector<http::experimental::client> res;
+    std::vector<http::client> res;
     res.reserve(c.concurrency);
     for (unsigned i = 0; i < c.concurrency; i++) {
         res.push_back(get_client(c));
@@ -403,7 +403,7 @@ void workload_main(const test_config& c, sharded<abort_source>* as) {
         create_alternator_table_with_gsi(cli);
     }
 
-    using fun_t = std::function<future<>(const test_config&, http::experimental::client&, uint64_t)>;
+    using fun_t = std::function<future<>(const test_config&, http::client&, uint64_t)>;
     std::map<std::string, fun_t> workloads = {
         {"read",  get_item},
         {"scan", scan},
@@ -424,7 +424,7 @@ void workload_main(const test_config& c, sharded<abort_source>* as) {
     }
     fun_t fun = it->second;
 
-    static thread_local std::vector<http::experimental::client> cli_pool;
+    static thread_local std::vector<http::client> cli_pool;
     smp::invoke_on_all([&c] {
         cli_pool = make_client_pool(c);
     }).get();

--- a/test/scylla_gdb/gdb_utils.py
+++ b/test/scylla_gdb/gdb_utils.py
@@ -43,16 +43,34 @@ class get_task(gdb.Function):
     Because we stopped Scylla while it was idle, we don't expect to find
     any ready task with get_local_tasks(), but we can find one with a
     find_vptrs() loop. I noticed that a nice one (with multiple tasks chained
-    to it for "scylla fiber") is one from http_server::do_accept_one.
+    to it for "scylla fiber") is one from http_server's accept loop.
+
+    Current seastar: accept_loop/do_accept_one are coroutines. find_vptrs()
+    picks up the coroutine frame via its resume function pointer (first
+    word). The task (promise_type) lives at offset +16 in the frame,
+    after the resume and destroy function pointers.
+
+    Older seastar: do_accept_one uses .then() chains, producing
+    seastar::continuation objects (which are tasks directly).
     """
     def __init__(self):
         super(get_task, self).__init__('get_task')
 
     def invoke(self):
+        continuation_task = None
         for obj_addr, vtable_addr in find_vptrs():
-            name = resolve(vtable_addr, startswith='vtable for seastar::continuation')
-            if name and 'do_accept_one' in name:
-                return obj_addr.cast(gdb.lookup_type('uintptr_t'))
+            name = resolve(vtable_addr)
+            if not name:
+                continue
+            # New seastar: accept_loop is a coroutine
+            if 'accept_loop' in name:
+                return (obj_addr + 16).cast(gdb.lookup_type('uintptr_t'))
+            # Old seastar: continuation with do_accept_one
+            if continuation_task is None \
+                    and name.startswith('vtable for seastar::continuation') \
+                    and 'do_accept_one' in name:
+                continuation_task = obj_addr.cast(gdb.lookup_type('uintptr_t'))
+        return continuation_task
 
 
 class get_coroutine(gdb.Function):

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -196,7 +196,7 @@ class scylla_rest_client {
     sstring _host;
     uint16_t _port;
     sstring _host_name;
-    http::experimental::client _api_client;
+    http::client _api_client;
 
     std::vector<api_request> _request_history;
 

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -229,7 +229,7 @@ class utils::gcp::storage::client::impl {
     std::optional<google_credentials> _credentials;
     seastar::semaphore _unlimited;
     seastar::semaphore& _limits;
-    seastar::http::experimental::client _client;
+    seastar::http::client _client;
     shared_ptr<seastar::tls::certificate_credentials> _certs;
     future<> authorize(request_wrapper& req, const std::string& scope);
 public:
@@ -261,7 +261,7 @@ utils::gcp::storage::client::impl::impl(const utils::http::url_info& url, std::o
     , _credentials(std::move(c))
     , _unlimited(std::numeric_limits<ssize_t>::max())
     , _limits(memory ? *memory : _unlimited)
-    , _client(std::make_unique<utils::http::dns_connection_factory>(url.host, url.port, url.is_https(), gcp_storage, certs), 100, seastar::http::experimental::client::retry_requests::yes)
+    , _client(std::make_unique<utils::http::dns_connection_factory>(url.host, url.port, url.is_https(), gcp_storage, certs), 100, seastar::http::client::retry_requests::yes)
 {}
 
 utils::gcp::storage::client::impl::impl(std::string_view endpoint, std::optional<google_credentials> c, seastar::semaphore* memory, shared_ptr<seastar::tls::certificate_credentials> certs)

--- a/utils/gcp/object_storage_retry_strategy.hh
+++ b/utils/gcp/object_storage_retry_strategy.hh
@@ -15,7 +15,7 @@ namespace utils::gcp::storage {
 // GCP object storage retry strategy
 // General guidelines https://docs.cloud.google.com/storage/docs/retry-strategy
 
-class object_storage_retry_strategy : public seastar::http::experimental::retry_strategy {
+class object_storage_retry_strategy : public seastar::http::retry_strategy {
 protected:
     unsigned _max_retries;
     mutable exponential_backoff_retry _exr;

--- a/utils/http.hh
+++ b/utils/http.hh
@@ -20,7 +20,7 @@ namespace utils::http {
 
 future<shared_ptr<tls::certificate_credentials>> system_trust_credentials();
 
-class dns_connection_factory : public seastar::http::experimental::connection_factory {
+class dns_connection_factory : public seastar::http::connection_factory {
 protected:
     std::string _host;
     int _port;

--- a/utils/rest/client.cc
+++ b/utils/rest/client.cc
@@ -82,7 +82,7 @@ seastar::future<> rest::httpclient::send(const handler_func& f, seastar::abort_s
 
     // NOTE: similar to utils::http::dns_connection_factory, but that type does
     // not properly handle numeric hosts (don't validate certs for those)
-    class my_connection_factory : public http::experimental::connection_factory {
+    class my_connection_factory : public http::connection_factory {
         socket_address _addr;
         shared_ptr<tls::certificate_credentials> _creds;
         tls::tls_options _tls_options;
@@ -104,7 +104,7 @@ seastar::future<> rest::httpclient::send(const handler_func& f, seastar::abort_s
         }
     };
 
-    http::experimental::client client(std::make_unique<my_connection_factory>(socket_address(addr, _port), _creds, _tls_options, _host));
+    http::client client(std::make_unique<my_connection_factory>(socket_address(addr, _port), _creds, _tls_options, _host));
 
     std::exception_ptr p;
     try {
@@ -125,11 +125,11 @@ seastar::future<> rest::httpclient::send(const handler_func& f, seastar::abort_s
     }
 }
 
-seastar::future<> rest::simple_send(seastar::http::experimental::client& client, seastar::http::request& req, const handler_func_ex& f, seastar::abort_source* as) {
+seastar::future<> rest::simple_send(seastar::http::client& client, seastar::http::request& req, const handler_func_ex& f, seastar::abort_source* as) {
     co_await simple_send(client, req, f, nullptr, as);
 }
 
-seastar::future<> rest::simple_send(seastar::http::experimental::client& client, seastar::http::request& req, const handler_func_ex& f, const http::experimental::retry_strategy* strategy, seastar::abort_source* as) {
+seastar::future<> rest::simple_send(seastar::http::client& client, seastar::http::request& req, const handler_func_ex& f, const http::retry_strategy* strategy, seastar::abort_source* as) {
     if (as) {
         as->check();
     }

--- a/utils/rest/client.hh
+++ b/utils/rest/client.hh
@@ -113,8 +113,8 @@ private:
 
 using handler_func_ex = std::function<future<>(const seastar::http::reply&, seastar::input_stream<char>&)>;
 
-seastar::future<> simple_send(seastar::http::experimental::client&, seastar::http::request&, const handler_func_ex&, seastar::abort_source* = nullptr);
-seastar::future<> simple_send(seastar::http::experimental::client&, seastar::http::request&, const handler_func_ex&, const http::experimental::retry_strategy* strategy, seastar::abort_source* = nullptr);
+seastar::future<> simple_send(seastar::http::client&, seastar::http::request&, const handler_func_ex&, seastar::abort_source* = nullptr);
+seastar::future<> simple_send(seastar::http::client&, seastar::http::request&, const handler_func_ex&, const http::retry_strategy* strategy, seastar::abort_source* = nullptr);
 
 // Interface for redacting sensitive data from HTTP requests and responses before logging.
 class http_log_filter {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -83,7 +83,7 @@ future<> ignore_reply(const http::reply& rep, input_stream<char>&& in_) {
     co_await util::skip_entire_stream(in);
 }
 
-client::client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<http::experimental::retry_strategy> rs)
+client::client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<http::retry_strategy> rs)
         : _host(std::move(host))
         , _cfg(std::move(cfg))
         , _creds_sem(1)
@@ -153,7 +153,7 @@ shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, s
     return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{});
 }
 
-shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, semaphore& mem, std::unique_ptr<http::experimental::retry_strategy> rs, global_factory gf) {
+shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, semaphore& mem, std::unique_ptr<http::retry_strategy> rs, global_factory gf) {
     return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{}, std::move(rs));
 }
 
@@ -233,7 +233,7 @@ future<semaphore_units<>> client::claim_memory(size_t size, abort_source* as) {
     return get_units(_memory, size);
 }
 
-client::group_client::group_client(std::unique_ptr<http::experimental::connection_factory> f, unsigned max_conn) : http(std::move(f), max_conn) {
+client::group_client::group_client(std::unique_ptr<http::connection_factory> f, unsigned max_conn) : http(std::move(f), max_conn) {
 }
 
 void client::group_client::register_metrics(std::string class_name, std::string host) {
@@ -329,8 +329,8 @@ client::group_client& client::find_or_create_client() {
     }
 }
 
-http::experimental::client::reply_handler client::wrap_handler(http::request& request,
-                                                               http::experimental::client::reply_handler handler,
+http::client::reply_handler client::wrap_handler(http::request& request,
+                                                               http::client::reply_handler handler,
                                                                std::optional<http::reply::status_type> expected) {
     return [this, &request, expected, handler = std::move(handler)](const http::reply& rep, input_stream<char>&& in) -> future<> {
         auto _in = std::move(in);
@@ -383,7 +383,7 @@ http::experimental::client::reply_handler client::wrap_handler(http::request& re
 }
 
 future<> client::make_request(http::request req,
-                              http::experimental::client::reply_handler handle,
+                              http::client::reply_handler handle,
                               std::optional<http::reply::status_type> expected,
                               seastar::abort_source* as) {
     return make_request(
@@ -393,8 +393,8 @@ future<> client::make_request(http::request req,
 }
 
 future<> client::make_request(http::request req,
-                              http::experimental::client::reply_handler handle,
-                              const http::experimental::retry_strategy& rs,
+                              http::client::reply_handler handle,
+                              const http::retry_strategy& rs,
                               error_handler err_handler,
                               std::optional<http::reply::status_type> expected,
                               seastar::abort_source* as) {
@@ -410,7 +410,7 @@ future<> client::make_request(http::request req,
 
 future<> client::make_request(http::request req,
                               reply_handler_ext handle_ex,
-                              const http::experimental::retry_strategy& rs,
+                              const http::retry_strategy& rs,
                               error_handler err_handler,
                               std::optional<http::reply::status_type> expected,
                               seastar::abort_source* as) {
@@ -428,7 +428,7 @@ future<> client::make_request(http::request req, reply_handler_ext handle_ex, st
         }, expected, as);
 }
 
-future<> client::get_object_header(sstring object_name, http::experimental::client::reply_handler handler, seastar::abort_source* as) {
+future<> client::get_object_header(sstring object_name, http::client::reply_handler handler, seastar::abort_source* as) {
     s3l.trace("HEAD {}", object_name);
     auto req = http::request::make("HEAD", _host, object_name);
     return make_request(std::move(req), std::move(handler), http::reply::status_type::ok, as);
@@ -1302,7 +1302,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
     }
 
     future<> make_filling_fiber() {
-        seastar::http::experimental::no_retry_strategy no_retry;
+        seastar::http::no_retry_strategy no_retry;
         s3l.trace("Fiber starts cycle for object '{}'", _object_name);
         while (!_is_finished) {
             try {

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -131,20 +131,20 @@ class client : public enable_shared_from_this<client> {
         }
     };
     struct group_client {
-        seastar::http::experimental::client http;
+        seastar::http::client http;
         io_stats read_stats;
         io_stats write_stats;
         uint64_t prefetch_bytes = 0;
         uint64_t downloads_blocked_on_memory = 0;
         seastar::metrics::metric_groups metrics;
-        group_client(std::unique_ptr<http::experimental::connection_factory> f, unsigned max_conn);
+        group_client(std::unique_ptr<http::connection_factory> f, unsigned max_conn);
         void register_metrics(std::string class_name, std::string host);
     };
     std::unordered_map<seastar::scheduling_group, group_client> _https;
     using global_factory = std::function<shared_ptr<client>(std::string)>;
     global_factory _gf;
     semaphore& _memory;
-    std::unique_ptr<seastar::http::experimental::retry_strategy> _retry_strategy;
+    std::unique_ptr<seastar::http::retry_strategy> _retry_strategy;
 
     struct private_tag {};
 
@@ -157,17 +157,17 @@ class client : public enable_shared_from_this<client> {
     using error_handler = std::function<void(std::exception_ptr)>;
     using reply_handler_ext = noncopyable_function<future<>(group_client&, const http::reply&, input_stream<char>&& body)>;
 
-    http::experimental::client::reply_handler wrap_handler(http::request& request,
-                                                           http::experimental::client::reply_handler handler,
+    http::client::reply_handler wrap_handler(http::request& request,
+                                                           http::client::reply_handler handler,
                                                            std::optional<http::reply::status_type> expected);
 
     future<> make_request(http::request req,
-                          http::experimental::client::reply_handler handle = ignore_reply,
+                          http::client::reply_handler handle = ignore_reply,
                           std::optional<http::reply::status_type> expected = std::nullopt,
                           seastar::abort_source* = nullptr);
     future<> make_request(http::request req,
-                          http::experimental::client::reply_handler handle,
-                          const http::experimental::retry_strategy& rs,
+                          http::client::reply_handler handle,
+                          const http::retry_strategy& rs,
                           error_handler err_handler,
                           std::optional<http::reply::status_type> expected,
                           seastar::abort_source* as);
@@ -178,16 +178,16 @@ class client : public enable_shared_from_this<client> {
                           seastar::abort_source* = nullptr);
     future<> make_request(http::request req,
                           reply_handler_ext handle,
-                          const seastar::http::experimental::retry_strategy& rs,
+                          const seastar::http::retry_strategy& rs,
                           error_handler err_handler,
                           std::optional<http::reply::status_type> expected = std::nullopt,
                           seastar::abort_source* = nullptr);
-    future<> get_object_header(sstring object_name, http::experimental::client::reply_handler handler, seastar::abort_source* = nullptr);
+    future<> get_object_header(sstring object_name, http::client::reply_handler handler, seastar::abort_source* = nullptr);
 public:
 
-    client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<seastar::http::experimental::retry_strategy> rs = nullptr);
+    client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<seastar::http::retry_strategy> rs = nullptr);
     static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, global_factory gf = {});
-    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, std::unique_ptr<seastar::http::experimental::retry_strategy> rs, global_factory gf = {});
+    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, std::unique_ptr<seastar::http::retry_strategy> rs, global_factory gf = {});
     static shared_ptr<client> make(std::string url, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf = {});
 
     future<uint64_t> get_object_size(sstring object_name, seastar::abort_source* = nullptr);

--- a/utils/s3/credentials_providers/instance_profile_credentials_provider.cc
+++ b/utils/s3/credentials_providers/instance_profile_credentials_provider.cc
@@ -32,7 +32,7 @@ future<> instance_profile_credentials_provider::reload() {
 static constexpr auto EC2_SECURITY_CREDENTIALS_RESOURCE = "/latest/meta-data/iam/security-credentials";
 
 future<> instance_profile_credentials_provider::update_credentials() {
-    http::experimental::client http_client(std::make_unique<utils::http::dns_connection_factory>(ec2_metadata_ip, port, false, ec2_md_logger),
+    http::client http_client(std::make_unique<utils::http::dns_connection_factory>(ec2_metadata_ip, port, false, ec2_md_logger),
                                            1,
                                            1_MiB,
                                            std::make_unique<default_aws_retry_strategy>());

--- a/utils/s3/credentials_providers/sts_assume_role_credentials_provider.cc
+++ b/utils/s3/credentials_providers/sts_assume_role_credentials_provider.cc
@@ -44,7 +44,7 @@ future<> sts_assume_role_credentials_provider::update_credentials() {
     req.set_query_param("Action", "AssumeRole");
     req.set_query_param("RoleSessionName", format("{}", utils::make_random_uuid()));
     req.set_query_param("RoleArn", role_arn);
-    http::experimental::client http_client(
+    http::client http_client(
         std::make_unique<utils::http::dns_connection_factory>(sts_host, port, is_secured, sts_logger), 1, 1024, std::make_unique<default_aws_retry_strategy>());
     co_await http_client.make_request(
         std::move(req),

--- a/utils/s3/default_aws_retry_strategy.cc
+++ b/utils/s3/default_aws_retry_strategy.cc
@@ -13,12 +13,12 @@
 #include <seastar/util/short_streams.hh>
 #include "utils/log.hh"
 
-namespace seastar::http::experimental {
+namespace seastar::http {
 extern logging::logger rs_logger;
 }
 
 using namespace std::chrono_literals;
-using namespace seastar::http::experimental;
+using namespace seastar::http;
 
 namespace aws {
 

--- a/utils/s3/default_aws_retry_strategy.hh
+++ b/utils/s3/default_aws_retry_strategy.hh
@@ -13,7 +13,7 @@ namespace aws {
 
 class aws_error;
 
-class default_aws_retry_strategy : public seastar::http::experimental::retry_strategy {
+class default_aws_retry_strategy : public seastar::http::retry_strategy {
 protected:
     unsigned _max_retries;
 

--- a/vector_search/client.cc
+++ b/vector_search/client.cc
@@ -65,7 +65,7 @@ bool is_request_aborted(std::exception_ptr& err) {
     return try_catch<abort_requested_exception>(err) != nullptr;
 }
 
-class client_connection_factory : public http::experimental::connection_factory {
+class client_connection_factory : public http::connection_factory {
     client::endpoint_type _endpoint;
     shared_ptr<tls::certificate_credentials> _creds;
 

--- a/vector_search/client.hh
+++ b/vector_search/client.hh
@@ -67,7 +67,7 @@ private:
     std::chrono::milliseconds backoff_retry_max() const;
 
     endpoint_type _endpoint;
-    seastar::http::experimental::client _http_client;
+    seastar::http::client _http_client;
     seastar::future<> _checking_status_future = seastar::make_ready_future();
     seastar::abort_source _as;
     logging::logger& _logger;


### PR DESCRIPTION
Changed seastar::http::experimental to seastar::http to reflect graduation of the seastar http API.

Changed call to seastar::rename_file() (in sstables/storage.cc, sstables/sstable_directory.cc, sstable/sstables.cc and db/hints/internal/hint_storage.cc) to reflect new default parameter.

Updated scylla_gdb test helper get_task() to work with updated
accept loop in Seatar. This is just test code (attempts to find
a task to operate on), not used in real scylla-gdb.py work, but
nevertheless the adjustment keeps backward compatibility.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1798
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2043

* seastar 485a62b2...510f3148 (43):
  > reactor_backend: fix iocb double-free and shutdown hang during AIO teardown
  > file: fix default DMA alignment
  > http: add to_reply() to redirect_exception with extra-header support
  > core: propagate syscall errors via `coroutine::exception`
  > file: assert dma alignments are powers of two
  > doc: Document undocumented io_tester features and fix output example
  > backtrace: print the build_id along with the backtrace
  > reactor: default to oneline backtraces
  > Merge 'json: formatter: support types with user-defined conversion to sstring' from Benny Halevy
    tests: json_formatter: test formatter::write with string types
    json: formatter: support types with user-defined conversion to sstring
  > httpd_test: fix build failure with Seastar_SSTRING=OFF
  > net/tls: introduce ssl_call wrapper for SSL I/O
  > build: disable unused command line argument error for C++ module
  > coroutine/generator: fix setup of generator's waiting task
  > tests/tls: set 1000-day validity for self-signed CA cert
  > net: tls: openssl: disable certificate compression
  > reactor: reduce steady_clock::now() calls per scheduling quantum
  > fair_queue: remove notify_request_finished()
  > loop: use small_vector for parallel_for_each_state incomplete futures
  > dodge false sharing in spinlock
  > Merge 'Handle nowait support for reads and writes independently' from Pavel Emelyanov
    file: Change nowait_works mode detection
    file: Introduce read-only nowait_mode
    filesystem: Make nowait_works bit a enum class too
    file: Make nowait_works bit a enum class
  > Merge 'net/tls: improve OpenSSL error queue hygiene' from Gellért Peresztegi-Nagy
    net/tls: assert clean error queue before SSL operations
    net/tls: clear error queue after successful SSL operations
    net/tls: clear error queue after successful SSL_CTX_new
    net/tls: drain error queue on unexpected error codes
    net/tls: use make_openssl_error for BIO creation failure
  > vla.hh: add missing includes
  > Merge 'smp: make smp::count non-static' from Avi Kivity
    smp: convert all smp::count usages to instance-aware alternatives
    smp: add per-instance shard_count and this_smp() infrastructure
    disk_params: document pre-init smp::count access with explicit 0
    reactor_backend: document pre-init smp::count access with explicit 0
    tests: alien_test: pass shard count to alien thread explicitly
  > build: fix cmake missing ninja on Ubuntu 26.04
  > rpc: Fix uint64 wraparound of expired timeout in send_entry()
  > Merge 'Generalize some RPC tests' from Pavel Emelyanov
    tests: Generalize async connection-based scheduling RPC tests
    tests: Generalize sync connection-based scheduling RPC tests
    tests: Remove redundant variadic/nonvariadic RPC tuple tests
    tests: Generalize max timeout RPC tests
  > net: tls: openssl: Share BIO ptrs across shards
  > http: fix compilation on clang 22 with c++26
  > build: openssl tools needed for test cert generation
  > reactor: support rename2
  > future: fix forwarding of reference types
  > Merge 'Zero-copy http chunked data sink' from Pavel Emelyanov
    http: Make chunked data sink zero-copy
    tests/prometheus_http: Rewrite on top of http::client
    tests/httpd: Rewrite content_length_limit on top of http::client
  > tests: Replace ad-hoc http_consumer with production HTTP parser
  > Merge 'co_return to accept same expressions and types as return' from Alexey Bashtanov
    tests/unit/{coroutines,futures}: strict types on co_return and set_value
    api: introduce version 10:
    core/{coroutine,future}: make `co_return` more strict with types
    core/{coroutine,future}: preparations to fix `co_return` type semantics
  > Merge 'Perftune.py: add special handling for mlx5 rss queues number calculation' from Vladislav Zolotarov
    perftune.py: NetPerfTuner: enhance RSS (a.k.a. "Rx") queues accounting for mlx5 devices
    perftune.py: update docstring of NetPerfTuner.__get_rps_cpus() method
    perftune.py: add a method that parses and models the output of the 'ethtool -l' command for a given interface
  > httpd: rewrite do_accepts/do_accept_one as coroutines
  > file: add mmap support to file
  > http: Move client code out of experimental namespace
  > file: add hugetlbfs support to file system detection
  > tests: Replace test_source_impl with util::as_input_stream
  > tests: Replace buf_source_impl with util::as_input_stream
  > Merge 'rpc_tester: expose throuput for rpc tester' from Marcin Szopa
    rpc_tester: remove unused payload size variable from job_rpc_streaming class
    rpc_tester: add start time tracking for throughput calculation, print throughput and msg/s for job_rpc
    rpc_tester: refactor result emission to use dedicated functions for messages and throughput
  > iostream: cast first argument of `std::min` to `size_t`

Not backporting the entire commit. Two seastar commits need to be backported, will be handled manually.
