### PR TITLE
test: fix wait for cdc generation publishing

### DIFF
--- a/test/cluster/test_cdc_generation_clearing.py
+++ b/test/cluster/test_cdc_generation_clearing.py
@@ -17,10 +17,24 @@ import asyncio
 import pytest
 import logging
 import time
-from typing import Optional
+from typing import Callable
 
 
 logger = logging.getLogger(__name__)
+
+
+async def fetch_committed_gen_ids(cql, host: Host, live_hosts: list[Host]) -> set[str]:
+    query_committed_gen_ids = SimpleStatement(
+        "SELECT host_id, committed_cdc_generations FROM system.topology",
+        consistency_level = ConsistencyLevel.ONE)
+
+    live_host_ids = {live_host.host_id for live_host in live_hosts}
+    committed_rows = await cql.run_async(query_committed_gen_ids, host=host)
+    committed_topology_rows = [row for row in committed_rows if row.host_id in live_host_ids]
+    assert len(committed_topology_rows) != 0
+    committed_cdc_generations = committed_topology_rows[0].committed_cdc_generations
+    assert committed_cdc_generations is not None
+    return {gen[1] for gen in committed_cdc_generations}
 
 
 @pytest.mark.asyncio
@@ -28,52 +42,55 @@ logger = logging.getLogger(__name__)
 async def test_cdc_generation_clearing(manager: ManagerClient):
     """Test that obsolete CDC generations are removed from CDC_GENERATIONS_V3 and TOPOLOGY.committed_cdc_generations
        if their timestamp is old enough according to the topology coordinator's clock."""
+
+    increase_leeway_injection = 'increase_cdc_generation_leeway'
+    cleanup_injection = 'clean_obsolete_cdc_generations_change_ts_ub'
+
+    cmdline = ['--logger-log-level', 'storage_service=trace:raft_topology=trace']
+    config = {'error_injections_at_startup': [increase_leeway_injection]}
+
     logger.info("Bootstrapping first node")
-    servers = [await manager.server_add(cmdline=['--logger-log-level', 'storage_service=trace:raft_topology=trace'],
-                                        config={'error_injections_at_startup': ['increase_cdc_generation_leeway']})]
+    servers = [await manager.server_add(cmdline=cmdline, config=config)]
 
-    log_file1 = await manager.server_open_log(servers[0].server_id)
-    mark: Optional[int] = None
+    cql = manager.get_cql()
 
-    query_gen_ids = SimpleStatement(
-        "SELECT id FROM system.cdc_generations_v3 WHERE key = 'cdc_generations'",
-        consistency_level = ConsistencyLevel.ONE)
+    async def wait_for_published_generations() -> tuple[set[str], list[Host]]:
+        deadline = time.time() + 60
 
-    async def tried_to_remove_new_gen() -> Optional[tuple[int, set[str], list[Host]]]:
-        await log_file1.wait_for("CDC generation publisher fiber has nothing to do. Sleeping.", from_mark=mark)
-        new_mark = await log_file1.mark()
+        hosts = await wait_for_cql_and_get_hosts(cql, servers, deadline)
+        await wait_for_cdc_generations_publishing(cql, hosts, deadline)
 
-        cql = manager.get_cql()
-        hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
-        new_gen_ids = {r.id for r in await cql.run_async(query_gen_ids)}
-
-        return (new_mark, new_gen_ids, hosts)
+        committed_gen_ids = await fetch_committed_gen_ids(cql, hosts[0], hosts)
+        return committed_gen_ids, hosts
 
     # The first generation should not be removed. We cannot remove the only generation.
-    mark, gen_ids, hosts = await wait_for(tried_to_remove_new_gen, time.time() + 60)
+    gen_ids, hosts = await wait_for_published_generations()
     logger.info(f"Generations after first clearing attempt: {gen_ids}")
     assert len(gen_ids) == 1
-    await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
     first_gen_id = next(iter(gen_ids))
+    await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
+    await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
 
     logger.info("Bootstrapping second node")
-    servers += [await manager.server_add()]
+    servers += [await manager.server_add(cmdline=cmdline, config=config)]
 
     # The first and second generations should not be removed. The first generation's timestamp is too close to the
     # topology coordinator's clock, which is ensured by the `increase_cdc_generation_leeway` error injection.
-    mark, gen_ids, hosts = await wait_for(tried_to_remove_new_gen, time.time() + 60)
+    gen_ids, hosts = await wait_for_published_generations()
     logger.info(f"Generations after second clearing attempt: {gen_ids}")
     assert len(gen_ids) == 2 and first_gen_id in gen_ids
     await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
     await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
     second_gen_id = max(gen_ids)
 
-    async with inject_error(manager.api, servers[0].ip_addr, "clean_obsolete_cdc_generations_change_ts_ub"):
+    await asyncio.gather(*[manager.api.enable_injection(server.ip_addr, cleanup_injection, one_shot=False) for server in servers])
+    config['error_injections_at_startup'].append(cleanup_injection)
+    try:
         logger.info("Bootstrapping third node")
-        servers += [await manager.server_add()]
+        servers += [await manager.server_add(cmdline=cmdline, config=config)]
 
         # The first and second generations should be removed thanks to the above injection.
-        mark, gen_ids, hosts = await wait_for(tried_to_remove_new_gen, time.time() + 60)
+        gen_ids, hosts = await wait_for_published_generations()
         logger.info(f"Generations after third clearing attempt: {gen_ids}")
         assert len(gen_ids) == 1 and first_gen_id not in gen_ids and second_gen_id not in gen_ids
         await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
@@ -81,14 +98,17 @@ async def test_cdc_generation_clearing(manager: ManagerClient):
         third_gen_id = max(gen_ids)
 
         logger.info("Bootstrapping fourth node")
-        servers += [await manager.server_add()]
+        servers += [await manager.server_add(cmdline=cmdline, config=config)]
 
         # The third generation should be removed thanks to the above injection.
-        mark, gen_ids, hosts = await wait_for(tried_to_remove_new_gen, time.time() + 60)
+        gen_ids, hosts = await wait_for_published_generations()
         logger.info(f"Generations after fourth clearing attempt: {gen_ids}")
         assert len(gen_ids) == 1 and third_gen_id not in gen_ids
         await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
         await check_system_topology_and_cdc_generations_v3_consistency(manager, hosts)
+    finally:
+        config['error_injections_at_startup'].remove(cleanup_injection)
+        await asyncio.gather(*[manager.api.disable_injection(server.ip_addr, cleanup_injection) for server in servers])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The cdc test test_cdc_generation_clearing checks the CDC generations are changed as expected by the cdc generation publisher fiber after topology operations.

It waits for the fiber to emit a log on the first server to indicate it has finished its operation. The cdc fiber runs on the topology coordinator, typically on the first server, but the group0 leadership may be transferred to another node during the test. In that case the test will not find the expected log and fail.

To make the test more robust against this, we change it to wait for cdc generation publishing by querying the topology table that the fiber updates instead of querying the logs. This does not depend on the identity of the topology coordinator. We wait for the unpublished generations to be empty and the committed generations to match the expected generations, meaning the fiber published all generations and decided not to remove the expected generations, so this should match the previous behavior of the test.

We also change the test injections to be more robust against leadership transfer - instead of injecting it only on the first server, assuming it's the leader, we enable the injections on all servers.

Fixes SCYLLADB-2102

backport for CI stability