### PR TITLE
cql3: lazily allocate _columns_of_cas_result_set in modification/batch statements (24 bytes saved for modification_statement for batch_statement structs each)

### DIFF
--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -47,8 +47,8 @@ batch_statement::batch_statement(int bound_terms, type type_,
     : cql_statement_opt_metadata(timeout_for_type(type_))
     , _bound_terms(bound_terms), _type(type_), _statements(std::move(statements))
     , _attrs(std::move(attrs))
-    , _has_conditions(std::ranges::any_of(_statements, [] (auto&& s) { return s.statement->has_conditions(); }))
     , _stats(stats)
+    , _has_conditions(std::ranges::any_of(_statements, [] (auto&& s) { return s.statement->has_conditions(); }))
 {
     validate();
     if (has_conditions()) {
@@ -404,7 +404,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
     return qp.proxy().cas(schema, std::move(cas_shard), *request_ptr, request->read_command(qp), request->key(),
             {read_timeout, qs.get_permit(), qs.get_client_state(), qs.get_trace_state()},
             std::move(cl_for_paxos).assume_value(), cl_for_learn, batch_timeout, cas_timeout).then([this, request = std::move(request)] (bool is_applied) {
-        return request->build_cas_result_set(_metadata, _columns_of_cas_result_set, is_applied);
+        return request->build_cas_result_set(_metadata, *_columns_of_cas_result_set, is_applied);
     });
 }
 
@@ -414,7 +414,7 @@ void batch_statement::build_cas_result_set_metadata() {
     }
     const auto& schema = *_statements.front().statement->s;
 
-    _columns_of_cas_result_set.resize(schema.all_columns_count());
+    _columns_of_cas_result_set = std::make_unique<column_set>(schema.all_columns_count());
 
     // Add the mandatory [applied] column to result set metadata
     std::vector<lw_shared_ptr<column_specification>> columns;
@@ -424,14 +424,14 @@ void batch_statement::build_cas_result_set_metadata() {
     columns.push_back(applied);
 
     for (const auto& def : schema.primary_key_columns()) {
-        _columns_of_cas_result_set.set(def.ordinal_id);
+        _columns_of_cas_result_set->set(def.ordinal_id);
     }
     for (const auto& s : _statements) {
-        _columns_of_cas_result_set.union_with(s.statement->columns_of_cas_result_set());
+        _columns_of_cas_result_set->union_with(s.statement->columns_of_cas_result_set());
     }
-    columns.reserve(_columns_of_cas_result_set.count());
+    columns.reserve(_columns_of_cas_result_set->count());
     for (const auto& def : schema.all_columns()) {
-        if (_columns_of_cas_result_set.test(def.ordinal_id)) {
+        if (_columns_of_cas_result_set->test(def.ordinal_id)) {
             columns.emplace_back(def.column_specification);
         }
     }

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -55,9 +55,6 @@ private:
     type _type;
     std::vector<single_statement> _statements;
     std::unique_ptr<attributes> _attrs;
-    // True if *any* statement of the batch has IF .. clause. In
-    // this case entire batch is considered a CAS batch.
-    bool _has_conditions;
     // If the BATCH has conditions, it must return columns which
     // are involved in condition expressions in its result set.
     // Unlike Cassandra, Scylla always returns all columns,
@@ -67,8 +64,13 @@ private:
     // Cassandra returns a result set only if CAS succeeds. If
     // any statement in the batch has IF EXISTS, we must return
     // all columns of the table, including the primary key.
-    column_set _columns_of_cas_result_set;
+    std::unique_ptr<column_set> _columns_of_cas_result_set;
     cql_stats& _stats;
+    // True if *any* statement of the batch has IF .. clause. In
+    // this case entire batch is considered a CAS batch.
+    // Placed last to avoid 7B padding hole between it and the
+    // next 8B-aligned field; padding is now at the struct tail.
+    bool _has_conditions;
 public:
     /**
      * Creates a new BatchStatement from a list of statements

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -61,7 +61,6 @@ modification_statement::modification_statement(statement_type type_, uint32_t bo
     , type{type_}
     , _bound_terms{bound_terms}
     , _columns_to_read(schema_->all_columns_count())
-    , _columns_of_cas_result_set(schema_->all_columns_count())
     , s{schema_}
     , attrs{std::move(attrs_)}
     , _column_operations{}
@@ -452,7 +451,7 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
     return qp.proxy().cas(s, std::move(cas_shard), *request_ptr, request->read_command(qp), request->key(),
             {read_timeout, qs.get_permit(), qs.get_client_state(), qs.get_trace_state()},
             std::move(cl_for_paxos).assume_value(), cl_for_learn, statement_timeout, cas_timeout).then([this, request = std::move(request), tablet_info = std::move(tablet_info)] (bool is_applied) mutable {
-        auto result = request->build_cas_result_set(_metadata, _columns_of_cas_result_set, is_applied);
+        auto result = request->build_cas_result_set(_metadata, *_columns_of_cas_result_set, is_applied);
         if (tablet_info) {
             result->add_tablet_info(std::move(*tablet_info));
         }
@@ -461,6 +460,8 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
 }
 
 void modification_statement::build_cas_result_set_metadata() {
+
+    _columns_of_cas_result_set = std::make_unique<column_set>(s->all_columns_count());
 
     std::vector<lw_shared_ptr<column_specification>> columns;
     // Add the mandatory [applied] column to result set metadata
@@ -479,11 +480,11 @@ void modification_statement::build_cas_result_set_metadata() {
         // columns, then the existence condition applies only to the static columns themselves, and
         // so we don't want to include regular columns in that case.
         for (const auto& def : all_columns) {
-            _columns_of_cas_result_set.set(def.ordinal_id);
+            _columns_of_cas_result_set->set(def.ordinal_id);
         }
     } else {
         expr::for_each_expression<expr::column_value>(_condition, [&] (const expr::column_value& col) {
-            _columns_of_cas_result_set.set(col.col->ordinal_id);
+            _columns_of_cas_result_set->set(col.col->ordinal_id);
         });
     }
     columns.reserve(columns.size() + all_columns.size());
@@ -491,13 +492,13 @@ void modification_statement::build_cas_result_set_metadata() {
     // the same column can be used twice in the condition list:
     // if a > 0 and a < 3.
     for (const auto& def : all_columns) {
-        if (_columns_of_cas_result_set.test(def.ordinal_id)) {
+        if (_columns_of_cas_result_set->test(def.ordinal_id)) {
             columns.emplace_back(def.column_specification);
         }
     }
     // Ensure we prefetch all of the columns of the result set. This is also
     // necessary to check conditions.
-    _columns_to_read.union_with(_columns_of_cas_result_set);
+    _columns_to_read.union_with(*_columns_of_cas_result_set);
     _metadata = seastar::make_shared<cql3::metadata>(std::move(columns));
 }
 

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -59,7 +59,7 @@ private:
     // of a schema if we have IF EXISTS/IF NOT EXISTS. Does *not*
     // contain LIST columns prefetched to apply updates, unless
     // these columns are also used in conditions.
-    column_set _columns_of_cas_result_set;
+    std::unique_ptr<column_set> _columns_of_cas_result_set;
 public:
     const schema_ptr s;
     const std::unique_ptr<attributes> attrs;
@@ -69,8 +69,14 @@ protected:
     cql_stats& _stats;
 
     expr::expression _condition = expr::conjunction{{}}; // TRUE
+protected:
+    shared_ptr<const restrictions::statement_restrictions> _restrictions;
 private:
     const ks_selector _ks_sel;
+
+    // The following fields are cold (only used during prepare or CAS paths).
+    // They are placed last so that padding falls at the struct tail, and the
+    // hot cache line 3 contains _restrictions and _ks_sel instead.
 
     // True if this statement has _if_exists or _if_not_exists or other
     // conditions that apply to static/regular columns, respectively.
@@ -95,9 +101,6 @@ private:
     bool _selects_a_collection = false;
 
     std::optional<bool> _is_raw_counter_shard_write;
-
-protected:
-    shared_ptr<const restrictions::statement_restrictions> _restrictions;
 public:
     typedef std::optional<std::unordered_map<sstring, bytes_opt>> json_cache_opt;
 
@@ -197,7 +200,8 @@ public:
 
     // Columns of the statement result set (only CAS statement
     // returns a result set).
-    const column_set& columns_of_cas_result_set() const { return _columns_of_cas_result_set; }
+    // Precondition: has_conditions() (i.e., build_cas_result_set_metadata() was called).
+    const column_set& columns_of_cas_result_set() const { return *_columns_of_cas_result_set; }
 
     // Build a read_command instance to fetch the previous mutation from storage. The mutation is
     // fetched if we need to check LWT conditions or apply updates to non-frozen list elements.


### PR DESCRIPTION
## Motivation

Both `modification_statement` and `batch_statement` store a `_columns_of_cas_result_set` field (`column_set` wrapping `boost::dynamic_bitset`) that is only populated for CAS (IF EXISTS / IF condition) statements. The vast majority of prepared INSERT/UPDATE/DELETE/BATCH statements are not conditional, yet they pay the full inline cost of a `column_set` (24 bytes: pointer + size + capacity for the dynamic_bitset buffer).

## Changes

Replace `column_set _columns_of_cas_result_set` with `std::unique_ptr<column_set>` in both `modification_statement` and `batch_statement`. The unique_ptr is only allocated in `build_cas_result_set_metadata()`, which is called only for CAS statements during prepare.

## Size measurements (x86-64, gcc, release)

| Struct | Before | After | Saved | % reduction |
|--------|--------|-------|-------|-------------|
| `modification_statement` | 232B | 208B | 24B | 10.3% |
| `batch_statement` | 144B | 120B | 24B | 16.7% |

Notably, `batch_statement` now fits within 2 cache lines (120B ≤ 128B), whereas before at 144B it spilled into a 3rd cache line.

## Performance (perf-simple-query, release, smp1, 10K partitions, 2.2GHz fixed, 5 runs, last iteration)

| Metric | Baseline (master) | This branch | Delta |
|--------|------------------|-------------|-------|
| insns/op | 32,036 | 32,129 | +93 (+0.29%, noise) |
| tps | 147,600 | 149,897 | +2,297 (+1.6%) |
| allocs/op | 58.1 | 58.1 | unchanged |

No regression.

Refs: https://github.com/scylladb/scylladb/issues/29047