### PR TITLE
Update seastar submodule

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -14,7 +14,7 @@
 #include "utils/log.hh"
 #include <fmt/ranges.h>
 #include <seastar/http/function_handlers.hh>
-#include <seastar/http/short_streams.hh>
+#include <seastar/util/short_streams.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/defer.hh>

--- a/api/client_routes.cc
+++ b/api/client_routes.cc
@@ -7,7 +7,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
- #include <seastar/http/short_streams.hh>
+ #include <seastar/util/short_streams.hh>
 
 #include "client_routes.hh"
 #include "api/api.hh"

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -36,7 +36,7 @@
 #include "gms/gossiper.hh"
 #include "db/system_keyspace.hh"
 #include <seastar/http/exception.hh>
-#include <seastar/http/short_streams.hh>
+#include <seastar/util/short_streams.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/exception.hh>

--- a/api/system.cc
+++ b/api/system.cc
@@ -19,7 +19,7 @@
 #include <seastar/core/relabel_config.hh>
 #include <seastar/http/exception.hh>
 #include <seastar/util/short_streams.hh>
-#include <seastar/http/short_streams.hh>
+#include <seastar/util/short_streams.hh>
 
 #include "utils/log.hh"
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -13,7 +13,7 @@
 #include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/units.hh>
-#include <seastar/http/short_streams.hh>
+#include <seastar/util/short_streams.hh>
 #include <seastar/util/closeable.hh>
 
 #include "init.hh"

--- a/vector_search/client.cc
+++ b/vector_search/client.cc
@@ -13,7 +13,7 @@
 #include "utils/exponential_backoff_retry.hh"
 #include "utils/rjson.hh"
 #include <seastar/http/request.hh>
-#include <seastar/http/short_streams.hh>
+#include <seastar/util/short_streams.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/net/api.hh>
 #include <seastar/coroutine/as_future.hh>


### PR DESCRIPTION
Includes of now-removed header seastar/http/short_streams.hh were redirected
to seastar/util/short_streams.hh.

* seastar 510f3148...4ccea322 (24):
  > Merge 'github: revamp test matrix (allpairs, containers, arm)' from Travis Downs
    github/gen-matrix.py: add sanitize mode, exclude g++ debug+sanitize
    github: pin all actions to commit SHAs
    github: add arch dimension (x86 / arm) to the test matrix
    github/gen-matrix.py: use all-pairs coverage instead of full cartesian
    cmake: fail fast if clang >= 20 is paired with fmt < 11
    github: test on clang-21, clang-22, gcc-15, gcc-16
    github/test.yaml: factor build setup into install-build-env.sh
    github/test.yaml: run inside an ubuntu:26.04 container
    github: bump actions to Node 24 versions
    github/test.yaml: echo workflow inputs at start of run
    github: generate test matrix via gen-matrix.py
  > Merge 'reactor_backend: refactor aio retry into a long-lasting coroutine' from Benny Halevy
    reactor_backend: retry_loop: add a timer when waiting after a retry failure
    reactor_backend: signal retry_loop from retry_iocb
    reactor_backend: extract cancel_iocb and retry_iocb helpers
    reactor_backend: aio_storage_context: rename schedule_retry to signal_retry_loop
    reactor_backend: turn aio retry into a long-lasting coroutine
  > reactor: Remove deprecated cpu_id() method
  > sstring: Remove deprecated reset() method
  > net: Remove deprecated make_udp_channel
  > http: Remove deprecated httpd::short_streams.hh header
  > util: Remove deprecated disable_failure_guard
  > http: Remove deprecated httpd::mime_types namespace
  > util: Remove deprecated later() function
  > tests: avoid printing std::vector in BOOST_CHECK_EQUAL
  > cmake: don't require i40e/sfc DPDK PMDs on RISC-V
  > build: also detect GCC's -Wno-error=cpp for #warning
  > rpc: use fmt::format for remote exception reporting
  > build: add fmt-12-1-dev cooking ingredient
  > coroutine: disable g++ coroutine destroy-in-suspend bug workaround for fixed versions
  > core/alien: honor message_queue alignment when allocating queue array
  > modules: export more symbols
  > core: use std::hardware_destructive_interference_size for cache_line_size
  > core, util: add initial RISC-V port
  > Merge 'tests: fix two C++26 ambiguities in unit/perf tests' from Travis Downs
    tests/perf: fix ranges::find string-literal ambiguity under C++26
    tests/httpd: fix sstring + std::string ambiguity under C++26
  > tests/generator: silence gcc -Wmismatched-new-delete around sync_fibonacci_sequence
  > seastar-json2code.py: support module dependencies
  > bool_class: make operators constexpr
  > http: declare unsigned-char alphabet in ragel parsers

Routine submodule update, not backporting. Nothing in the update is an important fix.