### PR TITLE
Decouple object storage coordinates from tablet restore transitions (a.k.a. system_distributed.snapshots table)

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -550,6 +550,13 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
         auto endpoint = rjson::to_string_view(location["endpoint"]);
         auto bucket = rjson::to_string_view(location["bucket"]);
         auto dc = rjson::to_string_view(location["datacenter"]);
+        auto prefix = location.HasMember("prefix") ? rjson::to_string_view(location["prefix"]) : std::string_view{};
+
+        // FIXME: once manifest_prefix handling is reworked to combine with
+        // the location prefix, this restriction can be lifted.
+        if (!prefix.empty()) {
+            throw httpd::bad_param_exception("backup location 'prefix' must be empty for now");
+        }
 
         if (!location.HasMember("manifests") || !location["manifests"].IsArray()) {
             throw httpd::bad_param_exception("backup location entry must have 'manifests' array");
@@ -567,7 +574,7 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
                     keyspace, table, snapshot, dc, endpoint, bucket, manifests.size());
 
         auto table_id = validate_table(ctx.db.local(), keyspace, table);
-        auto task_id = co_await sst_loader.local().restore_tablets(table_id, keyspace, table, snapshot, sstring(endpoint), sstring(bucket), std::move(manifests));
+        auto task_id = co_await sst_loader.local().restore_tablets(table_id, keyspace, table, snapshot, sstring(endpoint), sstring(bucket), sstring(prefix), std::move(manifests));
         co_return json::json_return_type(fmt::to_string(task_id));
     });
 }

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -128,6 +128,22 @@ schema_ptr snapshot_sstables() {
     return schema;
 }
 
+schema_ptr snapshot_remote_locations() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS);
+        return schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS, std::make_optional(id))
+                .with_column("snapshot_name", utf8_type, column_kind::partition_key)
+                .with_column("datacenter", utf8_type, column_kind::clustering_key)
+                .with_column("endpoint", utf8_type)
+                .with_column("bucket", utf8_type)
+                .with_column("prefix", utf8_type)
+                .with_column("state", int32_type)
+                .with_hash_version()
+                .build();
+    }();
+    return schema;
+}
+
 // This is the set of tables which this node ensures to exist in the cluster.
 // It does that by announcing the creation of these schemas on initialization
 // of the `system_distributed_keyspace` service (see `start()`), unless it first
@@ -144,11 +160,12 @@ static std::vector<schema_ptr> ensured_tables() {
         cdc_desc(),
         cdc_timestamps(),
         snapshot_sstables(),
+        snapshot_remote_locations(),
     };
 }
 
 std::vector<schema_ptr> system_distributed_keyspace::all_distributed_tables() {
-    return {view_build_status(), cdc_desc(), cdc_timestamps(), snapshot_sstables()};
+    return {view_build_status(), cdc_desc(), cdc_timestamps(), snapshot_sstables(), snapshot_remote_locations()};
 }
 
 system_distributed_keyspace::system_distributed_keyspace(cql3::query_processor& qp, service::migration_manager& mm, service::storage_proxy& sp)
@@ -510,6 +527,25 @@ future<> system_distributed_keyspace::update_sstable_download_status(sstring sna
                                   internal_distributed_query_state(),
                                   {downloaded == is_downloaded::yes ? true : false, snapshot_name, ks, table, dc, rack, dht::token::to_int64(start_token), sstable_id.uuid()},
                                   cql3::query_processor::cache_internal::no);
+}
+
+future<> system_distributed_keyspace::insert_snapshot_remote_location(sstring snapshot_name, sstring datacenter, sstring endpoint, sstring bucket, sstring prefix, db::consistency_level cl) {
+    static const sstring query = format("INSERT INTO {}.{} (snapshot_name, datacenter, endpoint, bucket, prefix, state) VALUES (?, ?, ?, ?, ?, ?) USING TTL {}",
+                                        NAME, SNAPSHOT_REMOTE_LOCATIONS, SNAPSHOT_SSTABLES_TTL_SECONDS);
+    // State 4 = snapshot_state::remote (data exists only in object storage)
+    co_await _qp.execute_internal(query, cl, internal_distributed_query_state(),
+                                  {std::move(snapshot_name), std::move(datacenter), std::move(endpoint), std::move(bucket), std::move(prefix), int32_t(4)},
+                                  cql3::query_processor::cache_internal::yes);
+}
+
+future<system_distributed_keyspace::snapshot_remote_location_entry> system_distributed_keyspace::get_snapshot_remote_location(sstring snapshot_name, sstring datacenter, db::consistency_level cl) const {
+    static const sstring query = format("SELECT endpoint, bucket, prefix FROM {}.{} WHERE snapshot_name = ? AND datacenter = ?", NAME, SNAPSHOT_REMOTE_LOCATIONS);
+    auto rs = co_await _qp.execute_internal(query, cl, internal_distributed_query_state(), {snapshot_name, datacenter}, cql3::query_processor::cache_internal::yes);
+    if (rs->empty()) {
+        throw std::runtime_error(format("No snapshot remote location found for snapshot '{}' in datacenter '{}'", snapshot_name, datacenter));
+    }
+    auto& row = rs->one();
+    co_return snapshot_remote_location_entry{row.get_as<sstring>("endpoint"), row.get_as<sstring>("bucket"), row.get_as<sstring>("prefix")};
 }
 
 } // namespace db

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -71,6 +71,10 @@ public:
      * The data the coordinator node puts in this table comes from the snapshot manifests. */
     static constexpr auto SNAPSHOT_SSTABLES = "snapshot_sstables";
 
+    /* This table is used by the backup and restore code to store snapshot
+     * remote location metadata per datacenter. */
+    static constexpr auto SNAPSHOT_REMOTE_LOCATIONS = "snapshot_remote_locations";
+
     static constexpr uint64_t SNAPSHOT_SSTABLES_TTL_SECONDS = std::chrono::seconds(std::chrono::days(3)).count();
 
     /* Information required to modify/query some system_distributed tables, passed from the caller. */
@@ -130,6 +134,15 @@ public:
                                             sstables::sstable_id sstable_id,
                                             dht::token start_token,
                                             is_downloaded downloaded) const;
+
+    struct snapshot_remote_location_entry {
+        sstring endpoint;
+        sstring bucket;
+        sstring prefix;
+    };
+
+    future<> insert_snapshot_remote_location(sstring snapshot_name, sstring datacenter, sstring endpoint, sstring bucket, sstring prefix, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+    future<snapshot_remote_location_entry> get_snapshot_remote_location(sstring snapshot_name, sstring datacenter, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM) const;
 
 private:
     future<> create_tables(std::vector<schema_ptr> tables);

--- a/docs/dev/snapshot_sstables.md
+++ b/docs/dev/snapshot_sstables.md
@@ -50,3 +50,45 @@ The following C++ APIs are provided in `db::system_distributed_keyspace`:
 - insert\_snapshot\_sstable
 
 - get\_snapshot\_sstables
+
+---
+
+# system\_distributed.snapshot\_remote\_locations
+
+## Purpose
+
+This table stores per-datacenter object storage coordinates for snapshots. When the
+restore\_tablets API is called, it populates this table with the endpoint, bucket and
+prefix for the given snapshot and datacenter. Worker nodes look up the object storage
+location from this table using the snapshot name carried in the tablet transition.
+
+## Schema
+
+~~~
+CREATE TABLE system_distributed.snapshot_remote_locations (
+    snapshot_name text,
+    datacenter text,
+    endpoint text,
+    bucket text,
+    prefix text,
+    state int,
+    PRIMARY KEY (snapshot_name, datacenter)
+)
+~~~
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `snapshot_name` | text (partition key) | Name of the snapshot |
+| `datacenter` | text (clustering key) | Datacenter where the snapshot is located |
+| `endpoint` | text | Object storage endpoint URL |
+| `bucket` | text | Object storage bucket name |
+| `prefix` | text | Prefix path within the bucket |
+| `state` | int | Snapshot state (0=unknown, 1=local, 2=being\_backed\_up, 3=remote\_and\_local, 4=remote) |
+
+## APIs
+
+The following C++ APIs are provided in `db::system_distributed_keyspace`:
+
+- insert\_snapshot\_remote\_location
+
+- get\_snapshot\_remote\_location

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -993,8 +993,9 @@ problems in practice.
 # Tablet restore transition
 
 The `restore` tablet transition kind is used by the tablet-aware restore to download SSTables
-from object storage. The transition contains `restore_config` with snapshot name, endpoint and
-bucket.
+from object storage. The transition contains a `snapshot_name` string identifying the snapshot.
+The object storage coordinates (endpoint, bucket) are looked up from the
+`system_distributed.snapshot_remote_locations` table using the snapshot name and datacenter.
 
 Like `repair`, the `restore` transition does not change token ownership — replicas remain intact.
 The topology coordinator processes a tablet in this stage by calling the `RESTORE_TABLET` RPC on

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -136,13 +136,13 @@ tablet_transition_info::tablet_transition_info(tablet_transition_stage stage,
                                                tablet_replica_set next,
                                                std::optional<tablet_replica> pending_replica,
                                                service::session_id session_id,
-                                               std::optional<locator::restore_config> restore_cfg)
+                                               sstring snapshot_name)
     : stage(stage)
     , transition(transition)
     , next(std::move(next))
     , pending_replica(std::move(pending_replica))
     , session_id(session_id)
-    , restore_cfg(std::move(restore_cfg))
+    , snapshot_name(std::move(snapshot_name))
     , writes(get_selector_for_writes(stage))
     , reads(get_selector_for_reads(stage))
 { }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -269,13 +269,6 @@ struct tablet_task_info {
     static std::unordered_set<sstring> deserialize_repair_dcs_filter(sstring filter);
 };
 
-struct restore_config {
-    sstring snapshot_name;
-    sstring endpoint;
-    sstring bucket;
-    bool operator==(const restore_config&) const = default;
-};
-
 /// Stores information about a single tablet.
 struct tablet_info {
     tablet_replica_set replicas;
@@ -385,7 +378,7 @@ struct tablet_transition_info {
     tablet_replica_set next;
     std::optional<tablet_replica> pending_replica; // Optimization (next - tablet_info::replicas)
     service::session_id session_id;
-    std::optional<locator::restore_config> restore_cfg;
+    sstring snapshot_name;
     write_replica_set_selector writes;
     read_replica_set_selector reads;
 
@@ -394,7 +387,7 @@ struct tablet_transition_info {
                            tablet_replica_set next,
                            std::optional<tablet_replica> pending_replica,
                            service::session_id session_id = {},
-                           std::optional<locator::restore_config> rcfg = std::nullopt);
+                           sstring snapshot_name = {});
 
     bool operator==(const tablet_transition_info&) const = default;
 };

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -50,8 +50,8 @@ public:
     tablet_mutation_builder& set_resize_task_info(locator::tablet_task_info info, const gms::feature_service& features);
     tablet_mutation_builder& del_resize_task_info(const gms::feature_service& features);
     tablet_mutation_builder& set_base_table(table_id base_table);
-    tablet_mutation_builder& set_restore_config(dht::token last_token, locator::restore_config rcfg);
-    tablet_mutation_builder& del_restore_config(dht::token last_token);
+    tablet_mutation_builder& set_snapshot_name(dht::token last_token, sstring snapshot_name);
+    tablet_mutation_builder& del_snapshot_name(dht::token last_token);
 
 
     mutation build() {

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -40,9 +40,6 @@ static thread_local auto tablet_task_info_type = user_type_impl::get_instance(
 static thread_local auto replica_type = tuple_type_impl::get_instance({uuid_type, int32_type});
 static thread_local auto replica_set_type = list_type_impl::get_instance(replica_type, false);
 static thread_local auto tablet_info_type = tuple_type_impl::get_instance({long_type, long_type, replica_set_type});
-static thread_local auto restore_config_type = user_type_impl::get_instance(
-        "system", "restore_config", {"snapshot_name", "endpoint", "bucket"},
-        {utf8_type, utf8_type, utf8_type}, false);
 
 data_type get_replica_set_type() {
     return replica_set_type;
@@ -55,7 +52,6 @@ data_type get_tablet_info_type() {
 void tablet_add_repair_scheduler_user_types(const sstring& ks, replica::database& db) {
     db.find_keyspace(ks).add_user_type(repair_scheduler_config_type);
     db.find_keyspace(ks).add_user_type(tablet_task_info_type);
-    db.find_keyspace(ks).add_user_type(restore_config_type);
 }
 
 static bool strongly_consistent_tables_enabled = false;
@@ -92,7 +88,7 @@ schema_ptr make_tablets_schema() {
             .with_column("migration_task_info", tablet_task_info_type)
             .with_column("resize_task_info", tablet_task_info_type, column_kind::static_column)
             .with_column("base_table", uuid_type, column_kind::static_column)
-            .with_column("restore_config", restore_config_type);
+            .with_column("snapshot_name", utf8_type);
 
     if (strongly_consistent_tables_enabled) {
         builder
@@ -222,15 +218,6 @@ data_value tablet_task_info_to_data_value(const locator::tablet_task_info& info)
         data_value(info.sched_time),
         data_value(locator::tablet_task_info::serialize_repair_hosts_filter(info.repair_hosts_filter)),
         data_value(locator::tablet_task_info::serialize_repair_dcs_filter(info.repair_dcs_filter)),
-    });
-    return result;
-};
-
-data_value restore_config_to_data_value(const locator::restore_config& cfg) {
-    data_value result = make_user_value(restore_config_type, {
-        data_value(cfg.snapshot_name),
-        data_value(cfg.endpoint),
-        data_value(cfg.bucket),
     });
     return result;
 };
@@ -459,8 +446,8 @@ tablet_mutation_builder::set_repair_task_info(dht::token last_token, locator::ta
 }
 
 tablet_mutation_builder&
-tablet_mutation_builder::set_restore_config(dht::token last_token, locator::restore_config rcfg) {
-    _m.set_clustered_cell(get_ck(last_token), "restore_config", restore_config_to_data_value(rcfg), _ts);
+tablet_mutation_builder::set_snapshot_name(dht::token last_token, sstring snapshot_name) {
+    _m.set_clustered_cell(get_ck(last_token), "snapshot_name", data_value(std::move(snapshot_name)), _ts);
     return *this;
 }
 
@@ -476,8 +463,8 @@ tablet_mutation_builder::del_repair_task_info(dht::token last_token, const gms::
 }
 
 tablet_mutation_builder&
-tablet_mutation_builder::del_restore_config(dht::token last_token) {
-    auto col = _s->get_column_definition("restore_config");
+tablet_mutation_builder::del_snapshot_name(dht::token last_token) {
+    auto col = _s->get_column_definition("snapshot_name");
     _m.set_clustered_cell(get_ck(last_token), *col, atomic_cell::make_dead(_ts, gc_clock::now()));
     return *this;
 }
@@ -570,22 +557,6 @@ static
 locator::tablet_task_info deserialize_tablet_task_info(cql3::untyped_result_set_row::view_type raw_value) {
     return tablet_task_info_from_cell(
             tablet_task_info_type->deserialize_value(raw_value));
-}
-
-locator::restore_config restore_config_from_cell(const data_value& v) {
-    std::vector<data_value> dv = value_cast<user_type_impl::native_type>(v);
-    auto result = locator::restore_config{
-        value_cast<sstring>(dv[0]),
-        value_cast<sstring>(dv[1]),
-        value_cast<sstring>(dv[2]),
-    };
-    return result;
-}
-
-static
-locator::restore_config deserialize_restore_config(cql3::untyped_result_set_row::view_type raw_value) {
-    return restore_config_from_cell(
-            restore_config_type->deserialize_value(raw_value));
 }
 
 locator::repair_scheduler_config repair_scheduler_config_from_cell(const data_value& v) {
@@ -800,9 +771,9 @@ tablet_id process_one_row(replica::database* db, table_id table, tablet_map& map
         }
     }
 
-    std::optional<locator::restore_config> restore_cfg;
-    if (row.has("restore_config")) {
-        restore_cfg = deserialize_restore_config(row.get_view("restore_config"));
+    sstring snapshot_name;
+    if (row.has("snapshot_name")) {
+        snapshot_name = row.get_as<sstring>("snapshot_name");
     }
 
     locator::tablet_task_info migration_task_info;
@@ -828,7 +799,7 @@ tablet_id process_one_row(replica::database* db, table_id table, tablet_map& map
             session_id = service::session_id(row.get_as<utils::UUID>("session"));
         }
         map.set_tablet_transition_info(tid, tablet_transition_info{stage, transition,
-                std::move(new_tablet_replicas), pending_replica, session_id, std::move(restore_cfg)});
+                std::move(new_tablet_replicas), pending_replica, session_id, std::move(snapshot_name)});
     }
 
     tablet_logger.debug("Set sstables_repaired_at={} table={} tablet={}", sstables_repaired_at, table, tid);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5781,7 +5781,7 @@ future<> storage_service::restore_tablets(table_id table, sstring snap_name, sst
                 updates.emplace_back(tablet_mutation_builder_for_base_table(write_timestamp, table)
                     .set_stage(last_token, locator::tablet_transition_stage::restore)
                     .set_new_replicas(last_token, tmap.get_tablet_info(tid).replicas)
-                    .set_restore_config(last_token, locator::restore_config{ snap_name, endpoint, bucket })
+                    .set_snapshot_name(last_token, snap_name)
                     .set_transition(last_token, locator::tablet_transition_kind::restore)
                     .build());
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5736,13 +5736,13 @@ future<> storage_service::del_tablet_replica(table_id table, dht::token token, l
     });
 }
 
-future<> storage_service::restore_tablets(table_id table, sstring snap_name, sstring endpoint, sstring bucket) {
+future<> storage_service::restore_tablets(table_id table, sstring snap_name) {
     auto holder = _async_gate.hold();
 
     if (this_shard_id() != 0) {
         // group0 is only set on shard 0.
         co_return co_await container().invoke_on(0, [&] (auto& ss) {
-            return ss.restore_tablets(table, snap_name, endpoint, bucket);
+            return ss.restore_tablets(table, snap_name);
         });
     }
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -968,7 +968,7 @@ public:
     future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> add_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> del_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
-    future<> restore_tablets(table_id, sstring snap_name, sstring endpoint, sstring bucket);
+    future<> restore_tablets(table_id, sstring snap_name);
     future<> set_tablet_balancing_enabled(bool);
 
     future<> await_topology_quiesced();

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2320,12 +2320,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 }
                     break;
                 case locator::tablet_transition_stage::restore: {
-                    if (!trinfo.restore_cfg.has_value()) {
-                        on_internal_error(rtlogger, format("Cannot handle restore transition without config for tablet {}", gid));
+                    if (trinfo.snapshot_name.empty()) {
+                        on_internal_error(rtlogger, format("Cannot handle restore transition without snapshot name for tablet {}", gid));
                     }
                     if (action_failed(tablet_state.restore)) {
                         rtlogger.debug("Clearing restore transition for {} due to error", gid);
-                        updates.emplace_back(get_mutation_builder().del_transition(last_token).del_restore_config(last_token).build());
+                        updates.emplace_back(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).build());
                         break;
                     }
                     if (advance_in_background(gid, tablet_state.restore, "restore", [this, gid, &tmap] () -> future<> {
@@ -2342,7 +2342,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         });
                     })) {
                         rtlogger.debug("Clearing restore transition for {}", gid);
-                        updates.emplace_back(get_mutation_builder().del_transition(last_token).del_restore_config(last_token).build());
+                        updates.emplace_back(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).build());
                     }
                 }
                     break;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -959,11 +959,11 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
     if (!trinfo) {
         throw std::runtime_error(fmt::format("No transition info for tablet {}", tid));
     }
-    if (!trinfo->restore_cfg) {
-        throw std::runtime_error(format("No restore config for tablet {} restore transition", tid));
+    if (trinfo->snapshot_name.empty()) {
+        throw std::runtime_error(format("No snapshot name for tablet {} restore transition", tid));
     }
 
-    sstring snapshot_name = trinfo->restore_cfg->snapshot_name;
+    sstring snapshot_name = trinfo->snapshot_name;
 
     auto s = _db.local().find_schema(tid.table);
     auto tablet_range = tmap.get_token_range(tid.tablet);

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1170,18 +1170,14 @@ class sstables_loader::tablet_restore_task_impl : public tasks::task_manager::ta
     sharded<sstables_loader>& _loader;
     table_id _tid;
     sstring _snap_name;
-    sstring _endpoint;
-    sstring _bucket;
 
 public:
     tablet_restore_task_impl(tasks::task_manager::module_ptr module, sharded<sstables_loader>& loader, sstring ks,
-            table_id tid, sstring snap_name, sstring endpoint, sstring bucket) noexcept
+            table_id tid, sstring snap_name) noexcept
         : tasks::task_manager::task::impl(module, tasks::task_id::create_random_id(), 0, "node", ks, "", "", tasks::task_id::create_null_id())
         , _loader(loader)
         , _tid(std::move(tid))
         , _snap_name(std::move(snap_name))
-        , _endpoint(std::move(endpoint))
-        , _bucket(std::move(bucket))
     {
         _status.progress_units = "batches";
     }
@@ -1205,7 +1201,7 @@ public:
 protected:
     virtual future<> run() override {
         auto& loader = _loader.local();
-        co_await loader._ss.local().restore_tablets(_tid, _snap_name, _endpoint, _bucket);
+        co_await loader._ss.local().restore_tablets(_tid, _snap_name);
 
         auto& db = loader._db.local();
         auto s = db.find_schema(_tid);
@@ -1237,6 +1233,6 @@ future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring ke
     co_await container().invoke_on(0, [tid, tablet_count] (auto& sl) -> future<> {
         co_await sl._ss.local().alter_table_with_tablet_hints(tid, tablet_count, tablet_count);
     });
-    auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name), std::move(endpoint), std::move(bucket));
+    auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name));
     co_return task->id();
 }

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -963,8 +963,7 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
         throw std::runtime_error(format("No restore config for tablet {} restore transition", tid));
     }
 
-    locator::restore_config restore_cfg = *trinfo->restore_cfg;
-    llog.info("Downloading sstables for tablet {} from {}@{}/{}", tid, restore_cfg.snapshot_name, restore_cfg.endpoint, restore_cfg.bucket);
+    sstring snapshot_name = trinfo->restore_cfg->snapshot_name;
 
     auto s = _db.local().find_schema(tid.table);
     auto tablet_range = tmap.get_token_range(tid.tablet);
@@ -974,11 +973,14 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
     auto datacenter = topo.get_datacenter();
     auto rack = topo.get_rack();
 
-    auto sst_infos = co_await _sys_dist_ks.get_snapshot_sstables(restore_cfg.snapshot_name, keyspace_name, table_name, datacenter, rack,
+    auto snapshot_info = co_await _sys_dist_ks.get_snapshot_remote_location(snapshot_name, datacenter);
+    llog.info("Downloading sstables for tablet {} from {}@{}/{}", tid, snapshot_name, snapshot_info.endpoint, snapshot_info.bucket);
+
+    auto sst_infos = co_await _sys_dist_ks.get_snapshot_sstables(snapshot_name, keyspace_name, table_name, datacenter, rack,
             db::consistency_level::LOCAL_QUORUM, tablet_range.start().transform([] (auto& v) { return v.value(); }), tablet_range.end().transform([] (auto& v) { return v.value(); }));
     llog.debug("{} SSTables found for tablet {}", sst_infos.size(), tid);
     if (sst_infos.empty()) {
-        throw std::runtime_error(format("No SSTables found in system_distributed.snapshot_sstables for {}", restore_cfg.snapshot_name));
+        throw std::runtime_error(format("No SSTables found in system_distributed.snapshot_sstables for {}", snapshot_name));
     }
 
     auto [ fully, partially ] = co_await get_sstables_for_tablet(sst_infos, tablet_range, [] (const auto& si) { return si.first_token; }, [] (const auto& si) { return si.last_token; });
@@ -999,7 +1001,7 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
         toc_names_by_prefix[e.prefix].emplace_back(e.toc_name);
     }
 
-    auto ep_type = _storage_manager.get_endpoint_type(restore_cfg.endpoint);
+    auto ep_type = _storage_manager.get_endpoint_type(snapshot_info.endpoint);
     sstables::sstable_open_config cfg {
         .load_bloom_filter = false,
     };
@@ -1009,7 +1011,7 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
 
     auto sstables_on_shards = co_await map_reduce(toc_names_by_prefix, [&] (auto ent) {
         return replica::distributed_loader::get_sstables_from_object_store(_db, s->ks_name(), s->cf_name(),
-                std::move(ent.second), restore_cfg.endpoint, ep_type, restore_cfg.bucket, std::move(ent.first), cfg, [&] { return nullptr; }).then_unpack([] (table_id, auto sstables) {
+                std::move(ent.second), snapshot_info.endpoint, ep_type, snapshot_info.bucket, std::move(ent.first), cfg, [&] { return nullptr; }).then_unpack([] (table_id, auto sstables) {
                     return make_ready_future<std::vector<sstables_col>>(std::move(sstables));
                 });
     }, std::vector<prefix_sstables>(this_smp_shard_count()), [&] (std::vector<prefix_sstables> a, std::vector<sstables_col> b) {
@@ -1049,7 +1051,7 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
             return init;
         });
 
-    co_await container().invoke_on_all([tid, &downloaded_ssts, snap_name = restore_cfg.snapshot_name, keyspace_name, table_name, datacenter, rack] (auto& loader) -> future<> {
+    co_await container().invoke_on_all([tid, &downloaded_ssts, snap_name = snapshot_name, keyspace_name, table_name, datacenter, rack] (auto& loader) -> future<> {
         auto shard_ssts = std::move(downloaded_ssts[this_shard_id()]);
         co_await max_concurrent_for_each(shard_ssts, 16, [&loader, tid, snap_name, keyspace_name, table_name, datacenter, rack](const auto& min_info) -> future<> {
             sstables::shared_sstable attached_sst = co_await loader.attach_sstable(tid.table, min_info);
@@ -1228,6 +1230,9 @@ protected:
 
 future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, sstring prefix, utils::chunked_vector<sstring> manifests) {
     auto tablet_count = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
+
+    auto datacenter = _db.local().get_token_metadata().get_topology().get_datacenter();
+    co_await _sys_dist_ks.insert_snapshot_remote_location(snap_name, datacenter, endpoint, bucket, prefix);
 
     co_await container().invoke_on(0, [tid, tablet_count] (auto& sl) -> future<> {
         co_await sl._ss.local().alter_table_with_tablet_hints(tid, tablet_count, tablet_count);

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1226,7 +1226,7 @@ protected:
     }
 };
 
-future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, utils::chunked_vector<sstring> manifests) {
+future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, sstring prefix, utils::chunked_vector<sstring> manifests) {
     auto tablet_count = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
 
     co_await container().invoke_on(0, [tid, tablet_count] (auto& sl) -> future<> {

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -151,7 +151,7 @@ public:
             sstring prefix, std::vector<sstring> sstables,
             sstring endpoint, sstring bucket, stream_scope scope, bool primary_replica);
 
-    future<tasks::task_id> restore_tablets(table_id, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, utils::chunked_vector<sstring> manifests);
+    future<tasks::task_id> restore_tablets(table_id, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, sstring prefix, utils::chunked_vector<sstring> manifests);
 
     class download_task_impl;
     class tablet_restore_task_impl;


### PR DESCRIPTION
The tablet-aware restore currently stores object storage coordinates (endpoint, bucket) directly in the restore_config cell that travels with each tablet transition in system.tablets. This is both wasteful (the same endpoint and bucket apply to all tablets in a restore operation for a given datacenter) and not flexible (there's no good way to store more than one endpoint:bucket pair on config).

This PR introduces a new system_distributed.snapshots table that maps (snapshot, datacenter) to the object storage coordinates. The restore API populates this table once before creating tablet transitions. The RESTORE_TABLET RPC handler on each worker node then looks up the endpoint and bucket from this table using the snapshot name.

After this change, the per-tablet restore_config can be relaxed -- instead of user-defined type it can be replaced with a simple snapshot_name string in the transition metadata.

Prerequisite for SCYLLADB-2176, without this change the new topology operation would need to carry the same restore_config onboard
Fixes SCYLLADB-1871

Tablet-aware restore is not yet released feature, not backporting