### PR TITLE
build: degrade -Wpass-failed from error to warning

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -20,6 +20,7 @@ add_compile_options(
   "-Werror"
   "-Wextra"
   "-Wno-error=deprecated-declarations"
+  "-Wno-error=pass-failed"
   "-Wimplicit-fallthrough"
   ${_supported_warnings})
 

--- a/configure.py
+++ b/configure.py
@@ -1859,7 +1859,8 @@ def get_warning_options(cxx):
                 for w in warnings
                 if flag_supported(flag=w, compiler=cxx)]
 
-    return ' '.join(warnings + ['-Wno-error=deprecated-declarations'])
+    return ' '.join(warnings + ['-Wno-error=deprecated-declarations',
+                                    '-Wno-error=pass-failed'])
 
 
 def get_clang_inline_threshold():


### PR DESCRIPTION
-Wpass-failed warns when an explicitly requested optimization (e.g. `#pragma GCC unroll`) cannot be performed. Since the standard library contains those pragmas, this is more or less out of a developer's control. We can play with inlining, but cannot guarantee it will work.

Since the condition isn't fatal in any way, degrade it back to its default disposition, a warning (it was upgraded to an error via -Werror). Don't suppress it entirely since in hot paths we do want to address it.

Only seen sporadically in upcoming code, so no need to backport.