### PR TITLE
Make gossiper's versioned value use chunked_string and use it for CACHE_HITRATES values

### DIFF
--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -37,7 +37,7 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
                     // We return the enum index and not it's name to stay compatible to origin
                     // method that the state index are static but the name can be changed.
                     version_val.application_state = static_cast<std::underlying_type<gms::application_state>::type>(as_type);
-                    version_val.value = app_state.value();
+                    version_val.value = app_state.value().linearize();
                     version_val.version = app_state.version().value();
                     val.application_state.push(version_val);
                 }

--- a/gms/endpoint_state.cc
+++ b/gms/endpoint_state.cc
@@ -42,7 +42,9 @@ bool endpoint_state::is_cql_ready() const noexcept {
         return false;
     }
     try {
-        return boost::lexical_cast<int>(app_state->value());
+        return app_state->value().with_linearized([] (std::string_view sv) {
+            return boost::lexical_cast<int>(sv);
+        });
     } catch (...) {
         return false;
     }
@@ -51,7 +53,7 @@ bool endpoint_state::is_cql_ready() const noexcept {
 locator::host_id endpoint_state::get_host_id() const noexcept {
     locator::host_id host_id;
     if (auto app_state = get_application_state_ptr(application_state::HOST_ID)) {
-        host_id = locator::host_id(utils::UUID(app_state->value()));
+        host_id = locator::host_id(utils::UUID(app_state->value().linearize()));
         if (!host_id) {
             on_internal_error_noexcept(logger, format("Node has null host_id"));
         }
@@ -63,9 +65,9 @@ std::optional<locator::endpoint_dc_rack> endpoint_state::get_dc_rack() const {
     if (const auto* dc_state = get_application_state_ptr(application_state::DC)) {
         const auto* rack_state = get_application_state_ptr(application_state::RACK);
         if (dc_state->value().empty() || !rack_state || rack_state->value().empty()) {
-            on_internal_error_noexcept(logger, format("Node {} has empty dc={} or rack={}", get_host_id(), dc_state->value(), rack_state ? rack_state->value() : "(null)"));
+            on_internal_error_noexcept(logger, format("Node {} has empty dc={} or rack={}", get_host_id(), dc_state->value(), rack_state ? rack_state->value() : utils::chunked_string("(null)")));
         } else {
-            return std::make_optional<locator::endpoint_dc_rack>(dc_state->value(), rack_state->value());
+            return std::make_optional<locator::endpoint_dc_rack>(dc_state->value().linearize(), rack_state->value().linearize());
         }
     }
     return std::nullopt;

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1500,7 +1500,7 @@ std::optional<endpoint_state> gossiper::get_state_for_version_bigger_than(locato
                     reqd_endpoint_state.emplace(eps.get_heart_beat_state(), eps.get_ip());
                 }
                 auto& key = entry.first;
-                logger.trace("Adding state of {}, {}: {}" , for_endpoint, key, value.value());
+                logger.trace("Adding state of {}, {}: {}" , for_endpoint, key, value.value().linearize());
                 reqd_endpoint_state->add_application_state(key, value);
             }
         }
@@ -1511,7 +1511,7 @@ std::optional<endpoint_state> gossiper::get_state_for_version_bigger_than(locato
 sstring gossiper::get_rpc_address(const locator::host_id& endpoint) const {
     auto* v = get_application_state_ptr(endpoint, gms::application_state::RPC_ADDRESS);
     if (v) {
-        return v->value();
+        return v->value().linearize();
     }
     return fmt::to_string(endpoint);
 }
@@ -2275,7 +2275,7 @@ sstring gossiper::get_application_state_value(locator::host_id endpoint, applica
     if (!v) {
         return {};
     }
-    return v->value();
+    return v->value().linearize();
 }
 
 /**
@@ -2299,24 +2299,25 @@ void gossiper::force_newer_generation() {
     eps.get_heart_beat_state().force_newer_generation_unsafe();
 }
 
-static std::string_view do_get_gossip_status(const gms::versioned_value* app_state) noexcept {
+static sstring do_get_gossip_status(const gms::versioned_value* app_state) noexcept {
     if (!app_state) {
-        return gms::versioned_value::STATUS_UNKNOWN;
+        return sstring(gms::versioned_value::STATUS_UNKNOWN);
     }
-    const std::string_view value = app_state->value();
-    const auto pos = value.find(',');
-    if (value.empty() || !pos) {
-        return gms::versioned_value::STATUS_UNKNOWN;
-    }
-    // npos allowed (full value)
-    return value.substr(0, pos);
+    return app_state->value().with_linearized([] (std::string_view value) -> sstring {
+        const auto pos = value.find(',');
+        if (value.empty() || !pos) {
+            return sstring(gms::versioned_value::STATUS_UNKNOWN);
+        }
+        // npos allowed (full value)
+        return sstring(value.substr(0, pos));
+    });
 }
 
-std::string_view gossiper::get_gossip_status(const endpoint_state& ep_state) const noexcept {
+sstring gossiper::get_gossip_status(const endpoint_state& ep_state) const noexcept {
     return do_get_gossip_status(ep_state.get_application_state_ptr(application_state::STATUS));
 }
 
-std::string_view gossiper::get_gossip_status(const locator::host_id& endpoint) const noexcept {
+sstring gossiper::get_gossip_status(const locator::host_id& endpoint) const noexcept {
     return do_get_gossip_status(get_application_state_ptr(endpoint, application_state::STATUS));
 }
 
@@ -2345,7 +2346,7 @@ void gossiper::check_snitch_name_matches(sstring local_snitch_name) const {
             continue;
         }
 
-        if (remote_snitch_name->value() != local_snitch_name) {
+        if (remote_snitch_name->value() != std::string_view(local_snitch_name)) {
             throw std::runtime_error(format("Snitch check failed. This node cannot join the cluster because it uses {} and not {}", local_snitch_name, remote_snitch_name->value()));
         }
     }
@@ -2370,7 +2371,7 @@ void gossiper::append_endpoint_state(std::stringstream& ss, const endpoint_state
         if (app_state == application_state::TOKENS) {
             continue;
         }
-        fmt::print(ss, "  {}:{}:{}\n", app_state, versioned_val.version(), versioned_val.value());
+        fmt::print(ss, "  {}:{}:{}\n", app_state, versioned_val.version(), versioned_val.value().linearize());
     }
     const auto& app_state_map = state.get_application_state_map();
     if (app_state_map.contains(application_state::TOKENS)) {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -574,8 +574,8 @@ public:
     bool is_cql_ready(const locator::host_id& endpoint) const;
     void force_newer_generation();
 public:
-    std::string_view get_gossip_status(const endpoint_state& ep_state) const noexcept;
-    std::string_view get_gossip_status(const locator::host_id& endpoint) const noexcept;
+    sstring get_gossip_status(const endpoint_state& ep_state) const noexcept;
+    sstring get_gossip_status(const locator::host_id& endpoint) const noexcept;
 private:
     uint64_t _nr_run = 0;
     uint64_t _msg_processing = 0;

--- a/gms/versioned_value.hh
+++ b/gms/versioned_value.hh
@@ -12,6 +12,7 @@
 
 #include <seastar/core/sstring.hh>
 #include "locator/host_id.hh"
+#include "utils/chunked_string.hh"
 #include "version_generator.hh"
 #include "gms/inet_address.hh"
 #include "dht/token.hh"
@@ -37,7 +38,7 @@ namespace gms {
 
 class versioned_value {
     version_type _version;
-    sstring _value;
+    utils::chunked_string _value;
 public:
     // this must be a char that cannot be present in any token
     static constexpr std::string_view DELIMITER{","};
@@ -49,25 +50,14 @@ public:
     static constexpr std::string_view SHUTDOWN{"shutdown"};
 
     [[nodiscard]] version_type version() const noexcept { return _version; };
-    [[nodiscard]] const sstring& value() const noexcept { return _value; };
+    [[nodiscard]] const utils::chunked_string& value() const noexcept { return _value; };
 
     bool operator==(const versioned_value& other) const noexcept {
         return _version == other._version &&
                _value   == other._value;
     }
 
-    explicit versioned_value(const sstring& value, version_type version = version_generator::get_next_version())
-        : _version(version), _value(value) {
-#if 0
-        // blindly interning everything is somewhat suboptimal -- lots of VersionedValues are unique --
-        // but harmless, and interning the non-unique ones saves significant memory.  (Unfortunately,
-        // we don't really have enough information here in VersionedValue to tell the probably-unique
-        // values apart.)  See CASSANDRA-6410.
-        this.value = value.intern();
-#endif
-    }
-
-    explicit versioned_value(sstring&& value, version_type version = version_generator::get_next_version()) noexcept
+    explicit versioned_value(utils::chunked_string value, version_type version = version_generator::get_next_version()) noexcept
         : _version(version), _value(std::move(value)) {
     }
 
@@ -76,7 +66,7 @@ public:
     }
 
     static versioned_value clone_with_higher_version(const versioned_value& value) noexcept {
-        return versioned_value(value.value());
+        return versioned_value(utils::chunked_string(utils::chunked_string_view(value.value())));
     }
 
 private:
@@ -146,8 +136,8 @@ public:
         return versioned_value(fmt::to_string(fmt::join(features, ",")));
     }
 
-    static versioned_value cache_hitrates(const sstring& hitrates) {
-        return versioned_value(hitrates);
+    static versioned_value cache_hitrates(utils::chunked_string hitrates) {
+        return versioned_value(std::move(hitrates));
     }
 
     static versioned_value cql_ready(bool value) {
@@ -164,6 +154,10 @@ public:
 
 template <> struct fmt::formatter<gms::versioned_value> : fmt::formatter<string_view> {
     static auto format(const gms::versioned_value& v, fmt::format_context& ctx) {
-        return fmt::format_to(ctx.out(), "Value({},{})", v.value(), v.version());
+        auto out = fmt::format_to(ctx.out(), "Value(");
+        for (bytes_view frag : fragment_range(managed_bytes_view(v.value().data()))) {
+            out = fmt::format_to(out, "{}", utils::to_string_view(frag));
+        }
+        return fmt::format_to(out, ",{})", v.version());
     }
 };

--- a/idl/gossip_digest.idl.hh
+++ b/idl/gossip_digest.idl.hh
@@ -32,7 +32,7 @@ enum class application_state:int {
 };
 
 class versioned_value {
-    sstring value();
+    utils::chunked_string value();
     gms::version_type version();
 };
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4916,13 +4916,14 @@ table::cache_hit_rate table::get_hit_rate(const gms::gossiper& gossiper, locator
             float f = -1.0f; // missing state means old node
             if (state) {
                 const auto me = format("{}.{}", _schema->ks_name(), _schema->cf_name());
-                const auto& value = state->value();
-                const auto i = value.find(me);
-                if (i != sstring::npos) {
-                    f = strtof(&value[i + me.size() + 1], nullptr);
-                } else {
-                    f = 0.0f; // empty state means that node has rebooted
-                }
+                f = state->value().with_linearized([&] (std::string_view value) -> float {
+                    const auto i = value.find(me);
+                    if (i != std::string_view::npos) {
+                        return strtof(value.data() + i + me.size() + 1, nullptr);
+                    } else {
+                        return 0.0f; // empty state means that node has rebooted
+                    }
+                });
                 set_hit_rate(addr, cache_temperature(f));
                 return cache_hit_rate{cache_temperature(f), lowres_clock::now()};
             }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4916,14 +4916,23 @@ table::cache_hit_rate table::get_hit_rate(const gms::gossiper& gossiper, locator
             float f = -1.0f; // missing state means old node
             if (state) {
                 const auto me = format("{}.{}", _schema->ks_name(), _schema->cf_name());
-                f = state->value().with_linearized([&] (std::string_view value) -> float {
-                    const auto i = value.find(me);
-                    if (i != std::string_view::npos) {
-                        return strtof(value.data() + i + me.size() + 1, nullptr);
-                    } else {
-                        return 0.0f; // empty state means that node has rebooted
+                utils::chunked_string_view csv(state->value());
+                auto it = std::search(csv.begin(), csv.end(), me.begin(), me.end());
+                if (it != csv.end()) {
+                    // Skip past the table name and the ':' separator
+                    std::advance(it, me.size() + 1);
+                    // Extract float value until ';' or end into a small buffer
+                    char buf[16];
+                    size_t n = 0;
+                    while (it != csv.end() && *it != ';' && n < sizeof(buf) - 1) {
+                        buf[n++] = *it;
+                        ++it;
                     }
-                });
+                    buf[n] = '\0';
+                    f = strtof(buf, nullptr);
+                } else {
+                    f = 0.0f; // empty state means that node has rebooted
+                }
                 set_hit_rate(addr, cache_temperature(f));
                 return cache_hit_rate{cache_temperature(f), lowres_clock::now()};
             }

--- a/service/cache_hitrate_calculator.hh
+++ b/service/cache_hitrate_calculator.hh
@@ -10,6 +10,7 @@
 
 #include "replica/database_fwd.hh"
 #include "schema/schema_fwd.hh"
+#include "utils/chunked_string.hh"
 #include <seastar/core/timer.hh>
 #include <seastar/core/sharded.hh>
 
@@ -36,8 +37,6 @@ class cache_hitrate_calculator : public seastar::async_sharded_service<cache_hit
     bool _stopped = false;
     float _diff = 0;
     std::unordered_map<table_id, stat> _rates;
-    size_t _slen = 0;
-    std::string _gstate;
     uint64_t _published_nr = 0;
     lowres_clock::time_point _published_time;
     future<> _done = make_ready_future();

--- a/service/load_broadcaster.hh
+++ b/service/load_broadcaster.hh
@@ -39,7 +39,7 @@ public:
 
     virtual future<> on_change(gms::inet_address endpoint, locator::host_id id, const gms::application_state_map& states, gms::permit_id pid) override {
         return on_application_state_change(endpoint, id, states, gms::application_state::LOAD, pid, [this] (gms::inet_address endpoint, locator::host_id id, const gms::versioned_value& value, gms::permit_id) {
-            _load_info[id] = std::stod(value.value());
+            _load_info[id] = value.value().with_linearized([] (std::string_view sv) { return std::stod(std::string(sv)); });
             return make_ready_future<>();
         });
     }
@@ -47,7 +47,7 @@ public:
     virtual future<> on_join(gms::inet_address endpoint, locator::host_id id, gms::endpoint_state_ptr ep_state, gms::permit_id pid) override {
         auto* local_value = ep_state->get_application_state_ptr(gms::application_state::LOAD);
         if (local_value) {
-            _load_info[id] = std::stod(local_value->value());
+            _load_info[id] = local_value->value().with_linearized([] (std::string_view sv) { return std::stod(std::string(sv)); });
         }
         return make_ready_future();
     }

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -219,7 +219,7 @@ bool migration_manager::have_schema_agreement() {
             match = false;
             return stop_iteration::yes;
         }
-        auto remote_version = table_schema_version(utils::UUID{schema->value()});
+        auto remote_version = table_schema_version(utils::UUID{schema->value().linearize()});
         if (our_version != remote_version) {
             mlogger.log(log_level::info, rate_limit, "Schema mismatch for {} ({} != {}).",
                         endpoint, our_version, remote_version);

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -154,19 +154,17 @@ future<lowres_clock::duration> cache_hitrate_calculator::recalculate_hitrates() 
     };
 
     auto finally = defer([this] noexcept {
-        _gstate = std::string(); // free memory, do not trust clear() to do that for string
         _rates.clear();
     });
 
     _rates = co_await _db.map_reduce0(cf_to_cache_hit_stats, std::unordered_map<table_id, stat>(), sum_stats_per_cf);
     _diff = 0;
-    _gstate.reserve(_slen); // assume length did not change from previous iteration
-    _slen = 0;
 
     // set calculated rates on all shards
     auto cpuid = this_shard_id();
-    co_await _db.invoke_on_all([this, cpuid] (replica::database& db) {
-        return do_for_each(_rates, [this, cpuid, &db] (auto&& r) mutable {
+    std::vector<std::string> parts;
+    co_await _db.invoke_on_all([this, cpuid, &parts] (replica::database& db) {
+        return do_for_each(_rates, [this, cpuid, &db, &parts] (auto&& r) mutable {
             auto cf_opt = db.get_tables_metadata().get_table_if_exists(r.first);
             if (!cf_opt) { // a table may be added before map/reduce completes and this code runs
                 return;
@@ -180,13 +178,23 @@ future<lowres_clock::duration> cache_hitrate_calculator::recalculate_hitrates() 
             if (this_shard_id() == cpuid) {
                 // calculate max difference between old rate and new one for all cfs
                 _diff = std::max(_diff, std::abs(float(cf->get_global_cache_hit_rate()) - rate));
-                _gstate += format("{}.{}:{:0.6f};", cf->schema()->ks_name(), cf->schema()->cf_name(), rate);
+                parts.push_back(format("{}.{}:{:0.6f};", cf->schema()->ks_name(), cf->schema()->cf_name(), rate));
             }
             cf->set_global_cache_hit_rate(cache_temperature(rate));
         });
     });
 
-    _slen = _gstate.size();
+    // Build gstate as a chunked_string from accumulated parts
+    size_t total_size = 0;
+    for (auto& p : parts) {
+        total_size += p.size();
+    }
+    utils::chunked_string gstate(utils::chunked_string::initialized_later{}, total_size);
+    auto view = gstate.mutable_view();
+    for (auto& p : parts) {
+        write_fragmented(view, std::string_view(p));
+    }
+
     using namespace std::chrono_literals;
     auto now = lowres_clock::now();
     // Publish CACHE_HITRATES in case:
@@ -212,9 +220,9 @@ future<lowres_clock::duration> cache_hitrate_calculator::recalculate_hitrates() 
         llogger.debug("Send CACHE_HITRATES update max_diff={}, published_nr={}", _diff, _published_nr);
         ++_published_nr;
         _published_time = now;
-        co_await container().invoke_on(0, [&gstate = _gstate] (cache_hitrate_calculator& self) {
+        co_await container().invoke_on(0, [gstate = std::move(gstate)] (cache_hitrate_calculator& self) mutable {
             return self._gossiper.add_local_application_state(gms::application_state::CACHE_HITRATES,
-                    gms::versioned_value::cache_hitrates(gstate));
+                    gms::versioned_value::cache_hitrates(std::move(gstate)));
         });
     } else {
         llogger.debug("Skip CACHE_HITRATES update max_diff={}, published_nr={}", _diff, _published_nr);

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -20,7 +20,7 @@
 #include "replica/database.hh"
 #include "locator/abstract_replication_strategy.hh"
 
-#include <cstdlib>
+#include <charconv>
 
 namespace service {
 
@@ -274,34 +274,35 @@ future<> view_update_backlog_broker::on_change(gms::inet_address endpoint, locat
             return make_ready_future<>();
         }
 
-        size_t current;
-        size_t max;
-        api::timestamp_type ticks;
-        const char* start_bound = value.value().data();
-        char* end_bound;
-        for (auto* ptr : {&current, &max}) {
-            errno = 0;
-            *ptr = std::strtoull(start_bound, &end_bound, 10);
-            if (errno == ERANGE) {
+        return value.value().with_linearized([&] (std::string_view sv) {
+            size_t current;
+            size_t max;
+            api::timestamp_type ticks;
+            const char* first = sv.data();
+            const char* last = sv.data() + sv.size();
+
+            for (auto* ptr : {&current, &max}) {
+                auto [p, ec] = std::from_chars(first, last, *ptr);
+                if (ec != std::errc{} || p == last) {
+                    return make_ready_future();
+                }
+                first = p + 1; // skip delimiter
+            }
+            if (max == 0) {
                 return make_ready_future();
             }
-            start_bound = end_bound + 1;
-        }
-        if (max == 0) {
-            return make_ready_future();
-        }
-        errno = 0;
-        ticks = std::strtoll(start_bound, &end_bound, 10);
-        if (ticks == 0 || errno == ERANGE || end_bound != value.value().data() + value.value().size()) {
-            return make_ready_future();
-        }
-        auto backlog = view_update_backlog_timestamped{db::view::update_backlog{current, max}, ticks};
-        return _sp.invoke_on_all([id, backlog] (service::storage_proxy& sp) {
-            auto[it, inserted] = sp._view_update_backlogs.try_emplace(id, backlog);
-            if (!inserted && it->second.ts < backlog.ts) {
+            auto [p, ec] = std::from_chars(first, last, ticks);
+            if (ticks == 0 || ec != std::errc{} || p != last) {
+                return make_ready_future();
+            }
+            auto backlog = view_update_backlog_timestamped{db::view::update_backlog{current, max}, ticks};
+            return _sp.invoke_on_all([id, backlog] (service::storage_proxy& sp) {
+                auto[it, inserted] = sp._view_update_backlogs.try_emplace(id, backlog);
+                if (!inserted && it->second.ts < backlog.ts) {
                 it->second = backlog;
             }
             return make_ready_future();
+        });
         });
     });
 }

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -8,6 +8,7 @@
  */
 
 #include <seastar/core/sleep.hh>
+#include <seastar/util/defer.hh>
 #include "gms/inet_address.hh"
 #include "load_meter.hh"
 #include "load_broadcaster.hh"
@@ -152,73 +153,73 @@ future<lowres_clock::duration> cache_hitrate_calculator::recalculate_hitrates() 
         return a;
     };
 
-    return _db.map_reduce0(cf_to_cache_hit_stats, std::unordered_map<table_id, stat>(), sum_stats_per_cf).then([this] (std::unordered_map<table_id, stat> rates) mutable {
-        _diff = 0;
-        _gstate.reserve(_slen); // assume length did not change from previous iteration
-        _slen = 0;
-        _rates = std::move(rates);
-        // set calculated rates on all shards
-        return _db.invoke_on_all([this, cpuid = this_shard_id()] (replica::database& db) {
-            return do_for_each(_rates, [this, cpuid, &db] (auto&& r) mutable {
-                auto cf_opt = db.get_tables_metadata().get_table_if_exists(r.first);
-                if (!cf_opt) { // a table may be added before map/reduce completes and this code runs
-                    return;
-                }
-                auto& cf = cf_opt;
-                stat& s = r.second;
-                float rate = 0;
-                if (s.h) {
-                    rate = s.h / (s.h + s.m);
-                }
-                if (this_shard_id() == cpuid) {
-                    // calculate max difference between old rate and new one for all cfs
-                    _diff = std::max(_diff, std::abs(float(cf->get_global_cache_hit_rate()) - rate));
-                    _gstate += format("{}.{}:{:0.6f};", cf->schema()->ks_name(), cf->schema()->cf_name(), rate);
-                }
-                cf->set_global_cache_hit_rate(cache_temperature(rate));
-            });
-        });
-    }).then([this] {
-        _slen = _gstate.size();
-        using namespace std::chrono_literals;
-        auto now = lowres_clock::now();
-        // Publish CACHE_HITRATES in case:
-        //
-        // - We haven't published it at all
-        // - The diff is bigger than 1% and we haven't published in the last 5 seconds
-        // - The diff is really big 10%
-        //
-        // Note: A peer node can know the cache hitrate through read_data
-        // read_mutation_data and read_digest RPC verbs which have
-        // cache_temperature in the response. So there is no need to update
-        // CACHE_HITRATES through gossip in high frequency.
-        bool do_publish = (_published_nr == 0) ||
-                          (_diff > 0.1) ||
-                          ( _diff > 0.01 && (now - _published_time) > 5000ms);
-
-        // We do the recalculation faster if the diff is bigger than 0.01. It
-        // is useful to do the calculation even if we do not publish the
-        // CACHE_HITRATES though gossip, since the recalculation will call the
-        // table->set_global_cache_hit_rate to set the hitrate.
-        auto recalculate_duration = _diff > 0.01 ? lowres_clock::duration(500ms) : lowres_clock::duration(2000ms);
-        if (do_publish) {
-            llogger.debug("Send CACHE_HITRATES update max_diff={}, published_nr={}", _diff, _published_nr);
-            ++_published_nr;
-            _published_time = now;
-            return container().invoke_on(0, [&gstate = _gstate] (cache_hitrate_calculator& self) {
-                return self._gossiper.add_local_application_state(gms::application_state::CACHE_HITRATES,
-                        gms::versioned_value::cache_hitrates(gstate));
-            }).then([recalculate_duration] {
-                return recalculate_duration;
-            });
-        } else {
-            llogger.debug("Skip CACHE_HITRATES update max_diff={}, published_nr={}", _diff, _published_nr);
-            return make_ready_future<lowres_clock::duration>(recalculate_duration);
-        }
-    }).finally([this] {
+    auto finally = defer([this] noexcept {
         _gstate = std::string(); // free memory, do not trust clear() to do that for string
         _rates.clear();
     });
+
+    _rates = co_await _db.map_reduce0(cf_to_cache_hit_stats, std::unordered_map<table_id, stat>(), sum_stats_per_cf);
+    _diff = 0;
+    _gstate.reserve(_slen); // assume length did not change from previous iteration
+    _slen = 0;
+
+    // set calculated rates on all shards
+    auto cpuid = this_shard_id();
+    co_await _db.invoke_on_all([this, cpuid] (replica::database& db) {
+        return do_for_each(_rates, [this, cpuid, &db] (auto&& r) mutable {
+            auto cf_opt = db.get_tables_metadata().get_table_if_exists(r.first);
+            if (!cf_opt) { // a table may be added before map/reduce completes and this code runs
+                return;
+            }
+            auto& cf = cf_opt;
+            stat& s = r.second;
+            float rate = 0;
+            if (s.h) {
+                rate = s.h / (s.h + s.m);
+            }
+            if (this_shard_id() == cpuid) {
+                // calculate max difference between old rate and new one for all cfs
+                _diff = std::max(_diff, std::abs(float(cf->get_global_cache_hit_rate()) - rate));
+                _gstate += format("{}.{}:{:0.6f};", cf->schema()->ks_name(), cf->schema()->cf_name(), rate);
+            }
+            cf->set_global_cache_hit_rate(cache_temperature(rate));
+        });
+    });
+
+    _slen = _gstate.size();
+    using namespace std::chrono_literals;
+    auto now = lowres_clock::now();
+    // Publish CACHE_HITRATES in case:
+    //
+    // - We haven't published it at all
+    // - The diff is bigger than 1% and we haven't published in the last 5 seconds
+    // - The diff is really big 10%
+    //
+    // Note: A peer node can know the cache hitrate through read_data
+    // read_mutation_data and read_digest RPC verbs which have
+    // cache_temperature in the response. So there is no need to update
+    // CACHE_HITRATES through gossip in high frequency.
+    bool do_publish = (_published_nr == 0) ||
+                      (_diff > 0.1) ||
+                      ( _diff > 0.01 && (now - _published_time) > 5000ms);
+
+    // We do the recalculation faster if the diff is bigger than 0.01. It
+    // is useful to do the calculation even if we do not publish the
+    // CACHE_HITRATES though gossip, since the recalculation will call the
+    // table->set_global_cache_hit_rate to set the hitrate.
+    auto recalculate_duration = _diff > 0.01 ? lowres_clock::duration(500ms) : lowres_clock::duration(2000ms);
+    if (do_publish) {
+        llogger.debug("Send CACHE_HITRATES update max_diff={}, published_nr={}", _diff, _published_nr);
+        ++_published_nr;
+        _published_time = now;
+        co_await container().invoke_on(0, [&gstate = _gstate] (cache_hitrate_calculator& self) {
+            return self._gossiper.add_local_application_state(gms::application_state::CACHE_HITRATES,
+                    gms::versioned_value::cache_hitrates(gstate));
+        });
+    } else {
+        llogger.debug("Skip CACHE_HITRATES update max_diff={}, published_nr={}", _diff, _published_nr);
+    }
+    co_return recalculate_duration;
 }
 
 future<> cache_hitrate_calculator::stop() {

--- a/service/raft/group0_state_id_handler.cc
+++ b/service/raft/group0_state_id_handler.cc
@@ -52,7 +52,7 @@ void group0_state_id_handler::refresh() {
             return std::nullopt;
         }
 
-        return utils::UUID{state_id_ptr->value()};
+        return utils::UUID{state_id_ptr->value().linearize()};
     }) | std::ranges::views::filter([](const auto& state_id) {
         return state_id.has_value();
     }) | std::ranges::views::transform([](const auto& state_id) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1817,7 +1817,7 @@ future<> storage_service::on_change(gms::inet_address endpoint, locator::host_id
             co_await notify_cql_change(endpoint, host_id, ep_state->is_cql_ready());
         }
         if (auto it = states.find(application_state::INTERNAL_IP); it != states.end()) {
-            co_await maybe_reconnect_to_preferred_ip(endpoint, inet_address(it->second.value()), host_id);
+            co_await maybe_reconnect_to_preferred_ip(endpoint, inet_address(it->second.value().linearize()), host_id);
         }
     }
 }
@@ -1880,9 +1880,9 @@ std::optional<db::system_keyspace::peer_info> storage_service::get_peer_info_for
             std::string_view name)
     {
         try {
-            field = T(value.value());
+            field = T(value.value().linearize());
         } catch (...) {
-            on_internal_error(slogger, fmt::format("failed to parse {} {} for {}: {}", name, value.value(),
+            on_internal_error(slogger, fmt::format("failed to parse {} {} for {}: {}", name, value.value().linearize(),
                 endpoint, std::current_exception()));
         }
     };
@@ -1913,8 +1913,8 @@ std::optional<locator::endpoint_dc_rack> storage_service::get_dc_rack_for(const 
         return std::nullopt;
     }
     return locator::endpoint_dc_rack{
-        .dc = dc->value(),
-        .rack = rack->value(),
+        .dc = dc->value().linearize(),
+        .rack = rack->value().linearize(),
     };
 }
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -118,7 +118,7 @@ sstring get_application_state_gently(const gms::application_state_map& epmap, gm
         return sstring{};
     }
     // it's versioned_value::value(), not std::optional::value() - it does not throw
-    return it->second.value();
+    return it->second.value().linearize();
 }
 } // namespace
 

--- a/utils/chunked_string.hh
+++ b/utils/chunked_string.hh
@@ -279,3 +279,23 @@ inline chunked_string& chunked_string::operator=(chunked_string_view o) {
 managed_bytes from_hex(utils::chunked_string_view view);
 
 } // namespace utils
+
+template <> struct fmt::formatter<utils::chunked_string> : fmt::formatter<std::string_view> {
+    auto format(const utils::chunked_string& s, fmt::format_context& ctx) const {
+        auto out = ctx.out();
+        for (bytes_view frag : fragment_range(managed_bytes_view(s.data()))) {
+            out = fmt::format_to(out, "{}", utils::to_string_view(frag));
+        }
+        return out;
+    }
+};
+
+template <> struct fmt::formatter<utils::chunked_string_view> : fmt::formatter<std::string_view> {
+    auto format(utils::chunked_string_view s, fmt::format_context& ctx) const {
+        auto out = ctx.out();
+        for (bytes_view frag : fragment_range(s.data())) {
+            out = fmt::format_to(out, "{}", utils::to_string_view(frag));
+        }
+        return out;
+    }
+};


### PR DESCRIPTION
CACHE_HITRATES value can be very large string and this will cause large allocation warning. Store it in chunked_string instead, but since CACHE_HITRATES is stored in gossiper's versioned value the versioned value is also changed to use chunked_string. This changes IDL but this is fine since sstring and chunked_string serializations are compatible.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1942

No need to backport since it is a large change and the issue it solves is a warning only.