### PR TITLE
doc: remove broken References section from sstables-3-index

### DIFF
--- a/docs/architecture/sstable/sstable3/sstables-3-index.rst
+++ b/docs/architecture/sstable/sstable3/sstables-3-index.rst
@@ -131,24 +131,6 @@ Its size is the same as the value stored in ``promoted_index_blocks_count``. The
 
 It is possible to read those offsets (commonly referred to as "offsets map") directly without reading the entire promoted index. This, in turn, allows searching through the promoted index using binary search which results in O(log N) reads instead of O (N). 
 
-References
-..........
-
-The following code parts in Cassandra deal with index serialisation/de-serialisation:
-
-* `ColumnIndex.java, buildRowIndex`_ 
-
-* `RowIndexEntry.java`_ 
-
-* `IndexInfo.java`_
-
-.. _`ColumnIndex.java, buildRowIndex`: https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/db/ColumnIndex.java
-
-.. _`IndexInfo.java`: https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/io/sstable/IndexInfo.java
-
-.. _`RowIndexEntry.java`: https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/db/RowIndexEntry.java
-
-
 Additional Information
 ----------------------
 


### PR DESCRIPTION
Remove the References section containing broken links to Cassandra source files that no longer exist.

Fixes https://github.com/scylladb/scylladb/issues/30080

This PR removes broken links, so the minimum backport is to versions 2026.1 and 2026.2 (the lates LTS and the upcoming stable version).