### PR TITLE
alternator: add system tables for export S3 functionality

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+#include "db/tags/extension.hh"
 #include "utils/assert.hh"
 #include "db/system_distributed_keyspace.hh"
 
@@ -27,6 +28,7 @@
 #include "service/migration_manager.hh"
 #include "locator/host_id.hh"
 #include "view_info.hh"
+#include "alternator/ttl_tag.hh"
 
 #include <seastar/core/seastar.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -273,6 +275,49 @@ schema_ptr snapshot_remote_locations() {
     return schema;
 }
 
+schema_ptr alternator_export_to_s3_exports() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::ALTERNATOR_EXPORT_TO_S3_EXPORTS);
+        auto s = schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::ALTERNATOR_EXPORT_TO_S3_EXPORTS, std::make_optional(id));
+        s.with_column("export_arn", utf8_type, column_kind::partition_key)
+         .with_column("client_token", utf8_type)
+         .with_column("request", utf8_type)
+         .with_column("export_manifest", utf8_type)
+         .with_column("export_status", utf8_type)
+         .with_column("failure_code", utf8_type)
+         .with_column("failure_message", utf8_type)
+         .with_column("item_count", long_type)
+         .with_column("export_id_token", utf8_type)
+         .with_column("snapshot_tag", utf8_type)
+         .with_column("accepted_at", timestamp_type)
+         .with_column("completed_at", timestamp_type)
+         .with_column("node_id", utf8_type)
+         .with_column("metadata_expires_at", timestamp_type)
+         .set_comment("Alternator export to S3 export metadata")
+         .with_hash_version();
+        std::map<sstring, sstring> tags_map = {{TTL_TAG_KEY, "metadata_expires_at"}};
+        s.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>(std::move(tags_map)));
+        return s.build();
+    }();
+    return schema;
+}
+
+schema_ptr alternator_export_to_s3_client_tokens() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::ALTERNATOR_EXPORT_TO_S3_CLIENT_TOKENS);
+        return schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::ALTERNATOR_EXPORT_TO_S3_CLIENT_TOKENS, std::make_optional(id))
+                .with_column("client_token", utf8_type, column_kind::partition_key)
+                .with_column("export_arn", utf8_type)
+                .with_column("request", utf8_type)
+                .with_column("node_id", utf8_type)
+                .set_comment("Alternator export to S3 client token idempotency")
+                .set_default_time_to_live(std::chrono::hours(8))
+                .with_hash_version()
+                .build();
+    }();
+    return schema;
+}
+
 // This is the set of tables which this node ensures to exist in the cluster.
 // It does that by announcing the creation of these schemas on initialization
 // of the `system_distributed_keyspace` service (see `start()`), unless it first
@@ -296,6 +341,8 @@ static std::vector<schema_ptr> ensured_tables() {
         snapshot_nodes(),
         snapshot_sstables(),
         snapshot_remote_locations(),
+        alternator_export_to_s3_exports(),
+        alternator_export_to_s3_client_tokens(),
     };
 }
 
@@ -307,7 +354,9 @@ std::vector<schema_ptr> system_distributed_keyspace::all_distributed_tables() {
         snapshot_tables(),
         snapshot_tablets(),
         snapshot_nodes(),
-        snapshot_sstables()
+        snapshot_sstables(),
+        alternator_export_to_s3_exports(),
+        alternator_export_to_s3_client_tokens(),
     };
 }
 

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -83,6 +83,10 @@ public:
      * remote location metadata per datacenter. */
     static constexpr auto SNAPSHOT_REMOTE_LOCATIONS = "snapshot_remote_locations";
 
+    /* Alternator export to S3 metadata tables. */
+    static constexpr auto ALTERNATOR_EXPORT_TO_S3_EXPORTS = "alternator_export_to_s3_exports";
+    static constexpr auto ALTERNATOR_EXPORT_TO_S3_CLIENT_TOKENS = "alternator_export_to_s3_client_tokens";
+
     static constexpr uint64_t SNAPSHOT_SSTABLES_TTL_SECONDS = std::chrono::seconds(std::chrono::days(3)).count();
 
     /* Information required to modify/query some system_distributed tables, passed from the caller. */

--- a/test/alternator/test_export.py
+++ b/test/alternator/test_export.py
@@ -1,0 +1,14 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+import pytest
+from cassandra import ConsistencyLevel
+from cassandra.query import SimpleStatement
+
+# Test that the internal system-distributed tables for alternator export to S3 exist and are queryable.
+@pytest.mark.parametrize("table_name", ['alternator_export_to_s3_exports', 'alternator_export_to_s3_client_tokens'])
+def test_export_to_s3_checks_if_internal_tables_exist(cql, table_name):
+    statement = SimpleStatement(f"SELECT * FROM system_distributed.{table_name} LIMIT 1", consistency_level=ConsistencyLevel.ONE)
+    # we don't care about the results, we just want to make sure the read succeeds
+    cql.execute(statement)

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -24,6 +24,8 @@ import requests
 import json
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.protocol import InvalidRequest
+from cassandra.query import SimpleStatement
+from cassandra import ConsistencyLevel
 import threading
 import random
 import re
@@ -1520,3 +1522,45 @@ async def test_deferred_stream_enablement_on_tablets(manager: ManagerClient):
     finally:
         table.delete()
         table.meta.client.get_waiter('table_not_exists').wait(TableName=table.name)
+
+# The Alternator S3 export feature stores its metadata in tables under the
+# replicated system_distributed keyspace, created automatically when Alternator
+# starts. Verify that these tables are created on every node of a multi-node
+# cluster and each node sees other nodes' data. The test will write one row per node
+# into each table and run SELECT from every node to verify that all rows are visible.
+# Writes and reads use QUORUM so that, on the RF=3 system_distributed keyspace, every read is
+# guaranteed to observe every write.
+async def test_export_to_s3_system_tables_readable_on_all_nodes(manager: ManagerClient):
+    # Each entry maps a table name to a function building an INSERT for that
+    # table given a unique per-node id, plus the number of rows we expect to
+    # see once every node has inserted its row.
+
+    table_name_primary_key_primary_value_pattern_list = [
+        ('alternator_export_to_s3_exports', 'export_arn', 'export-%s'),
+        ('alternator_export_to_s3_client_tokens', 'client_token', 'token-%s'),
+    ]
+
+    servers = await manager.servers_add(3, config=alternator_config, auto_rack_dc='dc1')
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    # Each node inserts one distinct row into each table.
+    for i, host in enumerate(hosts):
+        for table, key, key_value_pattern in table_name_primary_key_primary_value_pattern_list:
+            await cql.run_async(SimpleStatement(f"INSERT INTO system_distributed.{table} ({key}) VALUES ('{key_value_pattern % i}')",
+                                                consistency_level=ConsistencyLevel.QUORUM),
+                                host=host)
+
+    # Every node must now see all the rows written by all nodes.
+    expected_count = len(hosts)
+    for host in hosts:
+        for table, key, key_value_pattern in table_name_primary_key_primary_value_pattern_list:
+            keys = set()
+            expected_keys = {key_value_pattern % i for i in range(expected_count)}
+            rows = await cql.run_async(
+                SimpleStatement(f"SELECT {key} FROM system_distributed.{table} WHERE {key} IN {tuple(expected_keys)}",
+                                consistency_level=ConsistencyLevel.QUORUM),
+                host=host)
+            for row in rows:
+                keys.add(row[0])
+            assert keys == expected_keys, \
+                f"node {host} sees {keys} in {table}, expected {expected_keys}"

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -25,6 +25,8 @@ import requests
 import json
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.protocol import InvalidRequest
+from cassandra.query import SimpleStatement
+from cassandra import ConsistencyLevel
 import threading
 import random
 import re
@@ -2084,4 +2086,44 @@ async def test_alternator_mtls_and_plain_http(manager: ScyllaClusterManager, tmp
         alternator_bad.meta.client.list_tables()
 
 
+# The Alternator S3 export feature stores its metadata in tables under the
+# replicated system_distributed keyspace, created automatically when Alternator
+# starts. Verify that these tables are created on every node of a multi-node
+# cluster and each node sees other nodes' data. The test will write one row per node
+# into each table and run SELECT from every node to verify that all rows are visible.
+# Writes and reads use QUORUM so that, on the RF=3 system_distributed keyspace, every read is
+# guaranteed to observe every write.
+async def test_export_to_s3_system_tables_readable_on_all_nodes(manager: ManagerClient):
+    # Each entry maps a table name to a function building an INSERT for that
+    # table given a unique per-node id, plus the number of rows we expect to
+    # see once every node has inserted its row.
 
+    table_name_primary_key_primary_value_pattern_list = [
+        ('alternator_export_to_s3_exports', 'export_arn', 'export-%s'),
+        ('alternator_export_to_s3_client_tokens', 'client_token', 'token-%s'),
+    ]
+
+    servers = await manager.servers_add(3, config=alternator_config, auto_rack_dc='dc1')
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    # Each node inserts one distinct row into each table.
+    for i, host in enumerate(hosts):
+        for table, key, key_value_pattern in table_name_primary_key_primary_value_pattern_list:
+            await cql.run_async(SimpleStatement(f"INSERT INTO system_distributed.{table} ({key}) VALUES ('{key_value_pattern % i}')",
+                                                consistency_level=ConsistencyLevel.QUORUM),
+                                host=host)
+
+    # Every node must now see all the rows written by all nodes.
+    expected_count = len(hosts)
+    for host in hosts:
+        for table, key, key_value_pattern in table_name_primary_key_primary_value_pattern_list:
+            keys = set()
+            expected_keys = {key_value_pattern % i for i in range(expected_count)}
+            rows = await cql.run_async(
+                SimpleStatement(f"SELECT {key} FROM system_distributed.{table} WHERE {key} IN {tuple(expected_keys)}",
+                                consistency_level=ConsistencyLevel.QUORUM),
+                host=host)
+            for row in rows:
+                keys.add(row[0])
+            assert keys == expected_keys, \
+                f"node {host} sees {keys} in {table}, expected {expected_keys}"


### PR DESCRIPTION
Add system distributed tables, that will be used by S3 export feature.
- system_distributed.alternator_export_to_s3_exports - table containing info about exports either in progress or completed (or failed). Rows in the table will live up to 90 days (DynamoDB life time expectance) starting from the moment the export completed or failed.
- system_distributed.alternator_export_to_s3_client_tokens - table containing client tokens that were supplied by users.

Add basic tests (`select *`). We're using common code so we expect everything to work once `select` works.
Add cluster test to make sure the table is shared across all nodes.

The tables themselves are unusued so far, because the feature itself is large and splitted across several PRs and tables usage comes later.

Fixes: SCYLLADB-1886

Backport: none, new feature.