### PR TITLE
stables_loader: restore original tablet hints after tablet-aware restore is done or if it fails

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -128,6 +128,26 @@ schema_ptr snapshot_sstables() {
     return schema;
 }
 
+schema_ptr snapshot_cql_tables() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_CQL_TABLES);
+        return schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_CQL_TABLES, std::make_optional(id))
+                // Name of the snapshot
+                .with_column("snapshot_name", utf8_type, column_kind::partition_key)
+                // Keyspace where the table belongs
+                .with_column("keyspace", utf8_type, column_kind::clustering_key)
+                // Table name
+                .with_column("table", utf8_type, column_kind::clustering_key)
+                // Whether this table is a materialized view
+                .with_column("is_view", boolean_type)
+                // CQL schema string of the table
+                .with_column("schema", utf8_type)
+                .with_hash_version()
+                .build();
+    }();
+    return schema;
+}
+
 // This is the set of tables which this node ensures to exist in the cluster.
 // It does that by announcing the creation of these schemas on initialization
 // of the `system_distributed_keyspace` service (see `start()`), unless it first
@@ -144,11 +164,12 @@ static std::vector<schema_ptr> ensured_tables() {
         cdc_desc(),
         cdc_timestamps(),
         snapshot_sstables(),
+        snapshot_cql_tables(),
     };
 }
 
 std::vector<schema_ptr> system_distributed_keyspace::all_distributed_tables() {
-    return {view_build_status(), cdc_desc(), cdc_timestamps(), snapshot_sstables()};
+    return {view_build_status(), cdc_desc(), cdc_timestamps(), snapshot_sstables(), snapshot_cql_tables()};
 }
 
 system_distributed_keyspace::system_distributed_keyspace(cql3::query_processor& qp, service::migration_manager& mm, service::storage_proxy& sp)
@@ -447,6 +468,17 @@ future<> system_distributed_keyspace::insert_snapshot_sstable(sstring snapshot_n
             cql3::query_processor::cache_internal::yes).discard_result();
 }
 
+future<> system_distributed_keyspace::insert_snapshot_cql_table(sstring snapshot_name, sstring ks, sstring table, bool is_view, sstring schema, db::consistency_level cl) {
+    static constexpr uint64_t ttl_seconds = std::chrono::seconds(std::chrono::days(3)).count();
+    sstring query = format("INSERT INTO {}.{} (snapshot_name, \"keyspace\", \"table\", is_view, \"schema\") VALUES (?, ?, ?, ?, ?) USING TTL {}", NAME, SNAPSHOT_CQL_TABLES, ttl_seconds);
+    return _qp.execute_internal(
+            query,
+            cl,
+            internal_distributed_query_state(),
+            { std::move(snapshot_name), std::move(ks), std::move(table), is_view, std::move(schema) },
+            cql3::query_processor::cache_internal::yes).discard_result();
+}
+
 future<utils::chunked_vector<snapshot_sstable_entry>>
 system_distributed_keyspace::get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl, std::optional<dht::token> start_token, std::optional<dht::token> end_token) const {
     utils::chunked_vector<snapshot_sstable_entry> sstables;
@@ -510,6 +542,24 @@ future<> system_distributed_keyspace::update_sstable_download_status(sstring sna
                                   internal_distributed_query_state(),
                                   {downloaded == is_downloaded::yes ? true : false, snapshot_name, ks, table, dc, rack, dht::token::to_int64(start_token), sstable_id.uuid()},
                                   cql3::query_processor::cache_internal::no);
+}
+
+future<sstring>
+system_distributed_keyspace::get_snapshot_cql_table_schema(sstring snapshot_name, sstring ks, sstring table, db::consistency_level cl) const {
+    sstring query = format("SELECT \"schema\" FROM {}.{}"
+            " WHERE snapshot_name = ? AND \"keyspace\" = ? AND \"table\" = ?", NAME, SNAPSHOT_CQL_TABLES);
+
+    auto cql = co_await _qp.execute_internal(
+            query + ";",
+            cl,
+            internal_distributed_query_state(),
+            { std::move(snapshot_name), std::move(ks), std::move(table) },
+            cql3::query_processor::cache_internal::yes);
+
+    if (!cql || cql->empty()) {
+        throw std::runtime_error(format("Snapshot {} for {}.{} doesn't exist", snapshot_name, ks, table));
+    }
+    co_return cql->one().get_as<sstring>("schema");
 }
 
 } // namespace db

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -70,6 +70,9 @@ public:
     /* This table is used by the backup and restore code to store per-sstable metadata.
      * The data the coordinator node puts in this table comes from the snapshot manifests. */
     static constexpr auto SNAPSHOT_SSTABLES = "snapshot_sstables";
+    /* This table is used by the backup and restore code to store per-table CQL schema metadata.
+     * The data the coordinator node puts in this table comes from the snapshot manifests. */
+    static constexpr auto SNAPSHOT_CQL_TABLES = "snapshot_cql_tables";
 
     static constexpr uint64_t SNAPSHOT_SSTABLES_TTL_SECONDS = std::chrono::seconds(std::chrono::days(3)).count();
 
@@ -121,6 +124,8 @@ public:
      * Returns a vector of `snapshot_sstable_entry` structs containing `sstable_id`, `first_token`, `last_token`,
      * `toc_name`, and `prefix`. Uses consistency level `LOCAL_QUORUM` by default. */
     future<utils::chunked_vector<snapshot_sstable_entry>> get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM, std::optional<dht::token> start_token = std::nullopt, std::optional<dht::token> end_token = std::nullopt) const;
+    future<> insert_snapshot_cql_table(sstring snapshot_name, sstring ks, sstring table, bool is_view, sstring schema, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+    future<sstring> get_snapshot_cql_table_schema(sstring snapshot_name, sstring ks, sstring table, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM) const;
 
     future<> update_sstable_download_status(sstring snapshot_name,
                                             sstring ks,

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -170,7 +170,8 @@ or
 # System tables
 There are a few system tables that object storage related code needs to touch in order to operate.
 * [system_distributed.snapshot_sstables](docs/dev/snapshot_sstables.md) - Used during restore by worker nodes to get the list of SSTables that need to be downloaded from object storage and restored locally.
-* [system.sstables](docs/dev/system_keyspace.md#systemsstables) - Used to keep track of SSTables on object storage when a keyspace is created with object storage storage_options.
+* [system_distributed.snapshot_cql_tables](docs/dev/snapshot_cql_tables.md) - Used during restore to get the CQL schema of tables that need to be restored.
+* [system.sstables](docs/dev/system_keyspace.md#systemsstables) - Used to keep track of SSTables on object storage when a keyspace is created with S3 storage_options.
 
 # Manipulating S3 data
 

--- a/docs/dev/snapshot_cql_tables.md
+++ b/docs/dev/snapshot_cql_tables.md
@@ -1,0 +1,64 @@
+# system\_distributed.snapshot\_cql\_tables
+
+## Purpose
+
+This table is used during tablet-aware restore to store the CQL schema of tables included in a snapshot.
+The schema of the table is then altered (table is dropped and recreated with a new schema) so that
+the min_tablet_count/max_tablet_count hints are set equal to the tablet count, thus preventing the load
+balancer from kicking in. The schema of the restored table is then restored to the original schema stored
+in the snapshot_cql_tables table.
+
+Note that rows are inserted with a TTL so that stale restore metadata is automatically cleaned up.
+This is a temporary solution which will be replaced at some point with a mechanism for either
+cleaning up snapshots once restore is done or by doing it manually.
+
+## Schema
+
+~~~
+CREATE TABLE system_distributed.snapshot_cql_tables (
+    snapshot_name text,
+    "keyspace" text,
+    "table" text,
+    is_view boolean,
+    "schema" text,
+    PRIMARY KEY (snapshot_name, "keyspace", "table")
+)
+~~~
+
+Column descriptions:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `snapshot_name` | text (partition key) | Name of the snapshot |
+| `keyspace` | text (clustering key) | Keyspace the table belongs to |
+| `table` | text (clustering key) | Table name within the keyspace |
+| `is_view` | boolean | Whether this table is a materialized view |
+| `schema` | text | CQL schema string of the table |
+
+## APIs
+
+The following C++ APIs are provided in `db::system_distributed_keyspace`:
+
+### insert\_snapshot\_cql\_table
+
+```cpp
+future<> insert_snapshot_cql_table(
+    sstring snapshot_name, sstring ks, sstring table,
+    bool is_view, sstring schema,
+    db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+```
+
+Inserts a single table entry for a given snapshot, keyspace, and table.
+The row is written with a 3-day TTL (this will change in the future, see the note in the beginning).
+
+### get\_snapshot\_cql\_table\_schema
+
+```cpp
+future<sstring> get_snapshot_cql_table_schema(
+    sstring snapshot_name, sstring ks, sstring table,
+    db::consistency_level cl = db::consistency_level::LOCAL_QUORUM) const;
+```
+
+Retrieves the CQL schema string for a specific table within a snapshot.
+The combination of `snapshot_name`, `ks`, and `table` forms the full primary key,
+so exactly one row is expected.

--- a/locator/tablet_sharder.hh
+++ b/locator/tablet_sharder.hh
@@ -15,6 +15,39 @@
 
 namespace locator {
 
+// Returns the shard of the replica for the given host in the replica set,
+// or nullopt if the host is not in the set.
+inline std::optional<shard_id> get_shard(const tablet_replica_set& replicas, host_id host) {
+    for (auto&& r : replicas) {
+        if (r.host == host) {
+            return r.shard;
+        }
+    }
+    return std::nullopt;
+}
+
+// Returns the shard that should serve reads for a given tablet on the given host,
+// taking into account any in-progress tablet transition.
+// Returns nullopt if the host does not own a replica for this tablet.
+inline std::optional<shard_id> get_shard_for_reads(const tablet_map& tmap, tablet_id tid, host_id host) {
+    auto& tinfo = tmap.get_tablet_info(tid);
+    auto* trinfo = tmap.get_tablet_transition_info(tid);
+
+    if (!trinfo) {
+        return get_shard(tinfo.replicas, host);
+    }
+
+    // See "Shard assignment stability" from doc/dev/topology-over-raft.md for explanation of logic.
+    if (trinfo->pending_replica && trinfo->pending_replica->host == host) {
+        if (trinfo->transition == tablet_transition_kind::intranode_migration && trinfo->reads == read_replica_set_selector::previous) {
+            return get_shard(tinfo.replicas, host);
+        }
+        return trinfo->pending_replica->shard;
+    }
+
+    return get_shard(tinfo.replicas, host);
+}
+
 /// Implements sharder object which reflects assignment of tablets of a given table to local shards.
 /// Token ranges which don't have local tablets are reported to belong to shard 0.
 class tablet_sharder : public dht::sharder {
@@ -30,15 +63,6 @@ private:
             _tmap = &_tm.tablets().get_tablet_map(_table);
         }
     }
-
-    std::optional<unsigned> get_shard(const tablet_replica_set& replicas, host_id host) const {
-        for (auto&& r : replicas) {
-            if (r.host == host) {
-                return r.shard;
-            }
-        }
-        return std::nullopt;
-    };
 
     dht::shard_replica_set choose_shard_for_writes(tablet_id tid, host_id host, std::optional<write_replica_set_selector> sel = std::nullopt) const {
         auto* trinfo = _tmap->get_tablet_transition_info(tid);
@@ -80,23 +104,7 @@ private:
 
     std::optional<shard_id> choose_shard_for_reads(tablet_id tid, host_id host) const {
         ensure_tablet_map();
-        auto* trinfo = _tmap->get_tablet_transition_info(tid);
-        auto& tinfo = _tmap->get_tablet_info(tid);
-
-        if (!trinfo) {
-            return get_shard(tinfo.replicas, host);
-        }
-
-        // See "Shard assignment stability" from doc/dev/topology-over-raft.md for explanation of logic.
-
-        if (trinfo->pending_replica && trinfo->pending_replica->host == host) {
-            if (trinfo->transition == tablet_transition_kind::intranode_migration && trinfo->reads == read_replica_set_selector::previous) {
-                return get_shard(tinfo.replicas, host);
-            }
-            return trinfo->pending_replica->shard;
-        }
-
-        return get_shard(tinfo.replicas, host);
+        return get_shard_for_reads(*_tmap, tid, host);
     }
 public:
     tablet_sharder(const token_metadata& tm, table_id table, std::optional<host_id> host = std::nullopt)
@@ -162,7 +170,7 @@ public:
         auto* trinfo = _tmap->get_tablet_transition_info(tid);
         auto& tinfo = _tmap->get_tablet_info(tid);
 
-        auto shard = get_shard(tinfo.replicas, _host).value_or(0);
+        auto shard = locator::get_shard(tinfo.replicas, _host).value_or(0);
 
         if (!trinfo) {
             return {shard};

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1278,14 +1278,12 @@ tablet_range_splitter::tablet_range_splitter(schema_ptr schema, const tablet_map
 {
     // Filter all tablets and save only those that have a replica on the specified host.
     for (auto tid = std::optional(tablets.first_tablet()); tid; tid = tablets.next_tablet(*tid)) {
-        const auto& tablet_info = tablets.get_tablet_info(*tid);
-
-        auto replica_it = std::ranges::find_if(tablet_info.replicas, [&] (auto&& r) { return r.host == host; });
-        if (replica_it == tablet_info.replicas.end()) {
+        auto shard = get_shard_for_reads(tablets, *tid, host);
+        if (!shard) {
             continue;
         }
 
-        _tablet_ranges.emplace_back(range_split_result{replica_it->shard, dht::to_partition_range(tablets.get_token_range(*tid))});
+        _tablet_ranges.emplace_back(range_split_result{*shard, dht::to_partition_range(tablets.get_token_range(*tid))});
     }
     _tablet_ranges_it = _tablet_ranges.begin();
 }

--- a/main.cc
+++ b/main.cc
@@ -2381,7 +2381,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             checkpoint(stop_signal, "starting sstables loader");
-            sst_loader.start(std::ref(db), std::ref(ss), std::ref(messaging), std::ref(view_builder), std::ref(view_building_worker), std::ref(task_manager), std::ref(sstm), std::ref(sys_dist_ks), dbcfg.streaming_scheduling_group).get();
+            sst_loader.start(std::ref(db), std::ref(ss), std::ref(messaging), std::ref(view_builder), std::ref(view_building_worker), std::ref(task_manager), std::ref(sstm), std::ref(sys_dist_ks), std::ref(qp), dbcfg.streaming_scheduling_group).get();
             auto stop_sst_loader = defer_verbose_shutdown("sstables loader", [&sst_loader] {
                 sst_loader.stop().get();
             });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -61,6 +61,7 @@
 #include "gms/inet_address.hh"
 #include "utils/log.hh"
 #include "service/migration_manager.hh"
+#include "schema/schema_builder.hh"
 #include "service/raft/raft_group0.hh"
 #include "gms/gossiper.hh"
 #include "gms/feature_service.hh"
@@ -3117,6 +3118,81 @@ future<> storage_service::wait_for_topology_not_busy() {
         release_guard(std::move(guard));
         co_await _topology_state_machine.event.when();
         guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
+    }
+}
+
+future<> storage_service::alter_table_with_tablet_hints(schema_ptr schema,
+                                                        std::optional<size_t> min_tablet_count,
+                                                        std::optional<size_t> max_tablet_count,
+                                                        bool wait_balancer) {
+    if (this_shard_id() != 0) {
+        on_internal_error(slogger, "Only shard 0 can execute alter_table_with_tablet_hints");
+    }
+
+    if (!min_tablet_count && !max_tablet_count) {
+        slogger.info("alter_table_with_tablet_hints: no tablet hints to set for {}.{}, skipping",
+            schema->ks_name(), schema->cf_name());
+        co_return;
+    }
+
+    if (wait_balancer && min_tablet_count != max_tablet_count) {
+        throw std::invalid_argument(format(
+            "wait_balancer requires both min_tablet_count and max_tablet_count to be provided and equal, got min={} max={}",
+            min_tablet_count ? to_sstring(*min_tablet_count) : "nullopt",
+            max_tablet_count ? to_sstring(*max_tablet_count) : "nullopt"));
+    }
+
+    std::map<sstring, sstring> tablet_options;
+    if (min_tablet_count) {
+        tablet_options["min_tablet_count"] = to_sstring(*min_tablet_count);
+    }
+    if (max_tablet_count) {
+        tablet_options["max_tablet_count"] = to_sstring(*max_tablet_count);
+    }
+
+    schema_builder builder(schema);
+    builder.set_tablet_options(std::move(tablet_options));
+    auto modified_schema = builder.build();
+
+    auto& mm = _migration_manager.local();
+    auto& sp = mm.get_storage_proxy();
+
+    while (true) {
+        auto group0_guard = co_await mm.start_group0_operation();
+        auto ts = group0_guard.write_timestamp();
+        sstring description = format("Altering table {}.{} with tablet count hints min_tablet_count={} max_tablet_count={}",
+            schema->ks_name(), schema->cf_name(),
+            min_tablet_count ? to_sstring(*min_tablet_count) : "unchanged",
+            max_tablet_count ? to_sstring(*max_tablet_count) : "unchanged");
+
+        auto mutations = co_await prepare_column_family_update_announcement(sp, modified_schema, /*view_updates=*/{}, ts);
+
+        if (!mutations.empty()) {
+            try {
+                co_await mm.announce(std::move(mutations), std::move(group0_guard), description);
+                break;
+            } catch (group0_concurrent_modification&) {
+                slogger.info("Concurrent operation is detected while starting, retrying.");
+            }
+        }
+    }
+
+    if (!wait_balancer) {
+        co_return;
+    }
+
+    while (true) {
+        auto tmptr = get_token_metadata_ptr();
+        auto& tmap = tmptr->tablets().get_tablet_map(schema->id());
+        auto tablet_count = tmap.tablet_count();
+
+        // FIXME: Checking tablet_count <= max_tablet_count should be enough, but the restore code currently has a limitation and it cannot handle
+        // any merges or splits until the restore transitions are done
+        if (tablet_count == *max_tablet_count) {
+            break;
+        }
+        co_await _topology_state_machine.event.when();
+        // FIXME: add an abort_source propagated from the root of the restore operation (SCYLLADB-1076)
     }
 }
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -1077,6 +1077,14 @@ public:
     void set_train_dict_callback(decltype(_train_dict));
     seastar::future<> notify_client_routes_change(const client_routes_service::client_route_keys& client_route_keys);
 
+    // Alters the given table's min/max tablet count hints. Only the engaged
+    // hints are applied; if both are disengaged the call is a no-op. When
+    // wait_balancer is set, waits for the load balancer to reach the requested
+    // tablet count (which requires both hints to be engaged and equal).
+    future<> alter_table_with_tablet_hints(schema_ptr schema,
+                                           std::optional<size_t> min_tablet_count,
+                                           std::optional<size_t> max_tablet_count,
+                                           bool wait_balancer = true);
 
     friend class join_node_rpc_handshaker;
     friend class node_ops::node_ops_virtual_task;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1206,7 +1206,16 @@ public:
 protected:
     virtual future<> run() override {
         auto& loader = _loader.local();
-        co_await loader._ss.local().restore_tablets(_tid, _snap_name, _endpoint, _bucket);
+
+        std::exception_ptr eptr;
+        try {
+            co_await loader._ss.local().restore_tablets(_tid, _snap_name, _endpoint, _bucket);
+        } catch (...) {
+            llog.error("Failed to restore tablets for table_id {}. Error: {}", _tid, std::current_exception());
+            eptr = std::current_exception();
+        }
+
+        llog.info("Restoring table with tid {} to the original schema", _tid);
 
         // Get table schema from snapshot_cql_tables table and
         // call alter_table_with_tablet_hints to restore the table schema to its original form
@@ -1220,6 +1229,10 @@ protected:
         auto max_tablet_count = original_schema->tablet_options().max_tablet_count;
         // Use the current_schema object and set the tablet hints on it that we got from the original schema
         co_await loader._ss.local().alter_table_with_tablet_hints(current_schema, min_tablet_count, max_tablet_count, false);
+
+        if (eptr) {
+            std::rethrow_exception(eptr);
+        }
 
         auto& db = loader._db.local();
         auto s = db.find_schema(_tid);

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -885,6 +885,7 @@ sstables_loader::sstables_loader(sharded<replica::database>& db,
         tasks::task_manager& tm,
         sstables::storage_manager& sstm,
         db::system_distributed_keyspace& sys_dist_ks,
+        cql3::query_processor& qp,
         seastar::scheduling_group sg)
     : _db(db)
     , _ss(ss)
@@ -894,6 +895,7 @@ sstables_loader::sstables_loader(sharded<replica::database>& db,
     , _task_manager_module(make_shared<task_manager_module>(tm))
     , _storage_manager(sstm)
     , _sys_dist_ks(sys_dist_ks)
+    , _qp(qp)
     , _sched_group(std::move(sg))
 {
     tm.register_module("sstables_loader", _task_manager_module);

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -41,6 +41,8 @@
 #include "utils/rjson.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "table_helper.hh"
+#include "replica/schema_describe_helper.hh"
+#include "replica/tablets.hh"
 
 #include <cfloat>
 #include <algorithm>
@@ -1258,8 +1260,21 @@ protected:
 future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, utils::chunked_vector<sstring> manifests) {
     auto tablet_count = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
 
-    co_await container().invoke_on(0, [tid, tablet_count] (auto& sl) -> future<> {
+    co_await container().invoke_on(0, [tid, tablet_count, snap_name, keyspace, table] (auto& sl) -> future<> {
+        // Save the original schema of the table in system_distributed.snapshot_cql_table,
+        // so that the restore process can reconstruct the original table schema after attaching the downloaded sstables to the table.
         auto schema = sl._db.local().find_schema(tid);
+        auto schema_desc = schema->describe(replica::make_schema_describe_helper(schema, sl._db.local().as_data_dictionary()), cql3::describe_option::STMTS);
+        auto create_stmt = schema_desc.create_statement.value().linearize();
+        bool schema_exists = true;
+        try {
+            co_await sl._sys_dist_ks.get_snapshot_cql_table_schema(snap_name, keyspace, table);
+        } catch (const std::runtime_error&) {
+            schema_exists = false;
+        }
+        if (!schema_exists) {
+            co_await sl._sys_dist_ks.insert_snapshot_cql_table(snap_name, keyspace, table, schema->is_view(), create_stmt);
+        }
         co_await sl._ss.local().alter_table_with_tablet_hints(schema, tablet_count, tablet_count);
     });
     auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name), std::move(endpoint), std::move(bucket));

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -40,6 +40,7 @@
 #include "sstables/object_storage_client.hh"
 #include "utils/rjson.hh"
 #include "db/system_distributed_keyspace.hh"
+#include "table_helper.hh"
 
 #include <cfloat>
 #include <algorithm>
@@ -1206,6 +1207,19 @@ protected:
     virtual future<> run() override {
         auto& loader = _loader.local();
         co_await loader._ss.local().restore_tablets(_tid, _snap_name, _endpoint, _bucket);
+
+        // Get table schema from snapshot_cql_tables table and
+        // call alter_table_with_tablet_hints to restore the table schema to its original form
+        auto current_schema = loader.local_db().find_schema(_tid);
+
+        auto original_schema_str = co_await loader._sys_dist_ks.get_snapshot_cql_table_schema(_snap_name, current_schema->ks_name(), current_schema->cf_name());
+
+        auto original_schema = table_helper::parse_new_cf_statement(loader._qp, original_schema_str);
+
+        auto min_tablet_count = original_schema->tablet_options().min_tablet_count;
+        auto max_tablet_count = original_schema->tablet_options().max_tablet_count;
+        // Use the current_schema object and set the tablet hints on it that we got from the original schema
+        co_await loader._ss.local().alter_table_with_tablet_hints(current_schema, min_tablet_count, max_tablet_count, false);
 
         auto& db = loader._db.local();
         auto s = db.find_schema(_tid);

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1227,7 +1227,12 @@ protected:
 };
 
 future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, utils::chunked_vector<sstring> manifests) {
-    co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
+    auto tablet_count = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
+
+    co_await container().invoke_on(0, [tid, tablet_count] (auto& sl) -> future<> {
+        auto schema = sl._db.local().find_schema(tid);
+        co_await sl._ss.local().alter_table_with_tablet_hints(schema, tablet_count, tablet_count);
+    });
     auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name), std::move(endpoint), std::move(bucket));
     co_return task->id();
 }

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -153,6 +153,10 @@ public:
 
     future<tasks::task_id> restore_tablets(table_id, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, utils::chunked_vector<sstring> manifests);
 
+    replica::database& local_db() {
+        return _db.local();
+    }
+
     class download_task_impl;
     class tablet_restore_task_impl;
 };

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -31,6 +31,7 @@ struct restore_result {
 
 namespace sstables { class storage_manager; }
 
+namespace cql3 { class query_processor; }
 namespace netw { class messaging_service; }
 namespace db {
 class system_distributed_keyspace;
@@ -93,6 +94,7 @@ private:
     shared_ptr<task_manager_module> _task_manager_module;
     sstables::storage_manager& _storage_manager;
     db::system_distributed_keyspace& _sys_dist_ks;
+    cql3::query_processor& _qp;
     seastar::scheduling_group _sched_group;
 
     // Note that this is obviously only valid for the current shard. Users of
@@ -121,6 +123,7 @@ public:
             tasks::task_manager& tm,
             sstables::storage_manager& sstm,
             db::system_distributed_keyspace& sys_dist_ks,
+            cql3::query_processor& qp,
             seastar::scheduling_group sg);
 
     future<> stop();

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -22,7 +22,7 @@
 
 static logging::logger tlogger("table_helper");
 
-static schema_ptr parse_new_cf_statement(cql3::query_processor& qp, const sstring& create_cql) {
+schema_ptr table_helper::parse_new_cf_statement(cql3::query_processor& qp, const sstring& create_cql) {
     auto db = qp.db();
 
     auto parsed = cql3::query_processor::parse_statement(create_cql, cql3::dialect{});

--- a/table_helper.hh
+++ b/table_helper.hh
@@ -127,6 +127,8 @@ public:
             return std::chrono::system_clock::time_point(nanoseconds((++last_event_nanos) * 100));
         }
     }
+
+    static schema_ptr parse_new_cf_statement(cql3::query_processor& qp, const sstring& create_cql);
 };
 
 struct bad_column_family : public std::exception {

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -27,6 +27,8 @@
 #include "replica/database_fwd.hh"
 #include "tasks/task_handler.hh"
 #include "service/storage_proxy.hh"
+#include "replica/schema_describe_helper.hh"
+#include "utils/UUID_gen.hh"
 
 #include "test/lib/test_utils.hh"
 #include "test/lib/random_utils.hh"
@@ -90,10 +92,10 @@ SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works, *boost::unit_test::pr
 
 using namespace sstables;
 
-future<> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
+future<sstring> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
     sharded<db::snapshot_ctl> ctl;
     co_await ctl.start(std::ref(env.db()), std::ref(env.get_storage_proxy()), std::ref(env.get_task_manager()), std::ref(env.get_sstorage_manager()), db::snapshot_ctl::config{});
-    auto prefix = "/backup";
+    auto prefix = fmt::format("/backup-{}", utils::UUID_gen::get_time_UUID());
 
     auto task_id = co_await ctl.local().start_backup(endpoint, bucket, prefix, "ks", "cf", "snapshot", false);
     auto task = tasks::task_handler{env.get_task_manager().local(), task_id};
@@ -101,6 +103,7 @@ future<> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
     BOOST_REQUIRE(status.state == tasks::task_manager::task_state::done);
 
     co_await ctl.stop();
+    co_return prefix;
 }
 
 future<> check_snapshot_sstables(cql_test_env& env) {
@@ -143,12 +146,13 @@ SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_t
 
             auto ep = storage_options.to_map()["endpoint"];
             auto bucket = storage_options.to_map()["bucket"];
-            backup(env, ep, bucket).get();
+            auto prefix = backup(env, ep, bucket).get();
+            auto manifest_path = prefix + "/manifest.json";
 
-            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "unexpected_snapshot", {"/backup/manifest.json"}, db::consistency_level::ONE).get(), std::runtime_error);;
+            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "unexpected_snapshot", {manifest_path}, db::consistency_level::ONE).get(), std::runtime_error);;
 
             // populate system_distributed.snapshot_sstables with the content of the snapshot manifest
-            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "snapshot", {"/backup/manifest.json"}, db::consistency_level::ONE).get();
+            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "snapshot", {manifest_path}, db::consistency_level::ONE).get();
 
             check_snapshot_sstables(env).get();
     }, false, db_cfg_ptr, 10);

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -25,6 +25,7 @@
 #include "sstables/storage.hh"
 #include "sstables_loader.hh"
 #include "replica/database_fwd.hh"
+#include "replica/tablets.hh"
 #include "tasks/task_handler.hh"
 #include "service/storage_proxy.hh"
 #include "replica/schema_describe_helper.hh"
@@ -178,4 +179,37 @@ SEASTAR_TEST_CASE(test_snapshot_cql_tables_api_works, *boost::unit_test::precond
 
         BOOST_CHECK_EQUAL(result_schema, schema);
     }, db_cfg_ptr);
+}
+
+void verify_tablet_options(cql_test_env& env, table_id tid, size_t desired_count, bool hints_expected) {
+    auto schema = env.local_db().find_schema(tid);
+    auto schema_desc = schema->describe(replica::make_schema_describe_helper(schema, env.local_db().as_data_dictionary()), cql3::describe_option::STMTS);
+    auto create_stmt = schema_desc.create_statement.value().linearize();
+
+    auto min_tablet_count = fmt::format("'min_tablet_count': '{}'", desired_count);
+    auto max_tablet_count = fmt::format("'max_tablet_count': '{}'", desired_count);
+
+    BOOST_CHECK_EQUAL(create_stmt.find(min_tablet_count) != sstring::npos, hints_expected);
+    BOOST_CHECK_EQUAL(create_stmt.find(max_tablet_count) != sstring::npos, hints_expected);
+}
+
+SEASTAR_TEST_CASE(test_restore_alter_table_with_tablet_hints, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    auto db_cfg_ptr = make_shared<db::config>();
+    db_cfg_ptr->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+
+    return do_with_some_data_in_thread({"cf"}, [] (cql_test_env& env) {
+        table_id tid = env.local_db().find_uuid("ks", "cf");
+
+        auto token_metadata = env.local_db().get_token_metadata_ptr();
+        auto& tmap = token_metadata->tablets().get_tablet_map(tid);
+        auto desired_count = tmap.tablet_count();
+
+        verify_tablet_options(env, tid, desired_count, false);
+
+        auto schema = env.local_db().find_schema(tid);
+
+        env.get_storage_service().local().alter_table_with_tablet_hints(schema, desired_count, desired_count).get();
+
+        verify_tablet_options(env, tid, desired_count, true);
+    }, false, db_cfg_ptr, 10);
 }

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -26,7 +26,6 @@
 #include "sstables_loader.hh"
 #include "replica/database_fwd.hh"
 #include "tasks/task_handler.hh"
-#include "db/system_distributed_keyspace.hh"
 #include "service/storage_proxy.hh"
 
 #include "test/lib/test_utils.hh"
@@ -153,4 +152,26 @@ SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_t
 
             check_snapshot_sstables(env).get();
     }, false, db_cfg_ptr, 10);
+}
+
+SEASTAR_TEST_CASE(test_snapshot_cql_tables_api_works, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    auto db_cfg_ptr = make_shared<db::config>();
+
+    return do_with_cql_env([] (cql_test_env& env) -> future<> {
+        auto snapshot_name = "snapshot";
+        auto ks = "ks";
+        auto table = "cf";
+        auto is_view = false;
+        auto schema = "CREATE TABLE ks.cf (pk int PRIMARY KEY, v int)";
+
+        // insert some test data into snapshot_cql_tables table
+        co_await env.get_system_distributed_keyspace().local().insert_snapshot_cql_table(
+                snapshot_name, ks, table, is_view, schema, db::consistency_level::ONE);
+
+        // read it back and check if it is correct
+        auto result_schema = co_await env.get_system_distributed_keyspace().local().get_snapshot_cql_table_schema(
+                snapshot_name, ks, table, db::consistency_level::ONE);
+
+        BOOST_CHECK_EQUAL(result_schema, schema);
+    }, db_cfg_ptr);
 }

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -748,12 +748,10 @@ async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_s
 
     servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
 
-    await manager.disable_tablet_balancing()
     cql = manager.get_cql()
 
     num_keys = 10
     tablet_count=5
-    tablet_count_for_restore=8 # should be tablet_count rounded up to the power of two
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count}}};")
@@ -764,7 +762,7 @@ async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_s
         await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, 'test', object_storage, manager, logger) for s in servers))
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count_for_restore}, 'max_tablet_count': {tablet_count_for_restore}}};")
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int );")
 
         logger.info(f'Restore cluster via {servers[1].ip_addr}')
         manifests = [ f'{s.server_id}/{snap_name}/manifest.json' for s in servers ]

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -908,6 +908,62 @@ async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: Ma
             # So the best thing to do is to make sure restore task finishes at all
             await asyncio.wait_for(manager.api.wait_task(servers[1].ip_addr, tid), timeout=60)
 
+@pytest.mark.parametrize(("min_tablet_count_before_backup", "max_tablet_count_before_backup", "min_tablet_count_before_restore", "max_tablet_count_before_restore"), [
+    (1, 1, 2, 2),
+    (4, 4, 2, 2),
+])
+async def test_restore_tablets_with_different_tablet_hints(build_mode: str, manager: ManagerClient, object_storage,
+                                                           min_tablet_count_before_backup, max_tablet_count_before_backup,
+                                                           min_tablet_count_before_restore, max_tablet_count_before_restore):
+    '''This test checks:
+    1. That restore with tablets works when the tablet count changes between backup and restore (currently by
+    altering the table with tablets hints set to the tablet count from the backup manifest).
+    2. The restore code is well equipped to handle potential shards not owning any tablets, or nodes not owning any tablets,
+    thus verifying that the tablet count written in the manifest is calculated correctly and that restore code
+    can handle tablet counts of 0'''
+
+    topology = topo(rf = 1, nodes = 3, racks = 1, dcs = 1)
+
+    servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
+
+    cql = manager.get_cql()
+
+    # We need enough keys to have a high probability of spanning keys all over the tablet ranges.
+    # The SSTable downloading code will throw sstables_partially_contained unless the restoring code
+    # correctly sets the tablet hints to what was originally populated in the backup manifest.
+    num_keys = 1000
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {min_tablet_count_before_backup}, 'max_tablet_count': {max_tablet_count_before_backup}}};")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, value) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
+        snap_name,_ = await take_snapshot(ks, servers, manager, logger)
+        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, 'test', object_storage, manager, logger) for s in servers))
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {min_tablet_count_before_restore}, 'max_tablet_count': {max_tablet_count_before_restore}}};")
+
+        logger.info(f'Restore cluster via {servers[1].ip_addr}')
+        manifests = [ f'{s.server_id}/{snap_name}/manifest.json' for s in servers ]
+        tid = await manager.api.restore_tablets(servers[1].ip_addr, ks, 'test', snap_name, servers[0].datacenter,object_storage.address, object_storage.bucket_name, manifests)
+        status = await manager.api.wait_task(servers[1].ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done')
+
+        # FIXME:Disable the tablet balancer before checking mutations to avoid
+        # MUTATION_FRAGMENTS returning inconsistent results during inter-node
+        # tablet migrations (different nodes see different ERM stages).
+        await manager.disable_tablet_balancing()
+        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
+
+        # Verify that restore used the tablet hints from the backup manifest,
+        # not the ones set on the pre-restore table.
+        # FIXME: this check will be removed as it's irelevant after we implement the cleanup phase of tablet aware restore
+        # but the test will remain relevant as it was designed to fail if the restore code doesnt properly fix the tablet
+        # count to what was written in the backup manifest.
+        desc = (await cql.run_async(f"DESC TABLE {ks}.test"))[0].create_statement
+        assert f"'min_tablet_count': '{min_tablet_count_before_backup}'" in desc, f"Expected min_tablet_count={min_tablet_count_before_backup} in: {desc}"
+        assert f"'max_tablet_count': '{max_tablet_count_before_backup}'" in desc, f"Expected max_tablet_count={max_tablet_count_before_backup} in: {desc}"
 
 async def test_restore_with_non_existing_sstable(manager: ManagerClient, object_storage):
     '''Check that restore task fails well when given a non-existing sstable'''

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -956,14 +956,10 @@ async def test_restore_tablets_with_different_tablet_hints(build_mode: str, mana
         await manager.disable_tablet_balancing()
         await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
 
-        # Verify that restore used the tablet hints from the backup manifest,
-        # not the ones set on the pre-restore table.
-        # FIXME: this check will be removed as it's irelevant after we implement the cleanup phase of tablet aware restore
-        # but the test will remain relevant as it was designed to fail if the restore code doesnt properly fix the tablet
-        # count to what was written in the backup manifest.
+        # Verify that restore altered the table back with the tablet hints set before restore started
         desc = (await cql.run_async(f"DESC TABLE {ks}.test"))[0].create_statement
-        assert f"'min_tablet_count': '{min_tablet_count_before_backup}'" in desc, f"Expected min_tablet_count={min_tablet_count_before_backup} in: {desc}"
-        assert f"'max_tablet_count': '{max_tablet_count_before_backup}'" in desc, f"Expected max_tablet_count={max_tablet_count_before_backup} in: {desc}"
+        assert f"'min_tablet_count': '{min_tablet_count_before_restore}'" in desc, f"Expected min_tablet_count={min_tablet_count_before_restore} in: {desc}"
+        assert f"'max_tablet_count': '{max_tablet_count_before_restore}'" in desc, f"Expected max_tablet_count={max_tablet_count_before_restore} in: {desc}"
 
 async def test_restore_with_non_existing_sstable(manager: ManagerClient, object_storage):
     '''Check that restore task fails well when given a non-existing sstable'''


### PR DESCRIPTION
During tablet-aware-restore, the table's tablet hints are temporarily altered to match the backup manifest.
After restore completes, or if it fails, the table schema should be returned to its original state.

This PR adds a cleanup phase to the tablet restore task that reads the original table schema from system_distributed.snapshot_cql_tables and alters the table back to its original tablet hints. If the original schema had no tablet hints, the alter_table_with_tablet_hints function is noop.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-986

Prerequisite PRs:
- https://github.com/scylladb/scylladb/pull/30023
- https://github.com/scylladb/scylladb/pull/30069

No backport needed since this is a new feature targeting tablet-aware restore.