### PR TITLE
compaction_manager: unregister compaction module on early shutdown

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1301,9 +1301,16 @@ future<> compaction_manager::really_do_stop() noexcept {
     cmlog.info("Stopped");
 }
 
-// Should return immediately when _state == state::none.
 void compaction_manager::do_stop() noexcept {
-    if (_state == state::none || _stop_future) {
+    if (_stop_future) {
+        return;
+    }
+
+    if (_state == state::none) {
+        // Possible when the node shuts down before enable() is called,
+        // e.g. due to an early startup failure. The task manager module
+        // was registered in the constructor and must be unregistered.
+        _stop_future = _task_manager_module->stop();
         return;
     }
 

--- a/main.cc
+++ b/main.cc
@@ -1297,6 +1297,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_cm = defer_verbose_shutdown("compaction_manager", [&cm] {
                cm.stop().get();
             });
+
+            utils::get_local_injector().inject("stop_before_starting_compaction_manager",
+                    [] { throw std::runtime_error("injected failure before starting compaction_manager"); });
+
             cm.invoke_on_all(&compaction::compaction_manager::start, std::ref(*cfg), only_on_shard0(&*disk_space_monitor_shard0)).get();
 
             auto compaction_throughput_update = io_throughput_updater("compaction", dbcfg.compaction_scheduling_group, cfg->compaction_throughput_mb_per_sec);

--- a/test/cluster/test_stop_before_starting_compaction_manager.py
+++ b/test/cluster/test_stop_before_starting_compaction_manager.py
@@ -1,0 +1,20 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import pytest
+from test.pylib.manager_client import ManagerClient
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_stop_before_starting_compaction_manager(manager: ManagerClient) -> None:
+    """Test that Scylla doesn't crash when stopped during boot after constructing compaction manager (and thus
+    registering its task_manager module), but before enabling it (calling compaction_manager::enable()).
+
+    Reproducer for SCYLLADB-2106.
+    """
+    await manager.server_add(
+            config={"error_injections_at_startup": ["stop_before_starting_compaction_manager"]},
+            expected_error="injected failure before starting compaction_manager")


### PR DESCRIPTION
The compaction module is registered with task_manager in the compaction_manager
constructor, and unregistered in compaction_manager::really_do_stop(), which
was gated behind `_state != state::none` in compaction_manager::do_stop().
Since enable() -- which transitions _state from none to running -- is called
later during startup (from database::start() or the disk space monitor callback)
than the compaction_manager constructor, an early shutdown could leave the
compaction module registered after compaction_manager::do_stop() returned.
task_manager::stop() then aborted with 'Tried to stop task manager while
some modules were not unregistered'.

Fix compaction_manager::do_stop() to call _task_manager_module->stop() even
when `_state == state::none`, so that the compaction module is always properly
unregistered.

Fixes: SCYLLADB-2106

Backport to all supported branches, as the bug is there and it has
already caused a failure in 2026.1 CI.