### PR TITLE
logalloc_test: speed up the background_reclaim test

### DIFF
--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -806,6 +806,7 @@ SEASTAR_THREAD_TEST_CASE(background_reclaim) {
     st_cfg.abort_on_lsa_bad_alloc = false;
     st_cfg.lsa_reclamation_step = 1;
     st_cfg.background_reclaim_sched_group = background_reclaim_scheduling_group;
+    st_cfg.background_reclaim_shares_adjust_period = 1ms;
     logalloc::shard_tracker().configure(st_cfg);
 
     auto stop_lsa_background_reclaim = defer([&] () noexcept {
@@ -817,7 +818,7 @@ SEASTAR_THREAD_TEST_CASE(background_reclaim) {
     for (int i = 0; i < 50; ++i) {
         // Background reclaim is supposed to eventually ensure a certain amount of free memory.
         while (memory::free_memory() < background_reclaim_free_memory_threshold) {
-            thread::maybe_yield();
+            seastar::sleep(std::chrono::milliseconds(1)).get();
         }
 
         auto compacted_pre = logalloc::shard_tracker().statistics().memory_compacted;

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -453,13 +453,13 @@ private:
         }
     }
 public:
-    explicit background_reclaimer(scheduling_group sg, noncopyable_function<void (size_t target)> reclaim)
+    explicit background_reclaimer(scheduling_group sg, std::chrono::nanoseconds adjust_shares_period, noncopyable_function<void (size_t target)> reclaim)
             : _sg(sg)
             , _reclaim(std::move(reclaim))
             , _adjust_shares_timer(default_scheduling_group(), [this] { adjust_shares(); })
             , _done(with_scheduling_group(_sg, [this] { return main_loop(); })) {
         if (sg != default_scheduling_group()) {
-            _adjust_shares_timer.arm_periodic(50ms);
+            _adjust_shares_timer.arm_periodic(adjust_shares_period);
         }
     }
     future<> stop() {
@@ -551,9 +551,9 @@ public:
     // Abort on allocation failure from LSA
     void enable_abort_on_bad_alloc() noexcept { _abort_on_bad_alloc = true; }
     bool should_abort_on_bad_alloc() const noexcept { return _abort_on_bad_alloc; }
-    void setup_background_reclaim(scheduling_group sg) {
+    void setup_background_reclaim(scheduling_group sg, std::chrono::nanoseconds adjust_shares_period) {
         SCYLLA_ASSERT(!_background_reclaimer);
-        _background_reclaimer.emplace(sg, [this] (size_t target) {
+        _background_reclaimer.emplace(sg, adjust_shares_period, [this] (size_t target) {
             reclaim(target, is_preemptible::yes);
         });
     }
@@ -2397,7 +2397,7 @@ void tracker::configure(const config& cfg) {
     if (cfg.abort_on_lsa_bad_alloc) {
         _impl->enable_abort_on_bad_alloc();
     }
-    _impl->setup_background_reclaim(cfg.background_reclaim_sched_group);
+    _impl->setup_background_reclaim(cfg.background_reclaim_sched_group, cfg.background_reclaim_shares_adjust_period);
     _impl->set_sanitizer_report_backtrace(cfg.sanitizer_report_backtrace);
 }
 

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -465,6 +465,7 @@ public:
     future<> stop() {
         _stopping = true;
         main_loop_wake();
+        _adjust_shares_timer.cancel();
         return std::move(_done);
     }
 };

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -65,6 +65,7 @@ public:
         bool sanitizer_report_backtrace = false; // Better reports but slower
         size_t lsa_reclamation_step;
         scheduling_group background_reclaim_sched_group;
+        std::chrono::nanoseconds background_reclaim_shares_adjust_period = std::chrono::milliseconds(50);
     };
 
     struct stats {


### PR DESCRIPTION
The waiting mechanisms used by the test cause some idle waits and pointless CPU spins.
To correct that, we make the background_reclaimer's share adjustment period configurable, we lower the period in the test, and we switch the waiting mechanism from a yield() spin to a sleep.

On my PC, that lower the duration of the test from ~10s to a few hundred ms. 

Fixes: SCYLLADB-2265

Test-only improvement, backport not desired.