### PR TITLE
tablet_allocator: table activity weighted tablet allocation

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1711,6 +1711,16 @@ db::config::config(std::shared_ptr<db::extensions> exts)
          "Maximum number of tablets which may be leaving a shard at the same time. Effecting only on topology coordinator. Set to the same value on all nodes.")
     , tablet_streaming_write_concurrency_per_shard(this, "tablet_streaming_write_concurrency_per_shard", liveness::LiveUpdate, value_status::Used, 2,
          "Maximum number of tablets which may be pending on a shard at the same time. Effecting only on topology coordinator. Set to the same value on all nodes.")
+    , tablets_activity_weighted_allocation_enabled(this, "tablets_activity_weighted_allocation_enabled", liveness::LiveUpdate, value_status::Used, true,
+         "Master switch for activity-aware Phase 3 tablet allocation. When enabled and the cluster feature flag is set, idle tables are compressed more aggressively to make room for active tables.")
+    , tablets_idle_table_rate_threshold(this, "tablets_idle_table_rate_threshold", liveness::LiveUpdate, value_status::Used, 0.1,
+         "Absolute floor for table activity classification: combined read+write rate (ops/sec) at or below which a table is always considered idle, regardless of percentile.")
+    , tablets_idle_percentile(this, "tablets_idle_percentile", liveness::LiveUpdate, value_status::Used, 75,
+         "Percentile of the activity distribution below which tables are classified as idle for tablet allocation purposes.")
+    , tablets_activity_ewma_window_seconds(this, "tablets_activity_ewma_window_seconds", liveness::LiveUpdate, value_status::Used, 900,
+         "EWMA smoothing window in seconds for per-table activity tracking. Longer windows provide more stability but slower reaction to workload changes.")
+    , tablets_activity_max_tablet_size_factor(this, "tablets_activity_max_tablet_size_factor", liveness::LiveUpdate, value_status::Used, 4,
+         "Maximum average tablet size multiplier allowed during activity-based compression. Limits how much idle tables can be compressed based on their data size.")
     , service_levels_interval(this, "service_levels_interval_ms", liveness::LiveUpdate, value_status::Used, 10000, "Controls how often service levels module polls configuration table")
 
     , audit(this, "audit", value_status::Used, "table",

--- a/db/config.hh
+++ b/db/config.hh
@@ -598,6 +598,11 @@ public:
     named_value<uint64_t> target_tablet_size_in_bytes;
     named_value<unsigned> tablet_streaming_read_concurrency_per_shard;
     named_value<unsigned> tablet_streaming_write_concurrency_per_shard;
+    named_value<bool> tablets_activity_weighted_allocation_enabled;
+    named_value<double> tablets_idle_table_rate_threshold;
+    named_value<unsigned> tablets_idle_percentile;
+    named_value<unsigned> tablets_activity_ewma_window_seconds;
+    named_value<unsigned> tablets_activity_max_tablet_size_factor;
 
     named_value<uint32_t> service_levels_interval;
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -195,6 +195,7 @@ public:
     // RPCs (and their warnings) to nodes that do not register the verb during a
     // rolling upgrade.
     gms::feature small_table_optimization_size_probe { *this, "SMALL_TABLE_OPTIMIZATION_SIZE_PROBE"sv };
+    gms::feature table_activity_tablet_allocation { *this, "TABLE_ACTIVITY_TABLET_ALLOCATION"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -42,11 +42,17 @@ struct tablet_load_stats final {
     std::unordered_map<::table_id, std::unordered_map<dht::token_range, uint64_t>> tablet_sizes;
 };
 
+struct table_activity_stats final {
+    double read_rate;
+    double write_rate;
+};
+
 struct load_stats {
     std::unordered_map<::table_id, locator::table_load_stats> tables;
     std::unordered_map<locator::host_id, uint64_t> capacity;
     std::unordered_map<locator::host_id, bool> critical_disk_utilization [[version 2025.3]];
     std::unordered_map<locator::host_id, locator::tablet_load_stats> tablet_stats [[version 2026.1]];
+    std::unordered_map<::table_id, locator::table_activity_stats> table_activity [[version 2026.4]];
 };
 
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1192,6 +1192,9 @@ load_stats& load_stats::operator+=(const load_stats& s) {
         tablet_stats[host].effective_capacity = tablet_ls.effective_capacity;
         tablet_stats[host].add_tablet_sizes(tablet_ls);
     }
+    for (auto& [id, activity] : s.table_activity) {
+        table_activity[id] += activity;
+    }
     return *this;
 }
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -586,6 +586,21 @@ struct combined_load_stats {
 
 using tablet_load_stats_map = std::unordered_map<host_id, tablet_load_stats>;
 
+// Per-table activity rates for activity-weighted tablet allocation.
+struct table_activity_stats {
+    double read_rate = 0;
+    double write_rate = 0;
+
+    table_activity_stats& operator+=(const table_activity_stats& s) noexcept {
+        read_rate += s.read_rate;
+        write_rate += s.write_rate;
+        return *this;
+    }
+    friend table_activity_stats operator+(table_activity_stats a, const table_activity_stats& b) {
+        return a += b;
+    }
+};
+
 struct load_stats {
     std::unordered_map<table_id, table_load_stats> tables;
 
@@ -598,6 +613,11 @@ struct load_stats {
     // Size-based load balancing data
     tablet_load_stats_map tablet_stats;
 
+    // Per-table activity rates (ops/sec) for activity-weighted allocation.
+    // An entry with zero rates means the table was observed as idle.
+    // A missing entry means the reporting node did not report activity at all.
+    std::unordered_map<table_id, table_activity_stats> table_activity;
+    
     // Distinguishes a default-constructed (null) load_stats from one that has
     // been aggregated via operator+=.  A null element contributes nothing when
     // merged, while an aggregated-but-empty stats (e.g. from a node that

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1659,6 +1659,8 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
         .cell_size_warn_threshold_mb = db_config.compaction_large_cell_warning_threshold_mb,
         .cql_warnings_enabled = db_config.large_data_cql_warnings,
     };
+    cfg.activity_ewma_window_seconds = db_config.tablets_activity_ewma_window_seconds();
+    cfg.activity_rate_tick_interval = std::chrono::seconds{std::max(cfg.activity_ewma_window_seconds / 10, 1U)};
 
     return cfg;
 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -483,6 +483,8 @@ public:
         utils::updateable_value<bool> enable_compacting_data_for_streaming_and_repair;
         utils::updateable_value<bool> enable_tombstone_gc_for_streaming_and_repair;
         db::guardrail_config guardrail_config;
+        unsigned activity_ewma_window_seconds = 900;
+        std::chrono::seconds activity_rate_tick_interval;
     };
 
     using snapshot_details = db::snapshot_ctl::table_snapshot_details;
@@ -1221,6 +1223,10 @@ public:
 
     locator::combined_load_stats table_load_stats() const;
 
+    // Activity rates for tablet allocation (ops/sec, EWMA-smoothed).
+    double activity_read_rate() const { return _read_rate_ewma.rate(); }
+    double activity_write_rate() const { return _write_rate_ewma.rate(); }
+
     const db::view::stats& get_view_stats() const {
         return _view_stats;
     }
@@ -1420,6 +1426,10 @@ public:
 private:
     timer<> _off_strategy_trigger;
     void do_update_off_strategy_trigger();
+
+    mutable utils::moving_average _read_rate_ewma;
+    utils::moving_average _write_rate_ewma;
+    timer<lowres_clock> _activity_rate_timer;
 
     compaction_group* try_get_compaction_group_with_static_sharding() const;
 public:

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -280,6 +280,8 @@ table::make_mutation_reader(schema_ptr s,
         rd = _config.data_listeners->on_read(s, range, slice, std::move(rd));
     }
 
+    _read_rate_ewma.add();
+
     return rd;
 }
 
@@ -2180,6 +2182,7 @@ table::start() {
     if (_schema->memtable_flush_period() > 0) {
         _flush_timer.arm(std::chrono::milliseconds(_schema->memtable_flush_period()));
     }
+    _activity_rate_timer.arm(_config.activity_rate_tick_interval);
 }
 
 future<>
@@ -2188,6 +2191,7 @@ table::stop() noexcept {
         co_return;
     }
     _flush_timer.cancel();
+    _activity_rate_timer.cancel();
     // Allow `compaction_group::stop` to stop ongoing compactions
     // while they may still hold the table _async_gate
     auto gate_closed_fut = _async_gate.close();
@@ -3367,6 +3371,13 @@ table::table(schema_ptr schema, config config, lw_shared_ptr<const storage_optio
     , _row_locker(_schema)
     , _flush_timer([this]{ on_flush_timer(); })
     , _off_strategy_trigger([this] { trigger_offstrategy_compaction(); })
+    , _read_rate_ewma(std::chrono::seconds(_config.activity_ewma_window_seconds), _config.activity_rate_tick_interval)
+    , _write_rate_ewma(std::chrono::seconds(_config.activity_ewma_window_seconds), _config.activity_rate_tick_interval)
+    , _activity_rate_timer([this] {
+        _read_rate_ewma.update();
+        _write_rate_ewma.update();
+        _activity_rate_timer.arm(_config.activity_rate_tick_interval);
+    })
 {
     if (!_config.enable_disk_writes) {
         tlogger.warn("Writes disabled, column family no durable.");
@@ -5125,6 +5136,7 @@ template<typename... Args>
 void table::do_apply(compaction_group& cg, db::rp_handle&& h, Args&&... args) {
     utils::latency_counter lc;
     _stats.writes.set_latency(lc);
+    _write_rate_ewma.add();
     db::replay_position rp = h;
     check_valid_rp(rp);
     try {
@@ -5141,7 +5153,6 @@ void table::do_apply(compaction_group& cg, db::rp_handle&& h, Args&&... args) {
     }
     _stats.writes.mark(lc);
 }
-
 api::timestamp_type table::get_max_timestamp_for_tablet(locator::tablet_id tid) const {
     return std::ranges::max(storage_group_for_id(tid.value()).compaction_groups_immediate()
         | std::views::transform([](const compaction_group_ptr& cg_ptr) {

--- a/serializer.hh
+++ b/serializer.hh
@@ -20,6 +20,7 @@
 #include <variant>
 
 #include <type_traits>
+#include <bit>
 
 namespace ser {
 
@@ -245,6 +246,24 @@ template<> struct serializer<int32_t> : public integral_serializer<int32_t> {};
 template<> struct serializer<uint32_t> : public integral_serializer<uint32_t> {};
 template<> struct serializer<int64_t> : public integral_serializer<int64_t> {};
 template<> struct serializer<uint64_t> : public integral_serializer<uint64_t> {};
+
+template<> struct serializer<double> {
+    template <typename Input>
+    static double read(Input& i) {
+        return std::bit_cast<double>(deserialize_integral<uint64_t>(i));
+    }
+    template<typename Output>
+    static void write(Output& out, double v) {
+        if (std::isnan(v)) {
+            v = std::numeric_limits<double>::quiet_NaN();
+        }
+        serialize_integral(out, std::bit_cast<uint64_t>(v));
+    }
+    template <typename Input>
+    static void skip(Input& i) {
+        read(i);
+    }
+};
 
 template<typename Output>
 void safe_serialize_as_uint32(Output& output, uint64_t data);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6153,6 +6153,11 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
             load_stats.tables.emplace(id, std::move(combined_ls.table_ls));
             tablet_sizes_per_shard[this_shard_id()].size += load_stats.tablet_stats[this_host].add_tablet_sizes(combined_ls.tablet_ls);
 
+            load_stats.table_activity[id] += locator::table_activity_stats{
+                table->activity_read_rate(),
+                table->activity_write_rate()
+            };
+
             co_await coroutine::maybe_yield();
         }
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2682,6 +2682,11 @@ public:
         };
         std::unordered_map<table_id, scale_info> table_scaling;
 
+        // Determine if activity-weighted allocation should be used.
+        const bool activity_weighted_enabled = _db.get_config().tablets_activity_weighted_allocation_enabled()
+            && _db.features().table_activity_tablet_allocation;
+        const bool have_activity_data = _table_load_stats && !_table_load_stats->table_activity.empty();
+
         for (auto&& [rack, shard_count] : shards_per_rack) {
             double cur_avg_tablets_per_shard = 0;
             double new_avg_tablets_per_shard = 0;
@@ -2724,24 +2729,244 @@ public:
                 overloaded ? " (overloaded!)" : "");
 
             if (overloaded) {
-                auto scale = scale_info{_tablets_per_shard_goal / new_avg_tablets_per_shard, rack};
+                if (!activity_weighted_enabled) {
+                    // Legacy uniform scaling.
+                    auto scale = scale_info{_tablets_per_shard_goal / new_avg_tablets_per_shard, rack};
 
-                for (auto&& [table, table_plan]: plan.tables) {
-                    // Tables converging to powers of two have a fixed merge trajectory;
-                    // scaling them would interfere with it.
-                    if (table_plan.converging_to_pow2()) {
-                        continue;
+                    for (auto&& [table, table_plan]: plan.tables) {
+                        // Tables converging to powers of two have a fixed merge trajectory;
+                        // scaling them would interfere with it.
+                        if (table_plan.converging_to_pow2()) {
+                            continue;
+                        }
+                        auto* rs = rs_by_table[table];
+                        auto rf = rs->get_replication_factor_data(rack.dc);
+
+
+                        if (rf && (rf->is_numeric() || std::ranges::contains(rf->get_rack_list(), rack.rack))) {
+                            auto [i, inserted] = table_scaling.try_emplace(table, scale);
+                            if (!inserted) {
+                                if (scale.factor < i->second.factor) {
+                                    i->second = std::move(scale);
+                                }
+                            }
+                        }
                     }
-                    auto* rs = rs_by_table[table];
-                    auto rf = rs->get_replication_factor_data(rack.dc);
+                } else if (!have_activity_data) {
+                    // Activity enabled but data unavailable (e.g., rolling upgrade
+                    // where topology coordinator cleared activity, or first cycle
+                    // after leader failover): pin to current counts to avoid making
+                    // harmful decisions without activity information.
+                    // New tables (current=0) are not pinned: they use legacy uniform.
+                    lblogger.debug("Activity-weighted allocation enabled but activity data missing for rack {}.{}, pinning to current counts",
+                                   rack.dc, rack.rack);
+                    const scale_info uniform_scale{_tablets_per_shard_goal / new_avg_tablets_per_shard, rack};
+                    for (auto&& [table, table_plan] : plan.tables) {
+                        // Tables converging to powers of two have a fixed merge trajectory;
+                        // their current count is intentionally inflated mid-convergence,
+                        // so pinning to it would interfere with the trajectory.
+                        if (table_plan.converging_to_pow2()) {
+                            continue;
+                        }
+                        auto* rs = rs_by_table[table];
+                        auto rf = rs->get_replication_factor_data(rack.dc);
+                        if (rf && (rf->is_numeric() || std::ranges::contains(rf->get_rack_list(), rack.rack))) {
+                            // New tables have uniform scaling
+                            if (table_plan.current_tablet_count == 0) {
+                                auto [i, inserted] = table_scaling.try_emplace(table, uniform_scale);
+                                if (!inserted && uniform_scale.factor < i->second.factor) {
+                                    i->second = uniform_scale;
+                                }
+                            } else {
+                                if (table_plan.target_tablet_count > 0) {
+                                    const double pin_factor = double(table_plan.current_tablet_count) / double(table_plan.target_tablet_count);
+                                    scale_info pin_scale{pin_factor, rack};
+                                    auto [i, inserted] = table_scaling.try_emplace(table, pin_scale);
+                                    if (!inserted) {
+                                        if (pin_factor < i->second.factor) {
+                                            i->second = std::move(pin_scale);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    // Activity-weighted compression.
+                    const double idle_threshold = _db.get_config().tablets_idle_table_rate_threshold();
+                    const unsigned idle_percentile = _db.get_config().tablets_idle_percentile();
+                    const unsigned size_factor = _db.get_config().tablets_activity_max_tablet_size_factor();
 
-                    // If table has no replicas in this rack, scaling it won't help and is harmful to its distribution
-                    // in other DCs or racks.
-                    if (rf && (rf->is_numeric() || std::ranges::contains(rf->get_rack_list(), rack.rack))) {
-                        auto [i, inserted] = table_scaling.try_emplace(table, scale);
-                        if (!inserted) {
-                            if (scale.factor < i->second.factor) {
-                                i->second = std::move(scale);
+                    // Compute combined rates and per-shard factors for tables in this rack.
+                    struct table_activity_info {
+                        table_id id;
+                        double combined_rate;
+                        size_t target;
+                        size_t floor;
+                        double per_shard_factor; // tablets_per_shard = tablet_count * per_shard_factor
+                    };
+                    std::vector<table_activity_info> rack_tables;
+
+                    for (auto&& [table, table_plan] : plan.tables) {
+                        // Tables converging to powers of two have a fixed merge trajectory;
+                        // exclude them from activity-weighted compression so their
+                        // selective-merge decision is preserved. They still count toward
+                        // the per-shard goal via target_tablet_count_for_scaling.
+                        if (table_plan.converging_to_pow2()) {
+                            continue;
+                        }
+                        auto* rs = rs_by_table[table];
+                        auto rf = rs->get_replication_factor_data(rack.dc);
+                        if (!rf || !(rf->is_numeric() || std::ranges::contains(rf->get_rack_list(), rack.rack))) {
+                            continue;
+                        }
+
+                        // Per-shard factor: how many per-shard tablets does one absolute tablet represent.
+                        double psf = 0;
+                        if (rf->is_numeric()) {
+                            auto racks_in_dc = racks_per_dc.at(rack.dc).size();
+                            psf = double(rf->count()) / shard_count / racks_in_dc;
+                        } else {
+                            psf = 1.0 / shard_count;
+                        }
+
+                        double combined_rate = 0;
+                        if (auto it = _table_load_stats->table_activity.find(table); it != _table_load_stats->table_activity.end()) {
+                            combined_rate = it->second.read_rate + it->second.write_rate;
+                        }
+
+                        // Compute floor: max(shard_count, ceil(size / (factor * target_tablet_size)))
+                        size_t floor_from_shards = shard_count;
+                        size_t floor_from_size = 1;
+                        const auto* table_stats = load_stats_for_table(table);
+                        if (table_stats && table_stats->size_in_bytes > 0 && size_factor > 0) {
+                            auto max_tablet_size = uint64_t(size_factor) * _target_tablet_size;
+                            floor_from_size = (table_stats->size_in_bytes + max_tablet_size - 1) / max_tablet_size;
+                        }
+                        size_t floor = std::max(floor_from_shards, floor_from_size);
+                        floor = std::min(floor, table_plan.target_tablet_count);
+
+                        rack_tables.push_back({table, combined_rate, table_plan.target_tablet_count, floor, psf});
+                    }
+
+                    // Find percentile threshold.
+                    std::vector<double> rates;
+                    rates.reserve(rack_tables.size());
+                    for (auto& t : rack_tables) {
+                        rates.push_back(t.combined_rate);
+                    }
+                    std::sort(rates.begin(), rates.end());
+
+                    double percentile_threshold = 0;
+                    if (!rates.empty()) {
+                        size_t idx = std::min<size_t>(rates.size() - 1, (rates.size() - 1) * idle_percentile / 100);
+                        percentile_threshold = rates[idx];
+                    }
+                    double boundary = std::max(idle_threshold, percentile_threshold);
+
+                    // Classify and compute weighted compressible ranges (in per-shard units).
+                    double needed_savings = new_avg_tablets_per_shard - _tablets_per_shard_goal;
+                    double total_weighted_savings = 0;
+                    double total_unweighted_savings = 0;
+
+                    struct idle_info {
+                        size_t idx;
+                        double weight;
+                        double weighted_compressible_ps; // in per-shard units
+                    };
+                    std::vector<idle_info> idle_tables;
+                    std::vector<size_t> active_table_indices;
+
+                    for (size_t i = 0; i < rack_tables.size(); ++i) {
+                        auto& t = rack_tables[i];
+                        if (t.combined_rate <= boundary) {
+                            double weight = (boundary > 0) ? (1.0 - t.combined_rate / boundary) : 1.0;
+                            double compressible = double(t.target) - double(t.floor);
+                            if (compressible < 0) {
+                                compressible = 0;
+                            }
+                            double weighted_compressible_ps = compressible * weight * t.per_shard_factor;
+                            total_weighted_savings += weighted_compressible_ps;
+                            double unweighted_compressible_ps = compressible * t.per_shard_factor;
+                            total_unweighted_savings += unweighted_compressible_ps;
+                            idle_tables.push_back({i, weight, weighted_compressible_ps});
+                        } else {
+                            active_table_indices.push_back(i);
+                        }
+                    }
+
+                    if (total_weighted_savings > 0) {
+                        double fraction = needed_savings / total_weighted_savings;
+
+                        if (fraction <= 1.0) {
+                            // Idle tables can absorb the deficit.
+                            for (auto& idle : idle_tables) {
+                                auto& t = rack_tables[idle.idx];
+                                // Convert per-shard savings back to absolute tablet reduction.
+                                double compressible = double(t.target) - double(t.floor);
+                                size_t reduction = std::lround(compressible * idle.weight * fraction);
+                                size_t new_target = (t.target > reduction) ? (t.target - reduction) : t.floor;
+                                new_target = std::max(new_target, t.floor);
+                                if (new_target < t.target) {
+                                    auto scale_f = double(new_target) / double(plan.tables[t.id].target_tablet_count);
+                                    auto [it, inserted] = table_scaling.try_emplace(t.id, scale_info{scale_f, rack});
+                                    if (!inserted && scale_f < it->second.factor) {
+                                        it->second = scale_info{scale_f, rack};
+                                    }
+                                }
+                            }
+                        } else {
+                            // Compress all idle tables to floors, then compress active uniformly.
+                            for (auto& idle : idle_tables) {
+                                auto& t = rack_tables[idle.idx];
+                                if (t.floor < t.target) {
+                                    auto scale_f = double(t.floor) / double(plan.tables[t.id].target_tablet_count);
+                                    auto [it, inserted] = table_scaling.try_emplace(t.id, scale_info{scale_f, rack});
+                                    if (!inserted && scale_f < it->second.factor) {
+                                        it->second = scale_info{scale_f, rack};
+                                    }
+                                }
+                            }
+
+                            // Remaining deficit after idle compression (in per-shard units).
+                            double remaining = needed_savings - total_unweighted_savings;
+                            double active_compressible_ps = 0;
+                            for (auto idx : active_table_indices) {
+                                auto& t = rack_tables[idx];
+                                double compressible = double(t.target) - double(t.floor);
+                                if (compressible > 0) {
+                                    active_compressible_ps += compressible * t.per_shard_factor;
+                                }
+                            }
+
+                            if (remaining > 0 && active_compressible_ps > 0) {
+                                double active_fraction = std::min(1.0, remaining / active_compressible_ps);
+                                for (auto idx : active_table_indices) {
+                                    auto& t = rack_tables[idx];
+                                    double compressible = double(t.target) - double(t.floor);
+                                    if (compressible <= 0) {
+                                        continue;
+                                    }
+                                    size_t reduction = std::lround(compressible * active_fraction);
+                                    size_t new_target = (t.target > reduction) ? (t.target - reduction) : t.floor;
+                                    new_target = std::max(new_target, t.floor);
+                                    if (new_target < t.target) {
+                                        auto scale_f = double(new_target) / double(plan.tables[t.id].target_tablet_count);
+                                        auto [it, inserted] = table_scaling.try_emplace(t.id, scale_info{scale_f, rack});
+                                        if (!inserted && scale_f < it->second.factor) {
+                                            it->second = scale_info{scale_f, rack};
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        // No idle compressible range: uniform compression of all tables.
+                        scale_info scale{_tablets_per_shard_goal / new_avg_tablets_per_shard, rack};
+                        for (auto& t : rack_tables) {
+                            auto [it, inserted] = table_scaling.try_emplace(t.id, scale);
+                            if (!inserted && scale.factor < it->second.factor) {
+                                it->second = scale;
                             }
                         }
                     }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -4696,6 +4696,7 @@ future<topology_coordinator::tablet_load_stats_collect_result> topology_coordina
 
     std::unordered_map<table_id, size_t> total_replicas;
     bool table_load_stats_invalid = false;
+    bool table_activity_incomplete = false;
 
     for (auto& [dc, nodes] : tm->get_datacenter_token_owners_nodes()) {
         locator::load_stats dc_stats;
@@ -4743,6 +4744,11 @@ future<topology_coordinator::tablet_load_stats_collect_result> topology_coordina
             }
 
             _load_stats_per_node[dst] = node_stats;
+            // If a node reports table load stats but not activity data,
+            // it is likely an older node that does not support this feature.
+            if (!node_stats.tables.empty() && node_stats.table_activity.empty()) {
+                table_activity_incomplete = true;
+            }
             dc_stats += node_stats;
         });
 
@@ -4792,11 +4798,19 @@ future<topology_coordinator::tablet_load_stats_collect_result> topology_coordina
         stats.tables.clear();
     }
 
+    // If any node reported table load stats without table_activity, the
+    // cluster-wide activity view is incomplete. Clear all activity data
+    // so the allocator pins tablet counts to current values.
+    if (table_activity_incomplete) {
+        stats.table_activity.clear();
+    }
+
     co_return tablet_load_stats_collect_result{
         .stats = make_lw_shared<const locator::load_stats>(std::move(stats)),
         .complete = !table_load_stats_invalid,
     };
 }
+
 
 future<> topology_coordinator::refresh_tablet_load_stats() {
     auto [load_stats, _] = co_await collect_tablet_load_stats(require_live_nodes::no);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3314,6 +3314,16 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_shrinks_respecting_rack_allocation)
             stats.set_tablet_sizes(tmptr, t3_2, 1);
         }
 
+        // Provide activity data so activity-weighted allocation can proceed.
+        stats.set_table_activity(t1_1, 0, 1.0);
+        stats.set_table_activity(t1_2, 0, 1.0);
+        stats.set_table_activity(t1_3, 0, 1.0);
+        stats.set_table_activity(t1_4, 0, 1.0);
+        stats.set_table_activity(t1_5, 0, 1.0);
+        stats.set_table_activity(t2_1, 0, 1.0);
+        stats.set_table_activity(t3_1, 0, 1.0);
+        stats.set_table_activity(t3_2, 0, 1.0);
+
         rebalance_tablets(e, &stats);
 
         auto& tmeta = stm.get()->tablets();
@@ -5254,22 +5264,26 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_option_and_config_changes) {
         // min_per_shard_tablet_count wants 5 * 3 = 15 (16) tablets
         e.execute_cql(fmt::format("ALTER TABLE {}.table1 "
                                   "WITH tablets = {{'min_per_shard_tablet_count': 5}}", ks_name1)).get();
+        load_stats.set_table_activity(table1, 0, 1.0);
         rebalance_tablets(e, &load_stats);
         BOOST_REQUIRE_EQUAL(get_tablet_count(), 16);
 
         // Check that hint can be dropped.
         e.execute_cql(fmt::format("ALTER TABLE {}.table1 WITH tablets = {{}}", ks_name1)).get();
+        load_stats.set_table_activity(table1, 0, 1.0);
         rebalance_tablets(e, &load_stats);
         BOOST_REQUIRE_EQUAL(get_tablet_count(), 2);
 
         // Default kicks in if keyspace setting and hint are missing.
         e.execute_cql(format("ALTER KEYSPACE {} with tablets = {{'enabled': true}}", ks_name1, dc)).get();
+        load_stats.set_table_activity(table1, 0, 1.0);
         rebalance_tablets(e, &load_stats);
         BOOST_REQUIRE_EQUAL(get_tablet_count(), 32);
 
         // initial scale can be live-updated.
         auto& cfg = e.db_config();
         cfg.tablets_initial_scale_factor(5);
+        load_stats.set_table_activity(table1, 0, 1.0);
         rebalance_tablets(e, &load_stats);
         BOOST_REQUIRE_EQUAL(get_tablet_count(), 16);
 
@@ -5277,17 +5291,20 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_option_and_config_changes) {
 
         // merge
         cfg.tablets_per_shard_goal(1);
+        load_stats.set_table_activity(table1, 0, 1.0);
         rebalance_tablets(e, &load_stats);
         BOOST_REQUIRE_EQUAL(get_tablet_count(), 4);
 
         // split
         cfg.tablets_per_shard_goal(100);
+        load_stats.set_table_activity(table1, 0, 1.0);
         rebalance_tablets(e, &load_stats);
         BOOST_REQUIRE_EQUAL(get_tablet_count(), 16);
 
         // initial scale can be smaller than 1.
         // 0.5 tablet/shard * 3 shards = 1.5 tablets =~ 2 tablets.
         cfg.tablets_initial_scale_factor(0.5);
+        load_stats.set_table_activity(table1, 0, 1.0);
         rebalance_tablets(e, &load_stats);
         BOOST_REQUIRE_EQUAL(get_tablet_count(), 2);
     }, cfg).get();
@@ -5328,6 +5345,11 @@ SEASTAR_THREAD_TEST_CASE(test_creating_lots_of_tables_doesnt_overflow_metadata) 
         auto& stm = e.shared_token_metadata().local();
 
         load_stats.set_default_tablet_sizes(stm.get());
+
+        // Provide activity data so Phase 3 can compress.
+        for (auto& table : tables) {
+            load_stats.set_table_activity(table, 0, 1.0);
+        }
 
         {
             load_sketch load(stm.get(), load_stats.get());
@@ -7971,6 +7993,160 @@ SEASTAR_TEST_CASE(test_load_stats_split_ready_invalidation) {
     }
 
     return make_ready_future<>();
+}
+
+// Activity-weighted tablet allocation tests
+SEASTAR_THREAD_TEST_CASE(test_activity_weighted_idle_tables_compress_more) {
+    // Active table keeps more budget when goal is exceeded.
+    cql_test_config cfg{};
+    cfg.db_config->tablets_per_shard_goal.set(10);
+    cfg.db_config->tablets_initial_scale_factor.set(0);
+    cfg.db_config->tablets_activity_weighted_allocation_enabled.set(true);
+    cfg.db_config->tablets_idle_table_rate_threshold.set(0.1);
+    cfg.db_config->tablets_idle_percentile.set(75);
+
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+        auto host1 = topo.add_node(node_state::normal, 1);
+
+        auto& stats = topo.get_shared_load_stats();
+        auto& stm = e.shared_token_metadata().local();
+
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 8);
+
+        auto t1 = add_table(e, ks_name).get();
+        auto t2 = add_table(e, ks_name).get();
+        auto t3 = add_table(e, ks_name).get();
+        auto t4 = add_table(e, ks_name).get();
+
+        auto tmptr = stm.get();
+        stats.set_tablet_sizes(tmptr, t1, 1);
+        stats.set_tablet_sizes(tmptr, t2, 1);
+        stats.set_tablet_sizes(tmptr, t3, 1);
+        stats.set_tablet_sizes(tmptr, t4, 1);
+
+        stats.set_table_activity(t1, 0, 1000.0);
+        stats.set_table_activity(t2, 0, 0.0);
+        stats.set_table_activity(t3, 0, 0.0);
+        stats.set_table_activity(t4, 0, 0.0);
+
+        apply_resize_decisions(e, stats);
+
+        auto& tmeta = stm.get()->tablets();
+        auto t1_decision = tmeta.get_tablet_map(t1).resize_decision();
+        auto t2_decision = tmeta.get_tablet_map(t2).resize_decision();
+        auto t3_decision = tmeta.get_tablet_map(t3).resize_decision();
+        auto t4_decision = tmeta.get_tablet_map(t4).resize_decision();
+        // Active table should NOT get a merge decision.
+        BOOST_REQUIRE(!t1_decision.is_merge());
+        // At least one idle table should get a merge decision.
+        BOOST_REQUIRE(t2_decision.is_merge() || t3_decision.is_merge() || t4_decision.is_merge());
+    }, cfg).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_activity_weighted_disabled_uses_uniform) {
+    cql_test_config cfg{};
+    cfg.db_config->tablets_per_shard_goal.set(10);
+    cfg.db_config->tablets_initial_scale_factor.set(0);
+    cfg.db_config->tablets_activity_weighted_allocation_enabled.set(false);
+
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+        auto host1 = topo.add_node(node_state::normal, 1);
+
+        auto& stats = topo.get_shared_load_stats();
+        auto& stm = e.shared_token_metadata().local();
+
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 8);
+
+        auto t1 = add_table(e, ks_name).get();
+        auto t2 = add_table(e, ks_name).get();
+
+        auto tmptr = stm.get();
+        stats.set_tablet_sizes(tmptr, t1, 1);
+        stats.set_tablet_sizes(tmptr, t2, 1);
+
+        stats.set_table_activity(t1, 0, 1000.0);
+        stats.set_table_activity(t2, 0, 0.0);
+
+        apply_resize_decisions(e, stats);
+
+        auto& tmeta = stm.get()->tablets();
+        auto t1_decision = tmeta.get_tablet_map(t1).resize_decision();
+        auto t2_decision = tmeta.get_tablet_map(t2).resize_decision();
+        // Uniform: both tables get the same decision.
+        BOOST_REQUIRE_EQUAL(t1_decision.is_merge(), t2_decision.is_merge());
+    }, cfg).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_activity_weighted_missing_data_pins_counts) {
+    cql_test_config cfg{};
+    cfg.db_config->tablets_per_shard_goal.set(10);
+    cfg.db_config->tablets_initial_scale_factor.set(0);
+    cfg.db_config->tablets_activity_weighted_allocation_enabled.set(true);
+
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+        auto host1 = topo.add_node(node_state::normal, 1);
+
+        auto& stats = topo.get_shared_load_stats();
+        auto& stm = e.shared_token_metadata().local();
+
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 8);
+
+        auto t1 = add_table(e, ks_name).get();
+        auto t2 = add_table(e, ks_name).get();
+
+        auto tmptr = stm.get();
+        stats.set_tablet_sizes(tmptr, t1, 1);
+        stats.set_tablet_sizes(tmptr, t2, 1);
+
+        // No table_activity: pin to current.
+        apply_resize_decisions(e, stats);
+
+        auto& tmeta = stm.get()->tablets();
+        auto t1_decision = tmeta.get_tablet_map(t1).resize_decision();
+        auto t2_decision = tmeta.get_tablet_map(t2).resize_decision();
+        BOOST_REQUIRE(!t1_decision.is_merge());
+        BOOST_REQUIRE(!t1_decision.is_split());
+        BOOST_REQUIRE(!t2_decision.is_merge());
+        BOOST_REQUIRE(!t2_decision.is_split());
+    }, cfg).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_activity_weighted_all_tables_equally_active) {
+    cql_test_config cfg{};
+    cfg.db_config->tablets_per_shard_goal.set(10);
+    cfg.db_config->tablets_initial_scale_factor.set(0);
+    cfg.db_config->tablets_activity_weighted_allocation_enabled.set(true);
+    cfg.db_config->tablets_idle_table_rate_threshold.set(0.1);
+
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+        auto host1 = topo.add_node(node_state::normal, 1);
+
+        auto& stats = topo.get_shared_load_stats();
+        auto& stm = e.shared_token_metadata().local();
+
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 8);
+
+        auto t1 = add_table(e, ks_name).get();
+        auto t2 = add_table(e, ks_name).get();
+
+        auto tmptr = stm.get();
+        stats.set_tablet_sizes(tmptr, t1, 1);
+        stats.set_tablet_sizes(tmptr, t2, 1);
+
+        stats.set_table_activity(t1, 0, 1000.0);
+        stats.set_table_activity(t2, 0, 1000.0);
+
+        apply_resize_decisions(e, stats);
+
+        auto& tmeta = stm.get()->tablets();
+        auto t1_decision = tmeta.get_tablet_map(t1).resize_decision();
+        auto t2_decision = tmeta.get_tablet_map(t2).resize_decision();
+        BOOST_REQUIRE_EQUAL(t1_decision.is_merge(), t2_decision.is_merge());
+    }, cfg).get();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/lib/topology_builder.hh
+++ b/test/lib/topology_builder.hh
@@ -72,6 +72,10 @@ struct shared_load_stats {
         }).get();
         set_size(table, tablet_size * tmap.tablet_count());
     }
+
+    void set_table_activity(table_id table, double read_rate, double write_rate) {
+        stats.table_activity[table] = locator::table_activity_stats{read_rate, write_rate};
+    }
 };
 
 /// Modifies topology inside a given cql_test_env.


### PR DESCRIPTION
## Summary

This series adds activity-aware tablet allocation. Instead of uniformly scaling all tables when the per-shard tablet goal is exceeded, the allocator now preferentially compresses idle tables while protecting active ones.

## Motivation

The current uniform scaling treats all tables equally regardless of their workload. This can lead to suboptimal decisions where heavily-used tables get their tablet counts reduced just because idle tables exist on the same shard. Activity-weighted allocation directs compression pressure toward tables that won't suffer performance degradation.

## Design

The feature introduces per-shard EWMA-smoothed activity rate tracking (read + write ops/sec) on each table, reported through the existing load stats protocol to the topology coordinator. The allocator then uses this data to classify tables as idle or active and compress accordingly.

Three operating modes ensure safety during rollout:

1. **Feature disabled** — legacy uniform scaling, no behavior change.
2. **Feature enabled, data missing** (rolling upgrade) — pin all tables to current counts.
3. **Feature enabled, data available** — activity-weighted compression targeting idle tables first.

## Patch breakdown

1. **serializer: add support for double type serialization** — wire format support for floating-point activity rates via `std::bit_cast<uint64_t>`.

2. **config: add activity-weighted allocation config options and feature flag** — five config knobs and the `TABLE_ACTIVITY_TABLET_ALLOCATION` cluster feature gate.

3. **table: add per-shard EWMA activity rate tracking on table** — per-table read/write rate EWMAs ticked every 10s (default 900s window).

4. **load_stats: populate load_stats with activity rates and detect missing data** — `table_activity_stats` struct in load stats with incomplete-reporting detection.

5. **tablet_allocator: activity-weighted compression in tablet allocator** — the core algorithm: percentile-based idle classification, proportional idle compression, uniform active fallback, and size-based floor clamping.

6. **test: add activity-weighted allocation unit tests** — unit tests covering idle compression, disabled mode, missing data, and uniform-activity cases.

## Configuration

| Option | Default | Description |
|--------|---------|-------------|
| `tablets_activity_weighted_allocation_enabled` | `true` | Master switch |
| `tablets_idle_table_rate_threshold` | `0.1` ops/sec | Absolute idle floor |
| `tablets_idle_percentile` | `75` | Percentile boundary for idle classification |
| `tablets_activity_ewma_window_seconds` | `900` | EWMA smoothing window |
| `table_activity_max_tablet_size_factor` | `4` | Max tablet size growth during compression |

Fixes: SCYLLADB-480

This is a new feature, and backporting is not needed.