### PR TITLE
cql3: lazily allocate _columns_to_read in modification_statement

### DIFF
--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -60,7 +60,6 @@ modification_statement::modification_statement(statement_type type_, uint32_t bo
     : cql_statement_opt_metadata(modification_statement_timeout(*schema_))
     , type{type_}
     , _bound_terms{bound_terms}
-    , _columns_to_read(schema_->all_columns_count())
     , _columns_of_cas_result_set(schema_->all_columns_count())
     , s{schema_}
     , attrs{std::move(attrs_)}
@@ -497,7 +496,10 @@ void modification_statement::build_cas_result_set_metadata() {
     }
     // Ensure we prefetch all of the columns of the result set. This is also
     // necessary to check conditions.
-    _columns_to_read.union_with(_columns_of_cas_result_set);
+    if (!_columns_to_read) {
+        _columns_to_read = std::make_unique<column_set>(s->all_columns_count());
+    }
+    _columns_to_read->union_with(_columns_of_cas_result_set);
     _metadata = seastar::make_shared<cql3::metadata>(std::move(columns));
 }
 
@@ -752,7 +754,10 @@ void modification_statement::add_operation(::shared_ptr<operation> op) {
     }
     if (op->requires_read()) {
         _requires_read = true;
-        _columns_to_read.set(op->column.ordinal_id);
+        if (!_columns_to_read) {
+            _columns_to_read = std::make_unique<column_set>(s->all_columns_count());
+        }
+        _columns_to_read->set(op->column.ordinal_id);
         if (op->column.type->is_collection() ) {
             auto ctype = static_pointer_cast<const collection_type_impl>(op->column.type);
             if (!ctype->is_multi_cell()) {

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -52,7 +52,7 @@ private:
     // columns, to match Cassandra behaviour.
     // This bitset contains a mask of ordinal_id identifiers
     // of the required columns.
-    column_set _columns_to_read;
+    std::unique_ptr<column_set> _columns_to_read;
     // A CAS statement returns a result set with the columns
     // used in condition expression. This is a mask of ordinal_id
     // identifiers of the required columns. Contains all columns
@@ -193,7 +193,8 @@ public:
     bool requires_lwt() const { return _requires_lwt; }
 
     // Columns used in this statement conditions or operations.
-    const column_set& columns_to_read() const { return _columns_to_read; }
+    // Precondition: requires_read() || has_conditions() (i.e., _columns_to_read is populated).
+    const column_set& columns_to_read() const { return *_columns_to_read; }
 
     // Columns of the statement result set (only CAS statement
     // returns a result set).


### PR DESCRIPTION
**Motivation:**
Every cached INSERT/UPDATE/DELETE prepared statement stores a `column_set` (`boost::dynamic_bitset`, 32 bytes inline + heap allocation for bit buffer) for `_columns_to_read`. This bitset tracks which columns must be prefetched for operations that require a read (list append/prepend, counter updates) or for CAS conditions.

For simple INSERT/UPDATE statements without list operations or CAS conditions, `_columns_to_read` stays all-zeros and is never accessed at execution time. The `read_command()` method that uses it is only called when `requires_read()` is true (list ops) or from CAS execution paths.

Replace with `unique_ptr<column_set>` that is only allocated when an operation `requires_read()` or when CAS builds its metadata. This saves 24 bytes inline (32B column_set → 8B unique_ptr) per cached non-CAS, non-list modification statement, plus avoidance of the heap allocation for the dynamic_bitset bit buffer.

**Memory savings:** 24 bytes inline per cached non-CAS, non-list INSERT/UPDATE/DELETE statement (plus heap savings from avoided bit buffer allocation).

**Safety:** `columns_to_read()` dereferences the unique_ptr directly. This is safe because it is only called from `read_command()` which is gated by `requires_read()==true` (which sets up `_columns_to_read`), or from `cas_request` which goes through `build_cas_result_set_metadata` (which also sets up `_columns_to_read`).

**Tests:**
- Full release build passes
- boost/cas tests: pass
- boost/modification tests: pass
- boost/update tests: pass
- perf_simple_query (5 runs, smp1, 10K partitions): 58.1 allocs/op, 32,100 insns/op — no regression vs baseline

Refs: https://github.com/scylladb/scylladb/issues/29047