### PR TITLE
replica: Fix use-after-free in get_sstables_from_object_store

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -237,9 +237,9 @@ distributed_loader::get_sstables_from_upload_dir(sharded<replica::database>& db,
 
 future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
 distributed_loader::get_sstables_from_object_store(sharded<replica::database>& db, sstring ks, sstring cf, std::vector<sstring> sstables, sstring endpoint, sstring type, sstring bucket, sstring prefix, sstables::sstable_open_config cfg, std::function<seastar::abort_source*()> get_abort_src) {
-    return get_sstables_from(db, ks, cf, cfg, [bucket, endpoint, type, prefix, sstables=std::move(sstables), &get_abort_src] (auto& global_table, auto& directory) {
+    return get_sstables_from(db, ks, cf, cfg, [bucket, endpoint, type, prefix, sstables=std::move(sstables), get_abort_src] (auto& global_table, auto& directory) {
         return directory.start(global_table.as_sharded_parameter(),
-            sharded_parameter([bucket, endpoint, type, prefix, &get_abort_src] {
+            sharded_parameter([bucket, endpoint, type, prefix, get_abort_src] {
                 seastar::abort_source* as = get_abort_src ? get_abort_src() : nullptr;
                 auto opts = data_dictionary::make_object_storage_options(endpoint, type, bucket, prefix, as);
                 return make_lw_shared<const data_dictionary::storage_options>(std::move(opts));


### PR DESCRIPTION
The lambdas inside get_sstables_from_object_store captured get_abort_src by reference, but get_abort_src is a by-value function parameter living on the stack frame of get_sstables_from_object_store. Since the outer lambda is moved into seastar::async via get_sstables_from and executed after get_sstables_from_object_store returns, the reference becomes dangling.

Fix by capturing get_abort_src by value (copying the std::function) in both lambdas.

Found by AddressSanitizer: stack-use-after-return at distributed_loader.cc:243.

Fixes SCYLLADB-2172

Only required for tablet-aware-restore, which is work in progress. Not backporting

Prerequisite to fix SCYLLADB-1871 -- the PR will change coroutine frame layout for sstables_loader::download_tablet_sstables calling get_sstables_from_object_store and this dangling reference will surface