### PR TITLE
cql: detect and reject conflicting LWT arithmetic SET operations

### DIFF
--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -365,6 +365,15 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
 
     computed_function_values cached_fn_calls;
 
+    // Track LWT arithmetic columns and clustering key per statement to detect conflicts:
+    // if two statements target the same row and both do arithmetic on the same column,
+    // they both compute from the pre-batch value and the result would be incorrect.
+    struct stmt_col_info {
+        bytes ck_bytes;        // serialized clustering key, identifies the row within the partition
+        column_set lwt_cols;   // columns subject to LWT arithmetic (SET col = col +/- val)
+    };
+    std::vector<stmt_col_info> seen_stmts;
+
     for (size_t i = 0; i < _statements.size(); ++i) {
 
         modification_statement& statement = *_statements[i].statement;
@@ -386,6 +395,30 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
         cached_fn_calls.merge(std::move(const_cast<cql3::query_options&>(statement_options).take_cached_pk_function_calls()));
 
         std::vector<query::clustering_range> ranges = statement.create_clustering_ranges(statement_options, json_cache);
+
+        if (statement.requires_lwt()) {
+            column_set my_lwt_cols = statement.lwt_arithmetic_columns();
+            if (my_lwt_cols.count() > 0) {
+                // LWT arithmetic UPDATEs always target a specific row; extract its key.
+                bytes my_ck_bytes = (!ranges.empty() && ranges.front().start())
+                        ? to_bytes(ranges.front().start()->value().representation())
+                        : bytes{};
+                for (const auto& prev : seen_stmts) {
+                    if (prev.ck_bytes != my_ck_bytes) {
+                        continue;
+                    }
+                    // Conflict: both statements do arithmetic on the same column in the same row.
+                    for (auto id = prev.lwt_cols.find_first(); id != column_set::npos; id = prev.lwt_cols.find_next(id)) {
+                        if (my_lwt_cols.test(id)) {
+                            throw exceptions::invalid_request_exception(
+                                format("Multiple arithmetic SET operations on column {} targeting the same row in the same BATCH",
+                                       schema->column_at(id).name_as_text()));
+                        }
+                    }
+                }
+                seen_stmts.emplace_back(stmt_col_info{std::move(my_ck_bytes), std::move(my_lwt_cols)});
+            }
+        }
 
         request->add_row_update(statement, std::move(ranges), std::move(json_cache), statement_options);
     }

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -763,6 +763,16 @@ void modification_statement::add_operation(::shared_ptr<operation> op) {
 
     if (op->requires_lwt()) {
         _requires_lwt = true;
+        // If we have two operations on the same column, e.g., 'r = r + 1,
+        // r = r + 2', both would use the same old value of r and the result
+        // will not be useful. So it's not allowed.
+        for (const auto& existing : _column_operations) {
+            if (existing->requires_lwt() && existing->column.ordinal_id == op->column.ordinal_id) {
+                throw exceptions::invalid_request_exception(
+                    format("Multiple arithmetic SET operations on column {} in the same statement",
+                           op->column.name_as_text()));
+            }
+        }
     }
 
     if (op->column.is_counter()) {
@@ -774,6 +784,16 @@ void modification_statement::add_operation(::shared_ptr<operation> op) {
     }
 
     _column_operations.push_back(std::move(op));
+}
+
+column_set modification_statement::lwt_arithmetic_columns() const {
+    column_set result(s->all_columns_count());
+    for (const auto& op : _column_operations) {
+        if (op->requires_lwt()) {
+            result.set(op->column.ordinal_id);
+        }
+    }
+    return result;
 }
 
 void modification_statement::inc_cql_stats(bool is_internal) const {

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -192,6 +192,12 @@ public:
     // True if any of the update operations requires LWT for atomicity.
     bool requires_lwt() const { return _requires_lwt; }
 
+    // Returns the set of columns that are the target of LWT arithmetic operations
+    // (e.g., r in SET r = r + 1). These columns are both read (for the old value)
+    // and written (with the computed result), making them sensitive to stale reads
+    // when multiple statements in a batch touch the same row.
+    column_set lwt_arithmetic_columns() const;
+
     // Columns used in this statement conditions or operations.
     const column_set& columns_to_read() const { return _columns_to_read; }
 

--- a/test/cqlpy/test_lwt.py
+++ b/test/cqlpy/test_lwt.py
@@ -330,6 +330,38 @@ def test_lwt_counter_syntax_numeric_types(cql, test_keyspace, scylla_only):
             row = cql.execute(f'SELECT {col} FROM {table} WHERE p = {p}').one()
             assert getattr(row, col) == 1, f'expected 1 after subtraction for type {t}, got {getattr(row, col)}'
 
+# Two arithmetic operations on the same column, e.g., SET r = r + 1, r = r + 2
+# should not be allowed in the same UPDATE because both will use the same old
+# value of r and will give nonsensical results.
+def test_lwt_counter_syntax_double_update(cql, table1, scylla_only):
+    p = unique_key_int()
+    with pytest.raises(InvalidRequest):
+        cql.execute(f'UPDATE {table1} SET r = r + 1, r = r + 2 WHERE p={p} AND c=1 IF EXISTS')
+    with pytest.raises(InvalidRequest):
+        cql.execute(f'UPDATE {table1} SET r = r - 1, r = r - 2 WHERE p={p} AND c=1 IF EXISTS')
+    with pytest.raises(InvalidRequest):
+        cql.execute(f'UPDATE {table1} SET r = r + 1, r = r - 2 WHERE p={p} AND c=1 IF EXISTS')
+
+# Two arithmetic operations on the same column in separate statements of the
+# same BATCH targeting the same row also should not be allowed: both statements
+# will read the same old value of r and write back independently, giving the
+# wrong result. This is a Scylla extension (issue #10568).
+def test_lwt_counter_syntax_double_update_batch(cql, table1, scylla_only):
+    p = unique_key_int()
+    # Two separate statements in the same BATCH targeting the same row and column
+    # both use the old value of r for their arithmetic, so the result would be wrong.
+    # This must be rejected.
+    with pytest.raises(InvalidRequest, match='BATCH'):
+        cql.execute(f'BEGIN BATCH UPDATE {table1} SET r = r + 1 WHERE p={p} AND c=1 IF EXISTS; UPDATE {table1} SET r = r + 2 WHERE p={p} AND c=1 IF EXISTS; APPLY BATCH')
+    with pytest.raises(InvalidRequest, match='BATCH'):
+        cql.execute(f'BEGIN BATCH UPDATE {table1} SET r = r - 1 WHERE p={p} AND c=1 IF EXISTS; UPDATE {table1} SET r = r - 2 WHERE p={p} AND c=1 IF EXISTS; APPLY BATCH')
+    # Two statements on different rows (different c) may each do arithmetic on r - no conflict.
+    cql.execute(f'UPDATE {table1} SET r = 0 WHERE p={p} AND c=1 IF r = null')
+    cql.execute(f'UPDATE {table1} SET r = 0 WHERE p={p} AND c=2 IF r = null')
+    cql.execute(f'BEGIN BATCH UPDATE {table1} SET r = r + 1 WHERE p={p} AND c=1 IF EXISTS; UPDATE {table1} SET r = r + 2 WHERE p={p} AND c=2 IF EXISTS; APPLY BATCH')
+    assert list(cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=1'))[0].r == 1
+    assert list(cql.execute(f'SELECT r FROM {table1} WHERE p={p} AND c=2'))[0].r == 2
+
 # Currently, the syntax "SET r = p + 1" (different column on LHS and RHS) is
 # NOT allowed - the CQL grammar only allows "X = X +/- value", so mismatching
 # columns is a syntax error, regardless of whether the statement has an IF


### PR DESCRIPTION
When multiple SET operations in the same statement (or in the same BATCH) target the same column with arithmetic (e.g., SET r = r + 1, r = r + 2), the result is wrong because all operations read the same pre-operation   value of r. Detect and reject such conflicts at prepare time with a clear error message.
    
Two cases are handled:
1. Within a single UPDATE: adding the same column twice with arithmetic is rejected in modification_statement::add_operation().
2. Across statements in a BATCH: if two statements target the same row and both have LWT arithmetic on the same column, the batch is rejected in batch_statement::execute_without_conditions().
