### PR TITLE
schema: shrink column_definition 112B→104B (8B, 7.1%) and skip v3_columns heap (~2.6KB/20-col table) for non-compact tables

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1749,7 +1749,7 @@ static schema_mutations make_table_mutations(schema_ptr table, api::timestamp_ty
     mutation indices_mutation(indexes(), pkey);
 
     if (with_columns_and_triggers) {
-        for (auto&& column : table->v3().all_columns()) {
+        for (auto&& column : table->v3_all_columns()) {
             if (column.is_view_virtual()) {
                 throw std::logic_error("view_virtual column found in non-view table");
             }
@@ -1889,13 +1889,15 @@ static void make_update_columns_mutations(schema_ptr old_table,
     mutation view_virtual_columns_mutation(view_virtual_columns(), partition_key::from_singular(*columns(), old_table->ks_name()));
     mutation computed_columns_mutation(computed_columns(), partition_key::from_singular(*columns(), old_table->ks_name()));
 
-    auto diff = difference(old_table->v3().columns_by_name(), new_table->v3().columns_by_name());
+    const auto& old_columns = old_table->all_columns_by_name();
+    const auto& new_columns = new_table->all_columns_by_name();
+    auto diff = difference(old_columns, new_columns);
 
     // columns that are no longer needed
     for (auto&& name : diff.entries_only_on_left) {
         // Thrift only knows about the REGULAR ColumnDefinition type, so don't consider other type
         // are being deleted just because they are not here.
-        const column_definition& column = *old_table->v3().columns_by_name().at(name);
+        const column_definition& column = *old_columns.at(name);
         if (column.is_view_virtual()) {
             drop_column_from_schema_mutation(view_virtual_columns(), old_table, column.name_as_text(), timestamp, mutations);
         } else {
@@ -1908,7 +1910,7 @@ static void make_update_columns_mutations(schema_ptr old_table,
 
     // newly added columns and old columns with updated attributes
     for (auto&& name : boost::range::join(diff.entries_differing, diff.entries_only_on_right)) {
-        const column_definition& column = *new_table->v3().columns_by_name().at(name);
+        const column_definition& column = *new_columns.at(name);
         if (column.is_view_virtual()) {
             add_column_to_schema_mutation(new_table, column, timestamp, view_virtual_columns_mutation);
         } else {
@@ -2645,7 +2647,7 @@ static schema_mutations make_view_mutations(view_ptr view, api::timestamp_type t
     mutation indices_mutation(indexes(), pkey);
 
     if (with_columns) {
-        for (auto&& column : view->v3().all_columns()) {
+        for (auto&& column : view->v3_all_columns()) {
             if (column.is_view_virtual()) {
                 add_column_to_schema_mutation(view, column, timestamp, view_virtual_columns_mutation);
             } else {

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -404,7 +404,9 @@ void schema::rebuild() {
         }
     }
 
-    _v3_columns = v3_columns::from_v2_schema(*this);
+    if (is_compact_table()) {
+        _v3_columns = v3_columns::from_v2_schema(*this);
+    }
     _full_slice = make_shared<query::partition_slice>(partition_slice_builder(*this).build());
     compute_all_columns_in_select_order();
 }

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -796,11 +796,11 @@ sstring index_metadata::get_default_index_name(const sstring& cf_name,
 
 column_definition::column_definition(bytes name, data_type type, column_kind kind, column_id component_index, column_view_virtual is_view_virtual, column_computation_ptr computation, api::timestamp_type dropped_at)
         : _name(std::move(name))
+        , _computation(std::move(computation))
         , _dropped_at(dropped_at)
         , _is_atomic(type->is_atomic())
         , _is_counter(type->is_counter())
         , _is_view_virtual(is_view_virtual)
-        , _computation(std::move(computation))
         , type(std::move(type))
         , id(component_index)
         , kind(kind)

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -591,10 +591,6 @@ private:
     };
     raw_schema _raw;
     schema_static_props _static_props;
-    // Populated only for compact storage tables (legacy).
-    // For non-compact tables, left default-constructed (empty) and
-    // v3_all_columns()/all_columns_by_name() delegate to all_columns().
-    v3_columns _v3_columns;
     mutable schema_registry_entry* _registry_entry = nullptr;
     std::unique_ptr<::view_info> _view_info;
     mutable schema_ptr _cdc_schema;
@@ -615,6 +611,11 @@ private:
     column_count_type _static_column_count;
 
     std::vector<const column_definition*> _all_columns_in_select_order;
+
+    // Populated only for compact storage tables (legacy).
+    // For non-compact tables, left default-constructed (empty) and
+    // v3_all_columns()/all_columns_by_name() delegate to all_columns().
+    v3_columns _v3_columns;
 
     extensions_map& extensions() {
         return _raw._props.extensions;
@@ -1000,7 +1001,7 @@ public:
     // Returns the CQL3-view columns: for compact storage tables, this is the
     // v3-transformed layout; for non-compact tables, returns all_columns().
     const columns_type& v3_all_columns() const noexcept {
-        if (!_v3_columns.all_columns().empty()) {
+        if (is_compact_table()) {
             return _v3_columns.all_columns();
         }
         return all_columns();
@@ -1012,7 +1013,7 @@ public:
     // to rebuild), and v3_columns keeps its own _columns_by_name for compact
     // tables. No allocation or copy on the DDL path.
     const std::unordered_map<bytes, const column_definition*>& all_columns_by_name() const {
-        if (!_v3_columns.columns_by_name().empty()) {
+        if (is_compact_table()) {
             return _v3_columns.columns_by_name();
         }
         return columns_by_name();

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -232,11 +232,8 @@ public:
     };
 private:
     bytes _name;
-    api::timestamp_type _dropped_at;
-    bool _is_atomic;
-    bool _is_counter;
-    column_view_virtual _is_view_virtual;
     column_computation_ptr _computation;
+    api::timestamp_type _dropped_at;
 
     struct thrift_bits {
         thrift_bits()
@@ -246,7 +243,12 @@ private:
         // more...?
     };
 
+    // Group small fields together to minimize padding.
     thrift_bits _thrift_bits;
+    bool _is_atomic;
+    bool _is_counter;
+    column_view_virtual _is_view_virtual;
+
     friend class schema;
 public:
     column_definition(bytes name, data_type type, column_kind kind,

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -591,6 +591,9 @@ private:
     };
     raw_schema _raw;
     schema_static_props _static_props;
+    // Populated only for compact storage tables (legacy).
+    // For non-compact tables, left default-constructed (empty) and
+    // v3_all_columns()/all_columns_by_name() delegate to all_columns().
     v3_columns _v3_columns;
     mutable schema_registry_entry* _registry_entry = nullptr;
     std::unique_ptr<::view_info> _view_info;
@@ -994,8 +997,25 @@ private:
 
     managed_string get_create_statement(const schema_describe_helper& helper, bool with_internals) const;
 public:
-    const v3_columns& v3() const {
-        return _v3_columns;
+    // Returns the CQL3-view columns: for compact storage tables, this is the
+    // v3-transformed layout; for non-compact tables, returns all_columns().
+    const columns_type& v3_all_columns() const noexcept {
+        if (!_v3_columns.all_columns().empty()) {
+            return _v3_columns.all_columns();
+        }
+        return all_columns();
+    }
+
+    // Returns a name-to-column map for schema diffing. Only needed for DDL operations.
+    // Returns a reference to a pre-built map in both branches: schema::rebuild()
+    // populates _columns_by_name from all_columns() (identical to what this used
+    // to rebuild), and v3_columns keeps its own _columns_by_name for compact
+    // tables. No allocation or copy on the DDL path.
+    const std::unordered_map<bytes, const column_definition*>& all_columns_by_name() const {
+        if (!_v3_columns.columns_by_name().empty()) {
+            return _v3_columns.columns_by_name();
+        }
+        return columns_by_name();
     }
 
     // Make a copy of the schema with reversed clustering order.

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -412,7 +412,7 @@ sstable_schema make_sstable_schema(const schema& s, const encoding_stats& enc_st
         }
     };
 
-    for (const auto& column : s.v3().all_columns()) {
+    for (const auto& column : s.v3_all_columns()) {
         add_column(column);
     }
 


### PR DESCRIPTION
## Motivation

The `schema` struct (1112B) contains a `v3_columns` field (112B) that is only populated for compact storage tables (deprecated since Cassandra 3.0, CREATE disabled by default in Scylla). For non-compact tables (the vast majority), this field is default-constructed and never accessed on the query hot path, yet it sits between hot fields, pushing them further apart.

Additionally, `column_definition` (112B) has suboptimal field ordering with 8B of internal padding wasted on alignment gaps between bool and pointer fields.

## Nature of change (3 commits)

1. **Skip v3_columns computation for non-compact tables**: Only call `v3_columns::from_v2_schema()` for compact storage tables. For non-compact tables, the member remains default-constructed (empty). Saves N×112B heap per non-compact table (column_definition copies + map overhead). For a 20-column table: ~2.6KB heap saved per shard.

2. **Move v3_columns to end of struct**: Moves the cold 112B v3_columns field to the end so hot fields (_offsets, _columns_by_name, partition_key_type, full_slice) are packed closer together. struct size unchanged (1112B) but better cache locality on the query path.

3. **Reorder column_definition fields**: Eliminates 8B of internal padding by grouping 1-byte fields together. **112B → 104B per column_definition (8B saved, 7.1%)**. With ~20 columns per table, this saves 160B per schema instance.

## Total savings per non-compact table schema

- Schema struct itself: 1112B (unchanged — v3_columns must remain for ABI/IDL compatibility)
- column_definition: 112B → 104B = 8B × N columns saved (160B for a 20-column table)
- v3_columns heap allocation: eliminated entirely for non-compact tables (~2.6KB for 20 columns)
- Cache locality: hot fields packed into fewer cache lines

## Measured (perf-simple-query, release, smp 1, taskset -c 0, fixed 2.2GHz, 10K partitions, 5 runs)

| Metric | Master | This PR | Delta |
|--------|--------|---------|-------|
| insns/op (median) | 32,036 | 32,055 | +19 (+0.06%, neutral) |
| allocs/op | 58.1 | 58.1 | unchanged |
| tps (median) | 147,600 | 148,900 | within noise |

No regression.

*Note: struct-size figures above were re-verified against current `master` via `clang -fdump-record-layouts-simple` after rebasing. The original 104B/96B/88B/1040B figures were measured against master as it stood when this PR was first authored, and drifted upward since because unrelated master commits changed `column_definition::_computation` from a cloning `unique_ptr` (8B) to a sharing `shared_ptr` (16B), and migrated `schema`'s column storage to `chunked_vector`. The absolute savings this PR delivers (8B per column_definition, ~2.6KB per 20-column table) are unchanged — only the before/after baseline shifted. The perf table above is from the original benchmarking run against the then-current master and has not been re-measured after the rebase.*

Refs: #29047

Backport: no, benign improvement
