### PR TITLE
cql3: lazily allocate _ordering_comparator in select_statement (Memory savings: 24 bytes per cached SELECT statement (without ORDER BY))

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -222,7 +222,7 @@ select_statement::select_statement(schema_ptr schema,
     , _limit(std::move(limit))
     , _per_partition_limit_unset_guard(per_partition_limit)
     , _per_partition_limit(std::move(per_partition_limit))
-    , _ordering_comparator(std::move(ordering_comparator))
+    , _ordering_comparator(ordering_comparator ? std::make_unique<ordering_comparator_type>(std::move(ordering_comparator)) : nullptr)
     , _stats(stats)
     , _ks_sel(::is_internal_keyspace(schema->ks_name()) ? ks_selector::SYSTEM : ks_selector::NONSYSTEM)
     , _attrs(std::move(attrs))
@@ -982,7 +982,7 @@ select_statement::process_results_complex(foreign_ptr<lw_shared_ptr<query::resul
         auto rs = builder.build();
 
         if (needs_post_query_ordering()) {
-            rs->sort(_ordering_comparator);
+            rs->sort(*_ordering_comparator);
             if (_is_reversed) {
                 rs->reverse();
             }

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -90,7 +90,7 @@ protected:
     /**
      * The comparator used to orders results when multiple keys are selected (using IN).
      */
-    ordering_comparator_type _ordering_comparator;
+    std::unique_ptr<ordering_comparator_type> _ordering_comparator;
 
     query::partition_slice::option_set _opts;
     cql_stats& _stats;


### PR DESCRIPTION
**Motivation:**
Every cached SELECT prepared statement stores an `ordering_comparator_type` (`std::function`, 32 bytes) even though the vast majority of queries do not use ORDER BY with IN or ANN rescoring. This wastes 32 bytes per cached `select_statement`.

Replace with `unique_ptr<ordering_comparator_type>` that is only allocated when an ordering comparator is actually needed. This saves 24 bytes (32B std::function → 8B unique_ptr) per cached SELECT statement without ORDER BY.

The `needs_post_query_ordering()` check becomes a null pointer check (`static_cast<bool>` on `unique_ptr`), which is equivalent in cost to the previous `std::function` emptiness check. For queries that DO use ORDER BY, one extra pointer dereference is added during result sorting — negligible compared to the sort operation itself.

**Memory savings:** 24 bytes per cached SELECT statement (without ORDER BY).

**Tests:**
- Full release build passes
- boost/select tests: pass
- perf_simple_query (5 runs, smp1, 10K partitions): 58.1 allocs/op, 32,090 insns/op — no regression vs baseline

Refs: https://github.com/scylladb/scylladb/issues/29047