### PR TITLE
test: Prevent false negatives in test_start_scylla_with_view_building_disabled

### DIFF
--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -73,14 +73,14 @@ async def test_view_building_scheduling_group(manager: ManagerClient):
 
 # A sanity check test ensures that starting and shutting down Scylla when view building is
 # disabled is conducted properly and we don't run into any issues.
+@pytest.mark.check_nodes_for_errors
 async def test_start_scylla_with_view_building_disabled(manager: ManagerClient):
     server = await manager.server_add(config={"view_building": "false"})
+    # The test framework will make sure no errors have been reported.
+    # We could simply grep the logs of the node, searching for "ERROR".
+    # However, some errors are expected and they could make the test flaky.
+    # That already happened in SCYLLA-2317.
     await manager.server_stop_gracefully(server_id=server.server_id)
-
-    # Make sure there have been no errors.
-    log = await manager.server_open_log(server.server_id)
-    res = await log.grep(r"ERROR.*\[shard [0-9]+:[a-z]+\]")
-    assert len(res) == 0
 
 # While view building is in progress, drop the index (which changes the schema
 # of the base table). The state of the view table corresponding to the index

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -29,6 +29,7 @@ markers =
     prepare_3_nodes_cluster: prepare 3 nodes cluster for test case based on suite.yaml (all tests from old topology folder)
     prepare_3_racks_cluster: prepare 3 nodes cluster in 1 dc and 3 racks for test case based on suite.yaml
     single_node: test that are mark like this, should be using only one node, and should boot much quicker (dtest only)
+    check_nodes_for_errors: when set, take into account all produced errors, not just critical ones
     exclude_errors: do not consider a logging message as an error if it contains any of the specified strings (dtest only)
     cluster_options: specify cluster options used to initialize a cluster (dtest only)
     perf: mark for performance tests, these tests will automatically apply non_gating marker


### PR DESCRIPTION
The previous form of the test was essentially flaky. Some errors are expected and the test framework explicitly filters them out (cf. ManagerClient::filter_errors). A simple grep doesn't do that, and so we ran into a false negative in SCYLLADB-2317.

Fix this by removing the grep. The test framework should detect any anomaly and report them automatically.

Fixes: SCYLLADB-2317

Backport: We should backport the fix to all supported branches to prevent more CI failures.