### PR TITLE
readers: shrink reader-side structs (reader_permit::impl 488B→376B, evictable_reader overrides → unique_ptr, drop dead _next_range)

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -140,11 +140,10 @@ class reader_permit::impl
         : public boost::intrusive::list_base_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink>>
         , public enable_shared_from_this<reader_permit::impl> {
 public:
+    // Lazily allocated: only needed when permit waits for memory or is inactive.
     struct auxiliary_data {
-        promise<> pr;
-        std::optional<shared_future<>> fut;
-        reader_concurrency_semaphore::read_func func;
-        std::optional<reader_concurrency_semaphore::inactive_read> ir;
+        std::optional<shared_future<>> fut;  // only for memory-wait path
+        std::optional<reader_concurrency_semaphore::inactive_read> ir;  // only for inactive reads
     };
 
 private:
@@ -155,24 +154,31 @@ private:
     sstring _op_name;
     std::string_view _op_name_view;
     const reader_resources _base_resources;
-    bool _base_resources_consumed = false;
     reader_resources _resources;
-    reader_permit::state _state = reader_permit::state::active;
-    uint64_t _need_cpu_branches = 0;
-    bool _marked_as_need_cpu = false;
-    uint64_t _awaits_branches = 0;
-    bool _marked_as_awaits = false;
     std::exception_ptr _ex; // exception the permit was aborted with, nullptr if not aborted
     timer<db::timeout_clock> _ttl_timer;
     query::max_result_size _max_result_size{query::result_memory_limiter::unlimited_result_size};
+    tracing::trace_state_ptr _trace_ptr;
+
+    // Used by with_permit/with_ready_permit for admission signaling.
+    // Kept inline since it's used on the hot (direct admission) path.
+    promise<> _pr;
+    // Used by with_permit/with_ready_permit to store the read function.
+    // Kept inline since it's checked on the hot (direct admission) path.
+    reader_concurrency_semaphore::read_func _func;
+
+    // Lazily allocated: only needed for memory-wait or inactive-read paths.
+    std::unique_ptr<auxiliary_data> _aux_data;
+
+    uint64_t _need_cpu_branches = 0;
+    uint64_t _awaits_branches = 0;
     uint64_t _sstables_read = 0;
     size_t _requested_memory = 0;
     uint64_t _oom_kills = 0;
-    tracing::trace_state_ptr _trace_ptr;
-
-    // Not strictly related to the permit.
-    // Used by the semaphore to to manage the permit.
-    auxiliary_data _aux_data;
+    reader_permit::state _state = reader_permit::state::active;
+    bool _base_resources_consumed = false;
+    bool _marked_as_need_cpu = false;
+    bool _marked_as_awaits = false;
 
 private:
     void on_permit_need_cpu() {
@@ -227,7 +233,7 @@ private:
             case state::waiting_for_admission:
             case state::waiting_for_memory:
             case state::waiting_for_execution:
-                _aux_data.pr.set_exception(ex);
+                _pr.set_exception(ex);
                 maybe_dump_reader_permit_diagnostics(_semaphore, "timed out", this);
                 _semaphore.dequeue_permit(*this);
                 break;
@@ -331,8 +337,31 @@ public:
         return _state;
     }
 
+    // Returns the lazily-allocated auxiliary data, allocating it if needed.
+    // Must only be called from contexts where allocation is acceptable (i.e.,
+    // NOT from noexcept functions). The memory-wait and inactive-read paths
+    // call this when the permit transitions to those states.
     auxiliary_data& aux_data() {
-        return _aux_data;
+        if (!_aux_data) {
+            _aux_data = std::make_unique<auxiliary_data>();
+        }
+        return *_aux_data;
+    }
+
+    // Returns the auxiliary data without allocating. Asserts that it has
+    // already been allocated. Use in noexcept contexts where the permit
+    // is known to have auxiliary_data (e.g., it is already inactive).
+    auxiliary_data& aux_data_ref() noexcept {
+        SCYLLA_ASSERT(_aux_data);
+        return *_aux_data;
+    }
+
+    reader_concurrency_semaphore::read_func& func() {
+        return _func;
+    }
+
+    promise<>& promise() {
+        return _pr;
     }
 
     void on_waiting_for_admission() {
@@ -380,7 +409,7 @@ public:
 
         _ttl_timer.cancel();
         _state = reader_permit::state::preemptive_aborted;
-        _aux_data.pr.set_exception(ex);
+        _pr.set_exception(ex);
         _semaphore.on_permit_preemptive_aborted();
     }
 
@@ -916,27 +945,27 @@ void reader_concurrency_semaphore::inactive_read_handle::abandon() noexcept {
     if (_permit) {
         auto& permit = **_permit;
         auto& sem = permit.semaphore();
-        sem.close_reader(std::move(permit.aux_data().ir->reader));
+        sem.close_reader(std::move(permit.aux_data_ref().ir->reader));
         sem.dequeue_permit(permit);
         // Break the handle <-> inactive read connection, to prevent the inactive
         // read attempting to detach(). Not only is that unnecessary (the handle
         // is abandoning the inactive read), but detach() will reset _permit,
         // which might be the last permit instance alive. Destroying it could
         // yank out *this from under our feet.
-        permit.aux_data().ir->handle = nullptr;
-        permit.aux_data().ir.reset();
+        permit.aux_data_ref().ir->handle = nullptr;
+        permit.aux_data_ref().ir.reset();
     }
 }
 
 reader_concurrency_semaphore::inactive_read_handle::inactive_read_handle(reader_permit permit) noexcept
     : _permit(permit) {
-    (*_permit)->aux_data().ir->handle = this;
+    (*_permit)->aux_data_ref().ir->handle = this;
 }
 
 reader_concurrency_semaphore::inactive_read_handle::inactive_read_handle(inactive_read_handle&& o) noexcept
     : _permit(std::exchange(o._permit, std::nullopt)) {
     if (_permit) {
-        (*_permit)->aux_data().ir->handle = this;
+        (*_permit)->aux_data_ref().ir->handle = this;
     }
 }
 
@@ -948,8 +977,7 @@ reader_concurrency_semaphore::inactive_read_handle::operator=(inactive_read_hand
     abandon();
     _permit = std::exchange(o._permit, std::nullopt);
     if (_permit) {
-        (*_permit)->aux_data().ir->handle = this;
-    }
+        (*_permit)->aux_data_ref().ir->handle = this;    }
     return *this;
 }
 
@@ -996,14 +1024,15 @@ future<> reader_concurrency_semaphore::execution_loop() noexcept {
             auto& permit = _ready_list.front();
             dequeue_permit(permit);
             permit.on_executing();
-            auto e = std::move(permit.aux_data());
+            auto func = std::move(permit.func());
+            auto pr = std::move(permit.promise());
 
             tracing::trace(permit.trace_state(), "[reader concurrency semaphore {}] executing read", _name);
 
             try {
-                e.func(reader_permit(permit.shared_from_this())).forward_to(std::move(e.pr));
+                func(reader_permit(permit.shared_from_this())).forward_to(std::move(pr));
             } catch (...) {
-                e.pr.set_exception(std::current_exception());
+                pr.set_exception(std::current_exception());
             }
 
             // We now possibly have >= CPU concurrency, so even if the above read
@@ -1175,7 +1204,7 @@ reader_concurrency_semaphore::inactive_read_handle reader_concurrency_semaphore:
     }
     if (permit->get_state() == reader_permit::state::waiting_for_memory) {
         // Kill all outstanding memory requests, the read is going to be evicted.
-        permit->aux_data().pr.set_exception(std::make_exception_ptr(std::bad_alloc{}));
+        permit->promise().set_exception(std::make_exception_ptr(std::bad_alloc{}));
         dequeue_permit(*permit);
     }
     permit->on_register_as_inactive();
@@ -1207,7 +1236,7 @@ reader_concurrency_semaphore::inactive_read_handle reader_concurrency_semaphore:
 }
 
 void reader_concurrency_semaphore::set_notify_handler(inactive_read_handle& irh, eviction_notify_handler&& notify_handler, std::optional<std::chrono::seconds> ttl_opt) {
-    auto& ir = *(*irh._permit)->aux_data().ir;
+    auto& ir = *(*irh._permit)->aux_data_ref().ir;
     ir.notify_handler = std::move(notify_handler);
     if (ttl_opt) {
         irh._permit->set_timeout(lowres_clock::now() + *ttl_opt);
@@ -1268,7 +1297,7 @@ future<> reader_concurrency_semaphore::evict_inactive_reads_for_table(table_id i
     auto it = _inactive_reads.begin();
     while (it != _inactive_reads.end()) {
         auto& permit = *it;
-        auto& ir = *permit.aux_data().ir;
+        auto& ir = *permit.aux_data_ref().ir;
         ++it;
         if (ir.reader.schema()->id() == id && overlaps_with_range(ir)) {
             do_detach_inactive_reader(permit, evict_reason::manual);
@@ -1309,7 +1338,7 @@ future<> reader_concurrency_semaphore::stop() noexcept {
 
 void reader_concurrency_semaphore::do_detach_inactive_reader(reader_permit::impl& permit, evict_reason reason) noexcept {
     dequeue_permit(permit);
-    auto& ir = *permit.aux_data().ir;
+    auto& ir = *permit.aux_data_ref().ir;
     ir.detach();
     ir.reader.permit()->on_evicted();
     tracing::trace(permit.trace_state(), "[reader_concurrency_semaphore {}] evicted, reason: {}", _name, reason);
@@ -1373,15 +1402,15 @@ future<> reader_concurrency_semaphore::enqueue_waiter(reader_permit::impl& permi
     if (auto ex = check_queue_size("wait")) {
         return make_exception_future<>(std::move(ex));
     }
-    auto& ad = permit.aux_data();
-    ad.pr = {};
-    auto fut = ad.pr.get_future();
+    permit.promise() = {};
+    auto fut = permit.promise().get_future();
     if (wait == wait_on::admission) {
         permit.on_waiting_for_admission();
         _wait_list.push_to_admission_queue(permit);
         ++_stats.reads_enqueued_for_admission;
     } else {
         permit.on_waiting_for_memory();
+        auto& ad = permit.aux_data();
         ad.fut.emplace(std::move(fut));
         fut = ad.fut->get_future();
         _wait_list.push_to_memory_queue(permit);
@@ -1509,7 +1538,7 @@ future<> reader_concurrency_semaphore::do_wait_admission(reader_permit::impl& pe
 
     permit.on_admission();
     ++_stats.reads_admitted;
-    if (permit.aux_data().func) {
+    if (permit.func()) {
         return with_ready_permit(permit);
     }
     return make_ready_future<>();
@@ -1558,17 +1587,17 @@ void reader_concurrency_semaphore::maybe_admit_waiters() noexcept {
                 permit.on_admission();
                 ++_stats.reads_admitted;
             }
-            if (permit.aux_data().func) {
+            if (permit.func()) {
                 permit.unlink();
                 _ready_list.push_back(permit);
                 _ready_list_cv.signal();
                 permit.on_waiting_for_execution();
                 ++_stats.waiters;
             } else {
-                permit.aux_data().pr.set_value();
+                permit.promise().set_value();
             }
         } catch (...) {
-            permit.aux_data().pr.set_exception(std::current_exception());
+            permit.promise().set_exception(std::current_exception());
         }
     }
     if (admit == can_admit::maybe) {
@@ -1586,7 +1615,7 @@ void reader_concurrency_semaphore::maybe_wake_execution_loop() noexcept {
 future<> reader_concurrency_semaphore::request_memory(reader_permit::impl& permit, size_t memory) {
     // Already blocked on memory?
     if (permit.get_state() == reader_permit::state::waiting_for_memory) {
-        return permit.aux_data().fut->get_future();
+        return permit.aux_data_ref().fut->get_future();
     }
 
     if (_resources.memory > 0 || (consumed_resources().memory + memory) < get_serialize_limit()) {
@@ -1704,7 +1733,7 @@ future<> reader_concurrency_semaphore::with_permit(schema_ptr schema, const char
         db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr, reader_permit_opt& permit_holder, read_func func) {
     permit_holder = reader_permit(*this, std::move(schema), std::string_view(op_name), {1, static_cast<ssize_t>(memory)}, timeout, std::move(trace_ptr));
     auto permit = *permit_holder;
-    permit->aux_data().func = std::move(func);
+    permit->func() = std::move(func);
     return do_wait_admission(*permit);
 }
 
@@ -1712,9 +1741,8 @@ future<> reader_concurrency_semaphore::with_ready_permit(reader_permit::impl& pe
     if (auto ex = check_queue_size("ready")) {
         return make_exception_future<>(std::move(ex));
     }
-    auto& ad = permit.aux_data();
-    ad.pr = {};
-    auto fut = ad.pr.get_future();
+    permit.promise() = {};
+    auto fut = permit.promise().get_future();
     permit.unlink();
     _ready_list.push_back(permit);
     permit.on_waiting_for_execution();
@@ -1724,7 +1752,7 @@ future<> reader_concurrency_semaphore::with_ready_permit(reader_permit::impl& pe
 }
 
 future<> reader_concurrency_semaphore::with_ready_permit(reader_permit permit, read_func func) {
-    permit->aux_data().func = std::move(func);
+    permit->func() = std::move(func);
     return with_ready_permit(*permit);
 }
 
@@ -1741,7 +1769,7 @@ void reader_concurrency_semaphore::broken(std::exception_ptr ex) {
     }
     while (!_wait_list.empty()) {
         auto& permit = _wait_list.front();
-        permit.aux_data().pr.set_exception(ex);
+        permit.promise().set_exception(ex);
         dequeue_permit(permit);
     }
 }

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -236,9 +236,11 @@ private:
     position_in_partition _next_position_in_partition = position_in_partition::for_partition_start();
     // These are used when the reader has to be recreated (after having been
     // evicted while paused) and the range and/or slice it is recreated with
-    // differs from the original ones.
-    std::optional<dht::partition_range> _range_override;
-    std::optional<query::partition_slice> _slice_override;
+    // differs from the original ones. Held behind unique_ptr since this only
+    // happens on the rare reader-recreation path, keeping the common-case
+    // reader smaller.
+    std::unique_ptr<dht::partition_range> _range_override;
+    std::unique_ptr<query::partition_slice> _slice_override;
 
     mutation_reader_opt _reader;
 
@@ -347,7 +349,7 @@ void evictable_reader::update_next_position() {
 }
 
 void evictable_reader::adjust_partition_slice() {
-    _slice_override = _ps;
+    _slice_override = std::make_unique<query::partition_slice>(_ps);
 
     auto ranges = _slice_override->default_row_ranges();
     query::trim_clustering_row_ranges_to(*_schema, ranges, _next_position_in_partition);
@@ -392,7 +394,7 @@ mutation_reader evictable_reader::recreate_reader() {
             return make_empty_mutation_reader(_schema, _permit);
         }
 
-        _range_override = dht::partition_range({dht::partition_range::bound(*_last_pkey, partition_range_is_inclusive)}, _pr->end());
+        _range_override = std::make_unique<dht::partition_range>(dht::partition_range({dht::partition_range::bound(*_last_pkey, partition_range_is_inclusive)}, _pr->end()));
         range = &*_range_override;
 
         _reader_recreated = true;

--- a/readers/mutation_reader.hh
+++ b/readers/mutation_reader.hh
@@ -137,9 +137,6 @@ public:
         // unless the reader is fast-forwarded to a new range.
         bool _end_of_stream = false;
 
-        // Set by fill buffer for segregating output by partition range.
-        std::optional<dht::partition_range> _next_range;
-
         schema_ptr _schema;
         reader_permit _permit;
         friend class mutation_reader;


### PR DESCRIPTION
## Motivation

`reader_permit::impl` is heap-allocated for **every read operation** in the system, so its size directly impacts memory footprint and cache behavior on the hottest read path.

Previously its `auxiliary_data` (160B) was stored **inline**, holding `promise<>`, `optional<shared_future<>>`, `read_func`, and `optional<inactive_read>` — even though `shared_future` and `inactive_read` are only used on rare paths (memory-wait and inactive reads respectively).

## Change

- Move `promise<>` (used on the hot direct-admission path) and `read_func` (checked on the hot path) **inline** into `impl`.
- Reduce `auxiliary_data` to only `optional<shared_future<>>` + `optional<inactive_read>` (120B), allocated **lazily** via `unique_ptr` only when a permit waits for memory or becomes inactive.
- Reorder `impl` fields to eliminate padding: 8B-aligned fields first, then 8B counters, then bools/enum at the end (zero internal padding).

The hot path (`with_permit` → direct admission → `with_ready_permit`) no longer triggers **any** `auxiliary_data` heap allocation, since it only needs the inline `promise` and `func`.

The lazy allocation on the memory-wait path is safe: "waiting for memory" means the semaphore's logical reader-memory budget is exhausted, not system OOM. The 120B `aux_data` allocation comes from the general heap, which is unconstrained by the `reader_concurrency_semaphore` budget.

## Savings

| Struct | Before | After | Saved |
|---|---|---|---|
| `reader_permit::impl` | 488B | **376B** | **112B (23%)** |
| `auxiliary_data` | 160B (inline) | 120B (lazy, heap-only on rare paths) | not in `impl` |

With the 8B `shared_ptr` header, `impl` now fits in exactly **6 cache lines** (384B = 6×64B), down from **8 cache lines** (496B). Since one `impl` is allocated per concurrent read, this reduces both memory footprint and cache pressure across the read path.

## Benchmark

Controlled **interleaved A/B**: baseline and this commit built from the **same base**, run alternately (A/B/A/B…) in one quiet session to cancel thermal/scheduler drift. `perf-simple-query` (release, `--smp 1 --partitions 10000`, `taskset -c 0`, CPU pinned at 2.2GHz, **24 samples each**):

| Metric | Baseline | This PR | Delta |
|---|---|---|---|
| insns/op | 32,024 | 31,857 | **−0.52%** |
| cycles/op | 14,682 | 14,293 | **−2.65%** |
| tps | 147,401 | 151,278 | **+2.63%** |
| allocs/op | 58.1 | 58.1 | **unchanged** |

- `allocs/op` is **unchanged**, confirming the hot path performs zero extra `auxiliary_data` allocations by design.
- `cycles/op` drops ~5× more than `insns/op` → **IPC improves**: the win is cache locality (6 cache lines vs 8), not fewer instructions.
- Baseline and candidate `tps` distributions **do not overlap** (baseline 145.3K–149.0K, candidate 150.2K–152.6K), so the throughput gain is statistically robust.

## Tests

- All 38 `reader_concurrency_semaphore` unit tests pass.

Backport: no, benign improvement


---

## Additional reader-side struct shrinks folded into this PR

### `evictable_reader` range/slice overrides → `unique_ptr` (−248 B)

`_range_override` (`optional<dht::partition_range>`, 96 B) and `_slice_override` (`optional<query::partition_slice>`, 168 B) are only populated on the rare evict-then-recreate-with-different-range/slice path, yet reserved 264 B inline in **every** `evictable_reader`. Held behind `unique_ptr` instead → two 8 B pointers, allocating only on that rare path. **−248 B per evictable_reader.** All existing uses (`reset()`, `operator->`, `operator*`, `&*`, bool tests) work unchanged; only the two assignment sites needed `make_unique`.

### Remove dead `_next_range` from `mutation_reader::impl` (−96 B)

`optional<dht::partition_range> _next_range` in `mutation_reader::impl` (the base class of every reader implementation) is never read or written anywhere in the tree — only its declaration exists. Removed. **−96 B per reader instance**, no behavioural change.

Both verified with `mutation_reader_test` (smp=2) passing ("No errors detected").
