### PR TITLE
mv: synchronize view update completion during shutdown using a gate

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2093,9 +2093,10 @@ future<> view_update_generator::mutate_MV(
             // to database::max_concurrent_local_view_updates. Local view updates are cpu-bound, so the cpu won't idle even
             // if the concurrency is low and executing too many view updates concurrently can unnecessarily increase latency and memory usage.
             auto count_units = co_await seastar::get_units(_db.get_view_update_concurrency_sem(), 1);
+            auto gate_holder = _gate.hold();
             local_view_update = _proxy.local().mutate_mv_locally(mut.s, *mut_ptr, tr_state, db::commitlog::force_sync::no).then_wrapped(
                     [s = mut.s, &stats, &cf_stats, tr_state, base_token, view_token, my_address, mut_ptr = std::move(mut_ptr),
-                            count_units = std::move(count_units), memory_units, this] (future<>&& f) mutable {
+                            count_units = std::move(count_units), memory_units, h = std::move(gate_holder), this] (future<>&& f) mutable {
                 --stats.writes;
                 memory_units = nullptr;
                 _proxy.local().update_view_update_backlog();
@@ -2131,9 +2132,10 @@ future<> view_update_generator::mutate_MV(
             stats.view_updates_pushed_remote += updates_pushed_remote;
             cf_stats.total_view_updates_pushed_remote += updates_pushed_remote;
             schema_ptr s = mut.s;
+            auto gate_holder = _gate.hold();
             future<> remote_view_update = apply_to_remote_endpoints(_proxy.local(), std::move(view_ermp), *target_endpoint, std::move(remote_endpoints), std::move(mut), base_token, view_token, allow_hints, tr_state).then_wrapped(
                 [s = std::move(s), &stats, &cf_stats, tr_state, base_token, view_token, target_endpoint, updates_pushed_remote,
-                 memory_units, apply_update_synchronously, this] (future<>&& f) mutable {
+                 memory_units, apply_update_synchronously, h = std::move(gate_holder), this] (future<>&& f) mutable {
                 memory_units = nullptr;
                 _proxy.local().update_view_update_backlog();
                 if (f.failed()) {

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -290,7 +290,8 @@ void view_update_generator::do_abort() noexcept {
 }
 
 future<> view_update_generator::drain() {
-    return _proxy.local().abort_view_writes();
+    co_await _proxy.local().abort_view_writes();
+    co_await _gate.close();
 }
 
 future<> view_update_generator::stop() {

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -20,6 +20,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/core/gate.hh>
 
 using namespace seastar;
 
@@ -75,6 +76,7 @@ private:
     class progress_tracker;
     std::unique_ptr<progress_tracker> _progress_tracker;
     optimized_optional<abort_source::subscription> _early_abort_subscription;
+    seastar::gate _gate;
     void do_abort() noexcept;
 public:
     view_update_generator(replica::database& db, sharded<service::storage_proxy>& proxy, node_update_backlog& node_backlog, abort_source& as);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2811,7 +2811,10 @@ future<> database::stop() {
     for (auto& [sg, sem] : _view_update_concurrency_semaphores) {
         co_await sem.wait(max_concurrent_local_view_updates);
     }
-    co_await _view_update_memory_sem.wait(max_memory_pending_view_updates());
+    if (_view_update_memory_sem.current() != max_memory_pending_view_updates()) {
+        dblog.error("View update memory semaphore is not fully replenished while shutting down database. "
+                    "The shutdown may fail when the view updates try accessing objects that have already been destroyed");
+    }
     if (_commitlog) {
         co_await _commitlog->release();
     }

--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -19,7 +19,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.tablets import get_tablet_replica
 from test.pylib.util import wait_for, wait_for_view
-from test.cluster.mv.tablets.test_mv_tablets import get_tablet_replicas
+from test.cluster.mv.tablets.test_mv_tablets import get_tablet_replicas, pin_the_only_tablet
 
 
 logger = logging.getLogger(__name__)
@@ -510,3 +510,41 @@ async def test_mv_write_during_node_join(manager: ManagerClient):
             if len(rows) == 1 and rows[0].cnt == N:
                 return True
         await wait_for(all_rows_found, time.time() + 60)
+
+# In this test we stop the server shortly after starting generating a view update.
+# The view update is delayed, so the cleanup code processed after the update executes
+# while we're already shutting down. This code should not reference any objects destroyed
+# earlier in the shutdown sequence. The test passes if the server doesn't crash during shutdown.
+# Reproduces issue SCYLLADB-2301
+@pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
+async def test_no_crash_on_shutdown_with_pending_remote_view_update(manager: ManagerClient) -> None:
+    node_count = 2
+    servers = await manager.servers_add(node_count, config={'tablets_mode_for_new_keyspaces': 'enabled'})
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        # await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': 1}}")
+        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, PRIMARY KEY (key, c))")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv AS SELECT * FROM {ks}.tab "
+                        "WHERE c IS NOT NULL and key IS NOT NULL PRIMARY KEY (c, key)")
+
+        await wait_for_view(cql, 'mv', node_count)
+
+        # Pin base and view on different servers to ensure remote view updates
+        await pin_the_only_tablet(manager, ks, "tab", servers[0])
+        await pin_the_only_tablet(manager, ks, "mv", servers[1])
+
+        # delay_before_remote_view_update delays remote view updates by 500ms.
+        # This ensures the update is still in-flight when we stop the server.
+        await manager.api.enable_injection(servers[0].ip_addr, "delay_before_remote_view_update", one_shot=False)
+
+        # Insert a row — this triggers a fire-and-forget remote view update
+        # that will be delayed 500ms by the injection.
+        await cql.run_async(f"INSERT INTO {ks}.tab (key, c) VALUES (1, 1)")
+
+        # Stop the server immediately. The remote view update is still pending
+        # (held by the 500ms injection sleep). During shutdown, VUG is destroyed
+        # while the detached continuation still references it.
+        # Without the fix, this crashes with exit code -11 (SIGSEGV).
+        await manager.server_stop_gracefully(servers[0].server_id)
+        # Start the server again for clean test shutdown
+        await manager.server_start(servers[0].server_id)


### PR DESCRIPTION
During the graceful shutdown process, we have a few mechanisms for
making sure that the view updates finish before other services can be
shut down.

The main ones are cancelling abstract write handlers for generated view
updates, which happens during view_update_generator::drain() and waiting
until semaphore units that are held over the view update's duration are
all released, happenning in database::stop().

Only the second mechanism waits until the follow-up work for view updates
(such as updating metrics and view update backlog) finishes. So the follow-up
lambda may execute at any point before database::stop(). In particular, it
may execute when the view_update_generator is already destroyed. This
can cause the process to abort, because the follow-up lambda references
the view_update_builder. This patch introduces the test exercising this
exact scenario.

In this patch we make sure that all view updates complete (or are aborted)
before destroying the view_update_generator. We achieve that by adding
a gate that is held over the duration of each view update, and closing
the gate while draining the view_update_builder. This waits for the same
condition as waiting for semaphores to clear, but to use the semaphore
we need access to database's private members, and the semaphore counting
memory usage of view updates is not the designated option for shutdown
synchronization - the gate exists specifically for this purpose.

We also remove the wait on the semaphore from database::stop(). When we
start stopping database, all view updates (and their continuations) must
be already stopped - otherwise, they'll try accessing view_update_generator
which is already destroyed.

Fixes: SCYLLADB-2301