### PR TITLE
Vnodes to tablets migration pow2 convergence

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -3250,6 +3250,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"path"
+                 },
+                 {
+                     "name":"include",
+                     "description":"Optional status details to include in the response. Supported values: 'tablet_status' (include per-table pow2 convergence information when migration status is 'tablets')",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
                  }
              ]
          }]
@@ -3948,6 +3956,67 @@
                   "$ref":"vnode_tablet_migration_node_status"
                },
                "description":"Per-node storage mode information. Empty if the keyspace is not being migrated."
+            },
+            "tablets":{
+               "type":"tablet_status",
+               "description":"Tablet status. Only present when ?include=tablet_status and migration status is 'tablets'."
+            }
+         }
+      },
+      "tablet_status":{
+         "id":"tablet_status",
+         "description":"Tablet status for a keyspace",
+         "properties":{
+            "pow2_convergence":{
+               "type":"tablets_pow2_convergence_status",
+               "description":"Pow2 convergence status"
+            }
+         }
+      },
+      "tablets_pow2_convergence_status":{
+         "id":"tablets_pow2_convergence_status",
+         "description":"Pow2 convergence status for all tables in a keyspace",
+         "properties":{
+            "status":{
+               "type":"string",
+               "description":"Overall convergence status: `in_progress` or `complete`"
+            },
+            "tables_converging":{
+               "type":"long",
+               "description":"Number of tables still converging to pow2 tablet layout"
+            },
+            "tables_total":{
+               "type":"long",
+               "description":"Total number of tables in the keyspace"
+            },
+            "tables":{
+               "type":"array",
+               "items":{
+                  "$ref":"table_pow2_convergence_info"
+               },
+               "description":"Per-table convergence information"
+            }
+         }
+      },
+      "table_pow2_convergence_info":{
+         "id":"table_pow2_convergence_info",
+         "description":"Pow2 convergence info for a single table",
+         "properties":{
+            "table":{
+               "type":"string",
+               "description":"The table name"
+            },
+            "converging":{
+               "type":"boolean",
+               "description":"Whether the table is currently converging to a pow2 tablet layout"
+            },
+            "current_tablet_count":{
+               "type":"long",
+               "description":"The current number of tablets"
+            },
+            "target_pow2_tablet_count":{
+               "type":"long",
+               "description":"The target pow2 tablet count (0 if not converging)"
             }
          }
       },

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1788,6 +1788,8 @@ rest_get_vnode_tablet_migration(http_context& ctx, sharded<service::storage_serv
         throw std::runtime_error("vnodes-to-tablets migration requires all nodes to support the VNODES_TO_TABLETS_MIGRATIONS cluster feature");
     }
     auto keyspace = validate_keyspace(ctx, req);
+    auto include = req->get_query_param("include");
+    auto with_tablet_status = include == "tablet_status";
     auto status = co_await ss.local().run_with_no_api_lock([keyspace] (service::storage_service& ss) {
         return ss.get_tablets_migration_status_with_node_details(keyspace);
     });
@@ -1803,6 +1805,29 @@ rest_get_vnode_tablet_migration(http_context& ctx, sharded<service::storage_serv
         n.intended_mode = node.intended_mode;
         result.nodes.push(n);
     }
+
+    if (with_tablet_status && status.status == service::storage_service::migration_status::tablets) {
+        auto pow2_status = ss.local().get_tablets_pow2_convergence_status(keyspace);
+
+        ss::tablets_pow2_convergence_status pow2_result;
+        pow2_result.status = pow2_status.tables_converging == 0 ? "complete" : "in_progress";
+        pow2_result.tables_converging = pow2_status.tables_converging;
+        pow2_result.tables_total = pow2_status.tables_total;
+        pow2_result.tables._set = true;
+        for (const auto& t : pow2_status.tables) {
+            ss::table_pow2_convergence_info info;
+            info.table = t.table_name;
+            info.converging = t.converging;
+            info.current_tablet_count = t.current_tablet_count;
+            info.target_pow2_tablet_count = t.target_pow2_tablet_count;
+            pow2_result.tables.push(info);
+        }
+
+        ss::tablet_status tablets;
+        tablets.pow2_convergence = pow2_result;
+        result.tablets = tablets;
+    }
+
     co_return result;
 }
 

--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -698,12 +698,13 @@ void view_building_coordinator::generate_tablet_resize_updates(utils::chunked_ve
         vbc_logger.debug("Task {} was split into task {} and task {}", task.id, new_id, new_id2);
     };
 
-    // Task with tablet id `n` is updated to new task with tablet id `n/2` (integer division).
-    // If task with tablet id `n/2` is already created (information is stored in `created_tablet_ids`), only old task is removed.
+    // Task's token is looked up in the new tablet map to find the new tablet id.
+    // If a task for that new tablet was already created (tracked in `created_tablet_ids`),
+    // only the old task is removed.
     auto merge_task = [&] (std::unordered_set<locator::tablet_id>& created_tablet_ids, const view_building_task& task) {
         builder.del_task(task.id);
 
-        auto new_tid = locator::tablet_id(old_tmap.get_tablet_id(task.last_token).id / 2);
+        auto new_tid = new_tmap.get_tablet_id(task.last_token);
         if (!created_tablet_ids.contains(new_tid)) {
             created_tablet_ids.insert(new_tid);
             auto new_id = create_task_copy(task, new_tmap.get_last_token(new_tid));

--- a/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
+++ b/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
@@ -232,6 +232,36 @@ Procedure
          Keyspace: ks
          Status: tablets
 
+   #. Optionally, wait for tablet layout normalization to complete:
+
+      After finalization, a tablet normalization process takes place in the
+      background which transforms the tablets of all migrated tables into a
+      power-of-two layout. Until power-of-two convergence is complete, the
+      tablet layout of all these tables will be suboptimal, causing degraded
+      performance. Run the following command repeatedly to monitor the per-table
+      status of this background work:
+
+      .. code-block:: console
+
+         scylla nodetool migrate-to-tablets status <keyspace> --with-tablet-status
+
+      **Example:**
+
+      .. code-block:: console
+
+         $ scylla nodetool migrate-to-tablets status ks --with-tablet-status
+         Keyspace: ks
+         Status: tablets
+
+         Tablet info:
+           Pow2 tablet layout convergence: in progress
+           Tables converging: 2/3
+
+         Table   Status       Tablets   Target
+         t1      converging   2301      2048
+         t2      converging   2176      2048
+         t3      converged    2048      -
+
 Rollback Procedure
 ------------------
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -184,6 +184,7 @@ public:
     gms::feature large_data_guardrails { *this, "LARGE_DATA_GUARDRAILS"sv };
     gms::feature keyspace_multi_rf_change { *this, "KEYSPACE_MULTI_RF_CHANGE"sv };
     gms::feature view_building_tasks_min_task_id { *this, "VIEW_BUILDING_TASKS_MIN_TASK_ID"sv };
+    gms::feature tablet_pow2_convergence { *this, "TABLET_POW2_CONVERGENCE"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -44,6 +44,23 @@ std::pair<tablet_id, std::optional<tablet_id>> tablet_map::sibling_tablets(table
 
     auto& merge_plan = std::get<resize_decision::merge>(_resize_decision.way);
 
+    if (!merge_plan.selected_left_tablets.empty()) {
+        // Check if t is the left sibling of a selected pair.
+        if (std::ranges::binary_search(merge_plan.selected_left_tablets, t)) {
+            auto right = next_tablet(t);
+            return std::make_pair(t, right);
+        }
+        // Check if t is the right sibling of a selected pair.
+        if (t != first_tablet()) {
+            auto left = tablet_id(t.value() - 1);
+            if (std::ranges::binary_search(merge_plan.selected_left_tablets, left)) {
+                return std::make_pair(left, t);
+            }
+        }
+        // Not part of any selected pair
+        return std::make_pair(t, std::nullopt);
+    }
+
     if (!merge_plan.isolated_tablet || t < *merge_plan.isolated_tablet) {
         auto first_sibling = tablet_id(t.value() & ~0x1);
         auto second_sibling = next_tablet(first_sibling);
@@ -812,6 +829,29 @@ future<> tablet_map::for_each_sibling_tablets(seastar::noncopyable_function<futu
     }
 
     auto& merge_plan = std::get<resize_decision::merge>(_resize_decision.way);
+
+    if (!merge_plan.selected_left_tablets.empty()) {
+        // Selective merge: only selected pairs are siblings, everything else is a singleton.
+        size_t sel_idx = 0;
+        std::optional<tablet_id> tid = first_tablet();
+        while (tid) {
+            auto cur = *tid;
+            tid = next_tablet(cur);
+            if (sel_idx < merge_plan.selected_left_tablets.size() && cur == merge_plan.selected_left_tablets[sel_idx]) {
+                // This is a selected left tablet; pair it with the next one.
+                if (!tid) {
+                    on_internal_error(tablet_logger, format("Selected left tablet {} has no right sibling", cur));
+                }
+                auto right = *tid;
+                tid = next_tablet(right);
+                ++sel_idx;
+                co_await func(make_desc(cur), make_desc(right));
+            } else {
+                co_await func(make_desc(cur), std::nullopt);
+            }
+        }
+        co_return;
+    }
 
     std::optional<tablet_id> tid = first_tablet();
     while (tid) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1978,7 +1978,11 @@ auto fmt::formatter<locator::resize_decision_way>::format(const locator::resize_
             fmt::format_to(ctx.out(), "split");
         },
         [&] (const locator::resize_decision::merge& merge) {
-            fmt::format_to(ctx.out(), "merge(isolated={})", merge.isolated_tablet);
+            if (!merge.selected_left_tablets.empty()) {
+                fmt::format_to(ctx.out(), "merge(selected={})", merge.selected_left_tablets);
+            } else {
+                fmt::format_to(ctx.out(), "merge(isolated={})", merge.isolated_tablet);
+            }
         }), way);
     return ctx.out();
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -604,7 +604,7 @@ tablet_layout tablet_map::get_layout() const {
 
 tablet_map tablet_map::clone() const {
     return tablet_map(_tablet_ids, _tablets, _transitions, _resize_decision, _resize_task_info,
-                      _repair_scheduler_config, _raft_info);
+                      _repair_scheduler_config, _raft_info, _target_pow2_tablet_count);
 }
 
 future<tablet_map> tablet_map::clone_gently() const {
@@ -632,7 +632,8 @@ future<tablet_map> tablet_map::clone_gently() const {
     }
 
     co_return tablet_map(std::move(ids), std::move(tablets), std::move(transitions),
-                         _resize_decision, _resize_task_info, _repair_scheduler_config, std::move(raft_info));
+                         _resize_decision, _resize_task_info, _repair_scheduler_config, std::move(raft_info),
+                         _target_pow2_tablet_count);
 }
 
 void tablet_map::check_tablet_id(tablet_id id) const {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -716,6 +716,7 @@ private:
     tablet_task_info _resize_task_info;
     std::optional<repair_scheduler_config> _repair_scheduler_config;
     raft_info_container _raft_info;
+    size_t _target_pow2_tablet_count = 0; // 0 means no convergence in progress
 
     // Internal constructor, used by clone() and clone_gently().
     tablet_map(tablet_id_map ids,
@@ -724,7 +725,8 @@ private:
                resize_decision resize_decision,
                tablet_task_info resize_task_info,
                std::optional<repair_scheduler_config> repair_scheduler_config,
-               raft_info_container raft_info)
+               raft_info_container raft_info,
+               size_t target_pow2_tablet_count)
         : _tablet_ids(std::move(ids))
         , _tablets(std::move(tablets))
         , _transitions(std::move(transitions))
@@ -732,6 +734,7 @@ private:
         , _resize_task_info(std::move(resize_task_info))
         , _repair_scheduler_config(std::move(repair_scheduler_config))
         , _raft_info(std::move(raft_info))
+        , _target_pow2_tablet_count(target_pow2_tablet_count)
     {}
 public:
     /// Constructs a tablet map.
@@ -908,6 +911,10 @@ public:
     const locator::resize_decision& resize_decision() const;
     const tablet_task_info& resize_task_info() const;
     const std::optional<locator::repair_scheduler_config> get_repair_scheduler_config() const;
+
+    size_t target_pow2_tablet_count() const { return _target_pow2_tablet_count; }
+    void set_target_pow2_tablet_count(size_t count) { _target_pow2_tablet_count = count; }
+    bool is_converging_to_pow2() const { return _target_pow2_tablet_count != 0; }
 public:
     /// Use only on tablet_map constructed with initialized_later tag to populate its contents.
     /// Must be called for consecutive tablet ids and with increasing last_token.

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -844,8 +844,9 @@ public:
     }
 
     // Returns the pair of sibling tablets for a given tablet id.
-    // If the tablet count is odd, the last tablet does not have a sibling and
-    // the second element of the pair will be disengaged.
+    // The second element will be disengaged if the tablet does not have a
+    // sibling: either it was picked as the isolated tablet for merge, or the
+    // merge is a selective merge and the given tablet does not participate in it.
     std::pair<tablet_id, std::optional<tablet_id>> sibling_tablets(tablet_id t) const;
 
     /// Returns true iff tablet has a given replica.

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -458,6 +458,12 @@ struct resize_decision {
         // In case the current tablet count is odd, this is the id of the tablet
         // which will not be merged.
         std::optional<tablet_id> isolated_tablet;
+        // When non-empty, only these specific adjacent pairs are merged:
+        // each entry is the left tablet of a pair (left, left + 1).
+        // Must be sorted and must not contain overlapping pairs
+        // (e.g., [1, 2] is invalid because pairs (1,2) and (2,3) share tablet 2).
+        // Cannot be used together with isolated_tablet.
+        std::vector<tablet_id> selected_left_tablets;
         auto operator<=>(const merge&) const = default;
     };
     using way_type = std::variant<none, split, merge>;

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -84,6 +84,7 @@ schema_ptr make_tablets_schema() {
             .with_column("resize_type", utf8_type, column_kind::static_column)
             .with_column("resize_seq_number", long_type, column_kind::static_column)
             .with_column("isolated_tablet_for_merge", long_type, column_kind::static_column)
+            .with_column("selected_tablets_for_merge", list_type_impl::get_instance(long_type, false), column_kind::static_column)
             .with_column("repair_time", timestamp_type)
             .with_column("repair_task_info", tablet_task_info_type)
             .with_column("repair_scheduler_config", repair_scheduler_config_type, column_kind::static_column)
@@ -278,6 +279,15 @@ tablet_map_to_mutations(const tablet_map& tablets, table_id id, const sstring& k
         if (merge.isolated_tablet) {
             m.set_static_cell("isolated_tablet_for_merge", data_value(int64_t(size_t(*merge.isolated_tablet))), ts);
         }
+        if (!merge.selected_left_tablets.empty()) {
+            std::vector<data_value> values;
+            values.reserve(merge.selected_left_tablets.size());
+            for (auto tid : merge.selected_left_tablets) {
+                values.emplace_back(int64_t(tid.value()));
+            }
+            auto list_type = list_type_impl::get_instance(long_type, false);
+            m.set_static_cell("selected_tablets_for_merge", make_list_value(list_type, std::move(values)), ts);
+        }
     }
     if (features.tablet_resize_virtual_task && tablets.resize_task_info().is_valid()) {
         m.set_static_cell("resize_task_info", tablet_task_info_to_data_value(tablets.resize_task_info()), ts);
@@ -417,6 +427,15 @@ tablet_mutation_builder::set_resize_decision(locator::resize_decision resize_dec
             if (merge.isolated_tablet) {
                 _m.set_static_cell("isolated_tablet_for_merge", data_value(int64_t(size_t(*merge.isolated_tablet))), _ts);
             }
+            if (!merge.selected_left_tablets.empty()) {
+                std::vector<data_value> values;
+                values.reserve(merge.selected_left_tablets.size());
+                for (auto tid : merge.selected_left_tablets) {
+                    values.emplace_back(int64_t(tid.value()));
+                }
+                auto list_type = list_type_impl::get_instance(long_type, false);
+                _m.set_static_cell("selected_tablets_for_merge", make_list_value(list_type, std::move(values)), _ts);
+            }
         }
         auto resize_task_info = std::holds_alternative<resize_decision::split>(resize_decision.way)
             ? locator::tablet_task_info::make_split_request()
@@ -425,6 +444,12 @@ tablet_mutation_builder::set_resize_decision(locator::resize_decision resize_dec
         resize_task_info.sched_time = db_clock::now();
         return set_resize_task_info(std::move(resize_task_info), features);
     } else {
+        // Clear merge-parameter columns on revocation to prevent stale values
+        // from being picked up by a subsequent merge decision.
+        auto col1 = _s->get_column_definition("isolated_tablet_for_merge");
+        _m.set_static_cell(*col1, atomic_cell::make_dead(_ts, gc_clock::now()));
+        auto col2 = _s->get_column_definition("selected_tablets_for_merge");
+        _m.set_static_cell(*col2, atomic_cell::make_dead(_ts, gc_clock::now()));
         return del_resize_task_info(features);
     }
     return *this;
@@ -925,10 +950,20 @@ struct tablet_metadata_builder {
                     } else if (resize_type_name == "split") {
                         return locator::resize_decision(locator::resize_decision::split(), resize_seq_number);
                     } else if (resize_type_name == "merge") {
-                        return locator::resize_decision(locator::resize_decision::merge {
+                        auto merge = locator::resize_decision::merge {
                             .isolated_tablet = row.get_opt<int64_t>("isolated_tablet_for_merge")
                                     .transform([] (int64_t v) { return tablet_id(v); })
-                        }, resize_seq_number);
+                        };
+                        if (row.has("selected_tablets_for_merge")) {
+                            auto list_type = list_type_impl::get_instance(long_type, false);
+                            auto values = value_cast<list_type_impl::native_type>(
+                                list_type->deserialize(row.get_view("selected_tablets_for_merge")));
+                            merge.selected_left_tablets.reserve(values.size());
+                            for (const auto& v : values) {
+                                merge.selected_left_tablets.emplace_back(tablet_id(value_cast<int64_t>(v)));
+                            }
+                        }
+                        return locator::resize_decision(std::move(merge), resize_seq_number);
                     } else {
                         throw std::runtime_error(format("Unknown resize_type '{}' for table {}", resize_type_name, table));
                     }

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -85,6 +85,7 @@ schema_ptr make_tablets_schema() {
             .with_column("resize_seq_number", long_type, column_kind::static_column)
             .with_column("isolated_tablet_for_merge", long_type, column_kind::static_column)
             .with_column("selected_tablets_for_merge", list_type_impl::get_instance(long_type, false), column_kind::static_column)
+            .with_column("target_pow2_tablet_count", long_type, column_kind::static_column)
             .with_column("repair_time", timestamp_type)
             .with_column("repair_task_info", tablet_task_info_type)
             .with_column("repair_scheduler_config", repair_scheduler_config_type, column_kind::static_column)
@@ -298,6 +299,10 @@ tablet_map_to_mutations(const tablet_map& tablets, table_id id, const sstring& k
         if (config) {
             m.set_static_cell("repair_scheduler_config", repair_scheduler_config_to_data_value(*config), ts);
         }
+    }
+
+    if (tablets.target_pow2_tablet_count() > 0) {
+        m.set_static_cell("target_pow2_tablet_count", data_value(int64_t(tablets.target_pow2_tablet_count())), ts);
     }
 
     tablet_id tid = tablets.first_tablet();
@@ -977,6 +982,13 @@ struct tablet_metadata_builder {
             if (row.has("repair_scheduler_config")) {
                 auto config = deserialize_repair_scheduler_config(row.get_view("repair_scheduler_config"));
                 current->map.set_repair_scheduler_config(std::move(config));
+            }
+
+            if (row.has("target_pow2_tablet_count")) {
+                auto count = row.get_as<int64_t>("target_pow2_tablet_count");
+                if (count > 0) {
+                    current->map.set_target_pow2_tablet_count(size_t(count));
+                }
             }
         }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -258,6 +258,7 @@ storage_service::storage_service(abort_source& abort_source,
         _tablets_module->make_virtual_task<service::tablet_virtual_task>(*this);
         _global_topology_requests_module->make_virtual_task<service::topo::global_topology_request_virtual_task>(*this);
         _vnodes_to_tablets_migration_module->make_virtual_task<service::vnodes_to_tablets::migration_virtual_task>(*this);
+        _vnodes_to_tablets_migration_module->make_virtual_task<service::vnodes_to_tablets::pow2_convergence_virtual_task>(*this);
     }
     register_metrics();
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -66,6 +66,7 @@
 #include "gms/feature_service.hh"
 #include <seastar/core/thread.hh>
 #include <algorithm>
+#include <bit>
 #include "locator/local_strategy.hh"
 #include "locator/tablet_replication_strategy.hh"
 #include "utils/user_provided_param.hh"
@@ -3975,21 +3976,31 @@ future<> storage_service::update_tablet_metadata(const locator::tablet_metadata_
 
 locator::tablet_map storage_service::build_tablet_map_for_migration(
         const locator::token_metadata& tm,
-        const locator::static_effective_replication_map_ptr& erm) const {
+        const locator::static_effective_replication_map_ptr& erm,
+        size_t target_pow2) const {
     const auto& sorted_tokens = tm.sorted_tokens();
 
+    // Construct token boundaries: union of vnode tokens + optional pow2 boundaries.
+    // target_pow2 == 0 means no pow2 convergence target and only wrap-around pre-split.
     utils::chunked_vector<dht::raw_token> last_tokens;
-    size_t tablet_count = sorted_tokens.size();
-    last_tokens.reserve(tablet_count + 1); // +1 for possible wrapping tablet
-    for (const auto& t : sorted_tokens) {
-        last_tokens.emplace_back(t);
+    auto presplit_pow2 = std::max<size_t>(target_pow2, 1);
+    auto log2count = std::bit_width(presplit_pow2) - 1;
+    last_tokens.reserve(sorted_tokens.size() + presplit_pow2);
+
+    auto vnode_view = sorted_tokens
+        | std::views::transform([] (const auto& t) { return dht::raw_token(t); });
+    auto pow2_view = std::views::iota(size_t{0}, presplit_pow2)
+        | std::views::transform([&] (size_t i) { return dht::raw_token(dht::last_token_of_compaction_group(log2count, i)); });
+
+    std::ranges::set_union(vnode_view, pow2_view, std::back_inserter(last_tokens));
+
+    if (last_tokens.empty() || last_tokens.back() != dht::raw_token(dht::last_token())) {
+        on_internal_error(slogger, "build_migrating_tablet_map: token list does not end with the maximum token");
     }
-    // Add an extra tablet for the wrapping range if needed.
-    auto needs_wrapping_tablet = sorted_tokens.back() != dht::token::last();
-    if (needs_wrapping_tablet) {
-        last_tokens.emplace_back(dht::token::last());
-        tablet_count++;
-    }
+
+    // Construct tablet map and assign replicas.
+    locator::tablet_map tmap(std::move(last_tokens));
+    auto tablet_count = tmap.tablet_count();
 
     // Stateful lambdas for round-robin shard assignment per node.
     std::unordered_map<locator::host_id, std::function<shard_id()>> next_shard_for;
@@ -4000,16 +4011,26 @@ locator::tablet_map storage_service::build_tablet_map_for_migration(
         };
     });
 
-    locator::tablet_map tmap(std::move(last_tokens));
+    size_t vnode_idx = 0;
     for (size_t i = 0; i < tablet_count; ++i) {
         auto tablet = locator::tablet_id(i);
-        auto vnode_token = needs_wrapping_tablet && i == tablet_count - 1 ? tmap.get_last_token(locator::tablet_id{0}) : tmap.get_last_token(tablet);
+        auto tablet_last = dht::raw_token(tmap.get_last_token(tablet));
+        while (vnode_idx < sorted_tokens.size() && dht::raw_token(sorted_tokens[vnode_idx]) < tablet_last) {
+            ++vnode_idx;
+        }
+        auto vnode_token = (vnode_idx < sorted_tokens.size())
+            ? sorted_tokens[vnode_idx]
+            : sorted_tokens[0]; // wrap-around vnode
         auto vnode_replica_hosts = erm->get_natural_replicas(vnode_token, true);
         locator::tablet_replica_set tablet_replicas;
         for (auto host : vnode_replica_hosts) {
             tablet_replicas.push_back(locator::tablet_replica{host, next_shard_for[host]()});
         }
         tmap.set_tablet(tablet, locator::tablet_info(std::move(tablet_replicas)));
+    }
+
+    if (target_pow2 && tablet_count != target_pow2) {
+        tmap.set_target_pow2_tablet_count(target_pow2);
     }
 
     return tmap;
@@ -4102,23 +4123,69 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
 
         // Build a tablet_map from vnode token boundaries.
         //
-        // The map contains one tablet per vnode, plus one extra tablet for the
-        // wrap-around range (last_vnode_token, MAX_TOKEN] when
-        // last_vnode_token != MAX_TOKEN. Each tablet has the same replicas as
-        // the corresponding vnode. Shards are assigned in round-robin fashion
-        // per node so that tablets are evenly distributed within each node.
-        // (FIXME: we should consider tablet sizes as well)
+        // Each vnode token becomes a tablet boundary, giving one tablet per
+        // vnode range. If the last vnode token is not MAX_TOKEN, an additional
+        // tablet is created to cover the wrap-around range
+        // (last_vnode_token, MAX_TOKEN].
+        // Tablets inherit their replica hosts from their corresponding vnode
+        // and shards are assigned in round-robin fashion per node so that
+        // tablets are evenly distributed within each node.
         //
-        // This map will serve as a template for per-table tablet map mutations.
-        // Each table in the keyspace receives its own tablet map, but all maps
-        // have identical tablet boundaries and replica placement.
+        // However, this direct 1:1 mapping is not sufficient in terms of
+        // performance because vnode token ranges vary in size, producing
+        // unevenly sized tablets that are harder to balance across the cluster.
+        // When the TABLET_POW2_CONVERGENCE feature is enabled, we additionally
+        // inject artificial power-of-two boundary tokens into the tablet map,
+        // a process referred to as "pre-splitting". These tokens define the
+        // target uniform tablet layout and subdivide the vnode-based tablets
+        // into smaller tablets. After migration, selective merges remove the
+        // vnode boundaries, gradually converging the tablet map toward the
+        // power-of-two layout without needing any additional splits.
+        //
+        // Here is an illustrative example:
+        //
+        // Before (4 vnodes, uneven):
+        //
+        //   V4               V1       V2        V3                V4
+        //   |----------------|------|-----------|-----------------|
+        //
+        // Power-of-two boundaries (P=4, evenly spaced):
+        //
+        //  min           P1            P2            P3          max
+        //   |------------|-------------|-------------|------------|
+        //
+        // After set_union (7 tablets):
+        //
+        //   0            P1 V1      V2 P2       V3   P3          max
+        //   |------------|--|-------|--|--------|----|------------|
+        //
+        // Post-migration merges eliminate V1, V2, V3 boundaries by merging
+        // tablets with IDs (1, 2, 3) and (4, 5):
+        //
+        //  min           P1            P2            P3          max
+        //   |------------|-------------|-------------|------------|
+
         const auto& tm = get_token_metadata();
+
+        // Estimate table sizes when pow2 convergence is enabled.
+        // The estimates are used by the tablet allocator to determine the
+        // target pow2 tablet count per table.
+        auto& rs = ks.get_replication_strategy();
+        const auto* trs = dynamic_cast<const locator::tablet_aware_replication_strategy*>(&rs);
+        if (!trs) {
+            throw std::runtime_error(fmt::format(
+                "Keyspace '{}' uses a replication strategy that does not support tablets. Please convert to NetworkTopologyStrategy first.",
+                ks_name));
+        }
+
+        target_pow2_per_table_map target_pow2s;
+        bool use_pow2_presplit = bool(_feature_service.tablet_pow2_convergence);
+        if (use_pow2_presplit) {
+            auto estimated_sizes = co_await collect_table_sizes_for_migration(tm, trs, tables_to_migrate);
+            target_pow2s = co_await _tablet_allocator.local().compute_migration_target_pow2s(trs, estimated_sizes);
+        }
+
         auto erm = ks.get_static_effective_replication_map();
-
-        auto tmap = build_tablet_map_for_migration(tm, erm);
-        const auto tablet_count = tmap.tablet_count();
-
-        slogger.info("Built tablet map for tables in keyspace {} with {} tablet(s)", ks_name, tablet_count);
 
         // Build tablet map mutations for all tables and persist them to group0 (system.tablets)
         // in a single command.
@@ -4129,7 +4196,11 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         // (e.g., finalization) and prevent failures from group0 conflicts, we
         // should turn this into a topology request.
         utils::chunked_vector<canonical_mutation> updates;
-        for (const auto& [tid, cf_name] : tables_to_migrate) {
+
+        auto append_tablet_map_mutations = [&] (table_id tid, const sstring& cf_name, const locator::tablet_map& tmap, size_t target_pow2) -> future<> {
+            slogger.info("Built tablet map for table {}.{} with {} tablet(s) (target pow2={})",
+                         ks_name, cf_name, tmap.tablet_count(), target_pow2);
+
             co_await replica::tablet_map_to_mutations(
                 tmap,
                 tid,
@@ -4140,6 +4211,22 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
                 [&] (mutation m) -> future<> {
                     updates.emplace_back(co_await make_canonical_mutation_gently(m));
                 });
+        };
+
+        if (use_pow2_presplit) {
+            for (const auto& [tid, cf_name] : tables_to_migrate) {
+                size_t target_pow2 = 0;
+                if (auto it = target_pow2s.find(tid); it != target_pow2s.end()) {
+                    target_pow2 = it->second;
+                }
+                auto tmap = build_tablet_map_for_migration(tm, erm, target_pow2);
+                co_await append_tablet_map_mutations(tid, cf_name, tmap, target_pow2);
+            }
+        } else {
+            auto shared_tmap = build_tablet_map_for_migration(tm, erm, 0);
+            for (const auto& [tid, cf_name] : tables_to_migrate) {
+                co_await append_tablet_map_mutations(tid, cf_name, shared_tmap, 0);
+            }
         }
 
         topology_change change{std::move(updates)};
@@ -4154,8 +4241,8 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         }
 
         for (const auto& [tid, cf_name] : tables_to_migrate) {
-            slogger.info("Successfully built tablet map for table {}.{} ({} tablet(s))",
-                         ks_name, cf_name, tablet_count);
+            slogger.info("Successfully built tablet map for table {}.{}",
+                         ks_name, cf_name);
         }
         break;
     }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3973,6 +3973,48 @@ future<> storage_service::update_tablet_metadata(const locator::tablet_metadata_
     wake_up_topology_state_machine();
 }
 
+locator::tablet_map storage_service::build_tablet_map_for_migration(
+        const locator::token_metadata& tm,
+        const locator::static_effective_replication_map_ptr& erm) const {
+    const auto& sorted_tokens = tm.sorted_tokens();
+
+    utils::chunked_vector<dht::raw_token> last_tokens;
+    size_t tablet_count = sorted_tokens.size();
+    last_tokens.reserve(tablet_count + 1); // +1 for possible wrapping tablet
+    for (const auto& t : sorted_tokens) {
+        last_tokens.emplace_back(t);
+    }
+    // Add an extra tablet for the wrapping range if needed.
+    auto needs_wrapping_tablet = sorted_tokens.back() != dht::token::last();
+    if (needs_wrapping_tablet) {
+        last_tokens.emplace_back(dht::token::last());
+        tablet_count++;
+    }
+
+    // Stateful lambdas for round-robin shard assignment per node.
+    std::unordered_map<locator::host_id, std::function<shard_id()>> next_shard_for;
+    tm.for_each_token_owner([&] (const locator::node& node) {
+        auto host = node.host_id();
+        next_shard_for[host] = [num_shards = node.get_shard_count(), idx = 0u] () mutable {
+            return shard_id(idx++ % num_shards);
+        };
+    });
+
+    locator::tablet_map tmap(std::move(last_tokens));
+    for (size_t i = 0; i < tablet_count; ++i) {
+        auto tablet = locator::tablet_id(i);
+        auto vnode_token = needs_wrapping_tablet && i == tablet_count - 1 ? tmap.get_last_token(locator::tablet_id{0}) : tmap.get_last_token(tablet);
+        auto vnode_replica_hosts = erm->get_natural_replicas(vnode_token, true);
+        locator::tablet_replica_set tablet_replicas;
+        for (auto host : vnode_replica_hosts) {
+            tablet_replicas.push_back(locator::tablet_replica{host, next_shard_for[host]()});
+        }
+        tmap.set_tablet(tablet, locator::tablet_info(std::move(tablet_replicas)));
+    }
+
+    return tmap;
+}
+
 future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) {
     // Called via run_with_no_api_lock (forwards to shard 0).
     SCYLLA_ASSERT(this_shard_id() == 0);
@@ -4031,47 +4073,13 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         // This map will serve as a template for per-table tablet map mutations.
         // Each table in the keyspace receives its own tablet map, but all maps
         // have identical tablet boundaries and replica placement.
-
         const auto& tm = get_token_metadata();
-        const auto& sorted_tokens = tm.sorted_tokens();
-
-        utils::chunked_vector<dht::raw_token> last_tokens;
-        size_t tablet_count = sorted_tokens.size();
-        last_tokens.reserve(tablet_count + 1); // +1 for possible wrapping tablet
-        for (const auto& t : sorted_tokens) {
-            last_tokens.emplace_back(t);
-        }
-        // Add an extra tablet for the wrapping range if needed.
-        auto needs_wrapping_tablet = sorted_tokens.back() != dht::token::last();
-        if (needs_wrapping_tablet) {
-            last_tokens.emplace_back(dht::token::last());
-            tablet_count++;
-        }
-
-        slogger.info("Building tablet maps for tables in keyspace {} with {} tablet(s)", ks_name, tablet_count);
-
-        // Stateful lambdas for round-robin shard assignment per node.
-        std::unordered_map<locator::host_id, std::function<shard_id()>> next_shard_for;
-        tm.for_each_token_owner([&] (const locator::node& node) {
-            auto host = node.host_id();
-            next_shard_for[host] = [num_shards = node.get_shard_count(), idx = 0u]() mutable {
-                return shard_id(idx++ % num_shards);
-            };
-        });
-
         auto erm = ks.get_static_effective_replication_map();
 
-        locator::tablet_map tmap(std::move(last_tokens));
-        for (size_t i = 0; i < tablet_count; ++i) {
-            auto tablet = locator::tablet_id(i);
-            auto vnode_token = needs_wrapping_tablet && i == tablet_count - 1 ? tmap.get_last_token(locator::tablet_id{0}) : tmap.get_last_token(tablet);
-            auto vnode_replica_hosts = erm->get_natural_replicas(vnode_token, true);
-            locator::tablet_replica_set tablet_replicas;
-            for (auto host : vnode_replica_hosts) {
-                tablet_replicas.push_back(locator::tablet_replica{host, next_shard_for[host]()});
-            }
-            tmap.set_tablet(tablet, locator::tablet_info(std::move(tablet_replicas)));
-        }
+        auto tmap = build_tablet_map_for_migration(tm, erm);
+        const auto tablet_count = tmap.tablet_count();
+
+        slogger.info("Built tablet map for tables in keyspace {} with {} tablet(s)", ks_name, tablet_count);
 
         // Build tablet map mutations for all tables and persist them to group0 (system.tablets)
         // in a single command.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4407,6 +4407,48 @@ future<storage_service::keyspace_migration_status> storage_service::get_tablets_
     co_return result;
 }
 
+storage_service::tablets_pow2_convergence_status
+storage_service::get_tablets_pow2_convergence_status(const sstring& ks_name) const {
+    auto& db = _db.local();
+    auto& ks = db.find_keyspace(ks_name);
+
+    if (!ks.uses_tablets()) {
+        throw std::runtime_error(fmt::format("Keyspace '{}' does not use tablets", ks_name));
+    }
+
+    if (!_feature_service.tablet_pow2_convergence) {
+        throw std::runtime_error("TABLET_POW2_CONVERGENCE cluster feature is not enabled");
+    }
+
+    const auto& tm = get_token_metadata();
+    const auto& tablet_metadata = tm.tablets();
+
+    tablets_pow2_convergence_status status;
+    status.tables_converging = 0;
+    status.tables_total = 0;
+
+    for (const auto& schema : ks.metadata()->tables()) {
+        if (!tablet_metadata.has_tablet_map(schema->id())) {
+            continue;
+        }
+        auto& tmap = tablet_metadata.get_tablet_map(schema->id());
+        bool converging = tmap.is_converging_to_pow2();
+
+        status.tables.push_back(table_pow2_convergence_info{
+            .table_name = schema->cf_name(),
+            .converging = converging,
+            .current_tablet_count = tmap.tablet_count(),
+            .target_pow2_tablet_count = tmap.target_pow2_tablet_count(),
+        });
+        status.tables_total++;
+        if (converging) {
+            status.tables_converging++;
+        }
+    }
+
+    return status;
+}
+
 future<> storage_service::finalize_tablets_migration(const sstring& ks_name) {
     // Called via run_with_no_api_lock (forwards to shard 0).
     SCYLLA_ASSERT(this_shard_id() == 0);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4015,6 +4015,45 @@ locator::tablet_map storage_service::build_tablet_map_for_migration(
     return tmap;
 }
 
+future<std::unordered_map<table_id, uint64_t>> storage_service::collect_table_sizes_for_migration(
+    const locator::token_metadata& tm,
+    const locator::tablet_aware_replication_strategy* trs,
+    const std::vector<std::pair<table_id, sstring>>& tables_to_estimate) {
+
+    std::unordered_map<table_id, uint64_t> table_sizes;
+
+    const auto& local_dc = tm.get_topology().get_location().dc;
+    auto local_rf = trs->get_replication_factor(local_dc);
+    if (local_rf == 0) {
+        throw std::runtime_error(fmt::format(
+            "Cannot estimate table sizes for migration: replication factor for local DC '{}' is zero. Try again on a node with a non-zero replication factor.", local_dc));
+    }
+
+    const auto local_host = tm.get_my_id();
+
+    double local_fraction = 0.0;
+    auto token_ownership = dht::token::describe_ownership(tm.sorted_tokens());
+    for (const auto& [tok, fraction] : token_ownership) {
+        if (tm.get_endpoint(tok) == local_host) {
+            local_fraction += fraction;
+        }
+    }
+
+    if (local_fraction <= 0) {
+        throw std::runtime_error(fmt::format(
+            "Cannot estimate table sizes for migration: local token ownership fraction is {}", local_fraction));
+    }
+
+    for (const auto& [tid, ignored_cf_name] : tables_to_estimate) {
+        auto& cf = _db.local().find_column_family(tid);
+        auto local_size = static_cast<uint64_t>(cf.get_stats().live_disk_space_used.on_disk);
+        auto estimated_total_size = static_cast<uint64_t>(local_size / local_fraction) / local_rf;
+        table_sizes.emplace(tid, estimated_total_size);
+    }
+
+    co_return table_sizes;
+}
+
 future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) {
     // Called via run_with_no_api_lock (forwards to shard 0).
     SCYLLA_ASSERT(this_shard_id() == 0);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -1105,6 +1105,7 @@ public:
     friend class tablet_virtual_task;
     friend class topo::global_topology_request_virtual_task;
     friend class vnodes_to_tablets::migration_virtual_task;
+    friend class vnodes_to_tablets::pow2_convergence_virtual_task;
 };
 
 }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -368,6 +368,10 @@ private:
 
     locator::tablet_map build_tablet_map_for_migration(const locator::token_metadata& tm,
             const locator::static_effective_replication_map_ptr& erm) const;
+    future<std::unordered_map<table_id, uint64_t>> collect_table_sizes_for_migration(
+        const locator::token_metadata& tm,
+        const locator::tablet_aware_replication_strategy* trs,
+        const std::vector<std::pair<table_id, sstring>>& tables_to_estimate);
 
     future<mutable_token_metadata_ptr> get_mutable_token_metadata_ptr() noexcept {
         return _shared_token_metadata.get()->clone_async().then([this] (token_metadata tm) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -325,6 +325,19 @@ public:
     future<> set_node_intended_storage_mode(intended_storage_mode mode);
     future<> finalize_tablets_migration(const sstring& ks_name);
 
+    struct table_pow2_convergence_info {
+        sstring table_name;
+        bool converging;
+        size_t current_tablet_count;
+        size_t target_pow2_tablet_count; // 0 means not set
+    };
+    struct tablets_pow2_convergence_status {
+        size_t tables_converging;
+        size_t tables_total;
+        std::vector<table_pow2_convergence_info> tables;
+    };
+    tablets_pow2_convergence_status get_tablets_pow2_convergence_status(const sstring& ks_name) const;
+
     void start_tablet_split_monitor();
 private:
     using acquire_merge_lock = bool_class<class acquire_merge_lock_tag>;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -367,7 +367,8 @@ private:
     future<> snitch_reconfigured();
 
     locator::tablet_map build_tablet_map_for_migration(const locator::token_metadata& tm,
-            const locator::static_effective_replication_map_ptr& erm) const;
+            const locator::static_effective_replication_map_ptr& erm,
+            size_t target_pow2 = 0) const;
     future<std::unordered_map<table_id, uint64_t>> collect_table_sizes_for_migration(
         const locator::token_metadata& tm,
         const locator::tablet_aware_replication_strategy* trs,

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -366,6 +366,9 @@ private:
     void register_metrics();
     future<> snitch_reconfigured();
 
+    locator::tablet_map build_tablet_map_for_migration(const locator::token_metadata& tm,
+            const locator::static_effective_replication_map_ptr& erm) const;
+
     future<mutable_token_metadata_ptr> get_mutable_token_metadata_ptr() noexcept {
         return _shared_token_metadata.get()->clone_async().then([this] (token_metadata tm) {
             // bump the token_metadata ring_version

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -4695,7 +4695,12 @@ private:
     future<tablet_map> merge_tablets(token_metadata_ptr tm, table_id table) {
         auto& tablets = tm->tablets().get_tablet_map(table);
 
-        tablet_map new_tablets(div_ceil(tablets.tablet_count(), 2), tablets.has_raft_info(), tablet_map::initialized_later());
+        auto& merge_plan = std::get<resize_decision::merge>(tablets.resize_decision().way);
+        size_t new_count = merge_plan.selected_left_tablets.empty()
+            ? div_ceil(tablets.tablet_count(), 2)
+            : tablets.tablet_count() - merge_plan.selected_left_tablets.size();
+
+        tablet_map new_tablets(new_count, tablets.has_raft_info(), tablet_map::initialized_later());
 
         std::optional<tablet_id> new_tid = new_tablets.first_tablet();
         co_await tablets.for_each_sibling_tablets([&] (tablet_desc left, std::optional<tablet_desc> right) {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -27,6 +27,7 @@
 #include "locator/load_sketch.hh"
 #include "replica/database.hh"
 #include "gms/feature_service.hh"
+#include <bit>
 #include <iterator>
 #include <ranges>
 #include <utility>

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2185,6 +2185,14 @@ public:
         std::unordered_map<table_id, table_sizing> tables;
     };
 
+    struct new_table_info {
+        schema_ptr schema;
+        const tablet_aware_replication_strategy* rs;
+        // Externally-known data size, if available.
+        // When set, used instead of load_stats_for_table().
+        std::optional<uint64_t> size_in_bytes;
+    };
+
     struct tablet_count_and_reason {
         size_t tablet_count = 0;
         sstring reason;
@@ -2307,7 +2315,7 @@ public:
         };
     }
 
-    future<sizing_plan> make_sizing_plan(schema_ptr new_table = nullptr, const tablet_aware_replication_strategy* new_rs = nullptr) {
+    future<sizing_plan> make_sizing_plan(std::vector<new_table_info> new_tables = {}) {
         std::unordered_map<table_id, const tablet_aware_replication_strategy*> rs_by_table;
         sizing_plan plan;
 
@@ -2322,7 +2330,7 @@ public:
             }
         });
 
-        auto process_table = [&] (table_id table, const locator::table_group_set& tables, schema_ptr s, db::tablet_options tablet_options, const tablet_aware_replication_strategy* rs, size_t tablet_count) {
+        auto process_table = [&] (table_id table, const locator::table_group_set& tables, schema_ptr s, db::tablet_options tablet_options, const tablet_aware_replication_strategy* rs, size_t tablet_count, std::optional<uint64_t> expected_size_opt = std::nullopt) {
             table_sizing& table_plan = plan.tables[table];
             table_plan.current_tablet_count = tablet_count;
             table_plan.pow2_count = tablet_options.pow2_count.value_or(
@@ -2386,7 +2394,11 @@ public:
                 return total_size;
             });
 
-            if (total_size_opt) {
+            if (expected_size_opt) {
+                auto total_size = *expected_size_opt;
+                auto tablet_count_from_size = total_size / target_tablet_size;
+                maybe_apply({tablet_count_from_size, format("new table with size={}", total_size)});
+            } else if (total_size_opt) {
                 auto total_size = *total_size_opt;
 
                 auto cur_decision = _tm->tablets().get_tablet_map(table).resize_decision();
@@ -2458,8 +2470,8 @@ public:
             co_await coroutine::maybe_yield();
         }
 
-        if (new_table) {
-            process_table(new_table->id(), {new_table->id()}, new_table, new_table->tablet_options(), new_rs, 0);
+        for (const auto& nt : new_tables) {
+            process_table(nt.schema->id(), {nt.schema->id()}, nt.schema, nt.schema->tablet_options(), nt.rs, 0, nt.size_in_bytes);
         }
 
         // Below section ensures we respect the _tablets_per_shard_goal.
@@ -4551,7 +4563,7 @@ public:
     tablet_map allocate_tablets_for_new_base_table(const tablet_aware_replication_strategy* tablet_rs, const schema& s) {
         auto tm = _db.get_shared_token_metadata().get();
         auto lb = make_load_balancer(tm, nullptr, nullptr, nullptr, {});
-        auto plan = lb.make_sizing_plan(s.shared_from_this(), tablet_rs).get();
+        auto plan = lb.make_sizing_plan({{s.shared_from_this(), tablet_rs}}).get();
         auto& table_plan = plan.tables[s.id()];
         auto tablet_count = table_plan.target_tablet_count_aligned;
         auto map = tablet_rs->allocate_tablets_for_new_table(s.shared_from_this(), tm, tablet_count).get();

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -4570,6 +4570,39 @@ public:
         return map;
     }
 
+    // Computes per-table target pow2 counts for tables being migrated from
+    // vnodes to tablets.
+    future<target_pow2_per_table_map> compute_migration_target_pow2s(
+            const tablet_aware_replication_strategy* rs,
+            const size_per_table_map& size_per_table) {
+        target_pow2_per_table_map target_pow2s;
+        auto tm_ptr = _db.get_shared_token_metadata().get();
+        auto lb = make_load_balancer(tm_ptr, nullptr, nullptr, nullptr, {});
+
+        std::vector<load_balancer::new_table_info> new_tables;
+        for (const auto& [tid, size] : size_per_table) {
+            auto s = _db.find_column_family(tid).schema();
+            new_tables.push_back({s, rs, size});
+        }
+
+        auto plan = co_await lb.make_sizing_plan(std::move(new_tables));
+
+        auto is_pow2 = [] (size_t n) { return n > 0 && std::has_single_bit(n); };
+
+        for (const auto& [tid, size] : size_per_table) {
+            auto it = plan.tables.find(tid);
+            if (it != plan.tables.end()) {
+                auto target = it->second.target_tablet_count_aligned;
+                if (!is_pow2(target)) {
+                    throw std::runtime_error(format("Invalid target tablet count {} for table {}; must be a power of two", target, tid));
+                }
+                target_pow2s[tid] = target;
+            }
+        }
+
+        co_return target_pow2s;
+    }
+
     // Allocate tablets for multiple new tables, which may be co-located with each other, or co-located with an existing base table.
     void allocate_tablets_for_new_tables(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) {
         utils::get_local_injector().inject("pause_in_allocate_tablets_for_new_table", utils::wait_for_message(std::chrono::minutes(5))).get();
@@ -4815,6 +4848,12 @@ void tablet_allocator::set_use_table_aware_balancing(bool use_tablet_aware_balan
 
 future<locator::tablet_map> tablet_allocator::resize_tablets(locator::token_metadata_ptr tm, table_id table) {
     return impl().resize_tablets(std::move(tm), table);
+}
+
+future<target_pow2_per_table_map> tablet_allocator::compute_migration_target_pow2s(
+        const locator::tablet_aware_replication_strategy* rs,
+        const size_per_table_map& size_per_table) {
+    return impl().compute_migration_target_pow2s(rs, size_per_table);
 }
 
 tablet_allocator_impl& tablet_allocator::impl() {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2175,11 +2175,22 @@ public:
         bool pow2_count; // Whether tablet count for the table should be a power of two.
         bool tablet_merges_allowed; // Whether merges are allowed for the table.
 
+        // Tablet count used only when accounting for the _tablets_per_shard_goal.
+        // For converging tables this is the steady-state target the table is heading
+        // to, not its current (pre-split) count nor the active merge round target.
+        // For all other tables it equals target_tablet_count.
+        size_t target_tablet_count_for_scaling;
+
         // Final tablet count.
         // It's target_tablet_count aligned to power of 2 if pow2_count == true.
         size_t target_tablet_count_aligned;
 
         resize_decision::way_type resize_decision; // Decision which should be emitted to achieve target_tablet_count_aligned.
+
+        bool converging_to_pow2() const {
+            auto* m = std::get_if<locator::resize_decision::merge>(&resize_decision);
+            return m && !m->selected_left_tablets.empty();
+        }
     };
 
     struct sizing_plan {
@@ -2331,25 +2342,36 @@ public:
             }
         });
 
-        auto process_table = [&] (table_id table, const locator::table_group_set& tables, schema_ptr s, db::tablet_options tablet_options, const tablet_aware_replication_strategy* rs, size_t tablet_count, std::optional<uint64_t> expected_size_opt = std::nullopt) {
-            table_sizing& table_plan = plan.tables[table];
-            table_plan.current_tablet_count = tablet_count;
-            table_plan.pow2_count = tablet_options.pow2_count.value_or(
-                    _db.features().arbitrary_tablet_boundaries ? db::tablet_options::default_pow2_count : true);
-            table_plan.tablet_merges_allowed = !s->tablet_merges_forbidden();
-            if (!table_plan.tablet_merges_allowed) {
-                // Block merge decisions for Alternator tablet tables whose
-                // stream configuration forbids merges. Tablet merges produce
-                // 2 parents per child which is incompatible with the DynamoDB
-                // Streams API. If a merge is already in progress on the tmap,
-                // suppressing new_resize_decision here causes the existing
-                // revocation logic in tables_being_resized to cancel the merge.
-                lblogger.debug("Table {} ({}.{}): suppressing new merge decision because tablet merges are forbidden",
-                            table, s->ks_name(), s->cf_name());
+        auto get_total_size = [&] (const locator::table_group_set& tables) -> std::optional<size_t> {
+            size_t total_size = 0;
+            for (auto t : tables) {
+                const auto* table_stats = load_stats_for_table(t);
+                if (!table_stats) {
+                    return std::nullopt;
+                }
+                total_size += table_stats->size_in_bytes;
             }
+            return total_size;
+        };
 
-            rs_by_table[table] = rs;
+        struct sizing_result {
+            tablet_count_and_reason target;
+            std::optional<uint64_t> avg_tablet_size;
+        };
 
+        // Computes the target tablet count for a table from its sizing inputs.
+        //
+        // This is the core sizing logic shared by process_table() and the
+        // _tablets_per_shard_goal accounting for converging tables. It is a pure
+        // computation: it does not write into the plan and does not read the
+        // table's live resize_decision from the tmap. Instead, current_tablet_count
+        // and cur_decision are passed in explicitly, so callers can ask "what would
+        // the target be for this count and decision", e.g. a converging table's
+        // steady-state target (target_pow2 with a none decision).
+        auto compute_target_tablet_count = [&] (table_id table, const locator::table_group_set& tables, const schema_ptr& s,
+                const db::tablet_options& tablet_options, const tablet_aware_replication_strategy* rs,
+                size_t tablet_count, const locator::resize_decision& cur_decision,
+                std::optional<uint64_t> expected_size_opt) -> sizing_result {
             // for a group of co-located tablets of size g with average tablet size t, the migration unit
             // size is g*t. in order to keep the migration unit size reasonable, we set a lower target tablet size
             // as the group size increases.
@@ -2383,17 +2405,8 @@ public:
                 maybe_apply(tablet_count_from_min_per_shard_tablet_count(*s, shards_per_dc, shards_per_rack, *rs, min_per_shard_tablet_count));
             }
 
-            auto total_size_opt = std::invoke([&] -> std::optional<size_t> {
-                size_t total_size = 0;
-                for (auto table : tables) {
-                    const auto* table_stats = load_stats_for_table(table);
-                    if (!table_stats) {
-                        return std::nullopt;
-                    }
-                    total_size += table_stats->size_in_bytes;
-                }
-                return total_size;
-            });
+            auto total_size_opt = get_total_size(tables);
+            sizing_result result;
 
             if (expected_size_opt) {
                 auto total_size = *expected_size_opt;
@@ -2402,9 +2415,8 @@ public:
             } else if (total_size_opt) {
                 auto total_size = *total_size_opt;
 
-                auto cur_decision = _tm->tablets().get_tablet_map(table).resize_decision();
-                auto avg_tablet_size = total_size / std::max<size_t>(table_plan.current_tablet_count * tables.size(), 1);
-                auto tablet_count_from_size = table_plan.current_tablet_count;
+                auto avg_tablet_size = total_size / std::max<size_t>(tablet_count * tables.size(), 1);
+                auto tablet_count_from_size = tablet_count;
 
                 // Split based on avg_tablet_size, or if the current resize_decision is split, apply hysteresis,
                 // so it would get cancelled only when crossing back the half-way point.
@@ -2421,14 +2433,14 @@ public:
                     }
                 }
 
-                table_plan.avg_tablet_size = avg_tablet_size;
+                result.avg_tablet_size = avg_tablet_size;
                 maybe_apply({tablet_count_from_size, format("avg_tablet_size={}", avg_tablet_size)});
             } else {
                 // When we don't have tablet size info, allow tablet count to increase but not to decrease.
                 // Increasing will always bring us closer to the true target count, since tablet_count_from_size
                 // can only increase the count above it, but decreasing may go against the true target count
                 // if tablet_count_from_size would demand more tablets.
-                maybe_apply({table_plan.current_tablet_count, "current count"});
+                maybe_apply({tablet_count, "current count"});
             }
 
             // Apply max_tablet_count cap after all other factors have been considered.
@@ -2445,11 +2457,101 @@ public:
                 target_tablet_count = {size, "force_tablet_count_decrease"};
             }
 
-            table_plan.target_tablet_count = target_tablet_count.tablet_count;
-            table_plan.target_tablet_count_reason = target_tablet_count.reason;
+            result.target = target_tablet_count;
+            return result;
+        };
+
+        auto process_table = [&] (table_id table, const locator::table_group_set& tables, schema_ptr s, db::tablet_options tablet_options, const tablet_aware_replication_strategy* rs, size_t tablet_count, std::optional<uint64_t> expected_size_opt = std::nullopt) {
+            table_sizing& table_plan = plan.tables[table];
+            table_plan.current_tablet_count = tablet_count;
+            table_plan.pow2_count = tablet_options.pow2_count.value_or(
+                    _db.features().arbitrary_tablet_boundaries ? db::tablet_options::default_pow2_count : true);
+            table_plan.tablet_merges_allowed = !s->tablet_merges_forbidden();
+            if (!table_plan.tablet_merges_allowed) {
+                // Block merge decisions for Alternator tablet tables whose
+                // stream configuration forbids merges. Tablet merges produce
+                // 2 parents per child which is incompatible with the DynamoDB
+                // Streams API. If a merge is already in progress on the tmap,
+                // suppressing new_resize_decision here causes the existing
+                // revocation logic in tables_being_resized to cancel the merge.
+                lblogger.debug("Table {} ({}.{}): suppressing new merge decision because tablet merges are forbidden",
+                            table, s->ks_name(), s->cf_name());
+            }
+
+            rs_by_table[table] = rs;
+
+            locator::resize_decision cur_decision;
+            if (_tm->tablets().has_tablet_map(table)) {
+                cur_decision = _tm->tablets().get_tablet_map(table).resize_decision();
+            }
+
+            auto [target_tablet_count_and_reason, avg_tablet_size] = compute_target_tablet_count(
+                    table, tables, s, tablet_options, rs, tablet_count, cur_decision, expected_size_opt);
+
+            table_plan.target_tablet_count = target_tablet_count_and_reason.tablet_count;
+            table_plan.target_tablet_count_reason = target_tablet_count_and_reason.reason;
+            table_plan.target_tablet_count_for_scaling = target_tablet_count_and_reason.tablet_count;
+            if (avg_tablet_size) {
+                table_plan.avg_tablet_size = avg_tablet_size;
+            }
 
             lblogger.debug("Table {} ({}.{}) target_tablet_count: {} ({}), pow2_count: {}, opt: {}", table, s->ks_name(), s->cf_name(),
                     table_plan.target_tablet_count, table_plan.target_tablet_count_reason, table_plan.pow2_count, tablet_options.to_map());
+        };
+
+        // Produce a sizing plan for tables converging to pow2 layout.
+        // Unlike process_table(), the merge decision is a selective merge based on token boundaries, not a full merge based on average tablet size.
+        // avg_tablet_size is computed only for urgency ordering in make_resize_plan().
+        auto process_converging_table = [&] (table_id table, const locator::table_group_set& tables, schema_ptr s, db::tablet_options tablet_options, const tablet_aware_replication_strategy* rs, const tablet_map& tmap) {
+            size_t target_pow2 = tmap.target_pow2_tablet_count();
+            if (!std::has_single_bit(target_pow2)) {
+                lblogger.error("Table {} ({}.{}) has target_pow2_tablet_count={} which is not a power of two; skipping pow2 convergence",
+                        table, s->ks_name(), s->cf_name(), target_pow2);
+                return;
+            }
+            if (target_pow2 >= tmap.tablet_count()) {
+                lblogger.error("Table {} ({}.{}) has target_pow2_tablet_count={} which is not less than the current tablet count={}; skipping pow2 convergence",
+                        table, s->ks_name(), s->cf_name(), target_pow2, tmap.tablet_count());
+                return;
+            }
+            if (s->tablet_merges_forbidden()) {
+                lblogger.debug("Table {} ({}.{}): suppressing pow2 convergence merge decision because tablet merges are forbidden",
+                        table, s->ks_name(), s->cf_name());
+                return;
+            }
+
+            table_sizing& table_plan = plan.tables[table];
+            table_plan.current_tablet_count = tmap.tablet_count();
+            table_plan.pow2_count = true;
+
+            rs_by_table[table] = rs;
+
+            auto total_size_opt = get_total_size(tables);
+            if (total_size_opt) {
+                table_plan.avg_tablet_size = *total_size_opt / std::max<size_t>(tmap.tablet_count() * tables.size(), 1);
+            }
+
+            auto selected = select_tablets_for_pow2_merge(tmap);
+            table_plan.target_tablet_count = tmap.tablet_count() - selected.size();
+            table_plan.target_tablet_count_reason = "pow2_convergence";
+            table_plan.target_tablet_count_aligned = table_plan.target_tablet_count;
+            if (!selected.empty()) {
+                table_plan.resize_decision = resize_decision::merge{.selected_left_tablets = std::move(selected)};
+            }
+
+            // For the _tablets_per_shard_goal accounting, count the converging table
+            // with the steady-state pow2 target it is heading to, not its inflated
+            // current tablet count nor the active merge round target.
+            auto result = compute_target_tablet_count(
+                    table, tables, s, tablet_options, rs, target_pow2, locator::resize_decision{}, std::nullopt);
+            table_plan.target_tablet_count_for_scaling = result.target.tablet_count;
+
+            lblogger.debug("Table {} ({}.{}) current_tablet_count: {}, target_tablet_count: {} ({}), target_tablet_count_for_scaling: {}",
+                    table, s->ks_name(), s->cf_name(),
+                    table_plan.current_tablet_count,
+                    table_plan.target_tablet_count,
+                    table_plan.target_tablet_count_reason,
+                    table_plan.target_tablet_count_for_scaling);
         };
 
         for (const auto& [table, tables] : _tm->tablets().all_table_groups()) {
@@ -2461,13 +2563,18 @@ public:
             if (s == nullptr || rs == nullptr) {
                 continue;
             }
+
             auto tablet_options = combine_tablet_options(
                     tables | std::views::transform([&] (table_id table) { return _db.get_tables_metadata().get_table_if_exists(table); })
                            | std::views::filter([] (auto t) { return t != nullptr; })
                            | std::views::transform([] (auto t) { return t->schema()->tablet_options(); })
             );
 
-            process_table(table, tables, s, tablet_options, rs, tmap.tablet_count());
+            if (tmap.is_converging_to_pow2()) {
+                process_converging_table(table, tables, s, tablet_options, rs, tmap);
+            } else {
+                process_table(table, tables, s, tablet_options, rs, tmap.tablet_count());
+            }
             co_await coroutine::maybe_yield();
         }
 
@@ -2531,7 +2638,7 @@ public:
                 cur_avg_tablets_per_shard += cur_tablets_per_shard;
                 lblogger.debug("cur_avg_tablets_per_shard [dc={}, rack={}, table={}]: {:.3f}", rack.dc, rack.rack, table, cur_tablets_per_shard);
 
-                auto new_tablets_per_shard = get_avg_tablets_per_shard(table_plan.target_tablet_count);
+                auto new_tablets_per_shard = get_avg_tablets_per_shard(table_plan.target_tablet_count_for_scaling);
                 new_avg_tablets_per_shard += new_tablets_per_shard;
                 lblogger.debug("new_avg_tablets_per_shard [dc={}, rack={}, table={}]: {:.3f}", rack.dc, rack.rack, table, new_tablets_per_shard);
             }
@@ -2550,6 +2657,11 @@ public:
                 auto scale = scale_info{_tablets_per_shard_goal / new_avg_tablets_per_shard, rack};
 
                 for (auto&& [table, table_plan]: plan.tables) {
+                    // Tables converging to powers of two have a fixed merge trajectory;
+                    // scaling them would interfere with it.
+                    if (table_plan.converging_to_pow2()) {
+                        continue;
+                    }
                     auto* rs = rs_by_table[table];
                     auto rf = rs->get_replication_factor_data(rack.dc);
 
@@ -2582,6 +2694,12 @@ public:
         //   table_plan.resize_decision
 
         for (auto&& [table, table_plan] : plan.tables) {
+            // Converging tables already have their resize decision and aligned
+            // tablet count set by process_converging_table().
+            if (table_plan.converging_to_pow2()) {
+                continue;
+            }
+
             if (!table_plan.pow2_count) {
                 table_plan.target_tablet_count_aligned = table_plan.target_tablet_count;
             } else {
@@ -2614,6 +2732,36 @@ public:
         }
 
         co_return std::move(plan);
+    }
+
+    // Selects pairs of adjacent tablets that can be merged without crossing
+    // a target pow2 boundary. Returns a vector of left tablet IDs.
+    static std::vector<tablet_id> select_tablets_for_pow2_merge(const tablet_map& tmap) {
+        size_t tablet_count = tmap.tablet_count();
+        size_t target_tablet_count = tmap.target_pow2_tablet_count();
+        std::vector<tablet_id> selected;
+
+        if (target_tablet_count == 1) {
+            for (size_t i = 0; i + 1 < tablet_count; i += 2) {
+                selected.push_back(tablet_id(i));
+            }
+            return selected;
+        }
+
+        // Number of bits to shift an unbiased token to get its pow2 segment index.
+        // target_tablet_count is a power of two, so each segment spans 2^shift tokens.
+        unsigned shift = 64 - log2ceil(target_tablet_count);
+
+        for (size_t i = 0; i + 1 < tablet_count; ++i) {
+            uint64_t left_start = tmap.get_first_token(tablet_id(i)).unbias();
+            uint64_t right_end = tmap.get_last_token(tablet_id(i + 1)).unbias();
+            // Same segment if they don't cross a pow2 boundary
+            if ((left_start >> shift) == (right_end >> shift)) {
+                selected.push_back(tablet_id(i));
+                ++i; // skip right tablet (non-overlapping pairs)
+            }
+        }
+        return selected;
     }
 
     future<table_resize_plan> make_resize_plan(const migration_plan& plan) {
@@ -4794,6 +4942,16 @@ private:
 
         lblogger.info("Merge tablets for table {}, decreasing tablet count from {} to {}",
                       table, tablets.tablet_count(), new_tablets.tablet_count());
+
+        if (tablets.is_converging_to_pow2()) {
+            auto target_pow2 = tablets.target_pow2_tablet_count();
+            new_tablets.set_target_pow2_tablet_count(target_pow2);
+            if (new_tablets.tablet_count() == target_pow2 && new_tablets.get_layout() == locator::tablet_layout::pow_of_2) {
+                lblogger.info("Table {} reached pow2 layout with {} tablets, clearing pow2 target", table, new_tablets.tablet_count());
+                new_tablets.set_target_pow2_tablet_count(0);
+            }
+        }
+
         co_return std::move(new_tablets);
     }
 public:

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -20,6 +20,10 @@ namespace db {
 class system_keyspace;
 }
 
+namespace locator {
+class tablet_aware_replication_strategy;
+}
+
 namespace service {
 
 class topology;
@@ -127,6 +131,8 @@ public:
 };
 
 using tablet_migration_info = locator::tablet_migration_info;
+using size_per_table_map = std::unordered_map<table_id, uint64_t>;
+using target_pow2_per_table_map = std::unordered_map<table_id, size_t>;
 
 /// Represents intention to emit resize (split or merge) request for a
 /// table, and finalize or revoke the request previously initiated.
@@ -350,6 +356,15 @@ public:
     void set_use_table_aware_balancing(bool);
 
     future<locator::tablet_map> resize_tablets(locator::token_metadata_ptr, table_id);
+
+    /// Computes target power-of-two tablet counts for tables being migrated from
+    /// vnodes to tablets.
+    ///
+    /// Uses make_sizing_plan() to determine target pow2 counts per table based on
+    /// per-table size estimates and replication strategy.
+    future<target_pow2_per_table_map> compute_migration_target_pow2s(
+        const locator::tablet_aware_replication_strategy* rs,
+        const size_per_table_map& size_per_table);
 
     /// Should be called when the node is no longer a leader.
     void on_leadership_lost();

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -16,6 +16,7 @@
 #include "tasks/task_handler.hh"
 #include "tasks/virtual_task_hint.hh"
 #include "utils/UUID_gen.hh"
+#include <cmath>
 #include <seastar/coroutine/maybe_yield.hh>
 
 namespace service {
@@ -342,6 +343,9 @@ future<std::optional<status_helper>> tablet_virtual_task::get_status_helper(task
             update_status(task_info, res.status, sched_nr);
             res.status.state = tasks::task_manager::task_state::running;
             res.status.children = task_type == locator::tablet_task_type::split ? co_await get_children(get_module(), id, _ss.get_token_metadata_ptr()) : utils::chunked_vector<tasks::task_identity>{};
+            if (task_type == locator::tablet_task_type::merge && tmap.is_converging_to_pow2()) {
+                res.status.parent_id = vnodes_to_tablets::pow2_convergence_virtual_task::make_table_task_id(schema->ks_name(), schema->cf_name());
+            }
             co_return res;
         }
     }
@@ -657,6 +661,362 @@ future<std::vector<tasks::task_stats>> migration_virtual_task::get_stats() {
         result.push_back(make_task_stats(make_task_id(ks_name), ks_name));
     }
     co_return result;
+}
+
+// pow2_convergence_virtual_task
+
+tasks::task_id pow2_convergence_virtual_task::make_ks_task_id(const sstring& keyspace) {
+    auto uuid = utils::UUID_gen::get_name_UUID("pow2_convergence:" + keyspace);
+    return tasks::task_id{uuid};
+}
+
+tasks::task_id pow2_convergence_virtual_task::make_table_task_id(const sstring& keyspace, const sstring& table) {
+    auto uuid = utils::UUID_gen::get_name_UUID("pow2_convergence:" + keyspace + ":" + table);
+    return tasks::task_id{uuid};
+}
+
+tasks::task_stats pow2_convergence_virtual_task::make_task_stats(tasks::task_id id,
+        const sstring& keyspace, const sstring& table,
+        const sstring& scope, const sstring& entity) {
+    return tasks::task_stats{
+        .task_id = id,
+        .type = "pow2_convergence",
+        .kind = tasks::task_kind::cluster,
+        .scope = scope,
+        .state = tasks::task_manager::task_state::running,
+        .sequence_number = 0,
+        .keyspace = keyspace,
+        .table = table,
+        .entity = entity,
+        .shard = 0,
+        .start_time = {},
+        .end_time = {},
+    };
+}
+
+tasks::task_status pow2_convergence_virtual_task::make_task_status(tasks::task_id id,
+        const sstring& keyspace, const sstring& table, const sstring& scope,
+        tasks::task_manager::task_state state,
+        tasks::task_manager::task::progress progress,
+        const sstring& progress_units, const sstring& entity,
+        tasks::task_id parent_id,
+        utils::chunked_vector<tasks::task_identity> children) {
+    auto stats = make_task_stats(id, keyspace, table, scope, entity);
+    return tasks::task_status{
+        .task_id = stats.task_id,
+        .type = stats.type,
+        .kind = stats.kind,
+        .scope = stats.scope,
+        .state = state,
+        .is_abortable = tasks::is_abortable::no,
+        .start_time = stats.start_time,
+        .end_time = stats.end_time,
+        .parent_id = parent_id,
+        .sequence_number = stats.sequence_number,
+        .shard = stats.shard,
+        .keyspace = stats.keyspace,
+        .table = stats.table,
+        .entity = stats.entity,
+        .progress_units = progress_units,
+        .progress = progress,
+        .children = std::move(children),
+    };
+}
+
+std::optional<pow2_convergence_virtual_task::table_match>
+pow2_convergence_virtual_task::find_converging_table_for_task_id(tasks::task_id id) const {
+    auto& db = _ss._db.local();
+    const auto& tablet_metadata = _ss.get_token_metadata().tablets();
+    for (const auto& ks_name : db.get_all_keyspaces()) {
+        auto& ks = db.find_keyspace(ks_name);
+        if (!ks.uses_tablets()) {
+            continue;
+        }
+        for (const auto& schema : ks.metadata()->tables()) {
+            if (!tablet_metadata.has_tablet_map(schema->id())) {
+                continue;
+            }
+            auto& tmap = tablet_metadata.get_tablet_map(schema->id());
+            if (!tmap.is_converging_to_pow2()) {
+                continue;
+            }
+            if (make_table_task_id(ks_name, schema->cf_name()) == id) {
+                return table_match{ks_name, schema->cf_name(), schema->id()};
+            }
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<sstring>
+pow2_convergence_virtual_task::find_converging_ks_for_task_id(tasks::task_id id) const {
+    auto& db = _ss._db.local();
+    const auto& tablet_metadata = _ss.get_token_metadata().tablets();
+    for (const auto& ks_name : db.get_all_keyspaces()) {
+        auto& ks = db.find_keyspace(ks_name);
+        if (!ks.uses_tablets()) {
+            continue;
+        }
+        bool has_converging_table = false;
+        for (const auto& schema : ks.metadata()->tables()) {
+            if (!tablet_metadata.has_tablet_map(schema->id())) {
+                continue;
+            }
+            if (tablet_metadata.get_tablet_map(schema->id()).is_converging_to_pow2()) {
+                has_converging_table = true;
+                break;
+            }
+        }
+        if (!has_converging_table) {
+            continue;
+        }
+        if (make_ks_task_id(ks_name) == id) {
+            return ks_name;
+        }
+    }
+    return std::nullopt;
+}
+
+tasks::task_manager::task_group pow2_convergence_virtual_task::get_group() const noexcept {
+    return tasks::task_manager::task_group::pow2_convergence_group;
+}
+
+future<std::optional<tasks::virtual_task_hint>> pow2_convergence_virtual_task::contains(tasks::task_id task_id) const {
+    if (!task_id.uuid().is_name_based()) {
+        co_return std::nullopt;
+    }
+    // Try as a table-level task first.
+    auto table_match = find_converging_table_for_task_id(task_id);
+    if (table_match) {
+        co_return tasks::virtual_task_hint{
+            .table_id = table_match->id,
+            .keyspace_name = table_match->keyspace,
+        };
+    }
+    // Try as a keyspace-level task.
+    auto ks_name = find_converging_ks_for_task_id(task_id);
+    if (ks_name) {
+        co_return tasks::virtual_task_hint{.keyspace_name = *ks_name};
+    }
+    co_return std::nullopt;
+}
+
+future<std::vector<tasks::task_stats>> pow2_convergence_virtual_task::get_stats() {
+    std::vector<tasks::task_stats> result;
+    auto& db = _ss._db.local();
+    const auto& tablet_metadata = _ss.get_token_metadata().tablets();
+
+    for (const auto& ks_name : db.get_all_keyspaces()) {
+        auto& ks = db.find_keyspace(ks_name);
+        if (!ks.uses_tablets()) {
+            continue;
+        }
+        bool has_converging_table = false;
+        for (const auto& schema : ks.metadata()->tables()) {
+            if (!tablet_metadata.has_tablet_map(schema->id())) {
+                continue;
+            }
+            auto& tmap = tablet_metadata.get_tablet_map(schema->id());
+            if (!tmap.is_converging_to_pow2()) {
+                continue;
+            }
+            has_converging_table = true;
+            auto target = tmap.target_pow2_tablet_count();
+            auto current = tmap.tablet_count();
+            result.push_back(make_task_stats(
+                make_table_task_id(ks_name, schema->cf_name()),
+                ks_name, schema->cf_name(), "table",
+                fmt::format("{} tablets (target: {})", current, target)));
+        }
+        if (has_converging_table) {
+            result.push_back(make_task_stats(
+                make_ks_task_id(ks_name), ks_name, "", "keyspace", ""));
+        }
+    }
+    co_return result;
+}
+
+future<std::optional<tasks::task_status>> pow2_convergence_virtual_task::get_status(tasks::task_id id, tasks::virtual_task_hint hint) {
+    auto& ks_name = hint.keyspace_name;
+    if (!ks_name) {
+        co_return std::nullopt;
+    }
+
+    auto& db = _ss._db.local();
+    const auto& tablet_metadata = _ss.get_token_metadata().tablets();
+    auto my_id = _ss.get_token_metadata().get_my_id();
+
+    if (hint.table_id) {
+        // Table-level task.
+        auto tid = *hint.table_id;
+        if (!tablet_metadata.has_tablet_map(tid)) {
+            co_return std::nullopt;
+        }
+        auto& tmap = tablet_metadata.get_tablet_map(tid);
+        if (!tmap.is_converging_to_pow2()) {
+            co_return std::nullopt;
+        }
+
+        auto table_ptr = db.get_tables_metadata().get_table_if_exists(tid);
+        if (!table_ptr) {
+            co_return std::nullopt;
+        }
+        auto schema = table_ptr->schema();
+        auto target = tmap.target_pow2_tablet_count();
+        auto current = tmap.tablet_count();
+        double pct = std::round(static_cast<double>(target) * 100.0 / static_cast<double>(current));
+        auto entity = fmt::format("{} tablets (target: {})", current, target);
+
+        // Check for active merge task as child.
+        utils::chunked_vector<tasks::task_identity> children;
+        auto& task_info = tmap.resize_task_info();
+        if (task_info.is_valid() && task_info.request_type == locator::tablet_task_type::merge) {
+            children.push_back(tasks::task_identity{
+                .host_id = my_id,
+                .task_id = tasks::task_id{task_info.tablet_task_id.uuid()},
+            });
+        }
+
+        co_return make_task_status(id, *ks_name, schema->cf_name(), "table",
+            tasks::task_manager::task_state::running, {pct, 100},
+            "percent", entity, make_ks_task_id(*ks_name), std::move(children));
+    }
+
+    // Keyspace-level task.
+    auto& ks = db.find_keyspace(*ks_name);
+    if (!ks.uses_tablets()) {
+        co_return std::nullopt;
+    }
+
+    double tables_converging = 0;
+    double tables_total = 0;
+    utils::chunked_vector<tasks::task_identity> children;
+
+    for (const auto& schema : ks.metadata()->tables()) {
+        if (!tablet_metadata.has_tablet_map(schema->id())) {
+            continue;
+        }
+        auto& tmap = tablet_metadata.get_tablet_map(schema->id());
+        if (!tmap.is_converging_to_pow2()) {
+            continue;
+        }
+        tables_total++;
+        children.push_back(tasks::task_identity{
+            .host_id = my_id,
+            .task_id = make_table_task_id(*ks_name, schema->cf_name()),
+        });
+    }
+
+    if (tables_total == 0) {
+        co_return std::nullopt;
+    }
+
+    co_return make_task_status(id, *ks_name, "", "keyspace",
+        tasks::task_manager::task_state::running, {tables_converging, tables_total},
+        "tables", "", tasks::task_id::create_null_id(), std::move(children));
+}
+
+future<std::optional<tasks::task_status>> pow2_convergence_virtual_task::wait(tasks::task_id id, tasks::virtual_task_hint hint) {
+    auto& ks_name = hint.keyspace_name;
+    if (!ks_name) {
+        co_return std::nullopt;
+    }
+
+    auto& db = _ss._db.local();
+    tasks::tmlogger.info("pow2_convergence_virtual_task: waiting for pow2 convergence to finish: task_id={}, keyspace={}", id, *ks_name);
+
+    if (hint.table_id) {
+        // Table-level wait: wait until this table's target_pow2 becomes 0.
+        auto tid = *hint.table_id;
+        while (true) {
+            auto tmptr = _ss.get_token_metadata_ptr();
+            if (!tmptr->tablets().has_tablet_map(tid)) {
+                // Table was deleted.
+                co_return std::nullopt;
+            }
+            if (!tmptr->tablets().get_tablet_map(tid).is_converging_to_pow2()) {
+                break;
+            }
+            co_await _ss._topology_state_machine.event.wait();
+        }
+
+        auto table_ptr = db.get_tables_metadata().get_table_if_exists(tid);
+        sstring table_name = table_ptr ? table_ptr->schema()->cf_name() : "";
+
+        auto status = make_task_status(id, *ks_name, table_name, "table",
+            tasks::task_manager::task_state::done, {100, 100},
+            "percent", "", make_ks_task_id(*ks_name), {});
+        status.end_time = db_clock::now();
+        co_return status;
+    }
+
+    // Keyspace-level wait: wait until all tracked tables have finished converging.
+    // Record the initial set of converging tables so that we can report progress in task status.
+    std::set<table_id> tracked_tables;
+    {
+        if (!db.has_keyspace(*ks_name)) {
+            co_return std::nullopt;
+        }
+        auto& ks = db.find_keyspace(*ks_name);
+        const auto& tablet_metadata = _ss.get_token_metadata().tablets();
+        for (const auto& schema : ks.metadata()->tables()) {
+            if (!tablet_metadata.has_tablet_map(schema->id())) {
+                continue;
+            }
+            if (tablet_metadata.get_tablet_map(schema->id()).is_converging_to_pow2()) {
+                tracked_tables.insert(schema->id());
+            }
+        }
+    }
+
+    if (tracked_tables.empty()) {
+        co_return std::nullopt;
+    }
+
+    double tables_total = tracked_tables.size();
+
+    while (true) {
+        auto tmptr = _ss.get_token_metadata_ptr();
+        const auto& tablet_metadata = tmptr->tablets();
+        double tables_completed = 0;
+
+        for (auto it = tracked_tables.begin(); it != tracked_tables.end(); ) {
+            if (!tablet_metadata.has_tablet_map(*it)) {
+                // Table was deleted.
+                it = tracked_tables.erase(it);
+                tables_total--;
+            } else if (!tablet_metadata.get_tablet_map(*it).is_converging_to_pow2()) {
+                // Convergence finished for this table.
+                tables_completed++;
+                ++it;
+            } else {
+                // Table is still converging.
+                ++it;
+            }
+        }
+
+        if (tables_total == 0) {
+            // All tracked tables were deleted.
+            co_return std::nullopt;
+        }
+
+        if (tables_completed == tables_total) {
+            break;
+        }
+
+        co_await _ss._topology_state_machine.event.wait();
+    }
+
+    auto status = make_task_status(id, *ks_name, "", "keyspace",
+        tasks::task_manager::task_state::done, {tables_total, tables_total},
+        "tables", "", tasks::task_id::create_null_id(), {});
+    status.end_time = db_clock::now();
+    co_return status;
+}
+
+future<> pow2_convergence_virtual_task::abort(tasks::task_id id, tasks::virtual_task_hint hint) noexcept {
+    // Pow2 convergence cannot be aborted.
+    return make_ready_future<>();
 }
 
 task_manager_module::task_manager_module(tasks::task_manager& tm, service::storage_service& ss) noexcept

--- a/service/task_manager_module.hh
+++ b/service/task_manager_module.hh
@@ -110,6 +110,44 @@ private:
             tasks::task_manager::task::progress progress);
 };
 
+class pow2_convergence_virtual_task : public tasks::task_manager::virtual_task::impl {
+private:
+    service::storage_service& _ss;
+public:
+    pow2_convergence_virtual_task(tasks::task_manager::module_ptr module,
+            service::storage_service& ss)
+        : tasks::task_manager::virtual_task::impl(std::move(module))
+        , _ss(ss)
+    {}
+    virtual tasks::task_manager::task_group get_group() const noexcept override;
+    virtual future<std::optional<tasks::virtual_task_hint>> contains(tasks::task_id task_id) const override;
+
+    virtual future<std::optional<tasks::task_status>> get_status(tasks::task_id id, tasks::virtual_task_hint hint) override;
+    virtual future<std::optional<tasks::task_status>> wait(tasks::task_id id, tasks::virtual_task_hint hint) override;
+    virtual future<> abort(tasks::task_id id, tasks::virtual_task_hint hint) noexcept override;
+    virtual future<std::vector<tasks::task_stats>> get_stats() override;
+
+    static tasks::task_id make_ks_task_id(const sstring& keyspace);
+    static tasks::task_id make_table_task_id(const sstring& keyspace, const sstring& table);
+private:
+    struct table_match {
+        sstring keyspace;
+        sstring table;
+        table_id id;
+    };
+    std::optional<table_match> find_converging_table_for_task_id(tasks::task_id id) const;
+    std::optional<sstring> find_converging_ks_for_task_id(tasks::task_id id) const;
+    static tasks::task_stats make_task_stats(tasks::task_id id, const sstring& keyspace,
+            const sstring& table, const sstring& scope, const sstring& entity);
+    static tasks::task_status make_task_status(tasks::task_id id, const sstring& keyspace,
+            const sstring& table, const sstring& scope,
+            tasks::task_manager::task_state state,
+            tasks::task_manager::task::progress progress,
+            const sstring& progress_units, const sstring& entity,
+            tasks::task_id parent_id,
+            utils::chunked_vector<tasks::task_identity> children);
+};
+
 class task_manager_module : public tasks::task_manager::module {
 private:
     service::storage_service& _ss;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -115,6 +115,7 @@ public:
         tablets_group,
         global_topology_change_group,
         vnodes_to_tablets_migration_group,
+        pow2_convergence_group,
     };
 
     class task : public enable_lw_shared_from_this<task> {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -680,6 +680,51 @@ SEASTAR_THREAD_TEST_CASE(test_siblings) {
             { tablet_id(4), std::nullopt }
         }));
     }
+
+    // Selective merge (first tablet is singleton, last tablet is a pair, has singletons and pairs in between)
+    {
+        tablet_map tmap(9);
+        tmap.set_resize_decision(locator::resize_decision{
+            locator::resize_decision::merge{ .selected_left_tablets = {tablet_id(1), tablet_id(5), tablet_id(7)} },
+            1
+        });
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(0)) == std::make_pair(tablet_id(0), std::nullopt));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(1)) == std::make_pair(tablet_id(1), tablet_id(2)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(2)) == std::make_pair(tablet_id(1), tablet_id(2)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(3)) == std::make_pair(tablet_id(3), std::nullopt));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(4)) == std::make_pair(tablet_id(4), std::nullopt));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(5)) == std::make_pair(tablet_id(5), tablet_id(6)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(6)) == std::make_pair(tablet_id(5), tablet_id(6)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(7)) == std::make_pair(tablet_id(7), tablet_id(8)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(8)) == std::make_pair(tablet_id(7), tablet_id(8)));
+        BOOST_REQUIRE(get_siblings(tmap) == sibling_map({
+            { tablet_id(0), std::nullopt },
+            { tablet_id(1), tablet_id(2) },
+            { tablet_id(3), std::nullopt },
+            { tablet_id(4), std::nullopt },
+            { tablet_id(5), tablet_id(6) },
+            { tablet_id(7), tablet_id(8) }
+        }));
+    }
+
+    // Selective merge (first tablet is a pair, last tablet is a singleton)
+    {
+        tablet_map tmap(5);
+        tmap.set_resize_decision(locator::resize_decision{
+            locator::resize_decision::merge{ .selected_left_tablets = {tablet_id(0), tablet_id(2)} },
+            1
+        });
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(0)) == std::make_pair(tablet_id(0), tablet_id(1)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(1)) == std::make_pair(tablet_id(0), tablet_id(1)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(2)) == std::make_pair(tablet_id(2), tablet_id(3)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(3)) == std::make_pair(tablet_id(2), tablet_id(3)));
+        BOOST_REQUIRE(tmap.sibling_tablets(tablet_id(4)) == std::make_pair(tablet_id(4), std::nullopt));
+        BOOST_REQUIRE(get_siblings(tmap) == sibling_map({
+            { tablet_id(0), tablet_id(1) },
+            { tablet_id(2), tablet_id(3) },
+            { tablet_id(4), std::nullopt }
+        }));
+    }
 }
 
 SEASTAR_THREAD_TEST_CASE(test_invalid_colocated_tables) {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -7599,4 +7599,134 @@ SEASTAR_THREAD_TEST_CASE(test_migration_target_pow2_from_size) {
     }, std::move(cfg)).get();
 }
 
+// Verify that a converging table does not cause unrelated tables to be
+// scaled down via the per-shard-goal mechanism.
+//
+// During pow2 convergence a table temporarily carries an inflated tablet
+// count (vnode boundaries + pow2 boundaries). If the per-shard-goal
+// accounting naively uses this inflated count, it will incorrectly conclude
+// the cluster is overloaded and scale down other tables.
+//
+// The fix accounts converging tables at their steady-state pow2 target
+// (via target_tablet_count_for_scaling). This test verifies that a
+// non-converging table in a separate keyspace is not resized during the
+// entire convergence of a second table.
+SEASTAR_THREAD_TEST_CASE(test_pow2_convergence_does_not_trigger_scale_down) {
+    cql_test_config cfg;
+    cfg.need_remote_proxy = true;
+    cfg.db_config->tablets_per_shard_goal.set(10);
+    do_with_cql_env_thread([] (auto& e) {
+        const int rf = 1;
+        const unsigned shard_count = 1;
+
+        // Build the topology: 1 node, 1 shard.
+        topology_builder topo(e);
+        auto host = topo.add_node(node_state::normal, shard_count);
+
+        // Create two keyspaces with one table each.
+        // Table A: non-converging, stable at 4 tablets.
+        // Table B: converging, starts at 32 tablets with target_pow2 = 4.
+        auto ks_a = add_keyspace(e, {{topo.dc(), rf}});
+        auto table_a = add_table(e, ks_a).get();
+
+        auto ks_b = add_keyspace(e, {{topo.dc(), rf}});
+        auto table_b = add_table(e, ks_b).get();
+
+        auto& stm = e.shared_token_metadata().local();
+        const size_t table_a_tablet_count = 4;
+        const size_t table_b_tablet_count = 32;
+        const size_t target_pow2_b = 4;
+
+        // Set up Table A with a stable 4-tablet pow2 map.
+        mutate_tablets(e, [&](tablet_metadata& tmeta) -> future<> {
+            auto boundaries = dht::get_uniform_tokens(table_a_tablet_count);
+            tablet_map tmap(std::move(boundaries));
+            for (auto tid : tmap.tablet_ids()) {
+                tmap.set_tablet(tid, tablet_info{tablet_replica_set{{tablet_replica{host, shard_id(tid.value() % shard_count)}}}});
+            }
+            tmeta.set_tablet_map(table_a, std::move(tmap));
+            co_return;
+        });
+
+        mutate_tablets(e, [&](tablet_metadata& tmeta) -> future<> {
+            auto boundaries = dht::get_uniform_tokens(table_b_tablet_count);
+            tablet_map tmap(std::move(boundaries));
+            for (auto tid : tmap.tablet_ids()) {
+                tmap.set_tablet(tid, tablet_info{tablet_replica_set{{tablet_replica{host, shard_id(0)}}}});
+            }
+            tmap.set_target_pow2_tablet_count(target_pow2_b);
+            tmeta.set_tablet_map(table_b, std::move(tmap));
+            co_return;
+        });
+
+        // Verify initial state.
+        {
+            auto& tmap_a = stm.get()->tablets().get_tablet_map(table_a);
+            BOOST_REQUIRE_EQUAL(tmap_a.tablet_count(), table_a_tablet_count);
+            auto& tmap_b = stm.get()->tablets().get_tablet_map(table_b);
+            BOOST_REQUIRE_EQUAL(tmap_b.tablet_count(), table_b_tablet_count);
+            BOOST_REQUIRE(tmap_b.is_converging_to_pow2());
+        }
+
+        // Lower "initial" tablets so it doesn't force splits after convergence.
+        e.execute_cql(fmt::format("alter keyspace {} with tablets = {{'enabled': true, 'initial': 1}}", ks_a)).get();
+        e.execute_cql(fmt::format("alter keyspace {} with tablets = {{'enabled': true, 'initial': 1}}", ks_b)).get();
+
+        // Set load stats so both tables are at ideal avg tablet size (no
+        // size-based resize pressure). Use target_pow2 as the effective
+        // number of tablets for sizing Table B's total size.
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
+        load_stats.set_default_tablet_sizes(stm.get());
+        load_stats.set_size(table_a, service::default_target_tablet_size * table_a_tablet_count);
+        load_stats.set_size(table_b, service::default_target_tablet_size * target_pow2_b);
+
+        // Per-shard-goal math (tablets_per_shard_goal = 10, shards = 1):
+        //
+        // Buggy (naive current count):
+        //   (4 + 32) * RF / shards = 36 / 1 = 36 > 10 -> scale-down triggered
+        //
+        // Fixed (converging table counted at steady-state target):
+        //   (4 + ~4) * RF / shards = 8 / 1 = 8 < 10 -> no scale-down
+
+        // Run the load balancer to convergence, checking at every iteration
+        // that Table A is never resized.
+        rebalance_tablets(e, &load_stats, {}, [&] (const migration_plan& plan) {
+            auto& tmap_b = stm.get()->tablets().get_tablet_map(table_b);
+            if (!tmap_b.is_converging_to_pow2()) {
+                return true;
+            }
+            auto it = plan.resize_plan().resize.find(table_a);
+            if (it != plan.resize_plan().resize.end()) {
+                BOOST_FAIL(fmt::format(
+                        "Table A got a {} decision during Table B convergence: current tablet count = {}",
+                        it->second.way, stm.get()->tablets().get_tablet_map(table_a).tablet_count()));
+            }
+            return false;
+        });
+
+        // Verify final state.
+        {
+            auto& tmap_a = stm.get()->tablets().get_tablet_map(table_a);
+            BOOST_REQUIRE_EQUAL(tmap_a.tablet_count(), table_a_tablet_count);
+
+            auto& tmap_b = stm.get()->tablets().get_tablet_map(table_b);
+            BOOST_REQUIRE_EQUAL(tmap_b.tablet_count(), target_pow2_b);
+            BOOST_REQUIRE(!tmap_b.is_converging_to_pow2());
+            BOOST_REQUIRE(tmap_b.get_layout() == tablet_layout::pow_of_2);
+        }
+
+        // Verify stability: no further action after convergence.
+        {
+            auto& talloc = e.get_tablet_allocator().local();
+            auto& sys_ks = e.get_system_keyspace().local();
+            auto& topology = e.get_topology_state_machine().local()._topology;
+            auto plan = talloc.balance_tablets(stm.get(), &topology, &sys_ks, load_stats.get()).get();
+            BOOST_REQUIRE(plan.empty());
+        }
+
+        e.execute_cql(fmt::format("drop keyspace {}", ks_a)).get();
+        e.execute_cql(fmt::format("drop keyspace {}", ks_b)).get();
+    }, std::move(cfg)).get();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -7412,4 +7412,191 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_pow2_convergence) {
     }, std::move(cfg)).get();
 }
 
+// Verify that compute_migration_target_pow2s() returns a pow2 target that
+// matches the tablet count of a fresh empty tablet-based table under the same
+// topology and replication strategy.
+SEASTAR_THREAD_TEST_CASE(test_migration_target_pow2_from_scale) {
+    cql_test_config cfg;
+    cfg.need_remote_proxy = true;
+    do_with_cql_env_thread([] (auto& e) {
+        const int rf = 1;
+        const unsigned shard_count = 1;
+        const int n_nodes = 3;
+
+        // Build topology.
+        topology_builder topo(e);
+        for (int i = 0; i < n_nodes; ++i) {
+            topo.add_node(node_state::normal, shard_count);
+        }
+
+        auto& stm = e.shared_token_metadata().local();
+
+        // Create a tablets-based table (reference).
+        // Read its tablet count, then drop it to avoid noise when computing
+        // the migration target.
+        auto ks_ref = add_keyspace(e, {{topo.dc(), rf}});
+        auto t_ref = add_table(e, ks_ref).get();
+        auto fresh_tablet_count = stm.get()->tablets().get_tablet_map(t_ref).tablet_count();
+        e.execute_cql(fmt::format("drop keyspace {}", ks_ref)).get();
+
+        // Create a vnode-based table with the same RS.
+        // This is the table we will compute the migration target for.
+        auto ks_vnode = "vnode_ks";
+        e.execute_cql(fmt::format("create keyspace {} with replication = {{'class': 'NetworkTopologyStrategy', '{}': {}}}"
+                                  " and tablets = {{'enabled': false}}",
+                                  ks_vnode, topo.dc(), rf)).get();
+        e.execute_cql(fmt::format("create table {}.t (pk int primary key)", ks_vnode)).get();
+        auto t_cmp = e.local_db().find_schema(ks_vnode, "t")->id();
+
+        auto& ks = e.local_db().find_keyspace(ks_vnode);
+        auto* trs = dynamic_cast<const tablet_aware_replication_strategy*>(&ks.get_replication_strategy());
+        BOOST_REQUIRE(trs);
+
+        // Compute migration target for the vnode-based table with size = 0 (empty).
+        service::size_per_table_map sizes = {{t_cmp, 0}};
+        auto target_pow2s = e.get_tablet_allocator().local().compute_migration_target_pow2s(trs, sizes).get();
+
+        auto it = target_pow2s.find(t_cmp);
+        BOOST_REQUIRE(it != target_pow2s.end());
+        auto target_pow2 = it->second;
+
+        BOOST_REQUIRE_MESSAGE(std::has_single_bit(target_pow2),
+            fmt::format("Target pow2 {} is not a power of two", target_pow2));
+        BOOST_REQUIRE_MESSAGE(target_pow2 == fresh_tablet_count,
+            fmt::format("Migration target pow2 ({}) does not match fresh-table tablet count ({})",
+                        target_pow2, fresh_tablet_count));
+
+        e.execute_cql(fmt::format("drop keyspace {}", ks_vnode)).get();
+    }, std::move(cfg)).get();
+}
+
+// Verify that compute_migration_target_pow2s() returns a pow2 target that
+// matches the tablet count of a fresh empty table even under per-shard-goal
+// pressure. The pow2 target is expected to be scaled down based on the
+// per-shard-goal budget.
+SEASTAR_THREAD_TEST_CASE(test_migration_target_pow2_near_goal) {
+    cql_test_config cfg;
+    cfg.need_remote_proxy = true;
+    cfg.db_config->tablets_per_shard_goal.set(10);
+    do_with_cql_env_thread([] (auto& e) {
+        const int rf = 1;
+        const unsigned shard_count = 1;
+        const int n_nodes = 3;
+
+        // Build topology.
+        topology_builder topo(e);
+        for (int i = 0; i < n_nodes; ++i) {
+            topo.add_node(node_state::normal, shard_count);
+        }
+
+        auto& stm = e.shared_token_metadata().local();
+
+        // Create a pressure table that occupies most of the goal budget.
+        // With goal=10, RF=1, 1 shard/node: budget is 10 tablets/shard.
+        // Create the table with 8 tablets to leave very little room.
+        auto ks_pressure = add_keyspace(e, {{topo.dc(), rf}}, 8);
+        auto t_pressure = add_table(e, ks_pressure).get();
+
+        // Create a reference table in a separate keyspace under the same
+        // pressure conditions. Read its tablet count, then drop it to avoid
+        // noise when computing the migration target.
+        auto ks_ref = add_keyspace(e, {{topo.dc(), rf}});
+        auto t_ref = add_table(e, ks_ref).get();
+        auto fresh_tablet_count = stm.get()->tablets().get_tablet_map(t_ref).tablet_count();
+        e.execute_cql(fmt::format("drop keyspace {}", ks_ref)).get();
+
+        // Create a vnode-based table with the same RS.
+        auto ks_vnode = "vnode_ks";
+        e.execute_cql(fmt::format("create keyspace {} with replication = {{'class': 'NetworkTopologyStrategy', '{}': {}}}"
+                                  " and tablets = {{'enabled': false}}",
+                                  ks_vnode, topo.dc(), rf)).get();
+        e.execute_cql(fmt::format("create table {}.t (pk int primary key)", ks_vnode)).get();
+        auto t_cmp = e.local_db().find_schema(ks_vnode, "t")->id();
+
+        auto& ks = e.local_db().find_keyspace(ks_vnode);
+        auto* trs = dynamic_cast<const tablet_aware_replication_strategy*>(&ks.get_replication_strategy());
+        BOOST_REQUIRE(trs);
+
+        // Compute migration target with size = 0 (empty).
+        service::size_per_table_map sizes = {{t_cmp, 0}};
+        auto target_pow2s = e.get_tablet_allocator().local().compute_migration_target_pow2s(trs, sizes).get();
+
+        auto it = target_pow2s.find(t_cmp);
+        BOOST_REQUIRE(it != target_pow2s.end());
+        auto target_pow2 = it->second;
+
+        BOOST_REQUIRE_MESSAGE(std::has_single_bit(target_pow2),
+            fmt::format("Target pow2 {} is not a power of two", target_pow2));
+        BOOST_REQUIRE_MESSAGE(target_pow2 == fresh_tablet_count,
+            fmt::format("Migration target pow2 ({}) does not match fresh-table tablet count ({}) under near-goal pressure",
+                        target_pow2, fresh_tablet_count));
+
+        e.execute_cql(fmt::format("drop keyspace {}", ks_pressure)).get();
+        e.execute_cql(fmt::format("drop keyspace {}", ks_vnode)).get();
+    }, std::move(cfg)).get();
+}
+
+// Verify that compute_migration_target_pow2s() with a non-zero size produces
+// a pow2 target that falls within the load balancer's split/merge thresholds.
+// This exercises the size_per_table argument.
+SEASTAR_THREAD_TEST_CASE(test_migration_target_pow2_from_size) {
+    cql_test_config cfg;
+    cfg.need_remote_proxy = true;
+    cfg.db_config->tablets_initial_scale_factor(1); // lower initial tablets so it doesn't interfere with size-driven scaling
+    do_with_cql_env_thread([] (auto& e) {
+        const int rf = 1;
+        const unsigned shard_count = 1;
+        const int n_nodes = 1;
+
+        // Build topology.
+        topology_builder topo(e);
+        for (int i = 0; i < n_nodes; ++i) {
+            topo.add_node(node_state::normal, shard_count);
+        }
+
+        const std::vector<uint64_t> test_sizes = {
+            10ULL * 1024 * 1024 * 1024,   // 10 GiB
+            32ULL * 1024 * 1024 * 1024,   // 32 GiB
+        };
+
+        auto& stm = e.shared_token_metadata().local();
+
+        for (auto S : test_sizes) {
+            testlog.info("Testing size_per_table parity with size = {} bytes", S);
+
+            auto ks_vnode = "vnode_ks";
+            e.execute_cql(fmt::format("create keyspace {} with replication = {{'class': 'NetworkTopologyStrategy', '{}': {}}}"
+                                      " and tablets = {{'enabled': false}}",
+                                      ks_vnode, topo.dc(), rf)).get();
+            e.execute_cql(fmt::format("create table {}.t (pk int primary key)", ks_vnode)).get();
+            auto t_cmp = e.local_db().find_schema(ks_vnode, "t")->id();
+
+            auto& ks = e.local_db().find_keyspace(ks_vnode);
+            auto* trs = dynamic_cast<const tablet_aware_replication_strategy*>(&ks.get_replication_strategy());
+            BOOST_REQUIRE(trs);
+
+            // Compute migration target for a given size.
+            service::size_per_table_map sizes = {{t_cmp, S}};
+            auto target_pow2s = e.get_tablet_allocator().local().compute_migration_target_pow2s(trs, sizes).get();
+
+            auto it = target_pow2s.find(t_cmp);
+            BOOST_REQUIRE(it != target_pow2s.end());
+            auto target_pow2 = it->second;
+
+            BOOST_REQUIRE_MESSAGE(std::has_single_bit(target_pow2),
+                fmt::format("Target pow2 {} is not a power of two (size={})", target_pow2, S));
+
+            auto avg_tablet_size = S / target_pow2;
+            BOOST_REQUIRE_MESSAGE(avg_tablet_size <= service::default_target_tablet_size * 2,
+                fmt::format("Average tablet size {} exceeds split threshold ({}), expected a larger pow2 target (size={})",
+                            avg_tablet_size, service::default_target_tablet_size, S));
+            BOOST_REQUIRE_MESSAGE(avg_tablet_size >= service::default_target_tablet_size / 2,
+                fmt::format("Average tablet size {} is below the merge threshold ({}), expected a smaller pow2 target (size={})",
+                            avg_tablet_size, service::default_target_tablet_size, S));
+
+            e.execute_cql(fmt::format("drop keyspace {}", ks_vnode)).get();
+        }
+    }, std::move(cfg)).get();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -7281,4 +7281,135 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_dropped_table) {
     }).get();
 }
 
+// Tests convergence of a tablet map with arbitrary boundaries to a uniform
+// pow2 layout. This applies to tables produced by vnodes-to-tablets migration,
+// where tablet boundaries inherit the random vnode token distribution.
+//
+// The test constructs a tablet map with 8 pow2 token ranges and then injects
+// a deterministic number of extra tokens into those ranges to cover various
+// merge conditions:
+// - Token range with 0 extra tokens: no merges needed
+// - Token range with 1 extra token:  1 merge round (1 merged tablet pair)
+// - Token range with 2 extra tokens: 2 merge rounds (1 merged tablet pair in first round, 1 merged tablet pair in second round)
+// - Token range with 3 extra tokens: 2 merge rounds (2 merged tablet pairs in first round, 1 merged tablet pair in second round)
+// - Token range with 4 extra tokens: 3 merge rounds (2 merged tablet pairs in first round, 1 merged tablet pair in second round, 1 merged tablet pair in third round)
+//
+// Tablets within each pow2 token range are assigned different replica sets to
+// exercise the merge colocation path.
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_pow2_convergence) {
+    cql_test_config cfg;
+    cfg.need_remote_proxy = true;
+    do_with_cql_env_thread([] (auto& e) {
+        const int rf = 3;
+        const int n_racks = 3;
+        const int nodes_per_rack = 2;
+        const unsigned shard_count = 2;
+
+        // Build the topology.
+
+        topology_builder topo(e);
+
+        std::vector<host_id> hosts;
+        for (int r = 0; r < n_racks; ++r) {
+            if (r > 0) {
+                topo.start_new_rack();
+            }
+            for (int n = 0; n < nodes_per_rack; ++n) {
+                hosts.push_back(topo.add_node(node_state::normal, shard_count));
+            }
+        }
+
+        // Compute tablet boundaries by starting with pow2 boundaries and
+        // injecting extra tokens within each pow2 token range.
+
+        const size_t target_pow2 = 8;
+        const int n_extra_tokens_per_range[target_pow2] = {0, 1, 2, 3, 4, 0, 0, 0};
+        const size_t initial_tablet_count = target_pow2 + std::accumulate(std::begin(n_extra_tokens_per_range), std::end(n_extra_tokens_per_range), 0);
+
+        utils::chunked_vector<dht::raw_token> pow2_boundaries = dht::get_uniform_tokens(target_pow2);
+        utils::chunked_vector<dht::raw_token> all_boundaries;
+
+        for (size_t seg = 0; seg < target_pow2; ++seg) {
+            uint64_t seg_start = (seg == 0) ? dht::first_token().unbias() : dht::token(pow2_boundaries[seg - 1]).unbias() + 1;
+            uint64_t seg_end = dht::token(pow2_boundaries[seg]).unbias();
+            int n_extra = n_extra_tokens_per_range[seg];
+            for (int j = 0; j < n_extra; ++j) {
+                // Place extra tokens within the segment.
+                size_t even_spacing = (seg_end - seg_start) / (n_extra + 1);
+                uint64_t even_pos = seg_start + even_spacing * (j + 1);
+                uint64_t skew = even_spacing / 10;
+                uint64_t pos = (j % 2 == 0) ? even_pos - skew : even_pos + skew; // skew tokens slightly to break evenness
+                all_boundaries.push_back(dht::raw_token(dht::token::bias(pos)));
+            }
+            // Add the pow2 boundary itself.
+            all_boundaries.push_back(pow2_boundaries[seg]);
+        }
+
+        // Create the table.
+        auto ks_name = add_keyspace(e, {{topo.dc(), rf}});
+        auto table1 = add_table(e, ks_name).get();
+        auto& stm = e.shared_token_metadata().local();
+
+        // Introduce a tablet map with arbitrary boundaries.
+        mutate_tablets(e, [&](tablet_metadata& tmeta) -> future<> {
+            tablet_map tmap(std::move(all_boundaries));
+
+            // Assign replicas: cycle through different (host, shard) combinations
+            // so that adjacent tablets within a segment have different replica sets.
+            size_t host_offset = 0;
+            for (auto tid : tmap.tablet_ids()) {
+                tablet_replica_set replicas;
+                replicas.reserve(rf);
+                for (int r = 0; r < rf; ++r) {
+                    auto h = hosts[(host_offset + r * nodes_per_rack) % hosts.size()];
+                    auto s = shard_id((host_offset + r) % shard_count);
+                    replicas.push_back(tablet_replica{h, s});
+                }
+                tmap.set_tablet(tid, tablet_info{std::move(replicas)});
+                ++host_offset;
+            }
+
+            // Set the pow2 target.
+            tmap.set_target_pow2_tablet_count(target_pow2);
+
+            tmeta.set_tablet_map(table1, std::move(tmap));
+            co_return;
+        });
+
+        // Verify initial state.
+        {
+            auto& tmap = stm.get()->tablets().get_tablet_map(table1);
+            BOOST_REQUIRE_EQUAL(tmap.tablet_count(), initial_tablet_count);
+            BOOST_REQUIRE(tmap.is_converging_to_pow2());
+            BOOST_REQUIRE(tmap.get_layout() == tablet_layout::arbitrary);
+            check_tablet_invariants(stm.get()->tablets());
+        }
+
+        // Lower "initial" tablets option so it doesn't force splits after
+        // convergence reduces the tablet count below the initial value.
+        e.execute_cql(fmt::format("alter keyspace {} with tablets = {{'enabled': true, 'initial': 1}}", ks_name)).get();
+
+        // Set tablet sizes so the load balancer has stats for the table.
+        // Use the default target size so normal resize logic doesn't
+        // interfere (it would only merge if tablets are small).
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
+        load_stats.set_default_tablet_sizes(stm.get());
+        load_stats.set_size(table1, service::default_target_tablet_size * target_pow2);
+
+        // Run the load balancer until convergence.
+        rebalance_tablets(e, &load_stats);
+
+        // Verify final state.
+        {
+            auto& tmap = stm.get()->tablets().get_tablet_map(table1);
+            BOOST_REQUIRE_EQUAL(tmap.tablet_count(), target_pow2);
+            BOOST_REQUIRE(!tmap.is_converging_to_pow2());
+            BOOST_REQUIRE(tmap.get_layout() == tablet_layout::pow_of_2);
+            check_tablet_invariants(stm.get()->tablets());
+        }
+
+        e.execute_cql(fmt::format("drop keyspace {}", ks_name)).get();
+    }, std::move(cfg)).get();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/vnodes_to_tablets_migration_test.cc
+++ b/test/boost/vnodes_to_tablets_migration_test.cc
@@ -8,35 +8,29 @@
 
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>
-#include <seastar/util/bool_class.hh>
 
 #include "db/config.hh"
 #include "test/lib/cql_test_env.hh"
 #include "locator/tablets.hh"
 #include "service/storage_service.hh"
 
-using aligned_last_token = bool_class<class aligned_last_token_tag>;
-
 BOOST_AUTO_TEST_SUITE(vnodes_to_tablets_migration_test)
 
-// Verify creation of extra tablet for wrap-around vnodes.
+// Verify that the initial tablet map produced by prepare_for_tablets_migration()
+// contains all vnode token boundaries, the MAX_TOKEN, and the pow2 boundaries
+// needed for convergence to a uniform power-of-two layout.
 //
-// Tablets cannot wrap around the token ring as vnodes do; the last token of
-// the last tablet must always be MAX_TOKEN. So, when we build the tablet map,
-// if a wrap-around vnode exists (i.e., the last vnode token is not MAX_TOKEN),
-// it needs to be split into two tablets: (last_vnode_token, last_token()] and
-// [first_token(), first_vnode_token].
-static future<> test_migration_tablet_boundaries(aligned_last_token aligned) {
-    std::vector<int64_t> tokens{-7686143364045646507, 0, 7158264828641642373}; // some random tokens
-    if (aligned) {
-        tokens.back() = dht::last_token().raw();
-    }
-
+// MAX_TOKEN is verified explicitly as a tablet map invariant: since tablets
+// do not wrap around the token ring, the last tablet must always end at
+// MAX_TOKEN. It does not matter where MAX_TOKEN came from. Depending on the
+// vnode layout, MAX_TOKEN may already be present as a vnode boundary; with pow2
+// pre-splitting, it is also the terminal pow2 boundary.
+static future<> test_tablet_map_creation(std::vector<int64_t> tokens) {
     cql_test_config cfg;
     auto initial_token = fmt::format("{}", fmt::join(tokens, ", "));
     cfg.db_config->initial_token.set(std::move(initial_token));
 
-    return do_with_cql_env_thread([tokens, aligned] (cql_test_env& e) {
+    return do_with_cql_env_thread([tokens] (cql_test_env& e) {
         auto ks_name = sstring("test_migration_ks");
         e.execute_cql(format("CREATE KEYSPACE {} "
                 "WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} "
@@ -50,34 +44,114 @@ static future<> test_migration_tablet_boundaries(aligned_last_token aligned) {
         auto& stm = e.local_db().get_shared_token_metadata();
         auto& tmap = stm.get()->tablets().get_tablet_map(tid);
 
-        auto expected = std::vector<dht::token>{};
-        for (const auto& t : tokens) {
-            expected.push_back(dht::token(t));
-        }
-        if (!aligned) {
-            expected.push_back(dht::last_token());
+        // Collect actual tablet boundaries.
+        std::set<dht::token> tablet_boundaries;
+        for (size_t i = 0; i < tmap.tablet_count(); ++i) {
+            tablet_boundaries.insert(tmap.get_last_token(locator::tablet_id(i)));
         }
 
-        auto actual = std::vector<dht::token>{};
-        for (size_t i = 0; i < tmap.tablet_count(); ++i) {
-            actual.push_back(tmap.get_last_token(locator::tablet_id(i)));
+        // Build expected vnode boundaries.
+        std::set<dht::token> vnode_boundaries;
+        for (const auto& t : tokens) {
+            vnode_boundaries.insert(dht::token(t));
         }
-        BOOST_TEST_INFO("actual: " << fmt::format("{}", fmt::join(actual, ", ")));
-        BOOST_TEST_INFO("expected: " << fmt::format("{}", fmt::join(expected, ", ")));
-        BOOST_REQUIRE_EQUAL_COLLECTIONS(actual.begin(), actual.end(), expected.begin(), expected.end());
+
+        // Verify all vnode boundaries are present.
+        std::vector<dht::token> missing_vnode;
+        std::set_difference(vnode_boundaries.begin(), vnode_boundaries.end(),
+                            tablet_boundaries.begin(), tablet_boundaries.end(),
+                            std::back_inserter(missing_vnode));
+        BOOST_REQUIRE_MESSAGE(missing_vnode.empty(),
+            fmt::format("Vnode boundaries missing from tablet map: {}", fmt::join(missing_vnode, ", ")));
+
+        // Verify MAX_TOKEN independently from the pow2-boundary check: ending
+        // the tablet map at MAX_TOKEN is a tablet-map invariant, not just an
+        // incidental pow2 boundary.
+        BOOST_REQUIRE_EQUAL(tmap.get_last_token(tmap.last_tablet()), dht::last_token());
+
+        // The tablet map must have a pow2 target set.
+        BOOST_REQUIRE(tmap.is_converging_to_pow2());
+        size_t P = tmap.target_pow2_tablet_count();
+        BOOST_REQUIRE_MESSAGE(std::has_single_bit(P),
+                fmt::format("target_pow2_tablet_count {} is not a power of two", P));
+        BOOST_REQUIRE_MESSAGE(P < tmap.tablet_count(),
+                fmt::format("target_pow2_tablet_count {} must be less than the current tablet count {}", P, tmap.tablet_count()));
+
+        // Verify all pow2 boundaries are present.
+        std::set<dht::token> pow2_boundaries;
+        for (const auto& t : dht::get_uniform_tokens(P)) {
+            pow2_boundaries.insert(dht::token(t));
+        }
+
+        std::vector<dht::token> missing_pow2;
+        std::set_difference(pow2_boundaries.begin(), pow2_boundaries.end(),
+                            tablet_boundaries.begin(), tablet_boundaries.end(),
+                            std::back_inserter(missing_pow2));
+        BOOST_REQUIRE_MESSAGE(missing_pow2.empty(),
+            fmt::format("Pow2 boundaries missing from tablet map: {}", fmt::join(missing_pow2, ", ")));
+
+        // Verify no spurious boundaries.
+        std::set<dht::token> expected_boundaries;
+        std::set_union(vnode_boundaries.begin(), vnode_boundaries.end(),
+                       pow2_boundaries.begin(), pow2_boundaries.end(),
+                       std::inserter(expected_boundaries, expected_boundaries.end()));
+        expected_boundaries.insert(dht::last_token());
+
+        std::vector<dht::token> extra;
+        std::set_difference(tablet_boundaries.begin(), tablet_boundaries.end(),
+                            expected_boundaries.begin(), expected_boundaries.end(),
+                            std::back_inserter(extra));
+        BOOST_REQUIRE_MESSAGE(extra.empty(),
+            fmt::format("Unexpected boundaries in tablet map: {}", fmt::join(extra, ", ")));
     }, cfg);
 }
 
-// When the last vnode token != MAX_TOKEN, the wrap-around vnode is split
-// into two tablets. Expect one more tablet than vnodes.
-SEASTAR_TEST_CASE(test_unaligned_last_token) {
-    return test_migration_tablet_boundaries(aligned_last_token::no);
+// Verify tablet map creation with unaligned last token.
+SEASTAR_TEST_CASE(test_tablet_map_creation_unaligned_last_token) {
+    return test_tablet_map_creation({-7686143364045646507, 0, 7158264828641642373}); // some random tokens
 }
 
-// When the last vnode token == MAX_TOKEN, no split is needed.
-// Expect exactly one tablet per vnode.
-SEASTAR_TEST_CASE(test_aligned_last_token) {
-    return test_migration_tablet_boundaries(aligned_last_token::yes);
+// Verify tablet map creation with aligned last token.
+SEASTAR_TEST_CASE(test_tablet_map_creation_aligned_last_token) {
+    return test_tablet_map_creation({-7686143364045646507, 0, dht::last_token().raw()});
+}
+
+// Verify that pow2 convergence is skipped if the input vnode tokens already
+// form a power-of-two tablet layout and the vnode count is smaller than the target pow2.
+// This can happen only when vnode tokens are explicitly provided via --initial-token.
+SEASTAR_TEST_CASE(test_tablet_map_creation_already_pow2_layout) {
+    std::vector<int64_t> tokens;
+    int vnode_count = 4;
+    for (const auto& t : dht::get_uniform_tokens(vnode_count)) {
+        tokens.push_back(dht::token(t).raw());
+    }
+
+    cql_test_config cfg;
+    auto initial_token = fmt::format("{}", fmt::join(tokens, ", "));
+    cfg.db_config->initial_token.set(std::move(initial_token));
+    // Set scale factor to a high-enough value to ensure that the target pow2
+    // is not smaller than the vnode count. This produces an initial tablet map
+    // with no convergence needed.
+    cfg.db_config->tablets_initial_scale_factor.set(vnode_count * 2);
+
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        auto ks_name = sstring("test_migration_ks");
+        e.execute_cql(format("CREATE KEYSPACE {} "
+                "WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} "
+                "AND tablets = {{'enabled': false}}", ks_name)).get();
+
+        e.execute_cql(format("CREATE TABLE {}.t (pk int PRIMARY KEY)", ks_name)).get();
+        auto tid = e.local_db().find_schema(ks_name, "t")->id();
+
+        e.get_storage_service().local().prepare_for_tablets_migration(ks_name).get();
+
+        auto& stm = e.local_db().get_shared_token_metadata();
+        auto& tmap = stm.get()->tablets().get_tablet_map(tid);
+
+        BOOST_REQUIRE(tmap.get_layout() == locator::tablet_layout::pow_of_2);
+        BOOST_REQUIRE(!tmap.is_converging_to_pow2());
+        BOOST_REQUIRE_EQUAL(tmap.target_pow2_tablet_count(), 0);
+    }, cfg);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -208,7 +208,7 @@ async def verify_migration_status(manager: ManagerClient, server: ServerInfo,
         # Verify migration status via the tasks API
         tm = TaskManagerClient(manager.api)
         tasks = await tm.list_tasks(server.ip_addr, "vnodes_to_tablets_migration")
-        ks_tasks = [t for t in tasks if t.keyspace == ks]
+        ks_tasks = [t for t in tasks if t.keyspace == ks and t.type == "vnodes_to_tablets_migration"]
 
         if expected_status == "migrating_to_tablets":
             assert len(ks_tasks) == 1, f"Expected 1 virtual task for keyspace '{ks}', got {len(ks_tasks)}"
@@ -724,7 +724,7 @@ async def test_migration_task_not_abortable(manager: ManagerClient):
 
         tm = TaskManagerClient(manager.api)
         tasks = await tm.list_tasks(server.ip_addr, "vnodes_to_tablets_migration")
-        ks_tasks = [t for t in tasks if t.keyspace == ks]
+        ks_tasks = [t for t in tasks if t.keyspace == ks and t.type == "vnodes_to_tablets_migration"]
         assert len(ks_tasks) == 1, f"Expected 1 migration task for keyspace '{ks}', got {len(ks_tasks)}"
 
         task = ks_tasks[0]
@@ -759,9 +759,10 @@ async def test_migration_wait_task(manager: ManagerClient):
         await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
 
         tasks = await tm.list_tasks(server.ip_addr, "vnodes_to_tablets_migration")
-        assert len(tasks) == 1
-        assert tasks[0].keyspace == ks
-        task_id = tasks[0].task_id
+        migration_tasks = [t for t in tasks if t.type == "vnodes_to_tablets_migration"]
+        assert len(migration_tasks) == 1
+        assert migration_tasks[0].keyspace == ks
+        task_id = migration_tasks[0].task_id
 
         log = await manager.server_open_log(server.server_id)
         mark = await log.mark()
@@ -785,9 +786,10 @@ async def test_migration_wait_task(manager: ManagerClient):
         await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
 
         tasks = await tm.list_tasks(server.ip_addr, "vnodes_to_tablets_migration")
-        assert len(tasks) == 1
-        assert tasks[0].keyspace == ks
-        task_id = tasks[0].task_id
+        migration_tasks = [t for t in tasks if t.type == "vnodes_to_tablets_migration"]
+        assert len(migration_tasks) == 1
+        assert migration_tasks[0].keyspace == ks
+        task_id = migration_tasks[0].task_id
 
         logger.info("Marking the node for tablets migration and restarting")
         await manager.api.upgrade_node_to_tablets(server.ip_addr)

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -62,18 +62,18 @@ def get_sstable_token_ranges(scylla_path: str, scylla_yaml: str, sstable_data_fi
     return ranges
 
 
-def sstable_range_within_vnode(first_token: int, last_token: int, vnode_boundaries: list[int]) -> bool:
-    """Check whether an SSTable's token range falls entirely within a single vnode range.
+def sstable_within_single_range(first_token: int, last_token: int, boundaries: list[int]) -> bool:
+    """Check whether an SSTable's token range falls entirely within a single range.
 
     Args:
         first_token: The first token in the SSTable.
         last_token: The last token in the SSTable.
-        vnode_boundaries: Sorted list of vnode token boundaries.
+        boundaries: Sorted list of token boundaries (e.g., vnode or tablet boundaries).
 
     Returns:
-        True if both first_token and last_token fall within the same vnode range.
+        True if both first_token and last_token fall within the same range.
     """
-    for token in vnode_boundaries:
+    for token in boundaries:
         if first_token < token <= last_token:
             return False
     return True
@@ -104,6 +104,61 @@ async def verify_data_integrity(cql, ks, table, num_keys, cl=ConsistencyLevel.QU
         extra = data.keys() - expected.keys()
         wrong = {k: (data[k], expected[k]) for k in data.keys() & expected.keys() if data[k] != expected[k]}
         assert False, f"Data mismatch: missing keys {missing}, extra keys {extra}, wrong values {wrong}"
+
+
+def compute_pow2_boundaries(target_pow2: int) -> list[int]:
+    """Compute pow2 tablet boundaries.
+
+    Mirrors the C++ dht::get_uniform_tokens() function:
+        for i in [1, count]: n = i * UINT64_MAX / count; bias(n)
+    where bias(n) converts from unsigned to signed by subtracting 2^63.
+    """
+    UINT64_MAX = (1 << 64) - 1
+    INT64_MIN = -(1 << 63)
+    return [(i * UINT64_MAX) // target_pow2 + INT64_MIN for i in range(1, target_pow2 + 1)]
+
+
+async def get_target_pow2_tablet_count(manager: ManagerClient, server: ServerInfo, ks: str, table_name: str) -> int:
+    """Read target_pow2_tablet_count from system.tablets for a given table."""
+    host = manager.get_cql().cluster.metadata.get_host(server.ip_addr)
+    await read_barrier(manager.api, server.ip_addr)
+    table_id = await manager.get_table_or_view_id(ks, table_name)
+    rows = await manager.get_cql().run_async(
+        f"SELECT DISTINCT target_pow2_tablet_count FROM system.tablets WHERE table_id = {table_id}",
+        host=host)
+    assert len(rows) > 0, f"No rows found in system.tablets for table {ks}.{table_name}"
+    return rows[0].target_pow2_tablet_count
+
+
+async def verify_tablet_map_boundaries(manager: ManagerClient, server: ServerInfo,
+                                       ks: str, table_name: str,
+                                       vnode_boundaries: list[int]) -> list:
+    """Verify the initial tablet map contains exactly the union of vnode boundaries, max token, and pow2 boundaries.
+
+    Returns the tablet_replicas list for further checks by the caller.
+    """
+    tablet_replicas = await get_all_tablet_replicas(manager, server, ks, table_name)
+    tablet_tokens = set(tr.last_token for tr in tablet_replicas)
+
+    vnode_set = set(vnode_boundaries)
+    missing_vnodes = vnode_set - tablet_tokens
+    assert not missing_vnodes, f"Vnode boundaries missing from tablet map: {sorted(missing_vnodes)}"
+
+    assert MAX_TOKEN in tablet_tokens, "MAX_TOKEN missing from tablet map"
+
+    target_pow2 = await get_target_pow2_tablet_count(manager, server, ks, table_name)
+    assert target_pow2 and target_pow2 & (target_pow2 - 1) == 0, \
+        f"target_pow2_tablet_count {target_pow2} is not a power of two"
+
+    pow2_set = set(compute_pow2_boundaries(target_pow2))
+    missing_pow2 = pow2_set - tablet_tokens
+    assert not missing_pow2, f"Pow2 boundaries missing from tablet map: {sorted(missing_pow2)}"
+
+    expected_all = vnode_set | pow2_set | {MAX_TOKEN}
+    extra = tablet_tokens - expected_all
+    assert not extra, f"Unexpected boundaries in tablet map: {sorted(extra)}"
+
+    return tablet_replicas
 
 
 async def verify_migration_status(manager: ManagerClient, server: ServerInfo,
@@ -201,7 +256,7 @@ async def test_migration(manager: ManagerClient):
         assert len(pre_migration_sstables) == num_shards * num_flushes
         pre_migration_ranges = get_sstable_token_ranges(scylla_path, scylla_yaml, pre_migration_sstables)
         cross_vnode_count = sum(1 for first, last in pre_migration_ranges
-                                if not sstable_range_within_vnode(first, last, vnode_boundaries))
+                                if not sstable_within_single_range(first, last, vnode_boundaries))
         logger.info(f"Pre-migration: {cross_vnode_count}/{len(pre_migration_ranges)} SSTables span multiple vnodes")
 
         logger.info("Verifying migration status before starting migration")
@@ -216,20 +271,8 @@ async def test_migration(manager: ManagerClient):
             expected_node_statuses={host_id: ('vnodes', 'vnodes')})
 
         logger.info("Verifying that the tablet map was created")
-        expected_tablet_tokens = vnode_boundaries if vnode_boundaries[-1] == MAX_TOKEN else vnode_boundaries + [MAX_TOKEN]
-        expected_tablet_count = len(expected_tablet_tokens)
-        tablet_count = await get_tablet_count(manager, server, ks, 'test')
-        assert tablet_count == expected_tablet_count, \
-            f"Expected {expected_tablet_count} tablet(s), got {tablet_count}"
-
-        tablet_replicas = await get_all_tablet_replicas(manager, server, ks, 'test')
-        assert len(tablet_replicas) == expected_tablet_count, \
-            f"Expected {expected_tablet_count} tablet replica entries, got {len(tablet_replicas)}"
-
-        logger.info("Verifying that tablet tokens match vnode tokens plus max token")
-        tablet_tokens = sorted([tr.last_token for tr in tablet_replicas])
-        assert tablet_tokens == expected_tablet_tokens, \
-            f"Tablet tokens {tablet_tokens} do not match expected {expected_tablet_tokens}"
+        tablet_replicas = await verify_tablet_map_boundaries(manager, server, ks, 'test', vnode_boundaries)
+        tablet_boundaries = sorted([tr.last_token for tr in tablet_replicas])
 
         logger.info("Verifying data integrity after building tablet map and before resharding")
         await verify_data_integrity(cql, ks, "test", num_keys)
@@ -257,14 +300,14 @@ async def test_migration(manager: ManagerClient):
         post_restart_ranges = get_sstable_token_ranges(scylla_path, scylla_yaml, post_restart_sstables)
         logger.info(f"Post-restart SSTable token ranges:")
         for i, (first, last) in enumerate(post_restart_ranges):
-            within = sstable_range_within_vnode(first, last, vnode_boundaries)
-            logger.info(f"  SSTable {i}: tokens [{first}, {last}], within single vnode: {within}")
+            within = sstable_within_single_range(first, last, tablet_boundaries)
+            logger.info(f"  SSTable {i}: tokens [{first}, {last}], within single tablet: {within}")
 
-        logger.info("Verifying that every post-restart SSTable falls within a single vnode range")
+        logger.info("Verifying that every post-restart SSTable falls within a single tablet range")
         for i, (first, last) in enumerate(post_restart_ranges):
-            assert sstable_range_within_vnode(first, last, vnode_boundaries), \
+            assert sstable_within_single_range(first, last, tablet_boundaries), \
                 f"Post-restart SSTable {i} with token range [{first}, {last}] " \
-                f"spans multiple vnode ranges (boundaries: {vnode_boundaries})"
+                f"spans multiple tablet ranges (boundaries: {tablet_boundaries})"
 
         logger.info("Verifying data integrity after restart")
         await verify_data_integrity(cql, ks, "test", num_keys)
@@ -338,10 +381,7 @@ async def test_migration_rollback(manager: ManagerClient):
         await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
 
         logger.info("Verifying that the tablet map was created")
-        expected_tablet_count = len(vnode_boundaries) if vnode_boundaries[-1] == MAX_TOKEN else len(vnode_boundaries) + 1
-        tablet_count = await get_tablet_count(manager, server, ks, 'test')
-        assert tablet_count == expected_tablet_count, \
-            f"Expected {expected_tablet_count} tablet(s), got {tablet_count}"
+        await verify_tablet_map_boundaries(manager, server, ks, 'test', vnode_boundaries)
 
         logger.info("Marking node for tablets migration")
         await manager.api.upgrade_node_to_tablets(server.ip_addr)
@@ -461,15 +501,7 @@ async def test_migration_multinode(manager: ManagerClient):
             expected_node_statuses={host_id: ('vnodes', 'vnodes') for host_id in host_ids})
 
         logger.info("Verifying tablet map")
-        expected_tablet_tokens = all_vnode_tokens if all_vnode_tokens[-1] == MAX_TOKEN else all_vnode_tokens + [MAX_TOKEN]
-        expected_tablet_count = len(expected_tablet_tokens)
-        tablet_replicas = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
-        assert len(tablet_replicas) == expected_tablet_count, \
-            f"Expected {expected_tablet_count} tablets, got {len(tablet_replicas)}"
-
-        tablet_tokens = sorted([tr.last_token for tr in tablet_replicas])
-        assert tablet_tokens == expected_tablet_tokens, \
-            f"Tablet tokens do not match expected tokens"
+        tablet_replicas = await verify_tablet_map_boundaries(manager, servers[0], ks, 'test', all_vnode_tokens)
 
         for tr in tablet_replicas:
             replica_hosts = set(r[0] for r in tr.replicas)

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -879,3 +879,115 @@ async def test_migration_multiple_keyspaces(manager: ManagerClient):
             for row in rows:
                 assert row.intended_storage_mode is None, \
                     f"intended_storage_mode should be cleared for node {row.host_id} after all migrations are done, got '{row.intended_storage_mode}'"
+
+
+@pytest.mark.asyncio
+async def test_tablet_status_in_migration_api(manager: ManagerClient):
+    """"Verify the ?include=tablet_status query parameter in the migration API.
+
+    When set, the migration API response is extended with a 'tablets' field that
+    contains per-table pow2 convergence status. Intended for use after migration
+    finalization to track convergence progress via the same API.
+
+    Steps:
+    1. Before migration: no-op; no 'tablets' field in response.
+    2. During migration: no-op; no 'tablets' field in response.
+    3. After finalization: 'tablets' field is present and its fields have correct values.
+    4. Without query param: no 'tablets' field in response.
+    5. After pow2 convergence: convergence is reported as completed for all tables.
+    """
+    num_shards = 3
+    tokens_per_node = 16
+
+    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} random tokens")
+    cfg = {'num_tokens': tokens_per_node}
+    servers = await manager.servers_add(1, cmdline=['--smp', str(num_shards)], config=cfg)
+    server = servers[0]
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    logger.info("Creating keyspace with two empty vnode-based tables")
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': false}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, c int)")
+        await cql.run_async(f"CREATE TABLE {ks}.t2 (pk int PRIMARY KEY, c int)")
+
+        logger.info("Before migration - verify no tablet status in response")
+        status = await manager.api.get_vnode_tablet_migration_status(server.ip_addr, ks, with_tablet_status=True)
+        assert status['status'] == 'vnodes'
+        assert 'tablets' not in status, "tablets field should not be present before migration"
+
+        logger.info("Starting vnodes-to-tablets migration")
+        await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
+
+        logger.info("Marking node for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+
+        logger.info("Restarting node to trigger resharding")
+        await manager.server_restart(server.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info("During migration - verify no tablet status in response")
+        status = await manager.api.get_vnode_tablet_migration_status(server.ip_addr, ks, with_tablet_status=True)
+        assert status['status'] == 'migrating_to_tablets'
+        assert 'tablets' not in status, "tablets field should not be present during migration"
+
+        # Disable tablet balancing to prevent pow2 convergence from running
+        # before we can check the post-finalization status.
+        await manager.api.disable_tablet_balancing(server.ip_addr)
+
+        logger.info("Finalizing migration")
+        await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
+
+        logger.info("After finalization - verify tablet status is present with in_progress convergence")
+        status = await manager.api.get_vnode_tablet_migration_status(server.ip_addr, ks, with_tablet_status=True)
+        assert status['status'] == 'tablets'
+        assert 'tablets' in status, "tablets field should be present after finalization"
+
+        pow2 = status['tablets']['pow2_convergence']
+        assert pow2['status'] == 'in_progress'
+        assert pow2['tables_total'] == 2
+        assert pow2['tables_converging'] == 2
+        assert len(pow2['tables']) == 2
+
+        table_names = {t['table'] for t in pow2['tables']}
+        assert table_names == {'t1', 't2'}, f"Expected tables t1 and t2, got {table_names}"
+
+        for t in pow2['tables']:
+            assert 'converging' in t
+            assert 'current_tablet_count' in t
+            assert 'target_pow2_tablet_count' in t
+            assert t['converging'] is True
+
+            # Verify current/target tablet counts match system.tablets
+            table_name = t['table']
+            expected_count = await get_tablet_count(manager, server, ks, table_name)
+            expected_target = await get_target_pow2_tablet_count(manager, server, ks, table_name)
+            assert t['current_tablet_count'] == expected_count, \
+                f"Table {table_name}: API reports {t['current_tablet_count']} tablets, system.tablets has {expected_count}"
+            assert t['target_pow2_tablet_count'] == expected_target, \
+                f"Table {table_name}: API reports target {t['target_pow2_tablet_count']}, system.tablets has {expected_target}"
+
+        logger.info("Without query param - verify no tablet status")
+        status = await manager.api.get_vnode_tablet_migration_status(server.ip_addr, ks, with_tablet_status=False)
+        assert 'tablets' not in status, "tablets field should not be present without query param"
+
+        # Re-enable tablet balancing to allow pow2 convergence to proceed.
+        await manager.api.enable_tablet_balancing(server.ip_addr)
+
+        logger.info("After pow2 convergence - verify all tables have converged")
+        await wait_for_pow2_convergence(manager, server, ks, 't1')
+        await wait_for_pow2_convergence(manager, server, ks, 't2')
+
+        status = await manager.api.get_vnode_tablet_migration_status(server.ip_addr, ks, with_tablet_status=True)
+        pow2 = status['tablets']['pow2_convergence']
+        assert pow2['status'] == 'complete'
+        assert pow2['tables_converging'] == 0
+        assert pow2['tables_total'] == 2
+
+        for t in pow2['tables']:
+            assert t['converging'] is False
+            assert t['target_pow2_tablet_count'] == 0
+            tablet_count = t['current_tablet_count']
+            assert tablet_count > 0 and (tablet_count & (tablet_count - 1)) == 0, \
+                f"Tablet count {tablet_count} for table {t['table']} is not a power of two"

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -882,6 +882,60 @@ async def test_migration_multiple_keyspaces(manager: ManagerClient):
 
 
 @pytest.mark.asyncio
+async def test_migration_multiple_tables(manager: ManagerClient):
+    """Verify vnodes-to-tablets migration on keyspace with multiple tables.
+
+    The test verifies that all tables get correct tablet maps, that resharding
+    and finalization work for all tables, and that pow2 convergence completes
+    for every table.
+    """
+    num_shards = 3
+    tokens_per_node = 16
+
+    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} random tokens")
+    cfg = {'num_tokens': tokens_per_node}
+    servers = await manager.servers_add(1, cmdline=['--smp', str(num_shards)], config=cfg)
+    server = servers[0]
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    vnode_boundaries = await get_all_vnode_tokens(cql)
+    logger.info(f"Vnode boundaries ({len(vnode_boundaries)} tokens): {vnode_boundaries}")
+
+    logger.info("Creating keyspace with two vnode tables")
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': false}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, c int)")
+        await cql.run_async(f"CREATE TABLE {ks}.t2 (pk int PRIMARY KEY, c int)")
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet maps)")
+        await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
+
+        logger.info("Verifying tablet map boundaries for both tables")
+        await verify_tablet_map_boundaries(manager, server, ks, 't1', vnode_boundaries)
+        await verify_tablet_map_boundaries(manager, server, ks, 't2', vnode_boundaries)
+
+        logger.info("Marking node for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+
+        logger.info("Restarting the node to trigger resharding")
+        await manager.server_restart(server.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info("Finalizing tablets migration")
+        await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
+
+        logger.info("Verifying that the keyspace schema has tablets enabled")
+        res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'")
+        assert len(res) == 1 and res[0].initial_tablets is not None, \
+            "keyspace is still using vnodes after migration finalization"
+
+        logger.info("Waiting for pow2 convergence on both tables")
+        await wait_for_pow2_convergence(manager, server, ks, 't1')
+        await wait_for_pow2_convergence(manager, server, ks, 't2')
+
+
+@pytest.mark.asyncio
 async def test_tablet_status_in_migration_api(manager: ManagerClient):
     """"Verify the ?include=tablet_status query parameter in the migration API.
 

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1047,3 +1047,147 @@ async def test_tablet_status_in_migration_api(manager: ManagerClient):
             tablet_count = t['current_tablet_count']
             assert tablet_count > 0 and (tablet_count & (tablet_count - 1)) == 0, \
                 f"Tablet count {tablet_count} for table {t['table']} is not a power of two"
+
+
+@pytest.mark.asyncio
+async def test_pow2_convergence_virtual_task(manager: ManagerClient):
+    """Verify that pow2 convergence is tracked via a virtual task.
+
+    Coverage:
+    - Task visibility: keyspace-level and table-level tasks appear during convergence.
+    - Progress: keyspace task reports tables converged/total; table tasks report percent complete.
+    - Parent-child: table tasks reference keyspace task as parent; keyspace task lists
+      table tasks as children.
+    - Not abortable: abort attempt is rejected.
+    - Wait API: wait on keyspace-level task returns "done" when convergence finishes.
+    - Lifetime: tasks disappear after convergence completes.
+
+    Edge cases not covered (but could be added in the future):
+    - Drop converging keyspace during task wait.
+    - Drop converging table during task wait.
+    - Drop all converging tables during task wait.
+    """
+    num_shards = 3
+    tokens_per_node = 16
+
+    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} random tokens")
+    cfg = {'num_tokens': tokens_per_node}
+    servers = await manager.servers_add(1, cmdline=['--smp', str(num_shards)], config=cfg)
+    server = servers[0]
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    logger.info("Creating keyspace with two empty vnode-based tables")
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': false}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, c int)")
+        await cql.run_async(f"CREATE TABLE {ks}.t2 (pk int PRIMARY KEY, c int)")
+
+        # Disable tablet balancing so convergence doesn't start after finalization.
+        await manager.api.disable_tablet_balancing(server.ip_addr)
+
+        logger.info("Starting vnodes-to-tablets migration")
+        await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
+
+        logger.info("Marking node for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+
+        logger.info("Restarting node to trigger resharding")
+        await manager.server_restart(server.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info("Finalizing migration")
+        await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
+
+        # At this point: migration is done, tables have target_pow2 != 0,
+        # but load balancing is disabled so no merges will run.
+
+        tm = TaskManagerClient(manager.api)
+
+        logger.info("Verifying pow2 convergence tasks appear in task manager")
+        tasks = await tm.list_tasks(server.ip_addr, "vnodes_to_tablets_migration")
+
+        # Filter pow2_convergence tasks.
+        convergence_tasks = [t for t in tasks if t.type == "pow2_convergence"]
+        ks_tasks = [t for t in convergence_tasks if t.scope == "keyspace" and t.keyspace == ks]
+        table_tasks = [t for t in convergence_tasks if t.scope == "table" and t.keyspace == ks]
+
+        assert len(ks_tasks) == 1, f"Expected 1 keyspace-level convergence task, got {len(ks_tasks)}"
+        assert len(table_tasks) == 2, f"Expected 2 table-level convergence tasks, got {len(table_tasks)}"
+
+        ks_task = ks_tasks[0]
+        assert ks_task.kind == "cluster"
+        assert ks_task.state == "running"
+
+        table_names = {t.table for t in table_tasks}
+        assert table_names == {'t1', 't2'}, f"Expected tables t1 and t2, got {table_names}"
+        for t in table_tasks:
+            assert t.kind == "cluster"
+            assert t.state == "running"
+
+        logger.info("Verifying keyspace-level task status (progress and children)")
+        ks_status = await tm.get_task_status(server.ip_addr, ks_task.task_id)
+        assert ks_status.kind == "cluster"
+        assert ks_status.state == "running"
+        assert ks_status.is_abortable is False
+        assert ks_status.progress_units == "tables"
+        assert ks_status.progress_total == 2, f"Expected total=2, got {ks_status.progress_total}"
+        assert ks_status.progress_completed == 0, f"Expected completed=0, got {ks_status.progress_completed}"
+
+        # Children should be the two table-level task IDs.
+        children_task_ids = {c['task_id'] for c in ks_status.children_ids}
+        expected_children = {t.task_id for t in table_tasks}
+        assert children_task_ids == expected_children, \
+            f"Keyspace task children mismatch: got {children_task_ids}, expected {expected_children}"
+
+        logger.info("Verifying table-level task status (progress, entity, parent)")
+        for t_task in table_tasks:
+            t_status = await tm.get_task_status(server.ip_addr, t_task.task_id)
+            assert t_status.kind == "cluster"
+            assert t_status.state == "running"
+            assert t_status.is_abortable is False
+            assert t_status.progress_units == "percent"
+            assert t_status.progress_total == 100
+            # Validate progress against the authoritative values in system.tablets.
+            current_tablet_count = await get_tablet_count(manager, server, ks, t_task.table)
+            target_pow2_tablet_count = await get_target_pow2_tablet_count(manager, server, ks, t_task.table)
+            assert current_tablet_count > 0, f"Table {t_task.table}: expected current_tablet_count > 0, got {current_tablet_count}"
+            expected_progress = int((target_pow2_tablet_count * 100.0 / current_tablet_count) + 0.5)
+            assert t_status.progress_completed == expected_progress, \
+                f"Table {t_task.table}: expected progress {expected_progress} (target={target_pow2_tablet_count}, current={current_tablet_count}), got {t_status.progress_completed}"
+            expected_entity = f"{current_tablet_count} tablets (target: {target_pow2_tablet_count})"
+            assert t_status.entity == expected_entity, \
+                f"Table {t_task.table}: expected entity '{expected_entity}', got '{t_status.entity}'"
+            # Parent should be the keyspace-level task.
+            assert t_status.parent_id == ks_task.task_id, \
+                f"Table {t_task.table}: expected parent_id={ks_task.task_id}, got {t_status.parent_id}"
+
+        logger.info("Verifying convergence tasks are not abortable")
+        with pytest.raises(HTTPError):
+            await tm.abort_task(server.ip_addr, ks_task.task_id)
+
+        with pytest.raises(HTTPError):
+            await tm.abort_task(server.ip_addr, table_tasks[0].task_id)
+
+        logger.info("Starting wait on keyspace-level convergence task")
+        log = await manager.server_open_log(server.server_id)
+        mark = await log.mark()
+
+        wait_task = asyncio.create_task(tm.wait_for_task(server.ip_addr, ks_task.task_id))
+
+        await log.wait_for('pow2_convergence_virtual_task: waiting for pow2 convergence to finish', from_mark=mark)
+
+        logger.info("Enabling tablet load balancing to let convergence proceed")
+        await manager.api.enable_tablet_balancing(server.ip_addr)
+
+        logger.info("Waiting for convergence to complete via task manager")
+        wait_status = await asyncio.wait_for(wait_task, timeout=120)
+        assert wait_status.state == "done", f"Expected 'done' state, got '{wait_status.state}'"
+        assert wait_status.progress_completed == wait_status.progress_total, \
+            f"Expected progress_completed == progress_total, got {wait_status.progress_completed}/{wait_status.progress_total}"
+
+        logger.info("Verifying convergence tasks have disappeared")
+        tasks = await tm.list_tasks(server.ip_addr, "vnodes_to_tablets_migration")
+        convergence_tasks = [t for t in tasks if t.type == "pow2_convergence"]
+        assert len(convergence_tasks) == 0, \
+            f"Expected no convergence tasks after completion, got {len(convergence_tasks)}"

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -6,6 +6,7 @@
 import os
 import glob
 import json
+import time
 import pytest
 import asyncio
 import logging
@@ -159,6 +160,38 @@ async def verify_tablet_map_boundaries(manager: ManagerClient, server: ServerInf
     assert not extra, f"Unexpected boundaries in tablet map: {sorted(extra)}"
 
     return tablet_replicas
+
+
+async def verify_pow2_layout(manager: ManagerClient, server: ServerInfo,
+                             ks: str, table_name: str):
+    """Verify that the tablet map has an exact uniform pow2 layout."""
+    tablet_replicas = await get_all_tablet_replicas(manager, server, ks, table_name)
+    tablet_count = len(tablet_replicas)
+    assert tablet_count > 0 and tablet_count & (tablet_count - 1) == 0, \
+        f"Tablet count {tablet_count} is not a power of two"
+
+    tablet_tokens = sorted(tr.last_token for tr in tablet_replicas)
+    expected_tokens = compute_pow2_boundaries(tablet_count)
+
+    assert tablet_tokens == expected_tokens
+
+
+async def wait_for_pow2_convergence(manager: ManagerClient, server: ServerInfo,
+                                    ks: str, table_name: str, timeout: float = 120):
+    """Wait until pow2 convergence completes and verify the result.
+
+    Polls target_pow2_tablet_count in system.tablets until it is cleared,
+    indicating that the tablet map has converged to a power-of-two layout.
+    Once cleared, verifies that the resulting tablet map has a pow2 layout.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        target = await get_target_pow2_tablet_count(manager, server, ks, table_name)
+        if target is None or target == 0:
+            await verify_pow2_layout(manager, server, ks, table_name)
+            return
+        await asyncio.sleep(1)
+    assert False, f"Pow2 convergence for {ks}.{table_name} did not complete within {timeout}s"
 
 
 async def verify_migration_status(manager: ManagerClient, server: ServerInfo,
@@ -327,6 +360,9 @@ async def test_migration(manager: ManagerClient):
         logger.info("Verifying migration status after finalization")
         await verify_migration_status(manager, server, ks, expected_status='tablets', expected_node_statuses={})
 
+        logger.info("Waiting for pow2 convergence to complete")
+        await wait_for_pow2_convergence(manager, server, ks, 'test')
+
 
 async def test_migration_rollback(manager: ManagerClient):
     """Verify rollback of vnodes-to-tablets migration on a single-node cluster.
@@ -460,7 +496,7 @@ async def test_migration_multinode(manager: ManagerClient):
     """
     num_nodes = 2
     num_shards = 3
-    tokens_per_node = 64
+    tokens_per_node = 16
     num_keys = 1000
 
     logger.info(f"Starting {num_nodes} nodes with {num_shards} shards each, {tokens_per_node} random tokens per node")
@@ -579,6 +615,9 @@ async def test_migration_multinode(manager: ManagerClient):
         logger.info("Final data integrity check")
         total_keys = num_keys + num_nodes * num_nodes * 10 # original keys + 10 keys per node inserted during rolling restarts
         await verify_data_integrity(cql, ks, "test", total_keys)
+
+        logger.info("Waiting for pow2 convergence to complete")
+        await wait_for_pow2_convergence(manager, servers[0], ks, 'test')
 
 
 async def setup_single_node(manager: ManagerClient):

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -341,9 +341,10 @@ class ScyllaRESTAPIClient:
         """Set the node's intended storage mode to vnodes"""
         await self.client.put_json(f"/storage_service/vnode_tablet_migrations/node/storage_mode?intended_mode=vnodes", host=node_ip)
 
-    async def get_vnode_tablet_migration_status(self, node_ip: str, ks: str) -> dict:
+    async def get_vnode_tablet_migration_status(self, node_ip: str, ks: str, with_tablet_status: bool = False) -> dict:
         """Get vnodes-to-tablets migration status for a keyspace"""
-        return await self.client.get_json(f"/storage_service/vnode_tablet_migrations/keyspaces/{ks}", host=node_ip)
+        params = {"include": "tablet_status"} if with_tablet_status else {}
+        return await self.client.get_json(f"/storage_service/vnode_tablet_migrations/keyspaces/{ks}", host=node_ip, params=params)
 
     async def finalize_vnode_tablet_migration(self, node_ip: str, ks: str) -> None:
         """Finalize vnodes-to-tablets migration for all tables in a keyspace"""

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -2474,7 +2474,13 @@ void migrate_to_tablets_status_operation(scylla_rest_client& client, const bpo::
         throw std::invalid_argument("keyspace is required");
     }
     auto keyspace = vm["keyspace"].as<sstring>();
-    auto res = client.get(fmt::format("/storage_service/vnode_tablet_migrations/keyspaces/{}", keyspace));
+    const bool with_tablet_status = vm.contains("with-tablet-status");
+
+    auto url = fmt::format("/storage_service/vnode_tablet_migrations/keyspaces/{}", keyspace);
+    if (with_tablet_status) {
+        url += "?include=tablet_status";
+    }
+    auto res = client.get(url);
 
     auto node_status = [] (std::string_view current_mode, std::string_view intended_mode) -> std::string_view {
         if (intended_mode == "vnodes" && current_mode == "vnodes") {
@@ -2502,6 +2508,44 @@ void migrate_to_tablets_status_operation(scylla_rest_client& client, const bpo::
             table.add(
                 std::string(rjson::to_string_view(node["host_id"])),
                 std::string(node_status(current, intended)));
+        }
+        table.print();
+    }
+
+    if (!with_tablet_status) {
+        return;
+    }
+
+    fmt::print(std::cout, "\nTablet info:\n");
+
+    auto status = rjson::to_string_view(res["status"]);
+    if (status != "tablets") {
+        fmt::print(std::cout, "  Pow2 tablet layout convergence: not applicable (keyspace uses vnodes)\n");
+        return;
+    }
+
+    const auto& tablets = res["tablets"];
+    const auto& pow2 = tablets["pow2_convergence"];
+    auto convergence_status = rjson::to_string_view(pow2["status"]);
+    auto tables_converging = pow2["tables_converging"].GetUint64();
+    auto tables_total = pow2["tables_total"].GetUint64();
+
+    fmt::print(std::cout, "  Pow2 tablet layout convergence: {}\n", convergence_status);
+    fmt::print(std::cout, "  Tables converging: {}/{}\n", tables_converging, tables_total);
+
+    const auto& tables = pow2["tables"].GetArray();
+    if (!tables.Empty()) {
+        fmt::print(std::cout, "\n");
+        Tabulate table;
+        table.add("Table", "Status", "Tablets", "Target");
+        for (const auto& t : tables) {
+            auto converging = t["converging"].GetBool();
+            auto target = t["target_pow2_tablet_count"].GetUint64();
+            table.add(
+                std::string(rjson::to_string_view(t["table"])),
+                std::string(converging ? "converging" : "converged"),
+                fmt::to_string(t["current_tablet_count"].GetUint64()),
+                converging ? fmt::to_string(target) : std::string("-"));
         }
         table.print();
     }
@@ -4466,7 +4510,9 @@ Subcommands:
                         "status",
                         "Show migration status for a keyspace",
                         "",
-                        { },
+                        {
+                            typed_option<>("with-tablet-status", "Include per-table tablet layout convergence to pow2 status (only relevant after migration finalization)"),
+                        },
                         {
                             typed_option<sstring>("keyspace", "The keyspace to check status for", 1),
                         },


### PR DESCRIPTION
The vnodes-to-tablets migration procedure introduced in 00409b6 constructs the tablet map of a migrated table as a direct 1:1 mapping of the vnode layout: one tablet per vnode, with the same token boundaries and replica hosts. This has the undesirable effect that migrated tables start out with highly uneven tablet token ranges, with some tablets up to 10x larger than average and others up to 1000x smaller. Such tablets are hard to balance across shards.

This PR introduces a pow2 convergence mechanism that normalizes the initial tablet map of a migrated table into a uniform pow2 layout. The machanism has two phases:
1. Pre-splitting: migration pre-splits the vnode-based initial tablet map at the boundaries of the power of two that is indicated by the load balancer's sizing policy.
2. Post-migration merging - after migration finalization, the load balancer runs multiple rounds of selective merges to eliminate the vnode boundaries while preserving the target pow2 boundaries.

The target power of two is determined by the migration code and communicated to the load balancer via a new `target_pow2_tablet_count` column in `system.tablets`. This column also serves as a flag: only tables that carry a non-zero value participate in pow2 convergence. Tables that were migrated before this feature remain unchanged.

To drive the second phase, a new "selective" merge mode is introduced. In contrast to the regular table-wide merge mode, this new mode allows the load balancer to merge only a subset of tablet pairs, the ones that do not cross pow2 boundaries. Depending on the max number of tablets per pow2 segment, multiple selective merge rounds may be needed until the desired pow2 is achieved. Once this happens, the merge finalization marks the end of the convergence by clearing the `target_pow2_tablet_count` for this table. During pow2 convergence, the load balancer suppresses regular splits and merges for the migrated tables. However, selective merges share the same priority and shard budget as regular resize work for other tables.

Target pow2 tablet counts are derived using the load balancer's sizing policy. This ensures that migrated tables do not require additional resizing after pow2 convergence, which would require more work. To prevent unnecessary scale-downs on other tables, the load balancer has been modified to count the converging tables with their target tablet counts instead of their current inflated tablet counts.   

The PR also adds operational visibility for this background work. The migration status API and its nodetool wrapper can now report per-table pow2 convergence status (example outputs are included in the patch descriptions). A virtual task is added as well. The migration guide is extended with an optional post-finalization step for users who want to wait until pow2 convergence completes.

Example tablet counts for various scenarios:
* Common setup: 1 DC, racks=3, RF=3, num_tokens = 256, tablets_initial_scale_factor=10, tablets_per_shard_goal=100

| Scenario                      | Topology                 | target | initial w/o pre-splits | initial w/ pre-splits |
|-------------------------------|--------------------------|--------|------------------------|-----------------------|
| 1 small table, small cluster  | 1 node/rack, 2 shards    | 32     | 769                    | 800                   |
| 12 small tables               | 1 node/rack, 2 shards    | 16     | 769                    | 784                   |
| 1 large table (1TiB)          | 3 nodes/rack, 2 shards   | 256    | 2305                   | 2560                  |
| 1 small table, medium cluster | 3 nodes/rack, 32 shards  | 1024   | 2305                   | 3328                  |
| 1 small table, large cluster  | 3 nodes/rack, 192 shards | 8192   | 2305                   | 10496                 |

*{initial w/o pre-splits} = num_tokens * num_nodes + 1
*{initial w/ pre-splits} = num_tokens * num_nodes + target (assuming no overlap between vnode and pow2 tokens)

Fixes SCYLLADB-1595.
Fixes SCYLLADB-1141.

Performance optimization, no backport is needed.