### PR TITLE
sstables: shrink sstable struct from 1416B to 1240B (176B saved, ~12% reduction)

### DIFF
--- a/sstables/component_type.hh
+++ b/sstables/component_type.hh
@@ -12,6 +12,8 @@
 #include <seastar/core/sstring.hh>
 #include <fmt/format.h>
 
+#include "enum_set.hh"
+
 namespace sstables {
 
 enum class component_type {
@@ -34,6 +36,31 @@ enum class component_type {
 };
 
 constexpr size_t num_component_types = size_t(component_type::Unknown);
+
+// Type-safe set of recognized component types. Excludes Unknown, which is
+// not a real component (it marks entries kept in _unrecognized_components).
+using component_super_enum = super_enum<component_type,
+        component_type::Index,
+        component_type::CompressionInfo,
+        component_type::Data,
+        component_type::TOC,
+        component_type::Summary,
+        component_type::Digest,
+        component_type::CRC,
+        component_type::Filter,
+        component_type::Statistics,
+        component_type::TemporaryTOC,
+        component_type::TemporaryStatistics,
+        component_type::Scylla,
+        component_type::Rows,
+        component_type::Partitions,
+        component_type::TemporaryHashes>;
+using component_set = enum_set<component_super_enum>;
+
+// Ensure component_set covers exactly the component_type domain below Unknown.
+// The highest enumerator in the set must be the one just before Unknown.
+static_assert(component_super_enum::max_sequence == num_component_types - 1,
+        "component_set must cover every component_type below Unknown; update the list when adding a new component_type");
 
 struct sstable;
 struct component_name {

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -537,6 +537,11 @@ private:
     std::unique_ptr<file_writer> _index_writer;
     std::unique_ptr<file_writer> _rows_writer;
     std::unique_ptr<file_writer> _partitions_writer;
+    // Accumulates the per-component digests (CRC32) as each component is
+    // written; serialized into the Scylla metadata's ComponentsDigests map at
+    // the end of the write. Lives here rather than on the sstable so that
+    // read-only sstables don't carry this write-only state.
+    scylla_metadata::components_digests _components_digests;
     optimized_optional<trie::bti_row_index_writer> _bti_row_index_writer;
     optimized_optional<trie::bti_partition_index_writer> _bti_partition_index_writer;
     // The key of the last `consume_new_partition` call.
@@ -1026,18 +1031,22 @@ uint32_t writer::close_digest_writer(std::unique_ptr<file_writer>& w) {
 
 void writer::close_data_writer() {
     auto writer = close_writer(_data_writer);
-    if (!_compression_enabled) {
+    const uint32_t full_checksum = [&] {
+        if (_compression_enabled) {
+            return _sst._components->compression.get_full_checksum();
+        }
         auto chksum_wr = static_cast<crc32_checksummed_file_writer*>(writer.get());
-        _sst.write_digest(chksum_wr->full_checksum());
+        auto checksum = chksum_wr->full_checksum();
         _sst.write_crc(chksum_wr->finalize_checksum());
-    } else {
-        _sst.write_digest(_sst._components->compression.get_full_checksum());
-    }
+        return checksum;
+    }();
+    _sst.write_digest(full_checksum);
+    _components_digests.map[component_type::Data] = full_checksum;
 }
 
 void writer::close_index_writer() {
     if (_index_writer) {
-        _sst.get_components_digests().map[component_type::Index] = close_digest_writer(_index_writer);
+        _components_digests.map[component_type::Index] = close_digest_writer(_index_writer);
     }
 }
 
@@ -1047,7 +1056,7 @@ void writer::close_partitions_writer() {
             _sst.get_version(),
             _first_key.value(),
             _last_key.value());
-        _sst.get_components_digests().map[component_type::Partitions] = close_digest_writer(_partitions_writer);
+        _components_digests.map[component_type::Partitions] = close_digest_writer(_partitions_writer);
     }
 }
 
@@ -1060,7 +1069,7 @@ void writer::close_rows_writer() {
         // upload to be a no-op, which breaks some assumptions).
         uint32_t garbage = seastar::cpu_to_be(0x13371337);
         _rows_writer->write(reinterpret_cast<const char*>(&garbage), sizeof(garbage));
-        _sst.get_components_digests().map[component_type::Rows] = close_digest_writer(_rows_writer);
+        _components_digests.map[component_type::Rows] = close_digest_writer(_rows_writer);
     }
 }
 
@@ -1799,6 +1808,12 @@ stop_iteration writer::consume_end_of_partition() {
 }
 
 void writer::consume_end_of_stream() {
+    // The TOC digest was computed when the TOC was written (during open_sstable,
+    // in the writer ctor). Record it first, before the other components, so the
+    // ComponentsDigests map is populated in the same order as the components are
+    // written - keeping the serialized (unordered_map iteration) order stable.
+    _components_digests.map[component_type::TOC] = _sst._toc_digest;
+
     _cfg.monitor->on_data_write_completed();
 
   if (_sst._components->summary) {
@@ -1827,7 +1842,7 @@ void writer::consume_end_of_stream() {
     close_data_writer();
 
   if (_sst._components->summary) {
-    _sst.write_summary();
+    _components_digests.map[component_type::Summary] = _sst.write_summary();
   }
 
     if (_delayed_filter) {
@@ -1835,9 +1850,13 @@ void writer::consume_end_of_stream() {
     } else {
         _sst.maybe_rebuild_filter_from_index(_num_partitions_consumed);
     }
-    _sst.write_filter();
-    _sst.write_statistics();
-    _sst.write_compression();
+    if (auto digest = _sst.write_filter()) {
+        _components_digests.map[component_type::Filter] = *digest;
+    }
+    _components_digests.map[component_type::Statistics] = _sst.write_statistics();
+    if (auto digest = _sst.write_compression()) {
+        _components_digests.map[component_type::CompressionInfo] = *digest;
+    }
     // Note: during the SSTable write, the `compressor` object in `_sst._components->compression`
     // can only compress, not decompress. We have to create a decompressing `compressor` here.
     // (The reason we split the two is that we don't want to keep the compressor-specific compression
@@ -1882,7 +1901,8 @@ void writer::consume_end_of_stream() {
             ld_records = scylla_metadata::large_data_records{.elements = std::move(records)};
         }
     }
-    _sst.write_scylla_metadata(_shard, std::move(identifier), std::move(ld_stats), std::move(ts_stats), std::move(ld_records));
+    // The TOC digest was recorded at the top of this function.
+    _sst.write_scylla_metadata(_shard, std::move(identifier), std::move(_components_digests), std::move(ld_stats), std::move(ts_stats), std::move(ld_records));
     if (!_cfg.leave_unsealed) {
         _sst.seal_sstable(_cfg.backup).get();
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1063,7 +1063,9 @@ void sstable::write_toc(std::unique_ptr<crc32_digest_file_writer> w) {
         });
     });
 
-    _components_digests.map[component_type::TOC] = w->full_checksum();
+    // The TOC digest is also computed on read (read_toc); the writer records it
+    // in the Scylla metadata's ComponentsDigests map via _toc_digest.
+    _toc_digest = w->full_checksum();
 }
 
 void sstable::write_crc(const checksum& c) {
@@ -1080,7 +1082,6 @@ void sstable::write_digest(uint32_t full_checksum) {
         auto digest = to_sstring<bytes>(full_checksum);
         write(v, w, digest);
     }, buffer_size);
-    _components_digests.map[component_type::Data] = full_checksum;
 }
 
 thread_local std::array<std::vector<int>, downsampling::BASE_SAMPLING_LEVEL> downsampling::_sample_pattern_cache;
@@ -1235,13 +1236,12 @@ future<> sstable::read_compression() {
     _components->compression.discard_hidden_options();
 }
 
-void sstable::write_compression() {
+std::optional<uint32_t> sstable::write_compression() {
     if (!has_component(component_type::CompressionInfo)) {
-        return;
+        return std::nullopt;
     }
 
-    auto digest = write_simple_with_digest<component_type::CompressionInfo>(_components->compression);
-    _components_digests.map[component_type::CompressionInfo] = digest;
+    return write_simple_with_digest<component_type::CompressionInfo>(_components->compression);
 }
 
 void sstable::validate_partitioner() {
@@ -1520,9 +1520,8 @@ future<> sstable::read_partitions_db_footer() {
     }
 }
 
-void sstable::write_statistics() {
-    auto digest = write_simple_with_digest<component_type::Statistics>(_components->statistics);
-    _components_digests.map[component_type::Statistics] = digest;
+uint32_t sstable::write_statistics() {
+    return write_simple_with_digest<component_type::Statistics>(_components->statistics);
 }
 
 void sstable::mark_as_being_repaired(const service::session_id& id) {
@@ -1632,8 +1631,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
 
 // Rewrites a single SSTable component along with updated Scylla metadata.
 // This is used when modifying components (e.g., Statistics) without rewriting the entire SSTable.
-// 1. Write the component file (e.g., Statistics-*.db)
-//    - This calculates and stores the component's digest in _components_digests.map[type]
+// 1. Write the component file (e.g., Statistics-*.db) and obtain its digest
 // 2. Update the Scylla metadata's ComponentsDigests map with the new component digest
 // 3. Calculate the Scylla metadata's own digest based on its updated data
 // 4. Write the Scylla metadata component file
@@ -1643,9 +1641,9 @@ void sstable::write_component_with_metadata(component_type type, scylla_metadata
         on_internal_error(sstlog, "Only Statistics component can be rewritten.");
     }
 
-    write_component(type);
+    auto digest = write_component(type);
 
-    metadata.get_or_create_components_digests().map[type] = _components_digests.map[type];
+    metadata.get_or_create_components_digests().map[type] = digest;
     metadata.digest = serialized_checksum(_version, metadata.data);
 
     write_simple<component_type::Scylla>(metadata);
@@ -1837,17 +1835,16 @@ future<> sstable::read_filter(sstable_open_config cfg) {
     });
 }
 
-void sstable::write_filter() {
+std::optional<uint32_t> sstable::write_filter() {
     if (!has_component(component_type::Filter)) {
-        return;
+        return std::nullopt;
     }
 
     auto f = downcast_ptr<utils::filter::murmur3_bloom_filter>(_components->filter.get());
 
     auto&& bs = f->bits();
     auto filter_ref = sstables::filter_ref(f->num_hashes(), bs.get_storage());
-    auto digest = write_simple_with_digest<component_type::Filter>(filter_ref);
-    _components_digests.map[component_type::Filter] = digest;
+    return write_simple_with_digest<component_type::Filter>(filter_ref);
 }
 
 void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions) {
@@ -2040,11 +2037,10 @@ bool sstable::is_component_rewrite_supported(component_type type) {
     }
 }
 
-void sstable::write_component(component_type type) {
+uint32_t sstable::write_component(component_type type) {
     switch (type) {
     case component_type::Statistics:
-        write_statistics();
-        break;
+        return write_statistics();
     default:
         on_internal_error(sstlog, fmt::format("Writing component {} is not supported.", component_name(*this, type)));
     }
@@ -2348,6 +2344,7 @@ static sstable_column_kind to_sstable_column_kind(column_kind k) {
 
 void
 sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
+        scylla_metadata::components_digests components_digests,
         std::optional<scylla_metadata::large_data_stats> ld_stats, std::optional<scylla_metadata::ext_timestamp_stats> ts_stats,
         std::optional<scylla_metadata::large_data_records> ld_records) {
     auto&& first_key = get_first_decorated_key();
@@ -2425,7 +2422,7 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
         sstable_schema.columns.elements.push_back(sstable_column_description{to_sstable_column_kind(col.kind), {col.name()}, {to_bytes(col.type->name())}});
     }
     _components->scylla_metadata->data.set<scylla_metadata_type::Schema>(std::move(sstable_schema));
-    _components->scylla_metadata->data.set<scylla_metadata_type::ComponentsDigests>(scylla_metadata::components_digests{_components_digests});
+    _components->scylla_metadata->data.set<scylla_metadata_type::ComponentsDigests>(std::move(components_digests));
 
     _components->scylla_metadata->digest = serialized_checksum(_version, _components->scylla_metadata->data);
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -914,7 +914,7 @@ future<std::pair<std::vector<sstring>, uint32_t>> sstable::read_and_parse_toc(fi
 // This is small enough, and well-defined. Easier to just read it all
 // at once
 future<> sstable::read_toc(sstable_open_config cfg) noexcept {
-    if (_recognized_components.size()) {
+    if (_recognized_components) {
         co_return;
     }
 
@@ -929,13 +929,13 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
                     continue;
                 }
                 try {
-                    _recognized_components.insert(reverse_map(c, sstable_version_constants::get_component_map(_version)));
+                    add_component(reverse_map(c, sstable_version_constants::get_component_map(_version)));
                 } catch (std::out_of_range& oor) {
                     _unrecognized_components.push_back(c);
                     sstlog.info("Unrecognized TOC component was found: {} in sstable {}", c, toc_filename());
                 }
             }
-            if (!_recognized_components.size()) {
+            if (!_recognized_components) {
                 throw_malformed_sstable_exception("Empty TOC", toc_filename());
             }
         });
@@ -949,32 +949,36 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
 
 void sstable::generate_toc() {
     // Creating table of components.
-    _recognized_components.insert(component_type::TOC);
-    _recognized_components.insert(component_type::Statistics);
-    _recognized_components.insert(component_type::Digest);
+    add_component(component_type::TOC);
+    add_component(component_type::Statistics);
+    add_component(component_type::Digest);
     if (has_summary_and_index(_version)) {
-        _recognized_components.insert(component_type::Index);
-        _recognized_components.insert(component_type::Summary);
+        add_component(component_type::Index);
+        add_component(component_type::Summary);
     } else {
-        _recognized_components.insert(component_type::Partitions);
-        _recognized_components.insert(component_type::Rows);
+        add_component(component_type::Partitions);
+        add_component(component_type::Rows);
     }
-    _recognized_components.insert(component_type::Data);
+    add_component(component_type::Data);
     if (_schema->bloom_filter_fp_chance() != 1.0) {
-        _recognized_components.insert(component_type::Filter);
+        add_component(component_type::Filter);
     }
     if (!_schema->get_compressor_params().compression_enabled()) {
-        _recognized_components.insert(component_type::CRC);
+        add_component(component_type::CRC);
     } else {
-        _recognized_components.insert(component_type::CompressionInfo);
+        add_component(component_type::CompressionInfo);
     }
-    _recognized_components.insert(component_type::Scylla);
+    add_component(component_type::Scylla);
 }
 
 future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_components() const {
     std::unordered_map<component_type, file> files;
-    for (auto c : _recognized_components) {
+    auto bits = _recognized_components;
+    while (bits) {
+        auto idx = __builtin_ctz(bits);
+        auto c = static_cast<component_type>(idx);
         files.emplace(c, co_await open_file(c, open_flags::ro));
+        bits &= bits - 1;
     }
     co_return std::move(files);
 }
@@ -1051,12 +1055,12 @@ void sstable::write_toc(std::unique_ptr<crc32_digest_file_writer> w) {
     sstlog.debug("Writing TOC file {} ", toc_filename());
 
     do_write_simple(*w, [&] (version_types v, file_writer& w) {
-        for (auto&& key : _recognized_components) {
+        for_each_component([&] (component_type key) {
             // new line character is appended to the end of each component name.
             auto value = sstable_version_constants::get_component_map(v).at(key) + "\n";
             bytes b = bytes(reinterpret_cast<const bytes::value_type *>(value.c_str()), value.size());
             write(v, w, b);
-        }
+        });
     });
 
     _components_digests.map[component_type::TOC] = w->full_checksum();
@@ -2728,7 +2732,7 @@ uint64_t sstable::filter_size() const {
 }
 
 bool sstable::has_component(component_type f) const {
-    return _recognized_components.contains(f);
+    return (_recognized_components & component_mask(f)) != 0;
 }
 
 std::optional<bool> sstable::originated_on_this_node() const {
@@ -2825,10 +2829,10 @@ sstring sstable::filename(const sstring& dir, const sstring& ks, const sstring& 
 
 std::vector<std::pair<component_type, sstring>> sstable::all_components() const {
     std::vector<std::pair<component_type, sstring>> all;
-    all.reserve(_recognized_components.size() + _unrecognized_components.size());
-    for (auto& c : _recognized_components) {
+    all.reserve(__builtin_popcount(_recognized_components) + _unrecognized_components.size());
+    for_each_component([&] (component_type c) {
         all.push_back(std::make_pair(c, sstable_version_constants::get_component_map(_version).at(c)));
-    }
+    });
     for (auto& c : _unrecognized_components) {
         all.push_back(std::make_pair(component_type::Unknown, c));
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -931,7 +931,10 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
                 try {
                     add_component(reverse_map(c, sstable_version_constants::get_component_map(_version)));
                 } catch (std::out_of_range& oor) {
-                    _unrecognized_components.push_back(c);
+                    if (!_unrecognized_components) {
+                        _unrecognized_components = std::make_unique<std::vector<sstring>>();
+                    }
+                    _unrecognized_components->push_back(c);
                     sstlog.info("Unrecognized TOC component was found: {} in sstable {}", c, toc_filename());
                 }
             }
@@ -2829,12 +2832,15 @@ sstring sstable::filename(const sstring& dir, const sstring& ks, const sstring& 
 
 std::vector<std::pair<component_type, sstring>> sstable::all_components() const {
     std::vector<std::pair<component_type, sstring>> all;
-    all.reserve(__builtin_popcount(_recognized_components) + _unrecognized_components.size());
+    size_t unrecognized_size = _unrecognized_components ? _unrecognized_components->size() : 0;
+    all.reserve(__builtin_popcount(_recognized_components) + unrecognized_size);
     for_each_component([&] (component_type c) {
         all.push_back(std::make_pair(c, sstable_version_constants::get_component_map(_version).at(c)));
     });
-    for (auto& c : _unrecognized_components) {
-        all.push_back(std::make_pair(component_type::Unknown, c));
+    if (_unrecognized_components) {
+        for (auto& c : *_unrecognized_components) {
+            all.push_back(std::make_pair(component_type::Unknown, c));
+        }
     }
     return all;
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -8,6 +8,7 @@
 
 #include "utils/log.hh"
 #include <atomic>
+#include <bit>
 #include <concepts>
 #include <cstdlib>
 #include <vector>
@@ -976,12 +977,8 @@ void sstable::generate_toc() {
 
 future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_components() const {
     std::unordered_map<component_type, file> files;
-    auto bits = _recognized_components;
-    while (bits) {
-        auto idx = __builtin_ctz(bits);
-        auto c = static_cast<component_type>(idx);
+    for (auto c : _recognized_components) {
         files.emplace(c, co_await open_file(c, open_flags::ro));
-        bits &= bits - 1;
     }
     co_return std::move(files);
 }
@@ -2735,7 +2732,7 @@ uint64_t sstable::filter_size() const {
 }
 
 bool sstable::has_component(component_type f) const {
-    return (_recognized_components & component_mask(f)) != 0;
+    return _recognized_components.contains(f);
 }
 
 std::optional<bool> sstable::originated_on_this_node() const {
@@ -2833,7 +2830,7 @@ sstring sstable::filename(const sstring& dir, const sstring& ks, const sstring& 
 std::vector<std::pair<component_type, sstring>> sstable::all_components() const {
     std::vector<std::pair<component_type, sstring>> all;
     size_t unrecognized_size = _unrecognized_components ? _unrecognized_components->size() : 0;
-    all.reserve(__builtin_popcount(_recognized_components) + unrecognized_size);
+    all.reserve(std::popcount(_recognized_components.mask()) + unrecognized_size);
     for_each_component([&] (component_type c) {
         all.push_back(std::make_pair(c, sstable_version_constants::get_component_map(_version).at(c)));
     });

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1628,7 +1628,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         new_sst->seal_sstable(false).get();
         new_sst->open_data().get();
 
-        _cloned_to_sstable_filename = new_sst->component_basename(component_type::Data);
+        _cloned_to_sstable_filename = std::make_unique<sstring>(new_sst->component_basename(component_type::Data));
         return new_sst;
     });
 }
@@ -3791,7 +3791,7 @@ sstable::unlink(storage::sync_dir sync) noexcept {
 
     try {
         if (_cloned_to_sstable_filename) {
-            co_await get_large_data_handler().maybe_update_large_data_entries_sstable_name(shared_from_this(), _cloned_to_sstable_filename.value());
+            co_await get_large_data_handler().maybe_update_large_data_entries_sstable_name(shared_from_this(), *_cloned_to_sstable_filename);
         } else {
             co_await get_large_data_handler().maybe_delete_large_data_entries(shared_from_this());
         }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2843,19 +2843,19 @@ std::vector<std::pair<component_type, sstring>> sstable::all_components() const 
 }
 
 future<> sstable::snapshot(const sstring& name) const {
-    auto lock = co_await get_units(mutate_sem(), 1);
+    auto lock = co_await get_units(_mutate_sem, 1);
     co_await _storage->snapshot(*this, format("{}/{}", sstables::snapshots_dir, name));
 }
 
 future<> sstable::change_state(sstable_state to, delayed_commit_changes* delay_commit) {
-    auto lock = co_await get_units(mutate_sem(), 1);
+    auto lock = co_await get_units(_mutate_sem, 1);
     co_await _storage->change_state(*this, to, _generation, delay_commit);
     _state = to;
 }
 
 future<> sstable::pick_up_from_upload(sstable_state to, generation_type new_generation) {
     // just in case, not really needed as the sstable is not yet in use while in the upload dir
-    auto lock = co_await get_units(mutate_sem(), 1);
+    auto lock = co_await get_units(_mutate_sem, 1);
     co_await _storage->change_state(*this, to, new_generation, nullptr);
     _generation = std::move(new_generation);
     _state = to;
@@ -3776,7 +3776,7 @@ utils::hashed_key sstable::make_hashed_key(const schema& s, const partition_key&
 future<>
 sstable::unlink(storage::sync_dir sync) noexcept {
     // Serialize with other calls to unlink or potentially ongoing mutations.
-    auto lock = co_await get_units(mutate_sem(), 1);
+    auto lock = co_await get_units(_mutate_sem, 1);
     if (_unlinked) {
         co_return;
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2846,19 +2846,19 @@ std::vector<std::pair<component_type, sstring>> sstable::all_components() const 
 }
 
 future<> sstable::snapshot(const sstring& name) const {
-    auto lock = co_await get_units(_mutate_sem, 1);
+    auto lock = co_await get_units(mutate_sem(), 1);
     co_await _storage->snapshot(*this, format("{}/{}", sstables::snapshots_dir, name));
 }
 
 future<> sstable::change_state(sstable_state to, delayed_commit_changes* delay_commit) {
-    auto lock = co_await get_units(_mutate_sem, 1);
+    auto lock = co_await get_units(mutate_sem(), 1);
     co_await _storage->change_state(*this, to, _generation, delay_commit);
     _state = to;
 }
 
 future<> sstable::pick_up_from_upload(sstable_state to, generation_type new_generation) {
     // just in case, not really needed as the sstable is not yet in use while in the upload dir
-    auto lock = co_await get_units(_mutate_sem, 1);
+    auto lock = co_await get_units(mutate_sem(), 1);
     co_await _storage->change_state(*this, to, new_generation, nullptr);
     _generation = std::move(new_generation);
     _state = to;
@@ -3779,7 +3779,7 @@ utils::hashed_key sstable::make_hashed_key(const schema& s, const partition_key&
 future<>
 sstable::unlink(storage::sync_dir sync) noexcept {
     // Serialize with other calls to unlink or potentially ongoing mutations.
-    auto lock = co_await get_units(_mutate_sem, 1);
+    auto lock = co_await get_units(mutate_sem(), 1);
     if (_unlinked) {
         co_return;
     }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -659,14 +659,7 @@ private:
 
     // The mutate semaphore is used to serialize operations like rewrite_statistics
     // with linking or moving the sstable between directories.
-    // Lazily allocated since it's only needed on rare mutation paths.
-    mutable std::unique_ptr<named_semaphore> _mutate_sem;
-    named_semaphore& mutate_sem() const {
-        if (!_mutate_sem) {
-            _mutate_sem = std::make_unique<named_semaphore>(1, named_semaphore_exception_factory{"sstable mutate"});
-        }
-        return *_mutate_sem;
-    }
+    mutable named_semaphore _mutate_sem{1, named_semaphore_exception_factory{"sstable mutate"}};
     std::unique_ptr<sstring> _cloned_to_sstable_filename;
     // Used only for writing sstable.
     scylla_metadata::components_digests _components_digests;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -665,7 +665,14 @@ private:
 
     // The mutate semaphore is used to serialize operations like rewrite_statistics
     // with linking or moving the sstable between directories.
-    mutable named_semaphore _mutate_sem{1, named_semaphore_exception_factory{"sstable mutate"}};
+    // Lazily allocated since it's only needed on rare mutation paths.
+    mutable std::unique_ptr<named_semaphore> _mutate_sem;
+    named_semaphore& mutate_sem() const {
+        if (!_mutate_sem) {
+            _mutate_sem = std::make_unique<named_semaphore>(1, named_semaphore_exception_factory{"sstable mutate"});
+        }
+        return *_mutate_sem;
+    }
     std::optional<sstring> _cloned_to_sstable_filename;
     // Used only for writing sstable.
     scylla_metadata::components_digests _components_digests;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -550,8 +550,22 @@ private:
         return component_name(*this, f);
     }
 
-    std::unordered_set<component_type, enum_hash<component_type>> _recognized_components;
+    // Bitmask of recognized component types present for this sstable.
+    // component_type has 16 values, so uint32_t provides room for growth.
+    static_assert(static_cast<unsigned>(component_type::Unknown) < 32,
+                  "component_type values must fit in a uint32_t bitmask");
+    uint32_t _recognized_components = 0;
     std::vector<sstring> _unrecognized_components;
+
+    static uint32_t component_mask(component_type c) noexcept {
+        return uint32_t(1) << static_cast<unsigned>(c);
+    }
+    void add_component(component_type c) noexcept {
+        _recognized_components |= component_mask(c);
+    }
+    void remove_component(component_type c) noexcept {
+        _recognized_components &= ~component_mask(c);
+    }
 
     foreign_ptr<lw_shared_ptr<shareable_components>> _components = make_foreign(make_lw_shared<shareable_components>());
     column_translation _column_translation;
@@ -653,6 +667,15 @@ private:
     uint32_t _toc_digest{};
 public:
     bool has_component(component_type f) const;
+    template<typename Func>
+    void for_each_component(Func&& fn) const {
+        auto bits = _recognized_components;
+        while (bits) {
+            auto idx = __builtin_ctz(bits);
+            fn(static_cast<component_type>(idx));
+            bits &= bits - 1;
+        }
+    }
     sstables_manager& manager() { return _manager; }
     const sstables_manager& manager() const { return _manager; }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -554,21 +554,15 @@ private:
         return component_name(*this, f);
     }
 
-    // Bitmask of recognized component types present for this sstable.
-    // component_type has 16 values, so uint32_t provides room for growth.
-    static_assert(static_cast<unsigned>(component_type::Unknown) < 32,
-                  "component_type values must fit in a uint32_t bitmask");
-    uint32_t _recognized_components = 0;
+    // Set of recognized component types present for this sstable.
+    component_set _recognized_components;
     std::unique_ptr<std::vector<sstring>> _unrecognized_components;
 
-    static uint32_t component_mask(component_type c) noexcept {
-        return uint32_t(1) << static_cast<unsigned>(c);
-    }
     void add_component(component_type c) noexcept {
-        _recognized_components |= component_mask(c);
+        _recognized_components.set(c);
     }
     void remove_component(component_type c) noexcept {
-        _recognized_components &= ~component_mask(c);
+        _recognized_components.remove(c);
     }
 
     foreign_ptr<lw_shared_ptr<shareable_components>> _components = make_foreign(make_lw_shared<shareable_components>());
@@ -681,11 +675,8 @@ public:
     bool has_component(component_type f) const;
     template<typename Func>
     void for_each_component(Func&& fn) const {
-        auto bits = _recognized_components;
-        while (bits) {
-            auto idx = __builtin_ctz(bits);
-            fn(static_cast<component_type>(idx));
-            bits &= bits - 1;
+        for (auto c : _recognized_components) {
+            fn(c);
         }
     }
     sstables_manager& manager() { return _manager; }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -367,11 +367,15 @@ public:
     }
 
     const std::set<generation_type>& compaction_ancestors() const {
-        return _compaction_ancestors;
+        static const std::set<generation_type> empty;
+        return _compaction_ancestors ? *_compaction_ancestors : empty;
     }
 
     void add_ancestor(generation_type generation) {
-        _compaction_ancestors.insert(generation);
+        if (!_compaction_ancestors) {
+            _compaction_ancestors = std::make_unique<std::set<generation_type>>();
+        }
+        _compaction_ancestors->insert(generation);
     }
 
     // Returns true iff this sstable contains data which belongs to many shards.
@@ -572,7 +576,8 @@ private:
     std::optional<open_flags> _open_mode;
     // _compaction_ancestors track which sstable generations were used to generate this sstable.
     // it is then used to generate the ancestors metadata in the statistics or scylla components.
-    std::set<generation_type> _compaction_ancestors;
+    // Lazily allocated — only populated during compaction output.
+    std::unique_ptr<std::set<generation_type>> _compaction_ancestors;
     file _index_file;
     seastar::shared_ptr<cached_file> _cached_index_file;
     file _data_file;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -559,7 +559,7 @@ private:
     static_assert(static_cast<unsigned>(component_type::Unknown) < 32,
                   "component_type values must fit in a uint32_t bitmask");
     uint32_t _recognized_components = 0;
-    std::vector<sstring> _unrecognized_components;
+    std::unique_ptr<std::vector<sstring>> _unrecognized_components;
 
     static uint32_t component_mask(component_type c) noexcept {
         return uint32_t(1) << static_cast<unsigned>(c);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -661,8 +661,9 @@ private:
     // with linking or moving the sstable between directories.
     mutable named_semaphore _mutate_sem{1, named_semaphore_exception_factory{"sstable mutate"}};
     std::unique_ptr<sstring> _cloned_to_sstable_filename;
-    // Used only for writing sstable.
-    scylla_metadata::components_digests _components_digests;
+    // Digest (CRC32) of the TOC component. Computed when the TOC is written
+    // (write path) or read (read path), and validated against the on-disk
+    // Scylla metadata's ComponentsDigests on load.
     uint32_t _toc_digest{};
 public:
     bool has_component(component_type f) const;
@@ -723,19 +724,22 @@ private:
     void open_sstable(const sstring& origin);
 
     future<> read_compression();
-    void write_compression();
+    // Writes the CompressionInfo component (if present) and returns its digest.
+    std::optional<uint32_t> write_compression();
 
     future<> read_scylla_metadata() noexcept;
 
     void write_scylla_metadata(shard_id shard,
                                run_identifier identifier,
+                               scylla_metadata::components_digests components_digests,
                                std::optional<scylla_metadata::large_data_stats> ld_stats,
                                std::optional<scylla_metadata::ext_timestamp_stats> ts_stats,
                                std::optional<scylla_metadata::large_data_records> ld_records = std::nullopt);
 
     future<> read_filter(sstable_open_config cfg = {});
 
-    void write_filter();
+    // Writes the Filter component (if present) and returns its digest.
+    std::optional<uint32_t> write_filter();
     // Rebuild a bloom filter from the index with the given number of
     // partitions, if the partition estimate provided during bloom
     // filter initialisation was not good.
@@ -749,9 +753,10 @@ private:
     future<> read_toc(sstable_open_config cfg = {}) noexcept;
     future<> read_summary() noexcept;
 
-    void write_summary() {
-        auto digest = write_simple_with_digest<component_type::Summary>(_components->summary);
-        _components_digests.map[component_type::Summary] = digest;
+    // Writes the Summary component and returns its digest, to be recorded by
+    // the writer in the ComponentsDigests map.
+    uint32_t write_summary() {
+        return write_simple_with_digest<component_type::Summary>(_components->summary);
     }
 
     // To be called when we try to load an SSTable that lacks a Summary. Could
@@ -761,7 +766,8 @@ private:
     future<> read_partitions_db_footer();
 
     future<> read_statistics();
-    void write_statistics();
+    // Writes the Statistics component and returns its digest.
+    uint32_t write_statistics();
     // Validate metadata that's used to optimize reads when user specifies
     // a clustering key range. If this specific metadata is incorrect, then
     // it should be cleared. Otherwise, it could lead to bad decisions.
@@ -804,8 +810,8 @@ private:
     void disable_component_memory_reload();
 
     static bool is_component_rewrite_supported(component_type type);
-    // Must be called in a seastar thread
-    void write_component(component_type type);
+    // Must be called in a seastar thread. Returns the component's digest.
+    uint32_t write_component(component_type type);
 public:
     // Finds first position_in_partition in a given partition.
     // If reversed is false, then the first position is actually the first row (can be the static one).
@@ -1074,11 +1080,6 @@ public:
 
     std::optional<uint32_t> get_digest() const {
         return _components->digest;
-    }
-
-    // Used only for writing sstable.
-    scylla_metadata::components_digests& get_components_digests() {
-        return _components_digests;
     }
 
     std::optional<uint32_t> get_component_digest(component_type c) const;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -673,7 +673,7 @@ private:
         }
         return *_mutate_sem;
     }
-    std::optional<sstring> _cloned_to_sstable_filename;
+    std::unique_ptr<sstring> _cloned_to_sstable_filename;
     // Used only for writing sstable.
     scylla_metadata::components_digests _components_digests;
     uint32_t _toc_digest{};

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -858,8 +858,9 @@ future<> object_storage_base::wipe(const sstable& sst, sync_dir) noexcept {
 
     co_await sstables_registry.update_entry_status(owner(), node_owner, sst.generation(), status_removing);
 
-    co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
-        co_await delete_object(make_object_name(sst, type));
+    // Delete all recognized components in parallel
+    co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (component_type c) -> future<> {
+        co_await delete_object(make_object_name(sst, c));
     });
 
     co_await sstables_registry.delete_entry(owner(), node_owner, sst.generation());

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -105,21 +105,19 @@ public:
     }
     void assert_toc(const std::set<component_type>& expected_components) {
         for (auto& expected : expected_components) {
-            if(!_sst->_recognized_components.contains(expected)) {
-                BOOST_FAIL(seastar::format("Expected component of TOC missing: {}\n ... in: {}",
-                                  expected,
-                                  std::set<component_type>(
-                                      cbegin(_sst->_recognized_components),
-                                      cend(_sst->_recognized_components))));
+            if(!_sst->has_component(expected)) {
+                std::set<component_type> present;
+                _sst->for_each_component([&] (component_type c) { present.insert(c); });
+                BOOST_FAIL(seastar::format("Expected component of TOC missing: {}\n ... in: {}", expected, present));
             }
         }
-        for (auto& present : _sst->_recognized_components) {
+        _sst->for_each_component([&] (component_type present) {
             if (!expected_components.contains(present)) {
                 BOOST_FAIL(seastar::format("Unexpected component of TOC: {}\n ... when expecting: {}",
                                   present,
                                   expected_components));
             }
-        }
+        });
     }
 };
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -115,8 +115,8 @@ SEASTAR_TEST_CASE(datafile_generation_09) {
         BOOST_REQUIRE(sst1_s.last_key.value == sst2_s.last_key.value);
 
         sstables::test(sst2).read_toc().get();
-        auto& sst1_c = sstables::test(sst).get_components();
-        auto& sst2_c = sstables::test(sst2).get_components();
+        auto sst1_c = sstables::test(sst).get_components();
+        auto sst2_c = sstables::test(sst2).get_components();
 
         BOOST_REQUIRE(sst1_c == sst2_c);
     });
@@ -3166,10 +3166,10 @@ future<> test_sstable_bytes_correctness(sstring tname, test_env_config cfg) {
         auto get_bytes_on_disk_from_storage = [&] (const sstables::shared_sstable& sst) {
             uint64_t bytes_on_disk = 0;
             auto& underlying_storage = const_cast<sstables::storage&>(sst->get_storage());
-            for (auto& component_type : sstables::test(sst).get_components()) {
-                file f = underlying_storage.open_component(*sst, component_type, open_flags::ro, file_open_options{}, true).get();
+            sst->for_each_component([&] (component_type comp) {
+                file f = underlying_storage.open_component(*sst, comp, open_flags::ro, file_open_options{}, true).get();
                 bytes_on_disk += f.size().get();
-            }
+            });
             return bytes_on_disk;
         };
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -1022,13 +1022,24 @@ static void corrupt_sstable(sstables::shared_sstable sst, component_type compone
     auto close_f = deferred_close(f);
     const auto mem_align = f.memory_dma_alignment();
     const auto dma_align = f.disk_write_dma_alignment();
-    auto block_offset = align_down(size - 1, dma_align);
+    // For most components we corrupt the last byte. The TOC is special: it is a
+    // newline-separated list of component names, and its last byte is the trailing
+    // newline of the last entry. write_toc() emits entries via for_each_component(),
+    // i.e. in ascending component_type order, so for me-format sstables the last
+    // entry is always "Scylla.db". Flipping its trailing newline turns it into an
+    // unrecognized entry and drops the Scylla component, and read_scylla_metadata()
+    // then skips TOC digest validation altogether (it is gated on
+    // has_component(Scylla)) -- so the corruption would go undetected.
+    // Corrupt the first byte instead: that renames the first entry (the lowest
+    // component_type, never Scylla, and only needed after TOC validation) while
+    // keeping the Scylla component recognized, so the TOC digest mismatch is caught.
+    const auto corrupt_offset = component == component_type::TOC ? uint64_t(0) : size - 1;
+    const auto block_offset = align_down(corrupt_offset, uint64_t(dma_align));
     auto buf = seastar::temporary_buffer<char>::aligned(mem_align, dma_align);
     f.dma_read(block_offset, buf.get_write(), dma_align).get();
-    // Flip one bit in the last byte of the file to corrupt it minimally.
-    // Using a single-bit flip avoids creating values that overflow
-    // during parsing.
-    buf.get_write()[size - 1 - block_offset] += 1;
+    // Increment one byte to corrupt the file minimally. Keeping the change small
+    // avoids creating values that overflow during parsing.
+    buf.get_write()[corrupt_offset - block_offset] += 1;
     f.dma_write(block_offset, buf.get(), dma_align).get();
     f.truncate(size).get();
 }

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -248,8 +248,8 @@ SEASTAR_TEST_CASE(check_toc_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", sstables::generation_type(1), [] (shared_sstable sst1, shared_sstable sst2) {
         sstables::test(sst2).read_toc().get();
-        auto& sst1_c = sstables::test(sst1).get_components();
-        auto& sst2_c = sstables::test(sst2).get_components();
+        auto sst1_c = sstables::test(sst1).get_components();
+        auto sst2_c = sstables::test(sst2).get_components();
 
         BOOST_REQUIRE(sst1_c == sst2_c);
     });
@@ -923,9 +923,8 @@ static future<> test_component_digest_persistence(component_type component, ssta
         const auto muts = tests::generate_random_mutations(random_schema, 2).get();
         auto sst_original = make_sstable_containing(env.make_sstable(schema, version), muts).get();
 
-        auto& components = sstables::test(sst_original).get_components();
-        bool has_component = components.find(component) != components.end();
-        BOOST_REQUIRE(has_component);
+        bool has_comp = sst_original->has_component(component);
+        BOOST_REQUIRE(has_comp);
 
         auto toc_path = fmt::to_string(sst_original->toc_filename());
         auto entry_desc = sstables::parse_path(toc_path, schema->ks_name(), schema->cf_name()).value();

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -109,7 +109,7 @@ public:
         return _sst->read_summary_entry(i);
     }
 
-    auto& get_components() {
+    auto get_components() const {
         return _sst->_recognized_components;
     }
 
@@ -128,8 +128,8 @@ public:
     future<sstable_ptr> store(sstring dir, sstables::generation_type generation) {
         _sst->_generation = generation;
         co_await _sst->_storage->change_dir_for_test(dir);
-        _sst->_recognized_components.erase(component_type::Index);
-        _sst->_recognized_components.erase(component_type::Data);
+        _sst->remove_component(component_type::Index);
+        _sst->remove_component(component_type::Data);
         co_await seastar::async([sst = _sst] {
             sst->open_sstable("test");
             sst->write_statistics();
@@ -157,7 +157,7 @@ public:
         _sst->_index_file_size = std::max(1UL, uint64_t(data_file_size * 0.1));
         _sst->_metadata_size_on_disk = std::max(1UL, uint64_t(data_file_size * 0.01));
         // scylla component must be present for a sstable to be considered fully expired.
-        _sst->_recognized_components.insert(component_type::Scylla);
+        _sst->add_component(component_type::Scylla);
         _sst->_components->statistics.contents[metadata_type::Stats] = std::make_unique<stats_metadata>(std::move(stats));
         _sst->_first = dht::decorate_key(*_sst->_schema, first_key);
         _sst->_last = dht::decorate_key(*_sst->_schema, last_key);
@@ -173,7 +173,7 @@ public:
 
     void rewrite_toc_without_component(component_type component) {
         SCYLLA_ASSERT(component != component_type::TOC);
-        _sst->_recognized_components.erase(component);
+        _sst->remove_component(component);
         remove_file(fmt::to_string(_sst->toc_filename())).get();
         _sst->_storage->open(*_sst);
         _sst->seal_sstable(false).get();
@@ -206,7 +206,7 @@ public:
     }
 
     void write_filter() {
-        _sst->_recognized_components.insert(component_type::Filter);
+        _sst->add_component(component_type::Filter);
         _sst->write_filter();
     }
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -110,7 +110,7 @@ public:
     }
 
     auto get_components() const {
-        return _sst->_recognized_components;
+        return _sst->_recognized_components.mask();
     }
 
     void set_data_file_size(uint64_t size) {


### PR DESCRIPTION
## Motivation

The `sstable` struct is 1416B, with several fields that are only used in rare paths (writing, cloning, deletion) yet occupy space for every sstable opened for reading. With 10,000+ sstables per shard, this adds up.

## Nature of change

1. **Replace _recognized_components unordered_set with an enum_set**: `unordered_set<component_type>` (56B) → a type-safe `component_set` (`enum_set` over the recognized `component_type` values). The `enum_set`'s `size_t` mask occupies the padding that previously followed the struct's other small fields, so the layout shrinks while gaining compile-time component checking. `has_component()`/`add_component()`/`for_each_component()` now delegate to `enum_set`. Saves **48B/sstable**. (Started as a hand-rolled `uint32_t` bitmask; switched to `enum_set` per review feedback to reuse the existing facility instead of open-coding bit twiddling.)

2. **Lazily allocate _compaction_ancestors**: `std::set<generation_type>` (48B) → `unique_ptr` (8B). Only used for legacy sstables with ancestors. Saves **40B/sstable**.

3. **Lazily allocate _unrecognized_components**: `std::vector<sstring>` (24B) → `unique_ptr<vector>` (8B). Only populated when unknown components exist. Saves **16B/sstable**.

4. **Lazily allocate _cloned_to_sstable_filename**: `optional<sstring>` (24B) → `unique_ptr<sstring>` (8B). Only set when cloning for resharding. Saves **16B/sstable**.

5. **Move _components_digests write state into the writer**: the ComponentsDigests map is purely write-side state (on read, digests are validated against the on-disk map, never against this field), yet it lived on every sstable — including the read-only majority — as an `unordered_map` (~56B) that stayed empty for its whole lifetime. Hiding it behind a `unique_ptr` would still leave an 8B pointer plus a per-write heap allocation, and the state simply does not belong on the sstable. Instead it now lives in `sstables::mc::writer`, whose lifetime spans the entire write; the component-writing helpers return their digest instead of stashing it in a member, and the writer hands the assembled map to `write_scylla_metadata()`. Removes the member entirely. Saves **56B/sstable**. The `TOC` digest keeps its home in `sstable::_toc_digest` (also computed on read) and is copied into the writer's map first, preserving `unordered_map` insertion (and hence serialized) order — **on-disk bytes are unchanged**.

**Total savings: 176B per sstable (1416B → 1240B, ~12% reduction).**
For 10,000 sstables: **~1.7MB saved per shard.**

## Notes on revisions

- An earlier revision lazily allocated `_mutate_sem` (`named_semaphore`, 96B → `unique_ptr`). This was **reverted**: `unlink()` is `noexcept` and acquires the mutate semaphore, so lazy allocation could throw `bad_alloc` from inside a `noexcept` function and `std::terminate`; the semaphore is also acquired during `change_state()` (staging/streaming), not only rare paths, and a `named_semaphore` releases its dynamic waiter storage when idle, so the eager member's steady-state footprint is small. Keeping it inline avoids the terminate hazard for no measurable memory win.
- Includes a test-robustness fix for `test_digest_validation_toc`: `corrupt_sstable()` flips the last byte of the TOC, which (now that component order is deterministic) is always `Scylla.db`'s trailing newline; corrupting it drops the Scylla component and skips TOC digest validation. The test now corrupts the first TOC byte (lowest `component_type`, never `Scylla`) so the mismatch is reliably detected.

## Measured (perf-simple-query, release, smp 1, taskset -c 0, fixed 2.2GHz, 10K partitions, 5 runs)

| Metric | Master | This PR | Delta |
|--------|--------|---------|-------|
| insns/op (median) | 32,036 | 32,040 | +4 (neutral) |
| allocs/op | 58.1 | 58.1 | unchanged |
| tps (median) | 147,600 | 147,500 | within noise |

No regression. The lazily allocated fields are not on the query hot path. (perf-simple-query exercises reads and does not touch the write-side fields; the change is a struct-size/footprint improvement rather than a throughput one.)

Refs: #29047

Backport: no, benign improvement
