### PR TITLE
Add system_distributed.snapshot_cql_tables table

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -128,6 +128,26 @@ schema_ptr snapshot_sstables() {
     return schema;
 }
 
+schema_ptr snapshot_cql_tables() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_CQL_TABLES);
+        return schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_CQL_TABLES, std::make_optional(id))
+                // Name of the snapshot
+                .with_column("snapshot_name", utf8_type, column_kind::partition_key)
+                // Keyspace where the table belongs
+                .with_column("keyspace_name", utf8_type, column_kind::clustering_key)
+                // Table name
+                .with_column("table_name", utf8_type, column_kind::clustering_key)
+                // Whether this table is a materialized view
+                .with_column("is_view", boolean_type)
+                // CQL create statement of the table
+                .with_column("create_statement", utf8_type)
+                .with_hash_version()
+                .build();
+    }();
+    return schema;
+}
+
 // This is the set of tables which this node ensures to exist in the cluster.
 // It does that by announcing the creation of these schemas on initialization
 // of the `system_distributed_keyspace` service (see `start()`), unless it first
@@ -144,11 +164,12 @@ static std::vector<schema_ptr> ensured_tables() {
         cdc_desc(),
         cdc_timestamps(),
         snapshot_sstables(),
+        snapshot_cql_tables(),
     };
 }
 
 std::vector<schema_ptr> system_distributed_keyspace::all_distributed_tables() {
-    return {view_build_status(), cdc_desc(), cdc_timestamps(), snapshot_sstables()};
+    return {view_build_status(), cdc_desc(), cdc_timestamps(), snapshot_sstables(), snapshot_cql_tables()};
 }
 
 system_distributed_keyspace::system_distributed_keyspace(cql3::query_processor& qp, service::migration_manager& mm, service::storage_proxy& sp)
@@ -447,6 +468,17 @@ future<> system_distributed_keyspace::insert_snapshot_sstable(sstring snapshot_n
             cql3::query_processor::cache_internal::yes).discard_result();
 }
 
+future<> system_distributed_keyspace::insert_snapshot_cql_table(sstring snapshot_name, sstring ks, sstring table, bool is_view, sstring schema, db::consistency_level cl) {
+    static constexpr uint64_t ttl_seconds = std::chrono::seconds(std::chrono::days(3)).count();
+    sstring query = format("INSERT INTO {}.{} (snapshot_name, keyspace_name, table_name, is_view, create_statement) VALUES (?, ?, ?, ?, ?) USING TTL {}", NAME, SNAPSHOT_CQL_TABLES, ttl_seconds);
+    return _qp.execute_internal(
+            query,
+            cl,
+            internal_distributed_query_state(),
+            { std::move(snapshot_name), std::move(ks), std::move(table), is_view, std::move(schema) },
+            cql3::query_processor::cache_internal::yes).discard_result();
+}
+
 future<utils::chunked_vector<snapshot_sstable_entry>>
 system_distributed_keyspace::get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl, std::optional<dht::token> start_token, std::optional<dht::token> end_token) const {
     utils::chunked_vector<snapshot_sstable_entry> sstables;
@@ -510,6 +542,24 @@ future<> system_distributed_keyspace::update_sstable_download_status(sstring sna
                                   internal_distributed_query_state(),
                                   {downloaded == is_downloaded::yes ? true : false, snapshot_name, ks, table, dc, rack, dht::token::to_int64(start_token), sstable_id.uuid()},
                                   cql3::query_processor::cache_internal::no);
+}
+
+future<sstring>
+system_distributed_keyspace::get_snapshot_cql_table_schema(sstring snapshot_name, sstring ks, sstring table, db::consistency_level cl) const {
+    sstring query = format("SELECT create_statement FROM {}.{}"
+            " WHERE snapshot_name = ? AND keyspace_name = ? AND table_name = ?", NAME, SNAPSHOT_CQL_TABLES);
+
+    auto cql = co_await _qp.execute_internal(
+            query,
+            cl,
+            internal_distributed_query_state(),
+            { snapshot_name, ks, table },
+            cql3::query_processor::cache_internal::yes);
+
+    if (!cql || cql->empty()) {
+        throw std::runtime_error(format("Snapshot {} for {}.{} doesn't exist", snapshot_name, ks, table));
+    }
+    co_return cql->one().get_as<sstring>("create_statement");
 }
 
 } // namespace db

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -70,6 +70,9 @@ public:
     /* This table is used by the backup and restore code to store per-sstable metadata.
      * The data the coordinator node puts in this table comes from the snapshot manifests. */
     static constexpr auto SNAPSHOT_SSTABLES = "snapshot_sstables";
+    /* This table is used by the backup and restore code to store per-table CQL schema metadata.
+     * The data the coordinator node puts in this table comes from the snapshot manifests. */
+    static constexpr auto SNAPSHOT_CQL_TABLES = "snapshot_cql_tables";
 
     static constexpr uint64_t SNAPSHOT_SSTABLES_TTL_SECONDS = std::chrono::seconds(std::chrono::days(3)).count();
 
@@ -121,6 +124,8 @@ public:
      * Returns a vector of `snapshot_sstable_entry` structs containing `sstable_id`, `first_token`, `last_token`,
      * `toc_name`, and `prefix`. Uses consistency level `LOCAL_QUORUM` by default. */
     future<utils::chunked_vector<snapshot_sstable_entry>> get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM, std::optional<dht::token> start_token = std::nullopt, std::optional<dht::token> end_token = std::nullopt) const;
+    future<> insert_snapshot_cql_table(sstring snapshot_name, sstring ks, sstring table, bool is_view, sstring schema, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+    future<sstring> get_snapshot_cql_table_schema(sstring snapshot_name, sstring ks, sstring table, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM) const;
 
     future<> update_sstable_download_status(sstring snapshot_name,
                                             sstring ks,

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -170,7 +170,8 @@ or
 # System tables
 There are a few system tables that object storage related code needs to touch in order to operate.
 * [system_distributed.snapshot_sstables](docs/dev/snapshot_sstables.md) - Used during restore by worker nodes to get the list of SSTables that need to be downloaded from object storage and restored locally.
-* [system.sstables](docs/dev/system_keyspace.md#systemsstables) - Used to keep track of SSTables on object storage when a keyspace is created with object storage storage_options.
+* [system_distributed.snapshot_cql_tables](docs/dev/snapshot_cql_tables.md) - Used during restore to get the CQL schema of tables that need to be restored.
+* [system.sstables](docs/dev/system_keyspace.md#systemsstables) - Used to keep track of SSTables on object storage when a keyspace is created with S3 storage_options.
 
 # Manipulating S3 data
 

--- a/docs/dev/snapshot_cql_tables.md
+++ b/docs/dev/snapshot_cql_tables.md
@@ -1,0 +1,43 @@
+# system\_distributed.snapshot\_cql\_tables
+
+## Purpose
+
+This table is used during tablet-aware restore to store the CQL schema of tables included in a snapshot.
+The schema of the table is then altered (table is dropped and recreated with a new schema) so that
+the min_tablet_count/max_tablet_count hints are set equal to the tablet count, thus preventing the load
+balancer from kicking in. The schema of the restored table is then restored to the original schema stored
+in the snapshot_cql_tables table.
+
+Note that rows are inserted with a TTL so that stale restore metadata is automatically cleaned up.
+This is a temporary solution which will be replaced at some point with a mechanism for either
+cleaning up snapshots once restore is done or by doing it manually.
+
+## Schema
+
+~~~
+CREATE TABLE system_distributed.snapshot_cql_tables (
+    snapshot_name text,
+    keyspace_name text,
+    table_name text,
+    is_view boolean,
+    create_statement text,
+    PRIMARY KEY (snapshot_name, keyspace_name, table_name)
+)
+~~~
+
+Column descriptions:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `snapshot_name` | text (partition key) | Name of the snapshot |
+| `keyspace_name` | text (clustering key) | Keyspace the table belongs to |
+| `table_name` | text (clustering key) | Table name within the keyspace |
+| `is_view` | boolean | Whether this table is a materialized view |
+| `create_statement` | text | CQL create statement of the table |
+
+## APIs
+
+The following C++ APIs are provided in `db::system_distributed_keyspace`:
+
+- insert\_snapshot\_cql\_table
+- get\_snapshot\_cql\_table\_schema

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -27,6 +27,8 @@
 #include "replica/database_fwd.hh"
 #include "tasks/task_handler.hh"
 #include "service/storage_proxy.hh"
+#include "replica/schema_describe_helper.hh"
+#include "utils/UUID_gen.hh"
 
 #include "test/lib/test_utils.hh"
 #include "test/lib/random_utils.hh"
@@ -90,10 +92,10 @@ SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works, *boost::unit_test::pr
 
 using namespace sstables;
 
-future<> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
+future<sstring> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
     sharded<db::snapshot_ctl> ctl;
     co_await ctl.start(std::ref(env.db()), std::ref(env.get_storage_proxy()), std::ref(env.get_task_manager()), std::ref(env.get_sstorage_manager()), db::snapshot_ctl::config{});
-    auto prefix = "/backup";
+    auto prefix = fmt::format("/backup-{}", utils::UUID_gen::get_time_UUID());
 
     auto task_id = co_await ctl.local().start_backup(endpoint, bucket, prefix, "ks", "cf", "snapshot", false);
     auto task = tasks::task_handler{env.get_task_manager().local(), task_id};
@@ -101,6 +103,7 @@ future<> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
     BOOST_REQUIRE(status.state == tasks::task_manager::task_state::done);
 
     co_await ctl.stop();
+    co_return prefix;
 }
 
 future<> check_snapshot_sstables(cql_test_env& env) {
@@ -143,12 +146,13 @@ SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_t
 
             auto ep = storage_options.to_map()["endpoint"];
             auto bucket = storage_options.to_map()["bucket"];
-            backup(env, ep, bucket).get();
+            auto prefix = backup(env, ep, bucket).get();
+            auto manifest_path = prefix + "/manifest.json";
 
-            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "unexpected_snapshot", {"/backup/manifest.json"}, db::consistency_level::ONE).get(), std::runtime_error);;
+            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "unexpected_snapshot", {manifest_path}, db::consistency_level::ONE).get(), std::runtime_error);;
 
             // populate system_distributed.snapshot_sstables with the content of the snapshot manifest
-            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "snapshot", {"/backup/manifest.json"}, db::consistency_level::ONE).get();
+            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "snapshot", {manifest_path}, db::consistency_level::ONE).get();
 
             check_snapshot_sstables(env).get();
     }, false, db_cfg_ptr, 10);

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -26,7 +26,6 @@
 #include "sstables_loader.hh"
 #include "replica/database_fwd.hh"
 #include "tasks/task_handler.hh"
-#include "db/system_distributed_keyspace.hh"
 #include "service/storage_proxy.hh"
 
 #include "test/lib/test_utils.hh"
@@ -153,4 +152,26 @@ SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_t
 
             check_snapshot_sstables(env).get();
     }, false, db_cfg_ptr, 10);
+}
+
+SEASTAR_TEST_CASE(test_snapshot_cql_tables_api_works, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    auto db_cfg_ptr = make_shared<db::config>();
+
+    return do_with_cql_env([] (cql_test_env& env) -> future<> {
+        auto snapshot_name = "snapshot";
+        auto ks = "ks";
+        auto table = "cf";
+        auto is_view = false;
+        auto schema = "CREATE TABLE ks.cf (pk int PRIMARY KEY, v int)";
+
+        // insert some test data into snapshot_cql_tables table
+        co_await env.get_system_distributed_keyspace().local().insert_snapshot_cql_table(
+                snapshot_name, ks, table, is_view, schema, db::consistency_level::ONE);
+
+        // read it back and check if it is correct
+        auto result_schema = co_await env.get_system_distributed_keyspace().local().get_snapshot_cql_table_schema(
+                snapshot_name, ks, table, db::consistency_level::ONE);
+
+        BOOST_CHECK_EQUAL(result_schema, schema);
+    }, db_cfg_ptr);
 }


### PR DESCRIPTION
This patch creates the snapshot_cql_tables with the following schema:
```
CREATE TABLE system_distributed_tablets.snapshot_nodes (
    snapshot_name text,
    keyspace text, table text,
    is_view boolean, schema text)
  PRIMARY KEY (snapshot_name, keyspace, table);
```

The table is used during tablet aware restore
for storing the original schema whilst the restore process is ongoing.
Tablet aware restore needs to lock the min/max tablet count hints with a specific value to avoid splits.
This table helps remember the original tablet count hints and restoring them once the tablet aware restore process is done.

Fixes SCYLLADB-783
Fixes SCYLLADB-2378

New functionality, no need to backport.