### PR TITLE
vector_search: implement bm25 client endpoint

### DIFF
--- a/cql3/statements/external_search/vector_indexed_table_select_statement.cc
+++ b/cql3/statements/external_search/vector_indexed_table_select_statement.cc
@@ -85,6 +85,16 @@ auto wrap_result_to_error_message(C&& c) {
     return result_to_error_message_wrapper<C>{std::move(c)};
 }
 
+std::vector<float> get_ann_ordering_vector(const select_statement::prepared_ann_ordering_type& prepared_ann_ordering, const query_options& options) {
+    auto const& [ann_column, ann_vector_expr] = prepared_ann_ordering;
+    auto expr_value = expr::evaluate(ann_vector_expr, options);
+    if (expr_value.is_null()) {
+        throw exceptions::invalid_request_exception(fmt::format("Unsupported null value for column {}", ann_column->name_as_text()));
+    }
+    auto values = value_cast<vector_type_impl::native_type>(ann_column->type->deserialize(std::move(expr_value).to_bytes()));
+    return util::to_vector<float>(values);
+}
+
 } // anonymous namespace
 
 std::optional<ann_ordering_info> get_ann_ordering_info(
@@ -250,8 +260,8 @@ future<shared_ptr<cql_transport::messages::result_message>> vector_indexed_table
         auto aoe = abort_on_expiry(timeout);
         auto filter_json = _prepared_filter.to_json(options);
         uint64_t fetch = static_cast<uint64_t>(std::ceil(limit * secondary_index::vector_index::get_oversampling(_index.metadata().options())));
-        auto pkeys = co_await qp.vector_store_client().ann(
-                _schema->ks_name(), _index.metadata().name(), _schema, get_ann_ordering_vector(options), fetch, filter_json, aoe.abort_source());
+        auto pkeys = co_await qp.vector_store_client().ann(_schema->ks_name(), _index.metadata().name(), _schema,
+                get_ann_ordering_vector(_prepared_ann_ordering, options), fetch, filter_json, aoe.abort_source());
         if (!pkeys.has_value()) {
             co_await coroutine::return_exception(
                     exceptions::invalid_request_exception(std::visit(vector_search::vector_store_client::ann_error_visitor{}, pkeys.error())));
@@ -284,16 +294,6 @@ lw_shared_ptr<query::read_command> vector_indexed_table_select_statement::prepar
             query::row_limit(get_inner_loop_limit(fetch_limit, _selection->is_aggregate())), query::partition_limit(query::max_partitions),
             _query_start_time_point, tracing::make_trace_info(state.get_trace_state()), query_id::create_null_id(), query::is_first_page::no,
             options.get_timestamp(state));
-}
-
-std::vector<float> vector_indexed_table_select_statement::get_ann_ordering_vector(const query_options& options) const {
-    auto [ann_column, ann_vector_expr] = _prepared_ann_ordering;
-    auto expr_value = expr::evaluate(ann_vector_expr, options);
-    if (expr_value.is_null()) {
-        throw exceptions::invalid_request_exception(fmt::format("Unsupported null value for column {}", _prepared_ann_ordering.first->name_as_text()));
-    }
-    auto values = value_cast<vector_type_impl::native_type>(ann_column->type->deserialize(std::move(expr_value).to_bytes()));
-    return util::to_vector<float>(values);
 }
 
 future<::shared_ptr<cql_transport::messages::result_message>> vector_indexed_table_select_statement::query_base_table(query_processor& qp,

--- a/cql3/statements/external_search/vector_indexed_table_select_statement.hh
+++ b/cql3/statements/external_search/vector_indexed_table_select_statement.hh
@@ -73,8 +73,6 @@ private:
 
     lw_shared_ptr<query::read_command> prepare_command_for_base_query(query_processor& qp, service::query_state& state, const query_options& options, uint64_t fetch_limit) const;
 
-    std::vector<float> get_ann_ordering_vector(const query_options& options) const;
-
     future<::shared_ptr<cql_transport::messages::result_message>> query_base_table(query_processor& qp, service::query_state& state,
             const query_options& options, const std::vector<vector_search::primary_key>& pkeys, lowres_clock::time_point timeout) const;
 

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -2766,15 +2766,9 @@ def test_query_vectorsearch_return_similarity_dot_product_overflow(vs, needs_vec
 # a score much larger than 1, the mildly similar item around 1, and the
 # highly dissimilar item should have a large negative score.
 #
-# This test reproduces a bug in the vector store: When the similarity score
-# overflows the 32-bit calculation, it returns the same value "null" for both
-# +infinity and -infinity. Alternator currently assumes it's +infinity
-# (because only the results with the *highest* scores are returned from the
-# query), but in test like this one when we inspect all the items and their
-# scores, we can catch this discrepancy - the -inf result also gets
-# incorrectly returned as +inf. This test is marked xfail until the bug is
-# fixed.
-@pytest.mark.xfail(reason='vector store returns same "null" similarity for both +inf and -inf')
+# This test used to reproduce a bug in the vector store: When the similarity score
+# overflowed the 32-bit calculation, it returned the same value "null" for both
+# +infinity and -infinity.
 def test_query_vectorsearch_return_similarity_dot_product_overflow2(vs, needs_vector_store):
     BIG = 1e38  # Near FLT_MAX; dot product BIG * BIG overflows float32
     with new_test_table(vs,

--- a/test/vector_search/utils.hh
+++ b/test/vector_search/utils.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "schema/schema_builder.hh"
+#include "types/types.hh"
 #include "test/lib/cql_test_env.hh"
 #include "db/config.hh"
 #include <seastar/core/future.hh>
@@ -123,6 +125,26 @@ constexpr auto CORRECT_RESPONSE_FOR_TEST_TABLE = R"({
     },
     "similarity_scores": [0.1, 0.2]
 })";
+
+// A sample correct BM25 response for the test table schema (make_test_schema()).
+constexpr auto CORRECT_BM25_RESPONSE_FOR_TEST_TABLE = R"({
+    "primary_keys": {
+        "pk1": [5, 6],
+        "pk2": [7, 8],
+        "ck1": [9, 1],
+        "ck2": [2, 3]
+    },
+    "scores": [0.1, 0.2]
+})";
+
+inline schema_ptr make_test_schema(const seastar::sstring& ks = "ks", const seastar::sstring& cf = "idx") {
+    return schema_builder(this_smp_shard_count(), ks, cf)
+            .with_column("pk1", byte_type, column_kind::partition_key)
+            .with_column("pk2", byte_type, column_kind::partition_key)
+            .with_column("ck1", byte_type, column_kind::clustering_key)
+            .with_column("ck2", byte_type, column_kind::clustering_key)
+            .build();
+}
 
 inline auto create_test_table(cql_test_env& env, const seastar::sstring& ks, const seastar::sstring& cf) -> future<schema_ptr> {
     co_await env.execute_cql(fmt::format(R"(

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -361,7 +361,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
                 vs.start_background_tasks();
 
                 // server responds with 404 - client should return service_error
-                server->next_ann_response({status_type::not_found, "idx2 not found"});
+                server->next_ann_response({status_type::not_found, R"("idx2 not found")"});
                 auto keys = co_await vs.ann("ks", "idx2", schema, std::vector<float>{0.3, 0.2, 0.1}, 1, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!server->ann_requests().empty());
                 BOOST_REQUIRE_EQUAL(server->ann_requests().back().body, R"({"vector":[0.3,0.2,0.1],"limit":1})");

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -1147,3 +1147,105 @@ SEASTAR_TEST_CASE(vector_store_client_abort_due_to_query_timeout) {
                 co_await server->stop();
             }));
 }
+
+SEASTAR_TEST_CASE(vector_store_client_test_bm25_aborted) {
+    auto server = co_await make_unavailable_server();
+    auto cfg = config();
+    cfg.vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
+    auto vs = vector_store_client{cfg};
+    auto schema = make_test_schema();
+    auto as = abort_source_timeout();
+    configure(vs).with_dns_refresh_interval(milliseconds(10)).with_dns_resolver([&server](auto const& host) -> future<std::optional<inet_address>> {
+        BOOST_CHECK_EQUAL(host, "good.authority.here");
+        co_await sleep(milliseconds(100));
+        co_return inet_address(server->host());
+    });
+
+    vs.start_background_tasks();
+
+    auto keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset(milliseconds(10)));
+    BOOST_REQUIRE(!keys);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::aborted>(keys.error()));
+
+    co_await vs.stop();
+    co_await server->stop();
+}
+
+SEASTAR_TEST_CASE(vector_store_client_test_bm25_request) {
+    auto server = co_await make_vs_mock_server(vs_mock_server::mode::bm25);
+    auto cfg = config();
+    cfg.vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
+    auto vs = vector_store_client{cfg};
+    auto schema = make_test_schema();
+    auto as = abort_source_timeout();
+    configure(vs).with_dns_refresh_interval(seconds(1)).with_dns({{"good.authority.here", "127.0.0.1"}});
+
+    vs.start_background_tasks();
+
+    // server responds with 404 - client should return service_error
+    server->next_search_response({status_type::not_found, "idx2 not found"});
+    auto keys = co_await vs.bm25("ks", "idx2", schema, "quote\"back\\slash\nnewline", 1, as.reset());
+    BOOST_REQUIRE(!server->search_requests().empty());
+    BOOST_REQUIRE_EQUAL(server->search_requests().back().body, R"({"query":"quote\"back\\slash\nnewline","limit":1})");
+    BOOST_REQUIRE_EQUAL(server->search_requests().back().path, "/api/v1/indexes/ks/idx2/bm25");
+    BOOST_REQUIRE(!keys);
+    auto* err = std::get_if<vector_store_client::service_error>(&keys.error());
+    BOOST_CHECK(err != nullptr);
+    BOOST_CHECK_EQUAL(err->status, status_type::not_found);
+    BOOST_CHECK_EQUAL(err->message, "idx2 not found");
+
+    // missing primary_keys in the reply - service should return format error
+    server->next_search_response({status_type::ok, R"({"primary_keys1":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"scores":[0.1,0.2]})"});
+    keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset());
+    BOOST_REQUIRE(!keys);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+
+    // missing scores in the reply - service should return format error
+    server->next_search_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"scores1":[0.1,0.2]})"});
+    keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset());
+    BOOST_REQUIRE(!keys);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+
+    // missing pk1 key in the reply - service should return format error
+    server->next_search_response({status_type::ok, R"({"primary_keys":{"pk11":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"scores":[0.1,0.2]})"});
+    keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset());
+    BOOST_REQUIRE(!keys);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+
+    // missing ck1 key in the reply - service should return format error
+    server->next_search_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck11":[9,1],"ck2":[2,3]},"scores":[0.1,0.2]})"});
+    keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset());
+    BOOST_REQUIRE(!keys);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+
+    // wrong size of pk2 key in the reply - service should return format error
+    server->next_search_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7],"ck1":[9,1],"ck2":[2,3]},"scores":[0.1,0.2]})"});
+    keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset());
+    BOOST_REQUIRE(!keys);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+
+    // wrong size of ck2 key in the reply - service should return format error
+    server->next_search_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2]},"scores":[0.1,0.2]})"});
+    keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset());
+    BOOST_REQUIRE(!keys);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+
+    // non-numeric scores element in the reply - service should return format error
+    server->next_search_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"scores":[null,0.2]})"});
+    keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset());
+    BOOST_REQUIRE(!keys);
+    BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+
+    // correct reply - service should return keys with relevance scores
+    server->next_search_response({status_type::ok, CORRECT_BM25_RESPONSE_FOR_TEST_TABLE});
+    keys = co_await vs.bm25("ks", "idx", schema, "hello world", 2, as.reset());
+    BOOST_REQUIRE(keys);
+    BOOST_REQUIRE_EQUAL(keys->size(), 2);
+    BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(0).partition.key().explode()), "[05, 07]");
+    BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(0).clustering.explode()), "[09, 02]");
+    BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(1).partition.key().explode()), "[06, 08]");
+    BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(1).clustering.explode()), "[01, 03]");
+
+    co_await vs.stop();
+    co_await server->stop();
+}

--- a/test/vector_search/vs_mock_server.hh
+++ b/test/vector_search/vs_mock_server.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "utils.hh"
+#include "utils/assert.hh"
 #include "utils/rjson.hh"
 #include <seastar/http/request.hh>
 #include <chrono>
@@ -26,6 +27,8 @@ namespace test::vector_search {
 
 class vs_mock_server {
 public:
+    enum class mode { ann, bm25 };
+
     struct request {
         seastar::sstring path;
         seastar::sstring body;
@@ -40,12 +43,17 @@ public:
         : _port(port) {
     }
 
-    explicit vs_mock_server(response next_ann_response)
-        : _next_ann_response(std::move(next_ann_response)) {
+    explicit vs_mock_server(response next_search_response)
+        : _next_search_response(std::move(next_search_response)) {
     }
 
     explicit vs_mock_server(seastar::httpd::http_server::server_credentials_ptr credentials)
         : _credentials(credentials) {
+    }
+
+    explicit vs_mock_server(mode m)
+        : _mode(m)
+        , _next_search_response(default_response(m)) {
     }
 
     vs_mock_server() = default;
@@ -76,27 +84,56 @@ public:
         return _port;
     }
 
-    const std::vector<request>& ann_requests() const {
-        return _ann_requests;
+    const std::vector<request>& search_requests() const {
+        return _search_requests;
     }
 
     const std::vector<request>& status_requests() const {
         return _status_requests;
     }
 
-    void next_ann_response(response response) {
-        _next_ann_response = std::move(response);
+    void next_search_response(response r) {
+        _next_search_response = std::move(r);
     }
 
-    void ann_response_delay(std::chrono::seconds delay) {
-        _ann_response_delay = delay;
+    void search_response_delay(std::chrono::seconds delay) {
+        _search_response_delay = delay;
     }
 
     void next_status_response(response response) {
         _next_status_response = std::move(response);
     }
 
+    /// Compatibility alias for mode::ann — use search_requests() instead.
+    const std::vector<request>& ann_requests() const {
+        SCYLLA_ASSERT(_mode == mode::ann);
+        return search_requests();
+    }
+
+    /// Compatibility alias for mode::ann — use next_search_response() instead.
+    void next_ann_response(response r) {
+        SCYLLA_ASSERT(_mode == mode::ann);
+        next_search_response(std::move(r));
+    }
+
+    /// Compatibility alias for mode::ann — use search_response_delay() instead.
+    void ann_response_delay(std::chrono::seconds delay) {
+        SCYLLA_ASSERT(_mode == mode::ann);
+        search_response_delay(delay);
+    }
+
 private:
+    static response default_response(mode m) {
+        if (m == mode::bm25) {
+            return {seastar::http::reply::status_type::ok, CORRECT_BM25_RESPONSE_FOR_TEST_TABLE};
+        }
+        return {seastar::http::reply::status_type::ok, CORRECT_RESPONSE_FOR_TEST_TABLE};
+    }
+
+    static seastar::sstring mode_suffix(mode m) {
+        return m == mode::bm25 ? "/bm25" : "/ann";
+    }
+
     seastar::future<> listen() {
         co_await try_on_loopback_address([this](auto host) -> seastar::future<> {
             auto [s, addr] = co_await new_http_server(
@@ -110,14 +147,21 @@ private:
         });
     }
 
-    seastar::future<std::unique_ptr<seastar::http::reply>> handle_ann_request(
+    seastar::future<std::unique_ptr<seastar::http::reply>> handle_search_request(
             std::unique_ptr<seastar::http::request> req, std::unique_ptr<seastar::http::reply> rep) {
-        request r{.path = INDEXES_PATH + "/" + req->get_path_param("path"), .body = co_await util::read_entire_stream_contiguous(*req->content_stream)};
-        _ann_requests.push_back(std::move(r));
-        rep->set_status(_next_ann_response.status);
-        rep->write_body("json", _next_ann_response.body);
-        if (_ann_response_delay > 0s) {
-            co_await seastar::sleep(_ann_response_delay);
+        auto full_path = req->get_path_param("path");
+        // Only handle requests matching our configured mode suffix; return 404 for others.
+        if (!full_path.ends_with(mode_suffix(_mode))) {
+            rep->set_status(seastar::http::reply::status_type::not_found);
+            rep->write_body("json", R"("not found")");
+            co_return rep;
+        }
+        request r{.path = INDEXES_PATH + "/" + full_path, .body = co_await util::read_entire_stream_contiguous(*req->content_stream)};
+        _search_requests.push_back(std::move(r));
+        rep->set_status(_next_search_response.status);
+        rep->write_body("json", _next_search_response.body);
+        if (_search_response_delay > 0s) {
+            co_await seastar::sleep(_search_response_delay);
         }
         co_return rep;
     }
@@ -135,7 +179,7 @@ private:
                 new seastar::httpd::function_handler(
                         [this](std::unique_ptr<seastar::http::request> req,
                                 std::unique_ptr<seastar::http::reply> rep) -> seastar::future<std::unique_ptr<seastar::http::reply>> {
-                            return handle_ann_request(std::move(req), std::move(rep));
+                            return handle_search_request(std::move(req), std::move(rep));
                         },
                         "json"));
         r.add(seastar::httpd::operation_type::GET, seastar::httpd::url("/api/v1/status").remainder("status"),
@@ -147,13 +191,14 @@ private:
                         "json"));
     }
 
+    mode _mode = mode::ann;
     uint16_t _port = 0;
     seastar::sstring _host;
     std::unique_ptr<seastar::httpd::http_server> _http_server;
-    std::vector<request> _ann_requests;
+    std::vector<request> _search_requests;
     std::vector<request> _status_requests;
-    response _next_ann_response{seastar::http::reply::status_type::ok, CORRECT_RESPONSE_FOR_TEST_TABLE};
-    std::chrono::seconds _ann_response_delay = std::chrono::seconds(0);
+    response _next_search_response = default_response(_mode);
+    std::chrono::seconds _search_response_delay = std::chrono::seconds(0);
     response _next_status_response{seastar::http::reply::status_type::ok, rjson::quote_json_string("SERVING")};
     const seastar::sstring INDEXES_PATH = "/api/v1/indexes";
     seastar::httpd::http_server::server_credentials_ptr _credentials;

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -40,9 +40,11 @@ namespace {
 using namespace std::chrono_literals;
 
 using ann_error = vector_search::vector_store_client::ann_error;
+using fts_error = vector_search::vector_store_client::fts_error;
 using configuration_exception = exceptions::configuration_exception;
 using duration = lowres_clock::duration;
 using vs_vector = vector_search::vector_store_client::vs_vector;
+using query_string = vector_search::vector_store_client::query_string;
 using limit = vector_search::vector_store_client::limit;
 using host_name = vector_search::vector_store_client::host_name;
 using http_path = sstring;
@@ -159,7 +161,8 @@ auto write_ann_json(vs_vector vs_vector, limit limit, const rjson::value& filter
     return seastar::format(R"({{"vector":[{}],"limit":{},"filter":{}}})", fmt::join(vs_vector, ","), limit, rjson::print(filter));
 }
 
-auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::expected<primary_keys, ann_error> {
+auto read_scored_primary_keys_json(rjson::value const& json, schema_ptr const& schema, std::string_view score_field_name)
+        -> std::expected<primary_keys, ann_error> {
     if (!json.HasMember("primary_keys")) {
         vslogger.error("Vector Store returned invalid JSON: missing 'primary_keys'");
         return std::unexpected{service_reply_format_error{}};
@@ -170,23 +173,24 @@ auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::e
         return std::unexpected{service_reply_format_error{}};
     }
 
-    if (!json.HasMember("similarity_scores")) {
-        vslogger.error("Vector Store returned invalid JSON: missing 'similarity_scores'");
+    auto const* score_json = rjson::find(json, score_field_name);
+    if (score_json == nullptr) {
+        vslogger.error("Vector Store returned invalid JSON: missing '{}'", score_field_name);
         return std::unexpected{service_reply_format_error{}};
     }
-    auto const& similarity_json = json["similarity_scores"];
-    if (!similarity_json.IsArray()) {
-        vslogger.error("Vector Store returned invalid JSON: 'similarity_scores' is not an array");
+    if (!score_json->IsArray()) {
+        vslogger.error("Vector Store returned invalid JSON: '{}' is not an array", score_field_name);
         return std::unexpected{service_reply_format_error{}};
     }
-    auto const& similarity_arr = json["similarity_scores"].GetArray();
+    auto const& score_arr = score_json->GetArray();
 
-    // We assume that the similarity_arr, and all the key arrays in keys_json
-    // have the same length, which is the number of nearest neighbors returned
+    // We assume that the score_arr, and all the key arrays in keys_json
+    // have the same length, which is the number of results returned
     // by the vector store.
-    auto size = similarity_arr.Size();
+    auto size = score_arr.Size();
 
     auto keys = primary_keys{};
+    keys.reserve(size);
     for (auto idx = 0U; idx < size; ++idx) {
         auto pk = pk_from_json(keys_json, idx, schema);
         if (!pk) {
@@ -196,15 +200,29 @@ auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::e
         if (!ck) {
             return std::unexpected{ck.error()};
         }
-        auto const& sim_val = similarity_arr[idx];
-        if (sim_val.IsNumber()) {
-            keys.push_back(primary_key{dht::decorate_key(*schema, *pk), *ck, sim_val.GetFloat()});
+        auto const& score_val = score_arr[idx];
+        float score = 0;
+        if (score_val.IsNumber()) {
+            score = score_val.GetFloat();
         } else {
-            vslogger.error("Vector Store returned invalid JSON: 'similarity_scores[{}]'={} is not a number", idx, rjson::print(sim_val));
+            vslogger.error("Vector Store returned invalid JSON: '{}[{}]'={} is not a number", score_field_name, idx, rjson::print(score_val));
             return std::unexpected{service_reply_format_error{}};
         }
+        keys.push_back(primary_key{dht::decorate_key(*schema, *pk), *ck, score});
     }
     return std::move(keys);
+}
+
+auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::expected<primary_keys, ann_error> {
+    return read_scored_primary_keys_json(json, schema, "similarity_scores");
+}
+
+auto write_bm25_json(query_string query, limit limit) -> json_content {
+    return seastar::format(R"({{"query":{},"limit":{}}})", rjson::from_string(query), limit);
+}
+
+auto read_bm25_json(rjson::value const& json, schema_ptr const& schema) -> std::expected<primary_keys, fts_error> {
+    return read_scored_primary_keys_json(json, schema, "scores");
 }
 
 bool should_vector_store_service_be_disabled(std::vector<sstring> const& uris) {
@@ -388,6 +406,40 @@ struct vector_store_client::impl {
         }
     }
 
+    auto bm25(keyspace_name keyspace, index_name name, schema_ptr schema, query_string fts_query, limit limit, abort_source& as)
+            -> future<std::expected<primary_keys, fts_error>> {
+        if (is_disabled()) {
+            vslogger.error("Disabled Vector Store while calling bm25");
+            co_return std::unexpected{disabled{}};
+        }
+
+        auto path = format("/api/v1/indexes/{}/{}/bm25", keyspace, name);
+        auto content = write_bm25_json(std::move(fts_query), limit);
+
+        auto resp = co_await request(operation_type::POST, std::move(path), std::move(content), as);
+        if (!resp) {
+            co_return std::unexpected{std::visit(
+                    [](auto&& err) {
+                        return fts_error{err};
+                    },
+                    resp.error())};
+        }
+
+        if (resp->status != status_type::ok) {
+            auto error_content = decode_error_message(resp->content);
+            vslogger.error("Vector Store returned error: HTTP status {}: {}", resp->status, error_content);
+            co_return std::unexpected{service_error{resp->status, std::move(error_content)}};
+        }
+
+        try {
+            co_return read_bm25_json(rjson::parse(std::move(resp->content)), schema);
+        } catch (const rjson::error& e) {
+            vslogger.error("Vector Store returned invalid JSON: {}", e.what());
+            co_return std::unexpected{service_reply_format_error{}};
+        }
+    }
+
+
     future<clients::request_result> request(
             seastar::httpd::operation_type method, seastar::sstring path, std::optional<seastar::sstring> content, seastar::abort_source& as) {
         auto success_or_aborted = [](const auto& result) {
@@ -440,7 +492,12 @@ auto vector_store_client::get_index_status(keyspace_name keyspace, index_name na
 
 auto vector_store_client::ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter,
         abort_source& as) -> future<std::expected<primary_keys, ann_error>> {
-    return _impl->ann(keyspace, name, schema, vs_vector, limit, filter, as);
+    return _impl->ann(std::move(keyspace), std::move(name), schema, std::move(vs_vector), limit, filter, as);
+}
+
+auto vector_store_client::bm25(keyspace_name keyspace, index_name name, schema_ptr schema, query_string fts_query, limit limit, abort_source& as)
+        -> future<std::expected<primary_keys, fts_error>> {
+    return _impl->bm25(std::move(keyspace), std::move(name), schema, std::move(fts_query), limit, as);
 }
 
 void vector_store_client_tester::set_dns_refresh_interval(vector_store_client& vsc, std::chrono::milliseconds interval) {

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -199,16 +199,6 @@ auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::e
         auto const& sim_val = similarity_arr[idx];
         if (sim_val.IsNumber()) {
             keys.push_back(primary_key{dht::decorate_key(*schema, *pk), *ck, sim_val.GetFloat()});
-        } else if (sim_val.IsNull()) {
-            // JSON does not support infinite values, and serde_json serializes
-            // both +inf and -inf as null. This can only happen with the
-            // DOT_PRODUCT similarity function when the dot product overflows
-            // float32 (very high magnitude vectors). Since we can't distinguish
-            // +inf from -inf here, we use +inf as a conservative approximation
-            // (the item will be ranked highly, which is appropriate for a very
-            // large positive dot product; the -inf case is very unlikely in
-            // practice).
-            keys.push_back(primary_key{dht::decorate_key(*schema, *pk), *ck, std::numeric_limits<float>::infinity()});
         } else {
             vslogger.error("Vector Store returned invalid JSON: 'similarity_scores[{}]'={} is not a number", idx, rjson::print(sim_val));
             return std::unexpected{service_reply_format_error{}};

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -85,6 +85,24 @@ auto parse_service_uri(std::string_view uri_) -> std::optional<uri> {
     return {{schema, host, *port}};
 }
 
+auto decode_error_message(const std::vector<seastar::temporary_buffer<char>>& content) -> sstring {
+    if (content.size() == 1) {
+        auto body = std::string_view(content.front().get(), content.front().size());
+        auto json = rjson::try_parse(body);
+        if (json && json->IsString()) {
+            return sstring(rjson::to_string_view(*json));
+        }
+        return sstring(body);
+    }
+
+    auto body = vector_search::response_content_to_sstring(content);
+    auto json = rjson::try_parse(body);
+    if (json && json->IsString()) {
+        return sstring(rjson::to_string_view(*json));
+    }
+    return body;
+}
+
 auto get_key_column_value(const rjson::value& item, std::size_t idx, const column_definition& column) -> std::expected<bytes, ann_error> {
     auto const& column_name = column.name_as_text();
     auto const* keys_obj = rjson::find(item, column_name);
@@ -329,7 +347,7 @@ struct vector_store_client::impl {
             co_return index_status::creating;
         }
         try {
-            auto json = rjson::parse(response_content_to_sstring(resp->content));
+            auto json = rjson::parse(std::move(resp->content));
             const auto* status = rjson::find(json, "status");
             if (!status || !status->IsString()) {
                 co_return index_status::creating;
@@ -367,7 +385,7 @@ struct vector_store_client::impl {
         }
 
         if (resp->status != status_type::ok) {
-            auto error_content = response_content_to_sstring(resp->content);
+            auto error_content = decode_error_message(resp->content);
             vslogger.error("Vector Store returned error: HTTP status {}: {}", resp->status, error_content);
             co_return std::unexpected{service_error{resp->status, std::move(error_content)}};
         }

--- a/vector_search/vector_store_client.hh
+++ b/vector_search/vector_store_client.hh
@@ -13,11 +13,16 @@
 #include "seastarx.hh"
 #include "error.hh"
 #include "utils/rjson.hh"
-#include <seastar/core/shared_future.hh>
-#include <seastar/core/shared_ptr.hh>
-#include <seastar/http/reply.hh>
-#include <seastar/core/sharded.hh>
+#include <chrono>
 #include <expected>
+#include <functional>
+#include <variant>
+#include <vector>
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/http/reply.hh>
 
 class schema;
 namespace db {
@@ -48,6 +53,7 @@ class vector_store_client final : public seastar::peering_sharded_service<vector
 public:
     using config = db::config;
     using vs_vector = std::vector<float>;
+    using query_string = std::string;
     using host_name = sstring;
     using index_name = sstring;
     using keyspace_name = sstring;
@@ -66,6 +72,7 @@ public:
 
     using ann_error = std::variant<disabled, aborted, addr_unavailable, service_unavailable, service_error, service_reply_format_error>;
     using ann_error_visitor = error_visitor;
+    using fts_error = ann_error;
 
     explicit vector_store_client(config const& cfg);
     ~vector_store_client();
@@ -101,6 +108,14 @@ public:
     /// similar).
     auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as)
             -> future<std::expected<primary_keys, ann_error>>;
+
+    /// Request the vector store service for the primary keys of the top
+    /// full-text search results. Each returned primary_key has its similarity
+    /// field set to the BM25 relevance score returned by the vector store,
+    /// which sorts the results in decreasing relevance order (higher score =
+    /// more relevant).
+    auto bm25(keyspace_name keyspace, index_name name, schema_ptr schema, query_string fts_query, limit limit, abort_source& as)
+            -> future<std::expected<primary_keys, fts_error>>;
 
 private:
     friend struct vector_store_client_tester;


### PR DESCRIPTION
ScyllaDB needs to support full-text search queries through the vector store service. This adds the client-side BM25 endpoint so ScyllaDB can request ranked full-text search results from the vector store, alongside the existing ANN (approximate nearest neighbor) endpoint.

This PR also includes a small ANN-side cleanup because BM25 and ANN share the same vector-store client path. Keeping these related fixes here makes the new BM25 path use the same request/response handling conventions and API-aligned behavior from the start, instead of landing BM25 first and immediately following up with another round of client-side adjustments.

Tests are added mirroring the ann() test suite. The test infrastructure is extended with a mock server mode and a lightweight schema builder helper to avoid spinning up a full CQL environment where it is not needed.

Fixes SCYLLADB-1511

New feature, no backport.