### PR TITLE
doc: add support for the new OCI instance-recommendations

### DIFF
--- a/docs/getting-started/cloud-instance-recommendations.rst
+++ b/docs/getting-started/cloud-instance-recommendations.rst
@@ -501,6 +501,10 @@ For Intel Xeon processors, each OCPU corresponds to two hardware execution threa
      - OCPU
      - Mem (GB)
      - Storage
+   * - VM.DenseIO.E5.Flex (see `Flexible Shapes <https://docs.oracle.com/en-us/iaas/Content/Compute/References/computeshapes.htm#flexible>`_)
+     - 8 - 48
+     - 96 - 576
+     - 6.8 - 40.8
    * - VM.DenseIO2.8
      - 8
      - 120

--- a/docs/getting-started/cloud-instance-recommendations.rst
+++ b/docs/getting-started/cloud-instance-recommendations.rst
@@ -505,24 +505,5 @@ For Intel Xeon processors, each OCPU corresponds to two hardware execution threa
      - 8 - 48
      - 96 - 576
      - 6.8 - 40.8
-   * - VM.DenseIO2.8
-     - 8
-     - 120
-     - 6.4 TB
-   * - VM.DenseIO2.16
-     - 16
-     - 240
-     - 12.8 TB
-   * - VM.DenseIO2.24
-     - 24
-     - 320 
-     - 25.6 TB
-   * - BM.DenseIO2.52 
-     - 52 
-     - 768 
-     - 51.2 TB
-   * - BM.HPC2.36 
-     - 36 
-     - 384 
-     - 6.7 TB
+
 


### PR DESCRIPTION
Adds support for VM.DenseIO.E5.Flex.

Fixes https://scylladb.atlassian.net/browse/RELENG-562

The support was added in 2026.2, so this PR must be backported to branch-2026.2.