### PR TITLE
cql3: lazily allocate _idx_opt behind unique_ptr (saving: 128 bytes per non-index statement (136B inline optional → 8B unique_ptr))

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1210,8 +1210,12 @@ statement_restrictions::statement_restrictions(private_tag,
         const expr::allow_local_index allow_local_for_idx(
                 !has_partition_key_unrestricted_components()
                 && partition_key_restrictions_is_all_eq());
-        std::tie(_idx_opt, _idx_restrictions) = do_find_idx(
+        auto [idx_found, idx_restrictions] = do_find_idx(
                 _uses_secondary_indexing, sim, search_groups, allow_local_for_idx);
+        if (idx_found) {
+            _idx_opt = std::make_unique<secondary_index::index>(std::move(*idx_found));
+        }
+        _idx_restrictions = std::move(idx_restrictions);
     }
 
     calculate_column_defs_for_filtering_and_erase_restrictions_used_for_index(db, sc_pk_pred_vectors, sc_ck_pred_vectors, sc_nonpk_pred_vectors);
@@ -1429,7 +1433,7 @@ static std::pair<std::optional<secondary_index::index>, expr::expression> do_fin
 
 std::pair<std::optional<secondary_index::index>, expr::expression>
 statement_restrictions::find_idx(const secondary_index::secondary_index_manager& sim) const {
-    return {_idx_opt, _idx_restrictions};
+    return {_idx_opt ? std::optional<secondary_index::index>(*_idx_opt) : std::nullopt, _idx_restrictions};
 }
 
 bool statement_restrictions::has_eq_restriction_on_column(const column_definition& column) const {
@@ -1448,8 +1452,8 @@ void statement_restrictions::calculate_column_defs_for_filtering_and_erase_restr
     std::vector<const column_definition*> column_defs_for_filtering;
     if (need_filtering()) {
         std::optional<secondary_index::index> opt_idx;
-        if (_check_indexes) {
-            opt_idx = _idx_opt;
+        if (_check_indexes && _idx_opt) {
+            opt_idx = *_idx_opt;
         }
         auto column_uses_indexing = [&opt_idx] (const single_column_predicate_vectors& pred_vectors,
                                                 const column_definition* cdef) {

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -222,7 +222,7 @@ private:
     std::unordered_set<const column_definition*> _columns_with_eq;
     std::vector<const column_definition*> _column_defs_for_filtering;
     schema_ptr _view_schema;
-    std::optional<secondary_index::index> _idx_opt;
+    std::unique_ptr<secondary_index::index> _idx_opt;
     expr::expression _idx_restrictions = expr::conjunction({});
     get_partition_key_ranges_fn_t _get_partition_key_ranges_fn;
     get_clustering_bounds_fn_t _get_clustering_bounds_fn;


### PR DESCRIPTION
## Motivation

`statement_restrictions` (576 bytes) contains `std::optional<secondary_index::index> _idx_opt` — 136 bytes inline (sizeof(optional<secondary_index::index>) = 136). This field is only populated for index-backed queries (the minority of prepared statements).

## Savings

**128 bytes per non-index statement** (136B inline optional → 8B unique_ptr).

## Measured Performance

**Performance-neutral.** Re-measured independently (5 runs each, smp1, 10K partitions, 10s, release build):

- Master: 32,567 / 32,513 / 32,605 / 32,550 / 32,539 insns/op (median 32,550)
- This PR: 32,544 / 32,140 / 31,725 / 32,551 / 32,462 insns/op (median 32,462)

No statistically significant difference. 

## Changes

- `std::optional<secondary_index::index> _idx_opt` → `std::unique_ptr<secondary_index::index>`
- Assignment uses `std::make_unique`
- `.has_value()` → implicit bool, `*_idx_opt` unchanged

No functional change.

Refs: #29047