### PR TITLE
repair: shrink repair_row by 56 bytes (136->80, -41%) via out-of-line sync boundary

### DIFF
--- a/repair/row.hh
+++ b/repair/row.hh
@@ -128,4 +128,13 @@ public:
     }
 };
 
+// copy() and size() enumerate repair_row's members by hand (copy() because the
+// type is move-only, size() to account for the out-of-line sync boundary). This
+// guard fires if the layout changes - e.g. a member is added - so both are
+// revisited rather than silently mishandling the new field. Update the expected
+// size deliberately together with copy()/size() when the layout legitimately
+// changes.
+static_assert(sizeof(repair_row) == 80,
+        "repair_row layout changed: revisit copy() and size() member-by-member handling");
+
 

--- a/repair/row.hh
+++ b/repair/row.hh
@@ -7,6 +7,7 @@
  */
 
 #pragma once
+#include <memory>
 #include <optional>
 #include "mutation/frozen_mutation.hh"
 #include <seastar/core/shared_ptr.hh>
@@ -23,7 +24,12 @@ class repair_hash;
 class repair_row {
     std::optional<frozen_mutation_fragment> _fm;
     lw_shared_ptr<const decorated_key_with_hash> _dk_with_hash;
-    std::optional<repair_sync_boundary> _boundary;
+    // Only the master side needs a sync boundary; on the follower side it is
+    // always empty. Hold it behind a unique_ptr so an empty boundary costs one
+    // pointer (8B) instead of an inline std::optional<repair_sync_boundary>
+    // (64B), shrinking the per-row footprint that is multiplied by the number
+    // of rows buffered during a repair round.
+    std::unique_ptr<repair_sync_boundary> _boundary;
     std::optional<repair_hash> _hash;
     is_dirty_on_master _dirty_on_master;
     lw_shared_ptr<mutation_fragment> _mf;
@@ -37,11 +43,25 @@ public:
             lw_shared_ptr<mutation_fragment> mf = {})
             : _fm(std::move(fm))
             , _dk_with_hash(std::move(dk_with_hash))
-            , _boundary(pos ? std::optional<repair_sync_boundary>(repair_sync_boundary{_dk_with_hash->dk, std::move(*pos)}) : std::nullopt)
+            , _boundary(pos ? std::make_unique<repair_sync_boundary>(repair_sync_boundary{_dk_with_hash->dk, std::move(*pos)}) : nullptr)
             , _hash(std::move(hash))
             , _dirty_on_master(dirty_on_master)
             , _mf(std::move(mf))
     { }
+    // repair_row is move-only because _boundary is held behind a unique_ptr.
+    // The few places that intentionally duplicate a row (copying out of the
+    // working buffer) must use copy() so the deep copy of the sync boundary is
+    // explicit rather than accidental.
+    repair_row copy() const {
+        repair_row r;
+        r._fm = _fm;
+        r._dk_with_hash = _dk_with_hash;
+        r._boundary = _boundary ? std::make_unique<repair_sync_boundary>(*_boundary) : nullptr;
+        r._hash = _hash;
+        r._dirty_on_master = _dirty_on_master;
+        r._mf = _mf;
+        return r;
+    }
     lw_shared_ptr<mutation_fragment>& get_mutation_fragment_ptr() { return _mf; }
     mutation_fragment& get_mutation_fragment() {
         if (!_mf) {
@@ -73,7 +93,8 @@ public:
         }
         auto size = sizeof(repair_row) + _fm->representation().size();
         if (_boundary) {
-            size += _boundary->pk.external_memory_usage() + _boundary->position.external_memory_usage();
+            // Account for the heap node itself; it used to be inline in sizeof(repair_row).
+            size += sizeof(repair_sync_boundary) + _boundary->pk.external_memory_usage() + _boundary->position.external_memory_usage();
         }
         if (_mf) {
             size += _mf->memory_usage();

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1528,8 +1528,8 @@ private:
                    | std::ranges::to<repair_hash_set>();
         }
         if (update_buf) {
-            // Both row_diff and _working_row_buf and are ordered, merging
-            // two sored list to make sure the combination of row_diff
+            // Both row_diff and _working_row_buf are ordered, merging
+            // two sorted lists to make sure the combination of row_diff
             // and _working_row_buf are ordered. The rows are spliced (moved)
             // out of row_diff, so it is left empty afterwards.
             utils::merge_to_gently(_working_row_buf, std::move(row_diff),

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1445,7 +1445,7 @@ private:
     copy_rows_from_working_row_buf() {
         std::list<repair_row> rows;
         for (const repair_row& r : _working_row_buf) {
-            rows.push_back(r);
+            rows.push_back(r.copy());
             co_await coroutine::maybe_yield();
         }
         co_return rows;
@@ -1456,7 +1456,7 @@ private:
         std::list<repair_row> rows;
         for (const repair_row& r : _working_row_buf) {
             if (set_diff.contains(r.hash())) {
-                rows.push_back(r);
+                rows.push_back(r.copy());
             }
             co_await coroutine::maybe_yield();
         }
@@ -1511,20 +1511,29 @@ private:
         stats().rx_row_nr += row_diff.size();
         stats().rx_row_nr_peer[from] += row_diff.size();
         if (update_buf) {
-            // Both row_diff and _working_row_buf and are ordered, merging
-            // two sored list to make sure the combination of row_diff
-            // and _working_row_buf are ordered.
-            utils::merge_to_gently(_working_row_buf, row_diff,
-                 [this] (const repair_row& x, const repair_row& y) { return _cmp(x.boundary(), y.boundary()) < 0; });
+            // Accumulate the row hashes before merging: merge_to_gently below
+            // splices row_diff's nodes into _working_row_buf (leaving row_diff
+            // empty), and the combined hash is an XOR so it is independent of
+            // the order in which the hashes are added.
             for (auto& r : row_diff) {
                 thread::maybe_yield();
                 _working_row_buf_combined_hash.add(r.hash());
             }
         }
         if (update_hash_set) {
+            // Build the peer hash set before the merge below, which moves
+            // row_diff's rows into _working_row_buf and leaves row_diff empty.
             _peer_row_hash_sets[node_idx] = row_diff
                    | std::views::transform([] (repair_row& r) { thread::maybe_yield(); return r.hash(); })
                    | std::ranges::to<repair_hash_set>();
+        }
+        if (update_buf) {
+            // Both row_diff and _working_row_buf and are ordered, merging
+            // two sored list to make sure the combination of row_diff
+            // and _working_row_buf are ordered. The rows are spliced (moved)
+            // out of row_diff, so it is left empty afterwards.
+            utils::merge_to_gently(_working_row_buf, std::move(row_diff),
+                 [this] (const repair_row& x, const repair_row& y) { return _cmp(x.boundary(), y.boundary()) < 0; });
         }
         // Repair rows in row_diff will be flushed to disk by flush_rows_in_working_row_buf,
         // so we skip calling do_apply_rows here.

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -346,9 +346,9 @@ SEASTAR_TEST_CASE(repair_rows_size_considers_external_memory) {
         repair_row row_with_mf{frozen_mf, std::nullopt, nullptr, std::nullopt, is_dirty_on_master::no, mf};
         BOOST_REQUIRE_EQUAL(row_with_mf.size(), fmf_size + mf->memory_usage() + sizeof(repair_row));
 
-        // Test that boundary memory is counted.
+        // Test that boundary memory is counted, including its heap node.
         repair_row row_with_boundary{frozen_mf, pos, dk_ptr, std::nullopt, is_dirty_on_master::no, nullptr};
-        BOOST_REQUIRE_EQUAL(row_with_boundary.size(), fmf_size + boundary.pk.external_memory_usage() + boundary.position.external_memory_usage() + sizeof(repair_row));
+        BOOST_REQUIRE_EQUAL(row_with_boundary.size(), fmf_size + sizeof(repair_sync_boundary) + boundary.pk.external_memory_usage() + boundary.position.external_memory_usage() + sizeof(repair_row));
     });
 }
 

--- a/test/boost/stall_free_test.cc
+++ b/test/boost/stall_free_test.cc
@@ -7,9 +7,12 @@
  */
 
 #include <compare>
+#include <list>
+#include <memory>
 #include <random>
 #include <set>
 #include <unordered_set>
+#include <vector>
 
 #include <seastar/util/later.hh>
 
@@ -51,6 +54,61 @@ SEASTAR_THREAD_TEST_CASE(test_merge4) {
     std::list<int> expected{1};
     utils::merge_to_gently(l1, l2, std::less<int>());
     BOOST_CHECK(l1 == expected);
+}
+
+// Exercise the move/splice overload of merge_to_gently with a move-only
+// element type. It must merge in sorted order, leave the source list empty,
+// and never copy the elements.
+namespace {
+auto deref_less = [] (const std::unique_ptr<int>& a, const std::unique_ptr<int>& b) {
+    return *a < *b;
+};
+std::list<std::unique_ptr<int>> make_ptr_list(std::initializer_list<int> vals) {
+    std::list<std::unique_ptr<int>> l;
+    for (int v : vals) {
+        l.push_back(std::make_unique<int>(v));
+    }
+    return l;
+}
+std::vector<int> deref_all(const std::list<std::unique_ptr<int>>& l) {
+    std::vector<int> out;
+    for (const auto& p : l) {
+        out.push_back(*p);
+    }
+    return out;
+}
+}
+
+SEASTAR_THREAD_TEST_CASE(test_merge_move_interleaved) {
+    auto l1 = make_ptr_list({1, 2, 5, 8});
+    auto l2 = make_ptr_list({3});
+    utils::merge_to_gently(l1, std::move(l2), deref_less);
+    BOOST_CHECK((deref_all(l1) == std::vector<int>{1, 2, 3, 5, 8}));
+    BOOST_CHECK(l2.empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_merge_move_tail) {
+    auto l1 = make_ptr_list({1});
+    auto l2 = make_ptr_list({3, 5, 6});
+    utils::merge_to_gently(l1, std::move(l2), deref_less);
+    BOOST_CHECK((deref_all(l1) == std::vector<int>{1, 3, 5, 6}));
+    BOOST_CHECK(l2.empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_merge_move_into_empty) {
+    std::list<std::unique_ptr<int>> l1;
+    auto l2 = make_ptr_list({3, 5, 6});
+    utils::merge_to_gently(l1, std::move(l2), deref_less);
+    BOOST_CHECK((deref_all(l1) == std::vector<int>{3, 5, 6}));
+    BOOST_CHECK(l2.empty());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_merge_move_empty_source) {
+    auto l1 = make_ptr_list({1, 4});
+    std::list<std::unique_ptr<int>> l2;
+    utils::merge_to_gently(l1, std::move(l2), deref_less);
+    BOOST_CHECK((deref_all(l1) == std::vector<int>{1, 4}));
+    BOOST_CHECK(l2.empty());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_clear_gently_string) {

--- a/utils/stall_free.hh
+++ b/utils/stall_free.hh
@@ -47,6 +47,27 @@ void merge_to_gently(std::list<T>& list1, const std::list<T>& list2, Compare com
     }
 }
 
+// Similar to std::merge but it does not stall. Must run inside a seastar
+// thread. It merges items from list2 into list1 by splicing nodes, so the
+// element type only needs to be movable (not copyable) and no per-element
+// allocation/copy is performed. list2 is left empty on return.
+template<class T, class Compare>
+requires LessComparable<T, T, Compare>
+void merge_to_gently(std::list<T>& list1, std::list<T>&& list2, Compare comp) {
+    auto first1 = list1.begin();
+    auto last1 = list1.end();
+    while (!list2.empty()) {
+        seastar::thread::maybe_yield();
+        auto first2 = list2.begin();
+        if (first1 == last1 || comp(*first2, *first1)) {
+            // Move (splice) the next list2 node in front of first1.
+            list1.splice(first1, list2, first2);
+        } else {
+            ++first1;
+        }
+    }
+}
+
 // The clear_gently functions are meant for
 // gently destroying the contents of containers and smart pointers.
 // The containers can be reused after clear_gently


### PR DESCRIPTION
`repair_row` stored its sync boundary as an inline `std::optional<repair_sync_boundary>` (~64 bytes), but only the master side ever populates it; on the follower side it is always empty.
Since one `repair_row` exists per buffered row during a repair round, that inline footprint is multiplied by the number of rows in flight.

Hold the boundary behind a `std::unique_ptr<repair_sync_boundary>` instead, so an empty boundary costs one pointer (8 bytes) rather than 64.
This makes `repair_row` move-only, so the few sites that intentionally duplicate a row out of the working buffer now call an explicit `copy()` that deep-copies the boundary, rather than relying on an implicit copy constructor. 
`size()` now adds `sizeof(repair_sync_boundary)` for the heap node that used to be inline. A `static_assert(sizeof(repair_row) == 80)` guards the layout so any future member change forces `copy()` and `size()` to be revisited rather than silently mishandling the new field.

To avoid copying the now move-only rows when merging the per-peer diff into the working buffer, add a move/splice overload of `utils::merge_to_gently(list1, list2&&, comp)` that splices `list2`'s nodes into `list1` in sorted order, 
leaving `list2` empty and performing no per-element allocation or copy. `apply_rows_on_master` is reordered so the row hashes (an order-independent XOR) and the peer hash set are accumulated before the merge consumes `row_diff`.

Tests: extend `stall_free_test` with four cases covering the new move overload (interleaved, tail, into-empty, empty-source; 
all assert the source is left empty), and update `repair_rows_size_considers_external_memory` to expect the out-of-line boundary node.

No wire/on-disk format change.

Backport: no, benign improvement.