### PR TITLE
build: drop python3-pytest-sugar from install-dependencies.sh --future

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -44,7 +44,6 @@ debian_base_packages=(
     python3-pytest
     python3-pytest-asyncio
     python3-pytest-timeout
-    python3-pytest-sugar
     python3-pexpect
     libsnappy-dev
     libjsoncpp-dev
@@ -387,7 +386,10 @@ if $PRINT_PIP_SYMLINK; then
 fi
 
 if ! $FUTURE; then
-    fedora_packages+=(toxiproxy)
+    fedora_packages+=(
+        toxiproxy
+        python3-pytest-sugar
+    )
 fi
 
 umask 0022


### PR DESCRIPTION
The python3-pytest-sugar package was orphaned from Fedora [1] and isn't provided by Fedora 45.

Drop it from the future toolchain so it can build. Arguably it doesn't belong in the current toolchain either (it's not necessary, just nice) but I don't want to regenerated the toolchain just for that.

[1] https://src.fedoraproject.org/rpms/python-pytest-sugar/c/094443596a244452d27203c61442a1483f19651e?branch=rawhide

No backport, preparing for future toolchain. Release branches won't be affected by the orphaning.