### PR TITLE
[DRAFT - Do not merge] replica: lazily allocate CAS/LWT stats and view stats in replica::table (14976B to 7128B) 

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -897,19 +897,22 @@ void set_column_family(http_context& ctx, routes& r, sharded<replica::database>&
 
     cf::get_cas_prepare.set(r, [&db] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_time_histogram(db, req->get_path_param("name"), [](const replica::column_family& cf) {
-            return cf.get_stats().cas_prepare.histogram();
+            auto& s = cf.get_stats();
+            return s.cas_prepare ? s.cas_prepare->histogram() : utils::time_estimated_histogram{};
         });
     });
 
     cf::get_cas_propose.set(r, [&db] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_time_histogram(db, req->get_path_param("name"), [](const replica::column_family& cf) {
-            return cf.get_stats().cas_accept.histogram();
+            auto& s = cf.get_stats();
+            return s.cas_accept ? s.cas_accept->histogram() : utils::time_estimated_histogram{};
         });
     });
 
     cf::get_cas_commit.set(r, [&db] (std::unique_ptr<http::request> req) {
         return map_reduce_cf_time_histogram(db, req->get_path_param("name"), [](const replica::column_family& cf) {
-            return cf.get_stats().cas_learn.histogram();
+            auto& s = cf.get_stats();
+            return s.cas_learn ? s.cas_learn->histogram() : utils::time_estimated_histogram{};
         });
     });
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -521,13 +521,15 @@ private:
     lw_shared_ptr<const storage_options> _storage_opts;
     memtable_table_shared_data _memtable_shared_data;
     mutable table_stats _stats;
-    mutable db::view::stats _view_stats;
+    // View stats are only needed for base tables (not for view tables themselves).
+    // Allocated only for base tables (not views), saving 5688B per view table per shard.
+    mutable std::unique_ptr<db::view::stats> _view_stats;
     // Row locker stats are lazily allocated since only LWT/CAS operations
     // use row locking. Saves 2176B per non-CAS table per shard.
     mutable std::unique_ptr<row_locker::stats> _row_locker_stats;
 
     row_locker::stats& get_row_locker_stats() const {
-        if (!_row_locker_stats) [[unlikely]] {
+        if (!_row_locker_stats) {
             _row_locker_stats = std::make_unique<row_locker::stats>();
         }
         return *_row_locker_stats;
@@ -1255,11 +1257,13 @@ public:
     locator::combined_load_stats table_load_stats() const;
 
     const db::view::stats& get_view_stats() const {
-        return _view_stats;
+        assert(_view_stats && "get_view_stats() called on a view table");
+        return *_view_stats;
     }
 
     db::view::stats& view_stats() const noexcept {
-        return _view_stats;
+        assert(_view_stats && "view_stats() called on a view table");
+        return *_view_stats;
     }
 
     replica::cf_stats* cf_stats() const {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -420,9 +420,31 @@ struct table_stats {
     mutation_application_stats memtable_app_stats;
     utils::timed_rate_moving_average_summary_and_histogram reads{256};
     utils::timed_rate_moving_average_summary_and_histogram writes{256};
-    utils::timed_rate_moving_average_summary_and_histogram cas_prepare{256};
-    utils::timed_rate_moving_average_summary_and_histogram cas_accept{256};
-    utils::timed_rate_moving_average_summary_and_histogram cas_learn{256};
+    // CAS histograms are lazily allocated since most tables never use CAS.
+    // Each instance is ~1.5KB + ~2KB heap; deferring allocation saves
+    // ~10.5KB per non-CAS table per shard.
+    std::unique_ptr<utils::timed_rate_moving_average_summary_and_histogram> cas_prepare;
+    std::unique_ptr<utils::timed_rate_moving_average_summary_and_histogram> cas_accept;
+    std::unique_ptr<utils::timed_rate_moving_average_summary_and_histogram> cas_learn;
+
+    utils::timed_rate_moving_average_summary_and_histogram& get_cas_prepare() {
+        if (!cas_prepare) {
+            cas_prepare = std::make_unique<utils::timed_rate_moving_average_summary_and_histogram>(256);
+        }
+        return *cas_prepare;
+    }
+    utils::timed_rate_moving_average_summary_and_histogram& get_cas_accept() {
+        if (!cas_accept) {
+            cas_accept = std::make_unique<utils::timed_rate_moving_average_summary_and_histogram>(256);
+        }
+        return *cas_accept;
+    }
+    utils::timed_rate_moving_average_summary_and_histogram& get_cas_learn() {
+        if (!cas_learn) {
+            cas_learn = std::make_unique<utils::timed_rate_moving_average_summary_and_histogram>(256);
+        }
+        return *cas_learn;
+    }
     utils::estimated_histogram estimated_sstable_per_read{35};
     utils::timed_rate_moving_average_and_histogram tombstone_scanned;
     utils::timed_rate_moving_average_and_histogram live_scanned;
@@ -500,7 +522,16 @@ private:
     memtable_table_shared_data _memtable_shared_data;
     mutable table_stats _stats;
     mutable db::view::stats _view_stats;
-    mutable row_locker::stats _row_locker_stats;
+    // Row locker stats are lazily allocated since only LWT/CAS operations
+    // use row locking. Saves 2176B per non-CAS table per shard.
+    mutable std::unique_ptr<row_locker::stats> _row_locker_stats;
+
+    row_locker::stats& get_row_locker_stats() const {
+        if (!_row_locker_stats) [[unlikely]] {
+            _row_locker_stats = std::make_unique<row_locker::stats>();
+        }
+        return *_row_locker_stats;
+    }
 
     uint64_t _failed_counter_applies_to_memtable = 0;
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2241,17 +2241,22 @@ void table::set_metrics() {
                         [this] { return _stats.pending_sstable_deletions; })(cf)(ks)
         });
 
-        // Metrics related to row locking
+        // Metrics related to row locking.
+        // Uses pointer-to-member to avoid duplicating the metric registration
+        // for each of the 4 lock types (exclusive/shared × row/partition).
         auto add_row_lock_metrics = [this, ks, cf] (row_locker::single_lock_stats row_locker::stats::*member, sstring stat_name) {
+            auto get_stats = [this, member] () -> row_locker::single_lock_stats* {
+                return _row_locker_stats ? &(_row_locker_stats.get()->*member) : nullptr;
+            };
             _metrics.add_group("column_family", {
                 ms::make_total_operations(format("row_lock_{}_acquisitions", stat_name),
-                        [this, member] {return _row_locker_stats ? (_row_locker_stats.get()->*member).lock_acquisitions : uint64_t(0);},
+                        [get_stats] { auto s = get_stats(); return s ? s->lock_acquisitions : uint64_t(0); },
                         ms::description(format("Row lock acquisitions for {} lock", stat_name)))(cf)(ks).set_skip_when_empty(),
                 ms::make_queue_length(format("row_lock_{}_operations_currently_waiting_for_lock", stat_name),
-                        [this, member] {return _row_locker_stats ? (_row_locker_stats.get()->*member).operations_currently_waiting_for_lock : uint64_t(0);},
+                        [get_stats] { auto s = get_stats(); return s ? s->operations_currently_waiting_for_lock : uint64_t(0); },
                         ms::description(format("Operations currently waiting for {} lock", stat_name)))(cf)(ks),
                 ms::make_histogram(format("row_lock_{}_waiting_time", stat_name), ms::description(format("Histogram representing time that operations spent on waiting for {} lock", stat_name)),
-                        [this, member] {return _row_locker_stats ? to_metrics_histogram((_row_locker_stats.get()->*member).estimated_waiting_for_lock) : seastar::metrics::histogram{};})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty()
+                        [get_stats] { auto s = get_stats(); return s ? to_metrics_histogram(s->estimated_waiting_for_lock) : seastar::metrics::histogram{}; })(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty()
             });
         };
         add_row_lock_metrics(&row_locker::stats::exclusive_row, "exclusive_row");
@@ -2260,8 +2265,8 @@ void table::set_metrics() {
         add_row_lock_metrics(&row_locker::stats::shared_partition, "shared_partition");
 
         // View metrics are created only for base tables, so there's no point in adding them to views (which cannot act as base tables for other views)
-        if (!_schema->is_view()) {
-            _view_stats.register_stats();
+        if (_view_stats) {
+            _view_stats->register_stats();
         }
 
         if (uses_tablets()) {
@@ -2323,7 +2328,9 @@ void table::set_metrics() {
 
 void table::deregister_metrics() {
     _metrics.clear();
-    _view_stats._metrics.clear();
+    if (_view_stats) {
+        _view_stats->_metrics.clear();
+    }
 }
 
 size_t compaction_group::live_sstable_count() const noexcept {
@@ -3347,10 +3354,10 @@ table::table(schema_ptr schema, config config, lw_shared_ptr<const storage_optio
     , _config(std::move(config))
     , _erm(std::move(erm))
     , _storage_opts(std::move(sopts))
-    , _view_stats(format("{}_{}_view_replica_update", _schema->ks_name(), _schema->cf_name()),
+    , _view_stats(_schema->is_view() ? nullptr : std::make_unique<db::view::stats>(
+                         format("{}_{}_view_replica_update", _schema->ks_name(), _schema->cf_name()),
                          keyspace_label(_schema->ks_name()),
-                         column_family_label(_schema->cf_name())
-                        )
+                         column_family_label(_schema->cf_name())))
     , _compaction_manager(compaction_manager)
     , _compaction_strategy(make_compaction_strategy(_schema->compaction_strategy(), _schema->compaction_strategy_options()))
     , _sg_manager(make_storage_group_manager())

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2242,18 +2242,22 @@ void table::set_metrics() {
         });
 
         // Metrics related to row locking
-        auto add_row_lock_metrics = [this, ks, cf] (row_locker::single_lock_stats& stats, sstring stat_name) {
+        auto add_row_lock_metrics = [this, ks, cf] (row_locker::single_lock_stats row_locker::stats::*member, sstring stat_name) {
             _metrics.add_group("column_family", {
-                ms::make_total_operations(format("row_lock_{}_acquisitions", stat_name), stats.lock_acquisitions, ms::description(format("Row lock acquisitions for {} lock", stat_name)))(cf)(ks).set_skip_when_empty(),
-                ms::make_queue_length(format("row_lock_{}_operations_currently_waiting_for_lock", stat_name), stats.operations_currently_waiting_for_lock, ms::description(format("Operations currently waiting for {} lock", stat_name)))(cf)(ks),
+                ms::make_total_operations(format("row_lock_{}_acquisitions", stat_name),
+                        [this, member] {return _row_locker_stats ? (_row_locker_stats.get()->*member).lock_acquisitions : uint64_t(0);},
+                        ms::description(format("Row lock acquisitions for {} lock", stat_name)))(cf)(ks).set_skip_when_empty(),
+                ms::make_queue_length(format("row_lock_{}_operations_currently_waiting_for_lock", stat_name),
+                        [this, member] {return _row_locker_stats ? (_row_locker_stats.get()->*member).operations_currently_waiting_for_lock : uint64_t(0);},
+                        ms::description(format("Operations currently waiting for {} lock", stat_name)))(cf)(ks),
                 ms::make_histogram(format("row_lock_{}_waiting_time", stat_name), ms::description(format("Histogram representing time that operations spent on waiting for {} lock", stat_name)),
-                        [&stats] {return to_metrics_histogram(stats.estimated_waiting_for_lock);})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty()
+                        [this, member] {return _row_locker_stats ? to_metrics_histogram((_row_locker_stats.get()->*member).estimated_waiting_for_lock) : seastar::metrics::histogram{};})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty()
             });
         };
-        add_row_lock_metrics(_row_locker_stats.exclusive_row, "exclusive_row");
-        add_row_lock_metrics(_row_locker_stats.shared_row, "shared_row");
-        add_row_lock_metrics(_row_locker_stats.exclusive_partition, "exclusive_partition");
-        add_row_lock_metrics(_row_locker_stats.shared_partition, "shared_partition");
+        add_row_lock_metrics(&row_locker::stats::exclusive_row, "exclusive_row");
+        add_row_lock_metrics(&row_locker::stats::shared_row, "shared_row");
+        add_row_lock_metrics(&row_locker::stats::exclusive_partition, "exclusive_partition");
+        add_row_lock_metrics(&row_locker::stats::shared_partition, "shared_partition");
 
         // View metrics are created only for base tables, so there's no point in adding them to views (which cannot act as base tables for other views)
         if (!_schema->is_view()) {
@@ -2270,16 +2274,16 @@ void table::set_metrics() {
             _metrics.add_group("column_family", {
                     ms::make_summary("read_latency_summary", ms::description("Read latency summary"), [this] {return to_metrics_summary(_stats.reads.summary());})(cf)(ks).set_skip_when_empty(),
                     ms::make_summary("write_latency_summary", ms::description("Write latency summary"), [this] {return to_metrics_summary(_stats.writes.summary());})(cf)(ks).set_skip_when_empty(),
-                    ms::make_summary("cas_prepare_latency_summary", ms::description("CAS prepare round latency summary"), [this] {return to_metrics_summary(_stats.cas_prepare.summary());})(cf)(ks).set_skip_when_empty(),
-                    ms::make_summary("cas_propose_latency_summary", ms::description("CAS accept round latency summary"), [this] {return to_metrics_summary(_stats.cas_accept.summary());})(cf)(ks).set_skip_when_empty(),
-                    ms::make_summary("cas_commit_latency_summary", ms::description("CAS learn round latency summary"), [this] {return to_metrics_summary(_stats.cas_learn.summary());})(cf)(ks).set_skip_when_empty(),
+                    ms::make_summary("cas_prepare_latency_summary", ms::description("CAS prepare round latency summary"), [this] {return _stats.cas_prepare ? to_metrics_summary(_stats.cas_prepare->summary()) : seastar::metrics::histogram{};})(cf)(ks).set_skip_when_empty(),
+                    ms::make_summary("cas_propose_latency_summary", ms::description("CAS accept round latency summary"), [this] {return _stats.cas_accept ? to_metrics_summary(_stats.cas_accept->summary()) : seastar::metrics::histogram{};})(cf)(ks).set_skip_when_empty(),
+                    ms::make_summary("cas_commit_latency_summary", ms::description("CAS learn round latency summary"), [this] {return _stats.cas_learn ? to_metrics_summary(_stats.cas_learn->summary()) : seastar::metrics::histogram{};})(cf)(ks).set_skip_when_empty(),
 
                     ms::make_histogram("read_latency", ms::description("Read latency histogram"), [this] {return to_metrics_histogram(_stats.reads.histogram());})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
                     ms::make_histogram("sstables_per_read", ms::description("Number of sstables accessed to serve a single-partition read."), [this] {return _stats.estimated_sstable_per_read.get_histogram();})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
                     ms::make_histogram("write_latency", ms::description("Write latency histogram"), [this] {return to_metrics_histogram(_stats.writes.histogram());})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
-                    ms::make_histogram("cas_prepare_latency", ms::description("CAS prepare round latency histogram"), [this] {return to_metrics_histogram(_stats.cas_prepare.histogram());})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
-                    ms::make_histogram("cas_propose_latency", ms::description("CAS accept round latency histogram"), [this] {return to_metrics_histogram(_stats.cas_accept.histogram());})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
-                    ms::make_histogram("cas_commit_latency", ms::description("CAS learn round latency histogram"), [this] {return to_metrics_histogram(_stats.cas_learn.histogram());})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
+                    ms::make_histogram("cas_prepare_latency", ms::description("CAS prepare round latency histogram"), [this] {return _stats.cas_prepare ? to_metrics_histogram(_stats.cas_prepare->histogram()) : seastar::metrics::histogram{};})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
+                    ms::make_histogram("cas_propose_latency", ms::description("CAS accept round latency histogram"), [this] {return _stats.cas_accept ? to_metrics_histogram(_stats.cas_accept->histogram()) : seastar::metrics::histogram{};})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
+                    ms::make_histogram("cas_commit_latency", ms::description("CAS learn round latency histogram"), [this] {return _stats.cas_learn ? to_metrics_histogram(_stats.cas_learn->histogram()) : seastar::metrics::histogram{};})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
                     ms::make_gauge("cache_hit_rate", ms::description("Cache hit rate"), [this] {return float(_global_cache_hit_rate);})(cf)(ks)
             });
         }
@@ -4763,14 +4767,14 @@ table::local_base_lock(
     _row_locker.upgrade(s);
     if (rows.size() == 1 && rows[0].is_singular() && rows[0].start() && !rows[0].start()->value().is_empty(*s)) {
         // A single clustering row is involved.
-        return _row_locker.lock_ck(pk, rows[0].start()->value(), true, timeout, _row_locker_stats);
+        return _row_locker.lock_ck(pk, rows[0].start()->value(), true, timeout, get_row_locker_stats());
     } else {
         // More than a single clustering row is involved. Most commonly it's
         // the entire partition, so let's lock the entire partition. We could
         // lock less than the entire partition in more elaborate cases where
         // just a few individual rows are involved, or row ranges, but we
         // don't think this will make a practical difference.
-        return _row_locker.lock_pk(pk, true, timeout, _row_locker_stats);
+        return _row_locker.lock_pk(pk, true, timeout, get_row_locker_stats());
     }
 }
 

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -126,7 +126,7 @@ future<prepare_response> paxos_state::prepare(storage_proxy& sp, paxos_store& pa
     auto stats_updater = defer([&sp, schema, lc] () mutable noexcept {
         if (auto table = sp.get_db().local().get_tables_metadata().get_table_if_exists(schema->id())) {
             auto& stats = table->get_stats();
-            stats.cas_prepare.mark(lc.stop().latency());
+            stats.get_cas_prepare().mark(lc.stop().latency());
         }
     });
 
@@ -216,7 +216,7 @@ future<bool> paxos_state::accept(storage_proxy& sp, paxos_store& paxos_store, tr
     auto stats_updater = defer([&sp, schema, lc] () mutable noexcept {
         if (auto table = sp.get_db().local().get_tables_metadata().get_table_if_exists(schema->id())) {
             auto& stats = table->get_stats();
-            stats.cas_accept.mark(lc.stop().latency());
+            stats.get_cas_accept().mark(lc.stop().latency());
         }
     });
 
@@ -260,7 +260,7 @@ future<> paxos_state::learn(storage_proxy& sp, paxos_store& paxos_store, schema_
     auto stats_updater = defer([&sp, schema, lc] () mutable noexcept {
         if (auto table = sp.get_db().local().get_tables_metadata().get_table_if_exists(schema->id())) {
             auto& stats = table->get_stats();
-            stats.cas_learn.mark(lc.stop().latency());
+            stats.get_cas_learn().mark(lc.stop().latency());
         }
     });
 


### PR DESCRIPTION
## Motivation

`replica::table` is 14,976B per table per shard. Several large stats structures are embedded inline but only used conditionally:

- **table_stats CAS histograms** (3 × 1496B = 4488B inline): only written during   LWT/CAS operations (`paxos_state.cc`)
- **row_locker::stats** (2176B): only written during LWT row-locking
- **db::view::stats** (5688B): only needed for base tables (not view tables)

## Changes

### Commit 1: Lazily allocate CAS histograms and row locker stats

Replace three inline `timed_rate_moving_average_summary_and_histogram` (1496B each) and inline `row_locker::stats` (2176B) with `std::unique_ptr`, lazily allocated on first use.

- table_stats: 8520B → 4056B (−4464B, 52%)
- row_locker::stats: 2176B → 8B (−2168B)
- All metrics use lambdas + `.set_skip_when_empty()`

### Commit 2: Lazily allocate view stats for view tables

Replace inline `db::view::stats` (5688B) with `std::unique_ptr`, allocated only for non-view (base) tables. View tables get nullptr (saving 5688B).
Base tables allocate on heap — same total memory but smaller struct improves cache locality.

## Result

**sizeof(replica::table): 14,976B → 7,128B (−7,848B, 52% reduction)**

## Tests

- `view_build_test` — PASS (exercises view_update_generator with view_stats)
- `view_schema_test` — PASS (exercises get_view_stats() on base tables)
- `database_test` — PASS (exercises table construction/destruction)

## Benchmark (perf_simple_query, smp1, 10K partitions, 2.2GHz fixed, 5 runs)

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| insns/op | 32,010 | 32,085 | +0.23% |
| tps | ~147K | ~148.5K | neutral/slightly better |
| allocs/op | 58.1 | 58.1 | unchanged |

Performance neutral as expected — none of the lazified paths are on the perf_simple_query hot path.

Backport: no, benign improvement