### PR TITLE
Alternator vector search: Implement projected columns (for filtering and selecting)

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -68,6 +68,7 @@
 #include "cql3/statements/ks_prop_defs.hh"
 #include "cql3/statements/index_target.hh"
 #include "index/secondary_index.hh"
+#include "index/vector_index.hh"
 #include "alternator/ttl_tag.hh"
 #include "vector_search/vector_store_client.hh"
 #include "utils/simple_value_with_expiry.hh"
@@ -588,9 +589,29 @@ future<rjson::value> executor::fill_table_description(schema_ptr schema, table_s
             rjson::value entry = rjson::empty_object();
             rjson::add(entry, "IndexName", rjson::from_string(im.name()));
             rjson::value vector_attribute = rjson::empty_object();
+            std::vector<std::string> projected_non_key_attrs;
             auto target_it = opts.find(cql3::statements::index_target::target_option_name);
             if (target_it != opts.end()) {
-                rjson::add(vector_attribute, "AttributeName", rjson::from_string(target_it->second));
+                // target option is either a plain attribute name or a JSON object {"tc":...,"fc":[...]}
+                std::string attr_name(target_it->second);
+                if (!attr_name.empty() && attr_name[0] == '{') {
+                    // JSON format: extract "tc" (vector column) and "fc"
+                    // (projected non-key attributes).
+                    try {
+                        auto target_json = rjson::parse(attr_name);
+                        if (const rjson::value* tc = rjson::find(target_json, "tc")) {
+                            attr_name = rjson::to_string(*tc);
+                        }
+                        if (const rjson::value* fc = rjson::find(target_json, "fc"); fc && fc->IsArray()) {
+                            for (const auto& elem : fc->GetArray()) {
+                                if (elem.IsString()) {
+                                    projected_non_key_attrs.emplace_back(rjson::to_string(elem));
+                                }
+                            }
+                        }
+                    } catch (...) {}
+                }
+                rjson::add(vector_attribute, "AttributeName", rjson::from_string(attr_name));
             }
             auto dims_it = opts.find("dimensions");
             if (dims_it != opts.end()) {
@@ -603,10 +624,21 @@ future<rjson::value> executor::fill_table_description(schema_ptr schema, table_s
                 }
             }
             rjson::add(entry, "VectorAttribute", std::move(vector_attribute));
-            // Always return a Projection. Currently only KEYS_ONLY is
-            // supported, so we always return that.
+            // Projection is derived from the target option's "fc" field: a
+            // non-empty fc means INCLUDE with those non-key attributes.
+            // Otherwise KEYS_ONLY. ProjectionType=ALL is not supported
+            // for vector indexes.
             rjson::value projection = rjson::empty_object();
-            rjson::add(projection, "ProjectionType", "KEYS_ONLY");
+            if (!projected_non_key_attrs.empty()) {
+                rjson::add(projection, "ProjectionType", "INCLUDE");
+                rjson::value nka_arr = rjson::empty_array();
+                for (const auto& attr : projected_non_key_attrs) {
+                    rjson::push_back(nka_arr, rjson::from_string(attr));
+                }
+                rjson::add(projection, "NonKeyAttributes", std::move(nka_arr));
+            } else {
+                rjson::add(projection, "ProjectionType", "KEYS_ONLY");
+            }
             rjson::add(entry, "Projection", std::move(projection));
             auto sf_it = opts.find("similarity_function");
             if (sf_it != opts.end()) {
@@ -1348,7 +1380,8 @@ static bool has_vector_index_on_attribute(const schema& s, std::string_view attr
         // LSI are implemented as materialized views, not secondary indexes).
         const auto& opts = im.options();
         auto target_it = opts.find(cql3::statements::index_target::target_option_name);
-        if (target_it != opts.end() && target_it->second == attribute_name) {
+        if (target_it != opts.end() &&
+                secondary_index::vector_index::get_target_column(target_it->second) == attribute_name) {
             return true;
         }
     }
@@ -1628,23 +1661,73 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             }
             int dimensions = get_dimensions(*vector_attribute_v, "VectorIndexes");
             std::string similarity_function = get_similarity_function(v, "VectorIndexes");
-            // The optional Projection parameter is only supported with
-            // ProjectionType=KEYS_ONLY. Other values are not yet supported.
+            // Parse the Projection parameter.
+            // Supported values: KEYS_ONLY (default) and INCLUDE.
+            // ALL is not yet supported (the vector store would need to store the
+            // entire :attrs map blob and dynamically look up any attribute at
+            // query time, which is not yet implemented).
+            // For INCLUDE, NonKeyAttributes must be a list of attribute names.
+            std::string projection_type = "KEYS_ONLY";
+            std::vector<std::string> non_key_attributes;
             const rjson::value* projection_v = rjson::find(v, "Projection");
             if (projection_v) {
                 if (!projection_v->IsObject()) {
                     co_return api_error::validation("VectorIndexes Projection must be an object.");
                 }
                 const rjson::value* projection_type_v = rjson::find(*projection_v, "ProjectionType");
-                if (!projection_type_v || !projection_type_v->IsString() ||
-                        rjson::to_string_view(*projection_type_v) != "KEYS_ONLY") {
-                    co_return api_error::validation("VectorIndexes Projection: only ProjectionType=KEYS_ONLY is currently supported.");
+                if (!projection_type_v || !projection_type_v->IsString()) {
+                    co_return api_error::validation("VectorIndexes Projection: ProjectionType must be a string.");
                 }
+                std::string_view pt = rjson::to_string_view(*projection_type_v);
+                if (pt == "KEYS_ONLY") {
+                    projection_type = "KEYS_ONLY";
+                } else if (pt == "ALL") {
+                    co_return api_error::validation(
+                        "VectorIndexes Projection: ProjectionType=ALL is not yet supported "
+                        "for vector indexes.  Use KEYS_ONLY or INCLUDE instead.");
+                } else if (pt == "INCLUDE") {
+                    projection_type = "INCLUDE";
+                    const rjson::value* nka_v = rjson::find(*projection_v, "NonKeyAttributes");
+                    if (!nka_v || !nka_v->IsArray() || nka_v->Empty()) {
+                        co_return api_error::validation(
+                            "VectorIndexes Projection=INCLUDE requires a non-empty NonKeyAttributes list.");
+                    }
+                    for (const auto& elem : nka_v->GetArray()) {
+                        if (!elem.IsString()) {
+                            co_return api_error::validation(
+                                "VectorIndexes NonKeyAttributes elements must be strings.");
+                        }
+                        non_key_attributes.emplace_back(rjson::to_string_view(elem));
+                    }
+                } else {
+                    co_return api_error::validation(fmt::format(
+                        "VectorIndexes Projection: unsupported ProjectionType '{}'; "
+                        "supported values are KEYS_ONLY and INCLUDE.", pt));
+                }
+            }
+            // Build the target option: if we have non-key projected attributes (INCLUDE),
+            // use the JSON format {"tc": attr, "fc": [...projected_non_key...]}.
+            // No "pk" field: Alternator vector indexes are always Global (not Local).
+            // Pre-filtering still works because IndexEntry::new() merges primary_key_columns
+            // into filtering_columns automatically.
+            // For KEYS_ONLY, use the simple string format (no filtering columns).
+            sstring target_option;
+            if (!non_key_attributes.empty()) {
+                rjson::value target_json = rjson::empty_object();
+                rjson::add(target_json, "tc", rjson::from_string(attribute_name));
+                rjson::value fc_arr = rjson::empty_array();
+                for (const auto& attr : non_key_attributes) {
+                    rjson::push_back(fc_arr, rjson::from_string(attr));
+                }
+                rjson::add(target_json, "fc", std::move(fc_arr));
+                target_option = rjson::print(std::move(target_json));
+            } else {
+                target_option = sstring(attribute_name);
             }
             // Add a vector index metadata entry to the base table schema.
             index_options_map index_options;
             index_options[db::index::secondary_index::custom_class_option_name] = "vector_index";
-            index_options[cql3::statements::index_target::target_option_name] = sstring(attribute_name);
+            index_options[cql3::statements::index_target::target_option_name] = std::move(target_option);
             index_options["dimensions"] = std::to_string(dimensions);
             index_options["similarity_function"] = similarity_function;
             builder.with_index(index_metadata{sstring(index_name), index_options,
@@ -2047,25 +2130,72 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                     }
                     int dimensions = get_dimensions(*vector_attribute_v, "VectorIndexUpdates");
                     std::string similarity_function = get_similarity_function(it->value, "VectorIndexUpdates");
-                    // The optional Projection parameter is only supported with
-                    // ProjectionType=KEYS_ONLY. Other values are not yet supported.
+                    // The optional Projection parameter is supported:
+                    // KEYS_ONLY (default) and INCLUDE with NonKeyAttributes.
+                    // ALL is not yet supported (the vector store would need to store the
+                    // entire :attrs map blob and dynamically look up any attribute at
+                    // query time, which is not yet implemented).
+                    std::string update_projection_type = "KEYS_ONLY";
+                    std::vector<std::string> update_non_key_attributes;
                     const rjson::value* projection_v = rjson::find(it->value, "Projection");
                     if (projection_v) {
                         if (!projection_v->IsObject()) {
                             co_return api_error::validation("VectorIndexUpdates Projection must be an object.");
                         }
                         const rjson::value* projection_type_v = rjson::find(*projection_v, "ProjectionType");
-                        if (!projection_type_v || !projection_type_v->IsString() ||
-                                rjson::to_string_view(*projection_type_v) != "KEYS_ONLY") {
-                            co_return api_error::validation("VectorIndexUpdates Projection: only ProjectionType=KEYS_ONLY is currently supported.");
+                        if (!projection_type_v || !projection_type_v->IsString()) {
+                            co_return api_error::validation("VectorIndexUpdates Projection: ProjectionType must be a string.");
                         }
+                        std::string_view pt = rjson::to_string_view(*projection_type_v);
+                        if (pt == "KEYS_ONLY") {
+                            update_projection_type = "KEYS_ONLY";
+                        } else if (pt == "ALL") {
+                            co_return api_error::validation(
+                                "VectorIndexUpdates Projection: ProjectionType=ALL is not yet supported "
+                                "for vector indexes.  Use KEYS_ONLY or INCLUDE instead.");
+                        } else if (pt == "INCLUDE") {
+                            update_projection_type = "INCLUDE";
+                            const rjson::value* nka_v = rjson::find(*projection_v, "NonKeyAttributes");
+                            if (!nka_v || !nka_v->IsArray() || nka_v->Empty()) {
+                                co_return api_error::validation(
+                                    "VectorIndexUpdates Projection=INCLUDE requires a non-empty NonKeyAttributes list.");
+                            }
+                            for (const auto& elem : nka_v->GetArray()) {
+                                if (!elem.IsString()) {
+                                    co_return api_error::validation(
+                                        "VectorIndexUpdates NonKeyAttributes elements must be strings.");
+                                }
+                                update_non_key_attributes.emplace_back(rjson::to_string_view(elem));
+                            }
+                        } else {
+                            co_return api_error::validation(fmt::format(
+                                "VectorIndexUpdates Projection: unsupported ProjectionType '{}'; "
+                                "supported values are KEYS_ONLY and INCLUDE.", pt));
+                        }
+                    }
+                    // Build the target option, using JSON format for INCLUDE.
+                    // No "pk" field: Alternator vector indexes are always Global (not Local).
+                    // Pre-filtering still works because IndexEntry::new() merges primary_key_columns
+                    // into filtering_columns automatically.
+                    sstring update_target_option;
+                    if (!update_non_key_attributes.empty()) {
+                        rjson::value target_json = rjson::empty_object();
+                        rjson::add(target_json, "tc", rjson::from_string(attribute_name));
+                        rjson::value fc_arr = rjson::empty_array();
+                        for (const auto& attr : update_non_key_attributes) {
+                            rjson::push_back(fc_arr, rjson::from_string(attr));
+                        }
+                        rjson::add(target_json, "fc", std::move(fc_arr));
+                        update_target_option = rjson::print(std::move(target_json));
+                    } else {
+                        update_target_option = sstring(attribute_name);
                     }
                     // A vector index will use CDC on this table, so the CDC
                     // log table name will need to fit our length limits
                     validate_cdc_log_name_length(builder.cf_name());
                     index_options_map index_options;
                     index_options[db::index::secondary_index::custom_class_option_name] = "vector_index";
-                    index_options[cql3::statements::index_target::target_option_name] = sstring(attribute_name);
+                    index_options[cql3::statements::index_target::target_option_name] = std::move(update_target_option);
                     index_options["dimensions"] = std::to_string(dimensions);
                     index_options["similarity_function"] = similarity_function;
                     builder.with_index(index_metadata{index_name, index_options,
@@ -2467,7 +2597,7 @@ static std::unordered_map<bytes, int> vector_index_attributes(const schema& s) {
             continue;
         }
         try {
-            ret[to_bytes(target_it->second)] = std::stoi(dims_it->second);
+            ret[to_bytes(secondary_index::vector_index::get_target_column(target_it->second))] = std::stoi(dims_it->second);
         } catch (...) {}
     }
     return ret;

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1625,6 +1625,13 @@ static future<executor::request_return_type> query_vector(
     if (limit == 0) {
         co_return api_error::validation("Limit must be greater than 0");
     }
+    // The maximum limit for vector search matches the CQL constant
+    // max_ann_query_limit in vector_indexed_table_select_statement.
+    static constexpr uint32_t max_vector_search_limit = 1000;
+    if (limit > max_vector_search_limit) {
+        co_return api_error::validation(
+            format("Limit must not be greater than {}", max_vector_search_limit));
+    }
 
     // Consistent reads are not supported for vector search, just like GSI.
     if (get_read_consistency(request) != db::consistency_level::LOCAL_ONE) {

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -36,6 +36,7 @@
 #include "service/pager/query_pagers.hh"
 #include "service/storage_proxy.hh"
 #include "index/secondary_index.hh"
+#include "cql3/statements/index_target.hh"
 #include "utils/assert.hh"
 #include "utils/overloaded_functor.hh"
 #include "utils/error_injection.hh"
@@ -1315,12 +1316,16 @@ static rjson::value value_to_prefilter_json(const rjson::value& value) {
             throw api_error::validation("N type value must be a string");
         }
         std::string_view num_str = rjson::to_string_view(inner);
+        // Validate and parse as double to reject non-finite or malformed values.
         double d;
         auto [ptr, ec] = std::from_chars(num_str.data(), num_str.data() + num_str.size(), d);
         if (ec != std::errc{} || ptr != num_str.data() + num_str.size() || !std::isfinite(d)) {
             throw api_error::validation(format(
                 "VectorSearch KeyConditionExpression N value '{}' is not a valid number", num_str));
         }
+        // Send as a JSON number so the vector store can distinguish numeric
+        // restrictions from string restrictions and apply numeric ordering
+        // (not lexicographic string ordering) for < > <= >= comparisons.
         return rjson::value(d);
     }
     throw api_error::validation(format(
@@ -1330,18 +1335,18 @@ static rjson::value value_to_prefilter_json(const rjson::value& value) {
 
 // Converts a single primitive condition from a parsed KeyConditionExpression
 // to vector store pre-filter JSON restriction(s), appended to restrictions_arr.
-// projected_cols maps projected attribute names to their column definitions;
-// any attribute not in this map triggers a ValidationException.
+// projected_cols is the set of allowed projected attribute names;
+// any attribute not in this set triggers a ValidationException.
 static void primitive_condition_to_prefilter(
         const parsed::primitive_condition& cond,
-        const std::unordered_map<std::string, const column_definition*>& projected_cols,
+        const std::unordered_set<std::string>& projected_cols,
         rjson::value& restrictions_arr)
 {
     using ctype = parsed::primitive_condition::type;
 
-    // Return the column_definition for a parsed::value that must be a top-level
+    // Return the attribute name for a parsed::value that must be a top-level
     // attribute path referencing a projected column.
-    auto require_projected_col = [&](const parsed::value& v) -> const column_definition& {
+    auto require_projected_col = [&](const parsed::value& v) -> std::string_view {
         const parsed::path& path = std::get<parsed::path>(v._value);
         if (path.has_operators()) {
             throw api_error::validation(
@@ -1354,7 +1359,7 @@ static void primitive_condition_to_prefilter(
                 "attribute of the vector index; only projected attributes can "
                 "be used for pre-filtering", path.root()));
         }
-        return *it->second;
+        return *it;
     };
 
     // Extract the resolved DynamoDB JSON value from a parsed::constant literal.
@@ -1388,7 +1393,7 @@ static void primitive_condition_to_prefilter(
         }
         const parsed::value& col_v   = col_left ? cond._values[0] : cond._values[1];
         const parsed::value& const_v = col_left ? cond._values[1] : cond._values[0];
-        const column_definition& cdef = require_projected_col(col_v);
+        std::string_view col_name = require_projected_col(col_v);
 
         // If the constant is on the left (e.g. :v < pk), flip the direction.
         const char* op_str;
@@ -1416,7 +1421,7 @@ static void primitive_condition_to_prefilter(
         auto rhs_json = value_to_prefilter_json(require_resolved_val(const_v));
         auto restriction = rjson::empty_object();
         rjson::add(restriction, "type", rjson::from_string(op_str));
-        rjson::add(restriction, "lhs", rjson::from_string(cdef.name_as_text()));
+        rjson::add(restriction, "lhs", rjson::from_string(col_name));
         rjson::add(restriction, "rhs", std::move(rhs_json));
         rjson::push_back(restrictions_arr, std::move(restriction));
 
@@ -1426,7 +1431,7 @@ static void primitive_condition_to_prefilter(
             throw api_error::validation(
                 "VectorSearch KeyConditionExpression IN must have an attribute name as its first operand");
         }
-        const column_definition& cdef = require_projected_col(cond._values[0]);
+        std::string_view col_name = require_projected_col(cond._values[0]);
         auto rhs_arr = rjson::empty_array();
         for (size_t i = 1; i < cond._values.size(); ++i) {
             rjson::push_back(rhs_arr, value_to_prefilter_json(
@@ -1434,7 +1439,7 @@ static void primitive_condition_to_prefilter(
         }
         auto restriction = rjson::empty_object();
         rjson::add(restriction, "type", rjson::from_string("IN"));
-        rjson::add(restriction, "lhs", rjson::from_string(cdef.name_as_text()));
+        rjson::add(restriction, "lhs", rjson::from_string(col_name));
         rjson::add(restriction, "rhs", std::move(rhs_arr));
         rjson::push_back(restrictions_arr, std::move(restriction));
 
@@ -1445,10 +1450,10 @@ static void primitive_condition_to_prefilter(
             throw api_error::validation(
                 "VectorSearch KeyConditionExpression BETWEEN must have an attribute and two constant bounds");
         }
-        const column_definition& cdef = require_projected_col(cond._values[0]);
+        std::string_view col_name = require_projected_col(cond._values[0]);
         auto lower_json = value_to_prefilter_json(require_resolved_val(cond._values[1]));
         auto upper_json = value_to_prefilter_json(require_resolved_val(cond._values[2]));
-        auto col_json = rjson::from_string(cdef.name_as_text());
+        auto col_json = rjson::from_string(col_name);
 
         auto restr_ge = rjson::empty_object();
         rjson::add(restr_ge, "type", rjson::from_string(">="));
@@ -1472,12 +1477,13 @@ static void primitive_condition_to_prefilter(
 // Parses a KeyConditionExpression from a vector search request and builds a
 // pre-filter JSON object for the vector store (same format as the CQL filter
 // in vector_search/filter.cc). The expression may only reference projected
-// attributes; currently those are the base table's key columns. Returns an
-// empty JSON object if no KeyConditionExpression is present.
+// attributes: key columns plus any non-key attributes listed in non_key_projected_attrs.
+// Returns an empty JSON object if no KeyConditionExpression is present.
 static rjson::value parse_vector_search_prefilter(
         parsed::expression_cache& parsed_expr_cache,
         const rjson::value& request,
         const schema& schema,
+        const std::vector<std::string>& non_key_projected_attrs,
         std::unordered_set<std::string>& used_attribute_names,
         std::unordered_set<std::string>& used_attribute_values)
 {
@@ -1505,14 +1511,17 @@ static rjson::value parse_vector_search_prefilter(
     resolve_condition_expression(parsed_expr, attr_names, attr_values,
             used_attribute_names, used_attribute_values);
 
-    // Build the map of projected attribute name -> column_definition.
-    // Currently only the base table's key columns are projected.
-    std::unordered_map<std::string, const column_definition*> projected_cols;
+    // Build the set of allowed projected attribute names:
+    // base table key columns plus any INCLUDE-projected non-key attributes.
+    std::unordered_set<std::string> projected_cols;
     for (const column_definition& cdef : schema.partition_key_columns()) {
-        projected_cols[cdef.name_as_text()] = &cdef;
+        projected_cols.insert(cdef.name_as_text());
     }
     for (const column_definition& cdef : schema.clustering_key_columns()) {
-        projected_cols[cdef.name_as_text()] = &cdef;
+        projected_cols.insert(cdef.name_as_text());
+    }
+    for (const std::string& attr : non_key_projected_attrs) {
+        projected_cols.insert(attr);
     }
 
     // Flatten the expression into AND-connected primitive conditions.
@@ -1572,6 +1581,7 @@ static future<executor::request_return_type> query_vector(
     std::string_view index_name = rjson::to_string_view(*index_name_v);
     int dimensions = 0;
     bool is_vector = false;
+    std::vector<std::string> non_key_projected_attrs;
     for (const index_metadata& im : base_schema->indices()) {
         if (im.name() == index_name) {
             const auto& opts = im.options();
@@ -1588,10 +1598,27 @@ static future<executor::request_return_type> query_vector(
                 } catch (std::logic_error&) {}
             }
             throwing_assert(dimensions > 0);
+            // Projection info is encoded in the target option's "fc" field:
+            // a non-empty "fc" array means INCLUDE with those non-key attrs; otherwise KEYS_ONLY.
+            auto target_it = opts.find(cql3::statements::index_target::target_option_name);
+            if (target_it != opts.end() && !target_it->second.empty() && target_it->second[0] == '{') {
+                try {
+                    auto target_json = rjson::parse(target_it->second);
+                    if (const rjson::value* fc = rjson::find(target_json, "fc"); fc && fc->IsArray()) {
+                        for (const auto& elem : fc->GetArray()) {
+                            if (elem.IsString()) {
+                                non_key_projected_attrs.emplace_back(rjson::to_string_view(elem));
+                            }
+                        }
+                    }
+                } catch (...) {}
+            }
+
             is_vector = true;
             break;
         }
     }
+    std::string projection_type = non_key_projected_attrs.empty() ? "KEYS_ONLY" : "INCLUDE";
     if (!is_vector) {
         co_return api_error::validation(
             format("VectorSearch IndexName '{}' is not a vector index.", index_name));
@@ -1686,15 +1713,20 @@ static future<executor::request_return_type> query_vector(
     }
     std::optional<alternator::attrs_to_get> attrs_to_get_opt;
     if (select == select_type::projection) {
-        // ALL_PROJECTED_ATTRIBUTES for a vector index: return only key attributes.
-        alternator::attrs_to_get key_attrs;
+        // ALL_PROJECTED_ATTRIBUTES for a vector index. Asks for the key
+        // attributes plus any non-key attributes projected into the vector
+        // index.
+        alternator::attrs_to_get all_projected_attrs;
         for (const column_definition& cdef : base_schema->partition_key_columns()) {
-            attribute_path_map_add("Select", key_attrs, cdef.name_as_text());
+            attribute_path_map_add("Select", all_projected_attrs, cdef.name_as_text());
         }
         for (const column_definition& cdef : base_schema->clustering_key_columns()) {
-            attribute_path_map_add("Select", key_attrs, cdef.name_as_text());
+            attribute_path_map_add("Select", all_projected_attrs, cdef.name_as_text());
         }
-        attrs_to_get_opt = std::move(key_attrs);
+        for (const std::string& attr : non_key_projected_attrs) {
+            attribute_path_map_add("Select", all_projected_attrs, attr);
+        }
+        attrs_to_get_opt = std::move(all_projected_attrs);
     } else {
         attrs_to_get_opt = calculate_attrs_to_get(request, parsed_expr_cache, used_attribute_names, select);
     }
@@ -1712,9 +1744,9 @@ static future<executor::request_return_type> query_vector(
     filter flt(parsed_expr_cache, request, filter::request_type::QUERY,
                used_attribute_names, used_attribute_values);
     // KeyConditionExpression: pre-filter sent to the vector store before ANN search.
-    // Only projected attributes (currently key columns) are allowed.
+    // Only projected attributes (key columns plus INCLUDE-projected non-key attrs) are allowed.
     rjson::value pre_filter = parse_vector_search_prefilter(
-            parsed_expr_cache, request, *base_schema,
+            parsed_expr_cache, request, *base_schema, non_key_projected_attrs,
             used_attribute_names, used_attribute_values);
     const rjson::value* expression_attribute_names = rjson::find(request, "ExpressionAttributeNames");
     verify_all_are_used(expression_attribute_names, used_attribute_names, "ExpressionAttributeNames", "Query");
@@ -1727,12 +1759,51 @@ static future<executor::request_return_type> query_vector(
     co_await verify_permission(enforce_authorization, warn_authorization,
             client_state, base_schema, auth::permission::SELECT, stats);
 
+    // For Select=SPECIFIC_ATTRIBUTES with an INCLUDE-projection vector index,
+    // if all requested attributes are covered by key columns or projected non-key
+    // attributes, we can skip the base-table read: ask the vector store to return
+    // those non-key attrs and build the response directly from the vector store result.
+    std::vector<std::string> specific_return_columns;
+    bool specific_attrs_all_projected = false;
+    if (select == select_type::regular && !flt && projection_type == "INCLUDE" && attrs_to_get_opt) {
+        std::unordered_set<std::string> key_col_names;
+        for (const column_definition& cdef : base_schema->partition_key_columns()) {
+            key_col_names.insert(cdef.name_as_text());
+        }
+        for (const column_definition& cdef : base_schema->clustering_key_columns()) {
+            key_col_names.insert(cdef.name_as_text());
+        }
+        std::unordered_set<std::string> projected_non_key_set(
+                non_key_projected_attrs.begin(), non_key_projected_attrs.end());
+        bool all_projected = true;
+        for (const auto& [attr, subpath] : *attrs_to_get_opt) {
+            // has_value() means the node is a leaf (no sub-path narrowing) which
+            // is the safe case. !has_value() means the path drills into a nested
+            // attribute (has_members/has_indexes), which we cannot handle here.
+            if (!subpath.has_value() ||
+                    (!key_col_names.count(attr) && !projected_non_key_set.count(attr))) {
+                all_projected = false;
+                break;
+            }
+        }
+        if (all_projected) {
+            specific_attrs_all_projected = true;
+            for (const auto& [attr, _] : *attrs_to_get_opt) {
+                if (!key_col_names.count(attr)) {
+                    specific_return_columns.push_back(attr);
+                }
+            }
+        }
+    }
+
     // Query the vector store for the approximate nearest neighbors.
     auto timeout = executor::default_timeout();
     abort_on_expiry aoe(timeout);
     auto pkeys_result = co_await vsc.ann(
             base_schema->ks_name(), std::string(index_name), base_schema,
-            std::move(query_vec), limit, pre_filter, aoe.abort_source());
+            std::move(query_vec), limit, pre_filter, aoe.abort_source(),
+            (select == select_type::projection && !flt && projection_type == "INCLUDE") ? non_key_projected_attrs :
+            (specific_attrs_all_projected ? specific_return_columns : std::vector<std::string>{}));
     if (!pkeys_result.has_value()) {
         const sstring error_msg = std::visit(vector_search::error_visitor{}, pkeys_result.error());
         co_return api_error::validation(error_msg);
@@ -1750,11 +1821,18 @@ static future<executor::request_return_type> query_vector(
         co_return rjson::print(std::move(response));
     }
 
-    // For SELECT=ALL_PROJECTED_ATTRIBUTES with no filter: skip fetching from
-    // the base table and build items directly from the key columns returned by
-    // the vector store. If a filter is present, fall through to the base-table
-    // fetch to apply it.
-    if (select == select_type::projection && !flt) {
+    // Fast path: build the response directly from the vector store result -
+    // which includes the key columns and potentially additional non-key
+    // projected columns which we asked for. This applies to three cases:
+    // - ALL_PROJECTED_ATTRIBUTES on a KEYS_ONLY index: return only key cols.
+    // - ALL_PROJECTED_ATTRIBUTES on an INCLUDE index: return key + projected
+    // - SPECIFIC_ATTRIBUTES where all requested attrs are covered by projected
+    //   columns (specific_attrs_all_projected): same as the case above but
+    //   only the key columns present in attrs_to_get_opt are included.
+    bool use_vs_fast_path = (select == select_type::projection && !flt &&
+                             (projection_type == "KEYS_ONLY" || projection_type == "INCLUDE")) ||
+                            specific_attrs_all_projected;
+    if (use_vs_fast_path) {
         rjson::value items_json = rjson::empty_array();
         rjson::value scores_json = rjson::empty_array();
         for (const auto& pkey : pkeys) {
@@ -1762,19 +1840,41 @@ static future<executor::request_return_type> query_vector(
             std::vector<bytes> exploded_pk = pkey.partition.key().explode();
             auto exploded_pk_it = exploded_pk.begin();
             for (const column_definition& cdef : base_schema->partition_key_columns()) {
-                rjson::value key_val = rjson::empty_object();
-                rjson::add_with_string_name(key_val, type_to_string(cdef.type), json_key_column_value(*exploded_pk_it, cdef));
-                rjson::add_with_string_name(item, std::string_view(cdef.name_as_text()), std::move(key_val));
+                if (!specific_attrs_all_projected || attrs_to_get_opt->contains(cdef.name_as_text())) {
+                    rjson::value key_val = rjson::empty_object();
+                    rjson::add_with_string_name(key_val, type_to_string(cdef.type), json_key_column_value(*exploded_pk_it, cdef));
+                    rjson::add_with_string_name(item, std::string_view(cdef.name_as_text()), std::move(key_val));
+                }
                 ++exploded_pk_it;
             }
             if (base_schema->clustering_key_size() > 0) {
                 std::vector<bytes> exploded_ck = pkey.clustering.explode();
                 auto exploded_ck_it = exploded_ck.begin();
                 for (const column_definition& cdef : base_schema->clustering_key_columns()) {
-                    rjson::value key_val = rjson::empty_object();
-                    rjson::add_with_string_name(key_val, type_to_string(cdef.type), json_key_column_value(*exploded_ck_it, cdef));
-                    rjson::add_with_string_name(item, std::string_view(cdef.name_as_text()), std::move(key_val));
+                    if (!specific_attrs_all_projected || attrs_to_get_opt->contains(cdef.name_as_text())) {
+                        rjson::value key_val = rjson::empty_object();
+                        rjson::add_with_string_name(key_val, type_to_string(cdef.type), json_key_column_value(*exploded_ck_it, cdef));
+                        rjson::add_with_string_name(item, std::string_view(cdef.name_as_text()), std::move(key_val));
+                    }
                     ++exploded_ck_it;
+                }
+            }
+            if (projection_type == "INCLUDE") {
+                // Non-key projected column values are stored as Alternator type-tagged
+                // blobs and returned by the vector store as "0x<hex>" strings via
+                // try_to_json(). Decode each blob to get the DynamoDB attribute value.
+                for (auto const& [col_name, col_val] : pkey.column_values) {
+                    // Alternator non-key attributes are stored as blobs and
+                    // serialized by try_to_json() as "0x<hex>" JSON strings.
+                    throwing_assert(col_val.IsString());
+                    auto hex_sv = rjson::to_string_view(col_val);
+                    throwing_assert(hex_sv.size() >= 2 && hex_sv[0] == '0' && hex_sv[1] == 'x');
+                    try {
+                        auto raw = from_hex(hex_sv.substr(2));
+                        rjson::add_with_string_name(item, col_name, alternator::deserialize_item(bytes_view(raw)));
+                    } catch (...) {
+                        // Ignore malformed or undeserializable values
+                    }
                 }
             }
             rjson::push_back(items_json, std::move(item));
@@ -1793,11 +1893,6 @@ static future<executor::request_return_type> query_vector(
         }
         co_return rjson::print(std::move(response));
     }
-
-    // TODO: For SELECT=SPECIFIC_ATTRIBUTES, if they are part of the projected
-    // attributes, we should use the above optimized code path - not fall through
-    // to the read from the base table as below as we need to do if the specific
-    // attributes contain non-projected columns.
 
     // Fetch the matching items from the base table and build the response.
     // When a filter is present, we always fetch the full item so that all
@@ -1844,21 +1939,26 @@ static future<executor::request_return_type> query_vector(
             }
             if (select != select_type::count) {
                 if (select == select_type::projection) {
-                    // A filter caused us to fall through here instead of
-                    // taking the projection early-exit above. Reconstruct
-                    // the key-only item from the full item we fetched.
-                    rjson::value key_item = rjson::empty_object();
-                    for (const column_definition& cdef : base_schema->partition_key_columns()) {
-                        if (const rjson::value* v = rjson::find(*opt_item, cdef.name_as_text())) {
-                            rjson::add_with_string_name(key_item, cdef.name_as_text(), rjson::copy(*v));
+                    // We fell through to the base table fetch instead of
+                    // taking the projection early-exit above.
+                    // Return key columns plus any non-key projected attrs
+                    // (the latter is empty for KEYS_ONLY indexes).
+                    rjson::value proj_item = rjson::empty_object();
+                    auto add_if_present = [&](std::string_view name) {
+                        if (const rjson::value* v = rjson::find(*opt_item, name)) {
+                            rjson::add_with_string_name(proj_item, name, rjson::copy(*v));
                         }
+                    };
+                    for (const column_definition& cdef : base_schema->partition_key_columns()) {
+                        add_if_present(cdef.name_as_text());
                     }
                     for (const column_definition& cdef : base_schema->clustering_key_columns()) {
-                        if (const rjson::value* v = rjson::find(*opt_item, cdef.name_as_text())) {
-                            rjson::add_with_string_name(key_item, cdef.name_as_text(), rjson::copy(*v));
-                        }
+                        add_if_present(cdef.name_as_text());
                     }
-                    rjson::push_back(items_json, std::move(key_item));
+                    for (const std::string& attr : non_key_projected_attrs) {
+                        add_if_present(attr);
+                    }
+                    rjson::push_back(items_json, std::move(proj_item));
                 } else {
                     // When a filter caused us to fetch the full item, apply the
                     // requested projection (attrs_to_get_opt) before returning it.

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1293,6 +1293,248 @@ static std::vector<float> parse_vector(const rjson::value& value, int dimensions
     return out;
 }
 
+// Converts a DynamoDB typed value (e.g. {"S": "hello"} or {"N": "42"}) to a
+// JSON value in the format expected by the vector store pre-filter.
+// Only scalar types S (string) and N (number) are supported; any other type
+// (L, M, SS, NS, BS, BOOL, NULL, B, ...) triggers a ValidationException.
+static rjson::value value_to_prefilter_json(const rjson::value& value) {
+    if (!value.IsObject() || value.MemberCount() != 1) {
+        throw api_error::validation(
+            "value in VectorSearch KeyConditionExpression must be a typed DynamoDB value");
+    }
+    auto it = value.MemberBegin();
+    std::string_view type_tag = rjson::to_string_view(it->name);
+    const rjson::value& inner = it->value;
+    if (type_tag == "S") {
+        if (!inner.IsString()) {
+            throw api_error::validation("S type value must be a string");
+        }
+        return rjson::copy(inner);
+    } else if (type_tag == "N") {
+        if (!inner.IsString()) {
+            throw api_error::validation("N type value must be a string");
+        }
+        std::string_view num_str = rjson::to_string_view(inner);
+        double d;
+        auto [ptr, ec] = std::from_chars(num_str.data(), num_str.data() + num_str.size(), d);
+        if (ec != std::errc{} || ptr != num_str.data() + num_str.size() || !std::isfinite(d)) {
+            throw api_error::validation(format(
+                "VectorSearch KeyConditionExpression N value '{}' is not a valid number", num_str));
+        }
+        return rjson::value(d);
+    }
+    throw api_error::validation(format(
+        "Type '{}' is not supported in VectorSearch KeyConditionExpression; "
+        "only S (string) and N (number) are supported", type_tag));
+}
+
+// Converts a single primitive condition from a parsed KeyConditionExpression
+// to vector store pre-filter JSON restriction(s), appended to restrictions_arr.
+// projected_cols maps projected attribute names to their column definitions;
+// any attribute not in this map triggers a ValidationException.
+static void primitive_condition_to_prefilter(
+        const parsed::primitive_condition& cond,
+        const std::unordered_map<std::string, const column_definition*>& projected_cols,
+        rjson::value& restrictions_arr)
+{
+    using ctype = parsed::primitive_condition::type;
+
+    // Return the column_definition for a parsed::value that must be a top-level
+    // attribute path referencing a projected column.
+    auto require_projected_col = [&](const parsed::value& v) -> const column_definition& {
+        const parsed::path& path = std::get<parsed::path>(v._value);
+        if (path.has_operators()) {
+            throw api_error::validation(
+                "VectorSearch KeyConditionExpression does not support nested attribute paths");
+        }
+        auto it = projected_cols.find(std::string(path.root()));
+        if (it == projected_cols.end()) {
+            throw api_error::validation(format(
+                "VectorSearch KeyConditionExpression references attribute '{}' which is not a projected "
+                "attribute of the vector index; only projected attributes can "
+                "be used for pre-filtering", path.root()));
+        }
+        return *it->second;
+    };
+
+    // Extract the resolved DynamoDB JSON value from a parsed::constant literal.
+    auto require_resolved_val = [](const parsed::value& v) -> const rjson::value& {
+        if (!v.is_constant()) {
+            throw api_error::validation(
+                "value in VectorSearch KeyConditionExpression must be a constant");
+        }
+        const parsed::constant& c = std::get<parsed::constant>(v._value);
+        // We're after resolve_condition_expression(), so only literals remain
+        // not ":name" references.
+        throwing_assert(std::holds_alternative<parsed::constant::literal>(c._value));
+        return *std::get<parsed::constant::literal>(c._value);
+    };
+
+    if (cond._op == ctype::EQ || cond._op == ctype::LT || cond._op == ctype::LE ||
+            cond._op == ctype::GT || cond._op == ctype::GE) {
+        // Binary comparison: one operand is a column path, the other a constant.
+        if (cond._values.size() != 2) {
+            throw api_error::validation("VectorSearch KeyConditionExpression binary comparison must have two operands");
+        }
+        bool col_left = cond._values[0].is_path();
+        bool col_right = cond._values[1].is_path();
+        if (!col_left && !col_right) {
+            throw api_error::validation(
+                "VectorSearch KeyConditionExpression comparison must reference an attribute name");
+        }
+        if (col_left && col_right) {
+            throw api_error::validation(
+                "VectorSearch KeyConditionExpression comparison must include a constant value");
+        }
+        const parsed::value& col_v   = col_left ? cond._values[0] : cond._values[1];
+        const parsed::value& const_v = col_left ? cond._values[1] : cond._values[0];
+        const column_definition& cdef = require_projected_col(col_v);
+
+        // If the constant is on the left (e.g. :v < pk), flip the direction.
+        const char* op_str;
+        if (col_left) {
+            switch (cond._op) {
+            case ctype::EQ: op_str = "=="; break;
+            case ctype::LT: op_str = "<";  break;
+            case ctype::LE: op_str = "<="; break;
+            case ctype::GT: op_str = ">";  break;
+            case ctype::GE: op_str = ">="; break;
+            // The outer "if" guarantees cond._op is one of EQ/LT/LE/GT/GE;
+            // the default cases below are unreachable by construction.
+            default: on_internal_error(elogger, "can't happen");
+            }
+        } else {
+            switch (cond._op) {
+            case ctype::EQ: op_str = "=="; break;
+            case ctype::LT: op_str = ">";  break; // :v < pk -> pk > :v
+            case ctype::LE: op_str = ">="; break; // :v <= pk -> pk >= :v
+            case ctype::GT: op_str = "<";  break; // :v > pk -> pk < :v
+            case ctype::GE: op_str = "<="; break; // :v >= pk -> pk <= :v
+            default: on_internal_error(elogger, "can't happen");
+            }
+        }
+        auto rhs_json = value_to_prefilter_json(require_resolved_val(const_v));
+        auto restriction = rjson::empty_object();
+        rjson::add(restriction, "type", rjson::from_string(op_str));
+        rjson::add(restriction, "lhs", rjson::from_string(cdef.name_as_text()));
+        rjson::add(restriction, "rhs", std::move(rhs_json));
+        rjson::push_back(restrictions_arr, std::move(restriction));
+
+    } else if (cond._op == ctype::IN) {
+        // IN operator: first value is the column, the remaining are constants.
+        if (cond._values.empty() || !cond._values[0].is_path()) {
+            throw api_error::validation(
+                "VectorSearch KeyConditionExpression IN must have an attribute name as its first operand");
+        }
+        const column_definition& cdef = require_projected_col(cond._values[0]);
+        auto rhs_arr = rjson::empty_array();
+        for (size_t i = 1; i < cond._values.size(); ++i) {
+            rjson::push_back(rhs_arr, value_to_prefilter_json(
+                    require_resolved_val(cond._values[i])));
+        }
+        auto restriction = rjson::empty_object();
+        rjson::add(restriction, "type", rjson::from_string("IN"));
+        rjson::add(restriction, "lhs", rjson::from_string(cdef.name_as_text()));
+        rjson::add(restriction, "rhs", std::move(rhs_arr));
+        rjson::push_back(restrictions_arr, std::move(restriction));
+
+    } else if (cond._op == ctype::BETWEEN) {
+        // a BETWEEN b AND c is expanded to two restrictions: a >= b AND a <= c.
+        if (cond._values.size() != 3 || !cond._values[0].is_path() ||
+                !cond._values[1].is_constant() || !cond._values[2].is_constant()) {
+            throw api_error::validation(
+                "VectorSearch KeyConditionExpression BETWEEN must have an attribute and two constant bounds");
+        }
+        const column_definition& cdef = require_projected_col(cond._values[0]);
+        auto lower_json = value_to_prefilter_json(require_resolved_val(cond._values[1]));
+        auto upper_json = value_to_prefilter_json(require_resolved_val(cond._values[2]));
+        auto col_json = rjson::from_string(cdef.name_as_text());
+
+        auto restr_ge = rjson::empty_object();
+        rjson::add(restr_ge, "type", rjson::from_string(">="));
+        rjson::add(restr_ge, "lhs", rjson::copy(col_json));
+        rjson::add(restr_ge, "rhs", std::move(lower_json));
+        rjson::push_back(restrictions_arr, std::move(restr_ge));
+
+        auto restr_le = rjson::empty_object();
+        rjson::add(restr_le, "type", rjson::from_string("<="));
+        rjson::add(restr_le, "lhs", std::move(col_json));
+        rjson::add(restr_le, "rhs", std::move(upper_json));
+        rjson::push_back(restrictions_arr, std::move(restr_le));
+
+    } else {
+        throw api_error::validation(
+            "VectorSearch KeyConditionExpression uses an unsupported operator for vector search "
+            "pre-filtering; supported operators are =, <, <=, >, >=, IN, BETWEEN");
+    }
+}
+
+// Parses a KeyConditionExpression from a vector search request and builds a
+// pre-filter JSON object for the vector store (same format as the CQL filter
+// in vector_search/filter.cc). The expression may only reference projected
+// attributes; currently those are the base table's key columns. Returns an
+// empty JSON object if no KeyConditionExpression is present.
+static rjson::value parse_vector_search_prefilter(
+        parsed::expression_cache& parsed_expr_cache,
+        const rjson::value& request,
+        const schema& schema,
+        std::unordered_set<std::string>& used_attribute_names,
+        std::unordered_set<std::string>& used_attribute_values)
+{
+    const rjson::value* key_cond_expr = rjson::find(request, "KeyConditionExpression");
+    if (!key_cond_expr) {
+        return rjson::empty_object();
+    }
+    if (!key_cond_expr->IsString()) {
+        throw api_error::validation("KeyConditionExpression must be a string");
+    }
+    if (key_cond_expr->GetStringLength() == 0) {
+        throw api_error::validation("KeyConditionExpression must not be empty");
+    }
+
+    parsed::condition_expression parsed_expr;
+    try {
+        parsed_expr = parsed_expr_cache.parse_condition_expression(
+                rjson::to_string_view(*key_cond_expr), "KeyConditionExpression");
+    } catch (expressions_syntax_error& e) {
+        throw api_error::validation(e.what());
+    }
+
+    const rjson::value* attr_names  = rjson::find(request, "ExpressionAttributeNames");
+    const rjson::value* attr_values = rjson::find(request, "ExpressionAttributeValues");
+    resolve_condition_expression(parsed_expr, attr_names, attr_values,
+            used_attribute_names, used_attribute_values);
+
+    // Build the map of projected attribute name -> column_definition.
+    // Currently only the base table's key columns are projected.
+    std::unordered_map<std::string, const column_definition*> projected_cols;
+    for (const column_definition& cdef : schema.partition_key_columns()) {
+        projected_cols[cdef.name_as_text()] = &cdef;
+    }
+    for (const column_definition& cdef : schema.clustering_key_columns()) {
+        projected_cols[cdef.name_as_text()] = &cdef;
+    }
+
+    // Flatten the expression into AND-connected primitive conditions.
+    // OR and NOT are rejected by condition_expression_and_list().
+    std::vector<const parsed::primitive_condition*> conditions;
+    condition_expression_and_list(parsed_expr, conditions);
+
+    auto restrictions_arr = rjson::empty_array();
+    for (const parsed::primitive_condition* cond : conditions) {
+        primitive_condition_to_prefilter(*cond, projected_cols, restrictions_arr);
+    }
+
+    if (restrictions_arr.Empty()) {
+        return rjson::empty_object();
+    }
+
+    auto result = rjson::empty_object();
+    rjson::add(result, "restrictions", std::move(restrictions_arr));
+    rjson::add(result, "allow_filtering", rjson::value(true));
+    return result;
+}
+
 // Converts a similarity score (float) to a JSON value. JSON does not support
 // infinite or NaN values, so if the score is infinite (which can happen with
 // the DOT_PRODUCT similarity function on non-normalized vectors) we clamp to
@@ -1454,9 +1696,19 @@ static future<executor::request_return_type> query_vector(
         co_return api_error::validation(
             "VectorSearch does not support QueryFilter; use FilterExpression instead");
     }
+    // KeyConditions (the old-style API) is not supported for vector search Queries.
+    if (rjson::find(request, "KeyConditions")) {
+        co_return api_error::validation(
+            "VectorSearch does not support KeyConditions; use KeyConditionExpression instead");
+    }
     // FilterExpression: post-filter the vector search results by any attribute.
     filter flt(parsed_expr_cache, request, filter::request_type::QUERY,
                used_attribute_names, used_attribute_values);
+    // KeyConditionExpression: pre-filter sent to the vector store before ANN search.
+    // Only projected attributes (currently key columns) are allowed.
+    rjson::value pre_filter = parse_vector_search_prefilter(
+            parsed_expr_cache, request, *base_schema,
+            used_attribute_names, used_attribute_values);
     const rjson::value* expression_attribute_names = rjson::find(request, "ExpressionAttributeNames");
     verify_all_are_used(expression_attribute_names, used_attribute_names, "ExpressionAttributeNames", "Query");
     const rjson::value* expression_attribute_values = rjson::find(request, "ExpressionAttributeValues");
@@ -1471,7 +1723,6 @@ static future<executor::request_return_type> query_vector(
     // Query the vector store for the approximate nearest neighbors.
     auto timeout = executor::default_timeout();
     abort_on_expiry aoe(timeout);
-    rjson::value pre_filter = rjson::empty_object(); // TODO, implement
     auto pkeys_result = co_await vsc.ann(
             base_schema->ks_name(), std::string(index_name), base_schema,
             std::move(query_vec), limit, pre_filter, aoe.abort_source());

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1618,7 +1618,6 @@ static future<executor::request_return_type> query_vector(
             break;
         }
     }
-    std::string projection_type = non_key_projected_attrs.empty() ? "KEYS_ONLY" : "INCLUDE";
     if (!is_vector) {
         co_return api_error::validation(
             format("VectorSearch IndexName '{}' is not a vector index.", index_name));
@@ -1765,7 +1764,7 @@ static future<executor::request_return_type> query_vector(
     // those non-key attrs and build the response directly from the vector store result.
     std::vector<std::string> specific_return_columns;
     bool specific_attrs_all_projected = false;
-    if (select == select_type::regular && !flt && projection_type == "INCLUDE" && attrs_to_get_opt) {
+    if (select == select_type::regular && !flt && !non_key_projected_attrs.empty() && attrs_to_get_opt) {
         std::unordered_set<std::string> key_col_names;
         for (const column_definition& cdef : base_schema->partition_key_columns()) {
             key_col_names.insert(cdef.name_as_text());
@@ -1802,7 +1801,7 @@ static future<executor::request_return_type> query_vector(
     auto pkeys_result = co_await vsc.ann(
             base_schema->ks_name(), std::string(index_name), base_schema,
             std::move(query_vec), limit, pre_filter, aoe.abort_source(),
-            (select == select_type::projection && !flt && projection_type == "INCLUDE") ? non_key_projected_attrs :
+            (select == select_type::projection && !flt && !non_key_projected_attrs.empty()) ? non_key_projected_attrs :
             (specific_attrs_all_projected ? specific_return_columns : std::vector<std::string>{}));
     if (!pkeys_result.has_value()) {
         const sstring error_msg = std::visit(vector_search::error_visitor{}, pkeys_result.error());
@@ -1829,8 +1828,7 @@ static future<executor::request_return_type> query_vector(
     // - SPECIFIC_ATTRIBUTES where all requested attrs are covered by projected
     //   columns (specific_attrs_all_projected): same as the case above but
     //   only the key columns present in attrs_to_get_opt are included.
-    bool use_vs_fast_path = (select == select_type::projection && !flt &&
-                             (projection_type == "KEYS_ONLY" || projection_type == "INCLUDE")) ||
+    bool use_vs_fast_path = (select == select_type::projection && !flt) ||
                             specific_attrs_all_projected;
     if (use_vs_fast_path) {
         rjson::value items_json = rjson::empty_array();
@@ -1859,7 +1857,7 @@ static future<executor::request_return_type> query_vector(
                     ++exploded_ck_it;
                 }
             }
-            if (projection_type == "INCLUDE") {
+            if (!non_key_projected_attrs.empty()) {
                 // Non-key projected column values are stored as Alternator type-tagged
                 // blobs and returned by the vector store as "0x<hex>" strings via
                 // try_to_json(). Decode each blob to get the DynamoDB attribute value.

--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -269,7 +269,7 @@ response = table.query(
 | `IndexName` | Required. Must name a vector index on this table (not a GSI or LSI). |
 | `VectorSearch.QueryVector` | Required. A DynamoDB `AttributeValue` of type `L` (all elements of type `N`) or the ScyllaDB-specific type `FLOAT32VECTOR` (plain floating-point JSON numbers). |
 | QueryVector length | Must match the `Dimensions` configured for the named vector index. |
-| `Limit` | Required. Defines _k_ — how many nearest neighbors to return. Must be a positive integer. |
+| `Limit` | Required. Defines _k_ — how many nearest neighbors to return. Must be a positive integer no greater than 1000. |
 
 **Differences from standard Query:**
 
@@ -281,7 +281,9 @@ different way, and explicitly rejects others that have no meaningful interpretat
   `ExclusiveStartKey`. In vector search, `Limit` defines _k_: the ANN
   algorithm runs once and returns exactly the _k_ nearest neighbors. There
   is no natural "next page" — each page would require a full re-run of the
-  search — so **`ExclusiveStartKey` is rejected**.
+  search — so **`ExclusiveStartKey` is rejected**. Because vector search does
+  not support pagination, `Limit` is capped at 1000; if you need more results
+  you must issue separate queries with different query vectors.
 
 - **Results are ordered by vector distance, not by sort key.** A standard
   Query returns rows in sort-key order; `ScanIndexForward=false` reverses

--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -294,13 +294,6 @@ different way, and explicitly rejects others that have no meaningful interpretat
   reflect writes instantly, so strongly-consistent reads are impossible.
   **`ConsistentRead=true` is rejected.**
 
-- **No key condition.** A standard Query requires a `KeyConditionExpression`
-  to select which partition to read. Vector search queries the vector store
-  globally across all partitions of the table. `KeyConditions` and
-  `KeyConditionExpression` are therefore not applicable and are silently
-  ignored. (Local vector indexes, which would scope the search to a single
-  partition and use `KeyConditionExpression`, are not yet supported.)
-
 **Select parameter:**
 
 The standard DynamoDB `Select` parameter is supported for vector search queries
@@ -328,19 +321,38 @@ therefore significantly slower than returning only projected attributes with
 `ALL_PROJECTED_ATTRIBUTES`.  For latency-sensitive applications, prefer
 `ALL_PROJECTED_ATTRIBUTES` or limiting `SPECIFIC_ATTRIBUTES` to key columns.
 
-**FilterExpression:**
+**Filtering: pre-filter and post-filter:**
 
-Vector search supports `FilterExpression` for post-filtering results. This
-works the same way as `FilterExpression` on a standard DynamoDB `Query`: after
-the ANN search, the filter is applied to each candidate item and only matching
-items are returned.
+Vector search supports two complementary filtering mechanisms:
 
-**Important:** filtering happens _after_ the `Limit` nearest neighbors have
-already been selected by the vector index. If the filter discards some of
-those candidates, the response may contain **fewer than `Limit` items**. The
-server does not automatically fetch additional neighbors to replace filtered-out
-items. This is identical to how `FilterExpression` interacts with `Limit` in a
-standard DynamoDB `Query`.
+**Pre-filtering (`KeyConditionExpression`):** conditions are sent to the vector
+store before the ANN search, so the search is performed only over matching
+items. Because pre-filtering is evaluated inside the vector store, only
+attributes that are projected into the vector index can be referenced — today
+that means the base table's key columns (hash key and range key if present).
+Supported operators are `=`, `<`, `<=`, `>`, `>=`, `IN`, and `BETWEEN`;
+conditions are combined with `AND`. `OR` and `NOT` are rejected because the
+vector store's pre-filter API only accepts a flat list of conditions implicitly
+ANDed together. The `<>` (not-equal) operator is also rejected. In cases where
+`OR` would otherwise test a single attribute against multiple values, `IN` can
+often serve as a replacement: instead of `p = :v1 OR p = :v2`, write
+`p IN (:v1, :v2)`. `KeyConditions` (the legacy non-expression API) is **not**
+supported and will be rejected with a `ValidationException`.
+
+Pre-filtering guarantees that the response contains exactly `Limit` items
+whenever at least that many items match the filter, because the ANN search
+operates only within the matching subset.
+
+**Post-filtering (`FilterExpression`):** after the ANN search returns its `Limit`
+nearest-neighbor candidates, the filter is applied to each candidate and only
+matching items are returned. Because filtering happens _after_ the `Limit`
+candidates have already been selected, some may be discarded, and the response
+may contain **fewer than `Limit` items**. The server does not automatically
+fetch additional neighbors to replace filtered-out items. Any attribute may be
+referenced in a `FilterExpression`, not only projected columns. This is
+identical to how `FilterExpression` interacts with `Limit` in a standard
+DynamoDB `Query`. `QueryFilter` (the legacy non-expression filter API) is **not**
+supported and will be rejected with a `ValidationException`.
 
 The response always includes two count fields:
 
@@ -373,10 +385,6 @@ The response always includes two count fields:
   any base-table reads. When a `FilterExpression` is present, however, the full
   item must be fetched from the base table to evaluate the filter, and only the
   projected (key) attributes are returned for items that pass.
-
-> **Note:** `QueryFilter` (the legacy non-expression filter API) is **not**
-> supported for vector search queries and will be rejected with a
-> `ValidationException`. Use `FilterExpression` instead.
 
 **ReturnScores field:**
 

--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -80,13 +80,15 @@ returned when `Select=ALL_PROJECTED_ATTRIBUTES` is used in a vector search query
 | `ProjectionType` | Description |
 |-----------------|-------------|
 | `KEYS_ONLY` | Only the primary key attributes of the base table (hash key and range key if present) are projected into the index. This is the default when `Projection` is omitted. |
-| `ALL` | All table attributes are projected into the index. *(Not yet supported.)* |
-| `INCLUDE` | The primary key attributes plus the additional non-key attributes listed in `NonKeyAttributes` are projected. *(Not yet supported.)* |
+| `ALL` | *(Not yet supported — returns a `ValidationException`.)* |
+| `INCLUDE` | The primary key attributes plus the additional non-key attributes listed in `NonKeyAttributes` are projected. |
 
-> **Note:** Currently only `ProjectionType=KEYS_ONLY` is implemented. Specifying
-> `ProjectionType=ALL` or `ProjectionType=INCLUDE` returns a `ValidationException`.
-> Since `KEYS_ONLY` is also the default, omitting `Projection` entirely is
-> equivalent to specifying `{'ProjectionType': 'KEYS_ONLY'}`.
+> **Note:** `ProjectionType=ALL` is not yet implemented for vector indexes. The underlying
+> difficulty is that `ALL` has no fixed attribute list: each item may carry any attributes,
+> so the vector store would need to store and dynamically search the entire attribute map,
+> which is not yet supported.  Use `INCLUDE` to project a known set of non-key attributes.
+> Since `KEYS_ONLY` is the default when `Projection` is omitted, specifying
+> `{'ProjectionType': 'KEYS_ONLY'}` is equivalent to omitting the `Projection` field entirely.
 
 Example (using boto3):
 ```python
@@ -135,8 +137,8 @@ Each element of the list is an object with exactly one of the following keys:
 
 The `Projection` field in the `Create` action is optional and accepts the same
 values as the `Projection` field in `CreateTable`'s `VectorIndexes` (see above).
-Currently only `ProjectionType=KEYS_ONLY` is supported; it is also the default
-when `Projection` is omitted.
+`ProjectionType=KEYS_ONLY` and `ProjectionType=INCLUDE` are both supported.
+`KEYS_ONLY` is the default when `Projection` is omitted.
 
 The `SimilarityFunction` field is also optional and accepts the same values as
 in `CreateTable`'s `VectorIndexes` (see above). Defaults to `COSINE` when omitted.
@@ -161,8 +163,9 @@ field in the `TableDescription` object when the table has at least one
 vector index. The structure mirrors the `CreateTable` input: a list of
 objects each containing `IndexName`, `VectorAttribute`
 (`AttributeName` + `Dimensions`), and `Projection` (`ProjectionType`).
-Currently `Projection` always contains `{"ProjectionType": "KEYS_ONLY"}`
-because that is the only supported projection type.
+`Projection` reflects the projection type used when the index was created:
+`{"ProjectionType": "KEYS_ONLY"}` or
+`{"ProjectionType": "INCLUDE", "NonKeyAttributes": [...]}`.
 If a `SimilarityFunction` was specified at index creation, it is returned
 at the index level (alongside `IndexName`, `VectorAttribute`, and `Projection`).
 When `SimilarityFunction` was not specified, `COSINE` is returned as the default.
@@ -303,7 +306,7 @@ and controls which attributes are returned for each matching item:
 
 | `Select` value | Behavior |
 |----------------|----------|
-| `ALL_PROJECTED_ATTRIBUTES` (default) | Return only the attributes projected to the vector index. Currently, only the primary key attributes (hash key, and range key if present) are projected; support for configuring additional projected attributes is not yet implemented. Note that the vector attribute itself is **not** included: the vector store may not retain the original floating-point values (e.g., it may quantize them), so the authoritative copy lives only in the base table. This is the most efficient option because Scylla can return the results directly from the vector store without an additional fetch from the base table. |
+| `ALL_PROJECTED_ATTRIBUTES` (default) | Return only the attributes projected to the vector index: the primary key attributes (hash key, and range key if present), plus any additional non-key attributes specified via `ProjectionType=INCLUDE`. Note that the vector attribute itself is **not** included: the vector store may not retain the original floating-point values (e.g., it may quantize them), so the authoritative copy lives only in the base table. This is the most efficient option because Scylla can return the results directly from the vector store without an additional fetch from the base table. |
 | `ALL_ATTRIBUTES` | Return all attributes of each matching item, fetched from the base table. |
 | `SPECIFIC_ATTRIBUTES` | Return only the attributes named in `ProjectionExpression` or `AttributesToGet`. |
 | `COUNT` | Return only the count of matching items; no `Items` list is included in the response. |
@@ -330,8 +333,9 @@ Vector search supports two complementary filtering mechanisms:
 **Pre-filtering (`KeyConditionExpression`):** conditions are sent to the vector
 store before the ANN search, so the search is performed only over matching
 items. Because pre-filtering is evaluated inside the vector store, only
-attributes that are projected into the vector index can be referenced — today
-that means the base table's key columns (hash key and range key if present).
+attributes that are projected into the vector index can be referenced — the
+base table's key columns (hash key and range key if present), plus any
+non-key attributes projected with `ProjectionType=INCLUDE`.
 Supported operators are `=`, `<`, `<=`, `>`, `>=`, `IN`, and `BETWEEN`;
 conditions are combined with `AND`. `OR` and `NOT` are rejected because the
 vector store's pre-filter API only accepts a flat list of conditions implicitly
@@ -344,6 +348,29 @@ supported and will be rejected with a `ValidationException`.
 Pre-filtering guarantees that the response contains exactly `Limit` items
 whenever at least that many items match the filter, because the ANN search
 operates only within the matching subset.
+
+**Type semantics for non-key projected attributes:**
+
+Unlike key attributes, non-key attributes projected with `ProjectionType=INCLUDE`
+do not have a fixed schema. Each item may store any DynamoDB attribute type for
+those columns — or omit them entirely. Pre-filter comparisons are type-aware:
+an item is treated as not matching whenever the filtered attribute is absent or
+has a different type from the comparison value in the expression. Specifically:
+
+- An item where the attribute is **missing** does not match any filter on that
+  attribute.
+- An item where the attribute holds a value of the **wrong type** — for example,
+  a string value compared with a numeric operator — does not match.
+
+For example, the filter `x < 5` (where `5` is a number) matches only items
+where `x` holds a numeric value less than `5`. An item where `x` is missing
+does not match. An item where `x` holds the string value `"6"` also does not
+match — a string vs. number comparison is a type mismatch and is never a match,
+regardless of what lexicographic ordering would say.
+
+Only the scalar DynamoDB attribute types `S` (string) and `N` (number) are
+supported in non-key projected attributes. Attributes of other types (lists,
+maps, sets, etc.) are treated as absent.
 
 **Post-filtering (`FilterExpression`):** after the ANN search returns its `Limit`
 nearest-neighbor candidates, the filter is applied to each candidate and only

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -128,6 +128,11 @@ def run_vector_store_cmd(pid, dir):
         'VECTOR_STORE_SCYLLADB_URI': f'{ip}:9042',
         'VECTOR_STORE_SCYLLADB_USERNAME': 'cassandra',
         'VECTOR_STORE_SCYLLADB_PASSWORD_FILE': f'{dir}/.password',
+        # Reduce the vector store's default sleep intervals, to make tests
+        # notice changes faster, and pass faster.
+        'VECTOR_STORE_MONITOR_INDEXES_INTERVAL': '50ms',
+        'VECTOR_STORE_CDC_FINE_SLEEP_INTERVAL': '50ms',
+        'VECTOR_STORE_INDEX_STATUS_UPDATE_INTERVAL': '50ms',
     }
     global vector_store_executable # set by the code below
     cmd = [

--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -510,6 +510,7 @@ def new_named_table_unauthorized(dynamodb, tabname, **kwargs):
         # table 
         dynamodb.meta.client.get_waiter('table_exists').wait(TableName=tabname)
         dynamodb.meta.client.delete_table(TableName=tabname)
+        raise
 
 
 # When a role is allowed to CreateTable, the role is automatically granted

--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -25,6 +25,7 @@ from test.pylib.skip_types import skip_env
 from .util import unique_table_name, random_string, new_test_table
 from .test_gsi_updatetable import wait_for_gsi, wait_for_gsi_gone
 from .test_gsi import assert_index_query
+from test.alternator.test_vector import vs, needs_vector_store, wait_for_vector_index_active, table_vs, add_vs_to_client, vector_store_configured, VECTOR_STORE_TIMEOUT
 
 # new_role() is a context manager for temporarily creating a new role with
 # a unique name and returning its name and the secret key needed to connect
@@ -1187,3 +1188,190 @@ def test_rbac_system_table_write(dynamodb, cql, test_table_s):
                 UpdateExpression='SET #val = :val',
                 ExpressionAttributeNames={'#val': 'value'},
                 ExpressionAttributeValues={':val': old_val}))
+
+#############################################################################
+# Tests for RBAC on vector search operations - Query with VectorSearch,
+# CreateTable with VectorIndexes, and UpdateTable with VectorIndexUpdates.
+# The tests verify that the permissions required for these operations
+# are as expected, but also that the external vector store is really able to
+# read the base-table data to perform its indexing.
+#
+# Note that unlike GSI/LSI where the index is a separate table (a materialized
+# view) with its own permissions, the vector index is *not* a CQL table so
+# it doesn't have its own permissions. Instead, the permission to do a
+# Query requires SELECT permissions on the *base* table. Having permissions
+# on the base table is also important to allow Select='ALL_ATTRIBUTES'.
+
+# new_vs_for_role() creates a boto3 resource supporting vector search API
+# extensions, authenticated with the given role and key instead of the default
+# credentials. Like new_dynamodb(), but with add_vs_to_client() applied
+# so that the connection can send/receive VectorSearch parameters.
+@contextmanager
+def new_vs_for_role(vs, role, key):
+    with new_dynamodb(vs, role, key) as d:
+        with add_vs_to_client(d.meta.client):
+            yield d
+
+# Like authorized(), but also accepts a "Vector Store is disabled" error:
+# permissions are checked before the vector store is accessed, so this
+# error still means the operation was authorized. Using this function instead
+# of authorized() will allow us to test permissions on Query even if the
+# vector store is not configured.
+def authorized_vs(fn):
+    try:
+        return authorized(fn)
+    except ClientError as e:
+        if 'Vector Store is disabled' not in e.response['Error']['Message']:
+            raise
+
+# Test that a Query with VectorSearch requires SELECT permission on the table,
+# just like a regular Query without VectorSearch does (but unlike a Query on
+# a GSI or LSI, which checks permissions on the separate index table).
+def test_rbac_vector_query(vs, cql, table_vs):
+    with new_role(cql) as (role, key):
+        with new_vs_for_role(vs, role, key) as d:
+            # Sanity check: the original superuser (vs) who created the shared
+            # table_vs can perform a vector search query on it. If the vector
+            # store is not configured, we get "Vector Store is disabled" which
+            # still means it was authorized (see authorized_vs() above).
+            authorized_vs(lambda: table_vs.query(IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1))
+            # But in the new role's connection d, without SELECT permissions,
+            # is not allowed to perform the query:
+            tab = d.Table(table_vs.name)
+            unauthorized(lambda: tab.query(IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1))
+            # Adding SELECT permission to the table, vector search must succeed:
+            with temporary_grant(cql, 'SELECT', cql_table_name(tab), role):
+                authorized_vs(lambda: tab.query(IndexName='vind',
+                    VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1))
+                # Select=ALL_ATTRIBUTES is also allowed
+                authorized_vs(lambda: tab.query(IndexName='vind',
+                    VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1,
+                    Select='ALL_ATTRIBUTES'))
+
+# Test that creating a table with a VectorIndexes parameter requires the
+# same CREATE permission as creating a regular table without VectorIndexes.
+def test_rbac_createtable_vectorindexes(vs, cql):
+    schema = {
+        'KeySchema': [{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        'AttributeDefinitions': [{'AttributeName': 'p', 'AttributeType': 'S'}],
+        'VectorIndexes': [{'IndexName': 'vind',
+                           'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}],
+    }
+    with new_role(cql) as (role, key):
+        with new_vs_for_role(vs, role, key) as d:
+            table_name = unique_table_name()
+            # Without CREATE permissions, CreateTable with VectorIndexes fails:
+            new_named_table_unauthorized(d, table_name, **schema)
+            # With CREATE permissions, CreateTable with VectorIndexes succeeds:
+            with temporary_grant(cql, 'CREATE', 'ALL KEYSPACES', role):
+                with new_named_table(d, table_name, **schema):
+                    pass
+
+# Test that adding or deleting a vector index via UpdateTable requires
+# ALTER permission on the table, just as adding or deleting a GSI does.
+# The vector index is treated as a feature of the base table (like a GSI),
+# so modifying it requires ALTER rather than CREATE/DROP.
+def test_rbac_updatetable_vectorindex(vs, cql):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        with new_role(cql) as (role, key):
+            with new_vs_for_role(vs, role, key) as d:
+                tab = d.Table(table.name)
+                create_vi = {'VectorIndexUpdates': [{'Create': {
+                    'IndexName': 'vind',
+                    'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                }}]}
+                delete_vi = {'VectorIndexUpdates': [{'Delete': {'IndexName': 'vind'}}]}
+                # Without ALTER permissions, adding a vector index is denied:
+                unauthorized(lambda: tab.meta.client.update_table(
+                    TableName=tab.name, **create_vi))
+                # With ALTER permissions, adding a vector index is allowed:
+                with temporary_grant(cql, 'ALTER', cql_table_name(tab), role):
+                    authorized(lambda: tab.meta.client.update_table(
+                        TableName=tab.name, **create_vi))
+                # Wait for the vector index to actually exist before we try
+                # to delete it. Use the admin vs connection (table) which has
+                # full permissions and a vs-patched client to parse the response.
+                if vector_store_configured(table):
+                    wait_for_vector_index_active(table, 'vind')
+                # Without ALTER permissions, deleting the vector index is denied.
+                # Use a harmless UpdateTable first to wait until the permission
+                # revocation has taken effect, same technique as in
+                # test_rbac_updatetable_gsi above.
+                unauthorized(lambda: tab.meta.client.update_table(
+                    TableName=tab.name, BillingMode='PAY_PER_REQUEST'))
+                with pytest.raises(ClientError, match='AccessDeniedException'):
+                    tab.meta.client.update_table(TableName=tab.name, **delete_vi)
+                # With ALTER permissions, deleting the vector index is allowed:
+                with temporary_grant(cql, 'ALTER', cql_table_name(tab), role):
+                    authorized(lambda: tab.meta.client.update_table(
+                        TableName=tab.name, **delete_vi))
+
+# The previous tests checked which permissions are required to create and
+# query a vector index, but didn't check that the vector store really had
+# the permissions to read the base table, and could successfully index the
+# data. For example, we can create a base table that the user has permissions
+# to ALTER and MODIFY but not SELECT, so the user can create a vector index,
+# write to the table, but not be able to Query on it - but the vector store
+# will still be able to index the data, and this index can be read by another
+# user who has permissions to SELECT the table.
+# This test is needs_vector_store, i.e., it will be skipped if the vector
+# store is not configured.
+def test_rbac_vectorstore_indexing(vs, needs_vector_store, cql):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        with new_role(cql) as (role, key):
+            with new_vs_for_role(vs, role, key) as d:
+                tab = d.Table(table.name)
+                # Grant ALTER and MODIFY to the role, but *not* SELECT.
+                with temporary_grant(cql, 'ALTER', cql_table_name(table), role):
+                    with temporary_grant(cql, 'MODIFY', cql_table_name(table), role):
+                        p1 = random_string()
+                        # The role is allowed to insert an item (we haven't
+                        # created an index yet, we'll expect this item to be
+                        # visible in prefill).
+                        authorized(lambda: tab.put_item(Item={'p': p1, 'v': [1, 0, 0]}))
+                        # Create the vector index - ALTER permission allows this.
+                        authorized(lambda: tab.meta.client.update_table(
+                            TableName=tab.name, VectorIndexUpdates=[{'Create': {
+                                'IndexName': 'vind',
+                                'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}
+                            }}]))
+                        # Without SELECT permissions, the role cannot Query
+                        # the vector index.
+                        unauthorized(lambda: tab.query(IndexName='vind',
+                            VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1))
+                        # Wait for the backfill to complete. We can call
+                        # wait_for_vector_index_active() even on tab, without
+                        # SELECT permissions, because it uses DescribeTable to
+                        # check, not a Query.
+                        wait_for_vector_index_active(table, 'vind')
+                        # The superuser can query and find the prefilled item.
+                        result = table.query(IndexName='vind',
+                            VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1)
+                        assert result.get('Items') and result['Items'][0]['p'] == p1
+                        # Also test the CDC path: the role writes a new item after
+                        # the index is ACTIVE and the vector store should pick it up
+                        # via the CDC log, even though the role lacks SELECT.
+                        p2 = random_string()
+                        authorized(lambda: tab.put_item(Item={'p': p2, 'v': [0, 1, 0]}))
+                        # The superuser ("table") can see the new data:
+                        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+                        while True:
+                            result = table.query(IndexName='vind',
+                                VectorSearch={'QueryVector': [0, 1, 0]}, Limit=1)
+                            if result.get('Items') and result['Items'][0]['p'] == p2:
+                                break
+                            if time.monotonic() > deadline:
+                                pytest.fail('Timed out waiting for vector store to index the item via CDC')
+                            time.sleep(0.1)
+                        # If we now grant SELECT permissions to the role, it should
+                        # be able to query and find both items:
+                        with temporary_grant(cql, 'SELECT', cql_table_name(table), role):
+                            result = authorized(lambda: tab.query(IndexName='vind',
+                                VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2))
+                            assert {item['p'] for item in result['Items']} == {p1, p2}

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -490,14 +490,6 @@ def test_query_vector_item_metrics(vs, metrics, needs_vector_store):
 # in test_vector.py. This test is specifically about the *efficiency*: once
 # the optimization is implemented, returning projected attrs should not require
 # reading the base table at all.
-#
-# This optimization is not yet implemented: the vector store's ann() response
-# currently carries only primary-key columns (partition + clustering key) and
-# a similarity score; it does not yet return the projected non-key attribute
-# values.  Until the vector-store protocol is extended and the executor fast
-# path wired up for INCLUDE projection, this test is expected to fail.
-@pytest.mark.xfail(reason="INCLUDE fast-path (no base-table read) not yet implemented; "
-                           "ann() response does not carry projected column values")
 def test_vector_projection_include_no_base_table_read(vs, metrics, needs_vector_store):
     with new_test_table(vs,
             KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
@@ -539,12 +531,6 @@ def test_vector_projection_include_no_base_table_read(vs, metrics, needs_vector_
 # The correctness of SPECIFIC_ATTRIBUTES for INCLUDE projection is already
 # verified by test_vector_projection_include in test_vector.py.  This test
 # is specifically about the *efficiency* of the projected-attr case.
-#
-# This optimization is not yet implemented for the same reason as
-# test_vector_projection_include_no_base_table_read (ann() does not return
-# projected column values), so this test is also expected to fail.
-@pytest.mark.xfail(reason="INCLUDE fast-path (no base-table read) not yet implemented; "
-                           "ann() response does not carry projected column values")
 def test_vector_projection_include_specific_attributes_no_base_table_read(vs, metrics, needs_vector_store):
     with new_test_table(vs,
             KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -469,7 +469,7 @@ def test_query_vector_item_metrics(vs, metrics, needs_vector_store):
         assert after[base_metric] - before[base_metric] == 0
 
         # A SELECT=ALL_PROJECTED_ATTRIBUTES query increments items_from_vs
-        # and returned_items, but not items_from_base_table.
+        # and returned_items, but not items_from_base_table (KEYS_ONLY index).
         the_metrics = get_metrics(metrics)
         before = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
         result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2, Select='ALL_PROJECTED_ATTRIBUTES')
@@ -479,6 +479,112 @@ def test_query_vector_item_metrics(vs, metrics, needs_vector_store):
         assert after[vs_metric] - before[vs_metric] == 2
         assert after[returned_metric] - before[returned_metric] == 2
         assert after[base_metric] - before[base_metric] == 0
+
+# Test that SELECT=ALL_PROJECTED_ATTRIBUTES on an INCLUDE-projected vector
+# index does not read the base table (items_from_base_table stays 0), i.e.,
+# the projected non-key attributes are returned directly from the vector store
+# without a round-trip to Scylla's base table.
+#
+# The correctness of SELECT=ALL_PROJECTED_ATTRIBUTES (and other Select types)
+# for INCLUDE projection is already verified by test_vector_projection_include
+# in test_vector.py. This test is specifically about the *efficiency*: once
+# the optimization is implemented, returning projected attrs should not require
+# reading the base table at all.
+#
+# This optimization is not yet implemented: the vector store's ann() response
+# currently carries only primary-key columns (partition + clustering key) and
+# a similarity score; it does not yet return the projected non-key attribute
+# values.  Until the vector-store protocol is extended and the executor fast
+# path wired up for INCLUDE projection, this test is expected to fail.
+@pytest.mark.xfail(reason="INCLUDE fast-path (no base-table read) not yet implemented; "
+                           "ann() response does not carry projected column values")
+def test_vector_projection_include_no_base_table_read(vs, metrics, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        for i in range(3):
+            table.put_item(Item={'p': random_string(), 'v': [i, 0, 0], 'x': str(i), 'y': 'extra'})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+             'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']}}}])
+        wait_for_vector_index_active(table, 'vind')
+
+        vs_metric = 'scylla_alternator_vector_search_query_items_from_vs'
+        returned_metric = 'scylla_alternator_vector_search_query_returned_items'
+        base_metric = 'scylla_alternator_vector_search_query_items_from_base_table'
+        the_metrics = get_metrics(metrics)
+        before = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2,
+                             Select='ALL_PROJECTED_ATTRIBUTES')
+        assert result['Count'] == 2
+        # Projected non-key attr 'x' must be present; non-projected 'y' must not.
+        for item in result['Items']:
+            assert 'x' in item, f"projected attr 'x' missing from item {item}"
+            assert 'y' not in item, f"non-projected attr 'y' unexpectedly present in item {item}"
+        the_metrics = get_metrics(metrics)
+        after = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        assert after[vs_metric] - before[vs_metric] == 2
+        assert after[returned_metric] - before[returned_metric] == 2
+        # The key assertion: projected attrs should come from the vector store,
+        # not from a base-table read.
+        assert after[base_metric] - before[base_metric] == 0
+
+# Companion to test_vector_projection_include_no_base_table_read above, for
+# SELECT=SPECIFIC_ATTRIBUTES.  When requesting only a projected attribute ('x'),
+# the vector store already has the value and the base table should not be read.
+# When requesting a non-projected attribute ('y'), the vector store does not
+# have it, so a base-table read is required.
+#
+# The correctness of SPECIFIC_ATTRIBUTES for INCLUDE projection is already
+# verified by test_vector_projection_include in test_vector.py.  This test
+# is specifically about the *efficiency* of the projected-attr case.
+#
+# This optimization is not yet implemented for the same reason as
+# test_vector_projection_include_no_base_table_read (ann() does not return
+# projected column values), so this test is also expected to fail.
+@pytest.mark.xfail(reason="INCLUDE fast-path (no base-table read) not yet implemented; "
+                           "ann() response does not carry projected column values")
+def test_vector_projection_include_specific_attributes_no_base_table_read(vs, metrics, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        for i in range(3):
+            table.put_item(Item={'p': random_string(), 'v': [i, 0, 0], 'x': str(i), 'y': 'extra'})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+             'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']}}}])
+        wait_for_vector_index_active(table, 'vind')
+
+        vs_metric = 'scylla_alternator_vector_search_query_items_from_vs'
+        returned_metric = 'scylla_alternator_vector_search_query_returned_items'
+        base_metric = 'scylla_alternator_vector_search_query_items_from_base_table'
+
+        # Requesting only 'x' (projected): vector store has the value, no base-table read.
+        the_metrics = get_metrics(metrics)
+        before = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2,
+                             Select='SPECIFIC_ATTRIBUTES', ProjectionExpression='x')
+        assert result['Count'] == 2
+        the_metrics = get_metrics(metrics)
+        after = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        assert after[vs_metric] - before[vs_metric] == 2
+        assert after[returned_metric] - before[returned_metric] == 2
+        assert after[base_metric] - before[base_metric] == 0
+
+        # Requesting only 'y' (not projected into the index): vector store does
+        # not have it, so the base table must be read.
+        the_metrics = get_metrics(metrics)
+        before = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2,
+                             Select='SPECIFIC_ATTRIBUTES', ProjectionExpression='y')
+        assert result['Count'] == 2
+        the_metrics = get_metrics(metrics)
+        after = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        assert after[vs_metric] - before[vs_metric] == 2
+        assert after[returned_metric] - before[returned_metric] == 2
+        assert after[base_metric] - before[base_metric] == 2
 
 # Test counters for DescribeEndpoints:
 def test_describe_endpoints_operations(dynamodb, metrics):

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -1024,6 +1024,34 @@ def test_query_vectorsearch_limit_bad(table_vs):
                 Limit=bad_limit
             )
 
+# The maximum allowed Limit for vector search. Set as max_vector_search_limit
+# in executor.cc, and analogous to CQL's max_ann_query_limit defined in
+# select_statement.hh.
+MAX_VECTOR_SEARCH_LIMIT = 1000
+
+# Test that a Query with VectorSearch does not allow a Limit above
+# MAX_VECTOR_SEARCH_LIMIT. This limit also exists in CQL as max_ann_query_limit
+# in vector_indexed_table_select_statement (select_statement.hh). The allowed
+# Limit needs to be limited because vector search does not support pagination.
+def test_query_vectorsearch_limit_too_large(table_vs):
+    with pytest.raises(ClientError, match='ValidationException.*Limit'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 2, 3]},
+            Limit=MAX_VECTOR_SEARCH_LIMIT + 1,
+        )
+
+# Test that a Query with VectorSearch with Limit=MAX_VECTOR_SEARCH_LIMIT
+# (the maximum allowed value) succeeds - it should not be rejected.
+# The query may return fewer results than the limit (the table_vs fixture
+# has few items, possibly none), but must not fail with a validation error.
+def test_query_vectorsearch_limit_at_max(table_vs, needs_vector_store):
+    table_vs.query(
+        IndexName='vind',
+        VectorSearch={'QueryVector': [1, 2, 3]},
+        Limit=MAX_VECTOR_SEARCH_LIMIT,
+    )
+
 # Test that a Query with VectorSearch does not support ConsistentRead=True,
 # just like queries on a GSI.
 def test_query_vectorsearch_consistent_read(table_vs):

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -42,12 +42,12 @@ boto3.dynamodb.types.DYNAMODB_CONTEXT = decimal.Context(prec=100)
 # but the more "official" way would be to modify botocore's JSON configuration
 # file, botocore/data/dynamodb/2012-08-10/service-2.json.
 
-# add_vs_to_client() is a context manager that modifies the given boto3
-# client to accept the new vector-search parameters in requests and responses,
-# and also monkey-patches the TypeSerializer/TypeDeserializer so that the
-# Vector type is serialized as FLOAT32VECTOR. The patches are restored on exit.
-@contextmanager
-def add_vs_to_client(client):
+# add_vs_to_resource() modifies the given boto3 resource (and the low-level
+# boto3 client held by it) to accept the new vector-search parameters in
+# requests and responses. It also modifies the resource to serialize and
+# deserialize Vector() values to the optimized FLOAT32VECTOR format.
+def add_vs_to_resource(resource):
+    client = resource.meta.client
     # All the new parameter "shapes" that we will use below for the
     # new parameters of the different operations:
     new_shapes = {
@@ -185,26 +185,19 @@ def add_vs_to_client(client):
     attribute_value_shape._cache.pop('members', None)
     shape_resolver._shape_cache.pop('AttributeValue', None)
 
-    # Monkey-patch boto3 resource's TypeSerializer so that values of type
-    # "Vector" (a class defined below) are serialized into the JSON request as
-    # {"FLOAT32VECTOR": [1.0, ...]} (JSON numbers) instead of the standard
-    # list encoding {"L": [{"N": "1.0"}, ...]}. This allows the high-level
-    # resource interface (table.put_item etc.) to send Vector attributes
-    # without needing client_no_transform.
-    _orig_serialize = boto3.dynamodb.types.TypeSerializer.serialize
-    def _serialize_with_vector(self, value):
-        if isinstance(value, Vector):
-            return {'FLOAT32VECTOR': list(value)}
-        return _orig_serialize(self, value)
-    boto3.dynamodb.types.TypeSerializer.serialize = _serialize_with_vector
-    _had_deserialize = hasattr(boto3.dynamodb.types.TypeDeserializer, '_deserialize_float32vector')
-    boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector = lambda self, value: Vector(value)
-    try:
-        yield
-    finally:
-        boto3.dynamodb.types.TypeSerializer.serialize = _orig_serialize
-        if not _had_deserialize:
-            del boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector
+    # Patch the resource's _injector serializer/deserializer so that Vector
+    # values are sent as FLOAT32VECTOR instead of the standard DynamoDB list
+    # encoding, and FLOAT32VECTOR responses are deserialized back to Vector.
+    class _VectorTypeSerializer(boto3.dynamodb.types.TypeSerializer):
+        def serialize(self, value):
+            if isinstance(value, Vector):
+                return {'FLOAT32VECTOR': list(value)}
+            return super().serialize(value)
+    class _VectorTypeDeserializer(boto3.dynamodb.types.TypeDeserializer):
+        def _deserialize_float32vector(self, value):
+            return Vector(value)
+    resource._injector._serializer = _VectorTypeSerializer()
+    resource._injector._deserializer = _VectorTypeDeserializer()
 
 
 @pytest.fixture(scope="module")
@@ -212,15 +205,14 @@ def vs(new_dynamodb_session, dynamodb):
     if is_aws(dynamodb):
         skip_env('Scylla-only: vector search extensions not available on DynamoDB')
     resource = new_dynamodb_session()
-    with add_vs_to_client(resource.meta.client):
-        yield resource
+    add_vs_to_resource(resource)
+    yield resource
 
 # Use the Vector(list) type for test values that are meant to be stored as
 # optimized vectors (array of floats instead of JSON list of numbers).
-# The serialization monkey-patching in the vs fixture will cause this list
-# to be serialized and sent to Alternator as
-# {'FLOAT32VECTOR': [1.0, 2.0, ...]}} instead of the standard list-of-numbers
-# {'L': [{'N': '1.0'}, ...]}.
+# The _injector patching in the vs fixture will cause this list to be
+# serialized and sent to Alternator as {'FLOAT32VECTOR': [1.0, 2.0, ...]}
+# instead of the standard list-of-numbers {'L': [{'N': '1.0'}, ...]}.
 class Vector(list):
     pass
 

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -1376,11 +1376,12 @@ def test_query_vector_cdc_lwt(vs, needs_vector_store):
 # Similar to test_query_vector_cdc, this test also that a vector search Query
 # find data inserted after the index was created. But this test adds a twist:
 # before creating the index, we insert a malformed value for the vector
-# attribute (a string). We check that this malformed is ignored by the initial
-# prefill scan, but should not prevent a later write with a well-formed vector
-# from being indexed and returned by queries.
+# attribute (a string or wrong-length vector). We check that this malformed
+# value is ignored by the initial prefill scan, but should not prevent a later
+# write with a well-formed vector from being indexed and returned by queries.
+@pytest.mark.parametrize('use_update_item', [False, True], ids=['put_item', 'update_item'])
 @pytest.mark.parametrize('malformed', ['garbage', [1,2]], ids=['string','wrong_length'])
-def test_query_vector_cdc_malformed_prefill(vs, needs_vector_store, malformed):
+def test_query_vector_cdc_malformed_prefill(vs, needs_vector_store, malformed, use_update_item):
     with new_test_table(vs,
             KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
             AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
@@ -1403,7 +1404,12 @@ def test_query_vector_cdc_malformed_prefill(vs, needs_vector_store, malformed):
         assert len(result['Items']) == 1 and result['Items'][0]['p'] == p2
         # Now replace the value of p1 by a properly formed vector. It should
         # be eventually picked up by CDC and indexed by the vector index:
-        table.put_item(Item={'p': p1, 'v': [1, Decimal("0.1"), 0]})
+        if use_update_item:
+            table.update_item(Key={'p': p1},
+                UpdateExpression='SET v = :v',
+                ExpressionAttributeValues={':v': [1, Decimal("0.1"), 0]})
+        else:
+            table.put_item(Item={'p': p1, 'v': [1, Decimal("0.1"), 0]})
         deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
         while True:
             result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]},
@@ -1645,6 +1651,18 @@ def test_batchwriteitem_vectorindex_bad_vector(table_vs):
         with table_vs.batch_writer() as batch:
             batch.put_item(Item={'p': p, 'v': [1, Decimal('1e100'), 3]})
 
+# If one item in the batch is valid and another is invalid, the entire
+# batch should be rejected and neither item should be inserted:
+def test_batchwriteitem_vectorindex_bad_and_good(table_vs):
+    p_good = random_string()
+    p_bad = random_string()
+    with pytest.raises(ClientError, match='ValidationException'):
+        with table_vs.batch_writer() as batch:
+            batch.put_item(Item={'p': p_good, 'v': [1, 2, 3]})
+            batch.put_item(Item={'p': p_bad,  'v': 'not a list'})
+    assert 'Item' not in table_vs.get_item(Key={'p': p_good}, ConsistentRead=True)
+    assert 'Item' not in table_vs.get_item(Key={'p': p_bad},  ConsistentRead=True)
+
 # Test that DeleteItem removes the item from the vector index.
 # Two variants are tested via parametrize:
 # - without clustering key (no_ck): deleting the only item in a partition
@@ -1700,6 +1718,115 @@ def test_deleteitem_vectorindex(vs, needs_vector_store, with_ck):
             if time.monotonic() > deadline:
                 pytest.fail('Timed out waiting for deleted item to disappear from vector index')
             time.sleep(0.1)
+
+# Test that PutItem or UpdateItem on an existing item replaces its vector in
+# the index: the old vector is removed and the new one is indexed. Two items
+# are inserted so we can verify the ordering changes after the replace.
+@pytest.mark.parametrize('use_update_item', [False, True], ids=['put_item', 'update_item'])
+def test_replace_vector_vectorindex(vs, needs_vector_store, use_update_item):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p1 = random_string()
+        p2 = random_string()
+        # Insert two different items and index them.
+        table.put_item(Item={'p': p1, 'v': [1, 0, 0]})
+        table.put_item(Item={'p': p2, 'v': [0, 1, 0]})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        # Initially, search [1, 0, 0] returns p1 first, p2 second.
+        result = table.query(IndexName='vind',
+                             VectorSearch={'QueryVector': [1, 0, 0]},
+                             Limit=2)
+        assert [item['p'] for item in result['Items']] == [p1, p2]
+        # Replace p1's vector with [-1, 0, 0] (opposite direction, now farthest
+        # from [1, 0, 0]), using either PutItem or UpdateItem.
+        if use_update_item:
+            table.update_item(Key={'p': p1},
+                UpdateExpression='SET v = :v',
+                ExpressionAttributeValues={':v': [-1, 0, 0]})
+        else:
+            table.put_item(Item={'p': p1, 'v': [-1, 0, 0]})
+        # Wait until the index reflects the change: p2 should now come before p1
+        # in a search for [1, 0, 0].
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(IndexName='vind',
+                                 VectorSearch={'QueryVector': [1, 0, 0]},
+                                 Limit=2)
+            got = [item['p'] for item in result.get('Items', [])]
+            if got == [p2, p1]:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail(f'Timed out waiting for index to reflect replaced vector; last order: {got}')
+            time.sleep(0.1)
+
+# Test that UpdateItem modifying non-vector attributes does not affect the
+# vector index: the item remains discoverable by its unchanged vector, and
+# its updated attributes are returned with Select='ALL_ATTRIBUTES'.
+def test_updateitem_nonvector_vectorindex(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': [1, 0, 0], 'x': 'before'})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        # UpdateItem to change a non-vector attribute.
+        table.update_item(Key={'p': p},
+            UpdateExpression='SET x = :newx',
+            ExpressionAttributeValues={':newx': 'after'})
+        # The item should still be findable by its vector, which didn't change.
+        # Select='ALL_ATTRIBUTES' fetches the full item from the base table (x
+        # is not projected), so the updated x should be visible immediately
+        # without any delay (note that actually, the item is read with eventual
+        # consistency so there can be a delay, on on our single-node setup there
+        # won't be any consistency delay).
+        result = table.query(IndexName='vind',
+                             VectorSearch={'QueryVector': [1, 0, 0]},
+                             Select='ALL_ATTRIBUTES',
+                             Limit=1)
+        assert result['Items'] == [{'p': p, 'v': [1, 0, 0], 'x': 'after'}]
+
+# Test that UpdateItem removing the vector attribute (but not the item itself)
+# causes the item to be removed from the vector index. The item should still
+# exist in the base table (readable via GetItem), but must no longer appear
+# in vector search results.
+def test_updateitem_remove_vector_vectorindex(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': [1, 0, 0], 'x': 'hello'})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(IndexName='vind',
+                             VectorSearch={'QueryVector': [1, 0, 0]},
+                             Limit=1)
+        # Verify the item was indexed
+        assert result['Items'] == [{'p': p}]
+        # Remove only the vector attribute, leaving the rest of the item intact.
+        table.update_item(Key={'p': p}, UpdateExpression='REMOVE v')
+        # The item must eventually disappear from the vector index.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(IndexName='vind',
+                                 VectorSearch={'QueryVector': [1, 0, 0]},
+                                 Limit=1)
+            if not result['Items']:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail('Timed out waiting for item to disappear from vector index after vector attribute removal')
+            time.sleep(0.1)
+        # The item itself must still exist in the base table, just without 'v'.
+        result = table.get_item(Key={'p': p}, ConsistentRead=True)
+        assert result['Item'] == {'p': p, 'x': 'hello'}
 
 # Test vector index with Alternator TTL together. A table is created without
 # TTL enabled, data is inserted with expiration time set to the past (but
@@ -2808,6 +2935,55 @@ def test_query_vectorsearch_return_similarity_dot_product_overflow2(vs, needs_ve
         assert scores[1] == pytest.approx(0.5, abs=1e-5)
         # The highly dissimilar item's score should be large and negative.
         assert scores[2] < -BIG
+
+# In virtually all the tests above, we used vectors of dimension 3 as an
+# example. But dimensions up to MAX_VECTOR_DIMENSION are allowed, so let's
+# have at least one test that actually uses MAX_VECTOR_DIMENSION to check
+# that it works end-to-end - indexing (via either prefill or CDC) and
+# querying.
+@pytest.mark.parametrize('via_cdc', [False, True], ids=['prefill', 'cdc'])
+def test_query_vector_max_dimension(vs, needs_vector_store, via_cdc):
+    dim = MAX_VECTOR_DIMENSION
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            **({} if not via_cdc else
+               {'VectorIndexes': [{'IndexName': 'vind',
+                                   'VectorAttribute': {'AttributeName': 'v',
+                                                       'Dimensions': dim}}]}
+            )) as table:
+        if via_cdc:
+            # The index was already created in new_test_table above. Wait for
+            # it to become ACTIVE so that subsequent writes are picked up via
+            # CDC rather than prefill.
+            wait_for_vector_index_active(table, 'vind')
+        # Build a query vector: all zeros except the first element which is 1.
+        # The item we insert has exactly this vector, so it is the nearest
+        # neighbor of the query.
+        query_vec = Vector([1.0] + [0.0] * (dim - 1))
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': query_vec})
+        if not via_cdc:
+            # For the prefill case the index is created after the data, so
+            # we create it now and wait for the prefill scan to complete.
+            table.update(VectorIndexUpdates=[{'Create':
+                {'IndexName': 'vind',
+                 'VectorAttribute': {'AttributeName': 'v', 'Dimensions': dim}}}])
+            wait_for_vector_index_active(table, 'vind')
+        # Retry the query until the item appears in the results.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': query_vec},
+                Limit=1,
+            )
+            if result.get('Items') and result['Items'][0]['p'] == p:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail(f'Timed out waiting for MAX_VECTOR_DIMENSION={dim} item to appear via '
+                            f'{"CDC" if via_cdc else "prefill"}')
+            time.sleep(0.1)
 
 ##############################################################################
 # CONTINUE HERE - MAKE A DECISION! PRE-FILTERING:

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -720,6 +720,27 @@ def test_updatetable_vectorindex_taken_name_or_attribute(vs):
                       'VectorAttribute': {'AttributeName': bad_attr, 'Dimensions': 17 }
                     }}])
 
+# Like test_updatetable_vectorindex_taken_name_or_attribute() above, but the
+# existing vector index was created with an INCLUDE projection. In this case
+# the target option is stored as JSON ({"tc":"v","fc":[...]}) rather than a
+# plain attribute name, and the duplicate-attribute check must still work.
+def test_updatetable_vectorindex_taken_attribute_include(vs):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            VectorIndexes=[
+                {'IndexName': 'vec',
+                 'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                 'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']}}
+            ]) as table:
+        # 'v' is already the target of an INCLUDE-projected vector index;
+        # adding a second vector index on the same attribute must be rejected.
+        with pytest.raises(ClientError, match='ValidationException.*AttributeName'):
+            table.update(VectorIndexUpdates=[{'Create':
+                {'IndexName': 'newind',
+                 'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}
+                }}])
+
 # In test_updatetable_vectorindex_taken_name_or_attribute() above we tested
 # that we can't add a vector index with the same name as an existing GSI or
 # LSI. Here we check that the reverse also holds - we can't add a GSI with
@@ -1670,6 +1691,36 @@ def test_updateitem_vectorindex_bad_vector(table_vs):
             UpdateExpression='SET v = :val',
             ExpressionAttributeValues={':val': [1, Decimal('1e100'), 3]})
 
+# Like test_putitem_vectorindex_bad_vector and test_updateitem_vectorindex_bad_vector
+# above, but the table uses an INCLUDE-projected vector index. In this case the
+# target column is stored as JSON (which also lists the projected attributes),
+# and it we need to extract the attribute name correctly to know which
+# attributes in the update we need to validate.
+def test_putitem_updateitem_vectorindex_bad_vector_include(vs):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            VectorIndexes=[
+                {'IndexName': 'vind',
+                 'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                 'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']}}
+            ]) as table:
+        p = random_string()
+        # A list of the wrong length - should be rejected by PutItem:
+        with pytest.raises(ClientError, match='ValidationException'):
+            table.put_item(Item={'p': p, 'v': [1, 2]})
+        with pytest.raises(ClientError, match='ValidationException'):
+            table.put_item(Item={'p': p, 'v': [1, 2, 3, 4]})
+        # A list of the wrong length - should be rejected by UpdateItem:
+        with pytest.raises(ClientError, match='ValidationException'):
+            table.update_item(Key={'p': p},
+                UpdateExpression='SET v = :val',
+                ExpressionAttributeValues={':val': [1, 2]})
+        with pytest.raises(ClientError, match='ValidationException'):
+            table.update_item(Key={'p': p},
+                UpdateExpression='SET v = :val',
+                ExpressionAttributeValues={':val': [1, 2, 3, 4]})
+
 # Same as test_putitem_vectorindex_bad_vector but using BatchWriteItem.
 def test_batchwriteitem_vectorindex_bad_vector(table_vs):
     p = random_string()
@@ -2066,6 +2117,13 @@ def test_vector_projection_bad(vs):
         # 'not_an_object',   # We can't check this with boto3
         {'ProjectionType': 'GARBAGE'},
         {},  # missing ProjectionType
+        {'ProjectionType': 'INCLUDE'},  # INCLUDE without NonKeyAttributes
+        {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': []},  # INCLUDE with empty list
+        # ProjectionType=ALL is not yet supported for vector indexes.
+        # Supporting it would require the vector store to store and search
+        # across the entire :attrs map blob (arbitrary per-item attributes),
+        # rather than a fixed list of named columns as INCLUDE does.
+        {'ProjectionType': 'ALL'},
     ]
     for bad_projection in bad_projections:
         with pytest.raises(ClientError, match='ValidationException.*Projection'):
@@ -2091,7 +2149,7 @@ def test_vector_projection_bad(vs):
 
 # Test that a vector index created with Projection={'ProjectionType': 'KEYS_ONLY'}
 # (via CreateTable or UpdateTable) works correctly:
-# - The ProjectionType=KEYS_ONLY is accepted
+# - DescribeTable returns the correct Projection (no NonKeyAttributes)
 # - Select=ALL_PROJECTED_ATTRIBUTES returns only the primary key attributes
 # - Select=ALL_ATTRIBUTES returns all attributes
 # ProjectionType=KEYS_ONLY matches the default vector index behavior, so it
@@ -2121,6 +2179,12 @@ def test_vector_projection_keys_only(vs, needs_vector_store, via_update):
         p = random_string()
         table.put_item(Item={'p': p, 'v': [1, 0, 0], 'x': 'hello'})
         wait_for_vector_index_active(table, 'vind')
+        # DescribeTable returns the correct Projection.
+        desc = table.meta.client.describe_table(TableName=table.name)
+        vec_indexes = desc['Table'].get('VectorIndexes', [])
+        assert len(vec_indexes) == 1
+        assert vec_indexes[0]['Projection']['ProjectionType'] == 'KEYS_ONLY'
+        assert 'NonKeyAttributes' not in vec_indexes[0]['Projection']
         # Select=ALL_PROJECTED_ATTRIBUTES returns only the primary key.
         result = table.query(
             IndexName='vind',
@@ -2135,6 +2199,269 @@ def test_vector_projection_keys_only(vs, needs_vector_store, via_update):
             Limit=1,
             Select='ALL_ATTRIBUTES')
         assert result['Items'] == [{'p': p, 'v': [1, 0, 0], 'x': 'hello'}]
+
+# Test that a vector index created with Projection={'ProjectionType': 'INCLUDE'}
+# and NonKeyAttributes works correctly:
+# - DescribeTable returns the correct Projection (including NonKeyAttributes)
+# - Select=ALL_PROJECTED_ATTRIBUTES returns key + non-key projected attributes only
+# - Select=ALL_ATTRIBUTES returns all attributes (base table lookup)
+# - KeyConditionExpression can filter on the projected non-key attribute (pre-filter)
+@pytest.mark.parametrize('via_update', [False, True], ids=['createtable', 'updatetable'])
+def test_vector_projection_include(vs, needs_vector_store, via_update):
+    if via_update:
+        ctx = new_test_table(vs,
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}])
+    else:
+        ctx = new_test_table(vs,
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+                VectorIndexes=[{
+                    'IndexName': 'vind',
+                    'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                    'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']},
+                }])
+    with ctx as table:
+        if via_update:
+            table.update(VectorIndexUpdates=[{'Create': {
+                'IndexName': 'vind',
+                'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']},
+            }}])
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': [1, 0, 0], 'x': 'hello', 'y': 'world'})
+        wait_for_vector_index_active(table, 'vind')
+        # DescribeTable returns the correct Projection.
+        desc = table.meta.client.describe_table(TableName=table.name)
+        vec_indexes = desc['Table'].get('VectorIndexes', [])
+        assert len(vec_indexes) == 1
+        assert vec_indexes[0]['Projection']['ProjectionType'] == 'INCLUDE'
+        assert vec_indexes[0]['Projection']['NonKeyAttributes'] == ['x']
+        # Select=ALL_PROJECTED_ATTRIBUTES returns only key + projected non-key attrs.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            Limit=1,
+            Select='ALL_PROJECTED_ATTRIBUTES')
+        assert result['Items'] == [{'p': p, 'x': 'hello'}]
+        # Select=ALL_ATTRIBUTES returns the full item.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            Limit=1,
+            Select='ALL_ATTRIBUTES')
+        assert result['Items'] == [{'p': p, 'v': [1, 0, 0], 'x': 'hello', 'y': 'world'}]
+
+# Test that a INCLUDE-projected non-key attribute can be used in a
+# KeyConditionExpression (pre-filter sent to the vector store).
+def test_vector_projection_include_prefilter(vs, needs_vector_store):
+    # Create the table WITHOUT a vector index first, put items, then add the
+    # index so that the initial scan backfill sees the items (and their 'x'
+    # filtering column values) rather than relying solely on CDC.
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        # Two items: "keep" has x='a', "drop" is nearer but x='b'.
+        table.put_item(Item={'p': p + '_drop', 'v': Vector([0, 0, 1]), 'x': 'b'})
+        table.put_item(Item={'p': p + '_keep', 'v': Vector([0.1, 0, 1]), 'x': 'a'})
+        table.update(VectorIndexUpdates=[{'Create': {
+            'IndexName': 'vind',
+            'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+            'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']},
+        }}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditionExpression='x = :val',
+            ExpressionAttributeValues={':val': 'a'},
+        )
+        assert result['Count'] == 1
+        assert result['Items'][0]['p'] == p + '_keep'
+
+# Like test_vector_projection_include_prefilter but uses a number (N-type)
+# attribute for pre-filtering. Numbers are stored by Alternator as CQL
+# decimal, not as raw UTF-8, so this exercises the N-type decoding path in
+# extract_alternator_scalar.
+def test_vector_projection_include_prefilter_number(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        table.put_item(Item={'p': p + '_drop', 'v': Vector([0, 0, 1]), 'score': Decimal('1')})
+        table.put_item(Item={'p': p + '_keep', 'v': Vector([0.1, 0, 1]), 'score': Decimal('2')})
+        table.update(VectorIndexUpdates=[{'Create': {
+            'IndexName': 'vind',
+            'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+            'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['score']},
+        }}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditionExpression='score = :val',
+            ExpressionAttributeValues={':val': Decimal('2')},
+        )
+        assert result['Count'] == 1
+        assert result['Items'][0]['p'] == p + '_keep'
+
+# Test that when a numeric pre-filter (e.g. x < 2) is used on an INCLUDE-
+# projected attribute, items where the attribute is either missing entirely or
+# has the wrong type (a string instead of a number) are silently filtered out
+# rather than causing an error. Only items with a matching numeric value should
+# be returned.
+def test_vector_projection_include_prefilter_type_mismatch(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        # Four items close to the query vector [1, 0, 0] so all four appear as
+        # nearest neighbors within Limit=4.  Only "_keep" has a numeric x < 2.
+        # "_drop_num" has x=3 (numeric but out of range).
+        # "_drop_str" has x='hello' (string, wrong type for a numeric filter).
+        # "_drop_missing" has no x attribute at all.
+        table.put_item(Item={'p': p + '_keep',         'v': Vector([1,   0, 0]), 'x': Decimal('1')})
+        table.put_item(Item={'p': p + '_drop_num',     'v': Vector([0.9, 0, 0]), 'x': Decimal('3')})
+        table.put_item(Item={'p': p + '_drop_str',     'v': Vector([0.8, 0, 0]), 'x': 'hello'})
+        table.put_item(Item={'p': p + '_drop_missing', 'v': Vector([0.7, 0, 0])})
+        table.update(VectorIndexUpdates=[{'Create': {
+            'IndexName': 'vind',
+            'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+            'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']},
+        }}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            Limit=4,
+            KeyConditionExpression='x < :val',
+            ExpressionAttributeValues={':val': Decimal('2')},
+        )
+        assert result['Count'] == 1
+        assert result['Items'][0]['p'] == p + '_keep'
+
+# Test that numeric pre-filter comparisons (e.g. x < 5) use numeric ordering,
+# not lexicographic string ordering. This is a regression test: if N-type
+# attributes are stored and compared as strings, "10" < "5" and "20" < "5"
+# would be true (wrong), returning items that should be excluded.
+def test_vector_projection_include_prefilter_number_ordering(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        # Items with x=1, x=2, x=10, x=20 (numbers) and x='1' (string).
+        # A filter of x < 5 should return only x=1 and x=2.
+        # Lexicographic comparison would incorrectly also match x=10 and x=20.
+        # The S-type string '1' must NOT match even though '1' parses as 1 < 5:
+        # type mismatches (S-type vs a numeric filter) must be rejected.
+        table.put_item(Item={'p': p + '_1',    'v': Vector([1,   0, 0]), 'x': Decimal('1')})
+        table.put_item(Item={'p': p + '_2',    'v': Vector([0.9, 0, 0]), 'x': Decimal('2')})
+        table.put_item(Item={'p': p + '_10',   'v': Vector([0.8, 0, 0]), 'x': Decimal('10')})
+        table.put_item(Item={'p': p + '_20',   'v': Vector([0.7, 0, 0]), 'x': Decimal('20')})
+        table.put_item(Item={'p': p + '_str1', 'v': Vector([0.6, 0, 0]), 'x': '1'})
+        table.update(VectorIndexUpdates=[{'Create': {
+            'IndexName': 'vind',
+            'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+            'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']},
+        }}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            Limit=5,
+            KeyConditionExpression='x < :val',
+            ExpressionAttributeValues={':val': Decimal('5')},
+        )
+        assert result['Count'] == 2
+        items_x = {item['x'] for item in result['Items']}
+        assert items_x == {Decimal('1'), Decimal('2')}
+
+# Test that a KeyConditionExpression referencing an attribute that is NOT in
+# the vector index's NonKeyAttributes list is rejected with a
+# ValidationException. Pre-filtering is only allowed on projected attributes.
+def test_vector_projection_include_prefilter_non_projected(vs):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            VectorIndexes=[{
+                'IndexName': 'vind',
+                'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']},
+            }]) as table:
+        # 'y' is not in NonKeyAttributes=['x'], so this must be rejected.
+        with pytest.raises(ClientError, match='ValidationException.*y'):
+            table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]},
+                Limit=1,
+                KeyConditionExpression='y = :val',
+                ExpressionAttributeValues={':val': 'hello'},
+            )
+        # Same for a KEYS_ONLY index: no non-key attribute may be used.
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            VectorIndexes=[{
+                'IndexName': 'vind',
+                'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                'Projection': {'ProjectionType': 'KEYS_ONLY'},
+            }]) as table:
+        with pytest.raises(ClientError, match='ValidationException.*x'):
+            table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]},
+                Limit=1,
+                KeyConditionExpression='x = :val',
+                ExpressionAttributeValues={':val': 'hello'},
+            )
+
+# Test that INCLUDE-projected filtering columns are picked up via CDC (i.e.
+# for items written AFTER the index is created), not just via the initial
+# backfill scan. The CDC consumer is a separate code path from the scan.
+def test_vector_projection_include_prefilter_cdc(vs, needs_vector_store):
+    # Create the table WITH the vector index so items are indexed via CDC.
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            VectorIndexes=[{
+                'IndexName': 'vind',
+                'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']},
+            }]) as table:
+        # Wait until the empty-table prefill scan completes so subsequent
+        # writes are guaranteed to go through the CDC path.
+        wait_for_vector_index_active(table, 'vind')
+        p = random_string()
+        # Two items written after the index exists → indexed via CDC.
+        # "drop" is nearer to the query vector but has x='b'; "keep" has x='a'.
+        table.put_item(Item={'p': p + '_drop', 'v': Vector([0, 0, 1]),   'x': 'b'})
+        table.put_item(Item={'p': p + '_keep', 'v': Vector([0.1, 0, 1]), 'x': 'a'})
+        # Retry until both items are visible, then check that the pre-filter works.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [0, 0, 1]},
+                Limit=2,
+            )
+            if len(result.get('Items', [])) == 2:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail('Timed out waiting for CDC-indexed items to appear')
+            time.sleep(0.1)
+        # Both items are now indexed. Apply the pre-filter.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=2,
+            KeyConditionExpression='x = :val',
+            ExpressionAttributeValues={':val': 'a'},
+        )
+        assert result['Count'] == 1
+        assert result['Items'][0]['p'] == p + '_keep'
 
 # As we saw in test_item.py::test_attribute_allowed_chars in the DynamoDB API
 # attribute names can contain any characters whatsoever, including quotes,

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -923,6 +923,9 @@ def test_putitem_vectorindex_updatetable(vs):
 # global queries on it, not filtering to a specific partition, may get
 # results from other tests - so such tests will need to create their own
 # table instead of using this shared one.
+# If vector store is configured, we wait for the vector index to become
+# active before yielding the table, so tests that use this fixture can
+# read from it immediately.
 @pytest.fixture(scope="module")
 def table_vs(vs):
     with new_test_table(vs,
@@ -932,6 +935,8 @@ def table_vs(vs):
                 {'IndexName': 'vind',
                  'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}
             ]) as table:
+        if vector_store_configured(table):
+            wait_for_vector_index_active(table, 'vind')
         yield table
 
 # Test that a Query with a VectorSearch parameter without an IndexName
@@ -1107,7 +1112,7 @@ def vector_store_configured(table_vs):
 # It is assumed that if Scylla is configured to use the vector store, then
 # the reverse is also true - the vector store is configured to use Scylla,
 # so we can check the end-to-end functionality.
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def needs_vector_store(table_vs):
     if not vector_store_configured(table_vs):
         skip_env('Vector Store is not configured (run with --vs)')

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -2805,24 +2805,40 @@ def test_createtable_query_similarity_function(vs, needs_vector_store):
     p_small = random_string()
     p_big   = random_string()
     p_close = random_string()
-    for sf, expected_p in [('COSINE', p_small),
-                            ('DOT_PRODUCT', p_big),
-                            ('EUCLIDEAN', p_close)]:
-        with new_test_table(vs,
-                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
-                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
-            table.put_item(Item={'p': p_small, 'v': [Decimal("0.5"), Decimal("0"),    Decimal("0")]})
-            table.put_item(Item={'p': p_big,   'v': [Decimal("2"),   Decimal("0.01"), Decimal("0")]})
-            table.put_item(Item={'p': p_close, 'v': [Decimal("1"),   Decimal("0.3"),  Decimal("0")]})
+    similarity_functions = [
+        ('COSINE',      p_small),
+        ('DOT_PRODUCT', p_big),
+        ('EUCLIDEAN',   p_close),
+    ]
+    # Use a single table with all three indexes (one per similarity function),
+    # each on its own vector attribute (multiple indexes on the same attribute
+    # are not allowed). All indexes are created before waiting for any of them,
+    # so their prefill scans run in parallel. This also tests that a table can
+    # have multiple vector indexes with different similarity functions at once.
+    small_v = Vector([0.5,  0,    0])
+    big_v   = Vector([2,    0.01, 0])
+    close_v = Vector([1,    0.3,  0])
+    query_v = Vector([1,    0,    0])
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        table.put_item(Item={'p': p_small, 'v_COSINE': small_v, 'v_DOT_PRODUCT': small_v, 'v_EUCLIDEAN': small_v})
+        table.put_item(Item={'p': p_big,   'v_COSINE': big_v,   'v_DOT_PRODUCT': big_v,   'v_EUCLIDEAN': big_v})
+        table.put_item(Item={'p': p_close, 'v_COSINE': close_v, 'v_DOT_PRODUCT': close_v, 'v_EUCLIDEAN': close_v})
+        # Create all three indexes before waiting for any of them, so their
+        # prefill scans run in parallel.
+        for sf, _ in similarity_functions:
             table.update(VectorIndexUpdates=[{'Create': {
-                'IndexName': 'vind',
-                'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                'IndexName': f'vind_{sf}',
+                'VectorAttribute': {'AttributeName': f'v_{sf}', 'Dimensions': 3},
                 'SimilarityFunction': sf,
             }}])
-            wait_for_vector_index_active(table, 'vind')
+        for sf, _ in similarity_functions:
+            wait_for_vector_index_active(table, f'vind_{sf}')
+        for sf, expected_p in similarity_functions:
             result = table.query(
-                IndexName='vind',
-                VectorSearch={'QueryVector': [Decimal("1"), Decimal("0"), Decimal("0")]},
+                IndexName=f'vind_{sf}',
+                VectorSearch={'QueryVector': query_v},
                 Limit=1,
                 Select='ALL_PROJECTED_ATTRIBUTES',
             )

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -1227,6 +1227,27 @@ def test_vectorindex_status_without_vector_store(vs):
 # vector store to index data. Centralized here so it can be adjusted easily.
 VECTOR_STORE_TIMEOUT = 20
 
+def retrying(msg, timeout=VECTOR_STORE_TIMEOUT):
+    """Retry loop generator. Yields on each attempt, sleeping 0.1s between
+    retries. Fails after timeout seconds with 'Timed out waiting for <msg>'.
+    Use timeout to override the default timeout.
+
+    Usage::
+
+        for _ in retrying('X to happen'):
+            try:
+                if condition:
+                    break
+            except ClientError:
+                pass
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        yield
+        if time.monotonic() > deadline:
+            pytest.fail('Timed out waiting for ' + msg)
+        time.sleep(0.05)
+
 # Test that a vector search Query returns the nearest-neighbour item.
 # The vector store is eventually consistent: after put_item the ANN index
 # takes time to reflect the new item, so we retry until it appears.
@@ -1242,8 +1263,7 @@ def test_query_vector_prefill(vs, needs_vector_store):
         table.update(VectorIndexUpdates=[{'Create':
             {'IndexName': 'vind',
              'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('vector store to return the expected item'):
             try:
                 result = table.query(
                     IndexName='vind',
@@ -1254,9 +1274,6 @@ def test_query_vector_prefill(vs, needs_vector_store):
                     break
             except ClientError:
                 pass
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for vector store to return the expected item')
-            time.sleep(0.1)
 
 # Same as test_query_vector_prefill but for a table with a clustering key, which
 # exercises the separate code path in query_vector() for hash+range tables.
@@ -1274,8 +1291,7 @@ def test_query_vector_with_ck_prefill(vs, needs_vector_store):
         table.update(VectorIndexUpdates=[{'Create':
             {'IndexName': 'vind',
              'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('vector store to return the expected item'):
             try:
                 result = table.query(
                     IndexName='vind',
@@ -1287,9 +1303,6 @@ def test_query_vector_with_ck_prefill(vs, needs_vector_store):
                     break
             except ClientError:
                 pass
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for vector store to return the expected item')
-            time.sleep(0.1)
 
 # Utility function for waiting until the given vector index is ACTIVE, which
 # means that when this function returns, we are guaranteed that:
@@ -1301,15 +1314,11 @@ def test_query_vector_with_ck_prefill(vs, needs_vector_store):
 # succeed, and also doesn't require knowing the dimensions of this index to
 # attempt a real Query.
 def wait_for_vector_index_active(table, index_name):
-    deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-    while True:
+    for _ in retrying(f'vector index "{index_name}" to become ACTIVE'):
         desc = table.meta.client.describe_table(TableName=table.name)
         for vi in desc.get('Table', {}).get('VectorIndexes', []):
             if vi['IndexName'] == index_name and vi['IndexStatus'] == 'ACTIVE':
                 return
-        if time.monotonic() > deadline:
-            pytest.fail(f'Timed out waiting for vector index "{index_name}" to become ACTIVE')
-        time.sleep(0.1)
 
 # Test that wait_for_vector_index_active(), waiting for IndexStatus==ACTIVE,
 # indeed reliably waits for the index to be ready. A Query issued immediately
@@ -1390,8 +1399,7 @@ def test_query_vector_cdc(vs, needs_vector_store):
         p = random_string()
         table.put_item(Item={'p': p, 'v': [1, 0, 0]})
         # Retry the query until the newly written item appears in the results.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('vector store to return the expected item via CDC'):
             try:
                 result = table.query(
                     IndexName='vind',
@@ -1402,9 +1410,6 @@ def test_query_vector_cdc(vs, needs_vector_store):
                     break
             except ClientError:
                 pass
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for vector store to return the expected item via CDC')
-            time.sleep(0.1)
 
 # Similar test to test_query_vector_cdc, where an item is written after the
 # vector index is created, but here the item is written using LWT (using a
@@ -1425,15 +1430,11 @@ def test_query_vector_cdc_lwt(vs, needs_vector_store):
         p = random_string()
         table.put_item(Item={'p': p, 'v': [1, 0, 0]},
             ConditionExpression='attribute_not_exists(p)')
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('vector store to index an item via CDC'):
             result = table.query(IndexName='vind',
                     VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1)
             if len(result['Items']) > 0:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for vector store index an item via CDC')
-            time.sleep(0.1)
         assert len(result['Items']) == 1 and result['Items'][0]['p'] == p
 
 
@@ -1474,16 +1475,11 @@ def test_query_vector_cdc_malformed_prefill(vs, needs_vector_store, malformed, u
                 ExpressionAttributeValues={':v': [1, Decimal("0.1"), 0]})
         else:
             table.put_item(Item={'p': p1, 'v': [1, Decimal("0.1"), 0]})
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('both p1 and p2 to be indexed'):
             result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]},
                                  Limit=10)
             if len(result['Items']) == 2 and {item['p'] for item in result['Items']} == {p2, p1}:
                 break
-            if time.monotonic() > deadline:
-                assert len(result['Items']) == 2 and {item['p'] for item in result['Items']} == {p2, p1}
-                break
-            time.sleep(0.1)
 
 # Test like test_query_vector_prefill, but with a query returning multiple
 # results. This helps us verify that:
@@ -1511,8 +1507,7 @@ def test_query_vector_multiple_results(vs, needs_vector_store):
             {'IndexName': 'vind',
              'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
         expected_order = [p1, p2, p3]
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying(f'items to appear in correct order: {expected_order}'):
             try:
                 result = table.query(
                     IndexName='vind',
@@ -1525,9 +1520,6 @@ def test_query_vector_multiple_results(vs, needs_vector_store):
                     break
             except ClientError:
                 pass
-            if time.monotonic() > deadline:
-                pytest.fail(f'Timed out waiting for correct ordered results; last got: {got}, expected {expected_order}')
-            time.sleep(0.1)
 
 # Same as test_query_vector_multiple_results but for a table with a
 # clustering key, to exercise the hash+range code path in query_vector().
@@ -1549,8 +1541,7 @@ def test_query_vector_with_ck_multiple_results(vs, needs_vector_store):
             {'IndexName': 'vind',
              'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
         expected_order = [(p1, c1), (p2, c2), (p3, c3)]
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying(f'items to appear in correct order: {expected_order}'):
             try:
                 result = table.query(
                     IndexName='vind',
@@ -1564,9 +1555,6 @@ def test_query_vector_with_ck_multiple_results(vs, needs_vector_store):
                     break
             except ClientError:
                 pass
-            if time.monotonic() > deadline:
-                pytest.fail(f'Timed out waiting for correct ordered results; last got: {got}, expected {expected_order}')
-            time.sleep(0.1)
 
 # Test that a vector search Query returns, with Select='ALL_ATTRIBUTES', the
 # full item content correctly (all attributes, correct key values) in the
@@ -1616,8 +1604,7 @@ def test_query_vector_full_items(vs, needs_vector_store, have_ck):
         expected_items = items[:3]
         # Wait until the returned items match the expected list exactly,
         # verifying both the full content of each item and their order.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('vector store to return the expected items'):
             try:
                 result = table.query(
                     IndexName='vind',
@@ -1629,9 +1616,6 @@ def test_query_vector_full_items(vs, needs_vector_store, have_ck):
                     break
             except ClientError:
                 pass
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for vector store to return the expected items')
-            time.sleep(0.1)
 
 # Test that PutItem rejects a vector attribute value that is invalid for
 # the declared vector index on that attribute. The index on table_vs declares
@@ -1788,8 +1772,7 @@ def test_deleteitem_vectorindex(vs, needs_vector_store, with_ck):
             item['c'] = c
             key['c'] = c
         table.put_item(Item=item)
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('item to appear in vector index'):
             result = table.query(IndexName='vind',
                                  VectorSearch={'QueryVector': [1, 0, 0]},
                                  Select='ALL_ATTRIBUTES',
@@ -1797,21 +1780,14 @@ def test_deleteitem_vectorindex(vs, needs_vector_store, with_ck):
             if len(result['Items']) > 0:
                 assert result['Items'][0] == item
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for item to appear in vector index')
-            time.sleep(0.1)
         # Delete the item and wait for it to disappear from the vector index.
         table.delete_item(Key=key)
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('deleted item to disappear from vector index'):
             result = table.query(IndexName='vind',
                                  VectorSearch={'QueryVector': [1, 0, 0]},
                                  Limit=1)
             if len(result.get('Items', [])) == 0:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for deleted item to disappear from vector index')
-            time.sleep(0.1)
 
 # Test that PutItem or UpdateItem on an existing item replaces its vector in
 # the index: the old vector is removed and the new one is indexed. Two items
@@ -1845,17 +1821,13 @@ def test_replace_vector_vectorindex(vs, needs_vector_store, use_update_item):
             table.put_item(Item={'p': p1, 'v': [-1, 0, 0]})
         # Wait until the index reflects the change: p2 should now come before p1
         # in a search for [1, 0, 0].
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('index to reflect replaced vector'):
             result = table.query(IndexName='vind',
                                  VectorSearch={'QueryVector': [1, 0, 0]},
                                  Limit=2)
             got = [item['p'] for item in result.get('Items', [])]
             if got == [p2, p1]:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail(f'Timed out waiting for index to reflect replaced vector; last order: {got}')
-            time.sleep(0.1)
 
 # Test that UpdateItem modifying non-vector attributes does not affect the
 # vector index: the item remains discoverable by its unchanged vector, and
@@ -1908,16 +1880,12 @@ def test_updateitem_remove_vector_vectorindex(vs, needs_vector_store):
         # Remove only the vector attribute, leaving the rest of the item intact.
         table.update_item(Key={'p': p}, UpdateExpression='REMOVE v')
         # The item must eventually disappear from the vector index.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('item to disappear from vector index after vector attribute removal'):
             result = table.query(IndexName='vind',
                                  VectorSearch={'QueryVector': [1, 0, 0]},
                                  Limit=1)
             if not result['Items']:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for item to disappear from vector index after vector attribute removal')
-            time.sleep(0.1)
         # The item itself must still exist in the base table, just without 'v'.
         result = table.get_item(Key={'p': p}, ConsistentRead=True)
         assert result['Item'] == {'p': p, 'x': 'hello'}
@@ -1965,17 +1933,13 @@ def test_vector_with_ttl(vs, needs_vector_store, have_ck):
         table.put_item(Item=item)
         # Wait for the item to appear in vector search. Since TTL is not yet
         # enabled, the item must be visible despite its past expiration time.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('item to appear in vector search before TTL was enabled'):
             result = table.query(IndexName='vind',
                                  VectorSearch={'QueryVector': [1, 0, 0]},
                                  Limit=1)
             if len(result.get('Items', [])) > 0:
                 assert result['Items'][0]['p'] == p
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for item to appear in vector search before TTL was enabled')
-            time.sleep(0.1)
         # Now enable TTL on the 'expiration' attribute. The item has its
         # expiration in the past, so TTL should delete it quickly.
         table.meta.client.update_time_to_live(
@@ -1984,8 +1948,8 @@ def test_vector_with_ttl(vs, needs_vector_store, have_ck):
         # Wait for the item to disappear from vector search. TTL deletes the
         # item from the database, and the deletion propagates to the vector
         # store via CDC.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT + float(period)
-        while True:
+        for _ in retrying('TTL-expired item to disappear from vector search',
+                          timeout=VECTOR_STORE_TIMEOUT + float(period)):
             result = table.query(
                 IndexName='vind',
                 VectorSearch={'QueryVector': [1, 0, 0]},
@@ -1994,9 +1958,6 @@ def test_vector_with_ttl(vs, needs_vector_store, have_ck):
             )
             if len(result['Items']) == 0:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for TTL-expired item to disappear from vector search')
-            time.sleep(0.1)
         # Since we used Select='ALL_PROJECTED_ATTRIBUTES', the loop above
         # already confirms the vector store removed the item (the results
         # come directly from the vector store, not the base table).
@@ -2046,8 +2007,7 @@ def test_query_vectorsearch_select(vs, needs_vector_store):
             {'IndexName': 'vind',
              'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
         # Wait for the item to appear in vector search.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('item to be indexed'):
             try:
                 result = table.query(
                     IndexName='vind',
@@ -2057,9 +2017,6 @@ def test_query_vectorsearch_select(vs, needs_vector_store):
                     break
             except ClientError:
                 pass
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for item to be indexed')
-            time.sleep(0.1)
         # ALL_PROJECTED_ATTRIBUTES (default when no Select): returns only the
         # primary key attributes.
         result = table.query(IndexName='vind',
@@ -2440,8 +2397,7 @@ def test_vector_projection_include_prefilter_cdc(vs, needs_vector_store):
         table.put_item(Item={'p': p + '_drop', 'v': Vector([0, 0, 1]),   'x': 'b'})
         table.put_item(Item={'p': p + '_keep', 'v': Vector([0.1, 0, 1]), 'x': 'a'})
         # Retry until both items are visible, then check that the pre-filter works.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('CDC-indexed items to appear'):
             result = table.query(
                 IndexName='vind',
                 VectorSearch={'QueryVector': [0, 0, 1]},
@@ -2449,9 +2405,6 @@ def test_vector_projection_include_prefilter_cdc(vs, needs_vector_store):
             )
             if len(result.get('Items', [])) == 2:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for CDC-indexed items to appear')
-            time.sleep(0.1)
         # Both items are now indexed. Apply the pre-filter.
         result = table.query(
             IndexName='vind',
@@ -2490,15 +2443,11 @@ def test_vector_attribute_allowed_chars(vs, needs_vector_store):
         table.put_item(Item={'p': p2, attribute_name: [0, 0, 1]})
         # Wait until the CDC-indexed update (v=[0, 0, 1]) is reflected in the
         # vector search results.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('items to appear in vector search'):
             result = table.query(IndexName='vind',
                 VectorSearch={'QueryVector': [0, 0, 1]}, Limit=2)
             if 'Items' in result and len(result['Items']) == 2 and result['Items'][0]['p'] == p2 and result['Items'][1]['p'] == p1:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for items to appear in vector search')
-            time.sleep(0.1)
 
 # Test FilterExpression for post-filtering vector search results: After Limit
 # results are found by the vector index and the full items are retrieved
@@ -2537,8 +2486,7 @@ def test_query_vectorsearch_filter_expression(vs, needs_vector_store, select):
              'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
         # Wait until nearest 4 items (nearest_ps) are visible in a query
         # without a filter.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('all items to be indexed'):
             try:
                 result = table.query(
                     IndexName='vind',
@@ -2549,9 +2497,6 @@ def test_query_vectorsearch_filter_expression(vs, needs_vector_store, select):
                     break
             except ClientError:
                 pass
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for all items to be indexed')
-            time.sleep(0.1)
         # Query with a FilterExpression that matches 2 of the 4 nearest
         # candidates (Limit=4). We expect Count=2 and ScannedCount=4. Note
         # that even though p_far also has x=keep, it was not among the 4
@@ -2594,8 +2539,7 @@ def test_query_vectorsearch_filter_expression_specific_attributes(vs, needs_vect
             {'IndexName': 'vind',
              'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
         # Wait until the 4 nearest items are visible without a filter.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('all items to be indexed'):
             try:
                 result = table.query(
                     IndexName='vind',
@@ -2606,9 +2550,6 @@ def test_query_vectorsearch_filter_expression_specific_attributes(vs, needs_vect
                     break
             except ClientError:
                 pass
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for all items to be indexed')
-            time.sleep(0.1)
         # Query with Select=SPECIFIC_ATTRIBUTES projecting only 'p', but
         # FilterExpression uses 'x' which is NOT in the projection. The
         # implementation must still retrieve 'x' from the base table to
@@ -3111,8 +3052,7 @@ def test_query_vector_float32vector_and_lon_cdc(vs, needs_vector_store):
         table.put_item(Item={'p': p_v, 'v': Vector([1.0, 0.0, 0.0])})
         table.put_item(Item={'p': p_l, 'v': [Decimal("1"), Decimal("0"), Decimal("0")]})
         # Retry the query until both items appear in the vector search results.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('V-type and L-type items to appear via CDC'):
             result = table.query(
                 IndexName='vind',
                 VectorSearch={'QueryVector': [Decimal("1"), Decimal("0"), Decimal("0")]},
@@ -3120,9 +3060,6 @@ def test_query_vector_float32vector_and_lon_cdc(vs, needs_vector_store):
             )
             if {item['p'] for item in result.get('Items', [])} == {p_v, p_l}:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for V-type and L-type items to appear via CDC')
-            time.sleep(0.1)
 
 # Test that VectorSearch.ReturnScores rejects unknown values and the
 # SIMILARITY+COUNT combination. No vector store needed.
@@ -3357,8 +3294,8 @@ def test_query_vector_max_dimension(vs, needs_vector_store, via_cdc):
                  'VectorAttribute': {'AttributeName': 'v', 'Dimensions': dim}}}])
             wait_for_vector_index_active(table, 'vind')
         # Retry the query until the item appears in the results.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying(f'MAX_VECTOR_DIMENSION={dim} item to appear via '
+                          f'{"CDC" if via_cdc else "prefill"}'):
             result = table.query(
                 IndexName='vind',
                 VectorSearch={'QueryVector': query_vec},
@@ -3366,10 +3303,6 @@ def test_query_vector_max_dimension(vs, needs_vector_store, via_cdc):
             )
             if result.get('Items') and result['Items'][0]['p'] == p:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail(f'Timed out waiting for MAX_VECTOR_DIMENSION={dim} item to appear via '
-                            f'{"CDC" if via_cdc else "prefill"}')
-            time.sleep(0.1)
 
 ##############################################################################
 # Tests for vector search pre-filtering via KeyConditionExpression.
@@ -3678,8 +3611,7 @@ def test_vector_projection_include_prefilter_updateitem_remove_column(vs, needs_
         # REMOVE the projected filtering column x from the item via CDC.
         # The item should (eventually) disappear from the filtered search:
         table.update_item(Key={'p': p}, UpdateExpression='REMOVE x')
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('x removal to be reflected in vector store pre-filter'):
             result = table.query(
                 IndexName='vind',
                 VectorSearch={'QueryVector': [1, 0, 0]},
@@ -3689,9 +3621,6 @@ def test_vector_projection_include_prefilter_updateitem_remove_column(vs, needs_
             )
             if result['Count'] == 0:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for x removal to be reflected in vector store pre-filter')
-            time.sleep(0.1)
         # The item still exists and still has its vector - so it must remain in
         # the vector index and be returned by an unfiltered query.
         #
@@ -3748,8 +3677,7 @@ def test_vector_projection_include_prefilter_updateitem_other_column_preserved(v
             UpdateExpression='SET x = :newx',
             ExpressionAttributeValues={':newx': 'new'})
         # Wait for the CDC event carrying x='new' to be picked up by the vector store.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('x=new to appear in vector store pre-filter'):
             result = table.query(
                 IndexName='vind',
                 VectorSearch={'QueryVector': [1, 0, 0]},
@@ -3759,9 +3687,6 @@ def test_vector_projection_include_prefilter_updateitem_other_column_preserved(v
             )
             if result['Count'] == 1:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for x=new to appear in vector store pre-filter')
-            time.sleep(0.1)
         # y was not changed by the UpdateItem. Its stored value must still be
         # 'stays' — the CDC event must not have erased it.
         result = table.query(
@@ -3805,8 +3730,7 @@ def test_vector_projection_include_prefilter_putitem_clears_old_column(vs, needs
         table.put_item(Item={'p': p, 'v': Vector([1, 0, 0])})
         # Once the CDC replacement event propagates, a pre-filter on x='hello'
         # must no longer match the item because x no longer exists on the item.
-        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
-        while True:
+        for _ in retrying('stale x=hello to be cleared from vector store after PutItem'):
             result = table.query(
                 IndexName='vind',
                 VectorSearch={'QueryVector': [1, 0, 0]},
@@ -3816,9 +3740,6 @@ def test_vector_projection_include_prefilter_putitem_clears_old_column(vs, needs
             )
             if result['Count'] == 0:
                 break
-            if time.monotonic() > deadline:
-                pytest.fail('Timed out waiting for stale x=hello to be cleared from vector store after PutItem')
-            time.sleep(0.1)
         # Verify the item is still indexed (the new vector is the same as before).
         result = table.query(
             IndexName='vind',

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -41,13 +41,13 @@ boto3.dynamodb.types.DYNAMODB_CONTEXT = decimal.Context(prec=100)
 # Users can use exactly the same code to get vector search support in boto3,
 # but the more "official" way would be to modify botocore's JSON configuration
 # file, botocore/data/dynamodb/2012-08-10/service-2.json.
-@pytest.fixture(scope="module")
-def vs(new_dynamodb_session, dynamodb):
-    if is_aws(dynamodb):
-        skip_env('Scylla-only: vector search extensions not available on DynamoDB')
-    resource = new_dynamodb_session()
-    client = resource.meta.client
-    # Patch the client to support the new APIs:
+
+# add_vs_to_client() is a context manager that modifies the given boto3
+# client to accept the new vector-search parameters in requests and responses,
+# and also monkey-patches the TypeSerializer/TypeDeserializer so that the
+# Vector type is serialized as FLOAT32VECTOR. The patches are restored on exit.
+@contextmanager
+def add_vs_to_client(client):
     # All the new parameter "shapes" that we will use below for the
     # new parameters of the different operations:
     new_shapes = {
@@ -197,13 +197,23 @@ def vs(new_dynamodb_session, dynamodb):
             return {'FLOAT32VECTOR': list(value)}
         return _orig_serialize(self, value)
     boto3.dynamodb.types.TypeSerializer.serialize = _serialize_with_vector
+    _had_deserialize = hasattr(boto3.dynamodb.types.TypeDeserializer, '_deserialize_float32vector')
     boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector = lambda self, value: Vector(value)
+    try:
+        yield
+    finally:
+        boto3.dynamodb.types.TypeSerializer.serialize = _orig_serialize
+        if not _had_deserialize:
+            del boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector
 
-    yield resource
 
-    # Restore the original serialize method and remove the deserializer patch.
-    boto3.dynamodb.types.TypeSerializer.serialize = _orig_serialize
-    del boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector
+@pytest.fixture(scope="module")
+def vs(new_dynamodb_session, dynamodb):
+    if is_aws(dynamodb):
+        skip_env('Scylla-only: vector search extensions not available on DynamoDB')
+    resource = new_dynamodb_session()
+    with add_vs_to_client(resource.meta.client):
+        yield resource
 
 # Use the Vector(list) type for test values that are meant to be stored as
 # optimized vectors (array of floats instead of JSON list of numbers).

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -3623,11 +3623,194 @@ def test_query_vectorsearch_prefilter_and_number_between(vs, needs_vector_store)
         assert {item['c'] for item in result['Items']} == {Decimal(1), Decimal(2)}
 
 
-# TODO: Like test_vector_projection_keys_only, write additional tests for
-# ProjectionType=INCLUDE with NonKeyAttributes and ProjectionType=ALL.
-# We don't yet support this feature, so I didn't bother to write such a
-# test yet, but I can write an xfailing test because we know what we
-# expect ALL_PROJECTED_ATTRIBUTES to return in that case.
+# More tests for pre-filtering on projected columns (ProjectionType=INCLUDE)
+# which focus on verifying that the vector store's projected columns are
+# correctly updated via CDC when the original item is modified, including
+# delicate operations like removing a projected column or replacing the whole
+# item.
+
+# Test that UpdateItem REMOVE on a projected filtering column causes the vector
+# store to clear the stored column value, so that subsequent pre-filter queries
+# on that column no longer match the item. However, the item itself should NOT
+# be deleted from the vector index since it still has its vector attribute -
+# and the item is still retrievable by an unfiltered vector search query.
+# The "however" part is actually a very important part of this test (and used
+# to fail due to a bug in the vector store).
+def test_vector_projection_include_prefilter_updateitem_remove_column(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        # Insert an item with the projected filtering column x='hello'.
+        table.put_item(Item={'p': p, 'v': Vector([1, 0, 0]), 'x': 'hello'})
+        table.update(VectorIndexUpdates=[{'Create': {
+            'IndexName': 'vind',
+            'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+            'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']},
+        }}])
+        wait_for_vector_index_active(table, 'vind')
+        # After the prefill finished, the item is retrievable with the pre-
+        # filter x="hello". Let's verify:
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            KeyConditionExpression='x = :val',
+            ExpressionAttributeValues={':val': 'hello'},
+            Limit=1)
+        assert result['Count'] == 1
+        assert result['Items'][0]['p'] == p
+        # REMOVE the projected filtering column x from the item via CDC.
+        # The item should (eventually) disappear from the filtered search:
+        table.update_item(Key={'p': p}, UpdateExpression='REMOVE x')
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]},
+                Limit=1,
+                KeyConditionExpression='x = :val',
+                ExpressionAttributeValues={':val': 'hello'},
+            )
+            if result['Count'] == 0:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail('Timed out waiting for x removal to be reflected in vector store pre-filter')
+            time.sleep(0.1)
+        # The item still exists and still has its vector - so it must remain in
+        # the vector index and be returned by an unfiltered query.
+        #
+        # This simple sanity check is actually an important test of its own -
+        # and used to fail due to a bug in the vector store where changing
+        # any non-vector attribute cause the vector store to mis-understand that
+        # the vector was deleted. It's not easy to check this bug without using
+        # projected columns in the test because we only knew above that the
+        # vector store actually processed the CDC event (and can check its
+        # result) by noticing the projected column changed.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            Limit=1,
+        )
+        assert result['Count'] == 1
+        assert result['Items'][0]['p'] == p
+
+# Test that UpdateItem updating only one of several projected filtering columns
+# does not erase the stored value of the other columns. The untouched column
+# must remain filterable after the CDC event is processed.
+def test_vector_projection_include_prefilter_updateitem_other_column_preserved(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': Vector([1, 0, 0]), 'x': 'old', 'y': 'stays'})
+        table.update(VectorIndexUpdates=[{'Create': {
+            'IndexName': 'vind',
+            'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+            'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x', 'y']},
+        }}])
+        wait_for_vector_index_active(table, 'vind')
+        # After the prefill finished, the item is retrievable with the pre-
+        # filter x="old" and y="stays". Let's verify:
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            Limit=1,
+            KeyConditionExpression='x = :val',
+            ExpressionAttributeValues={':val': 'old'})
+        assert result['Count'] == 1 and result['Items'][0]['p'] == p
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            Limit=1,
+            KeyConditionExpression='y = :val',
+            ExpressionAttributeValues={':val': 'stays'})
+        assert result['Count'] == 1 and result['Items'][0]['p'] == p
+        # With UpdateItem, change only x to 'new', leaving y unchanged.
+        # This change will go through CDC and eventually be reflected in
+        # vector search queries.
+        table.update_item(Key={'p': p},
+            UpdateExpression='SET x = :newx',
+            ExpressionAttributeValues={':newx': 'new'})
+        # Wait for the CDC event carrying x='new' to be picked up by the vector store.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]},
+                Limit=1,
+                KeyConditionExpression='x = :val',
+                ExpressionAttributeValues={':val': 'new'},
+            )
+            if result['Count'] == 1:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail('Timed out waiting for x=new to appear in vector store pre-filter')
+            time.sleep(0.1)
+        # y was not changed by the UpdateItem. Its stored value must still be
+        # 'stays' — the CDC event must not have erased it.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            Limit=1,
+            KeyConditionExpression='y = :val',
+            ExpressionAttributeValues={':val': 'stays'},
+        )
+        assert result['Count'] == 1
+        assert result['Items'][0]['p'] == p
+
+# Test that PutItem replacing an item that had a projected filtering column with
+# a new item that lacks that column causes the vector store to clear the old
+# column value. After the CDC event propagates, a pre-filter on the old column
+# value must not match the replaced item.
+def test_vector_projection_include_prefilter_putitem_clears_old_column(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        # Insert an item with filtering column x='hello'.
+        table.put_item(Item={'p': p, 'v': Vector([1, 0, 0]), 'x': 'hello'})
+        table.update(VectorIndexUpdates=[{'Create': {
+            'IndexName': 'vind',
+            'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+            'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['x']},
+        }}])
+        wait_for_vector_index_active(table, 'vind')
+        # After the prefill finished, the item is retrievable with the pre-
+        # filter x='hello'. Let's verify:
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            Limit=1,
+            KeyConditionExpression='x = :val',
+            ExpressionAttributeValues={':val': 'hello'})
+        assert result['Count'] == 1 and result['Items'][0]['p'] == p
+        # Replace the item via PutItem (CDC path) with a new item that has the
+        # same vector but no x attribute.
+        table.put_item(Item={'p': p, 'v': Vector([1, 0, 0])})
+        # Once the CDC replacement event propagates, a pre-filter on x='hello'
+        # must no longer match the item because x no longer exists on the item.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]},
+                Limit=1,
+                KeyConditionExpression='x = :val',
+                ExpressionAttributeValues={':val': 'hello'},
+            )
+            if result['Count'] == 0:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail('Timed out waiting for stale x=hello to be cleared from vector store after PutItem')
+            time.sleep(0.1)
+        # Verify the item is still indexed (the new vector is the same as before).
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 0, 0]},
+            Limit=1,
+        )
+        assert result['Count'] == 1
+        assert result['Items'][0]['p'] == p
 
 # TODO: test enabling vector index and Alternator Streams together, and
 # checking that Alternator Streams works as expected. Also we may need to

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -3001,37 +3001,272 @@ def test_query_vector_max_dimension(vs, needs_vector_store, via_cdc):
             time.sleep(0.1)
 
 ##############################################################################
-# CONTINUE HERE - MAKE A DECISION! PRE-FILTERING:
-# Tests *pre-filtering* for filtering on projected attributes, which can be (if
-# we continue the implementation) pushed to the vector store or right now -
-# key columns.
-# We need to decide: In DynamoDB pre-filtering is done with
-# KeyConditionExpression NOT FilterExpression.
-# KeyConditionExpression is the traditional approach in Query, but is a bit
-# weird because these aren't really "keys" (even though in CQL CREATE TABLE
-# syntax we pretend they are - and today, they really are keys).
-# Do we want to force the user to put these pre-filtering in KeyConditionExpression
-# instead of FilterExpression, and only allow FilterExpression for post-filtering
-# that must be done in Scylla?
-# Alternatively, we could put everything in FilterExpression. This is less
-# with DynamoDB's usual semantics but simpler for users.
-############################################################################
+# Tests for vector search pre-filtering via KeyConditionExpression.
+#
+# KeyConditionExpression in a vector search query is sent to the vector store
+# as a pre-filter: only nearest neighbors from the matching set are returned.
+# Only projected attributes (currently key columns) may be referenced.
+# Operators supported: =, <, <=, >, >=, IN, BETWEEN. OR and NOT are rejected.
+##############################################################################
 
-# WRITE TEST:
-# Test that if the FilterExpression happens to only use projected attributes
-# (by default this means key attributes) - or if we decide (see above) that
-# it's KeyconditionExpression, then it can be, and is, sent to the vector
-# store and performed there. We can check that this happens by noticing that
-# we get a full LIMIT of results, and not less.
+# Test that the old-style KeyConditions (non-expression API) is rejected for
+# vector search queries (just like QueryFilter is rejected).
+def test_query_vectorsearch_key_conditions_rejected(table_vs):
+    with pytest.raises(ClientError, match='ValidationException.*KeyConditions'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditions={'p': {'AttributeValueList': [{'S': 'x'}], 'ComparisonOperator': 'EQ'}},
+        )
 
-# WRITE TEST:
-# Test FilterExpression for post-filtering vector search results with
-# Select=ALL_PROJECTED_ATTRIBUTES where the filter only needs projected
-# attributes (currently those are key attributes). Here it is important
-# for efficency that the vector index applies the filter and we do not need
-# to retrive the full items from the base table at all. We can verify that
-# this code path was reached by checking that we got back LIMIT results, and
-# not fewer.
+# Test that KeyConditionExpression referencing a non-projected attribute is
+# rejected with a ValidationException.
+def test_query_vectorsearch_key_condition_nonprojected(table_vs):
+    # The table 'table_vs' has only 'p' as a key column. 'v' (the vector
+    # attribute) and 'x' (a regular attribute) are not projected.
+    for bad_attr in ['v', 'x']:
+        with pytest.raises(ClientError, match='ValidationException'):
+            table_vs.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [0, 0, 1]},
+                Limit=1,
+                KeyConditionExpression=f'{bad_attr} = :val',
+                ExpressionAttributeValues={':val': 'anything'},
+            )
+
+# Test that NOT in a KeyConditionExpression is rejected for vector search
+# pre-filtering.
+def test_query_vectorsearch_key_condition_not_rejected(table_vs):
+    with pytest.raises(ClientError, match='ValidationException'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditionExpression='NOT p = :p',
+            ExpressionAttributeValues={':p': 'x'},
+        )
+
+# Test that OR in a KeyConditionExpression is rejected for vector search
+# pre-filtering. This is because the vector store currently only supports
+# AND among a list of conditions given to it in the pre-filter.
+def test_query_vectorsearch_key_condition_or_rejected(table_vs):
+    with pytest.raises(ClientError, match='ValidationException'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditionExpression='p = :p1 OR p = :p2',
+            ExpressionAttributeValues={':p1': 'x', ':p2': 'y'},
+        )
+
+# Test that an unsupported operator (<>) in a KeyConditionExpression is
+# rejected for vector search pre-filtering. The vector store does not
+# currently support a not-equal operator.
+def test_query_vectorsearch_key_condition_ne_rejected(table_vs):
+    with pytest.raises(ClientError, match='ValidationException'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditionExpression='p <> :p',
+            ExpressionAttributeValues={':p': 'x'},
+        )
+
+# Test that a boolean function call (e.g. attribute_exists()) in a
+# KeyConditionExpression is rejected. attribute_exists() is valid in a
+# FilterExpression but not in a vector search KeyConditionExpression
+# because the vector store can't support it.
+def test_query_vectorsearch_key_condition_function_rejected(table_vs):
+    with pytest.raises(ClientError, match='ValidationException'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditionExpression='attribute_exists(p)',
+        )
+
+# Test that using an unsupported value type (e.g. a list) in a
+# KeyConditionExpression pre-filter is rejected with a ValidationException.
+# Only S (string) and N (number) are valid types for pre-filter comparisons.
+def test_query_vectorsearch_prefilter_bad_value_type(table_vs):
+    for bad_val in [
+        ['hello', 'world'],      # List -> DynamoDB L type
+        {'key': 'val'},          # Map -> DynamoDB M type
+        b'hello',                # bytes -> DynamoDB B type
+    ]:
+        with pytest.raises(ClientError, match='ValidationException.*not supported.*KeyConditionExpression'):
+            table_vs.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [0, 0, 1]},
+                Limit=1,
+                KeyConditionExpression='p = :p',
+                ExpressionAttributeValues={':p': bad_val},
+            )
+
+# Success-path test: KeyConditionExpression pre-filter is applied by the vector
+# store before ANN, so the result always contains exactly Limit items (if that
+# many matching items exist) regardless of how many non-matching items are
+# nearer to the query vector.
+#
+# Setup: 4 items in the table. 2 "keep" items have vectors far from the query
+# ([0,0,1]); 2 "drop" items have vectors very close to the query. With
+# Limit=2:
+#   - Without pre-filtering: ANN returns the 2 "drop" items (nearest), then a
+#     post-filter would keep 0 items.
+#   - With pre-filtering (KeyConditionExpression p IN ('keep1','keep2')): ANN
+#     only considers "keep" items and returns both -> Count=2, ScannedCount=2.
+def test_query_vectorsearch_prefilter_in(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p_keep1, p_keep2 = random_string(), random_string()
+        p_drop1, p_drop2 = random_string(), random_string()
+        # "drop" items are nearest to the query vector [0, 0, 1].
+        # "keep" items are farther away.
+        table.put_item(Item={'p': p_drop1, 'v': Vector([0, 0, 1])})
+        table.put_item(Item={'p': p_drop2, 'v': Vector([0, 0.1, 1])})
+        table.put_item(Item={'p': p_keep1, 'v': Vector([1, 0, 0])})
+        table.put_item(Item={'p': p_keep2, 'v': Vector([0.9, 0, 0])})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        # With Limit=2 and a pre-filter restricting to keep1/keep2, we expect
+        # exactly 2 results (both keep items), even though the 2 nearest overall
+        # items are the drop items.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=2,
+            KeyConditionExpression='p IN (:k1, :k2)',
+            ExpressionAttributeValues={':k1': p_keep1, ':k2': p_keep2},
+        )
+        assert result['Count'] == 2 and result['ScannedCount'] == 2
+        assert {item['p'] for item in result['Items']} == {p_keep1, p_keep2}
+        # Let's contrast the above pre-filter with how post-filter works:
+        # without a filter, Limit=2 returns the 2 nearest items - the "drop"
+        # items. A post-FilterExpression on 'p' asking for the keep items
+        # would then return 0 results. This demonstrates why pre-filtering is
+        # important.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=2,
+        )
+        assert {item['p'] for item in result['Items']} == {p_drop1, p_drop2}
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=2,
+            FilterExpression='p IN (:k1, :k2)',
+            ExpressionAttributeValues={':k1': p_keep1, ':k2': p_keep2},
+        )
+        assert result['Count'] == 0
+        assert result['ScannedCount'] == 2
+
+# Success-path test: KeyConditionExpression with equality on the partition key.
+# Similar to test_query_vectorsearch_prefilter_in but uses a single = condition.
+# With Limit=1, the pre-filter restricts the ANN to a single partition key, so
+# exactly 1 result is returned even though closer items exist.
+def test_query_vectorsearch_prefilter_equality(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p_keep = random_string()
+        p_drop = random_string()
+        table.put_item(Item={'p': p_drop, 'v': Vector([0, 0, 1])})   # nearest to query
+        table.put_item(Item={'p': p_keep, 'v': Vector([1, 0, 0])})   # farther
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=1,
+            KeyConditionExpression='p = :p',
+            ExpressionAttributeValues={':p': p_keep},
+        )
+        # The pre-filter restricts to p_keep only, so we get exactly 1 result
+        # even though p_drop is the nearest neighbor overall.
+        assert result['Count'] == 1 and result['Items'][0]['p'] == p_keep
+        assert result['ScannedCount'] == 1
+
+# Success-path test: KeyConditionExpression with a string inequality (<)
+# pre-filter. String comparisons in the vector store are lexicographic.
+# Also tests that when the constant is on the left-hand side of the
+# comparison (e.g. ':threshold > p'), the operator is correctly reversed
+# (treated as 'p < :threshold').
+def test_query_vectorsearch_prefilter_string_inequality(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        # All 'z_'-prefixed keys are lexicographically > 'm';
+        # the 'a_'-prefixed key is lexicographically < 'm'.
+        p_drop = 'z_' + random_string()   # nearest to query, key > 'm'
+        p_hi   = 'z_' + random_string()   # farther from query, key > 'm'
+        p_lo   = 'a_' + random_string()   # farther from query, key < 'm'
+        table.put_item(Item={'p': p_drop, 'v': Vector([0, 0, 1])})   # nearest to query
+        table.put_item(Item={'p': p_hi,   'v': Vector([1, 0, 0])})   # farther, high key
+        table.put_item(Item={'p': p_lo,   'v': Vector([0.9, 0, 0])}) # farther, low key
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        # Lexicographic inequality: p < 'm' keeps only p_lo ('a_...' < 'm').
+        # p_drop ('z_...') is nearest overall but is excluded by the pre-filter.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=1,
+            KeyConditionExpression='p < :threshold',
+            ExpressionAttributeValues={':threshold': 'm'},
+        )
+        assert result['Count'] == 1 and result['Items'][0]['p'] == p_lo
+        assert result['ScannedCount'] == 1
+        # Same inequality with the constant on the left-hand side: ':threshold > p'
+        # is equivalent to 'p < :threshold' (the operator is reversed internally).
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=1,
+            KeyConditionExpression=':threshold > p',
+            ExpressionAttributeValues={':threshold': 'm'},
+        )
+        assert result['Count'] == 1 and result['Items'][0]['p'] == p_lo
+        assert result['ScannedCount'] == 1
+
+# Success-path test: KeyConditionExpression with a AND on two conditions on
+# two projected attributes (the partition key and sort key). One of the
+# conditions is a BETWEEN condition on a number attribute.
+def test_query_vectorsearch_prefilter_and_number_between(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'},
+                       {'AttributeName': 'c', 'KeyType': 'RANGE'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'},
+                                   {'AttributeName': 'c', 'AttributeType': 'N'}]) as table:
+        p = random_string()
+        # c=1 and c=2 are "keep" items (c in [1,2]); c=3 and c=4 are "drop".
+        # "drop" items are nearest to the query vector.
+        table.put_item(Item={'p': p, 'c': 3, 'v': Vector([0, 0, 1])})
+        table.put_item(Item={'p': p, 'c': 4, 'v': Vector([0, 0.1, 1])})
+        table.put_item(Item={'p': p, 'c': 1, 'v': Vector([1, 0, 0])})
+        table.put_item(Item={'p': p, 'c': 2, 'v': Vector([0.9, 0, 0])})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=2,
+            KeyConditionExpression='p = :p AND c BETWEEN :lo AND :hi',
+            ExpressionAttributeValues={':p': p, ':lo': 1, ':hi': 2},
+        )
+        assert result['Count'] == 2 and result['ScannedCount'] == 2
+        assert {item['c'] for item in result['Items']} == {Decimal(1), Decimal(2)}
+
 
 # TODO: Like test_vector_projection_keys_only, write additional tests for
 # ProjectionType=INCLUDE with NonKeyAttributes and ProjectionType=ALL.

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -22,6 +22,7 @@
 #include <charconv>
 #include <exception>
 #include <fmt/ranges.h>
+#include <ranges>
 #include <regex>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/metrics.hh>
@@ -134,11 +135,20 @@ auto ck_from_json(rjson::value const& item, std::size_t idx, schema_ptr const& s
     return clustering_key_prefix::from_exploded(raw_ck);
 }
 
-auto write_ann_json(vs_vector vs_vector, limit limit, const rjson::value& filter) -> json_content {
-    if (filter.ObjectEmpty()) {
-        return seastar::format(R"({{"vector":[{}],"limit":{}}})", fmt::join(vs_vector, ","), limit);
+auto write_ann_json(vs_vector vs_vector, limit limit, const rjson::value& filter, const std::vector<std::string>& return_columns) -> json_content {
+    sstring cols_part;
+    if (!return_columns.empty()) {
+        // JSON-encode each column name as a quoted string, then join into an array.
+        // rjson::from_string handles any characters requiring JSON escaping.
+        auto quoted = return_columns | std::views::transform([](const std::string& s) {
+            return rjson::print(rjson::from_string(s));
+        });
+        cols_part = seastar::format(",\"return_columns\":[{}]", fmt::join(quoted, ","));
     }
-    return seastar::format(R"({{"vector":[{}],"limit":{},"filter":{}}})", fmt::join(vs_vector, ","), limit, rjson::print(filter));
+    if (filter.ObjectEmpty()) {
+        return seastar::format(R"({{"vector":[{}],"limit":{}{}}})", fmt::join(vs_vector, ","), limit, cols_part);
+    }
+    return seastar::format(R"({{"vector":[{}],"limit":{},"filter":{}{}}})", fmt::join(vs_vector, ","), limit, rjson::print(filter), cols_part);
 }
 
 auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::expected<primary_keys, ann_error> {
@@ -196,6 +206,25 @@ auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::e
             return std::unexpected{service_reply_format_error{}};
         }
     }
+
+    // Parse optional column_values: { column_name: [value_or_null, ...] }
+    if (json.HasMember("column_values") && json["column_values"].IsObject()) {
+        auto const& col_vals_json = json["column_values"];
+        for (auto it = col_vals_json.MemberBegin(); it != col_vals_json.MemberEnd(); ++it) {
+            auto const col_name = rjson::to_string_view(it->name);
+            if (!it->value.IsArray()) {
+                continue;
+            }
+            auto const& arr = it->value.GetArray();
+            for (auto idx = 0U; idx < size && idx < arr.Size(); ++idx) {
+                if (arr[idx].IsNull()) {
+                    continue; // attribute not present for this row
+                }
+                keys[idx].column_values.emplace(col_name, rjson::copy(arr[idx]));
+            }
+        }
+    }
+
     return std::move(keys);
 }
 
@@ -347,7 +376,8 @@ struct vector_store_client::impl {
         }
     }
 
-    auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as)
+    auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as,
+            const std::vector<std::string>& return_columns)
             -> future<std::expected<primary_keys, ann_error>> {
         if (is_disabled()) {
             vslogger.error("Disabled Vector Store while calling ann");
@@ -355,7 +385,7 @@ struct vector_store_client::impl {
         }
 
         auto path = format("/api/v1/indexes/{}/{}/ann", keyspace, name);
-        auto content = write_ann_json(std::move(vs_vector), limit, filter);
+        auto content = write_ann_json(std::move(vs_vector), limit, filter, return_columns);
 
         auto resp = co_await request(operation_type::POST, std::move(path), std::move(content), as);
         if (!resp) {
@@ -431,8 +461,8 @@ auto vector_store_client::get_index_status(keyspace_name keyspace, index_name na
 }
 
 auto vector_store_client::ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter,
-        abort_source& as) -> future<std::expected<primary_keys, ann_error>> {
-    return _impl->ann(keyspace, name, schema, vs_vector, limit, filter, as);
+        abort_source& as, const std::vector<std::string>& return_columns) -> future<std::expected<primary_keys, ann_error>> {
+    return _impl->ann(keyspace, name, schema, vs_vector, limit, filter, as, return_columns);
 }
 
 void vector_store_client_tester::set_dns_refresh_interval(vector_store_client& vsc, std::chrono::milliseconds interval) {

--- a/vector_search/vector_store_client.hh
+++ b/vector_search/vector_store_client.hh
@@ -38,6 +38,9 @@ struct primary_key {
     /// [0.0, 1.0] for cosine and euclidean; unbounded for dot product on
     /// non-normalized vectors.
     float similarity = 0.0f;
+    /// Values of filtering columns returned by the vector store
+    /// when return_columns is non-empty in the ann() call.
+    std::map<std::string, rjson::value> column_values;
 };
 
 /// A client with the vector-store service.
@@ -98,8 +101,10 @@ public:
     /// neighbors. Each returned primary_key has its similarity field set to
     /// the similarity score returned by the vector store, which sorts the
     /// results in decreasing similarity order (higher similarity score = more
-    /// similar).
-    auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as)
+    /// similar). When return_columns is non-empty, the vector store also returns
+    /// the values of those filtering columns in each primary_key's
+    /// column_values map.
+    auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as, const std::vector<std::string>& return_columns = {})
             -> future<std::expected<primary_keys, ann_error>>;
 
 private:


### PR DESCRIPTION
**The first 7 patches of this series is the content of pull request https://github.com/scylladb/scylladb/pull/29776, and will be removed that when this PR is merged**.

This series implements **projected columns** in Alternator vector index, analogous to the same concept (and using the same API) in DynamoDB's GSI and LSI. Before this patch, the vector store only gets access to the key columns, can only use those columns in pre-filtering and can only return them efficiently (a query needing any other column must perform additional, slow, base-table reads). With this patch we allow:

* Projecting (storing) additional non-key columns in the vector index via Projection=INCLUDE.
* These projected columns can be used in pre-filtering,
* and also for efficiently Select'ing these attributes without reading the base table.

As usual the series includes tests to verify that all of this happens correctly (including the efficiency part - that queries that we expect no to require base table reads, indeed don't do them).

This feature depends on a vector-store patch being committed first - https://github.com/scylladb/vector-store/pull/444, so it is in "draft" mode until then.

We've decided not to backport improvements to the Alternator vector search feature, so do not backport this one either.