### PR TITLE
pgo: add logstor workload

### DIFF
--- a/pgo/conf/logstor.yaml
+++ b/pgo/conf/logstor.yaml
@@ -1,0 +1,58 @@
+keyspace: logstor_ks
+
+keyspace_definition: |
+
+  CREATE KEYSPACE IF NOT EXISTS logstor_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};
+
+table: users
+
+table_definition: |
+
+  CREATE TABLE IF NOT EXISTS users (
+    userid bigint,
+    initials int,
+    first_name text,
+    last_name text,
+    password text,
+    email text,
+    address text,
+    userdata blob,
+    PRIMARY KEY(userid)
+  ) WITH storage_engine = 'logstor';
+
+columnspec:
+  - name: userid
+    population: exp(1..10000)
+
+  - name: initials
+    size: fixed(2)
+    population: gaussian(1..20000)
+
+  - name: first_name
+    size: fixed(5)
+
+  - name: last_name
+    size: fixed(5)
+
+  - name: password
+    size: fixed(80)
+
+  - name: email
+    size: uniform(16..50)
+
+  - name: address
+    size: uniform(16..50)
+
+  - name: userdata
+    size: fixed(840) # row size ~ 1k
+
+queries:
+  row-insert:
+    cql: insert into logstor_ks.users(userid, initials, first_name, last_name, password, email, address, userdata) values (?,?,?,?,?,?,?,?)
+    fields: samerow
+  read-cache:
+    cql: select * from logstor_ks.users where userid = ?
+    fields: samerow
+  read-disk:
+    cql: select * from logstor_ks.users where userid = ? BYPASS CACHE
+    fields: samerow

--- a/pgo/conf/logstor.yaml
+++ b/pgo/conf/logstor.yaml
@@ -1,0 +1,87 @@
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+#
+# cassandra-stress profile for the logstor PGO training workload.
+#
+# A logstor table is a key-value table: it has no clustering columns, and a write
+# replaces the whole partition rather than updating cells of it. The operations below
+# are the paths a logstor training run has to exercise - a write, a read the logstor
+# cache can serve, a read that has to go to a segment, a partition delete, and a range
+# scan - plus the compaction that the writes and the deletes drive once the dead records
+# they leave behind fill the segment pool.
+#
+# The number of partitions is not set here. `population: seq()` maps the seed of an
+# operation to the key of its partition, so the seed range that pgo.py passes in -pop is
+# the key range the workload touches. See LOGSTOR_ROWS in pgo.py, which sizes it against
+# the segment pool.
+#
+
+keyspace: logstor_ks
+
+# Tablets are enabled explicitly: the compaction groups of a logstor table are the
+# tablets of that table, and a fixed initial count keeps the number of compaction groups
+# a shard writes into the same between runs.
+keyspace_definition: |
+
+  CREATE KEYSPACE IF NOT EXISTS logstor_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'enabled': true, 'initial': 16};
+
+table: users
+
+table_definition: |
+
+  CREATE TABLE IF NOT EXISTS users (
+    userid bigint,
+    initials int,
+    first_name text,
+    last_name text,
+    password text,
+    email text,
+    address text,
+    userdata blob,
+    PRIMARY KEY(userid)
+  ) WITH storage_engine = 'logstor';
+
+columnspec:
+  - name: userid
+    population: seq(1..1000000000)
+
+  - name: initials
+    size: fixed(2)
+
+  - name: first_name
+    size: fixed(5)
+
+  - name: last_name
+    size: fixed(5)
+
+  - name: password
+    size: fixed(80)
+
+  - name: email
+    size: uniform(16..50)
+
+  - name: address
+    size: uniform(16..50)
+
+  - name: userdata
+    size: fixed(840) # row size ~ 1k
+
+queries:
+  row-insert:
+    cql: insert into logstor_ks.users(userid, initials, first_name, last_name, password, email, address, userdata) values (?,?,?,?,?,?,?,?)
+    fields: samerow
+  read-cache:
+    cql: select * from logstor_ks.users where userid = ?
+    fields: samerow
+  read-disk:
+    cql: select * from logstor_ks.users where userid = ? BYPASS CACHE
+    fields: samerow
+  row-delete:
+    cql: delete from logstor_ks.users where userid = ?
+    fields: samerow
+  scan:
+    cql: select * from logstor_ks.users where token(userid) >= token(:userid) limit 100
+    fields: samerow

--- a/pgo/pgo.py
+++ b/pgo/pgo.py
@@ -410,6 +410,8 @@ async def start_node(executable: PathLike, cluster_workdir: PathLike, addr: str,
         f"--alternator-write-isolation=only_rmw_uses_lwt",
         f"--authenticator=PasswordAuthenticator",
         f"--authorizer=CassandraAuthorizer",
+        '--experimental-features=logstor',
+        '--logstor-disk-size-in-mb=32'
     ] + list(extra_opts)
     training_logger.info(f"Using maintenance socket {socket}")
     return await run(['bash', '-c', fr"""exec {shlex.join(command)} >{q(logfile)} 2>&1"""], cwd=cluster_workdir)
@@ -820,6 +822,19 @@ async def train_repair(executable: PathLike, workdir: PathLike) -> None:
 
 trainers["repair"] = ("repair_dataset", train_repair)
 populators["repair_dataset"] = populate_repair
+
+# LOGSTOR ==================================================
+
+async def populate_logstor(executable: PathLike, workdir: PathLike) -> None:
+    async with with_cs_populate(executable=executable, workdir=workdir) as server:
+        await cs(cmd=["user", "profile=./conf/logstor.yaml", "ops(row-insert=1)"], n=100000, cl="local_quorum", node=server)
+
+async def train_logstor(executable: PathLike, workdir: PathLike) -> None:
+    async with with_cs_train(executable=executable, workdir=workdir) as server:
+        await cs(cmd=["user", "profile=./conf/logstor.yaml", "ops(row-insert=1,read-cache=1,read-disk=1)"], n=100000, cl="local_quorum", node=server)
+
+trainers["logstor"] = ("logstor_dataset", train_logstor)
+populators["logstor_dataset"] = populate_logstor
 
 ################################################################################
 # Training procedures

--- a/pgo/pgo.py
+++ b/pgo/pgo.py
@@ -541,18 +541,23 @@ async def quiesce_cluster(addrs: list[str]) -> None:
         await asyncio.sleep(10)
 
 @contextlib.asynccontextmanager
-async def with_cluster(executable: PathLike, workdir: PathLike, cpusets: Optional[list[str]] = None) -> AsyncIterator[tuple[list[str], list[Process]]]:
+async def with_cluster(executable: PathLike, workdir: PathLike, cpusets: Optional[list[str]] = None, node_opts: list[str] = []) -> AsyncIterator[tuple[list[str], list[Process]]]:
     """Provides a Scylla cluster.
     Doesn't monitor the state of the cluster in any way, just starts the cluster as
     the context manager enters, waits for each CQL port to open, yields the cluster's
     control info and stops the cluster as the context manager exits.
+
+    `node_opts` are extra command line options for the nodes. A workload which needs the
+    cluster configured in a particular way passes them here rather than having them added
+    to every cluster the training starts. The same options have to be passed when the
+    dataset of that workload is populated and when it is trained on.
     """
     meta = cluster_metadata(workdir)
     cluster_name = meta["name"]
     subnet = meta["subnet"]
     addrs = [f"{subnet}.{i}" for i in range(1,255)][:3]
     cpusets = cpusets or NODE_CPUSETS.get()
-    extra_opts = await get_bolt_opts(executable)
+    extra_opts = await get_bolt_opts(executable) + list(node_opts)
     training_logger.debug(f"BOLT opts for {executable} are {extra_opts}")
     training_logger.info(f"Starting a cluster of {executable} in {workdir}")
     procs = await start_cluster(addrs=addrs, executable=executable, workdir=workdir, cpusets=cpusets, cluster_name=cluster_name, extra_opts=extra_opts)
@@ -614,10 +619,10 @@ def kw(**kwargs):
 # But this facility isn't currently used.
 
 @contextlib.asynccontextmanager
-async def with_cs_populate(executable: PathLike, workdir: PathLike) -> AsyncIterator[str]:
+async def with_cs_populate(executable: PathLike, workdir: PathLike, node_opts: list[str] = []) -> AsyncIterator[str]:
     """Provides a Scylla cluster, creates the cassandra superuser, and waits
     for compactions to end before stopping it."""
-    async with with_cluster(executable=executable, workdir=workdir) as (addrs, procs):
+    async with with_cluster(executable=executable, workdir=workdir, node_opts=node_opts) as (addrs, procs):
         await setup_cassandra_user(workdir, addrs[0])
         yield addrs[0]
         async with asyncio.timeout(3600):
@@ -625,9 +630,9 @@ async def with_cs_populate(executable: PathLike, workdir: PathLike) -> AsyncIter
             await quiesce_cluster(addrs=addrs)
 
 @contextlib.asynccontextmanager
-async def with_cs_train(executable: PathLike, workdir: PathLike) -> AsyncIterator[str]:
+async def with_cs_train(executable: PathLike, workdir: PathLike, node_opts: list[str] = []) -> AsyncIterator[str]:
     """Provides a Scylla cluster and merges generated profile files after it's stopped."""
-    async with with_cluster(executable=executable, workdir=workdir) as (addrs, procs):
+    async with with_cluster(executable=executable, workdir=workdir, node_opts=node_opts) as (addrs, procs):
         yield addrs[0]
     await merge_profraw(workdir)
 
@@ -822,6 +827,75 @@ async def train_repair(executable: PathLike, workdir: PathLike) -> None:
 
 trainers["repair"] = ("repair_dataset", train_repair)
 populators["repair_dataset"] = populate_repair
+
+# LOGSTOR ==================================================
+#
+# Logstor is a log structured key-value engine. A write appends a record to the active
+# segment of its compaction group and repoints the primary index at it, a read either
+# finds the partition in the logstor cache or reads its record back out of a segment, and
+# compaction is what turns the dead records that the overwrites and the deletes leave
+# behind into free segments again.
+#
+# Which of those paths a run exercises, and how much each of them does, is decided by how
+# full the segment pool of a shard is, so the workload is sized against the pool rather
+# than in rows. Compaction does not start until the free segments fall under
+# logstor_compaction_trigger_threshold (5%) of the pool, and what it then pays per segment
+# it takes is the fraction of that segment which is still live - so a pool that is about
+# half live is the regime where compaction has to relocate real data instead of dropping
+# nearly empty segments. The dataset is populated to about that, and the training workload
+# then writes the free half of the pool several times over, so that compaction is running
+# for most of it.
+
+# The segment pool of one shard, and the rest of the logstor configuration of the training
+# cluster. Only the logstor cluster is started with these: every other workload runs
+# without the logstor feature and pays neither for the pool nor for formatting its files.
+LOGSTOR_DISK_SIZE_IN_MB = 256
+LOGSTOR_NODE_OPTS = [
+    "--experimental-features=logstor",
+    f"--logstor-disk-size-in-mb={LOGSTOR_DISK_SIZE_IN_MB}",
+]
+
+# Partitions of the dataset, which is what sizes it against the pool above. A row of
+# ./conf/logstor.yaml is ~1 KiB of values and measures ~1.9 KiB as a record, since a
+# record carries the description of the schema along with the frozen mutation. Every one
+# of the three RF=3 nodes holds the whole dataset, so the live bytes of the cluster come
+# to 3 * LOGSTOR_ROWS * 1.9 KiB against the 3 * 2 * LOGSTOR_DISK_SIZE_IN_MB of pool that
+# its six shards have between them - 0.83 GiB of 1.5 GiB, or 55%. The training mix deletes
+# one partition for every six it inserts, which settles that at ~6/7 of what was
+# populated, leaving the run at about half a pool.
+LOGSTOR_ROWS = 150000
+
+# Operations of the training workload. The dataset leaves ~45% of the pool free, which the
+# workload has to overwrite before compaction starts at all - a tenth of this run - and
+# what is left of it then runs against a pool that compaction is holding at ~92% in use.
+LOGSTOR_TRAIN_OPS = 2600000
+
+# The mix. Writes are weighted above reads because they also drive the compaction, the
+# separator and the segment allocation that no read touches. read-cache is not only a
+# cache hit: a write and a delete both evict the cached partition of the key they
+# overwrite, so a read-cache hits only when the last thing to touch its key was another
+# read-cache. At these weights that is 400 of the 1100 key-touching operations, and the
+# run measures a third of them hitting and the rest missing, reading the record out of
+# its segment and populating the cache with it. read-disk is BYPASS CACHE, which neither
+# looks in the cache nor populates it, and is the segment read path on its own. scan is
+# the range reader, which repair and tablet migration read through, and is weighted far
+# below the rest because one of them returns a hundred partitions.
+LOGSTOR_TRAIN_MIX = "ops(row-insert=600,read-cache=400,read-disk=200,row-delete=100,scan=1)"
+
+async def populate_logstor(executable: PathLike, workdir: PathLike) -> None:
+    async with with_cs_populate(executable=executable, workdir=workdir, node_opts=LOGSTOR_NODE_OPTS) as server:
+        # Sequential seeds, so that the population covers the key range exactly once
+        # instead of leaving a third of it unwritten the way random seeds would.
+        await cs(cmd=["user", "profile=./conf/logstor.yaml", "ops(row-insert=1)"],
+                 n=LOGSTOR_ROWS, pop=f"seq=1..{LOGSTOR_ROWS}", cl="local_quorum", node=server)
+
+async def train_logstor(executable: PathLike, workdir: PathLike) -> None:
+    async with with_cs_train(executable=executable, workdir=workdir, node_opts=LOGSTOR_NODE_OPTS) as server:
+        await cs(cmd=["user", "profile=./conf/logstor.yaml", LOGSTOR_TRAIN_MIX],
+                 n=LOGSTOR_TRAIN_OPS, pop=f"dist=UNIFORM(1..{LOGSTOR_ROWS})", cl="local_quorum", node=server)
+
+trainers["logstor"] = ("logstor_dataset", train_logstor)
+populators["logstor_dataset"] = populate_logstor
 
 ################################################################################
 # Training procedures


### PR DESCRIPTION
add a logstor workload in pgo training to improve logstor performance. the workload creates a key-value table that uses logstor, populates it with rows, then executes a workload with overwrites, reads, bypass-cache reads, and compaction.

measured -5% instructions/op for reads and -1% for writes.

Fixes SCYLLADB-2076

no backport - performance improvement for experimental feature