### PR TITLE
test/cluster: add pylib-style nodetool.py

### DIFF
--- a/test/cluster/test_compaction_backpressure.py
+++ b/test/cluster/test_compaction_backpressure.py
@@ -8,7 +8,6 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.tablets import get_tablet_replica
 from test.pylib.rest_client import inject_error_one_shot, inject_error
 from test.cluster.util import new_test_keyspace, new_test_table
-from test.cqlpy import nodetool
 
 import pytest
 import asyncio

--- a/test/cluster/test_encryption.py
+++ b/test/cluster/test_encryption.py
@@ -20,7 +20,7 @@ from test.pylib.manager_client import ManagerClient, ServerInfo
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.pylib.tablets import get_all_tablet_replicas
 
-from test.cqlpy import nodetool
+from test.pylib import nodetool
 
 from test.pylib.encryption_provider import KeyProviderFactory, KeyProvider, make_key_provider_factory, KMSKeyProviderFactory, LocalFileSystemKeyProviderFactory
 from test.cluster.util import new_test_keyspace, new_test_table
@@ -134,7 +134,7 @@ async def prepare_write_workload(cql: CassandraSession, table_name, flush=True, 
                                     )
 
     if flush:
-        nodetool.flush(cql, table_name)
+        await nodetool.flush(cql, table_name)
 
     return keys
 
@@ -316,7 +316,7 @@ async def validate_sstables_encryption(manager: ManagerClient, server: ServerInf
     """Verify sstables for table encrypted or not"""
     keyspace, column_family  = table_name.split(".")
     scylla_path = await manager.server_get_exe(server.server_id)
-    with nodetool.no_autocompaction_context(manager.cql, table_name):
+    async with nodetool.no_autocompaction_context(manager.cql, table_name):
         scylla_metadata = await get_sstable_metadata(manager, server, keyspace, column_family)
         logger.debug("validate_sstables_encrypted(): scylla_metadata=%s", scylla_metadata)
 
@@ -408,7 +408,7 @@ async def test_per_table_master_key(manager: ManagerClient, tmpdir):
                 keyspace, column_family  = table_name.split(".")
                 await validate_sstables_encryption(manager, servers[0],
                                                    table_name, True)
-                with nodetool.no_autocompaction_context(manager.cql, table_name):
+                async with nodetool.no_autocompaction_context(manager.cql, table_name):
                     scylla_metadata = await get_sstable_metadata(manager, servers[0], 
                                                                  keyspace, column_family)
                     table_key_ids = [metadata.get("extension_attributes", {})["scylla_key_id"]

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -19,7 +19,7 @@ from test.pylib.tablets import get_tablet_replicas
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import gather_safely, wait_for
 
-from test.cqlpy import nodetool
+from test.pylib import nodetool
 from test.cluster.util import get_topology_coordinator, find_server_by_host_id, keyspace_has_tablets, new_test_keyspace, new_test_table
 
 
@@ -352,7 +352,7 @@ async def test_canceling_hint_draining(manager: ManagerClient):
     sync_point = await create_sync_point(manager.api.client, s1.ip_addr)
 
     await manager.api.enable_injection(s1.ip_addr, "hinted_handoff_pause_hint_replay", False, {})
-    nodetool.excludenode(cql, host_id2)
+    await nodetool.excludenode(cql, host_id2)
     await cql.run_async(f"ALTER KEYSPACE ks WITH REPLICATION = {{'class': 'NetworkTopologyStrategy', 'dc': {[s1.rack, s3.rack]}}}")
 
     await manager.remove_node(s1.server_id, s2.server_id)

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -12,7 +12,7 @@ from typing import List, Union
 import pytest
 from cassandra.policies import WhiteListRoundRobinPolicy
 
-from test.cqlpy import nodetool
+from test.pylib import nodetool
 from cassandra import ConsistencyLevel, Unavailable
 from cassandra.cluster import NoHostAvailable
 from cassandra.protocol import InvalidRequest, ConfigurationException
@@ -83,21 +83,21 @@ async def test_putget_2dc_with_rf(
         query_batch % ";".join(kvs), consistency_level=ConsistencyLevel.QUORUM
     )
     conn.execute(query)
-    nodetool.flush_keyspace(conn, ks)
+    await nodetool.flush_keyspace(conn, ks)
     # overwrite each second value
     kvs = [update_query % (i * 4, i * 2) for i in range(50)]
     query = SimpleStatement(
         query_batch % "; ".join(kvs), consistency_level=ConsistencyLevel.QUORUM
     )
     conn.execute(query)
-    nodetool.flush_keyspace(conn, ks)
+    await nodetool.flush_keyspace(conn, ks)
     # overwrite each fifth value
     kvs = [update_query % (i * 20, i * 5) for i in range(20)]
     query = SimpleStatement(
         query_batch % "; ".join(kvs), consistency_level=ConsistencyLevel.QUORUM
     )
     conn.execute(query)
-    nodetool.flush_keyspace(conn, ks)
+    await nodetool.flush_keyspace(conn, ks)
 
     logger.info("Check written data is correct")
     query = SimpleStatement(f"SELECT * FROM {cf} WHERE key='k0'", consistency_level=ConsistencyLevel.QUORUM)
@@ -148,7 +148,7 @@ async def test_read_or_write_to_dc_with_rf_0_fails(request: pytest.FixtureReques
         dc1_connection.execute(SimpleStatement(
                 f"INSERT INTO {ks}.{table_name} ({columns[0].name}, {columns[1].name}) VALUES ('k{i}', 'value{i}')", consistency_level=cl))
 
-        nodetool.flush(dc1_connection, f"{ks}.{table_name}")
+        await nodetool.flush(dc1_connection, f"{ks}.{table_name}")
 
         select_query = SimpleStatement(f"SELECT * FROM {ks}.{table_name} WHERE {columns[0].name} = 'k{i}'", consistency_level=cl)
         # asserting SELECT's results may seem excessive, but it could happen that it'd fail and return nothing and not throw,

--- a/test/cluster/test_snapshot_with_tablets.py
+++ b/test/cluster/test_snapshot_with_tablets.py
@@ -9,7 +9,7 @@ import logging
 import os
 import json
 
-from test.cqlpy import nodetool
+from test.pylib import nodetool
 from test.pylib.manager_client import ManagerClient
 from test.cluster.object_store.test_backup import create_cluster, topo
 from test.cluster.util import new_test_keyspace, new_test_table, unique_name
@@ -61,7 +61,7 @@ async def prepare_write_workload(cql, table_name, flush=True, n: int = None):
                                     )
 
     if flush:
-        nodetool.flush(cql, table_name)
+        await nodetool.flush(cql, table_name)
 
 async def test_snapshot_on_all_nodes(manager: ManagerClient):
     """

--- a/test/pylib/nodetool.py
+++ b/test/pylib/nodetool.py
@@ -1,0 +1,72 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+"""Async nodetool-compatible helpers for Scylla cluster tests.
+
+Unlike ``test.cqlpy.nodetool``, this module is intentionally Scylla-only and
+also uses the async REST API.
+"""
+
+from __future__ import annotations
+
+import re
+
+from cassandra.cluster import Session as CassandraSession  # type: ignore # pylint: disable=no-name-in-module
+
+from test.pylib.rest_client import ScyllaRESTAPIClient
+
+_rest_client = ScyllaRESTAPIClient().client
+
+
+def _rest_host(cql: CassandraSession) -> str:
+    # If given an exclusive connection to a single node (get_cql_exclusive()),
+    # the request is sent to that specific node. Otherwise, if given a
+    # connection to the whole cluster (get_cql()), the request is sent to one
+    # of the nodes in the cluster, it is unspecified which one.
+    return str(cql.cluster.contact_points[0])
+
+
+def _parse_keyspace_table(name: str, separator_chars: str = ".") -> tuple[str, str | None]:
+    pattern = rf"(?P<keyspace>\w+)(?:[{separator_chars}](?P<table>\w+))?"
+    match = re.match(pattern, name)
+    if match is None:
+        raise ValueError(f"Invalid keyspace/table name: {name}")
+    return match.group("keyspace"), match.group("table")
+
+
+async def flush(cql: CassandraSession, table: str) -> None:
+    """Flush the memtables for table of the form ``ks.table``, like ``nodetool flush <ks> <table>``."""
+    ks, cf = table.split(".")
+    await _rest_client.post(f"/storage_service/keyspace_flush/{ks}", host=_rest_host(cql), params={"cf": cf})
+
+
+async def flush_keyspace(cql: CassandraSession, ks: str) -> None:
+    """Flush all tables in a keyspace, like ``nodetool flush <ks>``."""
+    await _rest_client.post(f"/storage_service/keyspace_flush/{ks}", host=_rest_host(cql))
+
+
+async def excludenode(cql: CassandraSession, excluded_host_id: str) -> None:
+    """Exclude a node from token ownership by host ID, like ``nodetool excludenode <host_id>``."""
+    await _rest_client.post("/storage_service/exclude_node/", host=_rest_host(cql), params={"hosts": excluded_host_id})
+
+
+class no_autocompaction_context:
+    """Disable autocompaction for keyspace(s) or keyspace.table(s)."""
+
+    def __init__(self, cql: CassandraSession, *names: str):
+        self._cql = cql
+        self._names = list(names)
+
+    async def __aenter__(self) -> "no_autocompaction_context":
+        for name in self._names:
+            ks, tbl = _parse_keyspace_table(name, ".:")
+            api_path = f"/storage_service/auto_compaction/{ks}" if not tbl else f"/column_family/autocompaction/{ks}:{tbl}"
+            await _rest_client.delete(api_path, host=_rest_host(self._cql))
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, exc_traceback) -> None:
+        for name in self._names:
+            ks, tbl = _parse_keyspace_table(name, ".:")
+            api_path = f"/storage_service/auto_compaction/{ks}" if not tbl else f"/column_family/autocompaction/{ks}:{tbl}"
+            await _rest_client.post(api_path, host=_rest_host(self._cql))


### PR DESCRIPTION
Tests in test/cqlpy use a tiny nodetool-like library, where calls to nodetool.flush() are translated to the parallel REST API request on Scylla - but use an external "nodetool" command when running the test against Cassandra.

Some tests/cluster also began using test/cqlpy/nodetool.py, but it is NOT a good fit for test/cluster tests, because:

1. It falls back to using the external "nodetool" when it thinks the REST API is not available. In cluster tests, no such fallback is needed (these tests can't be run on Cassandra). If the REST API is down, the test should fail - not fall back to an irrelevant method.

2. The nodetool.flush() et al. functions are not async, and cluster tests are supposed (by design...) to only use async APIs.

3. test/cqlpy/nodetool.py was not written in the "style" defined for the test/cluster codebase - specifically they don't have docstrings or strong typing.

This patch introduces test/pylib/nodetool.py, based on test/cqlpy/nodetool.py but fixing all the above problems - there are no Cassandra fallbacks, there are docstrings and type hints, and all the functions are async.

We also fix the test/cluster tests that used test/cqlpy/nodetool.py to switch to test/pylib/nodetool.py. Of course it means the newly async functions need to be "await"ed, not just called, so this patch changes that too.