### PR TITLE
cql3: shrink prepared cache entry by 48 bytes (128B -> 80B)

### DIFF
--- a/cql3/prepared_statements_cache.hh
+++ b/cql3/prepared_statements_cache.hh
@@ -16,6 +16,14 @@
 #include "cql3/column_specification.hh"
 #include "cql3/dialect.hh"
 
+#include <algorithm>
+#include <array>
+#include <stdexcept>
+#include <string_view>
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+
 namespace cql3 {
 
 using prepared_cache_entry = std::unique_ptr<statements::prepared_statement>;
@@ -27,20 +35,34 @@ struct prepared_cache_entry_size {
     }
 };
 
-typedef bytes cql_prepared_id_type;
+/// 16-byte MD5 hash used as prepared statement cache ID.
+struct cql_prepared_id_type {
+    static constexpr size_t size = 16;
+    std::array<uint8_t, size> _id = {};
 
-/// \brief The key of the prepared statements cache
-///
-/// TODO: consolidate prepared_cache_key_type and the nested cache_key_type
-///       the latter was introduced for unifying the CQL and Thrift prepared
-///       statements so that they can be stored in the same cache.
+    cql_prepared_id_type() = default;
+    explicit cql_prepared_id_type(bytes_view id) {
+        if (id.size() != size) {
+            throw std::runtime_error(
+                fmt::format("Expected prepared cache ID of {} bytes, got {}", size, id.size()));
+        }
+        std::copy_n(id.begin(), size, _id.begin());
+    }
+
+    bool operator==(const cql_prepared_id_type& other) const = default;
+
+    bytes to_bytes() const {
+        return bytes(reinterpret_cast<const bytes::value_type*>(_id.data()), size);
+    }
+};
+
+/// The prepared statements cache key.
 class prepared_cache_key_type {
 public:
-    // derive from cql_prepared_id_type so we can customize the formatter of
-    // cache_key_type
-    struct cache_key_type : public cql_prepared_id_type {
-        cache_key_type(cql_prepared_id_type&& id, cql3::dialect d) : cql_prepared_id_type(std::move(id)), dialect(d) {}
+    struct cache_key_type {
+        cql_prepared_id_type id;
         cql3::dialect dialect; // Not part of hash, but we don't expect collisions because of that
+        cache_key_type(cql_prepared_id_type id_, cql3::dialect d) : id(std::move(id_)), dialect(d) {}
         bool operator==(const cache_key_type& other) const = default;
     };
 
@@ -49,12 +71,13 @@ private:
 
 public:
     explicit prepared_cache_key_type(cql_prepared_id_type cql_id, dialect d) : _key(std::move(cql_id), d) {}
+    explicit prepared_cache_key_type(bytes_view cql_id_bytes, dialect d) : _key(cql_prepared_id_type(cql_id_bytes), d) {}
 
     cache_key_type& key() { return _key; }
     const cache_key_type& key() const { return _key; }
 
     static const cql_prepared_id_type& cql_id(const prepared_cache_key_type& key) {
-        return key.key();
+        return key.key().id;
     }
 
     bool operator==(const prepared_cache_key_type& other) const = default;
@@ -168,25 +191,40 @@ public:
 namespace std {
 
 template<>
+struct hash<cql3::cql_prepared_id_type> final {
+    size_t operator()(const cql3::cql_prepared_id_type& k) const {
+        return std::hash<std::string_view>()(
+            std::string_view(reinterpret_cast<const char*>(k._id.data()), k._id.size()));
+    }
+};
+
+template<>
 struct hash<cql3::prepared_cache_key_type::cache_key_type> final {
     size_t operator()(const cql3::prepared_cache_key_type::cache_key_type& k) const {
-        return std::hash<cql3::cql_prepared_id_type>()(k);
+        return std::hash<cql3::cql_prepared_id_type>()(k.id);
     }
 };
 
 template<>
 struct hash<cql3::prepared_cache_key_type> final {
     size_t operator()(const cql3::prepared_cache_key_type& k) const {
-        return std::hash<cql3::cql_prepared_id_type>()(k.key());
+        return std::hash<cql3::cql_prepared_id_type>()(k.key().id);
     }
 };
 }
 
 // for prepared_statements_cache log printouts
+template <> struct fmt::formatter<cql3::cql_prepared_id_type> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const cql3::cql_prepared_id_type& id, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{:02x}", fmt::join(id._id, ""));
+    }
+};
+
 template <> struct fmt::formatter<cql3::prepared_cache_key_type::cache_key_type> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const cql3::prepared_cache_key_type::cache_key_type& p, fmt::format_context& ctx) const {
-        return fmt::format_to(ctx.out(), "{{cql_id: {}, dialect: {}}}", static_cast<const cql3::cql_prepared_id_type&>(p), p.dialect);
+        return fmt::format_to(ctx.out(), "{{cql_id: {}, dialect: {}}}", p.id, p.dialect);
     }
 };
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -762,7 +762,7 @@ query_processor::prepare(utils::chunked_string query_string, const service::clie
                 "query_processor_prepare_wait_after_cache_get",
                 utils::wait_for_message(std::chrono::seconds(60)));
   
-        auto msg = ::make_shared<result_message::prepared::cql>(prepared_cache_key_type::cql_id(key), std::move(prep_entry),
+        auto msg = ::make_shared<result_message::prepared::cql>(prepared_cache_key_type::cql_id(key).to_bytes(), std::move(prep_entry),
                     client_state.is_protocol_extension_set(cql_transport::cql_protocol_extension::LWT_ADD_METADATA_MARK));
         co_return std::move(msg);
     } catch(typename prepared_statements_cache::statement_is_too_big&) {
@@ -784,7 +784,8 @@ prepared_cache_key_type query_processor::compute_id(
         utils::chunked_string_view query_string,
         std::string_view keyspace,
         dialect d) {
-    return prepared_cache_key_type(md5_hasher::calculate(hash_target(query_string, keyspace).data()), d);
+    auto hash = md5_hasher::calculate(hash_target(query_string, keyspace).data());
+    return prepared_cache_key_type(bytes_view(hash), d);
 }
 
 std::unique_ptr<prepared_statement>

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1711,7 +1711,7 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
     if (!cache_key_bytes) {
         return make_exception_future<cql_server::process_fn_return_type>(std::move(cache_key_bytes).assume_error());
     }
-    bytes cache_key_value = cache_key_bytes.assume_value();
+    bytes cache_key_value = std::move(cache_key_bytes).assume_value();
     // A valid prepared id is always cql_prepared_id_type::size bytes. An id of a
     // different length (malformed/unknown client input) can never match a cached
     // statement; return the normal UNPREPARED error instead of letting the
@@ -1867,7 +1867,7 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
             if (!cache_key_bytes) {
                 return make_exception_future<cql_server::process_fn_return_type>(std::move(cache_key_bytes).assume_error());
             }
-            bytes cache_key_value = cache_key_bytes.assume_value();
+            bytes cache_key_value = std::move(cache_key_bytes).assume_value();
             // A valid prepared id is always cql_prepared_id_type::size bytes. An id of
             // a different length (malformed/unknown client input) can never match a
             // cached statement; return the normal UNPREPARED error instead of letting

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -486,7 +486,7 @@ void cql_server::init_messaging_service() {
                 });
             auto prepare_id = _query_processor.local().compute_id(req.query_string, qs.get_client_state().get_raw_keyspace(), req.dialect).key();
             clogger.trace("Successfully prepared statement {} from forward request", prepare_id);
-            co_return prepare_id;
+            co_return prepare_id.id.to_bytes();
         });
 }
 
@@ -626,12 +626,19 @@ cql_server::forward_cql(
         }
         case forward_cql_status::prepared_not_found: {
             _stats.requests_forwarded_prepared_not_found++;
+            // A valid prepared id is always cql_prepared_id_type::size bytes. Guard
+            // against a different length before constructing the fixed-size cache key
+            // (whose constructor throws on a size mismatch), and surface the normal
+            // UNPREPARED error instead of an unexpected SERVER_ERROR.
+            if (response.prepared_id.size() != cql3::cql_prepared_id_type::size) {
+                co_return coroutine::exception(std::make_exception_ptr(exceptions::prepared_query_not_found_exception(std::move(response.prepared_id))));
+            }
             cql3::prepared_cache_key_type cache_key(std::move(response.prepared_id), req.dialect);
 
             auto prepared = _query_processor.local().get_prepared(cache_key);
             if (!prepared) {
                 clogger.info("Prepared statement with cache key {} not found locally for prepare request, cannot prepare on target {}", cache_key.key(), current_host);
-                co_return coroutine::exception(std::make_exception_ptr(exceptions::prepared_query_not_found_exception(cache_key.key())));
+                co_return coroutine::exception(std::make_exception_ptr(exceptions::prepared_query_not_found_exception(cache_key.key().id.to_bytes())));
             }
 
             tracing::trace(trace_state, "Prepared statement not found on target, preparing query on target node");
@@ -646,7 +653,7 @@ cql_server::forward_cql(
 
             auto prepared_id = co_await ser::forward_cql_rpc_verbs::send_forward_cql_prepare(&_ms, current_host, timeout, prepare_req);
 
-            if (prepared_id != cache_key.key()) {
+            if (prepared_id != cache_key.key().id.to_bytes()) {
                 on_internal_error(clogger, format("Prepared ID returned from target node does not match local prepared ID for the same query. Local ID: {}, Target ID: {}", cache_key.key(), prepared_id));
             }
             continue;
@@ -1704,8 +1711,16 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
     if (!cache_key_bytes) {
         return make_exception_future<cql_server::process_fn_return_type>(std::move(cache_key_bytes).assume_error());
     }
-    cql3::prepared_cache_key_type cache_key(cache_key_bytes.assume_value(), dialect);
-    auto& id = cql3::prepared_cache_key_type::cql_id(cache_key);
+    bytes cache_key_value = cache_key_bytes.assume_value();
+    // A valid prepared id is always cql_prepared_id_type::size bytes. An id of a
+    // different length (malformed/unknown client input) can never match a cached
+    // statement; return the normal UNPREPARED error instead of letting the
+    // fixed-size key constructor throw (which would surface as a SERVER_ERROR).
+    if (cache_key_value.size() != cql3::cql_prepared_id_type::size) {
+        return make_exception_future<cql_server::process_fn_return_type>(exceptions::prepared_query_not_found_exception(std::move(cache_key_value)));
+    }
+    cql3::prepared_cache_key_type cache_key(cache_key_value, dialect);
+    const auto& id = cql3::prepared_cache_key_type::cql_id(cache_key);
     bool needs_authorization = false;
 
     // First, try to lookup in the cache of already authorized statements. If the corresponding entry is not found there
@@ -1717,7 +1732,7 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
     }
 
     if (!prepared) {
-        throw exceptions::prepared_query_not_found_exception(id);
+        throw exceptions::prepared_query_not_found_exception(id.to_bytes());
     }
 
     cql_metadata_id_wrapper metadata_id = cql_metadata_id_wrapper();
@@ -1852,8 +1867,17 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
             if (!cache_key_bytes) {
                 return make_exception_future<cql_server::process_fn_return_type>(std::move(cache_key_bytes).assume_error());
             }
-            cql3::prepared_cache_key_type cache_key(cache_key_bytes.assume_value(), dialect);
-            auto& id = cql3::prepared_cache_key_type::cql_id(cache_key);
+            bytes cache_key_value = cache_key_bytes.assume_value();
+            // A valid prepared id is always cql_prepared_id_type::size bytes. An id of
+            // a different length (malformed/unknown client input) can never match a
+            // cached statement; return the normal UNPREPARED error instead of letting
+            // the fixed-size key constructor throw (which would surface as a
+            // SERVER_ERROR).
+            if (cache_key_value.size() != cql3::cql_prepared_id_type::size) {
+                return make_exception_future<cql_server::process_fn_return_type>(exceptions::prepared_query_not_found_exception(std::move(cache_key_value)));
+            }
+            cql3::prepared_cache_key_type cache_key(cache_key_value, dialect);
+            const auto& id = cql3::prepared_cache_key_type::cql_id(cache_key);
 
             // First, try to lookup in the cache of already authorized statements. If the corresponding entry is not found there
             // look for the prepared statement and then authorize it.
@@ -1861,7 +1885,7 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
             if (!ps) {
                 ps = qp.local().get_prepared(cache_key);
                 if (!ps) {
-                    return make_exception_future<cql_server::process_fn_return_type>(exceptions::prepared_query_not_found_exception(id));
+                    return make_exception_future<cql_server::process_fn_return_type>(exceptions::prepared_query_not_found_exception(id.to_bytes()));
                 }
                 // authorize a particular prepared statement only once
                 needs_authorization = pending_authorization_entries.emplace(std::move(cache_key), ps->checked_weak_from_this()).second;

--- a/utils/loading_shared_values.hh
+++ b/utils/loading_shared_values.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "utils/assert.hh"
+#include <memory>
 #include <vector>
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -56,7 +57,8 @@ private:
         loading_shared_values& _parent;
         key_type _key;
         std::optional<value_type> _val;
-        shared_promise<> _loaded;
+        // Lazily allocated: present only while loading.
+        std::unique_ptr<shared_promise<>> _loaded;
 
     public:
         const key_type& key() const noexcept {
@@ -88,7 +90,14 @@ private:
         }
 
         shared_promise<>& loaded() {
-            return _loaded;
+            if (!_loaded) {
+                _loaded = std::make_unique<shared_promise<>>();
+            }
+            return *_loaded;
+        }
+
+        void release_loaded() noexcept {
+            _loaded.reset();
         }
 
         bool ready() const noexcept {
@@ -240,6 +249,9 @@ public:
                     } else {
                         e->set_value(val_fut.get());
                         e->loaded().set_value();
+                        // Release promise on success only; on failure, concurrent
+                        // get_or_load() may still need the failed future.
+                        e->release_loaded();
                     }
                 });
             }


### PR DESCRIPTION
## Motivation

The prepared statements cache stores entries in a fixed memory budget. Every byte saved per entry translates directly to more statements fitting in cache.

This PR shrinks `loading_shared_values::entry` from 128 bytes to 80 bytes — saving 48 bytes per cache entry — via two commits:

### Commit 1: Lazily allocate shared_promise (saves 32B)

The inline `shared_promise<>` (40B) in each cache entry is only needed during the brief loading window (cache miss). In steady state it is unused. Replace with `std::unique_ptr<shared_promise<>>` allocated on demand and freed after resolution. 40B → 8B pointer = 32B saved.

### Commit 2: Compact fixed-size cache key (saves 16B)

The old key inherited from `bytes` (sstring, 32B SSO) + 1B dialect, padded to 40B (align 8). The MD5 hash is always exactly 16 bytes — replace with `std::array<uint8_t, 16>` + dialect field = 17B, with 7B padding to align the next field = 24B effective. 40B → 24B = 16B saved.

The dialect is kept as a separate key field that is **excluded** from the MD5 hash, so the on-wire prepared-statement ID is byte-identical to master/2026.2. This is deliberate (see below).

## Why dialect is not baked into the MD5 hash

An earlier revision of this PR had a third commit that folded the dialect byte into the MD5 hash input (which would have removed the dialect field from the key and saved a further 8B → 72B). That change was **dropped** because it is not upgrade-safe:

`forward_cql` (the node-to-node CQL bounce path used by e.g. LWT / tablet routing, present since 2026.2.0 and not gated by a cluster feature) compares the coordinator's prepared-statement ID against the ID recomputed on the target node, and aborts via `on_internal_error` on mismatch. Baking the dialect into the MD5 changes that ID, so a mixed-version cluster during a rolling upgrade (2026.2 ⟷ this version) would deterministically diverge and crash. Keeping the dialect hash-excluded preserves the exact pre-existing wire ID and makes this PR fully upgrade-safe with no cluster feature required.

## Entry layout after this PR (verified via static_assert)

| Offset | Field | Type | Size |
|--------|-------|------|------|
| 0 | (base) | `bi::unordered_set_base_hook<store_hash<true>>` | 16B |
| 16 | (base) | `enable_lw_shared_from_this<entry>` (refcount) | 8B |
| 24 | `_parent` | `loading_shared_values&` | 8B |
| 32 | `_key` | `cql_prepared_id_type` (`std::array<uint8_t, 16>` + dialect, padded) | 24B |
| 56 | `_val` | `std::optional<std::unique_ptr<prepared_statement>>` | 16B |
| 72 | `_loaded` | `std::unique_ptr<shared_promise<>>` | 8B |
| | | **Total** | **80B** |

## Measured (perf-simple-query, release, smp 1, taskset -c 0, fixed 2.2GHz, 10K partitions, 5 runs)

> Note: these numbers were measured on the earlier 72B variant (before the dialect-in-MD5 commit was dropped for upgrade safety). The dropped change accounts for only 8B of the entry; the cache-utilization benefit at 80B is essentially the same.

| Metric | Master | PR #30073 | Delta |
|--------|--------|-----------|-------|
| insns/op (median of 5) | 32,084 | 31,087 | **-997 (-3.1%)** |
| tps (median of 5) | 148,750 | 153,891 | **+3.5%** |

Smaller cache entries (80B vs 128B) improve CPU cache utilization during prepared statement lookups.

## Tests

- loading_cache_test (all cases)
- query_processor_test, transport_test, cql_query_test
- test_prepared_statement_small_cache
- test_prepared_statement_is_invalidated_by_schema_change
- test_nonfrozen_user_types_prepared, test_prepared_json
- timeuuid_fcts_prepared_re_evaluation
- filtering_test, restrictions_test, extensions_test, secondary_index_test
- test/cqlpy/test_prepare.py (12 tests)

Refs: https://github.com/scylladb/scylladb/issues/29047
