### PR TITLE
view: fix crash on static row update with collection index on regular column

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1139,12 +1139,22 @@ void view_updates::generate_update(
                     updatable_view_key_cols.emplace_back(view_col.id,
                         existing ? c->compute_value(*_base, base_key, *existing) : regular_column_transformation::result(),
                         c->compute_value(*_base, base_key, update));
-                } else {
-                    // The only other column_computation we have which has
-                    // depends_on_non_primary_key_column is
-                    // collection_column_computation, and we have a special
-                    // function to handle that case:
+                } else if (auto* ccc = dynamic_cast<const collection_column_computation*>(&computation)) {
+                    // A static row update cannot affect an index on a non-static
+                    // column (and vice versa), so skip this view when the column kinds
+                    // don't match — otherwise update_entry_for_computed_column
+                    // may try to read clustering key components or
+                    // collection data that don't exist in the update row.
+                    auto* base_col = _base->get_column_definition(ccc->collection_name());
+                    if (base_col && base_col->kind != update.column_kind()) {
+                        return;
+                    }
+                    // The collection_column_computation case is handled by a
+                    // separate function:
                     return update_entry_for_computed_column(base_key, update, existing, now);
+                } else {
+                    on_internal_error(vlogger, fmt::format("Unexpected type of computation for computed column {} in view {}.{}",
+                        view_col.name(), _view->ks_name(), _view->cf_name()));
                 }
             }
         } else {

--- a/schema/column_computation.hh
+++ b/schema/column_computation.hh
@@ -142,6 +142,10 @@ public:
         return true;
     }
 
+    const bytes& collection_name() const {
+        return _collection_name;
+    }
+
     std::vector<db::view::view_key_and_action> compute_values_with_action(const schema& schema, const partition_key& key,
             const db::view::clustering_or_static_row& row, const std::optional<db::view::clustering_or_static_row>& existing) const;
 };

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -2352,3 +2352,41 @@ def test_tombstone_gc_property_unnamed_index(cql, test_keyspace, scylla_only):
 
         desc_row = cql.execute(f"DESCRIBE MATERIALIZED VIEW {table}_v_idx_index").one()
         assert "tombstone_gc = {" in desc_row.create_statement
+
+# Verify that if a write includes a static row update on a table with a secondary
+# index on a regular (non-static) collection column, it doesn't fail.
+#
+# Reproduces https://scylladb.atlassian.net/browse/SCYLLADB-2030
+def test_static_row_update_with_regular_set_index(cql, test_keyspace):
+    schema = 'pk int, ck int, s int STATIC, x set<text>, PRIMARY KEY(pk, ck)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE INDEX ON {table}(x)")
+
+        # Test updating both static and non-static columns in the same write
+        cql.execute(f"INSERT INTO {table} (pk, ck, s, x) VALUES (1, 2, 3, {{'test'}})")
+        assert [(1, 2, 3, {'test'})] == list(cql.execute(f"SELECT * FROM {table} WHERE pk = 1 AND ck = 2"))
+        assert [(1, 2, 3, {'test'})] == list(cql.execute(f"SELECT * FROM {table} WHERE x CONTAINS 'test'"))
+
+        # Test updating just the static column
+        cql.execute(f"UPDATE {table} SET s = 4 WHERE pk = 1")
+        assert [(1, 2, 4, {'test'})] == list(cql.execute(f"SELECT * FROM {table} WHERE pk = 1 AND ck = 2"))
+        assert [(1, 2, 4, {'test'})] == list(cql.execute(f"SELECT * FROM {table} WHERE x CONTAINS 'test'"))
+
+# Verify that if a write includes a regular row update on a table with a secondary
+# index on a static collection column, it doesn't fail.
+#
+# Reproduces https://scylladb.atlassian.net/browse/SCYLLADB-2030
+def test_regular_row_update_with_static_set_index(cql, test_keyspace):
+    schema = 'pk int, ck int, s set<text> STATIC, x int, PRIMARY KEY(pk, ck)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE INDEX ON {table}(s)")
+
+        # Test updating both static and non-static columns in the same write
+        cql.execute(f"INSERT INTO {table} (pk, ck, s, x) VALUES (1, 2, {{'test'}}, 3)")
+        assert [(1, 2, {'test'}, 3)] == list(cql.execute(f"SELECT * FROM {table} WHERE pk = 1"))
+        assert [(1, 2, {'test'}, 3)] == list(cql.execute(f"SELECT * FROM {table} WHERE s CONTAINS 'test'"))
+
+        # Test updating just the regular column
+        cql.execute(f"UPDATE {table} SET x = 4 WHERE pk = 1 AND ck = 2")
+        assert [(1, 2, {'test'}, 4)] == list(cql.execute(f"SELECT * FROM {table} WHERE pk = 1 AND ck = 2"))
+        assert [(1, 2, {'test'}, 4)] == list(cql.execute(f"SELECT * FROM {table} WHERE s CONTAINS 'test'"))


### PR DESCRIPTION
When we generate mutations for view updates, we iterated over all key columns of the view and we prepare a set of differences between the old and new values for them to use later for deciding what mutations should we actually generate. However, if during this iteration we encounter a computed collection column, we take a different path because an update to such a column may generate more than one delete/modify/create mutation.
When we take this path, we look at the old value of the base table row and compare it to the value of the updated row and generate updates based on the difference. However, if the update affects the static row and the computed column is not static, we can't compare anything and we fail on one of:
- "Tried to get view row value for a static row update in a view with partition key having clustering columns from original table"
- marshal_exception ("not enough bytes") when a cell from the wrong column kind is found via column ID collision between the regular and static ID namespaces and misinterpreted as collection data.

This can also happen if the computed collection column comes from the static row and the update affects the regular row.

We fix this by checking whether the update row is of the same kind (static/regular) as the columuted column. If they differ, we return early knowing that an update to the static column cannot modify the secondary index on a regular column, and vice-versa. This mirrors the check that we're already doing for non-computed columns.

We also add a public accessor for collection_column_computation's _collection_name field, needed to look up the base column definition.

Fixes: SCYLLADB-2030
