### PR TITLE
types: optimize abstract_type layout and data_value with small-value optimization

### DIFF
--- a/types/set.hh
+++ b/types/set.hh
@@ -45,5 +45,5 @@ data_value make_set_value(data_type tuple_type, set_type_impl::native_type value
 
 template <typename NativeType>
 data_value::data_value(const std::unordered_set<NativeType>& v)
-    : data_value(new set_type_impl::native_type(v.begin(), v.end()), set_type_impl::get_instance(data_type_for<NativeType>(), true))
+    : data_value(external_tag{}, new set_type_impl::native_type(v.begin(), v.end()), set_type_impl::get_instance(data_type_for<NativeType>(), true))
 {}

--- a/types/types.cc
+++ b/types/types.cc
@@ -3530,7 +3530,7 @@ const std::type_info& abstract_type::native_typeid() const {
 }
 
 bytes abstract_type::decompose(const data_value& value) const {
-    if (!value._value) {
+    if (value.is_null()) {
         return {};
     }
     bytes b(bytes::initialized_later(), serialized_size(*this, value._value));
@@ -3553,20 +3553,20 @@ bool operator==(const data_value& x, const data_value& y) {
 }
 
 size_t data_value::serialized_size() const {
-    if (!_value) {
+    if (is_null()) {
         return 0;
     }
     return ::serialized_size(*_type, _value);
 }
 
 void data_value::serialize(bytes::iterator& out) const {
-    if (_value) {
+    if (!is_null()) {
         ::serialize(*_type, _value, out);
     }
 }
 
 bytes_opt data_value::serialize() const {
-    if (!_value) {
+    if (is_null()) {
         return std::nullopt;
     }
     bytes b(bytes::initialized_later(), serialized_size());
@@ -3576,7 +3576,7 @@ bytes_opt data_value::serialize() const {
 }
 
 bytes data_value::serialize_nonnull() const {
-    if (!_value) {
+    if (is_null()) {
         on_internal_error(tlogger, "serialize_nonnull called on null");
     }
     return std::move(*serialize());
@@ -3910,22 +3910,44 @@ data_type abstract_type::parse_type(const sstring& name)
 }
 
 data_value::~data_value() {
-    if (_value) {
+    // Only external (heap) values own a separate allocation; inline values hold
+    // only trivially-destructible natives and the null value owns nothing.
+    if (_value && !stored_internally()) {
         native_value_delete(*_type, _value);
     }
 }
 
-data_value::data_value(const data_value& v) : _value(nullptr), _type(v._type) {
-    if (v._value) {
+// Lock the layout: _value (8) + _internal (internal_storage_size, 24) + _type
+// (data_type, a 16-byte shared_ptr) = 48, no padding. internal_storage_size is
+// 24 (rather than 16) so the 16-byte natives stored as maybe_empty<T> (UUID,
+// timeuuid, cql_duration, which round up to 24) stay inline. Guard against a
+// silent size regression if any of these change.
+static_assert(sizeof(data_value) == 48);
+static_assert(alignof(data_value) == alignof(void*));
+
+data_value::data_value(const data_value& v) : _type(v._type) {
+    // Copy the inline buffer unconditionally: it always holds defined bytes
+    // (value-initialized), so this is branchless and harmless when v stored its
+    // value externally or is null. Then fix up _value: null stays null, an inline
+    // value points into our own buffer, and an external value is deep-cloned onto
+    // the heap (the inline copy above is unused in that case).
+    std::memcpy(static_cast<void*>(&_internal), static_cast<const void*>(&v._internal), internal_storage_size);
+    if (v._value == nullptr) {
+        _value = nullptr;
+    } else if (v.stored_internally()) {
+        // Inline storage holds only trivially-copyable natives.
+        _value = &_internal;
+    } else {
         _value = _type->native_value_clone(v._value);
     }
 }
 
 data_value&
 data_value::operator=(data_value&& x) noexcept {
-    auto tmp = std::move(x);
-    std::swap(tmp._value, this->_value);
-    std::swap(tmp._type, this->_type);
+    if (this != &x) {
+        this->~data_value();
+        new (this) data_value(std::move(x));
+    }
     return *this;
 }
 

--- a/types/types.hh
+++ b/types/types.hh
@@ -10,8 +10,12 @@
 
 #include <optional>
 #include <boost/functional/hash.hpp>
+#include <cstddef>
+#include <cstring>
 #include <iosfwd>
 #include <initializer_list>
+#include <new>
+#include <type_traits>
 #include <unordered_set>
 
 #include <seastar/core/sstring.hh>
@@ -31,6 +35,7 @@
 #include "utils/fragmented_temporary_buffer.hh"
 #include "utils/exceptions.hh"
 #include "utils/managed_bytes.hh"
+#include "utils/assert.hh"
 #include "utils/bit_cast.hh"
 #include "utils/chunked_vector.hh"
 #include "utils/lexicographical_compare.hh"
@@ -190,16 +195,83 @@ struct empty_type_representation {
 };
 
 class data_value {
-    void* _value;  // FIXME: use "small value optimization" for small types
-    data_type _type;
+public:
+    // Native values that are trivially copyable and trivially destructible and
+    // fit in this many bytes are stored inline, saving a heap allocation per
+    // value. This covers the common fixed-size scalars (bool, the integer and
+    // floating types, timestamps, UUID/timeuuid, duration). Larger or
+    // non-trivial natives (strings, bytes, collections, varint, decimal) stay
+    // on the heap.
+    static constexpr size_t internal_storage_size = 24;
+    static constexpr size_t internal_storage_align = alignof(void*);
 private:
-    data_value(void* value, data_type type) : _value(value), _type(std::move(type)) {}
+    // _value points at the stored native value, wherever it lives:
+    //   - nullptr           -> the null value (no stored native)
+    //   - &_internal        -> value stored inline in _internal
+    //   - any other pointer -> value stored on the heap (external)
+    // Keeping a single pointer (rather than a separate kind tag) makes _value
+    // branchless to read on the hot path; the inline-vs-external
+    // distinction is only needed on the cold copy/move/destroy paths, via
+    // stored_internally().
+    void* _value;
+    // Default-initialized so the inline buffer always holds defined bytes, even
+    // when the value lives on the heap (external) or is null and the buffer is
+    // unused. This lets the copy/move constructors memcpy it unconditionally
+    // (branchless, no indeterminate-byte reads for MemorySanitizer/Valgrind).
+    alignas(internal_storage_align) std::byte _internal[internal_storage_size]{};
+    data_type _type;
+
+    template <typename NativeType>
+    static constexpr bool fits_internal() {
+        return std::is_trivially_copyable_v<NativeType>
+                && std::is_trivially_destructible_v<NativeType>
+                && sizeof(NativeType) <= internal_storage_size
+                && alignof(NativeType) <= internal_storage_align;
+    }
+
+    // Whether the value is stored inline in _internal (as opposed to on the heap
+    // or being the null value).
+    bool stored_internally() const noexcept {
+        return _value == static_cast<const void*>(&_internal);
+    }
+
+    // Tag-dispatched private constructors, so there is no ambiguous void*-taking
+    // constructor where a null pointer silently means "the null value".
+    struct internal_tag {};
+    struct external_tag {};
+    struct null_tag {};
+    // _value points at _internal, but the native value is not constructed yet:
+    // the caller (make_from_native) must placement-construct it into _internal.
+    data_value(internal_tag, data_type type) noexcept
+        : _value(&_internal), _type(std::move(type)) {}
+    // Takes ownership of the heap-allocated native value `value` (must be non-null;
+    // a null value must use null_tag instead, so a null pointer here is a bug).
+    data_value(external_tag, void* value, data_type type) noexcept
+        : _value(value), _type(std::move(type)) { SCYLLA_ASSERT(value); }
+    data_value(null_tag, data_type type) noexcept
+        : _value(nullptr), _type(std::move(type)) {}
+
+    // make_new wraps a raw C++ value in maybe_empty<T> and forwards to make_from_native.
+    // make_from_native takes an already-wrapped native_type and decides inline vs heap.
     template <typename T>
     static data_value make_new(data_type type, T&& value);
+    // Constructs a data_value holding `value` (already a native_type), storing
+    // it inline when it is a small trivially-copyable type, otherwise on the heap.
+    template <typename NativeType>
+    static data_value make_from_native(data_type type, NativeType value);
+
+    template <typename NativeType, typename AbstractType> friend class concrete_type;
 public:
     ~data_value();
     data_value(const data_value&);
-    data_value(data_value&& x) noexcept : _value(x._value), _type(std::move(x._type)) {
+    data_value(data_value&& x) noexcept : _type(std::move(x._type)) {
+        // Copy the inline buffer unconditionally: it always holds defined bytes
+        // (value-initialized), so this is branchless and cheap, and harmless when
+        // x stored its value externally or is null. Then fix up _value: repoint
+        // it into our own buffer for an inline value, otherwise take x's pointer
+        // (external or null) as-is.
+        std::memcpy(static_cast<void*>(&_internal), static_cast<const void*>(&x._internal), internal_storage_size);
+        _value = x.stored_internally() ? &_internal : x._value;
         x._value = nullptr;
     }
     // common conversions from C++ types to database types
@@ -277,11 +349,14 @@ public:
     friend bool operator==(const data_value& x, const data_value& y);
     friend class abstract_type;
     static data_value make_null(data_type type) {
-        return data_value(nullptr, std::move(type));
+        return data_value(null_tag{}, std::move(type));
     }
+    // Low-level factory for non-trivial or oversized natives already heap-allocated
+    // by the caller. Inline-eligible types (trivially copyable/destructible, ≤24 B)
+    // never reach this path; they go through make_from_native's inline branch.
     template <typename T>
     static data_value make(data_type type, std::unique_ptr<T> value) {
-        return data_value(value.release(), std::move(type));
+        return data_value(external_tag{}, value.release(), std::move(type));
     }
     friend class empty_type_impl;
     template <typename T> friend const T& value_cast(const data_value&);
@@ -525,10 +600,31 @@ template <typename T>
 inline
 data_value
 data_value::make_new(data_type type, T&& v) {
-    maybe_empty<std::remove_reference_t<T>> value(std::forward<T>(v));
-    return data_value(type->native_value_clone(&value), type);
+    return make_from_native(std::move(type), maybe_empty<std::remove_reference_t<T>>(std::forward<T>(v)));
 }
 
+template <typename NativeType>
+inline
+data_value
+data_value::make_from_native(data_type type, NativeType value) {
+    if constexpr (fits_internal<NativeType>()) {
+        data_value dv(internal_tag{}, std::move(type));
+        ::new (static_cast<void*>(&dv._internal)) NativeType(std::move(value));
+        return dv;
+    } else {
+        // Non-trivial or oversized native (strings, bytes, collections, varint,
+        // decimal, …): heap-allocate as before. Inline-eligible types never
+        // reach this branch, so make() is heap-only.
+        return make(std::move(type), std::make_unique<NativeType>(std::move(value)));
+    }
+}
+
+// value_cast (and concrete_type::from_value) return a reference to the native
+// value stored inside the data_value. For inline (small-value-optimized) storage
+// that reference points into the data_value's own _internal buffer, and moving
+// the data_value repoints _value into the destination object. So a reference
+// obtained here must not be held across a move of the owning data_value: do not
+// move the owner while such a reference is live.
 template <typename T>
 const T& value_cast(const data_value& value) {
     return value_cast<T>(const_cast<data_value&&>(value));
@@ -563,11 +659,13 @@ public:
     using native_type = maybe_empty<NativeType>;
     using AbstractType::AbstractType;
 public:
+    // Used when the caller already holds a heap-allocated native (non-trivial types
+    // such as collections). Inline-eligible types use the by-value overload below.
     data_value make_value(std::unique_ptr<native_type> value) const {
         return data_value::make(this->shared_from_this(), std::move(value));
     }
     data_value make_value(native_type value) const {
-        return make_value(std::make_unique<native_type>(std::move(value)));
+        return data_value::make_from_native<native_type>(this->shared_from_this(), std::move(value));
     }
     data_value make_null() const {
         return data_value::make_null(this->shared_from_this());

--- a/types/types.hh
+++ b/types/types.hh
@@ -312,6 +312,10 @@ class user_type_impl;
 class abstract_type : public enable_shared_from_this<abstract_type> {
     sstring _name;
     std::optional<uint32_t> _value_length_if_fixed;
+    // Lazily computed by cql3_type_name(). Grouped here with the other large
+    // members so that _kind and the _contains_* bools below pack into a single
+    // trailing word, keeping sizeof(abstract_type) at one cache line (64 bytes).
+    mutable sstring _cql3_type_name;
 public:
     enum class kind : int8_t {
         ascii,
@@ -491,8 +495,6 @@ public:
     bool bound_value_needs_to_be_reserialized() const;
 
     friend class list_type_impl;
-private:
-    mutable sstring _cql3_type_name;
 protected:
     bool _contains_set_or_map = false;
     bool _contains_collection = false;


### PR DESCRIPTION
## Motivation

`data_value` is the C++ representation of a CQL native value. Every scalar value - bool, int, bigint, float, double, timestamp, UUID, timeuuid, duration - was heap-allocated via `std::unique_ptr<void>` on construction and freed on destruction.
This is wasteful for fixed-size types that are at most 24 bytes, since the allocation + pointer chase costs more than the value itself.
Additionally, `abstract_type` (the base of all CQL type descriptors) straddled two cache lines (72 bytes) due to suboptimal member ordering, 
and `user_type_impl` eagerly decoded all field names to UTF-8 strings even though that decoded form is only used on cold (DESCRIBE/JSON) paths.

## Changes

This PR contains two independent, stacked improvements:

1. **`types: pack abstract_type into a single cache line`** - Reorders members so that `sizeof(abstract_type)` shrinks from 72 → 64 bytes (one cache line).
   Pure declaration reorder, no behavioral change.


2. **`types: store small native values inline in data_value (SVO)`** - Adds a 24-byte inline buffer to `data_value`. Native values that are trivially copyable, trivially destructible, and ≤ 24 bytes are stored inline, saving one `new`/`delete` pair and one pointer indirection per value on the hot
   deserialize/make_value path. Non-trivial natives (strings, bytes, collections, varint, decimal) continue to use heap allocation.

   Storage is a single `void* _value`: `nullptr` means the NULL value, `&_internal` means the value is stored inline in the buffer, and any other pointer means it lives on the heap. This keeps `value_address()` branchless on the hot read path; the inline-vs-heap distinction is only needed on the cold copy/move/destroy paths (via `stored_internally()`).

   The 24-byte buffer (rather than 16) is deliberate: the 16-byte natives - UUID, timeuuid, cql_duration - are stored as `maybe_empty<T>`, whose leading emptiness flag plus alignment rounds them up to 24 bytes, so a 16-byte buffer would evict these common types back to the heap.

   This doubles `sizeof(data_value)` from 24 to 48 bytes - the trade-off is deliberate: larger inline footprint in exchange for eliminating allocation overhead per small value. A `static_assert` locks the 48-byte layout against silent regressions.

## Testing

- `boost/types_test` (66 cases): PASS
- `boost/user_types_test`: PASS
- `combined_tests` links and passes

## Benchmark Results

**`perf_simple_query`**, single P-core pinned at 2.2 GHz, `-c1`:

| | master | this PR | delta |
|---|---|---|---|
| **Median tps** | 147,747 | 147,243 | **-0.3%** |
| MAD | 821 (0.6%) | 884 (0.6%) | |
| Instructions/op | 32,195 | 32,058 | -0.4% |
| Cycles/op | 14,602 | 14,654 | +0.4% |

The read path (`perf_simple_query`) is **neutral** - it does not materialize native `data_value` objects, so the SVO savings do not manifest here. The benchmark confirms **no regression** on the read-hot path.

> Note: these figures were collected on an earlier revision of the SVO commit (union + `storage_kind` kind tag). The current revision uses the equivalent-size single-pointer layout described above. `sizeof(data_value)` is unchanged (48 bytes), so no change in conclusion is expected, but the table will be refreshed on a quiet machine.

The SVO benefit is expected on **write/parse paths** where `data_value` objects are constructed from CQL literals or deserialized into native form (INSERT, UPDATE, UDF evaluation, expression evaluation).
A targeted microbenchmark for `data_value` construction/destruction is planned as follow-up.

## Notes

- Backport: no (improvement, not a fix)
- AI-assisted: Yes
