### PR TITLE
utils/histogram: remove redundant std::function from meter_timer (32B/instance)

### DIFF
--- a/utils/histogram.hh
+++ b/utils/histogram.hh
@@ -207,14 +207,13 @@ using ihistogram = basic_ihistogram<std::chrono::microseconds>;
  * class and set a handler at its constructor.
  */
 class meter_timer {
-    std::function<void()> _fun;
     timer<> _timer;
 public:
     static constexpr latency_counter::duration tick_interval() {
         return std::chrono::seconds(10);
     }
 
-    meter_timer(std::function<void()>&& fun) : _fun(std::move(fun)), _timer(_fun) {
+    meter_timer(noncopyable_function<void()>&& fun) : _timer(std::move(fun)) {
         _timer.arm_periodic(tick_interval());
     }
 };


### PR DESCRIPTION
## Motivation

`meter_timer` stored the callback in a `std::function` member (32B) and then
passed it to the `timer` constructor, which stored its own copy as a
`noncopyable_function` (another 32B). The `_fun` member was never read after
construction — it existed solely to initialize the timer.

## Changes

Remove the `std::function` member and pass the callback directly to the timer
as a `noncopyable_function`. This saves 32B per `meter_timer` instance.

## Impact

`meter_timer` is embedded in `timed_rate_moving_average`, used in:
- `row_cache::stats`: 4 instances → 128B saved per row_cache
- `storage_proxy_stats::write_stats`: 6 instances → 192B saved
- `storage_proxy_stats::split_stats`: 8 instances → 256B saved
- `table_stats` CAS histograms: 7 instances → 224B saved (behind lazy ptr)
- alternator stats: 7 instances → 224B saved
- coordinator stats: 3 instances → 96B saved

## Benchmark

No hot-path change — only reduces struct size. Neutral by construction.

Backport: no, benign improvement