### PR TITLE
db/view/view_building_worker: fix race between tablet cleanup and staging sstable registration

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -208,6 +208,9 @@ future<> view_building_worker::register_staging_sstable_tasks(std::vector<sstabl
 }
 
 future<> view_building_worker::run_staging_sstables_registrator() {
+    co_await utils::get_local_injector().inject("view_building_worker_pause_before_starting_staging_registrator",
+            utils::wait_for_message(std::chrono::minutes(5)));
+
     while (!_as.abort_requested()) {
         bool sleep = false;
         try {

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -781,10 +781,32 @@ void view_building_worker::load_sstables(table_id table_id, std::vector<sstables
     });
 }
 
-void view_building_worker::cleanup_staging_sstables(locator::effective_replication_map_ptr erm, table_id table_id, locator::tablet_id tid) {
+future<> view_building_worker::cleanup_staging_sstables(locator::effective_replication_map_ptr erm, table_id table_id, locator::tablet_id tid) {
     auto& tablet_map = erm->get_token_metadata().tablets().get_tablet_map(table_id);
     auto tablet_range = tablet_map.get_token_range(tid);
 
+    // Remove entries from the shard-0 registration queue.
+    // Without this, a pending entry in `_sstables_to_register` would be moved into
+    // `_staging_sstables` by the registrator after cleanup deletes the tablet's storage,
+    // causing an infinite ENOENT retry loop (SCYLLADB-2312).
+    co_await container().invoke_on(0, [table_id, tablet_range] (view_building_worker& vbw0) -> future<> {
+        auto lock = co_await get_units(vbw0._staging_sstables_mutex, 1, vbw0._as);
+        auto it = vbw0._sstables_to_register.find(table_id);
+        if (it == vbw0._sstables_to_register.end()) {
+            co_return;
+        }
+        auto old_size = it->second.size();
+        std::erase_if(it->second, [&] (auto& info) {
+            return tablet_range.contains(info.last_token, dht::token_comparator());
+        });
+        if (old_size != it->second.size()) {
+            vbw_logger.info("cleanup_staging_sstables: removed {} entries from _sstables_to_register for table {}",
+                old_size - it->second.size(), table_id);
+        }
+    });
+
+    // Remove from local shard staging list.
+    auto lock = co_await get_units(_staging_sstables_mutex, 1, _as);
     auto [first, last] = std::ranges::remove_if(_staging_sstables[table_id], [&] (auto& sst) {
         auto sst_last_token = sst->get_last_decorated_key().token();
         return tablet_range.contains(sst_last_token, dht::token_comparator());

--- a/db/view/view_building_worker.hh
+++ b/db/view/view_building_worker.hh
@@ -159,7 +159,7 @@ public:
     // Used ONLY to load staging sstables migrated during intra-node tablet migration.
     void load_sstables(table_id table_id, std::vector<sstables::shared_sstable> ssts);
     // Used in cleanup/cleanup-target tablet transition stage
-    void cleanup_staging_sstables(locator::effective_replication_map_ptr erm, table_id table_id, locator::tablet_id tid);
+    future<> cleanup_staging_sstables(locator::effective_replication_map_ptr erm, table_id table_id, locator::tablet_id tid);
 
 private:
     future<view_building_state> get_latest_view_building_state(raft::term_t term);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5256,10 +5256,10 @@ future<> storage_service::cleanup_tablet(locator::global_tablet_id tablet) {
                 throw std::runtime_error(fmt::format("Tablet {} stage is not at cleanup/cleanup_target", tablet));
             }
         }
-        co_await _db.invoke_on(shard, [tablet, &sys_ks = _sys_ks, &vbw = _view_building_worker] (replica::database& db) {
+        co_await _db.invoke_on(shard, [tablet, &sys_ks = _sys_ks, &vbw = _view_building_worker] (replica::database& db) -> future<> {
             auto& table = db.find_column_family(tablet.table);
-            vbw.local().cleanup_staging_sstables(table.get_effective_replication_map(), tablet.table, tablet.tablet);
-            return table.cleanup_tablet(db, sys_ks.local(), tablet.tablet);
+            co_await vbw.local().cleanup_staging_sstables(table.get_effective_replication_map(), tablet.table, tablet.tablet);
+            co_await table.cleanup_tablet(db, sys_ks.local(), tablet.tablet);
         });
         co_return tablet_operation_result();
     });

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -1120,3 +1120,142 @@ async def test_coordinator_misses_cv_broadcast(manager: ManagerClient):
         await manager.api.disable_injection(servers[0].ip_addr, "view_building_coordinator_wait_before_await_event")
 
         await wait_for_view(cql, 'mv_cf_view', node_count)
+
+# Tablet migration cleanup races with view building worker staging SSTable handling,
+# causing infinite retry loop and stalled view builds.
+#
+# The race: when a staging sstable is in `_sstables_to_register` (pending group0 task creation),
+# `cleanup_staging_sstables()` (called by cleanup_tablet) doesn't remove it (only checks `_staging_sstables`).
+# After cleanup deletes the underlying files, the registrator moves the dangling reference into
+# `_staging_sstables` and creates a `process_staging` task. That task tries to link() the TOC file
+# which no longer exists, hitting ENOENT, and retries indefinitely.
+# Reproduces SCYLLADB-2312
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_staging_registration_race_with_tablet_migration(manager: ManagerClient):
+    node_count = 2
+    servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+    ])
+    cql, _ = await manager.get_ready_cql(servers)
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}} AND tablets = {{'initial': 1}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v int, PRIMARY KEY (key))")
+
+        # Populate the base table and build the MV to SUCCESS state
+        rows = 100
+        for i in range(rows):
+            await cql.run_async(f"INSERT INTO {ks}.tab (key, c, v) VALUES ({i}, {i}, 1)")
+
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv AS SELECT * FROM {ks}.tab "
+                        "WHERE key IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c, key) ")
+        await wait_for_view(cql, 'mv', node_count)
+
+        # Flush on node0
+        await manager.api.keyspace_flush(servers[0].ip_addr, ks, "tab")
+        await manager.api.keyspace_flush(servers[0].ip_addr, ks, "mv")
+
+        # Delete sstables on node0 and restart to lose data
+        await delete_table_sstables(manager, servers[0], ks, "tab")
+        await delete_table_sstables(manager, servers[0], ks, "mv")
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_start(servers[0].server_id)
+        await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30)
+
+        # Repair node0 with VUG injection to prevent processing of staging sstable.
+        # MV is SUCCESS, so repair uses `staging_directly_to_generator` path.
+        # The injection makes VUG fail to consume it, leaving it in staging on disk.
+        s0_log = await manager.server_open_log(servers[0].server_id)
+        s0_mark = await s0_log.mark()
+        await manager.api.enable_injection(servers[0].ip_addr, "view_update_generator_consume_staging_sstable", one_shot=False)
+        await manager.api.repair(servers[0].ip_addr, ks, "tab")
+        await s0_log.wait_for(f"Finished user-requested repair for tablet keyspace={ks}", from_mark=s0_mark, timeout=60)
+
+        # Add node2 and migrate tablet from node0 to node2.
+        # File streaming will transfer the staging sstable to node2 where it gets registered
+        # to VBW via register_staging_sstable_tasks() (stream_blob.cc handles staging state).
+        # But first, enable the registrator pause injection on node2 so it doesn't process
+        # the sstable before we trigger the second migration.
+        node2 = await manager.server_add(cmdline=cmdline_loggers, property_file={"dc": "dc1", "rack": "r1"}, config={
+            'error_injections_at_startup': ['view_building_worker_pause_before_starting_staging_registrator']
+        })
+
+        s0_host_id = await manager.get_host_id(servers[0].server_id)
+        n2_host_id = await manager.get_host_id(node2.server_id)
+        tablet_token = 0  # Doesn't matter since there is one tablet
+
+        async def get_replica_for_host(host_id):
+            replicas = await get_tablet_replicas(manager, servers[0], ks, "tab", tablet_token)
+            for r in replicas:
+                if r[0] == host_id:
+                    return r
+            return None
+
+        src_replica = await get_replica_for_host(s0_host_id)
+        assert src_replica is not None, "node0 is not a replica of the tablet"
+
+        n2_log = await manager.server_open_log(node2.server_id)
+        n2_mark = await n2_log.mark()
+
+        # First migration: node0 -> node2 (staging sstable arrives on node2 via file stream)
+        await manager.api.move_tablet(servers[0].ip_addr, ks, "tab",
+                                      src_replica[0], src_replica[1],
+                                      n2_host_id, 0, tablet_token)
+
+        # Second migration: node2 -> node3.
+        # cleanup_tablet on node2 calls cleanup_staging_sstables which only checks _staging_sstables.
+        # Since the sstable is still in _sstables_to_register, cleanup misses it.
+        # But table.cleanup_tablet removes the tablet's storage group (normal directory).
+        node3 = await manager.server_add(cmdline=cmdline_loggers, property_file={"dc": "dc1", "rack": "r1"})
+        n3_host_id = await manager.get_host_id(node3.server_id)
+
+        n2_replica = await get_replica_for_host(n2_host_id)
+        assert n2_replica is not None, "node2 is not a replica of the tablet"
+
+        await manager.api.move_tablet(servers[0].ip_addr, ks, "tab",
+                                      n2_replica[0], n2_replica[1],
+                                      n3_host_id, 0, tablet_token)
+
+        # Wait for cleanup to complete on node2
+        await n2_log.wait_for("Cleaned up tablet .* successfully", from_mark=n2_mark, timeout=60)
+
+        # Now unpause the registrator on node2.
+        # It will move the dangling sstable ref into _staging_sstables and create a process_staging task.
+        await manager.api.message_injection(node2.ip_addr, "view_building_worker_pause_before_starting_staging_registrator")
+        await manager.api.disable_injection(node2.ip_addr, "view_building_worker_pause_before_starting_staging_registrator")
+
+        # The process_staging task is stuck in infinite retry, so view building cannot
+        # complete. The task remains in system.view_building_tasks because the worker
+        # never reports completion to the coordinator.
+        async def all_view_building_tasks_finished():
+            tasks = await cql.run_async("SELECT * FROM system.view_building_tasks")
+            # Empty `view_building_tasks` table may contain single row with only static column set, so we need to filter it out
+            filtered = [t for t in tasks if t.id is not None]
+            if len(filtered) > 0:
+                return None
+            return True
+        await wait_for(all_view_building_tasks_finished, time.time() + 60)
+
+        # Wait for view update backlog to drain on node3 to avoid a race between the VBW
+        # task completing and the view updates being fully written to the MV replicas.
+        async def view_updates_drained():
+            metrics = await manager.metrics.query(node3.ip_addr)
+            backlog = metrics.get("scylla_database_view_update_backlog")
+            return True if (backlog is None or backlog == 0) else None
+        await wait_for(view_updates_drained, deadline=time.time() + 30)
+
+        n3_hosts = await wait_for_cql_and_get_hosts(cql, [node3], time.time() + 30)
+        s1_hosts = await wait_for_cql_and_get_hosts(cql, [servers[1]], time.time() + 30)
+
+        # Shut down servers[1] and verify node3's MV replica directly.
+        await manager.server_stop_gracefully(servers[1].server_id)
+        await assert_row_count_on_host(cql, n3_hosts[0], ks, "mv", rows)
+        await manager.server_start(servers[1].server_id)
+        await wait_for_cql_and_get_hosts(cql, [servers[1]], time.time() + 30)
+
+        # Shut down node3 and verify servers[1]'s MV replica directly.
+        await manager.server_stop_gracefully(node3.server_id)
+        await assert_row_count_on_host(cql, s1_hosts[0], ks, "mv", rows)
+        await manager.server_start(node3.server_id)
+        await wait_for_cql_and_get_hosts(cql, [node3], time.time() + 30)


### PR DESCRIPTION
db/view/view_building_worker: fix race between tablet cleanup and staging sstable registration
cleanup_staging_sstables() only purged the per-shard _staging_sstables
map but missed entries still pending in the shard-0 _sstables_to_register
queue. When a tablet migrated away while an sstable was queued for
registration, the following sequence caused an infinite retry loop:

1. File streaming registers staging sstable to _sstables_to_register
2. Tablet migrates away — cleanup_staging_sstables removes nothing
   (entry is in queue, not in _staging_sstables yet)
3. table::cleanup_tablet deletes the tablet's storage from disk
4. Registrator wakes up, commits process_staging task, moves the
   dangling sstable ref into _staging_sstables
5. Worker tries to link staging → normal, gets ENOENT, retries forever

Fix: make cleanup_staging_sstables async and have it also acquire the
shard-0 mutex to remove matching entries from _sstables_to_register
before cleaning the local _staging_sstables. This ensures the
registrator finds nothing to process after cleanup completes.

Fixes [SCYLLADB-2312](https://scylladb.atlassian.net/browse/SCYLLADB-2312)
Fixes SCYLLADB-2188

[SCYLLADB-2312]: https://scylladb.atlassian.net/browse/SCYLLADB-2312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This patch should be backported to all versions containing view building coordinator (2025.4 and newer).