### PR TITLE
test_backup.py: fix race in test_restore_tablets_vs_migration

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5041,8 +5041,12 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
         SCYLLA_ASSERT(keyspace);
         SCYLLA_ASSERT(table);
         auto s = _db.local().find_column_family(tablet.table).schema();
-        bool should_block = s->ks_name() == *keyspace && s->cf_name() == *table;
-        while (should_block && !handler.poll_for_message() && !_async_gate.is_closed()) {
+        if (s->ks_name() != *keyspace || s->cf_name() != *table) {
+            co_return;
+        }
+
+        rtlogger.info("block_tablet_streaming: waiting");
+        while (!handler.poll_for_message() && !_async_gate.is_closed()) {
             co_await sleep(std::chrono::milliseconds(100));
         }
     });

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -800,7 +800,13 @@ async def test_restore_tablets_vs_migration(build_mode: str, manager: ManagerCli
         current = tablet.replicas[0]
         target = s1_host_id if current[0] == s0_host_id else s0_host_id
         await asyncio.gather(*[manager.api.enable_injection(s.ip_addr, "block_tablet_streaming", False, parameters={'keyspace': ks, 'table': 'test'}) for s in servers])
+
+        target_server = servers[1] if target == s1_host_id else servers[0]
+        log = await manager.server_open_log(target_server.server_id)
+        mark = await log.mark()
+
         migration_task = asyncio.create_task(manager.api.move_tablet(servers[0].ip_addr, ks, "test", current[0], current[1], target, 0, tablet.last_token))
+        await log.wait_for("block_tablet_streaming: waiting", from_mark=mark, timeout=30)
 
         logger.info(f'Restore cluster via {servers[1].ip_addr}')
         manifests = [ f'{s.server_id}/{snap_name}/manifest.json' for s in servers ]


### PR DESCRIPTION
The test was racing move_tablet against restore_tablets without ensuring that move_tablet had actually reached the streaming phase before restore began. This caused restore to win the group0 race, putting the tablet into transition first, which made move_tablet fail with "Tablet is in transition".

Fix by adding a log message to the block_tablet_streaming error injection and waiting for it in the test, ensuring the move has entered the streaming phase (and is blocked) before restore starts.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2147

The test is part of master only. No backport required.