### PR TITLE
treewide: update method accessibility when checked by concepts

### DIFF
--- a/readers/mutation_fragment_v1_stream.hh
+++ b/readers/mutation_fragment_v1_stream.hh
@@ -14,7 +14,7 @@ class mutation_fragment_v1_stream final {
     range_tombstone_assembler _rt_assembler;
     std::optional<clustering_row> _row;
 
-    friend class mutation_fragment_v2; // so it sees our consumer methods
+public:     // consume() methods need to be visible to concepts like MutationFragmentConsumerV2
     mutation_fragment_opt consume(static_row mf) {
         return wrap(std::move(mf));
     }
@@ -41,7 +41,7 @@ class mutation_fragment_v1_stream final {
         _rt_assembler.on_end_of_stream();
         return wrap(std::move(mf));
     }
-
+private:
     future<mutation_fragment_opt> read_from_underlying() {
         auto mfp = co_await _reader();
         if (!mfp) [[unlikely]] {

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -1424,13 +1424,13 @@ private:
     // Compacted stream
     bool _has_compacted_partition_start = false;
 
-private:
     void maybe_push_partition_start() {
         if (_has_compacted_partition_start) {
             push_mutation_fragment(mutation_fragment_v2(*_schema, _permit, std::move(_last_uncompacted_partition_start)));
             _has_compacted_partition_start = false;
         }
     }
+public: // Needed for CompactedFragmentsConsumer concept
     void consume_new_partition(const dht::decorated_key& dk) {
         _has_compacted_partition_start = true;
         // We need to reset the partition's tombstone here. If the tombstone is
@@ -1464,6 +1464,7 @@ private:
     }
     void consume_end_of_stream() {
     }
+private:
     streamed_mutation::forwarding _fwd;
 
 public:


### PR DESCRIPTION
Clang 22 and below ignore method accessibility when checking concepts. Clang 23 now [1] checks 
accessibility. Make relevant methods public so concepts that check them have access.

The problem was that the concepts were evaluated at the use-site, which was a friend, but should have
been evaluated in some friendless global context. After the clang fix, the problems in our code were exposed.

[1] https://github.com/llvm/llvm-project/commit/ac3c588739a09ebb0f80a22ee10282592d858b47

Preparing for a new toolchain, so not backporting.