### PR TITLE
strong_consistency: handle down nodes in the leader cache

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1299,9 +1299,9 @@ shared_ptr<cql_transport::messages::result_message> query_processor::bounce_to_n
         cql3::computed_function_values cached_fn_calls,
         seastar::lowres_clock::time_point timeout,
         bool is_write,
-        noncopyable_function<void(locator::host_id)> on_node_resolved) {
+        locator::host_id_or_exception_callback on_forwarding_finished) {
     get_cql_stats().forwarded_requests++;
-    return ::make_shared<cql_transport::messages::result_message::bounce>(replica.host, replica.shard, std::move(cached_fn_calls), timeout, is_write, std::move(on_node_resolved));
+    return ::make_shared<cql_transport::messages::result_message::bounce>(replica.host, replica.shard, std::move(cached_fn_calls), timeout, is_write, std::move(on_forwarding_finished));
 }
 
 query_processor::consistency_level_set query_processor::to_consistency_level_set(const query_processor::cl_option_list& levels) {

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -526,7 +526,7 @@ public:
             cql3::computed_function_values cached_fn_calls,
             seastar::lowres_clock::time_point timeout,
             bool is_write,
-            noncopyable_function<void(locator::host_id)> on_node_resolved = {});
+            locator::host_id_or_exception_callback on_forwarding_finished = {});
 
     void update_authorized_prepared_cache_config();
 

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -80,7 +80,7 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
     using namespace service::strong_consistency;
     if (auto* redirect = get_if<need_redirect>(&mutate_result)) {
         bool is_write = true;
-        co_return co_await redirect_statement(qp, options, redirect->target, timeout, is_write, coordinator.get().get_stats(), std::move(redirect->on_node_resolved));
+        co_return co_await redirect_statement(qp, options, redirect->target, timeout, is_write, coordinator.get().get_stats(), std::move(redirect->on_forwarding_finished));
     }
     utils::get_local_injector().inject("sc_modification_statement_timeout", [&] {
         throw exceptions::mutation_write_timeout_exception{"", "", options.get_consistency(), 0, 0, db::write_type::SIMPLE};

--- a/cql3/statements/strong_consistency/select_statement.cc
+++ b/cql3/statements/strong_consistency/select_statement.cc
@@ -63,7 +63,7 @@ future<::shared_ptr<result_message>> select_statement::do_execute(query_processo
     using namespace service::strong_consistency;
     if (auto* redirect = get_if<need_redirect>(&query_result)) {
         bool is_write = false;
-        co_return co_await redirect_statement(qp, options, redirect->target, timeout, is_write, coordinator.get().get_stats(), std::move(redirect->on_node_resolved));
+        co_return co_await redirect_statement(qp, options, redirect->target, timeout, is_write, coordinator.get().get_stats(), std::move(redirect->on_forwarding_finished));
     }
 
     co_return co_await process_results(get<lw_shared_ptr<query::result>>(std::move(query_result)),

--- a/cql3/statements/strong_consistency/statement_helpers.cc
+++ b/cql3/statements/strong_consistency/statement_helpers.cc
@@ -21,13 +21,13 @@ future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement
         db::timeout_clock::time_point timeout,
         bool is_write,
         service::strong_consistency::stats& stats,
-        noncopyable_function<void(locator::host_id)> on_node_resolved)
+        locator::host_id_or_exception_callback on_forwarding_finished)
 {
     auto&& func_values_cache = const_cast<cql3::query_options&>(options).take_cached_pk_function_calls();
     const auto my_host_id = qp.db().real_database().get_token_metadata().get_topology().my_host_id();
     if (target.host != my_host_id) {
         ++(is_write ? stats.write_node_bounces : stats.read_node_bounces);
-        co_return qp.bounce_to_node(target, std::move(func_values_cache), timeout, is_write, std::move(on_node_resolved));
+        co_return qp.bounce_to_node(target, std::move(func_values_cache), timeout, is_write, std::move(on_forwarding_finished));
     }
     ++(is_write ? stats.write_shard_bounces : stats.read_shard_bounces);
     co_return qp.bounce_to_shard(target.shard, std::move(func_values_cache));

--- a/cql3/statements/strong_consistency/statement_helpers.hh
+++ b/cql3/statements/strong_consistency/statement_helpers.hh
@@ -10,7 +10,6 @@
 
 #include "cql3/cql_statement.hh"
 #include "locator/tablets.hh"
-#include <seastar/util/noncopyable_function.hh>
 
 namespace service::strong_consistency { struct stats; }
 
@@ -23,7 +22,7 @@ future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement
     db::timeout_clock::time_point timeout,
     bool is_write,
     service::strong_consistency::stats& stats,
-    noncopyable_function<void(locator::host_id)> on_node_resolved = {});
+    locator::host_id_or_exception_callback on_forwarding_finished = {});
 
 bool is_strongly_consistent(data_dictionary::database db, std::string_view ks_name);
 

--- a/locator/host_id.hh
+++ b/locator/host_id.hh
@@ -11,9 +11,16 @@
 
 #include "utils/UUID.hh"
 
+#include <seastar/util/noncopyable_function.hh>
+
+#include <exception>
+#include <variant>
+
 namespace locator {
 
 using host_id = utils::tagged_uuid<struct host_id_tag>;
+using host_id_or_exception = std::variant<host_id, std::exception_ptr>;
+using host_id_or_exception_callback = noncopyable_function<void(host_id_or_exception)>;
 
 }
 

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -199,8 +199,12 @@ static need_redirect redirect_to_leader(locator::tablet_replica target, groups_m
         // The `local()` here is needed to update the cache on the shard handling
         // the client request which may be different from the shard currently
         // executing the statement.
-        .on_node_resolved = [container = &gm.container(), group_id] (locator::host_id leader) {
-            container->local().leader_cache().put(group_id, leader);
+        .on_forwarding_finished = [container = &gm.container(), group_id] (locator::host_id_or_exception leader) {
+            if (std::holds_alternative<locator::host_id>(leader)) {
+                container->local().leader_cache().put(group_id, std::get<locator::host_id>(leader));
+            } else {
+                container->local().leader_cache().erase(group_id);
+            }
         },
     };
 }
@@ -240,11 +244,11 @@ auto coordinator::create_operation_ctx(const schema& schema, const dht::token& t
         // For now, reads skip the cache because any replica can serve them.
         if (use_leader_cache) {
             if (const auto cached = _groups_manager.leader_cache().get(raft_info.group_id)) {
-                if (const auto* target = find_replica(tablet_info, *cached)) {
+                if (const auto* target = find_replica(tablet_info, *cached); target && _gossiper.is_alive(target->host)) {
                     return make_ready_future<value_or_redirect<operation_ctx>>(
                         redirect_to_leader(*target, _groups_manager, raft_info.group_id));
                 }
-                // Cached leader is no longer a replica, evict it.
+                // Cached leader is no longer a replica/alive, evict it.
                 _groups_manager.leader_cache().erase(raft_info.group_id);
             }
         }

--- a/service/strong_consistency/coordinator.hh
+++ b/service/strong_consistency/coordinator.hh
@@ -40,7 +40,7 @@ enum class read_type {
 
 struct need_redirect {
     locator::tablet_replica target;
-    noncopyable_function<void(locator::host_id)> on_node_resolved;
+    locator::host_id_or_exception_callback on_forwarding_finished;
 };
 template <typename T = std::monostate>
 using value_or_redirect = std::variant<T, need_redirect>;

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -1894,3 +1894,77 @@ async def test_crash_recovery_after_flush(manager: ManagerClient):
             assert rows[0].c == pk * 10, f"pk={pk}: expected c={pk * 10}, got c={rows[0].c}"
 
     await manager.server_stop_gracefully(server.server_id)
+
+
+async def test_write_from_non_replica_after_leader_down(manager: ManagerClient):
+    """
+    Verify that if a raft group leader goes down, a non-replica node can still
+    successfully write by detecting the stale leader cache entry and evicting it.
+
+    Setup: 4-node cluster (RF=3, 1 tablet, --smp=1).
+    - --smp=1 ensures both writes hit the same shard on the non-replica, so
+      the leader-cache entry written by the first write is visible during
+      the second write.
+    - RF=3 gives 3 replicas and 1 non-replica.
+    - Stopping one of the 3 replicas (the leader) still leaves a quorum of 2,
+      so a new leader can be elected and the second write can succeed.
+    """
+    cmdline = DEFAULT_CMDLINE + ['--smp=1']
+    servers = await manager.servers_add(4, config=DEFAULT_CONFIG, cmdline=cmdline, auto_rack_dc='my_dc')
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}"
+            " AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, c int") as table:
+            table_name = table.split('.')[-1]
+            group_id = await get_table_raft_group_id(manager, ks, table_name)
+
+            tablet_replicas = await get_tablet_replicas(manager, servers[0], ks, table_name, 0)
+            replica_host_ids = [str(replica[0]) for replica in tablet_replicas]
+            assert len(replica_host_ids) == 3
+
+            # Identify the initial leader.
+            for i in range(4):
+                if host_ids[i] in replica_host_ids:
+                    leader_host_id = await wait_for_leader(manager, servers[i], group_id)
+                    break
+            for i in range(4):
+                if leader_host_id == host_ids[i]:
+                    leader_server = servers[i]
+                    break
+
+            # Pick the one node that is not a replica.
+            non_replica_host_id = [host_id for host_id in host_ids if str(host_id) not in replica_host_ids][0]
+            non_replica_host = [host for host in hosts if str(host.host_id) == str(non_replica_host_id)][0]
+            logger.info(f"Non-replica: {non_replica_host}, initial leader: {leader_host_id}")
+
+            # First write from the non-replica. This forces the node to resolve
+            # the leader (via a redirect roundtrip) and populate its leader cache.
+            logger.info("First write from non-replica - populates leader cache")
+            await cql.run_async(f"INSERT INTO {table} (pk, c) VALUES (1, 1)", host=non_replica_host)
+
+            logger.info(f"Stopping leader {leader_host_id}")
+            await manager.server_stop(leader_server.server_id, convict=True)
+            await manager.others_not_see_server(leader_server.ip_addr)
+
+            # Wait until new election finishes. If we don't do that, the next write may be forwarded to the downed
+            # leader not because of a stale cache entry, but because the raft group hasn't started electing the new leader yet.
+            for i in range(4):
+                if host_ids[i] in replica_host_ids and host_ids[i] != leader_host_id:
+                    async def wait_for_new_leader():
+                        new_leader = await wait_for_leader(manager, servers[i], group_id)
+                        return None if new_leader == leader_host_id else new_leader
+                    await wait_for(wait_for_new_leader, time.time() + 60)
+
+            # Second write from the non-replica. Without the fix the non-replica
+            # would try to forward to the dead cached leader and get a write
+            # failure, because the stale cache entry is never evicted.
+            logger.info("Second write from non-replica after leader change")
+            await cql.run_async(f"INSERT INTO {table} (pk, c) VALUES (2, 2)", host=non_replica_host)
+
+            # Verify the row was written.
+            rows = await cql.run_async(f"SELECT * FROM {table} WHERE pk = 2", host=non_replica_host)
+            assert len(rows) == 1
+            assert rows[0].c == 2

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -26,7 +26,6 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/util/noncopyable_function.hh>
 
 namespace cql_transport {
 
@@ -101,18 +100,18 @@ class result_message::bounce : public result_message {
     cql3::computed_function_values _cached_fn_calls;
     std::optional<seastar::lowres_clock::time_point> _timeout;
     std::optional<bool> _is_write;
-    noncopyable_function<void(locator::host_id)> _on_node_resolved;
+    locator::host_id_or_exception_callback _on_forwarding_finished;
 
 public:
     bounce(locator::host_id host, unsigned shard, cql3::computed_function_values cached_fn_calls,
            std::optional<seastar::lowres_clock::time_point> timeout = std::nullopt, std::optional<bool> is_write = std::nullopt,
-           noncopyable_function<void(locator::host_id)> on_node_resolved = {})
+           locator::host_id_or_exception_callback on_forwarding_finished = {})
         : _host(host)
         , _shard(shard)
         , _cached_fn_calls(std::move(cached_fn_calls))
         , _timeout(std::move(timeout))
         , _is_write(std::move(is_write))
-        , _on_node_resolved(std::move(on_node_resolved))
+        , _on_forwarding_finished(std::move(on_forwarding_finished))
     {}
     virtual void accept(result_message::visitor& v) const override {
         v.visit(*this);
@@ -141,8 +140,8 @@ public:
         return std::move(_cached_fn_calls);
     }
 
-    const noncopyable_function<void(locator::host_id)>& on_node_resolved() const {
-        return _on_node_resolved;
+    const locator::host_id_or_exception_callback& on_forwarding_finished() const {
+        return _on_forwarding_finished;
     }
 };
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -539,7 +539,7 @@ future<forward_cql_execute_response> cql_server::handle_forward_execute(
     };
 }
 
-future<cql_server::forward_cql_result>
+future<foreign_ptr<std::unique_ptr<cql_transport::response>>>
 cql_server::forward_cql(
     locator::host_id target_host,
     unsigned target_shard,
@@ -547,7 +547,8 @@ cql_server::forward_cql(
     bool is_write,
     uint16_t stream,
     tracing::trace_state_ptr trace_state,
-    forward_cql_execute_request req)
+    forward_cql_execute_request req,
+    const locator::host_id_or_exception_callback& on_forwarding_finished)
 {
     clogger.trace("Forwarding CQL request to {} shard {}", target_host, target_shard);
     tracing::trace(trace_state, "Forwarding CQL request to {} shard {}", target_host, target_shard);
@@ -562,6 +563,9 @@ cql_server::forward_cql(
             std::exception_ptr eptr = response_fut.get_exception();
             if (try_catch<seastar::rpc::timeout_error>(eptr)) {
                 clogger.debug("Forwarding CQL request to {} shard {} failed due to RPC timeout. Will return blanket timeout exception", target_host, target_shard);
+                if (on_forwarding_finished) {
+                    on_forwarding_finished(eptr);
+                }
                 eptr = is_write
                     ? std::make_exception_ptr(exceptions::mutation_write_timeout_exception(
                         format("Write request timed out while forwarding to {}", target_host), db::consistency_level::ONE, 0, 0, db::write_type::SIMPLE))
@@ -569,6 +573,9 @@ cql_server::forward_cql(
                         format("Read request timed out while forwarding to {}", target_host), db::consistency_level::ONE, 0, 0, false));
             } else if (try_catch<seastar::rpc::closed_error>(eptr)) {
                 clogger.debug("Forwarding CQL request to {} shard {} failed due to RPC closed connection. Will return blanket failure exception", target_host, target_shard);
+                if (on_forwarding_finished) {
+                    on_forwarding_finished(eptr);
+                }
                 eptr = is_write
                     ? std::make_exception_ptr(exceptions::mutation_write_failure_exception(
                         format("Write request failed while forwarding to {}", target_host), db::consistency_level::ONE, 0, 0, 0, db::write_type::SIMPLE))
@@ -586,10 +593,10 @@ cql_server::forward_cql(
             _stats.requests_forwarded_successfully++;
             clogger.trace("Forwarded CQL request executed successfully on replica: {}", target_host);
             tracing::trace(trace_state, "Forwarded CQL request executed successfully on replica: {}", target_host);
-            co_return forward_cql_result{
-                .response = std::make_unique<cql_transport::response>(stream, cql_binary_opcode::RESULT, response.response_flags, std::move(response.response_body)),
-                .final_host = current_host,
-            };
+            if (on_forwarding_finished) {
+                on_forwarding_finished(current_host);
+            }
+            co_return std::make_unique<cql_transport::response>(stream, cql_binary_opcode::RESULT, response.response_flags, std::move(response.response_body));
         case forward_cql_status::error: {
             _stats.requests_forwarded_failed++;
             clogger.trace("Forwarded CQL request failed on replica: {}", target_host);
@@ -597,15 +604,9 @@ cql_server::forward_cql(
             auto result = std::make_unique<cql_transport::response>(stream, cql_binary_opcode::ERROR,
                                                         response.response_flags, std::move(response.response_body));
             if (response.timeout) {
-                co_return forward_cql_result{
-                    .response = co_await sleep_until_timeout_passes(*response.timeout, std::move(result)),
-                    .final_host = current_host,
-                };
+                co_return co_await sleep_until_timeout_passes(*response.timeout, std::move(result));
             }
-            co_return forward_cql_result{
-                .response = std::move(result),
-                .final_host = current_host,
-            };
+            co_return std::move(result);
         }
         case forward_cql_status::prepared_not_found: {
             _stats.requests_forwarded_prepared_not_found++;
@@ -1929,16 +1930,11 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
                 .cached_fn_calls = std::move(cached_fn_calls),
             };
 
-            auto result = co_await forward_cql(
+            auto response = co_await forward_cql(
                 target_host, shard, (*bounce_msg)->timeout().value(), (*bounce_msg)->is_write().value(),
-                stream, trace_state, std::move(req));
+                stream, trace_state, std::move(req), (*bounce_msg)->on_forwarding_finished());
 
-            const auto& on_node_resolved = (*bounce_msg)->on_node_resolved();
-            if (on_node_resolved) {
-                on_node_resolved(result.final_host);
-            }
-
-            co_return cql_server::result_with_foreign_response_ptr(std::move(result.response));
+            co_return cql_server::result_with_foreign_response_ptr(std::move(response));
         }
     }
     co_return std::move(msg);

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -383,12 +383,9 @@ private:
     future<> uninit_messaging_service();
     future<forward_cql_execute_response> handle_forward_execute(service::query_state& qs, forward_cql_execute_request& req);
 
-    struct forward_cql_result {
-        foreign_ptr<std::unique_ptr<cql_transport::response>> response;
-        locator::host_id final_host;
-    };
-    future<forward_cql_result> forward_cql(locator::host_id target_host, unsigned target_shard, seastar::lowres_clock::time_point timeout,
-            bool is_write, uint16_t stream, tracing::trace_state_ptr trace_state, forward_cql_execute_request req);
+    future<foreign_ptr<std::unique_ptr<cql_transport::response>>> forward_cql(locator::host_id target_host, unsigned target_shard, seastar::lowres_clock::time_point timeout,
+            bool is_write, uint16_t stream, tracing::trace_state_ptr trace_state, forward_cql_execute_request req,
+            const locator::host_id_or_exception_callback& on_forwarding_finished = {});
 
     virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override;
     scheduling_group get_scheduling_group_for_new_connection() const override {


### PR DESCRIPTION
Currently, we populate the leader cache even if statement execution
fails on the supposed leader and we accept the cached leader for forwarding
even if it's currently down.
This can lead to being unable to forward to the raft group leader even
if it's re-elected after the raft group identifies that the leader went down.
And even if we didn't forward to down cached leaders, user requests could still
fail in the window before gossiper learns that the node is down due to exceeding
its retry policy budget.
We fix it in this patch by applying the following changes:
1. check if the cached leader is down before accepting it as forwarding target
2. evict the leader from the cache if it is down while trying to select it as the
forwarding target
3. evict the leader for a group from the cache if the forwarding RPC failed when
trying to forward to some assumed leader

Point 3. is achieved by allowing to pass an exception_ptr to the on_node_resolved
callback and treating it as a signal to evict the leader in the cache in the callback.
The callback is renamed to on_forwarding_finished, because now it can also be called
if we don't successfully resolve the final node.

We also add a test verifying that we can still execute requests successfully even
if the raft grou leader is stopped