### PR TITLE
test/backup: Reduce s3 logging from trace to debug

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -471,7 +471,7 @@ async def create_cluster(topology, manager, logger, object_storage=None):
         objconf = object_storage.create_endpoint_conf()
         cfg['object_storage_endpoints'] = objconf
 
-    cmd = [ '--logger-log-level', 'sstables_loader=debug:sstable_directory=trace:snapshots=trace:s3=trace:sstable=debug:http=debug:api=info' ]
+    cmd = [ '--logger-log-level', 'sstables_loader=debug:sstable_directory=trace:snapshots=trace:s3=debug:sstable=debug:http=debug:api=info' ]
     servers = []
     host_ids = {}
 


### PR DESCRIPTION
Change s3 log level from TRACE to DEBUG in backup tests.

TRACE level generates excessive log volume with too much low-level detail about S3 operations. While it was usefult in the early days of S3 client, nowadays DEBUG level likely provides sufficient diagnostic information for backup test troubleshooting.

The reduced log volume significantly improves test performance, which is the main outcome of this change:
- Less I/O time writing logs during test execution
- Faster teardown: each test scans all server logs for errors, and smaller logs mean faster grep operations (23.3s → 9.97s for 8-node cluster teardown)

Impact on test_restore_with_streaming_scopes[topology4] (8 nodes):
- Log volume: 49 MB → 23 MB (reduced by half)
- Test runtime: 82.55s → 57.53s (30% faster)
- Teardown time: 23.3s → 9.97s (57% faster)

Tests that start smaller clusters also have notable timing improvements

Improving testing times, not backporting