### PR TITLE
Simplify handler injection call sites to use appropriate existing API

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3080,11 +3080,7 @@ future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, s
         });
     });
 
-    co_await utils::get_local_injector().inject("truncate_compaction_disabled_wait", [] (auto& handler) -> future<> {
-        dblog.info("truncate_compaction_disabled_wait: wait");
-        co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
-        dblog.info("truncate_compaction_disabled_wait: done");
-    }, false);
+    co_await utils::get_local_injector().inject("truncate_compaction_disabled_wait", utils::wait_for_message{std::chrono::minutes{5}}, false);
 
     const auto should_flush = with_snapshot;
     dblog.trace("{} {}.{} and views on all shards", should_flush ? "Flushing" : "Clearing", s->ks_name(), s->cf_name());

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4409,9 +4409,9 @@ future<std::unordered_map<sstring, table::snapshot_details>> table::get_snapshot
                 auto& sd = all_snapshots.at(snapshot_name);
                 sd.total += details.total;
                 sd.live += details.live;
-                utils::get_local_injector().inject("get_snapshot_details", [&] (auto& handler) -> future<> {
+                utils::get_local_injector().inject("get_snapshot_details", [] {
                     throw std::runtime_error("Injected exception in get_snapshot_details");
-                }).get();
+                });
             }
         }
         return all_snapshots;
@@ -4439,9 +4439,9 @@ future<table::snapshot_details> table::get_snapshot_details(fs::path snapshot_di
             auto sd = co_await io_check(file_stat, snapshot_directory, name, follow_symlink::no);
             auto size = sd.allocated_size;
 
-            utils::get_local_injector().inject("per-snapshot-get_snapshot_details", [&] (auto& handler) -> future<> {
+            utils::get_local_injector().inject("per-snapshot-get_snapshot_details", [] {
                 throw std::runtime_error("Injected exception in per-snapshot-get_snapshot_details");
-            }).get();
+            });
 
             // The manifest and schema.cql files are the only files expected to be in this directory not belonging to the SSTable.
             //

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1274,11 +1274,7 @@ future<compaction::compaction_type_options::split> tablet_storage_group_manager:
 future<> tablet_storage_group_manager::split_all_storage_groups(tasks::task_info tablet_split_task_info) {
     compaction::compaction_type_options::split opt = co_await split_compaction_options();
 
-    co_await utils::get_local_injector().inject("split_storage_groups_wait", [] (auto& handler) -> future<> {
-        dblog.info("split_storage_groups_wait: waiting");
-        co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
-        dblog.info("split_storage_groups_wait: done");
-    }, false);
+    co_await utils::get_local_injector().inject("split_storage_groups_wait", utils::wait_for_message{std::chrono::minutes{5}}, false);
 
     co_await for_each_storage_group_gently([opt, tablet_split_task_info] (storage_group& storage_group) {
         return storage_group.split(opt, tablet_split_task_info);
@@ -5665,11 +5661,7 @@ future<> storage_group::stop(sstring reason) noexcept {
     // picking this group that is being stopped.
     auto closed_gate_fut = _async_gate.close();
 
-    co_await utils::get_local_injector().inject("wait_before_stop_compaction_groups", [] (auto& handler) -> future<> {
-        dblog.info("wait_before_stop_compaction_groups: wait");
-        co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
-        dblog.info("wait_before_stop_compaction_groups: done");
-    }, false);
+    co_await utils::get_local_injector().inject("wait_before_stop_compaction_groups", utils::wait_for_message{std::chrono::minutes{5}}, false);
 
     // Synchronizes with in-flight writes if any, and also takes care of flushing if needed.
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -770,10 +770,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
 
     for (const auto& gen_id : topology.committed_cdc_generations) {
         rtlogger.trace("topology_state_load: process committed cdc generation {}", gen_id);
-        co_await utils::get_local_injector().inject("topology_state_load_before_update_cdc", [](auto& handler) -> future<> {
-            rtlogger.info("topology_state_load_before_update_cdc hit, wait for message");
-            co_await handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(5));
-        });
+        co_await utils::get_local_injector().inject("topology_state_load_before_update_cdc", utils::wait_for_message{std::chrono::minutes(5)});
         co_await _cdc_gens.local().handle_cdc_generation(gen_id);
         if (gen_id == topology.committed_cdc_generations.back()) {
             rtlogger.debug("topology_state_load: the last committed CDC generation ID: {}", gen_id);
@@ -5114,10 +5111,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
         }
 
         if (file_stream_enabled && (trinfo->transition != locator::tablet_transition_kind::intranode_migration || table.uses_logstor())) {
-            co_await utils::get_local_injector().inject("migration_streaming_wait", [] (auto& handler) {
-                rtlogger.info("migration_streaming_wait: start");
-                return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(2));
-            });
+            co_await utils::get_local_injector().inject("migration_streaming_wait", utils::wait_for_message{std::chrono::minutes(2)});
 
             auto dst_node = trinfo->pending_replica->host;
             auto dst_shard_id = trinfo->pending_replica->shard;
@@ -5174,10 +5168,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
                 throw std::runtime_error(fmt::format("Cannot stream within the same node using regular migration, tablet: {}, shard {} -> {}",
                                                      tablet, leaving_replica->shard, trinfo->pending_replica->shard));
             }
-            co_await utils::get_local_injector().inject("migration_streaming_wait", [] (auto& handler) {
-                rtlogger.info("migration_streaming_wait: start");
-                return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(2));
-            });
+            co_await utils::get_local_injector().inject("migration_streaming_wait", utils::wait_for_message{std::chrono::minutes(2)});
             auto& table = _db.local().find_column_family(tablet.table);
             std::vector<sstring> tables = {table.schema()->cf_name()};
             auto my_id = tm->get_my_id();
@@ -5219,9 +5210,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
             auto& table = db.find_column_family(tablet.table);
             return table.maybe_split_compaction_group_of(tablet.tablet);
         });
-        co_await utils::get_local_injector().inject("pause_after_streaming_tablet", [] (auto& handler) {
-            return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(1));
-        });
+        co_await utils::get_local_injector().inject("pause_after_streaming_tablet", utils::wait_for_message{std::chrono::minutes(1)});
         co_return tablet_operation_result();
     });
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4491,7 +4491,7 @@ future<> storage_service::local_topology_barrier() {
     // share=false: each barrier_and_drain invocation needs its own message
     // to proceed. Without this, a single message_injection call would release
     // all past and future handlers sharing the same injection.
-    co_await utils::get_local_injector().inject("pause_before_barrier_and_drain", utils::wait_for_message(std::chrono::minutes(5), nullptr, false));
+    co_await utils::get_local_injector().inject("pause_before_barrier_and_drain", utils::wait_for_message(std::chrono::minutes(5)), false);
     if (_topology_state_machine._topology.tstate == topology::transition_state::write_both_read_old) {
         for (auto& n : _topology_state_machine._topology.transition_nodes) {
             if (!_address_map.find(locator::host_id{n.first.uuid()})) {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -776,11 +776,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         rtlogger.debug("start CDC generation publisher fiber");
 
         while (!_as.abort_requested()) {
-            co_await utils::get_local_injector().inject("cdc_generation_publisher_fiber", [] (auto& handler) -> future<> {
-                rtlogger.info("CDC generation publisher fiber sleeps after injection");
-                co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
-                rtlogger.info("CDC generation publisher fiber finishes sleeping after injection");
-            }, false);
+            co_await utils::get_local_injector().inject("cdc_generation_publisher_fiber", utils::wait_for_message{std::chrono::minutes{5}}, false);
 
             bool sleep = false;
             try {
@@ -870,11 +866,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
     future<> gossiper_orphan_remover_fiber() {
         rtlogger.debug("start gossiper orphan remover fiber");
         bool do_speedup_fiber = utils::get_local_injector().is_enabled("fast_orphan_removal_fiber");
-        co_await utils::get_local_injector().inject("fast_orphan_removal_fiber", [&](auto& handler) -> future<> {
-            // While testing, orphan ip is introduced, and its presence is captured. Wait is added before remover thread so that the presence of orphan ip is
-            // confirmed and the difference of gossiper ips before and after this thread application can be easily asserted.
-            return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(5));
-        });
+        // While testing, orphan ip is introduced, and its presence is captured. Wait is added before remover thread so that the presence of orphan ip is
+        // confirmed and the difference of gossiper ips before and after this thread application can be easily asserted.
+        co_await utils::get_local_injector().inject("fast_orphan_removal_fiber", utils::wait_for_message{std::chrono::minutes(5)});
         while (!_as.abort_requested()) {
             try {
                 auto guard = co_await start_operation();
@@ -2157,10 +2151,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                                                                            dst.host, _as, raft::server_id(dst.host.uuid()), gid);
                             });
                         }).then([] {
-                            return utils::get_local_injector().inject("wait_after_tablet_cleanup", [] (auto& handler) -> future<> {
-                                rtlogger.info("Waiting after tablet cleanup");
-                                return handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds{60});
-                            });
+                            return utils::get_local_injector().inject("wait_after_tablet_cleanup", utils::wait_for_message{std::chrono::seconds{60}});
                         });
                     })) {
                         transition_to(locator::tablet_transition_stage::end_migration);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -869,9 +869,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
     // entries from gossiper by committing the node as left in raft.
     future<> gossiper_orphan_remover_fiber() {
         rtlogger.debug("start gossiper orphan remover fiber");
-        bool do_speedup_fiber = false;
+        bool do_speedup_fiber = utils::get_local_injector().is_enabled("fast_orphan_removal_fiber");
         co_await utils::get_local_injector().inject("fast_orphan_removal_fiber", [&](auto& handler) -> future<> {
-            do_speedup_fiber = true;
             // While testing, orphan ip is introduced, and its presence is captured. Wait is added before remover thread so that the presence of orphan ip is
             // confirmed and the difference of gossiper ips before and after this thread application can be easily asserted.
             return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(5));
@@ -881,11 +880,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 auto guard = co_await start_operation();
                 utils::chunked_vector<canonical_mutation> updates;
                 int32_t timeout = 60;
-                co_await utils::get_local_injector().inject("speedup_orphan_removal", [&](auto& handler) -> future<> {
+                if (utils::get_local_injector().enter("speedup_orphan_removal")) {
                     // Removes all unjoined nodes. Just for testing purposes.
                     timeout = 0;
-                    co_return;
-                });
+                }
                 std::string reason = ::format("Ban the orphan nodes in group0. Orphan nodes HostId/IP:");
                 _gossiper.for_each_endpoint_state([&](const gms::endpoint_state& eps) -> void {
                     // Since generation is in seconds unit, converting current time to seconds eases comparison computations.

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -413,10 +413,7 @@ future<utils::chunked_vector<task_identity>> task_manager::virtual_task::impl::g
     }
 
     auto nodes = module->get_nodes();
-    co_await utils::get_local_injector().inject("tasks_vt_get_children", [] (auto& handler) -> future<> {
-        tmlogger.info("tasks_vt_get_children: waiting");
-        co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds{60});
-    });
+    co_await utils::get_local_injector().inject("tasks_vt_get_children", utils::wait_for_message{std::chrono::seconds{60}});
     co_return co_await map_reduce(nodes, [ms, parent_id] (auto host_id) -> future<utils::chunked_vector<task_identity>> {
         return ser::tasks_rpc_verbs::send_tasks_get_children(ms, host_id, parent_id).then([host_id] (auto resp) {
             return resp | std::views::transform([host_id] (auto id) {

--- a/test/cluster/test_cdc_generation_clearing.py
+++ b/test/cluster/test_cdc_generation_clearing.py
@@ -123,7 +123,7 @@ async def test_unpublished_cdc_generations_arent_cleared(manager: ManagerClient)
         [host2, host3] = await wait_for_cql_and_get_hosts(cql, servers[-2:], time.time() + 60)
 
         log_file1 = await manager.server_open_log(servers[0].server_id)
-        await log_file1.wait_for(f"CDC generation publisher fiber sleeps after injection")
+        await log_file1.wait_for(f"cdc_generation_publisher_fiber: waiting for message")
         mark = await log_file1.mark()
 
         # The second and third generations are committed but unpublished due to the cdc_generation_publisher_fiber
@@ -137,7 +137,7 @@ async def test_unpublished_cdc_generations_arent_cleared(manager: ManagerClient)
         # what it has done in this step. Eventually, the CDC generation publisher will publish all generations and
         # delete the first and second ones.
         await handler.message()
-        await log_file1.wait_for(f"CDC generation publisher fiber sleeps after injection", from_mark=mark)
+        await log_file1.wait_for(f"cdc_generation_publisher_fiber: waiting for message", from_mark=mark)
         mark = await log_file1.mark()
         gen_ids = await get_gen_ids()
         assert len(gen_ids) == 2 and first_gen_id not in gen_ids

--- a/test/cluster/test_cdc_generation_data.py
+++ b/test/cluster/test_cdc_generation_data.py
@@ -51,7 +51,7 @@ async def test_group0_apply_while_node_is_being_shutdown(manager: ManagerClient)
 
     logger.info("Waiting for topology_state_load_before_update_cdc on s0")
     log = await manager.server_open_log(s0.server_id)
-    await log.wait_for('topology_state_load_before_update_cdc hit, wait for message')
+    await log.wait_for('topology_state_load_before_update_cdc: waiting for message')
 
     logger.info("Triggering s0 shutdown")
     stop_s0_task = asyncio.create_task(manager.server_stop_gracefully(s0.server_id))

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1901,7 +1901,7 @@ async def test_drop_keyspace_while_split(manager: ManagerClient):
 
     # start a DROP and wait for it to disable compaction
     drop_ks_task = cql.run_async(f'DROP KEYSPACE {ks};')
-    await s0_log.wait_for('truncate_compaction_disabled_wait: wait')
+    await s0_log.wait_for('truncate_compaction_disabled_wait: waiting for message')
 
     # release split
     await manager.api.message_injection(servers[0].ip_addr, "split_storage_groups_wait")
@@ -1948,13 +1948,13 @@ async def test_drop_with_tablet_migration_cleanup(manager: ManagerClient):
 
         # Wait until the leaving replica is about to be cleaned up.
         # storage_group's gate has been closed, but the compaction groups have not yet been stopped and disabled
-        await slog.wait_for("wait_before_stop_compaction_groups: wait", from_mark=smark)
+        await slog.wait_for("wait_before_stop_compaction_groups: waiting for message", from_mark=smark)
 
         # Start dropping the table
         drop_future = cql.run_async(f"DROP TABLE {ks}.test;")
 
         # Wait for truncate to complete disabling compaction
-        await slog.wait_for("truncate_compaction_disabled_wait: wait", from_mark=smark)
+        await slog.wait_for("truncate_compaction_disabled_wait: waiting for message", from_mark=smark)
 
         # Release the migration's tablet cleanup
         await manager.api.message_injection(server.ip_addr, "wait_before_stop_compaction_groups")

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -155,8 +155,8 @@ async def test_lwt_during_migration(manager: ManagerClient):
 
         logger.info("Open log")
         log = await manager.server_open_log(target_server.server_id)
-        logger.info(f"Wait for 'migration_streaming_wait: start' injection on {target_server.ip_addr}")
-        await log.wait_for('migration_streaming_wait: start')
+        logger.info(f"Wait for 'migration_streaming_wait: waiting for message' injection on {target_server.ip_addr}")
+        await log.wait_for('migration_streaming_wait: waiting for message')
 
         logger.info("Run an LWT while migration is in-progress")
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES (1, 1) IF NOT EXISTS")

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -538,7 +538,7 @@ async def test_restart_in_cleanup_stage_after_cleanup(manager: ManagerClient):
         # Start migration - move tablet to other node
         move_task = asyncio.create_task(manager.api.move_tablet(servers[0].ip_addr, ks, 'test', replica[0], replica[1], dst_host_id, 0, tablet_token))
 
-        await log.wait_for("Waiting after tablet cleanup", from_mark=mark, timeout=60)
+        await log.wait_for("wait_after_tablet_cleanup: waiting for message", from_mark=mark, timeout=60)
 
         # Restart the leaving replica (src_server)
         await manager.server_stop(src_server.server_id, convict=False)

--- a/test/cluster/test_tablets_parallel_decommission.py
+++ b/test/cluster/test_tablets_parallel_decommission.py
@@ -219,7 +219,7 @@ async def test_decommission_can_be_canceled(manager: ManagerClient):
         mark = await coord_log.mark()
         await manager.api.enable_injection(coord_serv.ip_addr, "wait_after_tablet_cleanup", one_shot=True)
         decomm_task = asyncio.create_task(manager.decommission_node(servers[1].server_id))
-        await coord_log.wait_for('Waiting after tablet cleanup', from_mark=mark)
+        await coord_log.wait_for('wait_after_tablet_cleanup: waiting for message', from_mark=mark)
         task = await tm.wait_task_appears(servers[0].ip_addr, 'node_ops', task_type='decommission', entity=decomm_hostid)
         task_id = task.task_id
         await manager.api.abort_task(servers[0].ip_addr, task_id)
@@ -268,7 +268,7 @@ async def test_decommission_is_rejected_when_another_one_is_still_pending(manage
         decomm_task = asyncio.create_task(manager.decommission_node(servers[1].server_id))
 
         # Trap the first decommission in the tablet draining stage
-        await coord_log.wait_for('Waiting after tablet cleanup', from_mark=mark)
+        await coord_log.wait_for('wait_after_tablet_cleanup: waiting for message', from_mark=mark)
 
         # Second decommission should fail, because if both decommissions succeeded, the rack would be empty.
         with pytest.raises(Exception, match="node decommission rejected: "):
@@ -438,7 +438,7 @@ async def test_decommission_fails_if_capacity_is_gone_during_draining(manager: M
 
         decomm_task = asyncio.create_task(manager.decommission_node(servers[2].server_id))
 
-        await coord_log.wait_for('Waiting after tablet cleanup', from_mark=mark)
+        await coord_log.wait_for('wait_after_tablet_cleanup: waiting for message', from_mark=mark)
 
         srv_to_remove = servers[1]
         await manager.server_stop_gracefully(srv_to_remove.server_id)
@@ -487,7 +487,7 @@ async def test_node_lost_during_decommission_drain(manager: ManagerClient):
         srv_to_remove = servers[1]
         nodetool_task = asyncio.create_task(manager.decommission_node(srv_to_remove.server_id))
 
-        mark, _ = await coord_log.wait_for('migration_streaming_wait: start', from_mark=mark)
+        mark, _ = await coord_log.wait_for('migration_streaming_wait: waiting for message', from_mark=mark)
         await manager.api.enable_injection(coord_serv.ip_addr, "topology_coordinator_pause_before_processing_backlog", one_shot=True)
         await manager.api.message_injection(coord_serv.ip_addr, "migration_streaming_wait")
 

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -45,7 +45,7 @@ async def test_truncate_while_migration(manager: ManagerClient):
         pending_node = servers[1]
         pending_log = await manager.server_open_log(pending_node.server_id)
 
-        await pending_log.wait_for('migration_streaming_wait: start')
+        await pending_log.wait_for('migration_streaming_wait: waiting for message')
         await manager.api.message_injection(pending_node.ip_addr, 'migration_streaming_wait')
 
         # Do a TRUNCATE TABLE while the tablet is being streamed
@@ -238,7 +238,7 @@ async def test_truncate_while_truncate_already_waiting(manager: ManagerClient):
         s1_log = await manager.server_open_log(servers[1].server_id)
 
         # Wait for tablet streaming to start
-        await s1_log.wait_for('migration_streaming_wait: start')
+        await s1_log.wait_for('migration_streaming_wait: waiting for message')
 
         # Run a truncate which will quickly time out, but the truncate fiber remains alive
         # Do not attempt to retry automatically (hense the FallthroughRetryPolicy)
@@ -322,7 +322,7 @@ async def test_parallel_truncate(manager: ManagerClient):
         s1_log = await manager.server_open_log(servers[1].server_id)
 
         # Wait for tablet streaming to start
-        await s1_log.wait_for('migration_streaming_wait: start')
+        await s1_log.wait_for('migration_streaming_wait: waiting for message')
 
         tf1 = cql.run_async(SimpleStatement(f'TRUNCATE TABLE {ks}.test', retry_policy=FallthroughRetryPolicy()))
         tf2 = cql.run_async(SimpleStatement(f'TRUNCATE TABLE {ks}.test1', retry_policy=FallthroughRetryPolicy()))

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -45,16 +45,11 @@ using error_injection_parameters = std::unordered_map<sstring, sstring>;
 // in class error_injection below). Parameters:
 // timeout - the timeout after which the pause is aborted
 // as (optional) - abort_source used to abort the pause
-// share - if true (default), injection handlers share received messages:
-//         every message can be received by all handlers (even if they start
-//         waiting in the future). If false, only one handler can receive a
-//         specific message; other handlers will wait for new messages.
 struct wait_for_message {
     std::chrono::milliseconds timeout;
-    abort_source* as;
-    bool share;
-    wait_for_message(std::chrono::milliseconds tmo, abort_source* a = nullptr, bool share_ = true) noexcept
-        : timeout(tmo), as(a), share(share_) {}
+    abort_source* as = nullptr;
+    wait_for_message(std::chrono::milliseconds tmo) noexcept : timeout(tmo) {}
+    wait_for_message(std::chrono::milliseconds tmo, abort_source* a) noexcept : timeout(tmo), as(a) {}
 };
 
 /**
@@ -552,12 +547,14 @@ public:
     // Injects a pause in the code execution that's woken up explicitly by the injector
     // request
     // \param wfm -- the wait_for_message instance that describes details of the pause
-    future<> inject(const std::string_view& name, utils::wait_for_message wfm) {
+    // \param share_messages -- if true, all concurrent handlers share received messages;
+    //   if false, each message is consumed by exactly one handler
+    future<> inject(const std::string_view& name, utils::wait_for_message wfm, bool share_messages = true) {
         co_await inject(name, [name, wfm] (injection_handler& handler) -> future<> {
             errinj_logger.info("{}: waiting for message", name);
             co_await handler.wait_for_message(std::chrono::steady_clock::now() + wfm.timeout, wfm.as);
             errinj_logger.info("{}: message received", name);
-        }, wfm.share);
+        }, share_messages);
     }
 
     template <typename T = std::string_view>
@@ -728,7 +725,7 @@ public:
 
     // \brief Inject "breakpoint"
     [[gnu::always_inline]]
-    future<> inject(const std::string_view& name, utils::wait_for_message wfm) {
+    future<> inject(const std::string_view& name, utils::wait_for_message wfm, bool share_messages = true) {
         return make_ready_future<>();
     }
 


### PR DESCRIPTION
Several error injection call sites use the verbose handler-lambda API when simpler alternatives already exist in the framework. This series converts them to use the appropriate overloads, reducing boilerplate and making the injection intent immediately obvious from the call site.

Cleaning up in-code debugging facilities, no need to backport