### PR TITLE
cql3: replace bytes with std::array<uint8_t, 16> in cql_metadata_id_type

### DIFF
--- a/cql3/result_set.cc
+++ b/cql3/result_set.cc
@@ -91,7 +91,8 @@ cql3::cql_metadata_id_type metadata::calculate_metadata_id() const {
         feed_hash(h, _column_info->_names[i]->type->name());
     }
     // Return first 16 bytes to have the same length as Cassandra's MD5
-    return cql_metadata_id_type(h.finalize().substr(0, 16));
+    auto hash = h.finalize();
+    return cql_metadata_id_type(bytes_view(hash).substr(0, 16));
 }
 
 prepared_metadata::prepared_metadata(const std::vector<lw_shared_ptr<column_specification>>& names,

--- a/cql3/statements/prepared_statement.hh
+++ b/cql3/statements/prepared_statement.hh
@@ -15,6 +15,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/core/checked_ptr.hh>
+#include <array>
 #include <vector>
 
 #include "exceptions/exceptions.hh"
@@ -27,10 +28,27 @@ class column_specification;
 class cql_statement;
 
 struct cql_metadata_id_type {
-    explicit cql_metadata_id_type(bytes&& metadata_id) : _metadata_id(std::move(metadata_id)) {}
-    bytes _metadata_id;
+    static constexpr size_t size = 16;
+
+    cql_metadata_id_type() : _id{} {}
+    explicit cql_metadata_id_type(bytes_view metadata_id) : _id{} {
+        if (metadata_id.size() != size) {
+            throw exceptions::protocol_exception(
+                fmt::format("Expected metadata_id of {} bytes, got {}", size, metadata_id.size()));
+        }
+        std::copy_n(metadata_id.begin(), size, _id.begin());
+    }
 
     bool operator==(const cql_metadata_id_type& other) const = default;
+
+    // For wire protocol: return a view for write_short_bytes
+    bytes_view to_bytes_view() const {
+        return bytes_view(reinterpret_cast<const bytes::value_type*>(_id.data()), size);
+    }
+private:
+    std::array<uint8_t, size> _id;
+
+    friend struct fmt::formatter<cql_metadata_id_type>;
 };
 
 namespace statements {
@@ -80,6 +98,6 @@ public:
 template <> struct fmt::formatter<cql3::cql_metadata_id_type> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const cql3::cql_metadata_id_type& m, fmt::format_context& ctx) const {
-        return fmt::format_to(ctx.out(), "{}", m._metadata_id);
+        return fmt::format_to(ctx.out(), "{:02x}", fmt::join(m._id, ""));
     }
 };

--- a/cql3/statements/raw/parsed_statement.cc
+++ b/cql3/statements/raw/parsed_statement.cc
@@ -48,7 +48,7 @@ prepared_statement::prepared_statement(
     , bound_names(std::move(bound_names_))
     , partition_key_bind_indices(std::move(partition_key_bind_indices))
     , warnings(std::move(warnings))
-    , _metadata_id(bytes{})
+    , _metadata_id()
 {
     statement->set_audit_info(std::move(audit_info));
 }

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -683,13 +683,13 @@ SEASTAR_TEST_CASE(test_system_schema_version_is_stable) {
 // The purpose of this check is to make sure that we don't accidentally change the metadata_id.
 // The metadata_id should be stable to avoid ping-pong when driver connects to a mixed cluster.
 void verify_metadata_id_is_stable(cql3::cql_metadata_id_type metadata_id, sstring known_hash) {
-    BOOST_REQUIRE_EQUAL(metadata_id._metadata_id, from_hex(known_hash));
+    BOOST_REQUIRE_EQUAL(metadata_id.to_bytes_view(), from_hex(known_hash));
 }
 
 BOOST_AUTO_TEST_CASE(metadata_id_from_empty_metadata) {
     auto m = cql3::metadata{std::vector<lw_shared_ptr<cql3::column_specification>>{}};
     auto metadata_id = m.calculate_metadata_id();
-    BOOST_REQUIRE_EQUAL(metadata_id._metadata_id.size(), 16);
+    BOOST_REQUIRE_EQUAL(metadata_id.to_bytes_view().size(), 16);
     verify_metadata_id_is_stable(metadata_id, "e3b0c44298fc1c149afbf4c8996fb924");
 }
 

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -171,12 +171,15 @@ SEASTAR_THREAD_TEST_CASE(test_response_metadata_changed_for_empty_request_metada
             "ks", "cf", ::make_shared<cql3::column_identifier>("v", true), utf8_type);
     cql3::metadata m({col});
     auto calculated_metadata_id = m.calculate_metadata_id();
-    auto expected_metadata_id = bytes(calculated_metadata_id._metadata_id);
+    auto expected_metadata_id = calculated_metadata_id.to_bytes_view();
 
+    // Create a different (zero-filled) metadata_id for request to trigger METADATA_CHANGED
+    bytes dummy_request_bytes(bytes::initialized_later(), 16);
+    std::fill(dummy_request_bytes.begin(), dummy_request_bytes.end(), int8_t(0));
     auto res = cql_transport::response(0, cql_transport::cql_binary_opcode::RESULT, tracing::trace_state_ptr());
     res.write(m, cql_transport::cql_metadata_id_wrapper(
-            cql3::cql_metadata_id_type(bytes{}),
-            cql3::cql_metadata_id_type(bytes(expected_metadata_id))), true);
+            cql3::cql_metadata_id_type(bytes_view(dummy_request_bytes)),
+            cql3::cql_metadata_id_type(bytes_view(expected_metadata_id))), true);
 
     memory_data_sink_buffers buffers;
     {

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -77,7 +77,7 @@ public:
     void write_long_string(const sstring& s);
     void write_string_list(std::vector<sstring> string_list);
     void write_bytes(bytes b);
-    void write_short_bytes(bytes b);
+    void write_short_bytes(bytes_view b);
     void write_inet(socket_address inet);
     void write_consistency(db::consistency_level c);
     void write_string_map(std::map<sstring, sstring> string_map);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1681,7 +1681,7 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
         if (!metadata_id_bytes) {
             return make_exception_future<cql_server::process_fn_return_type>(std::move(metadata_id_bytes).assume_error());
         }
-        metadata_id = cql_metadata_id_wrapper(cql3::cql_metadata_id_type(std::move(metadata_id_bytes).assume_value()), prepared->get_metadata_id());
+        metadata_id = cql_metadata_id_wrapper(cql3::cql_metadata_id_type(metadata_id_bytes.assume_value()), prepared->get_metadata_id());
     }
 
     auto q_state = std::make_unique<cql_query_state>(client_state, trace_state, std::move(permit));
@@ -2099,7 +2099,7 @@ public:
         _response.write_int(0x0004);
         _response.write_short_bytes(m.get_id());
         if (_metadata_id.has_response_metadata_id()) {
-            _response.write_short_bytes(_metadata_id.get_response_metadata_id()._metadata_id);
+            _response.write_short_bytes(_metadata_id.get_response_metadata_id().to_bytes_view());
         }
         _response.write(m.metadata(), _version);
         _response.write(*m.result_metadata(), _metadata_id);
@@ -2391,7 +2391,7 @@ void cql_server::response::write_bytes(bytes b)
     _body.write(b);
 }
 
-void cql_server::response::write_short_bytes(bytes b)
+void cql_server::response::write_short_bytes(bytes_view b)
 {
     write_short(cast_if_fits<uint16_t>(b.size()));
     _body.write(b);
@@ -2626,7 +2626,7 @@ void cql_server::response::write(const cql3::metadata& m, const cql_metadata_id_
     }
 
     if (flags.contains<cql3::metadata::flag::METADATA_CHANGED>()) {
-        write_short_bytes(metadata_id.get_response_metadata_id()._metadata_id);
+        write_short_bytes(metadata_id.get_response_metadata_id().to_bytes_view());
     }
 
     auto names_i = m.get_names().begin();


### PR DESCRIPTION
## Motivation

`cql_metadata_id_type` wraps a 16-byte hash (SHA-256 truncated to 16 bytes for CQL protocol metadata change detection). Previously it stored this in a `bytes` (basic_sstring) which occupies 32 bytes inline due to SSO layout (31 bytes data + 1 byte size field). Replacing with `std::array<uint8_t, 16>` saves 16 bytes.

## Memory savings

- **16 bytes per cached prepared statement** (each has a `_metadata_id` member)
- **Up to 32 bytes per in-flight CQL EXECUTE request** on the stack (`cql_metadata_id_wrapper` holds up to 2 `optional<cql_metadata_id_type>`)

With 10K cached prepared statements, this saves 160 KB of cache memory, allowing more statements to fit before eviction.

## Nature of change

- `cql_metadata_id_type` now stores `std::array<uint8_t, 16>` instead of `bytes`
- Constructor takes `bytes_view` instead of `bytes&&` (zero-copy from hash output)
- Validates input length at runtime (throws `protocol_exception` for malformed client frames instead of UB)
- Added `to_bytes()` method for wire protocol serialization
- Updated transport layer and tests

## Tests

- transport_test: passed (2/2 test cases)
- combined_tests metadata_id suite: all 8 tests passed

## Benchmark (perf-simple-query, release, smp1, cpu5 pinned 2.2GHz, 10K partitions, 5 runs)

| Metric | Master | This PR | Delta |
|--------|--------|---------|-------|
| allocs/op | 58.1 | 58.1 | 0 (expected) |
| insns/op | 32,230 | 32,060 | -170 |
| tps | 150K | 149-150K | neutral |

No performance regression. Savings are in memory density (not measured by this microbenchmark).

Refs #29047