### PR TITLE
replica: add support for tablet aware restore to alter the tablet hints prior to starting the transitions

### DIFF
--- a/locator/tablet_sharder.hh
+++ b/locator/tablet_sharder.hh
@@ -15,6 +15,39 @@
 
 namespace locator {
 
+// Returns the shard of the replica for the given host in the replica set,
+// or nullopt if the host is not in the set.
+inline std::optional<shard_id> get_shard(const tablet_replica_set& replicas, host_id host) {
+    for (auto&& r : replicas) {
+        if (r.host == host) {
+            return r.shard;
+        }
+    }
+    return std::nullopt;
+}
+
+// Returns the shard that should serve reads for a given tablet on the given host,
+// taking into account any in-progress tablet transition.
+// Returns nullopt if the host does not own a replica for this tablet.
+inline std::optional<shard_id> get_shard_for_reads(const tablet_map& tmap, tablet_id tid, host_id host) {
+    auto& tinfo = tmap.get_tablet_info(tid);
+    auto* trinfo = tmap.get_tablet_transition_info(tid);
+
+    if (!trinfo) {
+        return get_shard(tinfo.replicas, host);
+    }
+
+    // See "Shard assignment stability" from doc/dev/topology-over-raft.md for explanation of logic.
+    if (trinfo->pending_replica && trinfo->pending_replica->host == host) {
+        if (trinfo->transition == tablet_transition_kind::intranode_migration && trinfo->reads == read_replica_set_selector::previous) {
+            return get_shard(tinfo.replicas, host);
+        }
+        return trinfo->pending_replica->shard;
+    }
+
+    return get_shard(tinfo.replicas, host);
+}
+
 /// Implements sharder object which reflects assignment of tablets of a given table to local shards.
 /// Token ranges which don't have local tablets are reported to belong to shard 0.
 class tablet_sharder : public dht::sharder {
@@ -30,15 +63,6 @@ private:
             _tmap = &_tm.tablets().get_tablet_map(_table);
         }
     }
-
-    std::optional<unsigned> get_shard(const tablet_replica_set& replicas, host_id host) const {
-        for (auto&& r : replicas) {
-            if (r.host == host) {
-                return r.shard;
-            }
-        }
-        return std::nullopt;
-    };
 
     dht::shard_replica_set choose_shard_for_writes(tablet_id tid, host_id host, std::optional<write_replica_set_selector> sel = std::nullopt) const {
         auto* trinfo = _tmap->get_tablet_transition_info(tid);
@@ -80,23 +104,7 @@ private:
 
     std::optional<shard_id> choose_shard_for_reads(tablet_id tid, host_id host) const {
         ensure_tablet_map();
-        auto* trinfo = _tmap->get_tablet_transition_info(tid);
-        auto& tinfo = _tmap->get_tablet_info(tid);
-
-        if (!trinfo) {
-            return get_shard(tinfo.replicas, host);
-        }
-
-        // See "Shard assignment stability" from doc/dev/topology-over-raft.md for explanation of logic.
-
-        if (trinfo->pending_replica && trinfo->pending_replica->host == host) {
-            if (trinfo->transition == tablet_transition_kind::intranode_migration && trinfo->reads == read_replica_set_selector::previous) {
-                return get_shard(tinfo.replicas, host);
-            }
-            return trinfo->pending_replica->shard;
-        }
-
-        return get_shard(tinfo.replicas, host);
+        return get_shard_for_reads(*_tmap, tid, host);
     }
 public:
     tablet_sharder(const token_metadata& tm, table_id table, std::optional<host_id> host = std::nullopt)
@@ -162,7 +170,7 @@ public:
         auto* trinfo = _tmap->get_tablet_transition_info(tid);
         auto& tinfo = _tmap->get_tablet_info(tid);
 
-        auto shard = get_shard(tinfo.replicas, _host).value_or(0);
+        auto shard = locator::get_shard(tinfo.replicas, _host).value_or(0);
 
         if (!trinfo) {
             return {shard};

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1236,26 +1236,24 @@ lw_shared_ptr<load_stats> load_stats::migrate_tablet_size(locator::host_id leavi
     return result;
 }
 
-tablet_range_splitter::tablet_range_splitter(schema_ptr schema, const tablet_map& tablets, host_id host, const dht::partition_range_vector& ranges)
+tablet_range_splitter_for_reads::tablet_range_splitter_for_reads(schema_ptr schema, const tablet_map& tablets, host_id host, const dht::partition_range_vector& ranges)
     : _schema(std::move(schema))
     , _ranges(ranges)
     , _ranges_it(_ranges.begin())
 {
     // Filter all tablets and save only those that have a replica on the specified host.
     for (auto tid = std::optional(tablets.first_tablet()); tid; tid = tablets.next_tablet(*tid)) {
-        const auto& tablet_info = tablets.get_tablet_info(*tid);
-
-        auto replica_it = std::ranges::find_if(tablet_info.replicas, [&] (auto&& r) { return r.host == host; });
-        if (replica_it == tablet_info.replicas.end()) {
+        auto shard = get_shard_for_reads(tablets, *tid, host);
+        if (!shard) {
             continue;
         }
 
-        _tablet_ranges.emplace_back(range_split_result{replica_it->shard, dht::to_partition_range(tablets.get_token_range(*tid))});
+        _tablet_ranges.emplace_back(range_split_result{*shard, dht::to_partition_range(tablets.get_token_range(*tid))});
     }
     _tablet_ranges_it = _tablet_ranges.begin();
 }
 
-std::optional<tablet_range_splitter::range_split_result> tablet_range_splitter::operator()() {
+std::optional<tablet_range_splitter_for_reads::range_split_result> tablet_range_splitter_for_reads::operator()() {
     if (_ranges_it == _ranges.end() || _tablet_ranges_it == _tablet_ranges.end()) {
         return {};
     }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -1013,12 +1013,17 @@ struct tablet_routing_info {
 /// Return the resulting intersections, in order.
 /// The ranges are generated lazily (one at a time).
 ///
+/// The shard reported for each range is the one that serves reads for the
+/// owning tablet (see get_shard_for_reads()).
+//  This is the view the multishard reader expects: reads
+/// must be routed to the read shard.
+///
 /// Note: the caller is expected to pin tablets, by keeping an
 /// effective-replication-map alive.
-class tablet_range_splitter {
+class tablet_range_splitter_for_reads {
 public:
     struct range_split_result {
-        shard_id shard; // shard where the tablet owning this range lives
+        shard_id shard; // shard that serves reads for the tablet owning this range
         dht::partition_range range;
     };
 
@@ -1030,7 +1035,7 @@ private:
     std::vector<range_split_result>::iterator _tablet_ranges_it;
 
 public:
-    tablet_range_splitter(schema_ptr schema, const tablet_map& tablets, host_id host, const dht::partition_range_vector& ranges);
+    tablet_range_splitter_for_reads(schema_ptr schema, const tablet_map& tablets, host_id host, const dht::partition_range_vector& ranges);
     /// Returns nullopt when there are no more ranges.
     std::optional<range_split_result> operator()();
 };

--- a/replica/multishard_query.cc
+++ b/replica/multishard_query.cc
@@ -818,7 +818,7 @@ future<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> do_query
     auto result_builder = result_builder_factory();
 
     std::vector<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> results;
-    locator::tablet_range_splitter range_splitter{s, tablets, this_node_id, ranges};
+    locator::tablet_range_splitter_for_reads range_splitter{s, tablets, this_node_id, ranges};
     while (auto range_opt = range_splitter()) {
         auto& r = *results.emplace_back(co_await db.invoke_on(range_opt->shard,
                     [&result_builder, gs = global_schema_ptr(s), &query_cmd, &range_opt, gts = tracing::global_trace_state_ptr(trace_state), timeout] (replica::database& db) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -61,6 +61,7 @@
 #include "gms/inet_address.hh"
 #include "utils/log.hh"
 #include "service/migration_manager.hh"
+#include "schema/schema_builder.hh"
 #include "service/raft/raft_group0.hh"
 #include "gms/gossiper.hh"
 #include "gms/feature_service.hh"
@@ -3117,6 +3118,87 @@ future<> storage_service::wait_for_topology_not_busy() {
         release_guard(std::move(guard));
         co_await _topology_state_machine.event.when();
         guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
+    }
+}
+
+future<> storage_service::alter_table_with_tablet_hints(table_id tid,
+                                                        std::optional<size_t> min_tablet_count,
+                                                        std::optional<size_t> max_tablet_count,
+                                                        bool wait_balancer) {
+    if (this_shard_id() != 0) {
+        co_return co_await container().invoke_on(0, [&] (auto& ss) {
+            return ss.alter_table_with_tablet_hints(tid, min_tablet_count, max_tablet_count, wait_balancer);
+        });
+    }
+
+    if (!min_tablet_count && !max_tablet_count) {
+        slogger.info("alter_table_with_tablet_hints: the tablet hints passed are both nullopt, nothing to update");
+        co_return;
+    }
+
+    if (wait_balancer && min_tablet_count != max_tablet_count) {
+        throw std::invalid_argument(format(
+            "wait_balancer requires both min_tablet_count and max_tablet_count to be provided and equal, got min={} max={}",
+            min_tablet_count ? to_sstring(*min_tablet_count) : "nullopt",
+            max_tablet_count ? to_sstring(*max_tablet_count) : "nullopt"));
+    }
+
+    auto& mm = _migration_manager.local();
+    auto& sp = mm.get_storage_proxy();
+
+    while (true) {
+        auto group0_guard = co_await mm.start_group0_operation();
+
+        auto schema = _db.local().find_schema(tid);
+
+        // Start from existing tablet options to preserve any options
+        // not being modified (e.g. pow2_count).
+        auto tablet_options = schema->raw_tablet_options();
+        if (min_tablet_count) {
+            tablet_options["min_tablet_count"] = to_sstring(*min_tablet_count);
+        }
+        if (max_tablet_count) {
+            tablet_options["max_tablet_count"] = to_sstring(*max_tablet_count);
+        }
+
+        schema_builder builder(schema);
+        builder.set_tablet_options(std::move(tablet_options));
+        auto modified_schema = builder.build();
+
+        auto ts = group0_guard.write_timestamp();
+        sstring description = format("Altering table {}.{} with tablet count hints min_tablet_count={} max_tablet_count={}",
+            schema->ks_name(), schema->cf_name(),
+            min_tablet_count ? to_sstring(*min_tablet_count) : "unchanged",
+            max_tablet_count ? to_sstring(*max_tablet_count) : "unchanged");
+
+        auto mutations = co_await prepare_column_family_update_announcement(sp, modified_schema, /*view_updates=*/{}, ts);
+
+        if (!mutations.empty()) {
+            try {
+                co_await mm.announce(std::move(mutations), std::move(group0_guard), description);
+                break;
+            } catch (group0_concurrent_modification&) {
+                slogger.info("Concurrent operation is detected while starting, retrying.");
+            }
+        }
+    }
+
+    if (!wait_balancer) {
+        co_return;
+    }
+
+    while (true) {
+        auto tmptr = get_token_metadata_ptr();
+        auto& tmap = tmptr->tablets().get_tablet_map(tid);
+        auto tablet_count = tmap.tablet_count();
+
+        // FIXME: Checking tablet_count <= max_tablet_count should be enough, but the restore code currently has a limitation and it cannot handle
+        // any merges or splits until the restore transitions are done
+        if (tablet_count == *max_tablet_count) {
+            break;
+        }
+        co_await _topology_state_machine.event.when();
+        // FIXME: add an abort_source propagated from the root of the restore operation (SCYLLADB-1076)
     }
 }
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -1077,6 +1077,14 @@ public:
     void set_train_dict_callback(decltype(_train_dict));
     seastar::future<> notify_client_routes_change(const client_routes_service::client_route_keys& client_route_keys);
 
+    // Alters the given table's min/max tablet count hints. Only the engaged
+    // hints are applied; if both are disengaged the call is a no-op. When
+    // wait_balancer is set, waits for the load balancer to reach the requested
+    // tablet count (which requires both hints to be engaged and equal).
+    future<> alter_table_with_tablet_hints(table_id tid,
+                                           std::optional<size_t> min_tablet_count,
+                                           std::optional<size_t> max_tablet_count,
+                                           bool wait_balancer = true);
 
     friend class join_node_rpc_handshaker;
     friend class node_ops::node_ops_virtual_task;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1219,7 +1219,11 @@ protected:
 };
 
 future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, utils::chunked_vector<sstring> manifests) {
-    co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
+    auto tablet_count = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
+
+    co_await container().invoke_on(0, [tid, tablet_count] (auto& sl) -> future<> {
+        co_await sl._ss.local().alter_table_with_tablet_hints(tid, tablet_count, tablet_count);
+    });
     auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name), std::move(endpoint), std::move(bucket));
     co_return task->id();
 }

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -25,6 +25,8 @@
 #include "sstables/storage.hh"
 #include "sstables_loader.hh"
 #include "replica/database_fwd.hh"
+#include "replica/tablets.hh"
+#include "replica/schema_describe_helper.hh"
 #include "tasks/task_handler.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "service/storage_proxy.hh"
@@ -152,5 +154,38 @@ SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_t
             populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "snapshot", {"/backup/manifest.json"}, db::consistency_level::ONE).get();
 
             check_snapshot_sstables(env).get();
+    }, false, db_cfg_ptr, 10);
+}
+
+void verify_tablet_options(cql_test_env& env, table_id tid, size_t desired_count, bool hints_expected) {
+    auto schema = env.local_db().find_schema(tid);
+    auto schema_desc = schema->describe(replica::make_schema_describe_helper(schema, env.local_db().as_data_dictionary()), cql3::describe_option::STMTS);
+    auto create_stmt = schema_desc.create_statement.value().linearize();
+
+    auto min_tablet_count = fmt::format("'min_tablet_count': '{}'", desired_count);
+    auto max_tablet_count = fmt::format("'max_tablet_count': '{}'", desired_count);
+
+    BOOST_CHECK_EQUAL(create_stmt.find(min_tablet_count) != sstring::npos, hints_expected);
+    BOOST_CHECK_EQUAL(create_stmt.find(max_tablet_count) != sstring::npos, hints_expected);
+}
+
+SEASTAR_TEST_CASE(test_restore_alter_table_with_tablet_hints, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    auto db_cfg_ptr = make_shared<db::config>();
+    db_cfg_ptr->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+
+    return do_with_some_data_in_thread({"cf"}, [] (cql_test_env& env) {
+        table_id tid = env.local_db().find_uuid("ks", "cf");
+
+        auto token_metadata = env.local_db().get_token_metadata_ptr();
+        auto& tmap = token_metadata->tablets().get_tablet_map(tid);
+        auto desired_count = tmap.tablet_count();
+
+        verify_tablet_options(env, tid, desired_count, false);
+
+        auto schema = env.local_db().find_schema(tid);
+
+        env.get_storage_service().local().alter_table_with_tablet_hints(tid, desired_count, desired_count).get();
+
+        verify_tablet_options(env, tid, desired_count, true);
     }, false, db_cfg_ptr, 10);
 }

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -30,6 +30,8 @@
 #include "tasks/task_handler.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "service/storage_proxy.hh"
+#include "replica/schema_describe_helper.hh"
+#include "utils/UUID_gen.hh"
 
 #include "test/lib/test_utils.hh"
 #include "test/lib/random_utils.hh"
@@ -93,10 +95,10 @@ SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works, *boost::unit_test::pr
 
 using namespace sstables;
 
-future<> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
+future<sstring> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
     sharded<db::snapshot_ctl> ctl;
     co_await ctl.start(std::ref(env.db()), std::ref(env.get_storage_proxy()), std::ref(env.get_task_manager()), std::ref(env.get_sstorage_manager()), db::snapshot_ctl::config{});
-    auto prefix = "/backup";
+    auto prefix = fmt::format("/backup-{}", utils::UUID_gen::get_time_UUID());
 
     auto task_id = co_await ctl.local().start_backup(endpoint, bucket, prefix, "ks", "cf", "snapshot", false);
     auto task = tasks::task_handler{env.get_task_manager().local(), task_id};
@@ -104,6 +106,7 @@ future<> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
     BOOST_REQUIRE(status.state == tasks::task_manager::task_state::done);
 
     co_await ctl.stop();
+    co_return prefix;
 }
 
 future<> check_snapshot_sstables(cql_test_env& env) {
@@ -146,12 +149,13 @@ SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_t
 
             auto ep = storage_options.to_map()["endpoint"];
             auto bucket = storage_options.to_map()["bucket"];
-            backup(env, ep, bucket).get();
+            auto prefix = backup(env, ep, bucket).get();
+            auto manifest_path = prefix + "/manifest.json";
 
-            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "unexpected_snapshot", {"/backup/manifest.json"}, db::consistency_level::ONE).get(), std::runtime_error);;
+            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "unexpected_snapshot", {manifest_path}, db::consistency_level::ONE).get(), std::runtime_error);;
 
             // populate system_distributed.snapshot_sstables with the content of the snapshot manifest
-            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "snapshot", {"/backup/manifest.json"}, db::consistency_level::ONE).get();
+            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "snapshot", {manifest_path}, db::consistency_level::ONE).get();
 
             check_snapshot_sstables(env).get();
     }, false, db_cfg_ptr, 10);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -6085,7 +6085,7 @@ SEASTAR_THREAD_TEST_CASE(test_intranode_balance_threshold) {
     }, cfg).get();
 }
 
-SEASTAR_THREAD_TEST_CASE(test_tablet_range_splitter) {
+SEASTAR_THREAD_TEST_CASE(test_tablet_range_splitter_for_reads) {
     simple_schema ss;
 
     const auto dks = ss.make_pkeys(4);
@@ -6122,7 +6122,7 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_range_splitter) {
         }
     });
 
-    using result = tablet_range_splitter::range_split_result;
+    using result = tablet_range_splitter_for_reads::range_split_result;
     using bound = dht::partition_range::bound;
 
     std::vector<result> included_ranges;
@@ -6146,7 +6146,7 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_range_splitter) {
     auto check = [&] (const dht::partition_range_vector& ranges, std::vector<result> expected_result,
             std::source_location sl = std::source_location::current()) {
         testlog.info("check() @ {}:{} ranges={}", sl.file_name(), sl.line(), ranges);
-        locator::tablet_range_splitter range_splitter{ss.schema(), tmap, h1, ranges};
+        locator::tablet_range_splitter_for_reads range_splitter{ss.schema(), tmap, h1, ranges};
         auto it = expected_result.begin();
         while (auto range_opt = range_splitter()) {
             testlog.debug("result: shard={} range={}", range_opt->shard, range_opt->range);

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -902,6 +902,62 @@ async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: Ma
             # So the best thing to do is to make sure restore task finishes at all
             await asyncio.wait_for(manager.api.wait_task(servers[1].ip_addr, tid), timeout=60)
 
+@pytest.mark.parametrize(("min_tablet_count_before_backup", "max_tablet_count_before_backup", "min_tablet_count_before_restore", "max_tablet_count_before_restore"), [
+    (1, 1, 2, 2),
+    (4, 4, 2, 2),
+])
+async def test_restore_tablets_with_different_tablet_hints(build_mode: str, manager: ManagerClient, object_storage,
+                                                           min_tablet_count_before_backup, max_tablet_count_before_backup,
+                                                           min_tablet_count_before_restore, max_tablet_count_before_restore):
+    '''This test checks:
+    1. That restore with tablets works when the tablet count changes between backup and restore (currently by
+    altering the table with tablets hints set to the tablet count from the backup manifest).
+    2. The restore code is well equipped to handle potential shards not owning any tablets, or nodes not owning any tablets,
+    thus verifying that the tablet count written in the manifest is calculated correctly and that restore code
+    can handle tablet counts of 0'''
+
+    topology = topo(rf = 1, nodes = 3, racks = 1, dcs = 1)
+
+    servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
+
+    cql = manager.get_cql()
+
+    # We need enough keys to have a high probability of spanning keys all over the tablet ranges.
+    # The SSTable downloading code will throw sstables_partially_contained unless the restoring code
+    # correctly sets the tablet hints to what was originally populated in the backup manifest.
+    num_keys = 1000
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {min_tablet_count_before_backup}, 'max_tablet_count': {max_tablet_count_before_backup}}};")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, value) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
+        snap_name,_ = await take_snapshot(ks, servers, manager, logger)
+        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, 'test', object_storage, manager, logger) for s in servers))
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {min_tablet_count_before_restore}, 'max_tablet_count': {max_tablet_count_before_restore}}};")
+
+        logger.info(f'Restore cluster via {servers[1].ip_addr}')
+        manifests = [ f'{s.server_id}/{snap_name}/manifest.json' for s in servers ]
+        tid = await manager.api.restore_tablets(servers[1].ip_addr, ks, 'test', snap_name, servers[0].datacenter,object_storage.address, object_storage.bucket_name, manifests)
+        status = await manager.api.wait_task(servers[1].ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done')
+
+        # FIXME:Disable the tablet balancer before checking mutations to avoid
+        # MUTATION_FRAGMENTS returning inconsistent results during inter-node
+        # tablet migrations (different nodes see different ERM stages).
+        await manager.disable_tablet_balancing()
+        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
+
+        # Verify that restore used the tablet hints from the backup manifest,
+        # not the ones set on the pre-restore table.
+        # FIXME: this check will be removed as it's irelevant after we implement the cleanup phase of tablet aware restore
+        # but the test will remain relevant as it was designed to fail if the restore code doesnt properly fix the tablet
+        # count to what was written in the backup manifest.
+        desc = (await cql.run_async(f"DESC TABLE {ks}.test"))[0].create_statement
+        assert f"'min_tablet_count': '{min_tablet_count_before_backup}'" in desc, f"Expected min_tablet_count={min_tablet_count_before_backup} in: {desc}"
+        assert f"'max_tablet_count': '{max_tablet_count_before_backup}'" in desc, f"Expected max_tablet_count={max_tablet_count_before_backup} in: {desc}"
 
 async def test_restore_with_non_existing_sstable(manager: ManagerClient, object_storage):
     '''Check that restore task fails well when given a non-existing sstable'''

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -742,12 +742,10 @@ async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_s
 
     servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
 
-    await manager.disable_tablet_balancing()
     cql = manager.get_cql()
 
     num_keys = 10
     tablet_count=5
-    tablet_count_for_restore=8 # should be tablet_count rounded up to the power of two
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count}}};")
@@ -758,7 +756,7 @@ async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_s
         await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, 'test', object_storage, manager, logger) for s in servers))
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count_for_restore}, 'max_tablet_count': {tablet_count_for_restore}}};")
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int );")
 
         logger.info(f'Restore cluster via {servers[1].ip_addr}')
         manifests = [ f'{s.server_id}/{snap_name}/manifest.json' for s in servers ]


### PR DESCRIPTION
During tablet-aware restore, the destination table may have a different
tablet count than the original table at backup time. If the load
balancer splits or merges tablets during restore, SSTable downloads can
fail with sstables_partially_contained because the token ranges no
longer match.

This PR fixes the problem by temporarily altering the table's
min/max tablet hints to match the tablet count recorded in the backup
manifest before restoring, ensuring the load balancer brings the tablet
count to the expected value and doesn't change it during restore.

This PR adds:
- A new storage_service::alter_table_with_tablet_hints() function that performs
a group0 schema ALTER to set min_tablet_count and max_tablet_count on
a table, optionally waiting for the load balancer to reach the desired
tablet count (the optional waiting is going to be useful in the followup PR where we do the cleanup).
- A guard in sstables_loader ensuring the ALTER is only called on
shard 0, since it is a group0 operation.
- A patch enabling load balancer during the main tablet aware restore cluster test.
- Tests: 
* a unit test verifying alter_table_with_tablet_hints
correctly updates tablet options
* a cluster test that checks tablet aware restore works if the tablet count changes between the backup time and restore time and some edge cases related to shards not owning any tablets or entire nodes not owning any tablets.

Fixes: SCYLLADB-267

No backport needed — this is a new feature targeting tablet-aware
restore.