### PR TITLE
cql3: lazily allocate cold column_set members in modification/batch statements (modification_statement 232B→176B)

### DIFF
--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -48,8 +48,8 @@ batch_statement::batch_statement(int bound_terms, type type_,
     : cql_statement_opt_metadata(timeout_for_type(type_))
     , _bound_terms(bound_terms), _type(type_), _statements(std::move(statements))
     , _attrs(std::move(attrs))
-    , _has_conditions(std::ranges::any_of(_statements, [] (auto&& s) { return s.statement->has_conditions(); }))
     , _stats(stats)
+    , _has_conditions(std::ranges::any_of(_statements, [] (auto&& s) { return s.statement->has_conditions(); }))
 {
     validate();
     if (has_conditions()) {
@@ -413,7 +413,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
     return qp.proxy().cas(schema, std::move(cas_shard), *request_ptr, request->read_command(qp), request->key(),
             {read_timeout, qs.get_permit(), qs.get_client_state(), qs.get_trace_state()},
             std::move(cl_for_paxos).assume_value(), cl_for_learn, batch_timeout, cas_timeout).then([this, request = std::move(request)] (service::storage_proxy::cas_result cas_result) {
-        auto result = request->build_cas_result_set(_metadata, _columns_of_cas_result_set, cas_result.is_applied);
+        auto result = request->build_cas_result_set(_metadata, *_columns_of_cas_result_set, cas_result.is_applied);
         // Surface any coordinator-side large data guardrail soft limit violations
         // detected during the LWT to the client as a CQL warning.
         if (auto warning = db::large_data_soft_violation_warning(cas_result.large_data_violations); !warning.empty()) [[unlikely]] {
@@ -429,7 +429,7 @@ void batch_statement::build_cas_result_set_metadata() {
     }
     const auto& schema = *_statements.front().statement->s;
 
-    _columns_of_cas_result_set.resize(schema.all_columns_count());
+    _columns_of_cas_result_set = std::make_unique<column_set>(schema.all_columns_count());
 
     // Add the mandatory [applied] column to result set metadata
     std::vector<lw_shared_ptr<column_specification>> columns;
@@ -439,14 +439,21 @@ void batch_statement::build_cas_result_set_metadata() {
     columns.push_back(applied);
 
     for (const auto& def : schema.primary_key_columns()) {
-        _columns_of_cas_result_set.set(def.ordinal_id);
+        _columns_of_cas_result_set->set(def.ordinal_id);
     }
     for (const auto& s : _statements) {
-        _columns_of_cas_result_set.union_with(s.statement->columns_of_cas_result_set());
+        // A conditional BATCH may contain non-conditional statements (the CAS
+        // path supports this). Those don't have _columns_of_cas_result_set
+        // populated, so guard the access to avoid dereferencing a null
+        // unique_ptr. Skipping them matches the previous behaviour, where the
+        // member was a value-type empty column_set and the union was a no-op.
+        if (s.statement->has_conditions()) {
+            _columns_of_cas_result_set->union_with(s.statement->columns_of_cas_result_set());
+        }
     }
-    columns.reserve(_columns_of_cas_result_set.count());
+    columns.reserve(_columns_of_cas_result_set->count());
     for (const auto& def : schema.all_columns()) {
-        if (_columns_of_cas_result_set.test(def.ordinal_id)) {
+        if (_columns_of_cas_result_set->test(def.ordinal_id)) {
             columns.emplace_back(def.column_specification);
         }
     }

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -59,9 +59,6 @@ private:
     type _type;
     std::vector<single_statement> _statements;
     std::unique_ptr<attributes> _attrs;
-    // True if *any* statement of the batch has IF .. clause. In
-    // this case entire batch is considered a CAS batch.
-    bool _has_conditions;
     // If the BATCH has conditions, it must return columns which
     // are involved in condition expressions in its result set.
     // Unlike Cassandra, Scylla always returns all columns,
@@ -71,8 +68,13 @@ private:
     // Cassandra returns a result set only if CAS succeeds. If
     // any statement in the batch has IF EXISTS, we must return
     // all columns of the table, including the primary key.
-    column_set _columns_of_cas_result_set;
+    std::unique_ptr<column_set> _columns_of_cas_result_set;
     cql_stats& _stats;
+    // True if *any* statement of the batch has IF .. clause. In
+    // this case entire batch is considered a CAS batch.
+    // Placed last to avoid 7B padding hole between it and the
+    // next 8B-aligned field; padding is now at the struct tail.
+    bool _has_conditions;
 public:
     /**
      * Creates a new BatchStatement from a list of statements

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -60,7 +60,6 @@ modification_statement::modification_statement(statement_type type_, uint32_t bo
     : cql_statement_opt_metadata(modification_statement_timeout(*schema_))
     , type{type_}
     , _bound_terms{bound_terms}
-    , _columns_to_read(schema_->all_columns_count())
     , s{schema_}
     , attrs{std::move(attrs_)}
     , _column_operations{}
@@ -535,7 +534,10 @@ void modification_statement::build_cas_result_set_metadata() {
     }
     // Ensure we prefetch all of the columns of the result set. This is also
     // necessary to check conditions.
-    _columns_to_read.union_with(*_columns_of_cas_result_set);
+    if (!_columns_to_read) {
+        _columns_to_read = std::make_unique<column_set>(s->all_columns_count());
+    }
+    _columns_to_read->union_with(*_columns_of_cas_result_set);
     _metadata = seastar::make_shared<cql3::metadata>(std::move(columns));
 }
 
@@ -780,7 +782,10 @@ void modification_statement::add_operation(std::unique_ptr<operation> op) {
     }
     if (op->requires_read()) {
         _requires_read = true;
-        _columns_to_read.set(op->column.ordinal_id);
+        if (!_columns_to_read) {
+            _columns_to_read = std::make_unique<column_set>(s->all_columns_count());
+        }
+        _columns_to_read->set(op->column.ordinal_id);
         if (op->column.type->is_collection() ) {
             auto ctype = static_pointer_cast<const collection_type_impl>(op->column.type);
             if (!ctype->is_multi_cell()) {

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -61,7 +61,6 @@ modification_statement::modification_statement(statement_type type_, uint32_t bo
     , type{type_}
     , _bound_terms{bound_terms}
     , _columns_to_read(schema_->all_columns_count())
-    , _columns_of_cas_result_set(schema_->all_columns_count())
     , s{schema_}
     , attrs{std::move(attrs_)}
     , _column_operations{}
@@ -484,7 +483,7 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
             {read_timeout, qs.get_permit(), qs.get_client_state(), qs.get_trace_state()},
             std::move(cl_for_paxos).assume_value(), cl_for_learn, statement_timeout, cas_timeout, true, {},
             attrs->is_bypass_large_data_guardrails()).then([this, request = std::move(request), tablet_info = std::move(tablet_info)] (service::storage_proxy::cas_result cas_result) mutable {
-        auto result = request->build_cas_result_set(_metadata, _columns_of_cas_result_set, cas_result.is_applied);
+        auto result = request->build_cas_result_set(_metadata, *_columns_of_cas_result_set, cas_result.is_applied);
         if (tablet_info) {
             result->add_tablet_info(std::move(*tablet_info));
         }
@@ -498,6 +497,8 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
 }
 
 void modification_statement::build_cas_result_set_metadata() {
+
+    _columns_of_cas_result_set = std::make_unique<column_set>(s->all_columns_count());
 
     std::vector<lw_shared_ptr<column_specification>> columns;
     // Add the mandatory [applied] column to result set metadata
@@ -516,11 +517,11 @@ void modification_statement::build_cas_result_set_metadata() {
         // columns, then the existence condition applies only to the static columns themselves, and
         // so we don't want to include regular columns in that case.
         for (const auto& def : all_columns) {
-            _columns_of_cas_result_set.set(def.ordinal_id);
+            _columns_of_cas_result_set->set(def.ordinal_id);
         }
     } else {
         expr::for_each_expression<expr::column_value>(_condition, [&] (const expr::column_value& col) {
-            _columns_of_cas_result_set.set(col.col->ordinal_id);
+            _columns_of_cas_result_set->set(col.col->ordinal_id);
         });
     }
     columns.reserve(columns.size() + all_columns.size());
@@ -528,13 +529,13 @@ void modification_statement::build_cas_result_set_metadata() {
     // the same column can be used twice in the condition list:
     // if a > 0 and a < 3.
     for (const auto& def : all_columns) {
-        if (_columns_of_cas_result_set.test(def.ordinal_id)) {
+        if (_columns_of_cas_result_set->test(def.ordinal_id)) {
             columns.emplace_back(def.column_specification);
         }
     }
     // Ensure we prefetch all of the columns of the result set. This is also
     // necessary to check conditions.
-    _columns_to_read.union_with(_columns_of_cas_result_set);
+    _columns_to_read.union_with(*_columns_of_cas_result_set);
     _metadata = seastar::make_shared<cql3::metadata>(std::move(columns));
 }
 

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -55,7 +55,7 @@ private:
     // columns, to match Cassandra behaviour.
     // This bitset contains a mask of ordinal_id identifiers
     // of the required columns.
-    column_set _columns_to_read;
+    std::unique_ptr<column_set> _columns_to_read;
     // A CAS statement returns a result set with the columns
     // used in condition expression. This is a mask of ordinal_id
     // identifiers of the required columns. Contains all columns
@@ -198,7 +198,8 @@ public:
     bool requires_lwt() const { return _requires_lwt; }
 
     // Columns used in this statement conditions or operations.
-    const column_set& columns_to_read() const { return _columns_to_read; }
+    // Precondition: requires_read() || has_conditions() (i.e., _columns_to_read is populated).
+    const column_set& columns_to_read() const { return *_columns_to_read; }
 
     // Columns of the statement result set (only CAS statement
     // returns a result set).

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -62,7 +62,7 @@ private:
     // of a schema if we have IF EXISTS/IF NOT EXISTS. Does *not*
     // contain LIST columns prefetched to apply updates, unless
     // these columns are also used in conditions.
-    column_set _columns_of_cas_result_set;
+    std::unique_ptr<column_set> _columns_of_cas_result_set;
 public:
     const schema_ptr s;
     const std::unique_ptr<attributes> attrs;
@@ -72,8 +72,14 @@ protected:
     cql_stats& _stats;
 
     expr::expression _condition = expr::conjunction{{}}; // TRUE
+protected:
+    shared_ptr<const restrictions::statement_restrictions> _restrictions;
 private:
     const ks_selector _ks_sel;
+
+    // The following fields are cold (only used during prepare or CAS paths).
+    // They are placed last so that padding falls at the struct tail, and the
+    // hot cache line 3 contains _restrictions and _ks_sel instead.
 
     // True if this statement has _if_exists or _if_not_exists or other
     // conditions that apply to static/regular columns, respectively.
@@ -95,9 +101,6 @@ private:
     bool _sets_regular_columns = false;
 
     std::optional<bool> _is_raw_counter_shard_write;
-
-protected:
-    shared_ptr<const restrictions::statement_restrictions> _restrictions;
 public:
     typedef std::optional<std::unordered_map<sstring, bytes_opt>> json_cache_opt;
 
@@ -199,7 +202,8 @@ public:
 
     // Columns of the statement result set (only CAS statement
     // returns a result set).
-    const column_set& columns_of_cas_result_set() const { return _columns_of_cas_result_set; }
+    // Precondition: has_conditions() (i.e., build_cas_result_set_metadata() was called).
+    const column_set& columns_of_cas_result_set() const { return *_columns_of_cas_result_set; }
 
     // Build a read_command instance to fetch the previous mutation from storage. The mutation is
     // fetched if we need to check LWT conditions or apply updates to non-frozen list elements.


### PR DESCRIPTION
## Motivation

`modification_statement` (and its derived `batch_statement`) is the cached representation of every prepared `INSERT`/`UPDATE`/`DELETE`/`BATCH`. One instance is retained per distinct prepared write for the lifetime of the prepared-statements cache. Some of its members are `column_set` (`boost::dynamic_bitset<uint64_t>`, 32 B inline plus a heap-allocated bit buffer) that are only meaningful on cold paths:

- `_columns_to_read` — used only when the statement requires a read-before-write (collection list updates, counters) or has LWT conditions.
- `_columns_of_cas_result_set` — used only by LWT/CAS statements.

On `master` these are inline members, so **every** cached prepared write — including the overwhelmingly common plain `INSERT`/`UPDATE`/`DELETE` with no read-before-write and no conditions — eagerly constructs both bitsets and their heap bit buffers, even though they stay empty and are never read at execution time.

This series allocates those masks lazily:

- **`modification_statement`** — both masks are always populated and consumed together on the LWT/CAS path (`build_cas_result_set_metadata()` fills both, then unions `columns_to_read` with `columns_of_cas_result_set`). They are bundled into a single `cold_columns` node held by one `std::unique_ptr<cold_columns>`, engaged only when an operation requires a read or when CAS metadata is built. Two inline `column_set`s become a single 8 B pointer inline and, when needed, a single node allocation holding both masks contiguously.
- **`batch_statement`** — its single `_columns_of_cas_result_set` becomes a `std::unique_ptr<column_set>`, allocated only for conditional batches.

## Size reduction

Measured via a `sizeof` probe (`static_assert`) on dev builds with the clang from dbuild's frozen toolchain, `master` vs. branch (the exact sizes are toolchain-dependent):

| Struct | Before | After | Saved |
|---|---|---|---|
| `modification_statement` | 232 B | 176 B | **−56 B** |
| `batch_statement` | — | — | **−24 B** (one inline `column_set` → 8 B pointer) |

`modification_statement` removes two inline `column_set` members (and their bit-buffer allocations) in favour of one pointer; `batch_statement` removes its single inline `column_set`.

## Performance impact

These objects are built once at prepare time and cached; they are never constructed per query, so there is **no allocation on the per-query execution hot path**.

**Common path** (plain `INSERT`/`UPDATE`/`DELETE`, no read-before-write, no conditions): strictly better than `master`. Neither mask is allocated (`master` eagerly built two `column_set`s plus their two bit buffers for every such statement), and the cached object is 56 B smaller inline, improving prepared-statements-cache density.

**LWT / read-before-write path:**

- *Prepare time:* a single `cold_columns` node is allocated, holding both masks. This is **one fewer heap allocation** than two independent `std::unique_ptr<column_set>` members would require (the previous, two-pointer revision of this PR), and the two bitsets are constructed contiguously in one node.
- *Execution time (CAS):* reaching either mask costs a single pointer indirection (`_cold->…`), the same as a per-member pointer. Because both masks now live in one node, the CAS path — which consults `columns_to_read` for the `read_command` and `columns_of_cas_result_set` when building the result set — touches a **single cache line** instead of two separately heap-allocated bitsets. Locality is therefore at least as good as, and typically better than, both `master` (two inline-but-separately-buffered bitsets) and a two-pointer layout.

Net: the common write path gets smaller and allocation-free; the LWT path does fewer prepare-time allocations and has better cache locality, with no extra execution-time indirection. As this is a prepare-time/layout change off the per-query hot path, no microbenchmark is included.

## Correctness

Accessors `columns_to_read()` / `columns_of_cas_result_set()` dereference the pointer and carry a documented precondition, asserted with `throwing_assert` (always-on). All call sites are guarded so the node is always engaged when reached:

- `read_command()` reads `columns_to_read()` and is reached only under `requires_read()` at its caller.
- `cas_request::read_command` calls `columns_to_read()` only after skipping statements with neither conditions nor reads (`has_conditions() || requires_read()`).
- `columns_of_cas_result_set()` is only reached for statements with conditions, after `build_cas_result_set_metadata()` engaged the node.
- In `batch_statement::build_cas_result_set_metadata()`, the per-statement union is guarded with `has_conditions()`: a conditional BATCH may legally contain non-conditional sub-statements, which no longer carry a mask. The guard precisely preserves the previous no-op behaviour (where the member was a value-type empty `column_set`).
- `ensure_cold()` is only ever called from the prepare/construction path, never from the per-query execution path, so the shared, read-only cached prepared statement is not mutated across executions. In `add_operation()`, the node is engaged before `_requires_read` is set, so a throwing allocation leaves the (discarded) statement consistent.

## Testing

dbuild (frozen toolchain) dev build: clean, no new warnings. `combined_tests` linked clean. Verified green (`*** No errors detected`):
`test_batch`, `test_batch_insert_statement`, `test_insert_statement`, `test_list_append_limit`, `test_list_insert_update`, `test_map_insert_update`, `test_set_insert_update`.

Backport: no, benign improvement

---

This consolidates and supersedes #30047, #30045.
