### PR TITLE
Add `BM25()` scoring expression for fulltext search queries

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -386,7 +386,7 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
         bool bypass_cache = false;
         auto attrs = std::make_unique<cql3::attributes::raw>();
         expression wclause = conjunction{};
-        bool is_ann_ordering = false;
+        bool is_similarity_ordering = false;
     }
     : K_SELECT (
                 ( (K_JSON K_DISTINCT)=> K_JSON { statement_subtype = raw::select_statement::parameters::statement_subtype::JSON; }
@@ -401,7 +401,7 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
              )
       ( K_WHERE w=whereClause { wclause = std::move(w); } )?
       ( K_GROUP K_BY gbcolumns=listOfIdentifiers)?
-      ( K_ORDER K_BY orderByClause[orderings, is_ann_ordering] ( ',' orderByClause[orderings, is_ann_ordering] )* )?
+      ( K_ORDER K_BY orderByClause[orderings, is_similarity_ordering] ( ',' orderByClause[orderings, is_similarity_ordering] )* )?
       ( K_PER K_PARTITION K_LIMIT rows=intValue { per_partition_limit = std::move(rows); } )?
       ( K_LIMIT rows=intValue { limit = std::move(rows); } )?
       ( K_ALLOW K_FILTERING  { allow_filtering = true; } )?
@@ -459,15 +459,24 @@ whereClause returns [uexpression clause]
         { clause = conjunction{std::move(terms)}; }
     ;
 
-orderByClause[raw::select_statement::parameters::orderings_type& orderings, bool& is_ann_ordering]
+orderByClause[raw::select_statement::parameters::orderings_type& orderings, bool& is_similarity_ordering]
     @init{
         raw::select_statement::ordering ordering = raw::select_statement::ordering::ascending;
         std::optional<expression> ann_ordering;
     }
-    : c=cident (K_ANN K_OF t=term {ann_ordering=std::move(t);})? (K_ASC | K_DESC { ordering = raw::select_statement::ordering::descending; })?
+    : K_BM25 '(' c=cident ',' t=term ')'
+    {
+        if (!orderings.empty()) {
+            throw exceptions::invalid_request_exception(
+                "BM25 ordering does not support any other ordering");
+        }
+        is_similarity_ordering = true;
+        orderings.emplace_back(c, raw::select_statement::bm25_ordering{std::move(t)});
+    }
+    | c=cident (K_ANN K_OF t=term {ann_ordering=std::move(t);})? (K_ASC | K_DESC { ordering = raw::select_statement::ordering::descending; })?
     {
         if (!ann_ordering) {
-            if (is_ann_ordering) {
+            if (is_similarity_ordering) {
                 throw exceptions::invalid_request_exception(
                     "ANN ordering does not support any other ordering");
             }
@@ -478,7 +487,7 @@ orderByClause[raw::select_statement::parameters::orderings_type& orderings, bool
                     "Descending ANN ordering is not supported");
             }
             if (!orderings.empty()) {
-                if (is_ann_ordering) {
+                if (is_similarity_ordering) {
                     throw exceptions::invalid_request_exception(
                         "Cannot specify more than one ANN ordering");
                 } else {
@@ -486,7 +495,7 @@ orderByClause[raw::select_statement::parameters::orderings_type& orderings, bool
                         "ANN ordering does not support any other ordering");
                 }
             }
-            is_ann_ordering = true;
+            is_similarity_ordering = true;
             orderings.emplace_back(c, ann_ordering.value());
         }
     }
@@ -1891,6 +1900,11 @@ relation returns [uexpression e]
         }); }
     | name=cident K_CONTAINS { rt = oper_t::CONTAINS; } (K_KEY { rt = oper_t::CONTAINS_KEY; })?
         t=term { $e = binary_operator(unresolved_identifier{std::move(name)}, rt, std::move(t)); }
+    | K_BM25 '(' name=cident ',' t=term ')' type=relationType threshold=term
+        { $e = binary_operator(
+            bm25_call{unresolved_identifier{std::move(name)}, std::move(t)},
+            type,
+            std::move(threshold)); }
     | name=cident '[' key=term ']' type=relationType t=term { $e = binary_operator(subscript{.val = unresolved_identifier{std::move(name)}, .sub = std::move(key)}, type, std::move(t)); }
     | ids=tupleOfIdentifiers
       ( K_IN
@@ -2406,6 +2420,8 @@ K_SCYLLA_CLUSTERING_BOUND: S C Y L L A '_' C L U S T E R I N G '_' B O U N D;
 K_GROUP:       G R O U P;
 
 K_LIKE:        L I K E;
+
+K_BM25:        B M '2' '5';
 
 K_TIMEOUT:     T I M E O U T;
 K_PRUNE:       P R U N E;

--- a/cql3/expr/expr-utils.hh
+++ b/cql3/expr/expr-utils.hh
@@ -123,6 +123,8 @@ inline bool is_compare(oper_t op) {
 bool is_token_function(const function_call&);
 bool is_token_function(const expression&);
 
+bool has_bm25_function(const expression&);
+
 bool is_partition_token_for_schema(const function_call&, const schema&);
 bool is_partition_token_for_schema(const expression&, const schema&);
 

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -832,6 +832,9 @@ auto fmt::formatter<cql3::expr::expression::printer>::format(const cql3::expr::e
             },
             [&] (const temporary& t) {
                 out = fmt::format_to(out, "@temporary{}", t.index);
+            },
+            [&] (const bm25_call& bm) {
+                out = fmt::format_to(out, "BM25({}, {})", to_printer(bm.column), to_printer(bm.query_term));
             }
         }, pr.expr_to_print);
     return out;
@@ -965,6 +968,9 @@ bool recurse_until(const expression& e, const noncopyable_function<bool (const e
                 }
                 return false;
             },
+            [&] (const bm25_call& bm) {
+                return recurse_until(bm.column, predicate_fun) || recurse_until(bm.query_term, predicate_fun);
+            },
             [](LeafExpression auto const&) {
                 return false;
             }
@@ -1039,6 +1045,9 @@ expression search_and_replace(const expression& e,
                         .sub = recurse(s.sub),
                         .type = s.type,
                     };
+                },
+                [&] (const bm25_call& bm) -> expression {
+                    return bm25_call{recurse(bm.column), recurse(bm.query_term)};
                 },
                 [&] (LeafExpression auto const& e) -> expression {
                     return e;
@@ -1336,6 +1345,12 @@ static
 cql3::raw_value
 do_evaluate(const temporary& t, const evaluation_inputs& inputs) {
     return inputs.temporaries[t.index];
+}
+
+static
+cql3::raw_value
+do_evaluate(const bm25_call&, const evaluation_inputs&) {
+    on_internal_error(expr_logger, "BM25 expression cannot be evaluated directly - it is handled by the fulltext index");
 }
 
 cql3::raw_value evaluate(const expression& e, const evaluation_inputs& inputs) {
@@ -1915,6 +1930,10 @@ void fill_prepare_context(expression& e, prepare_context& ctx) {
         [](untyped_constant&) {},
         [](constant&) {},
         [](temporary&) {},
+        [&](bm25_call& bm) {
+            fill_prepare_context(bm.column, ctx);
+            fill_prepare_context(bm.query_term, ctx);
+        },
     }, e);
 }
 
@@ -1989,6 +2008,9 @@ type_of(const expression& e) {
                     return t;
                 },
             }, e.type);
+        },
+        [] (const bm25_call&) -> data_type {
+            return float_type;
         },
         [] (const ExpressionElement auto& e) -> data_type {
             return e.type;
@@ -2190,6 +2212,10 @@ bool is_token_function(const expression& e) {
     return is_token_function(*fun_call);
 }
 
+bool has_bm25_function(const expression& e) {
+    return find_binop(e, [](const binary_operator& o) { return is<bm25_call>(o.lhs); });
+}
+
 bool is_partition_token_for_schema(const function_call& fun_call, const schema& table_schema) {
     if (!is_token_function(fun_call)) {
         return false;
@@ -2276,6 +2302,9 @@ aggregation_depth(const cql3::expr::expression& e) {
         [] (const field_selection& fs) {
             return aggregation_depth(fs.structure);
         },
+        [] (const bm25_call&) {
+            return 0u;
+        },
         [] (const LeafExpression auto&) {
             return 0u;
         },
@@ -2361,6 +2390,9 @@ levellize_aggregation_depth(const cql3::expr::expression& e, unsigned desired_de
         [&] (field_selection fs) -> expression {
             recurse(fs.structure);
             return fs;
+        },
+        [&] (bm25_call bm) -> expression {
+            return bm;
         },
         [&] (LeafExpression auto leaf) -> expression {
             return leaf;

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -72,6 +72,7 @@ struct tuple_constructor;
 struct collection_constructor;
 struct usertype_constructor;
 struct temporary;
+struct bm25_call;
 
 template <typename T>
 concept ExpressionElement
@@ -91,6 +92,7 @@ concept ExpressionElement
         || std::same_as<T, collection_constructor>
         || std::same_as<T, usertype_constructor>
         || std::same_as<T, temporary>
+        || std::same_as<T, bm25_call>
         ;
 
 template <typename Func>
@@ -111,6 +113,7 @@ concept invocable_on_expression
         && std::invocable<Func, collection_constructor>
         && std::invocable<Func, usertype_constructor>
         && std::invocable<Func, temporary>
+        && std::invocable<Func, bm25_call>
         ;
 
 template <typename Func>
@@ -131,6 +134,7 @@ concept invocable_on_expression_ref
         && std::invocable<Func, collection_constructor&>
         && std::invocable<Func, usertype_constructor&>
         && std::invocable<Func, temporary&>
+        && std::invocable<Func, bm25_call&>
         ;
 
 /// A CQL expression -- union of all possible expression types.
@@ -463,13 +467,29 @@ struct temporary {
     data_type type;
 };
 
+// BM25 fulltext scoring call.
+// Represents BM25(column, query_term) in WHERE and ORDER BY clauses.
+// This is a planner directive — it's never evaluated at runtime.
+// The fulltext index performs the actual BM25 scoring.
+// Before preparation, `column` is an unresolved_identifier.
+// After preparation, `column` is a column_value.
+struct bm25_call {
+    expression column;
+    expression query_term;
+
+    friend bool operator==(const bm25_call& a, const bm25_call& b) {
+        return a.column == b.column && a.query_term == b.query_term;
+    }
+};
+
 // now that all expression types are fully defined, we can define expression::impl
 struct expression::impl final {
     using variant_type = std::variant<
             conjunction, binary_operator, column_value, unresolved_identifier,
             column_mutation_attribute, function_call, cast, field_selection,
             bind_variable, untyped_constant, constant, tuple_constructor,
-            collection_constructor, usertype_constructor, subscript, temporary>;
+            collection_constructor, usertype_constructor, subscript, temporary,
+            bm25_call>;
     variant_type v;
     impl(variant_type v) : v(std::move(v)) {}
 };

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1397,6 +1397,26 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
         [&] (const function_call& fc) -> std::optional<expression> {
             return prepare_function_call(fc, db, keyspace, schema_opt, std::move(receiver));
         },
+        [&] (const bm25_call& bm) -> std::optional<expression> {
+            if (!schema_opt) {
+                throw exceptions::invalid_request_exception("BM25 requires a schema context");
+            }
+            // Prepare the column argument
+            auto prepared_col = try_prepare_expression(bm.column, db, keyspace, schema_opt, nullptr);
+            if (!prepared_col) {
+                throw exceptions::invalid_request_exception("Could not resolve column argument of BM25");
+            }
+            // Prepare the query term argument - it should be text type
+            auto text_receiver = make_lw_shared<column_specification>(
+                keyspace, schema_opt->cf_name(),
+                ::make_shared<column_identifier>("bm25_query", true),
+                expr::type_of(*prepared_col));
+            auto prepared_term = try_prepare_expression(bm.query_term, db, keyspace, schema_opt, text_receiver);
+            if (!prepared_term) {
+                throw exceptions::invalid_request_exception("Could not resolve query term argument of BM25");
+            }
+            return bm25_call{std::move(*prepared_col), std::move(*prepared_term)};
+        },
         [&] (const cast& c) -> std::optional<expression> {
             return cast_prepare_expression(c, db, keyspace, schema_opt, receiver);
         },
@@ -1502,6 +1522,9 @@ test_assignment(const expression& expr, data_dictionary::database db, const sstr
         [&] (const usertype_constructor& uc) -> test_result {
             return usertype_constructor_test_assignment(uc, db, keyspace, schema_opt, receiver);
         },
+        [&] (const bm25_call&) -> test_result {
+            on_internal_error(expr_logger, "bm25_call is not yet reachable via test_assignment()");
+        },
         [&] (const temporary& t) -> test_result {
             on_internal_error(expr_logger, "temporary found in test_assignment, should have been introduced post-prepare");
         },
@@ -1601,6 +1624,9 @@ test_assignment_any_size_float_vector(const expression& expr) {
             on_internal_error(expr_logger, fmt::format("unexpected collection_constructor style {}", static_cast<unsigned>(c.style)));
         },
         [&] (const usertype_constructor& uc) -> test_result {
+            return NOT_ASSIGNABLE;
+        },
+        [&] (const bm25_call&) -> test_result {
             return NOT_ASSIGNABLE;
         },
         [&] (const temporary& t) -> test_result {
@@ -1740,6 +1766,13 @@ static lw_shared_ptr<column_specification> get_lhs_receiver(const expression& pr
                 schema.ks_name(), schema.cf_name(),
                 ::make_shared<column_identifier>(format("{:user}", fun_call), true),
                 return_type);
+        },
+        [&](const bm25_call&) -> lw_shared_ptr<column_specification> {
+            return make_lw_shared<column_specification>(
+                schema.ks_name(),
+                schema.cf_name(),
+                ::make_shared<column_identifier>("bm25", true),
+                float_type);
         },
         [](const auto& other) -> lw_shared_ptr<column_specification> {
             on_internal_error(expr_logger, format("get_lhs_receiver: unexpected expression: {}", other));

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -254,6 +254,15 @@ binary_operator validate_and_prepare_new_restriction(const binary_operator& rest
         // Token restriction
         std::vector<const column_definition*> column_defs = to_column_definitions(as<function_call>(prepared_binop.lhs).args);
         validate_token_relation(column_defs, prepared_binop.op, *schema);
+    } else if (auto* bm = as_if<bm25_call>(&prepared_binop.lhs)) {
+        // BM25 fulltext scoring restriction - validate the column argument
+        const auto* col = as_if<column_value>(&bm->column);
+        if (!col) {
+            throw exceptions::invalid_request_exception("First argument to BM25 must be a column");
+        }
+        if (prepared_binop.op == oper_t::LIKE) {
+            throw exceptions::invalid_request_exception("LIKE cannot be used with BM25");
+        }
     } else {
         // Anything else
         throw exceptions::invalid_request_exception(

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -554,6 +554,29 @@ to_predicates(
                         [&] (const temporary&) -> std::vector<predicate> {
                             return cannot_solve(oper);
                         },
+                        [&] (const bm25_call& bm) -> std::vector<predicate> {
+                            // BM25(col, query_term) > threshold
+                            const auto* col = as_if<column_value>(&bm.column);
+                            if (!col) {
+                                return cannot_solve(oper);
+                            }
+                            auto solve = [oper] (const query_options& options) {
+                                managed_bytes_opt val = evaluate(oper.rhs, options).to_managed_bytes_opt();
+                                if (!val) {
+                                    return empty_value_set;
+                                }
+                                return value_set(value_list{*val});
+                            };
+                            return to_vector(predicate{
+                                .solve_for = std::move(solve),
+                                .filter = oper,
+                                .on = on_column{col->col},
+                                .is_singleton = false,
+                                .order = oper.order,
+                                .op = oper.op,
+                                .is_bm25 = true,
+                            });
+                        },
                     }, oper.lhs);
                 },
             [] (const column_value& cv) -> std::vector<predicate> {
@@ -591,6 +614,9 @@ to_predicates(
             },
             [] (const usertype_constructor& uc) -> std::vector<predicate> {
                 return cannot_solve(uc);
+            },
+            [] (const bm25_call& bm) -> std::vector<predicate> {
+                return cannot_solve(bm);
             },
             [] (const temporary& t) -> std::vector<predicate> {
                 return cannot_solve(t);
@@ -676,6 +702,9 @@ is_predicate_supported_by(const predicate& pred, const secondary_index::index& i
     }
     return std::visit(overloaded_functor{
         [&] (const on_column& oc) -> ret_t {
+            if (pred.is_bm25) {
+                return idx.supports_bm25_expression(*oc.column);
+            }
             if (pred.is_subscript) {
                 return idx.supports_subscript_expression(*oc.column, *pred.op);
             }
@@ -1112,6 +1141,7 @@ statement_restrictions::statement_restrictions(private_tag,
         }
     }
     _has_multi_column = has_mc_clustering;
+    bool has_queriable_fulltext_index = false;
     if (_check_indexes) {
         auto cf = db.find_column_family(schema);
         auto& sim = cf.get_index_manager();
@@ -1129,6 +1159,16 @@ statement_restrictions::statement_restrictions(private_tag,
                 && index_supports_some_column(sc_pk_pred_vectors, sim, allow_local)
                 && !type.is_delete();
         _has_queriable_regular_index = index_supports_some_column(sc_nonpk_pred_vectors, sim, allow_local)
+                && !type.is_delete();
+        single_column_predicate_vectors sc_nonpk_match_pred_vectors;
+        for (const auto& [col, preds] : sc_nonpk_pred_vectors) {
+            for (const auto& pred : preds) {
+                if (pred.is_bm25) {
+                    sc_nonpk_match_pred_vectors[col].push_back(pred);
+                }
+            }
+        }
+        has_queriable_fulltext_index = index_supports_some_column(sc_nonpk_match_pred_vectors, sim, allow_local)
                 && !type.is_delete();
     } else {
         _has_queriable_ck_index = false;
@@ -1183,6 +1223,10 @@ statement_restrictions::statement_restrictions(private_tag,
     }
 
     if (!is_empty_restriction(_nonprimary_key_restrictions)) {
+        if (has_bm25_restriction() && !has_queriable_fulltext_index) {
+            throw exceptions::invalid_request_exception(
+                "No fulltext index found for FTS query");
+        }
         if (_has_queriable_regular_index && _partition_range_is_simple) {
             _uses_secondary_indexing = true;
         } else if (!allow_filtering && !type.is_delete() && !type.is_update()) {
@@ -1304,6 +1348,13 @@ statement_restrictions::clustering_key_restrictions_has_only_eq() const {
 bool
 statement_restrictions::has_token_restrictions() const {
     return has_partition_token(_partition_key_restrictions, *_schema);
+}
+
+bool
+statement_restrictions::has_bm25_restriction() const {
+    return expr::has_bm25_function(_nonprimary_key_restrictions)
+        || expr::has_bm25_function(_clustering_columns_restrictions)
+        || expr::has_bm25_function(_partition_key_restrictions);
 }
 
 bool

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -88,6 +88,7 @@ struct predicate {
     expr::comparison_order order = expr::comparison_order::cql;
     std::optional<expr::oper_t> op;  // the binary operator, if any
     bool is_subscript = false;       // whether the LHS is a subscript (map element access)
+    bool is_bm25 = false;            // whether the LHS is a BM25 function call
 };
 
 ///In some cases checking if columns have indexes is undesired of even
@@ -306,6 +307,8 @@ public:
     bool uses_secondary_indexing() const {
         return _uses_secondary_indexing;
     }
+
+    bool has_bm25_restriction() const;
 
     const expr::expression& get_partition_key_restrictions() const {
         return _partition_key_restrictions;

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -76,6 +76,9 @@ selectable_processes_selection(const expr::expression& selectable) {
         [&] (const expr::usertype_constructor&) -> bool {
             on_internal_error(slogger, "collection_constructor found its way to selector context");
         },
+        [&] (const expr::bm25_call&) -> bool {
+            on_internal_error(slogger, "bm25_call found its way to selector context");
+        },
         [&] (const expr::temporary& t) -> bool {
             // Well it doesn't process the selection, but it's not bypasses the selection completely
             // so we can't use the fast path. In any case it won't be seen.

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -46,7 +46,11 @@ public:
     // Vector of floats with dimension the same as the vector indexed column.
     // This vector is the target for the nearest neighbors in ANN queries.
     using ann_vector = expr::expression;
-    using ordering_type = std::variant<ordering, ann_vector>;
+    // BM25 ordering stores the query term for fulltext scoring.
+    struct bm25_ordering {
+        expr::expression query_term;
+    };
+    using ordering_type = std::variant<ordering, ann_vector, bm25_ordering>;
     class parameters final {
     public:
         using orderings_type = std::vector<std::pair<shared_ptr<column_identifier::raw>, ordering_type>>;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2236,6 +2236,127 @@ future<::shared_ptr<cql_transport::messages::result_message>> vector_indexed_tab
             }));
 }
 
+static std::optional<bm25_ordering_info> get_bm25_ordering_info(
+        data_dictionary::database db,
+        schema_ptr schema,
+        lw_shared_ptr<const raw::select_statement::parameters> parameters,
+        prepare_context& ctx) {
+
+    if (parameters->orderings().empty()) {
+        return std::nullopt;
+    }
+
+    auto [column_id, ordering] = parameters->orderings().front();
+    auto* bm25_ord = std::get_if<raw::select_statement::bm25_ordering>(&ordering);
+    if (!bm25_ord) {
+        return std::nullopt;
+    }
+
+    ::shared_ptr<column_identifier> column = column_id->prepare_column_identifier(*schema);
+    const column_definition* def = schema->get_column_definition(column->name());
+    if (!def) {
+        throw exceptions::invalid_request_exception(
+                fmt::format("Undefined column name {} in ORDER BY BM25", column->text()));
+    }
+
+    auto query_term_receiver = make_lw_shared<column_specification>(
+            schema->ks_name(), schema->cf_name(), column, def->type);
+    auto query_term = expr::prepare_expression(bm25_ord->query_term, db, schema->ks_name(), schema.get(), query_term_receiver);
+    expr::fill_prepare_context(query_term, ctx);
+
+    auto cf = db.find_column_family(schema);
+    auto& sim = cf.get_index_manager();
+
+    for (const auto& idx : sim.list_indexes()) {
+        if (idx.supports_bm25_expression(*def)) {
+            return bm25_ordering_info{idx};
+        }
+    }
+
+    throw exceptions::invalid_request_exception("No fulltext index found for FTS query");
+}
+
+::shared_ptr<cql3::statements::select_statement> fulltext_indexed_table_select_statement::prepare(data_dictionary::database db,
+        schema_ptr schema, uint32_t bound_terms, lw_shared_ptr<const parameters> parameters,
+        ::shared_ptr<selection::selection> selection, ::shared_ptr<const restrictions::statement_restrictions> restrictions,
+        ::shared_ptr<std::vector<size_t>> group_by_cell_indices, bool is_reversed,
+        ordering_comparator_type ordering_comparator, std::optional<expr::expression> limit,
+        std::optional<expr::expression> per_partition_limit, cql_stats& stats,
+        std::optional<bm25_ordering_info> ordering_info,
+        std::unique_ptr<attributes> attrs) {
+
+    auto& sim = db.find_column_family(schema).get_index_manager();
+    auto [where_index_opt, _] = restrictions->find_idx(sim);
+
+    auto index_opt = ordering_info
+            ? std::optional{std::move(ordering_info->index)}
+            : std::move(where_index_opt);
+
+    if (!index_opt) {
+        throw exceptions::invalid_request_exception("No fulltext index found for FTS query");
+    }
+
+    return ::make_shared<cql3::statements::fulltext_indexed_table_select_statement>(
+            schema,
+            bound_terms,
+            parameters,
+            std::move(selection),
+            std::move(restrictions),
+            std::move(group_by_cell_indices),
+            is_reversed,
+            std::move(ordering_comparator),
+            std::move(limit),
+            std::move(per_partition_limit),
+            stats,
+            *index_opt,
+            std::move(attrs));
+}
+
+fulltext_indexed_table_select_statement::fulltext_indexed_table_select_statement(schema_ptr schema, uint32_t bound_terms,
+        lw_shared_ptr<const parameters> parameters, ::shared_ptr<selection::selection> selection,
+        ::shared_ptr<const restrictions::statement_restrictions> restrictions,
+        ::shared_ptr<std::vector<size_t>> group_by_cell_indices, bool is_reversed,
+        ordering_comparator_type ordering_comparator, std::optional<expr::expression> limit,
+        std::optional<expr::expression> per_partition_limit, cql_stats& stats,
+        const secondary_index::index& index,
+        std::unique_ptr<attributes> attrs)
+    : select_statement{schema, bound_terms, parameters, selection, restrictions, group_by_cell_indices,
+              is_reversed, ordering_comparator, limit, per_partition_limit, stats, std::move(attrs)}
+    , _index{index} {
+
+    if (!limit.has_value()) {
+        throw exceptions::invalid_request_exception("FTS queries require a LIMIT");
+    }
+
+    if (per_partition_limit.has_value()) {
+        throw exceptions::invalid_request_exception("FTS queries do not support per-partition limits");
+    }
+
+    if (selection->is_aggregate()) {
+        throw exceptions::invalid_request_exception("FTS queries cannot be run with aggregation");
+    }
+}
+
+future<shared_ptr<cql_transport::messages::result_message>> fulltext_indexed_table_select_statement::do_execute(
+        query_processor& qp, service::query_state& state, const query_options& options) const {
+    // Fulltext search execution is not yet implemented.
+    // Query with empty partition ranges to return an empty result set with the correct metadata.
+    auto slice = make_partition_slice(options);
+    auto max_size = qp.proxy().get_max_result_size(slice);
+    auto cmd = ::make_lw_shared<query::read_command>(_schema->id(), _schema->version(),
+            std::move(slice),
+            max_size,
+            query::tombstone_limit(qp.proxy().get_tombstone_limit()));
+    co_return co_await qp.proxy()
+            .query_result(_schema, cmd, {}, options.get_consistency(),
+                    {db::timeout_clock::now() + get_timeout(state.get_client_state(), options),
+                     state.get_permit(), state.get_client_state(), state.get_trace_state()})
+            .then(wrap_result_to_error_message(
+                    [this, &cmd, &options](service::storage_proxy::coordinator_query_result qr) {
+                        return process_results(std::move(qr.query_result), cmd, options, gc_clock::now());
+                    }));
+}
+
 namespace raw {
 
 static void validate_attrs(const cql3::attributes::raw& attrs) {
@@ -2329,6 +2450,9 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     std::optional<ann_ordering_info> ann_ordering_info_opt = get_ann_ordering_info(db, schema, _parameters, ctx);
     bool is_ann_query = ann_ordering_info_opt.has_value();
 
+    std::optional<bm25_ordering_info> bm25_ordering_info_opt = get_bm25_ordering_info(db, schema, _parameters, ctx);
+    bool has_bm25_ordering = bm25_ordering_info_opt.has_value();
+
     if (prepared_selectors.empty() && (!_group_by_columns.empty() || (is_ann_query && ann_ordering_info_opt->is_rescoring_enabled))) {
         // We have a "SELECT * GROUP BY" or "SELECT * ORDER BY ANN" with rescoring enabled. If we leave prepared_selectors
         // empty, below we choose selection::wildcard() for SELECT *, and either:
@@ -2390,8 +2514,10 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
         throw exceptions::invalid_request_exception("PER PARTITION LIMIT is not allowed with aggregate queries.");
     }
 
-    auto restrictions = prepare_restrictions(db, schema, ctx, selection, for_view, _parameters->allow_filtering() || is_ann_query,
+    auto restrictions = prepare_restrictions(db, schema, ctx, selection, for_view, _parameters->allow_filtering() || is_ann_query || has_bm25_ordering,
             restrictions::check_indexes(!_parameters->is_mutation_fragments()));
+
+    bool is_fts_query = restrictions->has_bm25_restriction() || has_bm25_ordering;
 
     if (_parameters->is_distinct()) {
         validate_distinct_selection(*schema, *selection, *restrictions);
@@ -2401,10 +2527,10 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
 
     auto orderings = _parameters->orderings();
 
-    if (!orderings.empty() && !is_ann_query) {
+    if (!orderings.empty() && !is_ann_query && !is_fts_query) {
         std::visit([&](auto&& ordering) {
             using T = std::decay_t<decltype(ordering)>;
-            if constexpr (!std::is_same_v<T, select_statement::ann_vector>) {
+            if constexpr (!std::is_same_v<T, select_statement::ann_vector> && !std::is_same_v<T, raw::select_statement::bm25_ordering>) {
                 throwing_assert(!for_view);
                 verify_ordering_is_allowed(*_parameters, *restrictions);
                 prepared_orderings_type prepared_orderings = prepare_orderings(*schema);
@@ -2417,7 +2543,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     }
 
     std::vector<sstring> warnings;
-    if (!is_ann_query) {
+    if (!is_ann_query && !is_fts_query) {
         check_needs_filtering(*restrictions, cfg.strict_allow_filtering(), warnings);
         ensure_filtering_columns_retrieval(db, *selection, *restrictions);
     }
@@ -2518,6 +2644,22 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
         stmt = vector_indexed_table_select_statement::prepare(db, schema, ctx.bound_variables_size(), _parameters, std::move(selection), std::move(restrictions),
                 std::move(group_by_cell_indices), is_reversed_, std::move(ordering_comparator), std::move(ann_ordering_info_opt->_prepared_ann_ordering),
                 prepare_limit(db, ctx, _limit), prepare_limit(db, ctx, _per_partition_limit), stats, ann_ordering_info_opt->_index, std::move(prepared_attrs));
+    } else if (is_fts_query) {
+        stmt = fulltext_indexed_table_select_statement::prepare(
+            db,
+            schema,
+            ctx.bound_variables_size(),
+            _parameters,
+            std::move(selection),
+            std::move(restrictions),
+            std::move(group_by_cell_indices),
+            is_reversed_,
+            std::move(ordering_comparator),
+            prepare_limit(db, ctx, _limit),
+            prepare_limit(db, ctx, _per_partition_limit),
+            stats,
+            std::move(bm25_ordering_info_opt),
+            std::move(prepared_attrs));
     } else if (restrictions->uses_secondary_indexing()) {
         stmt = view_indexed_table_select_statement::prepare(
                 db,

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -404,5 +404,52 @@ private:
             std::vector<dht::partition_range> partition_ranges) const;
 };
 
+struct bm25_ordering_info {
+    secondary_index::index index;
+};
+
+class fulltext_indexed_table_select_statement : public select_statement {
+    secondary_index::index _index;
+
+public:
+    static ::shared_ptr<cql3::statements::select_statement> prepare(data_dictionary::database db,
+            schema_ptr schema,
+            uint32_t bound_terms,
+            lw_shared_ptr<const parameters> parameters,
+            ::shared_ptr<selection::selection> selection,
+            ::shared_ptr<const restrictions::statement_restrictions> restrictions,
+            ::shared_ptr<std::vector<size_t>> group_by_cell_indices,
+            bool is_reversed,
+            ordering_comparator_type ordering_comparator,
+            std::optional<expr::expression> limit,
+            std::optional<expr::expression> per_partition_limit,
+            cql_stats& stats,
+            std::optional<bm25_ordering_info> ordering_info,
+            std::unique_ptr<cql3::attributes> attrs);
+
+    fulltext_indexed_table_select_statement(schema_ptr schema,
+            uint32_t bound_terms,
+            lw_shared_ptr<const parameters> parameters,
+            ::shared_ptr<selection::selection> selection,
+            ::shared_ptr<const restrictions::statement_restrictions> restrictions,
+            ::shared_ptr<std::vector<size_t>> group_by_cell_indices,
+            bool is_reversed,
+            ordering_comparator_type ordering_comparator,
+            std::optional<expr::expression> limit,
+            std::optional<expr::expression> per_partition_limit,
+            cql_stats& stats,
+            const secondary_index::index& index,
+            std::unique_ptr<cql3::attributes> attrs);
+
+private:
+    future<::shared_ptr<cql_transport::messages::result_message>> do_execute(
+            query_processor& qp, service::query_state& state, const query_options& options) const override;
+
+    void update_stats_rows_read(int64_t rows_read) const override {
+        _stats.rows_read += rows_read;
+        _stats.secondary_index_rows_read += rows_read;
+    }
+};
+
 }
 }

--- a/docs/dev/fulltext_search.md
+++ b/docs/dev/fulltext_search.md
@@ -1,0 +1,120 @@
+# Fulltext search (FTS) in Scylla
+
+Scylla supports fulltext search through the `fulltext_index` custom index type.
+FTS queries use the `BM25` operator to find rows matching a text query
+and optionally rank them by relevance.
+
+## Index creation
+
+A fulltext index is a custom index registered under the class name `fulltext_index`:
+
+```cql
+CREATE CUSTOM INDEX ON ks.t (v) USING 'fulltext_index';
+CREATE CUSTOM INDEX ON ks.t (v) USING 'fulltext_index' WITH OPTIONS = {'analyzer': 'english'};
+```
+
+### Column restrictions
+
+Fulltext indexes can only be created on regular (non-primary-key) columns of type
+`text`, `varchar`, or `ascii`. Attempting to index a column of any other type or
+a primary key column is rejected at creation time.
+
+### Index options
+
+| Option      | Values                                                                                              | Description                                                                 |
+|-------------|------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+| `analyzer`  | `standard`, `english`, `german`, `french`, `spanish`, `italian`, `portuguese`, `russian`, `simple`, `whitespace` | Text analyzer for tokenization. Determines how text is split into terms.    |
+| `positions` | `true`, `false`                                                                                      | Whether token positions are stored. Required for phrase queries.            |
+
+Unknown options are rejected with an error.
+
+### CDC requirement
+
+Fulltext indexes require CDC (Change Data Capture) to be enabled on the base table
+with specific settings:
+
+- **TTL** must be at least 86400 seconds (24 hours).
+- **Delta mode** must be `full`, or **postimage** must be enabled.
+
+These constraints exist because the external search backend (Tantivy) rebuilds
+and maintains the fulltext index asynchronously from CDC log entries. The 24-hour
+TTL ensures CDC entries are retained throughout the index build window.
+
+Dropping or weakening CDC on a table with an active fulltext index is rejected.
+
+### Tablets requirement
+
+Fulltext indexes require the table to use tablets (not vnodes).
+
+### Duplicate detection
+
+Like vector indexes, multiple **named** fulltext indexes on the same column are
+allowed (useful for zero-downtime recreation). Unnamed duplicate fulltext indexes
+on the same target are rejected.
+
+## Querying
+
+### BM25 operator
+
+`BM25(column, 'query_term')` scores rows using the BM25 ranking algorithm.
+It can appear in `WHERE` (as a filter) and/or `ORDER BY` (for relevance ranking):
+
+```cql
+-- Filter by BM25 score
+SELECT * FROM ks.t WHERE BM25(v, 'search term') > 0 LIMIT 10;
+
+-- Order by relevance
+SELECT * FROM ks.t ORDER BY BM25(v, 'search term') LIMIT 10;
+
+-- Both: filter and order
+SELECT * FROM ks.t WHERE BM25(v, 'term') > 0 ORDER BY BM25(v, 'term') LIMIT 10;
+
+-- With partition key restriction
+SELECT * FROM ks.t WHERE p = 1 AND BM25(v, 'term') > 0 LIMIT 10;
+
+-- Bind markers
+SELECT * FROM ks.t WHERE BM25(v, ?) > 0 LIMIT ?;
+```
+
+`BM25` is a reserved keyword — it cannot be used as a column, table, or keyspace name.
+
+### Query constraints
+
+All FTS queries enforce the following rules:
+
+- **LIMIT is required.** FTS queries without `LIMIT` are rejected.
+- **Per-partition LIMIT is not supported.** `PER PARTITION LIMIT` is rejected.
+- **Aggregation is not supported.** Queries with aggregate functions are rejected.
+- **A fulltext index must exist** on the queried column. Queries on columns
+  without a `fulltext_index` are rejected. A regular secondary index does not
+  satisfy this requirement.
+
+For `ORDER BY BM25`:
+
+- **BM25 must be the only ordering.** It cannot be combined with other
+  `ORDER BY` columns or with ANN ordering.
+
+## Implementation overview
+
+### Query routing
+
+A SELECT statement is classified as an FTS query when its `WHERE` clause
+contains a `BM25(...)` restriction, its `ORDER BY` clause contains a
+`BM25(...)` call, or both. FTS queries are handled by
+`fulltext_indexed_table_select_statement`.
+
+### Index resolution
+
+During statement preparation the fulltext index is resolved as follows:
+
+1. If `ORDER BY BM25` is present, the index is resolved from the ordering
+   clause — all indexes are scanned for one that covers the target column and
+   is of type `fulltext_index`. This follows the same pattern as ANN ordering.
+2. If only `WHERE BM25` is present, the index is resolved from the
+   restriction's index manager.
+3. When both are present, the ORDER BY index takes priority.
+
+### Execution
+
+Query execution against the Tantivy search backend is not yet implemented.
+Currently FTS queries return an empty result set with the correct metadata.

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -74,6 +74,14 @@ index::supports_expression_v index::supports_expression(const column_definition&
     }
 }
 
+index::supports_expression_v index::supports_bm25_expression(const column_definition& cdef) const {
+    if (cdef.name_as_text() != _target_column) {
+        return supports_expression_v::from_bool(false);
+    }
+    auto custom_class = secondary_index_manager::get_custom_class(_im);
+    return supports_expression_v::from_bool(custom_class && dynamic_cast<fulltext_index*>(custom_class->get()) != nullptr);
+}
+
 index::supports_expression_v index::supports_subscript_expression(const column_definition& cdef, const cql3::expr::oper_t op) const {
     using target_type = cql3::statements::index_target::target_type;
     if (cdef.name_as_text() != _target_column) {

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -87,6 +87,7 @@ public:
     };
 
     supports_expression_v supports_expression(const column_definition& cdef, const cql3::expr::oper_t op) const;
+    supports_expression_v supports_bm25_expression(const column_definition& cdef) const;
     supports_expression_v supports_subscript_expression(const column_definition& cdef, const cql3::expr::oper_t op) const;
     const index_metadata& metadata() const;
     const sstring& target_column() const {

--- a/test/cqlpy/test_fulltext_index.py
+++ b/test/cqlpy/test_fulltext_index.py
@@ -13,7 +13,7 @@
 import pytest
 import re
 from .util import new_test_table, new_test_keyspace, unique_name
-from cassandra.protocol import InvalidRequest
+from cassandra.protocol import InvalidRequest, SyntaxException
 
 # Fulltext search is not allowed in tables using vnodes, so all tests in this file need tablets
 @pytest.fixture(scope="function", autouse=True)
@@ -382,3 +382,211 @@ def test_fulltext_index_if_not_exists_cross_column(cql, test_keyspace):
         rows = list(cql.execute(f"SELECT index_name FROM system_schema.indexes WHERE keyspace_name='{ks}' AND table_name='{cf}'"))
         assert len(rows) == 1
         assert rows[0].index_name == idx
+
+
+###############################################################################
+# Tests for BM25() scoring expression
+#
+# These tests validate the CQL grammar additions for the BM25() scoring
+# expression used with fulltext indexes. They cover parsing, validation of
+# column types, restriction requirements (LIMIT, fulltext_index), and error
+# handling.
+###############################################################################
+
+
+def test_bm25_basic_parsing(cql, test_keyspace):
+    """BM25 should be accepted in a WHERE clause when a fulltext_index exists, the column is text, and LIMIT is provided."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE BM25(content, 'hello') > 0 LIMIT 1"))
+        assert isinstance(result, list)
+
+
+def test_bm25_without_comparison(cql, test_keyspace):
+    """WHERE BM25 without a comparison operator should be rejected."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        with pytest.raises(SyntaxException):
+            cql.execute(f"SELECT * FROM {table} WHERE BM25(content, 'hello') LIMIT 1")
+
+
+def test_bm25_requires_limit(cql, test_keyspace):
+    """A SELECT with BM25 but no LIMIT must be rejected."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        with pytest.raises(InvalidRequest, match="require a LIMIT"):
+            cql.execute(f"SELECT * FROM {table} WHERE BM25(content, 'hello') > 0")
+
+
+def test_bm25_requires_fulltext_index(cql, test_keyspace):
+    """A SELECT with BM25 on a column without a fulltext_index must be rejected."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        with pytest.raises(InvalidRequest, match="No fulltext index found"):
+            cql.execute(f"SELECT * FROM {table} WHERE BM25(content, 'hello') > 0 LIMIT 1")
+
+
+def test_bm25_regular_index_not_sufficient(cql, test_keyspace):
+    """A regular secondary index (non-fulltext) should not satisfy the BM25 requirement."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE INDEX ON {table}(content)")
+        with pytest.raises(InvalidRequest, match="No fulltext index found"):
+            cql.execute(f"SELECT * FROM {table} WHERE BM25(content, 'hello') > 0 LIMIT 1")
+
+
+@pytest.mark.parametrize("column_type", ["text", "varchar", "ascii"])
+def test_bm25_on_supported_text_types(cql, test_keyspace, column_type):
+    """BM25 should be accepted on text, varchar, and ascii columns when a fulltext_index exists."""
+    schema = f'p int primary key, content {column_type}'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        cql.execute(f"SELECT * FROM {table} WHERE BM25(content, 'hello') > 0 LIMIT 1")
+
+
+def test_bm25_with_bind_marker(cql, test_keyspace):
+    """BM25 should accept a bind marker (?) as the query string argument."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        stmt = cql.prepare(f"SELECT * FROM {table} WHERE BM25(content, ?) > 0 LIMIT 1")
+        cql.execute(stmt, ['hello'])
+
+
+def test_bm25_with_and_restriction(cql, test_keyspace):
+    """BM25 can be combined with other restrictions as conjunctions."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND BM25(content, 'hello') > 0 LIMIT 1")
+
+
+def test_bm25_on_nonexistent_column_fails(cql, test_keyspace):
+    """BM25 on a column that doesn't exist should be rejected."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        with pytest.raises(InvalidRequest, match="Unrecognized name nonexistent"):
+            cql.execute(f"SELECT * FROM {table} WHERE BM25(nonexistent, 'hello') > 0 LIMIT 1")
+
+
+def test_bm25_order_by(cql, test_keyspace):
+    """BM25 can be used in ORDER BY clause for relevance-based ordering."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        result = list(cql.execute(f"SELECT * FROM {table} ORDER BY BM25(content, 'hello') LIMIT 1"))
+        assert isinstance(result, list)
+
+
+def test_bm25_where_and_order_by(cql, test_keyspace):
+    """WHERE BM25 restriction and ORDER BY BM25 combined should be accepted."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE BM25(content, 'hello') > 0 ORDER BY BM25(content, 'hello') LIMIT 1"))
+        assert isinstance(result, list)
+
+
+def test_bm25_order_by_requires_limit(cql, test_keyspace):
+    """ORDER BY BM25 without a LIMIT must be rejected."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        with pytest.raises(InvalidRequest, match="require a LIMIT"):
+            cql.execute(f"SELECT * FROM {table} ORDER BY BM25(content, 'hello')")
+
+
+def test_bm25_order_by_requires_fulltext_index(cql, test_keyspace):
+    """ORDER BY BM25 on a column without a fulltext_index must be rejected."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        with pytest.raises(InvalidRequest, match="No fulltext index found"):
+            cql.execute(f"SELECT * FROM {table} ORDER BY BM25(content, 'hello') LIMIT 1")
+
+
+def test_bm25_order_by_regular_index_not_sufficient(cql, test_keyspace):
+    """A regular secondary index should not satisfy the ORDER BY BM25 requirement."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE INDEX ON {table}(content)")
+        with pytest.raises(InvalidRequest, match="No fulltext index found"):
+            cql.execute(f"SELECT * FROM {table} ORDER BY BM25(content, 'hello') LIMIT 1")
+
+
+@pytest.mark.parametrize("column_type", ["text", "varchar", "ascii"])
+def test_bm25_order_by_on_supported_text_types(cql, test_keyspace, column_type):
+    """ORDER BY BM25 should be accepted on text, varchar, and ascii columns
+    when a fulltext_index exists."""
+    schema = f'p int primary key, content {column_type}'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        cql.execute(f"SELECT * FROM {table} ORDER BY BM25(content, 'hello') LIMIT 1")
+
+
+def test_bm25_order_by_with_bind_marker(cql, test_keyspace):
+    """ORDER BY BM25 should accept a bind marker (?) as the query string argument."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        stmt = cql.prepare(f"SELECT * FROM {table} ORDER BY BM25(content, ?) LIMIT 1")
+        cql.execute(stmt, ['hello'])
+
+
+def test_bm25_where_and_order_by_with_bind_markers(cql, test_keyspace):
+    """WHERE BM25 and ORDER BY BM25 combined with bind markers should be accepted."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        stmt = cql.prepare(f"SELECT * FROM {table} WHERE BM25(content, ?) > 0 ORDER BY BM25(content, ?) LIMIT 1")
+        result = list(cql.execute(stmt, ['hello', 'hello']))
+        assert isinstance(result, list)
+
+
+def test_bm25_order_by_on_nonexistent_column_fails(cql, test_keyspace):
+    """ORDER BY BM25 on a column that doesn't exist should be rejected."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        with pytest.raises(InvalidRequest, match="Undefined column name nonexistent in ORDER BY BM25"):
+            cql.execute(f"SELECT * FROM {table} ORDER BY BM25(nonexistent, 'hello') LIMIT 1")
+
+
+def test_bm25_order_by_with_aggregation_fails(cql, test_keyspace):
+    """ORDER BY BM25 with aggregate functions must be rejected."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        with pytest.raises(InvalidRequest, match="aggregation"):
+            cql.execute(f"SELECT count(*) FROM {table} ORDER BY BM25(content, 'hello') LIMIT 1")
+
+
+def test_bm25_order_by_per_partition_limit_fails(cql, test_keyspace):
+    """ORDER BY BM25 with PER PARTITION LIMIT must be rejected."""
+    schema = 'p int primary key, content text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        with pytest.raises(InvalidRequest, match="per-partition"):
+            cql.execute(f"SELECT * FROM {table} ORDER BY BM25(content, 'hello') PER PARTITION LIMIT 1 LIMIT 1")
+
+
+def test_order_by_ann_then_bm25_rejected(cql, test_keyspace):
+    """Mixing ANN OF and BM25 orderings in a single query must be rejected."""
+    schema = 'p int primary key, content text, vec vector<float, 2>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(vec) USING 'vector_index'")
+        with pytest.raises(InvalidRequest, match="BM25 ordering does not support any other ordering"):
+            cql.execute(f"SELECT * FROM {table} ORDER BY vec ANN OF [1.0, 2.0], BM25(content, 'hello') LIMIT 1")
+
+
+def test_order_by_bm25_then_ann_rejected(cql, test_keyspace):
+    """Mixing BM25 and ANN OF orderings in a single query must be rejected."""
+    schema = 'p int primary key, content text, vec vector<float, 2>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(vec) USING 'vector_index'")
+        with pytest.raises(InvalidRequest, match="Cannot specify more than one ANN ordering"):
+            cql.execute(f"SELECT * FROM {table} ORDER BY BM25(content, 'hello'), vec ANN OF [1.0, 2.0] LIMIT 1")


### PR DESCRIPTION
This PR introduces the `BM25()` CQL operator — the query-side interface for fulltext search. 
It wires together grammar, expression preparation, index routing, and statement dispatch so that `WHERE BM25(col, 'term') > 0` and `ORDER BY BM25(col, 'term')` are parsed, validated, and routed to the `fulltext_index` backend.

### What's new

**Syntax**

```cql
-- Filter by BM25 score threshold
SELECT * FROM ks.t WHERE BM25(v, 'search term') > 0 LIMIT 10;

-- Order by relevance
SELECT * FROM ks.t ORDER BY BM25(v, 'search term') LIMIT 10;

-- Both combined
SELECT * FROM ks.t WHERE BM25(v, 'term') > 0 ORDER BY BM25(v, 'term') LIMIT 10;
```

`BM25` is a reserved keyword and cannot be used as a column or table name.

**Validation enforced at prepare time**

- A `fulltext_index` must exist on the target column; a regular secondary index does not satisfy this.
- `LIMIT` is required; `PER PARTITION LIMIT` and aggregate functions are rejected.
- `ORDER BY BM25` cannot be combined with other orderings or ANN.
- The column must be `text`, `varchar`, or `ascii`.

### Implementation sketch

The stack mirrors the ANN path:

1. **`bm25_call` expression** — a new `expression` variant that acts as a planner directive. It is never evaluated locally; `do_evaluate()` aborts on internal error.
2. **Grammar** — `K_BM25` keyword, a `BM25(col, term) op threshold` relation in `WHERE`, and a `BM25(col, term)` ordering in `ORDER BY`. `is_ann_ordering` is renamed to `is_similarity_ordering` so both ANN and BM25 share the mutual-exclusion check.
3. **Preparation** — `bm25_call` is prepared against `utf8_type` for the query term and returns `float_type`.
4. **Index routing** — `index::supports_bm25_expression()` returns true only for `fulltext_index`. Statement restrictions detect BM25 predicates, find a satisfying index, and gate the query.
5. **`fulltext_indexed_table_select_statement`** — a `select_statement` subclass that holds the resolved index, enforces the LIMIT requirement, and overrides `do_execute()`.

Fixes: SCYLLADB-1514