### PR TITLE
cql3/restrictions: lazily allocate _idx_tbl_ck_prefix behind unique_ptr (24 bytes saved per non-index statement)

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -2465,14 +2465,14 @@ void statement_restrictions::prepare_indexed_global(const schema& idx_tbl_schema
         // This means that p1 and p2 can have many different values (token is a hash, can have collisions).
         // Clustering prefix ends after token_restriction, all further restrictions have to be filtered.
         expr::expression token_restriction = replace_partition_token(_partition_key_restrictions, token_column, *_schema);
-        _idx_tbl_ck_prefix = std::vector{to_predicate_on_column(token_restriction, token_column, _schema.get())};
+        _idx_tbl_ck_prefix = std::make_unique<std::vector<predicate>>(std::vector{to_predicate_on_column(token_restriction, token_column, _schema.get())});
 
         return;
     }
 
     // If we're here, it means the index cannot be on a partition column: process_partition_key_restrictions()
     // avoids indexing when _partition_range_is_simple.  See _idx_tbl_ck_prefix blurb for its composition.
-    _idx_tbl_ck_prefix = std::vector<predicate>(1 + _schema->partition_key_size(), predicate{
+    _idx_tbl_ck_prefix = std::make_unique<std::vector<predicate>>(1 + _schema->partition_key_size(), predicate{
         .solve_for = nullptr,  // FIXME: this is all overwritten later. Should be refactored.
         .filter = expr::expression(expr::conjunction{}),
         .on = on_column{nullptr}, // Illegal but will be overwritten
@@ -2554,7 +2554,7 @@ void statement_restrictions::prepare_indexed_local(const schema& idx_tbl_schema,
     }
 
     // Local index clustering key is (indexed column, base clustering key)
-    _idx_tbl_ck_prefix = std::vector<predicate>();
+    _idx_tbl_ck_prefix = std::make_unique<std::vector<predicate>>();
     _idx_tbl_ck_prefix->reserve(1 + _clustering_prefix_restrictions.size());
 
     const column_definition& indexed_column = idx_tbl_schema.column_at(column_kind::clustering_key, 0);
@@ -2640,7 +2640,7 @@ std::vector<query::clustering_range> statement_restrictions::get_global_index_cl
 
 get_clustering_bounds_fn_t
 statement_restrictions::build_get_global_index_token_clustering_ranges_fn() const {
-    if (!_idx_tbl_ck_prefix.has_value()) {
+    if (!_idx_tbl_ck_prefix) {
         return {};
     }
 
@@ -2666,7 +2666,7 @@ std::vector<query::clustering_range> statement_restrictions::get_global_index_to
 
 get_clustering_bounds_fn_t
 statement_restrictions::build_get_local_index_clustering_ranges_fn() const {
-    if (!_idx_tbl_ck_prefix.has_value()) {
+    if (!_idx_tbl_ck_prefix) {
         return {};
     }
 

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -203,7 +203,7 @@ private:
     /// Elements are conjunctions of single-column binary operators with the same LHS.
     /// Element order follows the indexing-table clustering key.
     /// In case of a global index the first element's (token restriction) RHS is a dummy value, it is filled later.
-    std::optional<std::vector<predicate>> _idx_tbl_ck_prefix;
+    std::unique_ptr<std::vector<predicate>> _idx_tbl_ck_prefix;
 
     /// Parts of _where defining the partition range.
     ///


### PR DESCRIPTION
## Motivation

`statement_restrictions` is 576 bytes (9 cache lines). The `_idx_tbl_ck_prefix` field is `std::optional<std::vector<predicate>>` occupying 32 bytes inline, but is only populated for index-backed queries.

## Savings

**24 bytes per non-index statement** (32B inline optional → 8B unique_ptr).

For context, combined savings from the stack:
- #30036 (lazy index fns): 120B/stmt
- #30046 (idx_opt): 128B/stmt
- #30043 (not_null_columns): 48B/stmt
- #30045 (columns_to_read): 24B/stmt

## Measured Impact

**Performance: neutral.** perf_simple_query: 32,660 insns/op before and after. No regression.

## Changes

- `std::optional<std::vector<predicate>>` → `std::unique_ptr<std::vector<predicate>>`
- Assignments use `std::make_unique`
- `.has_value()` → implicit bool conversion

No functional change.

Refs: #29047