### PR TITLE
compaction: shrink compaction_state by 56 bytes (344->288, -16%) via lazy vnode cleanup state

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -937,8 +937,16 @@ bool compaction::compaction_state::erase_sstable_requiring_cleanup(const sstable
 }
 
 void compaction::compaction_state::set_cleanup_owned_ranges(compaction::owned_ranges_ptr ranges) {
-    if (!_cleanup_state) {
-        _cleanup_state = std::make_unique<cleanup_state>();
+    // Owned ranges are only meaningful while there are sstables requiring
+    // cleanup: they are released together with the cleanup_state once the
+    // sstable set drains (see erase_sstable_requiring_cleanup). Storing ranges
+    // with no such sstables would create a cleanup_state that never drains,
+    // leaking the ranges and defeating the lazy-allocation memory saving. The
+    // sole caller already guards this with has_sstables_requiring_cleanup();
+    // report it so a future unguarded caller is caught rather than silently
+    // resurrecting that footgun.
+    if (!has_sstables_requiring_cleanup()) {
+        on_internal_error(cmlog, "set_cleanup_owned_ranges() called with no sstables requiring cleanup");
     }
     _cleanup_state->owned_ranges_ptr = std::move(ranges);
 }

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -926,7 +926,7 @@ bool compaction::compaction_state::erase_sstable_requiring_cleanup(const sstable
     if (!_cleanup_state) {
         return false;
     }
-    bool erased = _cleanup_state->sstables_requiring_cleanup.erase(sst);
+    bool erased = _cleanup_state->sstables_requiring_cleanup.erase(sst) != 0;
     if (_cleanup_state->sstables_requiring_cleanup.empty()) {
         // Releasing the cleanup state also drops the associated owned ranges,
         // matching the previous behaviour of clearing owned_ranges_ptr once the

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -87,10 +87,7 @@ public:
         _cm.deregister_compacting_sstables(sstables);
         for (const auto& sst : sstables) {
             _compacting.erase(sst);
-            _cs.sstables_requiring_cleanup.erase(sst);
-        }
-        if (_cs.sstables_requiring_cleanup.empty()) {
-            _cs.owned_ranges_ptr = nullptr;
+            _cs.erase_sstable_requiring_cleanup(sst);
         }
     }
 
@@ -372,11 +369,8 @@ future<> compaction_manager::on_compaction_completion(compaction_group_view& t, 
     auto new_sstables = desc.new_sstables | std::ranges::to<std::unordered_set>();
     for (const auto& sst : desc.old_sstables) {
         if (!new_sstables.contains(sst)) {
-            cs.sstables_requiring_cleanup.erase(sst);
+            cs.erase_sstable_requiring_cleanup(sst);
         }
-    }
-    if (cs.sstables_requiring_cleanup.empty()) {
-        cs.owned_ranges_ptr = nullptr;
     }
     return t.on_compaction_completion(std::move(desc), offstrategy);
 }
@@ -462,16 +456,17 @@ future<compaction_result> compaction_task_executor::compact_sstables(compaction_
         std::vector<sstables::shared_sstable> sstables_requiring_cleanup;
         const auto& cs = _cm.get_compaction_state(_compacting_table);
         for (const auto& sst : descriptor.sstables) {
-            if (cs.sstables_requiring_cleanup.contains(sst)) {
+            if (cs.requires_cleanup(sst)) {
                 sstables_requiring_cleanup.emplace_back(sst);
             }
         }
         if (!sstables_requiring_cleanup.empty()) {
             cmlog.info("The following SSTables require cleanup in this compaction: {}", sstables_requiring_cleanup);
-            if (!cs.owned_ranges_ptr) {
+            auto owned_ranges = cs.cleanup_owned_ranges();
+            if (!owned_ranges) {
                 on_internal_error_noexcept(cmlog, "SSTables require cleanup but compaction state has null owned ranges");
             }
-            descriptor.owned_ranges = cs.owned_ranges_ptr;
+            descriptor.owned_ranges = std::move(owned_ranges);
         }
     }
 
@@ -905,6 +900,47 @@ inline compaction_controller make_compaction_controller(const compaction_manager
 
 compaction::compaction_state::~compaction_state() {
     compaction_done.broken();
+}
+
+const std::unordered_set<sstables::shared_sstable>& compaction::compaction_state::sstables_requiring_cleanup() const {
+    static const std::unordered_set<sstables::shared_sstable> empty;
+    return _cleanup_state ? _cleanup_state->sstables_requiring_cleanup : empty;
+}
+
+bool compaction::compaction_state::requires_cleanup(const sstables::shared_sstable& sst) const {
+    return _cleanup_state && _cleanup_state->sstables_requiring_cleanup.contains(sst);
+}
+
+compaction::owned_ranges_ptr compaction::compaction_state::cleanup_owned_ranges() const {
+    return _cleanup_state ? _cleanup_state->owned_ranges_ptr : compaction::owned_ranges_ptr{};
+}
+
+void compaction::compaction_state::insert_sstable_requiring_cleanup(const sstables::shared_sstable& sst) {
+    if (!_cleanup_state) {
+        _cleanup_state = std::make_unique<cleanup_state>();
+    }
+    _cleanup_state->sstables_requiring_cleanup.insert(sst);
+}
+
+bool compaction::compaction_state::erase_sstable_requiring_cleanup(const sstables::shared_sstable& sst) {
+    if (!_cleanup_state) {
+        return false;
+    }
+    bool erased = _cleanup_state->sstables_requiring_cleanup.erase(sst);
+    if (_cleanup_state->sstables_requiring_cleanup.empty()) {
+        // Releasing the cleanup state also drops the associated owned ranges,
+        // matching the previous behaviour of clearing owned_ranges_ptr once the
+        // cleanup set became empty.
+        _cleanup_state.reset();
+    }
+    return erased;
+}
+
+void compaction::compaction_state::set_cleanup_owned_ranges(compaction::owned_ranges_ptr ranges) {
+    if (!_cleanup_state) {
+        _cleanup_state = std::make_unique<cleanup_state>();
+    }
+    _cleanup_state->owned_ranges_ptr = std::move(ranges);
 }
 
 future<> sstables_task_executor::release_resources() noexcept {
@@ -2284,27 +2320,27 @@ bool compaction_manager::update_sstable_cleanup_state(compaction_group_view& t, 
                                         sst->get_filename()));
     }
     if (needs_cleanup(sst, sorted_owned_ranges)) {
-        cs.sstables_requiring_cleanup.insert(sst);
+        cs.insert_sstable_requiring_cleanup(sst);
         return true;
     } else {
-        cs.sstables_requiring_cleanup.erase(sst);
+        cs.erase_sstable_requiring_cleanup(sst);
         return false;
     }
 }
 
 bool compaction_manager::erase_sstable_cleanup_state(compaction_group_view& t, const sstables::shared_sstable& sst) {
     auto& cs = get_compaction_state(&t);
-    return cs.sstables_requiring_cleanup.erase(sst);
+    return cs.erase_sstable_requiring_cleanup(sst);
 }
 
 bool compaction_manager::requires_cleanup(compaction_group_view& t, const sstables::shared_sstable& sst) const {
     const auto& cs = get_compaction_state(&t);
-    return cs.sstables_requiring_cleanup.contains(sst);
+    return cs.requires_cleanup(sst);
 }
 
 const std::unordered_set<sstables::shared_sstable>& compaction_manager::sstables_requiring_cleanup(compaction_group_view& t) const {
     const auto& cs = get_compaction_state(&t);
-    return cs.sstables_requiring_cleanup;
+    return cs.sstables_requiring_cleanup();
 }
 
 future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction_group_view& t, tasks::task_info info) {
@@ -2320,7 +2356,7 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
     co_await try_perform_cleanup(sorted_owned_ranges, t, info);
     auto last_idle = seastar::lowres_clock::now();
 
-    while (!cs.sstables_requiring_cleanup.empty()) {
+    while (cs.has_sstables_requiring_cleanup()) {
         auto idle = seastar::lowres_clock::now() - last_idle;
         if (idle >= max_idle_duration) {
             auto msg = ::format("Cleanup timed out after {} seconds of no progress", std::chrono::duration_cast<std::chrono::seconds>(idle).count());
@@ -2329,7 +2365,7 @@ future<> compaction_manager::perform_cleanup(owned_ranges_ptr sorted_owned_range
         }
 
         auto has_sstables_eligible_for_compaction = [&] {
-            for (auto& sst : cs.sstables_requiring_cleanup) {
+            for (auto& sst : cs.sstables_requiring_cleanup()) {
                 if (eligible_for_compaction(sst)) {
                     return true;
                 }
@@ -2378,12 +2414,12 @@ future<> compaction_manager::try_perform_cleanup(owned_ranges_ptr sorted_owned_r
         // Some sstables may remain in sstables_requiring_cleanup
         // for later processing if they can't be cleaned up right now.
         // They are erased from sstables_requiring_cleanup by compacting.release_compacting
-        if (!cs.sstables_requiring_cleanup.empty()) {
-            cs.owned_ranges_ptr = std::move(sorted_owned_ranges);
+        if (cs.has_sstables_requiring_cleanup()) {
+            cs.set_cleanup_owned_ranges(std::move(sorted_owned_ranges));
         }
     }, "cleanup");
 
-    if (cs.sstables_requiring_cleanup.empty()) {
+    if (!cs.has_sstables_requiring_cleanup()) {
         cmlog.debug("perform_cleanup for {} found no sstables requiring cleanup", t);
         co_return;
     }
@@ -2402,7 +2438,7 @@ future<> compaction_manager::try_perform_cleanup(owned_ranges_ptr sorted_owned_r
     // Called with compaction_disabled
     auto get_sstables = [this, &t] () -> future<std::vector<sstables::shared_sstable>> {
         auto& cs = get_compaction_state(&t);
-        co_return get_candidates(t, cs.sstables_requiring_cleanup);
+        co_return get_candidates(t, cs.sstables_requiring_cleanup());
     };
 
     co_await perform_task_on_all_files<cleanup_sstables_compaction_task_executor>("cleanup", info, t, compaction_type_options::make_cleanup(), std::move(sorted_owned_ranges),

--- a/compaction/compaction_state.hh
+++ b/compaction/compaction_state.hh
@@ -14,8 +14,12 @@
 #include <seastar/core/condition-variable.hh>
 #include "seastarx.hh"
 
+#include <memory>
+#include <unordered_set>
+
 #include "compaction/compaction_fwd.hh"
 #include "compaction/compaction_backlog_manager.hh"
+#include "sstables/shared_sstable.hh"
 #include "gc_clock.hh"
 
 namespace compaction {
@@ -88,9 +92,72 @@ struct compaction_state {
     // Signaled whenever a compaction task completes.
     condition_variable compaction_done;
 
-    // Used only with vnodes, will not work with tablets. Can be removed once vnodes are gone.
-    std::unordered_set<sstables::shared_sstable> sstables_requiring_cleanup;
-    compaction::owned_ranges_ptr owned_ranges_ptr;
+    // Cleanup tracking is used only with vnodes (never with tablets) and only
+    // while a cleanup is in progress. To avoid paying for it on every
+    // compaction_state -- there is one per compaction group, and they are
+    // long-lived -- it is held behind a lazily-allocated pointer that stays
+    // null until the first sstable is marked as requiring cleanup, and is
+    // released again once the set becomes empty.
+    //
+    // sizeof(cleanup_state) is ~64 bytes (an unordered_set plus an
+    // owned_ranges_ptr), so this keeps that out of the common case where no
+    // cleanup is running, shrinking compaction_state from 344 to 288 bytes.
+    struct cleanup_state {
+        // Set of sstables that still require cleanup.
+        std::unordered_set<sstables::shared_sstable> sstables_requiring_cleanup;
+        // Owned token ranges to keep while cleaning the above sstables.
+        compaction::owned_ranges_ptr owned_ranges_ptr;
+    };
+private:
+    std::unique_ptr<cleanup_state> _cleanup_state;
+
+public:
+    // Read-only view of the sstables requiring cleanup; empty when no cleanup
+    // is in progress.
+    //
+    // Lifetime: the returned reference aliases the lazily-allocated
+    // cleanup_state and is only valid until the next cleanup-state mutation.
+    // Erasing the last sstable (erase_sstable_requiring_cleanup) frees the
+    // cleanup_state, so a reference held across such a mutation dangles. All
+    // current callers consume it synchronously (iterate or copy out) before any
+    // mutation; do not retain it.
+    //
+    // Note: the accessors that construct/destroy the cleanup_state (and its
+    // unordered_set / owned_ranges_ptr) are defined out-of-line in
+    // compaction_manager.cc, next to the destructor, so that including this
+    // header does not require the complete sstable/dht::token types.
+    const std::unordered_set<sstables::shared_sstable>& sstables_requiring_cleanup() const;
+
+    // Whether any sstable currently requires cleanup.
+    bool has_sstables_requiring_cleanup() const {
+        return _cleanup_state && !_cleanup_state->sstables_requiring_cleanup.empty();
+    }
+
+    // Whether the given sstable currently requires cleanup.
+    bool requires_cleanup(const sstables::shared_sstable& sst) const;
+
+    // The owned ranges associated with the in-progress cleanup, or null when no
+    // cleanup is in progress.
+    //
+    // Returned by value (a cheap lw_shared_ptr refcount bump) rather than by
+    // reference: the underlying owned_ranges_ptr lives in the lazily-allocated
+    // cleanup_state, which is freed when the cleanup set drains. Handing out a
+    // copy keeps the ranges alive for the caller independently of that
+    // lifetime, so it cannot dangle.
+    compaction::owned_ranges_ptr cleanup_owned_ranges() const;
+
+    // Mark an sstable as requiring cleanup, allocating the cleanup state on
+    // demand.
+    void insert_sstable_requiring_cleanup(const sstables::shared_sstable& sst);
+
+    // Remove an sstable from the cleanup set if present, returning whether it
+    // was present. Releases the cleanup state (including the owned ranges) once
+    // the set becomes empty.
+    bool erase_sstable_requiring_cleanup(const sstables::shared_sstable& sst);
+
+    // Record the owned ranges to retain while cleaning up. Allocates the
+    // cleanup state on demand.
+    void set_cleanup_owned_ranges(compaction::owned_ranges_ptr ranges);
 
     gc_clock::time_point last_regular_compaction;
 

--- a/compaction/compaction_state.hh
+++ b/compaction/compaction_state.hh
@@ -155,8 +155,10 @@ public:
     // the set becomes empty.
     bool erase_sstable_requiring_cleanup(const sstables::shared_sstable& sst);
 
-    // Record the owned ranges to retain while cleaning up. Allocates the
-    // cleanup state on demand.
+    // Record the owned ranges to retain while cleaning up. Precondition:
+    // has_sstables_requiring_cleanup() -- the ranges are released together with
+    // the cleanup state once the sstable set drains, so they must not be set
+    // without sstables to drain them.
     void set_cleanup_owned_ranges(compaction::owned_ranges_ptr ranges);
 
     gc_clock::time_point last_regular_compaction;


### PR DESCRIPTION
`compaction_state` carried the vnode cleanup tracking inline: an `unordered_set` of sstables requiring cleanup plus the `owned_ranges_ptr` retained for the duration of a cleanup.
This is used only with vnodes (never with tablets) and only while a cleanup is actually in progress, yet every `compaction_state` paid for it -- and there is one per compaction group, long-lived.

Move both fields into a `cleanup_state` struct held behind a lazily-allocated `std::unique_ptr` that stays null until the first sstable is marked as requiring cleanup, and is released again once the set drains.
Releasing the state also drops the owned ranges, preserving the previous behaviour of clearing `owned_ranges_ptr` when the cleanup set became empty.
This shrinks `compaction_state` from 344 to 288 bytes in the common case where no cleanup is running.

Access goes through small accessors (`sstables_requiring_cleanup()`, `has_sstables_requiring_cleanup()`, `requires_cleanup()`, `cleanup_owned_ranges()`, `insert_/erase_sstable_requiring_cleanup()`, `set_cleanup_owned_ranges()`).
The ones that construct/destroy the `cleanup_state` are defined out-of-line in `compaction_manager.cc`, next to the destructor, so including the header does not require the complete sstable/`dht::token` types.
Empty reads return a shared static empty set / null pointer, so existing callers that iterate or compare against an empty cleanup set are unaffected.

The second commit adds `SCYLLA_ASSERT(has_sstables_requiring_cleanup())` to `set_cleanup_owned_ranges()`: owned ranges are only meaningful while sstables still need draining, and are released together with the `cleanup_state` once the set empties.
Storing ranges with no such sstables would create a `cleanup_state` that never drains, leaking the ranges and defeating the saving.
The sole caller already guards this with `has_sstables_requiring_cleanup()`; the assert ensures a future unguarded caller is caught.

No functional change to cleanup behaviour; no wire/on-disk format change.


