### PR TITLE
test/cluster: don't advance to SERVING before CQL/Alternator connections are up

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -925,7 +925,7 @@ class ScyllaServer:
                 # STATUS=serving once all configured listeners are ready, and
                 # STATUS=entering maintenance mode once the maintenance socket is ready.
                 # Both mean the server is fully started and we don't need to wait further.
-                if self.check_serving_notification():
+                if server_up_state >= ServerUpState.CQL_ALTERNATOR_QUERIED and self.check_serving_notification():
                     server_up_state = ServerUpState.SERVING
                 if server_up_state >= expected_server_up_state:
                     if expected_error is not None:


### PR DESCRIPTION
Don't honor sd_notify SERVING until CQL/Alternator ports are verified reachable. Fixes a race introduced in af03f0e8c4 (PR #29758).

Refs: #29929
Fixes: SCYLLADB-2065

Backport not needed, tests fail on `next` since a few days.