### PR TITLE
docs: add Configuration Parameters link to system-configuration index

### DIFF
--- a/docs/operating-scylla/system-configuration/index.rst
+++ b/docs/operating-scylla/system-configuration/index.rst
@@ -7,10 +7,13 @@ System Configuration
    System Configuration Guide </getting-started/system-configuration/>
    scylla.yaml </operating-scylla/admin>
    ScyllaDB Snitches </operating-scylla/system-configuration/snitch/>
+   Configuration Parameters </reference/configuration-parameters>
 
 * :doc:`System Configuration Guide</getting-started/system-configuration/>`
 
 * :doc:`scylla.yaml</operating-scylla/admin>`
 
 * :doc:`ScyllaDB Snitches</operating-scylla/system-configuration/snitch/>`
+
+* :doc:`Configuration Parameters</reference/configuration-parameters>`
 


### PR DESCRIPTION
The \docs/operating-scylla/system-configuration/index.rst\ page listed the System Configuration Guide, scylla.yaml, and Snitches, but did not include a link to the Configuration Parameters reference page (\docs/reference/configuration-parameters.rst\).

Added the missing link both to the hidden toctree and to the visible bullet list.

Fixes https://github.com/scylladb/scylladb/issues/23110