### PR TITLE
doc: nodetool decommission - add links to related procedures

### DIFF
--- a/docs/operating-scylla/nodetool-commands/decommission.rst
+++ b/docs/operating-scylla/nodetool-commands/decommission.rst
@@ -39,4 +39,11 @@ this part is serialized with other vnode-based operations, including those from 
 Decommission which is still in the tablet draining phase can be canceled using Task Manager API.
 See :doc:`Task manager </operating-scylla/admin-tools/task-manager>`.
 
+.. rubric:: See also
+
+* :doc:`Remove a Node from a ScyllaDB Cluster (Down Scale) </operating-scylla/procedures/cluster-management/remove-node>`
+* :doc:`Decommissioning a Data Center </operating-scylla/procedures/cluster-management/decommissioning-data-center>`
+* :doc:`Replace a Running Node </operating-scylla/procedures/cluster-management/replace-running-node>`
+* :doc:`Failed Decommission Troubleshooting </troubleshooting/failed-decommission>`
+
 .. include:: nodetool-index.rst

--- a/docs/operating-scylla/nodetool-commands/decommission.rst
+++ b/docs/operating-scylla/nodetool-commands/decommission.rst
@@ -39,7 +39,7 @@ this part is serialized with other vnode-based operations, including those from 
 Decommission which is still in the tablet draining phase can be canceled using Task Manager API.
 See :doc:`Task manager </operating-scylla/admin-tools/task-manager>`.
 
-.. rubric:: See also
+See also
 
 * :doc:`Remove a Node from a ScyllaDB Cluster (Down Scale) </operating-scylla/procedures/cluster-management/remove-node>`
 * :doc:`Decommissioning a Data Center </operating-scylla/procedures/cluster-management/decommissioning-data-center>`


### PR DESCRIPTION
Adds a **See Also** section to the nodetool decommission page with links to the four related procedures/troubleshooting pages requested in the issue.

Fixes #18207