### PR TITLE
logstor: fix compaction state removal

### DIFF
--- a/replica/logstor/compaction.hh
+++ b/replica/logstor/compaction.hh
@@ -218,6 +218,7 @@ public:
     virtual void submit(replica::compaction_group&) = 0;
 
     virtual future<> stop_ongoing_compactions(replica::compaction_group&) = 0;
+    virtual future<> remove(replica::compaction_group&) = 0;
 
     virtual future<compaction_reenabler> disable_compaction(replica::compaction_group&) = 0;
     virtual compaction_reenabler disable_compaction_no_wait(replica::compaction_group&) = 0;

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -439,17 +439,12 @@ public:
 
     void submit(compaction_group&) override;
     future<> stop_ongoing_compactions(compaction_group&) override;
+    future<> remove(compaction_group&) override;
     future<compaction_reenabler> disable_compaction(replica::compaction_group&) override;
     compaction_reenabler disable_compaction_no_wait(replica::compaction_group&) override;
     future<> split_compaction(replica::table&, compaction_group&, mutation_writer::classify_by_token_group) override;
 
 private:
-
-    void maybe_erase_state(group_compaction_state_map::iterator it) {
-        if (it->second->is_empty()) {
-            _groups.erase(it);
-        }
-    }
 
     std::vector<log_segment_id> select_segments_for_compaction(const segment_descriptor_hist&);
     future<> do_compact(compaction_group&, abort_source&);
@@ -1418,7 +1413,11 @@ future<> compaction_manager_impl::stop_ongoing_compactions(compaction_group& cg)
     auto& state = *it->second;
     state.as.request_abort();
     co_await state.completion.get_future();
-    _groups.erase(it);
+}
+
+future<> compaction_manager_impl::remove(compaction_group& cg) {
+    co_await stop_ongoing_compactions(cg);
+    _groups.erase(&cg);
 }
 
 future<compaction_reenabler> compaction_manager_impl::disable_compaction(compaction_group& cg) {
@@ -1437,7 +1436,6 @@ future<compaction_reenabler> compaction_manager_impl::disable_compaction(compact
         auto it = _groups.find(&cg);
         if (it != _groups.end()) {
             --it->second->compaction_disabled_counter;
-            maybe_erase_state(it);
         }
     });
 }
@@ -1455,7 +1453,6 @@ compaction_reenabler compaction_manager_impl::disable_compaction_no_wait(compact
         auto it = _groups.find(&cg);
         if (it != _groups.end()) {
             --it->second->compaction_disabled_counter;
-            maybe_erase_state(it);
         }
     });
 }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3217,6 +3217,9 @@ future<> compaction_group::stop(sstring reason) noexcept {
   for (auto view : all_views()) {
     co_await _t._compaction_manager.remove(*view, reason);
   }
+    if (_t.uses_logstor()) {
+        co_await get_logstor_compaction_manager().remove(*this);
+    }
 
     if (flush_future.failed()) {
         co_await seastar::coroutine::return_exception_ptr(flush_future.get_exception());


### PR DESCRIPTION
previously the logstor compaction state for a compaction group could be removed by a compaction reenabler guard. this caused an invalid access in stop_ongoing_compactions, because it holds an iterator to the compaction state across a yield point, so the iterator can be invalidated if erased by another source concurrently.

we change the compaction state removal to be done only in a remove() function that is called when the compaction group is stopped, after waiting for ongoing compaction to stop and after the gates are closed. this is safer because we keep the compaction state while the compaction group exists, and remove it only when it's stopped and there are no compactions in progress. this is similar to compaction state removal for non-logstor tables in compaction_group::stop.

Fixes SCYLLADB-2199

this is a recent regression so no need for backport, but I will apply the fix to the backport https://github.com/scylladb/scylladb/pull/30059 in order to not introduce the regression there