### PR TITLE
fix: close readers in make_view_update_builder() on initialize() failure

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1614,7 +1614,16 @@ future<view_update_builder> make_view_update_builder(
         return view_updates(std::move(v), base);
     }) | std::ranges::to<std::vector<view_updates>>();
     auto builder = view_update_builder(std::move(db), base_table, base, std::move(vs), std::move(updates), std::move(existings), now);
-    co_await builder.initialize();
+    std::exception_ptr ep;
+    try {
+        co_await builder.initialize();
+    } catch (...) {
+        ep = std::current_exception();
+    }
+    if (ep) {
+        co_await builder.close();
+        std::rethrow_exception(ep);
+    }
     co_return builder;
 }
 


### PR DESCRIPTION
If view_update_builder::initialize() throws (e.g. due to permit timeout under I/O pressure), the coroutine frame is destroyed and the builder's default destructor runs. Since mutation_reader requires an explicit close() before destruction, ~mutation_reader() calls abort().

Add a try-catch around co_await builder.initialize() that calls builder.close() before rethrowing. This ensures readers are properly closed on all error paths.

Fixes: SCYLLADB-2325

**Please replace this line with justification for the backport/\* labels added to this PR**