### PR TITLE
utils/serialized_action: harden shutdown synchronization

### DIFF
--- a/utils/serialized_action.hh
+++ b/utils/serialized_action.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <functional>
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_future.hh>
@@ -25,6 +26,7 @@ private:
     std::function<future<>()> _func;
     seastar::shared_future<> _pending;
     seastar::semaphore _sem;
+    bool _join_called = false;
 private:
     future<> do_trigger() {
         _pending = {};
@@ -46,6 +48,9 @@ public:
     // When action is not currently running, it is started immediately if !later or
     // at some point in time soon after current fiber defers when later is true.
     future<> trigger(bool later = false, seastar::abort_source* as = nullptr) {
+        if (_join_called) {
+            return seastar::make_exception_future<>(seastar::broken_semaphore());
+        }
         if (_pending.valid()) {
             return as ? _pending.get_future(*as) : _pending.get_future();
         }
@@ -98,9 +103,12 @@ public:
         return trigger(true);
     }
 
-    // Waits for all invocations initiated in the past.
+    // Waits for all invocations initiated in the past, including
+    // those pending in the queue at the time of the call.
     future<> join() {
-        return get_units(_sem, 1).discard_result();
+        _join_called = true;
+        auto units = co_await get_units(_sem, 1);
+        _sem.broken();
     }
 
     // The adaptor is to be used as an argument to utils::observable.observe()
@@ -117,7 +125,11 @@ public:
 
     public:
         template <typename... Args>
-        void operator()(Args&&...) { (void)_action.trigger(); };
+        void operator()(Args&&...) {
+            (void)_action.trigger().handle_exception_type([] (const seastar::broken_semaphore&) {
+                // Avoid an ignored exceptional future warning for notifications after join() starts.
+            });
+        };
     };
 
     observing_adaptor make_observer() noexcept {

--- a/utils/serialized_action.hh
+++ b/utils/serialized_action.hh
@@ -64,7 +64,7 @@ public:
         }
 
         // run in background, synchronize using `ret`
-        (void)_sem.wait().then([this, later] () mutable {
+        (void)with_semaphore(_sem, 1, [this, later] () mutable {
             if (later) {
                 return seastar::yield().then([this] () mutable {
                     return do_trigger();
@@ -77,10 +77,6 @@ public:
             } else {
                 pr.set_value();
             }
-        });
-
-        ret = ret.finally([this] {
-            _sem.signal();
         });
 
         if (abortable) {


### PR DESCRIPTION
## Problem

`serialized_action::join()` is used as a shutdown barrier. After it returns, callers commonly destroy the owning object, and action lambdas often capture that owner by `this`.

The previous implementation waited for the internal semaphore once. This handles actions that are already running or triggers already queued before `join()`, because Seastar semaphores serve waiters FIFO. The problematic case is a late `trigger()` after `join()` has started while an older action is still running. Such a trigger can queue behind `join()`, allowing `join()` to return before that late trigger runs.

Review also found a separate semaphore bookkeeping bug in `trigger()`. The code manually waited on the semaphore and later signaled it through the caller-visible pending future. If the wait itself completed exceptionally, the signal path could still run and give back a semaphore unit that had never been acquired.

## Fix

Make `join()` a terminal operation for `serialized_action`. Once `join()` starts, new `trigger()` calls fail with `broken_semaphore`. `join()` still waits for work that was accepted before it started, and only then breaks the semaphore so later waiters are rejected.

I audited the existing `serialized_action` users. Some callers explicitly remove trigger sources before `join()`, such as audit and topology_coordinator. Others rely on observer destruction or broader shutdown ordering, such as database, compaction_manager, io_throughput_updater, and schema_push. The least locally fenced case is `migration_manager::_group0_barrier`, which is reachable through several external paths, including task status lookup and other services. That makes this better enforced in `serialized_action` itself rather than relying on each caller to prove all trigger entrances are closed.

This is generic hardening of the shutdown contract, not a fix for a confirmed topology_coordinator-specific reproducer.

Also restore acquire/release ownership in `trigger()` by using `with_semaphore()`. This keeps semaphore release tied to successful acquisition while preserving the existing behavior where action completion and action errors are reported through the shared pending future.

Refs SCYLLADB-1904

No backport: this is generic shutdown hardening without a confirmed user-visible reproducer. The semaphore bookkeeping fix closes a latent exceptional wait path noticed during review, not a known production failure.
