### PR TITLE
cql: reject global ANN queries on local vector indexes

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1966,6 +1966,11 @@ struct ann_ordering_info {
     bool is_rescoring_enabled;
 };
 
+static bool has_full_partition_key_eq_restrictions(const restrictions::statement_restrictions& restrictions) {
+    return !restrictions.has_partition_key_unrestricted_components()
+            && restrictions.partition_key_restrictions_is_all_eq();
+}
+
 static std::optional<ann_ordering_info> get_ann_ordering_info(
         data_dictionary::database db,
         schema_ptr schema,
@@ -2002,9 +2007,19 @@ static std::optional<ann_ordering_info> get_ann_ordering_info(
     auto& sim = cf.get_index_manager();
 
     auto indexes = sim.list_indexes();
-    auto it = std::find_if(indexes.begin(), indexes.end(), [&prepared_ann_ordering](const auto& ind) {
+    auto is_matching_vector_index = [&prepared_ann_ordering](const auto& ind) {
         return secondary_index::vector_index::is_vector_index_on_column(ind.metadata(), prepared_ann_ordering.first->name_as_text());
+    };
+
+    // Prefer global index when both local and global vector indexes exist on the
+    // same column. A global ANN query without PK restriction must not pick a
+    // local index.
+    auto it = std::find_if(indexes.begin(), indexes.end(), [&is_matching_vector_index](const auto& ind) {
+        return is_matching_vector_index(ind) && !ind.metadata().local();
     });
+    if (it == indexes.end()) {
+        it = std::find_if(indexes.begin(), indexes.end(), is_matching_vector_index);
+    }
 
     if (it == indexes.end()) {
         throw exceptions::invalid_request_exception("ANN ordering by vector requires the column to be indexed using 'vector_index'");
@@ -2074,6 +2089,12 @@ static select_statement::ordering_comparator_type get_similarity_ordering_compar
         ::shared_ptr<const restrictions::statement_restrictions> restrictions, ::shared_ptr<std::vector<size_t>> group_by_cell_indices, bool is_reversed,
         ordering_comparator_type ordering_comparator, prepared_ann_ordering_type prepared_ann_ordering, std::optional<expr::expression> limit,
         std::optional<expr::expression> per_partition_limit, cql_stats& stats, const secondary_index::index& index, std::unique_ptr<attributes> attrs) {
+
+    if (index.metadata().local() && !has_full_partition_key_eq_restrictions(*restrictions)) {
+        throw exceptions::invalid_request_exception(
+                "Global ANN query is not supported when only a local vector index is available. "
+                "Add WHERE restrictions with EQ on all partition key columns.");
+    }
 
     auto prepared_filter = vector_search::prepare_filter(*restrictions, parameters->allow_filtering());
 

--- a/test/cqlpy/test_vector_index.py
+++ b/test/cqlpy/test_vector_index.py
@@ -535,6 +535,16 @@ def test_local_and_global_vector_indexes_on_same_column(cql, test_keyspace, scyl
         cql.execute(f"CREATE CUSTOM INDEX ON {table}((p1, p2), v) USING 'sai'")
         cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'sai'")
 
+
+# Validates fix for VECTOR-609: global ANN query should fail when only a local
+# vector index exists.
+def test_global_ann_query_rejected_with_only_local_vector_index(cql, test_keyspace, scylla_only, skip_without_tablets):
+    schema = 'p1 int, p2 int, v vector<float, 3>, PRIMARY KEY ((p1, p2))'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}((p1, p2), v) USING 'sai'")
+        with pytest.raises(InvalidRequest, match='Global ANN query is not supported when only a local vector index is available'):
+            cql.execute(f"SELECT * FROM {table} ORDER BY v ANN OF [0.1, 0.2, 0.3] LIMIT 1")
+
 # Even with both local and global indexes, creating a second index of the
 # same locality on the same column should still be rejected as duplicate.
 def test_duplicate_global_vector_index_rejected(cql, test_keyspace, skip_on_scylla_vnodes):


### PR DESCRIPTION
An ANN query without full partition-key equality is a global search. When the only vector index on the target column was local, the coordinator still selected it and sent the request to vector store without a partition-key filter. Vector store returned no primary keys, so the user saw an empty result instead of an explicit error.

Fix this by preferring a global vector index when one exists on the ANN column. If planning falls back to a local vector index, require EQ restrictions on all partition key columns and reject the query otherwise.

Add a cqlpy regression test for VECTOR-609.

Fixes: VECTOR-609

