### PR TITLE
test/cqlpy/nodetool: fix NameError in compact_keyspace nodetool path

### DIFF
--- a/test/cqlpy/nodetool.py
+++ b/test/cqlpy/nodetool.py
@@ -112,7 +112,7 @@ def compact_keyspace(cql, ks, flush_memtables=True):
         requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_compaction/{ks}', params=params)
     else:
         args = [] if not flush_memtables else ["--flush-memtables", "false"]
-        args.extend([ks, cf])
+        args.extend([ks])
         run_nodetool(cql, "compact", *args)
 
 def take_snapshot(cql, table, tag, skip_flush):


### PR DESCRIPTION
compact_keyspace() operates on a whole keyspace and has no 'cf' variable in scope, but the nodetool fallback branch mistakenly passed it to args.extend([ks, cf]), which would raise NameError whenever that path was taken. Fix by passing only the keyspace.

Backport: only affects manual test runs against Cassandra, no backport needed.