### PR TITLE
test.py: reduce resource metrics gathering overhead

### DIFF
--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -384,11 +384,12 @@ class SystemResourceMonitor:
     def _monitor_resources(self, tmpdir: Path) -> None:
         sqlite_writer = SQLiteWriter(tmpdir / DEFAULT_DB_NAME)
         try:
-            while not self.stop_event.is_set():
+            _ = psutil.cpu_percent()  # first non-blocking call returns meaningless 0.0. Skip it.
+            while not self.stop_event.wait(timeout=2.0):
                 vm = psutil.virtual_memory()
                 timeline_record = SystemResourceMetric(
                     host_id=HOST_ID,
-                    cpu=psutil.cpu_percent(interval=0.1),
+                    cpu=psutil.cpu_percent(),
                     memory_free=vm.free,
                     memory_available=vm.available,
                     memory_used=vm.used,
@@ -398,8 +399,5 @@ class SystemResourceMonitor:
                     timestamp=datetime.now(),
                 )
                 sqlite_writer.write_row(timeline_record, SYSTEM_RESOURCE_METRICS_TABLE)
-
-                # Control the frequency of updates, for example, every 2 seconds
-                sleep(2)
         finally:
             sqlite_writer.close()

--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -279,13 +279,16 @@ def _is_cgroup_rw() -> bool:
     return False
 
 def propagate_subtree_controls(group: Path):
-    with open(group / 'cgroup.controllers', 'r') as f:
-        controllers = f.readline().strip()
-    if not controllers:
-        return
-    controllers = " ".join(map(lambda x: f"+{x}", controllers.split(" ")))
-    with open(group / 'cgroup.subtree_control', 'w') as f:
-        f.write(controllers)
+    # Only enable the memory controller. cpu.stat is available without
+    # enabling the cpu controller (it's base cgroup v2 accounting).
+    # Enabling all controllers (cpu, io, pids, etc.) adds unnecessary
+    # per-operation kernel overhead to child processes - in particular,
+    # the io controller adds accounting to every I/O operation.
+    with open(group / "cgroup.controllers", "r") as f:
+        if "memory" not in f.readline().split():
+            return
+    with open(group / "cgroup.subtree_control", "w") as f:
+        f.write("+memory")
 
 
 def setup_cgroup(is_required: bool) -> None:

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -304,8 +304,11 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         if not is_xdist_worker and SCYLLA_TEST_CGROUP_BASE_ENV not in os.environ:
             setup_cgroup(is_required=True)
         setup_worker_cgroup()
-        _system_resource_monitor = SystemResourceMonitor(temp_dir)
-        _system_resource_monitor.start()
+        # System-wide resource metrics (CPU%, memory) are identical from any process.
+        # Only the master needs to record them.
+        if not is_xdist_worker:
+            _system_resource_monitor = SystemResourceMonitor(temp_dir)
+            _system_resource_monitor.start()
 
 
 


### PR DESCRIPTION
Only enable the memory controller in cgroup subtree_control instead of all available controllers. cpu.stat is available in cgroup v2 without enabling the cpu controller (base accounting), and enabling io/pids/cpu controllers adds unnecessary per-operation kernel overhead to Scylla processes - particularly the memory controller's per-page-cache-operation accounting combined with io controller overhead during heavy I/O.

Additionally, restrict SystemResourceMonitor to the master process only. System-wide metrics (CPU%, memory) are identical from any process, so running a monitoring thread in each xdist worker was redundant and added unnecessary SQLite write contention and thread scheduling noise.

Replace cpu_percent(interval=0.1) with a non-blocking cpu_percent()
that returns CPU% since the previous call. Use stop_event.wait(timeout=2.0) as the
loop control to both space out iterations and allow immediate shutdown responsiveness.

Fixes SCYLLADB-2141