### PR TITLE
[Backport 2026.1] test/pylib: centralize timeout scaling and propagate build_mode in LWT helpers

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -30,7 +30,9 @@ ALL_MODES = {
     "sanitize": "Sanitize",
     "coverage": "Coverage",
 }
+
 DEBUG_MODES = {"debug", "sanitize"}
+MODES_TIMEOUT_FACTOR = {"release": 1, "sanitize": 3, "debug": 3, "dev": 2, "coverage": 1}
 
 HOST_ID = os.environ.get("SCYLLA_TEST_HOST_ID")
 if HOST_ID is None:

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -205,14 +205,6 @@ async def test_service_levels_work_during_recovery(manager: ManagerClient):
     assert sl_v1 not in [sl.service_level for sl in sls_list]
     assert set([sl.service_level for sl in sls_list]) == set(sls + [new_sl] + [DRIVER_SL_NAME])
 
-def default_timeout(mode):
-    if mode == "dev":
-        return "30s"
-    elif mode == "debug":
-        return "1m30s"
-    else:
-        # this branch shouldn't be reached
-        assert False
 
 def create_roles_stmts():
     return [
@@ -279,20 +271,21 @@ async def test_connections_parameters_auto_update(manager: ManagerClient, build_
     cluster_connections, sessions = await get_roles_connections(manager, servers)
 
     logging.info("Asserting all connections have default parameters")
+    str_to = lambda build_mode : "1m" if build_mode=="dev" else ("1m30s" if build_mode=="debug" else f"Faild bad mode {build_mode}")
     await assert_connections_params(manager, hosts, {
         "r1": {
             "workload_type": "unspecified",
-            "timeout": default_timeout(build_mode),
+            "timeout": str_to(build_mode),
             "scheduling_group": "sl:default",
         },
         "r2": {
             "workload_type": "unspecified",
-            "timeout": default_timeout(build_mode),
+            "timeout": str_to(build_mode),
             "scheduling_group": "sl:default",
         },
         "r3": {
             "workload_type": "unspecified",
-            "timeout": default_timeout(build_mode),
+            "timeout": str_to(build_mode),
             "scheduling_group": "sl:default",
         },
     })

--- a/test/cluster/lwt/lwt_common.py
+++ b/test/cluster/lwt/lwt_common.py
@@ -67,6 +67,7 @@ class Worker:
       bump global phase-ops counter via on_applied()
     It checks for applied state and retries on "uncertainty" timeouts.
     """
+
     def __init__(
         self,
         worker_id: int,
@@ -77,6 +78,7 @@ class Worker:
         other_columns: List[int],
         get_lower_bound: Callable[[int, int], int],
         on_applied: Callable[[int, int, int], None],
+        scale_timeout: Callable[[int | float], int | float],
         stop_event: asyncio.Event,
         counter_update_statement: Optional[PreparedStatement] = None,
         counters_random_delta: bool = False,
@@ -94,6 +96,7 @@ class Worker:
         self.cql = cql
         self.get_lower_bound = get_lower_bound
         self.on_applied = on_applied
+        self.scale_timeout = scale_timeout
         # counters
         self.counter_update_statement = counter_update_statement
         self.counters_random_delta = counters_random_delta
@@ -200,7 +203,7 @@ class Worker:
                     self.counter_deltas[pk] += delta
                     await self._inc_counter(pk, delta)
 
-                await asyncio.sleep(0.1)
+                await asyncio.sleep(self.scale_timeout(0.5))
 
             except Exception:
                 self.stop()
@@ -217,8 +220,10 @@ class BaseLWTTester:
 
     def __init__(
             self, manager: ManagerClient, ks: str, tbl: str,
-            num_workers: int = DEFAULT_WORKERS, num_keys: int = DEFAULT_NUM_KEYS, use_counters: bool = False,
-            counters_random_delta: bool = False, counters_max_delta: int = 5, counter_tbl: Optional[str] = None
+            num_workers: int = DEFAULT_WORKERS, num_keys: int = DEFAULT_NUM_KEYS, *,
+            scale_timeout: Callable[[int | float], int | float],
+            use_counters: bool = False, counters_random_delta: bool = False,
+            counters_max_delta: int = 5, counter_tbl: Optional[str] = None
     ):
         self.ks = ks
         self.tbl = tbl
@@ -233,6 +238,7 @@ class BaseLWTTester:
         self.migrations = 0
         self.phase = "warmup"  # "warmup" -> "migrating" -> "post"
         self.phase_ops = defaultdict(int)
+        self.scale_timeout = scale_timeout
         # counters config
         self.use_counters = use_counters
         self.counters_random_delta = counters_random_delta
@@ -253,12 +259,12 @@ class BaseLWTTester:
     def get_phase_ops(self, phase: str) -> int:
         return self.phase_ops.get(phase, 0)
 
-    async def wait_for_phase_ops(self, stop_event, phase: str, target: int, timeout: float = 120.0, poll: float = 0.2):
-        deadline = time.time() + timeout
+    async def wait_for_phase_ops(self, stop_event, phase: str, target: int, timeout: float = 120.0, poll: float = 1):
+        deadline = time.time() + self.scale_timeout(timeout)
         while time.time() < deadline and not stop_event.is_set():
             if self.get_phase_ops(phase) >= target:
                 return
-            await asyncio.sleep(poll)
+            await asyncio.sleep(self.scale_timeout(poll))
         raise asyncio.TimeoutError(
             f"phase '{phase}' did not reach {target} ops in time (have {self.get_phase_ops(phase)})")
 
@@ -292,6 +298,7 @@ class BaseLWTTester:
                 other_columns=other_columns,
                 get_lower_bound=self._get_lower_bound,
                 on_applied=self._on_applied,
+                scale_timeout=self.scale_timeout,
                 counter_update_statement=counter_stmt,
                 counters_random_delta=self.counters_random_delta,
                 counters_max_delta=self.counters_max_delta,
@@ -428,20 +435,20 @@ async def pick_non_replica_server(manager: ManagerClient, servers, replica_host_
 
 async def wait_for_tablet_count(
         manager: ManagerClient, server, ks: str, tbl: str,
-        predicate, target: int, timeout_s: int = 180, poll_s: float = 1.0
+        predicate, target: int, scale_timeout: Callable[[int | float], int | float], timeout_s: int = 180, poll_s: float = 1.0
     ):
     """
     Wait for tablet count to match predicate.
     predicate: callable like lambda c: c >= target (for split) or lambda c: c <= target (for merge)
     """
-    deadline = time.time() + timeout_s
+    deadline = time.time() + scale_timeout(timeout_s)
     last = None
     while time.time() < deadline:
         count = await get_tablet_count(manager, server, ks, tbl)
         last = count
         if predicate(count):
             return count
-        await asyncio.sleep(poll_s)
+        await asyncio.sleep(scale_timeout(poll_s))
     raise TimeoutError(f"tablet count wait timed out (last={last}, target={target})")
 
 

--- a/test/cluster/lwt/test_lwt_during_tablets_migration.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_migration.py
@@ -100,7 +100,7 @@ async def tablet_migration_ops(stop_event: asyncio.Event,
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='debug mode is too slow for this test')
-async def test_multi_column_lwt_during_migration(manager: ManagerClient):
+async def test_multi_column_lwt_during_migration(manager: ManagerClient, scale_timeout):
     """
     Test scenario:
       1. Start N servers with tablets enabled
@@ -137,6 +137,7 @@ async def test_multi_column_lwt_during_migration(manager: ManagerClient):
             "lwt_table",
             num_workers=DEFAULT_WORKERS,
             num_keys=DEFAULT_NUM_KEYS,
+            scale_timeout=scale_timeout,
         )
         await tester.create_schema()
         await tester.initialize_rows()
@@ -152,7 +153,7 @@ async def test_multi_column_lwt_during_migration(manager: ManagerClient):
             # Phase 1: warmup LWT (100 applied CAS)
             tester.set_phase(PHASE_WARMUP)
             logger.info("LWT warmup: waiting for %d applied CAS", WARMUP_LWT_CNT)
-            await tester.wait_for_phase_ops(stop_event_, PHASE_WARMUP, WARMUP_LWT_CNT, timeout=60, poll=0.2)
+            await tester.wait_for_phase_ops(stop_event_, PHASE_WARMUP, WARMUP_LWT_CNT, timeout=60, poll=1.0)
             logger.info("LWT warmup complete: %d ops", tester.get_phase_ops('warmup'))
 
             # Phase 2: migrations with LWT running
@@ -161,12 +162,15 @@ async def test_multi_column_lwt_during_migration(manager: ManagerClient):
             migration_task = asyncio.create_task(
                 tablet_migration_ops(stop_event_, manager, servers, tester, NUM_MIGRATIONS)
             )
-            await asyncio.wait_for(migration_task, timeout=NUM_MIGRATIONS * 2 + 15) # 20*2+15 = 55s
+            await asyncio.wait_for(
+                migration_task,
+                timeout=scale_timeout(NUM_MIGRATIONS * 2 + 15),  # 20*2+15 = 55s before scaling
+            )
             logger.info("LWT during migrating phase: %d ops", tester.get_phase_ops(PHASE_MIGRATING))
 
             tester.set_phase(PHASE_POST)
             logger.info("LWT post phase: waiting for %d applied CAS", POST_LWT_CNT)
-            await tester.wait_for_phase_ops(stop_event_, PHASE_POST, POST_LWT_CNT, timeout=180, poll=0.2)
+            await tester.wait_for_phase_ops(stop_event_, PHASE_POST, POST_LWT_CNT, timeout=180, poll=1.0)
             logger.info("LWT post complete: %d ops", tester.get_phase_ops(PHASE_POST))
 
         finally:

--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -91,6 +91,7 @@ async def run_random_resizes(
                 else (lambda c, tgt=target_cnt: c <= tgt)
             ),
             target=target_cnt,
+            scale_timeout=tester.scale_timeout,
             timeout_s=RESIZE_TIMEOUT
         )
 
@@ -134,7 +135,7 @@ async def run_random_resizes(
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='debug mode is too slow for this test')
-async def test_multi_column_lwt_during_split_merge(manager: ManagerClient):
+async def test_multi_column_lwt_during_split_merge(manager: ManagerClient, scale_timeout):
     """
     Test scenario:
       1. Start N servers with tablets enabled
@@ -175,6 +176,7 @@ async def test_multi_column_lwt_during_split_merge(manager: ManagerClient):
             table,
             num_workers=DEFAULT_WORKERS,
             num_keys=DEFAULT_NUM_KEYS,
+            scale_timeout=scale_timeout,
         )
 
         await tester.create_schema()
@@ -185,7 +187,7 @@ async def test_multi_column_lwt_during_split_merge(manager: ManagerClient):
             # Phase 1: warmup LWT (100 applied CAS)
             tester.set_phase(PHASE_WARMUP)
             logger.info("LWT warmup: waiting for %d applied CAS", WARMUP_LWT_CNT)
-            await tester.wait_for_phase_ops(stop_event_, PHASE_WARMUP, WARMUP_LWT_CNT, timeout=180, poll=0.2)
+            await tester.wait_for_phase_ops(stop_event_, PHASE_WARMUP, WARMUP_LWT_CNT, timeout=180, poll=1.0)
             logger.info("LWT warmup complete: %d ops", tester.get_phase_ops(PHASE_WARMUP))
 
             # Phase 2: randomized resizes with LWT running
@@ -206,7 +208,7 @@ async def test_multi_column_lwt_during_split_merge(manager: ManagerClient):
             # Phase 3: post resize LWT (100 applied CAS)
             tester.set_phase(PHASE_POST)
             logger.info("LWT post resize: waiting for %d applied CAS", POST_LWT_CNT)
-            await tester.wait_for_phase_ops(stop_event_, PHASE_POST, POST_LWT_CNT, timeout=180, poll=0.2)
+            await tester.wait_for_phase_ops(stop_event_, PHASE_POST, POST_LWT_CNT, timeout=180, poll=1.0)
             logger.info("LWT post resize complete: %d ops", tester.get_phase_ops(PHASE_POST))
 
             logger.info(

--- a/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
+++ b/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
@@ -240,6 +240,7 @@ async def run_random_resizes(
                 table,
                 predicate=predicate,
                 target=target_cnt,
+                scale_timeout=tester.scale_timeout,
                 timeout_s=RESIZE_TIMEOUT,
             ),
             wait_for_tablet_count(
@@ -249,6 +250,7 @@ async def run_random_resizes(
                 counter_table,
                 predicate=predicate,
                 target=target_cnt,
+                scale_timeout=tester.scale_timeout,
                 timeout_s=RESIZE_TIMEOUT,
             ),
         )
@@ -294,7 +296,7 @@ async def run_random_resizes(
 
 @pytest.mark.asyncio
 @pytest.mark.skip_mode("debug", "debug mode is too slow for this test")
-async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClient):
+async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClient, scale_timeout):
 
     cfg = {
         "enable_tablets": True,
@@ -331,6 +333,7 @@ async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClien
             table,
             num_workers=DEFAULT_WORKERS,
             num_keys=DEFAULT_NUM_KEYS,
+            scale_timeout=scale_timeout,
             use_counters=True,
             counters_random_delta=True,
             counters_max_delta=5,
@@ -345,7 +348,7 @@ async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClien
             # PHASE: warmup
             tester.set_phase(PHASE_WARMUP)
             logger.info("LWT warmup: waiting for %d applied CAS", WARMUP_LWT_CNT)
-            await tester.wait_for_phase_ops(stop_event_, PHASE_WARMUP, WARMUP_LWT_CNT, timeout=180, poll=0.2)
+            await tester.wait_for_phase_ops(stop_event_, PHASE_WARMUP, WARMUP_LWT_CNT, timeout=180, poll=1.0)
             logger.info("LWT warmup complete: %d ops", tester.get_phase_ops(PHASE_WARMUP))
 
             # PHASE: resize + migrate
@@ -399,7 +402,7 @@ async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClien
             # PHASE: post
             tester.set_phase(PHASE_POST)
             logger.info("LWT post resize: waiting for %d applied CAS", POST_LWT_CNT)
-            await tester.wait_for_phase_ops(stop_event_, PHASE_POST, POST_LWT_CNT, timeout=180, poll=0.2)
+            await tester.wait_for_phase_ops(stop_event_, PHASE_POST, POST_LWT_CNT, timeout=180, poll=1.0)
             logger.info("LWT post resize complete: %d ops", tester.get_phase_ops(PHASE_POST))
 
             total_ops = sum(tester.phase_ops.values())

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -911,7 +911,7 @@ async def test_lwt_shutdown(manager: ManagerClient):
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='debug', reason='dev is enough')
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_tablets_merge_waits_for_lwt(manager: ManagerClient):
+async def test_tablets_merge_waits_for_lwt(manager: ManagerClient, scale_timeout):
     """
     This is a regression test for #26437:
     1. A cluster with one node, a table with rf=1 and two tablets on the same shard.
@@ -975,7 +975,7 @@ async def test_tablets_merge_waits_for_lwt(manager: ManagerClient):
         m = await log0.mark()
 
         logger.info("Wait for tablet merge to complete")
-        await wait_for_tablet_count(manager, s0, ks, 'test', lambda c: c == 1, 1, timeout_s=15)
+        await wait_for_tablet_count(manager, s0, ks, 'test', lambda c: c == 1, 1, scale_timeout=scale_timeout, timeout_s=15)
 
         logger.info("Ensure the guard decided to retain the erm")
         m, _ = await log0.wait_for("tablet_metadata_guard::check: retain the erm and abort the guard",

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from itertools import chain, count, product
 from functools import cache, cached_property
 from random import randint
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 import pytest
 import xdist
@@ -32,7 +32,7 @@ from test.pylib.suite.base import (
     prepare_environment,
     init_testsuite_globals,
 )
-from test.pylib.util import get_modes_to_run
+from test.pylib.util import get_modes_to_run, scale_timeout_by_mode
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -139,6 +139,14 @@ def build_mode(request: pytest.FixtureRequest) -> str:
     if params_stash is None:
         return request.config.build_modes[0]
     return params_stash[BUILD_MODE]
+
+
+@pytest.fixture(scope=testpy_test_fixture_scope)
+def scale_timeout(build_mode: str) -> Callable[[int | float], int | float]:
+    def scale_timeout_inner(timeout: int | float) -> int | float:
+        return scale_timeout_by_mode(build_mode, timeout)
+
+    return scale_timeout_inner
 
 
 @pytest.fixture(scope=testpy_test_fixture_scope)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -30,7 +30,7 @@ from test import TOP_SRC_DIR, TEST_DIR
 from test.pylib.host_registry import Host, HostRegistry
 from test.pylib.pool import Pool
 from test.pylib.rest_client import ScyllaRESTAPIClient, HTTPError
-from test.pylib.util import LogPrefixAdapter, read_last_line, gather_safely, get_xdist_worker_id
+from test.pylib.util import LogPrefixAdapter, read_last_line, gather_safely, get_xdist_worker_id, scale_timeout_by_mode
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from functools import partial
 import aiohttp
@@ -83,7 +83,7 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
     # reason, so we increase the timeouts according to each mode's needs. The client
     # should avoid timing out its requests before the server times out - for this reason
     # we increase the CQL driver's client-side timeout in conftest.py.
-    request_timeout_in_ms = 90000 if mode in {'debug', 'sanitize'} else 30000
+    request_timeout_in_ms = scale_timeout_by_mode(mode, 30000)
 
     return {
         'cluster_name': cluster_name,

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -28,7 +28,7 @@ from cassandra.pool import Host # type: ignore # pylint: disable=no-name-in-modu
 from cassandra.query import Statement # type: ignore # pylint: disable=no-name-in-module
 from cassandra import DriverException, ConsistencyLevel  # type: ignore # pylint: disable=no-name-in-module
 
-from test import BUILD_DIR, TOP_SRC_DIR
+from test import BUILD_DIR, TOP_SRC_DIR, MODES_TIMEOUT_FACTOR
 from test.pylib.internal_types import ServerInfo
 
 logger = logging.getLogger(__name__)
@@ -379,6 +379,14 @@ def get_modes_to_run(config) -> list[str]:
     if not modes:
         raise RuntimeError('No modes configured. Please run ./configure.py first')
     return modes
+
+
+def scale_timeout_by_mode(mode: str, timeout: int | float) -> int | float:
+    """Scale timeout according to test.py mode semantics.
+    Each mode has a different scale: debug and sanitize modes are multiplied by 3, dev by 2.
+    Unknown modes are left unchanged.
+    """
+    return MODES_TIMEOUT_FACTOR.get(mode, 1) * timeout
 
 
 async def gather_safely(*awaitables: Awaitable):

--- a/test/pylib_test/test_util.py
+++ b/test/pylib_test/test_util.py
@@ -1,7 +1,8 @@
 import os
 import tempfile
 import pathlib
-from test.pylib.util import read_last_line
+import pytest
+from test.pylib.util import read_last_line, scale_timeout_by_mode
 
 def test_read_last_line():
     test_cases = [
@@ -26,3 +27,18 @@ def test_read_last_line():
             file_path = pathlib.Path(f.name)
             actual = read_last_line(file_path, test_case[2]) if len(test_case) == 3 else read_last_line(file_path)
             assert(actual == test_case[1])
+
+
+@pytest.mark.parametrize(
+    "mode,base_timeout,expected",
+    [
+        ("debug", 10, 30),
+        ("sanitize", 10, 30),
+        ("release", 10, 10),
+        ("dev", 10, 20),
+        ("coverage", 10, 10),
+        ("custom_exe", 10, 10),
+    ],
+)
+def test_scale_timeout_by_mode(mode, base_timeout, expected):
+    assert scale_timeout_by_mode(mode, base_timeout) == expected


### PR DESCRIPTION
This series improves timeout handling consistency across the test framework and makes build-mode effects explicit in LWT tests. (starting with LWT test that got flaky)

    Centralize timeout scaling
    Introduce scale_timeout(timeout) fixture in runner.py to provide a single, consistent mechanism for scaling test timeouts based on build mode.
    Previously, timeout adjustments were done in an ad-hoc manner across different helpers and tests. Centralizing the logic:
    Ensures consistent behavior across the test suite
    Simplifies maintenance and reasoning about timeout behavior
    Reduces duplication and per-test scaling logic
    This becomes increasingly important as tests run on heterogeneous hardware configurations, where different build modes (especially debug) can significantly impact execution time.

    Make scale_timeout explicit in LWT helpers
    Propagate scale_timeout explicitly through BaseLWTTester and Worker, validating it at construction time instead of relying on implicit pytest fixture injection inside helper classes.
    Additionally:
    Update wait_for_phase_ops() and wait_for_tablet_count() to use scale_timeout_by_mode() for consistent polling behavior across modes
    Update all LWT test call sites to pass build_mode explicitly
    Increase default timeout values, as the previous defaults were too short and prone to flakiness, particularly under slower configurations such as debug builds

Overall, this series improves determinism, reduces flakiness, and makes the interaction between build mode and test timing explicit and maintainable.

backport: not required just an enhansment for test.py infra

    (cherry picked from commit https://github.com/scylladb/scylladb/commit/73f1a652034542ecfa1a5a86aadfff8767da9cbf)
    (cherry picked from commit https://github.com/scylladb/scylladb/commit/a66565cc4263bdf853f1f4ca63151fdd2cafeb3f)
    (cherry picked from commit https://github.com/scylladb/scylladb/commit/b32ef8ecd5848bd92d3484ef963e587f31019ecf)

Parent PR: https://github.com/scylladb/scylladb/pull/28840