### PR TITLE
test/pylib: fix misleading comment about sd_notify readiness check

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -936,10 +936,16 @@ class ScyllaServer:
                     server_up_state = await self.get_cql_alternator_up_state() or server_up_state
                 if await is_expected_state_reached():
                     return
-                # Check for SERVING state via sd_notify. This is authoritative: Scylla sends
-                # STATUS=serving once all configured listeners are ready, and
-                # STATUS=entering maintenance mode once the maintenance socket is ready.
-                # Both mean the server is fully started and we don't need to wait further.
+                # Check for SERVING state via sd_notify. Scylla sends
+                # "STATUS=serving" once all configured listeners are ready, and
+                # "STATUS=entering maintenance mode" once the maintenance socket
+                # is ready. The notification is authoritative for Scylla-side
+                # listener startup, including non-default configured ports; the
+                # tests run on the same machine, so local connectivity follows.
+                # When waiting for SERVING, accept the notification only after
+                # the harness has verified its CQL/Alternator request path:
+                # CQL authentication/query readiness, Alternator request handling,
+                # and the persistent driver connection used by the test framework.
                 if server_up_state >= ServerUpState.CQL_ALTERNATOR_QUERIED and self.check_serving_notification():
                     server_up_state = ServerUpState.SERVING
                 if await is_expected_state_reached():

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -926,10 +926,16 @@ class ScyllaServer:
                     server_up_state = await self.get_cql_alternator_up_state() or server_up_state
                 if await is_expected_state_reached():
                     return
-                # Check for SERVING state via sd_notify. This is authoritative: Scylla sends
-                # STATUS=serving once all configured listeners are ready, and
-                # STATUS=entering maintenance mode once the maintenance socket is ready.
-                # Both mean the server is fully started and we don't need to wait further.
+                # Check for SERVING state via sd_notify. Scylla sends
+                # "STATUS=serving" once all configured listeners are ready, and
+                # "STATUS=entering maintenance mode" once the maintenance socket
+                # is ready. The notification is authoritative for Scylla-side
+                # listener startup, including non-default configured ports; the
+                # tests run on the same machine, so local connectivity follows.
+                # When waiting for SERVING, accept the notification only after
+                # the harness has verified its CQL/Alternator request path:
+                # CQL authentication/query readiness, Alternator request handling,
+                # and the persistent driver connection used by the test framework.
                 if server_up_state >= ServerUpState.CQL_ALTERNATOR_QUERIED and self.check_serving_notification():
                     server_up_state = ServerUpState.SERVING
                 if await is_expected_state_reached():


### PR DESCRIPTION
Follow-up to #29964: clarify the comment on the sd_notify SERVING check in ScyllaServer.start().

SERVING remains authoritative for Scylla-side listener startup in this local test setup, including non-default configured ports. The harness still waits for CQL/Alternator request readiness and the persistent driver connection before returning a server to tests.

Refs: #29964