### PR TITLE
build: fix collect-dist target failing with missing RPM/DEB rules

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -3005,9 +3005,9 @@ def write_build_file(f,
         build $builddir/{mode}/dist/tar/{scylla_product}-cqlsh-{scylla_version}-{scylla_release}.{arch}.tar.gz: copy tools/cqlsh/build/{scylla_product}-cqlsh-{scylla_version}-{scylla_release}.{arch}.tar.gz
         build $builddir/{mode}/dist/tar/{scylla_product}-cqlsh-package.tar.gz: copy tools/cqlsh/build/{scylla_product}-cqlsh-{scylla_version}-{scylla_release}.{arch}.tar.gz
 
-        build $builddir/{mode}/dist/rpm: collect_pkgs | {' '.join(all_rpms)} $builddir/dist/{mode}/redhat dist-cqlsh-rpm dist-python3-rpm
+        build $builddir/{mode}/dist/rpm: collect_pkgs | $builddir/dist/{mode}/redhat dist-cqlsh-rpm dist-python3-rpm
           pkgs = {' '.join(all_rpms)}
-        build $builddir/{mode}/dist/deb: collect_pkgs | {' '.join(all_debs)} $builddir/dist/{mode}/debian dist-cqlsh-deb dist-python3-deb
+        build $builddir/{mode}/dist/deb: collect_pkgs | $builddir/dist/{mode}/debian dist-cqlsh-deb dist-python3-deb
           pkgs = {' '.join(all_debs)}
         build collect-dist-{mode}: phony $builddir/{mode}/dist/rpm $builddir/{mode}/dist/deb
         build {mode}-dist: phony dist-server-{mode} dist-server-debuginfo-{mode} dist-python3-{mode} dist-unified-{mode} dist-cqlsh-{mode}


### PR DESCRIPTION
The collect_pkgs ninja rules for building collect-dist-{mode} listed individual RPM and DEB file paths as order-only dependencies. However, the rpmbuild/debbuild rules only declare the output *directory* (e.g. $builddir/dist/{mode}/redhat), not the individual files within it. This caused ninja to fail with:

```
ninja: error: '...scylla-....rpm', needed by 'build/.../dist/rpm',
missing and no known rule to make it
```

Fix by removing the individual package file paths from the order-only dependency list. The directory targets ($builddir/dist/{mode}/redhat, dist-cqlsh-rpm, dist-python3-rpm, etc.) already ensure the packages are built before collect_pkgs copies them via the $pkgs variable.

5694c93c12 ("build: add collect-dist target to organize build artifacts") intreduced this regression

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2215

**This regression is only in master, no need for backport**