### PR TITLE
service/storage_proxy.cc: pack scalar members in abstract_write_response_handler to reduce allocated size

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1728,9 +1728,7 @@ protected:
     shared_ptr<storage_proxy> _proxy;
     locator::effective_replication_map_ptr _effective_replication_map_ptr;
     tracing::trace_state_ptr _trace_state;
-    db::consistency_level _cl;
     size_t _total_block_for = 0;
-    db::write_type _type;
     std::unique_ptr<mutation_holder> _mutation_holder;
     host_id_vector_replica_set _targets; // who we sent this mutation to and still pending response
     // added dead_endpoints as a member here as well. This to be able to carry the info across
@@ -1738,9 +1736,11 @@ protected:
     // it should not be a huge burden. (flw)
     host_id_vector_topology_change _dead_endpoints;
     size_t _cl_acks = 0;
+    db::consistency_level _cl;
+    db::write_type _type;
+    error _error = error::NONE;
     bool _cl_achieved = false;
     bool _throttled = false;
-    error _error = error::NONE;
     std::optional<sstring> _message;
     size_t _failed = 0; // only failures that may impact consistency
     size_t _all_failures = 0; // total amount of failures
@@ -1775,8 +1775,8 @@ public:
             host_id_vector_topology_change dead_endpoints = {}, is_cancellable cancellable = is_cancellable::no)
             : _id(p->get_next_response_id()), _proxy(std::move(p))
             , _effective_replication_map_ptr(std::move(erm))
-            , _trace_state(trace_state), _cl(cl), _type(type), _mutation_holder(std::move(mh)), _targets(std::move(targets)),
-              _dead_endpoints(std::move(dead_endpoints)), _stats(stats), _expire_timer([this] { timeout_cb(); }), _permit(std::move(permit)),
+            , _trace_state(trace_state), _mutation_holder(std::move(mh)), _targets(std::move(targets)),
+              _dead_endpoints(std::move(dead_endpoints)), _cl(cl), _type(type), _stats(stats), _expire_timer([this] { timeout_cb(); }), _permit(std::move(permit)),
               _rate_limit_info(rate_limit_info), _view_backlog(max_backlog()) {
         // original comment from cassandra:
         // during bootstrap, include pending endpoints in the count


### PR DESCRIPTION
## What

`abstract_write_response_handler` is heap-allocated (via seastar `make_shared`) for **every in-flight write request**. Its small scalar members (`_cl`, `_type`, `_error`, and the `_cl_achieved`/`_throttled` bools) were interleaved with 8-byte-aligned pointer/`size_t` members, leaving two padding holes:

- after `_cl` (before `_total_block_for`)
- after `_type` (before `_mutation_holder`)

This groups the scalars into a single contiguous cluster, shrinking the handler **528 → 512 bytes**. The constructor initializer list is reordered to match (avoids `-Wreorder`). No behavioural change.

## Why it's worth 128 bytes, not 16

The seastar allocator rounds allocations up to size classes (`idx_frac_bits=2`: …, 448, **512**, **640**, …):

| sizeof | seastar size class | heap used |
|-------:|-------------------:|----------:|
| 528 (before) | 640 | 640 B |
| 512 (after)  | 512 | 512 B |

A 528-byte object lands in the **640** class; the packed 512-byte object lands exactly in the **512** class. So each in-flight write handler drops from 640 → 512 bytes of actual heap — a real **−128 B per concurrent write**, eight times the raw 16-byte `sizeof` delta.

## Testing

`build/dev/test/boost/combined_tests --run_test=storage_proxy_test` (smp=2) passes — "No errors detected". `service/storage_proxy.o` compiles cleanly.
