### PR TITLE
sstables_loader: Prevent table destruction during tablet restore down…

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1035,6 +1035,7 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
             std::vector<std::vector<minimal_sst_info>> local_min_infos(smp::count);
             co_await max_concurrent_for_each(sst_chunk, 16, [&loader, tid, &local_min_infos](const auto& sst) -> future<> {
                 auto& table = loader._db.local().find_column_family(tid.table);
+                auto stream_guard = table.stream_in_progress();
                 auto min_info = co_await download_sstable(loader._db.local(), table, sst, llog);
                 local_min_infos[min_info.shard].emplace_back(std::move(min_info));
             });

--- a/sstables_loader_helpers.cc
+++ b/sstables_loader_helpers.cc
@@ -22,6 +22,7 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
     auto components = sstable->all_components();
 
     utils::get_local_injector().inject("fail_download_sstable", [] { throw std::runtime_error("Failing sstable download"); });
+    co_await utils::get_local_injector().inject("pause_download_sstable", utils::wait_for_message(std::chrono::seconds(60)));
 
     // Move the TOC to the front to be processed first since `sstables::create_stream_sink` takes care
     // of creating behind the scene TemporaryTOC instead of usual one. This assures that in case of failure

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1185,3 +1185,66 @@ async def test_aborted_decommision_reenables_snapshot(manager: ManagerClient, ob
         logger.info("Decommissioned was aborted. Creating snapshot")
         await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
         await take_snapshot_on_one_server(ks, servers[0], manager, logger)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_drop_keyspace_during_tablet_restore(manager: ManagerClient, object_storage):
+    """Verify that dropping a keyspace while tablet restore is downloading
+    SSTables does not crash the node.
+
+    The restore path in sstables_loader calls find_column_family() and then
+    download_sstable() which writes SSTable components to the table's data
+    directory.  If DROP KEYSPACE is applied concurrently, the data directory
+    is removed while download_sstable is writing — causing an ENOENT abort.
+
+    Uses the 'pause_download_sstable' error injection to pause the download
+    after find_column_family() has succeeded (table still exists), then issues
+    DROP KEYSPACE and releases the injection to trigger the race.
+
+    The fix acquires a stream_in_progress() phaser guard before downloading,
+    which makes table::stop() block until the download completes.
+    """
+    topology = topo(rf=2, nodes=2, racks=1, dcs=1)
+    servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
+    await manager.disable_tablet_balancing()
+    cql = manager.get_cql()
+
+    num_keys = 24
+    tablet_count = 4
+
+    ks = unique_name("ks_")
+    cf = "test"
+
+    await cql.run_async(
+        f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}")
+    await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk text PRIMARY KEY, value int) WITH tablets = {{'min_tablet_count': {tablet_count}}}")
+    insert_stmt = cql.prepare(f"INSERT INTO {ks}.{cf} (pk, value) VALUES (?, ?)")
+    insert_stmt.consistency_level = ConsistencyLevel.ALL
+    await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
+
+    snap_name, sstables = await take_snapshot(ks, servers, manager, logger)
+    await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, cf, object_storage, manager, logger) for s in servers))
+
+    await cql.run_async(f"DROP KEYSPACE {ks}")
+    await cql.run_async(
+        f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}")
+    await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk text PRIMARY KEY, value int) WITH tablets = {{'min_tablet_count': {tablet_count}, 'max_tablet_count': {tablet_count}}}")
+
+    await manager.api.enable_injection(servers[1].ip_addr, "pause_download_sstable", one_shot=True)
+    server_log = await manager.server_open_log(servers[1].server_id)
+    log_mark = await server_log.mark()
+
+    manifests = [f'{s.server_id}/{snap_name}/manifest.json' for s in servers]
+    tid = await manager.api.restore_tablets(servers[0].ip_addr, ks, cf, snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
+
+    await server_log.wait_for("pause_download_sstable: waiting for message", from_mark=log_mark)
+
+    # Issue DROP concurrently — with the fix stream_in_progress() guard blocks
+    # table::stop() until download completes; without the fix the data directory
+    # is removed and download_sstable gets ENOENT → node aborts.
+    drop_task = asyncio.ensure_future(cql.run_async(f"DROP KEYSPACE {ks}"))
+    await server_log.wait_for(f"Dropping keyspace {ks}", from_mark=log_mark)
+
+    await manager.api.message_injection(servers[1].ip_addr, "pause_download_sstable")
+
+    await drop_task


### PR DESCRIPTION
…load

Similar to e5e6608f2063 ("sstables_loader: prevent use-after-free on table drop during streaming") which fixed the same class of race for load_and_stream, the tablet restore path also holds a replica::table& reference across the download_sstable() coroutine without preventing concurrent table destruction.

If DROP KEYSPACE is applied while download_sstable() is writing SSTable components to the table's data directory, the directory is removed mid-write causing ENOENT → abort (with --abort-on-internal-error).

Fix by acquiring a stream_in_progress() phaser guard after find_column_family() and before download_sstable(). table::stop() calls _pending_streams_phaser.close() which blocks until all outstanding guards are released, keeping the table alive for the duration of the download.

Fixes: SCYLLADB-2187

Fixing recent not released feature (tablet-aware restore), not backporting