### PR TITLE
fix(workflow): add content read permissions to seastar.yaml

### DIFF
--- a/.github/workflows/seastar.yaml
+++ b/.github/workflows/seastar.yaml
@@ -5,7 +5,8 @@ on:
     # 5AM everyday
     - cron: '0 5 * * *'
 
-permissions: {}
+permissions: 
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
should address the persistent workflow [seastar action failing](https://github.com/scylladb/scylladb/actions/workflows/seastar.yaml)

(or, if I the workflow is obsolete, it's best to remove it instead?)

