### PR TITLE
dist: add scylla-perf-collector subpackage to collect performance profiles

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -3059,14 +3059,14 @@ def write_build_file(f,
     for mode in build_modes:
         server_rpms_dir = f'$builddir/dist/{mode}/redhat/RPMS/{arch}'
         server_rpms = [f'{server_rpms_dir}/{scylla_product}{suffix}-{rpm_ver}.{arch}.rpm'
-                       for suffix in ['', '-server', '-debuginfo', '-conf', '-kernel-conf']]
+                       for suffix in ['', '-server', '-debuginfo', '-conf', '-kernel-conf', '-perf-collector']]
         cqlsh_rpms = [f'tools/cqlsh/build/redhat/RPMS/{arch}/{scylla_product}-cqlsh-{rpm_ver}.{arch}.rpm']
         python3_rpms = [f'tools/python3/build/redhat/RPMS/{arch}/{scylla_product}-python3-{rpm_ver}.{arch}.rpm']
         all_rpms = server_rpms + cqlsh_rpms + python3_rpms
 
         server_deb_dir = f'$builddir/dist/{mode}/debian'
         server_debs = [f'{server_deb_dir}/{scylla_product}{suffix}_{deb_ver}_{deb_arch}.deb'
-                       for suffix in ['', '-server', '-server-dbg', '-conf', '-kernel-conf']]
+                       for suffix in ['', '-server', '-server-dbg', '-conf', '-kernel-conf', '-perf-collector']]
         server_debs += [f'{server_deb_dir}/scylla-enterprise{suffix}_{deb_ver}_all.deb'
                         for suffix in ['', '-server', '-conf', '-kernel-conf']]
         cqlsh_debs = [f'tools/cqlsh/build/debian/{scylla_product}-cqlsh_{deb_ver}_{deb_arch}.deb',

--- a/dist/common/perf-collector/README.md
+++ b/dist/common/perf-collector/README.md
@@ -1,0 +1,17 @@
+# scylla-perf-collector
+
+This package collects system-wide perf samples using
+`perf record -a -F 2 -z --switch-output=1d --switch-max-files=15`.
+
+- Output is stored in `/var/log/scylla-perf/` as `perf.data.<timestamp>` files.
+- `perf` rotates the recording itself, switching to a new file once a day
+  (`--switch-output=1d`), so each rotated file is complete and never touched
+  again. There is no service restart and no gap in collection.
+- Old recordings are expired by `perf` via `--switch-max-files=15` (roughly two
+  weeks of daily files, including the one currently being written).
+- Recordings are zstd-compressed inline by `perf` (`-z`), so no external
+  compression step is needed.
+- The collector service runs in the `scylla-helper.slice` systemd slice.
+- At 2 Hz system-wide sampling the data rate is low, but ensure `/var/log` has
+  headroom for the retained recordings on high-core-count nodes.
+- Service: `scylla-perf-collector.service`.

--- a/dist/common/perf-collector/scylla-perf-collector.service
+++ b/dist/common/perf-collector/scylla-perf-collector.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Collect system-wide perf samples
+After=network.target
+
+[Service]
+Type=simple
+Slice=scylla-helper.slice
+ExecStart=/usr/bin/perf record -a -F 2 -z --switch-output=1d --switch-max-files=15 -o /var/log/scylla-perf/perf.data
+Restart=always
+RestartSec=10
+Nice=10
+IOSchedulingClass=idle
+CPUSchedulingPolicy=idle
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/common/scripts/scylla_setup
+++ b/dist/common/scripts/scylla_setup
@@ -269,6 +269,8 @@ if __name__ == '__main__':
                         help='skip rsyslog setup')
     parser.add_argument('--no-nofiles-setup', action='store_true', default=False,
                         help='skip LimitNOFILES setup')
+    parser.add_argument('--no-perf-collector-setup', action='store_true', default=False,
+                        help='skip perf collector setup')
     parser.add_argument('--rsyslog-server',
                         help='specify a remote rsyslog server to send Scylla logs to. Use ip:port format, if no port is given, Scylla-Monitoring rsyslog will be used')
     if len(sys.argv) == 1:
@@ -313,6 +315,7 @@ if __name__ == '__main__':
     swap_setup = not args.no_swap_setup
     rsyslog_setup = not args.no_rsyslog_setup
     nofiles_setup = not args.no_nofiles_setup
+    perf_collector_setup = not args.no_perf_collector_setup
     rsyslog_server = args.rsyslog_server
     selinux_reboot_required = False
     set_clocksource = False
@@ -540,6 +543,18 @@ if __name__ == '__main__':
     nofiles_setup = interactive_ask_service('Do you want to tune LimitNOFILES run Scylla on large node?', 'Yes - tune LimitNOFILES. No - skip this setup.', nofiles_setup)
     if nofiles_setup:
         run_setup_script('LimitNOFILE tuneup', 'scylla_nofile_setup')
+
+    if not is_nonroot():
+        perf_collector_setup = interactive_ask_service('Do you want to enable the perf data collector?', 'Yes - enables system-wide perf sampling for profiling and diagnostics. The collector runs with minimal overhead. No - skip this step.', perf_collector_setup)
+        args.no_perf_collector_setup = not perf_collector_setup
+        if perf_collector_setup:
+            perf_unit = systemd_unit('scylla-perf-collector.service')
+            perf_unit.enable()
+            perf_unit.start()
+        else:
+            perf_unit = systemd_unit('scylla-perf-collector.service')
+            perf_unit.stop()
+            perf_unit.disable()
 
     print('ScyllaDB setup finished.')
 

--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -46,6 +46,13 @@ Description: Scylla kernel tuning configuration
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.
 
+Package: %{product}-perf-collector
+Architecture: any
+Depends: linux-perf | linux-tools-generic
+Description: Scylla system-wide perf data collector
+ This package contains the system-wide perf data collector for ScyllaDB.
+ It collects low-overhead CPU profiling samples and rotates logs automatically.
+
 Package: %{product}
 Section: metapackages
 Architecture: any
@@ -53,6 +60,7 @@ Depends: %{product}-server (= ${binary:Version})
  , %{product}-kernel-conf (= ${binary:Version})
  , scylla-node-exporter
  , %{product}-cqlsh (= ${binary:Version})
+Recommends: %{product}-perf-collector (= ${binary:Version})
 Replaces: scylla-enterprise (<< 2025.1.0~)
 Breaks: scylla-enterprise (<< 2025.1.0~)
 Description: Scylla database metapackage

--- a/dist/debian/debian/scylla-perf-collector.install
+++ b/dist/debian/debian/scylla-perf-collector.install
@@ -1,0 +1,2 @@
+usr/lib/systemd/system/scylla-perf-collector.service
+var/log/scylla-perf

--- a/dist/debian/debian/scylla-perf-collector.postinst
+++ b/dist/debian/debian/scylla-perf-collector.postinst
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ -d /run/systemd/system ]; then
+    systemctl daemon-reload >/dev/null || true
+fi
+
+#DEBHELPER#

--- a/dist/debian/debian/scylla-perf-collector.prerm
+++ b/dist/debian/debian/scylla-perf-collector.prerm
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ -d /run/systemd/system ]; then
+    systemctl stop scylla-perf-collector.service || true
+    systemctl disable scylla-perf-collector.service || true
+fi
+
+#DEBHELPER#

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -11,6 +11,7 @@ Requires:       %{product}-server = %{version}-%{release}
 Requires:       %{product}-conf = %{version}-%{release}
 Requires:       %{product}-python3 = %{version}-%{release}
 Requires:       %{product}-kernel-conf = %{version}-%{release}
+Recommends:     %{product}-perf-collector = %{version}-%{release}
 Requires:       scylla-node-exporter
 Requires:       %{product}-cqlsh = %{version}-%{release}
 Provides:       scylla-enterprise = %{version}-%{release}
@@ -226,6 +227,32 @@ fi
 /opt/scylladb/kernel_conf/*
 %ghost /etc/sysctl.d/99-scylla-perfevent.conf
 %ghost /etc/sysctl.d/99-scylla-tcp.conf
+
+
+%package perf-collector
+Group:          Applications/Databases
+Summary:        Scylla system-wide perf data collector
+Requires:       perf
+%description perf-collector
+This package contains the system-wide perf data collector for ScyllaDB.
+It collects low-overhead CPU profiling samples and rotates them automatically.
+
+%post perf-collector
+/usr/bin/systemctl daemon-reload ||:
+
+%preun perf-collector
+if [ $1 -eq 0 ] ; then
+    /usr/bin/systemctl --no-reload disable scylla-perf-collector.service ||:
+    /usr/bin/systemctl stop scylla-perf-collector.service ||:
+fi
+
+%postun perf-collector
+/usr/bin/systemctl daemon-reload ||:
+
+%files perf-collector
+%defattr(-,root,root)
+%attr(0644,root,root) %{_unitdir}/scylla-perf-collector.service
+%attr(0755,root,root) %dir /var/log/scylla-perf
 
 
 %changelog

--- a/install.sh
+++ b/install.sh
@@ -356,6 +356,10 @@ installconfig 644 conf/cassandra-rackdc.properties "$retc"/scylla
 if $housekeeping; then
     installconfig 644 conf/housekeeping.cfg "$retc"/scylla.d
 fi
+# scylla-perf-collector
+if ! $nonroot; then
+    install -d -m755 "$root"/var/log/scylla-perf
+fi
 # scylla-kernel-conf
 if ! $nonroot; then
     install -m755 -d "$rusr/lib/sysctl.d"
@@ -395,6 +399,7 @@ if ! $without_systemd; then
     install -m644 dist/common/systemd/scylla-housekeeping-daily.service -Dt "$rsystemd"
     install -m644 dist/common/systemd/scylla-housekeeping-restart.service -Dt "$rsystemd"
     install -m644 dist/common/systemd/scylla-server.service -Dt "$rsystemd"
+    install -m644 dist/common/perf-collector/scylla-perf-collector.service -Dt "$rsystemd"
     install -m644 dist/common/systemd/*.slice -Dt "$rsystemd"
     install -m644 dist/common/systemd/*.timer -Dt "$rsystemd"
 fi


### PR DESCRIPTION
Introduce a system-wide perf data collector packaged as its own
subpackage (scylla-perf-collector) for both RPM and DEB builds.

This allows intermittent performance problems to be diagnosed
by downloading the perf recordings and looking at samples
collected at time points where problems were reported.

The collector runs perf record in the scylla-server slice,
sampling at 2 Hz system-wide, rotating output daily via
perf's built-in rotation with 14-day retention. Rotated files
are compressed.

The low sampling frequency was chosen to reduce the risk of
exhausting storage.

RPM:
- New %package perf-collector with Requires: perf, logrotate
- %post runs daemon-reload; %preun stops/disables on uninstall
- Superpackage (scylla) pulls in the subpackage via Requires

DEB:
- New binary package in control.template with
  Depends: linux-tools-common, logrotate
- New debian/scylla-perf-collector.{install,postinst,prerm} files
- Metapackage depends on the new subpackage

scylla_setup:
- Added --no-perf-collector-setup CLI flag
- Interactive prompt asks whether to enable the perf collector
- When enabled: enables and starts scylla-perf-collector.service
- When disabled: stops and disables the service
- Gated behind is_nonroot() since the service requires root

The service is not auto-enabled on package install. Instead,
scylla_setup gives the operator the choice, consistent with how other
optional services (fstrim, housekeeping, etc.) are handled.