### PR TITLE
test/cqlpy: test for precision in arithmetic operators

### DIFF
--- a/test/cqlpy/test_type_decimal.py
+++ b/test/cqlpy/test_type_decimal.py
@@ -10,8 +10,10 @@
 #############################################################################
 
 from decimal import Decimal
+import sys
+from contextlib import contextmanager
 import pytest
-from cassandra.protocol import InvalidRequest
+from cassandra.protocol import InvalidRequest, FunctionFailure
 
 from . import nodetool
 from .util import new_test_table, unique_key_int, new_materialized_view, new_secondary_index
@@ -87,7 +89,7 @@ def test_decimal_clustering_key_inline_high_precision(cql, table1):
 #     [note: Integer.MIN_VALUE=-2147483648, Integer.MAX_VALUE=2147483647]
 # This test passes on Cassandra 3 but fails on Cassandra 4 and 5 due to
 # CASSANDRA-20723 which limits the exponent to 309.
-def test_decimal_clustering_key_inline_overflow_exponent(cql, table1):
+def test_decimal_clustering_key_inline_overflow_exponent(cql, table1, cassandra_bug):
     p = unique_key_int()
     # The following numbers all have an exponent that is itself (without
     # any fractional part) already above the scale limit.
@@ -302,24 +304,212 @@ def test_decimal_si_and_mv_representation(cql, test_keyspace):
 # Adding two decimals with very different scales in operator+= rescales
 # both operands to the larger scale via pow(10, scale_diff). CQL's
 # decimal type allows arbitrary scales (int32 range), so a table with
-# values like 1e1000000000 and 1 forces pow(10, 1000000000) when
-# computing SUM() or AVG(), allocating a number with ~1 billion digits.
+# values like 1e500000000 and 1 forces pow(10, 500000000) when
+# computing SUM() or AVG(), allocating a number with ~500 million digits.
 # This is the same class of DoS as issue #8002 (to_string OOM)
 # but in arithmetic.
+# Cassandra has the same bug - whereas its arithmetic operations limit
+# the precision of the result to 10,000 digits (see tests below), for
+# aggregation sum() that we test here, it does not (CASSANDRA-21401).
+# We use the number 500 million and not higher because in Cassandra's
+# implementation, BigInteger (used to store the mantissa) has a hard
+# limit of around 537 million decimal digits (537M = 2^31/4 - where
+# 4=bitlength(10) was used by the Java code - incorrectly - instead of
+# log2(10) - to limit the number of binary digits to 2^31). So using 500
+# million digits can allow us to run this test on Cassandra - while still
+# timing out or OOMing if this bug exists.
 # This test is skipped because it would hang or crash the tests.
 # Reproduces SCYLLADB-1576
 @pytest.mark.skip_bug(
     link="https://scylladb.atlassian.net/browse/SCYLLADB-1576",
     reason="Decimal operator+= OOM on extreme scale difference",
 )
-def test_decimal_sum_extreme_scale_oom(cql, test_keyspace):
+def test_decimal_sum_extreme_scale_oom(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace,
             "p int, c decimal, PRIMARY KEY (p)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c) VALUES (?, ?)")
-        cql.execute(stmt, [1, Decimal('1e1000000000')])
+        cql.execute(stmt, [1, Decimal('1e500000000')])
         cql.execute(stmt, [2, Decimal('1')])
         result = list(cql.execute(f"SELECT sum(c) FROM {table}"))
         assert len(result) == 1
+
+# The following context manager is needed to work around a bug in how the
+# Python driver parses very long "decimal" values returned from the server.
+# By default, the driver fails to parse "decimal" values with more than
+# 4300 digits of precision. The reason is as follows:
+#
+# The driver parses decimal responses using DecimalType.deserialize().
+# This function does:
+#
+#    scale = int32_unpack(byts[:4])
+#    unscaled = varint_unpack(byts[4:])
+#    return Decimal('%de%d' % (unscaled, -scale))
+#
+# The problem is in the third line: The "%d" in the format string converts the
+# unscaled integer to a decimal string. And due to CVE-2020-10735 Python
+# limits that conversion to 4300 digits by default.
+# The following context manager can be used to temporarily increase this
+# limit beyond the default 4300.
+@contextmanager
+def int_max_str_digits(limit):
+    old_limit = sys.get_int_max_str_digits()
+    sys.set_int_max_str_digits(limit)
+    try:
+        yield
+    finally:
+        sys.set_int_max_str_digits(old_limit)
+
+# Check the precision of addition.
+# As explained above in test_decimal_sum_extreme_scale_oom(), we can't allow
+# addition to generate huge precision when adding two "decimal"s with wildly
+# different scales. Cassandra chose (commit d60e798) to limit the precision
+# of the result of addition to MAX_PRECISION = 10,000 digits, Scylla should
+# do the same as a solution for #13601. Let's check that this is indeed what
+# happens using arithmetic operators in SELECT.
+MAX_PRECISION = 10000
+@pytest.mark.xfail(reason="#2693 - arithmetic operators not yet implemented")
+def test_decimal_add_precision(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace,
+            "p int, a decimal, b decimal, PRIMARY KEY (p)") as table, \
+            int_max_str_digits(MAX_PRECISION * 2):
+        stmt = cql.prepare(f"INSERT INTO {table} (p, a, b) VALUES (?, ?, ?)")
+        # Test that 1e9999 + 1 produces the correct 10,000-digit result.
+        # 10,000 digits is exactly MAX_PRECISION, so no truncation happens.
+        cql.execute(stmt, [1, Decimal('1e' + str(MAX_PRECISION - 1)), Decimal('1')])
+        result = list(cql.execute(f"SELECT a + b FROM {table} WHERE p = 1"))
+        assert result == [(Decimal('1' + '0' * (MAX_PRECISION - 2) + '1'),)]
+        # 1e10000 + 1 would have 10,001 digits of precision, but Cassandra
+        # limits the precision to just 10,000 digits so the last digit will
+        # be zeroed out, and the result of the addition will be just 1e10000.
+        # Note that this truncation of the result is silent, it is not an error.
+        cql.execute(stmt, [2, Decimal('1e' + str(MAX_PRECISION)), Decimal('1')])
+        result = list(cql.execute(f"SELECT a + b FROM {table} WHERE p = 2"))
+        assert result == [(Decimal('1e' + str(MAX_PRECISION)),)]
+        # Check that the "truncation" of extra digits is actually HALF_UP
+        # rounding: 1e10000 + 5 has 10001 digits (10000...005), the 10001st
+        # digit is 5, so HALF_UP rounds the 10000th digit (0) up to 1:
+        # result is 10000...010 (= 10^10000 + 10), not 10000...000 (= 10^10000).
+        # Note: HALF_EVEN would give 10^10000 here (0 is even), so this
+        # assertion specifically verifies Java's HALF_UP rounding mode.
+        cql.execute(stmt, [3, Decimal('1e' + str(MAX_PRECISION)), Decimal('5')])
+        result = list(cql.execute(f"SELECT a + b FROM {table} WHERE p = 3"))
+        assert result == [(Decimal('1' + '0' * (MAX_PRECISION - 2) + '10'),)]
+        # For negative numbers, HALF_UP rounds away from zero (towards -inf),
+        # so -1e10000 + (-5) = -(10^10000 + 5) rounds to -(10^10000 + 10),
+        # not -(10^10000).
+        cql.execute(stmt, [4, Decimal('-1e' + str(MAX_PRECISION)), Decimal('-5')])
+        result = list(cql.execute(f"SELECT a + b FROM {table} WHERE p = 4"))
+        assert result == [(Decimal('-1' + '0' * (MAX_PRECISION - 2) + '10'),)]
+
+# Check the precision of division.
+# How many digits of precision do we expect when dividing 1.0 by 3.0? There is
+# no obvious answer. Cassandra decided in commit d60e798 (for CASSANDRA-15232)
+# to use the following rules:
+#  * expected scale is set to minimum precision (32) minus estimated position
+#    of first digit in quotient
+#  * scale should be at least as big as maximum scale of operands
+#  * scale should not be less than 32
+#  * scale should not be bigger than 1000
+#  * if actual quotient scale is bigger than calculated scale then result is
+#    rounded using HALF_UP mode
+#  * trailing zeros are stripped
+# For example, 1/3: the quotient has 0 digits before the decimal point, so
+# estimated position = 0, giving scale = 32 - 0 = 32. In general, the
+# estimated position (= integer digit count of the quotient) is computed from
+# operand precision and scale as (directly from DecimalType.java):
+#   position = (l.precision() - l.scale()) - (r.precision() - r.scale())
+@pytest.mark.xfail(reason="#2693 - arithmetic operators not yet implemented")
+def test_decimal_division_precision(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace,
+            "p int, a decimal, b decimal, PRIMARY KEY (p)") as table, \
+            int_max_str_digits(1001 + 32):
+        stmt = cql.prepare(f"INSERT INTO {table} (p, a, b) VALUES (?, ?, ?)")
+        # 1 / 3: quotient ~0.333 has 0 integer digits, estimated position = 0,
+        # scale = 32 - 0 = 32. The 33rd digit of 1/3 is 3 (< 5), so
+        # HALF_UP does not round up. Result: 0.333...3 with 32 threes.
+        cql.execute(stmt, [1, Decimal('1'), Decimal('3')])
+        result = list(cql.execute(f"SELECT a / b FROM {table} WHERE p = 1"))
+        assert result == [(Decimal('0.' + '3' * 32),)]
+        # 1 / 6: same scale 32. The 33rd digit of 1/6 is 6 (>= 5), so
+        # HALF_UP rounds the 32nd digit up: 0.1666...6 -> 0.1666...7.
+        # Result: 0.1 followed by 30 sixes then 7 (32 decimal places total).
+        cql.execute(stmt, [2, Decimal('1'), Decimal('6')])
+        result = list(cql.execute(f"SELECT a / b FROM {table} WHERE p = 2"))
+        assert result == [(Decimal('0.1' + '6' * 30 + '7'),)]
+        # 1 / 30: quotient ~0.0333 has -1 integer digits (position = (1-0)-(2-0) = -1),
+        # scale = 32 - (-1) = 33. The 34th digit is 3 (< 5), so no rounding.
+        # Result: 0.0 followed by 32 threes (33 decimal places total).
+        cql.execute(stmt, [3, Decimal('1'), Decimal('30')])
+        result = list(cql.execute(f"SELECT a / b FROM {table} WHERE p = 3"))
+        assert result == [(Decimal('0.0' + '3' * 32),)]
+        # 10 / 3: position = (2-0)-(1-0) = 1, so formula gives scale = 31,
+        # but the "not less than 32" floor kicks in, so scale = 32.
+        # Result: 3.333...3 with 32 threes after the decimal point.
+        cql.execute(stmt, [4, Decimal('10'), Decimal('3')])
+        result = list(cql.execute(f"SELECT a / b FROM {table} WHERE p = 4"))
+        assert result == [(Decimal('3.' + '3' * 32),)]
+        # When max(operand scale) exceeds the computed scale, the result
+        # scale is bumped up. Here a has scale 40 > 32, so result has scale 40
+        # (40 3's after the decimal point).
+        cql.execute(stmt, [5, Decimal('1.' + '0' * 40), Decimal('3')])
+        result = list(cql.execute(f"SELECT a / b FROM {table} WHERE p = 5"))
+        assert result == [(Decimal('0.' + '3' * 40),)]
+        # The scale is hard-capped at 1000. An operand with scale 1001 would
+        # push result scale to 1001, but the cap reduces it to 1000.
+        cql.execute(stmt, [6, Decimal('1.' + '0' * 1001), Decimal('3')])
+        result = list(cql.execute(f"SELECT a / b FROM {table} WHERE p = 6"))
+        assert result == [(Decimal('0.' + '3' * 1000),)]
+        # Exact divisions: trailing zeros are stripped.
+        # 1 / 4 = 0.25 exactly; computed scale = 32, but the trailing zeros
+        # are removed, leaving scale 2.
+        cql.execute(stmt, [7, Decimal('1'), Decimal('4')])
+        result = list(cql.execute(f"SELECT a / b FROM {table} WHERE p = 7"))
+        assert len(result) == 1
+        assert result[0][0] == Decimal('0.25')
+        assert result[0][0].as_tuple().exponent == Decimal('0.25').as_tuple().exponent
+
+# Test modulo operator for decimals. Check how it works for different
+# interesting cases, and also that we don't have CASSANDRA-15232 - if the
+# division produced a number with precision bigger than 34, it used to fail.
+@pytest.mark.xfail(reason="#2693 - arithmetic operators not yet implemented")
+def test_decimal_modulo(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace,
+            "p int, a decimal, b decimal, PRIMARY KEY (p)") as table:
+        stmt = cql.prepare(f"INSERT INTO {table} (p, a, b) VALUES (?, ?, ?)")
+        # Basic integer modulo.
+        cql.execute(stmt, [1, Decimal('7'), Decimal('3')])
+        result = list(cql.execute(f"SELECT a % b FROM {table} WHERE p = 1"))
+        assert result == [(Decimal('1'),)]
+        # Fractional result: scale of result = max(scale(a), scale(b)) = 1.
+        cql.execute(stmt, [2, Decimal('7.5'), Decimal('2')])
+        result = list(cql.execute(f"SELECT a % b FROM {table} WHERE p = 2"))
+        assert result == [(Decimal('1.5'),)]
+        # Negative dividend: sign of remainder follows the dividend (Java
+        # BigDecimal.remainder() semantics, i.e. truncation toward zero).
+        cql.execute(stmt, [3, Decimal('-7'), Decimal('3')])
+        result = list(cql.execute(f"SELECT a % b FROM {table} WHERE p = 3"))
+        assert result == [(Decimal('-1'),)]
+        # Negative divisor: sign of remainder still follows the dividend.
+        cql.execute(stmt, [4, Decimal('7'), Decimal('-3')])
+        result = list(cql.execute(f"SELECT a % b FROM {table} WHERE p = 4"))
+        assert result == [(Decimal('1'),)]
+        # Reproduces CASSANDRA-15232: before the fix, a % b would fail when the
+        # integer quotient (divideToIntegralValue) had more than 34 digits.
+        # 1e35 / 3 has a 35-digit integer part (33333...3 with 35 digits), and
+        # 1e35 % 3 = 1e35 - 3 * 33333...3 = 1.
+        cql.execute(stmt, [5, Decimal('1e35'), Decimal('3')])
+        result = list(cql.execute(f"SELECT a % b FROM {table} WHERE p = 5"))
+        assert result == [(Decimal('1'),)]
+        # Non-integer operands: 1.7 % 0.5.
+        # divideToIntegralValue(1.7/0.5) = 3, so 1.7 - 0.5*3 = 0.2.
+        # Result scale = max(scale(1.7), scale(0.5)) = max(1,1) = 1.
+        cql.execute(stmt, [6, Decimal('1.7'), Decimal('0.5')])
+        result = list(cql.execute(f"SELECT a % b FROM {table} WHERE p = 6"))
+        assert result == [(Decimal('0.2'),)]
+        # Division by zero raises a FunctionFailure with a "Division by zero" message.
+        cql.execute(stmt, [7, Decimal('1'), Decimal('0')])
+        with pytest.raises(FunctionFailure, match="Division by zero"):
+            list(cql.execute(f"SELECT a % b FROM {table} WHERE p = 7"))
 
 # Verify that toJson() on decimal values produces output consistent with
 # Java's BigDecimal.toString() specification.


### PR DESCRIPTION
We're planning to start implementing arithmetic operators even if not completely (e.g., the subset used for #10568 - add to CQL UPDATE the ability to calculate the new value).

One of the things we need to understand before doing this is what some of these operators do on the "decimal" type, because there are questions what needs to be done regarding the precision of the output of these operators - we need to answer both mundane quotes (how many digits should 1.0 / 3.0 have?) to more serious OOM concerns like SCYLLADB-1576.

In this patch we add extensive tests that verify exactly how Cassandra behaves for arithmetic operators on the "decimal" type. Cassandra's current behavior was introduced in 2019, in commit d60e798 (fixing CASSANDRA-15232), and it makes sense that when we'll implement operators in Scylla (issue #2693), we'll choose the same limitations and logic as Cassandra did, instead of inventing a different one. Or if we do decide to implement different behavior, we'll still want to know where we differ from Cassandra.

This patch also improves the existing test for excessive precision in the "sum" aggregation. It turns out that Cassandra has the same bug (CASSANDRA-21401) - they fixed the unlimited-precision bug of operators but not aggregations - but to reproduce it we need to use a more reasonable precision (500 million instead of one billion). The improved test "does its stuff" (i.e., fails badly due to the bug) on both Scylla and Cassandra.

Refs #2693 ("support arithmetic operators")