### PR TITLE
Remove database::get_config() usage from schema_ctxt

### DIFF
--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -734,8 +734,8 @@ future<frozen_schema_diff> schema_diff_per_shard::freeze() const {
 
 future<schema_diff_per_shard> schema_diff_per_shard::copy_from(replica::database& db, in_progress_types_storage& types_storage, const frozen_schema_diff& oth) {
     auto uts = std::make_shared<in_progress_types_storage_per_shard>(types_storage.local());
-    schema_ctxt ctxt(db.get_config(), uts, db.features(), &db);
-    schema_ctxt commited_ctxt(db.get_config(), uts->committed_storage(), db.features(), &db);
+    schema_ctxt ctxt(db.extensions(), db.get_config().murmur3_partitioner_ignore_msb_bits(), uts, db.features(), &db);
+    schema_ctxt commited_ctxt(db.extensions(), db.get_config().murmur3_partitioner_ignore_msb_bits(), uts->committed_storage(), db.features(), &db);
     schema_diff_per_shard result;
 
     for (const auto& c : oth.created) {

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -589,6 +589,7 @@ in_progress_types_storage_per_shard& in_progress_types_storage::local() {
 future<> schema_applier::merge_tables_and_views()
 {
     auto& user_types = _types_storage.local();
+    auto ctxt = _proxy.local().local_db().get_schema_ctxt();
     co_await _affected_tables_and_views.tables_and_views.start();
 
     // diffs bound to current shard
@@ -599,7 +600,7 @@ future<> schema_applier::merge_tables_and_views()
     // Create CDC tables before non-CDC base tables, because we want the base tables with CDC enabled
     // to point to their CDC tables.
     local_cdc = diff_table_or_view(_proxy, _before.cdc, _after.cdc, _reload, [&] (schema_mutations sm, schema_diff_side) {
-        return create_table_from_mutations(_proxy, std::move(sm), user_types, nullptr);
+        return create_table_from_mutations(ctxt, std::move(sm), user_types, nullptr);
     });
     local_tables = diff_table_or_view(_proxy, _before.tables, _after.tables, _reload, [&] (schema_mutations sm, schema_diff_side side) {
         // If the table has CDC enabled, find the CDC schema version and set it in the table schema.
@@ -635,7 +636,7 @@ future<> schema_applier::merge_tables_and_views()
             }
         }
 
-        return create_table_from_mutations(_proxy, std::move(sm), user_types, cdc_schema);
+        return create_table_from_mutations(ctxt, std::move(sm), user_types, cdc_schema);
     });
     local_views = diff_table_or_view(_proxy, _before.views, _after.views, _reload, [&] (schema_mutations sm, schema_diff_side side) {
         // The view schema mutation should be created with reference to the base table schema because we definitely know it by now.
@@ -671,7 +672,7 @@ future<> schema_applier::merge_tables_and_views()
         if (!base_schema) {
             base_schema = _proxy.local().local_db().find_schema(ks_name, base_name);
         }
-        view_ptr vp = create_view_from_mutations(_proxy, std::move(sm), user_types, base_schema);
+        view_ptr vp = create_view_from_mutations(ctxt, std::move(sm), user_types, base_schema);
 
         // Now when we have a referenced base - sanity check that we're not registering an old view
         // (this could happen when we skip multiple major versions in upgrade, which is unsupported.)

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -109,17 +109,19 @@ namespace {
         });
 }
 
-schema_ctxt::schema_ctxt(const db::config& cfg, std::shared_ptr<data_dictionary::user_types_storage> uts,
+schema_ctxt::schema_ctxt(const db::extensions& extensions, unsigned murmur3_partitioner_ignore_msb_bits,
+                         std::shared_ptr<data_dictionary::user_types_storage> uts,
                          const gms::feature_service& features, replica::database* db)
     : _db(db)
     , _features(features)
-    , _extensions(cfg.extensions())
-    , _murmur3_partitioner_ignore_msb_bits(cfg.murmur3_partitioner_ignore_msb_bits())
+    , _extensions(extensions)
+    , _murmur3_partitioner_ignore_msb_bits(murmur3_partitioner_ignore_msb_bits)
     , _user_types(std::move(uts))
 {}
 
 schema_ctxt::schema_ctxt(replica::database& db)
-    : schema_ctxt(db.get_config(), db.as_user_types_storage(), db.features(), &db)
+    : schema_ctxt(db.get_config().extensions(), db.get_config().murmur3_partitioner_ignore_msb_bits(),
+                  db.as_user_types_storage(), db.features(), &db)
 {}
 
 schema_ctxt::schema_ctxt(sharded<replica::database>& db)

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2003,7 +2003,8 @@ future<schema_ptr> create_table_from_name(sharded<service::storage_proxy>& proxy
     if (!sm.live()) {
         co_await coroutine::return_exception(std::runtime_error(format("{}:{} not found in the schema definitions keyspace.", qn.keyspace_name, qn.table_name)));
     }
-    const schema_ctxt& ctxt = proxy;
+    auto& db = proxy.local().local_db();
+    auto ctxt = db.get_schema_ctxt();
     // The CDC schema is set to nullptr because we don't have it yet, but we will
     // check and update it soon if needed in create_tables_from_tables_partition.
     co_return create_table_from_mutations(ctxt, std::move(sm), ctxt.user_types(), nullptr);
@@ -2574,7 +2575,8 @@ static future<view_ptr> create_view_from_table_row(sharded<service::storage_prox
     if (!sm.live()) {
         co_await coroutine::return_exception(std::runtime_error(format("{}:{} not found in the view definitions keyspace.", qn.keyspace_name, qn.table_name)));
     }
-    const schema_ctxt& ctxt = proxy;
+    auto& db = proxy.local().local_db();
+    auto ctxt = db.get_schema_ctxt();
     co_return create_view_from_mutations(ctxt, std::move(sm), ctxt.user_types());
 }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -46,7 +46,6 @@
 #include "replica/tablets.hh"
 
 #include "db/marshal/type_parser.hh"
-#include "db/config.hh"
 #include "db/extensions.hh"
 #include "utils/hashers.hh"
 
@@ -117,19 +116,6 @@ schema_ctxt::schema_ctxt(const db::extensions& extensions, unsigned murmur3_part
     , _extensions(extensions)
     , _murmur3_partitioner_ignore_msb_bits(murmur3_partitioner_ignore_msb_bits)
     , _user_types(std::move(uts))
-{}
-
-schema_ctxt::schema_ctxt(replica::database& db)
-    : schema_ctxt(db.get_config().extensions(), db.get_config().murmur3_partitioner_ignore_msb_bits(),
-                  db.as_user_types_storage(), db.features(), &db)
-{}
-
-schema_ctxt::schema_ctxt(sharded<replica::database>& db)
-    : schema_ctxt(db.local())
-{}
-
-schema_ctxt::schema_ctxt(sharded<service::storage_proxy>& proxy)
-    : schema_ctxt(proxy.local().get_db())
 {}
 
 namespace schema_tables {

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -67,7 +67,8 @@ class config;
 
 class schema_ctxt {
 public:
-    schema_ctxt(const config&, std::shared_ptr<data_dictionary::user_types_storage> uts, const gms::feature_service&,
+    schema_ctxt(const extensions&, unsigned murmur3_partitioner_ignore_msb_bits,
+                std::shared_ptr<data_dictionary::user_types_storage> uts, const gms::feature_service&,
                 replica::database* = nullptr);
     schema_ctxt(replica::database&);
     schema_ctxt(sharded<replica::database>&);

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -70,9 +70,6 @@ public:
     schema_ctxt(const extensions&, unsigned murmur3_partitioner_ignore_msb_bits,
                 std::shared_ptr<data_dictionary::user_types_storage> uts, const gms::feature_service&,
                 replica::database* = nullptr);
-    schema_ctxt(replica::database&);
-    schema_ctxt(sharded<replica::database>&);
-    schema_ctxt(sharded<service::storage_proxy>&);
 
     const db::extensions& extensions() const {
         return _extensions;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -483,7 +483,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
 {
     SCYLLA_ASSERT(dbcfg.available_memory != 0); // Detect misconfigured unit tests, see #7544
 
-    local_schema_registry().init(*this, std::chrono::seconds(get_config().schema_registry_grace_period())); // TODO: we're never unbound.
+    local_schema_registry().init(get_schema_ctxt(), std::chrono::seconds(get_config().schema_registry_grace_period())); // TODO: we're never unbound.
     setup_metrics();
 
     _row_cache_tracker.set_compaction_scheduling_group(dbcfg.memory_compaction_scheduling_group);
@@ -501,6 +501,11 @@ std::shared_ptr<data_dictionary::user_types_storage> database::as_user_types_sto
 
 const data_dictionary::user_types_storage& database::user_types() const noexcept {
     return *_user_types;
+}
+
+db::schema_ctxt database::get_schema_ctxt() {
+    return db::schema_ctxt(extensions(), get_config().murmur3_partitioner_ignore_msb_bits(),
+                           as_user_types_storage(), features(), this);
 }
 
 locator::static_effective_replication_map_ptr keyspace::get_static_effective_replication_map() const {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -150,6 +150,7 @@ class config;
 class extensions;
 class rp_handle;
 class data_listeners;
+class schema_ctxt;
 class large_data_handler;
 class system_table_corrupt_data_handler;
 class nop_corrupt_data_handler;
@@ -1764,6 +1765,7 @@ public:
     db::commitlog* commitlog_for(const schema_ptr& schema);
     std::shared_ptr<data_dictionary::user_types_storage> as_user_types_storage() const noexcept;
     const data_dictionary::user_types_storage& user_types() const noexcept;
+    db::schema_ctxt get_schema_ctxt();
     future<> init_commitlog();
     future<> init_logstor();
     future<> recover_logstor();

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1123,11 +1123,12 @@ static future<schema_ptr> get_schema_definition(table_schema_version v, locator:
             // with TTL (refresh TTL in case column mapping already existed prior to that).
             // We don't set the CDC schema here because it's not included in the RPC and we're
             // not using raft mode.
-            auto us = s.unfreeze(db::schema_ctxt(proxy), nullptr);
+            auto& db = proxy.local().local_db();
+            auto ctxt = db.get_schema_ctxt();
+            auto us = s.unfreeze(ctxt, nullptr);
             // if this is a view - sanity check that its schema doesn't need fixing.
             schema_ptr base_schema;
             if (us->is_view()) {
-                auto& db = proxy.local().local_db();
                 base_schema = db.find_schema(us->view_info()->base_id());
                 db::schema_tables::check_no_legacy_secondary_index_mv_schema(db, view_ptr(us), base_schema);
             }

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -48,7 +48,8 @@ struct dummy_init {
     dummy_init()
             : config(std::make_unique<db::config>())
             , fs({get_disabled_features_from_db_config(*config)}) {
-        local_schema_registry().init(db::schema_ctxt(*config, std::make_shared<data_dictionary::dummy_user_types_storage>(), fs),
+        local_schema_registry().init(db::schema_ctxt(config->extensions(), config->murmur3_partitioner_ignore_msb_bits(),
+                                                     std::make_shared<data_dictionary::dummy_user_types_storage>(), fs),
                                      std::chrono::seconds(config->schema_registry_grace_period()));
     }
 };

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -476,7 +476,7 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
 
     auto user_type_storage = std::make_shared<single_keyspace_user_types_storage>(std::move(utm));
     gms::feature_service features({get_disabled_features_from_db_config(dbcfg)});
-    db::schema_ctxt ctxt(dbcfg, user_type_storage, features);
+    db::schema_ctxt ctxt(dbcfg.extensions(), dbcfg.murmur3_partitioner_ignore_msb_bits(), user_type_storage, features);
 
     if (empty(tables)) {
         tables = std::move(views);


### PR DESCRIPTION
The ctxt object is used to carry necessary context around schema unfreezing. It collects some information it needs from replica::database::get_config(), thus generating unwanted dependency on global db::config. This PR make ctxt be created by the database itself (and by tests) ,thus eliminating one more dependency on large global db::config

Cleaning components dependencies, not backporting