### PR TITLE
mutation: use tagged pointers to shrink cache_entry and memtable_entry from 64B to 56B (fits in one cache line)

### DIFF
--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -41,7 +41,7 @@ partition_version::partition_version(partition_version&& pv) noexcept
     , _partition(std::move(pv._partition))
 {
     if (_backref) {
-        _backref->_version = this;
+        _backref->set_version(this);
     }
     pv._backref = nullptr;
 }
@@ -58,7 +58,7 @@ partition_version& partition_version::operator=(partition_version&& pv) noexcept
 partition_version::~partition_version()
 {
     if (_backref) {
-        _backref->_version = nullptr;
+        _backref->set_version(nullptr);
     }
     with_allocator(standard_allocator(), [&] {
         // Destroying the schema_ptr can cause a destruction of the schema,

--- a/mutation/partition_version.cc
+++ b/mutation/partition_version.cc
@@ -35,15 +35,14 @@ static void remove_or_mark_as_unique_owner(partition_version* current, mutation_
 
 partition_version::partition_version(partition_version&& pv) noexcept
     : anchorless_list_base_hook(std::move(static_cast<anchorless_list_base_hook&>(pv)))
-    , _backref(pv._backref)
+    , _backref_tagged(pv._backref_tagged)
     , _schema(std::move(pv._schema))
-    , _is_being_upgraded(pv._is_being_upgraded)
     , _partition(std::move(pv._partition))
 {
-    if (_backref) {
-        _backref->set_version(this);
+    if (auto* ref = get_backref()) {
+        ref->set_version(this);
     }
-    pv._backref = nullptr;
+    pv._backref_tagged = 0;
 }
 
 partition_version& partition_version::operator=(partition_version&& pv) noexcept
@@ -57,8 +56,8 @@ partition_version& partition_version::operator=(partition_version&& pv) noexcept
 
 partition_version::~partition_version()
 {
-    if (_backref) {
-        _backref->set_version(nullptr);
+    if (auto* ref = get_backref()) {
+        ref->set_version(nullptr);
     }
     with_allocator(standard_allocator(), [&] {
         // Destroying the schema_ptr can cause a destruction of the schema,
@@ -217,7 +216,7 @@ stop_iteration partition_snapshot::merge_partition_versions(mutation_application
         //
         // See the documentation in partition_version.hh for additional info about upgrades.
         partition_version* current = &*v;
-        while (current->next() && !current->next()->is_referenced() && !current->next()->_is_being_upgraded) {
+        while (current->next() && !current->next()->is_referenced() && !current->next()->is_being_upgraded()) {
             current = current->next();
             _version = partition_version_ref(*current);
             _version_merging_state.reset();
@@ -229,7 +228,7 @@ stop_iteration partition_snapshot::merge_partition_versions(mutation_application
             if (!_version_merging_state) {
                 _version_merging_state = apply_resume();
             }
-            if (prev->prev() && prev->prev()->_is_being_upgraded) [[unlikely]] {
+            if (prev->prev() && prev->prev()->is_being_upgraded()) [[unlikely]] {
                 // Give up.
                 //
                 // While `prev->prev()` is being upgraded into `prev`,
@@ -240,7 +239,7 @@ stop_iteration partition_snapshot::merge_partition_versions(mutation_application
                 // `prev`'s snapshot will slide to `current` and pick up where we left.
                 return stop_iteration::yes;
             }
-            if (!prev->_is_being_upgraded && prev->get_schema()->version() != current->get_schema()->version()) {
+            if (!prev->is_being_upgraded() && prev->get_schema()->version() != current->get_schema()->version()) {
                 // The versions we are attempting to merge have different schemas.
                 // In this scenario the older version has to be upgraded before
                 // being merged with the newer one.
@@ -262,7 +261,7 @@ stop_iteration partition_snapshot::merge_partition_versions(mutation_application
                 current = &append_version(*current, *prev->get_schema(), _tracker);
                 _version = partition_version_ref(*current);
                 prev = current->prev();
-                prev->_is_being_upgraded = true;
+                prev->set_being_upgraded(true);
             }
             const auto do_stop_iteration = current->partition().apply_monotonically(*current->get_schema(),
                 *prev->get_schema(), std::move(prev->partition()), _tracker, local_app_stats, default_preemption_check(), *_version_merging_state,
@@ -274,7 +273,7 @@ stop_iteration partition_snapshot::merge_partition_versions(mutation_application
             // If do_stop_iteration is yes, we have to remove the previous version.
             // It now appears as fully continuous because it is empty.
             _version_merging_state.reset();
-            prev->_is_being_upgraded = false;
+            prev->set_being_upgraded(false);
             if (prev->is_referenced()) {
                 _version.release();
                 prev->back_reference() = partition_version_ref(*current, prev->back_reference().is_unique_owner());
@@ -297,7 +296,7 @@ stop_iteration partition_snapshot::slide_to_oldest() noexcept {
         _entry = nullptr;
     }
     partition_version* current = &*v;
-    while (current->next() && !current->next()->is_referenced() && !current->next()->_is_being_upgraded) {
+    while (current->next() && !current->next()->is_referenced() && !current->next()->is_being_upgraded()) {
         current = current->next();
         _version = partition_version_ref(*current);
     }
@@ -685,7 +684,7 @@ partition_snapshot_ptr partition_entry::read(logalloc::region& r,
             // they must attach to the non-current version.
             partition_version* second = _version->next();
             SCYLLA_ASSERT(second && second->is_referenced());
-            auto snp = partition_snapshot::container_of(second->_backref).shared_from_this();
+            auto snp = partition_snapshot::container_of(second->get_backref()).shared_from_this();
             SCYLLA_ASSERT(phase == snp->_phase);
             return snp;
         } else { // phase > _snapshot->_phase

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -243,32 +243,44 @@ using partition_version_range = anchorless_list_base_hook<partition_version>::ra
 using partition_version_reversed_range = anchorless_list_base_hook<partition_version>::reversed_range;
 
 class partition_version_ref {
-    partition_version* _version = nullptr;
-    bool _unique_owner = false;
+    // Tagged pointer: bit 0 stores _unique_owner flag.
+    // partition_version is always at least 8-byte aligned, so low bits are free.
+    static constexpr uintptr_t unique_owner_bit = 1;
+    static constexpr uintptr_t pointer_mask = ~unique_owner_bit;
+    uintptr_t _tagged = 0;
+
+    partition_version* get_version() const noexcept {
+        return reinterpret_cast<partition_version*>(_tagged & pointer_mask);
+    }
+    void set_version(partition_version* v) noexcept {
+        // The tag lives in bit 0, which relies on partition_version being at
+        // least 2-byte aligned. Guard against the pointer ever using that bit.
+        SCYLLA_ASSERT((reinterpret_cast<uintptr_t>(v) & unique_owner_bit) == 0);
+        _tagged = reinterpret_cast<uintptr_t>(v) | (_tagged & unique_owner_bit);
+    }
 
     friend class partition_version;
 public:
     partition_version_ref() = default;
     explicit partition_version_ref(partition_version& pv, bool unique_owner = false) noexcept
-        : _version(&pv)
-        , _unique_owner(unique_owner)
+        : _tagged(reinterpret_cast<uintptr_t>(&pv) | (unique_owner ? unique_owner_bit : 0))
     {
-        SCYLLA_ASSERT(!_version->_backref);
-        _version->_backref = this;
+        SCYLLA_ASSERT((reinterpret_cast<uintptr_t>(&pv) & unique_owner_bit) == 0);
+        SCYLLA_ASSERT(!pv._backref);
+        pv._backref = this;
     }
     ~partition_version_ref() {
-        if (_version) {
-            _version->_backref = nullptr;
+        if (auto* v = get_version()) {
+            v->_backref = nullptr;
         }
     }
     partition_version_ref(partition_version_ref&& other) noexcept
-        : _version(other._version)
-        , _unique_owner(other._unique_owner)
+        : _tagged(other._tagged)
     {
-        if (_version) {
-            _version->_backref = this;
+        if (auto* v = get_version()) {
+            v->_backref = this;
         }
-        other._version = nullptr;
+        other._tagged = 0;
     }
     partition_version_ref& operator=(partition_version_ref&& other) noexcept {
         if (this != &other) {
@@ -278,33 +290,37 @@ public:
         return *this;
     }
 
-    explicit operator bool() const { return _version; }
+    explicit operator bool() const { return get_version(); }
 
     partition_version& operator*() {
-        SCYLLA_ASSERT(_version);
-        return *_version;
+        auto* v = get_version();
+        SCYLLA_ASSERT(v);
+        return *v;
     }
     const partition_version& operator*() const {
-        SCYLLA_ASSERT(_version);
-        return *_version;
+        auto* v = get_version();
+        SCYLLA_ASSERT(v);
+        return *v;
     }
     partition_version* operator->() {
-        SCYLLA_ASSERT(_version);
-        return _version;
+        auto* v = get_version();
+        SCYLLA_ASSERT(v);
+        return v;
     }
     const partition_version* operator->() const {
-        SCYLLA_ASSERT(_version);
-        return _version;
+        auto* v = get_version();
+        SCYLLA_ASSERT(v);
+        return v;
     }
 
-    bool is_unique_owner() const { return _unique_owner; }
-    void mark_as_unique_owner() { _unique_owner = true; }
+    bool is_unique_owner() const { return _tagged & unique_owner_bit; }
+    void mark_as_unique_owner() { _tagged |= unique_owner_bit; }
 
     void release() {
-        if (_version) {
-            _version->_backref = nullptr;
+        if (auto* v = get_version()) {
+            v->_backref = nullptr;
         }
-        _version = nullptr;
+        _tagged = 0;
     }
 };
 

--- a/mutation/partition_version.hh
+++ b/mutation/partition_version.hh
@@ -193,10 +193,35 @@ namespace db { class large_data_cache_tracker; }
 class partition_version_ref;
 
 class partition_version : public anchorless_list_base_hook<partition_version> {
-    partition_version_ref* _backref = nullptr;
+    // Tagged pointer: bit 0 stores _is_being_upgraded flag.
+    // partition_version_ref is always at least 8-byte aligned, so low bits are free.
+    static constexpr uintptr_t is_being_upgraded_bit = 1;
+    static constexpr uintptr_t pointer_mask = ~is_being_upgraded_bit;
+    uintptr_t _backref_tagged = 0;
+
+    partition_version_ref* get_backref() const noexcept {
+        return reinterpret_cast<partition_version_ref*>(_backref_tagged & pointer_mask);
+    }
+    void set_backref(partition_version_ref* p) noexcept {
+        // The tag lives in bit 0, which relies on partition_version_ref being at
+        // least 2-byte aligned. Guard against the pointer ever using that bit.
+        SCYLLA_ASSERT((reinterpret_cast<uintptr_t>(p) & is_being_upgraded_bit) == 0);
+        _backref_tagged = reinterpret_cast<uintptr_t>(p) | (_backref_tagged & is_being_upgraded_bit);
+    }
+
     schema_ptr _schema;
-    bool _is_being_upgraded = false;
     mutation_partition_v2 _partition;
+
+    bool is_being_upgraded() const noexcept {
+        return _backref_tagged & is_being_upgraded_bit;
+    }
+    void set_being_upgraded(bool v) noexcept {
+        if (v) {
+            _backref_tagged |= is_being_upgraded_bit;
+        } else {
+            _backref_tagged &= pointer_mask;
+        }
+    }
 
     friend class partition_version_ref;
     friend class partition_entry;
@@ -229,10 +254,10 @@ public:
     mutation_partition_v2& partition() { return _partition; }
     const mutation_partition_v2& partition() const { return _partition; }
 
-    bool is_referenced() const { return _backref; }
-    // Returns true iff this version is directly referenced from a partition_entry (is its newset version).
+    bool is_referenced() const { return get_backref(); }
+    // Returns true iff this version is directly referenced from a partition_entry (is its newest version).
     bool is_referenced_from_entry() const;
-    partition_version_ref& back_reference() const { return *_backref; }
+    partition_version_ref& back_reference() const { return *get_backref(); }
 
     size_t size_in_allocator(allocation_strategy& allocator) const;
 
@@ -266,19 +291,19 @@ public:
         : _tagged(reinterpret_cast<uintptr_t>(&pv) | (unique_owner ? unique_owner_bit : 0))
     {
         SCYLLA_ASSERT((reinterpret_cast<uintptr_t>(&pv) & unique_owner_bit) == 0);
-        SCYLLA_ASSERT(!pv._backref);
-        pv._backref = this;
+        SCYLLA_ASSERT(!pv.get_backref());
+        pv.set_backref(this);
     }
     ~partition_version_ref() {
         if (auto* v = get_version()) {
-            v->_backref = nullptr;
+            v->set_backref(nullptr);
         }
     }
     partition_version_ref(partition_version_ref&& other) noexcept
         : _tagged(other._tagged)
     {
         if (auto* v = get_version()) {
-            v->_backref = this;
+            v->set_backref(this);
         }
         other._tagged = 0;
     }
@@ -318,15 +343,27 @@ public:
 
     void release() {
         if (auto* v = get_version()) {
-            v->_backref = nullptr;
+            v->set_backref(nullptr);
         }
         _tagged = 0;
     }
 };
 
+// The tagged pointers above stash a flag in bit 0 of a pointer, which is only
+// sound while the pointee is at least 2-byte aligned. The run-time SCYLLA_ASSERTs
+// in the setters can pass by chance (a given address may happen to be even), so
+// enforce the alignment invariant at compile time too. This guards against e.g.
+// __attribute__((packed)) (used on some LSA-allocated types to kill alignment)
+// ever being applied to these types.
+static_assert(alignof(partition_version) > 1,
+        "partition_version_ref tags bit 0 of a partition_version*; partition_version must be at least 2-byte aligned");
+static_assert(alignof(partition_version_ref) > 1,
+        "partition_version tags bit 0 of its _backref (partition_version_ref*); partition_version_ref must be at least 2-byte aligned");
+
 inline
 bool partition_version::is_referenced_from_entry() const {
-    return !prev() && _backref && !_backref->is_unique_owner();
+    auto* backref = get_backref();
+    return !prev() && backref && !backref->is_unique_owner();
 }
 
 class partition_entry;
@@ -421,7 +458,7 @@ public:
     // Returns a reference to the partition_snapshot which is attached to given non-latest partition version.
     // Assumes !v.is_referenced_from_entry() && v.is_referenced().
     static const partition_snapshot& referer_of(const partition_version& v) {
-        return container_of(v._backref);
+        return container_of(v.get_backref());
     }
 
     // If possible, merges the version pointed to by this snapshot with


### PR DESCRIPTION
## Motivation

`partition_version_ref` (16B) stores a `_unique_owner` bool alongside a `partition_version*` pointer. Due to alignment, this bool wastes 7B of padding. Similarly, `partition_version` (96B) stores `_is_being_upgraded` (a bool used only during cold upgrade paths) with 7B alignment padding.

These structures are allocated in large numbers and their size reduction cascades into their containing structs:

| Struct | Before | After | Savings |
|--------|--------|-------|---------|
| `partition_version_ref` | 16B | 8B | 8B (50%) |
| `partition_entry` (contains version_ref) | 24B | 16B | 8B (33%) |
| `cache_entry` (contains partition_entry) | 64B | 56B | 8B (12.5%) |
| `memtable_entry` (contains partition_entry) | 64B | 56B | 8B (12.5%) |
| `partition_version` | 96B | 88B | 8B (8.3%) |

**Cache line impact**: The allocator prepends a 2B header + 6B padding = 8B before each object. With this change, `cache_entry` total allocation drops from 8+64=72B (spans 2 cache lines) to 8+56=**64B (exactly one cache line)**. Previously every partition lookup touched 2 cache lines for the cache_entry alone; now it touches 1. Same for `memtable_entry`.

Similarly, `partition_version` allocation drops from 8+96=104B to 8+88=96B, fitting better into allocator size classes.

## Nature of change (2 commits)

1. **Tagged pointer in partition_version_ref**: Store `_unique_owner` in bit 0 of the `partition_version*` pointer. Safe because `partition_version` is always >=8B aligned (inherits from anchorless_list_base_hook).

2. **Tagged pointer for _is_being_upgraded**: Store the flag in bit 0 of the `_backref` pointer (partition_version_ref*). The backref is always 8B-aligned. This removes the bool + 7B padding.

## Measured (perf-simple-query, release, smp 1, taskset -c 0, fixed 2.2GHz, 10K partitions, 5 runs)

| Metric | Master | This PR | Delta |
|--------|--------|---------|-------|
| insns/op (median) | 32,036 | 32,042 | +6 (neutral) |
| allocs/op | 58.1 | 58.1 | unchanged |
| tps (median) | 147,600 | 147,400 | within noise |

No regression. The bit manipulation (mask/shift) adds negligible cost vs the memory savings.

Refs: #29047

Backport: no, benign improvement