### PR TITLE
replica/utils: reduce table_stats histogram memory

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -426,8 +426,10 @@ struct table_stats {
     utils::timed_rate_moving_average_summary_and_histogram cas_accept{0};
     utils::timed_rate_moving_average_summary_and_histogram cas_learn{0};
     utils::estimated_histogram estimated_sstable_per_read{35};
-    utils::timed_rate_moving_average_and_histogram tombstone_scanned;
-    utils::timed_rate_moving_average_and_histogram live_scanned;
+    // {tombstone,live}_scanned REST emits the full ihistogram (to_json), but its
+    // "sample" array is unused. Size 0 leaves it empty, saving 1024*8 B.
+    utils::timed_rate_moving_average_and_histogram tombstone_scanned{0};
+    utils::timed_rate_moving_average_and_histogram live_scanned{0};
     utils::estimated_histogram estimated_coordinator_read;
     shared_ptr<alternator::table_stats> alternator_stats;
 };

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -420,9 +420,11 @@ struct table_stats {
     mutation_application_stats memtable_app_stats;
     utils::timed_rate_moving_average_summary_and_histogram reads{256};
     utils::timed_rate_moving_average_summary_and_histogram writes{256};
-    utils::timed_rate_moving_average_summary_and_histogram cas_prepare{256};
-    utils::timed_rate_moving_average_summary_and_histogram cas_accept{256};
-    utils::timed_rate_moving_average_summary_and_histogram cas_learn{256};
+    // cas_* REST emits a time_estimated_histogram (time_to_json_histogram), never
+    // ihistogram::sample, so this buffer is write-only. Size 0 saves 256*8 B.
+    utils::timed_rate_moving_average_summary_and_histogram cas_prepare{0};
+    utils::timed_rate_moving_average_summary_and_histogram cas_accept{0};
+    utils::timed_rate_moving_average_summary_and_histogram cas_learn{0};
     utils::estimated_histogram estimated_sstable_per_read{35};
     utils::timed_rate_moving_average_and_histogram tombstone_scanned;
     utils::timed_rate_moving_average_and_histogram live_scanned;

--- a/test/boost/summary_test.cc
+++ b/test/boost/summary_test.cc
@@ -59,3 +59,20 @@ BOOST_AUTO_TEST_CASE(test_summary_calculation) {
     summary.update();
     BOOST_CHECK_EQUAL(vector_to_string(summary.summary()), vector_to_string({0,0,0}));
 }
+
+// A capacity-0 sample buffer must accept mark()'s push_back as a no-op while
+// still maintaining the scalar stats. ihistogram has no timer (unlike the
+// timed_rate_* wrappers), so it can be exercised in a plain unit test.
+BOOST_AUTO_TEST_CASE(test_minimal_sample_buffer) {
+    for (size_t cap : {size_t(0), size_t(1)}) {
+        utils::ihistogram h(cap);
+        BOOST_CHECK_EQUAL(h.sample.capacity(), cap);
+        for (int i = 1; i <= 1000; i++) {
+            h.mark(std::chrono::microseconds(i));
+        }
+        BOOST_CHECK_EQUAL(h.sample.size(), cap); // never exceeds capacity
+        BOOST_CHECK_EQUAL(h.count, 1000);
+        BOOST_CHECK_EQUAL(h.min, 1);
+        BOOST_CHECK_EQUAL(h.max, 1000);
+    }
+}

--- a/test/boost/summary_test.cc
+++ b/test/boost/summary_test.cc
@@ -60,6 +60,39 @@ BOOST_AUTO_TEST_CASE(test_summary_calculation) {
     BOOST_CHECK_EQUAL(vector_to_string(summary.summary()), vector_to_string({0,0,0}));
 }
 
+// The snapshot is array<uint32,65> + uint64, not a full histogram; 65*4 = 260
+// isn't 8-aligned, so 4 B tail padding makes the net saving 256 (not 260) B.
+// Guard against the footprint regressing: summary_calculator must stay at least
+// 256 B smaller than the old two-full-histograms layout. We keep
+// sizeof(std::vector<double>) symbolic on both sides so the two vectors embedded
+// in summary_calculator cancel the two on the right, making the check independent
+// of the stdlib's vector layout (e.g. _GLIBCXX_DEBUG).
+static_assert(sizeof(utils::summary_calculator) + 256 <= 2 * sizeof(std::vector<double>) /* two vectors */ + 2 * sizeof(utils::time_estimated_histogram),
+        "summary_calculator previous-snapshot footprint regressed");
+
+// Two consecutive non-empty intervals: the second summary must reflect only the
+// second interval, proving the snapshot isolates per-interval deltas.
+BOOST_AUTO_TEST_CASE(test_summary_multi_interval) {
+    utils::summary_calculator summary;
+    fill_range(summary, 1000, std::chrono::microseconds(520), std::chrono::seconds(1));
+    summary.update();
+    auto first = summary.summary();
+    BOOST_CHECK_GT(first[0], 0);
+    BOOST_CHECK_LT(first[2], 2000000); // p99 of the [520us, 1s) interval stays sub-2s
+
+    // Second, non-empty interval entirely in the [2s, 3s) band.
+    fill_range(summary, 1000, std::chrono::seconds(2), std::chrono::seconds(3));
+    summary.update();
+    auto second = summary.summary();
+    // Must land in the [2s, 3s) band, i.e. above the first interval's p99.
+    BOOST_CHECK_GT(second[0], first[2]);
+    BOOST_CHECK_GE(second[0], 2000000);
+
+    // Empty interval => zeros.
+    summary.update();
+    BOOST_CHECK_EQUAL(vector_to_string(summary.summary()), vector_to_string({0,0,0}));
+}
+
 // A capacity-0 sample buffer must accept mark()'s push_back as a no-op while
 // still maintaining the scalar stats. ihistogram has no timer (unlike the
 // timed_rate_* wrappers), so it can be exercised in a plain unit test.

--- a/utils/histogram.hh
+++ b/utils/histogram.hh
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <boost/circular_buffer.hpp>
+#include <array>
+#include <cstdint>
 #include "latency.hh"
 #include <cmath>
 #include <seastar/core/timer.hh>
@@ -330,15 +332,25 @@ public:
 class summary_calculator {
     std::vector<double> _quantiles = { 0.5, 0.95, 0.99};
     std::vector<double> _summary = { 0, 0, 0};
-    time_estimated_histogram _previous_histogram;
+    // Snapshot of _current_histogram at the last update(), used to compute the
+    // per-interval per-bucket delta. A full time_estimated_histogram is overkill:
+    // per-bucket deltas are computed mod 2^32 (exact, since no single bucket can
+    // gain 2^32 samples within one tick_interval). _previous_count stays 64-bit
+    // (the cumulative, never-reset total of the monotonic _current_histogram).
+    std::array<uint32_t, time_estimated_histogram::NUM_BUCKETS> _previous_buckets = {};
+    uint64_t _previous_count = 0;
     time_estimated_histogram _current_histogram;
+    static_assert(sizeof(std::array<uint32_t, time_estimated_histogram::NUM_BUCKETS>) + sizeof(uint64_t)
+            < sizeof(time_estimated_histogram),
+            "previous-snapshot footprint must be smaller than a full time_estimated_histogram");
 public:
     /*!
      * \brief update the summary and histograms
      *
      * The update method is called every time tick.
-     * When done, _previous_histogram would equal _current_histogram
-     * and the _summary would contain the current _summary calculation
+     * When done, the previous snapshot (_previous_buckets/_previous_count) would
+     * equal _current_histogram and the _summary would contain the current
+     * _summary calculation
      *
      * The calculation is done in two stages. first, we determine what is
      * the cutoff for each quantile, for example, assume that there are new 1000
@@ -346,7 +358,7 @@ public:
      * The cutoffs will be 500, 950, and 990. We reuse the _summary array
      * to hold these values.
      *
-     * Second, while coping the _current_histogram to the _previous_histogram,
+     * Second, while copying the _current_histogram to the previous snapshot,
      * we collect the diffs. Each time we cross a cutoff value, we update the
      * _summary with the bucket limit (i.e., the latency value).
      *
@@ -356,7 +368,8 @@ public:
      *
      */
     void update() {
-        auto new_entries = _current_histogram.count() - _previous_histogram.count();
+        const uint64_t current_count = _current_histogram.count();
+        auto new_entries = current_count - _previous_count;
         if (new_entries == 0) {
             clear();
             return;
@@ -368,14 +381,17 @@ public:
         size_t total_diff = 0;
 
         for (size_t i = 0; i < _current_histogram.size(); i++) {
-            total_diff += _current_histogram[i] - _previous_histogram[i];
+            const uint32_t current_bucket = static_cast<uint32_t>(_current_histogram[i]);
+            // Per-interval per-bucket delta, computed modulo 2^32 (see _previous_buckets).
+            total_diff += static_cast<uint32_t>(current_bucket - _previous_buckets[i]);
             while (pos < _summary.size() && total_diff >= _summary[pos]) {
                 _summary[pos] = (i + 1 < _current_histogram.size()) ? _current_histogram.get_bucket_upper_limit(i):
                         _current_histogram.get_bucket_lower_limit(i);
                 pos++;
             }
-            _previous_histogram[i] = _current_histogram[i];
+            _previous_buckets[i] = current_bucket;
         }
+        _previous_count = current_count;
     }
 
     const std::vector<double>& quantiles() const noexcept {


### PR DESCRIPTION
Reduce per-table, per-shard memory held by `replica::table_stats` histograms. Three independent commits; each is self-contained and could be split out, but they are grouped here as they all target the same struct.

**1. replica: drop sample buffers for CAS latency histograms**
The three CAS histograms (`cas_prepare`, `cas_accept`, `cas_learn`) each own a 256-entry `boost::circular_buffer<int64_t>` sample buffer (2048 B) that is write-only — the CAS REST endpoints serialize the moving-average rate, never the ihistogram sample. Constructed with capacity 0; `mark()`'s `push_back` into a zero-capacity buffer is a well-defined no-op, so the update path is unchanged and no guard branch is added. Saves 3 × 2048 = **6144 B/table/shard**.

**2. replica: drop sample buffers for tombstone/live scan histograms**
`tombstone_scanned` and `live_scanned` each carry a 1024-entry sample buffer (8192 B). They are exposed via REST `/column_family/metrics/{tombstone,live}_scanned_histogram`, whose `to_json` emits histogram buckets + scalar statistics + a `sample` array — but no first-party tool consumes that sample array. Constructed with capacity 0; only observable effect is an empty `sample` array on those two endpoints. Saves 2 × 8192 = **16384 B/table/shard**.

**3. utils: shrink summary_calculator previous-histogram snapshot**
`summary_calculator` kept a full `time_estimated_histogram` (`_previous_histogram`) only to compute per-bucket deltas. Replaced with `std::array<uint32_t, 65> _previous_buckets` + `uint64_t _previous_count`; the per-bucket delta is computed modulo 2³², exact because `_current_histogram` is monotonic and `update()` runs every tick. Net saving (after a 4-byte tail-padding hole) is 256 B/calculator × 5 = **1280 B/table/shard**. A `static_assert` pins the footprint.

**Total: ~22.5 KiB heap + ~1.25 KiB inline per table per shard.**

Update path is untouched in all three (`avikivity`: statistics should just increment a variable — no added branch/deref). Builds (dbuild dev), `summary_test` (4/4) and `estimated_histogram_test` (11/11) pass.
