### PR TITLE
doc: update Web Installer docs with Manager and tarball support

### DIFF
--- a/docs/getting-started/installation-common/scylla-web-installer.rst
+++ b/docs/getting-started/installation-common/scylla-web-installer.rst
@@ -47,4 +47,57 @@ option to specify the version you want to install.
   curl -sSf get.scylladb.com/server | sudo bash -s -- --scylla-version |CURRENT_VERSION|
 
 
+Installing via Tarball
+---------------------------------------
+
+The Web Installer supports tarball installation as an alternative
+to the default package manager-based installation. This is useful for installing ScyllaDB
+on Linux distributions that are not officially supported via packages, or when you prefer
+not to use the system package manager or when you do not have superuser privileges.
+
+To install ScyllaDB using the tarball, run:
+
+.. code:: console
+
+    curl -sSf get.scylladb.com/server | sudo bash -s -- --tarball
+
+You can combine ``--tarball`` with ``--scylla-version`` to install a specific version:
+
+.. code:: console
+
+    curl -sSf get.scylladb.com/server | sudo bash -s -- --tarball --scylla-version |CURRENT_VERSION|
+
+On Linux distributions not supported via native packages, the Web Installer
+automatically falls back to tarball installation.
+
+See :doc:`Install ScyllaDB Without root Privileges </getting-started/installation-common/unified-installer>` for more information on the tarball-based (unified) installer.
+
+Install ScyllaDB Manager with Web Installer
+----------------------------------------------
+
+You can use the Web Installer to install `ScyllaDB Manager <https://manager.docs.scylladb.com/>`_, which provides automated backup, repair, and cluster management capabilities.
+
+To install ScyllaDB Manager, run:
+
+.. code:: console
+
+    curl -sSf get.scylladb.com/manager | sudo bash
+
+By default, this installs the latest official version of ScyllaDB Manager, including both
+``scylla-manager-server`` and ``scylla-manager-client`` packages.
+
+To install a specific version, use the ``--manager-version`` option:
+
+.. code:: console
+
+    curl -sSf get.scylladb.com/manager | sudo bash -s -- --manager-version 3.10
+
+Supported platforms for ScyllaDB Manager installation via Web Installer:
+
+* Debian / Ubuntu
+* RHEL / CentOS / Rocky Linux / Amazon Linux
+
+For full ScyllaDB Manager documentation, configuration, and usage instructions,
+see `ScyllaDB Manager Docs <https://manager.docs.scylladb.com/>`_.
+
 .. include:: /getting-started/_common/setup-after-install.rst


### PR DESCRIPTION
Document the new ScyllaDB Manager installation support via \get.scylladb.com/manager\, and the new \--tarball\ option for the server installer, including automatic fallback for unsupported OSes.

See https://github.com/scylladb/scylladb-web-install/pull/91

Fixes SCYLLADB-2202