### PR TITLE
schema: Move grace_period from schema_ctxt to schema_registry

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -114,7 +114,6 @@ schema_ctxt::schema_ctxt(const db::config& cfg, std::shared_ptr<data_dictionary:
     , _features(features)
     , _extensions(cfg.extensions())
     , _murmur3_partitioner_ignore_msb_bits(cfg.murmur3_partitioner_ignore_msb_bits())
-    , _schema_registry_grace_period(cfg.schema_registry_grace_period())
     , _user_types(std::move(uts))
 {}
 

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -81,10 +81,6 @@ public:
         return _murmur3_partitioner_ignore_msb_bits;
     }
 
-    uint32_t schema_registry_grace_period() const {
-        return _schema_registry_grace_period;
-    }
-
     const data_dictionary::user_types_storage& user_types() const noexcept {
         return *_user_types;
     }
@@ -101,7 +97,6 @@ private:
     const gms::feature_service& _features;
     const db::extensions& _extensions;
     const unsigned _murmur3_partitioner_ignore_msb_bits;
-    const uint32_t _schema_registry_grace_period;
     const std::shared_ptr<data_dictionary::user_types_storage> _user_types;
 };
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -483,7 +483,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
 {
     SCYLLA_ASSERT(dbcfg.available_memory != 0); // Detect misconfigured unit tests, see #7544
 
-    local_schema_registry().init(*this); // TODO: we're never unbound.
+    local_schema_registry().init(*this, std::chrono::seconds(get_config().schema_registry_grace_period())); // TODO: we're never unbound.
     setup_metrics();
 
     _row_cache_tracker.set_compaction_scheduling_group(dbcfg.memory_compaction_scheduling_group);

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -54,8 +54,9 @@ schema_registry_entry::schema_registry_entry(table_schema_version v, schema_regi
 
 schema_registry::~schema_registry() = default;
 
-void schema_registry::init(const db::schema_ctxt& ctxt) {
+void schema_registry::init(const db::schema_ctxt& ctxt, schema_registry_entry::erase_clock::duration grace_period) {
     _ctxt = std::make_unique<db::schema_ctxt>(ctxt);
+    _grace_period = grace_period;
 }
 
 void schema_registry::attach_table(schema_registry_entry& e) noexcept {
@@ -119,10 +120,6 @@ schema_registry_entry& schema_registry::get_entry(table_schema_version v) const 
         throw schema_version_not_found(v);
     }
     return e;
-}
-
-schema_registry_entry::erase_clock::duration schema_registry::grace_period() const {
-    return std::chrono::seconds(_ctxt->schema_registry_grace_period());
 }
 
 schema_ptr schema_registry::get(table_schema_version v) const {

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -112,18 +112,17 @@ public:
 class schema_registry {
     std::unordered_map<table_schema_version, lw_shared_ptr<schema_registry_entry>> _entries;
     std::unique_ptr<db::schema_ctxt> _ctxt;
+    schema_registry_entry::erase_clock::duration _grace_period{std::chrono::seconds(1)};
 
     friend class schema_registry_entry;
     schema_registry_entry& get_entry(table_schema_version) const;
-    // Duration for which unused entries are kept alive to avoid
-    // too frequent re-requests and syncs. Default is 1 second.
-    schema_registry_entry::erase_clock::duration grace_period() const;
+    schema_registry_entry::erase_clock::duration grace_period() const { return _grace_period; }
 private:
     void attach_table(schema_registry_entry&) noexcept;
 public:
     ~schema_registry();
     // workaround to this object being magically appearing from nowhere.
-    void init(const db::schema_ctxt&);
+    void init(const db::schema_ctxt&, schema_registry_entry::erase_clock::duration grace_period);
 
     // Looks up schema by version or loads it using supplied loader.
     // If the schema refers to a view, the loader must return both view and base schemas.

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -45,12 +45,11 @@ static schema_ptr random_schema() {
 struct dummy_init {
     std::unique_ptr<db::config> config;
     gms::feature_service fs;
-    seastar::lowres_clock::duration grace_period;
     dummy_init()
             : config(std::make_unique<db::config>())
-            , fs({get_disabled_features_from_db_config(*config)})
-            , grace_period(std::chrono::seconds(config->schema_registry_grace_period())) {
-        local_schema_registry().init(db::schema_ctxt(*config, std::make_shared<data_dictionary::dummy_user_types_storage>(), fs));
+            , fs({get_disabled_features_from_db_config(*config)}) {
+        local_schema_registry().init(db::schema_ctxt(*config, std::make_shared<data_dictionary::dummy_user_types_storage>(), fs),
+                                     std::chrono::seconds(config->schema_registry_grace_period()));
     }
 };
 


### PR DESCRIPTION
The schema_registry_grace_period field on schema_ctxt was only used by schema_registry itself for eviction timing. Move it to be a direct member of schema_registry, passed at init() time. This removes one db::config dependency from schema_ctxt.

Components dependency cleanup, not backporting