### PR TITLE
schema/sstables: shrink schema v3_columns and sstable recognized_components (120-180 bytes saved)

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1749,7 +1749,7 @@ static schema_mutations make_table_mutations(schema_ptr table, api::timestamp_ty
     mutation indices_mutation(indexes(), pkey);
 
     if (with_columns_and_triggers) {
-        for (auto&& column : table->v3().all_columns()) {
+        for (auto&& column : table->v3_all_columns()) {
             if (column.is_view_virtual()) {
                 throw std::logic_error("view_virtual column found in non-view table");
             }
@@ -1889,13 +1889,15 @@ static void make_update_columns_mutations(schema_ptr old_table,
     mutation view_virtual_columns_mutation(view_virtual_columns(), partition_key::from_singular(*columns(), old_table->ks_name()));
     mutation computed_columns_mutation(computed_columns(), partition_key::from_singular(*columns(), old_table->ks_name()));
 
-    auto diff = difference(old_table->v3().columns_by_name(), new_table->v3().columns_by_name());
+    auto old_columns = old_table->all_columns_by_name();
+    auto new_columns = new_table->all_columns_by_name();
+    auto diff = difference(old_columns, new_columns);
 
     // columns that are no longer needed
     for (auto&& name : diff.entries_only_on_left) {
         // Thrift only knows about the REGULAR ColumnDefinition type, so don't consider other type
         // are being deleted just because they are not here.
-        const column_definition& column = *old_table->v3().columns_by_name().at(name);
+        const column_definition& column = *old_columns.at(name);
         if (column.is_view_virtual()) {
             drop_column_from_schema_mutation(view_virtual_columns(), old_table, column.name_as_text(), timestamp, mutations);
         } else {
@@ -1908,7 +1910,7 @@ static void make_update_columns_mutations(schema_ptr old_table,
 
     // newly added columns and old columns with updated attributes
     for (auto&& name : boost::range::join(diff.entries_differing, diff.entries_only_on_right)) {
-        const column_definition& column = *new_table->v3().columns_by_name().at(name);
+        const column_definition& column = *new_columns.at(name);
         if (column.is_view_virtual()) {
             add_column_to_schema_mutation(new_table, column, timestamp, view_virtual_columns_mutation);
         } else {
@@ -2645,7 +2647,7 @@ static schema_mutations make_view_mutations(view_ptr view, api::timestamp_type t
     mutation indices_mutation(indexes(), pkey);
 
     if (with_columns) {
-        for (auto&& column : view->v3().all_columns()) {
+        for (auto&& column : view->v3_all_columns()) {
             if (column.is_view_virtual()) {
                 add_column_to_schema_mutation(view, column, timestamp, view_virtual_columns_mutation);
             } else {

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -404,7 +404,9 @@ void schema::rebuild() {
         }
     }
 
-    _v3_columns = v3_columns::from_v2_schema(*this);
+    if (is_compact_table()) {
+        _v3_columns = v3_columns::from_v2_schema(*this);
+    }
     _full_slice = make_shared<query::partition_slice>(partition_slice_builder(*this).build());
     compute_all_columns_in_select_order();
 }

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -413,7 +413,9 @@ void schema::rebuild() {
         }
     }
 
-    _v3_columns = v3_columns::from_v2_schema(*this);
+    if (is_compact_table()) {
+        _v3_columns = v3_columns::from_v2_schema(*this);
+    }
     _full_slice = make_shared<query::partition_slice>(partition_slice_builder(*this).build());
     compute_all_columns_in_select_order();
 }

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -591,6 +591,9 @@ private:
     };
     raw_schema _raw;
     schema_static_props _static_props;
+    // Populated only for compact storage tables (legacy).
+    // For non-compact tables, left default-constructed (empty) and
+    // v3_all_columns()/all_columns_by_name() delegate to all_columns().
     v3_columns _v3_columns;
     mutable schema_registry_entry* _registry_entry = nullptr;
     std::unique_ptr<::view_info> _view_info;
@@ -994,8 +997,25 @@ private:
 
     managed_string get_create_statement(const schema_describe_helper& helper, bool with_internals) const;
 public:
-    const v3_columns& v3() const {
-        return _v3_columns;
+    // Returns the CQL3-view columns: for compact storage tables, this is the
+    // v3-transformed layout; for non-compact tables, returns all_columns().
+    const std::vector<column_definition>& v3_all_columns() const noexcept {
+        if (!_v3_columns.all_columns().empty()) {
+            return _v3_columns.all_columns();
+        }
+        return all_columns();
+    }
+
+    // Returns a name-to-column map for schema diffing. Only needed for DDL operations.
+    std::unordered_map<bytes, const column_definition*> all_columns_by_name() const {
+        if (!_v3_columns.columns_by_name().empty()) {
+            return _v3_columns.columns_by_name();
+        }
+        std::unordered_map<bytes, const column_definition*> result;
+        for (const auto& def : all_columns()) {
+            result[def.name()] = &def;
+        }
+        return result;
     }
 
     // Make a copy of the schema with reversed clustering order.

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -591,6 +591,9 @@ private:
     };
     raw_schema _raw;
     schema_static_props _static_props;
+    // Populated only for compact storage tables (legacy).
+    // For non-compact tables, left default-constructed (empty) and
+    // v3_all_columns()/all_columns_by_name() delegate to all_columns().
     v3_columns _v3_columns;
     mutable schema_registry_entry* _registry_entry = nullptr;
     std::unique_ptr<::view_info> _view_info;
@@ -994,8 +997,25 @@ private:
 
     managed_string get_create_statement(const schema_describe_helper& helper, bool with_internals) const;
 public:
-    const v3_columns& v3() const {
-        return _v3_columns;
+    // Returns the CQL3-view columns: for compact storage tables, this is the
+    // v3-transformed layout; for non-compact tables, returns all_columns().
+    const columns_type& v3_all_columns() const noexcept {
+        if (!_v3_columns.all_columns().empty()) {
+            return _v3_columns.all_columns();
+        }
+        return all_columns();
+    }
+
+    // Returns a name-to-column map for schema diffing. Only needed for DDL operations.
+    std::unordered_map<bytes, const column_definition*> all_columns_by_name() const {
+        if (!_v3_columns.columns_by_name().empty()) {
+            return _v3_columns.columns_by_name();
+        }
+        std::unordered_map<bytes, const column_definition*> result;
+        for (const auto& def : all_columns()) {
+            result[def.name()] = &def;
+        }
+        return result;
     }
 
     // Make a copy of the schema with reversed clustering order.

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -591,10 +591,6 @@ private:
     };
     raw_schema _raw;
     schema_static_props _static_props;
-    // Populated only for compact storage tables (legacy).
-    // For non-compact tables, left default-constructed (empty) and
-    // v3_all_columns()/all_columns_by_name() delegate to all_columns().
-    v3_columns _v3_columns;
     mutable schema_registry_entry* _registry_entry = nullptr;
     std::unique_ptr<::view_info> _view_info;
     mutable schema_ptr _cdc_schema;
@@ -615,6 +611,11 @@ private:
     column_count_type _static_column_count;
 
     std::vector<const column_definition*> _all_columns_in_select_order;
+
+    // Populated only for compact storage tables (legacy).
+    // For non-compact tables, left default-constructed (empty) and
+    // v3_all_columns()/all_columns_by_name() delegate to all_columns().
+    v3_columns _v3_columns;
 
     extensions_map& extensions() {
         return _raw._props.extensions;

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -412,7 +412,7 @@ sstable_schema make_sstable_schema(const schema& s, const encoding_stats& enc_st
         }
     };
 
-    for (const auto& column : s.v3().all_columns()) {
+    for (const auto& column : s.v3_all_columns()) {
         add_column(column);
     }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -924,7 +924,7 @@ future<std::pair<std::vector<sstring>, uint32_t>> sstable::read_and_parse_toc(fi
 // This is small enough, and well-defined. Easier to just read it all
 // at once
 future<> sstable::read_toc(sstable_open_config cfg) noexcept {
-    if (_recognized_components.size()) {
+    if (_recognized_components) {
         co_return;
     }
 
@@ -939,13 +939,13 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
                     continue;
                 }
                 try {
-                    _recognized_components.insert(reverse_map(c, sstable_version_constants::get_component_map(_version)));
+                    add_component(reverse_map(c, sstable_version_constants::get_component_map(_version)));
                 } catch (std::out_of_range& oor) {
                     _unrecognized_components.push_back(c);
                     sstlog.info("Unrecognized TOC component was found: {} in sstable {}", c, toc_filename());
                 }
             }
-            if (!_recognized_components.size()) {
+            if (!_recognized_components) {
                 throw_malformed_sstable_exception("Empty TOC", toc_filename());
             }
         });
@@ -959,32 +959,36 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
 
 void sstable::generate_toc() {
     // Creating table of components.
-    _recognized_components.insert(component_type::TOC);
-    _recognized_components.insert(component_type::Statistics);
-    _recognized_components.insert(component_type::Digest);
+    add_component(component_type::TOC);
+    add_component(component_type::Statistics);
+    add_component(component_type::Digest);
     if (has_summary_and_index(_version)) {
-        _recognized_components.insert(component_type::Index);
-        _recognized_components.insert(component_type::Summary);
+        add_component(component_type::Index);
+        add_component(component_type::Summary);
     } else {
-        _recognized_components.insert(component_type::Partitions);
-        _recognized_components.insert(component_type::Rows);
+        add_component(component_type::Partitions);
+        add_component(component_type::Rows);
     }
-    _recognized_components.insert(component_type::Data);
+    add_component(component_type::Data);
     if (_schema->bloom_filter_fp_chance() != 1.0) {
-        _recognized_components.insert(component_type::Filter);
+        add_component(component_type::Filter);
     }
     if (!_schema->get_compressor_params().compression_enabled()) {
-        _recognized_components.insert(component_type::CRC);
+        add_component(component_type::CRC);
     } else {
-        _recognized_components.insert(component_type::CompressionInfo);
+        add_component(component_type::CompressionInfo);
     }
-    _recognized_components.insert(component_type::Scylla);
+    add_component(component_type::Scylla);
 }
 
 future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_components() const {
     std::unordered_map<component_type, file> files;
-    for (auto c : _recognized_components) {
+    auto bits = _recognized_components;
+    while (bits) {
+        auto idx = __builtin_ctz(bits);
+        auto c = static_cast<component_type>(idx);
         files.emplace(c, co_await open_file(c, open_flags::ro));
+        bits &= bits - 1;
     }
     co_return std::move(files);
 }
@@ -1075,12 +1079,12 @@ void sstable::write_toc(std::unique_ptr<crc32_digest_file_writer> w) {
     sstlog.debug("Writing TOC file {} ", toc_filename());
 
     do_write_simple(*w, [&] (version_types v, file_writer& w) {
-        for (auto&& key : _recognized_components) {
+        for_each_component([&] (component_type key) {
             // new line character is appended to the end of each component name.
             auto value = sstable_version_constants::get_component_map(v).at(key) + "\n";
             bytes b = bytes(reinterpret_cast<const bytes::value_type *>(value.c_str()), value.size());
             write(v, w, b);
-        }
+        });
     });
 
     _components_digests.map[component_type::TOC] = w->full_checksum();
@@ -2853,7 +2857,7 @@ uint64_t sstable::filter_size() const {
 }
 
 bool sstable::has_component(component_type f) const {
-    return _recognized_components.contains(f);
+    return (_recognized_components & component_mask(f)) != 0;
 }
 
 std::optional<bool> sstable::originated_on_this_node() const {
@@ -2951,10 +2955,10 @@ sstring sstable::filename(const sstring& dir, const sstring& ks, const sstring& 
 
 std::vector<std::pair<component_type, sstring>> sstable::all_components() const {
     std::vector<std::pair<component_type, sstring>> all;
-    all.reserve(_recognized_components.size() + _unrecognized_components.size());
-    for (auto& c : _recognized_components) {
+    all.reserve(__builtin_popcount(_recognized_components) + _unrecognized_components.size());
+    for_each_component([&] (component_type c) {
         all.push_back(std::make_pair(c, sstable_version_constants::get_component_map(_version).at(c)));
-    }
+    });
     for (auto& c : _unrecognized_components) {
         all.push_back(std::make_pair(component_type::Unknown, c));
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -925,7 +925,7 @@ future<std::pair<std::vector<sstring>, uint32_t>> sstable::read_and_parse_toc(fi
 // This is small enough, and well-defined. Easier to just read it all
 // at once
 future<> sstable::read_toc(sstable_open_config cfg) noexcept {
-    if (_recognized_components.size()) {
+    if (_recognized_components) {
         co_return;
     }
 
@@ -940,13 +940,13 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
                     continue;
                 }
                 try {
-                    _recognized_components.insert(reverse_map(c, sstable_version_constants::get_component_map(_version)));
+                    add_component(reverse_map(c, sstable_version_constants::get_component_map(_version)));
                 } catch (std::out_of_range& oor) {
                     _unrecognized_components.push_back(c);
                     sstlog.info("Unrecognized TOC component was found: {} in sstable {}", c, toc_filename());
                 }
             }
-            if (!_recognized_components.size()) {
+            if (!_recognized_components) {
                 throw_malformed_sstable_exception("Empty TOC", toc_filename());
             }
         });
@@ -960,32 +960,36 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
 
 void sstable::generate_toc() {
     // Creating table of components.
-    _recognized_components.insert(component_type::TOC);
-    _recognized_components.insert(component_type::Statistics);
-    _recognized_components.insert(component_type::Digest);
+    add_component(component_type::TOC);
+    add_component(component_type::Statistics);
+    add_component(component_type::Digest);
     if (has_summary_and_index(_version)) {
-        _recognized_components.insert(component_type::Index);
-        _recognized_components.insert(component_type::Summary);
+        add_component(component_type::Index);
+        add_component(component_type::Summary);
     } else {
-        _recognized_components.insert(component_type::Partitions);
-        _recognized_components.insert(component_type::Rows);
+        add_component(component_type::Partitions);
+        add_component(component_type::Rows);
     }
-    _recognized_components.insert(component_type::Data);
+    add_component(component_type::Data);
     if (_schema->bloom_filter_fp_chance() != 1.0) {
-        _recognized_components.insert(component_type::Filter);
+        add_component(component_type::Filter);
     }
     if (!_schema->get_compressor_params().compression_enabled()) {
-        _recognized_components.insert(component_type::CRC);
+        add_component(component_type::CRC);
     } else {
-        _recognized_components.insert(component_type::CompressionInfo);
+        add_component(component_type::CompressionInfo);
     }
-    _recognized_components.insert(component_type::Scylla);
+    add_component(component_type::Scylla);
 }
 
 future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_components() const {
     std::unordered_map<component_type, file> files;
-    for (auto c : _recognized_components) {
+    auto bits = _recognized_components;
+    while (bits) {
+        auto idx = __builtin_ctz(bits);
+        auto c = static_cast<component_type>(idx);
         files.emplace(c, co_await open_file(c, open_flags::ro));
+        bits &= bits - 1;
     }
     co_return std::move(files);
 }
@@ -1076,12 +1080,24 @@ void sstable::write_toc(std::unique_ptr<crc32_digest_file_writer> w) {
     sstlog.debug("Writing TOC file {} ", toc_filename());
 
     do_write_simple(*w, [&] (version_types v, file_writer& w) {
-        for (auto&& key : _recognized_components) {
+        auto write_component = [&] (component_type key) {
             // new line character is appended to the end of each component name.
             auto value = sstable_version_constants::get_component_map(v).at(key) + "\n";
             bytes b = bytes(reinterpret_cast<const bytes::value_type *>(value.c_str()), value.size());
             write(v, w, b);
+        };
+        // Write Scylla first: TOC digest validation on load is keyed off the Scylla
+        // component's metadata, so a truncated/partially-written TOC (e.g. after a
+        // crash mid-write) must not be able to garble the Scylla line and thereby
+        // silently disable that check.
+        if (has_component(component_type::Scylla)) {
+            write_component(component_type::Scylla);
         }
+        for_each_component([&] (component_type key) {
+            if (key != component_type::Scylla) {
+                write_component(key);
+            }
+        });
     });
 
     _components_digests.map[component_type::TOC] = w->full_checksum();
@@ -1385,10 +1401,14 @@ future<> sstable::validate_scylla_digest_value() {
 future<> sstable::validate_digests(sstable::skip_data_digest skip_data) {
     co_await validate_scylla_digest_value();
 
-    for (const auto& type : _recognized_components) {
+    auto bits = _recognized_components;
+    while (bits) {
+        auto idx = __builtin_ctz(bits);
+        auto type = static_cast<component_type>(idx);
         if (type != component_type::Data || !skip_data) {
             co_await compute_and_validate_component_digest(type);
         }
+        bits &= bits - 1;
     }
 }
 
@@ -2904,7 +2924,7 @@ uint64_t sstable::filter_size() const {
 }
 
 bool sstable::has_component(component_type f) const {
-    return _recognized_components.contains(f);
+    return (_recognized_components & component_mask(f)) != 0;
 }
 
 std::optional<bool> sstable::originated_on_this_node() const {
@@ -3002,10 +3022,10 @@ sstring sstable::filename(const sstring& dir, const sstring& ks, const sstring& 
 
 std::vector<std::pair<component_type, sstring>> sstable::all_components() const {
     std::vector<std::pair<component_type, sstring>> all;
-    all.reserve(_recognized_components.size() + _unrecognized_components.size());
-    for (auto& c : _recognized_components) {
+    all.reserve(__builtin_popcount(_recognized_components) + _unrecognized_components.size());
+    for_each_component([&] (component_type c) {
         all.push_back(std::make_pair(c, sstable_version_constants::get_component_map(_version).at(c)));
-    }
+    });
     for (auto& c : _unrecognized_components) {
         all.push_back(std::make_pair(component_type::Unknown, c));
     }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -555,8 +555,24 @@ private:
         return component_name(*this, f);
     }
 
-    std::unordered_set<component_type, enum_hash<component_type>> _recognized_components;
+    // Bitmask of recognized component types present for this sstable.
+    // component_type has 16 enumerators (Index..Unknown, values 0..15), so the
+    // largest mask is 1 << 15 — exactly filling a uint16_t. The static_assert
+    // guards against the enum growing past what the mask can hold.
+    static_assert(static_cast<unsigned>(component_type::Unknown) < 16,
+                  "component_type no longer fits in the uint16_t _recognized_components bitmask");
+    uint16_t _recognized_components = 0;
     std::vector<sstring> _unrecognized_components;
+
+    static uint16_t component_mask(component_type c) noexcept {
+        return uint16_t(1) << static_cast<unsigned>(c);
+    }
+    void add_component(component_type c) noexcept {
+        _recognized_components |= component_mask(c);
+    }
+    void remove_component(component_type c) noexcept {
+        _recognized_components &= ~component_mask(c);
+    }
 
     foreign_ptr<lw_shared_ptr<shareable_components>> _components = make_foreign(make_lw_shared<shareable_components>());
     column_translation _column_translation;
@@ -658,6 +674,15 @@ private:
     uint32_t _toc_digest{};
 public:
     bool has_component(component_type f) const;
+    template<typename Func>
+    void for_each_component(Func&& fn) const {
+        auto bits = _recognized_components;
+        while (bits) {
+            auto idx = __builtin_ctz(bits);
+            fn(static_cast<component_type>(idx));
+            bits &= bits - 1;
+        }
+    }
     sstables_manager& manager() { return _manager; }
     const sstables_manager& manager() const { return _manager; }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -559,8 +559,24 @@ private:
         return component_name(*this, f);
     }
 
-    std::unordered_set<component_type, enum_hash<component_type>> _recognized_components;
+    // Bitmask of recognized component types present for this sstable.
+    // component_type has 16 enumerators (Index..Unknown, values 0..15), so the
+    // largest mask is 1 << 15 — exactly filling a uint16_t. The static_assert
+    // guards against the enum growing past what the mask can hold.
+    static_assert(static_cast<unsigned>(component_type::Unknown) < 16,
+                  "component_type no longer fits in the uint16_t _recognized_components bitmask");
+    uint16_t _recognized_components = 0;
     std::vector<sstring> _unrecognized_components;
+
+    static uint16_t component_mask(component_type c) noexcept {
+        return uint16_t(1) << static_cast<unsigned>(c);
+    }
+    void add_component(component_type c) noexcept {
+        _recognized_components |= component_mask(c);
+    }
+    void remove_component(component_type c) noexcept {
+        _recognized_components &= ~component_mask(c);
+    }
 
     foreign_ptr<lw_shared_ptr<shareable_components>> _components = make_foreign(make_lw_shared<shareable_components>());
     column_translation _column_translation;
@@ -683,6 +699,15 @@ private:
     uint32_t _toc_digest{};
 public:
     bool has_component(component_type f) const;
+    template<typename Func>
+    void for_each_component(Func&& fn) const {
+        auto bits = _recognized_components;
+        while (bits) {
+            auto idx = __builtin_ctz(bits);
+            fn(static_cast<component_type>(idx));
+            bits &= bits - 1;
+        }
+    }
     sstables_manager& manager() { return _manager; }
     const sstables_manager& manager() const { return _manager; }
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -105,21 +105,17 @@ public:
     }
     void assert_toc(const std::set<component_type>& expected_components) {
         for (auto& expected : expected_components) {
-            if(!_sst->_recognized_components.contains(expected)) {
-                BOOST_FAIL(seastar::format("Expected component of TOC missing: {}\n ... in: {}",
-                                  expected,
-                                  std::set<component_type>(
-                                      cbegin(_sst->_recognized_components),
-                                      cend(_sst->_recognized_components))));
+            if(!_sst->has_component(expected)) {
+                BOOST_FAIL(seastar::format("Expected component of TOC missing: {}", expected));
             }
         }
-        for (auto& present : _sst->_recognized_components) {
+        _sst->for_each_component([&] (component_type present) {
             if (!expected_components.contains(present)) {
                 BOOST_FAIL(seastar::format("Unexpected component of TOC: {}\n ... when expecting: {}",
                                   present,
                                   expected_components));
             }
-        }
+        });
     }
 };
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -118,8 +118,8 @@ SEASTAR_TEST_CASE(datafile_generation_09) {
         BOOST_REQUIRE(sst1_s.last_key.value == sst2_s.last_key.value);
 
         sstables::test(sst2).read_toc().get();
-        auto& sst1_c = sstables::test(sst).get_components();
-        auto& sst2_c = sstables::test(sst2).get_components();
+        auto sst1_c = sstables::test(sst).get_components();
+        auto sst2_c = sstables::test(sst2).get_components();
 
         BOOST_REQUIRE(sst1_c == sst2_c);
     });
@@ -3205,10 +3205,10 @@ future<> test_sstable_bytes_correctness(sstring tname, test_env_config cfg) {
         auto get_bytes_on_disk_from_storage = [&] (const sstables::shared_sstable& sst) {
             uint64_t bytes_on_disk = 0;
             auto& underlying_storage = const_cast<sstables::storage&>(sst->get_storage());
-            for (auto& component_type : sstables::test(sst).get_components()) {
+            sst->for_each_component([&] (auto component_type) {
                 file f = underlying_storage.open_component(*sst, component_type, open_flags::ro, file_open_options{}, true).get();
                 bytes_on_disk += f.size().get();
-            }
+            });
             return bytes_on_disk;
         };
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -248,8 +248,8 @@ SEASTAR_TEST_CASE(check_toc_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", sstables::generation_type(1), [] (shared_sstable sst1, shared_sstable sst2) {
         sstables::test(sst2).read_toc().get();
-        auto& sst1_c = sstables::test(sst1).get_components();
-        auto& sst2_c = sstables::test(sst2).get_components();
+        auto sst1_c = sstables::test(sst1).get_components();
+        auto sst2_c = sstables::test(sst2).get_components();
 
         BOOST_REQUIRE(sst1_c == sst2_c);
     });
@@ -937,9 +937,8 @@ static future<> test_component_digest_persistence(component_type component, ssta
         const auto muts = tests::generate_random_mutations(random_schema, 2).get();
         auto sst_original = make_sstable_containing(env.make_sstable(schema, version), muts).get();
 
-        auto& components = sstables::test(sst_original).get_components();
-        bool has_component = components.find(component) != components.end();
-        BOOST_REQUIRE(has_component);
+        bool has_comp = sst_original->has_component(component);
+        BOOST_REQUIRE(has_comp);
 
         auto toc_path = fmt::to_string(sst_original->toc_filename());
         auto entry_desc = sstables::parse_path(toc_path, schema->ks_name(), schema->cf_name()).value();

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -248,8 +248,8 @@ SEASTAR_TEST_CASE(check_toc_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", sstables::generation_type(1), [] (shared_sstable sst1, shared_sstable sst2) {
         sstables::test(sst2).read_toc().get();
-        auto& sst1_c = sstables::test(sst1).get_components();
-        auto& sst2_c = sstables::test(sst2).get_components();
+        auto sst1_c = sstables::test(sst1).get_components();
+        auto sst2_c = sstables::test(sst2).get_components();
 
         BOOST_REQUIRE(sst1_c == sst2_c);
     });
@@ -937,9 +937,8 @@ static future<> test_component_digest_persistence(component_type component, ssta
         const auto muts = tests::generate_random_mutations(random_schema, 2).get();
         auto sst_original = make_sstable_containing(env.make_sstable(schema, version), muts).get();
 
-        auto& components = sstables::test(sst_original).get_components();
-        bool has_component = components.find(component) != components.end();
-        BOOST_REQUIRE(has_component);
+        bool has_comp = sst_original->has_component(component);
+        BOOST_REQUIRE(has_comp);
 
         auto toc_path = fmt::to_string(sst_original->toc_filename());
         auto entry_desc = sstables::parse_path(toc_path, schema->ks_name(), schema->cf_name()).value();
@@ -1037,13 +1036,20 @@ static void corrupt_sstable(sstables::shared_sstable sst, component_type compone
     auto close_f = deferred_close(f);
     const auto mem_align = f.memory_dma_alignment();
     const auto dma_align = f.disk_write_dma_alignment();
-    auto block_offset = align_down(size - 1, dma_align);
+    // Corrupt the first byte of the TOC, but the last byte of other components.
+    // The TOC lists component names; corrupting its last byte would garble the
+    // name on the last line, making that component unrecognized. For the Scylla
+    // component (last in the TOC) this would skip TOC digest validation entirely
+    // (it is gated on has_component(Scylla)). Corrupting the first byte instead
+    // keeps Scylla recognized so the digest mismatch is detected, regardless of
+    // the order in which component names are written to the TOC.
+    auto corrupt_pos = component == component_type::TOC ? uint64_t(0) : size - 1;
+    auto block_offset = align_down(corrupt_pos, dma_align);
     auto buf = seastar::temporary_buffer<char>::aligned(mem_align, dma_align);
     f.dma_read(block_offset, buf.get_write(), dma_align).get();
-    // Flip one bit in the last byte of the file to corrupt it minimally.
-    // Using a single-bit flip avoids creating values that overflow
-    // during parsing.
-    buf.get_write()[size - 1 - block_offset] += 1;
+    // Flip one bit to corrupt it minimally. A single-bit flip avoids creating
+    // values that overflow during parsing.
+    buf.get_write()[corrupt_pos - block_offset] += 1;
     f.dma_write(block_offset, buf.get(), dma_align).get();
     f.truncate(size).get();
 }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -109,7 +109,7 @@ public:
         return _sst->read_summary_entry(i);
     }
 
-    auto& get_components() {
+    auto get_components() const {
         return _sst->_recognized_components;
     }
 
@@ -128,8 +128,8 @@ public:
     future<sstable_ptr> store(sstring dir, sstables::generation_type generation) {
         _sst->_generation = generation;
         co_await _sst->_storage->change_dir_for_test(dir);
-        _sst->_recognized_components.erase(component_type::Index);
-        _sst->_recognized_components.erase(component_type::Data);
+        _sst->remove_component(component_type::Index);
+        _sst->remove_component(component_type::Data);
         co_await seastar::async([sst = _sst] {
             sst->open_sstable("test");
             sst->write_statistics();
@@ -157,7 +157,7 @@ public:
         _sst->_index_file_size = std::max(1UL, uint64_t(data_file_size * 0.1));
         _sst->_metadata_size_on_disk = std::max(1UL, uint64_t(data_file_size * 0.01));
         // scylla component must be present for a sstable to be considered fully expired.
-        _sst->_recognized_components.insert(component_type::Scylla);
+        _sst->add_component(component_type::Scylla);
         _sst->_components->statistics.contents[metadata_type::Stats] = std::make_unique<stats_metadata>(std::move(stats));
         _sst->_first = dht::decorate_key(*_sst->_schema, first_key);
         _sst->_last = dht::decorate_key(*_sst->_schema, last_key);
@@ -192,7 +192,7 @@ public:
 
     void rewrite_toc_without_component(component_type component) {
         SCYLLA_ASSERT(component != component_type::TOC);
-        _sst->_recognized_components.erase(component);
+        _sst->remove_component(component);
         remove_file(fmt::to_string(_sst->toc_filename())).get();
         _sst->_storage->open(*_sst);
         _sst->seal_sstable(false).get();
@@ -229,7 +229,7 @@ public:
     }
 
     void write_filter() {
-        _sst->_recognized_components.insert(component_type::Filter);
+        _sst->add_component(component_type::Filter);
         _sst->write_filter();
     }
 


### PR DESCRIPTION
## Motivation
Two independent, common-case memory reductions for frequently-instantiated objects:

1. **`schema::v3_columns`** — for non-compact tables (the vast majority) the `v3_columns` transformation is entirely redundant: it duplicates `all_columns()` with identical column specifications already set by `rebuild()`. 
Only deprecated compact-storage tables need it.
3. **`sstable::_recognized_components`** — tracked which component files exist using an `unordered_set<component_type>` (56B inline + a heap allocation), even though `component_type` values all fit in 0..15.

## Nature of change
1. **schema**: only call `v3_columns::from_v2_schema()` for compact-storage tables; the member stays inline but default-constructed (empty) otherwise.
Add `v3_all_columns()` and `all_columns_by_name()` that transparently delegate to `all_columns()` for non-compact tables. Also relocate `_v3_columns` to the end of the struct so the hot query fields pack closer together (size unchanged, better spatial locality).
3. **sstables**: replace `_recognized_components` with a `uint16_t` bitmask. Add `has_component()` (a single bitwise AND instead of a hash lookup) and `for_each_component()`. A `static_assert(component_type::Unknown < 16)` guards the enum from outgrowing the mask.

## Memory savings
- **schema (per non-compact table, per shard)**: ~N×104B column_definition copies + map overhead on the heap. For a 20-column table: ~2.5KB heap saved.
- **sstables (per sstable)**: 54B inline + ~64–128B heap = ~120–180B. For 10,000 sstables: ~1.2–1.8 MB saved.

## Tests
Unit tests (boost), full build in dev mode. `perf_simple_query` (smp1, 10K partitions, 3.2GHz, taskset -c 0) shows no regression (within noise; `allocs/op` unchanged) — these objects are not on the `perf_simple_query` hot path.

## Split out
This PR originally also shrank `tablet_info`. That part was reworked to follow the approach in [SCYLLADB-1976](https://scylladb.atlassian.net/browse/SCYLLADB-1976) — keep
the rarely-set repair/migration `tablet_task_info` in side maps on `tablet_map` (like `tablet_transition_info`) rather than inline in `tablet_info` — and now lives in its own PR.
This PR keeps only the schema and sstables changes, which target different objects and are independently reviewable.

Backport: no, benign improvement


[SCYLLADB-1976]: https://scylladb.atlassian.net/browse/SCYLLADB-1976