### PR TITLE
repair, test: fix split-repair synchronization test timeout in debug mode

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1213,7 +1213,7 @@ private:
             throw std::runtime_error(msg);
         }
 
-        co_await utils::get_local_injector().inject("incremental_repair_prepare_wait", utils::wait_for_message(60s));
+        co_await utils::get_local_injector().inject("incremental_repair_prepare_wait", utils::wait_for_message(10min));
         rlogger.debug("Disabling compaction for range={} for incremental repair", _range);
         auto reenablers_and_holders = co_await table.get_compaction_reenablers_and_lock_holders_for_repair(_db.local(), _frozen_topology_guard, _range);
         for (auto& lock_holder : reenablers_and_holders.lock_holders) {

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -2119,8 +2119,8 @@ async def test_split_and_incremental_repair_synchronization(manager: ManagerClie
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': {initial_tablets}}};")
 
-        # insert data
-        pks = range(256)
+        # insert data — use a small volume to keep split compactions fast in debug mode
+        pks = range(64)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in pks])
 
         # flush the table
@@ -2146,7 +2146,7 @@ async def test_split_and_incremental_repair_synchronization(manager: ManagerClie
             insert_stmt.consistency_level = ConsistencyLevel.ONE
 
             await manager.api.enable_injection(servers[0].ip_addr, "database_apply", one_shot=False, parameters={"ks_name": ks, "cf_name": "test", "what": "throw"})
-            pks = range(256, 512)
+            pks = range(64, 128)
             await asyncio.gather(*[cql.run_async(insert_stmt, (k, k)) for k in pks])
             await manager.api.disable_injection(servers[0].ip_addr, "database_apply")
 


### PR DESCRIPTION
The test_split_and_incremental_repair_synchronization[True] test was timing out waiting for 'Finalizing resize decision for table' in debug mode.

The root cause is a timing race: the incremental_repair_prepare_wait error injection has a hardcoded 60s auto-expiry timeout (wait_for_message(60s)), but split compactions in debug mode take ~58s per SSTable due to -O0 compilation and scheduler starvation (the maintenance_compaction group gets ~10% of wall-clock time). When the injection auto-expires before split finalization, the repair fails, leaving tablets stuck in transition=repair state. This prevents the topology coordinator from finalizing the split, causing the 600s test timeout.

Fix both contributing factors:

- Increase the injection timeout from 60s to 10min, giving split compactions ample time to complete before the injection auto-expires. The test explicitly messages the injection to release it (line 2200), so the longer timeout is just a safety net.

- Reduce data volume from 256 to 64 rows (and repair data from 256 to 64 rows), producing smaller SSTables that split much faster in debug mode.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2123.

Flakiness can affect 2026.2 and 2026.1, so let's backport to both.