### PR TITLE
cql3: replace shared_ptr with unique_ptr for column operations

### DIFF
--- a/cql3/operation.cc
+++ b/cql3/operation.cc
@@ -37,7 +37,7 @@ operation::set_element::to_string(const column_definition& receiver) const {
     return format("{}[{}] = {}", receiver.name_as_text(), _selector, _value);
 }
 
-shared_ptr<operation>
+std::unique_ptr<operation>
 operation::set_element::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     using exceptions::invalid_request_exception;
     auto rtype = dynamic_pointer_cast<const collection_type_impl>(receiver.type);
@@ -53,11 +53,11 @@ operation::set_element::prepare(data_dictionary::database db, const sstring& key
         if (_by_uuid) {
             auto&& idx = prepare_expression(_selector, db, keyspace, nullptr, lists::uuid_index_spec_of(*receiver.column_specification));
             verify_no_aggregate_functions(idx, "SET clause");
-            return make_shared<lists::setter_by_uuid>(receiver, std::move(idx), std::move(lval));
+            return std::make_unique<lists::setter_by_uuid>(receiver, std::move(idx), std::move(lval));
         } else {
             auto&& idx = prepare_expression(_selector, db, keyspace, nullptr, lists::index_spec_of(*receiver.column_specification));
             verify_no_aggregate_functions(idx, "SET clause");
-            return make_shared<lists::setter_by_index>(receiver, std::move(idx), std::move(lval));
+            return std::make_unique<lists::setter_by_index>(receiver, std::move(idx), std::move(lval));
         }
     } else if (rtype->get_kind() == abstract_type::kind::set) {
         throw invalid_request_exception(format("Invalid operation ({}) for set column {}", to_string(receiver), receiver.name_as_text()));
@@ -66,7 +66,7 @@ operation::set_element::prepare(data_dictionary::database db, const sstring& key
         verify_no_aggregate_functions(key, "SET clause");
         auto mval = prepare_expression(_value, db, keyspace, nullptr, maps::value_spec_of(*receiver.column_specification));
         verify_no_aggregate_functions(mval, "SET clause");
-        return make_shared<maps::setter_by_key>(receiver, std::move(key), std::move(mval));
+        return std::make_unique<maps::setter_by_key>(receiver, std::move(key), std::move(mval));
     }
     throwing_assert(0 && "prepare set_element collection type");
 }
@@ -83,7 +83,7 @@ operation::set_field::to_string(const column_definition& receiver) const {
     return format("{}.{} = {}", receiver.name_as_text(), *_field, _value);
 }
 
-shared_ptr<operation>
+std::unique_ptr<operation>
 operation::set_field::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     if (!receiver.type->is_user_type()) {
         throw exceptions::invalid_request_exception(
@@ -102,7 +102,7 @@ operation::set_field::prepare(data_dictionary::database db, const sstring& keysp
 
     auto val = prepare_expression(_value, db, keyspace, nullptr, user_types::field_spec_of(*receiver.column_specification, *idx));
     verify_no_aggregate_functions(val, "SET clause");
-    return make_shared<user_types::setter_by_field>(receiver, *idx, std::move(val));
+    return std::make_unique<user_types::setter_by_field>(receiver, *idx, std::move(val));
 }
 
 bool
@@ -120,7 +120,7 @@ operation::field_deletion::affected_column() const {
     return *_id;
 }
 
-shared_ptr<operation>
+std::unique_ptr<operation>
 operation::field_deletion::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     if (!receiver.type->is_user_type()) {
         throw exceptions::invalid_request_exception(
@@ -137,7 +137,7 @@ operation::field_deletion::prepare(data_dictionary::database db, const sstring& 
                 format("UDT column {} does not have a field named {}", receiver.name_as_text(), *_field));
     }
 
-    return make_shared<user_types::deleter_by_field>(receiver, *idx);
+    return std::make_unique<user_types::deleter_by_field>(receiver, *idx);
 }
 
 sstring
@@ -145,7 +145,7 @@ operation::addition::to_string(const column_definition& receiver) const {
     return format("{} = {} + {}", receiver.name_as_text(), receiver.name_as_text(), _value);
 }
 
-shared_ptr<operation>
+std::unique_ptr<operation>
 operation::addition::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
     verify_no_aggregate_functions(v, "SET clause");
@@ -153,7 +153,7 @@ operation::addition::prepare(data_dictionary::database db, const sstring& keyspa
     auto ctype = dynamic_pointer_cast<const collection_type_impl>(receiver.type);
     if (!ctype) {
         if (receiver.is_counter()) {
-            return make_shared<constants::adder>(receiver, std::move(v));
+            return std::make_unique<constants::adder>(receiver, std::move(v));
         }
         // Allow arithmetic on numeric non-counter columns in LWT updates
         // (issue #10568). Build an expression that constants:setter will use.
@@ -162,7 +162,7 @@ operation::addition::prepare(data_dictionary::database db, const sstring& keyspa
                 expr::column_value{&receiver},
                 expr::oper_t::ADD,
                 v);
-            return make_shared<constants::setter>(receiver, std::move(arith_expr));
+            return std::make_unique<constants::setter>(receiver, std::move(arith_expr));
         }
         throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name_as_text()));
     } else if (!ctype->is_multi_cell()) {
@@ -170,11 +170,11 @@ operation::addition::prepare(data_dictionary::database db, const sstring& keyspa
     }
 
     if (ctype->get_kind() == abstract_type::kind::list) {
-        return make_shared<lists::appender>(receiver, std::move(v));
+        return std::make_unique<lists::appender>(receiver, std::move(v));
     } else if (ctype->get_kind() == abstract_type::kind::set) {
-        return make_shared<sets::adder>(receiver, std::move(v));
+        return std::make_unique<sets::adder>(receiver, std::move(v));
     } else if (ctype->get_kind() == abstract_type::kind::map) {
-        return make_shared<maps::putter>(receiver, std::move(v));
+        return std::make_unique<maps::putter>(receiver, std::move(v));
     } else {
         throwing_assert(0 && "prepare addition collection type");
     }
@@ -190,14 +190,14 @@ operation::subtraction::to_string(const column_definition& receiver) const {
     return format("{} = {} - {}", receiver.name_as_text(), receiver.name_as_text(), _value);
 }
 
-shared_ptr<operation>
+std::unique_ptr<operation>
 operation::subtraction::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     auto ctype = dynamic_pointer_cast<const collection_type_impl>(receiver.type);
     if (!ctype) {
         if (receiver.is_counter()) {
             auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
             verify_no_aggregate_functions(v, "SET clause");
-            return make_shared<constants::subtracter>(receiver, std::move(v));
+            return std::make_unique<constants::subtracter>(receiver, std::move(v));
         }
         if (receiver.type->is_arithmetic()) {
             auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
@@ -206,7 +206,7 @@ operation::subtraction::prepare(data_dictionary::database db, const sstring& key
                 expr::column_value{&receiver},
                 expr::oper_t::SUB,
                 v);
-            return make_shared<constants::setter>(receiver, std::move(arith_expr));
+            return std::make_unique<constants::setter>(receiver, std::move(arith_expr));
         }
         throw exceptions::invalid_request_exception(format("Invalid operation ({}) for non counter column {}", to_string(receiver), receiver.name_as_text()));
     }
@@ -218,11 +218,11 @@ operation::subtraction::prepare(data_dictionary::database db, const sstring& key
     if (ctype->get_kind() == abstract_type::kind::list) {
         auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
         verify_no_aggregate_functions(v, "SET clause");
-        return make_shared<lists::discarder>(receiver, std::move(v));
+        return std::make_unique<lists::discarder>(receiver, std::move(v));
     } else if (ctype->get_kind() == abstract_type::kind::set) {
         auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
         verify_no_aggregate_functions(v, "SET clause");
-        return make_shared<sets::discarder>(receiver, std::move(v));
+        return std::make_unique<sets::discarder>(receiver, std::move(v));
     } else if (ctype->get_kind() == abstract_type::kind::map) {
         auto&& mtype = dynamic_pointer_cast<const map_type_impl>(ctype);
         // The value for a map subtraction is actually a set
@@ -233,7 +233,7 @@ operation::subtraction::prepare(data_dictionary::database db, const sstring& key
                 set_type_impl::get_instance(mtype->get_keys_type(), false));
         auto v = prepare_expression(_value, db, keyspace, nullptr, std::move(vr));
         verify_no_aggregate_functions(v, "SET clause");
-        return ::make_shared<sets::discarder>(receiver, std::move(v));
+        return std::make_unique<sets::discarder>(receiver, std::move(v));
     }
     throwing_assert(0 && "prepare subtraction collection type");
 }
@@ -248,7 +248,7 @@ operation::prepend::to_string(const column_definition& receiver) const {
     return format("{} = {} + {}", receiver.name_as_text(), _value, receiver.name_as_text());
 }
 
-shared_ptr<operation>
+std::unique_ptr<operation>
 operation::prepend::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
     verify_no_aggregate_functions(v, "SET clause");
@@ -259,7 +259,7 @@ operation::prepend::prepare(data_dictionary::database db, const sstring& keyspac
         throw exceptions::invalid_request_exception(format("Invalid operation ({}) for frozen list column {}", to_string(receiver), receiver.name_as_text()));
     }
 
-    return make_shared<lists::prepender>(receiver, std::move(v));
+    return std::make_unique<lists::prepender>(receiver, std::move(v));
 }
 
 bool
@@ -268,7 +268,7 @@ operation::prepend::is_compatible_with(const std::unique_ptr<raw_update>& other)
 }
 
 
-::shared_ptr <operation>
+std::unique_ptr<operation>
 operation::set_value::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     auto v = prepare_expression(_value, db, keyspace, nullptr, receiver.column_specification);
     verify_no_aggregate_functions(v, "SET clause");
@@ -280,24 +280,24 @@ operation::set_value::prepare(data_dictionary::database db, const sstring& keysp
     if (receiver.type->is_collection()) {
         auto k = receiver.type->get_kind();
         if (k == abstract_type::kind::list) {
-            return make_shared<lists::setter>(receiver, std::move(v));
+            return std::make_unique<lists::setter>(receiver, std::move(v));
         } else if (k == abstract_type::kind::set) {
-            return make_shared<sets::setter>(receiver, std::move(v));
+            return std::make_unique<sets::setter>(receiver, std::move(v));
         } else if (k == abstract_type::kind::map) {
-            return make_shared<maps::setter>(receiver, std::move(v));
+            return std::make_unique<maps::setter>(receiver, std::move(v));
         } else {
             throwing_assert(0 && "prepare set_value collection type");
         }
     }
 
     if (receiver.type->is_user_type()) {
-        return make_shared<user_types::setter>(receiver, std::move(v));
+        return std::make_unique<user_types::setter>(receiver, std::move(v));
     }
 
-    return ::make_shared<constants::setter>(receiver, std::move(v));
+    return std::make_unique<constants::setter>(receiver, std::move(v));
 }
 
-::shared_ptr <operation>
+std::unique_ptr<operation>
 operation::set_counter_value_from_tuple_list::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     static thread_local const data_type counter_tuple_type = tuple_type_impl::get_instance({int32_type, uuid_type, long_type, long_type});
     static thread_local const data_type counter_tuple_list_type = list_type_impl::get_instance(counter_tuple_type, true);
@@ -368,7 +368,7 @@ operation::set_counter_value_from_tuple_list::prepare(data_dictionary::database 
         }
     };
 
-    return make_shared<counter_setter>(receiver, std::move(v));
+    return std::make_unique<counter_setter>(receiver, std::move(v));
 };
 
 bool
@@ -383,7 +383,7 @@ operation::element_deletion::affected_column() const {
     return *_id;
 }
 
-shared_ptr<operation>
+std::unique_ptr<operation>
 operation::element_deletion::prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const {
     if (!receiver.type->is_collection()) {
         throw exceptions::invalid_request_exception(format("Invalid deletion operation for non collection column {}", receiver.name_as_text()));
@@ -394,15 +394,15 @@ operation::element_deletion::prepare(data_dictionary::database db, const sstring
     if (ctype->get_kind() == abstract_type::kind::list) {
         auto&& idx = prepare_expression(_element, db, keyspace, nullptr, lists::index_spec_of(*receiver.column_specification));
         verify_no_aggregate_functions(idx, "SET clause");
-        return make_shared<lists::discarder_by_index>(receiver, std::move(idx));
+        return std::make_unique<lists::discarder_by_index>(receiver, std::move(idx));
     } else if (ctype->get_kind() == abstract_type::kind::set) {
         auto&& elt = prepare_expression(_element, db, keyspace, nullptr, sets::value_spec_of(*receiver.column_specification));
         verify_no_aggregate_functions(elt, "SET clause");
-        return make_shared<sets::element_discarder>(receiver, std::move(elt));
+        return std::make_unique<sets::element_discarder>(receiver, std::move(elt));
     } else if (ctype->get_kind() == abstract_type::kind::map) {
         auto&& key = prepare_expression(_element, db, keyspace, nullptr, maps::key_spec_of(*receiver.column_specification));
         verify_no_aggregate_functions(key, "SET clause");
-        return make_shared<maps::discarder_by_key>(receiver, std::move(key));
+        return std::make_unique<maps::discarder_by_key>(receiver, std::move(key));
     }
     throwing_assert(0 && "prepare element_deletion collection type");
 }

--- a/cql3/operation.hh
+++ b/cql3/operation.hh
@@ -138,7 +138,7 @@ public:
          * be a true column.
          * @return the prepared update operation.
          */
-        virtual ::shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const = 0;
+        virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const = 0;
 
         /**
          * @return whether this operation can be applied alongside the {@code
@@ -175,7 +175,7 @@ public:
          * @param receiver the "column" this operation applies to.
          * @return the prepared delete operation.
          */
-        virtual ::shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const = 0;
+        virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const = 0;
     };
 
     class set_value;
@@ -192,7 +192,7 @@ public:
             : _selector(std::move(selector)), _value(std::move(value)), _by_uuid(by_uuid) {
         }
 
-        virtual shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
+        virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
 
         virtual bool is_compatible_with(const std::unique_ptr<raw_update>& other) const override;
     };
@@ -208,7 +208,7 @@ public:
             : _field(std::move(field)), _value(std::move(value)) {
         }
 
-        virtual shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
+        virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
 
         virtual bool is_compatible_with(const std::unique_ptr<raw_update>& other) const override;
     };
@@ -225,7 +225,7 @@ public:
 
         virtual const column_identifier::raw& affected_column() const override;
 
-        virtual shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
+        virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
     };
 
     class addition : public raw_update {
@@ -237,7 +237,7 @@ public:
                 : _value(std::move(value)) {
         }
 
-        virtual shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
+        virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
 
         virtual bool is_compatible_with(const std::unique_ptr<raw_update>& other) const override;
     };
@@ -251,7 +251,7 @@ public:
                 : _value(std::move(value)) {
         }
 
-        virtual shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
+        virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
 
         virtual bool is_compatible_with(const std::unique_ptr<raw_update>& other) const override;
     };
@@ -265,7 +265,7 @@ public:
                 : _value(std::move(value)) {
         }
 
-        virtual shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
+        virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
 
         virtual bool is_compatible_with(const std::unique_ptr<raw_update>& other) const override;
     };
@@ -280,7 +280,7 @@ public:
                 : _id(std::move(id)), _element(std::move(element)) {
         }
         virtual const column_identifier::raw& affected_column() const override;
-        virtual shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
+        virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
     };
 };
 

--- a/cql3/operation_impl.hh
+++ b/cql3/operation_impl.hh
@@ -21,7 +21,7 @@ protected:
 public:
     set_value(expr::expression value) : _value(std::move(value)) {}
 
-    virtual ::shared_ptr <operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
+    virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
 
 #if 0
         protected String toString(ColumnSpecification column)
@@ -36,7 +36,7 @@ public:
 class operation::set_counter_value_from_tuple_list : public set_value {
 public:
     using set_value::set_value;
-    ::shared_ptr <operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
+    std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override;
 };
 
 class operation::column_deletion : public raw_deletion {
@@ -51,9 +51,9 @@ public:
         return *_id;
     }
 
-    virtual ::shared_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override {
+    virtual std::unique_ptr<operation> prepare(data_dictionary::database db, const sstring& keyspace, const column_definition& receiver) const override {
         // No validation, deleting a column is always "well typed"
-        return ::make_shared<constants::deleter>(receiver);
+        return std::make_unique<constants::deleter>(receiver);
     }
 };
 

--- a/cql3/statements/delete_statement.cc
+++ b/cql3/statements/delete_statement.cc
@@ -76,9 +76,9 @@ delete_statement::prepare_internal(data_dictionary::database db, schema_ptr sche
             throw exceptions::invalid_request_exception(format("Invalid identifier {} for deletion (should not be a PRIMARY KEY part)", def->name_as_text()));
         }
 
-        auto&& op = deletion->prepare(db, schema->ks_name(), *def);
+        auto op = deletion->prepare(db, schema->ks_name(), *def);
         op->fill_prepare_context(ctx);
-        stmt->add_operation(op);
+        stmt->add_operation(std::move(op));
     }
     prepare_conditions(db, *schema, ctx, *stmt);
     stmt->process_where_clause(db, _where_clause, ctx);

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -743,7 +743,7 @@ bool modification_statement::depends_on(std::string_view ks_name, std::optional<
     return keyspace() == ks_name && (!cf_name || column_family() == *cf_name);
 }
 
-void modification_statement::add_operation(::shared_ptr<operation> op) {
+void modification_statement::add_operation(std::unique_ptr<operation> op) {
     if (op->column.is_static()) {
         _sets_static_columns = true;
     } else {

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -65,7 +65,7 @@ public:
     const std::unique_ptr<attributes> attrs;
 
 protected:
-    std::vector<::shared_ptr<operation>> _column_operations;
+    std::vector<std::unique_ptr<operation>> _column_operations;
     cql_stats& _stats;
 
     expr::expression _condition = expr::conjunction{{}}; // TRUE
@@ -139,7 +139,7 @@ public:
 
     bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
-    void add_operation(::shared_ptr<operation> op);
+    void add_operation(std::unique_ptr<operation> op);
 
     void inc_cql_stats(bool is_internal) const;
 

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -300,7 +300,7 @@ expr::expression get_key(const cql3::expr::expression& partition_key_restriction
 
 static
 expr::expression
-prepare_new_value(const std::vector<::shared_ptr<operation>>& operations) {
+prepare_new_value(const std::vector<std::unique_ptr<operation>>& operations) {
     if (operations.size() != 1) {
         throw service::broadcast_tables::unsupported_operation_error("only one operation is allowed and must be of the form \"value = X\"");
     }


### PR DESCRIPTION
**Motivation:**
The prepared statement cache is memory-bounded. Every byte saved per prepared statement means more statements can fit in the cache before evictions occur. Cache evictions force re-preparation (schema lookups, type checking, optimization). Workloads with many distinct prepared statements (multi-tenant, ORM-generated queries) benefit directly from smaller per-statement memory footprint.

**Nature of change:**
The `_column_operations` vector in `modification_statement` holds polymorphic operation objects via `seastar::shared_ptr`, but these objects are never shared — each is created during `prepare()`, stored in the vector, and only accessed by reference during execution.

Replace `shared_ptr<operation>` with `unique_ptr<operation>` throughout the prepare/execute path:
- `operation::raw_update::prepare()` / `raw_deletion::prepare()` return `unique_ptr`
- `modification_statement::add_operation()` takes `unique_ptr`
- `_column_operations` vector holds `unique_ptr`
- All `make_shared` → `std::make_unique` in operation.cc

**Memory savings:**
`seastar::make_shared` wraps each object in `shared_ptr_count_for<T>`, prepending a vtable pointer (8 bytes) + refcount (8 bytes) = **16 bytes overhead per operation**. A typical INSERT/UPDATE has 3-5 column operations, saving 48-80 bytes per prepared statement.

`unique_ptr` also makes ownership semantics explicit in the type system.

**Measured (perf-simple-query, release, smp 1, 10K partitions, 5 runs):**
| Metric | Master | PR #30010 | Delta |
|--------|--------|-----------|-------|
| allocs/op | 58.1 | 58.1 | no change |
| insns/op | 32,230 | 32,090 | -140 (-0.4%) |
| tps | 150K | 150K | within noise |

No per-request effect expected — this PR reduces memory per cached prepared statement (prepare-time), not per read request.

Refs: https://github.com/scylladb/scylladb/issues/29047