### PR TITLE
sstables: demote verbose I/O logging from debug to trace

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1085,7 +1085,7 @@ thread_local std::array<std::vector<int>, downsampling::BASE_SAMPLING_LEVEL> dow
 future<> sstable::do_read_simple(component_type type,
                                  noncopyable_function<future<> (version_types, file&&, uint64_t sz)> read_component) {
     auto component_name = filename(type);
-    sstlog.debug("Reading {} file {}", sstable_version_constants::get_component_map(_version).at(type), component_name);
+    sstlog.trace("Reading {} file {}", sstable_version_constants::get_component_map(_version).at(type), component_name);
     try {
         file fi = co_await new_sstable_component_file(_read_error_handler, type, open_flags::ro);
         uint64_t size = co_await fi.size();
@@ -1179,7 +1179,7 @@ void sstable::do_write_simple(file_writer& writer,
 void sstable::do_write_simple(component_type type,
         noncopyable_function<void (version_types version, file_writer& writer)> write_component, unsigned buffer_size) {
     auto file_path = filename(type);
-    sstlog.debug("Writing {} file {}", sstable_version_constants::get_component_map(_version).at(type), file_path);
+    sstlog.trace("Writing {} file {}", sstable_version_constants::get_component_map(_version).at(type), file_path);
 
     file_output_stream_options options;
     options.buffer_size = buffer_size;
@@ -1197,7 +1197,7 @@ void sstable::write_simple(const T& component) {
 uint32_t sstable::do_write_simple_with_digest(component_type type,
         noncopyable_function<void (version_types version, file_writer& writer)> write_component, unsigned buffer_size) {
     auto file_path = filename(type);
-    sstlog.debug("Writing {} file {}", sstable_version_constants::get_component_map(_version).at(type), file_path);
+    sstlog.trace("Writing {} file {}", sstable_version_constants::get_component_map(_version).at(type), file_path);
 
     file_output_stream_options options;
     options.buffer_size = buffer_size;

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -254,7 +254,7 @@ future<> filesystem_storage::touch_temp_dir(const sstable& sst) {
         co_return;
     }
     auto tmp = _dir.path() / fmt::format("{}{}", sst._generation, tempdir_extension);
-    sstlog.debug("Touching temp_dir={}", tmp);
+    sstlog.trace("Touching temp_dir={}", tmp);
     co_await sst.sstable_touch_directory_io_check(tmp);
     _temp_dir = std::move(tmp);
 }
@@ -263,7 +263,7 @@ future<> filesystem_storage::remove_temp_dir() {
     if (!_temp_dir) {
         co_return;
     }
-    sstlog.debug("Removing temp_dir={}", _temp_dir);
+    sstlog.trace("Removing temp_dir={}", _temp_dir);
     try {
         co_await remove_file(_temp_dir->native());
     } catch (...) {


### PR DESCRIPTION
Demote the following sstable operation logs from DEBUG to TRACE level:
- Reading component files
- Writing component files
- Touching temp directories
- Removing temp directories

These are low-level, per-file operations that generate excessive log volume with minimal diagnostic value. They don't deserve debug level and should only appear when sstable subsystem is explicitly set to trace for detailed I/O troubleshooting.

Improving debug logs, not backporting