### PR TITLE
test/cluster/mv/tablet: Improve determinism in test_mv_tablets_replace

### DIFF
--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -15,6 +15,7 @@ import pytest
 import asyncio
 import logging
 import time
+from typing import Callable
 
 from test.cluster.util import get_topology_coordinator, find_server_by_host_id
 from test.cluster.mv.tablets.test_mv_tablets import get_tablet_replicas
@@ -23,9 +24,47 @@ from test.cluster.util import new_test_keyspace, wait_for
 logger = logging.getLogger(__name__)
 
 
+async def get_disjoint_paired_replicas(manager, servers, ks):
+    """
+    finds disjoint sets for paired view and base replicas validates RF=2.
+    MV tablet pairing logic is rack-based so base and view rack will be validated.
+    returns placment that can be used later in the tests body.
+    """
+    base_replicas = await get_tablet_replicas(manager, servers[0], ks, "test", 0)
+    view_replicas = await get_tablet_replicas(manager, servers[0], ks, "tv", 0)
+    if len(base_replicas) != 2 or len(view_replicas) != 2:
+        logger.info("Waiting for RF=2 placement: base=%s view=%s", base_replicas, view_replicas)
+        return None
+    base_ids = {host for host, _ in base_replicas}
+    view_ids = {host for host, _ in view_replicas}
+    if base_ids & view_ids:
+        logger.info("Waiting for disjoint base/view replicas: base=%s view=%s", base_replicas, view_replicas)
+        return None
+    base_servers = [await find_server_by_host_id(manager, servers, host) for host, _ in base_replicas]
+    view_servers = [await find_server_by_host_id(manager, servers, host) for host, _ in view_replicas]
+    base_by_rack = {(s.datacenter, s.rack): s for s in base_servers}
+    view_by_rack = {(s.datacenter, s.rack): s for s in view_servers}
+    if len(base_by_rack) != len(base_servers) or len(view_by_rack) != len(view_servers):
+        logger.info("Waiting for one replica per rack: base=%s view=%s", base_servers, view_servers)
+        return None
+    if base_by_rack.keys() != view_by_rack.keys():
+        logger.info("Waiting for matching base/view racks: base=%s view=%s", base_by_rack, view_by_rack)
+        return None
+    return base_replicas, view_replicas, base_by_rack, view_by_rack
+
+
+def select_non_coordinator_replica_pair(base_by_rack, view_by_rack, coord_serv):
+    for location in view_by_rack.keys():
+        view_server = view_by_rack[location]
+        base_server = base_by_rack[location]
+        if (view_server.server_id != coord_serv.server_id and base_server.server_id != coord_serv.server_id):
+            return view_server, base_server
+    raise AssertionError(f"Could not find paired base/view replicas outside topology coordinator {coord_serv}. base_by_rack={base_by_rack}, view_by_rack={view_by_rack}")
+
+
 @pytest.mark.nightly
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
+async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient, scale_timeout: Callable[[int | float], int | float]):
     """
     Verifies that view replica pairing is stable in the case of node replace.
     After replace, the node is in left state, but still present in the replica set.
@@ -39,37 +78,38 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
         {"dc": "dc1", "rack": "r2"},
         {"dc": "dc1", "rack": "r2"}
     ])
+
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk) WITH SYNCHRONOUS_UPDATES = TRUE")
 
-        async def replicas_balanced():
-            base_replicas = [replica[0] for replica in await get_tablet_replicas(manager, servers[0], ks, "test", 0)]
-            view_replicas = [replica[0] for replica in await get_tablet_replicas(manager, servers[0], ks, "tv", 0)]
-            return len(set(base_replicas) & set(view_replicas)) == 0 or None
-        # There's 4 nodes and 4 tablets, so even if the initial placement is not balanced,
-        # each node should get 1 replica after some time.
-        await wait_for(replicas_balanced, time.time() + 60)
+        # wait for replicas to be in RF=2 and rack paired
+        async def read_disjoint_paired_replicas():
+            return await get_disjoint_paired_replicas(manager, servers, ks)
+
+        await wait_for(read_disjoint_paired_replicas, time.time() + scale_timeout(60))
 
         # Disable migrations concurrent with replace since we don't handle nodes going down during migration yet.
         # See https://github.com/scylladb/scylladb/issues/16527
         await manager.disable_tablet_balancing()
 
-        base_replicas = await get_tablet_replicas(manager, servers[0], ks, "test", 0)
-        logger.info(f'{ks}.test replicas: {base_replicas}')
-        view_replicas = await get_tablet_replicas(manager, servers[0], ks, "tv", 0)
-        logger.info(f'{ks}.tv replicas: {view_replicas}')
-        server_to_replace = await find_server_by_host_id(manager, servers, HostID(str(view_replicas[0][0])))
-        server_to_down = await find_server_by_host_id(manager, servers, HostID(str(base_replicas[0][0])))
+        # get topology coordinator so we wont stop it
+        coord = await get_topology_coordinator(manager)
+        coord_serv = await find_server_by_host_id(manager, servers, coord)
+
+        # make sure that our replicas are still in a good shape and paired correctly
+        base_replicas, view_replicas, base_by_rack, view_by_rack = await wait_for(read_disjoint_paired_replicas, time.time() + scale_timeout(60))
+        logger.info(f"{ks}.test replicas: {base_replicas}")
+        logger.info(f"{ks}.tv replicas: {view_replicas}")
+        server_to_replace, server_to_down = select_non_coordinator_replica_pair(base_by_rack, view_by_rack, coord_serv)
 
         logger.info('Downing a node to be replaced')
         # convict=False to avoid triggering SCYLLADB-1996
         await manager.server_stop(server_to_replace.server_id, convict=False)
+        await manager.others_not_see_server(server_to_replace.ip_addr)
 
         logger.info('Blocking tablet rebuild')
-        coord = await get_topology_coordinator(manager)
-        coord_serv = await find_server_by_host_id(manager, servers, coord)
         await manager.api.enable_injection(coord_serv.ip_addr, "tablet_transition_updates", one_shot=True)
         coord_log = await manager.server_open_log(coord_serv.server_id)
         coord_mark = await coord_log.mark()
@@ -83,9 +123,8 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
 
         await coord_log.wait_for('tablet_transition_updates: waiting', from_mark=coord_mark)
 
-        if server_to_down.server_id != server_to_replace.server_id:
-            # convict=False to avoid triggering SCYLLADB-1996
-            await manager.server_stop(server_to_down.server_id, convict=False)
+        await manager.server_stop(server_to_down.server_id, convict=False)
+        await manager.others_not_see_server(server_to_down.ip_addr)
 
         # The update is supposed to go to the second replica only, since the other one is downed.
         # If pairing would shift, the update to the view would be lost because the first replica
@@ -97,13 +136,14 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
 
         if server_to_down.server_id != server_to_replace.server_id:
             await manager.server_start(server_to_down.server_id)
+            await manager.servers_see_each_other(await manager.running_servers())
 
         logger.info('Unblocking tablet rebuild')
-        if coord_serv.server_id != server_to_down.server_id:
-            await manager.api.message_injection(coord_serv.ip_addr, "tablet_transition_updates")
+        await manager.api.message_injection(coord_serv.ip_addr, "tablet_transition_updates")
 
         logger.info('Waiting for replace')
         await replace_task
+        await manager.servers_see_each_other(await manager.running_servers())
 
         logger.info('Querying')
         assert [(4,3)] == list(await cql.run_async(f"SELECT * FROM {ks}.tv WHERE c=4"))


### PR DESCRIPTION
This change makes test_tablet_mv_replica_pairing_during_replace deterministic about the tablet placement it depends on. The test now waits for RF=2 base/view replicas that are disjoint, rack-paired, and do not include the topology coordinator before stopping nodes. It also waits for stopped nodes to be observed and uses scaled timeouts, keeping the test focused on the intended scenario: verifying that MV tablet replica pairing remains stable during node replace.

we need to backport to all active branches 