### PR TITLE
test: speed up test_types_with_and_without_nulls

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -141,8 +141,68 @@ def test_types_with_and_without_nulls(cql, test_keyspace):
             values[0] = 2
             cql.execute(insert_stmt, values)
 
+            one_null_keys = []
+            for i in range(len(type_defs)):
+                values = [i + 3] + [td.reference_value for td in type_defs]
+                values[i + 1] = None
+                cql.execute(insert_stmt, values)
+                one_null_keys.append(i + 3)
+
             use_wasm = is_scylla_util(cql)
             lang = "wasm" if use_wasm else "java"
+
+            if use_wasm:
+                # On Scylla each CREATE FUNCTION compiles the whole wasm module,
+                # which dominates the test runtime. Instead of 3 functions per
+                # type, create a single function of each kind taking arguments of
+                # all types at once (see test_types_with_and_without_nulls.rs).
+                # This keeps full per-type (de)serialization coverage while cutting
+                # the number of (expensive) compilations from 3*len(type_defs) to 3.
+                columns = ", ".join(td.column_name for td in type_defs)
+                first_type_defs = type_defs[:12]
+                second_type_defs = type_defs[12:]
+                first_columns = ", ".join(td.column_name for td in first_type_defs)
+                second_columns = ", ".join(td.column_name for td in second_type_defs)
+                arg_sig = ", ".join(f"a{i} {td.udf_type}" for i, td in enumerate(type_defs))
+                first_arg_sig = ", ".join(f"a{i} {td.udf_type}" for i, td in enumerate(first_type_defs))
+                second_arg_sig = ", ".join(f"a{i} {td.udf_type}" for i, td in enumerate(second_type_defs))
+                first_ret_tuple = "tuple<" + ", ".join(td.udf_type for td in first_type_defs) + ">"
+                second_ret_tuple = "tuple<" + ", ".join(td.udf_type for td in second_type_defs) + ">"
+
+                fn_identity_1 = unique_name()
+                identity_src_1 = read_function_from_file("test_types_with_and_without_nulls", "check_arg_and_return_1", fn_identity_1)
+                fn_identity_2 = unique_name()
+                identity_src_2 = read_function_from_file("test_types_with_and_without_nulls", "check_arg_and_return_2", fn_identity_2)
+                fn_called = unique_name()
+                called_src = read_function_from_file("test_types_with_and_without_nulls", "called_on_null", fn_called)
+                fn_null = unique_name()
+                null_src = read_function_from_file("test_types_with_and_without_nulls", "returns_null_on_null", fn_null)
+
+                identity_full_1 = f"({first_arg_sig}) CALLED ON NULL INPUT RETURNS {first_ret_tuple} LANGUAGE wasm AS '{identity_src_1}'"
+                identity_full_2 = f"({second_arg_sig}) CALLED ON NULL INPUT RETURNS {second_ret_tuple} LANGUAGE wasm AS '{identity_src_2}'"
+                called_full = f"({arg_sig}) CALLED ON NULL INPUT RETURNS text LANGUAGE wasm AS '{called_src}'"
+                null_full = f"({arg_sig}) RETURNS NULL ON NULL INPUT RETURNS text LANGUAGE wasm AS '{null_src}'"
+
+                with new_function(cql, test_keyspace, identity_full_1, fn_identity_1), \
+                     new_function(cql, test_keyspace, identity_full_2, fn_identity_2), \
+                     new_function(cql, test_keyspace, called_full, fn_called), \
+                     new_function(cql, test_keyspace, null_full, fn_null):
+                    expected_1 = tuple(td.reference_value for td in first_type_defs)
+                    got_1 = cql.execute(f"SELECT {fn_identity_1}({first_columns}) FROM {table} WHERE key = 1").one()[0]
+                    assert got_1 == expected_1, f"identity roundtrip mismatch: {got_1} != {expected_1}"
+                    expected_2 = tuple(td.reference_value for td in second_type_defs)
+                    got_2 = cql.execute(f"SELECT {fn_identity_2}({second_columns}) FROM {table} WHERE key = 1").one()[0]
+                    assert got_2 == expected_2, f"identity roundtrip mismatch: {got_2} != {expected_2}"
+
+                    assertRows(execute(cql, table, f"SELECT {fn_called}({columns}) FROM %s WHERE key = 1"), row("called"))
+                    assertRows(execute(cql, table, f"SELECT {fn_called}({columns}) FROM %s WHERE key = 2"), row("called"))
+
+                    assertRows(execute(cql, table, f"SELECT {fn_null}({columns}) FROM %s WHERE key = 1"), row("called"))
+                    assertRows(execute(cql, table, f"SELECT {fn_null}({columns}) FROM %s WHERE key = 2"), row(None))
+                    for key in one_null_keys:
+                        assertRows(execute(cql, table, f"SELECT {fn_called}({columns}) FROM %s WHERE key = {key}"), row("called"))
+                        assertRows(execute(cql, table, f"SELECT {fn_null}({columns}) FROM %s WHERE key = {key}"), row(None))
+                return
 
             for type_def in type_defs:
                 fun_name = unique_name()

--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -141,9 +141,10 @@ def test_types_with_and_without_nulls(cql, test_keyspace):
             values[0] = 2
             cql.execute(insert_stmt, values)
 
+            use_wasm = is_scylla(cql, test_keyspace)
+            lang = "wasm" if use_wasm else "java"
+
             for type_def in type_defs:
-                use_wasm = is_scylla(cql, test_keyspace)
-                lang = "wasm" if use_wasm else "java"
                 fun_name = unique_name()
                 fun_wasm_src = read_function_from_file("test_types_with_and_without_nulls", f"check_arg_and_return_{type_def.column_name}", fun_name) if use_wasm else 'return input;'
                 fun_src = f"(input {type_def.udf_type}) CALLED ON NULL INPUT RETURNS {type_def.udf_type} LANGUAGE {lang} AS '{fun_wasm_src}'"

--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -13,7 +13,7 @@ import uuid
 from ...porting import *
 
 from cassandra.util import Date
-from ....util import new_function, unique_name, new_secondary_index
+from ....util import new_function, unique_name, new_secondary_index, is_scylla as is_scylla_util
 import os
 
 def is_scylla(cql, test_keyspace):
@@ -141,7 +141,7 @@ def test_types_with_and_without_nulls(cql, test_keyspace):
             values[0] = 2
             cql.execute(insert_stmt, values)
 
-            use_wasm = is_scylla(cql, test_keyspace)
+            use_wasm = is_scylla_util(cql)
             lang = "wasm" if use_wasm else "java"
 
             for type_def in type_defs:

--- a/test/resource/wasm/rust/test_types_with_and_without_nulls.rs
+++ b/test/resource/wasm/rust/test_types_with_and_without_nulls.rs
@@ -2,231 +2,93 @@ use scylla_udf::{export_udf, Time, Timestamp};
 use chrono::NaiveDate;
 use uuid::Uuid;
 
+// The order of arguments must match type_defs in uf_types_test.py.
+type FirstTypes = (
+    Option<Timestamp>,
+    Option<NaiveDate>,
+    Option<Time>,
+    Option<Uuid>,
+    Option<Uuid>,
+    Option<i8>,
+    Option<i16>,
+    Option<i32>,
+    Option<i64>,
+    Option<f32>,
+    Option<f64>,
+    Option<bool>,
+);
+
+type SecondTypes = (
+    Option<String>,
+    Option<String>,
+    Option<(i32, String)>,
+);
 
 #[export_udf]
-fn check_arg_and_return_ts(x: Option<Timestamp>) -> Option<Timestamp> {
-    x
+fn check_arg_and_return_1(
+    ts: Option<Timestamp>,
+    dt: Option<NaiveDate>,
+    tim: Option<Time>,
+    uu: Option<Uuid>,
+    tu: Option<Uuid>,
+    ti: Option<i8>,
+    si: Option<i16>,
+    i: Option<i32>,
+    bi: Option<i64>,
+    f: Option<f32>,
+    d: Option<f64>,
+    x: Option<bool>,
+) -> FirstTypes {
+    (ts, dt, tim, uu, tu, ti, si, i, bi, f, d, x)
 }
 
 #[export_udf]
-fn called_on_null_ts(_: Option<Timestamp>) -> Option<String> {
+fn check_arg_and_return_2(
+    a: Option<String>,
+    txt: Option<String>,
+    tup: Option<(i32, String)>,
+) -> SecondTypes {
+    (a, txt, tup)
+}
+
+#[export_udf]
+fn called_on_null(
+    _ts: Option<Timestamp>,
+    _dt: Option<NaiveDate>,
+    _tim: Option<Time>,
+    _uu: Option<Uuid>,
+    _tu: Option<Uuid>,
+    _ti: Option<i8>,
+    _si: Option<i16>,
+    _i: Option<i32>,
+    _bi: Option<i64>,
+    _f: Option<f32>,
+    _d: Option<f64>,
+    _x: Option<bool>,
+    _a: Option<String>,
+    _txt: Option<String>,
+    _tup: Option<(i32, String)>,
+) -> Option<String> {
     Some("called".to_string())
 }
 
 #[export_udf]
-fn returns_null_on_null_ts(_: Timestamp) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_dt(x: Option<NaiveDate>) -> Option<NaiveDate> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_dt(_: Option<NaiveDate>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_dt(_: NaiveDate) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_tim(x: Option<Time>) -> Option<Time> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_tim(_: Option<Time>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_tim(_: Time) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_uu(x: Option<Uuid>) -> Option<Uuid> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_uu(_: Option<Uuid>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_uu(_: Uuid) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_tu(x: Option<Uuid>) -> Option<Uuid> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_tu(_: Option<Uuid>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_tu(_: Uuid) -> String {
-    "called".to_string()
-}
-
-
-#[export_udf]
-fn check_arg_and_return_ti(x: Option<i8>) -> Option<i8> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_ti(_: Option<i8>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_ti(_: i8) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_si(x: Option<i16>) -> Option<i16> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_si(_: Option<i16>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_si(_: i16) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_i(x: Option<i32>) -> Option<i32> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_i(_: Option<i32>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_i(_: i32) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_bi(x: Option<i64>) -> Option<i64> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_bi(_: Option<i64>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_bi(_: i64) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_f(x: Option<f32>) -> Option<f32> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_f(_: Option<f32>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_f(_: f32) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_d(x: Option<f64>) -> Option<f64> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_d(_: Option<f64>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_d(_: f64) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_x(x: Option<bool>) -> Option<bool> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_x(_: Option<bool>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_x(_: bool) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_a(x: Option<String>) -> Option<String> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_a(_: Option<String>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_a(_: String) -> String {
-    "called".to_string()
-}
-
-#[export_udf]
-fn check_arg_and_return_txt(x: Option<String>) -> Option<String> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_txt(_: Option<String>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_txt(_: String) -> String {
-    "called".to_string()
-}
-
-// # TypesTestDef(type, f"frozen<{type}>", "u", null),
-
-#[export_udf]
-fn check_arg_and_return_tup(x: Option<(i32, String)>) -> Option<(i32, String)> {
-    x
-}
-
-#[export_udf]
-fn called_on_null_tup(_: Option<(i32, String)>) -> Option<String> {
-    Some("called".to_string())
-}
-
-#[export_udf]
-fn returns_null_on_null_tup(_: (i32, String)) -> String {
+fn returns_null_on_null(
+    _ts: Timestamp,
+    _dt: NaiveDate,
+    _tim: Time,
+    _uu: Uuid,
+    _tu: Uuid,
+    _ti: i8,
+    _si: i16,
+    _i: i32,
+    _bi: i64,
+    _f: f32,
+    _d: f64,
+    _x: bool,
+    _a: String,
+    _txt: String,
+    _tup: (i32, String),
+) -> String {
     "called".to_string()
 }


### PR DESCRIPTION
The test exceeded the 60s threshold in CI due to expensive Wasm UDF setup. Profiling showed that the dominant cost is `CREATE FUNCTION`: each Wasm UDF creation compiles the whole generated Wasm module, taking ~620 ms locally and accounting for ~97% of the test body runtime.

This PR reduces the number of Wasm `CREATE FUNCTION` operations while keeping full type coverage.

Changes:

1. Hoist `is_scylla()` out of the per-type loop.
2. Use the lightweight `is_scylla()` from `util.py`, avoiding schema changes for Scylla detection.
3. Replace per-type Wasm UDF exports with combined Wasm functions:
   - identity roundtrip is split into two combined functions because Rust UDF tuple conversion supports up to 12 elements;
   - `called_on_null` and `returns_null_on_null` each use one combined function over all tested types;
   - one-null rows verify null handling for every argument position/type.

This keeps all original tested types and reduces Wasm function creations from 45 to 4.

Local dev result for `test_types_with_and_without_nulls`:

- before combined-UDF optimization: ~23s
- after: ~4.5s

CI result after rework:

- dev custom unit test stage: ~3m for the full selected UDF test set
- `Testing Scylla in dev mode` step dropped from ~3m38s to ~30s

No backport needed; this is a test-only runtime improvement.

Fixes: [SCYLLADB-2269](https://scylladb.atlassian.net/browse/SCYLLADB-2269)

[SCYLLADB-2269]: https://scylladb.atlassian.net/browse/SCYLLADB-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ