### PR TITLE
cql: request-side custom payload parsing

### DIFF
--- a/test/cqlpy/test_native_transport.py
+++ b/test/cqlpy/test_native_transport.py
@@ -5,9 +5,8 @@
 import pytest
 import time
 from . import nodetool
-from .util import new_session, new_test_table
+from .util import new_test_table
 from cassandra.cluster import NoHostAvailable
-from cassandra.protocol import ProtocolException
 from cassandra.query import SimpleStatement, BatchStatement, BatchType
 
 def test_enable_disable_binary(cql, test_keyspace):
@@ -34,55 +33,45 @@ def test_enable_disable_binary(cql, test_keyspace):
 
 
 def test_query_with_custom_payload(cql):
-    with new_session(cql, "cassandra") as tmp:
-        with pytest.raises(ProtocolException, match="truncated frame"):
-            tmp.execute(
-                SimpleStatement("SELECT * FROM system.local"),
-                custom_payload={"request-id": b"test-request-id"}
-            )
+    cql.execute(
+        SimpleStatement("SELECT * FROM system.local"),
+        custom_payload={"request-id": b"test-request-id"}
+    )
 
 
 def test_execute_prepared_with_custom_payload(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v text") as table:
         prepared = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
-        with new_session(cql, "cassandra") as tmp:
-            with pytest.raises(AssertionError, match="Got different query ID"):
-                tmp.execute(
-                    prepared.bind([1, "hello"]),
-                    custom_payload={"request-id": b"test-request-id"}
-                )
+        cql.execute(
+            prepared.bind([1, "hello"]),
+            custom_payload={"request-id": b"test-request-id"}
+        )
 
 
 def test_batch_with_custom_payload(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v text") as table:
-        with new_session(cql, "cassandra") as tmp:
-            batch = BatchStatement(batch_type=BatchType.UNLOGGED)
-            batch.add(SimpleStatement(f"INSERT INTO {table} (p, v) VALUES (1, 'a')"))
-            batch.add(SimpleStatement(f"INSERT INTO {table} (p, v) VALUES (2, 'b')"))
-            with pytest.raises(ProtocolException, match="Invalid query kind"):
-                tmp.execute(batch, custom_payload={"request-id": b"test-request-id"})
+        batch = BatchStatement(batch_type=BatchType.UNLOGGED)
+        batch.add(SimpleStatement(f"INSERT INTO {table} (p, v) VALUES (1, 'a')"))
+        batch.add(SimpleStatement(f"INSERT INTO {table} (p, v) VALUES (2, 'b')"))
+        cql.execute(batch, custom_payload={"request-id": b"test-request-id"})
 
 
 def test_request_with_multiple_payload_entries(cql):
-    with new_session(cql, "cassandra") as tmp:
-        with pytest.raises(ProtocolException, match="truncated frame"):
-            tmp.execute(
-                SimpleStatement("SELECT * FROM system.local"),
-                custom_payload={
-                    "key-one": b"value-one",
-                    "key-two": b"\xde\xad\xbe\xef",
-                    "key-three": b"",
-                }
-            )
+    cql.execute(
+        SimpleStatement("SELECT * FROM system.local"),
+        custom_payload={
+            "key-one": b"value-one",
+            "key-two": b"\xde\xad\xbe\xef",
+            "key-three": b"",
+        }
+    )
 
 
 def test_request_with_large_payload_value(cql):
-    with new_session(cql, "cassandra") as tmp:
-        with pytest.raises(ProtocolException, match="truncated frame"):
-            tmp.execute(
-                SimpleStatement("SELECT * FROM system.local"),
-                custom_payload={"large-key": b"x" * 8192}
-            )
+    cql.execute(
+        SimpleStatement("SELECT * FROM system.local"),
+        custom_payload={"large-key": b"x" * 8192}
+    )
 
 
 def test_custom_payload_does_not_affect_query_result(cql, test_keyspace):
@@ -91,12 +80,11 @@ def test_custom_payload_does_not_affect_query_result(cql, test_keyspace):
         cql.execute(f"INSERT INTO {table} (p, v) VALUES (2, 'world')")
 
         without = sorted(cql.execute(f"SELECT p, v FROM {table}"))
-        with new_session(cql, "cassandra") as tmp:
-            with pytest.raises(ProtocolException, match="truncated frame"):
-                tmp.execute(
-                    SimpleStatement(f"SELECT p, v FROM {table}"),
-                    custom_payload={
-                        "key-a": b"A" * 100,
-                        "key-b": b"B" * 200,
-                    }
-                )
+        with_payload = sorted(cql.execute(
+            SimpleStatement(f"SELECT p, v FROM {table}"),
+            custom_payload={
+                "key-a": b"A" * 100,
+                "key-b": b"B" * 200,
+            }
+        ))
+        assert without == with_payload

--- a/test/cqlpy/test_native_transport.py
+++ b/test/cqlpy/test_native_transport.py
@@ -5,8 +5,10 @@
 import pytest
 import time
 from . import nodetool
-from .util import new_test_table
+from .util import new_session, new_test_table
 from cassandra.cluster import NoHostAvailable
+from cassandra.protocol import ProtocolException
+from cassandra.query import SimpleStatement, BatchStatement, BatchType
 
 def test_enable_disable_binary(cql, test_keyspace):
     schema = 'k text, v text, primary key (k)'
@@ -29,3 +31,72 @@ def test_enable_disable_binary(cql, test_keyspace):
                 pause += pause
         else:
             assert False
+
+
+def test_query_with_custom_payload(cql):
+    with new_session(cql, "cassandra") as tmp:
+        with pytest.raises(ProtocolException, match="truncated frame"):
+            tmp.execute(
+                SimpleStatement("SELECT * FROM system.local"),
+                custom_payload={"request-id": b"test-request-id"}
+            )
+
+
+def test_execute_prepared_with_custom_payload(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v text") as table:
+        prepared = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        with new_session(cql, "cassandra") as tmp:
+            with pytest.raises(AssertionError, match="Got different query ID"):
+                tmp.execute(
+                    prepared.bind([1, "hello"]),
+                    custom_payload={"request-id": b"test-request-id"}
+                )
+
+
+def test_batch_with_custom_payload(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v text") as table:
+        with new_session(cql, "cassandra") as tmp:
+            batch = BatchStatement(batch_type=BatchType.UNLOGGED)
+            batch.add(SimpleStatement(f"INSERT INTO {table} (p, v) VALUES (1, 'a')"))
+            batch.add(SimpleStatement(f"INSERT INTO {table} (p, v) VALUES (2, 'b')"))
+            with pytest.raises(ProtocolException, match="Invalid query kind"):
+                tmp.execute(batch, custom_payload={"request-id": b"test-request-id"})
+
+
+def test_request_with_multiple_payload_entries(cql):
+    with new_session(cql, "cassandra") as tmp:
+        with pytest.raises(ProtocolException, match="truncated frame"):
+            tmp.execute(
+                SimpleStatement("SELECT * FROM system.local"),
+                custom_payload={
+                    "key-one": b"value-one",
+                    "key-two": b"\xde\xad\xbe\xef",
+                    "key-three": b"",
+                }
+            )
+
+
+def test_request_with_large_payload_value(cql):
+    with new_session(cql, "cassandra") as tmp:
+        with pytest.raises(ProtocolException, match="truncated frame"):
+            tmp.execute(
+                SimpleStatement("SELECT * FROM system.local"),
+                custom_payload={"large-key": b"x" * 8192}
+            )
+
+
+def test_custom_payload_does_not_affect_query_result(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v text") as table:
+        cql.execute(f"INSERT INTO {table} (p, v) VALUES (1, 'hello')")
+        cql.execute(f"INSERT INTO {table} (p, v) VALUES (2, 'world')")
+
+        without = sorted(cql.execute(f"SELECT p, v FROM {table}"))
+        with new_session(cql, "cassandra") as tmp:
+            with pytest.raises(ProtocolException, match="truncated frame"):
+                tmp.execute(
+                    SimpleStatement(f"SELECT p, v FROM {table}"),
+                    custom_payload={
+                        "key-a": b"A" * 100,
+                        "key-b": b"B" * 200,
+                    }
+                )

--- a/transport/request.hh
+++ b/transport/request.hh
@@ -304,6 +304,28 @@ public:
         return string_map;
     }
 
+    utils::result_with_exception_ptr<std::unordered_map<sstring, bytes>> read_string_bytes_map() {
+        std::unordered_map<sstring, bytes> map;
+        utils::result_with_exception_ptr<uint16_t> n = read_short();
+        if (!n) [[unlikely]] {
+            return bo::failure(std::move(n).assume_error());
+        }
+        for (auto i = 0; i < n.assume_value(); i++) {
+            utils::result_with_exception_ptr<sstring> key = read_string();
+            if (!key) [[unlikely]] {
+                return bo::failure(std::move(key).assume_error());
+            }
+            utils::result_with_exception_ptr<bytes> val = read_bytes();
+            if (!val) [[unlikely]] {
+                return bo::failure(std::move(val).assume_error());
+            }
+            map.emplace(std::piecewise_construct,
+                std::forward_as_tuple(std::move(key).assume_value()),
+                std::forward_as_tuple(std::move(val).assume_value()));
+        }
+        return map;
+    }
+
 private:
     enum class options_flag {
         VALUES,

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -942,7 +942,7 @@ std::unique_ptr<cql_server::response> cql_server::handle_exception(int16_t strea
     }
 }
 future<foreign_ptr<std::unique_ptr<cql_server::response>>>
-    cql_server::connection::process_request_one(fragmented_temporary_buffer::istream fbuf, uint8_t op, uint16_t stream, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit) {
+    cql_server::connection::process_request_one(fragmented_temporary_buffer::istream fbuf, uint8_t op, uint16_t stream, uint8_t flags, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit) {
     using auth_state = service::client_state::auth_state;
 
     auto cqlop = static_cast<cql_binary_opcode>(op);
@@ -968,7 +968,7 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
 
     auto linearization_buffer = std::make_unique<bytes_ostream>();
     auto linearization_buffer_ptr = linearization_buffer.get();
-    return futurize_invoke([this, cqlop, stream, &fbuf, &client_state, linearization_buffer_ptr, permit = std::move(permit), trace_state] () mutable {
+    return futurize_invoke([this, cqlop, stream, flags, &fbuf, &client_state, linearization_buffer_ptr, permit = std::move(permit), trace_state] () mutable {
         // When using authentication, we need to ensure we are doing proper state transitions,
         // i.e. we cannot simply accept any query/exec ops unless auth is complete
         switch (client_state.get_auth_state()) {
@@ -998,6 +998,16 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
             });
         };
         auto in = request_reader(std::move(fbuf), *linearization_buffer_ptr);
+
+        // Skip over the custom payload so the opcode parser reads from the
+        // correct position in the frame body.
+        if ((flags & cql_frame_flags::custom_payload) && _version >= 4) {
+            auto payload = in.read_string_bytes_map();
+            if (!payload) [[unlikely]] {
+                return make_exception_future<process_fn_return_type>(std::move(payload).assume_error());
+            }
+        }
+
         switch (cqlop) {
         case cql_binary_opcode::STARTUP:       return wrap_in_foreign(process_startup(stream, std::move(in), client_state, trace_state));
         case cql_binary_opcode::AUTH_RESPONSE: return wrap_in_foreign(process_auth_response(stream, std::move(in), client_state, trace_state));
@@ -1246,7 +1256,7 @@ future<> cql_server::connection::process_request() {
               return make_ready_future<>();
           }
           semaphore_units<> mem_permit = mem_permit_fut.get();
-          return this->read_and_decompress_frame(length, flags).then([this, op, stream, tracing_requested, mem_permit = make_service_permit(std::move(mem_permit)), request_start_time] (fragmented_temporary_buffer buf) mutable {
+          return this->read_and_decompress_frame(length, flags).then([this, op, stream, flags, tracing_requested, mem_permit = make_service_permit(std::move(mem_permit)), request_start_time] (fragmented_temporary_buffer buf) mutable {
 
             ++_server._stats.requests_served;
             ++_server._stats.requests_serving;
@@ -1272,8 +1282,8 @@ future<> cql_server::connection::process_request() {
                     op == uint8_t(cql_binary_opcode::BATCH));
 
             future<foreign_ptr<std::unique_ptr<cql_server::response>>> request_process_future = should_paralelize ?
-                    _process_request_stage(this, istream, op, stream, seastar::ref(_client_state), tracing_requested, mem_permit) :
-                    process_request_one(istream, op, stream, seastar::ref(_client_state), tracing_requested, mem_permit);
+                    _process_request_stage(this, istream, op, stream, flags, seastar::ref(_client_state), tracing_requested, mem_permit) :
+                    process_request_one(istream, op, stream, flags, seastar::ref(_client_state), tracing_requested, mem_permit);
 
             future<> request_response_future = request_process_future.then_wrapped([this, buf = std::move(buf), mem_permit, leave = std::move(leave), stream, request_start_time] (future<foreign_ptr<std::unique_ptr<cql_server::response>>> response_f) mutable {
                 try {

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -319,6 +319,7 @@ private:
                 fragmented_temporary_buffer::istream,
                 uint8_t,
                 uint16_t,
+                uint8_t,
                 service::client_state&,
                 tracing_request_type,
                 service_permit>;
@@ -336,7 +337,7 @@ private:
     private:
         friend class process_request_executor;
 
-        future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_request_one(fragmented_temporary_buffer::istream buf, uint8_t op, uint16_t stream, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit);
+        future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_request_one(fragmented_temporary_buffer::istream buf, uint8_t op, uint16_t stream, uint8_t flags, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit);
         unsigned frame_size() const;
         unsigned pick_request_cpu();
         utils::result_with_exception<cql_binary_frame_v3, exceptions::protocol_exception, class cql_frame_error> parse_frame(temporary_buffer<char> buf) const;


### PR DESCRIPTION
When a CQL client sends a request with the `CUSTOM_PAYLOAD` flag (`0x04`) set, the frame body starts with a [bytes map] before the message. Scylla never implemented parsing of this map on the request side. This caused it to fail parsing with protocol errors such as `"truncated frame: expected 65546 bytes"`.

This was discovered through DataStax Java Driver 4.19.x tests that attach a `request-id` to queries via custom payload. The same issue affects any CQL client that sets the `CUSTOM_PAYLOAD` flag.

Fix this by skipping over the custom payload [bytes map] from the frame body before dispatching to opcode-specific handlers. The payload contents are discarded since Scylla has no pluggable `QueryHandler`. Cassandra's default `QueryHandler` also discards them.

Fixes SCYLLADB-745

Reported on 2026.2, backport.