### PR TITLE
cql3: lazily allocate _not_null_columns in statement_restrictions (memory saving - 48 bytes (56B unordered_set → 8B unique_ptr) per cached statement)

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -904,7 +904,10 @@ statement_restrictions::statement_restrictions(private_tag,
     for (auto& pred : predicates) {
         if (pred.is_not_null_single_column) {
             auto* col = require_on_single_column(pred);
-            _not_null_columns.insert(col);
+            if (!_not_null_columns) {
+                _not_null_columns = std::make_unique<std::unordered_set<const column_definition*>>();
+            }
+            _not_null_columns->insert(col);
 
             if (!for_view) {
                 throw exceptions::invalid_request_exception(format("restriction '{}' is only supported in materialized view creation", pred.filter));
@@ -1352,7 +1355,7 @@ statement_restrictions::ck_restrictions_need_filtering() const {
 
 bool
 statement_restrictions::is_restricted(const column_definition* cdef) const {
-    if (_not_null_columns.contains(cdef)) {
+    if (_not_null_columns && _not_null_columns->contains(cdef)) {
         return true;
     }
 
@@ -2737,7 +2740,10 @@ void statement_restrictions::validate_primary_key(const query_options& options) 
 
 
 const std::unordered_set<const column_definition*> statement_restrictions::get_not_null_columns() const {
-    return _not_null_columns;
+    if (_not_null_columns) {
+        return *_not_null_columns;
+    }
+    return {};
 }
 
 shared_ptr<const statement_restrictions>

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -159,7 +159,7 @@ private:
     expr::expression _regular_columns_filter = expr::conjunction({});
 
 
-    std::unordered_set<const column_definition*> _not_null_columns;
+    std::unique_ptr<std::unordered_set<const column_definition*>> _not_null_columns;
 
     /**
      * The restrictions used to build the index expressions


### PR DESCRIPTION
**Motivation:**
Every cached prepared statement stores a `statement_restrictions` object containing an `std::unordered_set<const column_definition*>` for `_not_null_columns`. This set is only populated during CREATE MATERIALIZED VIEW when IS NOT NULL restrictions are present, yet it costs 56 bytes (empty unordered_set overhead) in every cached SELECT/UPDATE/DELETE statement.

Replace with `unique_ptr<unordered_set<...>>` that is only allocated when IS NOT NULL restrictions are actually encountered. This saves 48 bytes (56B unordered_set → 8B unique_ptr) per cached statement, improving prepared statement cache density.

The `_not_null_columns` field is only accessed from:
- `create_view_statement` (DDL, not on query execution path)
- `is_restricted()` (also only called from `create_view_statement`)

There is zero performance impact on the query execution hot path.

**Memory savings:** 48 bytes per cached prepared statement.

**Tests:**
- Full release build passes
- boost/statement_restrictions_test: pass
- boost/view_schema_test: pass
- boost/restrictions_test: pass
- perf_simple_query (5 runs, smp1, 10K partitions): 58.1 allocs/op, 32,090 insns/op — no regression vs baseline

Refs: https://github.com/scylladb/scylladb/issues/29047