### PR TITLE
repair: Abort follower repair_meta on session close

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -823,6 +823,7 @@ private:
     bool _small_table_optimization_tm_calculated = false;
     service::frozen_topology_guard _frozen_topology_guard;
     service::topology_guard _topology_guard;
+    optimized_optional<seastar::abort_source::subscription> _session_abort_sub;
     const bool _is_eligible_to_repair_rejection;
 private:
     incremental_repair_meta _incremental_repair_meta;
@@ -858,6 +859,12 @@ public:
     }
     uint32_t repair_meta_id() const {
         return _repair_meta_id;
+    }
+    void set_session_abort_subscription(optimized_optional<seastar::abort_source::subscription> sub) {
+        _session_abort_sub = std::move(sub);
+    }
+    void clear_session_abort_subscription() {
+        _session_abort_sub = {};
     }
     const std::optional<repair_sync_boundary>& current_sync_boundary() const {
         return _current_sync_boundary;
@@ -1009,6 +1016,7 @@ public:
         if (_stopped) {
             return _stopped->get_future();
         }
+        clear_session_abort_subscription();
         promise<> stopped;
         _stopped.emplace(stopped.get_future());
         auto gate_future = _gate.close();
@@ -1833,6 +1841,10 @@ public:
     repair_row_level_stop_handler(repair_service& rs, locator::host_id from, uint32_t repair_meta_id, sstring ks_name, sstring cf_name, dht::token_range range, bool mark_as_repaired) {
         rlogger.debug("<<< Finished Row Level Repair (Follower): local={}, peers={}, repair_meta_id={}, keyspace={}, cf={}, range={}",
                 rs.my_host_id(), from, repair_meta_id, ks_name, cf_name, range);
+        if (utils::get_local_injector().enter("repair_row_level_stop_skip_cleanup")) {
+            rlogger.info("repair_row_level_stop_handler: skipping cleanup due to error injection, repair_meta_id={}", repair_meta_id);
+            co_return;
+        }
         auto rm = rs.get_repair_meta(from, repair_meta_id);
         rm->set_repair_state_for_local_node(repair_state::row_level_stop_started);
         co_await rs.remove_repair_meta(from, repair_meta_id, std::move(ks_name), std::move(cf_name), std::move(range), mark_as_repaired);
@@ -3880,6 +3892,37 @@ repair_service::insert_repair_meta(
         rm->set_repair_state_for_local_node(repair_state::row_level_start_finished);
     } else {
         rlogger.debug("insert_repair_meta: Inserted repair_meta_id {} for node {}", id.repair_meta_id, id.ip);
+    }
+    if (topo_guard != service::null_topology_guard) {
+        auto& session_as = service::get_topology_session_manager().get_session_abort_source(topo_guard);
+        auto sub = session_as.subscribe([this, id, topo_guard] () noexcept {
+            auto it = repair_meta_map().find(id);
+            if (it == repair_meta_map().end()) {
+                return;
+            }
+            auto rm = it->second;
+            repair_meta_map().erase(it);
+            rlogger.info("Session {} closed, removing repair_meta_id {} for node {}", topo_guard, id.repair_meta_id, id.ip);
+            // Copy captures to stack locals before stop(), because stop() calls
+            // clear_session_abort_subscription() which destroys this closure object.
+            // After that, the outer lambda's captures (id, topo_guard) are freed.
+            // Stack locals remain valid for the inner lambda to capture from.
+            auto local_id = id;
+            auto local_topo_guard = topo_guard;
+            // Start stop() in the background. The topology_guard (gate::holder) inside
+            // repair_meta is released when stop() completes and the shared_ptr drops,
+            // which ensures session drain waits for this cleanup to finish.
+            (void)rm->stop().handle_exception([rm, local_id, local_topo_guard] (auto ep) {
+                rlogger.warn("Session {}: failed to stop orphaned repair_meta_id {} for node {}: {}", local_topo_guard, local_id.repair_meta_id, local_id.ip, ep);
+            });
+        });
+        if (!sub) {
+            repair_meta_map().erase(id);
+            rlogger.info("Session {} already closed, removing late repair_meta_id {} for node {}", topo_guard, id.repair_meta_id, id.ip);
+            co_await rm->stop();
+            co_return;
+        }
+        rm->set_session_abort_subscription(std::move(sub));
     }
 }
 

--- a/service/session.cc
+++ b/service/session.cc
@@ -38,6 +38,14 @@ session::guard session_manager::enter_session(session_id id) {
     return guard;
 }
 
+seastar::abort_source& session_manager::get_session_abort_source(session_id id) {
+    auto i = _sessions.find(id);
+    if (i == _sessions.end()) {
+        throw std::runtime_error(fmt::format("Session not found: {}", id));
+    }
+    return i->second->abort_source();
+}
+
 void session_manager::create_session(session_id id) {
     auto [i, created] = _sessions.emplace(id, std::make_unique<session>(id));
     if (created) {

--- a/service/session.hh
+++ b/service/session.hh
@@ -10,6 +10,7 @@
 
 #include "utils/UUID.hh"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/semaphore.hh>
@@ -42,6 +43,7 @@ public:
 private:
     session_id _id;
     seastar::named_gate _gate;
+    seastar::abort_source _as;
     std::optional<shared_future<>> _closed;
     link_type _link;
 public:
@@ -81,6 +83,7 @@ public:
     /// Can be called many times.
     void start_closing() noexcept {
         if (!_closed) {
+            _as.request_abort();
             _closed = seastar::shared_future<>(_gate.close());
         }
     }
@@ -93,6 +96,10 @@ public:
 
     session_id id() const {
         return _id;
+    }
+
+    seastar::abort_source& abort_source() noexcept {
+        return _as;
     }
 
     size_t gate_count() const {
@@ -116,6 +123,10 @@ public:
     session_manager();
 
     session::guard enter_session(session_id id);
+
+    /// Returns the abort_source associated with a session.
+    /// Throws if the session does not exist.
+    seastar::abort_source& get_session_abort_source(session_id id);
 
     /// Creates a session on this shard if it doesn't exist yet.
     /// If the session already exists does nothing.

--- a/test/boost/sessions_test.cc
+++ b/test/boost/sessions_test.cc
@@ -96,4 +96,133 @@ SEASTAR_TEST_CASE(test_session_closing) {
     });
 }
 
+// Verifies that when a session is closed, subscribers to its abort_source
+// are notified, enabling them to release their session guards and unblock
+// drain_closing_sessions(). This is the mechanism used to clean up orphaned
+// repair_meta instances on follower nodes.
+SEASTAR_TEST_CASE(test_session_abort_source_unblocks_drain) {
+    return seastar::async([] {
+        session_manager mgr;
+
+        auto id = session_id(utils::make_random_uuid());
+        mgr.create_session(id);
+
+        // Simulate a repair_meta holding a session guard
+        auto guard = std::make_optional<session::guard>(mgr.enter_session(id));
+        BOOST_REQUIRE(guard->valid());
+
+        // Subscribe to the session's abort_source (as insert_repair_meta does)
+        auto& session_as = mgr.get_session_abort_source(id);
+        BOOST_REQUIRE(!session_as.abort_requested());
+
+        bool aborted = false;
+        auto sub = session_as.subscribe([&] () noexcept {
+            aborted = true;
+            // Release the guard (simulates repair_meta cleanup)
+            guard.reset();
+        });
+        BOOST_REQUIRE(sub);
+
+        // Close the session — this should fire the abort_source
+        mgr.initiate_close_of_sessions_except({});
+        BOOST_REQUIRE(aborted);
+        BOOST_REQUIRE(!guard.has_value());
+        BOOST_REQUIRE(session_as.abort_requested());
+
+        // drain should complete immediately since the guard was released
+        mgr.drain_closing_sessions().get();
+    });
+}
+
+// Verifies that subscribing to an already-closed session's abort_source
+// returns an empty subscription (abort already requested).
+SEASTAR_TEST_CASE(test_session_abort_source_already_closed) {
+    return seastar::async([] {
+        session_manager mgr;
+
+        auto id = session_id(utils::make_random_uuid());
+        mgr.create_session(id);
+
+        mgr.initiate_close_of_sessions_except({});
+
+        auto& session_as = mgr.get_session_abort_source(id);
+        BOOST_REQUIRE(session_as.abort_requested());
+
+        // Subscribing after abort returns empty subscription
+        bool called = false;
+        auto sub = session_as.subscribe([&] () noexcept {
+            called = true;
+        });
+        BOOST_REQUIRE(!sub);
+        BOOST_REQUIRE(!called);
+
+        mgr.drain_closing_sessions().get();
+    });
+}
+
+// Verifies the late-subscription path used by insert_repair_meta(): if the
+// session is already closing, subscribe() returns an empty subscription and the
+// caller must release its guard explicitly.
+SEASTAR_TEST_CASE(test_session_abort_source_already_closed_requires_immediate_cleanup) {
+    return seastar::async([] {
+        session_manager mgr;
+
+        auto id = session_id(utils::make_random_uuid());
+        mgr.create_session(id);
+
+        auto guard = std::make_optional<session::guard>(mgr.enter_session(id));
+
+        mgr.initiate_close_of_sessions_except({});
+
+        auto& session_as = mgr.get_session_abort_source(id);
+        BOOST_REQUIRE(session_as.abort_requested());
+
+        bool called = false;
+        auto sub = session_as.subscribe([&] () noexcept {
+            called = true;
+        });
+        BOOST_REQUIRE(!sub);
+        BOOST_REQUIRE(!called);
+
+        auto f = mgr.drain_closing_sessions();
+        BOOST_REQUIRE(!f.available());
+
+        // This mirrors the insert_repair_meta() fix: when subscribe() returns
+        // empty, the late entrant must clean itself up immediately.
+        guard.reset();
+        f.get();
+    });
+}
+
+// Verifies that drain blocks until the abort subscriber releases the guard.
+SEASTAR_TEST_CASE(test_session_abort_source_drain_blocks_without_release) {
+    return seastar::async([] {
+        session_manager mgr;
+
+        auto id = session_id(utils::make_random_uuid());
+        mgr.create_session(id);
+
+        auto guard = std::make_optional<session::guard>(mgr.enter_session(id));
+
+        // Subscribe but do NOT release the guard in the callback
+        auto& session_as = mgr.get_session_abort_source(id);
+        bool aborted = false;
+        auto sub = session_as.subscribe([&] () noexcept {
+            aborted = true;
+            // Intentionally not releasing guard here
+        });
+
+        mgr.initiate_close_of_sessions_except({});
+        BOOST_REQUIRE(aborted);
+
+        // drain should block because the guard is still held
+        auto f = mgr.drain_closing_sessions();
+        BOOST_REQUIRE(!f.available());
+
+        // Now release the guard — drain should complete
+        guard.reset();
+        f.get();
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cluster/test_session_abort_repair_meta.py
+++ b/test/cluster/test_session_abort_repair_meta.py
@@ -1,0 +1,90 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import logging
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.repair import create_table_insert_data_for_repair
+
+
+logger = logging.getLogger(__name__)
+
+
+async def wait_for_cleanup_log(logs, marks, timeout: float = 15) -> list[tuple[str, object]]:
+    pattern = r"Session .* (closed, removing repair_meta_id|already closed, removing late repair_meta_id) .* for node"
+    tasks = [
+        asyncio.create_task(log.wait_for(pattern, from_mark=mark, timeout=timeout))
+        for log, mark in zip(logs, marks)
+    ]
+    try:
+        for task in asyncio.as_completed(tasks):
+            try:
+                _, matches = await task
+            except TimeoutError:
+                continue
+            if matches:
+                return matches
+        return []
+    finally:
+        for task in tasks:
+            task.cancel()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_session_abort_cleans_orphan_repair_meta(manager: ManagerClient):
+    """Verifies that orphaned repair_meta on a follower does not block
+    drain_closing_sessions() thanks to the session abort_source mechanism.
+
+    Reproduces the scenario from SCYLLADB-1805:
+    1. A tablet repair creates repair_meta on a follower with a session guard.
+    2. The follower's repair_row_level_stop handler skips cleanup (simulating
+       the stop RPC never properly cleaning up, leaving an orphan repair_meta
+       holding the session gate).
+    3. The topology coordinator advances past repair → end_repair, closing the
+       session and issuing a barrier_and_drain.
+    4. Without the fix, drain_closing_sessions() would hang because the orphan
+       repair_meta holds the session gate. With the fix, the session's
+       abort_source fires on close, which cleans up the orphan repair_meta,
+       allowing drain to complete and the tablet repair to finish.
+    """
+    servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(
+        manager, rf=3, tablets=1, nr_keys=10,
+        cmdline=['--logger-log-level', 'repair=info', '--logger-log-level', 'session=info'])
+
+    # token=-1 means repair all tablets in the table
+    token = -1
+
+    # Enable injection on ALL nodes to skip repair_meta cleanup in
+    # repair_row_level_stop_handler. This simulates an orphan repair_meta
+    # remaining on the follower after repair completes.
+    for s in servers:
+        await manager.api.enable_injection(s.ip_addr, "repair_row_level_stop_skip_cleanup", one_shot=True)
+
+    # Open logs to verify the cleanup via abort_source
+    logs = [await manager.server_open_log(s.server_id) for s in servers]
+    marks = [await log.mark() for log in logs]
+
+    # Trigger tablet repair. This will:
+    # 1. Run row-level repair (repair_meta created on follower with session guard)
+    # 2. Stop handler skips cleanup (orphan repair_meta left on follower)
+    # 3. Coordinator advances to end_repair → barrier_and_drain
+    # 4. Session close fires abort_source → orphan cleaned up
+    # 5. drain_closing_sessions completes → repair finishes
+    # Trigger tablet repair with a timeout to avoid hanging if the fix regresses.
+    await asyncio.wait_for(
+        manager.api.tablet_repair(servers[0].ip_addr, ks, "test", token),
+        timeout=120)
+
+    # Verify the session abort mechanism fired by checking logs.
+    # Cleanup can happen either from the abort_source callback or immediately
+    # when the follower races with a session that already started closing.
+    cleanup_msgs = await wait_for_cleanup_log(logs, marks)
+    assert len(cleanup_msgs) > 0, \
+        "Expected session abort_source cleanup log message for orphaned repair_meta"
+    logger.info(f"Found {len(cleanup_msgs)} abort_source cleanup message(s)")


### PR DESCRIPTION
During topology operations that use repair (for example, removenode), the topology coordinator sends stream_ranges to all normal nodes. Each node then becomes a repair coordinator for its own ranges and sends repair_row_level_start RPCs to follower nodes. Followers create repair_meta entries that keep the topology session gate open via topology_guard.

If a repair coordinator crashes after followers have created repair_meta entries but before it sends repair_row_level_stop, those follower-side entries become orphaned. In the usual crash case, gossip callbacks such as on_dead() or on_restart() remove repair_meta for the failed node. But that cleanup only happens if gossip detects the failure or restart. If the coordinator comes back quickly enough that the failure detector never fires, no cleanup happens on the follower side.

Later, when the topology coordinator calls drain_closing_sessions(), it can hang indefinitely: the session gate never reaches zero because the orphaned repair_meta entries still hold topology_guard, and nothing notifies them to release it.

Fix this by subscribing each follower repair_meta to the session's abort_source in insert_repair_meta(). When the session starts closing, the abort_source fires, the orphaned repair_meta is removed from the map, and stop() is launched in the background. Once stop() completes, the last shared_ptr to repair_meta is dropped, topology_guard is destroyed, and the gate holder is released, allowing drain_closing_sessions() to finish.

On the normal path, when repair_row_level_stop arrives before the session closes, remove_repair_meta() simply erases the subscription, so non-orphaned entries pay no extra cleanup cost.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1805

Backport to all active branches. Start with newer branches to get more mileages.