### PR TITLE
test: test_cdc_with_tablets: add read barrier

### DIFF
--- a/test/cluster/test_cdc_with_tablets.py
+++ b/test/cluster/test_cdc_with_tablets.py
@@ -193,6 +193,7 @@ async def test_cdc_virtual_tables(manager: ManagerClient):
                 if new_tablet_count == expected_tablet_count:
                     return True
             await wait_for(lambda: tablet_count_is(prev_tablet_count * 2), time.time() + 60)
+            await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
             new_history_count = (await cql.run_async(f"SELECT COUNT(*) AS cnt FROM system.cdc_streams_history WHERE table_id={log_table_id}"))[0].cnt
             assert new_history_count > prev_history_count
 
@@ -269,6 +270,7 @@ async def test_cdc_stream_split_and_merge_basic(manager: ManagerClient):
                 return True
 
         await wait_for(lambda: tablet_count_is(prev_tablet_count * 2), time.time() + 60)
+        await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
         await assert_streams_are_synchronized_with_tablets()
 
         # Reconstruct the stream set in each timestamp in two ways:
@@ -299,6 +301,7 @@ async def test_cdc_stream_split_and_merge_basic(manager: ManagerClient):
         prev_tablet_count = await get_tablet_count(manager, servers[0], ks, 'test_scylla_cdc_log')
         await cql.run_async(f"ALTER TABLE {ks}.test_scylla_cdc_log WITH tablets = {{'min_tablet_count': {prev_tablet_count // 2}}};")
         await wait_for(lambda: tablet_count_is(prev_tablet_count // 2), time.time() + 60)
+        await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
         await assert_streams_are_synchronized_with_tablets()
 
         await validate_stream_history()
@@ -385,6 +388,7 @@ async def test_cdc_stream_garbage_collection(manager: ManagerClient):
             if len(rows) > 0:
                 return True
         await wait_for(new_stream_timestamp_created, time.time() + 60)
+        await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
 
         ts_before = await cql.run_async(f"SELECT * FROM system.cdc_timestamps WHERE keyspace_name='{ks}' AND table_name='test' ORDER BY timestamp DESC")
         streams_before = await cql.run_async(f"SELECT * FROM system.cdc_streams WHERE keyspace_name='{ks}' AND table_name='test'")
@@ -398,6 +402,7 @@ async def test_cdc_stream_garbage_collection(manager: ManagerClient):
             if len(rows) == 1:
                 return True
         await wait_for(streams_garbage_collected, time.time() + 60)
+        await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
 
         ts_after = await cql.run_async(f"SELECT * FROM system.cdc_timestamps WHERE keyspace_name='{ks}' AND table_name='test' ORDER BY timestamp DESC")
         streams_after = await cql.run_async(f"SELECT * FROM system.cdc_streams WHERE keyspace_name='{ks}' AND table_name='test'")


### PR DESCRIPTION
Add group0 read barrier in test_cdc_with_tablets whenever we observed a condition such as tablet count change or cdc stream change, and we want to proceed to check that cdc tables are consistent with the change. For example, when we wait for tablet count change and then check the cdc streams changed as well.

The problem is that when we observe the tablet count change, for example, even though the cdc streams are changed in the same group0 operation, we may observe it during the group0 apply, when the operation is only partially applied. The read barrier ensures that the change we observed is fully applied.

Fixes SCYLLADB-2352

backport for CI stability