### PR TITLE
test: Optimize log scanner to eliminate executor overhead

### DIFF
--- a/test/pylib/log_browsing.py
+++ b/test/pylib/log_browsing.py
@@ -28,47 +28,40 @@ class FileSnapshot:
     Allows examining a snapshot of a file, assuming the file is append-only.
     The snapshot is determined at the time of opening.
 
-    Acts as an asynchronous context manager. Consume all lines like this:
+    Acts as a synchronous context manager for direct I/O operations.
+    Consume all lines like this:
 
-        async with FileSnapshot(thread_pool, path) as snap:
-            while (line := await snap.next_line()):
+        with FileSnapshot(path) as snap:
+            while (line := snap.next_line()):
                 # process line
 
     """
 
-    def __init__(self, thread_pool: ThreadPoolExecutor, path: Path, from_mark: MarkType = None):
-        self.thread_pool = thread_pool
+    def __init__(self, path: Path, from_mark: MarkType = None):
         self.path = path
         self.from_mark = from_mark
-        self.loop = asyncio.get_running_loop()
 
-    def _open(self):
+    def __enter__(self):
         size = self.path.stat().st_size
-        file = self.path.open(encoding="utf-8")
-        return file, size
-
-    def _readline(self) -> Tuple[MarkType, str]:
-        pos = self.file.tell()
-        line = self.file.readline()
-        return pos, line
-
-    async def __aenter__(self):
-        self.file, size = await self.loop.run_in_executor(self.thread_pool, self._open)
+        self.file = self.path.open(encoding="utf-8")
         self.to_mark = size
         if self.from_mark:
-            await self.loop.run_in_executor(self.thread_pool, self.file.seek, self.from_mark)
+            self.file.seek(self.from_mark)
         return self
 
-    async def next_line(self) -> Optional[str]:
-        pos, line = await self.loop.run_in_executor(self.thread_pool, self._readline)
-        if pos >= self.to_mark or not line:
+    def next_line(self) -> Optional[str]:
+        pos = self.file.tell()
+        if pos >= self.to_mark:
+            return None
+        line = self.file.readline()
+        if not line:
             return None
         if pos + len(line) > self.to_mark:
             return line[:self.to_mark - pos]
         return line
 
-    async def __aexit__(self, exc_type, exc, tb):
-        await self.loop.run_in_executor(self.thread_pool, self.file.close)
+    def __exit__(self, exc_type, exc, tb):
+        self.file.close()
 
 
 @universalasync_typed_wrap
@@ -145,12 +138,13 @@ class ScyllaLogFile:
 
             return await self._run_in_executor(log_file.tell, loop=loop), matches
 
-    async def _for_each_line_snapshot(self, from_mark: int | None = None):
+    def _for_each_line_snapshot(self, from_mark: int | None = None):
         """
         Yields lines from the file, without considering lines appended after the call started.
+        Uses direct I/O for performance.
         """
-        async with FileSnapshot(self.thread_pool, self.file, from_mark) as snap:
-            while line := await snap.next_line():
+        with FileSnapshot(self.file, from_mark) as snap:
+            while line := snap.next_line():
                 yield line
 
     async def grep(self,
@@ -170,18 +164,17 @@ class ScyllaLogFile:
         object for the matching expression.
         """
         loop = asyncio.get_running_loop()
-
-        expr = re.compile(expr)
-        filter_func = re.compile(filter_expr).search if filter_expr else lambda _: False
-        matches = []
-
-        async for line in self._for_each_line_snapshot(from_mark=from_mark):
-            if match := not filter_func(line) and expr.search(line):
-                matches.append((line, match))
-                if len(matches) == max_count:
-                    break
-
-        return matches
+        def _grep_sync():
+            expr_compiled = re.compile(expr)
+            filter_func = re.compile(filter_expr).search if filter_expr else lambda _: False
+            matches = []
+            for line in self._for_each_line_snapshot(from_mark=from_mark):
+                if match := not filter_func(line) and expr_compiled.search(line):
+                    matches.append((line, match))
+                    if len(matches) == max_count:
+                        break
+            return matches
+        return await loop.run_in_executor(self.thread_pool, _grep_sync)
 
     async def grep_for_errors(self,
                               distinct_errors: bool = False,
@@ -195,29 +188,29 @@ class ScyllaLogFile:
 
         Return a list of error messages.  Error message can be just one line or a list of lines.
         """
-
-        # Each line in scylla-*.log starts with log level, so, use re.match to search from the beginning of each line.
-        error_pattern = re.compile(r"ERROR\b")
-        info_pattern = re.compile(r"INFO\b")
-        matches = []
-
-        async with FileSnapshot(self.thread_pool, self.file, from_mark) as snap:
-            line = await snap.next_line()
-            while line:
-                if error_pattern.match(line):
-                    if distinct_errors:
-                        if line not in matches:
-                            matches.append(line)
-                    else:
-                        matches.append([line])
-                        while line := await snap.next_line():
-                            if info_pattern.match(line):
-                                break
-                            matches[-1].append(line)
-                        continue
-                line = await snap.next_line()
-
-        return matches
+        loop = asyncio.get_running_loop()
+        def _grep_errors_sync():
+            # Each line in scylla-*.log starts with log level, so, use re.match to search from the beginning of each line.
+            error_pattern = re.compile(r"ERROR\b")
+            info_pattern = re.compile(r"INFO\b")
+            matches = []
+            with FileSnapshot(self.file, from_mark) as snap:
+                line = snap.next_line()
+                while line:
+                    if error_pattern.match(line):
+                        if distinct_errors:
+                            if line not in matches:
+                                matches.append(line)
+                        else:
+                            matches.append([line])
+                            while line := snap.next_line():
+                                if info_pattern.match(line):
+                                    break
+                                matches[-1].append(line)
+                            continue
+                    line = snap.next_line()
+            return matches
+        return await loop.run_in_executor(self.thread_pool, _grep_errors_sync)
 
     async def find_backtraces(self, from_mark: int | None = None) -> list[str]:
         """
@@ -227,36 +220,33 @@ class ScyllaLogFile:
         If `from_mark` argument is given, the log is searched from that position, otherwise from the beginning.  
         Return a list of strings, where each string is a complete backtrace (all lines joined together).  
         """
-
-        backtraces = []
-
-        async with FileSnapshot(self.thread_pool, self.file, from_mark) as snap:
-            line = await snap.next_line()
-            while line:
-                if line.strip() == "Backtrace:":
-                    # Found a backtrace, collect all lines that start with exactly 2 spaces
-                    backtrace_lines = [line]
-                    while True:
-                        next_line = await snap.next_line()
-                        if not next_line:
-                            # End of file
-                            line = ""
-                            break
-                        if next_line.startswith("  ") and not next_line.startswith("   "):
-                            # Line starts with exactly 2 spaces (backtrace entry)
-                            backtrace_lines.append(next_line)
-                        else:
-                            # End of backtrace
-                            line = next_line
-                            break
-                    
-                    if backtrace_lines:
-                        # Join all backtrace lines into a single string
-                        backtraces.append(''.join(backtrace_lines))
-                    
-                    # Continue from current line (already read in the inner loop)
-                    continue
-                
-                line = await snap.next_line()
-
-        return backtraces
+        loop = asyncio.get_running_loop()
+        def _find_backtraces_sync():
+            backtraces = []
+            with FileSnapshot(self.file, from_mark) as snap:
+                line = snap.next_line()
+                while line:
+                    if line.strip() == "Backtrace:":
+                        # Found a backtrace, collect all lines that start with exactly 2 spaces
+                        backtrace_lines = [line]
+                        while True:
+                            next_line = snap.next_line()
+                            if not next_line:
+                                # End of file
+                                line = ""
+                                break
+                            if next_line.startswith("  ") and not next_line.startswith("   "):
+                                # Line starts with exactly 2 spaces (backtrace entry)
+                                backtrace_lines.append(next_line)
+                            else:
+                                # End of backtrace
+                                line = next_line
+                                break
+                        if backtrace_lines:
+                            # Join all backtrace lines into a single string
+                            backtraces.append(''.join(backtrace_lines))
+                        # Continue from current line (already read in the inner loop)
+                        continue
+                    line = snap.next_line()
+            return backtraces
+        return await loop.run_in_executor(self.thread_pool, _find_backtraces_sync)


### PR DESCRIPTION
On cluster test teardown there's log scanning for errors or backtraces. Surprisingly, this part takes notable time because the implementation is using asyncio.run_in_executor() for every single line read during grep operations. This adds ~400µs overhead per executor call, resulting in thousands of executor invocations for a typical Scylla log file.

For operations that scan existing log content (grep, grep_for_errors, find_backtraces), async I/O provides no benefit since it's reading a complete snapshot of the file. The async executor is only slowing things down with thread pool coordination overhead for no real gain.

This commit:
- Converts FileSnapshot from async to sync context manager
- Wraps the entire scan operation in a single run_in_executor() call
- Keeps wait_for() unchanged (async is needed for waiting on new lines)

Performance impact (measured locally on some tests, shown numbers are total test time / teardown log scanning time):

```
Test                              Nodes  Before            After
test_kill_coordinator_during_op   8      82.07s / 7.13s    76.55s / 0.33s
test_removenode                   4      34.01s / 4.83s    30.01s / 0.22s
test_raft_recovery[remove]        9      74.05s / 4.13s    67.54s / 0.23s
test_restore_streaming[topology1] 5      43.02s / 5.98s    38.01s / 0.34s
test_restore_streaming[topology4] 8      57.62s / 8.49s    44.52s / 0.53s
```

a note: Nodes column above equals to the number of log files scanned

Improving tests, not backporting