### PR TITLE
alternator: gate tablet stream CDC options for upgrade safety

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -36,6 +36,7 @@
 #include "cql3/result_set.hh"
 #include "bytes.hh"
 #include "service/pager/query_pagers.hh"
+#include <algorithm>
 #include <functional>
 #include "error.hh"
 #include "serialization.hh"
@@ -182,6 +183,9 @@ void executor::maybe_audit(
 
 static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type,
         const std::map<sstring, sstring>& tags_map, const gms::feature_service& feat, const db::tablets_mode_t::mode tablets_mode);
+
+static std::optional<unsigned> get_initial_tablet_count(const std::map<sstring, sstring>& tags_map,
+    const gms::feature_service& feat, const db::tablets_mode_t::mode tablets_mode);
 
 static const column_definition& attrs_column(const schema& schema) {
     const column_definition* cdef = schema.get_column_definition(bytes(executor::ATTRS_COLUMN_NAME));
@@ -1313,25 +1317,30 @@ static future<> mark_view_schemas_as_built(utils::chunked_vector<mutation>& out,
     }
 }
 
-// When Alternator Streams are requested on a tablet table, convert the
-// already-configured enabled=true CDC options into a deferred state:
+// When Alternator Streams are requested on a tablet table, update the
+// already-configured enabled=true CDC options:
+// - tablet_merge_blocked=true: suppress tablet merges that would produce
+//   2-parent shards incompatible with the DynamoDB Streams API
+//
+// If defer_enablement is true, also convert the options into a deferred state:
 // - enabled=false: don't create the CDC log table yet
 // - enable_requested=true: persist the user's intent for the topology
 //   coordinator to finalize later
-// - tablet_merge_blocked=true: suppress tablet merges that would produce
-//   2-parent shards incompatible with the DynamoDB Streams API
-// The topology coordinator will finalize enablement once all pending merges
-// complete (see maybe_finalize_pending_stream_enables in cdc/generation.cc).
+//
+// The topology coordinator will finalize deferred enablement once all pending
+// merges complete (see maybe_finalize_pending_stream_enables in cdc/generation.cc).
 //
 // Callers must ensure the builder already has CDC options with enabled=true.
-static void defer_enabling_streams_block_tablet_merges(schema_builder& builder) {
+static void block_tablet_merges_for_alternator_streams(schema_builder& builder, bool defer_enablement) {
     auto& exts = builder.get_extensions();
     auto ext = get_schema_extension<cdc::cdc_extension>(exts, cdc::cdc_extension::NAME);
     throwing_assert(ext);
     auto opts = ext->get_options();
     throwing_assert(opts.enabled());
-    opts.enabled(false);
-    opts.enable_requested(true);
+    if (defer_enablement) {
+        opts.enabled(false);
+        opts.enable_requested(true);
+    }
     opts.tablet_merge_blocked(true);
     builder.with_cdc_options(opts);
 }
@@ -1671,8 +1680,10 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
     }
 
     rjson::value* stream_specification = rjson::find(request, "StreamSpecification");
+    bool stream_enabled = false;
     if (stream_specification && stream_specification->IsObject()) {
         if (executor::add_stream_options(*stream_specification, builder, _proxy)) {
+            stream_enabled = true;
             validate_cdc_log_name_length(builder.cf_name());
         }
     }
@@ -1692,6 +1703,18 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
     builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>(tags_map));
 
     co_await verify_create_permission(enforce_authorization, warn_authorization, client_state, _stats);
+
+    if (stream_enabled) {
+        const bool uses_tablets = get_initial_tablet_count(tags_map, _proxy.features(), tablets_mode).has_value();
+        if (uses_tablets) {
+            if (!_proxy.features().cdc_block_tablet_merges_for_alternator_streams) {
+                co_return api_error::validation(
+                        "Alternator Streams on tablet tables are not supported until all nodes in the cluster "
+                        "support blocking tablet merges for Alternator Streams");
+            }
+            block_tablet_merges_for_alternator_streams(builder, /*defer_enablement=*/false);
+        }
+    }
 
     schema_ptr schema = builder.build();
     for (auto& view_builder : view_builders) {
@@ -1920,11 +1943,14 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                 empty_request = false;
                 if (add_stream_options(*stream_specification, builder, p.local(), tab->cdc_options())) {
                     validate_cdc_log_name_length(builder.cf_name());
-                    // On tablet tables, defer stream enablement and block
-                    // tablet merges (see defer_enabling_streams_block_tablet_merges).
                     bool uses_tablets = p.local().local_db().find_keyspace(tab->ks_name()).get_replication_strategy().uses_tablets();
                     if (uses_tablets) {
-                        defer_enabling_streams_block_tablet_merges(builder);
+                        if (!p.local().features().cdc_block_tablet_merges_for_alternator_streams) {
+                            co_return api_error::validation(
+                                    "Alternator Streams on tablet tables are not supported until all nodes in the cluster "
+                                    "support blocking tablet merges for Alternator Streams");
+                        }
+                        block_tablet_merges_for_alternator_streams(builder, /*defer_enablement=*/true);
                     }
                 }
                 auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
@@ -4519,14 +4545,8 @@ future<executor::request_return_type> executor::describe_continuous_backups(clie
     co_return rjson::print(std::move(response));
 }
 
-// Create the metadata for the keyspace in which we put the alternator
-// table if it doesn't already exist.
-// Currently, we automatically configure the keyspace based on the number
-// of nodes in the cluster: A cluster with 3 or more live nodes, gets RF=3.
-// A smaller cluster (presumably, a test only), gets RF=1. The user may
-// manually create the keyspace to override this predefined behavior.
-static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type ts,
-            const std::map<sstring, sstring>& tags_map, const gms::feature_service& feat, const db::tablets_mode_t::mode tablets_mode) {
+static std::optional<unsigned> get_initial_tablet_count(const std::map<sstring, sstring>& tags_map,
+        const gms::feature_service& feat, const db::tablets_mode_t::mode tablets_mode) {
     // Whether to use tablets for the table (actually for the keyspace of the
     // table) is determined by tablets_mode (taken from the configuration
     // option "tablets_mode_for_new_keyspaces"), as well as the presence and
@@ -4537,31 +4557,50 @@ static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_vie
     // an automatic selection of the best number of tablets).
     // Setting this tag to any non-numeric value (e.g., an empty string or the
     // word "none") will ask to disable tablets.
-    // When vnodes are asked for by the tag value, but tablets are enforced by config,
-    // throw an exception to the client.
-    std::optional<unsigned> initial_tablets;
+    if (!feat.tablets) {
+        return std::nullopt;
+    }
+    auto it = tags_map.find(INITIAL_TABLETS_TAG_KEY);
+    if (it != tags_map.end()) {
+        // Tag set. If it's a valid number, use it. If not - e.g., it's
+        // empty or a word like "none", disable tablets by setting
+        // initial_tablets to a disengaged optional.
+        try {
+            auto value = std::stol(it->second);
+            return static_cast<unsigned>(std::max(0L, value));
+        } catch (...) {
+            return std::nullopt;
+        }
+    }
+    else if (tablets_mode == db::tablets_mode_t::mode::enabled || tablets_mode == db::tablets_mode_t::mode::enforced) {
+        return 0;
+    }
+    return std::nullopt;
+}
+
+// Create the metadata for the keyspace in which we put the alternator
+// table if it doesn't already exist.
+// Currently, we automatically configure the keyspace based on the number
+// of nodes in the cluster: A cluster with 3 or more live nodes, gets RF=3.
+// A smaller cluster (presumably, a test only), gets RF=1. The user may
+// manually create the keyspace to override this predefined behavior.
+static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type ts,
+            const std::map<sstring, sstring>& tags_map, const gms::feature_service& feat, const db::tablets_mode_t::mode tablets_mode) {
+    auto initial_tablets = get_initial_tablet_count(tags_map, feat, tablets_mode);
     if (feat.tablets) {
-        auto it = tags_map.find(INITIAL_TABLETS_TAG_KEY);
-        if (it != tags_map.end()) {
-            // Tag set. If it's a valid number, use it. If not - e.g., it's
-            // empty or a word like "none", disable tablets by setting
-            // initial_tablets to a disengaged optional.
-            try {
-                initial_tablets = std::stol(tags_map.at(INITIAL_TABLETS_TAG_KEY));
-            } catch (...) {
+        if (tags_map.contains(INITIAL_TABLETS_TAG_KEY)) {
+            if (!initial_tablets) {
                 if (tablets_mode == db::tablets_mode_t::mode::enforced) {
+                    // When vnodes are asked for by the tag value, but tablets are enforced by config, throw an exception to the client.
                     throw api_error::validation(format("Tag {} containing non-numerical value requests vnodes, but vnodes are forbidden by configuration option `tablets_mode_for_new_keyspaces: enforced`", INITIAL_TABLETS_TAG_KEY));
                 }
-                initial_tablets = std::nullopt;
                 elogger.trace("Following {} tag containing non-numerical value, Alternator will attempt to create a keyspace {} with vnodes.", INITIAL_TABLETS_TAG_KEY, keyspace_name);
             }
         } else {
             // No per-table tag present, use the value from config
-            if (tablets_mode == db::tablets_mode_t::mode::enabled || tablets_mode == db::tablets_mode_t::mode::enforced) {
-                initial_tablets = 0;
+            if (initial_tablets) {
                 elogger.trace("Following the `tablets_mode_for_new_keyspaces` flag from the settings, Alternator will attempt to create a keyspace {} with tablets.", keyspace_name);
             } else {
-                initial_tablets = std::nullopt;
                 elogger.trace("Following the `tablets_mode_for_new_keyspaces` flag from the settings, Alternator will attempt to create a keyspace {} with vnodes.", keyspace_name);
             }
         }

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1326,9 +1326,9 @@ static future<> mark_view_schemas_as_built(utils::chunked_vector<mutation>& out,
 // Callers must ensure the builder already has CDC options with enabled=true.
 static void defer_enabling_streams_block_tablet_merges(schema_builder& builder) {
     auto& exts = builder.get_extensions();
-    auto it = exts.find(cdc::cdc_extension::NAME);
-    throwing_assert(it != exts.end());
-    auto opts = dynamic_pointer_cast<cdc::cdc_extension>(it->second)->get_options();
+    auto ext = get_schema_extension<cdc::cdc_extension>(exts, cdc::cdc_extension::NAME);
+    throwing_assert(ext);
+    auto opts = ext->get_options();
     throwing_assert(opts.enabled());
     opts.enabled(false);
     opts.enable_requested(true);

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1519,7 +1519,6 @@ bool executor::add_stream_options(const rjson::value& stream_specification, sche
     if (stream_enabled->GetBool()) {
         cdc::options opts;
         opts.enabled(true);
-        opts.tablet_merge_blocked(true);
         // cdc::delta_mode is ignored by Alternator, so aim for the least overhead.
         opts.set_delta_mode(cdc::delta_mode::keys);
         opts.ttl(std::chrono::duration_cast<std::chrono::seconds>(dynamodb_streams_max_window).count());

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -32,6 +32,7 @@
 #include "cdc/cdc_options.hh"
 #include "cdc/generation_service.hh"
 #include "cdc/log.hh"
+#include "gms/feature_service.hh"
 #include "service/migration_listener.hh"
 
 extern logging::logger cdc_log;
@@ -782,8 +783,9 @@ future<> generation_service::garbage_collect_cdc_streams(utils::chunked_vector<c
 
 future<utils::chunked_vector<canonical_mutation>> generation_service::maybe_finalize_pending_stream_enables(const locator::token_metadata& tm, api::timestamp_type ts) {
     utils::chunked_vector<canonical_mutation> muts;
+    const bool tablet_merge_block_feature = _db.features().cdc_block_tablet_merges_for_alternator_streams;
 
-    if (utils::get_local_injector().enter("delay_cdc_stream_finalization")) {
+    if (tablet_merge_block_feature && utils::get_local_injector().enter("delay_cdc_stream_finalization")) {
         co_return std::move(muts);
     }
 
@@ -796,6 +798,12 @@ future<utils::chunked_vector<canonical_mutation>> generation_service::maybe_fina
         // Only tablet tables can have enable_requested set
         if (!tm.tablets().has_tablet_map(id)) {
             co_return;
+        }
+
+        if (!tablet_merge_block_feature) {
+            on_internal_error(cdc_log, format(
+                    "Table {}.{} has pending Alternator Streams enablement before feature CDC_BLOCK_TABLET_MERGES_FOR_ALTERNATOR_STREAMS is cluster-enabled",
+                    s->ks_name(), s->cf_name()));
         }
 
         auto& tmap = tm.tablets().get_tablet_map(id);

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -485,15 +485,24 @@ std::map<sstring, sstring> cdc::options::to_map() const {
         return {};
     }
 
-    return {
+    std::map<sstring, sstring> ret = {
         { "enabled", enabled() ? "true" : "false" },
         { "preimage", fmt::format("{}", _preimage) },
         { "postimage", _postimage ? "true" : "false" },
         { "delta", fmt::format("{}", _delta_mode) },
         { "ttl", std::to_string(_ttl) },
-        { "enable_requested", enable_requested() ? "true" : "false" },
-        { "tablet_merge_blocked", _tablet_merge_blocked ? "true" : "false" },
     };
+    // enable_requested and tablet_merge_blocked are set to true only by feature-gated code.
+    // This feature is CDC_BLOCK_TABLET_MERGES_FOR_ALTERNATOR_STREAMS.
+    // Since absence decodes as false and older nodes throw on unknown CDC option names
+    // regardless of their values, we keep false values absent from the serialized map.
+    if (enable_requested()) {
+        ret.emplace("enable_requested", "true");
+    }
+    if (_tablet_merge_blocked) {
+        ret.emplace("tablet_merge_blocked", "true");
+    }
+    return ret;
 }
 
 sstring cdc::options::to_sstring() const {

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -426,8 +426,8 @@ std::pair<schema_ptr, std::vector<view_ptr>> alter_table_statement::prepare_sche
                 throw exceptions::invalid_request_exception("Cannot set default_time_to_live on a table with counters");
             }
 
-            if (auto it = schema_extensions.find(cdc::cdc_extension::NAME); it != schema_extensions.end()) {
-                const auto& cdc_opts = dynamic_pointer_cast<cdc::cdc_extension>(it->second)->get_options();
+            if (auto cdc_ext = get_schema_extension<cdc::cdc_extension>(schema_extensions, cdc::cdc_extension::NAME)) {
+                const auto& cdc_opts = cdc_ext->get_options();
                 if (!cdc_opts.is_enabled_set()) {
                     // "enabled" flag not specified
                     throw exceptions::invalid_request_exception("Altering CDC options requires specifying \"enabled\" flag");

--- a/cql3/statements/cf_prop_defs.cc
+++ b/cql3/statements/cf_prop_defs.cc
@@ -279,33 +279,18 @@ std::optional<caching_options> cf_prop_defs::get_caching_options() const {
 }
 
 const cdc::options* cf_prop_defs::get_cdc_options(const schema::extensions_map& schema_exts) const {
-    auto it = schema_exts.find(cdc::cdc_extension::NAME);
-    if (it == schema_exts.end()) {
-        return nullptr;
-    }
-
-    auto cdc_ext = dynamic_pointer_cast<cdc::cdc_extension>(it->second);
-    return &cdc_ext->get_options();
+    auto ext = get_schema_extension<cdc::cdc_extension>(schema_exts, cdc::cdc_extension::NAME);
+    return ext ? &ext->get_options() : nullptr;
 }
 
 const tombstone_gc_options* cf_prop_defs::get_tombstone_gc_options(const schema::extensions_map& schema_exts) const {
-    auto it = schema_exts.find(tombstone_gc_extension::NAME);
-    if (it == schema_exts.end()) {
-        return nullptr;
-    }
-
-    auto ext = dynamic_pointer_cast<tombstone_gc_extension>(it->second);
-    return &ext->get_options();
+    auto ext = get_schema_extension<tombstone_gc_extension>(schema_exts, tombstone_gc_extension::NAME);
+    return ext ? &ext->get_options() : nullptr;
 }
 
 const db::per_partition_rate_limit_options* cf_prop_defs::get_per_partition_rate_limit_options(const schema::extensions_map& schema_exts) const {
-    auto it = schema_exts.find(db::per_partition_rate_limit_extension::NAME);
-    if (it == schema_exts.end()) {
-        return nullptr;
-    }
-
-    auto ext = dynamic_pointer_cast<db::per_partition_rate_limit_extension>(it->second);
-    return &ext->get_options();
+    auto ext = get_schema_extension<db::per_partition_rate_limit_extension>(schema_exts, db::per_partition_rate_limit_extension::NAME);
+    return ext ? &ext->get_options() : nullptr;
 }
 
 std::optional<db::tablet_options::map_type> cf_prop_defs::get_tablet_options() const {

--- a/db/tags/utils.cc
+++ b/db/tags/utils.cc
@@ -11,7 +11,6 @@
 #include "db/tags/extension.hh"
 #include "schema/schema_builder.hh"
 #include "schema/schema_registry.hh"
-#include <seastar/core/on_internal_error.hh>
 #include "service/storage_proxy.hh"
 #include "data_dictionary/data_dictionary.hh"
 
@@ -20,22 +19,14 @@ static logging::logger tlogger("tags");
 namespace db {
 
 const std::map<sstring, sstring>* get_tags_of_table(schema_ptr schema) {
-    auto it = schema->extensions().find(tags_extension::NAME);
-    if (it == schema->extensions().end()) {
-        return nullptr;
-    }
-    auto tags_ext = static_pointer_cast<tags_extension>(it->second);
-    return &tags_ext->tags();
+    auto tags_ext = get_schema_extension<tags_extension>(schema->extensions(), tags_extension::NAME);
+    return tags_ext ? &tags_ext->tags() : nullptr;
 }
 
 std::optional<std::string> find_tag(const schema& s, const sstring& tag) {
-    auto it1 = s.extensions().find(tags_extension::NAME);
-    if (it1 == s.extensions().end()) {
-        return std::nullopt;
-    }
-    auto ext = dynamic_pointer_cast<tags_extension>(it1->second);
+    auto ext = get_schema_extension<tags_extension>(s.extensions(), tags_extension::NAME);
     if (!ext) {
-        on_internal_error(tlogger, fmt::format("tag extension found in table {}.{}, but has wrong type", s.ks_name(), s.cf_name()));
+        return std::nullopt;
     }
     const std::map<sstring, sstring>& tags_map = ext->tags();
     auto it2 = tags_map.find(tag);

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -151,6 +151,7 @@ public:
     gms::feature workload_prioritization { *this, "WORKLOAD_PRIORITIZATION"sv };
     gms::feature colocated_tablets { *this, "COLOCATED_TABLETS"sv };
     gms::feature cdc_with_tablets { *this, "CDC_WITH_TABLETS"sv };
+    gms::feature cdc_block_tablet_merges_for_alternator_streams { *this, "CDC_BLOCK_TABLET_MERGES_FOR_ALTERNATOR_STREAMS"sv };
     gms::feature counters_with_tablets { *this, "COUNTERS_WITH_TABLETS"sv };
     gms::feature file_stream { *this, "FILE_STREAM"sv };
     gms::feature compression_dicts { *this, "COMPRESSION_DICTS"sv };

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1783,7 +1783,12 @@ const cdc::options& schema::user_properties::get_cdc_options() const {
     const auto& schema_extensions = extensions;
 
     if (auto it = schema_extensions.find(cdc::cdc_extension::NAME); it != schema_extensions.end()) {
-        return dynamic_pointer_cast<cdc::cdc_extension>(it->second)->get_options();
+        auto ext = dynamic_pointer_cast<cdc::cdc_extension>(it->second);
+        if (!ext) {
+            on_internal_error(dblog,
+                    "Failed to decode CDC options from the schema extensions. The table schema may have been written by a newer Scylla version.");
+        }
+        return ext->get_options();
     }
     return default_cdc_options;
 }

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1671,6 +1671,12 @@ schema_ptr schema_builder::build() & {
     return build(new_raw);
 }
 
+void schema_extension_cast_failed(const sstring& name) {
+    on_internal_error(dblog, format(
+            "Failed to decode {} from the schema extensions. The table schema may have been written by a newer Scylla version.",
+            name));
+}
+
 schema_ptr schema_builder::build(schema::raw_schema& new_raw) {
     if (_static_props.use_schema_commitlog) {
         if (!_static_props.use_null_sharder) {
@@ -1715,15 +1721,17 @@ schema_ptr schema_builder::build(schema::raw_schema& new_raw) {
     prepare_dense_schema(new_raw);
 
     // cache `paxos_grace_seconds` value for fast access through the schema object, which is immutable
-    if (auto it = new_raw._props.extensions.find(db::paxos_grace_seconds_extension::NAME); it != new_raw._props.extensions.end()) {
-        new_raw._props._paxos_grace_seconds =
-            dynamic_pointer_cast<db::paxos_grace_seconds_extension>(it->second)->get_paxos_grace_seconds();
+    if (auto ext = get_schema_extension<db::paxos_grace_seconds_extension>(
+                new_raw._props.extensions,
+                db::paxos_grace_seconds_extension::NAME)) {
+        new_raw._props._paxos_grace_seconds = ext->get_paxos_grace_seconds();
     }
 
     // cache the `per_partition_rate_limit` parameters for fast access through the schema object.
-    if (auto it = new_raw._props.extensions.find(db::per_partition_rate_limit_extension::NAME); it != new_raw._props.extensions.end()) {
-        new_raw._per_partition_rate_limit_options =
-            dynamic_pointer_cast<db::per_partition_rate_limit_extension>(it->second)->get_options();
+    if (auto ext = get_schema_extension<db::per_partition_rate_limit_extension>(
+                new_raw._props.extensions,
+                db::per_partition_rate_limit_extension::NAME)) {
+        new_raw._per_partition_rate_limit_options = ext->get_options();
     }
 
     if (_static_props.use_null_sharder) {
@@ -1780,14 +1788,8 @@ void schema_builder::set_properties(schema::user_properties props) {
 
 const cdc::options& schema::user_properties::get_cdc_options() const {
     static const cdc::options default_cdc_options;
-    const auto& schema_extensions = extensions;
 
-    if (auto it = schema_extensions.find(cdc::cdc_extension::NAME); it != schema_extensions.end()) {
-        auto ext = dynamic_pointer_cast<cdc::cdc_extension>(it->second);
-        if (!ext) {
-            on_internal_error(dblog,
-                    "Failed to decode CDC options from the schema extensions. The table schema may have been written by a newer Scylla version.");
-        }
+    if (auto ext = get_schema_extension<cdc::cdc_extension>(extensions, cdc::cdc_extension::NAME)) {
         return ext->get_options();
     }
     return default_cdc_options;
@@ -1795,10 +1797,9 @@ const cdc::options& schema::user_properties::get_cdc_options() const {
 
 const ::tombstone_gc_options& schema::user_properties::get_tombstone_gc_options() const {
     static const ::tombstone_gc_options default_tombstone_gc_options;
-    const auto& schema_extensions = extensions;
 
-    if (auto it = schema_extensions.find(tombstone_gc_extension::NAME); it != schema_extensions.end()) {
-        return dynamic_pointer_cast<tombstone_gc_extension>(it->second)->get_options();
+    if (auto ext = get_schema_extension<tombstone_gc_extension>(extensions, tombstone_gc_extension::NAME)) {
+        return ext->get_options();
     }
     return default_tombstone_gc_options;
 }

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -1055,6 +1055,21 @@ public:
 
 bool operator==(const schema&, const schema&);
 
+void schema_extension_cast_failed(const sstring& name); // defined in schema.cc so the required headers don't go to schema.hh
+
+template <typename Extension>
+shared_ptr<Extension> get_schema_extension(const schema::extensions_map& extensions, const sstring& name) {
+    auto it = extensions.find(name);
+    if (it == extensions.end()) {
+        return nullptr;
+    }
+    auto ext = dynamic_pointer_cast<Extension>(it->second);
+    if (!ext) {
+        schema_extension_cast_failed(name);
+    }
+    return ext;
+}
+
 /**
  * Wrapper for schema_ptr used by functions that expect an engaged view_info field.
  */


### PR DESCRIPTION
This PR fixes the upgrade hazard around Alternator Streams on tablet tables.

The compatibility fix is to avoid writing the new CDC options used for blocking
tablet merges until the whole cluster supports
`CDC_BLOCK_TABLET_MERGES_FOR_ALTERNATOR_STREAMS`. During rolling upgrade, older
nodes must not observe these new options, even when they have false/default
values, because older nodes do not know how to decode them.

To make this safe, the PR:

- adds the `CDC_BLOCK_TABLET_MERGES_FOR_ALTERNATOR_STREAMS` feature gate;
- refuses to enable Alternator Streams on tablet tables until the feature is
  supported cluster-wide;
- serializes `enable_requested` and `tablet_merge_blocked` sparsely, so
  false/default values are not persisted for older nodes to see;
- treats impossible pending-enable states before feature enablement as internal
  errors.

The schema-extension changes are defensive hardening. They replace unsafe null
dereferences when an extension is present only as an undecodable preserved
placeholder with a logged internal error. They do not by themselves make such
schemas usable on an incompatible binary or make an incompatible persisted schema
bootable. The compatibility fix is the feature-gated write path above.

In this particular case, already-persisted incompatible metadata is not expected
in real deployments because this feature has not shipped yet. The hardening is
still useful because, if an impossible/incompatible schema state is encountered,
it fails explicitly instead of dereferencing null.

Fixes SCYLLADB-2062

We need to backport to 2026.2 to unblock this release.