### PR TITLE
utils/histogram: remove write-only per-sample circular buffer

### DIFF
--- a/utils/histogram.hh
+++ b/utils/histogram.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <boost/circular_buffer.hpp>
 #include "latency.hh"
 #include <cmath>
 #include <seastar/core/timer.hh>
@@ -74,11 +73,12 @@ public:
     double mean;
     double variance;
     int64_t sample_mask;
-    boost::circular_buffer<int64_t> sample;
-    basic_ihistogram(size_t size = 1024, int64_t _sample_mask = 0x80)
+    // The `size` parameter is retained for source compatibility with existing
+    // call sites; it previously sized a per-sample circular buffer that was
+    // never read and has been removed to save memory.
+    basic_ihistogram([[maybe_unused]] size_t size = 1024, int64_t _sample_mask = 0x80)
             : count(0), total(0), min(0), max(0), sum(0), started(0), mean(0), variance(0),
-              sample_mask(_sample_mask), sample(
-                    size) {
+              sample_mask(_sample_mask) {
     }
 
     template <typename Rep, typename Ratio>
@@ -103,7 +103,6 @@ public:
         sum += value;
         total++;
         count++;
-        sample.push_back(value);
     }
 
     void mark(latency_counter& lc) {
@@ -177,9 +176,6 @@ public:
             mean = m;
             count += o.count;
             total += o.total;
-            for (auto i : o.sample) {
-                sample.push_back(i);
-            }
         }
         return *this;
     }


### PR DESCRIPTION
## What

`basic_ihistogram` (`utils/histogram.hh`) embedded a `boost::circular_buffer<int64_t> sample`. Tracing every reference in the tree shows it is **only ever written** — `push_back` in `mark()` and copied in `operator+=` — and **never read** to produce any metric, percentile, or API output. Percentile/summary output comes separately from `summary_calculator`'s `time_estimated_histogram`. The buffer was dead memory.

## Why it matters

`table_stats` (`replica/database.hh`) is allocated **per-table × per-shard** and holds seven `ihistogram` instances:

- 5 × capacity 256 (`reads`, `writes`, `cas_prepare`, `cas_accept`, `cas_learn`)
- 2 × default capacity 1024 (`tombstone_scanned`, `live_scanned`)

That is `5*256 + 2*1024 = 3328` int64 entries ≈ **26 KB of heap per table per shard**, entirely unused. On a node with many tables across many shards this adds up to hundreds of MB.

## Change

- Remove the `sample` member and its two writers.
- Drop the now-unused `<boost/circular_buffer.hpp>` include.
- Keep the constructor's `size` parameter (marked `[[maybe_unused]]`) so the many call sites passing an explicit size are unaffected.

No functional change: the removed data was never observed.

## Testing

`summary_test` and `estimated_histogram_test` objects compile cleanly against the change.