### PR TITLE
logstor: disable logstor compaction in table truncate

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3020,6 +3020,7 @@ struct database::table_truncate_state {
     db::replay_position low_mark;
     db_clock::time_point truncated_at;
     std::vector<compaction::compaction_reenabler> cres;
+    std::vector<replica::logstor::compaction_reenabler> logstor_cres;
     bool did_flush;
 };
 
@@ -3067,6 +3068,13 @@ future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, s
                     st->cres.emplace_back(co_await cm.stop_and_disable_compaction("truncate", ts));
                 });
             });
+
+            if (cf.uses_logstor()) {
+                auto& logstor_cm = cf.get_logstor_compaction_manager();
+                co_await cf.parallel_foreach_logstor_compaction_group([&logstor_cm, &st] (replica::compaction_group& cg) -> future<> {
+                    st->logstor_cres.emplace_back(co_await logstor_cm.disable_compaction(cg));
+                });
+            }
 
             co_return make_foreign(std::move(st));
         });

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1387,6 +1387,7 @@ public:
     void enable_off_strategy_trigger();
 
     compaction::compaction_group_view& try_get_compaction_group_view_with_static_sharding() const;
+    future<> parallel_foreach_logstor_compaction_group(std::function<future<>(compaction_group&)> action);
     // Safely iterate through table states, while performing async operations on them.
     future<> parallel_foreach_compaction_group_view(std::function<future<>(compaction::compaction_group_view&)> action);
     compaction::compaction_group_view& compaction_group_view_for_sstable(const sstables::shared_sstable& sst) const;

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -1617,6 +1617,7 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
 
     // wait for read operations that use the old locations
     co_await index.await_pending_reads();
+    co_await utils::get_local_injector().inject("logstor_compaction_wait_before_remove_segments", utils::wait_for_message(std::chrono::seconds{60}));
 
     // Free the compacted segments
     auto& ss = cg.logstor_segments();

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -410,8 +410,13 @@ private:
         shared_future<> completion{make_ready_future<>()};
         abort_source as;
         int compaction_disabled_counter{0};
+
+        bool is_empty() const noexcept {
+            return !running && compaction_disabled_counter == 0 && completion.available();
+        }
     };
-    absl::flat_hash_map<compaction_group*, std::unique_ptr<group_compaction_state>> _groups;
+    using group_compaction_state_map = absl::flat_hash_map<compaction_group*, std::unique_ptr<group_compaction_state>>;
+    group_compaction_state_map _groups;
 
 public:
     compaction_manager_impl(segment_manager_impl& sm, compaction_config cfg)
@@ -439,6 +444,12 @@ public:
     future<> split_compaction(replica::table&, compaction_group&, mutation_writer::classify_by_token_group) override;
 
 private:
+
+    void maybe_erase_state(group_compaction_state_map::iterator it) {
+        if (it->second->is_empty()) {
+            _groups.erase(it);
+        }
+    }
 
     std::vector<log_segment_id> select_segments_for_compaction(const segment_descriptor_hist&);
     future<> do_compact(compaction_group&, abort_source&);
@@ -1426,6 +1437,7 @@ future<compaction_reenabler> compaction_manager_impl::disable_compaction(compact
         auto it = _groups.find(&cg);
         if (it != _groups.end()) {
             --it->second->compaction_disabled_counter;
+            maybe_erase_state(it);
         }
     });
 }
@@ -1443,6 +1455,7 @@ compaction_reenabler compaction_manager_impl::disable_compaction_no_wait(compact
         auto it = _groups.find(&cg);
         if (it != _groups.end()) {
             --it->second->compaction_disabled_counter;
+            maybe_erase_state(it);
         }
     });
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5545,6 +5545,13 @@ future<> table::parallel_foreach_compaction_group_view(std::function<future<>(co
     });
 }
 
+future<> table::parallel_foreach_logstor_compaction_group(std::function<future<>(compaction_group&)> action) {
+    if (!uses_logstor()) {
+        co_return;
+    }
+    co_await parallel_foreach_compaction_group(std::move(action));
+}
+
 compaction::compaction_group_view& table::compaction_group_view_for_sstable(const sstables::shared_sstable& sst) const {
     auto& cg = compaction_group_for_sstable(sst);
     return cg.view_for_sstable(sst);

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -458,6 +458,43 @@ async def test_drop_table(manager: ManagerClient):
             assert len(rows) == 1, f"Expected 1 row for key {i} in test2 after all operations, but got {len(rows)}"
             assert rows[0].v == value, f"Expected value of size {value_size} for key {i} in test2 after all operations, but got {len(rows[0].v)}"
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_drop_table_during_logstor_compaction(manager: ManagerClient):
+    cmdline = ['--logger-log-level', 'logstor=trace', '--logger-log-level', 'debug_error_injection=debug', '--smp=1']
+    cfg = {'experimental_features': ['logstor']}
+    server = await manager.server_add(cmdline=cmdline, config=cfg)
+    cql = manager.get_cql()
+    inj = 'logstor_compaction_wait_before_remove_segments'
+
+    async with new_test_keyspace(manager, "") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        value_size = 30 * 1024
+        base_value = 'a' * value_size
+        overwritten_value = 'b' * value_size
+
+        for i in range(20):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{base_value}')")
+
+        for _ in range(4):
+            for i in range(10):
+                await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{overwritten_value}')")
+
+        await manager.api.logstor_flush(server.ip_addr)
+
+        server_log = await manager.server_open_log(server.server_id)
+        await manager.api.enable_injection(server.ip_addr, inj, one_shot=True)
+        log_mark = await server_log.mark()
+
+        await manager.api.logstor_compaction(server.ip_addr)
+        await server_log.wait_for(f'{inj}: waiting for message', from_mark=log_mark, timeout=60)
+
+        drop_task = cql.run_async(f"DROP TABLE {ks}.test")
+        await server_log.wait_for(f"Dropping {ks}.test", from_mark=log_mark, timeout=60)
+
+        await manager.api.message_injection(server.ip_addr, inj)
+        await drop_task
+
 async def test_trigger_separator_flush(manager: ManagerClient):
     """
     Write to 2 tablets, one slower than the other.


### PR DESCRIPTION
in database::truncate_table_on_all_shards disable logstor compaction
before the table data is truncated, similarly to how non-logstor
compaction is disabled, to avoid race conditions between logstor
compaction and segments discarding.

Fixes [SCYLLADB-2186](https://scylladb.atlassian.net/browse/SCYLLADB-2186)

backport to 2026.2 for CI stability

[SCYLLADB-2186]: https://scylladb.atlassian.net/browse/SCYLLADB-2186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ