### PR TITLE
view_update_generator: hold gate in process_staging_sstables

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -242,6 +242,9 @@ future<> view_update_generator::process_staging_sstables(lw_shared_ptr<replica::
     for (auto& sst : sstables) {
         _progress_tracker->on_sstable_registration(sst);
     }
+    auto deregister_sstables = defer([this, &sstables] {
+        _progress_tracker->on_sstables_deregistration(sstables);
+    });
 
     co_await utils::get_local_injector().inject("view_update_generator_pause_before_processing",
             utils::wait_for_message(std::chrono::minutes(5)));
@@ -254,8 +257,6 @@ future<> view_update_generator::process_staging_sstables(lw_shared_ptr<replica::
     if (result == stop_iteration::yes) {
         throw abort_requested_exception{};
     }
-
-    _progress_tracker->on_sstables_deregistration(sstables);
 
     auto end_time = db_clock::now();
     auto duration = std::chrono::duration<float>(end_time - start_time);

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -237,17 +237,19 @@ std::pair<stop_iteration, uint64_t> view_update_generator::generate_updates_from
 }
 
 future<> view_update_generator::process_staging_sstables(lw_shared_ptr<replica::table> table, std::vector<sstables::shared_sstable> sstables) {
-    return seastar::async([this, table = std::move(table), &sstables] {
-        for(auto& sst: sstables) {
+    // TODO fix indent
+        for (auto& sst : sstables) {
             _progress_tracker->on_sstable_registration(sst);
         }
 
-        utils::get_local_injector().inject("view_update_generator_pause_before_processing",
-                utils::wait_for_message(std::chrono::minutes(5))).get();
+        co_await utils::get_local_injector().inject("view_update_generator_pause_before_processing",
+                utils::wait_for_message(std::chrono::minutes(5)));
 
         // Generate view updates from staging sstables
         auto start_time = db_clock::now();
-        auto [result, input_size] = generate_updates_from_staging_sstables(table, sstables);
+        auto [result, input_size] = co_await seastar::async([this, table, &sstables] {
+            return generate_updates_from_staging_sstables(table, sstables);
+        });
         if (result == stop_iteration::yes) {
             throw abort_requested_exception{};
         }
@@ -260,10 +262,9 @@ future<> view_update_generator::process_staging_sstables(lw_shared_ptr<replica::
         vug_logger.info("Processed {}.{}: {} sstables in {}ms = {}", s->ks_name(), s->cf_name(), sstables.size(),
                         std::chrono::duration_cast<std::chrono::milliseconds>(duration).count(),
                         utils::pretty_printed_throughput(input_size, duration));
-        
+
         // Move staging sstables to table's base directory
-        table->move_sstables_from_staging(sstables).get();
-    });
+        co_await table->move_sstables_from_staging(sstables);
 }
 
 // The .do_abort() just kicks the v.u.g. background fiber to wrap up and it

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -291,15 +291,16 @@ void view_update_generator::do_abort() noexcept {
 
 future<> view_update_generator::drain() {
     co_await _proxy.local().abort_view_writes();
-    co_await _gate.close();
+    if (!_gate.is_closed()) {
+        co_await _gate.close();
+    }
 }
 
 future<> view_update_generator::stop() {
     _db.unplug_view_update_generator();
     do_abort();
-    return std::move(_started).then([this] {
-        _registration_sem.broken();
-    });
+    co_await std::exchange(_started, make_ready_future<>());
+    _registration_sem.broken();
 }
 
 bool view_update_generator::should_throttle() const {

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -237,6 +237,8 @@ std::pair<stop_iteration, uint64_t> view_update_generator::generate_updates_from
 }
 
 future<> view_update_generator::process_staging_sstables(lw_shared_ptr<replica::table> table, std::vector<sstables::shared_sstable> sstables) {
+    auto holder = _gate.hold();
+
     for (auto& sst : sstables) {
         _progress_tracker->on_sstable_registration(sst);
     }

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -237,34 +237,33 @@ std::pair<stop_iteration, uint64_t> view_update_generator::generate_updates_from
 }
 
 future<> view_update_generator::process_staging_sstables(lw_shared_ptr<replica::table> table, std::vector<sstables::shared_sstable> sstables) {
-    // TODO fix indent
-        for (auto& sst : sstables) {
-            _progress_tracker->on_sstable_registration(sst);
-        }
+    for (auto& sst : sstables) {
+        _progress_tracker->on_sstable_registration(sst);
+    }
 
-        co_await utils::get_local_injector().inject("view_update_generator_pause_before_processing",
-                utils::wait_for_message(std::chrono::minutes(5)));
+    co_await utils::get_local_injector().inject("view_update_generator_pause_before_processing",
+            utils::wait_for_message(std::chrono::minutes(5)));
 
-        // Generate view updates from staging sstables
-        auto start_time = db_clock::now();
-        auto [result, input_size] = co_await seastar::async([this, table, &sstables] {
-            return generate_updates_from_staging_sstables(table, sstables);
-        });
-        if (result == stop_iteration::yes) {
-            throw abort_requested_exception{};
-        }
+    // Generate view updates from staging sstables
+    auto start_time = db_clock::now();
+    auto [result, input_size] = co_await seastar::async([this, table, &sstables] {
+        return generate_updates_from_staging_sstables(table, sstables);
+    });
+    if (result == stop_iteration::yes) {
+        throw abort_requested_exception{};
+    }
 
-        _progress_tracker->on_sstables_deregistration(sstables);
+    _progress_tracker->on_sstables_deregistration(sstables);
 
-        auto end_time = db_clock::now();
-        auto duration = std::chrono::duration<float>(end_time - start_time);
-        schema_ptr s = table->schema();
-        vug_logger.info("Processed {}.{}: {} sstables in {}ms = {}", s->ks_name(), s->cf_name(), sstables.size(),
-                        std::chrono::duration_cast<std::chrono::milliseconds>(duration).count(),
-                        utils::pretty_printed_throughput(input_size, duration));
+    auto end_time = db_clock::now();
+    auto duration = std::chrono::duration<float>(end_time - start_time);
+    schema_ptr s = table->schema();
+    vug_logger.info("Processed {}.{}: {} sstables in {}ms = {}", s->ks_name(), s->cf_name(), sstables.size(),
+                    std::chrono::duration_cast<std::chrono::milliseconds>(duration).count(),
+                    utils::pretty_printed_throughput(input_size, duration));
 
-        // Move staging sstables to table's base directory
-        co_await table->move_sstables_from_staging(sstables);
+    // Move staging sstables to table's base directory
+    co_await table->move_sstables_from_staging(sstables);
 }
 
 // The .do_abort() just kicks the v.u.g. background fiber to wrap up and it

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -689,6 +689,63 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_register_semaphore_unit_leak
     }, std::move(test_cfg)).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_view_update_generator_stop_during_process_staging_sstables) {
+    cql_test_config test_cfg;
+    auto& db_cfg = *test_cfg.db_config;
+
+    db_cfg.enable_cache(false);
+    db_cfg.enable_commitlog(false);
+
+    do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("create table t (p text, c text, v text, primary key (p, c))").get();
+        e.execute_cql("create materialized view tv as select * from t "
+                      "where p is not null and c is not null and v is not null "
+                      "primary key (v, c, p)").get();
+
+        auto table = e.local_db().find_column_family("ks", "t").shared_from_this();
+        auto s = table->schema();
+        const auto key = tests::generate_partition_key(s);
+        auto& view_update_generator = e.local_view_update_generator();
+
+        mutation m(s, key);
+        auto col = s->get_column_definition("v");
+        for (int i = 0; i < 1024; ++i) {
+            auto& row = m.partition().clustered_row(*s, clustering_key::from_exploded(*s, {to_bytes(fmt::format("c{}", i))}));
+            row.cells().apply(*col, atomic_cell::make_live(*col->type, 2345, col->type->decompose(sstring("x"))));
+        }
+
+        auto sst = table->make_streaming_staging_sstable();
+        auto sst_cfg = e.local_db().get_user_sstables_manager().configure_writer("test");
+        auto permit = e.local_db().get_reader_concurrency_semaphore().make_tracking_only_permit(s, "test", db::no_timeout, {});
+        sst->write_components(make_mutation_reader_from_mutations(m.schema(), std::move(permit), m), 1ul, s, sst_cfg, {}).get();
+        sst->open_data().get();
+        table->add_sstable_and_update_cache(sst).get();
+
+        constexpr std::string_view injection = "view_update_generator_pause_before_processing";
+        auto disable_injection = defer([injection] {
+            utils::get_local_injector().disable(injection);
+        });
+
+        utils::get_local_injector().enable(injection);
+        auto processing = view_update_generator.process_staging_sstables(table, {sst});
+
+        eventually_true([injection] {
+            return utils::get_local_injector().waiters(injection) > 0;
+        });
+
+        auto stop = view_update_generator.drain().then([&] {
+            return view_update_generator.stop();
+        });
+        utils::get_local_injector().receive_message(injection);
+
+        stop.get();
+        try {
+            processing.get();
+        } catch (abort_requested_exception&) {
+        }
+    }, std::move(test_cfg)).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
     using partition_size_map = std::map<dht::decorated_key, size_t, dht::ring_position_less_comparator>;
 


### PR DESCRIPTION
Add a gate in view_update_generator and hold it in
process_staging_sstables. This function is called from the
view_building_worker and it can happen that it's called while the view
update generator is shutting down, so we use the gate to block new
requests when stopping the view update generator and to wait for
in-flight processing before the view update generator is destroyed.

Fixes [SCYLLADB-2073](https://scylladb.atlassian.net/browse/SCYLLADB-2073)

backport - fixes segfault during shutdown.

[SCYLLADB-2073]: https://scylladb.atlassian.net/browse/SCYLLADB-2073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ