### PR TITLE
test: fix test_cas_semaphore flakiness due to paxos state table creat…

### DIFF
--- a/test/cluster/test_lwt_semaphore.py
+++ b/test/cluster/test_lwt_semaphore.py
@@ -17,7 +17,7 @@ from test.cluster.util import new_test_keyspace
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_cas_semaphore(manager):
     """ This is a regression test for scylladb/scylladb#19698 """
-    servers = await manager.servers_add(1, cmdline=['--smp', '1', '--write-request-timeout-in-ms', '500'])
+    servers = await manager.servers_add(1, cmdline=['--smp', '1'])
 
     host = await wait_for_cql_and_get_hosts(manager.cql, {servers[0]}, time.time() + 60)
 
@@ -25,12 +25,21 @@ async def test_cas_semaphore(manager):
         table = f"{ks}.test"
         await manager.cql.run_async(f"CREATE TABLE {table} (a int PRIMARY KEY, b int)")
 
+        # Lower write timeout only for the CAS phase, after paxos state table
+        # creation (which goes through raft) has had time to complete with the
+        # default timeout.
+        await manager.server_update_config(servers[0].server_id, 'write_request_timeout_in_ms', 500)
+
         async with inject_error(manager.api, servers[0].ip_addr, 'cas_timeout_after_lock'):
             res = [manager.cql.run_async(f"INSERT INTO {table} (a) VALUES (0) IF NOT EXISTS", host=host[0]) for r in range(10)]
             try:
                 await asyncio.gather(*res)
             except WriteTimeout:
                 pass
+
+        # Restore a generous timeout so the second batch isn't affected by
+        # lingering raft apply latency.
+        await manager.server_update_config(servers[0].server_id, 'write_request_timeout_in_ms', 10000)
 
         res = [manager.cql.run_async(f"INSERT INTO {table} (a) VALUES (0) IF NOT EXISTS", host=host[0]) for r in range(10)]
         await asyncio.gather(*res)


### PR DESCRIPTION
…ion timeout

The test was starting Scylla with --write-request-timeout-in-ms=500 on the command line. This tight timeout also applied to paxos state table creation, which goes through raft and can take longer than 500ms on slow platforms (e.g. aarch64/dev). When the first batch of CAS requests triggered paxos state table creation under error injection, the raft schema change could still be in-flight when the second batch fired, causing spurious WriteTimeout failures unrelated to the semaphore bug being tested.

Fix by changing the write timeout at runtime via the REST API: lower it to 500ms only for the error-injection CAS phase (after table creation is done), then restore it to 10000ms before the second batch that must succeed.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2104

No need to backport, rare problem on arm only.