### PR TITLE
sstables: Move enable_dangerous_direct_import_of_cassandra_counters t…

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -386,6 +386,7 @@ static auto configure_sstables_manager(const db::config& cfg, const database_con
         .format = cfg.sstable_format,
         .large_data_records_per_sstable = cfg.compaction_large_data_records_per_sstable,
         .ignore_component_digest_mismatch = cfg.ignore_component_digest_mismatch(),
+        .enable_dangerous_direct_import_of_cassandra_counters = cfg.enable_dangerous_direct_import_of_cassandra_counters(),
     };
 }
 
@@ -1607,7 +1608,6 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.enable_disk_writes = _config.enable_disk_writes;
     cfg.enable_commitlog = _config.enable_commitlog;
     cfg.enable_cache = _config.enable_cache;
-    cfg.enable_dangerous_direct_import_of_cassandra_counters = _config.enable_dangerous_direct_import_of_cassandra_counters;
     cfg.compaction_enforce_min_threshold = _config.compaction_enforce_min_threshold;
     cfg.dirty_memory_manager = _config.dirty_memory_manager;
     cfg.streaming_read_concurrency_semaphore = _config.streaming_read_concurrency_semaphore;
@@ -2581,7 +2581,6 @@ database::make_keyspace_config(const keyspace_metadata& ksm, system_keyspace is_
         cfg.enable_commitlog = false;
         cfg.enable_cache = false;
     }
-    cfg.enable_dangerous_direct_import_of_cassandra_counters = _cfg.enable_dangerous_direct_import_of_cassandra_counters();
     cfg.compaction_enforce_min_threshold = _cfg.compaction_enforce_min_threshold;
     // don't make system or internal keyspace writes wait for user writes (if under pressure)
     if (is_system || extensions().is_extension_internal_keyspace(ksm.name())) {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -463,7 +463,6 @@ public:
         bool enable_commitlog = true;
         bool enable_incremental_backups = false;
         utils::updateable_value<bool> compaction_enforce_min_threshold{false};
-        bool enable_dangerous_direct_import_of_cassandra_counters = false;
         replica::dirty_memory_manager* dirty_memory_manager = &default_dirty_memory_manager;
         reader_concurrency_semaphore* streaming_read_concurrency_semaphore;
         reader_concurrency_semaphore* compaction_concurrency_semaphore;
@@ -1472,7 +1471,6 @@ public:
         bool enable_cache = true;
         bool enable_incremental_backups = false;
         utils::updateable_value<bool> compaction_enforce_min_threshold{false};
-        bool enable_dangerous_direct_import_of_cassandra_counters = false;
         replica::dirty_memory_manager* dirty_memory_manager = &default_dirty_memory_manager;
         reader_concurrency_semaphore* streaming_read_concurrency_semaphore;
         reader_concurrency_semaphore* compaction_concurrency_semaphore;

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -184,7 +184,6 @@ distributed_loader::process_upload_dir(sharded<replica::database>& db, sharded<d
         lock_table(global_table, directory).get();
         sstables::sstable_directory::process_flags flags {
             .need_mutate_level = true,
-            .enable_dangerous_direct_import_of_cassandra_counters = db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters(),
             .allow_loading_materialized_view = false,
         };
         process_sstable_dir(directory, flags).get();
@@ -264,7 +263,6 @@ distributed_loader::get_sstables_from(sharded<replica::database>& db, sstring ks
         lock_table(global_table, directory).get();
         sstables::sstable_directory::process_flags flags {
             .need_mutate_level = true,
-            .enable_dangerous_direct_import_of_cassandra_counters = db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters(),
             .allow_loading_materialized_view = false,
             .sort_sstables_according_to_owner = false,
             .sstable_open_config = cfg,
@@ -383,7 +381,6 @@ future<> table_populator::process_subdir(sharded<sstables::sstable_directory>& d
 
     sstables::sstable_directory::process_flags flags {
         .throw_on_missing_toc = true,
-        .enable_dangerous_direct_import_of_cassandra_counters = _db.local().get_config().enable_dangerous_direct_import_of_cassandra_counters(),
         .allow_loading_materialized_view = true,
         .garbage_collect = true,
     };

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -222,7 +222,7 @@ void sstable_directory::validate(sstables::shared_sstable sst, process_flags fla
     schema_ptr s = sst->get_schema();
     if (s->is_counter() && !sst->has_scylla_component()) {
         sstring error = "Direct loading non-Scylla SSTables containing counters is not supported.";
-        if (flags.enable_dangerous_direct_import_of_cassandra_counters) {
+        if (_manager.get_config().enable_dangerous_direct_import_of_cassandra_counters) {
             dirlog.info("{} But trying to continue on user's request.", error);
         } else {
             dirlog.error("{} Use sstableloader instead.", error);

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -80,7 +80,6 @@ public:
     struct process_flags {
         bool need_mutate_level = false;
         bool throw_on_missing_toc = false;
-        bool enable_dangerous_direct_import_of_cassandra_counters = false;
         bool allow_loading_materialized_view = false;
         bool sort_sstables_according_to_owner = true;
         bool garbage_collect = false;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -123,6 +123,7 @@ public:
         utils::updateable_value<sstring> format = utils::updateable_value<sstring>(fmt::to_string(sstable_version_types::me));
         utils::updateable_value<uint32_t> large_data_records_per_sstable = utils::updateable_value<uint32_t>(10);
         bool ignore_component_digest_mismatch = false;
+        bool enable_dangerous_direct_import_of_cassandra_counters = false;
     };
 
 private:


### PR DESCRIPTION
…o sstables_manager

This flag controls how SSTables with Cassandra counters are validated during loading. It belongs on sstables_manager as sstable-layer configuration rather than being threaded through distributed_loader from db::config on every load operation.

The sstable_directory::validate() method now reads the flag directly from its _manager reference, removing it from process_flags and eliminating get_config() calls from distributed_loader.

Also remove the flag from replica::table_config and database::config structs in database.hh — those were dead code, never read by anyone.

Components inter-dependencies cleanup, not backporting