### PR TITLE
Add enter_count API and eliminate log-scanning for injection synchronization

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4434,10 +4434,7 @@ future<executor::request_return_type> executor::list_tables(client_state& client
 
     maybe_audit(audit_info, audit::statement_category::QUERY, "", "", "ListTables", request);
 
-    co_await utils::get_local_injector().inject("alternator_list_tables", [] (auto& handler) -> future<> {
-        handler.set("waiting", true);
-        co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
-    });
+    co_await utils::get_local_injector().inject("alternator_list_tables", utils::wait_for_message(5min));
 
     rjson::value* exclusive_start_json = rjson::find(request, "ExclusiveStartTableName");
     rjson::value* limit_json = rjson::find(request, "Limit");

--- a/api/api-doc/error_injection.json
+++ b/api/api-doc/error_injection.json
@@ -113,6 +113,30 @@
          ]
       },
       {
+         "path":"/v2/error_injection/injection/{injection}/enters",
+         "operations":[
+            {
+               "method":"GET",
+               "summary":"Get the total enter count for the injection across all shards",
+               "type":"long",
+               "nickname":"get_enter_count",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"injection",
+                     "description":"injection name",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/v2/error_injection/disconnect/{ip}",
          "operations":[
             {

--- a/api/error_injection.cc
+++ b/api/error_injection.cc
@@ -101,6 +101,13 @@ void set_error_injection(http_context& ctx, routes& r) {
             return make_ready_future<json::json_return_type>(json::json_void());
         });
     });
+
+    hf::get_enter_count.set(r, [](std::unique_ptr<request> req) -> future<json::json_return_type> {
+        sstring injection = req->get_path_param("injection");
+        auto& errinj = utils::get_local_injector();
+        auto count = co_await errinj.enter_count_on_all(injection);
+        co_return json::json_return_type(count);
+    });
 }
 
 } // namespace api

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -882,9 +882,7 @@ private:
             if (s->cf_name() != cf_name) {
                 co_return;
             }
-            slogger.info("storage_proxy::handle_read injection hit");
             co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{1});
-            slogger.info("storage_proxy::handle_read injection done");
         });
 
         // This erm ensures that tablet migrations wait for replica requests,

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1572,7 +1572,6 @@ public:
         }
 
         if (utils::get_local_injector().enter("determine_rf_change_actions_per_rack_throw")) {
-            lblogger.info("determine_rf_change_actions_per_rack_throw: entered");
             throw std::runtime_error("determine_rf_change_actions_per_rack_throw injection");
         }
 

--- a/test/boost/table_helper_test.cc
+++ b/test/boost/table_helper_test.cc
@@ -26,6 +26,7 @@
 #include "service/query_state.hh"
 #include "types/types.hh"
 #include "utils/error_injection.hh"
+#include "test/lib/error_injection.hh"
 
 // Regression test for use-after-free in table_helper::insert() when the
 // prepared_statements_cache entry is invalidated (e.g. DROP TABLE) while a
@@ -89,9 +90,7 @@ SEASTAR_TEST_CASE(test_concurrent_invalidation) {
         auto fiber_a = helper.insert(qp, mm, qs, make_opts);
 
         // Wait until fiber A is actually parked in wait_for_message.
-        while (utils::get_local_injector().waiters("table_helper_insert_before_execute") == 0) {
-            seastar::yield().get();
-        }
+        wait_for_injection_enter("table_helper_insert_before_execute").get();
 
         // Evict the prepared cache entry - drops its strong ref to the
         // modification_statement. helper._insert_stmt is the only ref left.

--- a/test/cluster/auth_cluster/test_auth_password_ensured.py
+++ b/test/cluster/auth_cluster/test_auth_password_ensured.py
@@ -37,8 +37,7 @@ async def test_auth_password_ensured(manager: ManagerClient) -> None:
     server = await manager.server_add(config=config, expected_server_up_state=ServerUpState.HOST_ID_QUERIED, connect_driver=False)
 
     logging.info("Waiting until PasswordAuthenticator pauses on the injected error")
-    server_log = await manager.server_open_log(server.server_id)
-    await server_log.wait_for("password_authenticator_start_pause: waiting for message")
+    await manager.api.wait_for_injection_enter(server.ip_addr, "password_authenticator_start_pause")
 
     with pytest.raises(NoHostAvailable, match="Unable to connect to any servers"):
         logging.info("Expecting driver connection failure, because password_authenticator_start_pause blocks serving CQL")

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -564,22 +564,18 @@ async def test_per_service_level_cql_requests_serving(manager: ManagerClient) ->
 
         # Enable error injection to pause CQL requests.
         await manager.api.enable_injection(server.ip_addr, "transport_cql_request_pause", False)
-        log = await manager.server_open_log(server.server_id)
 
         # Send two requests from user_a (sl:sl_a) and one from the cassandra
         # superuser (sl:default). Each pauses at the injection point, keeping
         # the cql_requests_serving gauge incremented.
-        mark = await log.mark()
         task_a1 = asyncio.ensure_future(asyncio.to_thread(session_a.execute, "SELECT * FROM system.local"))
-        await log.wait_for("transport_cql_request_pause: waiting for message", from_mark=mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "transport_cql_request_pause")
 
-        mark = await log.mark()
         task_a2 = asyncio.ensure_future(asyncio.to_thread(session_a.execute, "SELECT * FROM system.local"))
-        await log.wait_for("transport_cql_request_pause: waiting for message", from_mark=mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "transport_cql_request_pause", threshold=2)
 
-        mark = await log.mark()
         task_default = asyncio.ensure_future(asyncio.to_thread(session_default.execute, "SELECT * FROM system.local"))
-        await log.wait_for("transport_cql_request_pause: waiting for message", from_mark=mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "transport_cql_request_pause", threshold=3)
 
         # All three requests are now paused. Verify the per-SL gauges.
         # Use >= because a stray request from the manager's CQL session

--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -114,8 +114,6 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient, 
 
         logger.info('Blocking tablet rebuild')
         await manager.api.enable_injection(coord_serv.ip_addr, "tablet_transition_updates", one_shot=True)
-        coord_log = await manager.server_open_log(coord_serv.server_id)
-        coord_mark = await coord_log.mark()
 
         logger.info('Replacing the node')
         replace_cfg = ReplaceConfig(replaced_id = server_to_replace.server_id, reuse_ip_addr = False, use_host_id = True)
@@ -124,7 +122,7 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient, 
             "rack": server_to_replace.rack
         }))
 
-        await coord_log.wait_for('tablet_transition_updates: waiting', from_mark=coord_mark)
+        await manager.api.wait_for_injection_enter(coord_serv.ip_addr, "tablet_transition_updates")
 
         await manager.server_stop(server_to_down.server_id, convict=True)
         await manager.others_not_see_server(server_to_down.ip_addr)

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -192,8 +192,6 @@ async def do_test_backup_helper(manager: ManagerClient, object_storage,
         snap_name, files = await take_snapshot_on_one_server(ks, server, manager, logger)
 
         await manager.api.enable_injection(server.ip_addr, breakpoint_name, one_shot=True)
-        log = await manager.server_open_log(server.server_id)
-        mark = await log.mark()
 
         print('Backup snapshot')
         # use a unique path, because we're running more than one test using the same minio and ks/cf name.
@@ -203,7 +201,7 @@ async def do_test_backup_helper(manager: ManagerClient, object_storage,
         tid = await manager.api.backup(server.ip_addr, ks, cf, snap_name, object_storage.address, object_storage.bucket_name, prefix)
 
         print(f'Started task {tid}, aborting it early')
-        await log.wait_for(breakpoint_name + ': waiting', from_mark=mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, breakpoint_name)
         await handler(server, prefix, files, tid)
 
 async def do_test_backup_abort(manager: ManagerClient, object_storage,
@@ -415,8 +413,6 @@ async def do_abort_restore(manager: ManagerClient, object_storage):
         await cql.run_async(f"TRUNCATE TABLE {keyspace}.{table};")
         logger.info("Initiating restore operations...")
 
-        logs = [await manager.server_open_log(server.server_id) for server in servers]
-
         injection = "stream_mutation_fragments" # "block_load_and_stream"
         await asyncio.gather(*(manager.api.enable_injection(s.ip_addr, injection, True) for s in servers))
 
@@ -433,7 +429,7 @@ async def do_abort_restore(manager: ManagerClient, object_storage):
             )
             restore_task_ids[server.server_id] = restore_tid
 
-        await wait_all([l.wait_for(f"{injection}: waiting", timeout=10) for l in logs])
+        await wait_all([manager.api.wait_for_injection_enter(s.ip_addr, injection) for s in servers])
 
         logger.info("Aborting restore tasks...")
         await asyncio.gather(*(manager.api.abort_task(server.ip_addr, restore_task_ids[server.server_id]) for server in servers))
@@ -888,12 +884,10 @@ async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: Ma
         await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count}, 'max_tablet_count': {tablet_count}}};")
 
         await manager.api.enable_injection(servers[2].ip_addr, "pause_tablet_restore", one_shot=True)
-        log = await manager.server_open_log(servers[2].server_id)
-        mark = await log.mark()
 
         manifests = [ f'{s.server_id}/{snap_name}/manifest.json' for s in servers ]
         tid = await manager.api.restore_tablets(servers[1].ip_addr, ks, 'test', snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
-        await log.wait_for("pause_tablet_restore: waiting for message", from_mark=mark)
+        await manager.api.wait_for_injection_enter(servers[2].ip_addr, "pause_tablet_restore")
 
         if target == 'api':
             await manager.server_stop(servers[1].server_id, convict=True)

--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -239,7 +239,7 @@ async def test_reject_split_compaction(manager: ManagerClient, volumes_factory: 
                 await manager.api.enable_injection(servers[0].ip_addr, "split_sstable_rewrite", one_shot=False)
                 cql.execute_async(f"ALTER KEYSPACE {ks} WITH tablets = {{'initial': 32}}")
 
-                mark, _ = await log.wait_for("split_sstable_rewrite: waiting", from_mark=mark)
+                await manager.api.wait_for_injection_enter(servers[0].ip_addr, "split_sstable_rewrite")
 
                 logger.info("Create a big file on the target node to reach critical disk utilization level")
                 disk_info = psutil.disk_usage(workdir)
@@ -522,7 +522,7 @@ async def test_repair_failure_on_split_rejection(manager: ManagerClient, volumes
                 # Emit split decision during repair.
                 await run_split()
 
-                await log.wait_for("maybe_split_new_sstable_wait: waiting", from_mark=mark)
+                await manager.api.wait_for_injection_enter(servers[0].ip_addr, "maybe_split_new_sstable_wait")
                 await manager.api.disable_injection(coord_serv.ip_addr, "tablet_resize_finalization_postpone")
 
                 logger.info("Create a big file on the target node to reach critical disk utilization level")
@@ -619,7 +619,7 @@ async def test_sstables_incrementally_released_during_streaming(manager: Manager
 
                 decomm_task = asyncio.create_task(manager.decommission_node(servers[1].server_id))
                 await manager.enable_tablet_balancing()
-                mark, _ = await log.wait_for("tablet_stream_files_end_wait: waiting", from_mark=mark)
+                await manager.api.wait_for_injection_enter(servers[1].ip_addr, "tablet_stream_files_end_wait")
 
                 disk_info = psutil.disk_usage(workdir)
                 with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):

--- a/test/cluster/tasks/test_tablet_tasks.py
+++ b/test/cluster/tasks/test_tablet_tasks.py
@@ -529,9 +529,6 @@ async def test_tablet_resize_list(manager: ManagerClient):
             'tablet_load_stats_refresh_interval_in_seconds': 1
         }))
 
-        s1_log = await manager.server_open_log(servers[0].server_id)
-        s1_mark = await s1_log.mark()
-
         injection = "tablet_split_finalization_postpone"
         compaction_injection = "split_sstable_rewrite"
         await enable_injection(manager, servers, injection)
@@ -551,7 +548,7 @@ async def test_tablet_resize_list(manager: ManagerClient):
             assert task.table == table1
             assert task.keyspace == keyspace
 
-        await s1_log.wait_for("split_sstable_rewrite: waiting", from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "split_sstable_rewrite")
         await manager.api.message_injection(servers[0].ip_addr, "split_sstable_rewrite")
 
         status1 = await tm.get_task_status(servers[1].ip_addr, task0.task_id)

--- a/test/cluster/test_aggregation.py
+++ b/test/cluster/test_aggregation.py
@@ -49,10 +49,8 @@ async def test_cancel_mapreduce(manager: ManagerClient):
                 await cql.run_async(f"INSERT INTO {t} (pk, v) VALUES ({pk}, {v})")
 
             s1_log = await manager.server_open_log(s1.server_id)
-            s2_log = await manager.server_open_log(s2.server_id)
 
             s1_mark = await s1_log.mark()
-            s2_mark = await s2_log.mark()
 
             # Prevent finishing local mapreduce tasks on node 2.
             async with inject_error(manager.api, s2.ip_addr, "mapreduce_pause_dispatch_to_shards"):
@@ -70,7 +68,7 @@ async def test_cancel_mapreduce(manager: ManagerClient):
                     # Make sure node 1 is the supercoordinator and sends a mapreduce task to node 2.
                     await s1_log.wait_for(f"dispatching mapreduce_request=.* to address={host_id2}", from_mark=s1_mark, timeout=60)
                     # Make sure that node 2 is preventing its local mapreduce task from finishing.
-                    await s2_log.wait_for("mapreduce_pause_dispatch_to_shards: waiting for message", from_mark=s2_mark, timeout=60)
+                    await manager.api.wait_for_injection_enter(s2.ip_addr, "mapreduce_pause_dispatch_to_shards")
                     # Verify that the supercoordinator stops without an issue despite the ongoing mapreduce task.
                     await manager.server_stop_gracefully(s1.server_id, timeout=120)
 

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -1327,7 +1327,7 @@ async def test_alternator_invalid_shard_for_lwt(manager: ManagerClient):
     log = await manager.server_open_log(server.server_id)
 
     logger.info("Wait for intranode_migration_streaming_wait")
-    await log.wait_for("intranode_migration_streaming: waiting")
+    await manager.api.wait_for_injection_enter(server.ip_addr, "intranode_migration_streaming_wait")
 
     logger.info("Inject 'alternator_executor_batch_write_wait'")
     await manager.api.enable_injection(server.ip_addr,

--- a/test/cluster/test_alternator_proxy_protocol.py
+++ b/test/cluster/test_alternator_proxy_protocol.py
@@ -334,20 +334,6 @@ async def test_alternator_proxy_protocol_address_in_system_clients(alternator_pr
     fake_src_port = 54321
     port = ALTERNATOR_HTTPS_PROXY_PORT if use_ssl else ALTERNATOR_PROXY_PORT
 
-    async def wait_for_injection_waiting(injection_name: str, timeout: float = 10.0):
-        """Poll until the injection has set 'waiting' parameter, indicating it's paused."""
-        deadline = asyncio.get_event_loop().time() + timeout
-        while asyncio.get_event_loop().time() < deadline:
-            injection_state = await manager.api.get_injection(server.ip_addr, injection_name)
-            # Each shard returns an object with 'enabled' and 'parameters' (array of {key, value})
-            for state in injection_state:
-                if state.get('enabled'):
-                    for param in state.get('parameters', []):
-                        if param.get('key') == 'waiting' and str(param.get('value')).lower() in ('true', '1'):
-                            return
-            await asyncio.sleep(0.01)
-        raise TimeoutError(f"Injection {injection_name} did not reach waiting state within {timeout}s")
-
     # Enable the error injection that pauses ListTables execution
     async with inject_error(manager.api, server.ip_addr, "alternator_list_tables"):
         # Start the request in the background - it will pause at the injection point
@@ -367,7 +353,7 @@ async def test_alternator_proxy_protocol_address_in_system_clients(alternator_pr
         request_task.add_done_callback(log_task_error)
 
         # Wait until the injection has paused the request
-        await wait_for_injection_waiting("alternator_list_tables")
+        await manager.api.wait_for_injection_enter(server.ip_addr, "alternator_list_tables")
 
         # Query system.clients while the request is paused
         cql = manager.get_cql()

--- a/test/cluster/test_automatic_cleanup.py
+++ b/test/cluster/test_automatic_cleanup.py
@@ -111,7 +111,7 @@ async def test_cleanup_waits_for_stale_writes(manager: ManagerClient):
         logger.info("Start bootstrapping the third node")
         bootstrap_task = asyncio.create_task(manager.server_start(servers[2].server_id))
         logger.info("Waiting for topology_coordinator/write_both_read_new/after_barrier")
-        await log0.wait_for("topology_coordinator/write_both_read_new/after_barrier: waiting for message")
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "topology_coordinator/write_both_read_new/after_barrier")
 
         # Have a write request with write_both_read_new version stuck on both nodes:
         # - On the first node, this exercises the coordinator fencing code path.

--- a/test/cluster/test_bootstrap_with_quick_group0_join.py
+++ b/test/cluster/test_bootstrap_with_quick_group0_join.py
@@ -40,9 +40,7 @@ async def test_bootstrap_with_quick_group0_join(manager: ManagerClient):
     logger.info(f"Starting {s2}")
     start_task = asyncio.create_task(manager.server_start(s2.server_id))
 
-    s2_log = await manager.server_open_log(s2.server_id)
-
-    await s2_log.wait_for("join_group0_pause_before_config_check: waiting for message", timeout=60)
+    await manager.api.wait_for_injection_enter(s2.ip_addr, "join_group0_pause_before_config_check")
 
     s1_host_id = await manager.get_host_id(s1.server_id)
     s2_host_id = await manager.get_host_id(s2.server_id)

--- a/test/cluster/test_client_routes.py
+++ b/test/cluster/test_client_routes.py
@@ -254,7 +254,7 @@ async def test_client_routes_snapshot_transfer(request, manager: ManagerClient, 
 
     await manager.server_start(server_to_restart.server_id)
     log = await manager.server_open_log(server_to_restart.server_id)
-    await log.wait_for("block_group0_transfer_snapshot: waiting for message")
+    await manager.api.wait_for_injection_enter(server_to_restart.ip_addr, "block_group0_transfer_snapshot")
     cql = await manager.get_cql_exclusive(server_to_restart)
     await wait_for_expected_client_routes_size(cql, 0)
 

--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -258,10 +258,6 @@ async def test_fence_lwt_during_bootstap(manager: ManagerClient):
                                              cmdline=cmdline,
                                              start=False)]
 
-        logger.info("Open s0 log")
-        s0_log = await manager.server_open_log(servers[0].server_id)
-        s0_mark = await s0_log.mark()
-
         logger.info("Enable topology_coordinator/write_both_read_old/before_version_increment injection on s0")
         await manager.api.enable_injection(servers[0].ip_addr,
                                            'topology_coordinator/write_both_read_old/before_version_increment', 
@@ -271,7 +267,7 @@ async def test_fence_lwt_during_bootstap(manager: ManagerClient):
         s3_start_task = asyncio.create_task(manager.server_start(servers[3].server_id))
 
         logger.info(f"Waiting for 'topology_coordinator/write_both_read_old/before_version_increment' injection on {servers[0]}")
-        await s0_log.wait_for('topology_coordinator/write_both_read_old/before_version_increment: waiting for message', from_mark=s0_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "topology_coordinator/write_both_read_old/before_version_increment")
 
         logger.info(f"Injecting 'topology_state_load_error' into {servers[1]}")
         await manager.api.enable_injection(servers[1].ip_addr, 'topology_state_load_error', one_shot=False)

--- a/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
+++ b/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
@@ -43,12 +43,11 @@ async def test_gossiper_empty_self_id_on_shadow_round(manager: ManagerClient):
 
     logging.info("Starting cluster normally")
     node1 = await manager.server_add(cmdline=cmdline, start=False, config=cfg)
-    node1_log = await manager.server_open_log(node1.server_id)
     node2 = await manager.server_add(cmdline=cmdline, start=False, seeds=[node1.ip_addr])
     node2_log = await manager.server_open_log(node2.server_id)
     task1 = asyncio.create_task(manager.server_start(node1.server_id))
     task2 = asyncio.create_task(manager.server_start(node2.server_id))
-    await node1_log.wait_for("gossiper_publish_local_state_pause: waiting for message")
+    await manager.api.wait_for_injection_enter(node1.ip_addr, "gossiper_publish_local_state_pause")
     await manager.api.message_injection(node1.ip_addr, 'gossiper_publish_local_state_pause')
     await task1
     await task2
@@ -58,14 +57,13 @@ async def test_gossiper_empty_self_id_on_shadow_round(manager: ManagerClient):
     await manager.server_stop_gracefully(node2.server_id)
 
     # Remember logs
-    paused_node_mark = await node1_log.mark()
     reading_node_mark = await node2_log.mark()
 
     logging.info("Restarting cluster")
     # Start first node and make sure it's paused on gossiper_publish_local_state_pause
     task1 = asyncio.create_task(
         manager.server_start(node1.server_id, wait_interval=120))
-    await node1_log.wait_for("gossiper_publish_local_state_pause: waiting for message", from_mark=paused_node_mark)
+    await manager.api.wait_for_injection_enter(node1.ip_addr, "gossiper_publish_local_state_pause")
     logging.info("Found gossiper_publish_local_state_pause")
     # After the first node started and paused in start_gossiping, start the second node/
     task2 = asyncio.create_task(manager.server_start(node2.server_id))

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -747,8 +747,6 @@ async def test_tablet_migration_with_compaction(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    s1_log = await manager.server_open_log(s1.server_id)
-
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets={'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
 
@@ -786,7 +784,6 @@ async def test_tablet_migration_with_compaction(manager: ManagerClient):
 
         # Enable the injection that pauses streaming after the snapshot is taken
         await manager.api.enable_injection(s1.ip_addr, inj, one_shot=True)
-        log_mark = await s1_log.mark()
 
         # Start migration in the background; it will pause at the injection point
         migration_task = asyncio.ensure_future(
@@ -794,7 +791,7 @@ async def test_tablet_migration_with_compaction(manager: ManagerClient):
         )
 
         # Wait until streaming has taken the snapshot and is paused at the injection
-        await s1_log.wait_for(f'{inj}: waiting for message', from_mark=log_mark)
+        await manager.api.wait_for_injection_enter(s1.ip_addr, inj)
 
         # Trigger compaction while streaming is paused; the snapshot holds segment refs so
         # compaction can compact and free dead segments without affecting the in-flight data

--- a/test/cluster/test_long_query_timeout_erm.py
+++ b/test/cluster/test_long_query_timeout_erm.py
@@ -170,11 +170,10 @@ async def test_long_query_timeout_without_failure_erm(request, manager: ManagerC
 
     logger.info("Confirm reads are waiting on the injected error")
 
-    async def wait_for_log_on_any_node(server):
-        server_log = await manager.server_open_log(server.server_id)
-        await server_log.wait_for("mapreduce_pause_parallel_dispatch: waiting for message")
-
-    await wait_for_first_completed([wait_for_log_on_any_node(server) for server in servers])
+    await wait_for_first_completed([
+        manager.api.wait_for_injection_enter(server.ip_addr, "mapreduce_pause_parallel_dispatch")
+        for server in servers
+    ])
 
     if enable_tablets:
         logger.info("Add new node - ERM should not be blocked")

--- a/test/cluster/test_long_query_timeout_erm.py
+++ b/test/cluster/test_long_query_timeout_erm.py
@@ -94,12 +94,11 @@ async def test_long_query_timeout_erm(request, manager: ManagerClient, query_typ
 
     logger.info("Confirm reads are waiting on the injected error")
     server_to_kill = None
-    async def wait_for_log_on_any_node(server):
-        server_log = await manager.server_open_log(server.server_id)
-        await server_log.wait_for("storage_proxy::handle_read injection hit")
+    async def wait_for_enter_on_node(server):
+        await manager.api.wait_for_injection_enter(server.ip_addr, "storage_proxy::handle_read")
         return server
     async with asyncio.TaskGroup() as tg:
-        log_watch_tasks = [tg.create_task(wait_for_log_on_any_node(server)) for server in servers if server != selected_server]
+        log_watch_tasks = [tg.create_task(wait_for_enter_on_node(server)) for server in servers if server != selected_server]
         done, pending = await asyncio.wait(log_watch_tasks, return_when=asyncio.FIRST_COMPLETED)
         for t in pending:
             t.cancel()

--- a/test/cluster/test_major_compaction.py
+++ b/test/cluster/test_major_compaction.py
@@ -63,11 +63,9 @@ async def test_major_compaction_consider_only_existing_data(manager: ManagerClie
         injection_handler = await inject_error_one_shot(manager.api, server.ip_addr, injection)
 
         logger.info("Start major compaction")
-        log = await manager.server_open_log(server.server_id)
-        mark = await log.mark()
         compaction_task = asyncio.create_task(manager.api.keyspace_compaction(server.ip_addr, ks, cf, consider_only_existing_data=consider_only_existing_data))
         # wait for the injection to pause the compaction
-        await log.wait_for("major_compaction_wait: waiting", from_mark=mark, timeout=30)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "major_compaction_wait")
 
         # insert new backdated rows with deleted keys and flush them
         # into a new sstable that will not be part of the major compaction
@@ -176,7 +174,7 @@ async def test_shutdown_drain_during_compaction(manager: ManagerClient):
         # start compaction and wait for it to pause at the injection point
         logger.info("Start compaction")
         compaction_task = asyncio.create_task(manager.api.keyspace_compaction(server.ip_addr, ks, cf))
-        await log.wait_for("update_history_wait: waiting", from_mark=mark, timeout=30)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "update_history_wait")
 
         mark = await log.mark()
         # Start server shutdown
@@ -219,7 +217,6 @@ async def test_alter_compaction_strategy_during_compaction(manager: ManagerClien
         logger.info("Inject error to pause compaction midway")
         injection_name="twcs_get_sstables_for_compaction"
         await manager.api.enable_injection(node_ip=node1.ip_addr, injection=injection_name, one_shot=False)
-        server_log = await manager.server_open_log(node1.server_id)
 
         logger.info("Populate table and start compaction")
         insert_stmt = cql.prepare(f"INSERT INTO {ks}.{cf} (pk, ck, val) VALUES (?, ?, ?)")
@@ -229,7 +226,7 @@ async def test_alter_compaction_strategy_during_compaction(manager: ManagerClien
         compaction_task = asyncio.create_task(manager.api.keyspace_compaction(node_ip=node1.ip_addr, keyspace=ks, table=cf))
 
         logger.info("Waiting for compaction to be suspended")
-        await server_log.wait_for("twcs_get_sstables_for_compaction: waiting for message")
+        await manager.api.wait_for_injection_enter(node1.ip_addr, "twcs_get_sstables_for_compaction")
 
         logger.info("Alter compaction strategy")
         await cql.run_async(f"ALTER TABLE {ks}.{cf} WITH compaction = {{'class': 'LeveledCompactionStrategy'}};")
@@ -274,7 +271,7 @@ async def test_disable_autocompaction_during_major_compaction(manager: ManagerCl
         log = await manager.server_open_log(server.server_id)
         mark = await log.mark()
         compaction_task = asyncio.create_task(manager.api.keyspace_compaction(server.ip_addr, ks, cf))
-        await log.wait_for("major_compaction_wait: waiting", from_mark=mark, timeout=30)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "major_compaction_wait")
 
         # Now that major compaction is in progress, disable autocompaction on the table
         logger.info("Disabling autocompaction on the table")

--- a/test/cluster/test_node_shutdown_waits_for_pending_requests.py
+++ b/test/cluster/test_node_shutdown_waits_for_pending_requests.py
@@ -44,7 +44,7 @@ async def test_node_shutdown_waits_for_pending_requests(manager: ManagerClient) 
 
         logger.info(f'wait until the read request hit storage_proxy::handle_read on the node {servers[1]}')
         log_file2 = await manager.server_open_log(servers[1].server_id)
-        await log_file2.wait_for("storage_proxy::handle_read injection hit", timeout=60)
+        await manager.api.wait_for_injection_enter(servers[1].ip_addr, "storage_proxy::handle_read")
 
         logger.info(f'trigger shutdown of the node {servers[1]}')
         stop_future = asyncio.create_task(manager.server_stop_gracefully(servers[1].server_id))

--- a/test/cluster/test_nodetool.py
+++ b/test/cluster/test_nodetool.py
@@ -128,9 +128,9 @@ async def test_zero_token_node_down_leaving(manager: ManagerClient):
                                               "scylla-nodetool=trace",
                                               "-h", servers[0].ip_addr]
 
-    logs = [await manager.server_open_log(srv.server_id) for srv in servers]
-
-    await wait_for_first_completed([log.wait_for("delay_node_removal: waiting for message") for log in logs])
+    await wait_for_first_completed([
+        manager.api.wait_for_injection_enter(srv.ip_addr, "delay_node_removal") for srv in servers
+    ])
 
     result = subprocess.run(cmd, capture_output=True, text=True)
 
@@ -207,9 +207,9 @@ async def test_regular_node_joining(manager: ManagerClient):
                                               "scylla-nodetool=trace",
                                               "-h", servers[0].ip_addr]
 
-    logs = [await manager.server_open_log(srv.server_id) for srv in servers]
-
-    await wait_for_first_completed([log.wait_for("delay_node_bootstrap: waiting for message") for log in logs])
+    await wait_for_first_completed([
+        manager.api.wait_for_injection_enter(srv.ip_addr, "delay_node_bootstrap") for srv in servers
+    ])
     result = subprocess.run(cmd, capture_output=True, text=True)
 
     live_eps = await manager.api.client.get_json("/gossiper/endpoint/live", host=servers[0].ip_addr)

--- a/test/cluster/test_prepare_race.py
+++ b/test/cluster/test_prepare_race.py
@@ -16,8 +16,6 @@ from test.pylib.rest_client import inject_error_one_shot
 async def test_prepare_fails_if_cached_statement_is_invalidated_mid_prepare(manager: ManagerClient):
     server = await manager.server_add()
     cql = manager.get_cql()
-    log = await manager.server_open_log(server.server_id)
-    
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};") as ks:
         async with new_test_table(manager, ks, "pk int PRIMARY KEY") as table:
             query = f"SELECT * FROM {table} WHERE pk = ?"
@@ -26,9 +24,8 @@ async def test_prepare_fails_if_cached_statement_is_invalidated_mid_prepare(mana
             await cql.run_async(f"INSERT INTO {table} (pk) VALUES (8)")
 
             handler = await inject_error_one_shot(manager.api, server.ip_addr, "query_processor_prepare_wait_after_cache_get")
-            mark = await log.mark()
             prepare_future = loop.run_in_executor(None, lambda: cql.prepare(query))
-            await log.wait_for("query_processor_prepare_wait_after_cache_get: waiting for message", from_mark=mark, timeout=60)
+            await manager.api.wait_for_injection_enter(server.ip_addr, "query_processor_prepare_wait_after_cache_get")
 
             # Trigger table schema update (metadata-only) to invalidate prepared statements while PREPARE is paused.
             await cql.run_async(f"ALTER TABLE {table} WITH comment = 'invalidate-prepared-race'")
@@ -50,9 +47,8 @@ async def test_prepare_fails_if_cached_statement_is_invalidated_mid_prepare(mana
             await cql.run_async(f"ALTER TABLE {table} WITH comment = 'invalidate-prepared-race-again'")
 
             reprepare_handler = await inject_error_one_shot(manager.api, server.ip_addr, "query_processor_prepare_wait_after_cache_get")
-            reprepare_mark = await log.mark()
             execute_future = loop.run_in_executor(None, lambda: cql.execute(result, [8]))
-            await log.wait_for("query_processor_prepare_wait_after_cache_get: waiting for message", from_mark=reprepare_mark, timeout=60)
+            await manager.api.wait_for_injection_enter(server.ip_addr, "query_processor_prepare_wait_after_cache_get")
 
             await reprepare_handler.message()
             execute_done, _ = await asyncio.wait({execute_future}, timeout=15)

--- a/test/cluster/test_raft_no_quorum.py
+++ b/test/cluster/test_raft_no_quorum.py
@@ -114,8 +114,7 @@ async def test_quorum_lost_during_node_join(manager: ManagerClient, raft_op_time
         timeout=60))
 
     logger.info(f"waiting for the leader node {servers[0]} to start handling the join request")
-    log_file = await manager.server_open_log(servers[0].server_id)
-    await log_file.wait_for("join-node-before-add-entry: waiting", timeout=60)
+    await manager.api.wait_for_injection_enter(servers[0].ip_addr, "join-node-before-add-entry")
 
     logger.info("stopping the second and third nodes")
     await asyncio.gather(manager.server_stop_gracefully(servers[1].server_id),
@@ -161,8 +160,7 @@ async def test_quorum_lost_during_node_join_response_handler(manager: ManagerCli
 
     logger.info(
         f"waiting for the fourth node {servers[3]} to hit join-node-response_handler-before-read-barrier")
-    log_file = await manager.server_open_log(servers[3].server_id)
-    await log_file.wait_for("join-node-response_handler-before-read-barrier: waiting", timeout=60)
+    await manager.api.wait_for_injection_enter(servers[3].ip_addr, "join-node-response_handler-before-read-barrier")
 
     logger.info("stopping the second and third nodes")
     await asyncio.gather(manager.server_stop_gracefully(servers[1].server_id),

--- a/test/cluster/test_raft_recovery_during_join.py
+++ b/test/cluster/test_raft_recovery_during_join.py
@@ -58,8 +58,6 @@ async def test_raft_recovery_during_join(manager: ManagerClient):
     first_group0_id = (await cql.run_async(
             "SELECT value FROM system.scylla_local WHERE key = 'raft_group0_id'"))[0].value
 
-    coordinator_log = await manager.server_open_log(coordinator.server_id)
-
     logging.info(f'Blocking the topology coordinator in write_both_read_new on server {coordinator}')
     await manager.api.enable_injection(coordinator.ip_addr, 'delay_node_bootstrap', one_shot=False)
 
@@ -70,7 +68,7 @@ async def test_raft_recovery_during_join(manager: ManagerClient):
                                expected_error='Crashed in crash_before_topology_request_completion'))
 
     logging.info(f'Waiting until the topology coordinator blocks in write_both_read_new on node server {coordinator}')
-    await coordinator_log.wait_for("delay_node_bootstrap: waiting for message")
+    await manager.api.wait_for_injection_enter(coordinator.ip_addr, "delay_node_bootstrap")
 
     failed_server_host_id = await manager.get_host_id(failed_server.server_id)
 

--- a/test/cluster/test_sstable_cleanup_stop.py
+++ b/test/cluster/test_sstable_cleanup_stop.py
@@ -42,13 +42,10 @@ async def test_cleanup_stop(manager: ManagerClient):
 
         await check(keys)
 
-        s0_log = await manager.server_open_log(servers[0].server_id)
-        s0_mark = await s0_log.mark()
-
         await inject_error_one_shot(manager.api, servers[0].ip_addr, "sstable_cleanup_wait")
         cleanup_task = asyncio.create_task(manager.api.cleanup_keyspace(servers[0].ip_addr, ks))
 
-        await s0_log.wait_for('sstable_cleanup_wait: waiting', from_mark=s0_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "sstable_cleanup_wait")
 
         stop_cleanup = asyncio.create_task(manager.api.stop_compaction(servers[0].ip_addr, "CLEANUP"))
         await asyncio.sleep(1)

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -817,7 +817,7 @@ async def test_drop_table_during_insert(manager: ManagerClient):
         insert_fut = cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 0)")
 
         # Wait until the injection is actually hit.
-        await log.wait_for("sc_coordinator_wait_before_acquire_server: waiting for message", from_mark=mark, timeout=30)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "sc_coordinator_wait_before_acquire_server")
 
         # Drop the table while INSERT is paused.
         await cql.run_async(f"DROP TABLE {table}")

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -853,16 +853,13 @@ async def test_timed_out_queries(manager: ManagerClient):
     s1 = await manager.server_add(config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE)
     cql, _ = await manager.get_ready_cql([s1])
 
-    log = await manager.server_open_log(s1.server_id)
-
     async def try_query_with_timeout(exception_type, stmt: str, error_injection_name: str, timeout_sec: float):
         await manager.api.enable_injection(s1.ip_addr, error_injection_name, one_shot=True)
 
-        mark = await log.mark()
         request_timeout_ms = 100
 
         stmt_fut = cql.run_async(f"{stmt} USING TIMEOUT {request_timeout_ms}ms")
-        await log.wait_for(error_injection_name, from_mark=mark)
+        await manager.api.wait_for_injection_enter(s1.ip_addr, error_injection_name)
 
         sleep_length = timeout_sec + (request_timeout_ms / 1000)
         await asyncio.sleep(sleep_length)
@@ -1188,12 +1185,11 @@ async def test_abort_state_machine_apply_after_dropping_table(manager: ManagerCl
         ])
 
         log = await manager.server_open_log(target_server.server_id)
-        mark = await log.mark()
 
         # We won't wait for the follower to apply the state, so we can await this right away.
         await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)", host=leader_host)
 
-        await log.wait_for(wait_before_apply_injection, from_mark=mark)
+        await manager.api.wait_for_injection_enter(target_server.ip_addr, wait_before_apply_injection)
         mark = await log.mark()
 
         await cql.run_async(f"DROP TABLE {table}")
@@ -1256,12 +1252,11 @@ async def test_abort_state_machine_apply_during_shutdown(manager: ManagerClient)
         ])
 
         log = await manager.server_open_log(target_server.server_id)
-        mark = await log.mark()
 
         # We won't wait for the follower to apply the state, so we can await this right away.
         await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (0, 13)", host=leader_host)
 
-        await log.wait_for(wait_before_apply_injection, from_mark=mark)
+        await manager.api.wait_for_injection_enter(target_server.ip_addr, wait_before_apply_injection)
         mark = await log.mark()
 
         stop_task = asyncio.create_task(manager.server_stop_gracefully(target_server.server_id))

--- a/test/cluster/test_table_drop.py
+++ b/test/cluster/test_table_drop.py
@@ -95,7 +95,7 @@ async def test_drop_table_during_load_and_stream(manager: ManagerClient):
             manager.api.load_new_sstables(server.ip_addr, ks, cf, load_and_stream=True))
 
         # Wait until at least one shard hits the injection point
-        await server_log.wait_for("load_and_stream_before_streaming_batch: waiting for message", from_mark=log_mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "load_and_stream_before_streaming_batch")
         logger.info("load_and_stream paused at injection point")
 
         # Drop the table while streaming is paused.  With the stream_in_progress

--- a/test/cluster/test_tablet_stats.py
+++ b/test/cluster/test_tablet_stats.py
@@ -109,9 +109,6 @@ async def test_load_stats_refresh_during_shutdown(manager: ManagerClient):
         coord_idx = host_ids.index(coord)
         coord_server = servers[coord_idx]
 
-        log = await manager.server_open_log(coord_server.server_id)
-        mark = await log.mark()
-
         # Injection B: pause between run() returning and stop() being called.
         await manager.api.enable_injection(
             coord_server.ip_addr, "topology_coordinator_pause_before_stop", one_shot=True)
@@ -122,8 +119,7 @@ async def test_load_stats_refresh_during_shutdown(manager: ManagerClient):
 
         # Wait for injection B to fire. The coordinator has finished run() but
         # the schema change listener is still registered.
-        mark, _ = await log.wait_for(
-            "topology_coordinator_pause_before_stop: waiting", from_mark=mark)
+        await manager.api.wait_for_injection_enter(coord_server.ip_addr, "topology_coordinator_pause_before_stop")
 
         # Injection A: block refresh_tablet_load_stats() before it accesses _shared_tm.
         # Enable it now so it only catches the notification-triggered call.
@@ -137,7 +133,7 @@ async def test_load_stats_refresh_during_shutdown(manager: ManagerClient):
         async with new_test_table(manager, ks, "pk int PRIMARY KEY", reuse_tables=False):
             # Wait for injection A: refresh_tablet_load_stats() is now blocked before
             # accessing _shared_tm. The topology_coordinator is still alive (paused at B).
-            await log.wait_for("refresh_tablet_load_stats_pause: waiting", from_mark=mark)
+            await manager.api.wait_for_injection_enter(coord_server.ip_addr, "refresh_tablet_load_stats_pause")
 
             # Release injection B: coordinator proceeds through stop().
             # Without the fix, stop() returns quickly and run_topology_coordinator

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -798,8 +798,6 @@ async def test_multi_rf_increase_abort_0_N(request: pytest.FixtureRequest, manag
 
     coord = await get_topology_coordinator(manager)
     coord_serv = await find_server_by_host_id(manager, servers, coord)
-    log = await manager.server_open_log(coord_serv.server_id)
-    mark = await log.mark()
 
     for s in servers:
         await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
@@ -810,7 +808,7 @@ async def test_multi_rf_increase_abort_0_N(request: pytest.FixtureRequest, manag
 
     alter_task = asyncio.create_task(alter_keyspace())
 
-    await log.wait_for(f'{injection}: entered', from_mark=mark)
+    await manager.api.wait_for_injection_enter(coord_serv.ip_addr, injection)
     await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a', 'rack1b', 'rack1c']}, {'dc1': ['rack1a', 'rack1b', 'rack1c'], 'dc2': ['rack2a', 'rack2b', 'rack2c']})
 
     task_manager_client = TaskManagerClient(manager.api)
@@ -873,8 +871,6 @@ async def test_multi_rf_decrease_abort_0_N(request: pytest.FixtureRequest, manag
 
     coord = await get_topology_coordinator(manager)
     coord_serv = await find_server_by_host_id(manager, servers, coord)
-    log = await manager.server_open_log(coord_serv.server_id)
-    mark = await log.mark()
 
     for s in servers:
         await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
@@ -885,7 +881,7 @@ async def test_multi_rf_decrease_abort_0_N(request: pytest.FixtureRequest, manag
 
     alter_task = asyncio.create_task(alter_keyspace())
 
-    await log.wait_for(f'{injection}: entered', from_mark=mark)
+    await manager.api.wait_for_injection_enter(coord_serv.ip_addr, injection)
     await check_system_schema_keyspaces(manager, "ks1", {'dc1': ['rack1a', 'rack1b', 'rack1c'], 'dc2': ['rack2a', 'rack2b', 'rack2c']}, {'dc1': ['rack1a', 'rack1b', 'rack1c']})
 
     task_manager_client = TaskManagerClient(manager.api)
@@ -956,8 +952,6 @@ async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, ma
 
     coord = await get_topology_coordinator(manager)
     coord_serv = await find_server_by_host_id(manager, servers, coord)
-    log = await manager.server_open_log(coord_serv.server_id)
-    mark = await log.mark()
 
     for s in servers:
         await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
@@ -975,7 +969,7 @@ async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, ma
     alter_task2 = asyncio.create_task(alter_keyspace2())
     alter_task3 = asyncio.create_task(alter_keyspace3())
 
-    await log.wait_for(*[f'{injection}: entered' for _ in range(3)], from_mark=mark)
+    await manager.api.wait_for_injection_enter(coord_serv.ip_addr, injection, threshold=3)
 
     for s in servers:
         await manager.api.message_injection(s.ip_addr, injection)
@@ -1032,8 +1026,6 @@ async def test_multi_rf_increase_before_decrease_0_N(request: pytest.FixtureRequ
 
     coord = await get_topology_coordinator(manager)
     coord_serv = await find_server_by_host_id(manager, servers, coord)
-    log = await manager.server_open_log(coord_serv.server_id)
-    mark = await log.mark()
 
     for s in servers:
         await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
@@ -1044,7 +1036,7 @@ async def test_multi_rf_increase_before_decrease_0_N(request: pytest.FixtureRequ
 
     alter_task = asyncio.create_task(alter_keyspace())
 
-    await log.wait_for(f'{injection}: entered', from_mark=mark)
+    await manager.api.wait_for_injection_enter(coord_serv.ip_addr, injection)
 
     dc1_host_ids = set(host_ids[0:3])
     replicas_mid = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1362,7 +1362,7 @@ async def test_read_of_pending_replica_during_migration(manager: ManagerClient, 
         migration_task = asyncio.create_task(
             manager.api.move_tablet(servers[0].ip_addr, ks, "test", replica[0], replica[1], s1_host_id, dst_shard, tablet_token))
 
-        await s1_log.wait_for('stream_mutation_fragments: waiting', from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[1].ip_addr, "stream_mutation_fragments")
         s1_mark = await s1_log.mark()
 
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({key}, 1)")

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -373,7 +373,7 @@ async def test_streaming_is_guarded_by_topology_guard(manager: ManagerClient):
         # Once the writer reaches this place, it will wait for the message_injection() call below before proceeding.
         # The place we block the writer in should not hold to erm or topology_guard because that will block the migration
         # below and prevent test from proceeding.
-        await s1_log.wait_for('stream_mutation_fragments: waiting', from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[1].ip_addr, "stream_mutation_fragments")
         s1_mark = await s1_log.mark()
 
         # Should cause streaming to fail and be retried while leaving behind the replica-side writer.
@@ -451,7 +451,7 @@ async def test_table_dropped_during_streaming(manager: ManagerClient):
         # Once the writer reaches this place, it will wait for the message_injection() call below before proceeding.
         # We want to drop the table while streaming is deep in the process, where it will attempt to apply writes
         # to the dropped table.
-        await s1_log.wait_for('stream_mutation_fragments: waiting', from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[1].ip_addr, "stream_mutation_fragments")
 
         # Streaming blocks table drop, so we can't wait here.
         drop_task = cql.run_async(f"DROP TABLE {ks}.test")
@@ -674,7 +674,7 @@ async def test_tablet_split(manager: ManagerClient, injection_error: str):
 
         await manager.api.enable_injection(servers[0].ip_addr, injection_error, one_shot=True)
         compaction_task = asyncio.create_task(manager.api.keyspace_compaction(servers[0].ip_addr, ks))
-        await s1_log.wait_for(f"{injection_error}: waiting", from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, injection_error)
 
         # Now there's a split and migration need, so they'll potentially run concurrently.
         await manager.enable_tablet_balancing()
@@ -804,7 +804,7 @@ async def test_concurrent_tablet_migration_and_major(manager: ManagerClient, inj
         await manager.api.enable_injection(servers[0].ip_addr, injection_error, one_shot=True)
         logger.info("Started major compaction")
         compaction_task = asyncio.create_task(manager.api.keyspace_compaction(servers[0].ip_addr, ks))
-        await s1_log.wait_for(f"{injection_error}: waiting", from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, injection_error)
 
         tablet_replicas = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
 
@@ -846,7 +846,7 @@ async def test_concurrent_table_drop_and_major(manager: ManagerClient):
         await manager.api.enable_injection(servers[0].ip_addr, injection_error, one_shot=True)
         logger.info("Started major compaction")
         compaction_task = asyncio.create_task(manager.api.keyspace_compaction(servers[0].ip_addr, ks))
-        await s1_log.wait_for(f"{injection_error}: waiting", from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, injection_error)
 
         logger.info("Dropping table")
         await cql.run_async(f"DROP TABLE {ks}.test")
@@ -1266,13 +1266,13 @@ async def test_tombstone_gc_correctness_during_tablet_split(manager: ManagerClie
         await manager.enable_tablet_balancing()
 
         logger.info("Waits for split of sstable containing expired tombstones")
-        await s1_log.wait_for(f"split_sstable_rewrite: waiting", from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "split_sstable_rewrite")
         s1_mark = await s1_log.mark()
         await manager.api.message_injection(servers[0].ip_addr, "split_sstable_rewrite")
         await s1_log.wait_for(f"split_sstable_rewrite: released", from_mark=s1_mark)
 
         logger.info("Pause split of sstable containing deleted data")
-        await s1_log.wait_for(f"split_sstable_rewrite: waiting", from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "split_sstable_rewrite", threshold=2)
         s1_mark = await s1_log.mark()
 
         logger.info("Force compaction of split sstable containing expired tombstone")
@@ -1628,7 +1628,7 @@ async def test_drop_table_during_streaming(manager: ManagerClient, streaming_mod
             manager.api.move_tablet(servers[0].ip_addr, ks, "test", src_host_id, replica[1], dst_host_id, 0, tablet_token)
         )
 
-        await src_log.wait_for(f'{inj}: waiting for message', from_mark=src_mark)
+        await manager.api.wait_for_injection_enter(src_server.ip_addr, inj)
 
         logger.info("Dropping table while sender-side tablet stream is paused after snapshot")
         drop_task = cql.run_async(f"DROP TABLE {ks}.test")
@@ -1761,7 +1761,7 @@ async def test_split_correctness_on_tablet_count_change(manager: ManagerClient):
         await manager.enable_tablet_balancing()
 
         await log.wait_for('Emitting resize decision of type split', from_mark=log_mark)
-        await log.wait_for('splitting_mutation_writer_switch_wait: waiting', from_mark=log_mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "splitting_mutation_writer_switch_wait")
 
         # needs to skip update of repaired_at on merge, since it stops split task.
         await manager.api.enable_injection(server.ip_addr, "skip_update_repaired_at_for_merge", one_shot=False)
@@ -1859,7 +1859,7 @@ async def test_tablet_load_and_stream_and_split_synchronization(manager: Manager
 
         await cql.run_async(f"ALTER TABLE {ks}.test WITH tablets = {{'min_tablet_count': {initial_tablets * 2}}}")
 
-        await s1_log.wait_for(f"tablet_resize_finalization_post_barrier: waiting", from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "tablet_resize_finalization_post_barrier")
 
         await manager.api.enable_injection(servers[0].ip_addr, "stream_mutation_fragments", one_shot=True)
 
@@ -1869,7 +1869,7 @@ async def test_tablet_load_and_stream_and_split_synchronization(manager: Manager
         await manager.api.message_injection(server.ip_addr, "tablet_resize_finalization_post_barrier")
         await s1_log.wait_for('Detected tablet split for table', from_mark=s1_mark)
 
-        await s1_log.wait_for(f"stream_mutation_fragments: waiting", from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "stream_mutation_fragments")
         await manager.api.message_injection(server.ip_addr, "stream_mutation_fragments")
 
         await load_and_stream_task
@@ -2070,7 +2070,7 @@ async def test_tablets_barrier_waits_for_replica_erms(manager: ManagerClient):
         await manager.api.enable_injection(servers[0].ip_addr, "replica_query_wait", one_shot=False, parameters={"table": "test"})
 
         replica_query = cql.run_async(f"SELECT * from {ks}.test where pk={key} BYPASS CACHE", host=hosts[1])
-        await s0_log.wait_for('replica_query_wait: waiting', from_mark=s0_mark)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "replica_query_wait")
 
         version_before_move = await get_topology_version(cql, hosts[0])
 
@@ -2166,8 +2166,8 @@ async def test_split_and_incremental_repair_synchronization(manager: ManagerClie
             for server in servers:
                 await manager.api.enable_injection(server.ip_addr, "incremental_repair_prepare_wait", one_shot=True)
             repair_task = asyncio.create_task(manager.api.tablet_repair(servers[0].ip_addr, ks, "test", token, incremental_mode='incremental'))
-            await s0_log.wait_for('incremental_repair_prepare_wait: waiting', from_mark=s0_mark)
-            await s1_log.wait_for('incremental_repair_prepare_wait: waiting', from_mark=s1_mark)
+            await manager.api.wait_for_injection_enter(servers[0].ip_addr, "incremental_repair_prepare_wait")
+            await manager.api.wait_for_injection_enter(servers[1].ip_addr, "incremental_repair_prepare_wait")
 
             await run_split_prepare()
 
@@ -2312,7 +2312,7 @@ async def test_split_stopped_on_shutdown(manager: ManagerClient):
         await manager.enable_tablet_balancing()
 
         await log.wait_for('Emitting resize decision of type split', from_mark=log_mark)
-        await log.wait_for('splitting_mutation_writer_switch_wait: waiting', from_mark=log_mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "splitting_mutation_writer_switch_wait")
 
         log_mark = await log.mark()
 
@@ -2321,7 +2321,7 @@ async def test_split_stopped_on_shutdown(manager: ManagerClient):
         await log.wait_for('Stopping.*ongoing compactions', from_mark=log_mark)
         await manager.api.message_injection(server.ip_addr, "splitting_mutation_writer_switch_wait")
 
-        await log.wait_for('storage_service_drain_wait: waiting', from_mark=log_mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "storage_service_drain_wait")
         await log.wait_for('Failed to complete splitting of table', from_mark=log_mark)
 
         await manager.api.message_injection(server.ip_addr, "storage_service_drain_wait")

--- a/test/cluster/test_tablets_cql.py
+++ b/test/cluster/test_tablets_cql.py
@@ -50,7 +50,7 @@ async def test_alter_dropped_tablets_keyspace(manager: ManagerClient) -> None:
 
     logger.info(f"waiting for the leader node {servers[0]} to start handling the keyspace-rf-change request")
     leader_log_file = await manager.server_open_log(servers[0].server_id)
-    await leader_log_file.wait_for("wait-after-topology-coordinator-gets-event: waiting", timeout=10)
+    await manager.api.wait_for_injection_enter(servers[0].ip_addr, "wait-after-topology-coordinator-gets-event")
 
     logger.info(f"dropping KS from the follower node {servers[1]} so that the leader, which hangs on injected sleep, "
                 f"wakes up with the drop applied")
@@ -101,7 +101,7 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
 
         logger.info(f"waiting for the leader node {servers[0]} to start handling the keyspace-rf-change request")
         leader_log_file = await manager.server_open_log(servers[0].server_id)
-        await leader_log_file.wait_for("wait-before-committing-rf-change-event: waiting", timeout=10)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "wait-before-committing-rf-change-event")
 
         logger.info(f"creating another keyspace from the follower node {servers[1]} so that the leader, which hangs on injected sleep, "
                     f"wakes up with a changed schema")

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -184,8 +184,8 @@ async def test_lwt_during_migration(manager: ManagerClient):
                                     target_host_id, 0,
                                     target_host_id, 1, tablet.last_token))
 
-        logger.info(f"Wait for 'intranode_migration_streaming: waiting' injection on {target_server.ip_addr}")
-        await log.wait_for('intranode_migration_streaming: waiting')
+        logger.info(f"Wait for 'intranode_migration_streaming_wait' injection on {target_server.ip_addr}")
+        await manager.api.wait_for_injection_enter(target_server.ip_addr, "intranode_migration_streaming_wait")
 
         logger.info("Run another LWT while ingranode migration is in-progress")
         await cql.run_async(f"UPDATE {ks}.test SET c = 2 WHERE pk = 1 IF c = 1")
@@ -440,11 +440,8 @@ async def test_lwt_concurrent_base_table_recreation(manager: ManagerClient):
         lwt_task = cql.run_async(
             f"INSERT INTO {ks}.test (pk, c) VALUES (1, 1) IF NOT EXISTS")
 
-        logger.info("Open log")
-        log = await manager.server_open_log(server.server_id)
-
         logger.info("Wait for load_paxos_state-enter injection")
-        await log.wait_for('load_paxos_state-enter: waiting for message')
+        await manager.api.wait_for_injection_enter(server.ip_addr, "load_paxos_state-enter")
 
         await recreate_table()
 
@@ -823,7 +820,7 @@ async def test_lwt_shutdown(manager: ManagerClient):
         logger.info("Open log")
         log = await manager.server_open_log(s0.server_id)
         logger.info("Wait for 'paxos_state_learn_after_mutate' injection")
-        await log.wait_for('paxos_state_learn_after_mutate: waiting for message')
+        await manager.api.wait_for_injection_enter(s0.ip_addr, "paxos_state_learn_after_mutate")
 
         logger.info("Start node shutdown")
         stop_task = asyncio.create_task(manager.server_stop_gracefully(s0.server_id))
@@ -920,7 +917,7 @@ async def test_tablets_merge_waits_for_lwt(manager: ManagerClient, scale_timeout
         log0 = await manager.server_open_log(s0.server_id)
 
         logger.info("Wait for paxos_accept_proposal_wait")
-        await log0.wait_for("paxos_accept_proposal_wait: waiting for message")
+        await manager.api.wait_for_injection_enter(s0.ip_addr, "paxos_accept_proposal_wait")
 
         logger.info("Injecting tablet_force_tablet_count_decrease")
         await manager.api.enable_injection(s0.ip_addr, "tablet_force_tablet_count_decrease", one_shot=False)

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -545,9 +545,6 @@ async def test_merge_with_drop(manager: ManagerClient):
         expected_tablet_count = initial_tablets // 2
         await cql.run_async(f"ALTER TABLE {ks}.test WITH tablets = {{'min_tablet_count': {expected_tablet_count}}}")
 
-        s0_log = await manager.server_open_log(server.server_id)
-        s0_mark = await s0_log.mark()
-
         await manager.enable_tablet_balancing()
 
         # wait for merge to complete
@@ -561,10 +558,10 @@ async def test_merge_with_drop(manager: ManagerClient):
 
             await asyncio.sleep(.1)
 
-        await s0_log.wait_for('merge_completion_fiber: waiting', from_mark=s0_mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "merge_completion_fiber")
         await manager.api.enable_injection(server.ip_addr, "compaction_group_stop_wait", one_shot=True)
         await manager.api.message_injection(server.ip_addr, "merge_completion_fiber")
-        await s0_log.wait_for('compaction_group_stop_wait: waiting', from_mark=s0_mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "compaction_group_stop_wait")
 
         drop_table_fut = cql.run_async(f"drop table {ks}.test")
         await asyncio.sleep(0.1)
@@ -632,7 +629,7 @@ async def test_background_merge_deadlock(manager: ManagerClient):
         return tablet_count == 4 or None
     await wait_for(produced_one_merge, time.time() + 120)
 
-    mark, _ = await log.wait_for(f"merge_completion_fiber: waiting", from_mark=mark)
+    await manager.api.wait_for_injection_enter(servers[0].ip_addr, "merge_completion_fiber")
     await manager.api.message_injection(servers[0].ip_addr, "merge_completion_fiber")
     mark, _ = await log.wait_for(f"merge_completion_fiber: message received", from_mark=mark)
 

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -188,8 +188,6 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
                 logger.info(f"Will fail {self.stage}")
                 if self.stage == "streaming":
                     await manager.api.enable_injection(servers[3].ip_addr, "stream_mutation_fragments", one_shot=True)
-                    self.log = await manager.server_open_log(servers[3].server_id)
-                    self.mark = await self.log.mark()
                 elif self.stage in [ "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new", "end_migration", "do_revert_migration" ]:
                     await manager.api.enable_injection(servers[self.fail_idx].ip_addr, "raft_topology_barrier_and_drain_fail", one_shot=False,
                             parameters={'keyspace': self.ks, 'table': 'test', 'last_token': last_token, 'stage': self.stage.removeprefix('do_')})
@@ -216,7 +214,7 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
             async def wait(self):
                 logger.info(f"Wait for {self.stage} to happen")
                 if self.stage == "streaming":
-                    await self.log.wait_for('stream_mutation_fragments: waiting', from_mark=self.mark)
+                    await manager.api.wait_for_injection_enter(servers[3].ip_addr, "stream_mutation_fragments")
                 elif self.stage in [ "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new", "end_migration", "do_revert_migration" ]:
                     await self.log.wait_for('raft_topology_cmd: barrier handler waits', from_mark=self.mark);
                 elif self.stage == "cleanup":

--- a/test/cluster/test_tablets_parallel_decommission.py
+++ b/test/cluster/test_tablets_parallel_decommission.py
@@ -59,7 +59,7 @@ async def test_tablets_are_drained_in_parallel(manager: ManagerClient):
         decomm_task1 = asyncio.create_task(manager.decommission_node(servers[2].server_id)) # rack1
         decomm_task2 = asyncio.create_task(manager.decommission_node(servers[3].server_id)) # rack2
 
-        mark, _ = await log.wait_for('topology_coordinator_pause_before_processing_backlog: waiting', from_mark=mark)
+        await manager.api.wait_for_injection_enter(coord_srv.ip_addr, "topology_coordinator_pause_before_processing_backlog")
 
         # Pause topology until all requests are queued to workaround for group0 concurrent modification
         # preventing second request from being queued due to fast migrations on behalf of the first requests.
@@ -138,7 +138,7 @@ async def test_tablets_are_rebuilt_in_parallel(manager: ManagerClient, same_rack
         await manager.api.exclude_node(coord_srv.ip_addr, host_ids_to_remove)
         tasks = [asyncio.create_task(manager.remove_node(coord_srv.server_id, srv.server_id)) for srv in servers_to_remove]
 
-        mark, _ = await log.wait_for('topology_coordinator_pause_before_processing_backlog: waiting', from_mark=mark)
+        await manager.api.wait_for_injection_enter(coord_srv.ip_addr, "topology_coordinator_pause_before_processing_backlog")
 
         # Pause topology until all requests are queued to workaround for group0 concurrent modification
         # preventing second request from being queued due to fast migrations on behalf of the first requests.
@@ -191,7 +191,7 @@ async def test_decommission_can_be_canceled(manager: ManagerClient):
         task_id = task.task_id
         logger.info(f'decommission task: {task_id}')
 
-        await coord_log.wait_for('topology_coordinator_pause_before_processing_backlog: waiting', from_mark=mark)
+        await manager.api.wait_for_injection_enter(coord_serv.ip_addr, "topology_coordinator_pause_before_processing_backlog")
 
         # Aborting in a pending or paused state should be immediate even if migrations are ongoing.
         await manager.api.abort_task(servers[0].ip_addr, task_id)
@@ -337,7 +337,7 @@ async def test_decommission_start_time_is_stable(manager: ManagerClient):
         decomm_task = asyncio.create_task(manager.decommission_node(servers[1].server_id))
         decomm_hostid = await manager.get_host_id(servers[1].server_id)
 
-        await coord_log.wait_for('topology_coordinator_pause_after_node_transition: waiting for message', from_mark=mark)
+        await manager.api.wait_for_injection_enter(coord_serv.ip_addr, "topology_coordinator_pause_after_node_transition")
 
         tasks = await manager.api.get_tasks(servers[0].ip_addr, 'node_ops')
         logger.info(f'tasks: {tasks}')
@@ -385,7 +385,7 @@ async def test_decommission_can_not_be_canceled_once_running(manager: ManagerCli
         decomm_task = asyncio.create_task(manager.decommission_node(servers[1].server_id))
         decomm_hostid = await manager.get_host_id(servers[1].server_id)
 
-        await coord_log.wait_for('in_left_token_ring_transition: waiting', from_mark=mark)
+        await manager.api.wait_for_injection_enter(coord_serv.ip_addr, "in_left_token_ring_transition")
 
         tasks = await manager.api.get_tasks(servers[0].ip_addr, 'node_ops')
         logger.info(f'tasks: {tasks}')
@@ -496,7 +496,7 @@ async def test_node_lost_during_decommission_drain(manager: ManagerClient):
         decomm_task = task.task_id
         logger.info(f'decommission task: {decomm_task}')
 
-        await coord_log.wait_for('topology_coordinator_pause_before_processing_backlog: waiting', from_mark=mark)
+        await manager.api.wait_for_injection_enter(coord_serv.ip_addr, "topology_coordinator_pause_before_processing_backlog")
 
         await manager.server_stop(srv_to_remove.server_id, convict=True)
         await manager.server_not_sees_other_server(coord_serv.ip_addr, srv_to_remove.ip_addr)

--- a/test/cluster/test_topology_ops_with_rf_rack_valid.py
+++ b/test/cluster/test_topology_ops_with_rf_rack_valid.py
@@ -163,14 +163,12 @@ async def test_keyspace_creation_during_node_join(manager: ManagerClient, inject
 
     # Start adding a new node in a new rack (this will pause due to injection)
     logger.info(f"Starting to add new node in rack r4 (will pause {injection})")
-    log = await manager.server_open_log(servers[0].server_id)
-    mark = await log.mark()
     add_node_task = asyncio.create_task(
         manager.server_add(config=cfg, cmdline=cmdline,
                            property_file={"dc": "dc1", "rack": "r4"},
                            expected_error=server_add_expected_error)
     )
-    await log.wait_for(f"{inj}: waiting for message", from_mark=mark, timeout=60)
+    await manager.api.wait_for_injection_enter(servers[0].ip_addr, inj)
 
     if injection == "before_bootstrap":
         # Node is accepted but bootstrap hasn't started yet
@@ -211,11 +209,10 @@ async def test_keyspace_creation_during_node_join(manager: ManagerClient, inject
         await asyncio.gather(*[manager.api.enable_injection(s.ip_addr, inj, one_shot=True) for s in servers])
 
         # Start adding second node to rack r4
-        mark = await log.mark()
         add_node2_task = asyncio.create_task(
             manager.server_add(config=cfg, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r4"})
         )
-        await log.wait_for(f"{inj}: waiting for message", from_mark=mark, timeout=60)
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, inj)
 
         # Creating keyspace should succeed now because rack count remains at 4
         logger.info("Creating keyspace with RF=4 while second node joins r4 (should succeed - rack count unchanged)")
@@ -261,8 +258,6 @@ async def test_keyspace_creation_during_node_remove(manager: ManagerClient, op: 
 
     # Start the node operation (this will pause due to injection)
     logger.info(f"Starting to {op} node from rack r3 (will pause during {op})")
-    log = await manager.server_open_log(servers[0].server_id)
-    mark = await log.mark()
 
     if op == "remove":
         await manager.server_stop_gracefully(servers[2].server_id)
@@ -274,7 +269,7 @@ async def test_keyspace_creation_during_node_remove(manager: ManagerClient, op: 
             manager.decommission_node(servers[2].server_id)
         )
 
-    await log.wait_for(f"{inj}: waiting for message", from_mark=mark, timeout=60)
+    await manager.api.wait_for_injection_enter(servers[0].ip_addr, inj)
 
     # While the node operation is paused, try to create keyspace with RF=3
     # Should fail because operation would leave only 2 racks, making RF=3 invalid

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -109,7 +109,7 @@ async def test_truncate_with_concurrent_drop(manager: ManagerClient):
         # Start a TRUNCATE in the background
         trunc_future = cql.run_async(f'TRUNCATE TABLE {ks}.test', host=trunc_host)
         # Wait for the topology coordinator to reach a point wher it is about to start sending the truncate RPCs
-        await raft_leader_log.wait_for('truncate_table_wait: waiting for message')
+        await manager.api.wait_for_injection_enter(raft_leader.ip_addr, "truncate_table_wait")
         # Execute DROP TABLE
         await cql.run_async(f'DROP TABLE {ks}.test', host=drop_host)
         # Release TRUNCATE table in topology coordinator
@@ -283,7 +283,7 @@ async def test_replay_position_check_during_truncate(manager):
 
         truncate_task = cql.run_async(f"TRUNCATE {ks}.test")
 
-        await s1_log.wait_for(f"database_truncate_wait: waiting", from_mark=s1_mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "database_truncate_wait")
 
         keys = range(10)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
@@ -386,12 +386,12 @@ async def test_split_emitted_during_truncate(manager: ManagerClient):
         expected_tablet_count = 2
         # Force split on the test table
         await cql.run_async(f"ALTER TABLE {ks}.test WITH tablets = {{'min_tablet_count': {expected_tablet_count}}}")
-        await log.wait_for("tablet_split_monitor_wait: waiting", from_mark=mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "tablet_split_monitor_wait")
 
         truncate_task = cql.run_async(f"TRUNCATE {ks}.test")
 
         # Wait for truncation to disable compaction on existing groups and pause
-        await log.wait_for("database_truncate_wait: waiting", from_mark=mark)
+        await manager.api.wait_for_injection_enter(server.ip_addr, "database_truncate_wait")
 
         # Release split monitor so it calls set_split_mode(), creating new compaction groups
         await manager.api.message_injection(server.ip_addr, "tablet_split_monitor_wait")

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -87,12 +87,11 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
 
             # Wait for the topology change to start
             logger.info("Waiting for a topology change to start")
-            mark, _ = await target_server_log.wait_for("pause_before_barrier_and_drain: waiting for message")
+            await manager.api.wait_for_injection_enter(target_server.ip_addr, "pause_before_barrier_and_drain")
 
             # Pause write responses on the other node so it keeps the
             # write_response_handler alive on the target.
             await inject_error_on(manager, "storage_proxy_write_response_pause", [other_server])
-            other_server_log = await manager.server_open_log(other_server.server_id)
 
             # Send a write with CL=ONE so it completes from the coordinator's
             # local replica without waiting for the paused server.
@@ -102,7 +101,7 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
                 host=target_host)
 
             # Make sure the other replica got the write request and is paused.
-            await other_server_log.wait_for("storage_proxy_write_response_pause: waiting for message")
+            await manager.api.wait_for_injection_enter(other_server.ip_addr, "storage_proxy_write_response_pause");
 
             # Release the first barrier_and_drain — it completes because the write
             # handler holds the current version (not stale yet).
@@ -111,7 +110,7 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
             # Wait for the second barrier_and_drain. Between the first and second,
             # topology_state_load installs a new token_metadata version. The write
             # handler still holds the old version's ERM, which is now stale.
-            await target_server_log.wait_for("pause_before_barrier_and_drain: waiting for message", from_mark=mark)
+            await manager.api.wait_for_injection_enter(target_server.ip_addr, "pause_before_barrier_and_drain", threshold=2)
 
             # Start shutdown of the target node
             logger.info(f"Starting shutdown of node {target_server.server_id}")

--- a/test/cluster/test_write_query_during_cql_server_shutdown.py
+++ b/test/cluster/test_write_query_during_cql_server_shutdown.py
@@ -67,8 +67,7 @@ async def test_write_query_during_cql_server_shutdown(request: pytest.FixtureReq
 
         # Make sure nodes that have to pause the request response, got the write request and started waiting.
         for server in servers_to_pause:
-            paused_server_logs = await manager.server_open_log(server.server_id)
-            await paused_server_logs.wait_for("storage_proxy_write_response_pause: waiting for message")
+            await manager.api.wait_for_injection_enter(server.ip_addr, "storage_proxy_write_response_pause")
 
         # Start shutdown of the query coordinator node
         async def do_shutdown():

--- a/test/lib/error_injection.hh
+++ b/test/lib/error_injection.hh
@@ -8,7 +8,18 @@
 
 #pragma once
 
+#include <seastar/core/future.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include "utils/error_injection.hh"
+
+// Waits until enter_count for the named injection reaches the given threshold.
+// A replacement for busy-loop polling in unit tests.
+inline future<> wait_for_injection_enter(std::string_view injection_name, size_t threshold = 1) {
+    while (utils::get_local_injector().enter_count(injection_name) < threshold) {
+        co_await coroutine::maybe_yield();
+    }
+}
 
 // Injects the error for the duration of the scope on all shards.
 // Runs in seastar thread.

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -9,6 +9,7 @@ from __future__ import annotations                           # Type hints as str
 
 import logging
 import os.path
+import time
 from urllib.parse import quote
 from abc import ABCMeta
 from collections.abc import Mapping
@@ -366,6 +367,22 @@ class ScyllaRESTAPIClient:
 
     async def message_injection(self, node_ip: str, injection: str) -> None:
         await self.client.post(f"/v2/error_injection/injection/{quote(injection, safe='')}/message", host=node_ip)
+
+    async def wait_for_injection_enter(self, node_ip: str, injection: str, threshold: int = 1, deadline: float | None = None) -> None:
+        """Poll until the injection's enter count reaches the threshold.
+           Default threshold=1 waits for at least one enter.
+        """
+        from test.pylib.util import wait_for
+        if deadline is None:
+            deadline = time.time() + 60.0
+
+        async def _check():
+            count = await self.client.get_json(
+                f"/v2/error_injection/injection/{quote(injection, safe='')}/enters",
+                host=node_ip)
+            return count if count >= threshold else None
+
+        await wait_for(_check, deadline, label=f"injection_enter({injection})")
 
     async def inject_disconnect(self, node_ip: str, ip_to_disconnect_from: str) -> None:
         await self.client.post(f"/v2/error_injection/disconnect/{ip_to_disconnect_from}", host=node_ip)

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -2,6 +2,7 @@
 #include "raft/raft.hh"
 #include "replication.hh"
 #include "utils/error_injection.hh"
+#include "test/lib/error_injection.hh"
 #include <seastar/util/defer.hh>
 
 #ifdef SEASTAR_DEBUG
@@ -264,9 +265,7 @@ static void test_add_entry_load_snapshot_before_wait_aux(raft::wait_type type, b
     auto fut = server.add_entry(create_command(42), type, nullptr);
 
     // Wait for add_entry(42) to reach the injection point.
-    while (utils::get_local_injector().is_enabled("block_raft_add_entry_before_wait_for_entry")) {
-        seastar::thread::yield();
-    }
+    wait_for_injection_enter("block_raft_add_entry_before_wait_for_entry").get();
 
     // Wait for the entry to be applied.
     server.read_barrier(nullptr).get();

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -24,6 +24,7 @@
 #include <ranges>
 #include <algorithm>
 #include <chrono>
+#include <numeric>
 #include <type_traits>
 #include <optional>
 #include <unordered_map>
@@ -145,6 +146,7 @@ class error_injection {
         size_t shared_read_message_count{0};
         size_t waiter_count{0};
         bool disabled{false};
+        size_t enter_count{0};
         condition_variable received_message_cv;
         error_injection_parameters parameters;
         sstring injection_name;
@@ -383,12 +385,31 @@ public:
         return data ? data->shared_data->waiter_count : 0;
     }
 
+    // \brief Returns the number of times the named injection has been entered
+    // since it was enabled.
+    // \param name error injection name to check
+    size_t enter_count(const std::string_view& injection_name) const {
+        auto data = get_data(injection_name);
+        return data ? data->shared_data->enter_count : 0;
+    }
+
+    // \brief Returns the sum of enter_count across all shards.
+    static future<size_t> enter_count_on_all(const std::string_view& injection_name) {
+        auto counts = std::vector<size_t>(smp::count, 0);
+        co_await smp::invoke_on_all([&counts, name = sstring(injection_name)] {
+            counts[this_shard_id()] = _local.enter_count(name);
+        });
+        co_return std::accumulate(counts.begin(), counts.end(), size_t(0));
+    }
+
     // \brief Enter into error injection if it's enabled
     // \param name error injection name to check
     bool enter(const std::string_view& name) {
         if (!is_enabled(name)) {
             return false;
         }
+        auto* data = get_data(name);
+        ++data->shared_data->enter_count;
         if (is_one_shot(name)) {
             disable(name);
         }
@@ -531,6 +552,7 @@ public:
         }
 
         errinj_logger.debug("Triggering injection \"{}\" with injection handler", name);
+        ++data->shared_data->enter_count;
         injection_handler handler(data->shared_data, share_messages);
         data->handlers.push_back(handler);
 
@@ -657,6 +679,14 @@ public:
 
     size_t waiters(const std::string_view& name) const {
         return 0;
+    }
+
+    size_t enter_count(const std::string_view& name) const {
+        return 0;
+    }
+
+    static future<size_t> enter_count_on_all(const std::string_view& injection_name) {
+        return make_ready_future<size_t>(0);
     }
 
     bool enter(const std::string_view& name) const {


### PR DESCRIPTION
Tests that need to wait until an error injection is hit currently scan Scylla's log output for framework-generated messages like "{name}: waiting for message".

This series adds a proper API for injection entry detection:

   - A monotonic enter_count is maintained per injection, incremented each time the injection fires, and reset on enable().
   - A new REST endpoint GET /v2/error_injection/injection/{name}/enters returns the total count across all shards.
   - A pylib helper wait_for_injection_enter(ip, name, threshold=0) polls until the count exceeds the threshold, using the standard wait_for utility with backoff.

All test sites that previously did:

    log = await manager.server_open_log(server.server_id)
    await log.wait_for("injection_name: waiting for message")

Are converted to:

    await manager.api.wait_for_injection_enter(server.ip_addr, "injection_name")

This change also eliminates one parameter-based signaling pattern (alternator's handler.set("waiting", true) polled via get_injection_parameters()), and simplifies the alternator_list_tables injection to the standard wait_for_message form.

Improving error-injection facility, not backporting