### PR TITLE
Move group0 initialization before non system keyspaces instatiation

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2088,6 +2088,52 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 throw std::runtime_error("Detected a tablet with invalid replica shard, reducing shard count with tablet-enabled tables is not yet supported. Replace the node instead.");
             }
 
+            checkpoint(stop_signal, "starting CDC Generation Management service");
+            cdc::generation_service::config cdc_config;
+            cdc_config.ring_delay = std::chrono::milliseconds(cfg->ring_delay_ms());
+            cdc_generation_service.start(std::move(cdc_config), std::ref(sys_ks), std::ref(db)).get();
+            auto stop_cdc_generation_service = defer_verbose_shutdown("CDC Generation Management service", [] {
+                cdc_generation_service.stop().get();
+            });
+
+            utils::get_local_injector().inject("stop_after_starting_cdc_generation_service",
+                [] { std::raise(SIGSTOP); });
+
+            checkpoint(stop_signal, "starting group 0 service");
+            group0_service.start().get();
+            auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
+                sl_controller.local().abort_group0_operations();
+                group0_service.abort_and_drain().get();
+                group0_service.destroy();
+            });
+
+            utils::get_local_injector().inject("stop_after_starting_group0_service",
+                [] { std::raise(SIGSTOP); });
+
+            // Set up group0 service since it is needed by group0 setup just below
+            ss.local().set_group0(group0_service);
+
+            // Load address_map from system.peers and subscribe to gossiper events to keep it updated.
+            ss.local().init_address_map(gossip_address_map.local()).get();
+            auto cancel_address_map_subscription = defer_verbose_shutdown("storage service uninit address map", [&ss] {
+                ss.local().uninit_address_map().get();
+            });
+
+            // Need to make sure storage service stopped using group0 before running group0_service.abort()
+            // Normally it is done in storage_service::do_drain(), but in case start up fail we need to do it
+            // here as well
+            auto stop_group0_usage_in_storage_service = defer_verbose_shutdown("group 0 usage in local storage", [&ss] {
+               ss.local().wait_for_group0_stop().get();
+            });
+
+            if (!group0_service.maintenance_mode() && sys_ks.local().bootstrap_complete()) {
+                // Start group0 raft server early so that its log is replayed and
+                // mutations are applied to system tables before non-system keyspaces
+                // are loaded. The in-memory state machine is enabled later, after
+                // all its dependencies are initialized.
+                group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local()).get();
+            }
+
             checkpoint(stop_signal, "loading non-system sstables");
             replica::distributed_loader::init_non_system_keyspaces(db, proxy, sys_ks).get();
 
@@ -2177,17 +2223,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     return lifecycle_notifier.local().unregister_subscriber(&local_proxy);
                 }).get();
             });
-
-            checkpoint(stop_signal, "starting CDC Generation Management service");
-            cdc::generation_service::config cdc_config;
-            cdc_config.ring_delay = std::chrono::milliseconds(cfg->ring_delay_ms());
-            cdc_generation_service.start(std::move(cdc_config), std::ref(sys_ks), std::ref(db)).get();
-            auto stop_cdc_generation_service = defer_verbose_shutdown("CDC Generation Management service", [] {
-                cdc_generation_service.stop().get();
-            });
-
-            utils::get_local_injector().inject("stop_after_starting_cdc_generation_service",
-                [] { std::raise(SIGSTOP); });
 
             auto get_cdc_metadata = [] (cdc::generation_service& svc) { return std::ref(svc.get_cdc_metadata()); };
 
@@ -2343,42 +2378,14 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
              */
             db.local().enable_autocompaction_toggle();
 
-            checkpoint(stop_signal, "starting group 0 service");
-            group0_service.start().get();
-            auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
-                sl_controller.local().abort_group0_operations();
-                group0_service.abort_and_drain().get();
-                group0_service.destroy();
-            });
-
-            utils::get_local_injector().inject("stop_after_starting_group0_service",
-                [] { std::raise(SIGSTOP); });
-
-            // Set up group0 service earlier since it is needed by group0 setup just below
-            ss.local().set_group0(group0_service);
-
-            // Load address_map from system.peers and subscribe to gossiper events to keep it updated.
-            ss.local().init_address_map(gossip_address_map.local()).get();
-            auto cancel_address_map_subscription = defer_verbose_shutdown("storage service uninit address map", [&ss] {
-                ss.local().uninit_address_map().get();
-            });
-
-            // Need to make sure storage service stopped using group0 before running group0_service.abort()
-            // Normally it is done in storage_service::do_drain(), but in case start up fail we need to do it
-            // here as well
-            auto stop_group0_usage_in_storage_service = defer_verbose_shutdown("group 0 usage in local storage", [&ss] {
-               ss.local().wait_for_group0_stop().get();
-            });
-
-            if (!group0_service.maintenance_mode() && sys_ks.local().bootstrap_complete()) {
-                // Setup group0 early in case the node is bootstrapped already and the group exists.
-                // Need to do it before allowing incoming messaging service connections since
-                // storage proxy's and migration manager's verbs may access group0.
-                group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local()).get();
+            if (!group0_service.maintenance_mode() && sys_ks.local().bootstrap_complete() && group0_service.joined_group0()) {
+                // Enable the in-memory state machine now that non-system keyspaces
+                // are loaded — reload_state() reads tablet metadata and view building
+                // state which reference user table schemas.
                 group0_service.enable_group0_state_machine().get();
             }
 
-            // The call to setup_group0_if_exists() above guarantees that, if group0 is
+            // The call to enable_group0_state_machine() above guarantees that, if group0 is
             // created and started, the locally persisted group0 state has been applied
             // before it returns. As a result, tablet Raft groups are started using
             // tablet metadata that is at least as recent as the locally persisted version.

--- a/main.cc
+++ b/main.cc
@@ -2375,6 +2375,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 // Need to do it before allowing incoming messaging service connections since
                 // storage proxy's and migration manager's verbs may access group0.
                 group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local()).get();
+                group0_service.enable_group0_state_machine().get();
             }
 
             // The call to setup_group0_if_exists() above guarantees that, if group0 is

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -453,13 +453,12 @@ future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service:
     auto& persistence = srv_for_group0.persistence;
     auto& server = *srv_for_group0.server;
     co_await with_scheduling_group(_sg, [this, &srv_for_group0, group0_id] (this auto self) -> future<> {
-        auto& state_machine = dynamic_cast<group0_state_machine&>(srv_for_group0.state_machine);
+        _group0_sm = &dynamic_cast<group0_state_machine&>(srv_for_group0.state_machine);
         co_await _raft_gr.start_server_for_group(std::move(srv_for_group0));
         // Set _group0 immediately after the server is registered in _raft_gr._servers.
         // This ensures abort_and_drain()/destroy() can find and clean up the server
-        // even if enable_in_memory_state_machine() or later steps throw.
+        // even if enable_group0_state_machine() or later steps throw.
         _group0.emplace<raft::group_id>(group0_id);
-        co_await state_machine.enable_in_memory_state_machine();
     });
 
     // Fix for scylladb/scylladb#16683:
@@ -476,6 +475,11 @@ future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service:
             group0_log.warn("Could not create new snapshot, there are no entries applied");
         }
     }
+}
+
+future<> raft_group0::enable_group0_state_machine() {
+    SCYLLA_ASSERT(_group0_sm);
+    co_await _group0_sm->enable_in_memory_state_machine();
 }
 
 future<> raft_group0::leadership_monitor_fiber() {
@@ -517,7 +521,9 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, shared_p
     auto group0_id = raft::group_id{co_await sys_ks.get_raft_group0_id()};
     if (group0_id) {
         // Group 0 ID present means we've already joined group 0 before.
-        co_return co_await start_server_for_group0(group0_id, ss, qp, mm);
+        co_await start_server_for_group0(group0_id, ss, qp, mm);
+        co_await enable_group0_state_machine();
+        co_return;
     }
 
     raft::server* server = nullptr;
@@ -586,6 +592,7 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, shared_p
                 [] { std::raise(SIGSTOP); });
 
             co_await start_server_for_group0(group0_id, ss, qp, mm);
+            co_await enable_group0_state_machine();
             server = &_raft_gr.group0();
             // FIXME if we crash now or after getting added to the config but before storing group 0 ID,
             // we'll end with a bootstrapped server that possibly added some entries, but we won't remember that we have such a server

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -27,6 +27,7 @@ namespace service {
 extern const char* const raft_upgrade_doc;
 
 class migration_manager;
+class group0_state_machine;
 class raft_group0_client;
 class storage_service;
 
@@ -105,6 +106,7 @@ class raft_group0 {
     gms::feature_service& _feat;
     raft_group0_client& _client;
     seastar::scheduling_group _sg;
+    group0_state_machine* _group0_sm = nullptr;
 
     // Status of leader discovery. Initially there is no group 0,
     // and the variant contains no state. During initial cluster
@@ -197,6 +199,14 @@ public:
     // Cannot be called twice.
     //
     future<> setup_group0_if_exist(db::system_keyspace&, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm);
+
+    // Enable the in-memory state machine for group 0.
+    // This loads the persisted state (topology, schema, etc.) into memory.
+    // Must be called after all dependencies of reload_state() are initialized
+    // (e.g. CDC generation service, non-system keyspace schemas).
+    //
+    // Precondition: joined_group0().
+    future<> enable_group0_state_machine();
 
     // Check whether the given Raft server is a member of group 0 configuration
     // according to our current knowledge.

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1127,6 +1127,7 @@ private:
 
             if (!group0_service.maintenance_mode() && _sys_ks.local().bootstrap_complete()) {
                 group0_service.setup_group0_if_exist(_sys_ks.local(), _ss.local(), _qp.local(), _mm.local()).get();
+                group0_service.enable_group0_state_machine().get();
             }
             _groups_manager.invoke_on_all([](service::strong_consistency::groups_manager& m) {
                 return m.start();


### PR DESCRIPTION
Non system schema instantiation in `replica::distributed_loader::init_non_system_keyspaces` access tablets managed by group0, but a node may have crashed in the middle of raft command application and those tables may be inconsistent (there is no atomicity guaranty while a command is been applied. Fix that by moving existing group0 initialization before the call to `replica::distributed_loader::init_non_system_keyspaces`. The in memory state machine enablement stays in the same place since loading of a state machine into memory depends on schema already be instantiated into memory.

No need to backport since this does not fix any known bug. In fact migration manager (the component that group0 state machine uses to manage schema tables) is careful to make sure all schema mutations are in the same commitlog segment, so they will be seen as applied atomically, but the bug may happen with dependencies between schema and other components managed by group0 like topology. 