### PR TITLE
raft: don't block replace when group0 leader is unknown

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6035,7 +6035,7 @@ future<join_node_request_result> storage_service::join_node_request_handler(join
         t.arm(timeout);
 
         try {
-            while (!g0_server.current_leader() || *params.replaced_id == g0_server.current_leader()) {
+            while (*params.replaced_id == g0_server.current_leader()) {
                 // FIXME: Wait for the next term instead of sleeping in a loop
                 // Waiting for state change is not enough because a new leader
                 // might be chosen without us going through the candidate state.


### PR DESCRIPTION
The `join_node_request_handler` rejects replace requests when the node
being replaced is still seen as the group0 leader. It loops for up to
10s waiting for the leader to change. However, the loop condition also
blocked when `current_leader()` returned empty (no leader known):

```cpp
while (!g0_server.current_leader() || *params.replaced_id == g0_server.current_leader())
```

This is incorrect: if `current_leader()` is empty, it means the old
leader is already gone (election in progress). The replaced node is
no longer the leader, so the safety check is satisfied and the replace
should be allowed to proceed.

Remove the `!current_leader()` check so the loop only continues while the
replaced node is positively identified as the current leader.

Refs: SCYLLADB-2125

No backport needed: the failure rate is 2/17K in CI (dev mode only, caused by reactor stalls under extreme resource contention) and the code path only affects replace-after-kill scenarios where the replaced node was the group0 leader.