### PR TITLE
[DRAFT] cql3/restrictions: shrink statement_restrictions from 776B to 552B (-224B, 29%) [folds #30043 #30036 #30048 #30064]

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -2486,14 +2486,14 @@ void statement_restrictions::prepare_indexed_global(const schema& idx_tbl_schema
         // This means that p1 and p2 can have many different values (token is a hash, can have collisions).
         // Clustering prefix ends after token_restriction, all further restrictions have to be filtered.
         expr::expression token_restriction = replace_partition_token(_partition_key_restrictions, token_column, *_schema);
-        _idx_tbl_ck_prefix = std::vector{to_predicate_on_column(token_restriction, token_column, _schema.get())};
+        _idx_tbl_ck_prefix = std::make_unique<std::vector<predicate>>(std::vector{to_predicate_on_column(token_restriction, token_column, _schema.get())});
 
         return;
     }
 
     // If we're here, it means the index cannot be on a partition column: process_partition_key_restrictions()
     // avoids indexing when _partition_range_is_simple.  See _idx_tbl_ck_prefix blurb for its composition.
-    _idx_tbl_ck_prefix = std::vector<predicate>(1 + _schema->partition_key_size(), predicate{
+    _idx_tbl_ck_prefix = std::make_unique<std::vector<predicate>>(1 + _schema->partition_key_size(), predicate{
         .solve_for = nullptr,  // FIXME: this is all overwritten later. Should be refactored.
         .filter = expr::expression(expr::conjunction{}),
         .on = on_column{nullptr}, // Illegal but will be overwritten
@@ -2575,7 +2575,7 @@ void statement_restrictions::prepare_indexed_local(const schema& idx_tbl_schema,
     }
 
     // Local index clustering key is (indexed column, base clustering key)
-    _idx_tbl_ck_prefix = std::vector<predicate>();
+    _idx_tbl_ck_prefix = std::make_unique<std::vector<predicate>>();
     _idx_tbl_ck_prefix->reserve(1 + _clustering_prefix_restrictions.size());
 
     const column_definition& indexed_column = idx_tbl_schema.column_at(column_kind::clustering_key, 0);
@@ -2664,7 +2664,7 @@ std::vector<query::clustering_range> statement_restrictions::get_global_index_cl
 
 get_clustering_bounds_fn_t
 statement_restrictions::build_get_global_index_token_clustering_ranges_fn() const {
-    if (!_idx_tbl_ck_prefix.has_value()) {
+    if (!_idx_tbl_ck_prefix) {
         return {};
     }
 
@@ -2693,7 +2693,7 @@ std::vector<query::clustering_range> statement_restrictions::get_global_index_to
 
 get_clustering_bounds_fn_t
 statement_restrictions::build_get_local_index_clustering_ranges_fn() const {
-    if (!_idx_tbl_ck_prefix.has_value()) {
+    if (!_idx_tbl_ck_prefix) {
         return {};
     }
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1290,10 +1290,19 @@ statement_restrictions::statement_restrictions(private_tag,
     _get_partition_key_ranges_fn = build_partition_key_ranges_fn();
 
     _get_clustering_bounds_fn = build_get_clustering_bounds_fn();
-    _get_global_index_clustering_ranges_fn = build_get_global_index_clustering_ranges_fn();
-    _get_global_index_token_clustering_ranges_fn = build_get_global_index_token_clustering_ranges_fn();
-    _get_local_index_clustering_ranges_fn = build_get_local_index_clustering_ranges_fn();
-    _value_for_index_partition_key_fn = build_value_for_index_partition_key_fn();
+
+    auto global_idx_ck = build_get_global_index_clustering_ranges_fn();
+    auto global_idx_token_ck = build_get_global_index_token_clustering_ranges_fn();
+    auto local_idx_ck = build_get_local_index_clustering_ranges_fn();
+    auto idx_pk_val = build_value_for_index_partition_key_fn();
+    if (global_idx_ck || global_idx_token_ck || local_idx_ck || idx_pk_val) {
+        _index_fns = std::make_unique<index_query_fns>(index_query_fns{
+            std::move(global_idx_ck),
+            std::move(global_idx_token_ck),
+            std::move(local_idx_ck),
+            std::move(idx_pk_val),
+        });
+    }
 }
 
 bool
@@ -2635,7 +2644,10 @@ statement_restrictions::build_get_global_index_clustering_ranges_fn() const {
 
 std::vector<query::clustering_range> statement_restrictions::get_global_index_clustering_ranges(
         const query_options& options) const {
-    return _get_global_index_clustering_ranges_fn(options);
+    if (!_index_fns || !_index_fns->get_global_index_clustering_ranges_fn) {
+        on_internal_error(rlogger, "get_global_index_clustering_ranges called without index functions");
+    }
+    return _index_fns->get_global_index_clustering_ranges_fn(options);
 }
 
 get_clustering_bounds_fn_t
@@ -2661,7 +2673,10 @@ statement_restrictions::build_get_global_index_token_clustering_ranges_fn() cons
 
 std::vector<query::clustering_range> statement_restrictions::get_global_index_token_clustering_ranges(
     const query_options& options) const {
-    return _get_global_index_token_clustering_ranges_fn(options);
+    if (!_index_fns || !_index_fns->get_global_index_token_clustering_ranges_fn) {
+        on_internal_error(rlogger, "get_global_index_token_clustering_ranges called without index functions");
+    }
+    return _index_fns->get_global_index_token_clustering_ranges_fn(options);
 }
 
 get_clustering_bounds_fn_t
@@ -2678,7 +2693,10 @@ statement_restrictions::build_get_local_index_clustering_ranges_fn() const {
 
 std::vector<query::clustering_range> statement_restrictions::get_local_index_clustering_ranges(
         const query_options& options) const {
-    return _get_local_index_clustering_ranges_fn(options);
+    if (!_index_fns || !_index_fns->get_local_index_clustering_ranges_fn) {
+        on_internal_error(rlogger, "get_local_index_clustering_ranges called without index functions");
+    }
+    return _index_fns->get_local_index_clustering_ranges_fn(options);
 }
 
 get_singleton_value_fn_t
@@ -2713,7 +2731,10 @@ statement_restrictions::build_value_for_index_partition_key_fn() const {
 
 bytes_opt
 statement_restrictions::value_for_index_partition_key(const query_options& options) const {
-    return _value_for_index_partition_key_fn(options);
+    if (!_index_fns || !_index_fns->value_for_index_partition_key_fn) {
+        on_internal_error(rlogger, "value_for_index_partition_key called without index functions");
+    }
+    return _index_fns->value_for_index_partition_key_fn(options);
 }
 
 sstring statement_restrictions::to_string() const {

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -876,7 +876,10 @@ statement_restrictions::statement_restrictions(private_tag,
     for (auto& pred : predicates) {
         if (pred.is_not_null_single_column) {
             auto* col = require_on_single_column(pred);
-            _not_null_columns.insert(col);
+            if (!_not_null_columns) {
+                _not_null_columns = std::make_unique<std::unordered_set<const column_definition*>>();
+            }
+            _not_null_columns->insert(col);
 
             if (!for_view) {
                 throw exceptions::invalid_request_exception(format("restriction '{}' is only supported in materialized view creation", pred.filter));
@@ -1348,7 +1351,7 @@ statement_restrictions::ck_restrictions_need_filtering() const {
 
 bool
 statement_restrictions::is_restricted(const column_definition* cdef) const {
-    if (_not_null_columns.contains(cdef)) {
+    if (_not_null_columns && _not_null_columns->contains(cdef)) {
         return true;
     }
 
@@ -2751,7 +2754,10 @@ void statement_restrictions::validate_primary_key(const query_options& options) 
 
 
 const std::unordered_set<const column_definition*> statement_restrictions::get_not_null_columns() const {
-    return _not_null_columns;
+    if (_not_null_columns) {
+        return *_not_null_columns;
+    }
+    return {};
 }
 
 shared_ptr<const statement_restrictions>

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1074,10 +1074,22 @@ statement_restrictions::statement_restrictions(private_tag,
         // itself, matching the behavior of the old expression-walking code which
         // only recognized column_value and tuple_constructor in the LHS.
         if (pred.equality && !pred.is_subscript) {
+            // _columns_with_eq is a vector (for memory) but is only used as a
+            // membership set by has_eq_restriction_on_column(). Preserve the
+            // set semantics of the previous unordered_set by inserting a column
+            // only if it isn't already present, so repeated equality predicates
+            // on the same column don't bloat the vector.
+            auto add_unique = [this] (const column_definition* col) {
+                if (std::find(_columns_with_eq.begin(), _columns_with_eq.end(), col) == _columns_with_eq.end()) {
+                    _columns_with_eq.push_back(col);
+                }
+            };
             if (auto* sc = std::get_if<on_column>(&pred.on)) {
-                _columns_with_eq.insert(sc->column);
+                add_unique(sc->column);
             } else if (auto* mc = std::get_if<on_clustering_key_prefix>(&pred.on)) {
-                _columns_with_eq.insert(mc->columns.begin(), mc->columns.end());
+                for (const auto* col : mc->columns) {
+                    add_unique(col);
+                }
             }
         }
     }
@@ -1443,7 +1455,7 @@ statement_restrictions::find_idx(const secondary_index::secondary_index_manager&
 }
 
 bool statement_restrictions::has_eq_restriction_on_column(const column_definition& column) const {
-    return _columns_with_eq.contains(&column);
+    return std::find(_columns_with_eq.begin(), _columns_with_eq.end(), &column) != _columns_with_eq.end();
 }
 
 std::vector<const column_definition*> statement_restrictions::get_column_defs_for_filtering(data_dictionary::database db) const {

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -217,7 +217,7 @@ private:
     /// Elements are conjunctions of single-column binary operators with the same LHS.
     /// Element order follows the indexing-table clustering key.
     /// In case of a global index the first element's (token restriction) RHS is a dummy value, it is filled later.
-    std::optional<std::vector<predicate>> _idx_tbl_ck_prefix;
+    std::unique_ptr<std::vector<predicate>> _idx_tbl_ck_prefix;
 
     /// Parts of _where defining the partition range.
     ///

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -241,10 +241,16 @@ private:
     std::vector<predicate> _idx_column_predicates; ///< Predicates for the chosen index's target column.
     get_partition_key_ranges_fn_t _get_partition_key_ranges_fn;
     get_clustering_bounds_fn_t _get_clustering_bounds_fn;
-    get_clustering_bounds_fn_t _get_global_index_clustering_ranges_fn;
-    get_clustering_bounds_fn_t _get_global_index_token_clustering_ranges_fn;
-    get_clustering_bounds_fn_t _get_local_index_clustering_ranges_fn;
-    get_singleton_value_fn_t _value_for_index_partition_key_fn;
+
+    // Index-related query functions, only allocated for index-backed queries.
+    // For non-index queries (the common case), this is nullptr, saving ~120 bytes.
+    struct index_query_fns {
+        get_clustering_bounds_fn_t get_global_index_clustering_ranges_fn;
+        get_clustering_bounds_fn_t get_global_index_token_clustering_ranges_fn;
+        get_clustering_bounds_fn_t get_local_index_clustering_ranges_fn;
+        get_singleton_value_fn_t value_for_index_partition_key_fn;
+    };
+    std::unique_ptr<index_query_fns> _index_fns;
 public:
     /**
      * Creates a new empty <code>StatementRestrictions</code>.

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -234,7 +234,7 @@ private:
     check_indexes _check_indexes = check_indexes::yes;
     /// Columns that appear on the LHS of an EQ restriction (not IN).
     /// For multi-column EQ like (ck1, ck2) = (1, 2), all columns in the tuple are included.
-    std::unordered_set<const column_definition*> _columns_with_eq;
+    std::vector<const column_definition*> _columns_with_eq;
     std::vector<const column_definition*> _column_defs_for_filtering;
     schema_ptr _view_schema;
     std::unique_ptr<secondary_index::index> _idx_opt;

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <memory>
+#include <unordered_set>
 #include <vector>
 #include "bounds_slice.hh"
 #include "cql3/expr/expression.hh"
@@ -168,7 +170,7 @@ private:
     std::vector<expr::binary_operator> _scoring_function_restrictions;
 
 
-    std::unordered_set<const column_definition*> _not_null_columns;
+    std::unique_ptr<std::unordered_set<const column_definition*>> _not_null_columns;
 
     /**
      * The restrictions used to build the index expressions


### PR DESCRIPTION
## Motivation

`statement_restrictions` is held for the lifetime of every prepared statement in the prepared-statements cache.
Many of its members are only populated for specific query shapes (secondary-index queries, filtering, `IS NOT NULL` clauses), yet every cached statement - including the common non-index, non-filtering `SELECT`  - paid their full inline cost.

This PR shrinks the struct from **776B → 552B (−224B, −28.9%)** by making the rarely-used members lazily allocated or more compact. The struct now also fits more comfortably for the common case where none of these auxiliary structures are needed.

### Folded PRs

This is a per-struct series that folds the following standalone PRs into a single reviewable change against `statement_restrictions`:

- #30043 — `_not_null_columns`: `unordered_set` → lazy `unique_ptr` (only set for `IS NOT NULL`)
- #30036 — four `std::function` index-query members → a single lazily-allocated `index_query_fns` struct (only for index-backed queries)
- #30048 — `_columns_with_eq`: `unordered_set` → `vector`
- #30064 — `_idx_tbl_ck_prefix`: `std::optional<std::vector<...>>` → lazy `unique_ptr`

Note: the previously-proposed `_idx_opt` lazy change (#30046) is **already on master** (commit `f90b066405`), so it is not included here.

## Savings (measured, dev)

`sizeof(statement_restrictions)` via compiler `static_assert`:

| | size |
|---|---|
| master | 776 B |
| this PR | 552 B |
| **saved** | **224 B (−28.9%)** |

Per non-index, non-filtering prepared statement cached in the prepared-statements cache.

## Benchmark

`perf-simple-query`, smp 1, 10K partitions, `taskset -c 0`, CPU pinned 2.2 GHz, interleaved A/B (5 runs each, alternated, same base):

| Metric | master (median) | this PR (median) | Δ |
|--------|-----------------|------------------|---|
| instructions/op | 53,519 | 53,513 | −0.01% (flat) |
| cpu cycles/op | 24,199 | 23,936 | **−1.09%** |
| throughput (tps) | 88,964 | 90,099 | **+1.28%** |
| allocs/op | 64.1 | 64.1 | 0 |

All 5 interleaved pairs showed this branch faster (+480…+1686 tps). Instruction count is flat (pure memory-layout change); the small throughput/cycles improvement is consistent with better cache locality from the smaller struct.

## Tests

`test.py --mode dev` over the restriction/index code paths — **all green**:

- `test_filtering`, `test_allow_filtering`, `test_secondary_index`,
  `test_secondary_index_properties`, `test_select_collection_element`: 151 passed
- `test_materialized_view`: 68 passed
- Totals: 219 passed, 3 skipped, 40 xfailed, **0 failures**

Backport: no, benign improvement
