### PR TITLE
cql3: shrink query_options (small_vector value storage + pack _skip_metadata)

### DIFF
--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -12,6 +12,7 @@
 #include "query_options.hh"
 #include "db/consistency_level_type.hh"
 #include "cql3/column_identifier.hh"
+#include "utils/assert.hh"
 
 namespace cql3 {
 
@@ -22,13 +23,45 @@ thread_local const query_options::specific_options query_options::specific_optio
 
 thread_local query_options query_options::DEFAULT{default_cql_config,
     db::consistency_level::ONE, std::nullopt,
-    std::vector<cql3::raw_value_view>(), false, query_options::specific_options::DEFAULT};
+    cql3::raw_value_view_vector_with_unset(), false, query_options::specific_options::DEFAULT};
+
+query_options::query_options(query_options&& o) noexcept
+    : _cql_config(o._cql_config)
+    , _consistency(o._consistency)
+    , _names(std::move(o._names))
+    , _values(std::move(o._values))
+    , _value_views()
+    , _unset(std::move(o._unset))
+    , _skip_metadata(o._skip_metadata)
+    , _options(std::move(o._options))
+    , _batch_options(std::move(o._batch_options))
+    , _list_append_seq(o._list_append_seq)
+    , _cached_pk_fn_calls(std::move(o._cached_pk_fn_calls))
+{
+    // _value_views may contain views into _values's data. With small_vector,
+    // inline storage moves to a new address, invalidating those views.
+    // If _values is non-empty, re-create views from the new location.
+    // If _values is empty, _value_views was set independently (view-only path)
+    // and can be moved directly since it doesn't reference _values.
+    if (!_values.empty()) {
+        // Rebuilding from _values reproduces the 1:1, in-order view mapping
+        // established by fill_value_views() at construction. This is only valid
+        // while _value_views still mirrors _values one-to-one. prepare() reorders
+        // _value_views (for named bind markers) to a different size/order; moving
+        // such an object would silently rebuild the wrong views, so fail fast if
+        // that invariant was broken. See the analysis in issue #29047.
+        SCYLLA_ASSERT(o._value_views.size() == _values.size());
+        fill_value_views();
+    } else {
+        _value_views = std::move(o._value_views);
+    }
+}
 
 query_options::query_options(const cql_config& cfg,
                            db::consistency_level consistency,
                            std::optional<std::vector<std::string_view>> names,
-                           std::vector<cql3::raw_value> values,
-                           std::vector<cql3::raw_value_view> value_views,
+                           raw_value_vector values,
+                           raw_value_view_vector value_views,
                            cql3::unset_bind_variable_vector unset,
                            bool skip_metadata,
                            specific_options options
@@ -37,8 +70,8 @@ query_options::query_options(const cql_config& cfg,
    , _consistency(consistency)
    , _names(std::move(names))
    , _values(std::move(values))
-   , _value_views(value_views)
-   , _unset(unset)
+   , _value_views(std::move(value_views))
+   , _unset(std::move(unset))
    , _skip_metadata(skip_metadata)
    , _options(std::move(options))
 {
@@ -95,24 +128,28 @@ query_options::query_options(db::consistency_level cl, cql3::raw_value_vector_wi
 }
 
 query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<service::pager::paging_state> paging_state)
+        // Route through the raw_value_vector_with_unset constructor, which calls fill_value_views()
+        // after _values lands at its final address. Passing _values and _value_views separately to
+        // the 8-arg ctor is wrong for small_vector: its SBO move copies elements to a new address,
+        // invalidating any raw_value_views that pointed into the old inline buffer. The _value_views
+        // taken from *qo still point at the moved-from object's inline storage and become dangling.
+        // Reported by P. Paszkow (PR #30011) -- triggered by read_tablet_metadata()'s 1000-row pages.
         : query_options(qo->_cql_config,
         qo->_consistency,
         std::move(qo->_names),
-        std::move(qo->_values),
-        std::move(qo->_value_views),
-        std::move(qo->_unset),
+        raw_value_vector_with_unset(std::move(qo->_values), std::move(qo->_unset)),
         qo->_skip_metadata,
         query_options::specific_options{qo->_options.page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp}) {
 
 }
 
 query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<service::pager::paging_state> paging_state, int32_t page_size)
+        // Same fix as the overload above -- route through raw_value_vector_with_unset to ensure
+        // _value_views is rebuilt from the new _values location via fill_value_views().
         : query_options(qo->_cql_config,
         qo->_consistency,
         std::move(qo->_names),
-        std::move(qo->_values),
-        std::move(qo->_value_views),
-        std::move(qo->_unset),
+        raw_value_vector_with_unset(std::move(qo->_values), std::move(qo->_unset)),
         qo->_skip_metadata,
         query_options::specific_options{page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp}) {
 
@@ -130,7 +167,7 @@ void query_options::prepare(const std::vector<lw_shared_ptr<column_specification
     }
 
     auto& names = *_names;
-    std::vector<cql3::raw_value_view> ordered_values;
+    raw_value_view_vector ordered_values;
     ordered_values.reserve(specs.size());
     for (auto&& spec : specs) {
         auto& spec_name = spec->name->text();

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -28,11 +28,12 @@ thread_local query_options query_options::DEFAULT{default_cql_config,
 query_options::query_options(query_options&& o) noexcept
     : _cql_config(o._cql_config)
     , _consistency(o._consistency)
+    , _skip_metadata(o._skip_metadata)
     , _names(std::move(o._names))
     , _values(std::move(o._values))
     , _value_views()
     , _unset(std::move(o._unset))
-    , _skip_metadata(o._skip_metadata)
+    , _tablet_version_block(std::move(o._tablet_version_block))
     , _options(std::move(o._options))
     , _batch_options(std::move(o._batch_options))
     , _list_append_seq(o._list_append_seq)
@@ -68,11 +69,11 @@ query_options::query_options(const cql_config& cfg,
                            )
    : _cql_config(cfg)
    , _consistency(consistency)
+   , _skip_metadata(skip_metadata)
    , _names(std::move(names))
    , _values(std::move(values))
    , _value_views(std::move(value_views))
    , _unset(std::move(unset))
-   , _skip_metadata(skip_metadata)
    , _options(std::move(options))
 {
 }
@@ -86,11 +87,11 @@ query_options::query_options(const cql_config& cfg,
                              )
     : _cql_config(cfg)
     , _consistency(consistency)
+    , _skip_metadata(skip_metadata)
     , _names(std::move(names))
     , _values(std::move(values.values))
     , _value_views()
     , _unset(std::move(values.unset))
-    , _skip_metadata(skip_metadata)
     , _options(std::move(options))
 {
     fill_value_views();
@@ -105,11 +106,11 @@ query_options::query_options(const cql_config& cfg,
                              )
     : _cql_config(cfg)
     , _consistency(consistency)
+    , _skip_metadata(skip_metadata)
     , _names(std::move(names))
     , _values()
     , _value_views(std::move(value_views.values))
     , _unset(std::move(value_views.unset))
-    , _skip_metadata(skip_metadata)
     , _options(std::move(options))
 {
 }

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -12,6 +12,7 @@
 #include "query_options.hh"
 #include "db/consistency_level_type.hh"
 #include "cql3/column_identifier.hh"
+#include "utils/assert.hh"
 
 namespace cql3 {
 
@@ -22,13 +23,45 @@ thread_local const query_options::specific_options query_options::specific_optio
 
 thread_local query_options query_options::DEFAULT{default_cql_config,
     db::consistency_level::ONE, std::nullopt,
-    std::vector<cql3::raw_value_view>(), false, query_options::specific_options::DEFAULT};
+    cql3::raw_value_view_vector_with_unset(), false, query_options::specific_options::DEFAULT};
+
+query_options::query_options(query_options&& o) noexcept
+    : _cql_config(o._cql_config)
+    , _consistency(o._consistency)
+    , _names(std::move(o._names))
+    , _values(std::move(o._values))
+    , _value_views()
+    , _unset(std::move(o._unset))
+    , _skip_metadata(o._skip_metadata)
+    , _options(std::move(o._options))
+    , _batch_options(std::move(o._batch_options))
+    , _list_append_seq(o._list_append_seq)
+    , _cached_pk_fn_calls(std::move(o._cached_pk_fn_calls))
+{
+    // _value_views may contain views into _values's data. With small_vector,
+    // inline storage moves to a new address, invalidating those views.
+    // If _values is non-empty, re-create views from the new location.
+    // If _values is empty, _value_views was set independently (view-only path)
+    // and can be moved directly since it doesn't reference _values.
+    if (!_values.empty()) {
+        // Rebuilding from _values reproduces the 1:1, in-order view mapping
+        // established by fill_value_views() at construction. This is only valid
+        // while _value_views still mirrors _values one-to-one. prepare() reorders
+        // _value_views (for named bind markers) to a different size/order; moving
+        // such an object would silently rebuild the wrong views, so fail fast if
+        // that invariant was broken. See the analysis in issue #29047.
+        SCYLLA_ASSERT(o._value_views.size() == _values.size());
+        fill_value_views();
+    } else {
+        _value_views = std::move(o._value_views);
+    }
+}
 
 query_options::query_options(const cql_config& cfg,
                            db::consistency_level consistency,
                            std::optional<std::vector<std::string_view>> names,
-                           std::vector<cql3::raw_value> values,
-                           std::vector<cql3::raw_value_view> value_views,
+                           raw_value_vector values,
+                           raw_value_view_vector value_views,
                            cql3::unset_bind_variable_vector unset,
                            bool skip_metadata,
                            specific_options options
@@ -37,8 +70,8 @@ query_options::query_options(const cql_config& cfg,
    , _consistency(consistency)
    , _names(std::move(names))
    , _values(std::move(values))
-   , _value_views(value_views)
-   , _unset(unset)
+   , _value_views(std::move(value_views))
+   , _unset(std::move(unset))
    , _skip_metadata(skip_metadata)
    , _options(std::move(options))
 {
@@ -95,24 +128,28 @@ query_options::query_options(db::consistency_level cl, cql3::raw_value_vector_wi
 }
 
 query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<const service::pager::paging_state> paging_state)
+        // Route through the raw_value_vector_with_unset constructor, which calls fill_value_views()
+        // after _values lands at its final address. Passing _values and _value_views separately to
+        // the 8-arg ctor is wrong for small_vector: its SBO move copies elements to a new address,
+        // invalidating any raw_value_views that pointed into the old inline buffer. The _value_views
+        // taken from *qo still point at the moved-from object's inline storage and become dangling.
+        // Reported by P. Paszkow (PR #30011) -- triggered by read_tablet_metadata()'s 1000-row pages.
         : query_options(qo->_cql_config,
         qo->_consistency,
         std::move(qo->_names),
-        std::move(qo->_values),
-        std::move(qo->_value_views),
-        std::move(qo->_unset),
+        raw_value_vector_with_unset(std::move(qo->_values), std::move(qo->_unset)),
         qo->_skip_metadata,
         query_options::specific_options{qo->_options.page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp}) {
 
 }
 
 query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<const service::pager::paging_state> paging_state, int32_t page_size)
+        // Same fix as the overload above -- route through raw_value_vector_with_unset to ensure
+        // _value_views is rebuilt from the new _values location via fill_value_views().
         : query_options(qo->_cql_config,
         qo->_consistency,
         std::move(qo->_names),
-        std::move(qo->_values),
-        std::move(qo->_value_views),
-        std::move(qo->_unset),
+        raw_value_vector_with_unset(std::move(qo->_values), std::move(qo->_unset)),
         qo->_skip_metadata,
         query_options::specific_options{page_size, paging_state, qo->_options.serial_consistency, qo->_options.timestamp}) {
 
@@ -130,7 +167,7 @@ void query_options::prepare(const std::vector<lw_shared_ptr<column_specification
     }
 
     auto& names = *_names;
-    std::vector<cql3::raw_value_view> ordered_values;
+    raw_value_view_vector ordered_values;
     ordered_values.reserve(specs.size());
     for (auto&& spec : specs) {
         auto& spec_name = spec->name->text();

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -33,16 +33,23 @@ class column_specification;
 using computed_function_values = std::unordered_map<uint8_t, bytes_opt>;
 
 using unset_bind_variable_vector = utils::small_vector<bool, 16>;
+using raw_value_vector = utils::small_vector<cql3::raw_value, 16>;
+
+using raw_value_view_vector = utils::small_vector<cql3::raw_value_view, 16>;
 
 // Matches a raw_value_view with an unset vector to support CQL binary protocol
 // "unset" values.
 struct raw_value_view_vector_with_unset {
-    std::vector<raw_value_view> values;
+    raw_value_view_vector values;
     unset_bind_variable_vector unset;
 
-    raw_value_view_vector_with_unset(std::vector<raw_value_view> values_, unset_bind_variable_vector unset_) : values(std::move(values_)), unset(std::move(unset_)) {}
+    raw_value_view_vector_with_unset(raw_value_view_vector values_, unset_bind_variable_vector unset_) : values(std::move(values_)), unset(std::move(unset_)) {}
+    raw_value_view_vector_with_unset(std::vector<raw_value_view> values_, unset_bind_variable_vector unset_) : values(std::from_range, std::move(values_)), unset(std::move(unset_)) {}
     // Constructor with no unset support, for tests and internal queries
-    raw_value_view_vector_with_unset(std::vector<raw_value_view> values_) : values(std::move(values_)) {
+    raw_value_view_vector_with_unset(raw_value_view_vector values_) : values(std::move(values_)) {
+        unset.resize(values.size());
+    }
+    raw_value_view_vector_with_unset(std::vector<raw_value_view> values_) : values(std::from_range, std::move(values_)) {
         unset.resize(values.size());
     }
     raw_value_view_vector_with_unset() = default;
@@ -51,16 +58,22 @@ struct raw_value_view_vector_with_unset {
 // Matches a raw_value with an unset vector to support CQL binary protocol
 // "unset" values.
 struct raw_value_vector_with_unset {
-    std::vector<raw_value> values;
+    raw_value_vector values;
     unset_bind_variable_vector unset;
 
-    raw_value_vector_with_unset(std::vector<raw_value> values_, unset_bind_variable_vector unset_) : values(std::move(values_)), unset(std::move(unset_)) {}
+    raw_value_vector_with_unset(raw_value_vector values_, unset_bind_variable_vector unset_) : values(std::move(values_)), unset(std::move(unset_)) {}
+    // Constructor from std::vector (protocol/tracing paths)
+    raw_value_vector_with_unset(std::vector<raw_value> values_, unset_bind_variable_vector unset_) : values(std::from_range, std::move(values_)), unset(std::move(unset_)) {}
     // Constructor with no unset support, for tests and internal queries
-    raw_value_vector_with_unset(std::vector<raw_value> values_) : values(std::move(values_)) {
+    raw_value_vector_with_unset(raw_value_vector values_) : values(std::move(values_)) {
+        unset.resize(values.size());
+    }
+    raw_value_vector_with_unset(std::vector<raw_value> values_) : values(std::from_range, std::move(values_)) {
         unset.resize(values.size());
     }
     // Mostly for testing.
-    raw_value_vector_with_unset(std::initializer_list<raw_value> values_) : raw_value_vector_with_unset(std::vector(values_)) {}
+    raw_value_vector_with_unset(std::initializer_list<raw_value> values_, unset_bind_variable_vector unset_) : values(values_.begin(), values_.end()), unset(std::move(unset_)) {}
+    raw_value_vector_with_unset(std::initializer_list<raw_value> values_) : raw_value_vector_with_unset(raw_value_vector(values_.begin(), values_.end())) {}
     raw_value_vector_with_unset() = default;
 };
 
@@ -83,8 +96,8 @@ private:
     const cql_config& _cql_config;
     const db::consistency_level _consistency;
     const std::optional<std::vector<std::string_view>> _names;
-    std::vector<cql3::raw_value> _values;
-    std::vector<cql3::raw_value_view> _value_views;
+    raw_value_vector _values;
+    raw_value_view_vector _value_views;
     unset_bind_variable_vector _unset;
     const bool _skip_metadata;
     std::optional<locator::tablet_version_block> _tablet_version_block;
@@ -127,7 +140,7 @@ private:
     explicit query_options(query_options&& o, std::vector<Values> values_ranges);
 
 public:
-    query_options(query_options&&) = default;
+    query_options(query_options&& o) noexcept;
     explicit query_options(const query_options&) = default;
 
     explicit query_options(const cql_config& cfg,
@@ -140,8 +153,8 @@ public:
     explicit query_options(const cql_config& cfg,
                            db::consistency_level consistency,
                            std::optional<std::vector<std::string_view>> names,
-                           std::vector<cql3::raw_value> values,
-                           std::vector<cql3::raw_value_view> value_views,
+                           raw_value_vector values,
+                           raw_value_view_vector value_views,
                            unset_bind_variable_vector unset,
                            bool skip_metadata,
                            specific_options options
@@ -241,7 +254,7 @@ public:
         return _names;
     }
 
-    const std::vector<cql3::raw_value_view>& get_values() const noexcept {
+    const raw_value_view_vector& get_values() const noexcept {
         return _value_views;
     }
 

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -95,11 +95,13 @@ public:
 private:
     const cql_config& _cql_config;
     const db::consistency_level _consistency;
+    const bool _skip_metadata;
     const std::optional<std::vector<std::string_view>> _names;
     raw_value_vector _values;
     raw_value_view_vector _value_views;
     unset_bind_variable_vector _unset;
-    const bool _skip_metadata;
+    // _skip_metadata packed before _names (see commit "pack _skip_metadata") --
+    // _tablet_version_block added by TABLETS_ROUTING_V2 (e361059676).
     std::optional<locator::tablet_version_block> _tablet_version_block;
     const specific_options _options;
     std::optional<std::vector<query_options>> _batch_options;

--- a/test/boost/query_processor_test.cc
+++ b/test/boost/query_processor_test.cc
@@ -165,6 +165,70 @@ SEASTAR_TEST_CASE(test_querying_with_consumer) {
     });
 }
 
+/*
+ * Regression test for PR #30011 (paszkow's review comment).
+ *
+ * With utils::small_vector, moving a query_options that holds bind values in
+ * inline SBO storage copies those values to a new address, invalidating any
+ * raw_value_view that was pointing into the old buffer.  The two paging-
+ * continuation constructors:
+ *
+ *   query_options(unique_ptr<query_options>, paging_state)
+ *   query_options(unique_ptr<query_options>, paging_state, page_size)
+ *
+ * were delegating to the 8-arg constructor, passing _values and _value_views
+ * independently.  _value_views came from the moved-from object's inline
+ * storage and became stale pointers.  This is the same class of bug that
+ * corrupted tablet metadata read on the second page in read_tablet_metadata()
+ * (page_size=1000, `WHERE table_id = ?`).
+ *
+ * The fix routes through raw_value_vector_with_unset, which calls
+ * fill_value_views() after _values settles at its new address.
+ *
+ * Test: force multiple pages of query_internal() with a bind variable,
+ * verify every row on every page has the correct value.
+ */
+SEASTAR_TEST_CASE(test_paged_internal_query_with_bind_variable) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        // Table with a clustering column so one partition can span many rows.
+        e.execute_cql("CREATE TABLE ks.paged_bind (pk int, ck int, v int, PRIMARY KEY (pk, ck))").get();
+
+        // Insert 25 rows under pk=0 (we'll page with page_size=10 -> 3 pages).
+        const int row_count = 25;
+        int expected_sum = 0;
+        for (int i = 0; i < row_count; ++i) {
+            expected_sum += i;
+            e.local_qp().execute_internal(
+                "INSERT INTO ks.paged_bind (pk, ck, v) VALUES (?, ?, ?)",
+                {0, i, i},
+                cql3::query_processor::cache_internal::yes).get();
+        }
+        // Insert a decoy row in a different partition to confirm the WHERE
+        // clause is actually honoured across pages.
+        e.local_qp().execute_internal(
+            "INSERT INTO ks.paged_bind (pk, ck, v) VALUES (?, ?, ?)",
+            {1, 0, 999},
+            cql3::query_processor::cache_internal::yes).get();
+
+        int rows_seen = 0;
+        int sum_seen = 0;
+        // page_size=10 forces 3 paging rounds; the bind value is the bug trigger.
+        e.local_qp().query_internal(
+            "SELECT * FROM ks.paged_bind WHERE pk = ?",
+            db::consistency_level::ONE,
+            {data_value(0)},
+            10,
+            [&rows_seen, &sum_seen](const cql3::untyped_result_set_row& row) -> future<stop_iteration> {
+                ++rows_seen;
+                sum_seen += row.get_as<int>("v");
+                return make_ready_future<stop_iteration>(stop_iteration::no);
+            }).get();
+
+        BOOST_CHECK_EQUAL(rows_seen, row_count);
+        BOOST_CHECK_EQUAL(sum_seen, expected_sum);
+    });
+}
+
 namespace {
 
 using clevel = db::consistency_level;


### PR DESCRIPTION
**Motivation:**
`query_options` is constructed for every CQL request. Its `_values` and `_value_views` members are `std::vector`s that allocate from Seastar's per-core allocator even for small numbers of bind variables. Using `small_vector` eliminates these allocations for the common case, improving cache locality by keeping bind variable data inline with the `query_options` object.

**Nature of change:**
Replace `std::vector` with `utils::small_vector<T, 16>` for `_values`, `_value_views`, and `_unset` in `query_options` and the wrapper structs. N=16 accommodates the vast majority of real-world prepared statements without heap allocation.

A custom move constructor is required because `_value_views` contains views (pointers) into `_values`. With `std::vector`, move preserves heap pointer stability. With `small_vector` using inline storage, move copies data to a new address, invalidating existing views. The move constructor re-creates views from the new `_values` location.

**Optimization fix included:**
The 6-arg `query_options` constructor was copying `_value_views` and `_unset` from by-value parameters instead of moving them — a missed `std::move`. Fixed.

**Measured (perf-simple-query, release, smp 1, taskset -c 0, fixed 2.2GHz, 10K partitions, 5 runs):**

| Metric | Master | PR #30011 | Delta |
|--------|--------|-----------|-------|
| allocs/op | 58.1 | 56.1 | **-2 (-3.4%)** |
| insns/op (median of 5) | 32,084 | 31,817 | **-267 (-0.83%)** |
| tps (median of 5) | 148,750 | 147,521 | within noise |

Refs: https://github.com/scylladb/scylladb/issues/29047

---

## Additional packing folded into this PR

### Pack `_skip_metadata` (280 B → 272 B)

Move the `const bool _skip_metadata` up next to `_consistency` so it fills the alignment slack after the `consistency_level` enum instead of forcing a standalone padded slot before `_options`. Constructor init lists reordered to match (avoiding `-Wreorder`). **sizeof(query_options): 280 → 272 (−8 B per query).**
