### PR TITLE
utils::gcp::object_storage: Add abort source to remaining rest calls

### DIFF
--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -90,8 +90,8 @@ public:
     future<> copy_object(object_name src, object_name dst, abort_source* as) override {
         return _client->copy_object(src.str(), dst.str(), std::nullopt, std::nullopt, as);
     }
-    future<> delete_object(object_name name) override {
-        return _client->delete_object(name.str());
+    future<> delete_object(object_name name, abort_source* as) override {
+        return _client->delete_object(name.str(), as);
     }
     file make_readable_file(object_name name, abort_source* as) override {
         return _client->make_readable_file(name.str(), as);
@@ -165,11 +165,11 @@ public:
         co_await sink.flush();
         co_await sink.close();
     }
-    future<> copy_object(object_name src, object_name dst, abort_source*) override {
-        return _client->copy_object(src.bucket(), src.object(), dst.bucket(), dst.object());
+    future<> copy_object(object_name src, object_name dst, abort_source* as) override {
+        return _client->copy_object(src.bucket(), src.object(), dst.bucket(), dst.object(), as);
     }
-    future<> delete_object(object_name name) override {
-        return _client->delete_object(name.bucket(), name.object());
+    future<> delete_object(object_name name, abort_source* as) override {
+        return _client->delete_object(name.bucket(), name.object(), as);
     }
     file make_readable_file(object_name name, abort_source* as) override {
         auto src = _client->create_download_source(name.bucket(), name.object(), as);
@@ -197,6 +197,8 @@ public:
             utils::gcp::storage::bucket_paging _paging;
             utils::chunked_vector<utils::gcp::storage::object_info> _info;
             size_t _pos;
+            seastar::abort_source _as;
+
         public:
             list_impl(shared_ptr<gcp::storage::client> client, std::string bucket, std::string prefix, lister::filter_type filter)
                 : _client(std::move(client))
@@ -211,7 +213,7 @@ public:
                 while (true) {
                     if (_pos == _info.size()) {
                         _info.clear();
-                        _info = co_await _client->list_objects(_bucket, _prefix, _paging);
+                        _info = co_await _client->list_objects(_bucket, _prefix, _paging, &_as);
                         _pos = 0;
                     }
                     if (_info.empty()) {
@@ -228,6 +230,7 @@ public:
                 co_return std::nullopt;
             }
             future<> close() noexcept override {
+                _as.request_abort();
                 co_return;
             }
         };
@@ -282,7 +285,7 @@ public:
                 off += rem;
             }
 
-            auto existing = (co_await _client->list_objects(bucket, fmt::format("{}-temp-", object)))
+            auto existing = (co_await _client->list_objects(bucket, fmt::format("{}-temp-", object), as))
                 | std::views::transform([](auto& info) { return info.name; })
                 | std::ranges::to<std::unordered_set<std::string>>()
             ;
@@ -298,8 +301,8 @@ public:
             auto names = ranges | std::views::transform([](auto& p) { return p.name; }) | std::ranges::to<std::vector<std::string>>();
             co_await _client->merge_objects(bucket, object, names, {}, as);
 
-            co_await parallel_for_each(names, [this, bucket](auto& name) -> future<> {
-                co_await _client->delete_object(bucket, name);
+            co_await parallel_for_each(names, [this, bucket, as](auto& name) -> future<> {
+                co_await _client->delete_object(bucket, name, as);
             });
         }
 

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -72,7 +72,7 @@ public:
 
     virtual future<> put_object(object_name, ::memory_data_sink_buffers bufs, abort_source* = nullptr) = 0;
     virtual future<> copy_object(object_name src, object_name dst, abort_source* = nullptr) = 0;
-    virtual future<> delete_object(object_name) = 0;
+    virtual future<> delete_object(object_name, abort_source* = nullptr) = 0;
     virtual file make_readable_file(object_name, abort_source* = nullptr) = 0;
     virtual data_sink make_data_upload_sink(object_name, std::optional<unsigned> max_parts_per_piece, abort_source* = nullptr) = 0;
     virtual data_sink make_upload_sink(object_name, abort_source* = nullptr) = 0;

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -699,7 +699,7 @@ public:
         return _client->copy_object(std::move(src), std::move(dst), abort_source());
     }
     future<> delete_object(object_name name) const {
-        return _client->delete_object(std::move(name));
+        return _client->delete_object(std::move(name), abort_source());
     }
     file make_readable_file(object_name name) {
         return _client->make_readable_file(std::move(name), abort_source());

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -845,7 +845,7 @@ utils::gcp::storage::client::client(std::string_view endpoint, std::optional<goo
 utils::gcp::storage::client::~client() = default;
 
 
-future<> utils::gcp::storage::client::create_bucket(std::string_view project, rjson::value meta) {
+future<> utils::gcp::storage::client::create_bucket(std::string_view project, rjson::value meta, seastar::abort_source* as) {
     gcp_storage.debug("Create bucket {}:{}", project, rjson::get(meta, "name"));
 
     auto path = fmt::format("/storage/v1/b?project={}", project);
@@ -856,6 +856,8 @@ future<> utils::gcp::storage::client::create_bucket(std::string_view project, rj
         , body
         , APPLICATION_JSON
         , httpclient::method_type::POST
+        , {}
+        , as
     );
 
     switch (res.result()) {
@@ -867,7 +869,7 @@ future<> utils::gcp::storage::client::create_bucket(std::string_view project, rj
     }
 }
 
-future<> utils::gcp::storage::client::create_bucket(std::string_view project, std::string_view bucket, std::string_view region, std::string_view storage_class) {
+future<> utils::gcp::storage::client::create_bucket(std::string_view project, std::string_view bucket, std::string_view region, std::string_view storage_class, seastar::abort_source* as) {
     // Construct metadata. Could fmt::format, but this is somewhat safer.
     rjson::value meta = rjson::empty_object();
     rjson::add(meta, "name", std::string(bucket));
@@ -880,10 +882,10 @@ future<> utils::gcp::storage::client::create_bucket(std::string_view project, st
     rjson::add(iamConfiguration, "uniformBucketLevelAccess", std::move(uniformBucketLevelAccess));
     rjson::add(meta, "iamConfiguration", std::move(iamConfiguration));
 
-    co_await create_bucket(project, std::move(meta));
+    co_await create_bucket(project, std::move(meta), as);
 }
 
-future<> utils::gcp::storage::client::delete_bucket(std::string_view bucket_in) {
+future<> utils::gcp::storage::client::delete_bucket(std::string_view bucket_in, seastar::abort_source* as) {
     std::string bucket(bucket_in);
 
     gcp_storage.debug("Delete bucket {}", bucket);
@@ -895,6 +897,8 @@ future<> utils::gcp::storage::client::delete_bucket(std::string_view bucket_in) 
         , ""s
         , ""s
         , httpclient::method_type::DELETE
+        , {}
+        , as
     );
 
     switch (res.result()) {
@@ -924,7 +928,7 @@ static utils::gcp::storage::object_info create_info(const rjson::value& item) {
 // read all data from network, etc. Thus there is not all that much
 // point in it. Return chunked_vector to avoid large alloc, but keep it
 // in one object... for now...
-future<utils::chunked_vector<utils::gcp::storage::object_info>> utils::gcp::storage::client::list_objects(std::string_view bucket_in, std::string_view prefix, bucket_paging& pager) {
+future<utils::chunked_vector<utils::gcp::storage::object_info>> utils::gcp::storage::client::list_objects(std::string_view bucket_in, std::string_view prefix, bucket_paging& pager, seastar::abort_source* as) {
     utils::chunked_vector<utils::gcp::storage::object_info> result;
 
     if (pager.done) {
@@ -987,18 +991,20 @@ future<utils::chunked_vector<utils::gcp::storage::object_info>> utils::gcp::stor
 
         }
         , httpclient::method_type::GET
+        , {}
+        , as
     );
 
     co_return result;
 }
 
-future<utils::chunked_vector<utils::gcp::storage::object_info>> utils::gcp::storage::client::list_objects(std::string_view bucket, std::string_view prefix) {
+future<utils::chunked_vector<utils::gcp::storage::object_info>> utils::gcp::storage::client::list_objects(std::string_view bucket, std::string_view prefix, seastar::abort_source* as) {
     bucket_paging dummy(0);
-    co_return co_await list_objects(bucket, prefix, dummy);
+    co_return co_await list_objects(bucket, prefix, dummy, as);
 }
 
 // See https://cloud.google.com/storage/docs/deleting-objects
-future<> utils::gcp::storage::client::delete_object(std::string_view bucket_in, std::string_view object_name_in) {
+future<> utils::gcp::storage::client::delete_object(std::string_view bucket_in, std::string_view object_name_in, seastar::abort_source* as) {
     std::string bucket(bucket_in), object_name(object_name_in);
 
     gcp_storage.debug("Delete object {}:{}", bucket, object_name);
@@ -1007,7 +1013,7 @@ future<> utils::gcp::storage::client::delete_object(std::string_view bucket_in, 
 
     httpclient::result_type res;
     try {
-        res = co_await _impl->send_with_retry(path, GCP_OBJECT_SCOPE_READ_WRITE, ""s, ""s, httpclient::method_type::DELETE);
+        res = co_await _impl->send_with_retry(path, GCP_OBJECT_SCOPE_READ_WRITE, ""s, ""s, httpclient::method_type::DELETE, {}, as);
     } catch (const storage_io_error& ex) {
         if (ex.code().value() == ENOENT) {
             gcp_storage.debug("Could not delete {}:{} - no such object", bucket, object_name);
@@ -1030,13 +1036,13 @@ future<> utils::gcp::storage::client::delete_object(std::string_view bucket_in, 
 
 // See https://cloud.google.com/storage/docs/copying-renaming-moving-objects
 // GCP does not support moveTo across buckets.
-future<> utils::gcp::storage::client::rename_object(std::string_view bucket, std::string_view object_name, std::string_view new_bucket, std::string_view new_name) {
-    co_await copy_object(bucket, object_name, new_bucket, new_name);
-    co_await delete_object(bucket, object_name);
+future<> utils::gcp::storage::client::rename_object(std::string_view bucket, std::string_view object_name, std::string_view new_bucket, std::string_view new_name, seastar::abort_source* as) {
+    co_await copy_object(bucket, object_name, new_bucket, new_name, as);
+    co_await delete_object(bucket, object_name, as);
 }
 
 // See https://cloud.google.com/storage/docs/copying-renaming-moving-objects
-future<> utils::gcp::storage::client::rename_object(std::string_view bucket_in, std::string_view object_name_in, std::string_view new_name_in) {
+future<> utils::gcp::storage::client::rename_object(std::string_view bucket_in, std::string_view object_name_in, std::string_view new_name_in, seastar::abort_source* as) {
     std::string bucket(bucket_in), object_name(object_name_in), new_name(new_name_in);
 
     gcp_storage.debug("Move object {}:{} -> {}", bucket, object_name, new_name);
@@ -1051,6 +1057,8 @@ future<> utils::gcp::storage::client::rename_object(std::string_view bucket_in, 
         , ""s
         , ""s
         , httpclient::method_type::PUT
+        , {}
+        , as
     );
 
     switch (res.result()) {
@@ -1068,7 +1076,7 @@ future<> utils::gcp::storage::client::rename_object(std::string_view bucket_in, 
 // See https://cloud.google.com/storage/docs/copying-renaming-moving-objects
 // Copying an object in GCP can only process a certain amount of data in one call
 // Must keep doing it until all data is copied, and check response.
-future<> utils::gcp::storage::client::copy_object(std::string_view bucket_in, std::string_view object_name_in, std::string_view new_bucket_in, std::string_view to_name_in) {
+future<> utils::gcp::storage::client::copy_object(std::string_view bucket_in, std::string_view object_name_in, std::string_view new_bucket_in, std::string_view to_name_in, seastar::abort_source* as) {
     std::string bucket(bucket_in), object_name(object_name_in), new_bucket(new_bucket_in), to_name(to_name_in);
 
     auto path = fmt::format("/storage/v1/b/{}/o/{}/rewriteTo/b/{}/o/{}"
@@ -1085,6 +1093,8 @@ future<> utils::gcp::storage::client::copy_object(std::string_view bucket_in, st
             , body
             , APPLICATION_JSON
             , httpclient::method_type::POST
+            , {}
+            , as
         );
 
         if (res.result() != status_type::ok) {
@@ -1150,8 +1160,8 @@ future<utils::gcp::storage::object_info> utils::gcp::storage::client::merge_obje
     co_return create_info(resp);
 }
 
-future<> utils::gcp::storage::client::copy_object(std::string_view bucket, std::string_view object_name, std::string_view to_name) {
-    co_await copy_object(bucket, object_name, bucket, to_name);
+future<> utils::gcp::storage::client::copy_object(std::string_view bucket, std::string_view object_name, std::string_view to_name, seastar::abort_source* as) {
+    co_await copy_object(bucket, object_name, bucket, to_name, as);
 }
 
 seastar::data_sink utils::gcp::storage::client::create_upload_sink(std::string_view bucket, std::string_view object_name, rjson::value metadata, seastar::abort_source* as) const {

--- a/utils/gcp/object_storage.hh
+++ b/utils/gcp/object_storage.hh
@@ -92,48 +92,48 @@ namespace utils::gcp::storage {
         /**
          * Creates a named bucket in project and region, using storage_class
          */
-        future<> create_bucket(std::string_view project, std::string_view bucket, std::string_view region = {}, std::string_view storage_class = {});
+        future<> create_bucket(std::string_view project, std::string_view bucket, std::string_view region = {}, std::string_view storage_class = {}, seastar::abort_source* = nullptr);
         /**
          * Creates a named bucket in project, using provided metadata json 
          * See https://cloud.google.com/storage/docs/creating-buckets
          */
-        future<> create_bucket(std::string_view project, rjson::value meta);
+        future<> create_bucket(std::string_view project, rjson::value meta, seastar::abort_source* = nullptr);
         /**
          * Deletes a bucket. Note: bucket must be empty.
          */
-        future<> delete_bucket(std::string_view bucket);
+        future<> delete_bucket(std::string_view bucket, seastar::abort_source* = nullptr);
 
         /**
          * List objects in bucket. Optionally applies the @prefix as filter
          */
-        future<utils::chunked_vector<object_info>> list_objects(std::string_view bucket, std::string_view prefix = {});
+        future<utils::chunked_vector<object_info>> list_objects(std::string_view bucket, std::string_view prefix = {}, seastar::abort_source* = nullptr);
 
         /**
          * List objects in bucket. Optionally applies the @prefix as filter. Uses page size and offset as defined by 
          * the bucket_pager
          */
-        future<utils::chunked_vector<object_info>> list_objects(std::string_view bucket, std::string_view prefix, bucket_paging&);
+        future<utils::chunked_vector<object_info>> list_objects(std::string_view bucket, std::string_view prefix, bucket_paging&, seastar::abort_source* = nullptr);
 
         /**
          * Deletes a named object from bucket
          */
-        future<> delete_object(std::string_view bucket, std::string_view object_name);
+        future<> delete_object(std::string_view bucket, std::string_view object_name, seastar::abort_source* = nullptr);
         /**
          * Renames a named object in bucket
          */
-        future<> rename_object(std::string_view bucket, std::string_view object_name, std::string_view new_name);
+        future<> rename_object(std::string_view bucket, std::string_view object_name, std::string_view new_name, seastar::abort_source* = nullptr);
         /**
          * Moves a named object from one bucket to a different one using new name
          */
-        future<> rename_object(std::string_view bucket, std::string_view object_name, std::string_view new_bucket, std::string_view new_name);
+        future<> rename_object(std::string_view bucket, std::string_view object_name, std::string_view new_bucket, std::string_view new_name, seastar::abort_source* = nullptr);
         /**
          * Copies a named object to @new_name
          */
-        future<> copy_object(std::string_view bucket, std::string_view object_name, std::string_view to_name);
+        future<> copy_object(std::string_view bucket, std::string_view object_name, std::string_view to_name, seastar::abort_source* = nullptr);
         /**
          * Copies a named object to @new_bucket and @new_name
          */
-        future<> copy_object(std::string_view bucket, std::string_view object_name, std::string_view new_bucket, std::string_view to_name);
+        future<> copy_object(std::string_view bucket, std::string_view object_name, std::string_view new_bucket, std::string_view to_name, seastar::abort_source* = nullptr);
 
         /**
          * Merges sub-objects into a new destination. Actual file will be composed in order of subobject in `source_object`.


### PR DESCRIPTION
Fixes: SCYLLADB-1201

Adds optional abort source parameters to remaining, "short" calls to ensure all ops are abortable (hung rest calls etc), and to ensure API uniformity.

No backport needed. Enhancement.