### PR TITLE
dht: shrink decorated_key by storing token as raw 8-byte value

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1380,12 +1380,12 @@ private:
         // all overlapping input sstables have been exhausted.
         auto gc_not_exhausted = [this] (const sstables::shared_sstable& gc_sst) {
             auto gc_range = ::wrapping_interval<dht::token>::make(
-                gc_sst->get_first_decorated_key()._token,
-                gc_sst->get_last_decorated_key()._token);
+                gc_sst->get_first_decorated_key().token(),
+                gc_sst->get_last_decorated_key().token());
             for (const auto& input_sst : _sstables) {
                 auto input_range = ::wrapping_interval<dht::token>::make(
-                    input_sst->get_first_decorated_key()._token,
-                    input_sst->get_last_decorated_key()._token);
+                    input_sst->get_first_decorated_key().token(),
+                    input_sst->get_last_decorated_key().token());
                 if (gc_range.overlaps(input_range, dht::token_comparator())) {
                     return true; // overlaps with a remaining input sstable, not exhausted yet
                 }

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1381,12 +1381,12 @@ private:
         // all overlapping input sstables have been exhausted.
         auto gc_not_exhausted = [this] (const sstables::shared_sstable& gc_sst) {
             auto gc_range = ::wrapping_interval<dht::token>::make(
-                gc_sst->get_first_decorated_key()._token,
-                gc_sst->get_last_decorated_key()._token);
+                gc_sst->get_first_decorated_key().token(),
+                gc_sst->get_last_decorated_key().token());
             for (const auto& input_sst : _sstables) {
                 auto input_range = ::wrapping_interval<dht::token>::make(
-                    input_sst->get_first_decorated_key()._token,
-                    input_sst->get_last_decorated_key()._token);
+                    input_sst->get_first_decorated_key().token(),
+                    input_sst->get_last_decorated_key().token());
                 if (gc_range.overlaps(input_range, dht::token_comparator())) {
                     return true; // overlaps with a remaining input sstable, not exhausted yet
                 }

--- a/compaction/leveled_manifest.hh
+++ b/compaction/leveled_manifest.hh
@@ -329,13 +329,13 @@ public:
         auto it = candidates.begin();
         auto& first_sstable = *it;
         it++;
-        dht::token first = first_sstable->get_first_decorated_key()._token;
-        dht::token last = first_sstable->get_last_decorated_key()._token;
+        dht::token first = first_sstable->get_first_decorated_key().token();
+        dht::token last = first_sstable->get_last_decorated_key().token();
         while (it != candidates.end()) {
             auto& candidate_sstable = *it;
             it++;
-            dht::token first_candidate = candidate_sstable->get_first_decorated_key()._token;
-            dht::token last_candidate = candidate_sstable->get_last_decorated_key()._token;
+            dht::token first_candidate = candidate_sstable->get_first_decorated_key().token();
+            dht::token last_candidate = candidate_sstable->get_last_decorated_key().token();
 
             first = first <= first_candidate? first : first_candidate;
             last = last >= last_candidate ? last : last_candidate;
@@ -345,7 +345,7 @@ public:
 
     template <typename T>
     static std::vector<sstables::shared_sstable> overlapping(const schema& s, const sstables::shared_sstable& sstable, const T& others) {
-        return overlapping(s, sstable->get_first_decorated_key()._token, sstable->get_last_decorated_key()._token, others);
+        return overlapping(s, sstable->get_first_decorated_key().token(), sstable->get_last_decorated_key().token(), others);
     }
 
     /**
@@ -359,7 +359,7 @@ public:
         auto range = ::wrapping_interval<dht::token>::make(start, end);
 
         for (auto& candidate : sstables) {
-            auto candidate_range = ::wrapping_interval<dht::token>::make(candidate->get_first_decorated_key()._token, candidate->get_last_decorated_key()._token);
+            auto candidate_range = ::wrapping_interval<dht::token>::make(candidate->get_first_decorated_key().token(), candidate->get_last_decorated_key().token());
 
             if (range.overlaps(candidate_range, dht::token_comparator())) {
                 overlapped.push_back(candidate);

--- a/compaction/leveled_manifest.hh
+++ b/compaction/leveled_manifest.hh
@@ -334,13 +334,13 @@ public:
         auto it = candidates.begin();
         auto& first_sstable = *it;
         it++;
-        dht::token first = first_sstable->get_first_decorated_key()._token;
-        dht::token last = first_sstable->get_last_decorated_key()._token;
+        dht::token first = first_sstable->get_first_decorated_key().token();
+        dht::token last = first_sstable->get_last_decorated_key().token();
         while (it != candidates.end()) {
             auto& candidate_sstable = *it;
             it++;
-            dht::token first_candidate = candidate_sstable->get_first_decorated_key()._token;
-            dht::token last_candidate = candidate_sstable->get_last_decorated_key()._token;
+            dht::token first_candidate = candidate_sstable->get_first_decorated_key().token();
+            dht::token last_candidate = candidate_sstable->get_last_decorated_key().token();
 
             first = first <= first_candidate? first : first_candidate;
             last = last >= last_candidate ? last : last_candidate;
@@ -350,7 +350,7 @@ public:
 
     template <typename T>
     static std::vector<sstables::shared_sstable> overlapping(const schema& s, const sstables::shared_sstable& sstable, const T& others) {
-        return overlapping(s, sstable->get_first_decorated_key()._token, sstable->get_last_decorated_key()._token, others);
+        return overlapping(s, sstable->get_first_decorated_key().token(), sstable->get_last_decorated_key().token(), others);
     }
 
     /**
@@ -364,7 +364,7 @@ public:
         auto range = ::wrapping_interval<dht::token>::make(start, end);
 
         for (auto& candidate : sstables) {
-            auto candidate_range = ::wrapping_interval<dht::token>::make(candidate->get_first_decorated_key()._token, candidate->get_last_decorated_key()._token);
+            auto candidate_range = ::wrapping_interval<dht::token>::make(candidate->get_first_decorated_key().token(), candidate->get_last_decorated_key().token());
 
             if (range.overlaps(candidate_range, dht::token_comparator())) {
                 overlapped.push_back(candidate);

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -3109,7 +3109,13 @@ public:
         if (_step.reader.is_end_of_stream() && _step.reader.is_buffer_empty()) {
             // before going back to the minimum token, advance current_key to the end
             // and check for built views in that range.
-            _step.current_key = { _step.prange.end().value_or(dht::ring_position::max()).value().token(), partition_key::make_empty()};
+            // Use token::last() (the largest key-kind token) rather than the
+            // partition range's after_all_keys end bound: decorated_key stores its
+            // token as a raw value without the kind, so an after_all_keys token can't
+            // be represented (and asserts in debug builds). last() is >= every real
+            // first_token (always a key or minimum token), so check_for_built_views()
+            // still sees current_token() >= first_token for all views.
+            _step.current_key = { dht::token::last(), partition_key::make_empty() };
             check_for_built_views();
 
             _step.current_key = {dht::minimum_token(), partition_key::make_empty()};

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -3118,7 +3118,13 @@ public:
         if (_step.reader.is_end_of_stream() && _step.reader.is_buffer_empty()) {
             // before going back to the minimum token, advance current_key to the end
             // and check for built views in that range.
-            _step.current_key = { _step.prange.end().value_or(dht::ring_position::max()).value().token(), partition_key::make_empty()};
+            // Use token::last() (the largest key-kind token) rather than the
+            // partition range's after_all_keys end bound: decorated_key stores its
+            // token as a raw value without the kind, so an after_all_keys token can't
+            // be represented (and asserts in debug builds). last() is >= every real
+            // first_token (always a key or minimum token), so check_for_built_views()
+            // still sees current_token() >= first_token for all views.
+            _step.current_key = { dht::token::last(), partition_key::make_empty() };
             check_for_built_views();
 
             _step.current_key = {dht::minimum_token(), partition_key::make_empty()};

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -157,7 +157,7 @@ class view_builder final : public service::migration_listener::only_view_notific
         dht::decorated_key current_key{dht::minimum_token(), partition_key::make_empty()};
         std::vector<view_build_status> build_status;
 
-        const dht::token& current_token() const {
+        dht::token current_token() const {
             return current_key.token();
         }
     };

--- a/dht/decorated_key.hh
+++ b/dht/decorated_key.hh
@@ -30,11 +30,12 @@ namespace dht {
 // Total ordering defined by comparators is compatible with Origin's ordering.
 class decorated_key {
 public:
-    dht::token _token;
+    raw_token _token;
     partition_key _key;
 
+    // Accepts only key-kind tokens, or minimum_token() as a sentinel.
     decorated_key(dht::token t, partition_key k)
-        : _token(std::move(t))
+        : _token(t.is_minimum() ? raw_token() : raw_token(t))
         , _key(std::move(k)) {
     }
 
@@ -56,8 +57,8 @@ public:
     std::strong_ordering tri_compare(const schema& s, const decorated_key& other) const;
     std::strong_ordering tri_compare(const schema& s, const ring_position& other) const;
 
-    const dht::token& token() const noexcept {
-        return _token;
+    dht::token token() const noexcept {
+        return dht::token(_token);
     }
 
     const partition_key& key() const {
@@ -65,7 +66,7 @@ public:
     }
 
     size_t external_memory_usage() const {
-        return _key.external_memory_usage() + _token.external_memory_usage();
+        return _key.external_memory_usage();
     }
 
     size_t memory_usage() const {
@@ -102,6 +103,6 @@ template <> struct fmt::formatter<dht::decorated_key> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     template <typename FormatContext>
     auto format(const dht::decorated_key& dk, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "{{key: {}, token: {}}}", dk._key, dk._token);
+        return fmt::format_to(ctx.out(), "{{key: {}, token: {}}}", dk._key, dk.token());
     }
 };

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -281,7 +281,7 @@ bool ring_position::less_compare(const schema& s, const ring_position& other) co
 }
 
 std::strong_ordering ring_position_tri_compare(const schema& s, ring_position_view lh, ring_position_view rh) {
-    auto token_cmp = *lh._token <=> *rh._token;
+    auto token_cmp = lh._token <=> rh._token;
     if (token_cmp != 0) {
         return token_cmp;
     }
@@ -302,7 +302,7 @@ std::strong_ordering ring_position_tri_compare(const schema& s, ring_position_vi
 }
 
 std::strong_ordering ring_position_comparator_for_sstables::operator()(ring_position_view lh, sstables::decorated_key_view rh) const {
-    auto token_cmp = *lh._token <=> rh.token();
+    auto token_cmp = lh._token <=> rh.token();
     if (token_cmp != 0) {
         return token_cmp;
     }
@@ -574,7 +574,7 @@ double overlap_ratio(const dht::token_range& base, const dht::token_range& other
 auto fmt::formatter<dht::ring_position_view>::format(const dht::ring_position_view& pos, fmt::format_context& ctx) const
     -> decltype(ctx.out()) {
     auto out = ctx.out();
-    out = fmt::format_to(out, "{{{}", *pos._token);
+    out = fmt::format_to(out, "{{{}", pos.token());
     if (pos._key) {
         out = fmt::format_to(out, ", {}", *pos._key);
     }

--- a/dht/ring_position.hh
+++ b/dht/ring_position.hh
@@ -163,12 +163,29 @@ class ring_position_view {
     // For example {_token=t1, _key=nullptr, _weight=1} is ordered after {_token=t1, _key=k1, _weight=0},
     // but {_token=t1, _key=nullptr, _weight=-1} is ordered before it.
     //
-    const dht::token* _token; // always not nullptr
+    // Stored as a raw 8-byte token value (without the token kind) to keep this
+    // hot, by-value comparison type small (it is passed by value into the ring
+    // position comparators). The token kind is reconstructed on demand by
+    // token(): a disengaged raw value (INT64_MIN) maps to the minimum (before
+    // all keys) token, and the maximum (after all keys) sentinel is recognized
+    // via _weight == after_all_keys_weight.
+    raw_token _token;
     const partition_key* _key; // Can be nullptr
     int8_t _weight;
 private:
-    ring_position_view() noexcept : _token(nullptr), _key(nullptr), _weight(0) { }
-    explicit operator bool() const noexcept { return bool(_token); }
+    // _weight == disengaged_weight marks a disengaged ring_position_view,
+    // used by optimized_optional<ring_position_view>. Valid weights are -1/0/1,
+    // plus the special after_all_keys_weight for the maximum sentinel.
+    static constexpr int8_t disengaged_weight = std::numeric_limits<int8_t>::min();
+    // Dedicated weight for the after-all-keys (maximum_token) sentinel,
+    // distinguishing it from ring_position_view(token::last(), token_bound::end)
+    // which has weight 1. Both have raw value INT64_MAX and no key.
+    static constexpr int8_t after_all_keys_weight = 2;
+    ring_position_view() noexcept : _token(), _key(nullptr), _weight(disengaged_weight) { }
+    explicit operator bool() const noexcept { return _weight != disengaged_weight; }
+    // Private constructor for the after-all-keys sentinel.
+    ring_position_view(const dht::token& token, int8_t sentinel_weight)
+        : _token(token.raw()), _key(nullptr), _weight(sentinel_weight) { }
 public:
     using token_bound = ring_position::token_bound;
     struct after_key_tag {};
@@ -181,15 +198,17 @@ public:
 
     static ring_position_view max() noexcept {
         static auto max_token = maximum_token();
-        return { max_token, nullptr, 1 };
+        return ring_position_view(max_token, after_all_keys_weight);
     }
 
+    // Both minimum_token() and maximum_token() have raw() == INT64_MIN
+    // (disengaged raw_token).  after_all_keys_weight distinguishes max.
     bool is_min() const noexcept {
-        return _token->is_minimum();
+        return !_token && _weight != after_all_keys_weight;
     }
 
     bool is_max() const noexcept {
-        return _token->is_maximum();
+        return _weight == after_all_keys_weight;
     }
 
     static ring_position_view for_range_start(const partition_range& r) {
@@ -217,9 +236,10 @@ public:
     }
 
     ring_position_view(const dht::ring_position& pos, after_key after = after_key::no)
-        : _token(&pos.token())
+        : _token(pos.token().raw())
         , _key(pos.has_key() ? &*pos.key() : nullptr)
-        , _weight(pos.has_key() ? bool(after) : pos.relation_to_keys())
+        , _weight(pos.has_key() ? bool(after)
+                  : (pos.token().is_maximum() ? after_all_keys_weight : pos.relation_to_keys()))
     { }
 
     ring_position_view(const ring_position_view& pos) = default;
@@ -232,29 +252,40 @@ public:
     { }
 
     ring_position_view(const dht::decorated_key& key, after_key after_key = after_key::no)
-        : _token(&key.token())
+        : _token(key._token)
         , _key(&key.key())
         , _weight(bool(after_key))
     { }
 
     ring_position_view(const dht::token& token, const partition_key* key, int8_t weight)
-        : _token(&token)
+        : _token(token.raw())
         , _key(key)
-        , _weight(weight)
+        , _weight(!key && token.is_maximum() ? after_all_keys_weight : weight)
     { }
 
     explicit ring_position_view(const dht::token& token, token_bound bound = token_bound::start)
-        : _token(&token)
+        : _token(token.raw())
         , _key(nullptr)
-        , _weight(static_cast<std::underlying_type_t<token_bound>>(bound))
+        , _weight(token.is_maximum() ? after_all_keys_weight
+                  : static_cast<std::underlying_type_t<token_bound>>(bound))
     { }
 
-    const dht::token& token() const noexcept { return *_token; }
+    // Reconstructs the full token (with its kind) from the stored raw value.
+    // Returned by value because the kind is not stored.
+    dht::token token() const noexcept {
+        if (is_max()) {
+            return maximum_token();
+        }
+        return dht::token(_token);
+    }
     const partition_key* key() const { return _key; }
     int weight() const { return _weight; }
 
     // Only when key() == nullptr
-    token_bound get_token_bound() const { return token_bound(_weight); }
+    token_bound get_token_bound() const {
+        // after_all_keys_weight is logically "end" — it's past all keys.
+        return token_bound(_weight == after_all_keys_weight ? 1 : _weight);
+    }
     // Only when key() != nullptr
     after_key is_after_key() const { return after_key(_weight == 1); }
 
@@ -345,7 +376,7 @@ public:
     ring_position_ext& operator=(const ring_position_ext& other) = default;
 
     ring_position_ext(ring_position_view v)
-        : _token(*v._token)
+        : _token(v.token())
         , _key(v._key ? std::make_optional(*v._key) : std::nullopt)
         , _weight(v._weight)
     { }

--- a/dht/ring_position.hh
+++ b/dht/ring_position.hh
@@ -163,12 +163,26 @@ class ring_position_view {
     // For example {_token=t1, _key=nullptr, _weight=1} is ordered after {_token=t1, _key=k1, _weight=0},
     // but {_token=t1, _key=nullptr, _weight=-1} is ordered before it.
     //
-    const dht::token* _token; // always not nullptr
+    // Stored as a raw 8-byte token value (without the token kind) to keep this
+    // hot, by-value comparison type small (it is passed by value into the ring
+    // position comparators). The token kind is reconstructed on demand by
+    // token(): a disengaged raw value (INT64_MIN) maps to the minimum (before
+    // all keys) token, and the maximum (after all keys) sentinel is recognized
+    // via _weight == after_all_keys_weight.
+    raw_token _token;
     const partition_key* _key; // Can be nullptr
     int8_t _weight;
 private:
-    ring_position_view() noexcept : _token(nullptr), _key(nullptr), _weight(0) { }
-    explicit operator bool() const noexcept { return bool(_token); }
+    // _weight == disengaged_weight marks a disengaged ring_position_view,
+    // used by optimized_optional<ring_position_view>. Valid weights are -1/0/1,
+    // plus the special after_all_keys_weight for the maximum sentinel.
+    static constexpr int8_t disengaged_weight = std::numeric_limits<int8_t>::min();
+    // Dedicated weight for the after-all-keys (maximum_token) sentinel,
+    // distinguishing it from ring_position_view(token::last(), token_bound::end)
+    // which has weight 1. Both have raw value INT64_MAX and no key.
+    static constexpr int8_t after_all_keys_weight = 2;
+    ring_position_view() noexcept : _token(), _key(nullptr), _weight(disengaged_weight) { }
+    explicit operator bool() const noexcept { return _weight != disengaged_weight; }
 public:
     using token_bound = ring_position::token_bound;
     struct after_key_tag {};
@@ -184,12 +198,14 @@ public:
         return { max_token, nullptr, 1 };
     }
 
+    // maximum_token() has raw() == INT64_MAX (engaged), so !_token already
+    // excludes it; only minimum_token() is disengaged.
     bool is_min() const noexcept {
-        return _token->is_minimum();
+        return !_token;
     }
 
     bool is_max() const noexcept {
-        return _token->is_maximum();
+        return _weight == after_all_keys_weight;
     }
 
     static ring_position_view for_range_start(const partition_range& r) {
@@ -217,9 +233,10 @@ public:
     }
 
     ring_position_view(const dht::ring_position& pos, after_key after = after_key::no)
-        : _token(&pos.token())
+        : _token(pos.token().raw())
         , _key(pos.has_key() ? &*pos.key() : nullptr)
-        , _weight(pos.has_key() ? bool(after) : pos.relation_to_keys())
+        , _weight(pos.has_key() ? bool(after)
+                  : (pos.token().is_maximum() ? after_all_keys_weight : pos.relation_to_keys()))
     { }
 
     ring_position_view(const ring_position_view& pos) = default;
@@ -232,29 +249,40 @@ public:
     { }
 
     ring_position_view(const dht::decorated_key& key, after_key after_key = after_key::no)
-        : _token(&key.token())
+        : _token(key._token)
         , _key(&key.key())
         , _weight(bool(after_key))
     { }
 
     ring_position_view(const dht::token& token, const partition_key* key, int8_t weight)
-        : _token(&token)
+        : _token(token.raw())
         , _key(key)
-        , _weight(weight)
+        , _weight(!key && token.is_maximum() ? after_all_keys_weight : weight)
     { }
 
     explicit ring_position_view(const dht::token& token, token_bound bound = token_bound::start)
-        : _token(&token)
+        : _token(token.raw())
         , _key(nullptr)
-        , _weight(static_cast<std::underlying_type_t<token_bound>>(bound))
+        , _weight(token.is_maximum() ? after_all_keys_weight
+                  : static_cast<std::underlying_type_t<token_bound>>(bound))
     { }
 
-    const dht::token& token() const noexcept { return *_token; }
+    // Reconstructs the full token (with its kind) from the stored raw value.
+    // Returned by value because the kind is not stored.
+    dht::token token() const noexcept {
+        if (is_max()) {
+            return maximum_token();
+        }
+        return dht::token(_token);
+    }
     const partition_key* key() const { return _key; }
     int weight() const { return _weight; }
 
     // Only when key() == nullptr
-    token_bound get_token_bound() const { return token_bound(_weight); }
+    token_bound get_token_bound() const {
+        // after_all_keys_weight is logically "end" — it's past all keys.
+        return token_bound(_weight == after_all_keys_weight ? 1 : _weight);
+    }
     // Only when key() != nullptr
     after_key is_after_key() const { return after_key(_weight == 1); }
 
@@ -345,7 +373,7 @@ public:
     ring_position_ext& operator=(const ring_position_ext& other) = default;
 
     ring_position_ext(ring_position_view v)
-        : _token(*v._token)
+        : _token(v.token())
         , _key(v._key ? std::make_optional(*v._key) : std::nullopt)
         , _weight(v._weight)
     { }

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -285,7 +285,7 @@ inline constexpr std::strong_ordering tri_compare_raw(const int64_t l1, const in
 
 template <typename T>
 concept TokenCarrier = requires (const T& v) {
-    { v.token() } noexcept -> std::same_as<const token&>;
+    { v.token() } noexcept -> std::convertible_to<token>;
 };
 
 struct raw_token_less_comparator {

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -326,7 +326,7 @@ auto fmt::formatter<mutation>::format(const mutation& m, fmt::format_context& ct
         ++column_iterator;
     }
 
-    return fmt::format_to(out, "token: {}}}, {}\n}}", dk._token, mutation_partition::printer(s, m.partition()));
+    return fmt::format_to(out, "token: {}}}, {}\n}}", dk.token(), mutation_partition::printer(s, m.partition()));
 }
 
 namespace mutation_json {

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -126,7 +126,7 @@ public:
     const partition_key& key() const { return _ptr->_dk._key; };
     const dht::decorated_key& decorated_key() const { return _ptr->_dk; };
     dht::ring_position ring_position() const { return { decorated_key() }; }
-    const dht::token& token() const { return _ptr->_dk._token; }
+    dht::token token() const { return _ptr->_dk.token(); }
     const schema_ptr& schema() const { return _ptr->_schema; }
     const mutation_partition& partition() const { return _ptr->_p; }
     mutation_partition& partition() { return _ptr->_p; }

--- a/mutation/mutation_fragment_stream_validator.cc
+++ b/mutation/mutation_fragment_stream_validator.cc
@@ -63,7 +63,10 @@ mutation_fragment_stream_validator::validate(dht::token t, const partition_key* 
     if (_prev_partition_key.token() == t && pkey && _prev_partition_key.key().legacy_tri_compare(_schema, *pkey) >= 0) {
         return ooo_key_result(_schema, t, pkey, _prev_partition_key);
     }
-    _prev_partition_key._token = t;
+    if (t.is_maximum()) {
+        return validation_result::invalid(format("unexpected after-all-keys token: {}", t));
+    }
+    _prev_partition_key._token = t.is_minimum() ? dht::raw_token() : dht::raw_token(t);
     if (pkey) {
         _prev_partition_key._key = *pkey;
     } else {

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -1182,8 +1182,11 @@ future<> multishard_combining_reader::fill_buffer() {
         }
 
         while (!reader.is_buffer_empty() && !is_buffer_full()) {
-            if (const auto& mf = reader.peek_buffer(); mf.is_partition_start() && maybe_move_to_next_shard(&mf.as_partition_start().key().token())) {
-                return make_ready_future<>();
+            if (const auto& mf = reader.peek_buffer(); mf.is_partition_start()) {
+                const auto tok = mf.as_partition_start().key().token();
+                if (maybe_move_to_next_shard(&tok)) {
+                    return make_ready_future<>();
+                }
             }
             push_mutation_fragment(reader.pop_mutation_fragment());
         }

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -705,11 +705,11 @@ SEASTAR_TEST_CASE(gc_sstable_no_premature_release_with_overlapping_inputs_test) 
                 for (const auto& old_sst : desc.old_sstables) {
                     if (old_sst->get_origin() == "garbage_collection") {
                         gc_release_count++;
-                        auto gc_first = old_sst->get_first_decorated_key()._token;
-                        auto gc_last = old_sst->get_last_decorated_key()._token;
+                        auto gc_first = old_sst->get_first_decorated_key().token();
+                        auto gc_last = old_sst->get_last_decorated_key().token();
                         for (const auto& alive : alive_inputs) {
-                            auto alive_first = alive->get_first_decorated_key()._token;
-                            auto alive_last = alive->get_last_decorated_key()._token;
+                            auto alive_first = alive->get_first_decorated_key().token();
+                            auto alive_last = alive->get_last_decorated_key().token();
                             auto gc_range = ::wrapping_interval<dht::token>::make(gc_first, gc_last);
                             auto alive_range = ::wrapping_interval<dht::token>::make(alive_first, alive_last);
                             if (gc_range.overlaps(alive_range, dht::token_comparator())) {

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -707,11 +707,11 @@ SEASTAR_TEST_CASE(gc_sstable_no_premature_release_with_overlapping_inputs_test) 
                 for (const auto& old_sst : desc.old_sstables) {
                     if (old_sst->get_origin() == "garbage_collection") {
                         gc_release_count++;
-                        auto gc_first = old_sst->get_first_decorated_key()._token;
-                        auto gc_last = old_sst->get_last_decorated_key()._token;
+                        auto gc_first = old_sst->get_first_decorated_key().token();
+                        auto gc_last = old_sst->get_last_decorated_key().token();
                         for (const auto& alive : alive_inputs) {
-                            auto alive_first = alive->get_first_decorated_key()._token;
-                            auto alive_last = alive->get_last_decorated_key()._token;
+                            auto alive_first = alive->get_first_decorated_key().token();
+                            auto alive_last = alive->get_last_decorated_key().token();
                             auto gc_range = ::wrapping_interval<dht::token>::make(gc_first, gc_last);
                             auto alive_range = ::wrapping_interval<dht::token>::make(alive_first, alive_last);
                             if (gc_range.overlaps(alive_range, dht::token_comparator())) {

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -111,7 +111,7 @@ SEASTAR_THREAD_TEST_CASE(test_decorated_key_is_compatible_with_origin) {
     auto dk = partitioner.decorate_key(*s, key);
 
     // Expected value was taken from Origin
-    BOOST_REQUIRE_EQUAL(dk._token, token_from_long(4958784316840156970));
+    BOOST_REQUIRE_EQUAL(dk.token(), token_from_long(4958784316840156970));
     BOOST_REQUIRE(dk._key.equal(*s, key));
 }
 

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -265,6 +265,66 @@ SEASTAR_THREAD_TEST_CASE(test_ring_position_ordering) {
       .check();
 }
 
+// Covers the compact raw_token encoding used by decorated_key and
+// ring_position_view: the token is stored as a raw 8-byte value (without the
+// kind), and the min/max sentinels are reconstructed from that raw value and
+// (for ring_position_view) the weight. The interesting case is a real key
+// whose token raw value is INT64_MAX (INT64_MIN normalizes to INT64_MAX): it
+// must not be mistaken for the minimum/after-all-keys sentinels, which share
+// the boundary raw values INT64_MIN/INT64_MAX.
+SEASTAR_THREAD_TEST_CASE(test_ring_position_raw_token_encoding) {
+    simple_schema table;
+    auto s = table.schema();
+    auto pk = table.make_pkeys(1)[0].key();
+
+    // A normal key token round-trips through decorated_key and is neither sentinel.
+    {
+        auto dk = table.make_pkeys(1)[0];
+        BOOST_REQUIRE(!dk.token().is_minimum());
+        BOOST_REQUIRE(!dk.token().is_maximum());
+        BOOST_REQUIRE_EQUAL(dk.token(), dht::token(dk.token().raw()));
+        auto v = dht::ring_position_view(dk);
+        BOOST_REQUIRE(!v.is_min());
+        BOOST_REQUIRE(!v.is_max());
+    }
+
+    // minimum_token() (before_all_keys) is stored as a disengaged raw_token and
+    // round-trips back to the minimum.
+    {
+        dht::decorated_key dk(dht::minimum_token(), pk);
+        BOOST_REQUIRE(dk.token().is_minimum());
+        BOOST_REQUIRE_EQUAL(dk.token(), dht::minimum_token());
+    }
+
+    // A real key whose token raw value is INT64_MAX stays a key and is not the
+    // after-all-keys sentinel, even though both encode to raw INT64_MAX.
+    {
+        auto t_max_raw = dht::token(std::numeric_limits<int64_t>::max());
+        BOOST_REQUIRE_EQUAL(t_max_raw.raw(), std::numeric_limits<int64_t>::max());
+        BOOST_REQUIRE(!t_max_raw.is_maximum());
+        dht::decorated_key dk(t_max_raw, pk);
+        BOOST_REQUIRE(!dk.token().is_maximum());
+        BOOST_REQUIRE_EQUAL(dk.token(), t_max_raw);
+        BOOST_REQUIRE(!dht::ring_position_view(dk).is_max());
+    }
+
+    // ring_position_view sentinels report the right flags...
+    BOOST_REQUIRE(dht::ring_position_view::min().is_min());
+    BOOST_REQUIRE(!dht::ring_position_view::min().is_max());
+    BOOST_REQUIRE(dht::ring_position_view::max().is_max());
+    BOOST_REQUIRE(!dht::ring_position_view::max().is_min());
+
+    // ...and max() sorts strictly after the end bound of a key whose token raw
+    // value is INT64_MAX: same raw value, distinguished only by weight.
+    {
+        auto cmp = dht::ring_position_comparator(*s);
+        dht::decorated_key dk(dht::token(std::numeric_limits<int64_t>::max()), pk);
+        auto key_end = dht::ring_position(dk.token(), dht::ring_position::token_bound::end);
+        BOOST_REQUIRE(cmp(dht::ring_position_view(key_end), dht::ring_position_view::max()) < 0);
+        BOOST_REQUIRE(cmp(dht::ring_position_view::max(), dht::ring_position_view(key_end)) > 0);
+    }
+}
+
 SEASTAR_THREAD_TEST_CASE(test_token_no_wraparound_1) {
     auto t1 = token_from_long(0x5000'0000'0000'0000);
     auto t2 = token_from_long(0x7000'0000'0000'0000);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -809,8 +809,8 @@ static bool key_range_overlaps(table_for_tests& cf, const dht::decorated_key& a,
 }
 
 static bool sstable_overlaps(const lw_shared_ptr<replica::column_family>& cf, sstables::shared_sstable candidate1, sstables::shared_sstable candidate2) {
-    auto range1 = wrapping_interval<dht::token>::make(candidate1->get_first_decorated_key()._token, candidate1->get_last_decorated_key()._token);
-    auto range2 = wrapping_interval<dht::token>::make(candidate2->get_first_decorated_key()._token, candidate2->get_last_decorated_key()._token);
+    auto range1 = wrapping_interval<dht::token>::make(candidate1->get_first_decorated_key().token(), candidate1->get_last_decorated_key().token());
+    auto range2 = wrapping_interval<dht::token>::make(candidate2->get_first_decorated_key().token(), candidate2->get_last_decorated_key().token());
     return range1.overlaps(range2, dht::token_comparator());
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -804,8 +804,8 @@ static bool key_range_overlaps(table_for_tests& cf, const dht::decorated_key& a,
 }
 
 static bool sstable_overlaps(const lw_shared_ptr<replica::column_family>& cf, sstables::shared_sstable candidate1, sstables::shared_sstable candidate2) {
-    auto range1 = wrapping_interval<dht::token>::make(candidate1->get_first_decorated_key()._token, candidate1->get_last_decorated_key()._token);
-    auto range2 = wrapping_interval<dht::token>::make(candidate2->get_first_decorated_key()._token, candidate2->get_last_decorated_key()._token);
+    auto range1 = wrapping_interval<dht::token>::make(candidate1->get_first_decorated_key().token(), candidate1->get_last_decorated_key().token());
+    auto range2 = wrapping_interval<dht::token>::make(candidate2->get_first_decorated_key().token(), candidate2->get_last_decorated_key().token());
     return range1.overlaps(range2, dht::token_comparator());
 }
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3024,8 +3024,8 @@ SEASTAR_TEST_CASE(test_index_fast_forwarding_after_eof) {
             sst->load(sst->get_schema()->get_sharder()).get();
         }
 
-        const auto t1 = muts.front().decorated_key()._token;
-        const auto t2 = muts.back().decorated_key()._token;
+        const auto t1 = muts.front().decorated_key().token();
+        const auto t2 = muts.back().decorated_key().token();
         dht::partition_range_vector prs;
 
         prs.emplace_back(dht::ring_position::starting_at(dht::token{t1.raw() - 200}), dht::ring_position::ending_at(dht::token{t1.raw() - 100}));


### PR DESCRIPTION
## Motivation

`decorated_key` previously embedded a full `dht::token`, which is 16 bytes: an 8-byte value plus a `token_kind` enum. The enum is only 4 bytes of data but, sitting next to the 8-byte-aligned value, it costs a full **8 bytes once alignment padding is added** -
so the kind effectively doubles the token's size. Decorated keys only ever carry key-kind tokens (or the `before_all_keys` sentinel), so the kind is redundant and can be reconstructed on demand.
This PR stores the token as a `raw_token` (a bare 8-byte value), eliminating the padded enum.

## Change

The exact change is in the struct sizes (integers, deterministic, identical in dev and release). With the LSA allocator's 2-byte object header rounded up to 8-byte alignment:

| struct           | before | after | delta | allocated slot (obj + 2B hdr → 8B-aligned) |
|------------------|:------:|:-----:|:-----:|:------------------------------------------:|
| `decorated_key`  |  32 B  | 24 B  | −8 B  |                  —                         |
| `cache_entry`    |  56 B  | 48 B  | −8 B  |  64 B → **56 B**                           |
| `memtable_entry` |  56 B  | 48 B  | −8 B  |  64 B → **56 B**                           |

Note: master already fits these entries in a single 64-byte cache line since 33bc568989 ("mutation: use tagged pointer in partition_version_ref") took them from 64 B to 56 B. This PR shrinks them further to 48 B, so the allocated slot drops from a full cache line to 56 B - saving 8 B per live partition and leaving headroom before future growth spills into a second line.

## Savings - memory footprint (measured)

Measured end-to-end with `test/perf/memory_footprint_test` (fills a row cache and a memtable with 100,000 partitions, reports total LSA occupancy in bytes), release build, baseline = current master (f26f22a035):

| arena    | total before | total after | delta (bytes)     |
|----------|-------------:|------------:|------------------:|
| cache    | 100,837,008  | 100,037,066 | −799,942 (−0.79%) |
| memtable |  81,828,384  |  81,028,384 | −800,000 (−0.98%) |

The memtable delta is exactly 8 B × 100,000 entries; the cache delta differs by 58 bytes due to allocator/arena rounding. Total occupancy moves <1% because each partition also carries ~1 KB of row/key data - the saving is per-entry-struct: 8 B per live partition, on partition-dense workloads.

## Throughput (read hot path) — `perf-simple-query`

`ring_position_view` is passed **by value** into the hot ring-position comparators, so its size affects read throughput. It previously held a *pointer* to a token (8 B). Storing a by-value `dht::token` (16 B) would have grown the struct 24 → 32 and regressed throughput ~1.4%.
Instead it holds a `raw_token` (8 B), keeping the struct at 24 B and removing a dependent pointer load from the comparators. The token kind is reconstructed in `token()`: a disengaged `raw_token` (`INT64_MIN`) maps to the minimum (before-all-keys) token; the maximum (after-all-keys) sentinel is carried by a dedicated weight value (`after_all_keys_weight`).

Re-measured against current master (f26f22a035), release build, single pinned core, CPU boost off, 20×1 s samples per run, 7 interleaved A/B runs per side. All metrics, median across runs:

| metric          | master      | this PR     | delta  |
|-----------------|------------:|------------:|-------:|
| median tps      | 213,648     | 214,841     | +0.56% |
| min tps         | 207,348     | 210,156     | +1.35% |
| max tps         | 216,450     | 216,062     | −0.18% |
| MAD tps         | 659         | 807         | —      |
| cycles/op       | 17,366      | 17,262      | −0.60% |
| insns/op        | 36,091      | 36,114      | +0.06% |
| tasks/op        | 14.13       | 14.13       | 0      |
| allocs/op       | 58.12       | 58.12       | 0      |
| logallocs/op    | 0           | 0           | 0      |

Run-to-run variation of median tps is ~±0.7%, on the same order as the +0.56% delta, and warmed-up rounds converge to parity - so throughput is **neutral to marginally positive**; instruction count, tasks and allocations are exactly flat, cycles/op trends slightly down (−0.6%). An earlier revision of this description reported +1.50% tps, but that was measured against a pre-33bc568989 baseline where cache/memtable entries still straddled two cache lines; master has since gained the single-line fit - and with it that throughput win. What remains is the memory saving above and the smaller by-value comparator type, at no throughput cost.

<details>
<summary>Per-run data (14 runs, chronological, interleaved master/branch)</summary>

Environment: AMD Ryzen 7 8845HS, CPU boost disabled, pinned to a single core via `taskset`, release build, `perf-simple-query --smp 1 -m2G --duration 20` (20×1 s samples/run, concurrency 100, 10,000 partitions). Two passes: pass 1 = 3 rounds, pass 2 = 4 rounds; the first run of each pass is cold (visibly higher MAD).

| # | pass | side | median tps | MAD tps | min tps | max tps | cycles/op | insns/op | tasks/op | allocs/op |
|---|------|------|-----------:|--------:|--------:|--------:|----------:|---------:|---------:|----------:|
| 1 | 1 | master | 210,921 | 2,158 | 205,457 | 218,986 | 17,563 | 36,111 | 14.13 | 58.12 |
| 2 | 1 | branch | 214,841 | 1,329 | 208,425 | 216,062 | 17,262 | 36,111 | 14.13 | 58.12 |
| 3 | 1 | master | 213,648 | 1,109 | 207,348 | 215,049 | 17,369 | 36,069 | 14.13 | 58.12 |
| 4 | 1 | branch | 213,927 | 871 | 210,156 | 214,739 | 17,335 | 36,114 | 14.13 | 58.12 |
| 5 | 1 | master | 215,413 | 409 | 212,685 | 216,450 | 17,219 | 36,090 | 14.13 | 58.12 |
| 6 | 1 | branch | 215,450 | 407 | 212,560 | 216,125 | 17,237 | 36,099 | 14.13 | 58.12 |
| 7 | 2 | master | 210,652 | 3,214 | 202,216 | 213,875 | 17,607 | 36,091 | 14.13 | 58.12 |
| 8 | 2 | branch | 216,335 | 807 | 213,118 | 217,008 | 17,145 | 36,081 | 14.13 | 58.12 |
| 9 | 2 | master | 214,232 | 574 | 208,683 | 216,833 | 17,320 | 36,098 | 14.13 | 58.12 |
| 10 | 2 | branch | 211,199 | 653 | 207,486 | 212,181 | 17,570 | 36,122 | 14.13 | 58.12 |
| 11 | 2 | master | 213,561 | 659 | 205,885 | 214,495 | 17,366 | 36,101 | 14.13 | 58.12 |
| 12 | 2 | branch | 212,905 | 706 | 208,804 | 215,618 | 17,428 | 36,119 | 14.13 | 58.12 |
| 13 | 2 | master | 216,479 | 378 | 214,374 | 217,201 | 17,134 | 36,056 | 14.13 | 58.12 |
| 14 | 2 | branch | 215,147 | 976 | 213,306 | 216,693 | 17,240 | 36,128 | 14.13 | 58.12 |

</details>

## Testing

- Full dev boost suite: **3618 passed, 1 skipped, 0 failed**.
- `partitioner_test`, compaction, and sstable tests updated for the new token representation.
- New `partitioner_test` cases covering raw_token encoding of `decorated_key` and `ring_position_view`.
