### PR TITLE
perf_simple_query: add support for strongly consistent tables

### DIFF
--- a/db/consistency_level_type.hh
+++ b/db/consistency_level_type.hh
@@ -31,6 +31,8 @@ enum class consistency_level {
     LOCAL_ONE, MAX_VALUE = LOCAL_ONE
 };
 
+db::consistency_level consistency_level_from_string(std::string_view sv);
+
 }
 
 template <> struct fmt::formatter<db::consistency_level> {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2622,7 +2622,7 @@ auto fmt::formatter<db::operation_type>::format(db::operation_type op_type, fmt:
 }
 
 
-std::string_view fmt::formatter<db::consistency_level>::to_string(db::consistency_level cl) {
+static std::string_view consistency_level_to_string(db::consistency_level cl) {
     switch (cl) {
     using enum db::consistency_level;
     case ANY:
@@ -2650,6 +2650,27 @@ std::string_view fmt::formatter<db::consistency_level>::to_string(db::consistenc
     default:
         abort();
     }
+}
+
+std::string_view fmt::formatter<db::consistency_level>::to_string(db::consistency_level cl) {
+    return consistency_level_to_string(cl);
+}
+
+db::consistency_level db::consistency_level_from_string(std::string_view sv) {
+    static const auto string_to_cl = [] {
+        std::unordered_map<std::string_view, db::consistency_level> ret;
+        for (int i = static_cast<int>(db::consistency_level::MIN_VALUE);
+                i <= static_cast<int>(db::consistency_level::MAX_VALUE);
+                i++) {
+            auto cl = static_cast<db::consistency_level>(i);
+            ret.emplace(consistency_level_to_string(cl), cl);
+        }
+        return ret;
+    } ();
+    if (auto it = string_to_cl.find(sv); it != string_to_cl.end()) {
+        return it->second;
+    }
+    throw std::out_of_range(std::format("Expected a valid consistency level spelled in ALL CAPS, got \"{}\"", sv));
 }
 
 namespace replica {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1060,10 +1060,6 @@ private:
                 return raft_gr.start();
             }).get();
 
-            auto shutdown_db = defer_verbose_shutdown("database tables", [this] {
-                _db.invoke_on_all(&replica::database::shutdown).get();
-            });
-
             _view_update_generator.invoke_on_all(&db::view::view_update_generator::start).get();
 
             _paxos_store.start(std::ref(_sys_ks), std::ref(_feature_service), std::ref(_db), std::ref(_mm)).get();
@@ -1078,6 +1074,10 @@ private:
                 if (need) {
                     _proxy.invoke_on_all(&service::storage_proxy::stop_remote).get();
                 }
+            });
+
+            auto drain_db = defer_verbose_shutdown("database drain", [this] {
+                _db.invoke_on_all(&replica::database::drain).get();
             });
 
             _sl_controller.invoke_on_all([this, &group0_client] (qos::service_level_controller& service) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -449,14 +449,17 @@ public:
     }
 
     future<> create_keyspace(const cql_test_config& cfg, std::string_view name) {
-        sstring tablets = "";
+        sstring options = "";
         if (cfg.initial_tablets) {
-            tablets = format(" and tablets = {{'initial' : {}}}", *cfg.initial_tablets);
+            options = format(" and tablets = {{'initial' : {}}}", *cfg.initial_tablets);
         } else if (cfg.db_config->enable_tablets()) {
-            tablets = " and tablets = {'enabled' : true}";
+            options = " and tablets = {'enabled' : true}";
+        }
+        if (cfg.strongly_consistent_tables) {
+            options += " and consistency = 'global'";
         }
         auto query = seastar::format("create keyspace {} with replication = {{ 'class' : 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'replication_factor' : 1}}{};", name,
-                            tablets);
+                            options);
         return execute_cql(query).discard_result();
     }
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -198,8 +198,9 @@ private:
     struct core_local_state {
         service::client_state client_state;
 
-        core_local_state(auth::service& auth_service, qos::service_level_controller& sl_controller, timeout_config timeout)
-            : client_state(service::client_state::external_tag{}, auth_service, &sl_controller, timeout)
+        core_local_state(auth::service& auth_service, qos::service_level_controller& sl_controller, timeout_config timeout, abort_source& as)
+            : client_state(service::client_state::external_tag{}, auth_service, &sl_controller, timeout,
+                    socket_address(), false, &as)
         {
             client_state.set_login(auth::authenticated_user(testing_superuser));
         }
@@ -1247,7 +1248,7 @@ private:
 
             _group0_client = &group0_client;
 
-            _core_local.start(std::ref(_auth_service), std::ref(_sl_controller), cfg_in.query_timeout.value_or(infinite_timeout_config)).get();
+            _core_local.start(std::ref(_auth_service), std::ref(_sl_controller), cfg_in.query_timeout.value_or(infinite_timeout_config), std::ref(abort_sources)).get();
             auto stop_core_local = defer_verbose_shutdown("local client state", [this] { _core_local.stop().get(); });
 
             if (!local_db().has_keyspace(ks_name)) {

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -107,6 +107,7 @@ public:
     gms::inet_address broadcast_address = gms::inet_address("localhost");
     bool ms_listen = false;
     bool clean_data_dir_before_test = true;
+    bool strongly_consistent_tables = false;
 
     std::optional<db_clock::duration> batchlog_replay_timeout;
     std::chrono::milliseconds batchlog_delay = std::chrono::milliseconds(0);

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -64,13 +64,16 @@ static void execute_update_for_key(cql_test_env& env, const bytes& key, unsigned
     if (collection > 0) {
         col_suffix = fmt::format(", \"CC\" = {}", make_collection_literal(collection));
     }
+    // Strongly consistent writes need QUORUM/LOCAL_QUORUM.
+    // For eventual consistency it does not matter because there is only one node involved.
+    auto qo = std::make_unique<cql3::query_options>(db::consistency_level::QUORUM, std::vector<cql3::raw_value>{}, cql3::query_options::specific_options::DEFAULT);
     env.execute_cql(fmt::format("UPDATE cf SET "
         "\"C0\" = 0x8f75da6b3dcec90c8a404fb9a5f6b0621e62d39c69ba5758e5f41b78311fbb26cc7a,"
         "\"C1\" = 0xa8761a2127160003033a8f4f3d1069b7833ebe24ef56b3beee728c2b686ca516fa51,"
         "\"C2\" = 0x583449ce81bfebc2e1a695eb59aad5fcc74d6d7311fc6197b10693e1a161ca2e1c64,"
         "\"C3\" = 0x62bcb1dbc0ff953abc703bcb63ea954f437064c0c45366799658bd6b91d0f92908d7,"
         "\"C4\" = 0x222fcbe31ffa1e689540e1499b87fa3f9c781065fccd10e4772b4c7039c2efd0fb27{} "
-        "WHERE \"KEY\"= 0x{};", col_suffix, to_hex(key))).get();
+        "WHERE \"KEY\"= 0x{};", col_suffix, to_hex(key)), std::move(qo)).get();
 };
 
 static void execute_counter_update_for_key(cql_test_env& env, const bytes& key) {

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+#include "db/consistency_level_type.hh"
 #include "utils/assert.hh"
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -102,6 +103,7 @@ struct test_config {
     bool bypass_cache;
     std::optional<unsigned> initial_tablets;
     unsigned collection = 0;
+    db::consistency_level consistency_level;
 };
 
 std::ostream& operator<<(std::ostream& os, const test_config::run_mode& m) {
@@ -168,7 +170,7 @@ static std::vector<perf_result> test_read(cql_test_env& env, test_config& cfg) {
     auto id = env.prepare(query).get();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
-            return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
+            return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}, cfg.consistency_level).discard_result();
         }, cfg.concurrency, cfg.duration_in_seconds, cfg.operations_per_shard, cfg.stop_on_error);
 }
 
@@ -191,7 +193,7 @@ static std::vector<perf_result> test_write(cql_test_env& env, test_config& cfg) 
     auto id = env.prepare(query).get();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
-            return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
+            return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}, cfg.consistency_level).discard_result();
         }, cfg.concurrency, cfg.duration_in_seconds, cfg.operations_per_shard, cfg.stop_on_error);
 }
 
@@ -209,7 +211,7 @@ static std::vector<perf_result> test_delete(cql_test_env& env, test_config& cfg)
     auto id = env.prepare(query).get();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
-            return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
+            return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}, cfg.consistency_level).discard_result();
         }, cfg.concurrency, cfg.duration_in_seconds, cfg.operations_per_shard, cfg.stop_on_error);
 }
 
@@ -228,7 +230,7 @@ static std::vector<perf_result> test_counter_update(cql_test_env& env, test_conf
     auto id = env.prepare(query).get();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
-            return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}).discard_result();
+            return env.execute_prepared(id, {{cql3::raw_value::make_value(std::move(key))}}, cfg.consistency_level).discard_result();
         }, cfg.concurrency, cfg.duration_in_seconds, cfg.operations_per_shard, cfg.stop_on_error);
 }
 
@@ -336,6 +338,7 @@ int scylla_simple_query_main(int argc, char** argv) {
         ("counters", "test counters")
         ("collection", bpo::value<unsigned>()->default_value(0), "add map<text,text> collection column with N cells per row (excludes --counters)")
         ("tablets", "use tablets")
+        ("consistency-level", bpo::value<std::string>()->default_value("QUORUM"), "consistency level used for read and write operations")
         ("initial-tablets", bpo::value<unsigned>()->default_value(128), "initial number of tablets")
         ("sstable-summary-ratio", bpo::value<double>(), "Generate summary entry, so that summary file size / data file size ~= this ratio")
         ("sstable-format", bpo::value<std::string>(), "SSTable format name to use")
@@ -426,6 +429,7 @@ int scylla_simple_query_main(int argc, char** argv) {
             cfg.stop_on_error = app.configuration()["stop-on-error"].as<bool>();
             cfg.timeout = app.configuration()["timeout"].as<std::string>();
             cfg.bypass_cache = app.configuration().contains("bypass-cache");
+            cfg.consistency_level = db::consistency_level_from_string(app.configuration()["consistency-level"].as<std::string>());
             audit::audit::start_audit(env.local_db().get_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).handle_exception([&] (auto&& e) {
                 fmt::print("audit start failed: {}", e);
             }).get();

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -338,6 +338,7 @@ int scylla_simple_query_main(int argc, char** argv) {
         ("counters", "test counters")
         ("collection", bpo::value<unsigned>()->default_value(0), "add map<text,text> collection column with N cells per row (excludes --counters)")
         ("tablets", "use tablets")
+        ("strongly-consistent-tables", "use strongly consistent tables")
         ("consistency-level", bpo::value<std::string>()->default_value("QUORUM"), "consistency level used for read and write operations")
         ("initial-tablets", bpo::value<unsigned>()->default_value(128), "initial number of tablets")
         ("sstable-summary-ratio", bpo::value<double>(), "Generate summary entry, so that summary file size / data file size ~= this ratio")
@@ -389,6 +390,11 @@ int scylla_simple_query_main(int argc, char** argv) {
             if (app.configuration().contains("tablets")) {
                 cfg.db_config->tablets_mode_for_new_keyspaces.set(db::tablets_mode_t::mode::enabled);
                 cfg.initial_tablets = app.configuration()["initial-tablets"].as<unsigned>();
+            }
+            if (app.configuration().contains("strongly-consistent-tables")) {
+                cfg.db_config->experimental_features({db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES},
+                                                     db::config::config_source::CommandLine);
+                cfg.strongly_consistent_tables = true;
             }
             set_from_cli("audit", app, cfg.db_config->audit);
             set_from_cli("audit-keyspaces", app, cfg.db_config->audit_keyspaces);


### PR DESCRIPTION
This PR introduces support for strongly consistent tables in perf_simple_query. Strong consistency uses different code paths for reads and writes than eventual consistency, so having this option would allow us to measure the CPU performance impact that our changes to the feature have as we develop it.

The new flags are:

- `--strongly-consistent-tables` - required to use the strong consistency mechanism
- `--consistency {QUORUM,ONE}` - allows to choose between linearizable (QUORUM) and non-linearizable (ONE) reads; for eventually consistent tables it's irrelevant,

Here is a comparison between eventually consistent workloads and strongly consistent workloads:

## Eventual consistency

### Writes

```
./build/dev/scylla perf-simple-query --smp 1 --tablets --write
```

```
73751.37 tps ( 61.6 allocs/op,  16.4 logallocs/op,  14.3 tasks/op,   72669 insns/op,   52501 cycles/op,        0 errors)
77950.82 tps ( 61.4 allocs/op,  16.0 logallocs/op,  14.2 tasks/op,   72855 insns/op,   51338 cycles/op,        0 errors)
78595.56 tps ( 61.4 allocs/op,  16.0 logallocs/op,  14.2 tasks/op,   72842 insns/op,   51104 cycles/op,        0 errors)
78744.20 tps ( 61.4 allocs/op,  16.0 logallocs/op,  14.2 tasks/op,   72861 insns/op,   51054 cycles/op,        0 errors)
78453.29 tps ( 61.4 allocs/op,  16.0 logallocs/op,  14.2 tasks/op,   72853 insns/op,   51183 cycles/op,        0 errors)
throughput:
        mean=   77499.05 standard-deviation=2116.16
        median= 78453.29 median-absolute-deviation=1096.51
        maximum=78744.20 minimum=73751.37
instructions_per_op:
        mean=   72816.02 standard-deviation=82.27
        median= 72852.77 median-absolute-deviation=38.65
        maximum=72861.44 minimum=72669.39
cpu_cycles_per_op:
        mean=   51436.08 standard-deviation=604.71
        median= 51183.29 median-absolute-deviation=331.67
        maximum=52500.64 minimum=51054.11
```

### Reads

```
./build/dev/scylla perf-simple-query --smp 1 --tablets
```

```
78184.87 tps ( 64.2 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   54354 insns/op,   49656 cycles/op,        0 errors)
92910.45 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   54312 insns/op,   44497 cycles/op,        0 errors)
91294.18 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   54306 insns/op,   44699 cycles/op,        0 errors)
92578.77 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   54321 insns/op,   44525 cycles/op,        0 errors)
93321.79 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   54321 insns/op,   44417 cycles/op,        0 errors)
throughput:
        mean=   89658.01 standard-deviation=6458.37
        median= 92578.77 median-absolute-deviation=3252.44
        maximum=93321.79 minimum=78184.87
instructions_per_op:
        mean=   54322.68 standard-deviation=18.82
        median= 54320.72 median-absolute-deviation=10.97
        maximum=54354.32 minimum=54305.70
cpu_cycles_per_op:
        mean=   45558.83 standard-deviation=2292.94
        median= 44525.22 median-absolute-deviation=1061.52
        maximum=49656.44 minimum=44416.54
```

## Strong consistency

### Writes

```
./build/dev/scylla perf-simple-query --smp 1 --tablets --strongly-consistent-tables --consistency-level QUORUM --write
```

```
20855.21 tps (247.2 allocs/op,  33.2 logallocs/op,  48.0 tasks/op,  202800 insns/op,  182581 cycles/op,        0 errors)
21995.53 tps (246.1 allocs/op,  32.4 logallocs/op,  47.8 tasks/op,  204820 insns/op,  179122 cycles/op,        0 errors)
21849.27 tps (246.4 allocs/op,  32.3 logallocs/op,  47.9 tasks/op,  205589 insns/op,  180422 cycles/op,        0 errors)
21710.14 tps (246.9 allocs/op,  32.4 logallocs/op,  48.0 tasks/op,  206177 insns/op,  181624 cycles/op,        0 errors)
21810.33 tps (245.9 allocs/op,  32.3 logallocs/op,  47.7 tasks/op,  205794 insns/op,  180657 cycles/op,        0 errors)
throughput:
        mean=   21644.09 standard-deviation=452.75
        median= 21810.33 median-absolute-deviation=205.17
        maximum=21995.53 minimum=20855.21
instructions_per_op:
        mean=   205035.93 standard-deviation=1344.35
        median= 205588.80 median-absolute-deviation=757.70
        maximum=206177.49 minimum=202799.98
cpu_cycles_per_op:
        mean=   180881.25 standard-deviation=1303.51
        median= 180656.51 median-absolute-deviation=742.82
        maximum=182581.16 minimum=179122.33
```

### Reads (linearizable)

```
./build/dev/scylla perf-simple-query --smp 1 --tablets --strongly-consistent-tables --consistency-level QUORUM
```

```
95119.85 tps ( 62.6 allocs/op,   0.0 logallocs/op,  12.9 tasks/op,   47257 insns/op,   40947 cycles/op,        0 errors)
112376.59 tps ( 62.5 allocs/op,   0.0 logallocs/op,  12.8 tasks/op,   47261 insns/op,   36948 cycles/op,        0 errors)
112327.26 tps ( 62.5 allocs/op,   0.0 logallocs/op,  12.8 tasks/op,   47267 insns/op,   36958 cycles/op,        0 errors)
112052.26 tps ( 62.5 allocs/op,   0.0 logallocs/op,  12.8 tasks/op,   47268 insns/op,   36968 cycles/op,        0 errors)
111485.06 tps ( 62.5 allocs/op,   0.0 logallocs/op,  12.8 tasks/op,   47261 insns/op,   37077 cycles/op,        0 errors)
throughput:
        mean=   108672.20 standard-deviation=7584.28
        median= 112052.26 median-absolute-deviation=3655.06
        maximum=112376.59 minimum=95119.85
instructions_per_op:
        mean=   47262.80 standard-deviation=4.57
        median= 47261.39 median-absolute-deviation=4.16
        maximum=47267.79 minimum=47256.76
cpu_cycles_per_op:
        mean=   37779.84 standard-deviation=1771.35
        median= 36968.32 median-absolute-deviation=821.70
        maximum=40947.16 minimum=36948.42
```

### Reads (non-linearizable)

```
./build/dev/scylla perf-simple-query --smp 1 --tablets --strongly-consistent-tables --consistency-level ONE
````

```
104730.06 tps ( 52.1 allocs/op,   0.0 logallocs/op,   8.2 tasks/op,   42046 insns/op,   37091 cycles/op,        0 errors)
121493.94 tps ( 52.1 allocs/op,   0.0 logallocs/op,   8.1 tasks/op,   42076 insns/op,   34260 cycles/op,        0 errors)
121605.19 tps ( 52.1 allocs/op,   0.0 logallocs/op,   8.1 tasks/op,   42090 insns/op,   34207 cycles/op,        0 errors)
120899.48 tps ( 52.1 allocs/op,   0.0 logallocs/op,   8.1 tasks/op,   42079 insns/op,   34277 cycles/op,        0 errors)
121366.38 tps ( 52.1 allocs/op,   0.0 logallocs/op,   8.1 tasks/op,   42075 insns/op,   34130 cycles/op,        0 errors)
throughput:
        mean=   118019.01 standard-deviation=7433.61
        median= 121366.38 median-absolute-deviation=3474.93
        maximum=121605.19 minimum=104730.06
instructions_per_op:
        mean=   42073.50 standard-deviation=16.33
        median= 42076.41 median-absolute-deviation=5.78
        maximum=42090.30 minimum=42046.30
cpu_cycles_per_op:
        mean=   34792.90 standard-deviation=1285.69
        median= 34259.62 median-absolute-deviation=585.69
        maximum=37090.55 minimum=34130.37
```

This is a new feature so backport is not needed.
