### PR TITLE
 raft: optimize strongly consistent tablet raft group startup latency

### DIFF
--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -308,6 +308,25 @@ void fsm::become_candidate(bool is_prevote, bool is_leadership_transfer) {
     }
 }
 
+void fsm::send_ping_messages() {
+    // We are a follower but a leader is not known. It will not be known
+    // until a communication from a leader which (for an idle leader) may
+    // not happen any time soon since we use external failure detector and
+    // our leader does not send periodic empty append messages. By sending
+    // a special append message reject we solicit a reply from a leader
+    // (or trigger a vote request re-send from a candidate).
+    auto& cfg = get_configuration();
+    // If conf is joint it means a leader will send us a non joint one eventually
+    if (!cfg.is_joint() && cfg.current.contains(_my_id)) {
+        for (auto s : cfg.current) {
+            if (s.can_vote && s.addr.id != _my_id && _failure_detector.is_alive(s.addr.id)) {
+                logger.trace("[{}]: searching for a leader. Pinging {}", _tag, s.addr.id);
+                send_to(s.addr.id, append_reply{_current_term, _commit_idx, append_reply::rejected{index_t{0}, index_t{0}}});
+            }
+        }
+    }
+}
+
 bool fsm::has_output() const {
     logger.trace("fsm::has_output() {} stable index: {} last index: {}",
         _tag, _log.stable_idx(), _log.last_idx());
@@ -612,22 +631,7 @@ void fsm::tick() {
     }
 
     if (is_follower() && !current_leader() && _ping_leader) {
-        // We are a follower but a leader is not known. It will not be known
-        // until a communication from a leader which (for an idle leader) may
-        // not happen any time soon since we use external failure detector and
-        // our leader does not send periodic empty append messages. By sending
-        // a special append message reject we solicit a reply from a leader.
-        // Non leaders will ignore the append reply.
-        auto& cfg = get_configuration();
-        // If conf is joint it means a leader will send us a non joint one eventually
-        if (!cfg.is_joint() && cfg.current.contains(_my_id)) {
-            for (auto s : cfg.current) {
-                if (s.can_vote && s.addr.id != _my_id && _failure_detector.is_alive(s.addr.id)) {
-                    logger.trace("tick[{}]: searching for a leader. Pinging {}", _tag, s.addr.id);
-                    send_to(s.addr.id, append_reply{_current_term, _commit_idx, append_reply::rejected{index_t{0}, index_t{0}}});
-                }
-            }
-        }
+        send_ping_messages();
     }
 }
 

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -7,6 +7,7 @@
  */
 #include "fsm.hh"
 #include <random>
+#include <ranges>
 #include <seastar/core/coroutine.hh>
 #include "raft/raft.hh"
 #include "utils/assert.hh"
@@ -35,11 +36,37 @@ fsm::fsm(server_id id, sstring tag, term_t current_term, server_id voted_for, lo
     // After we observed the state advance commit_idx to persisted one (if provided)
     // so that the log can be replayed
     _commit_idx = std::max(_commit_idx, commit_idx);
-    logger.trace("fsm[{}]: starting, current term {}, log length {}, commit index {}", _tag, _current_term, _log.last_idx(), _commit_idx);
 
-    // Init timeout settings
-    if (_log.get_configuration().current.size() == 1 && _log.get_configuration().can_vote(_my_id)) {
-        become_candidate(_config.enable_prevoting);
+    // A node that "starts as a candidate" calls an election immediately on
+    // startup instead of waiting for the randomized election timeout. There is
+    // no existing leader to disrupt in these cases, so prevoting is skipped too
+    // -- the extra round-trip would be pure overhead. We start as a candidate:
+    //  - as the (voting) member of a single-node group: it is the only possible
+    //    leader, so it should take over right away;
+    //  - as the smallest-id voting member of a fresh multi-node group (empty
+    //    log, i.e. last_idx() == 0), but only when fast bootstrap is enabled.
+    //    Restricting it to a single, deterministically-chosen node avoids all
+    //    nodes racing to call an election simultaneously (which wastes a term
+    //    and risks split votes). Fast bootstrap is gated by a config flag so
+    //    that a bare fsm (e.g. in unit tests) keeps the classic behaviour of
+    //    starting as a follower; raft::server enables it.
+    // Any node with a non-empty log has already participated in the group and
+    // must go through the normal timeout path.
+    const auto& cfg = _log.get_configuration();
+    const bool start_as_candidate = cfg.can_vote(_my_id) && (
+        cfg.current.size() == 1 || (
+            _config.enable_fast_bootstrap &&
+            _log.last_idx() == index_t{0} &&
+            std::ranges::none_of(cfg.current, [this](const auto& m) {
+                return m.can_vote && m.addr.id < _my_id;
+            })
+        )
+    );
+    logger.trace("fsm[{}]: starting, current term {}, log length {}, commit index {}, start_as_candidate {}",
+            _tag, _current_term, _log.last_idx(), _commit_idx, start_as_candidate);
+
+    if (start_as_candidate) {
+        become_candidate(false);
     } else {
         reset_election_timeout();
     }

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -20,10 +20,11 @@ leader::~leader() {
     }
 }
 
-fsm::fsm(server_id id, term_t current_term, server_id voted_for, log log,
+fsm::fsm(server_id id, sstring tag, term_t current_term, server_id voted_for, log log,
         index_t commit_idx, failure_detector& failure_detector, fsm_config config,
         seastar::condition_variable& sm_events) :
-        _my_id(id), _current_term(current_term), _voted_for(voted_for),
+        _my_id(id), _tag(std::move(tag)),
+        _current_term(current_term), _voted_for(voted_for),
         _log(std::move(log)), _failure_detector(failure_detector), _config(config), _sm_events(sm_events) {
     if (id == raft::server_id{}) {
         throw std::invalid_argument("raft::fsm: raft instance cannot have id zero");
@@ -34,7 +35,7 @@ fsm::fsm(server_id id, term_t current_term, server_id voted_for, log log,
     // After we observed the state advance commit_idx to persisted one (if provided)
     // so that the log can be replayed
     _commit_idx = std::max(_commit_idx, commit_idx);
-    logger.trace("fsm[{}]: starting, current term {}, log length {}, commit index {}", _my_id, _current_term, _log.last_idx(), _commit_idx);
+    logger.trace("fsm[{}]: starting, current term {}, log length {}, commit index {}", _tag, _current_term, _log.last_idx(), _commit_idx);
 
     // Init timeout settings
     if (_log.get_configuration().current.size() == 1 && _log.get_configuration().can_vote(_my_id)) {
@@ -82,7 +83,7 @@ const log_entry& fsm::add_entry(T command) {
             // the old cluster has moved to operating under the
             // rules of C_new.
             logger.trace("[{}] A{}configuration change at index {} is not yet committed (config {}) (commit_idx: {})",
-                _my_id, _log.get_configuration().is_joint() ? " joint " : " ",
+                _tag, _log.get_configuration().is_joint() ? " joint " : " ",
                 _log.last_conf_idx(), _log.get_configuration(), _commit_idx);
             throw conf_change_in_progress();
         }
@@ -97,7 +98,7 @@ const log_entry& fsm::add_entry(T command) {
         tmp.enter_joint(command.current);
         command = std::move(tmp);
 
-        logger.trace("[{}] appending joint config entry at {}: {}", _my_id, _log.next_idx(), command);
+        logger.trace("[{}] appending joint config entry at {}: {}", _tag, _log.next_idx(), command);
     }
 
     utils::get_local_injector().inject("fsm::add_entry/test-failure",
@@ -129,13 +130,13 @@ void fsm::advance_commit_idx(index_t leader_commit_idx) {
     auto new_commit_idx = std::min(leader_commit_idx, _log.last_idx());
 
     logger.trace("advance_commit_idx[{}]: leader_commit_idx={}, new_commit_idx={}",
-        _my_id, leader_commit_idx, new_commit_idx);
+        _tag, leader_commit_idx, new_commit_idx);
 
     if (new_commit_idx > _commit_idx) {
         _commit_idx = new_commit_idx;
         _sm_events.signal();
         logger.trace("advance_commit_idx[{}]: signal apply_entries: committed: {}",
-            _my_id, _commit_idx);
+            _tag, _commit_idx);
     }
 }
 
@@ -186,7 +187,7 @@ void fsm::become_leader() {
     // in the log.
     leader_state().tracker.set_configuration(_log.get_configuration(), _log.last_idx());
     logger.trace("fsm::become_leader() {} stable index: {} last index: {}",
-        _my_id, _log.stable_idx(), _log.last_idx());
+        _tag, _log.stable_idx(), _log.last_idx());
 }
 
 void fsm::become_follower(server_id leader) {
@@ -290,7 +291,7 @@ void fsm::become_candidate(bool is_prevote, bool is_leadership_transfer) {
             continue;
         }
         logger.trace("{} [term: {}, index: {}, last log term: {}{}{}] sent vote request to {}",
-            _my_id, term, _log.last_idx(), _log.last_term(), is_prevote ? ", prevote" : "",
+            _tag, term, _log.last_idx(), _log.last_term(), is_prevote ? ", prevote" : "",
             is_leadership_transfer ? ", force" : "", server.id);
 
         send_to(server.id, vote_request{term, _log.last_idx(), _log.last_term(), is_prevote, is_leadership_transfer});
@@ -298,10 +299,10 @@ void fsm::become_candidate(bool is_prevote, bool is_leadership_transfer) {
     if (votes.tally_votes() == vote_result::WON) {
         // A single node cluster.
         if (is_prevote) {
-            logger.trace("become_candidate[{}] won prevote", _my_id);
+            logger.trace("become_candidate[{}] won prevote", _tag);
             become_candidate(false);
         } else {
-            logger.trace("become_candidate[{}] won vote", _my_id);
+            logger.trace("become_candidate[{}] won vote", _tag);
             become_leader();
         }
     }
@@ -309,7 +310,7 @@ void fsm::become_candidate(bool is_prevote, bool is_leadership_transfer) {
 
 bool fsm::has_output() const {
     logger.trace("fsm::has_output() {} stable index: {} last index: {}",
-        _my_id, _log.stable_idx(), _log.last_idx());
+        _tag, _log.stable_idx(), _log.last_idx());
 
     auto diff = _log.last_idx() - _log.stable_idx();
 
@@ -409,7 +410,7 @@ fsm_output fsm::get_output() {
 void fsm::advance_stable_idx(index_t idx) {
     index_t prev_stable_idx = _log.stable_idx();
     _log.stable_to(idx);
-    logger.trace("advance_stable_idx[{}]: prev_stable_idx={}, idx={}", _my_id, prev_stable_idx, idx);
+    logger.trace("advance_stable_idx[{}]: prev_stable_idx={}, idx={}", _tag, prev_stable_idx, idx);
     if (is_leader()) {
         auto leader_progress = leader_state().tracker.find(_my_id);
         if (leader_progress) {
@@ -442,10 +443,10 @@ void fsm::maybe_commit() {
         // this way, then all prior entries are committed
         // indirectly because of the Log Matching Property.
         logger.trace("maybe_commit[{}]: cannot commit because of term {} != {}",
-            _my_id, _log[new_commit_idx.value()]->term, _current_term);
+            _tag, _log[new_commit_idx.value()]->term, _current_term);
         return;
     }
-    logger.trace("maybe_commit[{}]: commit {}", _my_id, new_commit_idx);
+    logger.trace("maybe_commit[{}]: commit {}", _tag, new_commit_idx);
 
     _commit_idx = new_commit_idx;
     // We have a quorum of servers with match_idx greater than the
@@ -453,7 +454,7 @@ void fsm::maybe_commit() {
     _sm_events.signal();
 
     if (committed_conf_change) {
-        logger.trace("maybe_commit[{}]: committed conf change at idx {} (config: {})", _my_id, _log.last_conf_idx(), _log.get_configuration());
+        logger.trace("maybe_commit[{}]: committed conf change at idx {} (config: {})", _tag, _log.last_conf_idx(), _log.get_configuration());
         if (_log.get_configuration().is_joint()) {
             // 4.3. Arbitrary configuration changes using joint consensus
             //
@@ -461,7 +462,7 @@ void fsm::maybe_commit() {
             // system then transitions to the new configuration.
             configuration cfg(_log.get_configuration());
             cfg.leave_joint();
-            logger.trace("[{}] appending non-joint config entry at {}: {}", _my_id, _log.next_idx(), cfg);
+            logger.trace("[{}] appending non-joint config entry at {}: {}", _tag, _log.next_idx(), cfg);
             _log.emplace_back(seastar::make_lw_shared<log_entry>({_current_term, _log.next_idx(), std::move(cfg)}));
             leader_state().tracker.set_configuration(_log.get_configuration(), _log.last_idx());
             // Leaving joint configuration may commit more entries
@@ -483,7 +484,7 @@ void fsm::maybe_commit() {
         } else {
             auto lp = leader_state().tracker.find(_my_id);
             if (lp == nullptr || !lp->can_vote) {
-                logger.trace("maybe_commit[{}]: stepping down as leader", _my_id);
+                logger.trace("maybe_commit[{}]: stepping down as leader", _tag);
                 // 4.2.2 Removing the current leader
                 //
                 // The leader temporarily manages a configuration
@@ -543,7 +544,7 @@ void fsm::tick_leader() {
             if (progress.match_idx < _log.last_idx() || progress.commit_idx < _commit_idx) {
                 logger.trace("tick[{}]: replicate to {} because match={} < last_idx={} || "
                     "follower commit_idx={} < commit_idx={}",
-                    _my_id, progress.id, progress.match_idx, _log.last_idx(),
+                    _tag, progress.id, progress.match_idx, _log.last_idx(),
                     progress.commit_idx, _commit_idx);
 
                 replicate_to(progress, true);
@@ -561,15 +562,15 @@ void fsm::tick_leader() {
     }
 
     if (state.stepdown) {
-        logger.trace("tick[{}]: stepdown is active", _my_id);
+        logger.trace("tick[{}]: stepdown is active", _tag);
         auto me = leader_state().tracker.find(_my_id);
         if (me == nullptr || !me->can_vote) {
-            logger.trace("tick[{}]: not aborting stepdown because we have been removed from the configuration", _my_id);
+            logger.trace("tick[{}]: not aborting stepdown because we have been removed from the configuration", _tag);
             // Do not abort stepdown if not part of the current
             // config or non voting member since the node cannot
             // be a leader any longer
         } else if (*state.stepdown <= _clock.now()) {
-            logger.trace("tick[{}]: cancel stepdown", _my_id);
+            logger.trace("tick[{}]: cancel stepdown", _tag);
             // Cancel stepdown (only if the leader is part of the cluster)
             leader_state().log_limiter_semaphore->signal(_config.max_log_size);
             state.stepdown.reset();
@@ -577,7 +578,7 @@ void fsm::tick_leader() {
             _abort_leadership_transfer = true;
             _sm_events.signal(); // signal to handle aborting of leadership transfer
         } else if (state.timeout_now_sent) {
-            logger.trace("tick[{}]: resend timeout_now", _my_id);
+            logger.trace("tick[{}]: resend timeout_now", _tag);
             // resend timeout now in case it was lost
             send_to(*state.timeout_now_sent, timeout_now{_current_term});
         }
@@ -605,7 +606,7 @@ void fsm::tick() {
         // simply because there were no AppendEntries RPCs recently.
         _last_election_time = _clock.now();
     } else if (is_past_election_timeout()) {
-        logger.trace("tick[{}]: becoming a candidate at term {}, last election: {}, now: {}", _my_id,
+        logger.trace("tick[{}]: becoming a candidate at term {}, last election: {}, now: {}", _tag,
             _current_term, _last_election_time, _clock.now());
         become_candidate(_config.enable_prevoting);
     }
@@ -622,7 +623,7 @@ void fsm::tick() {
         if (!cfg.is_joint() && cfg.current.contains(_my_id)) {
             for (auto s : cfg.current) {
                 if (s.can_vote && s.addr.id != _my_id && _failure_detector.is_alive(s.addr.id)) {
-                    logger.trace("tick[{}]: searching for a leader. Pinging {}", _my_id, s.addr.id);
+                    logger.trace("tick[{}]: searching for a leader. Pinging {}", _tag, s.addr.id);
                     send_to(s.addr.id, append_reply{_current_term, _commit_idx, append_reply::rejected{index_t{0}, index_t{0}}});
                 }
             }
@@ -632,7 +633,7 @@ void fsm::tick() {
 
 void fsm::append_entries(server_id from, append_request&& request) {
     logger.trace("append_entries[{}] received ct={}, prev idx={} prev term={} commit idx={}, idx={} num entries={}",
-            _my_id, request.current_term, request.prev_log_idx, request.prev_log_term,
+            _tag, request.current_term, request.prev_log_idx, request.prev_log_term,
             request.leader_commit_idx, request.entries.size() ? request.entries[0]->idx : index_t(0), request.entries.size());
 
     SCYLLA_ASSERT(is_follower());
@@ -646,7 +647,7 @@ void fsm::append_entries(server_id from, append_request&& request) {
     auto [match, term] = _log.match_term(request.prev_log_idx, request.prev_log_term);
     if (!match) {
         logger.trace("append_entries[{}]: no matching term at position {}: expected {}, found {}",
-                _my_id, request.prev_log_idx, request.prev_log_term, term);
+                _tag, request.prev_log_idx, request.prev_log_term, term);
         // Reply false if log doesn't contain an entry at
         // prevLogIndex whose term matches prevLogTerm (§5.3).
         send_to(from, append_reply{_current_term, _commit_idx, append_reply::rejected{request.prev_log_idx, _log.last_idx()}});
@@ -688,7 +689,7 @@ void fsm::append_entries_reply(server_id from, append_reply&& reply) {
     }
 
     if (progress.state == follower_progress::state::SNAPSHOT) {
-        logger.trace("append_entries_reply[{}->{}]: ignored in snapshot state", _my_id, from);
+        logger.trace("append_entries_reply[{}->{}]: ignored in snapshot state", _tag, from);
         return;
     }
 
@@ -699,7 +700,7 @@ void fsm::append_entries_reply(server_id from, append_reply&& reply) {
         index_t last_idx = std::get<append_reply::accepted>(reply.result).last_new_idx;
 
         logger.trace("append_entries_reply[{}->{}]: accepted match={} last index={}",
-            _my_id, from, progress.match_idx, last_idx);
+            _tag, from, progress.match_idx, last_idx);
 
         progress.accepted(last_idx);
 
@@ -730,20 +731,20 @@ void fsm::append_entries_reply(server_id from, append_reply&& reply) {
         append_reply::rejected rejected = std::get<append_reply::rejected>(reply.result);
 
         logger.trace("append_entries_reply[{}->{}]: rejected match={} index={}",
-            _my_id, from, progress.match_idx, rejected.non_matching_idx);
+            _tag, from, progress.match_idx, rejected.non_matching_idx);
 
         // If non_matching_idx and last_idx are zero it means that a follower is looking for a leader
         // as such message cannot be a result of real mismatch.
         // Send an empty append message to notify it that we are the leader
         if (rejected.non_matching_idx == index_t{0} && rejected.last_idx == index_t{0}) {
-            logger.trace("append_entries_reply[{}->{}]: send empty append message", _my_id, from);
+            logger.trace("append_entries_reply[{}->{}]: send empty append message", _tag, from);
             replicate_to(progress, true);
             return;
         }
 
         // check reply validity
         if (progress.is_stray_reject(rejected)) {
-            logger.trace("append_entries_reply[{}->{}]: drop stray append reject", _my_id, from);
+            logger.trace("append_entries_reply[{}->{}]: drop stray append reject", _tag, from);
             return;
         }
 
@@ -769,7 +770,7 @@ void fsm::append_entries_reply(server_id from, append_reply&& reply) {
     opt_progress = leader_state().tracker.find(from);
     if (opt_progress != nullptr) {
         logger.trace("append_entries_reply[{}->{}]: next_idx={}, match_idx={}",
-            _my_id, from, opt_progress->next_idx, opt_progress->match_idx);
+            _tag, from, opt_progress->next_idx, opt_progress->match_idx);
 
         replicate_to(*opt_progress, false);
     }
@@ -797,7 +798,7 @@ void fsm::request_vote(server_id from, vote_request&& request) {
 
         logger.trace("{} [term: {}, index: {}, last log term: {}, voted_for: {}] "
             "voted for {} [log_term: {}, log_index: {}]",
-            _my_id, _current_term, _log.last_idx(), _log.last_term(), _voted_for,
+            _tag, _current_term, _log.last_idx(), _log.last_term(), _voted_for,
             from, request.last_log_term, request.last_log_idx);
         if (!request.is_prevote) { // Only record real votes
             // If a server grants a vote, it must reset its election
@@ -823,7 +824,7 @@ void fsm::request_vote(server_id from, vote_request&& request) {
         // candidates.
         logger.trace("{} [term: {}, index: {}, log_term: {}, voted_for: {}] "
             "rejected vote for {} [current_term: {}, log_term: {}, log_index: {}, is_prevote: {}]",
-            _my_id, _current_term, _log.last_idx(), _log.last_term(), _voted_for,
+            _tag, _current_term, _log.last_idx(), _log.last_term(), _voted_for,
             from, request.current_term, request.last_log_term, request.last_log_idx, request.is_prevote);
 
         send_to(from, vote_reply{_current_term, false, request.is_prevote});
@@ -833,12 +834,12 @@ void fsm::request_vote(server_id from, vote_request&& request) {
 void fsm::request_vote_reply(server_id from, vote_reply&& reply) {
     SCYLLA_ASSERT(is_candidate());
 
-    logger.trace("request_vote_reply[{}] received a {} vote from {}", _my_id, reply.vote_granted ? "yes" : "no", from);
+    logger.trace("request_vote_reply[{}] received a {} vote from {}", _tag, reply.vote_granted ? "yes" : "no", from);
 
     auto& state = std::get<candidate>(_state);
     // Should not register a reply to prevote as a real vote
     if (state.is_prevote != reply.is_prevote) {
-        logger.trace("request_vote_reply[{}] ignoring prevote from {} as state is vote", _my_id, from);
+        logger.trace("request_vote_reply[{}] ignoring prevote from {} as state is vote", _tag, from);
         return;
     }
     state.votes.register_vote(from, reply.vote_granted);
@@ -848,10 +849,10 @@ void fsm::request_vote_reply(server_id from, vote_reply&& reply) {
         break;
     case vote_result::WON:
         if (state.is_prevote) {
-            logger.trace("request_vote_reply[{}] won prevote", _my_id);
+            logger.trace("request_vote_reply[{}] won prevote", _tag);
             become_candidate(false);
         } else {
-            logger.trace("request_vote_reply[{}] won vote", _my_id);
+            logger.trace("request_vote_reply[{}] won vote", _tag);
             become_leader();
         }
         break;
@@ -864,14 +865,14 @@ void fsm::request_vote_reply(server_id from, vote_reply&& reply) {
 void fsm::replicate_to(follower_progress& progress, bool allow_empty) {
 
     logger.trace("replicate_to[{}->{}]: called next={} match={}",
-        _my_id, progress.id, progress.next_idx, progress.match_idx);
+        _tag, progress.id, progress.next_idx, progress.match_idx);
 
     while (progress.can_send_to()) {
         index_t next_idx = progress.next_idx;
         if (progress.next_idx > _log.last_idx()) {
             next_idx = index_t(0);
             logger.trace("replicate_to[{}->{}]: next past last next={} stable={}, empty={}",
-                    _my_id, progress.id, progress.next_idx, _log.last_idx(), allow_empty);
+                    _tag, progress.id, progress.next_idx, _log.last_idx(), allow_empty);
             if (!allow_empty) {
                 // Send out only persisted entries.
                 return;
@@ -901,7 +902,7 @@ void fsm::replicate_to(follower_progress& progress, bool allow_empty) {
             progress.become_snapshot(snapshot.idx);
             send_to(progress.id, install_snapshot{_current_term, snapshot});
             logger.trace("replicate_to[{}->{}]: send snapshot next={} snapshot={}",
-                    _my_id, progress.id, progress.next_idx,  snapshot.idx);
+                    _tag, progress.id, progress.next_idx,  snapshot.idx);
             return;
         }
 
@@ -919,7 +920,7 @@ void fsm::replicate_to(follower_progress& progress, bool allow_empty) {
                 const auto& entry = _log[next_idx.value()];
                 req.entries.push_back(entry);
                 logger.trace("replicate_to[{}->{}]: send entry idx={}, term={}",
-                             _my_id, progress.id, entry->idx, entry->term);
+                             _tag, progress.id, entry->idx, entry->term);
                 size += entry->get_size();
                 next_idx++;
                 if (progress.state == follower_progress::state::PROBE) {
@@ -935,7 +936,7 @@ void fsm::replicate_to(follower_progress& progress, bool allow_empty) {
                 progress.next_idx = next_idx;
             }
         } else {
-            logger.trace("replicate_to[{}->{}]: send empty", _my_id, progress.id);
+            logger.trace("replicate_to[{}->{}]: send empty", _tag, progress.id);
         }
 
         send_to(progress.id, std::move(req));
@@ -964,7 +965,7 @@ void fsm::install_snapshot_reply(server_id from, snapshot_reply&& reply) {
     follower_progress& progress = *opt_progress;
 
     if (progress.state != follower_progress::state::SNAPSHOT) {
-        logger.trace("install_snapshot_reply[{}]: called not in snapshot state", _my_id);
+        logger.trace("install_snapshot_reply[{}]: called not in snapshot state", _tag);
         return;
     }
 
@@ -981,7 +982,7 @@ void fsm::install_snapshot_reply(server_id from, snapshot_reply&& reply) {
 
 bool fsm::apply_snapshot(snapshot_descriptor snp, size_t max_trailing_entries, size_t max_trailing_bytes, bool local) {
     logger.trace("apply_snapshot[{}]: current term: {}, term: {}, idx: {}, id: {}, local: {}",
-            _my_id, _current_term, snp.term, snp.idx, snp.id, local);
+            _tag, _current_term, snp.term, snp.idx, snp.id, local);
     // If the snapshot is locally generated, all entries up to its index must have been locally applied,
     // so in particular they must have been observed as committed.
     // Remote snapshots are only applied if we're a follower.
@@ -994,7 +995,7 @@ bool fsm::apply_snapshot(snapshot_descriptor snp, size_t max_trailing_entries, s
     const auto& current_snp = _log.get_snapshot();
     if (snp.idx <= current_snp.idx || (!local && snp.idx <= _commit_idx)) {
         logger.error("apply_snapshot[{}]: ignore outdated snapshot {}/{} current one is {}/{}, commit_idx={}",
-                        _my_id, snp.id, snp.idx, current_snp.id, current_snp.idx, _commit_idx);
+                        _tag, snp.id, snp.idx, current_snp.id, current_snp.idx, _commit_idx);
         _output.snps_to_drop.push_back(snp.id);
         return false;
     }
@@ -1010,7 +1011,7 @@ bool fsm::apply_snapshot(snapshot_descriptor snp, size_t max_trailing_entries, s
         .is_local = local,
         .preserved_log_entries = _log.get_snapshot().idx.value() + 1 - new_first_index.value()});
     if (is_leader()) {
-        logger.trace("apply_snapshot[{}]: signal {} available units", _my_id, units);
+        logger.trace("apply_snapshot[{}]: signal {} available units", _tag, units);
         leader_state().log_limiter_semaphore->signal(units);
     }
     _sm_events.signal();
@@ -1039,18 +1040,18 @@ void fsm::transfer_leadership(logical_clock::duration timeout) {
 }
 
 void fsm::send_timeout_now(server_id id) {
-    logger.trace("send_timeout_now[{}] send timeout_now to {}", _my_id, id);
+    logger.trace("send_timeout_now[{}] send timeout_now to {}", _tag, id);
     send_to(id, timeout_now{_current_term});
     leader_state().timeout_now_sent = id;
     auto me = leader_state().tracker.find(_my_id);
     if (me == nullptr || !me->can_vote) {
-        logger.trace("send_timeout_now[{}] become follower", _my_id);
+        logger.trace("send_timeout_now[{}] become follower", _tag);
         become_follower({});
     }
 }
 
 void fsm::broadcast_read_quorum(read_id id) {
-    logger.trace("broadcast_read_quorum[{}] send read id {}", _my_id, id);
+    logger.trace("broadcast_read_quorum[{}] send read id {}", _tag, id);
     for (auto&& [_, p] : leader_state().tracker) {
         if (p.can_vote) {
             if (p.id == _my_id) {
@@ -1064,7 +1065,7 @@ void fsm::broadcast_read_quorum(read_id id) {
 
 void fsm::handle_read_quorum_reply(server_id from, const read_quorum_reply& reply) {
     SCYLLA_ASSERT(is_leader());
-    logger.trace("handle_read_quorum_reply[{}] got reply from {} for id {}", _my_id, from, reply.id);
+    logger.trace("handle_read_quorum_reply[{}] got reply from {} for id {}", _tag, from, reply.id);
     auto& state = leader_state();
     follower_progress* progress = state.tracker.find(from);
     if (progress == nullptr) {
@@ -1088,7 +1089,7 @@ void fsm::handle_read_quorum_reply(server_id from, const read_quorum_reply& repl
 
     _output.max_read_id_with_quorum = state.max_read_id_with_quorum = new_committed_read;
 
-    logger.trace("handle_read_quorum_reply[{}] new commit read {}", _my_id, new_committed_read);
+    logger.trace("handle_read_quorum_reply[{}] new commit read {}", _tag, new_committed_read);
 
     _sm_events.signal();
 }
@@ -1117,13 +1118,13 @@ std::optional<std::pair<read_id, index_t>> fsm::start_read_barrier(server_id req
             && !opt_progress->can_vote) {
         logger.trace("start_read_barrier[{}]: replicate to {} because follower commit_idx={} < commit_idx={}, "
                      "follower match_idx={} == last_idx={}, and follower can_vote={}",
-                     _my_id, requester, opt_progress->commit_idx, _commit_idx, opt_progress->match_idx,
+                     _tag, requester, opt_progress->commit_idx, _commit_idx, opt_progress->match_idx,
                      _log.last_idx(), opt_progress->can_vote);
         replicate_to(*opt_progress, true);
     }
 
     read_id id = next_read_id();
-    logger.trace("start_read_barrier[{}] starting read barrier with id {}", _my_id, id);
+    logger.trace("start_read_barrier[{}] starting read barrier with id {}", _tag, id);
     return std::make_pair(id, _commit_idx);
 }
 

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -893,6 +893,15 @@ void fsm::request_vote_reply(server_id from, vote_reply&& reply) {
     }
 }
 
+void fsm::maybe_resend_vote_request(server_id to) {
+    if (auto& state = candidate_state(); !state.votes.has_responded(to)) {
+        logger.trace("{} [term: {}] re-sending vote request to {} after receiving a ping_leader request",
+                _tag, _current_term, to);
+        send_to(to, vote_request{_current_term, _log.last_idx(), _log.last_term(),
+                state.is_prevote, false});
+    }
+}
+
 void fsm::replicate_to(follower_progress& progress, bool allow_empty) {
 
     logger.trace("replicate_to[{}->{}]: called next={} match={}",

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -152,6 +152,8 @@ struct leader {
 class fsm {
     // id of this node
     server_id _my_id;
+    // Human-readable tag for log messages (distinguishes raft instances)
+    sstring _tag;
     // What state the server is in. The default is follower.
     std::variant<follower, candidate, leader> _state;
     // _current_term, _voted_for && _log are persisted in persistence
@@ -343,7 +345,7 @@ protected: // For testing
     }
 
 public:
-    explicit fsm(server_id id, term_t current_term, server_id voted_for, log log,
+    explicit fsm(server_id id, sstring tag, term_t current_term, server_id voted_for, log log,
             index_t commit_idx, failure_detector& failure_detector, fsm_config conf,
             seastar::condition_variable& sm_events);
 
@@ -542,7 +544,7 @@ void fsm::step(server_id from, const follower& c, Message&& msg) {
         // extra round trip.
         become_candidate(false, true);
     } else if constexpr (std::is_same_v<Message, read_quorum>) {
-        logger.trace("[{}] receive read_quorum from {} for read id {}", _my_id, from, msg.id);
+        logger.trace("[{}] receive read_quorum from {} for read id {}", _tag, from, msg.id);
         advance_commit_idx(msg.leader_commit_idx);
         send_to(from, read_quorum_reply{_current_term, _commit_idx, msg.id});
     }
@@ -571,7 +573,7 @@ void fsm::step(server_id from, Message&& msg) {
         server_id leader{};
 
         logger.trace("{} [term: {}] received a message with higher term from {} [term: {}]",
-            _my_id, _current_term, from, msg.current_term);
+            _tag, _current_term, from, msg.current_term);
 
         if constexpr (std::is_same_v<Message, append_request> ||
                       std::is_same_v<Message, install_snapshot> ||
@@ -581,7 +583,7 @@ void fsm::step(server_id from, Message&& msg) {
             // Got a reply to read barrier with higher term. This should not happen.
             // Log and ignore
             logger.error("{} [term: {}] ignoring read barrier reply with higher term {}",
-                _my_id, _current_term, msg.current_term);
+                _tag, _current_term, msg.current_term);
             return;
         }
 
@@ -617,7 +619,7 @@ void fsm::step(server_id from, Message&& msg) {
         } else {
             // Ignore other cases
             logger.trace("{} [term: {}] ignored a message with lower term from {} [term: {}]",
-                _my_id, _current_term, from, msg.current_term);
+                _tag, _current_term, from, msg.current_term);
         }
         return;
 

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -290,6 +290,7 @@ private:
 
     void request_vote(server_id from, vote_request&& vote_request);
     void request_vote_reply(server_id from, vote_reply&& vote_reply);
+    void maybe_resend_vote_request(server_id to);
 
     void install_snapshot_reply(server_id from, snapshot_reply&& reply);
 
@@ -538,6 +539,8 @@ void fsm::step(server_id from, const candidate& c, Message&& msg) {
     } else if constexpr (std::is_same_v<Message, install_snapshot>) {
         send_to(from, snapshot_reply{.current_term = _current_term,
                      .success = false });
+    } else if constexpr (std::is_same_v<Message, append_reply>) {
+        maybe_resend_vote_request(from);
     }
 }
 
@@ -627,6 +630,19 @@ void fsm::step(server_id from, Message&& msg) {
         } else if constexpr (std::is_same_v<Message, vote_request>) {
             if (msg.is_prevote) {
                 send_to(from, vote_reply{_current_term, false, true});
+            }
+        } else if constexpr (std::is_same_v<Message, append_reply>) {
+            // A peer that is looking for a leader pings us with a stale-term
+            // append_reply (see ping_leader()/send_ping_messages()). If we are a
+            // candidate and that peer hasn't responded to our vote request yet,
+            // re-send it: the peer is clearly alive now and our original request
+            // may have been lost (e.g. the peer's raft server wasn't ready when we
+            // first became a candidate). We skip peers that already responded for
+            // this term -- re-sending to them would be pointless (a vote is final
+            // for a term), though it would be harmless since the receiver is
+            // idempotent.
+            if (is_candidate()) {
+                maybe_resend_vote_request(from);
             }
         } else {
             // Ignore other cases

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -266,6 +266,9 @@ private:
     void become_leader();
 
     void become_candidate(bool is_prevote, bool is_leadership_transfer = false);
+    // Send ping messages (append_reply rejected) to all peers to solicit
+    // a response from the leader. Called from ping_leader() and tick().
+    void send_ping_messages();
 
     // Controls whether the follower has been responsive recently,
     // so it makes sense to send more data to it.
@@ -409,9 +412,12 @@ public:
     }
 
     // Ask to search for a leader if one is not known.
+    // Immediately sends ping messages to all peers and keeps pinging
+    // on subsequent ticks until a leader is found.
     void ping_leader() {
         SCYLLA_ASSERT(!current_leader());
         _ping_leader = true;
+        send_ping_messages();
     }
 
     // Call this function to wait for the total size in bytes of log entries to

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -59,6 +59,12 @@ struct fsm_config {
     size_t max_log_size;
     // If set to true will enable prevoting stage during election
     bool enable_prevoting;
+    // If set to true, on a fresh multi-node group (empty log) the smallest-id
+    // voting member starts an election immediately on construction instead of
+    // waiting for the election timeout, which speeds up the initial leader
+    // election. Disabled by default so that a bare fsm starts as a follower;
+    // raft::server enables it.
+    bool enable_fast_bootstrap = false;
 };
 
 class fsm;

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -58,6 +58,23 @@ static const seastar::metrics::label server_id_label("id");
 static const seastar::metrics::label log_entry_type("log_entry_type");
 static const seastar::metrics::label message_type("message_type");
 
+// Result types for do_on_leader_with_retries action lambda.
+// retry_with_leader: retry on the specified leader. If the leader is the
+//   same as current, waits for a tick to avoid tight loops (e.g. when a
+//   transient_error redirects us back to the same node).
+// retry_now: retry immediately on the current leader. The action already
+//   waited for state to advance (e.g. wait_for_apply), so no tick needed.
+// done: the action completed successfully, stop retrying.
+struct retry_with_leader { server_id leader; };
+struct retry_now {};
+struct done {};
+using do_on_leader_result = std::variant<retry_with_leader, retry_now, done>;
+
+template <typename AsyncAction>
+concept LeaderAction = requires(const server_id& leader, AsyncAction aa) {
+    { aa(leader) } -> std::same_as<future<do_on_leader_result>>;
+};
+
 class server_impl : public rpc_server, public server {
 public:
     explicit server_impl(server_id uuid, std::unique_ptr<rpc> rpc,
@@ -330,13 +347,10 @@ private:
 
 
     seastar::named_gate _do_on_leader_gate;
-    // Call a function on a current leader until it returns stop_iteration::yes.
+    // Call a function on a current leader until it returns done{}.
     // Handles aborts and leader changes, adds a delay between
     // iterations to protect against tight loops.
-    template <typename AsyncAction>
-    requires requires(server_id& leader, AsyncAction aa) {
-        { aa(leader) } -> std::same_as<future<stop_iteration>>;
-    }
+    template <LeaderAction AsyncAction>
     future<> do_on_leader_with_retries(seastar::abort_source* as, AsyncAction&& action);
 
     future<> override_snapshot_thresholds();
@@ -694,21 +708,17 @@ future<add_entry_reply> server_impl::execute_add_entry(server_id from, command c
     }
 }
 
-template <typename AsyncAction>
-requires requires (server_id& leader, AsyncAction aa) {
-    { aa(leader) } -> std::same_as<future<stop_iteration>>;
-}
+template <LeaderAction AsyncAction>
 future<> server_impl::do_on_leader_with_retries(seastar::abort_source* as, AsyncAction&& action) {
-    server_id leader = _fsm->current_leader(), prev_leader{};
+    server_id leader = _fsm->current_leader();
 
     check_not_aborted();
     auto gh = _do_on_leader_gate.hold();
 
     while (true) {
         if (as && as->abort_requested()) {
-            throw request_aborted(format("Request aborted while performing action on leader, current leader: {}, previous leader: {}",
-                                         leader ? leader.to_sstring() : "unknown",
-                                         prev_leader ? prev_leader.to_sstring() : "unknown"));
+            throw request_aborted(format("Request aborted while performing action on leader, current leader: {}",
+                                         leader ? leader.to_sstring() : "unknown"));
         }
         check_not_aborted();
         if (leader == server_id{}) {
@@ -716,21 +726,23 @@ future<> server_impl::do_on_leader_with_retries(seastar::abort_source* as, Async
             leader = _fsm->current_leader();
             continue;
         }
-        if (prev_leader && leader == prev_leader) {
-            // This is to protect against tight loop in case we didn't get
-            // any new information about the current leader.
-            // This can happen if the server responds with a transient_error with
-            // an empty leader and the current node has not yet learned the new leader.
-            // We neglect an excessive delay if the newly elected leader is the same as
-            // the previous one, this supposed to be a rare.
-            co_await wait_for_next_tick(as);
-            prev_leader = leader = server_id{};
-            continue;
-        }
-        prev_leader = leader;
-        if (co_await action(leader) == stop_iteration::yes) {
+        auto result = co_await action(leader);
+        if (std::holds_alternative<done>(result)) {
             break;
         }
+        if (const auto* r = std::get_if<retry_with_leader>(&result)) {
+            if (r->leader && r->leader == leader) {
+                // The action redirected us back to the same leader.
+                // Wait for a tick to avoid tight loops — this can happen
+                // if the server responds with a transient_error pointing
+                // to itself and we haven't learned of a new leader yet.
+                co_await wait_for_next_tick(as);
+                leader = server_id{};
+            } else {
+                leader = r->leader;
+            }
+        }
+        // retry_now: just loop back immediately
     }
 }
 
@@ -755,7 +767,7 @@ future<> server_impl::add_entry(command command, wait_type type, seastar::abort_
         co_return co_await wait_for_entry(eid, type, as);
     }
 
-    co_await do_on_leader_with_retries(as, [&](server_id& leader) -> future<stop_iteration> {
+    co_await do_on_leader_with_retries(as, [&](const server_id& leader) -> future<do_on_leader_result> {
         auto reply = co_await [&]() -> future<add_entry_reply> {
             if (leader == _id) {
                 logger.trace("[{}] an entry proceeds on a leader", _tag);
@@ -775,7 +787,7 @@ future<> server_impl::add_entry(command command, wait_type type, seastar::abort_
         }();
         if (std::holds_alternative<raft::entry_id>(reply)) {
             co_await wait_for_entry(std::get<raft::entry_id>(reply), type, as);
-            co_return stop_iteration::yes;
+            co_return done{};
         }
         if (std::holds_alternative<raft::commit_status_unknown>(reply)) {
             // It should be impossible to obtain `commit_status_unknown` here
@@ -789,8 +801,7 @@ future<> server_impl::add_entry(command command, wait_type type, seastar::abort_
         }
         const auto& e = std::get<transient_error>(reply);
         logger.trace("[{}] got {}", _tag, e);
-        leader = e.leader;
-        co_return stop_iteration::no;
+        co_return retry_with_leader{e.leader};
     });
 }
 
@@ -874,7 +885,7 @@ future<> server_impl::modify_config(std::vector<config_member> add, std::vector<
         throw raft::not_a_leader{_fsm->current_leader()};
     }
 
-    co_await do_on_leader_with_retries(as, [&](server_id& leader) -> future<stop_iteration> {
+    co_await do_on_leader_with_retries(as, [&](const server_id& leader) -> future<do_on_leader_result> {
         auto reply = co_await [&]() -> future<add_entry_reply> {
             if (leader == _id) {
                 // Make a copy since of the params since we may
@@ -895,12 +906,11 @@ future<> server_impl::modify_config(std::vector<config_member> add, std::vector<
             // Do not wait for the entry locally. The reply means that the leader committed it,
             // and there is no reason to wait for our local commit index to match.
             // See also #9981.
-            co_return stop_iteration::yes;
+            co_return done{};
         }
         if (const auto e = std::get_if<raft::transient_error>(&reply)) {
             logger.trace("[{}] got {}", _tag, *e);
-            leader = e->leader;
-            co_return stop_iteration::no;
+            co_return retry_with_leader{e->leader};
         }
         if (std::holds_alternative<not_a_member>(reply)) {
             co_await coroutine::return_exception(std::get<not_a_member>(reply));
@@ -1565,15 +1575,14 @@ future<> server_impl::read_barrier(seastar::abort_source* as) {
     logger.trace("[{}] read_barrier start", _tag);
     index_t read_idx;
 
-    co_await do_on_leader_with_retries(as, [&](server_id& leader) -> future<stop_iteration> {
+    co_await do_on_leader_with_retries(as, [&](const server_id& leader) -> future<do_on_leader_result> {
         auto applied = _applied_idx;
         read_barrier_reply res;
         try {
             res = co_await get_read_idx(leader, as);
         } catch (const transport_error& e) {
             logger.trace("[{}] read_barrier on {} resulted in {}; retrying", _tag, leader, e);
-            leader = server_id{};
-            co_return stop_iteration::no;
+            co_return retry_with_leader{server_id{}};
         }
         if (std::holds_alternative<std::monostate>(res)) {
             // the leader is not ready to answer because it did not
@@ -1581,14 +1590,13 @@ future<> server_impl::read_barrier(seastar::abort_source* as) {
             // committed (if non were since start of the attempt) and retry.
             logger.trace("[{}] read_barrier leader not ready", _tag);
             co_await wait_for_apply(++applied, as);
-            co_return stop_iteration::no;
+            co_return retry_now{};
         }
         if (std::holds_alternative<raft::not_a_leader>(res)) {
-            leader = std::get<not_a_leader>(res).leader;
-            co_return stop_iteration::no;
+            co_return retry_with_leader{std::get<not_a_leader>(res).leader};
         }
         read_idx = std::get<index_t>(res);
-        co_return stop_iteration::yes;
+        co_return done{};
     });
 
     logger.trace("[{}] read_barrier read index {}, applied index {}", _tag, read_idx, _applied_idx);

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -402,7 +402,8 @@ future<> server_impl::start() {
                                  fsm_config {
                                      .append_request_threshold = _config.append_request_threshold,
                                      .max_log_size = _config.max_log_size,
-                                     .enable_prevoting = _config.enable_prevoting
+                                     .enable_prevoting = _config.enable_prevoting,
+                                     .enable_fast_bootstrap = true
                                  },
                                  _events);
 

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -118,6 +118,8 @@ private:
     std::unique_ptr<fsm> _fsm;
     // id of this server
     server_id _id;
+    // Human-readable tag for log messages
+    sstring _tag;
     server::configuration _config;
     std::optional<promise<>> _stepdown_promise;
     std::optional<shared_promise<>> _leader_promise;
@@ -347,7 +349,8 @@ server_impl::server_impl(server_id uuid, std::unique_ptr<rpc> rpc,
         seastar::shared_ptr<failure_detector> failure_detector, server::configuration config) :
                     _rpc(std::move(rpc)), _state_machine(std::move(state_machine)),
                     _persistence(std::move(persistence)), _failure_detector(failure_detector),
-                    _id(uuid), _config(config), _do_on_leader_gate("raft::server_impl::do_on_leader_gate")
+                    _id(uuid), _tag(config.tag.empty() ? format("{}", uuid) : std::move(config.tag)),
+                    _config(config), _do_on_leader_gate("raft::server_impl::do_on_leader_gate")
 {
     set_rpc_server(_rpc.get());
     if (_config.snapshot_threshold_log_size > _config.max_log_size) {
@@ -377,11 +380,11 @@ future<> server_impl::start() {
     auto commit_idx = co_await _persistence->load_commit_idx();
     raft::configuration rpc_config = log.get_configuration();
     index_t stable_idx = log.stable_idx();
-    logger.trace("[{}] start raft instance: snapshot id={} commit index={} last stable index={}", id(), snapshot.id, commit_idx, stable_idx);
+    logger.trace("[{}] start raft instance: snapshot id={} commit index={} last stable index={}", _tag, snapshot.id, commit_idx, stable_idx);
     if (commit_idx > stable_idx) {
         on_internal_error(logger, "Raft init failed: committed index cannot be larger then persisted one");
     }
-    _fsm = std::make_unique<fsm>(_id, term, vote, std::move(log), commit_idx, *_failure_detector,
+    _fsm = std::make_unique<fsm>(_id, _tag, term, vote, std::move(log), commit_idx, *_failure_detector,
                                  fsm_config {
                                      .append_request_threshold = _config.append_request_threshold,
                                      .max_log_size = _config.max_log_size,
@@ -445,7 +448,7 @@ future<> server_impl::wait_for_leader(seastar::abort_source* as) {
         co_return;
     }
 
-    logger.trace("[{}] the leader is unknown, waiting through uncertainty", id());
+    logger.trace("[{}] the leader is unknown, waiting through uncertainty", _tag);
     _fsm->ping_leader();
     if (!_leader_promise) {
         _leader_promise.emplace();
@@ -480,7 +483,7 @@ future<bool> server_impl::trigger_snapshot(seastar::abort_source* as) {
         logger.debug(
             "[{}] trigger_snapshot: last persisted snapshot descriptor index is up-to-date"
             ", applied index: {}, persisted snapshot descriptor index: {}, last fsm log index: {}"
-            ", last fsm snapshot index: {}", _id, _applied_idx, _snapshot_desc_idx,
+            ", last fsm snapshot index: {}", _tag, _applied_idx, _snapshot_desc_idx,
             _fsm->log_last_idx(), _fsm->log_last_snapshot_idx());
         co_return false;
     }
@@ -491,7 +494,7 @@ future<bool> server_impl::trigger_snapshot(seastar::abort_source* as) {
     // Wait for persisted snapshot index to catch up to this index.
     auto awaited_idx = _applied_idx;
 
-    logger.debug("[{}] snapshot request waiting for index {}", _id, awaited_idx);
+    logger.debug("[{}] snapshot request waiting for index {}", _tag, awaited_idx);
 
     try {
         optimized_optional<abort_source::subscription> sub;
@@ -525,7 +528,7 @@ future<bool> server_impl::trigger_snapshot(seastar::abort_source* as) {
     logger.debug(
         "[{}] snapshot request satisfied, awaited index {}, persisted snapshot descriptor index: {}"
         ", current applied index {}, last fsm log index {}, last fsm snapshot index {}",
-        _id, awaited_idx, _snapshot_desc_idx, _applied_idx,
+        _tag, awaited_idx, _snapshot_desc_idx, _applied_idx,
         _fsm->log_last_idx(), _fsm->log_last_snapshot_idx());
 
     co_return true;
@@ -561,11 +564,11 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
                 SCYLLA_ASSERT(snap_idx >= eid.idx);
                 if (snap_term == eid.term) {
                     logger.trace("[{}] wait_for_entry {}.{}: entry got truncated away, but has the snapshot's term"
-                                 " (snapshot index: {})", id(), eid.term, eid.idx, snap_idx);
+                                 " (snapshot index: {})", _tag, eid.term, eid.idx, snap_idx);
                     co_return;
                 }
 
-                logger.trace("[{}] wait_for_entry {}.{}: entry got truncated away", id(), eid.term, eid.idx);
+                logger.trace("[{}] wait_for_entry {}.{}: entry got truncated away", _tag, eid.term, eid.idx);
                 throw commit_status_unknown();
             }
 
@@ -586,7 +589,7 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
     }
 
     auto& container = type == wait_type::committed ? _awaited_commits : _awaited_applies;
-    logger.trace("[{}] waiting for entry {}.{}", id(), eid.term, eid.idx);
+    logger.trace("[{}] waiting for entry {}.{}", _tag, eid.term, eid.idx);
 
     // This will track the commit/apply status of the entry
     auto [it, inserted] = container.emplace(eid.idx, op_status{eid.term, promise<>()});
@@ -640,7 +643,7 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
         SCYLLA_ASSERT(it->second.abort);
     }
     co_await it->second.done.get_future();
-    logger.trace("[{}] done waiting for {}.{}", id(), eid.term, eid.idx);
+    logger.trace("[{}] done waiting for {}.{}", _tag, eid.term, eid.idx);
     co_return;
 }
 
@@ -663,7 +666,7 @@ future<entry_id> server_impl::add_entry_on_leader(command cmd, seastar::abort_so
         }
         memory_permit.release();
     }
-    logger.trace("[{}] adding entry after waiting for memory permit", id());
+    logger.trace("[{}] adding entry after waiting for memory permit", _tag);
 
     try {
         const log_entry& e = _fsm->add_entry(std::move(cmd));
@@ -683,7 +686,7 @@ future<add_entry_reply> server_impl::execute_add_entry(server_id from, command c
         co_return add_entry_reply{not_a_member{format("Add entry from {} was discarded since "
                                                          "it is not part of the configuration", from)}};
     }
-    logger.trace("[{}] adding a forwarded entry from {}", id(), from);
+    logger.trace("[{}] adding a forwarded entry from {}", _tag, from);
     try {
         co_return add_entry_reply{co_await add_entry_on_leader(std::move(cmd), as)};
     } catch (raft::not_a_leader& e) {
@@ -734,14 +737,14 @@ future<> server_impl::do_on_leader_with_retries(seastar::abort_source* as, Async
 future<> server_impl::add_entry(command command, wait_type type, seastar::abort_source* as) {
     if (command.size() > _config.max_command_size) {
         logger.trace("[{}] add_entry command size exceeds the limit: {} > {}",
-                     id(), command.size(), _config.max_command_size);
+                     _tag, command.size(), _config.max_command_size);
         throw command_is_too_big_error(command.size(), _config.max_command_size);
     }
     _stats.add_command++;
 
     check_not_aborted();
 
-    logger.trace("[{}] an entry is submitted", id());
+    logger.trace("[{}] an entry is submitted", _tag);
     if (!_config.enable_forwarding) {
         if (const auto leader = _fsm->current_leader(); leader != _id) {
             throw not_a_leader{leader};
@@ -755,17 +758,17 @@ future<> server_impl::add_entry(command command, wait_type type, seastar::abort_
     co_await do_on_leader_with_retries(as, [&](server_id& leader) -> future<stop_iteration> {
         auto reply = co_await [&]() -> future<add_entry_reply> {
             if (leader == _id) {
-                logger.trace("[{}] an entry proceeds on a leader", id());
+                logger.trace("[{}] an entry proceeds on a leader", _tag);
                 // Make a copy of the command since we may still
                 // retry and forward it.
                 co_return co_await execute_add_entry(leader, command, as);
             } else {
-                logger.trace("[{}] forwarding the entry to {}", id(), leader);
+                logger.trace("[{}] forwarding the entry to {}", _tag, leader);
                 try {
                     co_return co_await _rpc->send_add_entry(leader, command);
                 } catch (const transport_error& e) {
                     logger.trace("[{}] send_add_entry on {} resulted in {}; "
-                                 "rethrow as commit_status_unknown", _id, leader, e);
+                                 "rethrow as commit_status_unknown", _tag, leader, e);
                     throw raft::commit_status_unknown();
                 }
             }
@@ -785,7 +788,7 @@ future<> server_impl::add_entry(command command, wait_type type, seastar::abort_
             co_await coroutine::return_exception(std::get<not_a_member>(reply));
         }
         const auto& e = std::get<transient_error>(reply);
-        logger.trace("[{}] got {}", _id, e);
+        logger.trace("[{}] got {}", _tag, e);
         leader = e.leader;
         co_return stop_iteration::no;
     });
@@ -804,7 +807,7 @@ future<add_entry_reply> server_impl::execute_modify_config(server_id from,
         // Wait for a new slot to become available
         auto cfg = get_configuration().current;
         for (auto& s : add) {
-            logger.trace("[{}] adding server {} as {}", id(), s.addr.id,
+            logger.trace("[{}] adding server {} as {}", _tag, s.addr.id,
                     s.can_vote? "voter" : "non-voter");
             auto it = cfg.find(s);
             if (it == cfg.end()) {
@@ -813,14 +816,14 @@ future<add_entry_reply> server_impl::execute_modify_config(server_id from,
                 cfg.erase(s);
                 cfg.insert(s);
                 logger.trace("[{}] server {} already in configuration now {}",
-                        id(), s.addr.id, s.can_vote? "voter" : "non-voter");
+                        _tag, s.addr.id, s.can_vote? "voter" : "non-voter");
             } else {
                 logger.warn("[{}] the server {} already exists in configuration as {}",
-                        id(), s.addr.id, s.can_vote? "voter" : "non-voter");
+                        _tag, s.addr.id, s.can_vote? "voter" : "non-voter");
             }
         }
         for (auto& to_remove: del) {
-            logger.trace("[{}] removing server {}", id(), to_remove);
+            logger.trace("[{}] removing server {}", _tag, to_remove);
             // erase(to_remove) only available from C++23
             auto it = cfg.find(to_remove);
             if (it != cfg.end()) {
@@ -878,12 +881,12 @@ future<> server_impl::modify_config(std::vector<config_member> add, std::vector<
                 // still retry and forward them.
                 co_return co_await execute_modify_config(leader, add, del, as);
             } else {
-                logger.trace("[{}] forwarding the entry to {}", id(), leader);
+                logger.trace("[{}] forwarding the entry to {}", _tag, leader);
                 try {
                     co_return co_await _rpc->send_modify_config(leader, add, del);
                 } catch (const transport_error& e) {
                     logger.trace("[{}] send_modify_config on {} resulted in {}; "
-                                 "rethrow as commit_status_unknown", _id, leader, e);
+                                 "rethrow as commit_status_unknown", _tag, leader, e);
                     throw raft::commit_status_unknown();
                 }
             }
@@ -895,7 +898,7 @@ future<> server_impl::modify_config(std::vector<config_member> add, std::vector<
             co_return stop_iteration::yes;
         }
         if (const auto e = std::get_if<raft::transient_error>(&reply)) {
-            logger.trace("[{}] got {}", _id, *e);
+            logger.trace("[{}] got {}", _tag, *e);
             leader = e->leader;
             co_return stop_iteration::no;
         }
@@ -1038,7 +1041,7 @@ void server_impl::send_message(server_id id, Message m) {
                 try {
                     co_await server->_rpc->send_append_entries(id, m);
                 } catch(...) {
-                    logger.debug("[{}] io_fiber failed to send a message to {}: {}", server->_id, id, std::current_exception());
+                    logger.debug("[{}] io_fiber failed to send a message to {}: {}", server->_tag, id, std::current_exception());
                 }
                 server->_append_request_status[id].count--;
                 if (server->_append_request_status[id].count == 0) {
@@ -1121,7 +1124,7 @@ future<> server_impl::process_fsm_output(index_t& last_stable, fsm_output&& batc
 
     if (batch.snp) {
         const auto& [snp, is_local, preserve_log_entries] = *batch.snp;
-        logger.trace("[{}] io_fiber storing snapshot {}", _id, snp.id);
+        logger.trace("[{}] io_fiber storing snapshot {}", _tag, snp.id);
         // Persist the snapshot
         co_await _persistence->store_snapshot_descriptor(snp, preserve_log_entries);
         _snapshot_desc_idx = snp.idx;
@@ -1179,7 +1182,7 @@ future<> server_impl::process_fsm_output(index_t& last_stable, fsm_output&& batc
             send_message(m.first, std::move(m.second));
         } catch(...) {
             // Not being able to send a message is not a critical error
-            logger.debug("[{}] io_fiber failed to send a message to {}: {}", _id, m.first, std::current_exception());
+            logger.debug("[{}] io_fiber failed to send a message to {}: {}", _tag, m.first, std::current_exception());
         }
     }
 
@@ -1251,7 +1254,7 @@ future<> server_impl::process_server_requests(server_requests&& requests) {
 }
 
 future<> server_impl::io_fiber(index_t last_stable) {
-    logger.trace("[{}] io_fiber start", _id);
+    logger.trace("[{}] io_fiber start", _tag);
     try {
         while (true) {
             bool has_fsm_output = false;
@@ -1327,14 +1330,14 @@ void server_impl::send_snapshot(server_id dst, install_snapshot&& snp) {
             const log_level lvl = try_catch<raft::destination_not_alive_error>(eptr) != nullptr
                     ? log_level::debug
                     : log_level::error;
-            logger.log(lvl, "[{}] Transferring snapshot to {} failed with: {}", _id, dst, eptr);
+            logger.log(lvl, "[{}] Transferring snapshot to {} failed with: {}", _tag, dst, eptr);
         } else {
-            logger.trace("[{}] Transferred snapshot to {}", _id, dst);
+            logger.trace("[{}] Transferred snapshot to {}", _tag, dst);
             reply = f.get();
         }
         _fsm->step(dst, std::move(reply));
     }).handle_exception([this, dst] (std::exception_ptr ep) {
-        logger.error("[{}] Snapshot transfer to {} failed with: {}", _id, dst, ep);
+        logger.error("[{}] Snapshot transfer to {} failed with: {}", _tag, dst, ep);
     });
 }
 
@@ -1350,7 +1353,7 @@ future<snapshot_reply> server_impl::apply_snapshot(server_id from, install_snaps
         try {
             reply = co_await _snapshot_application_done[from].get_future();
         } catch (...) {
-            logger.error("apply_snapshot[{}] failed with {}", _id, std::current_exception());
+            logger.error("apply_snapshot[{}] failed with {}", _tag, std::current_exception());
         }
     }
     co_return reply;
@@ -1366,7 +1369,7 @@ future<> server_impl::applier_fiber() {
             co_await std::visit(make_visitor(
             [this] (log_entry_ptr_list& batch) -> future<> {
                 if (batch.empty()) {
-                    logger.trace("[{}] applier fiber: received empty batch", _id);
+                    logger.trace("[{}] applier fiber: received empty batch", _tag);
                     co_return;
                 }
 
@@ -1394,7 +1397,7 @@ future<> server_impl::applier_fiber() {
                     try {
                         co_await _state_machine->apply(std::move(commands));
                     } catch (abort_requested_exception& e) {
-                        logger.info("[{}] applier fiber stopped because state machine was aborted: {}", _id, e);
+                        logger.info("[{}] applier fiber stopped because state machine was aborted: {}", _tag, e);
                         throw stop_apply_fiber{};
                     } catch (...) {
                         std::throw_with_nested(raft::state_machine_error{});
@@ -1426,7 +1429,7 @@ future<> server_impl::applier_fiber() {
                     snp.term = last_term;
                     snp.idx = _applied_idx;
                     snp.config = _fsm->log_last_conf_for(_applied_idx);
-                    logger.trace("[{}] applier fiber: taking snapshot term={}, idx={}", _id, snp.term, snp.idx);
+                    logger.trace("[{}] applier fiber: taking snapshot term={}, idx={}", _tag, snp.term, snp.idx);
                     snp.id = co_await _state_machine->take_snapshot();
                     // Note that at this point (after the `co_await`), _fsm may already have applied a later snapshot.
                     // That's fine, `_fsm->apply_snapshot` will simply ignore our current attempt; we will soon receive
@@ -1435,7 +1438,7 @@ future<> server_impl::applier_fiber() {
                     auto max_trailing_bytes = force_snapshot ? 0 : _config.snapshot_trailing_size;
                     if (!_fsm->apply_snapshot(snp, max_trailing, max_trailing_bytes, true)) {
                         logger.trace("[{}] applier fiber: while taking snapshot term={} idx={} id={},"
-                                " fsm received a later snapshot at idx={}", _id, snp.term, snp.idx, snp.id, _fsm->log_last_snapshot_idx());
+                                " fsm received a later snapshot at idx={}", _tag, snp.term, snp.idx, snp.id, _fsm->log_last_snapshot_idx());
                     }
                     _stats.snapshots_taken++;
                 }
@@ -1443,7 +1446,7 @@ future<> server_impl::applier_fiber() {
             [this] (snapshot_descriptor& snp) -> future<> {
                 SCYLLA_ASSERT(snp.idx >= _applied_idx);
                 // Apply snapshot it to the state machine
-                logger.trace("[{}] apply_fiber applying snapshot {}", _id, snp.id);
+                logger.trace("[{}] apply_fiber applying snapshot {}", _tag, snp.id);
                 co_await _state_machine->load_snapshot(snp.id);
                 drop_waiters(&snp);
                 _applied_idx = snp.idx;
@@ -1465,11 +1468,11 @@ future<> server_impl::applier_fiber() {
                 snp.term = *applied_term;
                 snp.idx = _applied_idx;
                 snp.config = _fsm->log_last_conf_for(_applied_idx);
-                logger.trace("[{}] taking snapshot at term={}, idx={} due to request", _id, snp.term, snp.idx);
+                logger.trace("[{}] taking snapshot at term={}, idx={} due to request", _tag, snp.term, snp.idx);
                 snp.id = co_await _state_machine->take_snapshot();
                 if (!_fsm->apply_snapshot(snp, 0, 0, true)) {
                     logger.trace("[{}] while taking snapshot term={} idx={} id={} due to request,"
-                           " fsm received a later snapshot at idx={}", _id, snp.term, snp.idx, snp.id, _fsm->log_last_snapshot_idx());
+                           " fsm received a later snapshot at idx={}", _tag, snp.term, snp.idx, snp.id, _fsm->log_last_snapshot_idx());
                 }
                 _stats.snapshots_taken++;
             }
@@ -1519,7 +1522,7 @@ future<> server_impl::wait_for_apply(index_t idx, abort_source* as) {
 future<read_barrier_reply> server_impl::execute_read_barrier(server_id from, seastar::abort_source* as) {
     check_not_aborted();
 
-    logger.trace("[{}] execute_read_barrier start", _id);
+    logger.trace("[{}] execute_read_barrier start", _tag);
 
     std::optional<std::pair<read_id, index_t>> rid;
     try {
@@ -1532,7 +1535,7 @@ future<read_barrier_reply> server_impl::execute_read_barrier(server_id from, sea
         return make_ready_future<read_barrier_reply>(err);
     }
     logger.trace("[{}] execute_read_barrier read id is {} for commit idx {}",
-        _id, rid->first, rid->second);
+        _tag, rid->first, rid->second);
     if (as && as->abort_requested()) {
         return make_exception_future<read_barrier_reply>(
             request_aborted(format("Abort requested before waiting for read barrier from {}, read id is {} for commit idx {}", from, rid->first, rid->second)));
@@ -1559,7 +1562,7 @@ future<read_barrier_reply> server_impl::get_read_idx(server_id leader, seastar::
 }
 
 future<> server_impl::read_barrier(seastar::abort_source* as) {
-    logger.trace("[{}] read_barrier start", _id);
+    logger.trace("[{}] read_barrier start", _tag);
     index_t read_idx;
 
     co_await do_on_leader_with_retries(as, [&](server_id& leader) -> future<stop_iteration> {
@@ -1568,7 +1571,7 @@ future<> server_impl::read_barrier(seastar::abort_source* as) {
         try {
             res = co_await get_read_idx(leader, as);
         } catch (const transport_error& e) {
-            logger.trace("[{}] read_barrier on {} resulted in {}; retrying", _id, leader, e);
+            logger.trace("[{}] read_barrier on {} resulted in {}; retrying", _tag, leader, e);
             leader = server_id{};
             co_return stop_iteration::no;
         }
@@ -1576,7 +1579,7 @@ future<> server_impl::read_barrier(seastar::abort_source* as) {
             // the leader is not ready to answer because it did not
             // committed any entries yet, so wait for any entry to be
             // committed (if non were since start of the attempt) and retry.
-            logger.trace("[{}] read_barrier leader not ready", _id);
+            logger.trace("[{}] read_barrier leader not ready", _tag);
             co_await wait_for_apply(++applied, as);
             co_return stop_iteration::no;
         }
@@ -1588,14 +1591,14 @@ future<> server_impl::read_barrier(seastar::abort_source* as) {
         co_return stop_iteration::yes;
     });
 
-    logger.trace("[{}] read_barrier read index {}, applied index {}", _id, read_idx, _applied_idx);
+    logger.trace("[{}] read_barrier read index {}, applied index {}", _tag, read_idx, _applied_idx);
     co_return co_await wait_for_apply(read_idx, as);
 }
 
 void server_impl::abort_snapshot_transfer(server_id id) {
     auto it = _snapshot_abort_sources.find(id);
     if (it != _snapshot_abort_sources.end()) {
-        logger.trace("[{}] Request abort of snapshot transfer to {}", _id, id);
+        logger.trace("[{}] Request abort of snapshot transfer to {}", _tag, id);
         it->second->request_abort();
         _snapshot_abort_sources.erase(it);
     }
@@ -1603,7 +1606,7 @@ void server_impl::abort_snapshot_transfer(server_id id) {
 
 void server_impl::abort_snapshot_transfers() {
     for (auto&& [id, as] : _snapshot_abort_sources) {
-        logger.trace("[{}] Request abort of snapshot transfer to {}", _id, id);
+        logger.trace("[{}] Request abort of snapshot transfer to {}", _tag, id);
         as->request_abort();
     }
     _snapshot_abort_sources.clear();
@@ -1619,10 +1622,10 @@ void server_impl::handle_background_error(const char* fiber_name) {
     _is_alive = false;
     auto e = std::current_exception();
     if (_aborted && try_catch<const seastar::gate_closed_exception>(e)) {
-        logger.debug("[{}] {} fiber stopped while aborting raft server: {}", _id, fiber_name, e);
+        logger.debug("[{}] {} fiber stopped while aborting raft server: {}", _tag, fiber_name, e);
         return;
     }
-    logger.error("[{}] {} fiber stopped because of the error: {}", _id, fiber_name, e);
+    logger.error("[{}] {} fiber stopped because of the error: {}", _tag, fiber_name, e);
     if (_config.on_background_error) {
         _config.on_background_error(e);
     }
@@ -1631,7 +1634,7 @@ void server_impl::handle_background_error(const char* fiber_name) {
 future<> server_impl::abort(sstring reason) {
     _is_alive = false;
     _aborted = std::move(reason);
-    logger.trace("[{}]: abort() called", _id);
+    logger.trace("[{}]: abort() called", _tag);
     _fsm->stop();
     _events.broken();
     _snapshot_desc_idx_changed.broken();
@@ -1726,7 +1729,7 @@ future<> server_impl::set_configuration(config_member_set c_new, seastar::abort_
 
     if (_non_joint_conf_commit_promise) {
         logger.warn("[{}] set_configuration: a configuration change is still in progress (at index: {}, config: {})",
-            _id, _fsm->log_last_conf_idx(), cfg);
+            _tag, _fsm->log_last_conf_idx(), cfg);
         throw conf_change_in_progress{};
     }
 
@@ -1759,8 +1762,8 @@ future<> server_impl::set_configuration(config_member_set c_new, seastar::abort_
         _non_joint_conf_commit_promise.reset();
         // We need to 'observe' possible exceptions in f, otherwise they will be
         // considered unhandled and cause a warning.
-        (void)f.handle_exception([id = _id] (auto e) {
-            logger.trace("[{}] error while waiting for non-joint configuration to be committed: {}", id, e);
+        (void)f.handle_exception([tag = _tag] (auto e) {
+            logger.trace("[{}] error while waiting for non-joint configuration to be committed: {}", tag, e);
         });
         throw;
     }

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -63,6 +63,10 @@ public:
         // A callback to invoke if one of internal server
         // background activities has stopped because of an error.
         std::function<void(std::exception_ptr e)> on_background_error;
+        // Human-readable tag used in log messages instead of server_id.
+        // Helps distinguish raft instances when multiple groups share the
+        // same server_id. If empty, server_id is used as the default.
+        sstring tag;
     };
 
     virtual ~server() {}

--- a/raft/tracker.hh
+++ b/raft/tracker.hh
@@ -172,6 +172,10 @@ public:
         }
         return true;
     }
+    // Check if a voter has responded (voted or rejected) in this election.
+    bool has_responded(server_id id) const {
+        return _responded.contains(id);
+    }
     vote_result tally_votes() const {
         auto quorum = _suffrage.size() / 2 + 1;
         if (_granted >= quorum) {
@@ -200,6 +204,10 @@ public:
 
     void register_vote(server_id from, bool granted);
     vote_result tally_votes() const;
+    // Check if a voter has responded in the current election round.
+    bool has_responded(server_id id) const {
+        return _current.has_responded(id);
+    }
 
     friend fmt::formatter<votes>;
 };

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -172,7 +172,8 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
             on_internal_error(logger, 
                 ::format("table {}, tablet {} raft group {} background error {}", 
                     tablet.table, tablet.tablet, group_id, e));
-        }
+        },
+        .tag = format("sc-{}", group_id)
     };
     auto server = raft::create_server(my_id, std::move(rpc), std::move(state_machine),
             std::move(storage), _raft_gr.failure_detector(), config);

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -6,6 +6,7 @@
 
 from typing import Tuple
 import re
+from datetime import datetime
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import gather_safely, wait_for, Host
@@ -117,10 +118,11 @@ async def get_table_raft_group_id(manager: ManagerClient, ks: str, table: str):
     rows = await manager.get_cql().run_async(f"SELECT raft_group_id FROM system.tablets where table_id = {table_id}")
     return str(rows[0].raft_group_id)
 
-async def test_basic_write_read(manager: ManagerClient):
+async def test_basic_write_read(manager: ManagerClient, build_mode: str):
 
     logger.info("Bootstrapping cluster")
-    servers = await manager.servers_add(3, config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE, auto_rack_dc='my_dc')
+    cmdline = DEFAULT_CMDLINE + ['--logger-log-level', 'raft_commitlog=debug']
+    servers = await manager.servers_add(3, config=DEFAULT_CONFIG, cmdline=cmdline, auto_rack_dc='my_dc')
     (cql, hosts) = await manager.get_ready_cql(servers)
 
     logger.info("Load host_id-s for servers")
@@ -134,6 +136,10 @@ async def test_basic_write_read(manager: ManagerClient):
 
     logger.info("Creating a strongly-consistent keyspace")
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        # Open logs before CREATE TABLE so we can measure raft group bootstrap time.
+        server_logs = [await manager.server_open_log(s.server_id) for s in servers]
+        marks = [await log.mark() for log in server_logs]
+
         logger.info("Creating a table")
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -150,6 +156,68 @@ async def test_basic_write_read(manager: ManagerClient):
         else:
             leader_host_id = await wait_for_leader(manager, servers[1], group_id)
         leader_host = host_by_host_id(leader_host_id)
+
+        # Verify that SC raft group bootstrap (election + read_barrier) completed
+        # quickly on both replicas. With the start_as_candidate and retry_now
+        # optimizations, this should be nearly instant. Without them, it takes
+        # 1-2 seconds (election timeout) + 100ms (tick wait in read_barrier).
+        # Only check in dev mode — other builds have different performance.
+        #
+        # Sum the wall-clock bootstrap time across both replicas, then subtract
+        # raft log persistence (store_log_entries) which is I/O-bound and
+        # unrelated to the protocol optimization. Assert the adjusted sum < 100ms.
+        if build_mode == "dev":
+            ts_pattern = r'(\d{2}:\d{2}:\d{2},\d{3})'
+            total_startup_ms = 0.0
+            total_io_ms = 0.0
+            replicas_checked = 0
+            for i, (log, mark) in enumerate(zip(server_logs, marks)):
+                matches = await log.grep(
+                    f"update\\(\\): starting raft server for tablet .*, group id {group_id}",
+                    from_mark=mark)
+                if not matches:
+                    continue
+                done_matches = await log.grep(
+                    f"update\\(\\): raft server for tablet .* and group id {group_id} is started",
+                    from_mark=mark)
+                assert done_matches, (
+                    f"Server {i+1}: found 'starting raft server' but not 'is started' "
+                    f"for group {group_id}")
+                start_ts = re.search(ts_pattern, matches[0][0])
+                done_ts = re.search(ts_pattern, done_matches[0][0])
+                assert start_ts and done_ts, (
+                    f"Server {i+1}: could not parse timestamps from log lines")
+                t0 = datetime.strptime(start_ts.group(1), "%H:%M:%S,%f")
+                t1 = datetime.strptime(done_ts.group(1), "%H:%M:%S,%f")
+                elapsed_ms = (t1 - t0).total_seconds() * 1000
+                total_startup_ms += elapsed_ms
+
+                # Accumulate store_log_entries persistence that falls within [t0, t1].
+                store_starts = await log.grep(
+                    f"raft_commitlog - store_log_entries: group_id={group_id}",
+                    from_mark=mark)
+                store_ends = await log.grep(
+                    "raft_commitlog - store_log_entries completed:",
+                    from_mark=mark)
+                for s, e in zip(store_starts, store_ends):
+                    s_ts = re.search(ts_pattern, s[0])
+                    e_ts = re.search(ts_pattern, e[0])
+                    if s_ts and e_ts:
+                        s_t = datetime.strptime(s_ts.group(1), "%H:%M:%S,%f")
+                        e_t = datetime.strptime(e_ts.group(1), "%H:%M:%S,%f")
+                        if s_t >= t0 and e_t <= t1:
+                            total_io_ms += (e_t - s_t).total_seconds() * 1000
+
+                replicas_checked += 1
+
+            assert replicas_checked == 2, (
+                f"Expected 2 replicas with SC raft group logs, found {replicas_checked}")
+            logger.info(f"SC raft group startup: total={total_startup_ms:.0f}ms, "
+                        f"io={total_io_ms:.0f}ms, adjusted={total_startup_ms - total_io_ms:.0f}ms")
+            assert total_startup_ms - total_io_ms < 100, (
+                f"SC raft group startup took {total_startup_ms - total_io_ms:.0f}ms "
+                f"(total {total_startup_ms:.0f}ms minus {total_io_ms:.0f}ms io), "
+                f"expected <100ms (start_as_candidate + retry_now optimizations)")
 
         logger.info(f"Get the non-leader replica for the group {group_id}")
         non_leader_replica_host_id = [host_id for host_id in replica_host_ids if str(host_id) != str(leader_host_id)][0]

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2398,3 +2398,25 @@ BOOST_AUTO_TEST_CASE(test_state_change_notifications) {
     BOOST_CHECK(output.state_changed);
     BOOST_CHECK(fsm.is_leader());
 }
+
+// Test that ping_leader() sends ping messages immediately (not waiting for
+// the next tick).
+BOOST_AUTO_TEST_CASE(test_ping_leader_sends_immediately) {
+    server_id A_id = id(), B_id = id();
+    raft::configuration cfg = config_from_ids({A_id, B_id});
+    raft::log log(raft::snapshot_descriptor{.config = cfg});
+
+    auto A = create_follower(A_id, log);
+
+    // A is a follower with no known leader. Calling ping_leader() should
+    // immediately produce append_reply messages without waiting for a tick.
+    A.ping_leader();
+    auto output = A.get_output();
+    BOOST_CHECK_GE(output.messages.size(), 1);
+    // The message should be an append_reply (rejected) sent to B
+    auto& msg = output.messages[0];
+    BOOST_CHECK_EQUAL(msg.first, B_id);
+    BOOST_CHECK(std::holds_alternative<raft::append_reply>(msg.second));
+    auto& reply = std::get<raft::append_reply>(msg.second);
+    BOOST_CHECK(std::holds_alternative<raft::append_reply::rejected>(reply.result));
+}

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2511,3 +2511,92 @@ BOOST_AUTO_TEST_CASE(test_no_start_as_candidate_with_nonempty_log) {
 
     BOOST_CHECK(A.is_follower());
 }
+// Test that when a candidate's initial vote request is lost (peer not
+// available initially), it resends the vote request when the peer pings us
+// with a stale-term message.
+BOOST_AUTO_TEST_CASE(test_start_as_candidate_resend_on_peer_ping) {
+    server_id A_id = id(), B_id = id();
+    BOOST_CHECK(A_id < B_id);
+    raft::configuration cfg = config_from_ids({A_id, B_id});
+    raft::log log(raft::snapshot_descriptor{.config = cfg});
+
+    raft::fsm_config fcfg{.append_request_threshold = 1, .enable_prevoting = true,
+                          .enable_fast_bootstrap = true};
+    fsm_debug A(A_id, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fcfg);
+
+    BOOST_CHECK(A.is_candidate());
+    BOOST_CHECK_EQUAL(A.get_current_term(), term_t{1});
+
+    // Consume the initial vote request (simulating it being lost)
+    auto output = A.get_output();
+    BOOST_CHECK_EQUAL(output.messages.size(), 1);
+
+    // Simulate the peer starting later and pinging us with a stale-term
+    // append_reply (this is what ping_leader() sends at term 0)
+    A.step(B_id, raft::append_reply{term_t{0}, index_t{0},
+            raft::append_reply::rejected{index_t{0}, index_t{0}}});
+
+    // The candidate should resend its vote request to B
+    output = A.get_output();
+    BOOST_CHECK_GE(output.messages.size(), 1);
+    bool found_vote_request = false;
+    for (auto& [to, msg] : output.messages) {
+        if (auto* vr = std::get_if<raft::vote_request>(&msg)) {
+            BOOST_CHECK_EQUAL(to, B_id);
+            BOOST_CHECK(!vr->is_prevote);
+            BOOST_CHECK_EQUAL(vr->current_term, term_t{1});
+            found_vote_request = true;
+        }
+    }
+    BOOST_CHECK(found_vote_request);
+
+    // Now B grants the vote — A should become leader
+    A.step(B_id, raft::vote_reply{term_t{1}, true});
+    BOOST_CHECK(A.is_leader());
+}
+
+// Test that a candidate does NOT resend its vote request to a peer that has
+// already responded (voted) in the current term, even if that peer sends a
+// stale-term message.
+BOOST_AUTO_TEST_CASE(test_no_resend_to_responded_peer) {
+    server_id A_id = id(), B_id = id(), C_id = id();
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.config = cfg});
+
+    auto A = create_follower(A_id, log);
+    BOOST_CHECK(A.is_follower());
+
+    // Become a candidate via the normal election timeout.
+    election_timeout(A);
+    BOOST_CHECK(A.is_candidate());
+    auto output = A.get_output();
+    BOOST_CHECK(output.term_and_vote);
+    auto term = output.term_and_vote->first;
+
+    // B responds to our vote request (rejects it). A stays a candidate since
+    // there is no granting quorum (self-vote + rejection), but B has now
+    // responded for this term.
+    A.step(B_id, raft::vote_reply{term, false});
+    BOOST_CHECK(A.is_candidate());
+    (void)A.get_output();
+
+    // B (having responded) sends a stale-term ping — no resend to B.
+    A.step(B_id, raft::append_reply{term_t{0}, index_t{0},
+            raft::append_reply::rejected{index_t{0}, index_t{0}}});
+    output = A.get_output();
+    for (auto& [to, msg] : output.messages) {
+        BOOST_CHECK(to != B_id || !std::holds_alternative<raft::vote_request>(msg));
+    }
+
+    // C (which hasn't responded) sends a stale-term ping — we resend to C.
+    A.step(C_id, raft::append_reply{term_t{0}, index_t{0},
+            raft::append_reply::rejected{index_t{0}, index_t{0}}});
+    output = A.get_output();
+    bool resent_to_c = false;
+    for (auto& [to, msg] : output.messages) {
+        if (to == C_id && std::holds_alternative<raft::vote_request>(msg)) {
+            resent_to_c = true;
+        }
+    }
+    BOOST_CHECK(resent_to_c);
+}

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2420,3 +2420,94 @@ BOOST_AUTO_TEST_CASE(test_ping_leader_sends_immediately) {
     auto& reply = std::get<raft::append_reply>(msg.second);
     BOOST_CHECK(std::holds_alternative<raft::append_reply::rejected>(reply.result));
 }
+
+
+// Test that with fast bootstrap enabled, a fresh multi-node group (empty log)
+// makes the smallest-id voter immediately become a candidate at construction
+// time and send a vote request without prevoting. A non-voter with an even
+// smaller id is present to verify that non-voters are never selected to start
+// the election.
+BOOST_AUTO_TEST_CASE(test_start_as_candidate) {
+    server_id N_id = id(), A_id = id(), B_id = id();
+    // N_id is allocated first, so it has the smallest id overall, but it is a
+    // non-voter and must be ignored. A_id is the smallest voter.
+    BOOST_CHECK(N_id < A_id);
+    BOOST_CHECK(A_id < B_id);
+    raft::configuration cfg(raft::config_member_set{
+            raft::config_member{server_addr_from_id(N_id), is_voter::no},
+            raft::config_member{server_addr_from_id(A_id), is_voter::yes},
+            raft::config_member{server_addr_from_id(B_id), is_voter::yes}});
+
+    raft::fsm_config fcfg{.append_request_threshold = 1, .enable_prevoting = true,
+                          .enable_fast_bootstrap = true};
+
+    {
+        raft::log log(raft::snapshot_descriptor{.config = cfg});
+        fsm_debug A(A_id, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fcfg);
+
+        // Smallest-id voter on a fresh group: immediately a candidate (not a
+        // prevote candidate — prevoting is skipped on a fresh group). The
+        // smaller-id non-voter N is ignored.
+        BOOST_CHECK(A.is_candidate());
+        BOOST_CHECK(!A.is_prevote_candidate());
+        // Term should have been bumped to 1
+        BOOST_CHECK_EQUAL(A.get_current_term(), term_t{1});
+
+        // The output should contain a vote request (not prevote) to B only;
+        // the non-voter N is not asked to vote.
+        auto output = A.get_output();
+        BOOST_CHECK_EQUAL(output.messages.size(), 1);
+        BOOST_CHECK_EQUAL(output.messages[0].first, B_id);
+        auto& vr = std::get<raft::vote_request>(output.messages[0].second);
+        BOOST_CHECK(!vr.is_prevote);
+        BOOST_CHECK_EQUAL(vr.current_term, term_t{1});
+    }
+
+    {
+        // The larger-id voter must NOT start an election; it stays a
+        // follower and waits for the election timeout.
+        raft::log log(raft::snapshot_descriptor{.config = cfg});
+        fsm_debug B(B_id, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fcfg);
+        BOOST_CHECK(B.is_follower());
+    }
+
+    {
+        // The non-voter has the smallest id but is not eligible to start an
+        // election; it stays a follower.
+        raft::log log(raft::snapshot_descriptor{.config = cfg});
+        fsm_debug N(N_id, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fcfg);
+        BOOST_CHECK(N.is_follower());
+    }
+}
+
+// Test that fast bootstrap is gated by enable_fast_bootstrap: with the flag
+// off (the default), even the smallest-id voter on a fresh group stays a
+// follower. This is what keeps the bare fsm usable in tests.
+BOOST_AUTO_TEST_CASE(test_no_start_as_candidate_without_fast_bootstrap) {
+    server_id A_id = id(), B_id = id();
+    BOOST_CHECK(A_id < B_id);
+    raft::configuration cfg = config_from_ids({A_id, B_id});
+
+    raft::log log(raft::snapshot_descriptor{.config = cfg});
+    raft::fsm_config fcfg{.append_request_threshold = 1, .enable_prevoting = true};
+    fsm_debug A(A_id, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fcfg);
+
+    BOOST_CHECK(A.is_follower());
+}
+
+// Test that a non-empty log (a restarted server, not a fresh group) does not
+// trigger immediate candidacy even for the smallest-id voter with fast
+// bootstrap enabled.
+BOOST_AUTO_TEST_CASE(test_no_start_as_candidate_with_nonempty_log) {
+    server_id A_id = id(), B_id = id();
+    BOOST_CHECK(A_id < B_id);
+    raft::configuration cfg = config_from_ids({A_id, B_id});
+
+    // Snapshot at index 1 => non-empty log.
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{1}, .config = cfg});
+    raft::fsm_config fcfg{.append_request_threshold = 1, .enable_prevoting = true,
+                          .enable_fast_bootstrap = true};
+    fsm_debug A(A_id, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fcfg);
+
+    BOOST_CHECK(A.is_follower());
+}

--- a/test/raft/helpers.hh
+++ b/test/raft/helpers.hh
@@ -70,12 +70,10 @@ struct sm_events_container {
 
 class fsm_debug : public sm_events_container, public raft::fsm {
 public:
-    using raft::fsm::fsm;
-
     explicit fsm_debug(raft::server_id id, raft::term_t current_term, raft::server_id voted_for, raft::log log,
             raft::failure_detector& failure_detector, raft::fsm_config conf)
         : sm_events_container()
-        , fsm(id, current_term, voted_for, std::move(log), raft::index_t{0}, failure_detector, conf, sm_events) {
+        , fsm(id, format("{}", id), current_term, voted_for, std::move(log), raft::index_t{0}, failure_detector, conf, sm_events) {
     }
 
     void become_follower(raft::server_id leader) {

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -594,9 +594,14 @@ public:
             , _rpc_config(rpc_config)
             , _delays(rpc_config.network_delay > 0ms)
     {
-        _net[_id] = this;
         // Rounds to next power of 2
         _same_node_prefix = (1 << std::bit_width(_rpc_config.local_nodes)) - 1;
+    }
+    void publish() {
+        _net[_id] = this;
+    }
+    void unpublish() {
+        _net.erase(_id);
     }
     bool drop_packet() {
         return _rpc_config.drops && !(rand() % 5);
@@ -645,8 +650,8 @@ public:
                 return with_gate(_gate, [&, this] () mutable -> future<> {
                     return seastar::sleep(get_delay(id) + rand_extra_delay()).then(
                             [this, id = std::move(id), append_request = std::move(append_request)] {
-                        if ((*_connected)(id, _id)) {
-                            _net[id]->_client->append_entries(_id, append_request);
+                        if (auto it = _net.find(id); it != _net.end() && (*_connected)(id, _id)) {
+                            it->second->_client->append_entries(_id, append_request);
                         }
                     });
                 });
@@ -668,8 +673,8 @@ public:
                 (void)with_gate(_gate, [&, this] () mutable -> future<> {
                     return seastar::sleep(get_delay(id) + rand_extra_delay()).then(
                             [this, id = std::move(id), reply = std::move(reply)] {
-                        if ((*_connected)(id, _id)) {
-                            _net[id]->_client->append_entries_reply(rpc::_id, std::move(reply));
+                        if (auto it = _net.find(id); it != _net.end() && (*_connected)(id, _id)) {
+                            it->second->_client->append_entries_reply(rpc::_id, std::move(reply));
                         }
                     });
                 });
@@ -689,8 +694,8 @@ public:
             (void)with_gate(_gate, [&, this] () mutable -> future<> {
                 return seastar::sleep(get_delay(id) + rand_extra_delay()).then(
                         [this, id = std::move(id), vote_request = std::move(vote_request)] {
-                    if ((*_connected)(id, _id)) {
-                        _net[id]->_client->request_vote(rpc::_id, std::move(vote_request));
+                    if (auto it = _net.find(id); it != _net.end() && (*_connected)(id, _id)) {
+                        it->second->_client->request_vote(rpc::_id, std::move(vote_request));
                     }
                 });
             });
@@ -708,8 +713,8 @@ public:
         if (_delays) {
             (void)with_gate(_gate, [&, this] () mutable -> future<> {
                 return seastar::sleep(get_delay(id) + rand_extra_delay()).then([=, this] {
-                    if ((*_connected)(id, _id)) {
-                        _net[id]->_client->request_vote_reply(rpc::_id, vote_reply);
+                    if (auto it = _net.find(id); it != _net.end() && (*_connected)(id, _id)) {
+                        it->second->_client->request_vote_reply(rpc::_id, vote_reply);
                     }
                 });
             });
@@ -888,6 +893,7 @@ raft::server& raft_cluster<Clock>::get_server(size_t id) {
 template <typename Clock>
 future<> raft_cluster<Clock>::stop_server(size_t id, sstring reason) {
     cancel_ticker(id);
+    _servers[id].rpc->unpublish();
     co_await _servers[id].server->abort(std::move(reason));
     if (_snapshots->contains(to_raft_id(id))) {
         BOOST_CHECK_LE((*_snapshots)[to_raft_id(id)].size(), 2);
@@ -901,18 +907,30 @@ template <typename Clock>
 future<> raft_cluster<Clock>::reset_server(size_t id, initial_state state) {
     _servers[id] = create_server(id, state);
     co_await _servers[id].server->start();
+    _servers[id].rpc->publish();
     set_ticker_callback(id);
 }
 
 template <typename Clock>
 future<> raft_cluster<Clock>::start_all() {
-    co_await coroutine::parallel_for_each(_servers, [] (auto& r) {
-        return r.server->start();
+    // Start the leader (node 0) last. With fast bootstrap the smallest-id
+    // node becomes a candidate during start(), sending a vote_request to all
+    // peers. All peers must be started and published by that point, otherwise
+    // the request is dropped and node 0 loses its advantage: it is already a
+    // candidate so wait_until_candidate() won't tick it, and all nodes race
+    // equally once tickers start — the winner is non-deterministic.
+    BOOST_REQUIRE(_leader == 0);
+    co_await coroutine::parallel_for_each(std::views::iota(size_t{1}, _servers.size()), [this] (size_t i) -> future<> {
+        co_await _servers[i].server->start();
+        _servers[i].rpc->publish();
     });
+    co_await _servers[0].server->start();
+    _servers[0].rpc->publish();
     co_await init_raft_tickers();
     BOOST_TEST_MESSAGE("Electing first leader " << _leader);
     _servers[_leader].server->wait_until_candidate();
     co_await _servers[_leader].server->wait_election_done();
+    BOOST_REQUIRE(_servers[_leader].server->is_leader());
 }
 
 template <typename Clock>

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -41,7 +41,7 @@
 //      .nodes                       number of nodes
 //      .total_values                how many entries to append to leader nodes (default 100)
 //      .initial_term                initial term # for setup
-//      .initial_leader              what server is leader
+//      .initial_leader              what server is leader (always 0, required by fast bootstrap)
 //      .initial_states              initial logs of servers
 //          .le                      log entries
 //      .initial_snapshots           snapshots present at initial state for servers
@@ -271,7 +271,10 @@ struct test_case {
     const size_t nodes;
     const size_t total_values = 100;
     uint64_t initial_term = 1;
-    const size_t initial_leader = 0;
+    // The initial leader is always node 0 (smallest server_id). With fast
+    // bootstrap the smallest-id node starts an election immediately, so
+    // start_all() relies on this being 0.
+    static constexpr size_t initial_leader = 0;
     const std::vector<struct initial_log> initial_states;
     const std::vector<struct initial_snapshot> initial_snapshots;
     const std::vector<raft::server::configuration> config;
@@ -848,7 +851,7 @@ raft_cluster<Clock>::raft_cluster(test_case test,
         , _rpc_config(rpc_config)
         , _prevote(prevote)
         , _apply(apply)
-        , _leader(first_leader)
+        , _leader(test_case::initial_leader)
         , _tick_delta(tick_delta)
         , _verify_persisted_snapshots(test.verify_persisted_snapshots) {
 
@@ -1433,9 +1436,7 @@ template <typename Clock>
 std::vector<initial_state> raft_cluster<Clock>::get_states(test_case test, bool prevote) {
     std::vector<initial_state> states(test.nodes);       // Server initial states
 
-    size_t leader = test.initial_leader;
-
-    states[leader].term = raft::term_t{test.initial_term};
+    states[test.initial_leader].term = raft::term_t{test.initial_term};
 
     // Server initial logs, etc
     for (size_t i = 0; i < states.size(); ++i) {


### PR DESCRIPTION
### Problem
When a strongly consistent table is created, each tablet gets a fresh raft group where all nodes start as followers simultaneously. Since no leader exists, every node waits through the full randomized election timeout (10-20 ticks = 1-2 seconds) before anyone calls an election. This adds unnecessary latency to table creation and first-write readiness.

Additionally, after a fresh leader is elected, the initial read_barrier hits a "leader not ready" condition (no-op entry not yet committed in the current term). The retry mechanism in `do_on_leader_with_retries` misinterprets this as a "no progress" situation and waits for the next tick (100ms), even though the `read_barrier` code already waited for the entry to be applied before retrying.

### Changes
1. `start_as_candidate` config: designate one node (smallest host_id) to immediately call `become_candidate` in the fsm constructor, skipping the election timeout entirely.
2. Vote request resend on peer ping: if the initial vote request is lost (peer's raft server wasn't up yet), the candidate re-sends it as soon as the peer proves it's alive by pinging us. This makes `start_as_candidate` reliable regardless of startup ordering.
3. Immediate `ping_leader`: followers now send ping messages immediately when `wait_for_leader` is called, rather than waiting for the next tick. This closes the gap between peer startup and vote resend.
4. `do_on_leader_with_retries` refactoring: replace the stop_iteration + mutable leader reference API with an explicit result type (`retry_with_leader / retry_now / done`). The `retry_now` variant allows the read_barrier "leader not ready" path to retry immediately after `wait_for_apply`, without a tick wait.
5. Raft log tags: add a human-readable tag to all raft log messages (group0, sc-<group-id>) so that traces from different raft instances sharing the same server_id are easily distinguishable.

### Result
Strongly consistent tablet raft group bootstrap drops from ~1.2 seconds to <10ms (measured across 20 test runs: 1-9ms consistently).