### PR TITLE
cql3/compaction: reorder struct fields to eliminate padding (select_statement 296B→272B, compaction_descriptor 232B→216B)

### DIFF
--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -177,12 +177,8 @@ struct compaction_descriptor {
     // This is a snapshot of the table's sstable set, used only for the purpose of expiring tombstones.
     // If this sstable set cannot be provided, expiration will be disabled to prevent data from being resurrected.
     std::optional<sstables::sstable_set> all_sstables_snapshot;
-    // Level of sstable(s) created by compaction procedure.
-    int level;
     // Threshold size for sstable(s) to be created.
     uint64_t max_sstable_bytes;
-    // Can split large partitions at clustering boundary.
-    bool can_split_large_partition = false;
     // Run identifier of output sstables.
     sstables::run_id run_identifier;
     // The options passed down to the compaction code.
@@ -196,9 +192,13 @@ struct compaction_descriptor {
     compaction_sstable_creator_fn creator;
     compaction_sstable_replacer_fn replacer;
 
+    // Group small fields together to eliminate padding.
+    // Level of sstable(s) created by compaction procedure.
+    int level;
     // Denotes if this compaction task is comprised solely of completely expired SSTables
     has_only_fully_expired has_only_fully_expired = has_only_fully_expired::no;
-
+    // Can split large partitions at clustering boundary.
+    bool can_split_large_partition = false;
     // If set to true, gc will check only the compacting sstables to collect tombstones.
     // If set to false, gc will check the memtables, commit log and other uncompacting
     // sstables to decide if a tombstone can be collected. Note that these checks are
@@ -221,20 +221,20 @@ struct compaction_descriptor {
                                    compaction_type_options options = compaction_type_options::make_regular(),
                                    compaction::owned_ranges_ptr owned_ranges_ = {})
         : sstables(std::move(sstables))
-        , level(level)
         , max_sstable_bytes(max_sstable_bytes)
         , run_identifier(run_identifier)
         , options(options)
         , owned_ranges(std::move(owned_ranges_))
+        , level(level)
     {}
 
     explicit compaction_descriptor(::compaction::has_only_fully_expired has_only_fully_expired,
                                    std::vector<sstables::shared_sstable> sstables)
         : sstables(std::move(sstables))
-        , level(default_level)
         , max_sstable_bytes(default_max_sstable_bytes)
         , run_identifier(sstables::run_id::create_random_id())
         , options(compaction_type_options::make_regular())
+        , level(default_level)
         , has_only_fully_expired(has_only_fully_expired)
     {}
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -211,13 +211,10 @@ select_statement::select_statement(schema_ptr schema,
     : cql_statement(select_timeout(*restrictions))
     , _schema(schema)
     , _query_schema(is_reversed ? schema->get_reversed() : schema)
-    , _bound_terms(bound_terms)
     , _parameters(std::move(parameters))
     , _selection(std::move(selection))
     , _restrictions(std::move(restrictions))
-    , _restrictions_need_filtering(_restrictions->need_filtering())
     , _group_by_cell_indices(group_by_cell_indices)
-    , _is_reversed(is_reversed)
     , _limit_unset_guard(limit)
     , _limit(std::move(limit))
     , _per_partition_limit_unset_guard(per_partition_limit)
@@ -226,6 +223,9 @@ select_statement::select_statement(schema_ptr schema,
     , _stats(stats)
     , _ks_sel(::is_internal_keyspace(schema->ks_name()) ? ks_selector::SYSTEM : ks_selector::NONSYSTEM)
     , _attrs(std::move(attrs))
+    , _bound_terms(bound_terms)
+    , _restrictions_need_filtering(_restrictions->need_filtering())
+    , _is_reversed(is_reversed)
 {
     _opts = _selection->get_query_options();
     _opts.set_if<query::partition_slice::option::bypass_cache>(_parameters->bypass_cache());

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -65,18 +65,14 @@ public:
     using parameters = raw::select_statement::parameters;
     using ordering_comparator_type = raw::select_statement::ordering_comparator_type;
     using prepared_ann_ordering_type = raw::select_statement::prepared_ann_ordering_type;
-    bool _may_use_token_aware_routing;
 protected:
     static thread_local const lw_shared_ptr<const parameters> _default_parameters;
     schema_ptr _schema;
     schema_ptr _query_schema;
-    uint32_t _bound_terms;
     lw_shared_ptr<const parameters> _parameters;
     ::shared_ptr<selection::selection> _selection;
     const ::shared_ptr<const restrictions::statement_restrictions> _restrictions;
-    const bool _restrictions_need_filtering;
     ::shared_ptr<std::vector<size_t>> _group_by_cell_indices; ///< Indices in result row of cells holding GROUP BY values.
-    bool _is_reversed;
     expr::unset_bind_variable_guard _limit_unset_guard;
     std::optional<expr::expression> _limit;
     expr::unset_bind_variable_guard _per_partition_limit_unset_guard;
@@ -95,9 +91,15 @@ protected:
     query::partition_slice::option_set _opts;
     cql_stats& _stats;
     const ks_selector _ks_sel;
+    std::unique_ptr<cql3::attributes> _attrs;
+    // Group small fields together to eliminate padding.
+    uint32_t _bound_terms;
+    const bool _restrictions_need_filtering;
+    bool _is_reversed;
     bool _range_scan = false;
     bool _range_scan_no_bypass_cache = false;
-    std::unique_ptr<cql3::attributes> _attrs;
+public:
+    bool _may_use_token_aware_routing;
 private:
     future<shared_ptr<cql_transport::messages::result_message>> process_results_complex(foreign_ptr<lw_shared_ptr<query::result>> results,
         lw_shared_ptr<query::read_command> cmd, const query_options& options, gc_clock::time_point now) const;


### PR DESCRIPTION
## Motivation

Several hot structs have suboptimal field ordering with padding bytes wasted on alignment gaps. This PR reorders fields in two structs to eliminate padding without changing behavior.

## Nature of change (2 commits)

1. **select_statement field reorder**: Move smaller fields (bool, enum) adjacent to each other to eliminate alignment gaps. **296B → 272B (24B saved, 8.1%)**.

2. **compaction_descriptor field reorder**: Move `level` (int32_t), `has_only_fully_expired` (bool), and `can_split_large_partition` (bool) next to other small fields to eliminate padding. **232B → 216B (16B saved, 6.9%)**.

**Combined savings: 40B across the two structs.**

## Measured (perf-simple-query, release, smp 1, taskset -c 0, fixed 2.2GHz, 10K partitions, 5 runs)

| Metric | Master | This PR | Delta |
|--------|--------|---------|-------|
| insns/op (median) | 32,036 | 32,038 | +2 (neutral) |
| allocs/op | 58.1 | 58.1 | unchanged |
| tps (median) | 147,600 | 147,500 | within noise |

No regression. Pure field reordering with no behavioral change.

Refs: #29047

Backport: no, benign improvement