### PR TITLE
sstables_loader: hold token_metadata_ptr to prevent use-after-free in tablet_restore_task_impl::run()

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1198,7 +1198,12 @@ protected:
 
         auto& db = loader._db.local();
         auto s = db.find_schema(_tid);
-        const auto& topo = db.get_token_metadata().get_topology();
+        // Hold the token_metadata_ptr on the coroutine frame so the ref count keeps it alive
+        // across co_await suspension points. Without this, token_metadata can be replaced and
+        // cleared (via clear_gently) while the loop iterator still references its topology data.
+        // Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2149
+        auto md = db.get_token_metadata_ptr();
+        const auto& topo = md->get_topology();
         auto dc = topo.get_datacenter();
 
         for (const auto& rack : topo.get_datacenter_racks().at(dc) | std::views::keys) {


### PR DESCRIPTION
`tablet_restore_task_impl::run()` iterates `topo.get_datacenter_racks().at(dc) | std::views::keys` in a range-based for loop that contains a `co_await` in its body. The original code obtained `topo` as a raw `const auto&` from the temporary `lw_shared_ptr` returned by `get_token_metadata()` — the temporary was destroyed immediately, leaving no ref count to keep `token_metadata` alive.

### Problem

When the coroutine suspends at the inner `co_await get_snapshot_sstables(...)`, a Raft topology update can run on the reactor. `shared_token_metadata::set()` replaces the current metadata; the old one's ref count drops to 0, its destructor fires `clear_and_dispose_impl()`, and `topology::clear_gently()` starts erasing nodes from `_dc_racks` as a background fire-and-forget future (with yields between batches). When the coroutine resumes and the for-loop advances its iterator, the hash-node pointer references freed memory — heap-use-after-free, ASan abort, server crash.

Seen as 2 failures in 10,000 runs of `test_restore_tablets[gs-topology1]` (BYO #4028, aarch64 debug):

```
AddressSanitizer: heap-use-after-free on address 0xfc7fa5a30a20
READ of size 8 — _Node_const_iterator::operator++()
  sstables_loader::tablet_restore_task_impl::run() (.resume)  sstables_loader.cc:1204
freed by: utils::clear_gently<unordered_map<sstring, unordered_set<host_id>>>
```

### Changes

Store `db.get_token_metadata_ptr()` in a local variable `md` on the coroutine frame. Coroutine locals survive across all suspension points, so the elevated ref count keeps `token_metadata` (and its `_dc_racks`) alive for the entire duration of the loop — no data copying, existing range iteration unchanged.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2149

No backport needed since it is TAR change which is not operational yet