### PR TITLE
topology: defer system.peers removal for left nodes still referenced by tablets

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -482,7 +482,14 @@ future<storage_service::nodes_to_notify_after_sync> storage_service::sync_raft_t
 
     auto process_left_node = [&] (raft::server_id id, locator::host_id host_id, std::optional<gms::inet_address> ip, bool notify) -> future<> {
         if (ip) {
-            sys_ks_futures.push_back(_sys_ks.local().remove_endpoint(*ip));
+            // Don't remove from system.peers if the node is still referenced by tablet metadata.
+            // The IP needs to remain available in the address_map after restart so that
+            // operations like store_hint can resolve the host_id to an IP.
+            // The entry will be removed from system.peers when the node becomes "released"
+            // (all tablet migrations referencing it complete).
+            if (t.left_nodes_rs.find(id) == t.left_nodes_rs.end()) {
+                sys_ks_futures.push_back(_sys_ks.local().remove_endpoint(*ip));
+            }
 
             co_await _gossiper.force_remove_endpoint(host_id, gms::null_permit_id);
             if (notify) {
@@ -621,6 +628,14 @@ future<storage_service::nodes_to_notify_after_sync> storage_service::sync_raft_t
     if (prev_released) {
         auto nodes_to_release = get_released_nodes(t, *tmptr);
         std::erase_if(nodes_to_release, [&] (const auto& host_id) { return prev_released->contains(host_id); });
+        // Remove from system.peers now that the node is no longer referenced by tablet metadata.
+        // This completes the deferred removal from process_left_node.
+        for (const auto& host_id : nodes_to_release) {
+            auto ip = _address_map.find(host_id);
+            if (ip) {
+                sys_ks_futures.push_back(_sys_ks.local().remove_endpoint(*ip));
+            }
+        }
         std::copy(nodes_to_release.begin(), nodes_to_release.end(), std::back_inserter(nodes_to_notify.released));
     }
 

--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -64,8 +64,7 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
         server_to_down = await find_server_by_host_id(manager, servers, HostID(str(base_replicas[0][0])))
 
         logger.info('Downing a node to be replaced')
-        # convict=False to avoid triggering SCYLLADB-1996
-        await manager.server_stop(server_to_replace.server_id, convict=False)
+        await manager.server_stop(server_to_replace.server_id)
 
         logger.info('Blocking tablet rebuild')
         coord = await get_topology_coordinator(manager)
@@ -84,8 +83,7 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
         await coord_log.wait_for('tablet_transition_updates: waiting', from_mark=coord_mark)
 
         if server_to_down.server_id != server_to_replace.server_id:
-            # convict=False to avoid triggering SCYLLADB-1996
-            await manager.server_stop(server_to_down.server_id, convict=False)
+            await manager.server_stop(server_to_down.server_id)
 
         # The update is supposed to go to the second replica only, since the other one is downed.
         # If pairing would shift, the update to the view would be lost because the first replica
@@ -97,6 +95,18 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
 
         if server_to_down.server_id != server_to_replace.server_id:
             await manager.server_start(server_to_down.server_id)
+
+            # After restart, server_to_down gets its host_id -> IP mapping from system.peers,
+            # but since server_to_replace is already down and being replaced, its IP may have
+            # already been erased from system.peers. If the view replica hasn't been yet
+            # migrated from the server_to_replace, if we write to the base replica paired with it,
+            # we'll try to write a view update hint to it, which requires the IP mapping.
+            # We perform such a write here to trigger the view update and verify that the IP mapping
+            # is actually still present and the update goes through.
+            # This write reproduces SCYLLADB-1996
+            logger.info('Writing on restarted node to trigger view update to replaced node')
+            server_to_down_cql = await manager.get_cql_exclusive(server_to_down)
+            await server_to_down_cql.run_async(SimpleStatement(f"INSERT INTO {ks}.test (pk, c) VALUES (7, 8)", consistency_level=ConsistencyLevel.ONE))
 
         logger.info('Unblocking tablet rebuild')
         if coord_serv.server_id != server_to_down.server_id:


### PR DESCRIPTION
When a node enters left_token_ring state, process_left_node immediately removes it from system.peers. If another node restarts while a node is in the left state, the restarted node will find no IP for this node when it loads its address_map from system.peers. Any subsequent operation that needs the left node's IP (e.g. store_hint after a failed view update) crashes with:

  "No ip address for <host_id> when one is expected"

We fix this by deferring the system.peers removal: if the left node is still in left_nodes_rs (i.e. still referenced by tablet metadata), we skip the removal in process_left_node. The entry is instead removed when the node becomes "released" — when all tablet migrations referencing it complete and it's no longer in token_metadata topology. This is done in the existing released-nodes section of sync_raft_topology_nodes.

This scenario sometimes reproduced in test_tablet_mv_replica_pairing_during_replace test case. This test already prepares perfect conditions for the issue to occur but the trigger (writing a hint to the left node from the node which restarted) happened non-deterministically. We extend the test to include a write which directly triggers the last condition for the failure.

Fixes: SCYLLADB-1996