### PR TITLE
alternator: miscelleneous fixes to error handling

### DIFF
--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -354,6 +354,7 @@ filter::filter(parsed::expression_cache& parsed_expression_cache, const rjson::v
             resolve_condition_expression(parsed,
                     expression_attribute_names, expression_attribute_values,
                     used_attribute_names, used_attribute_values);
+            validate_filter_expression(parsed);
             _imp = expression_filter { std::move(parsed) };
         } catch(expressions_syntax_error& e) {
             throw api_error::validation(e.what());

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1893,6 +1893,9 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     // the response size, as DynamoDB does.
     _stats.api_operations.batch_get_item++;
     rjson::value& request_items = request["RequestItems"];
+    if (request_items.MemberCount() == 0) {
+        throw api_error::validation("BatchGetItem requires at least one table in RequestItems");
+    }
     auto start_time = std::chrono::steady_clock::now();
     // We need to validate all the parameters before starting any asynchronous
     // query, and fail the entire request on any parse error. So we parse all

--- a/alternator/expressions.cc
+++ b/alternator/expressions.cc
@@ -641,6 +641,93 @@ std::unordered_map<std::string_view, function_handler_type*> function_handlers {
     },
 };
 
+// validate_filter_expression() recursively validates a parsed condition
+// expression eagerly, after resolve_condition_expression() has substituted
+// all value references with their actual values, but before we need to
+// evaluate the filter expression on an actual item. It is only called for
+// FilterExpression, not for ConditionExpression, because ConditionExpression
+// is always evaluated against an item so lazy validation is sufficient.
+// FilterExpression, on the other hand, may never be evaluated at all if the
+// query returns zero items, so errors such as wrong function argument types
+// would be silently missed without this eager check.
+static void validate_value_in_filter_expression(const parsed::value& v) {
+    std::visit(overloaded_functor {
+        [&] (const parsed::constant&) { },
+        [&] (const parsed::value::function_call& f) {
+            // Only these functions, with these parameter counts, are allowed
+            // in ConditionExpression/FilterExpression. list_append() and
+            // if_not_exists() also appear in function_handlers, but those
+            // are only allowed in UpdateExpression, so they must not be
+            // accepted here even though function_handlers knows about them.
+            // The same checks below happen again lazily inside
+            // function_handlers, but would be silently missed if no items
+            // are scanned.
+            static const std::unordered_map<std::string_view, unsigned> condition_function_param_counts = {
+                {"attribute_exists", 1}, {"attribute_not_exists", 1}, {"size", 1},
+                {"attribute_type", 2}, {"begins_with", 2}, {"contains", 2},
+            };
+            auto count_it = condition_function_param_counts.find(std::string_view(f._function_name));
+            if (count_it == condition_function_param_counts.end()) {
+                throw api_error::validation(
+                        fmt::format("Invalid FilterExpression: unknown function '{}' called.", f._function_name));
+            }
+            if (f._parameters.size() != count_it->second) {
+                throw api_error::validation(
+                        fmt::format("Invalid FilterExpression: {}() accepts {} parameter{}, got {}",
+                                f._function_name, count_it->second,
+                                count_it->second == 1 ? "" : "s",
+                                f._parameters.size()));
+            }
+            // Some functions have additional checks on the types of their
+            // parameters, which we also want to validate eagerly:
+            // For begins_with(), any constant argument must be of type S or B.
+            if (f._function_name == "begins_with") {
+                for (const parsed::value& param : f._parameters) {
+                    if (param.is_constant()) {
+                        const rjson::value& val = calculate_value(std::get<parsed::constant>(param._value));
+                        if (!val.IsObject() || val.MemberCount() != 1
+                                || (val.MemberBegin()->name != "S" && val.MemberBegin()->name != "B")) {
+                            throw api_error::validation(
+                                    fmt::format("Invalid FilterExpression: begins_with() supports only string or binary type, got: {}", val));
+                        }
+                    }
+                }
+            }
+            // For attribute_type(), the second argument must be a string constant.
+            if (f._function_name == "attribute_type") {
+                if (!f._parameters[1].is_constant()) {
+                    throw api_error::validation(
+                            "Invalid FilterExpression: attribute_type()'s second parameter must be an expression attribute value");
+                }
+                const rjson::value& val = calculate_value(std::get<parsed::constant>(f._parameters[1]._value));
+                if (!val.IsObject() || val.MemberCount() != 1 || val.MemberBegin()->name != "S") {
+                    throw api_error::validation(
+                            fmt::format("Invalid FilterExpression: attribute_type() second parameter must refer to a string, got {}", val));
+                }
+            }
+            for (const parsed::value& param : f._parameters) {
+                validate_value_in_filter_expression(param);
+            }
+        },
+        [&] (const parsed::path&) { }
+    }, v._value);
+}
+
+void validate_filter_expression(const parsed::condition_expression& ce) {
+    std::visit(overloaded_functor {
+        [&] (const parsed::primitive_condition& cond) {
+            for (const parsed::value& v : cond._values) {
+                validate_value_in_filter_expression(v);
+            }
+        },
+        [&] (const parsed::condition_expression::condition_list& list) {
+            for (const parsed::condition_expression& cond : list.conditions) {
+                validate_filter_expression(cond);
+            }
+        }
+    }, ce._expression);
+}
+
 // Given a parsed::path and an item read from the table, extract the value
 // of a certain attribute path, such as "a" or "a.b.c[3]". Returns a null
 // value if the item or the requested attribute does not exist.

--- a/alternator/expressions.hh
+++ b/alternator/expressions.hh
@@ -65,6 +65,7 @@ void resolve_condition_expression(parsed::condition_expression& ce,
         const rjson::value* expression_attribute_values,
         std::unordered_set<std::string>& used_attribute_names,
         std::unordered_set<std::string>& used_attribute_values);
+void validate_filter_expression(const parsed::condition_expression& ce);
 
 void validate_value(const rjson::value& v, const char* caller);
 

--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -378,8 +378,10 @@ bytes get_key_from_typed_value(const rjson::value& key_typed_value, const column
     auto& value = get_typed_value(key_typed_value, type_to_string(column.type), column.name_as_text(), "key column");
     std::string_view value_view = rjson::to_string_view(value);
     if (value_view.empty()) {
+        const std::string_view type_word = column.type == utf8_type ? " string" :
+                column.type == bytes_type ? " binary" : "";
         throw api_error::validation(
-                format("The AttributeValue for a key attribute cannot contain an empty string value. Key: {}", column.name_as_text()));
+                fmt::format("The AttributeValue for a key attribute cannot contain an empty{} value. Key: {}", type_word, column.name_as_text()));
     }
     if (column.type == bytes_type) {
         // FIXME: it's difficult at this point to get information if value was provided

--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -353,6 +353,12 @@ def test_batch_get_item_two_tables(test_table, test_table_s):
     assert multiset(got_items1) == multiset(items1)
     assert multiset(got_items2) == multiset(items2)
 
+# We can't ask to read from zero tables - an empty RequestItems is not valid.
+def test_batch_get_item_zero(test_table_s):
+    with pytest.raises(ClientError, match='ValidationException'):
+        test_table_s.meta.client.batch_get_item(RequestItems={})
+
+
 # Test what do we get if we try to read two *missing* values in addition to
 # an existing one. It turns out the missing items are simply not returned,
 # with no sign they are missing.

--- a/test/alternator/test_filter_expression.py
+++ b/test/alternator/test_filter_expression.py
@@ -829,3 +829,50 @@ def test_filter_expression_scan_sort_key(filled_test_table):
     expected_items = [item for item in items if item['c'] == 3]
     print(expected_items)
     assert multiset(expected_items) == multiset(got_items)
+
+# When FilterExpression is used in a Query or Scan, the expression is parsed
+# before doing the query, so a parse error will be detected even if the query
+# yields no items. However, before we fixed SCYLLADB-2346, some of the
+# validations of the FilterExpression were only done at filtering time, so these
+# errors were NOT be reported if the query happens to return zero items - in
+# which case the filter was never actually invoked.
+# This test verifies that such errors are now correctly reported, even when
+# the query returns no items.
+def test_filter_expression_validation_without_results(test_table_sn):
+    # Use a partition key that doesn't exist, so the query returns zero items.
+    # The FilterExpression errors should still be caught eagerly.
+    p = random_string()
+    # begins_with() requires a string or bytes argument, not a number.
+    # This must raise a ValidationException even though the table is empty.
+    with pytest.raises(ClientError, match='ValidationException.*Invalid FilterExpression.*begins_with'):
+        test_table_sn.query(KeyConditionExpression='p=:p',
+            FilterExpression='begins_with(s, :n)',
+            ExpressionAttributeValues={':p': p, ':n': 3})
+    # The function begins_with() requires two arguments, not just one.
+    with pytest.raises(ClientError, match='ValidationException.*Invalid FilterExpression.*begins_with'):
+        test_table_sn.query(KeyConditionExpression='p=:p',
+            FilterExpression='begins_with(s)',
+            ExpressionAttributeValues={':p': p})
+    # An unknown function name must also raise a ValidationException eagerly.
+    with pytest.raises(ClientError, match='ValidationException.*Invalid FilterExpression.*dog'):
+        test_table_sn.query(KeyConditionExpression='p=:p',
+            FilterExpression='dog(s, :v)',
+            ExpressionAttributeValues={':p': p, ':v': 'hello'})
+    # list_append() and if_not_exists() are functions that exist for use in
+    # UpdateExpression, but are not allowed in a FilterExpression. Using them
+    # here must be eagerly rejected as an unknown function, even though the
+    # query returns zero items.
+    with pytest.raises(ClientError, match='ValidationException.*Invalid FilterExpression.*list_append'):
+        test_table_sn.query(KeyConditionExpression='p=:p',
+            FilterExpression='list_append(s, :v) = :v',
+            ExpressionAttributeValues={':p': p, ':v': 'hello'})
+    with pytest.raises(ClientError, match='ValidationException.*Invalid FilterExpression.*if_not_exists'):
+        test_table_sn.query(KeyConditionExpression='p=:p',
+            FilterExpression='if_not_exists(s, :v) = :v',
+            ExpressionAttributeValues={':p': p, ':v': 'hello'})
+    # attribute_type()'s second parameter must be a string constant, not a
+    # path to a document attribute. This must be caught eagerly too.
+    with pytest.raises(ClientError, match='ValidationException.*Invalid FilterExpression.*attribute_type'):
+        test_table_sn.query(KeyConditionExpression='p=:p',
+            FilterExpression='attribute_type(s, i)',
+            ExpressionAttributeValues={':p': p})

--- a/test/alternator/test_query.py
+++ b/test/alternator/test_query.py
@@ -421,6 +421,25 @@ def test_query_exclusivestartkey_spurious_column(test_table_sn):
             # 'x' is not part of the key, so this should cause an error
             ExclusiveStartKey= { 'p': p, 'c': 0, 'x': 3 })
 
+# Check that ExclusiveStartKey cannot use the wrong types for key columns.
+# In test_table_sn, the partition key should be a string (not a number), and
+# the sort key should be a number (not a string).
+def test_query_exclusivestartkey_wrong_types(test_table_sn):
+    p = random_string()
+    # DynamoDB gives the error message "The provided key element does not match
+    # the schema", while Alternator gives "Type mismatch: expected type S for
+    # key column p, got type "N"".
+    with pytest.raises(ClientError, match='ValidationException.*match'):
+        test_table_sn.query(
+            KeyConditions={'p': { 'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+            # 'p' should be a string, not a number.
+            ExclusiveStartKey= { 'p': 7, 'c': 42 })
+    with pytest.raises(ClientError, match='ValidationException.*match'):
+        test_table_sn.query(
+            KeyConditions={'p': { 'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+            # 'c' should be a number, not a string.
+            ExclusiveStartKey= { 'p': p, 'c': 'dog' })
+
 # The previous tests, and actually all tests in this file, all used a table
 # with both a partition key and a sort key. Naturally, "Query" is meant to
 # be used on a table with a sort key. However, it actually works also on


### PR DESCRIPTION
This series makes a few small improvements to Alternator's request validation, which in the following cases did not match what DynamoDB is validating:

1. FilterExpression should validate function calls in the expression before reading any items.
2. BatchGetItem with an empty RequestItems should be rejected
3. Error message when attempting to use an empty binary (B) key itself had errors ;-)

Fixes [SCYLLADB-2346](https://scylladb.atlassian.net/browse/SCYLLADB-2346).

[SCYLLADB-2346]: https://scylladb.atlassian.net/browse/SCYLLADB-2346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ