### PR TITLE
alternator: add routing-hint response header for single-partition operations

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2726,6 +2726,69 @@ db::timeout_clock::time_point executor::default_timeout() {
     return db::timeout_clock::now() + std::chrono::milliseconds(s_default_timeout_in_ms);
 }
 
+// If routing awareness is enabled and this node is not the right coordinator
+// for the given schema and partition key, adds the routing-hint header to ret.
+// The header format is:
+//   X-Scylla-Alternator-Routing-V1: <start_token>,<end_token>,<addr1>[/<shard1>],...
+// Tokens are int64 decimal values (as returned by dht::token::to_int64()).
+// In shard_aware mode each address is followed by /shard; in node_aware mode
+// the shard is omitted. Only replicas in the local DC are included.
+void executor::add_routing_header_if_needed(
+        request_return_type& ret,
+        const schema_ptr& schema,
+        const dht::token& token,
+        const client_state& cs) {
+    if constexpr (routing_awareness == node_awareness::none) {
+        return;
+    }
+    auto erm = schema->table().get_effective_replication_map();
+    const auto& topo = erm->get_token_metadata_ptr()->get_topology();
+
+    std::optional<locator::tablet_routing_info> routing_info;
+    if (routing_awareness == node_awareness::shard_aware) {
+        routing_info = erm->check_locality(token, cs.get_original_shard());
+    } else {
+        // node_aware: add header only if this node is not a natural replica.
+        // We cannot simply call check_locality() here: for tablets, it
+        // checks both host and shard, so it would incorrectly return routing
+        // info when this node IS a natural replica but shard 0 is not its
+        // natural shard. We must first check host membership alone.
+        auto my_host = topo.my_host_id();
+        auto replicas = erm->get_natural_replicas(token);
+        bool am_i_a_replica = std::ranges::any_of(replicas,
+                [my_host](const auto& r) { return r == my_host; });
+        if (!am_i_a_replica) {
+            // This node is not a replica; check_locality() with any shard
+            // (e.g., 0) gives us the routing info we need.
+            routing_info = erm->check_locality(token, 0);
+        }
+    }
+    if (!routing_info) {
+        return;
+    }
+
+    const auto& [range_start, range_end] = routing_info->token_range;
+    sstring value = fmt::format("{},{}", dht::token::to_int64(range_start), dht::token::to_int64(range_end));
+
+    // Append only replicas that are in the local DC
+    const sstring& local_dc = topo.get_datacenter();
+    for (const auto& replica : routing_info->tablet_replicas) {
+        if (topo.find_node(replica.host) == nullptr) {
+            continue;
+        }
+        if (topo.get_datacenter(replica.host) != local_dc) {
+            continue;
+        }
+        sstring addr = _gossiper.get_rpc_address(replica.host);
+        if (routing_awareness == node_awareness::shard_aware) {
+            value += fmt::format(",{}/{}", addr, replica.shard);
+        } else {
+            value += fmt::format(",{}", addr);
+        }
+    }
+    ret.extra_headers.emplace_back(sstring(ROUTING_HEADER_NAME), std::move(value));
+}
+
 static lw_shared_ptr<query::read_command> previous_item_read_command(service::storage_proxy& proxy,
         schema_ptr schema,
         const clustering_key& ck,
@@ -3126,6 +3189,7 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
     _stats.wcu_total[stats::wcu_types::PUT_ITEM] += wcu_total;
     per_table_stats->api_operations.put_item_latency.mark(std::chrono::steady_clock::now() - start_time);
     _stats.api_operations.put_item_latency.mark(std::chrono::steady_clock::now() - start_time);
+    add_routing_header_if_needed(res, op->schema(), op->token(), client_state);
     co_return res;
 }
 
@@ -3242,6 +3306,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
     _stats.wcu_total[stats::wcu_types::DELETE_ITEM] += wcu_total;
     per_table_stats->api_operations.delete_item_latency.mark(std::chrono::steady_clock::now() - start_time);
     _stats.api_operations.delete_item_latency.mark(std::chrono::steady_clock::now() - start_time);
+    add_routing_header_if_needed(res, op->schema(), op->token(), client_state);
     co_return res;
 }
 
@@ -4412,6 +4477,7 @@ future<executor::request_return_type> executor::update_item(client_state& client
     _stats.wcu_total[stats::wcu_types::UPDATE_ITEM] += wcu_total;
     per_table_stats->api_operations.update_item_latency.mark(std::chrono::steady_clock::now() - start_time);
     _stats.api_operations.update_item_latency.mark(std::chrono::steady_clock::now() - start_time);
+    add_routing_header_if_needed(res, op->schema(), op->token(), client_state);
     co_return res;
 }
 

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -32,7 +32,6 @@
 #include "tracing/trace_state.hh"
 #include "cdc/cdc_options.hh"
 
-
 namespace db {
     class system_distributed_keyspace;
     class system_keyspace;
@@ -109,18 +108,64 @@ class executor : public peering_sharded_service<executor> {
     future<> fill_table_size(rjson::value &table_description, schema_ptr schema, bool deleting);
 public:
     using client_state = service::client_state;
-    // request_return_type is the return type of the executor methods, which
-    // can be one of:
-    // 1. A string, which is the response body for the request.
+
+    // Controls whether Alternator returns a routing-hint response header when
+    // a request was sent to the "wrong" coordinator. The header, if returned,
+    // tells the driver the token range of the partition and which nodes in the
+    // local DC are the natural replicas for it.
+    //
+    // none        - no header is returned (default, current behavior)
+    // node_aware  - return header if this node is not one of the RF replicas;
+    //               works for both tablets and vnodes
+    // shard_aware - return header if this shard is not the right shard;
+    //               only meaningful for tablets (vnodes fall back to
+    //               node_aware behavior)
+    //
+    // This is currently a compile-time constant. In the future it may be
+    // configurable per port.
+    enum class node_awareness {
+        none,
+        node_aware,
+        shard_aware,
+    };
+
+    // request_return_type is the return type of the executor methods.
+    // It holds one of three response payloads:
+    // 1. A std::string, which is the response body for the request.
     // 2. A body_writer, an asynchronous function (returning future<>) that
     //    takes an output_stream and writes the response body into it.
-    // 3. An api_error, which is an error response that should be returned to
-    //    the client.
-    // The body_writer is used for streaming responses, where the response body
-    // is written in chunks to the output_stream. This allows for efficient
-    // handling of large responses without needing to allocate a large buffer
-    // in memory.
-    using request_return_type = std::variant<std::string, body_writer, api_error>;
+    //    This is used for streaming large responses without needing to
+    //    allocate a contiguous std::string for the entire response.
+    // 3. An api_error, which is an error response returned to the client.
+    // Additionally, extra_headers carries optional HTTP response headers
+    // that will be added to the reply (e.g., ROUTING_HEADER_NAME).
+    struct request_return_type {
+        std::variant<std::string, body_writer, api_error> response;
+        std::vector<std::pair<sstring, sstring>> extra_headers;
+        // Implicit conversion constructors that make it easy for functions
+        // that return a response (without extra headers) to just return a
+        // std::string, body_writer or api_error.
+        request_return_type(std::string s) : response(std::move(s)) {}
+        request_return_type(body_writer bw) : response(std::move(bw)) {}
+        request_return_type(api_error err) : response(std::move(err)) {}
+        // Default constructor: response holds a default-constructed std::string
+        // (the first variant alternative) and extra_headers is empty.
+        // This matches the behavior of the old bare std::variant default constructor.
+        request_return_type() = default;
+    };
+
+    // The current node-awareness mode. When not none, single-partition
+    // operations include a routing-hint header in the response when the
+    // request was sent to the wrong coordinator.
+    static constexpr node_awareness routing_awareness = node_awareness::node_aware;
+
+    // Name of the HTTP response header carrying the routing hint.
+    static constexpr std::string_view ROUTING_HEADER_NAME = "X-Scylla-Alternator-Routing-V1";
+
+    // If routing awareness is enabled and this node is not the right coordinator
+    // for the given schema and token, adds the routing-hint header to ret.
+    void add_routing_header_if_needed(request_return_type& ret, const schema_ptr& schema, const dht::token& token, const client_state& cs);
+
     stats _stats;
     // The metric_groups object holds this stat object's metrics registered
     // as long as the stats object is alive.

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -36,6 +36,10 @@
 #include "service/pager/query_pagers.hh"
 #include "service/storage_proxy.hh"
 #include "index/secondary_index.hh"
+#include "locator/tablets.hh"
+#include "locator/abstract_replication_strategy.hh"
+#include "replica/database.hh"
+#include "gms/gossiper.hh"
 #include "utils/assert.hh"
 #include "utils/overloaded_functor.hh"
 #include "utils/error_injection.hh"
@@ -1689,7 +1693,7 @@ future<executor::request_return_type> executor::query(client_state& client_state
         // If vector search is requested, we have a separate code path.
         // IndexName must be given and must refer to a vector index - not
         // to a GSI or LSI as the code below assumes.
-        return query_vector(_proxy, _vsc, std::move(request), client_state, trace_state, std::move(permit),
+        co_return co_await query_vector(_proxy, _vsc, std::move(request), client_state, trace_state, std::move(permit),
                 _enforce_authorization, _warn_authorization, _stats, *_parsed_expression_cache);
     }
 
@@ -1704,13 +1708,13 @@ future<executor::request_return_type> executor::query(client_state& client_state
 
     rjson::value* exclusive_start_key = rjson::find(request, "ExclusiveStartKey");
     if (table_type == table_or_view_type::gsi && cl != db::consistency_level::LOCAL_ONE) {
-        return make_ready_future<request_return_type>(api_error::validation(
-                "Consistent reads are not allowed on global indexes (GSI)"));
+        co_return api_error::validation(
+                "Consistent reads are not allowed on global indexes (GSI)");
     }
     rjson::value* limit_json = rjson::find(request, "Limit");
     uint32_t limit = limit_json ? limit_json->GetUint64() : std::numeric_limits<uint32_t>::max();
     if (limit <= 0) {
-        return make_ready_future<request_return_type>(api_error::validation("Limit must be greater than 0"));
+        co_return api_error::validation("Limit must be greater than 0");
     }
 
     const bool forward = get_bool_attribute(request, "ScanIndexForward", true);
@@ -1745,14 +1749,14 @@ future<executor::request_return_type> executor::query(client_state& client_state
     // A query is not allowed to filter on the partition key or the sort key.
     for (const column_definition& cdef : schema->partition_key_columns()) { // just one
         if (filter.filters_on(cdef.name_as_text())) {
-            return make_ready_future<request_return_type>(api_error::validation(
-                    format("QueryFilter can only contain non-primary key attributes: Partition key attribute: {}", cdef.name_as_text())));
+            co_return api_error::validation(
+                    format("QueryFilter can only contain non-primary key attributes: Partition key attribute: {}", cdef.name_as_text()));
         }
     }
     for (const column_definition& cdef : schema->clustering_key_columns()) {
         if (filter.filters_on(cdef.name_as_text())) {
-            return make_ready_future<request_return_type>(api_error::validation(
-                    format("QueryFilter can only contain non-primary key attributes: Sort key attribute: {}", cdef.name_as_text())));
+            co_return api_error::validation(
+                    format("QueryFilter can only contain non-primary key attributes: Sort key attribute: {}", cdef.name_as_text()));
         }
         // FIXME: this "break" can avoid listing some clustering key columns
         // we added for GSIs just because they existed in the base table -
@@ -1767,14 +1771,29 @@ future<executor::request_return_type> executor::query(client_state& client_state
     verify_all_are_used(expression_attribute_values, used_attribute_values, "ExpressionAttributeValues", "Query");
     query::partition_slice::option_set opts;
     opts.set_if<query::partition_slice::option::reversed>(!forward);
-    return do_query(_proxy, schema, exclusive_start_key, std::move(partition_ranges), std::move(ck_bounds), std::move(attrs_to_get), limit, cl,
-            std::move(filter), opts, client_state, _stats, std::move(trace_state), std::move(permit), _enforce_authorization, _warn_authorization).then(
-            [this, per_table_stats, start_time] (request_return_type result) {
-        auto duration = std::chrono::steady_clock::now() - start_time;
-        _stats.api_operations.query_latency.mark(duration);
-        per_table_stats->api_operations.query_latency.mark(duration);
-        return result;
-    });
+
+    // Extract the partition token for the routing hint before partition_ranges
+    // is moved. For base tables, Query always has an equality condition on the
+    // partition key, so partition_ranges[0] is a singular range whose token we
+    // can retrieve here. Skip for GSI queries.
+    // FIXME: Eventually, we should support routing hints for GSIs as well. It
+    // will require checking replicas of the view table, and will require the
+    // driver being aware that is reading from a separate table and not the base
+    // table.
+    std::optional<dht::token> routing_token;
+    if (table_type == table_or_view_type::base) {
+        routing_token = partition_ranges[0].start()->value().token();
+    }
+
+    auto ret = co_await do_query(_proxy, schema, exclusive_start_key, std::move(partition_ranges), std::move(ck_bounds), std::move(attrs_to_get), limit, cl,
+            std::move(filter), opts, client_state, _stats, std::move(trace_state), std::move(permit), _enforce_authorization, _warn_authorization);
+    if (routing_token) {
+        add_routing_header_if_needed(ret, schema, *routing_token, client_state);
+    }
+    auto duration = std::chrono::steady_clock::now() - start_time;
+    _stats.api_operations.query_latency.mark(duration);
+    per_table_stats->api_operations.query_latency.mark(duration);
+    co_return ret;
 }
 
 // Converts a multi-row selection result to JSON compatible with DynamoDB.
@@ -1881,7 +1900,9 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
     if (qr.query_result->row_count().value_or(0) > 0) {
         per_table_stats->operation_sizes.get_item_op_size_kb.add(bytes_to_kb_ceil(add_capacity._total_bytes));
     }
-    co_return rjson::print(std::move(res));
+    executor::request_return_type ret{rjson::print(std::move(res))};
+    add_routing_header_if_needed(ret, schema, dht::get_token(*schema, pk), client_state);
+    co_return ret;
 }
 
 future<executor::request_return_type> executor::batch_get_item(client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {

--- a/alternator/rmw_operation.hh
+++ b/alternator/rmw_operation.hh
@@ -18,6 +18,7 @@
 #include "executor.hh"
 #include "tracing/trace_state.hh"
 #include "keys/keys.hh"
+#include "dht/i_partitioner.hh"
 
 namespace alternator {
 
@@ -115,6 +116,7 @@ public:
     virtual ~rmw_operation() = default;
     const wcu_consumed_capacity_counter& consumed_capacity() const noexcept { return _consumed_capacity; }
     schema_ptr schema() const { return _schema; }
+    dht::token token() const { return dht::get_token(*_schema, _pk); }
     const rjson::value& request() const { return _request; }
     rjson::value&& move_request() && { return std::move(_request); }
     future<executor::request_return_type> execute(service::storage_proxy& proxy,

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -85,7 +85,7 @@ static void handle_CORS(const request& req, reply& rep, bool preflight) {
         rep.add_header("Access-Control-Allow-Origin", "*");
         // This is the list that DynamoDB returns for expose headers. I am
         // not sure why not just return "*" here, what's the risk?
-        rep.add_header("Access-Control-Expose-Headers", "x-amzn-RequestId,x-amzn-ErrorType,x-amzn-ErrorMessage,Date");
+        rep.add_header("Access-Control-Expose-Headers", "x-amzn-RequestId,x-amzn-ErrorType,x-amzn-ErrorMessage,Date,X-Scylla-Alternator-Routing-V1");
         if (preflight) {
             sstring s = req.get_header("Access-Control-Request-Headers");
             if (!s.empty()) {
@@ -150,6 +150,9 @@ public:
                  return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
              }
              auto res = resf.get();
+             for (auto& [name, value] : res.extra_headers) {
+                 rep->add_header(name, value);
+             }
              return std::visit(overloaded_functor {
                 [&] (std::string&& str) {
                     return _response_compressor.generate_reply(std::move(rep), std::move(accept_encoding),
@@ -163,7 +166,7 @@ public:
                     generate_error_reply(*rep, err);
                     return make_ready_future<std::unique_ptr<reply>>(std::move(rep));
                 }
-             }, std::move(res));
+             }, std::move(res.response));
          });
     }) { }
 
@@ -817,7 +820,7 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
             ex = std::current_exception();
         }
         if (audit_info) {
-            bool error = ex != nullptr || std::holds_alternative<api_error>(ret);
+            bool error = ex != nullptr || std::holds_alternative<api_error>(ret.response);
             co_await audit::inspect(*audit_info, client_state, error);
         }
         if (ex) {

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -112,8 +112,38 @@ host_id_vector_replica_set vnode_effective_replication_map::get_replicas_for_rea
     return *endpoints | std::ranges::to<host_id_vector_replica_set>();
 }
 
-std::optional<tablet_routing_info> vnode_effective_replication_map::check_locality(const token&, unsigned) const {
-    return {};
+std::optional<tablet_routing_info> vnode_effective_replication_map::check_locality(const token& search_token, unsigned) const {
+    // For strategies where all tokens map to the same set of endpoints
+    // (e.g. LocalStrategy), every node is a replica, so routing is always correct.
+    if (!_rs->natural_endpoints_depend_on_token()) {
+        return std::nullopt;
+    }
+
+    auto my_host = _tmptr->get_topology().my_host_id();
+    auto replicas = do_get_replicas(search_token, false);
+
+    // Check if we're a natural replica for this token.
+    bool am_i_a_replica = std::ranges::any_of(replicas, [my_host](const auto& r) { return r == my_host; });
+    if (am_i_a_replica) {
+        return std::nullopt; // correctly routed
+    }
+
+    // Not a natural replica. Compute the token range and return routing info.
+    // For vnodes, shard routing is not supported, so shard=0 is a placeholder.
+    auto vnode_token = _tmptr->first_token(search_token);
+    const auto& sorted = _tmptr->sorted_tokens();
+    auto it = std::ranges::lower_bound(sorted, vnode_token);
+    dht::token range_start = dht::token::minimum();
+    if (it != sorted.begin()) {
+        --it;
+        range_start = *it;
+    }
+
+    tablet_replica_set replica_set;
+    for (const auto& r : replicas) {
+        replica_set.push_back({r, 0});
+    }
+    return tablet_routing_info{std::move(replica_set), {range_start, vnode_token}};
 }
 
 std::optional<tablet_routing_info_v2> vnode_effective_replication_map::check_tablet_version(const token&, tablet_version_block) const {

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -1520,3 +1520,80 @@ async def test_deferred_stream_enablement_on_tablets(manager: ManagerClient):
     finally:
         table.delete()
         table.meta.client.get_waiter('table_not_exists').wait(TableName=table.name)
+
+def execute_and_get_routing_header(ip, method_name, **op_kwargs):
+    """Execute the given boto3 client method - for example 'get_item' -
+    and return the routing hint header value, or None if this header was not
+    present in the response."""
+    routing_header = 'X-Scylla-Alternator-Routing-V1'
+    op_name = ''.join(word.capitalize() for word in method_name.split('_'))
+    headers = None
+    client = get_alternator(ip).meta.client
+    def capture(http_response, parsed, **kwargs):
+        nonlocal headers
+        headers = http_response.headers
+    client.meta.events.register(f'after-call.dynamodb.{op_name}', capture)
+    try:
+        getattr(client, method_name)(**op_kwargs)
+    finally:
+        client.meta.events.unregister(f'after-call.dynamodb.{op_name}', capture)
+    return headers.get(routing_header) if headers is not None else None
+
+async def test_routing_hint_header(manager: ManagerClient):
+    """Simple test for the routing hint response header (#24997).
+    Create a cluster with 3 ordinary nodes plus a zero-token node
+    (join_ring=False). The zero-token node holds no data, so single-partition
+    requests to it should return a routing hint header listing the 3 replica
+    addresses. The same single-partition request sent to one of the 3 data-
+    holding nodes should not return the header.
+    The requests we test are GetItem, PutItem, UpdateItem, DeleteItem and Query.
+    """
+    # Start 3 ordinary nodes; these will hold all the data (RF=3).
+    servers = await manager.servers_add(3, config=alternator_config, auto_rack_dc='dc1')
+    # Add a zero-token node: it participates in the cluster but holds no tablets.
+    zero_token_server = await manager.server_add(
+        config=alternator_config | {'join_ring': False},
+        property_file={'dc': 'dc1', 'rack': 'rack-zero-token'})
+
+    alternator = get_alternator(servers[0].ip_addr)
+    table = alternator.create_table(
+        TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}])
+    replica_ips = {s.ip_addr for s in servers}
+    non_replica_ip = zero_token_server.ip_addr
+
+    # The operations we test for routing hints. No pre-existing item is needed:
+    # routing is determined from the partition key alone, regardless of whether
+    # the item exists.
+    key = {'p': 'hello'}
+    ops = [
+        ('get_item',    {'TableName': table.name, 'Key': key, 'ConsistentRead': True}),
+        ('put_item',    {'TableName': table.name, 'Item': key}),
+        ('update_item', {'TableName': table.name, 'Key': key,
+                         'UpdateExpression': 'SET x = :v',
+                         'ExpressionAttributeValues': {':v': 'world'}}),
+        ('delete_item', {'TableName': table.name, 'Key': key}),
+        ('query',       {'TableName': table.name,
+                         'KeyConditionExpression': 'p = :pk',
+                         'ExpressionAttributeValues': {':pk': 'hello'}}),
+    ]
+
+    for op_name, op_kwargs in ops:
+        # Request to the zero-token (non-replica) node should return a routing hint header.
+        header = execute_and_get_routing_header(non_replica_ip, op_name, **op_kwargs)
+        assert header is not None, f'{op_name}: expected routing header from non-replica node'
+        # The header format is: <start_token>,<end_token>,<ip1>,<ip2>,<ip3>
+        # (node_aware mode, no shard suffix). With RF=3 and 3 nodes holding data,
+        # all 3 replica IPs should appear in the header: 2 tokens + 3 IPs = 5 parts.
+        parts = header.split(',')
+        assert len(parts) == 5, f'{op_name}: expected 5 parts in header, got: {header}'
+        assert set(parts[2:]) == replica_ips, f'{op_name}: unexpected replica IPs in header: {header}'
+
+        # The same request to a replica node should NOT return a routing hint header.
+        for replica_ip in replica_ips:
+            header = execute_and_get_routing_header(replica_ip, op_name, **op_kwargs)
+            assert header is None, f'{op_name}: unexpected routing header from replica {replica_ip}'
+
+    table.delete()


### PR DESCRIPTION
This patch adds to Alternator a new HTTP response header when a single-partition request (GetItem, PutItem, UpdateItem, DeleteItem, or Query) was sent to the "wrong" node or shard - that doesn't hold this partition. The new header teaches the client about the replicas of the token range that contains that partition - and clients will be able to cache this information to improve their routing in the next requests.

The implementation supports three "awareness" modes:

1. **None**: As before this patch, the routing hint header is never returned.
2. **Node-aware**: If the request reached the wrong node, a header is added to the response listing the token range containing the partition and the nodes that have replicas of this range.
3. **Shard-aware**: If the request reached the wrong shard (even if on the right node), a header is sent - and it lists the right nodes and shards for the token range.

All modes are supported on tablets, while vnodes supports all but shard- aware mode (as vnodes do not have contiguous token ranges for individual shards).

NOTE: Currently, the awareness mode is hard-coded to be "node-aware". It will need to be configurable, but we should consider if it needs to configurable in the server, per-port (i.e., a certain port is a special node-aware port, etc.), or per-request (e.g., the client should send a request header asking for node-awareness).

The response header format is:

```
X-Scylla-Alternator-Routing-V1: <start_token>,<end_token>,<addr1>[/<shard1>],...
```

Tokens are int64 decimal values (as returned by dht::token::to_int64()). In shard_aware mode each address is followed by /shard; in node_aware mode the shard is omitted. Only replicas in the local DC are included.

The header is added to the following single-partition operations: GetItem, PutItem, UpdateItem, DeleteItem, and Query (base table only; GSI queries are left for future work).

Fixes #24997.