### PR TITLE
audit: drain writes before group0 shutdown

### DIFF
--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -329,7 +329,7 @@ future<> audit::log(const audit_info& audit_info, const service::client_state& c
             node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
             audit_info.query(), client_ip, audit_info.table(), username);
     }
-    return futurize_invoke(std::mem_fn(&storage_helper::write), _storage_helper_ptr, sinks, &audit_info, node_ip, client_ip, cl, username, error)
+    return _storage_helper_ptr->write(sinks, &audit_info, node_ip, client_ip, cl, username, error)
         .handle_exception([audit_info, node_ip, client_ip, cl, username, error] (auto ep) {
             logger.error("Unexpected exception when writing log with: node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {} exception {}",
                 node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
@@ -382,7 +382,7 @@ future<> audit::log_login(const sstring& username, socket_address client_ip, boo
         logger.debug("Login log written: node_ip {}, client_ip {}, username {}, error {}",
             node_ip, client_ip, username, error ? "true" : "false");
     }
-    return futurize_invoke(std::mem_fn(&storage_helper::write_login), _storage_helper_ptr, sinks, username, node_ip, client_ip, error)
+    return _storage_helper_ptr->write_login(sinks, username, node_ip, client_ip, error)
         .handle_exception([username, node_ip, client_ip, error] (auto ep) {
             logger.error("Unexpected exception when writing login log with: node_ip {} client_ip {} username {} error {} exception {}",
                 node_ip, client_ip, username, error, ep);

--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -304,6 +304,24 @@ future<> audit::shutdown() {
     co_await _rules_rebuild_action.join();
 }
 
+future<> audit::write_to_storage(audit_sink_set sinks,
+                                 const audit_info& audit_info,
+                                 socket_address node_ip,
+                                 socket_address client_ip,
+                                 std::optional<db::consistency_level> cl,
+                                 const sstring& username,
+                                 bool error) {
+    return _storage_helper_ptr->write(sinks, &audit_info, node_ip, client_ip, cl, username, error);
+}
+
+future<> audit::write_login_to_storage(audit_sink_set sinks,
+                                       const sstring& username,
+                                       socket_address node_ip,
+                                       socket_address client_ip,
+                                       bool error) {
+    return _storage_helper_ptr->write_login(sinks, username, node_ip, client_ip, error);
+}
+
 future<> audit::log(const audit_info& audit_info, const service::client_state& client_state, std::optional<db::consistency_level> cl, bool error) {
     std::string_view role;
     if (!_preprocessed_rules.rules().empty() && client_state.user() && client_state.user()->name) {
@@ -329,7 +347,7 @@ future<> audit::log(const audit_info& audit_info, const service::client_state& c
             node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
             audit_info.query(), client_ip, audit_info.table(), username);
     }
-    return _storage_helper_ptr->write(sinks, &audit_info, node_ip, client_ip, cl, username, error)
+    return write_to_storage(sinks, audit_info, node_ip, client_ip, cl, username, error)
         .handle_exception([audit_info, node_ip, client_ip, cl, username, error] (auto ep) {
             logger.error("Unexpected exception when writing log with: node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {} exception {}",
                 node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
@@ -382,7 +400,7 @@ future<> audit::log_login(const sstring& username, socket_address client_ip, boo
         logger.debug("Login log written: node_ip {}, client_ip {}, username {}, error {}",
             node_ip, client_ip, username, error ? "true" : "false");
     }
-    return _storage_helper_ptr->write_login(sinks, username, node_ip, client_ip, error)
+    return write_login_to_storage(sinks, username, node_ip, client_ip, error)
         .handle_exception([username, node_ip, client_ip, error] (auto ep) {
             logger.error("Unexpected exception when writing login log with: node_ip {} client_ip {} username {} error {} exception {}",
                 node_ip, client_ip, username, error, ep);

--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -203,6 +203,7 @@ audit::audit(locator::shared_token_metadata& token_metadata,
     , _audited_categories(std::move(audited_categories))
     , _audit_sinks(audit_sinks)
     , _preprocessed_rules(std::move(audit_rules))
+    , _pending_writes("audit::pending_writes")
     , _schema_listener(std::make_unique<audit_schema_listener>(_preprocessed_rules))
     , _migration_notifier(mm.get_notifier())
     , _cfg(cfg)
@@ -274,9 +275,13 @@ future<> audit::stop_storage() {
     if (!audit_instance().local_is_initialized()) {
         return make_ready_future<>();
     }
-    return audit_instance().invoke_on_all([] (audit& local_audit) {
+    return audit_instance().invoke_on_all([] (audit& local_audit) -> future<> {
+        // Close the gate first so in-flight writes are drained and any write
+        // entering afterwards is rejected by try_with_gate, then clear the flag
+        // and stop the helper.
+        co_await local_audit._pending_writes.close();
         local_audit._storage_running = false;
-        return local_audit._storage_helper_ptr->stop();
+        co_await local_audit._storage_helper_ptr->stop();
     });
 }
 
@@ -311,7 +316,9 @@ future<> audit::write_to_storage(audit_sink_set sinks,
                                  std::optional<db::consistency_level> cl,
                                  const sstring& username,
                                  bool error) {
-    return _storage_helper_ptr->write(sinks, &audit_info, node_ip, client_ip, cl, username, error);
+    return try_with_gate(_pending_writes, [this, sinks, &audit_info, node_ip, client_ip, cl, &username, error] {
+        return _storage_helper_ptr->write(sinks, &audit_info, node_ip, client_ip, cl, username, error);
+    });
 }
 
 future<> audit::write_login_to_storage(audit_sink_set sinks,
@@ -319,7 +326,9 @@ future<> audit::write_login_to_storage(audit_sink_set sinks,
                                        socket_address node_ip,
                                        socket_address client_ip,
                                        bool error) {
-    return _storage_helper_ptr->write_login(sinks, username, node_ip, client_ip, error);
+    return try_with_gate(_pending_writes, [this, sinks, &username, node_ip, client_ip, error] {
+        return _storage_helper_ptr->write_login(sinks, username, node_ip, client_ip, error);
+    });
 }
 
 future<> audit::log(const audit_info& audit_info, const service::client_state& client_state, std::optional<db::consistency_level> cl, bool error) {

--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -267,7 +267,7 @@ future<> audit::start_storage(const db::config& cfg) {
     });
     co_await audit_instance().invoke_on_all([&cfg] (audit& local_audit) -> future<> {
         co_await local_audit._storage_helper_ptr->start(cfg);
-        local_audit._storage_running = true;
+        local_audit._storage_started = true;
     });
 }
 
@@ -276,11 +276,10 @@ future<> audit::stop_storage() {
         return make_ready_future<>();
     }
     return audit_instance().invoke_on_all([] (audit& local_audit) -> future<> {
-        // Close the gate first so in-flight writes are drained and any write
-        // entering afterwards is rejected by try_with_gate, then clear the flag
-        // and stop the helper.
+        // Closing the gate is the single shutdown signal: in-flight writes are
+        // drained and any write entering afterwards is rejected by try_with_gate.
+        // The storage-ready flag is not cleared here; it only guards startup.
         co_await local_audit._pending_writes.close();
-        local_audit._storage_running = false;
         co_await local_audit._storage_helper_ptr->stop();
     });
 }
@@ -345,7 +344,7 @@ future<> audit::log(const audit_info& audit_info, const service::client_state& c
     const sstring& username = client_state.user() ? client_state.user()->name.value_or(anonymous_username) : no_username;
     socket_address client_ip = client_state.get_client_address().addr();
     socket_address node_ip = _token_metadata.get()->get_topology().my_address().addr();
-    if (!_storage_running) {
+    if (!_storage_started) {
         on_internal_error_noexcept(logger, fmt::format("Audit log dropped (storage not ready): node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {}",
             node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
             audit_info.query(), client_ip, audit_info.table(), username));
@@ -357,10 +356,20 @@ future<> audit::log(const audit_info& audit_info, const service::client_state& c
             audit_info.query(), client_ip, audit_info.table(), username);
     }
     return write_to_storage(sinks, audit_info, node_ip, client_ip, cl, username, error)
-        .handle_exception([audit_info, node_ip, client_ip, cl, username, error] (auto ep) {
-            logger.error("Unexpected exception when writing log with: node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {} exception {}",
-                node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
-                audit_info.query(), client_ip, audit_info.table(), username, ep);
+        .handle_exception([audit_info, node_ip, client_ip, cl, username, error] (std::exception_ptr ep) {
+            try {
+                std::rethrow_exception(ep);
+            } catch (const seastar::gate_closed_exception&) {
+                // The write raced with stop_storage() closing the gate. No audit
+                // generating request should be in flight once storage stops.
+                on_internal_error_noexcept(logger, fmt::format("Audit log dropped (storage stopped): node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {}",
+                    node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
+                    audit_info.query(), client_ip, audit_info.table(), username));
+            } catch (...) {
+                logger.error("Unexpected exception when writing log with: node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {} exception {}",
+                    node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
+                    audit_info.query(), client_ip, audit_info.table(), username, ep);
+            }
     });
 }
 
@@ -400,7 +409,7 @@ future<> audit::log_login(const sstring& username, socket_address client_ip, boo
         return make_ready_future<>();
     }
     socket_address node_ip = _token_metadata.get()->get_topology().my_address().addr();
-    if (!_storage_running) {
+    if (!_storage_started) {
         on_internal_error_noexcept(logger, fmt::format("Audit login log dropped (storage not ready): node_ip {} client_ip {} username {} error {}",
             node_ip, client_ip, username, error ? "true" : "false"));
         return make_ready_future<>();
@@ -410,9 +419,18 @@ future<> audit::log_login(const sstring& username, socket_address client_ip, boo
             node_ip, client_ip, username, error ? "true" : "false");
     }
     return write_login_to_storage(sinks, username, node_ip, client_ip, error)
-        .handle_exception([username, node_ip, client_ip, error] (auto ep) {
-            logger.error("Unexpected exception when writing login log with: node_ip {} client_ip {} username {} error {} exception {}",
-                node_ip, client_ip, username, error, ep);
+        .handle_exception([username, node_ip, client_ip, error] (std::exception_ptr ep) {
+            try {
+                std::rethrow_exception(ep);
+            } catch (const seastar::gate_closed_exception&) {
+                // The write raced with stop_storage() closing the gate. No audit
+                // generating request should be in flight once storage stops.
+                on_internal_error_noexcept(logger, fmt::format("Audit login log dropped (storage stopped): node_ip {} client_ip {} username {} error {}",
+                    node_ip, client_ip, username, error ? "true" : "false"));
+            } catch (...) {
+                logger.error("Unexpected exception when writing login log with: node_ip {} client_ip {} username {} error {} exception {}",
+                    node_ip, client_ip, username, error, ep);
+            }
     });
 }
 

--- a/audit/audit.hh
+++ b/audit/audit.hh
@@ -16,6 +16,7 @@
 #include "audit/audit_rule.hh"
 #include "audit/preprocessed_audit_rules.hh"
 #include <seastar/core/sharded.hh>
+#include <seastar/core/gate.hh>
 #include <seastar/util/log.hh>
 
 #include "enum_set.hh"
@@ -139,6 +140,7 @@ private:
 
     std::unique_ptr<storage_helper> _storage_helper_ptr;
     bool _storage_running = false;
+    seastar::named_gate _pending_writes;
     std::unique_ptr<audit_schema_listener> _schema_listener;
     service::migration_notifier& _migration_notifier;
 

--- a/audit/audit.hh
+++ b/audit/audit.hh
@@ -139,7 +139,11 @@ private:
     preprocessed_audit_rules _preprocessed_rules;
 
     std::unique_ptr<storage_helper> _storage_helper_ptr;
-    bool _storage_running = false;
+    // Guards only the startup window: set once when start_storage() finishes and
+    // never reset. The pending-writes gate handles shutdown by draining and
+    // rejecting writes, so this flag just prevents writes from reaching the
+    // storage helper before it is started.
+    bool _storage_started = false;
     seastar::named_gate _pending_writes;
     std::unique_ptr<audit_schema_listener> _schema_listener;
     service::migration_notifier& _migration_notifier;

--- a/audit/audit.hh
+++ b/audit/audit.hh
@@ -156,6 +156,18 @@ private:
     bool rules_may_log(statement_category cat, std::string_view keyspace, std::string_view table) const;
     audit_sink_set sinks_for(const audit_info& audit_info, std::string_view role) const;
     audit_sink_set sinks_for_login(const sstring& username) const;
+    future<> write_to_storage(audit_sink_set sinks,
+                              const audit_info& audit_info,
+                              socket_address node_ip,
+                              socket_address client_ip,
+                              std::optional<db::consistency_level> cl,
+                              const sstring& username,
+                              bool error);
+    future<> write_login_to_storage(audit_sink_set sinks,
+                                    const sstring& username,
+                                    socket_address node_ip,
+                                    socket_address client_ip,
+                                    bool error);
     future<> rebuild_rules();
 public:
     static seastar::sharded<audit>& audit_instance() {

--- a/configure.py
+++ b/configure.py
@@ -1734,6 +1734,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/statement_restrictions_test.cc',
     'test/boost/storage_proxy_test.cc',
     'test/boost/tablets_test.cc',
+    'test/boost/test_audit.cc',
     'test/boost/tracing_test.cc',
     'test/boost/user_function_test.cc',
     'test/boost/user_types_test.cc',

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -106,6 +106,7 @@ future<> table_helper::cache_table_info(cql3::query_processor& qp, service::migr
         co_return;
     }
 
+    std::exception_ptr eptr;
     try {
         bool success = co_await try_prepare(false, qp, qs, cql3::internal_dialect());
         if (_is_fallback_stmt && _prepared_stmt) {
@@ -115,25 +116,33 @@ future<> table_helper::cache_table_info(cql3::query_processor& qp, service::migr
             co_await try_prepare(true, qp, qs, cql3::internal_dialect()); // Can only return true or exception when preparing the fallback statement
         }
     } catch (...) {
-        auto eptr = std::current_exception();
+        eptr = std::current_exception();
+    }
 
-        // One of the possible causes for an error here could be the table that doesn't exist.
-        //FIXME: discarded future.
-        (void)qp.container().invoke_on(0, [&mm = mm.container(), create_cql = _create_cql] (cql3::query_processor& qp) -> future<> {
+    if (!eptr) {
+        co_return;
+    }
+
+    // One of the possible causes for an error here could be the table that doesn't exist.
+    // Await setup_table() (the group0-dependent metadata recovery) so the future is
+    // covered by the caller's gate and properly waited during shutdown, before group0
+    // is torn down.
+    try {
+        co_await qp.container().invoke_on(0, [&mm = mm.container(), create_cql = _create_cql] (cql3::query_processor& qp) -> future<> {
             co_return co_await table_helper::setup_table(qp, mm.local(), create_cql);
-        }).handle_exception([keyspace = _keyspace, name = _name] (std::exception_ptr ep) {
-            tlogger.debug("Failed to create {}.{} table in best-effort recovery path: {}", keyspace, name, ep);
         });
+    } catch (...) {
+        tlogger.debug("Failed to create {}.{} table in best-effort recovery path: {}", _keyspace, _name, std::current_exception());
+    }
 
-        // We throw the bad_column_family exception because the caller
-        // expects and accounts this type of errors.
-        try {
-            std::rethrow_exception(eptr);
-        } catch (std::exception& e) {
-            throw bad_column_family(_keyspace, _name, e);
-        } catch (...) {
-            throw bad_column_family(_keyspace, _name);
-        }
+    // We throw the bad_column_family exception because the caller
+    // expects and accounts this type of errors.
+    try {
+        std::rethrow_exception(eptr);
+    } catch (std::exception& e) {
+        throw bad_column_family(_keyspace, _name, e);
+    } catch (...) {
+        throw bad_column_family(_keyspace, _name);
     }
 }
 

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -388,6 +388,7 @@ add_scylla_test(combined_tests
     statement_restrictions_test.cc
     storage_proxy_test.cc
     tablets_test.cc
+    test_audit.cc
     tracing_test.cc
     user_function_test.cc
     user_types_test.cc

--- a/test/boost/test_audit.cc
+++ b/test/boost/test_audit.cc
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#undef SEASTAR_TESTING_MAIN
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/on_internal_error.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/later.hh>
+#include <sstream>
+
+#include "audit/audit.hh"
+#include "test/lib/cql_test_env.hh"
+
+#include "transport/messages/result_message.hh"
+#include "utils/error_injection.hh"
+
+BOOST_AUTO_TEST_SUITE(test_audit)
+
+#ifdef SCYLLA_ENABLE_ERROR_INJECTION
+
+// Storage stop must drain audit writes that are already in flight. The audit
+// write is parked mid-flight via the injection, then stop_storage() is called:
+// the close of the pending-writes gate cannot complete until the parked write
+// is released, and the record must still be persisted rather than lost.
+SEASTAR_TEST_CASE(test_audit_storage_stop_drains_in_flight_write) {
+    cql_test_config cfg;
+    cfg.db_config->audit("table");
+    cfg.db_config->audit_categories("DML");
+    cfg.db_config->audit_keyspaces("ks");
+
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        audit::audit::start_audit(env.db_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).get();
+        auto audit_stop = defer([] {
+            audit::audit::stop_audit().get();
+        });
+
+        audit::audit::start_storage(env.db_config()).get();
+
+        env.execute_cql("CREATE TABLE ks.audit_gate_test (id int PRIMARY KEY)").get();
+
+        utils::get_local_injector().enable("table_helper_insert_before_execute", true /*one_shot*/);
+        auto write_fut = env.execute_cql("INSERT INTO ks.audit_gate_test (id) VALUES (1)");
+
+        while (utils::get_local_injector().waiters("table_helper_insert_before_execute") == 0) {
+            seastar::yield().get();
+        }
+
+        auto stop_fut = audit::audit::stop_storage();
+        // The write is parked inside the gate on this shard, where stop_storage()'s
+        // invoke_on_all runs the gate close inline; the close cannot complete until
+        // the parked write leaves the gate, so stop must not be ready here.
+        BOOST_REQUIRE(!stop_fut.available());
+        BOOST_REQUIRE(utils::get_local_injector().waiters("table_helper_insert_before_execute") > 0);
+
+        utils::get_local_injector().receive_message("table_helper_insert_before_execute");
+        // The write entered the gate before stop closed it, so it must drain to
+        // completion (no gate_closed_exception) rather than being lost.
+        write_fut.get();
+        stop_fut.get();
+
+        auto msg = env.execute_cql("SELECT * FROM audit.audit_log").get();
+        auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
+        BOOST_REQUIRE(rows);
+        // Exactly one record: the in-flight write was drained, neither dropped
+        // nor duplicated by the racing shutdown.
+        BOOST_REQUIRE_EQUAL(rows->rs().result_set().rows().size(), 1u);
+    }, std::move(cfg));
+}
+
+#endif // SCYLLA_ENABLE_ERROR_INJECTION
+
+// A write that arrives after storage stop has closed the gate must be rejected
+// as a closed-gate condition ("storage stopped"), not mistaken for the startup
+// "storage not ready" window. The ready flag stays set across stop, so the late
+// write reaches the gate and is rejected there; the distinguishing signal is the
+// internal-error reason, which is asserted by capturing the audit log output.
+SEASTAR_TEST_CASE(test_audit_storage_stop_rejects_late_write) {
+    cql_test_config cfg;
+    cfg.db_config->audit("table");
+    cfg.db_config->audit_categories("DML");
+    cfg.db_config->audit_keyspaces("ks");
+
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        audit::audit::start_audit(env.db_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).get();
+        auto audit_stop = defer([] {
+            audit::audit::stop_audit().get();
+        });
+
+        audit::audit::start_storage(env.db_config()).get();
+
+        env.execute_cql("CREATE TABLE ks.audit_gate_test (id int PRIMARY KEY)").get();
+
+        // Stop storage with no write in flight, so the gate is fully closed and
+        // the storage helper stopped before the late write below is issued.
+        audit::audit::stop_storage().get();
+
+        // The late write hits an on_internal_error_noexcept path; keep it logging
+        // without aborting so the reason can be inspected.
+        seastar::testing::scoped_no_abort_on_internal_error no_abort;
+
+        std::ostringstream captured;
+        seastar::logger::set_ostream(captured);
+        auto restore_ostream = defer([] {
+            seastar::logger::set_ostream(std::cerr);
+        });
+
+        env.execute_cql("INSERT INTO ks.audit_gate_test (id) VALUES (2)").get();
+
+        auto log_output = captured.str();
+        // The closed gate must surface as "storage stopped", not the startup-only
+        // "storage not ready" condition that would mean the ready flag was reset.
+        BOOST_REQUIRE(log_output.find("Audit log dropped (storage stopped)") != std::string::npos);
+        BOOST_REQUIRE(log_output.find("storage not ready") == std::string::npos);
+    }, std::move(cfg));
+}
+
+// A table audit write to a missing table takes the group0-dependent recovery
+// path (table_helper::cache_table_info -> setup_table), which must be awaited
+// by the write rather than left running detached. If it were detached, the
+// recovery could outlive group0 at shutdown and the metadata-recovery ordering
+// guarantee would be violated. Because the write awaits recovery, the table is
+// guaranteed recreated by the time the write returns, so a later write can
+// persist and the audit subsystem stops cleanly afterwards.
+SEASTAR_TEST_CASE(test_audit_write_awaits_table_recovery) {
+    cql_test_config cfg;
+    cfg.db_config->audit("table");
+    cfg.db_config->audit_categories("DML");
+    cfg.db_config->audit_keyspaces("ks");
+
+    return do_with_cql_env_thread([] (cql_test_env& env) {
+        audit::audit::start_audit(env.db_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).get();
+        auto audit_stop = defer([] {
+            audit::audit::stop_audit().get();
+        });
+
+        audit::audit::start_storage(env.db_config()).get();
+
+        env.execute_cql("CREATE TABLE ks.audit_gate_test (id int PRIMARY KEY)").get();
+
+        // Drop the audit table so the next audited write misses on prepare and
+        // enters the recovery path. The drop is DDL on the audit keyspace, which
+        // is not audited (categories DML, keyspaces ks), so it triggers no write.
+        env.execute_cql("DROP TABLE audit.audit_log").get();
+
+        // This write takes the recovery path. It awaits setup_table, so when the
+        // statement returns the table has been recreated; the triggering record
+        // itself is dropped best-effort (the recovery rethrows for the caller).
+        env.execute_cql("INSERT INTO ks.audit_gate_test (id) VALUES (1)").get();
+
+        auto recovered = env.execute_cql("SELECT * FROM audit.audit_log").get();
+        auto recovered_rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(recovered);
+        BOOST_REQUIRE(recovered_rows);
+        BOOST_REQUIRE_EQUAL(recovered_rows->rs().result_set().rows().size(), 0u);
+
+        // With the table back in place this write prepares and persists normally.
+        env.execute_cql("INSERT INTO ks.audit_gate_test (id) VALUES (2)").get();
+
+        audit::audit::stop_storage().get();
+
+        auto msg = env.execute_cql("SELECT * FROM audit.audit_log").get();
+        auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
+        BOOST_REQUIRE(rows);
+        BOOST_REQUIRE_EQUAL(rows->rs().result_set().rows().size(), 1u);
+    }, std::move(cfg));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Table audit storage may need to recover table metadata through
group0 (see table_helper::setup_table). If group0 shuts down
while writes are still in-flight, the recovery ordering
guarantee is violated and audit records can be lost. Wait for in-flight
writes to complete before group0 stops.

Moreover, table_helper's `cache_table_info` may use group0. 
Add waiting in the caller keeps shutdown from tearing group0
down while recovery is still running.

The change introduces +1 alloc/op and task/op for
when the `table` audit log is emitted, however, based on
the benchmark the impact is marginal (e.g. median insn/op
increases by less than 100, that is less than 0.1%):

`scylla perf-simple-query --smp 1 --duration 30 --audit "table" --audit-keyspaces "ks" --audit-categories "DCL,DDL,AUTH,DML,QUERY"`

```
Before:
62592.56 tps (153.9 allocs/op,  14.1 logallocs/op,  27.6 tasks/op,  126366 insns/op,   49865 cycles/op,        0 errors)
throughput:
	mean=   62773.79 standard-deviation=1076.38
	median= 62902.36 median-absolute-deviation=416.54
	maximum=64188.17 minimum=58854.66
instructions_per_op:
	mean=   125401.63 standard-deviation=1517.00
	median= 125794.20 median-absolute-deviation=913.63
	maximum=127228.35 minimum=120555.95
cpu_cycles_per_op:
	mean=   49555.87 standard-deviation=513.26
	median= 49653.97 median-absolute-deviation=312.04
	maximum=50220.39 minimum=48171.33

After:
62851.98 tps (154.9 allocs/op,  14.1 logallocs/op,  28.6 tasks/op,  126272 insns/op,   49565 cycles/op,        0 errors)
throughput:
	mean=   63203.23 standard-deviation=818.74
	median= 63238.26 median-absolute-deviation=358.81
	maximum=64721.03 minimum=60093.03
instructions_per_op:
	mean=   125589.44 standard-deviation=1507.64
	median= 125892.82 median-absolute-deviation=899.22
	maximum=127400.88 minimum=120684.06
cpu_cycles_per_op:
	mean=   49264.47 standard-deviation=472.47
	median= 49397.39 median-absolute-deviation=333.96
	maximum=49894.23 minimum=47917.41
```

Fixes: SCYLLADB-2366

Backport: none, it's a minor improvement.