### PR TITLE
test: Order task-wait before finalization in test_migration_wait_task

### DIFF
--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -595,6 +595,8 @@ future<std::optional<tasks::task_status>> migration_virtual_task::wait(tasks::ta
         co_return std::nullopt;
     }
 
+    tasks::tmlogger.info("migration_virtual_task: waiting for vnodes-to-tablets migration to finish: task_id={}, keyspace={}", id, *ks_name);
+
     storage_service::migration_status status;
     while (true) {
         try {

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -704,8 +704,13 @@ async def test_migration_wait_task(manager: ManagerClient):
         assert tasks[0].keyspace == ks
         task_id = tasks[0].task_id
 
-        logger.info("Starting wait on the migration task")
+        log = await manager.server_open_log(server.server_id)
+        mark = await log.mark()
+
+        logger.info(f"Starting wait on the migration task '{task_id}'")
         wait_task = asyncio.create_task(tm.wait_for_task(server.ip_addr, task_id))
+
+        await log.wait_for('migration_virtual_task: waiting for vnodes-to-tablets migration to finish', from_mark=mark)
 
         logger.info("Rolling back migration")
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
@@ -731,8 +736,12 @@ async def test_migration_wait_task(manager: ManagerClient):
         await reconnect_driver(manager)
         cql, _ = await manager.get_ready_cql([server])
 
-        logger.info("Starting wait on the migration task")
+        mark = await log.mark()
+
+        logger.info(f"Starting wait on the migration task '{task_id}'")
         wait_task = asyncio.create_task(tm.wait_for_task(server.ip_addr, task_id))
+
+        await log.wait_for('migration_virtual_task: waiting for vnodes-to-tablets migration to finish', from_mark=mark)
 
         logger.info("Finalizing migration")
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)


### PR DESCRIPTION
The purpose of this test is to verify that the task manager's "wait" API works correctly for vnodes-to-tablets migration virtual tasks. It starts a `wait_task` HTTP request concurrently with a finalize (or rollback) operation, and asserts that the wait returns the correct final state ("done" or "suspended").

The test `uses asyncio.create_task()` to wrap the wait request into a task, and then immediately calls finalize. With asyncio's lazy task scheduling, the wait coroutine does not start until the event loop yields, so the finalization request reaches the server before wait, and therefore may also complete before it. Once finalization completes, the virtual migration task is no longer discoverable, causing a "task not found" error.

Add a log message in Scylla's wait handler and a synchronization point in the test to ensure that the wait request lands the server before finalization. This follows the same pattern used in `test_tablet_tasks.py::check_and_abort_repair_task`.

Fixes SCYLLADB-2077