### PR TITLE
build: correct non-installation of python3-pytest-sugar in Fedora 45

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -44,6 +44,7 @@ debian_base_packages=(
     python3-pytest
     python3-pytest-asyncio
     python3-pytest-timeout
+    python3-pytest-sugar
     python3-pexpect
     libsnappy-dev
     libjsoncpp-dev
@@ -101,7 +102,6 @@ fedora_packages=(
     python3-pytest
     python3-pytest-asyncio
     python3-pytest-timeout
-    python3-pytest-sugar
     python3-unidiff
     python3-humanfriendly
     python3-jinja2


### PR DESCRIPTION
In 57ad4fda70b3 ("build: drop python3-pytest-sugar from install-dependencies.sh --future"), we tried to drop python3-pytest-sugar from Fedora 45+ based toolchains, as the package was orphaned.

However, what we actually did, was remove it from Debian/Ubuntu, and keep it in Fedora.

Restore python3-pytest-sugar to Ubuntu (it's still carried by Ubuntu 26.04) and remove it from Fedora 45+ (it's still installed in the current toolchain).

Again only preparing for a future toolchain, current and past toolchains are not affected.