### PR TITLE
sstables: bump default validation level for sstable writer to partition-key

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1458,8 +1458,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_node_aggregated_table_metrics(this, "enable_node_aggregated_table_metrics", value_status::Used, true, "Enable aggregated per node, per keyspace and per table metrics reporting, applicable if enable_keyspace_column_family_metrics is false.")
     , enable_sstable_data_integrity_check(this, "enable_sstable_data_integrity_check", value_status::Used, false, "Enable interposer which checks for integrity of every sstable write."
         " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
-    , enable_sstable_key_validation(this, "enable_sstable_key_validation", value_status::Used, ENABLE_SSTABLE_KEY_VALIDATION, "Enable validation of partition and clustering keys monotonicity"
-        " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
+    , enable_sstable_key_validation(this, "enable_sstable_key_validation", value_status::Used, ENABLE_SSTABLE_KEY_VALIDATION, "Enable validation of clustering key monotonicity during sstable writes."
+        " When disabled, only partition key monotonicity is validated. Performance is affected to some extent as a result."
+        " Useful to help debugging problems that may arise at another layers.")
     , ignore_component_digest_mismatch(this, "ignore_component_digest_mismatch", value_status::Used, false,
         "When set, log a warning instead of refusing to load sstables with component digest mismatches."
         " Useful for recovering from corrupted non-vital components or working around bugs in digest calculation.")

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -257,7 +257,7 @@ sstable_writer_config sstables_manager::configure_writer(sstring origin) const {
     }
     cfg.validation_level = _config.enable_sstable_key_validation
             ? mutation_fragment_stream_validation_level::clustering_key
-            : mutation_fragment_stream_validation_level::token;
+            : mutation_fragment_stream_validation_level::partition_key;
     cfg.summary_byte_cost = summary_byte_cost(_config.sstable_summary_ratio);
 
     cfg.origin = std::move(origin);


### PR DESCRIPTION
When the validator was introduced to the sstable writer, there was a heated discussion about what the appropriate default validation level is. We finally settled at token level, as this avoids doing any potentially expensive key comparisons, all the validation is done by comparing integers. Whatever the default value is, it is always a tradeoff between safety and performance and token was selected as a good middle ground.
This patch bumps up the default validation level to partition-key, based on the observation that in 99.99% of cases, this still doesn't actually compare keys. Partition key order is based on token -- the order of which is already validated. Actual key comparison happens only for keys which share the same token, which is very rare. This change allows us to have full validation of partition ordering with virtually extra cost.

Backport: improvement, no backport