### PR TITLE
test/pylib: fix race in server_stop for starting servers

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1304,9 +1304,9 @@ class ScyllaCluster:
             await handle_join_failure()
             raise
         finally:
-            # server_stop() may have already removed the starting server
-            # if it interrupted this add_server() operation.
-            self.starting.pop(server.server_id, None)
+            # add_server() is the sole owner of self.starting entries.
+            # server_stop() only kills the process without touching this dict.
+            del self.starting[server.server_id]
 
         if expected_error:
             await handle_join_failure()
@@ -1445,21 +1445,25 @@ class ScyllaCluster:
         self.is_dirty = True
         if server_id in self.running:
             server = self.running[server_id]
-        else:
-            server = self.starting[server_id]
-        # Remove the server from `running` only after we successfully stop it.
-        # Stopping may fail and if we removed it from `running` now it might leak.
-        if gracefully:
-            await server.stop_gracefully()
-        else:
-            await server.stop()
-        if server_id in self.running:
+            # Remove the server from `running` only after we successfully stop it.
+            # Stopping may fail and if we removed it from `running` now it might leak.
+            if gracefully:
+                await server.stop_gracefully()
+            else:
+                await server.stop()
             self.running.pop(server_id)
             self.stopped[server_id] = server
         else:
-            # Starting servers are removed from self.starting by add_server()
-            # in its cleanup path. This is a fallback if server_stop() wins the race.
-            self.starting.pop(server_id, None)
+            # Server is still being bootstrapped by add_server(). Only kill the
+            # process — don't manipulate self.starting. add_server() is the sole
+            # owner of self.starting entries: it will observe the process death,
+            # move the server to self.stopped via handle_join_failure(), and
+            # remove it from self.starting in its finally block.
+            server = self.starting[server_id]
+            if gracefully:
+                await server.stop_gracefully()
+            else:
+                await server.stop()
 
     def server_mark_removed(self, server_id: ServerNum) -> None:
         """Mark server as removed."""


### PR DESCRIPTION
server_stop() and add_server() both manipulated self.starting, causing a race condition: server_stop() would pop the entry from self.starting, and then add_server()'s finally block would try to delete the same entry, resulting in a KeyError (or, with the previous pop(..., None) bandaid, silently losing track of state).

The root cause is dual ownership of self.starting entries. Fix this by establishing clear ownership: add_server() is the sole owner of self.starting entries — it adds them on creation and removes them in its finally block. server_stop() for starting servers now only kills the process without touching self.starting. The add_server() coroutine observes the process death, moves the server to self.stopped via handle_join_failure(), and removes it from self.starting in its finally block.

This eliminates the race entirely rather than papering over it with defensive pop(..., None) calls.

Fixes: SCYLLADB-2314

Backporting to 2026.1 where it was found. Also to 2026.2