### PR TITLE
add export-table-to-point-in-time command parsing and tests

### DIFF
--- a/alternator/error.hh
+++ b/alternator/error.hh
@@ -41,6 +41,9 @@ public:
     { }
 
     // Factory functions for some common types of DynamoDB API errors
+    static api_error invalid_export_time(std::string msg) {
+        return api_error("InvalidExportTimeException", std::move(msg));
+    }
     static api_error validation(std::string msg) {
         return api_error("ValidationException", std::move(msg));
     }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -165,6 +165,7 @@ public:
     future<request_return_type> get_shard_iterator(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
     future<request_return_type> get_records(client_state& client_state, tracing::trace_state_ptr, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
     future<request_return_type> describe_continuous_backups(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
+    future<request_return_type> export_table_to_point_in_time(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info);
 
     future<> start();
     future<> stop();

--- a/alternator/executor_util.cc
+++ b/alternator/executor_util.cc
@@ -37,15 +37,43 @@ std::optional<int> get_int_attribute(const rjson::value& value, std::string_view
     return attribute_value->GetInt();
 }
 
-std::string get_string_attribute(const rjson::value& value, std::string_view attribute_name, const char* default_return) {
+// Returns the string attribute, or `default_return` if the attribute is missing and `default_return` is supplied.
+// Throws an error if the attribute is missing and `default_return` is not supplied, or if the attribute exists but is not a string.
+std::string get_string_attribute(const rjson::value& value, std::string_view attribute_name, std::optional<std::string_view> default_return) {
     const rjson::value* attribute_value = rjson::find(value, attribute_name);
-    if (!attribute_value)
-        return default_return;
+    if (!attribute_value) {
+        if (default_return) {
+            return std::string{*default_return};
+        }
+        throw api_error::validation(fmt::format("Missing attribute {}", attribute_name));
+    }
     if (!attribute_value->IsString()) {
         throw api_error::validation(fmt::format("Expected string value for attribute {}, got: {}",
                 attribute_name, value));
     }
     return rjson::to_string(*attribute_value);
+}
+
+// Returns the string attribute, or `default_return` if the attribute is missing and `default_return` is supplied.
+// Throws an error if the attribute is missing and `default_return` is not supplied, or if the attribute exists but is an empty string or an attribute is not a string.
+// Note: `default_return` is allowed to be an empty string and it will be returned in case the attribute is missing.
+std::string get_non_empty_string_attribute(const rjson::value& value, std::string_view attribute_name, std::optional<std::string_view> default_return) {
+    const rjson::value* attribute_value = rjson::find(value, attribute_name);
+    if (!attribute_value) {
+        if (default_return) {
+            return std::string{*default_return};
+        }
+        throw api_error::validation(fmt::format("Missing attribute {}", attribute_name));
+    }
+    if (!attribute_value->IsString()) {
+        throw api_error::validation(fmt::format("Expected string value for attribute {}, got: {}",
+                attribute_name, value));
+    }
+    auto val = rjson::to_string(*attribute_value);
+    if (val.empty()) {
+        throw api_error::validation(fmt::format("Expected non-empty string value for attribute {}, got empty string", attribute_name));
+    }
+    return val;
 }
 
 bool get_bool_attribute(const rjson::value& value, std::string_view attribute_name, bool default_return) {

--- a/alternator/executor_util.hh
+++ b/alternator/executor_util.hh
@@ -53,10 +53,15 @@ using body_writer = noncopyable_function<future<>(output_stream<char>&&)>;
 /// api_error is thrown.
 std::optional<int> get_int_attribute(const rjson::value& value, std::string_view attribute_name);
 
-/// Get the value of a string attribute, or a default value if it is missing.
-/// If the attribute exists, but is not a string, a descriptive api_error is
-/// thrown.
-std::string get_string_attribute(const rjson::value& value, std::string_view attribute_name, const char* default_return);
+/// Get the value of a string attribute.
+/// If the value exists and is a string - it's returned.
+/// If the value is missing and `default_return` is supplied, the `default_return` value is returned.
+/// Otherwise a descriptive api_error is thrown.
+std::string get_string_attribute(const rjson::value& value, std::string_view attribute_name, std::optional<std::string_view> default_return = std::nullopt);
+
+/// Get the value of a string attribute. If `default_return` is supplied that value is optional and if not found -
+/// `default_return` will be returned (even if it's empty). Otherwise it must be present and non-empty, if not - a descriptive api_error will be thrown.
+std::string get_non_empty_string_attribute(const rjson::value& value, std::string_view attribute_name, std::optional<std::string_view> default_return = std::nullopt);
 
 /// Get the value of a boolean attribute, or a default value if it is missing.
 /// If the attribute exists, but is not a bool, a descriptive api_error is

--- a/alternator/export.cc
+++ b/alternator/export.cc
@@ -7,13 +7,30 @@
  */
 
 #include "alternator/export.hh"
+#include <boost/regex/v5/regex_fwd.hpp>
 #include <seastar/core/coroutine.hh>
+#include "alternator/error.hh"
+#include "alternator/executor.hh"
+#include "alternator/executor_util.hh"
+#include "auth/permission.hh"
+#include "service/storage_proxy.hh"
 #include "utils/rjson.hh"
 #include <algorithm>
+#include <array>
+#include <chrono>
+#include <limits>
 #include <string>
 #include <string_view>
+#include <boost/regex.hpp>
 
 namespace alternator {
+
+static std::optional<api_error> reject_unsupported_parameter(const rjson::value& request, std::string_view name) {
+    if (rjson::find(request, name)) {
+        return api_error::validation(fmt::format("{} attribute is not supported", name));
+    }
+    return std::nullopt;
+}
 
 // Interfaces for `sink` / `source` pipelines.
 // The `sink` pipeline consists of 3 stages:
@@ -208,4 +225,110 @@ std::unique_ptr<import_pipeline_interface> create_in_memory_source_pipeline(in_m
     return std::make_unique<in_memory_source>(storage, std::move(decompressor));
 }
 
+future<executor::request_return_type> executor::export_table_to_point_in_time(client_state& client_state, service_permit permit, rjson::value request, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+    _stats.api_operations.export_table_to_point_in_time++;
+
+    // Required parameters
+    auto table_arn = get_non_empty_string_attribute(request, "TableArn");
+    auto s3_bucket = get_non_empty_string_attribute(request, "S3Bucket");
+    static boost::regex s3_bucket_regex("^[a-z0-9][a-z0-9\\-\\.]{1,61}[a-z0-9]$");
+    if (!boost::regex_match(s3_bucket, s3_bucket_regex)) {
+        co_return api_error::validation(fmt::format("S3Bucket attribute: must match regex `^[a-z0-9][a-z0-9\\-\\.]{{1,61}}[a-z0-9]$`, not `{}`", s3_bucket));
+    }
+
+    // Validate that the table exists
+    auto parts = parse_arn(table_arn, "TableArn", "table", "");
+    maybe_audit(audit_info, audit::statement_category::QUERY, parts.keyspace_name, parts.table_name, "ExportTableToPointInTime", request);
+    try {
+        auto schema = _proxy.data_dictionary().find_schema(parts.keyspace_name, parts.table_name);
+        get_stats_from_schema(_proxy, *schema)->api_operations.export_table_to_point_in_time++;
+        co_await verify_permission(_enforce_authorization, _warn_authorization, client_state, schema, auth::permission::SELECT, _stats);
+    } catch (const data_dictionary::no_such_column_family&) {
+        co_return api_error::table_not_found(
+                fmt::format("TableArn: Invalid table ARN `{}` - not found", table_arn));
+    }
+
+    // Optional parameters
+    auto s3_prefix = get_non_empty_string_attribute(request, "S3Prefix", "");
+    if (s3_prefix.size() > 255) {
+        co_return api_error::validation(fmt::format("S3Prefix attribute: must not exceed 255 characters, got {}", s3_prefix.size()));
+    }
+
+    auto export_format = get_non_empty_string_attribute(request, "ExportFormat", "DYNAMODB_JSON");
+    if (export_format != "DYNAMODB_JSON") {
+        co_return api_error::validation(
+                fmt::format("ExportFormat attribute: must be DYNAMODB_JSON, not `{}`", export_format));
+    }
+
+    auto export_type = get_non_empty_string_attribute(request, "ExportType", "FULL_EXPORT");
+    if (export_type != "FULL_EXPORT") {
+        co_return api_error::validation(
+                fmt::format("ExportType attribute: must be FULL_EXPORT, not `{}`", export_type));
+    }
+
+    constexpr std::array unsupported_parameters{
+            "IncrementalExportSpecification",
+            "S3BucketOwner",
+            "S3SseAlgorithm",
+            "S3SseKmsKeyId",
+    };
+    for (auto name : unsupported_parameters) {
+        if (auto error = reject_unsupported_parameter(request, name)) {
+            co_return std::move(*error);
+        }
+    }
+
+    // ExportTime - only "now" (or close to now) is supported
+    // If not specified, use current time. If specified, must be within 5 minutes of now.
+    int64_t now = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    int64_t export_time = now;
+    const rjson::value* export_time_v = rjson::find(request, "ExportTime");
+    if (export_time_v) {
+        if (!export_time_v->IsInt64() && !export_time_v->IsUint64()) {
+            co_return api_error::validation("Expected integer attribute ExportTime");
+        }
+        if (export_time_v->IsUint64()) {
+            uint64_t value = export_time_v->GetUint64();
+            if (value > uint64_t(std::numeric_limits<int64_t>::max())) {
+                co_return api_error::validation("ExportTime is out of range");
+            }
+            export_time = value;
+        } else {
+            export_time = export_time_v->GetInt64();
+        }
+        auto diff = export_time > now ? export_time - now : now - export_time;
+        if (diff > 300) {
+            co_return api_error::invalid_export_time(fmt::format("ExportTime must be within 5 minutes of current time. "
+                                "ExportTime: {}, current time: {}", export_time, now));
+        }
+    }
+
+    auto client_token = get_non_empty_string_attribute(request, "ClientToken", "");
+
+    // Build the ExportDescription response
+    // The actual export functionality is not implemented yet - this just returns
+    // an IN_PROGRESS status to indicate the export has been accepted.
+    rjson::value export_desc = rjson::empty_object();
+
+    // AWS, when export is called without client token, will return uniquely generated client token in response.
+    rjson::add(export_desc, "ClientToken", client_token.empty() ? rjson::from_string("<empty>") : rjson::from_string(client_token));
+
+    // We create fake arn here, the content up to `/export/` will be likely the same in future,
+    // the last part (after `/export/`) will change - we need to encode a unique identifier of some sort there to
+    // recognise the export in future (we don't have it yet so we don't do it now).
+    rjson::add(export_desc, "ExportArn",
+            rjson::from_string(fmt::format("arn:aws:dynamodb:us-east-1:000000000000:table/{}@{}/export/export-placeholder",
+                    parts.keyspace_name, parts.table_name)));
+    rjson::add(export_desc, "ExportFormat", rjson::from_string(export_format));
+    rjson::add(export_desc, "ExportStatus", "FAILED");
+    rjson::add(export_desc, "ExportTime", rjson::value(export_time));
+    rjson::add(export_desc, "ExportType", rjson::from_string(export_type));
+    rjson::add(export_desc, "S3Bucket", rjson::from_string(s3_bucket));
+    rjson::add(export_desc, "S3Prefix", rjson::from_string(s3_prefix));
+    rjson::add(export_desc, "TableArn", rjson::from_string(table_arn));
+
+    rjson::value response = rjson::empty_object();
+    rjson::add(response, "ExportDescription", std::move(export_desc));
+    co_return rjson::print(std::move(response));
+}
 } // namespace alternator

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -939,6 +939,9 @@ server::server(executor& exec, service::storage_proxy& proxy, gms::gossiper& gos
         {"DescribeContinuousBackups", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
             return e.describe_continuous_backups(client_state, std::move(permit), std::move(json_request), audit_info);
         }},
+        {"ExportTableToPointInTime", [] (executor& e, executor::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit, rjson::value json_request, std::unique_ptr<request> req, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
+            return e.export_table_to_point_in_time(client_state, std::move(permit), std::move(json_request), audit_info);
+        }},
     } {
 }
 

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -84,6 +84,7 @@ static void register_metrics_with_optional_table(seastar::metrics::metric_groups
             OPERATION(describe_stream, "DescribeStream")
             OPERATION(get_shard_iterator, "GetShardIterator")
             OPERATION(get_records, "GetRecords")
+            OPERATION(export_table_to_point_in_time, "ExportTableToPointInTime")
     });
     OPERATION_LATENCY(put_item_latency, "PutItem")
     OPERATION_LATENCY(get_item_latency, "GetItem")

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -68,6 +68,7 @@ public:
         uint64_t describe_stream = 0;
         uint64_t get_shard_iterator = 0;
         uint64_t get_records = 0;
+        uint64_t export_table_to_point_in_time = 0;
 
 
         utils::timed_rate_moving_average_summary_and_histogram put_item_latency;

--- a/test/alternator/test_audit.py
+++ b/test/alternator/test_audit.py
@@ -548,9 +548,10 @@ def test_audit_ddl_operations(dynamodb, cql, alternator_audit_enabled):
 
 
 # Test auditing of QUERY table-level operations: DescribeTable, ListTagsOfResource,
-# DescribeTimeToLive, DescribeContinuousBackups, ListTables, DescribeEndpoints.
+# DescribeTimeToLive, DescribeContinuousBackups, ExportTableToPointInTime,
+# ListTables, DescribeEndpoints.
 # ListTables and DescribeEndpoints have empty keyspace/table.
-# Produces 6 audit entries.
+# Produces 7 audit entries.
 def test_audit_query_table_operations(dynamodb, cql, alternator_audit_enabled):
     with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table:
         ks_name = f"alternator_{table.name}"
@@ -574,6 +575,9 @@ def test_audit_query_table_operations(dynamodb, cql, alternator_audit_enabled):
         # DescribeContinuousBackups
         client.describe_continuous_backups(TableName=table.name)
         expected.append(("QUERY", "", False, ks_name, table.name, ["DescribeContinuousBackups", table.name]))
+        # ExportTableToPointInTime
+        client.export_table_to_point_in_time(TableArn=table_arn, S3Bucket="my-bucket")
+        expected.append(("QUERY", "", False, ks_name, table.name, ["ExportTableToPointInTime", table_arn, "my-bucket"]))
         # ListTables (empty keyspace)
         client.list_tables()
         expected.append(("QUERY", "", False, "", "", ["ListTables"]))

--- a/test/alternator/test_export.py
+++ b/test/alternator/test_export.py
@@ -1,0 +1,164 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+# Tests for the DynamoDB ExportTableToPointInTime (part of SCYLLADB-1939).
+
+import time
+
+import pytest
+from botocore.exceptions import ClientError
+
+from test.alternator.util import create_test_table, is_aws, random_string
+
+# This creates an empty table with string partition key and no sort key. We do
+# not use the shared test_table_s fixture because exports may take longer for a
+# table with data written by other tests.
+@pytest.fixture(scope='module')
+def test_table_s_for_export_only(dynamodb):
+    table = create_test_table(dynamodb,
+        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
+        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ])
+    enable_pitr(table)
+    yield table
+    table.delete()
+
+# Helper: enable PITR on a table (required for ExportTableToPointInTime on
+# DynamoDB). Returns the client used.
+def enable_pitr(table, timeout=120):
+    client = table.meta.client
+
+    # We don't need to call update_continuous_backups on ScyllaDB, because current implementation will work without it
+    # and not calling it allows us to avoid implementing the call itself.
+    if not is_aws(table):
+        return client
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            client.update_continuous_backups(
+                TableName=table.name,
+                PointInTimeRecoverySpecification={'PointInTimeRecoveryEnabled': True}
+            )
+            break
+        except ClientError as e:
+            # After table creation there's a delay until PITR can be enabled (and then another delay
+            # until PITR is actually active) - the first delay is notified to the user by ContinuousBackupsUnavailableException
+            # exception. So we catch it here and try again.
+            if e.response['Error']['Code'] == 'ContinuousBackupsUnavailableException':
+                # This is run against AWS (see `if` above), which is slow, so no point in testing often
+                time.sleep(2)
+            else:
+                raise
+    # Wait until PITR is actually active on DynamoDB.
+    while time.time() < deadline:
+        resp = client.describe_continuous_backups(TableName=table.name)
+        pitr = resp['ContinuousBackupsDescription'].get('PointInTimeRecoveryDescription', {})
+        if pitr.get('PointInTimeRecoveryStatus') == 'ENABLED':
+            return client
+        # This is run against AWS (see `if` above), which is slow, so no point in testing often
+        time.sleep(2)
+    raise TimeoutError(f"PITR did not become ENABLED on {table.name} within {timeout}s")
+
+
+# Test that ExportTableToPointInTime accepts valid parameters.
+# for scylla test we don't want to pass real S3 bucket (as we don't yet have a minio infrastructure to supply one for scylla and we want to
+# avoid creating real S3 buckets if possible) - thus we're making this test `scylla_only`.
+# In future it will be updated to use a minio bucket and `scylla_only` marker will be removed.
+def test_export_table_basic(test_table_s_for_export_only, scylla_only):
+    client = test_table_s_for_export_only.meta.client
+    table_arn = client.describe_table(TableName=test_table_s_for_export_only.name)['Table']['TableArn']
+    client_token = random_string(20)
+
+    response = client.export_table_to_point_in_time(
+        TableArn=table_arn,
+        S3Bucket='my-test-bucket',
+        S3Prefix='exports/test',
+        ExportFormat='DYNAMODB_JSON',
+        ClientToken=client_token,
+    )
+
+    assert 'ExportDescription' in response
+    export_desc = response['ExportDescription']
+    assert export_desc['ExportStatus'] == 'FAILED'
+    assert export_desc['S3Bucket'] == 'my-test-bucket'
+    assert export_desc['S3Prefix'] == 'exports/test'
+    assert export_desc['ExportFormat'] == 'DYNAMODB_JSON'
+    assert export_desc['ClientToken'] == client_token
+    assert export_desc['TableArn'] == table_arn
+    assert export_desc['ExportArn'].startswith(f"arn:aws:dynamodb:")
+
+
+# Test that non-DYNAMODB_JSON format (ION) is rejected.
+def test_export_table_unsupported_format_ion(dynamodb, test_table_s_for_export_only, scylla_only):
+    client = test_table_s_for_export_only.meta.client
+    table_arn = client.describe_table(TableName=test_table_s_for_export_only.name)['Table']['TableArn']
+
+    with pytest.raises(ClientError, match='ValidationException.*[eE]xportFormat'):
+        client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket='my-bucket',
+            ExportFormat='ION',
+        )
+
+
+# Test that incremental export is rejected.
+def test_export_table_unsupported_incremental(dynamodb, test_table_s_for_export_only, scylla_only):
+    client = test_table_s_for_export_only.meta.client
+    table_arn = client.describe_table(TableName=test_table_s_for_export_only.name)['Table']['TableArn']
+
+    with pytest.raises(ClientError, match='ValidationException.*[eE]xportType'):
+        client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket='my-bucket',
+            ExportType='INCREMENTAL_EXPORT',
+        )
+
+
+# Test that IncrementalExportSpecification is rejected.
+def test_export_table_unsupported_incremental_spec(dynamodb, test_table_s_for_export_only, scylla_only):
+    client = test_table_s_for_export_only.meta.client
+    table_arn = client.describe_table(TableName=test_table_s_for_export_only.name)['Table']['TableArn']
+
+    with pytest.raises(ClientError, match='ValidationException.*[iI]ncrementalExportSpecification'):
+        client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket='my-bucket',
+            IncrementalExportSpecification={
+                'ExportFromTime': int(time.time()) - 3600,
+                'ExportToTime': int(time.time()),
+                'ExportViewType': 'NEW_IMAGE',
+            },
+        )
+
+
+@pytest.mark.parametrize('unsupported_parameter, value', [
+    ('S3BucketOwner', '123456789012'),
+    ('S3SseAlgorithm', 'AES256'),
+    ('S3SseKmsKeyId', 'test-key-id'),
+])
+def test_export_table_unsupported_s3_options(test_table_s_for_export_only, scylla_only, unsupported_parameter, value):
+    client = test_table_s_for_export_only.meta.client
+    table_arn = client.describe_table(TableName=test_table_s_for_export_only.name)['Table']['TableArn']
+
+    with pytest.raises(ClientError, match=f'ValidationException.*{unsupported_parameter}'):
+        client.export_table_to_point_in_time(
+            TableArn=table_arn,
+            S3Bucket='my-bucket',
+            **{unsupported_parameter: value},
+        )
+
+
+# Test that ExportTime close to now is accepted.
+# This is a separate test for scylla only, as DynamoDB itself will reject ExportTime close to now.
+# For performance reasons in test we don't want to follow the suit with it.
+def test_export_table_export_time_now(test_table_s_for_export_only, scylla_only):
+    client = test_table_s_for_export_only.meta.client
+    table_arn = client.describe_table(TableName=test_table_s_for_export_only.name)['Table']['TableArn']
+
+    response = client.export_table_to_point_in_time(
+        TableArn=table_arn,
+        S3Bucket='my-bucket',
+        ExportTime=int(time.time()),
+    )
+    assert response['ExportDescription']['ExportStatus'] == 'FAILED'

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -405,6 +405,12 @@ def test_table_scan_operations(test_table_s, metrics):
         test_table_s.query(Limit=1, KeyConditionExpression='p=:p',
             ExpressionAttributeValues={':p': 'dog'})
 
+def test_export_table_operations(test_table_s, metrics):
+    table_arn = test_table_s.meta.client.describe_table(TableName=test_table_s.name)['Table']['TableArn']
+    with check_increases_operation(metrics, ['ExportTableToPointInTime']):
+        with check_table_increases_operation(metrics, ['ExportTableToPointInTime'], test_table_s.name):
+            test_table_s.meta.client.export_table_to_point_in_time(TableArn=table_arn, S3Bucket='my-bucket')
+
 # Test counter for Query with VectorSearch: both global and per-table.
 def test_query_vector_operations(vs, metrics):
     with new_test_table(vs,


### PR DESCRIPTION
This PR wires ExportTableToPointInTime into Alternator and validates the supported request parameters. It returns a temporary placeholder ExportDescription with FAILED status. It does not implement the real export lifecycle, metadata-backed identity, generated client-token/idempotency behavior, DescribeExport / ListExports integration, S3/native-backup execution, or full export authorization.

Fixes: SCYLLADB-1890

Backport: none, new feature.