### PR TITLE
Replace get_injection_parameters() with inject_parameter() where appropriate

### DIFF
--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1734,11 +1734,10 @@ public:
             });
         }
         return do_until([this] { return is_end_of_stream() || is_buffer_full(); }, [this] {
-            if (utils::get_local_injector().enter("sstables_mx_reader_fill_buffer_timeout")) {
-                const sstring table_name = utils::get_local_injector().get_injection_parameters("sstables_mx_reader_fill_buffer_timeout")["table"];
-                const sstring this_table_name = format("{}.{}", _schema->ks_name(), _schema->cf_name());
+            if (auto table_name = utils::get_local_injector().inject_parameter("sstables_mx_reader_fill_buffer_timeout", "table"); table_name) {
+                const auto this_table_name = format("{}.{}", _schema->ks_name(), _schema->cf_name());
                 // Repeat the sleep until the permit is aborted due to timeout.
-                if (table_name == this_table_name && !get_abort_exception()) {
+                if (*table_name == this_table_name && !get_abort_exception()) {
                     return seastar::sleep(std::chrono::milliseconds(10));
                 }
             }

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -762,18 +762,15 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
     } else {
         auto sstables = co_await table.take_storage_snapshot(req.range);
         co_await utils::get_local_injector().inject("wait_before_tablet_stream_files_after_snapshot", utils::wait_for_message(std::chrono::seconds(60)));
-        co_await utils::get_local_injector().inject("order_sstables_for_streaming", [&sstables] (auto& handler) -> future<> {
-            if (sstables.size() == 3) {
-                // make sure the sstables are ordered so that the sstable containing shadowed data is streamed last
-                const std::string_view shadowed_file = handler.template get<std::string_view>("shadowed_file").value();
-                for (int index: {0, 1}) {
-                    if (sstables[index].sst->component_basename(component_type::Data) == shadowed_file) {
-                        std::swap(sstables[index], sstables[2]);
-                    }
+        if (auto shadowed_file = utils::get_local_injector().inject_parameter<std::string_view>("order_sstables_for_streaming", "shadowed_file");
+                shadowed_file && sstables.size() == 3) {
+            // make sure the sstables are ordered so that the sstable containing shadowed data is streamed last
+            for (int index: {0, 1}) {
+                if (sstables[index].sst->component_basename(component_type::Data) == *shadowed_file) {
+                    std::swap(sstables[index], sstables[2]);
                 }
             }
-            return make_ready_future<>();
-        });
+        }
 
         auto& sst_gen = table.get_sstable_generation_generator();
 

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -5355,7 +5355,7 @@ future<> test_cache_tombstone_gc_overlap_checks(apply_delete_fn apply_delete) {
 
             _fut = db.flush(sstring(keyspace_name), sstring(table_name));
 
-            while (!err_inj.get_injection_parameters(injection_point_name).contains("suspended")) {
+            while (!err_inj.inject_parameter<std::string_view>(injection_point_name, "suspended")) {
                 sleep(1s).get();
             }
         }


### PR DESCRIPTION
Several error injection sites use the low-level get_injection_parameters() API to fetch the entire parameters map and then manually look up a single key. The inject_parameter() API is better suited for these cases — it combines the enabled check and typed single-parameter extraction in one call, returning std::optional.

Cleaning error injection usage, not backporting