### PR TITLE
test/pylib: fix starting server stop race

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1304,7 +1304,9 @@ class ScyllaCluster:
             await handle_join_failure()
             raise
         finally:
-            del self.starting[server.server_id]
+            # server_stop() may have already removed the starting server
+            # if it interrupted this add_server() operation.
+            self.starting.pop(server.server_id, None)
 
         if expected_error:
             await handle_join_failure()
@@ -1455,7 +1457,9 @@ class ScyllaCluster:
             self.running.pop(server_id)
             self.stopped[server_id] = server
         else:
-            self.starting.pop(server_id)
+            # Starting servers are removed from self.starting by add_server()
+            # in its cleanup path. This is a fallback if server_stop() wins the race.
+            self.starting.pop(server_id, None)
 
     def server_mark_removed(self, server_id: ServerNum) -> None:
         """Mark server as removed."""


### PR DESCRIPTION
## Problem
`test_localnodes_joining_nodes` intentionally starts a second node in the background with a delayed bootstrap, checks `/localnodes`, and then stops the still-starting server to avoid waiting for the full injection delay.

That creates a race in the test cluster manager. Stopping the process can make the background `add_server()` request fail and run its cleanup path first, removing the server from `ScyllaCluster.starting`. When the `/cluster/server/{id}/stop` request later resumes, it can try to remove the same entry and raise `KeyError`, which is returned to the test as HTTP 500.

The reverse ordering is possible too: `server_stop()` can remove the starting entry before `add_server()` reaches its `finally` block.

## Solution
Make cleanup of `ScyllaCluster.starting` idempotent in both paths:

- `add_server()` still performs the normal cleanup in its `finally` block, but tolerates the entry already being removed by an interrupting stop request.
- `server_stop()` keeps a fallback cleanup for starting servers, but tolerates the entry already being removed by `add_server()`.

Fixes SCYLLADB-2314

The problem was encountered on master, so let's fix it only there.