### PR TITLE
docs: fix Confluent CLI commands and add LDAP auth link

### DIFF
--- a/docs/operating-scylla/security/authentication.rst
+++ b/docs/operating-scylla/security/authentication.rst
@@ -37,6 +37,7 @@ Additional Resources
 * :doc:`Enable and Disable Authentication Without Downtime </operating-scylla/security/runtime-authentication/>`
 * :doc:`Enable Authorization </operating-scylla/security/enable-authorization/>` 
 * :doc:`Authorization </operating-scylla/security/authorization/>` 
+* :doc:`LDAP Authentication </operating-scylla/security/ldap-authentication/>`
 
 
 

--- a/docs/using-scylla/integrations/kafka-connector.rst
+++ b/docs/using-scylla/integrations/kafka-connector.rst
@@ -78,13 +78,13 @@ Use the Confluent CLI to restart Connect.
 
    .. code-block:: none
   
-      confluent local stop && confluent local start
+      confluent local services stop && confluent local services start
 
    The output will be similar to:
 
    .. code-block:: none
 
-       confluent local stop && confluent local start
+       confluent local services stop && confluent local services start
        Starting zookeeper
        zookeeper is [UP]
        Starting Kafka


### PR DESCRIPTION
## Summary

Two quick documentation fixes:

### Fix 1: Kafka Sink Connector CLI commands (#29121)
The Confluent CLI commands in \docs/using-scylla/integrations/kafka-connector.rst\ used the outdated \confluent local stop/start\ syntax. The current Confluent CLI requires the \services\ subcommand.

**Before:** \confluent local stop && confluent local start\
**After:** \confluent local services stop && confluent local services start\

### Fix 2: Add LDAP Authentication link (#23029)
The \docs/operating-scylla/security/authentication.rst\ page's Additional Resources section did not mention LDAP Authentication, even though \ldap-authentication.rst\ exists in the same directory.

Added a link to LDAP Authentication in the Additional Resources section.

Fixes https://github.com/scylladb/scylladb/issues/29121
Fixes https://github.com/scylladb/scylladb/issues/23029