### PR TITLE
test: query_processor: fix test_multi_rf_of_many_keyspaces_0_N flakiness

### DIFF
--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -981,14 +981,13 @@ async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, ma
 
     # Move each keyspace from dc1 to dc2 (dc1: 1->0, dc2: 0->3).
     async def alter_keyspace1():
-        await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};")
+        await cql.run_async("alter keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};", timeout=400)
 
     async def alter_keyspace2():
-        await cql.run_async("alter keyspace ks2 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};")
+        await cql.run_async("alter keyspace ks2 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};", timeout=400)
 
     async def alter_keyspace3():
-        await cql.run_async("alter keyspace ks3 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};")
-
+        await cql.run_async("alter keyspace ks3 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': [], 'dc2': ['rack2a', 'rack2b', 'rack2c']};", timeout=400)
     alter_task1 = asyncio.create_task(alter_keyspace1())
     alter_task2 = asyncio.create_task(alter_keyspace2())
     alter_task3 = asyncio.create_task(alter_keyspace3())


### PR DESCRIPTION
Multi-RF change handles multiple keyspaces concurrently, but tablet
rebuilds are not all started at once — the load balancer considers
machine load when scheduling them. With 3 keyspaces each having a base
table and materialized view, the total operation time approaches the
default 200s CQL timeout on slow/busy CI machines (observed at ~191s).

Double the timeout to 400s to provide sufficient margin.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2042.

Needs backport to 2026.2 that introduces multi RF and the test.