### PR TITLE
scylla-gdb: fix compaction-tasks command for compaction_group_view

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -5475,7 +5475,14 @@ class scylla_compaction_tasks(gdb.Command):
             task_list = [seastar_shared_ptr(t).get().dereference() for t in std_list(cm['_tasks'])]
 
         for task in task_list:
-            schema = schema_ptr(task['_compacting_table'].dereference()['_schema'])
+            compacting_table = task['_compacting_table']
+            try:
+                # _compacting_table is a compaction::compaction_group_view*
+                # downcast to the concrete type to access _t (table&) and its _schema
+                concrete = downcast_vptr(compacting_table)
+                schema = schema_ptr(concrete['_t']['_schema'])
+            except gdb.error:
+                schema = schema_ptr(compacting_table.dereference()['_schema'])
             key = 'type={}, state={:5}, {}'.format(task['_type'], str(task['_state']), schema.table_name())
             task_hist.add(key)
 


### PR DESCRIPTION
_compacting_table is now a compaction::compaction_group_view* (virtual interface) which doesn't have a _schema member directly. Use downcast_vptr() to get the concrete type and navigate through _t._schema.

Fallback to the old path for compatibility with older builds.

Reported by https://jenkins.scylladb.com/job/scylla-master/job/scylla-ci/29601/