### PR TITLE
full_position: use ring order for partition key comparison

### DIFF
--- a/keys/full_position.hh
+++ b/keys/full_position.hh
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "keys/keys.hh"
+#include "dht/ring_position.hh"
+#include "dht/i_partitioner.hh"
 #include "mutation/position_in_partition.hh"
 
 struct full_position;
@@ -33,8 +35,12 @@ struct full_position {
     }
 
     static std::strong_ordering cmp(const schema& s, const full_position& a, const full_position& b) {
-        partition_key::tri_compare pk_cmp(s);
-        if (auto res = pk_cmp(a.partition, b.partition); res != 0) {
+        // Use ring order (token first, then legacy raw-byte compare) to match the physical
+        // SSTable ordering. Using the type-aware partition_key::tri_compare here would give
+        // wrong results for key types (e.g. timeuuid) where semantic order differs from the
+        // raw-byte order used on disk, potentially causing paging cursors to be advanced past
+        // partitions that haven't been returned yet.
+        if (auto res = dht::ring_position_tri_compare(s, dht::decorate_key(s, a.partition), dht::decorate_key(s, b.partition)); res != 0) {
             return res;
         }
         position_in_partition::tri_compare pos_cmp(s);

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -59,6 +59,8 @@
 #include "db/view/view_builder.hh"
 #include "replica/mutation_dump.hh"
 #include "test/boost/database_test.hh"
+#include "test/lib/random_schema.hh"
+#include "dht/i_partitioner.hh"
 
 using namespace std::chrono_literals;
 using namespace sstables;
@@ -2434,6 +2436,31 @@ SEASTAR_TEST_CASE(replica_read_timeout_no_exception) {
             execute_test("queued reads", true);
         }
     }, cfg);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_full_position_cmp_ring_order) {
+    auto random_spec = tests::make_random_schema_specification(
+            get_name(),
+            std::uniform_int_distribution<size_t>(1, 4),
+            std::uniform_int_distribution<size_t>(2, 4),
+            std::uniform_int_distribution<size_t>(2, 8),
+            std::uniform_int_distribution<size_t>(2, 8));
+    auto random_schema = tests::random_schema{tests::random::get_int<uint32_t>(), *random_spec};
+    auto s = random_schema.schema();
+
+    testlog.info("Random schema:\n{}", random_schema.cql());
+
+    const auto pkeys = random_schema.make_pkeys(100) | std::views::transform([&] (auto&& pkey) {
+        return partition_key::from_exploded(*s, pkey);
+    }) | std::ranges::to<std::vector<partition_key>>();
+
+    const auto is_sorted_by_full_position = std::ranges::is_sorted(pkeys, [&s] (const partition_key& a, const partition_key& b) {
+        auto fa = full_position(a, position_in_partition::for_partition_start());
+        auto fb = full_position(b, position_in_partition::for_partition_start());
+        return full_position::cmp(*s, fa, fb) < 0;
+    });
+
+    BOOST_REQUIRE(is_sorted_by_full_position);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
full_position::cmp is called from storage_proxy to find the minimum last_position across replicas in the EMPTY_REPLICA_PAGES paging path. It was using partition_key::tri_compare (type-aware) instead of ring
order (token first, then legacy byte comparison).

The bug is benign, the comparator is not actually used currently because a tombstones are included in the digest. If the different replicas have different tombstones, a read repair will be triggered.

Fixes: SCYLLADB-2306

Backport: benign issue, no backport needed