### PR TITLE
Re-implement restore_tablets as a topology request

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -303,6 +303,7 @@ schema_ptr system_keyspace::topology() {
             .with_column("global_requests", set_type_impl::get_instance(timeuuid_type, true), column_kind::static_column)
             .with_column("paused_rf_change_requests", set_type_impl::get_instance(timeuuid_type, true), column_kind::static_column)
             .with_column("ongoing_rf_changes", set_type_impl::get_instance(timeuuid_type, true), column_kind::static_column)
+            .with_column("ongoing_restore_requests", set_type_impl::get_instance(timeuuid_type, true), column_kind::static_column)
             .set_comment("Current state of topology change machine")
             .with_hash_version()
             .build();
@@ -329,6 +330,8 @@ schema_ptr system_keyspace::topology_requests() {
             .with_column("snapshot_expiry", timestamp_type)
             .with_column("snapshot_skip_flush", boolean_type)
             .with_column("finalize_migration_ks_name", utf8_type)
+            .with_column("restore_table_id", uuid_type)
+            .with_column("restore_snapshot_name", utf8_type)
             .set_comment("Topology request tracking")
             .with_hash_version()
             .build();
@@ -3363,6 +3366,12 @@ future<service::topology> system_keyspace::load_topology_state(const std::unorde
             }
         }
 
+        if (some_row.has("ongoing_restore_requests")) {
+            for (auto&& v : deserialize_set_column(*topology(), some_row, "ongoing_restore_requests")) {
+                ret.ongoing_restore_requests.insert(value_cast<utils::UUID>(v));
+            }
+        }
+
         if (some_row.has("enabled_features")) {
             ret.enabled_features = decode_features(deserialize_set_column(*topology(), some_row, "enabled_features"));
         }
@@ -3608,6 +3617,10 @@ system_keyspace::topology_requests_entry system_keyspace::topology_request_row_t
     }
     if (row.has("finalize_migration_ks_name")) {
         entry.finalize_migration_ks_name = row.get_as<sstring>("finalize_migration_ks_name");
+    }
+    if (row.has("restore_table_id")) {
+        entry.restore_table_id = table_id(row.get_as<utils::UUID>("restore_table_id"));
+        entry.restore_snapshot_name = row.get_as<sstring>("restore_snapshot_name");
     }
 
     return entry;

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -428,6 +428,8 @@ public:
         std::optional<db_clock::time_point> snapshot_expiry;
         bool snapshot_skip_flush;
         std::optional<sstring> finalize_migration_ks_name;
+        std::optional<table_id> restore_table_id;
+        std::optional<sstring> restore_snapshot_name;
     };
     using topology_requests_entries = std::unordered_map<utils::UUID, system_keyspace::topology_requests_entry>;
 

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -177,6 +177,7 @@ are the currently supported global topology operations:
    coordinator executes the truncate request, it issues truncate RPCs to nodes which
    contain replicas of the table being truncated. It uses [sessions](#Topology guards)
    to make sure that no stale RPCs are executed outside of the scope of the request.
+- `restore_tablets` See [Tablet restore transition](#tablet-restore-transition) below.
 
 ## Tablet draining
 
@@ -997,11 +998,24 @@ from object storage. The transition contains a `snapshot_name` string identifyin
 The object storage coordinates (endpoint, bucket) are looked up from the
 `system_distributed.snapshot_remote_locations` table using the snapshot name and datacenter.
 
-Like `repair`, the `restore` transition does not change token ownership — replicas remain intact.
-The topology coordinator processes a tablet in this stage by calling the `RESTORE_TABLET` RPC on
-all tablet replicas. Each replica then downloads and attaches the SSTables that are contained in
-the tablet's token range. If the operation succeeds or fails, the transition is cleared and the
-failure to download SSTables is propagated back to user by the API handler itself.
+Restore is implemented as a `restore_tablets` global topology request. When the topology
+coordinator picks up this request, it populates per-tablet restore transitions for all tablets
+of the target table, sets the topology state machine into the `tablet_migration` track, and
+registers the request in `ongoing_restore_requests` (similar to `ongoing_rf_changes`).
+The existing tablet migration handler then processes the restore transitions by calling the
+`RESTORE_TABLET` RPC on all tablet replicas. Each replica downloads and attaches the SSTables
+that are contained in the tablet's token range. If the operation succeeds or fails, the
+transition is cleared.
 
+After the load balancer detects that no restore transitions remain for the table, it reports
+restore completion. The topology coordinator then removes the request from
+`ongoing_restore_requests` and marks it done. If any transition failed, the error is recorded
+in the request's `error` column and propagated to the caller.
+
+The caller (storage service) waits for the topology request to complete, which encompasses
+both transition population and all transitions being processed. Failure to download SSTables
+is propagated back to user by the API handler.
+
+Like `repair`, the `restore` transition does not change token ownership — replicas remain intact.
 Restore transitions are serialized per-tablet like any other transition (invariant [INV-TABL-2]),
 so they do not run concurrently with migrations or repairs on the same tablet.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5746,58 +5746,36 @@ future<> storage_service::restore_tablets(table_id table, sstring snap_name) {
         });
     }
 
-    // Holding tm around transit_tablet() can lead to deadlock, if state machine is busy
-    // with something which executes a barrier. The barrier will wait for tm to die, and
-    // transit_tablet() will wait for the barrier to finish.
-    // Due to that, we first collect tablet boundaries, then prepare and submit transition
-    // mutations. Since this code is called with equal min:max tokens set for the table,
-    // the tablet map cannot split and merge and, thus, the static vector of tokens should
-    // map to correct tablet boundaries throughout the whole operation
-    utils::chunked_vector<std::pair<locator::tablet_id, dht::token>> tablets;
-    {
-        const auto tm = get_token_metadata_ptr();
-        const auto& tmap = tm->tablets().get_tablet_map(table);
-        co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) {
-            auto last_token = tmap.get_last_token(tid);
-            tablets.push_back(std::make_pair(tid, last_token));
-            return make_ready_future<>();
-        });
+    utils::UUID request_id;
+    while (true) {
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
+        request_id = guard.new_group0_state_id();
+
+        topology_mutation_builder builder(guard.write_timestamp());
+        topology_request_tracking_mutation_builder trbuilder(request_id, _feature_service.topology_requests_type_column);
+
+        trbuilder.set_restore_tablets_data(table, snap_name)
+                 .set("done", false)
+                 .set("start_time", db_clock::now());
+
+        builder.queue_global_topology_request_id(request_id);
+        trbuilder.set("request_type", global_topology_request::restore_tablets);
+
+        topology_change change{{builder.build(), trbuilder.build()}};
+        group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, "Restore tablets");
+        try {
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
+            break;
+        } catch (group0_concurrent_modification&) {
+            slogger.debug("restore_tablets: concurrent modification, retrying");
+        }
     }
 
-    auto wait_one_transition = [this] (locator::global_tablet_id gid) {
-        return _topology_state_machine.event.wait([this, gid] {
-            auto& tmap = get_token_metadata().tablets().get_tablet_map(gid.table);
-            return !tmap.get_tablet_transition_info(gid.tablet);
-        });
-    };
+    auto error = co_await wait_for_topology_request_completion(request_id);
+    if (!error.empty()) {
+        throw std::runtime_error(error);
+    }
 
-    std::vector<future<>> wait;
-    co_await coroutine::parallel_for_each(tablets, [&] (const auto& tablet) -> future<> {
-        auto [ tid, last_token ] = tablet;
-        auto gid = locator::global_tablet_id{table, tid};
-        while (true) {
-            auto success = co_await try_transit_tablet(table, last_token, [&] (const locator::tablet_map& tmap, api::timestamp_type write_timestamp) {
-                utils::chunked_vector<canonical_mutation> updates;
-                updates.emplace_back(tablet_mutation_builder_for_base_table(write_timestamp, table)
-                    .set_stage(last_token, locator::tablet_transition_stage::restore)
-                    .set_new_replicas(last_token, tmap.get_tablet_info(tid).replicas)
-                    .set_snapshot_name(last_token, snap_name)
-                    .set_transition(last_token, locator::tablet_transition_kind::restore)
-                    .build());
-
-                sstring reason = format("Restoring tablet {}", gid);
-                return std::make_tuple(std::move(updates), std::move(reason));
-            });
-            if (success) {
-                wait.emplace_back(wait_one_transition(gid));
-                break;
-            }
-            slogger.debug("Tablet is in transition, waiting");
-            co_await wait_one_transition(gid);
-        }
-    });
-
-    co_await when_all_succeed(wait.begin(), wait.end()).discard_result();
     slogger.info("Restoring {} finished", table);
 }
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -508,6 +508,9 @@ struct fmt::formatter<service::plan_summary> : fmt::formatter<std::string_view> 
         if (plan.rack_list_colocation_plan().size()) {
             fmt::format_to(ctx.out(), "{}rack-list colocation ready: {}", get_delim(), plan.rack_list_colocation_plan().request_to_resume());
         }
+        if (!plan.restore_completions().empty()) {
+            fmt::format_to(ctx.out(), "{}restore completed for: {}", get_delim(), plan.restore_completions() | std::views::transform(&service::restore_completion_info::table));
+        }
         if (delim.empty()) {
             fmt::format_to(ctx.out(), "empty");
         }
@@ -1093,6 +1096,46 @@ public:
         return _topology != nullptr && _sys_ks != nullptr && !_topology->ongoing_rf_changes.empty();
     }
 
+    bool ongoing_restore() const {
+        return _topology != nullptr && _sys_ks != nullptr && !_topology->ongoing_restore_requests.empty();
+    }
+
+    // Check if any ongoing restore requests have completed (all their transitions cleared).
+    future<> check_restore_completions(migration_plan& plan) {
+        if (!ongoing_restore()) {
+            co_return;
+        }
+        for (const auto& request_id : _topology->ongoing_restore_requests) {
+            auto req_entry = co_await _sys_ks->get_topology_request_entry(request_id);
+            auto restore_tid = *req_entry.restore_table_id;
+
+            if (!_tm->tablets().has_tablet_map(restore_tid)) {
+                plan.add_restore_completion(restore_completion_info{
+                    .request_id = request_id,
+                    .table = restore_tid,
+                    .error = format("Table {} was dropped during restore", restore_tid),
+                });
+                continue;
+            }
+            const auto& tmap = _tm->tablets().get_tablet_map(restore_tid);
+            bool has_restore_transitions = false;
+            for (auto tablet : tmap.tablet_ids()) {
+                auto* trinfo = tmap.get_tablet_transition_info(tablet);
+                if (trinfo && trinfo->transition == locator::tablet_transition_kind::restore) {
+                    has_restore_transitions = true;
+                    break;
+                }
+            }
+            if (!has_restore_transitions) {
+                plan.add_restore_completion(restore_completion_info{
+                    .request_id = request_id,
+                    .table = restore_tid,
+                    .error = req_entry.error,
+                });
+            }
+        }
+    }
+
     future<migration_plan> make_plan() {
         const locator::topology& topo = _tm->get_topology();
         migration_plan plan;
@@ -1129,6 +1172,8 @@ public:
         if (plan.resize_plan().finalize_resize.empty()) {
             plan.set_repair_plan(co_await make_repair_plan(plan));
         }
+
+        co_await check_restore_completions(plan);
 
         auto level = plan.empty() ? seastar::log_level::debug : seastar::log_level::info;
         lblogger.log(level, "Prepared plan: {}", plan_summary(plan));

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -187,6 +187,12 @@ struct tablet_rack_list_colocation_plan {
     }
 };
 
+struct restore_completion_info {
+    utils::UUID request_id;
+    table_id table;
+    sstring error;
+};
+
 struct rf_change_completion_info {
     utils::UUID request_id;
     sstring ks_name;
@@ -224,6 +230,7 @@ private:
     tablet_repair_plan _repair_plan;
     tablet_rack_list_colocation_plan _rack_list_colocation_plan;
     keyspace_rf_change_plan _rf_change_plan;
+    std::vector<restore_completion_info> _restore_completions;
     bool _has_nodes_to_drain = false;
     std::vector<drain_failure> _drain_failures;
 public:
@@ -233,7 +240,14 @@ public:
 
     const migrations_vector& migrations() const { return _migrations; }
     bool empty() const { return !size(); }
-    size_t size() const { return _migrations.size() + _resize_plan.size() + _repair_plan.size() + _rack_list_colocation_plan.size() + _drain_failures.size() + _rf_change_plan.size(); }
+    size_t size() const { return _migrations.size()
+                               + _resize_plan.size()
+                               + _repair_plan.size()
+                               + _rack_list_colocation_plan.size()
+                               + _drain_failures.size()
+                               + _rf_change_plan.size()
+                               + _restore_completions.size();
+                        }
     size_t tablet_migration_count() const { return _migrations.size(); }
     size_t resize_decision_count() const { return _resize_plan.size(); }
     size_t tablet_repair_count() const { return _repair_plan.size(); }
@@ -258,6 +272,7 @@ public:
     void merge(migration_plan&& other) {
         std::move(other._migrations.begin(), other._migrations.end(), std::back_inserter(_migrations));
         std::move(other._drain_failures.begin(), other._drain_failures.end(), std::back_inserter(_drain_failures));
+        std::move(other._restore_completions.begin(), other._restore_completions.end(), std::back_inserter(_restore_completions));
         _has_nodes_to_drain |= other._has_nodes_to_drain;
         _resize_plan.merge(std::move(other._resize_plan));
         _repair_plan.merge(std::move(other._repair_plan));
@@ -291,6 +306,12 @@ public:
 
     void set_rf_change_plan(keyspace_rf_change_plan rf_change_plan) {
         _rf_change_plan = std::move(rf_change_plan);
+    }
+
+    const std::vector<restore_completion_info>& restore_completions() const { return _restore_completions; }
+
+    void add_restore_completion(restore_completion_info info) {
+        _restore_completions.emplace_back(std::move(info));
     }
 
     future<std::unordered_set<locator::global_tablet_id>> get_migration_tablet_ids() const;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1462,6 +1462,58 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             co_await _group0.client().add_entry(std::move(g0_cmd), std::move(guard), _as);
         }
         break;
+        case global_topology_request::restore_tablets: {
+            rtlogger.info("restore_tablets requested");
+
+            auto tid = *req_entry.restore_table_id;
+            auto snap_name = *req_entry.restore_snapshot_name;
+
+            utils::chunked_vector<canonical_mutation> updates;
+            sstring error;
+
+            try {
+                auto tmptr = get_token_metadata_ptr();
+                const auto& tmap = tmptr->tablets().get_tablet_map(tid);
+
+                replica::tablet_mutation_builder tablet_builder(guard.write_timestamp(), tid);
+                co_await tmap.for_each_tablet([&] (locator::tablet_id tablet, const locator::tablet_info& info) {
+                    auto last_token = tmap.get_last_token(tablet);
+                    tablet_builder
+                        .set_stage(last_token, locator::tablet_transition_stage::restore)
+                        .set_new_replicas(last_token, info.replicas)
+                        .set_snapshot_name(last_token, snap_name)
+                        .set_transition(last_token, locator::tablet_transition_kind::restore);
+                    return make_ready_future<>();
+                });
+                updates.emplace_back(tablet_builder.build());
+
+                updates.emplace_back(
+                    topology_mutation_builder(guard.write_timestamp())
+                        .set_transition_state(topology::transition_state::tablet_migration)
+                        .del_global_topology_request()
+                        .del_global_topology_request_id()
+                        .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id)
+                        .start_restore_request(req_id)
+                        .set_version(_topo_sm._topology.version + 1)
+                        .build());
+            } catch (const std::exception& e) {
+                error = e.what();
+                rtlogger.error("Couldn't set up restore transitions for table {}: {}", tid, std::current_exception());
+                updates.clear();
+
+                topology_mutation_builder builder(guard.write_timestamp());
+                builder.del_global_topology_request()
+                       .del_global_topology_request_id()
+                       .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id);
+                updates.emplace_back(builder.build());
+                updates.emplace_back(topology_request_tracking_mutation_builder(req_id)
+                                          .done(error)
+                                          .build());
+            }
+
+            co_await update_topology_state(std::move(guard), std::move(updates), "restore_tablets: set up tablet transitions");
+        }
+        break;
         }
     }
 
@@ -1855,6 +1907,18 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             co_await coroutine::maybe_yield();
             generate_resize_update(out, guard, table_id, resize_decision);
         }
+
+        for (const auto& completion : plan.restore_completions()) {
+            rtlogger.info("All restore transitions for table {} completed, finishing request {}", completion.table, completion.request_id);
+            out.emplace_back(
+                topology_mutation_builder(guard.write_timestamp())
+                    .finish_restore_request(_topo_sm._topology.ongoing_restore_requests, completion.request_id)
+                    .build());
+            out.emplace_back(
+                topology_request_tracking_mutation_builder(completion.request_id)
+                    .done(completion.error.empty() ? std::nullopt : std::optional<sstring>(completion.error))
+                    .build());
+        }
     }
 
     void log_active_transitions(size_t max_count) {
@@ -1913,6 +1977,17 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         });
 
         _tablets_ready = false;
+
+        // Build table_id -> request_id mapping for ongoing restore requests
+        // so that we can find the owning request when a restore transition fails.
+        std::unordered_map<table_id, utils::UUID> restore_request_for_table;
+        for (const auto& req_id : _topo_sm._topology.ongoing_restore_requests) {
+            auto req_entry = co_await _sys_ks.get_topology_request_entry(req_id);
+            if (req_entry.restore_table_id) {
+                restore_request_for_table[*req_entry.restore_table_id] = req_id;
+            }
+        }
+
         // We operate here on groups of co-located tablets.
         // The tablets of several tables may be co-located and share the same tablet map, and in
         // particular their transitions are shared. Therefore, each transition must be handled for
@@ -2373,8 +2448,16 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         on_internal_error(rtlogger, format("Cannot handle restore transition without snapshot name for tablet {}", gid));
                     }
                     if (action_failed(tablet_state.restore)) {
+                        auto ep = tablet_state.restore->get_exception();
                         rtlogger.debug("Clearing restore transition for {} due to error", gid);
                         updates.emplace_back(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).build());
+                        // Record error on the ongoing restore request so it's propagated to the caller.
+                        if (auto it = restore_request_for_table.find(gid.table); it != restore_request_for_table.end()) {
+                            updates.emplace_back(
+                                topology_request_tracking_mutation_builder(it->second)
+                                    .set("error", format("Restore failed for tablet {}: {}", gid, ep))
+                                    .build());
+                        }
                         break;
                     }
                     if (advance_in_background(gid, tablet_state.restore, "restore", [this, gid, &tmap] () -> future<> {

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -295,6 +295,16 @@ topology_mutation_builder& topology_mutation_builder::finish_rf_change_migration
     }
 }
 
+topology_mutation_builder& topology_mutation_builder::start_restore_request(const utils::UUID& req_id) {
+    return apply_set("ongoing_restore_requests", collection_apply_mode::update, std::vector<data_value>{req_id});
+}
+
+topology_mutation_builder& topology_mutation_builder::finish_restore_request(const std::unordered_set<utils::UUID>& current, const utils::UUID& req_id) {
+    auto new_values = current;
+    new_values.erase(req_id);
+    return apply_set("ongoing_restore_requests", collection_apply_mode::overwrite, new_values | std::views::transform([] (const auto& id) { return data_value{id}; }));
+}
+
 topology_mutation_builder& topology_mutation_builder::set_upgrade_state_done() {
     return apply_atomic("upgrade_state", "done");
 }
@@ -404,6 +414,13 @@ topology_request_tracking_mutation_builder& topology_request_tracking_mutation_b
 topology_request_tracking_mutation_builder& topology_request_tracking_mutation_builder::set_finalize_migration_data(
         const sstring& ks_name) {
     apply_atomic("finalize_migration_ks_name", ks_name);
+    return *this;
+}
+
+topology_request_tracking_mutation_builder& topology_request_tracking_mutation_builder::set_restore_tablets_data(
+        const table_id& tid, const sstring& snapshot_name) {
+    apply_atomic("restore_table_id", tid.uuid());
+    apply_atomic("restore_snapshot_name", snapshot_name);
     return *this;
 }
 

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -134,6 +134,8 @@ public:
     topology_mutation_builder& resume_rf_change_request(const std::unordered_set<utils::UUID>&, const utils::UUID&);
     topology_mutation_builder& start_rf_change_migrations(const utils::UUID&);
     topology_mutation_builder& finish_rf_change_migrations(const std::unordered_set<utils::UUID>&, const utils::UUID&);
+    topology_mutation_builder& start_restore_request(const utils::UUID& req_id);
+    topology_mutation_builder& finish_restore_request(const std::unordered_set<utils::UUID>& current, const utils::UUID& req_id);
     topology_node_mutation_builder& with_node(raft::server_id);
     canonical_mutation build() { return canonical_mutation{std::move(_m)}; }
 };
@@ -164,6 +166,7 @@ public:
     topology_request_tracking_mutation_builder& set_new_keyspace_rf_change_data(const sstring& ks_name, const std::map<sstring, sstring>& rf_per_dc);
     topology_request_tracking_mutation_builder& set_snapshot_tables_data(const std::unordered_set<table_id>&, const sstring& tag, bool);
     topology_request_tracking_mutation_builder& set_finalize_migration_data(const sstring& ks_name);
+    topology_request_tracking_mutation_builder& set_restore_tablets_data(const table_id& tid, const sstring& snapshot_name);
 
     canonical_mutation build() { return canonical_mutation{std::move(_m)}; }
 };

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -212,6 +212,7 @@ static std::unordered_map<global_topology_request, sstring> global_topology_requ
     {global_topology_request::noop_request, "noop_request"},
     {global_topology_request::finalize_migration, "finalize_migration"},
     {global_topology_request::quiesce, "quiesce"},
+    {global_topology_request::restore_tablets, "restore_tablets"},
 };
 
 global_topology_request global_topology_request_from_string(const sstring& s) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -91,6 +91,7 @@ enum class global_topology_request: uint16_t {
     snapshot_tables,
     finalize_migration,
     quiesce,
+    restore_tablets,
 };
 
 struct ring_slice {
@@ -213,6 +214,17 @@ struct topology {
     // The ids of ongoing RF change requests.
     // Here we keep the ids only for rf-changes using rack_lists.
     std::unordered_set<utils::UUID> ongoing_rf_changes;
+
+    // Set of request IDs for ongoing restore requests. The topology coordinator
+    // checks after each scheduling round whether all restore transitions for the
+    // request's table are cleared, and if so, marks the request as done.
+    //
+    // Currently this set contains at most one entry because restore requests
+    // are serialized by the global request queue (processed only when tstate is
+    // null). To support parallel restores for different tables, process queued
+    // restore_tablets requests inside handle_tablet_migration() so they can be
+    // absorbed into an existing tablet_migration round.
+    std::unordered_set<utils::UUID> ongoing_restore_requests;
 
     // The IDs of the committed yet unpublished CDC generations sorted by timestamps.
     std::vector<cdc::generation_id> unpublished_cdc_generations;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1205,25 +1205,6 @@ protected:
     virtual future<> run() override {
         auto& loader = _loader.local();
         co_await loader._ss.local().restore_tablets(_tid, _snap_name);
-
-        auto& db = loader._db.local();
-        auto s = db.find_schema(_tid);
-        // Hold the token_metadata_ptr on the coroutine frame so the ref count keeps it alive
-        // across co_await suspension points. Without this, token_metadata can be replaced and
-        // cleared (via clear_gently) while the loop iterator still references its topology data.
-        // Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2149
-        auto md = db.get_token_metadata_ptr();
-        const auto& topo = md->get_topology();
-        auto dc = topo.get_datacenter();
-
-        for (const auto& rack : topo.get_datacenter_racks().at(dc) | std::views::keys) {
-            auto result = co_await loader._sys_dist_ks.get_snapshot_sstables(_snap_name, s->ks_name(), s->cf_name(), dc, rack);
-            auto it = std::find_if(result.begin(), result.end(), [] (const auto& ent) { return !ent.downloaded; });
-            if (it != result.end()) {
-                llog.warn("Some replicas failed to download SSTables for {}:{} from {}", s->ks_name(), s->cf_name(), _snap_name);
-                throw std::runtime_error(format("Failed to download {}", it->toc_name));
-            }
-        }
     }
 };
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -980,7 +980,10 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
             db::consistency_level::LOCAL_QUORUM, tablet_range.start().transform([] (auto& v) { return v.value(); }), tablet_range.end().transform([] (auto& v) { return v.value(); }));
     llog.debug("{} SSTables found for tablet {}", sst_infos.size(), tid);
     if (sst_infos.empty()) {
-        throw std::runtime_error(format("No SSTables found in system_distributed.snapshot_sstables for {}", snapshot_name));
+        // It can happen when the restored table has more tablets than the original.
+        // Some tablets simply have no data in their token range.
+        llog.info("No SSTables found for tablet {}, skipping", tid);
+        co_return;
     }
 
     auto [ fully, partially ] = co_await get_sstables_for_tablet(sst_infos, tablet_range, [] (const auto& si) { return si.first_token; }, [] (const auto& si) { return si.last_token; });

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -851,7 +851,7 @@ async def test_restore_tablets_download_failure(build_mode: str, manager: Manage
         tid = await manager.api.restore_tablets(servers[0].ip_addr, ks, 'test', snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
         status = await manager.api.wait_task(servers[0].ip_addr, tid)
         assert 'state' in status and status['state'] == 'failed'
-        assert 'error' in status and 'Failed to download' in status['error']
+        assert 'error' in status and 'Failing sstable download' in status['error']
 
 
 @pytest.mark.parametrize("target", ['coordinator', 'replica', 'api'])


### PR DESCRIPTION
Instead of directly injecting per-tablet transitions from storage_service code, restore now submits a restore_tablets global topology request. Currently storage_service directly injects tablet transitions and polls for their completion. By moving the transitions population into dedicated topology request handler several improvements are done.

When a restore transition failed, it's silently cleared by the topology coordinator. The caller needs to manually get what had failed an why. Now it's done by reading the sstables' restoration state from system_distributed.snapshot_sstables, this PR simplifies this by placing the specific error onto topology request itself, so the caller just waits for one to succeed or not.

All other tablet operations (balancing, repairs, RF changes) are driven by the topology coordinator. Having restore bypass this via direct injection from storage_service is inconsistent and makes it harder to reason about concurrency with other operations.

Currently there's no record if there an ongoing restore or not. Now there is one, which should simplify waiting for the it to finish, in particular -- the "reattach" feature: when an API node dies and the caller needs to track restore progress it should connect to some other node and do it.


Now about the implementation. The topology coordinator picks up the topology request, populates per-tablet restore transitions, sets the transition state to tablet_migration, and marks the request as "ongoing". The existing tablet migration handler then processes the restore transitions (sends RESTORE_TABLET RPCs to replicas). Eventually all transitions finish and the corresponding request is completed.
    
Fixes SCYLLADB-2176
Contains #30019 -- not to carry endpoint/bucket pair in the topology request, it's kept in system.snapshots table

Tablet-aware restore is a new feature, not backporting