### PR TITLE
[Backport 2026.2] db/view/view_building_coordinator: add flag to mark if any remote work was finished

### DIFF
--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -65,8 +65,13 @@ future<service::group0_guard> view_building_coordinator::start_operation() {
 future<> view_building_coordinator::await_event() {
     _as.check();
     vbc_logger.debug("waiting for view building state machine event");
-    co_await _vb_sm.event.when();
+    if (!_remote_work_finished) {
+        // We missed a broadcast. If we waited on the condition variable,
+        // we'd get stuck for an indefinite amount of time. Prevent that.
+        co_await _vb_sm.event.when();
+    }
     vbc_logger.debug("event received");
+
 }
 
 future<> view_building_coordinator::commit_mutations(service::group0_guard guard, utils::chunked_vector<mutation> mutations, std::string_view description) {
@@ -114,6 +119,7 @@ future<> view_building_coordinator::run() {
         }
 
         bool sleep = false;
+        _remote_work_finished = false;
         try {
             auto guard_opt = co_await update_state(co_await start_operation());
             if (!guard_opt) {
@@ -497,6 +503,8 @@ future<std::optional<std::vector<utils::UUID>>> view_building_coordinator::work_
 
     if (rpc_failed) {
         co_await seastar::sleep(backoff_duration);
+        // Set `_remote_work_finished` to true in case the coordinator isn't waiting on the CV yet.
+        _remote_work_finished = true;
         _vb_sm.event.broadcast();
         co_return std::nullopt;
     }
@@ -507,6 +515,8 @@ future<std::optional<std::vector<utils::UUID>>> view_building_coordinator::work_
     auto lock = co_await get_shared_lock(_mutex);
     _finished_tasks.at(replica).insert_range(remote_results);
 
+    // Set `_remote_work_finished` to true in case the coordinator isn't waiting on the CV yet.
+    _remote_work_finished = true;
     _vb_sm.event.broadcast();
     co_return remote_results;
 }

--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -64,6 +64,8 @@ future<service::group0_guard> view_building_coordinator::start_operation() {
 
 future<> view_building_coordinator::await_event() {
     _as.check();
+    // This injection is enabled by `view_building_coordinator_wait_before_await_event_after_starting_tasks` injection in `view_building_coordinator::work_on_view_building()`
+    co_await utils::get_local_injector().inject("view_building_coordinator_wait_before_await_event", utils::wait_for_message(5min));
     vbc_logger.debug("waiting for view building state machine event");
     if (!_remote_work_finished) {
         // We missed a broadcast. If we waited on the condition variable,
@@ -399,6 +401,11 @@ future<> view_building_coordinator::work_on_view_building(service::group0_guard 
         } else {
             vbc_logger.debug("Nothing to do for replica {}", replica);
         }
+    }
+
+    if (utils::get_local_injector().enter("view_building_coordinator_wait_before_await_event_after_starting_tasks")) {
+        // `view_building_coordinator_wait_before_await_event` injection waits for a message before processing `view_building_coordinator::await_event()`
+        utils::get_local_injector().enable("view_building_coordinator_wait_before_await_event");
     }
 }
 

--- a/db/view/view_building_coordinator.hh
+++ b/db/view/view_building_coordinator.hh
@@ -54,6 +54,7 @@ class view_building_coordinator : public service::endpoint_lifecycle_subscriber 
     const raft::term_t _term;
     abort_source& _as;
 
+    bool _remote_work_finished;
     std::unordered_map<locator::tablet_replica, shared_future<std::optional<std::vector<utils::UUID>>>> _remote_work;
     shared_mutex _mutex; // guards `_finished_tasks` field
     std::unordered_map<locator::tablet_replica, std::unordered_set<utils::UUID>> _finished_tasks;

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -1018,3 +1018,46 @@ async def test_all_good_on_node_restart(manager: ManagerClient):
     log = await manager.server_open_log(servers[0].server_id)
     warnings = await log.grep(expr="view_building_state_observer failed with")
     assert len(warnings) == 0, f"Found view building state observer warnings: {warnings}"
+
+# The test verifies that the coordinator doesn't get stuck when waiting
+# for an event even if view building tasks finish almost immediately.
+# To achieve this, the test needs to make sure that:
+# - the view building task is started and sent to the worker
+# - the task is finished - this triggers the broadcast on the CV
+# - the task cleaning fiber removes the finished task - this indirectly triggers broadcast on the CV by commiting to group0
+# before unpausing the coordinator (`view_building_coordinator_wait_before_await_event`)
+# Reproduces scylladb/scylladb#27298
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_coordinator_misses_cv_broadcast(manager: ManagerClient):
+    node_count = 1
+    servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, auto_rack_dc="dc1")
+    cql, _ = await manager.get_ready_cql(servers)
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': 1}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v text, PRIMARY KEY (key, c))")
+
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+        await manager.api.enable_injection(servers[0].ip_addr, "view_building_coordinator_wait_before_await_event_after_starting_tasks", one_shot=True)
+        # At this point, the coordinator is waiting on the CV. 
+        # It will be awaken by creating the MV and it will start the work. 
+        # When the coordinator will schedule the first task, `view_building_coordinator_wait_before_await_event_after_starting_tasks` error injection
+        # will enable another `view_building_coordinator_wait_before_await_event` error injection, which will block the coordinator before awaiting the CV.
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv_cf_view AS SELECT * FROM {ks}.tab "
+                         "WHERE c IS NOT NULL and key IS NOT NULL AND v IS NOT NULL PRIMARY KEY (c, key, v) ")
+
+        # Make sure that the coordinator is waiting on the error injection
+        await log.wait_for("view_building_coordinator_wait_before_await_event: waiting for message", from_mark=mark, timeout=60)
+
+        # Make sure that the `finished_task_gc_fiber()` removed the finished task. Without this commited mutation
+        # will wake up the coordinator.
+        # The log message differs depending on whether there are other alive tasks or not - although there is only one task,
+        # the regex matches both cases for safety.
+        await log.wait_for("[Rr]emoving.*finished task", from_mark=mark, timeout=60)
+
+        # Unpause the coordinator. This won't trigger a CV broadcast, reproducing the issue.
+        await manager.api.disable_injection(servers[0].ip_addr, "view_building_coordinator_wait_before_await_event_after_starting_tasks")
+        await manager.api.message_injection(servers[0].ip_addr, "view_building_coordinator_wait_before_await_event")
+        await manager.api.disable_injection(servers[0].ip_addr, "view_building_coordinator_wait_before_await_event")
+
+        await wait_for_view(cql, 'mv_cf_view', node_count)


### PR DESCRIPTION
There is small windows just after view building coordinator releases
group0 guard and before it waits on view_building_state_machine's CV,
when the coordinator may miss CV broadcast triggered by finished remote
work.

To fix it, this patch adds a boolean flag, which is set to true before
broadcasting the CV and is checked before awaiting on the CV.

Fixes SCYLLADB-2029

The problem is not critical but it should be backported to 2025.4 and newer version, all of them contains view building coordinator.

(cherry picked from commit https://github.com/scylladb/scylladb/commit/c7f65131bfa8304b70759849ad7217103ec4ca0e)
(cherry picked from commit https://github.com/scylladb/scylladb/commit/c767ac7ef396b93b9091cc12ffdb80b13443ddfe)

Parent PR: https://github.com/scylladb/scylladb/pull/27313