### PR TITLE
raft: fix use-after-free in read_barrier() on shutdown

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5729,7 +5729,12 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
     }
 
     // Refresh is triggered after table creation, need to make sure we see the new tablets.
-    co_await _group0->group0_server().read_barrier(&_group0_as);
+    // Hold the group0 gate to prevent abort_and_drain() from destroying the
+    // raft server while read_barrier() is in flight (SCYLLADB-2071).
+    {
+        auto group0_holder = _group0->hold_group0_gate();
+        co_await _group0->group0_server().read_barrier(&_group0_as);
+    }
 
     using table_ids_t = std::unordered_set<table_id>;
     const auto table_ids = co_await std::invoke([this] () -> future<table_ids_t> {


### PR DESCRIPTION
\`load_stats_for_tablet_based_tables()\` called \`read_barrier()\` on the group0 raft server without holding the group0 gate. This created a race during shutdown: \`abort_and_drain()\` could proceed and destroy the server while \`read_barrier()\` was still suspended between \`do_on_leader_with_retries()\` and \`wait_for_apply()\`. Resuming the coroutine on a destroyed server caused UBSan: invalid vptr at \`raft/server.cc:1573\`.

Fix by calling \`hold_group0_gate()\` in \`load_stats_for_tablet_based_tables()\` before invoking \`read_barrier()\`. This matches the shutdown contract: callers that interact with the raft server across yield points must hold the gate.
\`abort_and_drain()\` closes the gate after aborting, so it will wait for all holders to release before destroying the server — the race window is closed.

Fixes: SCYLLADB-2071

Backport: The bug is present in 2026.1 and 2026.2 therefore we should also backport there.