### PR TITLE
utils/big_decimal: limit add/sub precision to 10000 digits

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1145,11 +1145,6 @@ static raw_value arithmetic_add(const expression& lhs_expr, const expression& rh
                     return serialized(l + r);
                 },
                 [&] (const decimal_type_impl& dtype) -> bytes {
-                    // NOTE: This addition is susceptible to SCYLLADB-1576 - adding
-                    // two decimals with wildly different scales (e.g. 1 and
-                    // 1e100000000) can cause huge allocations and CPU usage.
-                    // This case should be caught and rejected in big_decimal's
-                    // implementation, not here.
                     big_decimal l = value_cast<big_decimal>(dtype.deserialize(lhs_bv));
                     big_decimal r = value_cast<big_decimal>(dtype.deserialize(rhs_bv));
                     return serialized(l + r);

--- a/test/boost/big_decimal_test.cc
+++ b/test/boost/big_decimal_test.cc
@@ -349,6 +349,99 @@ BOOST_AUTO_TEST_CASE(test_big_decimal_sub) {
     test_sub("+10.", "1.e+1", "0");
 }
 
+// Build a string of 'n' copies of digit 'd' (as char).
+static std::string repeat_digit(char d, int n) {
+    return std::string(n, d);
+}
+
+// Tests for add/subtract precision limiting (SCYLLADB-1576 / CASSANDRA-15232):
+// Results exceeding 10,000 significant digits are rounded using HALF_UP.
+BOOST_AUTO_TEST_CASE(test_big_decimal_add_precision) {
+    // Adding values whose sum fits within MAX_PRECISION (10000) digits: exact.
+    // 1e9999 + 1 = 1000...0001 (10000 digits, no rounding).
+    {
+        big_decimal a{"1e9999"};
+        big_decimal b{"1"};
+        big_decimal result = a + b;
+        BOOST_REQUIRE((result <=> big_decimal{"1" + repeat_digit('0', 9998) + "1"}) == std::strong_ordering::equal);
+    }
+    // 1e10000 + 1 would have 10001 significant digits so need to round one
+    // digit. The dropped digit is 1 (< 5), so HALF_UP rounds down: result
+    // equals 1e10000.
+    {
+        big_decimal a{"1e10000"};
+        big_decimal b{"1"};
+        big_decimal result = a + b;
+        BOOST_REQUIRE((result <=> a) == std::strong_ordering::equal);
+    }
+    // 1e10000 + 5: the dropped digit is 5, so HALF_UP rounds up to
+    // 10^10000 + 10.
+    {
+        big_decimal a{"1e10000"};
+        big_decimal b{"5"};
+        big_decimal result = a + b;
+        // Expected value: 10^10000 + 10 = "1" followed by 9998 zeros then "10".
+        BOOST_REQUIRE((result <=> big_decimal{"1" + repeat_digit('0', 9998) + "10"}) == std::strong_ordering::equal);
+    }
+    // For negative numbers, HALF_UP rounds away from zero (towards -inf).
+    // -1e10000 + (-5) = -(10^10000 + 5) rounds to -(10^10000 + 10).
+    {
+        big_decimal a{"-1e10000"};
+        big_decimal b{"-5"};
+        big_decimal result = a + b;
+        BOOST_REQUIRE((result <=> big_decimal{"-1" + repeat_digit('0', 9998) + "10"}) == std::strong_ordering::equal);
+    }
+    // Wildly different scales: 1e100000000 + 1.
+    // The 1 is so insignificant (100 million orders of magnitude smaller) that
+    // it cannot affect any of the 10000 significant digits of 1e100000000.
+    // Result is 1e100000000 unchanged, no error (fixes SCYLLADB-1576).
+    {
+        big_decimal a{"1e100000000"};
+        big_decimal b{"1"};
+        big_decimal result = a + b;
+        BOOST_REQUIRE((result <=> big_decimal{"1e100000000"}) == std::strong_ordering::equal);
+    }
+    // Carry case: rounding 9...95 (10001 digits: 10000 nines then 5) to
+    // MAX_PRECISION digits rounds up, causing a carry all the way through
+    // (9...9 + 1 = 10^10000). The result is always a power of 10, so its
+    // mathematical value is unaffected by the bug. What the bug gets wrong is
+    // the representation: without the fix, unscaled = 10^10000 has 10001 digits,
+    // violating the MAX_PRECISION cap. Only the digit count catches the bug.
+    {
+        big_decimal a{repeat_digit('9', 10000) + "0"};
+        big_decimal b{"5"};
+        big_decimal result = a + b;
+        boost::multiprecision::cpp_int abs_unscaled = boost::multiprecision::abs(result.unscaled_value());
+        BOOST_REQUIRE(abs_unscaled.str().size() <= 10000);
+    }
+}
+
+// Same precision tests for subtraction.
+BOOST_AUTO_TEST_CASE(test_big_decimal_sub_precision) {
+    // -1e10000 - 5: same as adding -5 to -1e10000, rounds away from zero.
+    // Result is -(10^10000 + 10).
+    {
+        big_decimal a{"-1e10000"};
+        big_decimal b{"5"};
+        big_decimal result = a - b;
+        BOOST_REQUIRE((result <=> big_decimal{"-1" + repeat_digit('0', 9998) + "10"}) == std::strong_ordering::equal);
+    }
+    // 1e100000000 - 1: the 1 is insignificant, result stays 1e100000000.
+    {
+        big_decimal a{"1e100000000"};
+        big_decimal b{"1"};
+        big_decimal result = a - b;
+        BOOST_REQUIRE((result <=> big_decimal{"1e100000000"}) == std::strong_ordering::equal);
+    }
+    // Carry case (negative): same reasoning as the add carry case above.
+    {
+        big_decimal a{"-" + repeat_digit('9', 10000) + "0"};
+        big_decimal b{"5"};
+        big_decimal result = a - b;
+        boost::multiprecision::cpp_int abs_unscaled = boost::multiprecision::abs(result.unscaled_value());
+        BOOST_REQUIRE(abs_unscaled.str().size() <= 10000);
+    }
+}
 
 BOOST_AUTO_TEST_CASE(test_boost_multiprecision_sign) {
     namespace bmp = boost::multiprecision;

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -5058,25 +5058,18 @@ BOOST_AUTO_TEST_CASE(evaluate_add_arbitrary_precision_no_overflow) {
         big_decimal(large_plus_one.c_str()));
 }
 
-// The decimal type offers unlimited precision, but adding two numbers with
-// wildly different magnitudes - like 1 and 1e100000000 can require allocating
-// a huge number of digits, takes a huge amount of time and potentially
-// run out of memory. The expected behavior is to refuse this operation.
-// Reproduces SCYLLADB-1576.
+// Adding two decimals with wildly different magnitudes (e.g. 1e100000000 + 1)
+// used to require allocating ~100 million digits and could OOM (SCYLLADB-1576).
+// The fix silently rounds the result to at most MAX_PRECISION (10000) significant
+// digits, so the operation now succeeds and returns 1e100000000 unchanged
+// (the 1 is too small to affect any of the 10000 significant digits).
 BOOST_AUTO_TEST_CASE(evaluate_add_large_magnitude) {
-    // SCYLLADB-1576: currently OOMs or churns CPU for a long time instead of
-    // throwing. Remove the next line when fixed.
-    return;
-
-    // 1e10000000 is stored compactly as (unscaled=1, scale=-100000000), but
-    // adding 1 to it forces alignment of decimal points, allocating 100 million
-    // digits and running out of memory.
     auto make_decimal = [](const char* s) -> constant {
         return constant(raw_value::make_value(managed_bytes(decimal_type->decompose(big_decimal(s)))), decimal_type);
     };
-    BOOST_REQUIRE_THROW(
-        eval_add(make_decimal("1e100000000"), make_decimal("1")),
-        exceptions::invalid_request_exception);
+    big_decimal result = raw_to<big_decimal>(
+        eval_add(make_decimal("1e100000000"), make_decimal("1")), decimal_type);
+    BOOST_REQUIRE_EQUAL(result.to_string(), big_decimal("1e100000000").to_string());
 }
 
 // Adding two different numeric types is currently not supported and should

--- a/test/cqlpy/test_lwt.py
+++ b/test/cqlpy/test_lwt.py
@@ -9,6 +9,9 @@
 #############################################################################
 
 import re
+import sys
+from decimal import Decimal
+
 import pytest
 from cassandra.protocol import InvalidRequest, SyntaxException
 
@@ -444,18 +447,70 @@ def test_lwt_counter_syntax_float_on_integer(cql, table1, scylla_only):
     with pytest.raises(TypeError):
         cql.execute(dec_stmt, [3.5, p, 1])
 
-# Test that trying to add "decimal" values with wildly different scales is
-# rejected with an error, not allowed to proceed with ridiculous amount of
-# CPU and memory usage. Reproduces SCYLLADB-1576.
-# This test needs to be skipped while SCYLLADB-1576 is not fixed, otherwise
-# it will cause the test suite to hang or crash.
-@pytest.mark.skip_bug(reason="SCYLLADB-1576: hangs or OOMs instead of rejecting")
+# Test that trying to add "decimal" values with wildly different scales
+# is silently truncated to limited precision. Following Cassandra's lead in
+# CASSANDRA-15232 we limit add's precision to 10,000 digits. If we didn't
+# limit the result's precision, adding 1 to 1e100000000 would cause the server
+# to try to allocate memory for 100 million digits.
+# Reproduces SCYLLADB-1576.
 def test_lwt_counter_syntax_decimal_magnitude_difference(cql, test_keyspace, scylla_only):
-    # 1e100000000 is stored compactly as (unscaled=1, scale=-100000000), but
-    # adding 1 to it forces alignment of decimal points, potentially allocating
-    # 100 million digits and running out of memory.
+    MAX_PRECISION = 10000
     with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, d decimal') as table:
         p = unique_key_int()
         cql.execute(f"INSERT INTO {table} (p, d) VALUES ({p}, 1e100000000)")
-        with pytest.raises(InvalidRequest):
+        cql.execute(f"UPDATE {table} SET d = d + 1 WHERE p = {p} IF EXISTS")
+        result = cql.execute(f"SELECT d FROM {table} WHERE p = {p}").one().d
+        # The 1 is insignificant compared to 1e100000000 at 10,000-digit precision.
+        assert result == Decimal('1E+100000000')
+
+# Let's expand on test_lwt_counter_syntax_decimal_magnitude_difference testing
+# more accurately how "SET r = r + 1" behaves with large decimal values.
+# We test that adding 1 to a decimal with fewer than MAX_PRECISION digits gives
+# an accurate result, and that adding 1 to a decimal with exactly MAX_PRECISION
+# digits silently loses the added 1 (truncated to MAX_PRECISION digits).
+# This is the LWT equivalent of test_decimal_add_precision in
+# test_type_decimal.py.
+# Reproduces SCYLLADB-1576.
+def test_lwt_counter_syntax_decimal_add_precision(cql, test_keyspace, scylla_only):
+    MAX_PRECISION = 10000
+    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, d decimal') as table:
+        old_limit = sys.get_int_max_str_digits()
+        sys.set_int_max_str_digits(MAX_PRECISION * 2)
+        try:
+            # 1e9999 + 1 produces the correct 10,000-digit result.
+            # 10,000 digits is exactly MAX_PRECISION, so no truncation happens.
+            p = unique_key_int()
+            cql.execute(f"INSERT INTO {table} (p, d) VALUES ({p}, 1e{MAX_PRECISION-1})")
             cql.execute(f"UPDATE {table} SET d = d + 1 WHERE p = {p} IF EXISTS")
+            result = cql.execute(f"SELECT d FROM {table} WHERE p = {p}").one().d
+            assert result == Decimal('1' + '0' * (MAX_PRECISION - 2) + '1')
+            # 1e10000 + 1 would have 10,001 digits of precision, but Scylla
+            # limits the precision to just 10,000 digits so the last digit will
+            # be zeroed out, and the result of the addition will be just 1e10000.
+            # Note that this truncation of the result is silent, it is not an error.
+            p = unique_key_int()
+            cql.execute(f"INSERT INTO {table} (p, d) VALUES ({p}, 1e{MAX_PRECISION})")
+            cql.execute(f"UPDATE {table} SET d = d + 1 WHERE p = {p} IF EXISTS")
+            result = cql.execute(f"SELECT d FROM {table} WHERE p = {p}").one().d
+            assert result == Decimal('1e' + str(MAX_PRECISION))
+            # Check that the "truncation" of extra digits is actually HALF_UP
+            # rounding: 1e10000 + 5 has 10001 digits (10000...005), the 10001st
+            # digit is 5, so HALF_UP rounds the 10000th digit (0) up to 1:
+            # result is 10000...010 (= 10^10000 + 10), not 10000...000 (= 10^10000).
+            # Note: HALF_EVEN would give 10^10000 here (0 is even), so this
+            # assertion specifically verifies Java's HALF_UP rounding mode.
+            p = unique_key_int()
+            cql.execute(f"INSERT INTO {table} (p, d) VALUES ({p}, 1e{MAX_PRECISION})")
+            cql.execute(f"UPDATE {table} SET d = d + 5 WHERE p = {p} IF EXISTS")
+            result = cql.execute(f"SELECT d FROM {table} WHERE p = {p}").one().d
+            assert result == Decimal('1' + '0' * (MAX_PRECISION - 2) + '10')
+            # For negative numbers, HALF_UP rounds away from zero (towards -inf),
+            # so -1e10000 - 5 = -(10^10000 + 5) rounds to -(10^10000 + 10),
+            # not -(10^10000).
+            p = unique_key_int()
+            cql.execute(f"INSERT INTO {table} (p, d) VALUES ({p}, -1e{MAX_PRECISION})")
+            cql.execute(f"UPDATE {table} SET d = d - 5 WHERE p = {p} IF EXISTS")
+            result = cql.execute(f"SELECT d FROM {table} WHERE p = {p}").one().d
+            assert result == Decimal('-1' + '0' * (MAX_PRECISION - 2) + '10')
+        finally:
+            sys.set_int_max_str_digits(old_limit)

--- a/test/cqlpy/test_type_decimal.py
+++ b/test/cqlpy/test_type_decimal.py
@@ -87,7 +87,7 @@ def test_decimal_clustering_key_inline_high_precision(cql, table1):
 #     [note: Integer.MIN_VALUE=-2147483648, Integer.MAX_VALUE=2147483647]
 # This test passes on Cassandra 3 but fails on Cassandra 4 and 5 due to
 # CASSANDRA-20723 which limits the exponent to 309.
-def test_decimal_clustering_key_inline_overflow_exponent(cql, table1):
+def test_decimal_clustering_key_inline_overflow_exponent(cql, table1, cassandra_bug):
     p = unique_key_int()
     # The following numbers all have an exponent that is itself (without
     # any fractional part) already above the scale limit.
@@ -302,18 +302,26 @@ def test_decimal_si_and_mv_representation(cql, test_keyspace):
 # Adding two decimals with very different scales in operator+= rescales
 # both operands to the larger scale via pow(10, scale_diff). CQL's
 # decimal type allows arbitrary scales (int32 range), so a table with
-# values like 1e1000000000 and 1 forces pow(10, 1000000000) when
-# computing SUM() or AVG(), allocating a number with ~1 billion digits.
+# values like 1e500000000 and 1 forces pow(10, 500000000) when
+# computing SUM() or AVG(), allocating a number with ~500 million digits.
 # This is the same class of DoS as issue #8002 (to_string OOM)
 # but in arithmetic.
-# This test is skipped because it would hang or crash the tests.
+# Cassandra has the same bug - whereas its arithmetic operations limit
+# the precision of the result to 10,000 digits (see tests below), for
+# aggregation sum() that we test here, it does not (CASSANDRA-21401).
+# We use the number 500 million and not higher because in Cassandra's
+# implementation, BitInteger (used to store the mantissa) has a hard
+# limit of around 537 million decimal digits (537M = 2^31/4 - where
+# 4=bitlength(10) was used by the Java code - incorrectly - instead of
+# log2(10) - to limit the number of binary digits to 2^31). So using 500
+# million digits can allow us to run this test on Cassandra - while still
+# timing out or OOMing if this bug exists.
 # Reproduces SCYLLADB-1576
-@pytest.mark.skip_bug(reason="SCYLLADB-1576")
-def test_decimal_sum_extreme_scale_oom(cql, test_keyspace):
+def test_decimal_sum_extreme_scale_oom(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace,
             "p int, c decimal, PRIMARY KEY (p)") as table:
         stmt = cql.prepare(f"INSERT INTO {table} (p, c) VALUES (?, ?)")
-        cql.execute(stmt, [1, Decimal('1e1000000000')])
+        cql.execute(stmt, [1, Decimal('1e500000000')])
         cql.execute(stmt, [2, Decimal('1')])
         result = list(cql.execute(f"SELECT sum(c) FROM {table}"))
         assert len(result) == 1

--- a/utils/big_decimal.cc
+++ b/utils/big_decimal.cc
@@ -9,6 +9,7 @@
 #include "utils/assert.hh"
 #include "big_decimal.hh"
 #include <cassert>
+#include <numbers>
 #include "marshal_exception.hh"
 #include <seastar/core/format.hh>
 
@@ -301,32 +302,127 @@ std::strong_ordering big_decimal::tri_cmp_positive_nonzero_different_scale(const
     return int64_t(-diff_scale) <=> 0;
 }
 
+// Maximum number of significant decimal digits for addition/subtraction,
+// matching Cassandra's DecimalType.MAX_PRECISION (CASSANDRA-15232). Such
+// a limitation is necessary to avoid unlimited allocation when adding numbers
+// with wildly different scales - see SCYLLADB-1576.
+// Results exceeding this are silently rounded using HALF_UP (round half away
+// from zero), preventing unbounded memory growth.
+static constexpr int BIG_DECIMAL_MAX_PRECISION = 10000;
+
+// Round 'unscaled' to at most BIG_DECIMAL_MAX_PRECISION significant digits
+// using HALF_UP rounding (round half away from zero, matching Java's
+// RoundingMode.HALF_UP). Adjusts 'scale' to compensate for dropped digits.
+static void round_to_max_precision(boost::multiprecision::cpp_int& unscaled, int32_t& scale) {
+    if (unscaled == 0) {
+        return;
+    }
+    boost::multiprecision::cpp_int abs_u = boost::multiprecision::abs(unscaled);
+    // Fast path: use msb() as an upper bound on digit count.
+    // A number with msb position k has at most floor((k+1)*log10(2))+1 decimal digits.
+    // We need floor((k+1)*log10(2))+1 <= BIG_DECIMAL_MAX_PRECISION,
+    // i.e. k <= floor(BIG_DECIMAL_MAX_PRECISION * log2(10)) - 1.
+    // This avoids the expensive abs_u.str() call in the common case.
+    static constexpr double log2_10 = std::numbers::ln10 / std::numbers::ln2;
+    static constexpr unsigned int fast_exit_msb =
+        static_cast<unsigned int>(BIG_DECIMAL_MAX_PRECISION * log2_10) - 1;
+    if (boost::multiprecision::msb(abs_u) <= fast_exit_msb) [[likely]] {
+        return;
+    }
+    int num_digits = static_cast<int>(abs_u.str().size());
+    if (num_digits <= BIG_DECIMAL_MAX_PRECISION) {
+        return;
+    }
+    int excess = num_digits - BIG_DECIMAL_MAX_PRECISION;
+    boost::multiprecision::cpp_int divisor = boost::multiprecision::pow(boost::multiprecision::cpp_int(10), excess);
+    boost::multiprecision::cpp_int quotient = abs_u / divisor;
+    boost::multiprecision::cpp_int remainder = abs_u % divisor;
+    // HALF_UP: round away from zero when remainder * 2 >= divisor.
+    // This applies to both positive and negative numbers (away from zero).
+    if (remainder * 2 >= divisor) {
+        quotient += 1;
+        // A carry may have produced one extra digit (e.g., 999…9 + 1 = 10^MAX_PRECISION).
+        // Use the already-computed msb threshold to detect and correct this without
+        // a costly .str() call: any number with <= MAX_PRECISION decimal digits has
+        // msb <= fast_exit_msb, so msb > fast_exit_msb means one digit too many.
+        if (boost::multiprecision::msb(quotient) > fast_exit_msb) {
+            quotient /= 10;  // exact: carry result is always 10^MAX_PRECISION
+            ++excess;
+        }
+    }
+    unscaled = (unscaled < 0) ? -quotient : quotient;
+    // Dropping 'excess' low-order digits: the scale (number of fractional digits)
+    // decreases by 'excess', preserving the approximate value.
+    scale -= excess;
+}
+
 big_decimal& big_decimal::operator+=(const big_decimal& other)
 {
     if (_scale == other._scale) {
         _unscaled_value += other._unscaled_value;
-    } else {
-        boost::multiprecision::cpp_int rescale(10);
-        auto max_scale = std::max(_scale, other._scale);
-        boost::multiprecision::cpp_int u = _unscaled_value * boost::multiprecision::pow(rescale,  max_scale - _scale);
-        boost::multiprecision::cpp_int v = other._unscaled_value * boost::multiprecision::pow(rescale, max_scale - other._scale);
-        _unscaled_value = u + v;
-        _scale = max_scale;
+        round_to_max_precision(_unscaled_value, _scale);
+        return *this;
     }
+    boost::multiprecision::cpp_int rescale(10);
+    auto max_scale = std::max(_scale, other._scale);
+    // Shifts needed to align each operand to max_scale; one is always 0.
+    int64_t shift_this = (int64_t)max_scale - _scale;
+    int64_t shift_other = (int64_t)max_scale - other._scale;
+    // Assume (invariant maintained by round_to_max_precision) that both inputs
+    // have fewer than P = BIG_DECIMAL_MAX_PRECISION significant digits, so each
+    // unscaled value < 10^P.  When shift_this > 2*P, the aligned dominant
+    // operand u = _unscaled_value * 10^shift_this >= 10^(2P+1), while the
+    // dominated operand v = other._unscaled_value < 10^P, giving v/u < 10^(-P-1).
+    // In other words, 'other' is smaller than 1 unit in the (P+1)-th significant
+    // digit of '*this' and cannot affect the top P digits of the rounded result.
+    // Dropping it avoids allocating huge intermediate values (DoS/OOM protection,
+    // fixes SCYLLADB-1576).
+    constexpr int64_t max_safe_shift = 2LL * BIG_DECIMAL_MAX_PRECISION;
+    if (shift_this > max_safe_shift) {
+        // *this dominates; other is insignificant.
+        return *this;
+    }
+    if (shift_other > max_safe_shift) {
+        // other dominates; *this is insignificant.
+        _unscaled_value = other._unscaled_value;
+        _scale = other._scale;
+        return *this;
+    }
+    boost::multiprecision::cpp_int u = _unscaled_value * boost::multiprecision::pow(rescale, (uint32_t)shift_this);
+    boost::multiprecision::cpp_int v = other._unscaled_value * boost::multiprecision::pow(rescale, (uint32_t)shift_other);
+    _unscaled_value = u + v;
+    _scale = max_scale;
+    round_to_max_precision(_unscaled_value, _scale);
     return *this;
 }
 
 big_decimal& big_decimal::operator-=(const big_decimal& other) {
     if (_scale == other._scale) {
         _unscaled_value -= other._unscaled_value;
-    } else {
-        boost::multiprecision::cpp_int rescale(10);
-        auto max_scale = std::max(_scale, other._scale);
-        boost::multiprecision::cpp_int u = _unscaled_value * boost::multiprecision::pow(rescale,  max_scale - _scale);
-        boost::multiprecision::cpp_int v = other._unscaled_value * boost::multiprecision::pow(rescale, max_scale - other._scale);
-        _unscaled_value = u - v;
-        _scale = max_scale;
+        round_to_max_precision(_unscaled_value, _scale);
+        return *this;
     }
+    boost::multiprecision::cpp_int rescale(10);
+    auto max_scale = std::max(_scale, other._scale);
+    int64_t shift_this = (int64_t)max_scale - _scale;
+    int64_t shift_other = (int64_t)max_scale - other._scale;
+    // See operator+= for the derivation of max_safe_shift.
+    constexpr int64_t max_safe_shift = 2LL * BIG_DECIMAL_MAX_PRECISION;
+    if (shift_this > max_safe_shift) {
+        // *this dominates; other is insignificant.
+        return *this;
+    }
+    if (shift_other > max_safe_shift) {
+        // other dominates; result ≈ -other.
+        _unscaled_value = -other._unscaled_value;
+        _scale = other._scale;
+        return *this;
+    }
+    boost::multiprecision::cpp_int u = _unscaled_value * boost::multiprecision::pow(rescale, (uint32_t)shift_this);
+    boost::multiprecision::cpp_int v = other._unscaled_value * boost::multiprecision::pow(rescale, (uint32_t)shift_other);
+    _unscaled_value = u - v;
+    _scale = max_scale;
+    round_to_max_precision(_unscaled_value, _scale);
     return *this;
 }
 


### PR DESCRIPTION
This patch fixes SCYLLADB-1576, a long-standing bug where adding (or subtracting) two "decimal" values with wildly different scales — for example 1e100000000 + 1 — previously required aligning decimal points, which meant allocating ~100 million digits and either exhausting memory or spending a ridiculous amount of CPU for a tiny operation.
    
Fix by matching Cassandra's solution from CASSANDRA-15232: cap the result of addition and subtraction to BIG_DECIMAL_MAX_PRECISION = 10000 significant digits, rounding with HALF_UP (round half away from zero,    matching Java's RoundingMode.HALF_UP).
    
Implementation details in big_decimal.cc:

  * operator+= and operator-= recognize when the magnitude and the two
      inputs is so different that one of them doesn't change any digit
      in the result before the 10,000th digit. In this case, no addition is
      actually done, and the CPU or memory exhaustion is avoided.
    
   * When the addition needs to be done, it is done an then we call
      round_to_max_precision() to round the result to only 10,000 digits
      of precision.
    
   * round_to_max_precision() rounds an unscaled value to at most
      BIG_DECIMAL_MAX_PRECISION digits, adjusting scale to compensate.
      A fast path uses msb() as an O(1) upper bound on the digit count,
      avoiding the expensive .str() call for the overwhelmingly common
      case where the numbers don't have 10,000 digits of precision, so
      no rounding is needed at all.
    
Also update all affected tests:

   * big_decimal_test.cc: new test_big_decimal_add_precision and
      test_big_decimal_sub_precision covering exact, round-down,
      round-up (HALF_UP), negative, and large-magnitude cases.
   * expr_test.cc: evaluate_add_large_magnitude now verifies the rounded
      result instead of expecting a throw.
   * a few more tests in test/cqlpy now pass.
    
Fixes: SCYLLADB-1576

This can be considered a bug fix (maybe even a DoS-related fix), however it has been in our code for years and nobody except test-writers ever complained, so it's probably not worth backporting. 