### PR TITLE
cql3: lazily allocate index-related query functions in statement_restrictions

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1291,10 +1291,19 @@ statement_restrictions::statement_restrictions(private_tag,
     _get_partition_key_ranges_fn = build_partition_key_ranges_fn();
 
     _get_clustering_bounds_fn = build_get_clustering_bounds_fn();
-    _get_global_index_clustering_ranges_fn = build_get_global_index_clustering_ranges_fn();
-    _get_global_index_token_clustering_ranges_fn = build_get_global_index_token_clustering_ranges_fn();
-    _get_local_index_clustering_ranges_fn = build_get_local_index_clustering_ranges_fn();
-    _value_for_index_partition_key_fn = build_value_for_index_partition_key_fn();
+
+    auto global_idx_ck = build_get_global_index_clustering_ranges_fn();
+    auto global_idx_token_ck = build_get_global_index_token_clustering_ranges_fn();
+    auto local_idx_ck = build_get_local_index_clustering_ranges_fn();
+    auto idx_pk_val = build_value_for_index_partition_key_fn();
+    if (global_idx_ck || global_idx_token_ck || local_idx_ck || idx_pk_val) {
+        _index_fns = std::make_unique<index_query_fns>(index_query_fns{
+            std::move(global_idx_ck),
+            std::move(global_idx_token_ck),
+            std::move(local_idx_ck),
+            std::move(idx_pk_val),
+        });
+    }
 }
 
 bool
@@ -2635,7 +2644,10 @@ statement_restrictions::build_get_global_index_clustering_ranges_fn() const {
 
 std::vector<query::clustering_range> statement_restrictions::get_global_index_clustering_ranges(
         const query_options& options) const {
-    return _get_global_index_clustering_ranges_fn(options);
+    if (!_index_fns || !_index_fns->get_global_index_clustering_ranges_fn) {
+        on_internal_error(rlogger, "get_global_index_clustering_ranges called without index functions");
+    }
+    return _index_fns->get_global_index_clustering_ranges_fn(options);
 }
 
 get_clustering_bounds_fn_t
@@ -2661,7 +2673,10 @@ statement_restrictions::build_get_global_index_token_clustering_ranges_fn() cons
 
 std::vector<query::clustering_range> statement_restrictions::get_global_index_token_clustering_ranges(
     const query_options& options) const {
-    return _get_global_index_token_clustering_ranges_fn(options);
+    if (!_index_fns || !_index_fns->get_global_index_token_clustering_ranges_fn) {
+        on_internal_error(rlogger, "get_global_index_token_clustering_ranges called without index functions");
+    }
+    return _index_fns->get_global_index_token_clustering_ranges_fn(options);
 }
 
 get_clustering_bounds_fn_t
@@ -2678,7 +2693,10 @@ statement_restrictions::build_get_local_index_clustering_ranges_fn() const {
 
 std::vector<query::clustering_range> statement_restrictions::get_local_index_clustering_ranges(
         const query_options& options) const {
-    return _get_local_index_clustering_ranges_fn(options);
+    if (!_index_fns || !_index_fns->get_local_index_clustering_ranges_fn) {
+        on_internal_error(rlogger, "get_local_index_clustering_ranges called without index functions");
+    }
+    return _index_fns->get_local_index_clustering_ranges_fn(options);
 }
 
 get_singleton_value_fn_t
@@ -2696,7 +2714,10 @@ statement_restrictions::build_value_for_index_partition_key_fn() const {
 
 bytes_opt
 statement_restrictions::value_for_index_partition_key(const query_options& options) const {
-    return _value_for_index_partition_key_fn(options);
+    if (!_index_fns || !_index_fns->value_for_index_partition_key_fn) {
+        on_internal_error(rlogger, "value_for_index_partition_key called without index functions");
+    }
+    return _index_fns->value_for_index_partition_key_fn(options);
 }
 
 sstring statement_restrictions::to_string() const {

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 #include "bounds_slice.hh"
 #include "cql3/expr/expression.hh"
@@ -226,10 +227,16 @@ private:
     expr::expression _idx_restrictions = expr::conjunction({});
     get_partition_key_ranges_fn_t _get_partition_key_ranges_fn;
     get_clustering_bounds_fn_t _get_clustering_bounds_fn;
-    get_clustering_bounds_fn_t _get_global_index_clustering_ranges_fn;
-    get_clustering_bounds_fn_t _get_global_index_token_clustering_ranges_fn;
-    get_clustering_bounds_fn_t _get_local_index_clustering_ranges_fn;
-    get_singleton_value_fn_t _value_for_index_partition_key_fn;
+
+    // Index-related query functions, only allocated for index-backed queries.
+    // For non-index queries (the common case), this is nullptr, saving ~120 bytes.
+    struct index_query_fns {
+        get_clustering_bounds_fn_t get_global_index_clustering_ranges_fn;
+        get_clustering_bounds_fn_t get_global_index_token_clustering_ranges_fn;
+        get_clustering_bounds_fn_t get_local_index_clustering_ranges_fn;
+        get_singleton_value_fn_t value_for_index_partition_key_fn;
+    };
+    std::unique_ptr<index_query_fns> _index_fns;
 public:
     /**
      * Creates a new empty <code>StatementRestrictions</code>.


### PR DESCRIPTION
## Motivation

`statement_restrictions` stores 4 `std::function` members for index-backed queries. Each `std::function` is 32 bytes (libstdc++). For non-index queries (the vast majority), all 4 are empty but still occupy 128 bytes per cached prepared statement.

## Memory savings

- **120 bytes per cached non-index prepared statement** (128 bytes of empty std::functions replaced by 8-byte null unique_ptr)
- Index queries pay a one-time `make_unique` allocation during prepare (negligible)

## Nature of change

- New nested struct `index_query_fns` holds the 4 index-related `std::function` members
- `std::unique_ptr<index_query_fns> _index_fns` replaces the 4 direct members
- Only allocated when at least one index function is populated
- Getters validate non-null via `on_internal_error` (fires in all builds) before dereferencing

## Tests

- statement_restrictions_test: passed
- secondary_index_test: passed
- restrictions_test: passed

## Benchmark (perf-simple-query, release, smp1, cpu5 pinned 2.2GHz, 10K partitions, 5 runs)

| Metric | Master | This PR | Delta |
|--------|--------|---------|-------|
| allocs/op | 58.1 | 58.1 | 0 |
| insns/op | 32,230 | 32,070 | -160 |
| tps | 150K | 152K | neutral |

No performance regression.

Refs #29047