### PR TITLE
tools/scylla-nodetool: improve scrub status messages

### DIFF
--- a/test/nodetool/test_scrub.py
+++ b/test/nodetool/test_scrub.py
@@ -151,7 +151,7 @@ def test_scrub_validation_errors_exit_code(nodetool, scylla_only):
                     expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
                     expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"scrub_mode": "VALIDATE"},
                                      response=scrub_status.validation_errors.value)]},
-            ["scrub failed: there are invalid sstables"])
+            ["scrub found invalid sstables"])
 
     # Check that when the first scrub fails, nodetool goes on to scrub the remainder
     check_nodetool_fails_with(
@@ -163,7 +163,7 @@ def test_scrub_validation_errors_exit_code(nodetool, scylla_only):
                                      response=scrub_status.validation_errors.value),
                     expected_request("GET", "/storage_service/keyspace_scrub/ks2", params={"scrub_mode": "VALIDATE"},
                                      response=scrub_status.successful.value)]},
-            ["scrub failed: there are invalid sstables"])
+            ["scrub found invalid sstables"])
 
 
 def test_scrub_abort_exit_code(nodetool, scylla_only):
@@ -179,7 +179,7 @@ def test_scrub_abort_exit_code(nodetool, scylla_only):
                     expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
                     expected_request("GET", "/storage_service/keyspace_scrub/ks", params={"scrub_mode": "ABORT"},
                                      response=scrub_status.aborted.value)]},
-            ["scrub failed: aborted"])
+            ["scrub was aborted"])
 
     # Check that when the first scrub fails, nodetool goes on to scrub the remainder
     check_nodetool_fails_with(
@@ -191,7 +191,7 @@ def test_scrub_abort_exit_code(nodetool, scylla_only):
                                      response=scrub_status.aborted.value),
                     expected_request("GET", "/storage_service/keyspace_scrub/ks2", params={"scrub_mode": "ABORT"},
                                      response=scrub_status.successful.value)]},
-            ["scrub failed: aborted"])
+            ["scrub was aborted"])
 
 def test_scrub_drop_unfixable_sstables_option(nodetool):
     nodetool("scrub", "ks", "tbl1", "--mode=SEGREGATE", "--drop-unfixable-sstables", expected_requests=[

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -2301,9 +2301,9 @@ void scrub_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
             case api::scrub_status::unable_to_cancel:
                 continue;
             case api::scrub_status::aborted:
-                throw operation_failed_on_scylladb("scrub failed: aborted");
+                throw operation_failed_on_scylladb("scrub was aborted");
             case api::scrub_status::validation_errors:
-                throw operation_failed_on_scylladb("scrub failed: there are invalid sstables");
+                throw operation_failed_on_scylladb("scrub found invalid sstables");
         }
     }
 }


### PR DESCRIPTION
Scrub can finish with some distinct status messages, beyond just success and fail. These other statuses were reported as failures: scrub returns non-0 status code and prints an error message.
This is particularly confusing for --mode=validate, which can finish with status code "validation_errors". This means scrub finished successfully but found invalid sstables. But the error message suggested that scrub also failed. Improve the message, so it doesn't imply that scrub itself failed.

Backport: improvement, no backport