### PR TITLE
docs: add documentation for Full-Text Search and BM25 scoring function

### DIFF
--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -15,6 +15,7 @@ Querying data from data is done using a ``SELECT`` statement:
                    : [ GROUP BY `group_by_clause` ]
                    : [ ORDER BY `ordering_clause` ]
                    : [ ORDER BY `vector_column_name` ANN OF `vector` LIMIT `integer` ]
+                   : [ WHERE BM25 '(' `column_name` ',' `term` ')' '>' 0 ORDER BY BM25 '(' `column_name` ',' `term` ')' LIMIT `integer` ]
                    : [ PER PARTITION LIMIT (`integer` | `bind_marker`) ]
                    : [ LIMIT (`integer` | `bind_marker`) ]
                    : [ ALLOW FILTERING ]
@@ -381,6 +382,77 @@ For example::
    Vector indexes do not support all ScyllaDB features (e.g., tracing, TTL, paging, and grouping). More information
    about Vector Search is available in the
    `ScyllaDB Cloud documentation <https://cloud.docs.scylladb.com/stable/vector-search/>`_.
+
+.. _fulltext-queries:
+
+Full-Text Search queries (BM25) :label-note:`ScyllaDB Cloud`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+   Full-Text Search is supported in ScyllaDB Cloud only in clusters that have the Vector and Text Search feature enabled.
+   For more information, see the :doc:`Full-Text Search documentation </features/fulltext-search>`.
+
+The ``BM25()`` function enables full-text search queries over text columns that
+have a :ref:`full-text index <create-fulltext-index-statement>` created with
+``USING 'fulltext_index'``. ``BM25()`` takes a column name and a query string
+and scores rows using the BM25 ranking algorithm.
+
+A full-text search query must contain **both** of the following clauses,
+referencing the **same** column:
+
+* A ``WHERE`` filter of the exact form ``BM25(column, 'term') > 0``.
+* An ``ORDER BY BM25(column, 'term')`` clause that ranks the matching rows.
+
+Neither clause is accepted on its own. A query that has only ``WHERE BM25()`` or
+only ``ORDER BY BM25()`` is rejected, and the two clauses must reference the same
+column.
+
+**Syntax:**
+
+.. code-block::
+
+   fts_query: SELECT ... FROM `table_name`
+            :   WHERE BM25 '(' `column_name` ',' `term` ')' '>' 0
+            :   ORDER BY BM25 '(' `column_name` ',' `term` ')'
+            :   LIMIT `integer`
+
+In the ``WHERE`` clause, ``>`` is the only supported comparison operator, and the right-hand side must be
+the literal ``0``. The column must be of type ``text``, ``varchar``, or ``ascii``
+and have a ``fulltext_index``; it may be a regular or clustering-key column, but
+not a partition-key column.
+
+``ORDER BY BM25()`` must be the only ordering in the query - it cannot be combined
+with another ``ORDER BY`` column, a second ``BM25()`` ordering, or an ``ANN``
+ordering.
+
+**Examples:**
+
+Filter and rank by relevance::
+
+    SELECT * FROM articles
+        WHERE BM25(body, 'distributed database') > 0
+        ORDER BY BM25(body, 'distributed database')
+        LIMIT 10;
+
+Use bind markers for the query term::
+
+    SELECT * FROM articles
+        WHERE BM25(body, ?) > 0
+        ORDER BY BM25(body, ?)
+        LIMIT 10;
+
+The ``BM25()`` operator is not a reserved word. If a user-defined function named
+``bm25`` exists in a keyspace, unqualified ``BM25()`` becomes ambiguous; qualify
+the built-in operator as ``system.bm25(...)`` to disambiguate it.
+
+.. note::
+
+   ``BM25()`` is only valid in the ``WHERE`` and ``ORDER BY`` clauses.
+   It cannot be used as a selector in the ``SELECT`` clause.
+
+For the full list of query constraints and requirements, see
+:doc:`Full-Text Search </features/fulltext-search>`.
 
 .. _limit-clause:
 

--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -329,6 +329,52 @@ The ``similarity_function`` option is supported by both Cassandra SAI and Scylla
       -- ScyllaDB creates the equivalent of:
       CREATE INDEX ON my_table (ENTRIES(metadata_s));
 
+.. _create-fulltext-index-statement:
+
+Full-text Index :label-note:`ScyllaDB Cloud`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+   Full-text indexes are supported in ScyllaDB Cloud only in clusters that have the Vector and Text Search feature enabled.
+   For the full list of unsupported ScyllaDB features, see the
+   :doc:`Full-Text Search documentation </features/fulltext-search>`.
+
+ScyllaDB supports creating full-text indexes on text columns, enabling full-text search queries that rank results
+by relevance using the BM25 scoring algorithm. A full-text index is a custom index created using the ``CUSTOM``
+keyword and specifying the index type as ``fulltext_index``.
+
+CDC is enabled automatically on the base table when a full-text index is created.
+
+**Column restrictions:**
+
+* The indexed column must be of type ``text``, ``varchar``, or ``ascii``. Other types are rejected.
+* The indexed column must be a regular or clustering-key column. Partition-key columns cannot be indexed.
+* The table must use tablets (not vnodes).
+
+Example::
+
+   CREATE CUSTOM INDEX ON articles (body) USING 'fulltext_index';
+
+You can specify an analyzer to control how text is tokenized::
+
+   CREATE CUSTOM INDEX ON articles (body) USING 'fulltext_index'
+       WITH OPTIONS = {'analyzer': 'english'};
+
+The following options are supported for full-text indexes:
+
++----------------+-------------------------------------------------------------------------------------------+-------------------+
+| Option         | Description                                                                               | Default Value     |
++================+===========================================================================================+===================+
+| ``analyzer``   | Text analyzer for tokenization. Determines how text is split into terms.                  | ``standard``      |
+|                | Supported values (case-insensitive): ``standard``, ``english``, ``german``,               |                   |
+|                | ``french``, ``spanish``, ``italian``, ``portuguese``, ``russian``, ``simple``,            |                   |
+|                | ``whitespace``. CJK analyzers (``chinese``, ``japanese``, ``korean``) are not supported.  |                   |
++----------------+-------------------------------------------------------------------------------------------+-------------------+
+| ``positions``  | Whether token positions are stored. Required for phrase queries.                          | ``true``          |
+|                | Supported values: ``true``, ``false`` (case-insensitive).                                 |                   |
++----------------+-------------------------------------------------------------------------------------------+-------------------+
+
 .. _drop-index-statement:
 
 DROP INDEX

--- a/docs/dev/fulltext_search.md
+++ b/docs/dev/fulltext_search.md
@@ -1,0 +1,50 @@
+# Full-Text Search — Developer Notes
+
+For user-facing documentation (index creation, query syntax, constraints), see
+:doc:`Full-Text Search </features/fulltext-search>` and
+:ref:`Fulltext Index <create-fulltext-index-statement>` in the secondary-indexes reference.
+
+This document covers implementation details and decisions not included in the user documentation.
+
+## Design decisions
+
+### CJK analyzers not supported
+
+CJK (Chinese, Japanese, Korean) analyzers are intentionally not supported and are rejected
+at index creation time (VECTOR-672). Attempting to use `'analyzer': 'chinese'`, `'japanese'`,
+or `'korean'` will result in an error. The exclusion reflects the current scope of the
+Tantivy-based backend integration.
+
+### Duplicate index detection
+
+Creating a fulltext index with a name that already exists in the keyspace is rejected
+(`already exists`), and creating a second **unnamed** fulltext index on a column that already
+has one is rejected as a `duplicate of existing index`. `CREATE CUSTOM INDEX IF NOT EXISTS`
+silently succeeds without creating a duplicate. Because the `IF NOT EXISTS` name check matches
+across the whole keyspace, reusing an existing index name with `IF NOT EXISTS` on a different
+table or column silently does nothing (issue VECTOR-641).
+
+## Implementation overview
+
+### Query routing and prepare
+
+An FTS query is identified at prepare time by the presence of a `BM25(column, term)` call
+in the `ORDER BY` clause. The index is resolved from that column, and all structural
+validations are enforced at prepare time: `LIMIT` is required; `PER PARTITION LIMIT` and
+aggregation are rejected; a matching `WHERE BM25(column, ...) > 0` must be present on the
+**same column** as the `ORDER BY`; any additional `WHERE` restrictions are rejected. The
+search-term expression is captured during prepare so that bind markers are correctly
+evaluated at execute time.
+
+Additionally, at execute time the search term values in `WHERE` and `ORDER BY` are evaluated
+and compared - they must be identical. This catches mismatches that cannot be detected at
+prepare time, such as two different bind markers being given different values.
+
+### Execution
+
+At execute time, the search term is evaluated (resolving any bind markers) and sent to the
+external Vector Store (Tantivy backend) via the BM25 endpoint, which returns a ranked list
+of primary keys. ScyllaDB then fetches the corresponding base-table rows and returns them
+in rank order. For tables without clustering columns the fetch is batched into a single
+range query; for tables with clustering columns each key is fetched individually and the
+results are merged.

--- a/docs/features/fulltext-search.rst
+++ b/docs/features/fulltext-search.rst
@@ -1,0 +1,157 @@
+=================================
+Full-Text Search in ScyllaDB
+=================================
+
+What Is Full-Text Search
+-------------------------
+
+Full-Text Search (FTS) lets you find rows that contain specific words or
+phrases inside text columns. Unlike exact-match queries or ``LIKE`` filters,
+FTS uses an inverted index to tokenize text and rank results by relevance
+using the `BM25 <https://en.wikipedia.org/wiki/Okapi_BM25>`_ scoring
+algorithm.
+
+Typical use cases include:
+
+* Searching for keywords in product descriptions, articles, or log messages
+* Ranking results by how well they match a search query
+* Filtering rows that contain at least one matching term
+
+Creating a Full-Text Index
+-----------------------------
+
+Before you can run FTS queries, you must create a ``fulltext_index`` on the
+target column::
+
+    CREATE CUSTOM INDEX ON ks.t (v) USING 'fulltext_index';
+
+You can specify an analyzer to control how text is tokenized::
+
+    CREATE CUSTOM INDEX ON ks.t (v) USING 'fulltext_index'
+        WITH OPTIONS = {'analyzer': 'english'};
+
+**Requirements:**
+
+* The indexed column must be of type ``text``, ``varchar``, or ``ascii``.
+  Other types are rejected.
+* The indexed column must be a regular or clustering-key column. Partition-key
+  columns cannot be indexed.
+* The table must use tablets (not vnodes).
+* CDC must be enabled on the table with a TTL of at least 86400 seconds
+  (24 hours) and either ``delta = 'full'`` or postimage enabled.
+  CDC is enabled automatically when creating a fulltext index, so you do not
+  need to configure it manually.
+
+Querying with BM25
+-------------------
+
+FTS queries use the ``BM25()`` function to score rows against a search term.
+``BM25()`` takes two arguments: a column name and a query string.
+
+A full-text search query must use ``BM25()`` in **both** of these clauses, on
+the **same** column:
+
+* A ``WHERE`` clause of the exact form ``BM25(column, 'term') > 0`` to **filter**
+  the rows that match the search term.
+* An ``ORDER BY BM25(column, 'term')`` clause to **rank** the matching rows by
+  their BM25 relevance score (highest first).
+
+Neither clause works on its own - a query with only ``WHERE BM25()`` or only
+``ORDER BY BM25()`` is rejected, and both must reference the **same column** and
+the **same search term**. Every FTS query also requires a ``LIMIT``.
+
+For the full syntax reference, see :ref:`Full-Text Search queries (BM25) <fulltext-queries>`.
+
+Basic query
+~~~~~~~~~~~
+
+Filter the rows that contain the search term and rank them by relevance::
+
+    SELECT * FROM ks.t
+        WHERE BM25(v, 'search term') > 0
+        ORDER BY BM25(v, 'search term')
+        LIMIT 10;
+
+In the ``WHERE`` clause, ``>`` is the only supported operator and the right-hand
+side must be the literal ``0``. Operators such as ``>=``, ``=``, ``<``, ``<=``,
+and ``!=`` are rejected, as is any non-zero threshold.
+
+Filtering support
+~~~~~~~~~~~~~~~~~
+
+Additional ``WHERE`` restrictions (such as partition key equality) are not
+currently supported alongside ``BM25()`` and will be rejected. Support for
+combined filtering is planned for a future release.
+
+Using bind markers
+~~~~~~~~~~~~~~~~~~
+
+The query term can be supplied with a bind marker in prepared statements::
+
+    SELECT * FROM ks.t
+        WHERE BM25(v, ?) > 0
+        ORDER BY BM25(v, ?)
+        LIMIT 10;
+
+Disambiguating from a user-defined function
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``BM25`` is not a reserved word. If a keyspace defines a user-defined function
+named ``bm25``, an unqualified ``BM25()`` call becomes ambiguous; qualify the
+built-in operator as ``system.bm25(...)`` to select it explicitly.
+
+Unsupported ScyllaDB Features
+------------------------------
+
+Full-text indexes do not support all ScyllaDB features. The following features
+are not supported when using Full-Text Search:
+
+* Tracing
+* TTL (Time To Live)
+* Paging
+* Grouping (``GROUP BY``)
+
+Query Constraints
+------------------
+
+FTS queries enforce the following rules:
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Constraint
+     - Details
+   * - Both clauses required
+     - A query must include both a ``WHERE BM25() > 0`` filter and an
+       ``ORDER BY BM25()`` ranking. Both must reference the same column and
+       the same search term. Neither clause is accepted on its own.
+   * - ``>`` and literal ``0`` only
+     - In ``WHERE``, the only accepted form is ``BM25(column, 'term') > 0``.
+       Other operators (``>=``, ``=``, ``<``, ``<=``, ``!=``) and non-zero
+       thresholds are rejected.
+   * - Filtering support
+     - Only ``BM25(column, 'term') > 0`` is accepted in ``WHERE``. Any additional
+       restriction (e.g., a partition key equality) is rejected. Combined filtering
+       is planned for a future release.
+   * - ``LIMIT`` is required
+     - Every FTS query must include a ``LIMIT`` clause. Queries without
+       ``LIMIT`` are rejected.
+   * - ``PER PARTITION LIMIT`` not supported
+     - ``PER PARTITION LIMIT`` cannot be used with FTS queries.
+   * - Aggregation not supported
+     - FTS queries cannot include aggregate functions (e.g., ``COUNT(*)``,
+       ``SUM()``).
+   * - Fulltext index required
+     - The queried column must have a ``fulltext_index``. A regular secondary
+       index does not satisfy this requirement.
+   * - ``BM25()`` cannot appear in ``SELECT``
+     - ``BM25()`` is only valid in ``WHERE`` and ``ORDER BY`` clauses, not
+       as a selector.
+   * - Partition key columns excluded
+     - A ``fulltext_index`` cannot be created on a partition key column, so
+       ``BM25()`` cannot target one. Regular and clustering-key text columns
+       are supported.
+   * - Single ordering only
+     - ``ORDER BY BM25()`` cannot be combined with other ``ORDER BY`` columns,
+       a second ``BM25()`` ordering, or with ``ANN`` ordering.

--- a/docs/features/index.rst
+++ b/docs/features/index.rst
@@ -19,6 +19,7 @@ This document highlights ScyllaDB's key data modeling features.
    Incremental Repair </features/incremental-repair/>
    Automatic Repair </features/automatic-repair/>
    Vector Search </features/vector-search/>
+   Full-Text Search </features/fulltext-search/>
 
 .. panel-box::
   :title: ScyllaDB Features
@@ -49,3 +50,5 @@ This document highlights ScyllaDB's key data modeling features.
     directly in ScyllaDB, without external schedulers.
   * :doc:`Vector Search in ScyllaDB </features/vector-search/>` enables
     similarity-based queries on vector embeddings.
+  * :doc:`Full-Text Search </features/fulltext-search/>` lets you search and
+    rank text columns by relevance using the BM25 scoring algorithm.


### PR DESCRIPTION
Document the BM25() CQL operator, its WHERE and ORDER BY syntax, the fulltext_index requirement, column type constraints, and the LIMIT requirement.  Covers both the user-facing query syntax and a brief description of the internal query path for developers.

Fixes: SCYLLADB-2173