### PR TITLE
test: cluster: Deflake strongly consistent shutdown tests

### DIFF
--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -129,6 +129,7 @@ void raft_group_registry::init_rpc_verbs() {
         return handle_raft_rpc(cinfo, gid, from, dst, [from, append_request = std::move(append_request), original_shard_id = this_shard_id(), gid] (raft_rpc& rpc) mutable {
             if (auto ignore_group_id = utils::get_local_injector().inject_parameter<std::string_view>("raft_drop_incoming_append_entries_for_specified_group"); ignore_group_id) {
                 if (gid == raft::group_id{utils::UUID(*ignore_group_id)}) {
+                    rslog.debug("Dropping append request (size: {}) from {} for group {}", append_request.entries.size(), from, gid);
                     return;
                 }
             }

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -1053,127 +1053,19 @@ async def test_queries_while_dropping_table(manager: ManagerClient):
 
 
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
-async def test_queries_when_shutting_down(manager: ManagerClient):
+@pytest.mark.parametrize("target", ["leader", "follower"])
+async def test_queries_when_shutting_down(manager: ManagerClient, target: str):
     """
-    A simple test verifying that pending reads and writes are canceled
-    when the node starts shutting down.
+    Verify that Scylla has be stopped despite hanging opeartions
+    to strongly consistent tables. The test drops AppendEntries
+    requests on the followers to simulate a hanging call to
+    raft_server::add_entry.
 
-    The potential cause of the hanging we're testing here comes from being
-    stuck at a Raft operation when reading from strongly consistent table.
-    """
+    The read path is more difficult to verify and it's under active
+    work, so we skip it. It uses the same abortion mechanisms
+    as the write path, though.
 
-    smp = 2
-    config = DEFAULT_CONFIG | {"request_timeout_on_shutdown_in_seconds": 1}
-    cmdline = DEFAULT_CMDLINE + [
-        f"--smp={smp}",
-        "--logger-log-level", "cql_server=debug",
-        "--logger-log-level", "sc_coordinator=trace"
-    ]
-
-    servers = await manager.servers_add(3, config=config, cmdline=cmdline, auto_rack_dc="dc1")
-    cql, hosts = await manager.get_ready_cql(servers)
-
-    async def pick_leader_info(host_id: HostID) -> Tuple[Host, ServerInfo]:
-        for host, server in zip(hosts, servers):
-            srv_host_id = await manager.get_host_id(server.server_id)
-            if srv_host_id == host_id:
-                return (host, server)
-        raise RuntimeError(f"Can't find host for host_id {host_id}")
-
-    async def get_leader(keyspace: str, table: str) -> Tuple[Host, ServerInfo]:
-        logger.info("Select raft group id for the tablet")
-        group_id = await get_table_raft_group_id(manager, keyspace, table)
-
-        logger.info(f"Get current leader for the group {group_id}")
-        leader_host_id = await wait_for_leader(manager, servers[0], group_id)
-
-        logger.info(f"Leader of group {group_id} is {leader_host_id}")
-
-        leader_host, leader_info = await pick_leader_info(leader_host_id)
-        logger.info(f"Further information on leader of group {group_id}: server_id={leader_info.server_id}, ip={leader_info.ip_addr}")
-
-        return (leader_host, leader_info)
-
-    prevent_read_injection = "sc_coordinator_wait_before_query_read_barrier"
-    prevent_write_injection = "sc_coordinator_wait_before_add_entry"
-
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
-        async with new_test_table(manager, ks, "pk int PRIMARY KEY, v int") as table:
-            _, table_name = table.split(".")
-            leader_host, leader_info = await get_leader(ks, table_name)
-
-            log = await manager.server_open_log(leader_info.server_id)
-            mark = await log.mark()
-
-            await asyncio.gather(*[
-                asyncio.create_task(manager.api.enable_injection(leader_info.ip_addr, prevent_read_injection, one_shot=True)),
-                asyncio.create_task(manager.api.enable_injection(leader_info.ip_addr, prevent_write_injection, one_shot=True))
-            ])
-
-            read_fut = cql.run_async(f"SELECT * FROM {table} WHERE pk = 0", host=leader_host)
-            write_fut = cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)", host=leader_host)
-
-            await asyncio.gather(*[
-                asyncio.create_task(log.wait_for(prevent_read_injection, from_mark=mark)),
-                asyncio.create_task(log.wait_for(prevent_write_injection, from_mark=mark))
-            ])
-
-            mark = await log.mark()
-            stop_fut = asyncio.create_task(manager.server_stop_gracefully(leader_info.server_id))
-            
-            delta = 0.1
-            timeout = 60
-
-            # We don't know which shard coordiantes the request,
-            # so we need to wait for all of them
-            while delta < timeout:
-                matches = await log.grep(r"generic_server::shutdown completed", from_mark=mark)
-                if len(matches) >= smp:
-                    break
-                logger.debug(f"Grepped matches={matches}")
-                await asyncio.sleep(delta)
-                delta *= 2
-            if delta >= timeout:
-                pytest.fail("Exceeded timeout")
-
-            mark = await log.mark()
-
-            await asyncio.gather(*[
-                asyncio.create_task(manager.api.message_injection(leader_info.ip_addr, prevent_read_injection)),
-                asyncio.create_task(manager.api.message_injection(leader_info.ip_addr, prevent_write_injection))
-            ])
-
-            await asyncio.gather(*[
-                asyncio.create_task(log.wait_for(rf"mutate\(\): request timed out with error .*, table {table}", from_mark=mark)),
-                asyncio.create_task(log.wait_for(rf"query\(\): request timed out with error .*, table {table}", from_mark=mark))
-            ])
-
-            # We cannot predict what the result of the query is going to be.
-            # Technically, we could ensure either outcome, but it requires
-            # playing with more error injections. We don't really care about
-            # the result (the test just wants to make sure we stop the node
-            # fast enough), so let's just log it and call it a day.
-            try:
-                await read_fut
-                logger.debug("The read ended successfully")
-            except Exception as e:
-                logger.debug(f"The read ended in an exception: {e}")
-                pass
-            try:
-                await write_fut
-                logger.debug("The write ended successfully")
-            except Exception as e:
-                logger.debug(f"The write ended in an exception: {e}")
-                pass
-
-            await stop_fut
-
-
-@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
-async def test_abort_forwarded_write_upon_shutdown(manager: ManagerClient):
-    """
-    Test verifying that forwarded writes to strongly consistent tables are
-    aborted upon the shutdown of the target replica.
+    We test writes sent to both the coordinator and a follower.
     """
 
     smp = 2
@@ -1181,86 +1073,70 @@ async def test_abort_forwarded_write_upon_shutdown(manager: ManagerClient):
     cmdline = DEFAULT_CMDLINE + [
         f"--smp={smp}",
         "--logger-log-level", "cql_server=debug",
-        "--logger-log-level", "sc_coordinator=trace"
+        "--logger-log-level", "sc_coordinator=trace",
+        "--logger-log-level", "raft_group_registry=debug"
     ]
+    leader = await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r1"})
 
-    servers = await manager.servers_add(3, config=config, cmdline=cmdline, auto_rack_dc="dc1")
-    cql, hosts = await manager.get_ready_cql(servers)
+    follower_config = config | {"error_injections_at_startup": ["avoid_being_raft_leader"]}
+    followers = await manager.servers_add(2, config=follower_config, cmdline=cmdline, property_file=[
+        {"dc": "dc1", "rack": "r2"},
+        {"dc": "dc1", "rack": "r3"}
+    ])
 
-    async def pick_leader_info(host_id: HostID) -> Tuple[Host, ServerInfo]:
-        for host, server in zip(hosts, servers):
-            srv_host_id = await manager.get_host_id(server.server_id)
-            if srv_host_id == host_id:
-                return (host, server)
-        raise RuntimeError(f"Can't find host for host_id {host_id}")
+    cql, hosts = await manager.get_ready_cql([leader, *followers])
 
-    async def get_leader(keyspace: str, table: str) -> Tuple[Host, ServerInfo]:
-        logger.info("Select raft group id for the tablet")
-        group_id = await get_table_raft_group_id(manager, keyspace, table)
-
-        logger.info(f"Get current leader for the group {group_id}")
-        leader_host_id = await wait_for_leader(manager, servers[0], group_id)
-
-        logger.info(f"Leader of group {group_id} is {leader_host_id}")
-
-        leader_host, leader_info = await pick_leader_info(leader_host_id)
-        logger.info(f"Further information on leader of group {group_id}: server_id={leader_info.server_id}, ip={leader_info.ip_addr}")
-
-        return (leader_host, leader_info)
-
-    prevent_write_injection = "sc_coordinator_wait_before_add_entry"
+    leader_host = hosts[0]
+    nonleader_host = hosts[1]
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
         async with new_test_table(manager, ks, "pk int PRIMARY KEY, v int") as table:
             _, table_name = table.split(".")
-            leader_host, leader_info = await get_leader(ks, table_name)
 
-            nonleader_host, nonleader_info = next((host, server) for host, server in zip(hosts, servers) if host != leader_host)
-            logger.debug(f"Targetting host={nonleader_host}: server_id={nonleader_info.server_id}, ip={nonleader_info.ip_addr}")
+            logger.info(f"Select raft group id for the tablet of {ks}.{table_name}")
+            group_id = await get_table_raft_group_id(manager, ks, table_name)
 
-            log = await manager.server_open_log(leader_info.server_id)
-            mark = await log.mark()
+            await asyncio.gather(*[asyncio.create_task(manager.api.enable_injection(
+                follower.ip_addr,
+                "raft_drop_incoming_append_entries_for_specified_group",
+                one_shot=False,
+                parameters={"value": group_id}
+            )) for follower in followers])
 
-            await manager.api.enable_injection(leader_info.ip_addr, prevent_write_injection, one_shot=True)
+            logs = [await manager.server_open_log(follower.server_id) for follower in followers]
+            marks = [await log.mark() for log in logs]
 
-            # Send the mutation to a NON-leader.
-            write_fut = cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)", host=nonleader_host)
+            target_host = None
+            if target == "leader":
+                target_host = leader_host
+            elif target == "follower":
+                target_host = nonleader_host
+            write_fut = cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)", host=target_host)
 
-            await log.wait_for(prevent_write_injection, from_mark=mark)
-            mark = await log.mark()
+            error_log = rf"Dropping append request .* for group {group_id}"
+            await gather_safely(*[
+                asyncio.create_task(logs[0].wait_for(error_log, from_mark=marks[0])),
+                asyncio.create_task(logs[1].wait_for(error_log, from_mark=marks[1]))
+            ])
 
-            stop_fut = asyncio.create_task(manager.server_stop_gracefully(leader_info.server_id))
+            await manager.server_stop_gracefully(leader.server_id)
 
-            delta = 0.1
-            timeout = 60
-
-            # We don't know which shard coordiantes the request,
-            # so we need to wait for all of them
-            while delta < timeout:
-                matches = await log.grep(r"generic_server::shutdown completed", from_mark=mark)
-                if len(matches) >= smp:
-                    break
-                logger.debug(f"Grepped matches={matches}")
-                await asyncio.sleep(delta)
-                delta *= 2
-            if delta >= timeout:
-                pytest.fail("Exceeded timeout")
-
-            mark = await log.mark()
-
-            await manager.api.message_injection(leader_info.ip_addr, prevent_write_injection)
-            await log.wait_for(rf"mutate\(\): request timed out with error .*, table {table}")
-
-            # It doesn't matter what the outcome is, but let's await the future
-            # (as we should) and log the result.
             try:
-                await write_fut
-                logger.debug("The write ended successfully")
+                await asyncio.wait_for(write_fut, timeout=60)
+                logger.debug(f"Write awaited successfully")
             except Exception as e:
-                logger.debug(f"The write ended in an exception: {e}")
-                pass
+                # Acceptable. It doesn't matter what the result is.
+                logger.debug(f"Exception when awaiting write: {e}")
 
-            await stop_fut
+            # We need to disable the injections to be able to drop the keyspace and table.
+            await asyncio.gather(*[asyncio.create_task(manager.api.disable_injection(
+                follower.ip_addr,
+                "raft_drop_incoming_append_entries_for_specified_group"
+            )) for follower in followers])
+            await asyncio.gather(*[asyncio.create_task(manager.api.disable_injection(
+                follower.ip_addr,
+                "avoid_being_raft_leader"
+            )) for follower in followers])
 
 
 @pytest.mark.skip_bug(reason="SCYLLADB-1056")


### PR DESCRIPTION
We observed a failure of the test: test_queries_when_shutting_down.
The following instruction:

```
await asyncio.gather(*[
    asyncio.create_task(manager.api.message_injection(leader_info.ip_addr, prevent_read_injection)),
    asyncio.create_task(manager.api.message_injection(leader_info.ip_addr, prevent_write_injection))
])
```

timed out. The leader observed the logs corresponding to the read, but
not to the write.

---

There were a number of reasons that led to it:

* The Raft servers used in strong consistency have forwarding disabled.
* Because forwarding is disabled, the call to raft::server::add_entry
  enters its "short branch".
* Between messaging the error injection and messaging shutdown, there's
  a 30 ms window. Within this interval, the Raft leader could
  successfully replicate the entry to a follower and commit it.

The scenario could be summarised like this:

1. The leader performs add_entry_on_leader. It returns a ready future
   and yields.
2. The leader sends an RPC to its followers. Messaging is still alive,
   and it succeeds.
3. A follower receives the entry, persists it, and sends a confirmation
   to the leader.
4. The leader picks up the reply, processes it, and advances its commit
   index.
5. Eventually, the coroutine add_entry is resumed, and wait_for_entry
   returns successfully.

---

The truth is that we cannot predict the result of the write. Depending
on the timing, it may succeed or it may fail.

That's not the case for reads, though. When we enter read_barrier, we
immediately check if the provided abort source has been triggered. Since
the abort source is triggered by the time we message the error
injection, reads should not introduce flakiness in the test.

---

We fix the test by moving to a more reliable mechanism. Instead of an
artificial sleep before a call to add_entry, we execute it but force
the followers to drop incoming messages for that Raft group. This way,
the coordinator waits indefinitely long.

We give up on the read path. It's under active development and to
adjust the test, we'd need to either duplicate it, or implement very
artificial workarounds.

---

Lastly, we have a complementary test for forwarded requests,
test_abort_forwarded_write_upon_shutdown. It suffers from the very same
problems, though it hasn't produced a failure yet. We merge both tests
into one and parametrize it. The parametrization is useful because it
isolates AppendEntries requests sent to the followers.

Fixes SCYLLADB-2060

Backport: This PR stabilizes CI and it only fixes a test. There's no risk in backporting the changes, so we want to do it for all supported versions where the test is present (so only 2026.2).