### PR TITLE
cql3: use small_vector for expression lists to reduce heap allocations

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -441,7 +441,7 @@ unaliasedSelector returns [uexpression tmp]
        )*
     ;
 
-selectionFunctionArgs returns [std::vector<expression> a]
+selectionFunctionArgs returns [expression_list a]
     : '(' ')'
     | '(' s1=unaliasedSelector { a.push_back(std::move(s1)); }
           ( ',' sn=unaliasedSelector { a.push_back(std::move(sn)); } )*
@@ -454,7 +454,7 @@ countArgument
     ;
 
 whereClause returns [uexpression clause]
-    @init { std::vector<expression> terms; }
+    @init { expression_list terms; }
     : e1=relation { terms.push_back(std::move(e1)); } (K_AND en=relation { terms.push_back(std::move(en)); })*
         { clause = conjunction{std::move(terms)}; }
     ;
@@ -507,7 +507,7 @@ insertStatement returns [std::unique_ptr<raw::modification_statement> expr]
     @init {
         auto attrs = std::make_unique<cql3::attributes::raw>();
         std::vector<::shared_ptr<cql3::column_identifier::raw>> column_names;
-        std::vector<expression> values;
+        expression_list values;
         bool if_not_exists = false;
         bool default_unset = false;
         std::optional<expression> json_value;
@@ -615,7 +615,7 @@ updateStatement returns [std::unique_ptr<raw::update_statement> expr]
 
 updateConditions returns [uexpression cond]
     @init {
-        std::vector<expression> conditions;
+        expression_list conditions;
     }
     : c1=columnCondition { conditions.emplace_back(std::move(c1)); }
          ( K_AND cn=columnCondition { conditions.emplace_back(std::move(cn)); } )*
@@ -1633,7 +1633,7 @@ constant returns [untyped_constant constant]
     ;
 
 mapLiteral returns [collection_constructor map]
-    @init{std::vector<expression> m;}
+    @init{expression_list m;}
     : '{' { }
           ( k1=term ':' v1=term { m.push_back(tuple_constructor{{std::move(k1), std::move(v1)}}); }
             ( ',' kn=term ':' vn=term { m.push_back(tuple_constructor{{std::move(kn), std::move(vn)}}); } )*  )?
@@ -1641,7 +1641,7 @@ mapLiteral returns [collection_constructor map]
     ;
 
 setOrMapLiteral[uexpression t] returns [collection_constructor value]
-	@init{ std::vector<expression> e; }
+	@init{ expression_list e; }
     : ':' v=term { e.push_back(tuple_constructor{{std::move(t), std::move(v)}}); }
           ( ',' kn=term ':' vn=term { e.push_back(tuple_constructor{{std::move(kn), std::move(vn)}}); } )*
       { $value = collection_constructor{collection_constructor::style_type::map, std::move(e)}; }
@@ -1651,7 +1651,7 @@ setOrMapLiteral[uexpression t] returns [collection_constructor value]
     ;
 
 collectionLiteral returns [uexpression value]
-	@init{ std::vector<expression> l; }
+	@init{ expression_list l; }
     : '['
           ( t1=term { l.push_back(std::move(t1)); } ( ',' tn=term { l.push_back(std::move(tn)); } )* )?
       ']' { $value = collection_constructor{collection_constructor::style_type::list_or_vector, std::move(l)}; }
@@ -1669,7 +1669,7 @@ usertypeLiteral returns [uexpression ut]
     ;
 
 tupleLiteral returns [uexpression tt]
-    @init{ std::vector<expression> l; }
+    @init{ expression_list l; }
     @after{ $tt = tuple_constructor{std::move(l)}; }
     : '(' t1=term { l.push_back(std::move(t1)); } ( ',' tn=term { l.push_back(std::move(tn)); } )* ')'
     ;
@@ -1705,7 +1705,7 @@ allowedFunctionName returns [sstring s]
     | K_COUNT                       { $s = "count"; }
     ;
 
-functionArgs returns [std::vector<expression> a]
+functionArgs returns [expression_list a]
     : '(' ')'
     | '(' t1=term { a.push_back(std::move(t1)); }
           ( ',' tn=term { a.push_back(std::move(tn)); } )*
@@ -1901,7 +1901,7 @@ relation returns [uexpression e]
                     oper_t::IN,
                     collection_constructor {
                       .style = collection_constructor::style_type::list_or_vector,
-                      .elements = std::vector<expression>()
+                      .elements = expression_list()
                     }
                   );
               }
@@ -1960,15 +1960,15 @@ listOfIdentifiers returns [std::vector<::shared_ptr<cql3::column_identifier::raw
     : n1=cident { $ids.push_back(n1); } (',' ni=cident { $ids.push_back(ni); })*
     ;
 
-singleColumnInValues returns [std::vector<expression> list]
+singleColumnInValues returns [expression_list list]
     : '(' ( t1 = term { $list.push_back(std::move(t1)); } (',' ti=term { $list.push_back(std::move(ti)); })* )? ')'
     ;
 
-tupleOfTupleLiterals returns [std::vector<expression> literals]
+tupleOfTupleLiterals returns [expression_list literals]
     : '(' t1=tupleLiteral { $literals.emplace_back(std::move(t1)); } (',' ti=tupleLiteral { $literals.emplace_back(std::move(ti)); })* ')'
     ;
 
-tupleOfMarkersForTuples returns [std::vector<expression> markers]
+tupleOfMarkersForTuples returns [expression_list markers]
     : '(' m1=marker { $markers.emplace_back(std::move(m1)); } (',' mi=marker { $markers.emplace_back(std::move(mi)); })* ')'
     ;
 

--- a/cql3/expr/expr-utils.hh
+++ b/cql3/expr/expr-utils.hh
@@ -146,7 +146,7 @@ inline auto find_clustering_order(const expression& e) {
 /// Given a Boolean expression, compute its factors such as e=f1 AND f2 AND f3 ...
 /// If the expression is TRUE, may return no factors (happens today for an
 /// empty conjunction).
-std::vector<expression> boolean_factors(expression e);
+expression_list boolean_factors(expression e);
 
 /// Run the given function for each element in the top level conjunction.
 void for_each_boolean_factor(const expression& e, const noncopyable_function<void (const expression&)>& for_each_func);
@@ -203,7 +203,7 @@ extern assignment_testable::test_result test_assignment(const expression& expr, 
 
 // Test all elements of exprs for assignment. If all are exact match, return exact match. If any is not assignable,
 // return not assignable. Otherwise, return weakly assignable.
-extern assignment_testable::test_result test_assignment_all(const std::vector<expression>& exprs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver);
+extern assignment_testable::test_result test_assignment_all(const expression_list& exprs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver);
 
 extern shared_ptr<assignment_testable> as_assignment_testable(expression e, std::optional<data_type> type_opt);
 
@@ -271,8 +271,8 @@ cql3::expr::expression levellize_aggregation_depth(const cql3::expr::expression&
 
 
 struct aggregation_split_result {
-    std::vector<expression> inner_loop;
-    std::vector<expression> outer_loop;
+    expression_list inner_loop;
+    expression_list outer_loop;
     std::vector<cql3::raw_value> initial_values_for_temporaries; // same size as inner_loop
 };
 

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -75,7 +75,7 @@ static cql3::raw_value do_evaluate(const function_call&, const evaluation_inputs
 
 namespace {
 
-using children_t = std::vector<expression>; // conjunction's children.
+using children_t = expression_list; // conjunction's children.
 
 children_t explode_conjunction(expression e) {
     return expr::visit(overloaded_functor{
@@ -587,7 +587,7 @@ const column_value& get_subscripted_column(const expression& e) {
 
 expression make_conjunction(expression a, expression b) {
     auto children = explode_conjunction(std::move(a));
-    std::ranges::copy(explode_conjunction(std::move(b)), back_inserter(children));
+    std::ranges::copy(explode_conjunction(std::move(b)), std::back_inserter(children));
     return conjunction{std::move(children)};
 }
 
@@ -599,9 +599,9 @@ make_untyped_null() {
     };
 }
 
-std::vector<expression>
+expression_list
 boolean_factors(expression e) {
-    std::vector<expression> ret;
+    expression_list ret;
     for_each_boolean_factor(e, [&](const expression& boolean_factor) {
         ret.push_back(boolean_factor);
     });
@@ -986,7 +986,7 @@ expression search_and_replace(const expression& e,
                     return conjunction{
                             conj.children
                             | std::views::transform(recurse)
-                            | std::ranges::to<std::vector>()
+                            | std::ranges::to<expression_list>()
                     };
                 },
                 [&] (const binary_operator& oper) -> expression {
@@ -999,7 +999,7 @@ expression search_and_replace(const expression& e,
                     return tuple_constructor{
                         tc.elements
                             | std::views::transform(recurse)
-                            | std::ranges::to<std::vector>(),
+                            | std::ranges::to<expression_list>(),
                         tc.type
                     };
                 },
@@ -1008,7 +1008,7 @@ expression search_and_replace(const expression& e,
                         c.style,
                         c.elements
                             | std::views::transform(recurse)
-                            | std::ranges::to<std::vector>(),
+                            | std::ranges::to<expression_list>(),
                         c.type
                     };
                 },
@@ -1024,7 +1024,7 @@ expression search_and_replace(const expression& e,
                         fc.func,
                         fc.args
                             | std::views::transform(recurse)
-                            | std::ranges::to<std::vector>()
+                            | std::ranges::to<expression_list>()
                     };
                 },
                 [&] (const cast& c) -> expression {
@@ -2147,7 +2147,7 @@ convert_map_back_to_listlike(expression e) {
 
     auto type = dynamic_pointer_cast<const listlike_collection_type_impl>(type_of(e));
     auto map_type = map_type_impl::get_instance(type->name_comparator(), type->value_comparator(), true);
-    auto args = std::vector<expression>();
+    auto args = expression_list();
     args.push_back(std::move(e));
 
     return function_call{
@@ -2386,8 +2386,8 @@ split_aggregation(std::span<const expression> aggregation) {
     auto allocate_temporary = [&] () -> size_t {
         return nr_temporaries++;
     };
-    std::vector<expression> inner_vec;
-    std::vector<expression> outer_vec;
+    expression_list inner_vec;
+    expression_list outer_vec;
     std::vector<raw_value> initial_values_vec;
     for (auto& e : aggregation) {
         auto outer = search_and_replace(e, [&] (const expression& e) -> std::optional<expression> {
@@ -2410,7 +2410,7 @@ split_aggregation(std::span<const expression> aggregation) {
                     auto& agg = agg_fn->get_aggregate();
                     auto inner_fn = agg.aggregation_function;
                     auto outer_fn = agg.state_to_result_function;
-                    auto inner_args = std::vector<expression>();
+                    auto inner_args = expression_list();
                     inner_args.push_back(temporary{.index = temp, .type = agg.state_type});
                     inner_args.insert(inner_args.end(), fc->args.begin(), fc->args.end());
                     auto inner = function_call{
@@ -2418,7 +2418,7 @@ split_aggregation(std::span<const expression> aggregation) {
                         .args = std::move(inner_args),
                     };
                     // The result of evaluating inner should be stored in the same temporary.
-                    auto outer_args = std::vector<expression>();
+                    auto outer_args = expression_list();
                     outer_args.push_back(temporary{.index = temp, .type = agg.state_type});
                     auto outer = std::invoke([&] () -> expression {
                         if (outer_fn) {

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -19,6 +19,7 @@
 #include "cql3/functions/function_name.hh"
 #include "seastarx.hh"
 #include "cql3/values.hh"
+#include "utils/small_vector.hh"
 
 class row;
 
@@ -248,10 +249,15 @@ struct binary_operator {
     friend bool operator==(const binary_operator&, const binary_operator&) = default;
 };
 
+// A list of expressions with small buffer optimization.
+// Most CQL constructs (conjunctions, function args, tuples, collections)
+// have a small number of elements, so avoid heap allocation for the common case.
+using expression_list = utils::small_vector<expression, 4>;
+
 // A conjunction of expressions separated by the AND keyword.
 // For example: "a < 3 AND col1 = ? AND pk IN (1, 2)"
 struct conjunction {
-    std::vector<expression> children;
+    expression_list children;
 
     friend bool operator==(const conjunction&, const conjunction&) = default;
 };
@@ -287,7 +293,7 @@ struct function_call {
     // Before preparation "func" is a function_name.
     // During preparation it's converted into db::functions::function
     std::variant<functions::function_name, shared_ptr<db::functions::function>> func;
-    std::vector<expression> args;
+    expression_list args;
 
     // 0-based index of the function call within a CQL statement.
     // Used to populate the cache of execution results while passing to
@@ -404,7 +410,7 @@ struct constant {
 // For example: "('a', ?, some_column)"
 // During preparation tuple constructors with constant values are converted to expr::constant.
 struct tuple_constructor {
-    std::vector<expression> elements;
+    expression_list elements;
 
     // Might be nullptr before prepare.
     // After prepare always holds a valid type, although it might be reversed_type(tuple_type).
@@ -421,7 +427,7 @@ struct collection_constructor {
     style_type style;
 
     // For map constructors, elements is a list of key-pair tuples.
-    std::vector<expression> elements;
+    expression_list elements;
 
     // Might be nullptr before prepare.
     // After prepare always holds a valid type, although it might be reversed_type(collection_type).

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -269,7 +269,7 @@ map_prepare_expression(const collection_constructor& c, data_dictionary::databas
         return constant::make_null(receiver->type);
     }
 
-    std::vector<expression> values;
+    expression_list values;
     values.reserve(c.elements.size());
     bool all_terminal = true;
     for (auto&& entry : c.elements) {
@@ -385,7 +385,7 @@ set_prepare_expression(const collection_constructor& c, data_dictionary::databas
     }
 
     auto value_spec = set_value_spec_of(*receiver);
-    std::vector<expression> values;
+    expression_list values;
     values.reserve(c.elements.size());
     bool all_terminal = true;
     for (auto& e : c.elements)
@@ -463,7 +463,7 @@ list_prepare_expression(const collection_constructor& c, data_dictionary::databa
     }
 
     auto&& value_spec = list_value_spec_of(*receiver);
-    std::vector<expression> values;
+    expression_list values;
     values.reserve(c.elements.size());
     bool all_terminal = true;
     for (auto& e : c.elements) {
@@ -540,7 +540,7 @@ vector_prepare_expression(const collection_constructor& c, data_dictionary::data
     vector_validate_assignable_to(c, db, keyspace, schema_opt, *receiver);
 
     auto&& value_spec = vector_value_spec_of(*receiver);
-    std::vector<expression> values;
+    expression_list values;
     values.reserve(c.elements.size());
     bool all_terminal = true;
     for (auto& e : c.elements) {
@@ -641,7 +641,7 @@ tuple_constructor_prepare_nontuple(const tuple_constructor& tc, data_dictionary:
     if (receiver) {
         tuple_constructor_validate_assignable_to(tc, db, keyspace, schema_opt, *receiver);
     }
-    std::vector<expression> values;
+    expression_list values;
     bool all_terminal = true;
     for (size_t i = 0; i < tc.elements.size(); ++i) {
         lw_shared_ptr<column_specification> component_receiver;
@@ -955,7 +955,7 @@ sql_cast_prepare_expression(const cast& c, data_dictionary::database db, const s
     // We implement the cast to a function_call.
     return function_call{
         .func = std::move(fun),
-        .args = std::vector({*prepared_arg}),
+        .args = [&] { expression_list a; a.push_back(std::move(*prepared_arg)); return a; }(),
     };
 }
 
@@ -1131,7 +1131,7 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
                                                     fun->name(), fun->arg_types().size(), fc.args.size()));
     }
 
-    std::vector<expr::expression> parameters;
+    expr::expression_list parameters;
     parameters.reserve(partially_prepared_args.size());
     bool all_terminal = true;
     for (size_t i = 0; i < partially_prepared_args.size(); ++i) {
@@ -1221,7 +1221,7 @@ std::optional<expression> prepare_conjunction(const conjunction& conj,
                                                               std::move(child_receiver_name), boolean_type);
     }
 
-    std::vector<expression> prepared_children;
+    expression_list prepared_children;
 
     bool all_terminal = true;
     for (const expression& child : conj.children) {
@@ -1624,7 +1624,7 @@ prepare_expression(const expression& expr, data_dictionary::database db, const s
 }
 
 assignment_testable::test_result
-test_assignment_all(const std::vector<expression>& to_test, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+test_assignment_all(const expression_list& to_test, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
     using test_result = assignment_testable::test_result;
     test_result res = test_result::EXACT_MATCH;
     for (auto&& e : to_test) {
@@ -1857,7 +1857,7 @@ optimize_like(const expression& e) {
                     if ((type_of(*rhs) == utf8_type || type_of(*rhs) == ascii_type) && !rhs->is_null()) {
                         auto pattern = to_bytes(rhs->value.view());
                         auto func = ::make_shared<like_constant_function>(type_of(binop->lhs), pattern);
-                        auto args = std::vector<expression>();
+                        auto args = expression_list();
                         args.push_back(binop->lhs);
                         return function_call{std::move(func), std::move(args)};
                     }

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -62,7 +62,7 @@ void validate_single_column_relation(const column_value& lhs, oper_t oper, const
     }
 }
 
-std::vector<const column_definition*> to_column_definitions(const std::vector<expression>& cols) {
+std::vector<const column_definition*> to_column_definitions(const expression_list& cols) {
     std::vector<const column_definition*> result;
     result.reserve(cols.size());
 
@@ -263,7 +263,7 @@ binary_operator validate_and_prepare_new_restriction(const binary_operator& rest
     // Convert single element IN relation to an EQ relation
     if (prepared_binop.op == oper_t::IN) {
         if (is<collection_constructor>(prepared_binop.rhs)) {
-            const std::vector<expression>& elements = as<collection_constructor>(prepared_binop.rhs).elements;
+            const expression_list& elements = as<collection_constructor>(prepared_binop.rhs).elements;
             if (elements.size() == 1) {
                 prepared_binop.op = oper_t::EQ;
                 prepared_binop.rhs = elements[0];

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1214,7 +1214,7 @@ statement_restrictions::statement_restrictions(private_tag,
         auto partition_key_filter = expr::conjunction{
             .children = _single_column_partition_key_restrictions
                     | std::ranges::views::values
-                    | std::ranges::to<std::vector>(),
+                    | std::ranges::to<expr::expression_list>(),
         };
         _partition_level_filter = expr::make_conjunction(std::move(_partition_level_filter), std::move(partition_key_filter));
     }
@@ -1223,7 +1223,7 @@ statement_restrictions::statement_restrictions(private_tag,
         auto clustering_key_filter = expr::conjunction{
             .children = _single_column_clustering_key_restrictions
                     | std::ranges::views::values
-                    | std::ranges::to<std::vector>(),
+                    | std::ranges::to<expr::expression_list>(),
         };
         _clustering_row_level_filter = expr::make_conjunction(std::move(_clustering_row_level_filter), std::move(clustering_key_filter));
     }
@@ -1240,7 +1240,7 @@ statement_restrictions::statement_restrictions(private_tag,
         .children = _single_column_nonprimary_key_restrictions
                 | std::ranges::views::filter(make_column_kind_checker(column_kind::static_column))
                 | std::ranges::views::values
-                | std::ranges::to<std::vector>(),
+                | std::ranges::to<expr::expression_list>(),
     };
 
     _partition_level_filter = expr::make_conjunction(std::move(_partition_level_filter), std::move(static_columns_filter));
@@ -1249,7 +1249,7 @@ statement_restrictions::statement_restrictions(private_tag,
         .children = _single_column_nonprimary_key_restrictions
                 | std::ranges::views::filter(make_column_kind_checker(column_kind::regular_column))
                 | std::ranges::views::values
-                | std::ranges::to<std::vector>(),
+                | std::ranges::to<expr::expression_list>(),
     };
 
     _clustering_row_level_filter = expr::make_conjunction(std::move(_clustering_row_level_filter), std::move(regular_columns_filter));
@@ -1257,7 +1257,7 @@ statement_restrictions::statement_restrictions(private_tag,
     auto multi_column_restrictions = expr::conjunction{
         .children = expr::boolean_factors(_clustering_columns_restrictions)
                 | std::ranges::views::filter(contains_multi_column_restriction)
-                | std::ranges::to<std::vector>()
+                | std::ranges::to<expr::expression_list>()
     };
 
     _clustering_row_level_filter = expr::make_conjunction(std::move(_clustering_row_level_filter), std::move(multi_column_restrictions));
@@ -1355,7 +1355,7 @@ statement_restrictions::is_restricted(const column_definition* cdef) const {
 }
 
 
-const std::vector<expr::expression>& statement_restrictions::index_restrictions() const {
+const expr::expression_list& statement_restrictions::index_restrictions() const {
     return _index_restrictions;
 }
 
@@ -2496,7 +2496,7 @@ void statement_restrictions::prepare_indexed_global(const schema& idx_tbl_schema
             | std::views::take(_schema->partition_key_size()) // take only the partition key restrictions
             | std::views::transform(expr::as<expr::binary_operator>) // we know it's an EQ
             | std::views::transform(std::mem_fn(&expr::binary_operator::rhs)) // "solve" for the column value
-            | std::ranges::to<std::vector>();
+            | std::ranges::to<expr::expression_list>();
 
     auto pk_solvers = (*_idx_tbl_ck_prefix)
             | std::views::drop(1) // skip the token restriction

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -164,7 +164,7 @@ private:
     /**
      * The restrictions used to build the index expressions
      */
-    std::vector<expr::expression> _index_restrictions;
+    expr::expression_list _index_restrictions;
 
     /**
      * <code>true</code> if the secondary index need to be queried, <code>false</code> otherwise
@@ -179,7 +179,7 @@ private:
     bool _has_queriable_regular_index = false, _has_queriable_pk_index = false, _has_queriable_ck_index = false;
     bool _has_multi_column; ///< True iff _clustering_columns_restrictions has a multi-column restriction.
 
-    std::vector<expr::expression> _where; ///< The entire WHERE clause (factorized).
+    expr::expression_list _where; ///< The entire WHERE clause (factorized).
 
     /// Parts of _where defining the clustering slice.
     ///
@@ -269,7 +269,7 @@ public:
         check_indexes do_check_indexes);
 public:
 
-    const std::vector<expr::expression>& index_restrictions() const;
+    const expr::expression_list& index_restrictions() const;
 
     /**
      * Checks if the restrictions on the partition key is an IN restriction.

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -24,7 +24,7 @@ expr::expression
 make_count_rows_function_expression() {
     return expr::function_call{
             cql3::functions::function_name::native_function(cql3::functions::aggregate_fcts::COUNT_ROWS_FUNCTION_NAME),
-                    std::vector<cql3::expr::expression>()};
+                    cql3::expr::expression_list()};
 }
 
 

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -202,14 +202,14 @@ contains_ttl(const expr::expression& e) {
 
 class selection_with_processing : public selection {
 private:
-    std::vector<expr::expression> _selectors;
-    std::vector<expr::expression> _inner_loop;
-    std::vector<expr::expression> _outer_loop;
+    expr::expression_list _selectors;
+    expr::expression_list _inner_loop;
+    expr::expression_list _outer_loop;
     std::vector<raw_value> _initial_values_for_temporaries;
 public:
     selection_with_processing(schema_ptr schema, std::vector<const column_definition*> columns,
             std::vector<lw_shared_ptr<column_specification>> metadata,
-            std::vector<expr::expression> selectors)
+            expr::expression_list selectors)
         : selection(schema, std::move(columns), std::move(metadata),
             contains_writetime(expr::tuple_constructor{selectors}),
             contains_ttl(expr::tuple_constructor{selectors}),
@@ -526,7 +526,7 @@ uint32_t selection::add_column_for_post_processing(const column_definition& c) {
     auto metadata = collect_metadata(*schema, prepared_selectors);
     if (processes_selection(prepared_selectors) || prepared_selectors.size() != defs.size()) {
         return ::make_shared<selection_with_processing>(schema, std::move(defs), std::move(metadata),
-                prepared_selectors | std::views::transform(std::mem_fn(&prepared_selector::expr)) | std::ranges::to<std::vector>());
+                prepared_selectors | std::views::transform(std::mem_fn(&prepared_selector::expr)) | std::ranges::to<expr::expression_list>());
     } else {
         return ::make_shared<simple_selection>(schema, std::move(defs), std::move(metadata), false);
     }

--- a/cql3/statements/raw/insert_statement.hh
+++ b/cql3/statements/raw/insert_statement.hh
@@ -28,7 +28,7 @@ namespace raw {
 class insert_statement : public raw::modification_statement {
 private:
     const std::vector<::shared_ptr<column_identifier::raw>> _column_names;
-    const std::vector<expr::expression> _column_values;
+    const expr::expression_list _column_values;
 public:
     /**
      * A parsed <code>INSERT</code> statement.
@@ -41,7 +41,7 @@ public:
     insert_statement(cf_name name,
                   std::unique_ptr<attributes::raw> attrs,
                   std::vector<::shared_ptr<column_identifier::raw>> column_names,
-                  std::vector<expr::expression> column_values,
+                  expr::expression_list column_values,
                   bool if_not_exists);
 
     virtual ::shared_ptr<cql3::statements::modification_statement> prepare_internal(data_dictionary::database db, schema_ptr schema,

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2027,7 +2027,7 @@ static uint32_t add_similarity_function_to_selectors(
     auto func_name = functions::function_name::native_function(sstring(similarity_function_name));
 
     // Create the function arguments
-    std::vector<expr::expression> args;
+    expr::expression_list args;
     args.push_back(expr::column_value(ann_ordering_info._prepared_ann_ordering.first));
     args.push_back(ann_ordering_info._prepared_ann_ordering.second);
 
@@ -2296,7 +2296,7 @@ select_statement::maybe_jsonize_select_clause(std::vector<selection::prepared_se
         }
 
         // Prepare args for as_json_function
-        std::vector<expr::expression> args;
+        expr::expression_list args;
         args.reserve(prepared_selectors.size());
         for (const auto& prepared_selector : prepared_selectors) {
             args.push_back(std::move(prepared_selector.expr));

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -371,7 +371,7 @@ namespace raw {
 insert_statement::insert_statement(cf_name name,
                                    std::unique_ptr<attributes::raw> attrs,
                                    std::vector<::shared_ptr<column_identifier::raw>> column_names,
-                                   std::vector<expr::expression> column_values,
+                                   expr::expression_list column_values,
                                    bool if_not_exists)
     : raw::modification_statement{std::move(name), std::move(attrs), std::nullopt /* condition */, if_not_exists, false}
     , _column_names{std::move(column_names)}
@@ -397,7 +397,7 @@ insert_statement::prepare_internal(data_dictionary::database db, schema_ptr sche
         throw exceptions::invalid_request_exception("No columns provided to INSERT");
     }
 
-    std::vector<expr::expression> relations;
+    expr::expression_list relations;
     std::unordered_set<bytes> column_ids;
     for (size_t i = 0; i < _column_names.size(); i++) {
         auto&& col = _column_names[i];

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -147,8 +147,8 @@ expr::expression where_clause_to_relations(const std::string_view& where_clause,
 }
 
 sstring rename_columns_in_where_clause(const std::string_view& where_clause, std::vector<std::pair<::shared_ptr<column_identifier>, ::shared_ptr<column_identifier>>> renames, dialect d) {
-    std::vector<expr::expression> relations = boolean_factors(where_clause_to_relations(where_clause, d));
-    std::vector<expr::expression> new_relations;
+    expr::expression_list relations = boolean_factors(where_clause_to_relations(where_clause, d));
+    expr::expression_list new_relations;
     new_relations.reserve(relations.size());
 
     for (const expr::expression& old_relation : relations) {

--- a/service/mapreduce_service.cc
+++ b/service/mapreduce_service.cc
@@ -365,7 +365,7 @@ static shared_ptr<cql3::selection::selection> mock_selection(
         }
 
         auto reducible_aggr = aggr_function->reducible_aggregate_function();
-        auto arg_exprs = info->column_names | std::views::transform(name_as_expression) | std::ranges::to<std::vector<cql3::expr::expression>>();
+        auto arg_exprs = info->column_names | std::views::transform(name_as_expression) | std::ranges::to<cql3::expr::expression_list>();
         auto fc_expr = cql3::expr::function_call{reducible_aggr, arg_exprs};
         auto column_identifier = make_shared<cql3::column_identifier>(info->name.name, false);
         auto prepared_expr = cql3::expr::prepare_expression(fc_expr, db.as_data_dictionary(), "", schema.get(), nullptr);

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -119,7 +119,7 @@ static unresolved_identifier make_column(const char* col_name) {
     return unresolved_identifier{::make_shared<column_identifier_raw>(col_name, true)};
 }
 
-static function_call make_token(std::vector<expression> args) {
+static function_call make_token(expression_list args) {
     return function_call {
         .func = functions::function_name::native_function("token"),
         .args = args
@@ -366,9 +366,9 @@ BOOST_AUTO_TEST_CASE(expr_printer_parse_and_print_test) {
 }
 
 BOOST_AUTO_TEST_CASE(boolean_factors_test) {
-    BOOST_REQUIRE_EQUAL(boolean_factors(make_bool_const(true)), std::vector<expression>({make_bool_const(true)}));
+    BOOST_REQUIRE_EQUAL(boolean_factors(make_bool_const(true)), expression_list({make_bool_const(true)}));
 
-    BOOST_REQUIRE_EQUAL(boolean_factors(constant::make_null(boolean_type)), std::vector<expression>({constant::make_null(boolean_type)}));
+    BOOST_REQUIRE_EQUAL(boolean_factors(constant::make_null(boolean_type)), expression_list({constant::make_null(boolean_type)}));
 
     bind_variable bv1{0};
     bind_variable bv2{1};
@@ -377,9 +377,9 @@ BOOST_AUTO_TEST_CASE(boolean_factors_test) {
 
     BOOST_REQUIRE_EQUAL(
         boolean_factors(
-            conjunction{std::vector<expression>({bv1, bv2, bv3, bv4})}
+            conjunction{expression_list({bv1, bv2, bv3, bv4})}
         ),
-        std::vector<expression>(
+        expression_list(
             {bv1, bv2, bv3, bv4}
         )
     );
@@ -387,13 +387,13 @@ BOOST_AUTO_TEST_CASE(boolean_factors_test) {
     BOOST_REQUIRE_EQUAL(
         boolean_factors(
             conjunction{
-                std::vector<expression>({
+                expression_list({
                     make_conjunction(bv1, bv2),
                     make_conjunction(bv3, bv4)
                 })
             }
         ),
-        std::vector<expression>(
+        expression_list(
             {bv1, bv2, bv3, bv4}
         )
     );
@@ -640,7 +640,7 @@ BOOST_AUTO_TEST_CASE(evaluate_set_collection_constructor_with_empty) {
 BOOST_AUTO_TEST_CASE(evaluate_map_collection_constructor_with_empty) {
     // TODO: Empty multi-cell collections are trated as NULL in the database,
     // should the conversion happen in evaluate?
-    expression empty_map = make_map_constructor(std::vector<expression>(), int32_type, int32_type);
+    expression empty_map = make_map_constructor(expression_list(), int32_type, int32_type);
     BOOST_REQUIRE_EQUAL(evaluate(empty_map, evaluation_inputs{}), make_int_int_map_raw({}));
 }
 
@@ -1383,7 +1383,7 @@ BOOST_AUTO_TEST_CASE(prepare_token) {
 
     expression prepared = prepare_expression(tok, db, "test_ks", table_schema.get(), nullptr);
 
-    std::vector<expression> expected_args = {column_value(table_schema->get_column_definition("p1")),
+    expression_list expected_args = {column_value(table_schema->get_column_definition("p1")),
                                  column_value(table_schema->get_column_definition("p2")),
                                  column_value(table_schema->get_column_definition("p3"))};
 
@@ -1402,7 +1402,7 @@ BOOST_AUTO_TEST_CASE(prepare_token_no_args) {
                                   .build();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
-    expression tok = make_token(std::vector<expression>());
+    expression tok = make_token(expression_list());
 
     BOOST_REQUIRE_THROW(prepare_expression(tok, db, "test_ks", table_schema.get(), nullptr),
                         exceptions::invalid_request_exception);
@@ -3171,7 +3171,7 @@ BOOST_AUTO_TEST_CASE(evaluate_conjunction_one_true) {
 
 // Helper function that evaluates a conjunction with given elements
 raw_value eval_conj(std::vector<raw_value> elements) {
-    std::vector<expression> conj_children;
+    expression_list conj_children;
     for (const raw_value& element : elements) {
         conj_children.push_back(constant(element, boolean_type));
     }
@@ -3888,9 +3888,9 @@ enum struct expected_rhs_type {
 
 // Generates invalid RHS values for use in prepare_binary_operator tests.
 // The argument specifies what type of RHS values are right, so we can avoid them when generating the wrong ones.
-std::vector<expression> get_invalid_rhs_values(expected_rhs_type expected_rhs) {
+expression_list get_invalid_rhs_values(expected_rhs_type expected_rhs) {
     // Start by adding values that are wrong in all prepare_binary_operator tests
-    std::vector<expression> invalid_rhs_vals = {
+    expression_list invalid_rhs_vals = {
         make_bool_untyped("true"), make_duration_untyped("365d"), make_hex_untyped("0xdeadbeef"),
         // A tuple where the third element has a type that doesn't match the one expected by multi_column_tuple
         tuple_constructor{.elements =
@@ -3992,7 +3992,7 @@ void test_prepare_binary_operator_invalid_rhs_values(const expression& good_bino
                                                      expected_rhs_type expected_rhs,
                                                      data_dictionary::database db,
                                                      const schema_ptr& table_schema) {
-    std::vector<expression> invalid_rhs_vals = get_invalid_rhs_values(expected_rhs);
+    expression_list invalid_rhs_vals = get_invalid_rhs_values(expected_rhs);
 
     for (const expression& invalid_rhs : invalid_rhs_vals) {
         binary_operator invalid_binop = as<binary_operator>(good_binop);
@@ -4685,7 +4685,7 @@ BOOST_AUTO_TEST_CASE(prepare_token_func_without_receiver) {
         BOOST_REQUIRE(token_fun != nullptr);
         BOOST_REQUIRE((*token_fun)->name() == functions::function_name::native_function("token"));
 
-        std::vector<expression> expected_args = {column_value(table_schema->get_column_definition("pk1")),
+        expression_list expected_args = {column_value(table_schema->get_column_definition("pk1")),
                                                  column_value(table_schema->get_column_definition("pk2")),
                                                  make_int_const(1234)};
         BOOST_REQUIRE_EQUAL(prepared_token->args, expected_args);

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -32,7 +32,7 @@ namespace {
 /// Returns statement_restrictions::get_clustering_bounds() of where_clause, with reasonable defaults in
 /// boilerplate.
 query::clustering_row_ranges slice(
-        const std::vector<expr::expression>& where_clause, cql_test_env& env,
+        const expr::expression_list& where_clause, cql_test_env& env,
         const sstring& table_name = "t", const sstring& keyspace_name = "ks") {
     prepare_context ctx;
     return restrictions::analyze_statement_restrictions(
@@ -402,7 +402,7 @@ SEASTAR_TEST_CASE(index_selection) {
         auto check = [&](std::string_view where_clause) -> expected {
             prepare_context ctx;
             auto factors = where_clause.empty()
-                ? std::vector<expr::expression>{}
+                ? expr::expression_list{}
                 : boolean_factors(cql3::util::where_clause_to_relations(where_clause, cql3::dialect{}));
             auto sr = restrictions::analyze_statement_restrictions(
                     e.data_dictionary(),
@@ -1156,7 +1156,7 @@ static shared_ptr<const restrictions::statement_restrictions> make_restrictions(
         const sstring& table_name = "t", const sstring& keyspace_name = "ks") {
     prepare_context ctx;
     auto factors = where_clause.empty()
-            ? std::vector<expr::expression>{}
+            ? expr::expression_list{}
             : boolean_factors(cql3::util::where_clause_to_relations(where_clause, cql3::dialect{}));
     return restrictions::analyze_statement_restrictions(
             env.data_dictionary(),

--- a/test/lib/expr_test_utils.cc
+++ b/test/lib/expr_test_utils.cc
@@ -356,19 +356,19 @@ constant make_int_vector_const(const std::vector<int32_t>& values) {
     return constant(make_int_vector_raw(values), vector_type_impl::get_instance(int32_type, values.size()));
 }
 
-collection_constructor make_list_constructor(std::vector<expression> elements, data_type elements_type) {
+collection_constructor make_list_constructor(expression_list elements, data_type elements_type) {
     return collection_constructor{.style = collection_constructor::style_type::list_or_vector,
                                   .elements = std::move(elements),
                                   .type = list_type_impl::get_instance(elements_type, true)};
 }
 
-collection_constructor make_set_constructor(std::vector<expression> elements, data_type elements_type) {
+collection_constructor make_set_constructor(expression_list elements, data_type elements_type) {
     return collection_constructor{.style = collection_constructor::style_type::set,
                                   .elements = std::move(elements),
                                   .type = set_type_impl::get_instance(elements_type, true)};
 }
 
-collection_constructor make_map_constructor(const std::vector<expression> elements,
+collection_constructor make_map_constructor(const expression_list elements,
                                             data_type key_type,
                                             data_type element_type) {
     return collection_constructor{.style = collection_constructor::style_type::map,
@@ -379,7 +379,7 @@ collection_constructor make_map_constructor(const std::vector<expression> elemen
 collection_constructor make_map_constructor(const std::vector<std::pair<expression, expression>>& elements,
                                             data_type key_type,
                                             data_type element_type) {
-    std::vector<expression> map_element_pairs;
+    expression_list map_element_pairs;
     for (const std::pair<expression, expression>& element : elements) {
         map_element_pairs.push_back(tuple_constructor{.elements = {element.first, element.second},
                                                       .type = tuple_type_impl::get_instance({key_type, element_type})});
@@ -387,12 +387,12 @@ collection_constructor make_map_constructor(const std::vector<std::pair<expressi
     return make_map_constructor(map_element_pairs, key_type, element_type);
 }
 
-tuple_constructor make_tuple_constructor(std::vector<expression> elements, std::vector<data_type> element_types) {
+tuple_constructor make_tuple_constructor(expression_list elements, std::vector<data_type> element_types) {
     return tuple_constructor{.elements = std::move(elements),
                              .type = tuple_type_impl::get_instance(std::move(element_types))};
 }
 
-collection_constructor make_vector_constructor(std::vector<expression> elements, data_type elements_type, vector_dimension_t dimension) {
+collection_constructor make_vector_constructor(expression_list elements, data_type elements_type, vector_dimension_t dimension) {
     return collection_constructor{.style = collection_constructor::style_type::vector,
                                   .elements = std::move(elements),
                                   .type = vector_type_impl::get_instance(elements_type, dimension)};

--- a/test/lib/expr_test_utils.hh
+++ b/test/lib/expr_test_utils.hh
@@ -107,16 +107,16 @@ constant make_int_int_map_const(const std::vector<std::pair<int32_t, int32_t>>& 
 
 constant make_int_vector_const(const std::vector<int32_t>& values);
 
-collection_constructor make_list_constructor(std::vector<expression> elements, data_type elements_type);
-collection_constructor make_set_constructor(std::vector<expression> elements, data_type elements_type);
-collection_constructor make_map_constructor(const std::vector<expression> elements,
+collection_constructor make_list_constructor(expression_list elements, data_type elements_type);
+collection_constructor make_set_constructor(expression_list elements, data_type elements_type);
+collection_constructor make_map_constructor(const expression_list elements,
                                             data_type key_type,
                                             data_type element_type);
 collection_constructor make_map_constructor(const std::vector<std::pair<expression, expression>>& elements,
                                             data_type key_type,
                                             data_type element_type);
-tuple_constructor make_tuple_constructor(std::vector<expression> elements, std::vector<data_type> element_types);
-collection_constructor make_vector_constructor(std::vector<expression> elements, data_type elements_type, vector_dimension_t dimension);
+tuple_constructor make_tuple_constructor(expression_list elements, std::vector<data_type> element_types);
+collection_constructor make_vector_constructor(expression_list elements, data_type elements_type, vector_dimension_t dimension);
 usertype_constructor make_usertype_constructor(std::vector<std::pair<std::string_view, constant>> field_values);
 
 ::lw_shared_ptr<column_specification> make_receiver(data_type receiver_type, sstring name = "receiver_name");


### PR DESCRIPTION
**Motivation:**
Every CQL statement parse/prepare allocates multiple `std::vector`s for expression argument lists (function args, conjunction children, tuple elements, collection elements). These vectors typically hold 1-4 elements but each requires a separate heap allocation. Under high concurrency, this creates allocator pressure and pointer-chasing on every expression traversal.

**Trade-off — allocation count vs memory density:**
This PR prioritizes reducing per-statement allocation count (fewer heap blocks, better locality, less fragmentation) at the potential cost of slightly increased per-statement memory for some patterns. This may **not** improve prepared statement cache density, and could slightly reduce it for workloads with many empty or >4-element expression lists.

| Elements | std::vector (total) | small_vector (total) | Delta |
|----------|-------------------------------|----------------------|-------|
| 0 | 24 bytes | 56 bytes | +32 worse |
| 1 | ~56 bytes (24 + alloc overhead) | 56 bytes | neutral |
| 2-4 | ~72-88 bytes | 56 bytes | -16 to -32 better |
| >4 | 24 + N×8 | 56 + N×8 | +32 worse |

The benefit is primarily:
- Reduced allocator pressure under concurrent workloads (fewer malloc/free calls)
- Better cache locality (inline data vs pointer chase to separate heap block)
- Less memory fragmentation (fewer small heap blocks)

These are throughput and latency benefits, not memory density benefits.

**Nature of change:**
Replace `std::vector<expression>` with `utils::small_vector<expression, 4>` (aliased as `expr::expression_list`) in 4 expression structs: `conjunction::children`, `function_call::args`, `tuple_constructor::elements`, `collection_constructor::elements`.

`expression` is 8 bytes (`unique_ptr<impl>`), N=4 chosen because most CQL functions have 1-3 args, WHERE clauses typically have 2-4 conditions.

**Note:** PR #29994 adds `external_memory_usage()` for prepared stmt cache sizing. When both land, the sizing helper should account for inline buffer vs heap.

**Performance:** `perf_cql_parser` shows ~112K→113K tps (within noise). `perf_simple_query` results pending to measure allocation pressure benefits.

**Open question:** If cache density is the primary goal, this PR may not be the right trade-off. The benefit is under high-QPS concurrent workloads where allocation pressure dominates. Happy to hear feedback on whether this aligns with current priorities.