### PR TITLE
utils/bloom_filter: shrink bloom_filter by 8 bytes (80->72, -10%) by dropping redundant _stats reference

### DIFF
--- a/utils/bloom_filter.cc
+++ b/utils/bloom_filter.cc
@@ -42,11 +42,11 @@ bloom_filter::bloom_filter(int hashes, bitmap&& bs, filter_format format) noexce
     , _hash_count(hashes)
     , _format(format)
 {
-    _stats.memory_size += memory_size();
+    _shard_stats.memory_size += memory_size();
 }
 
 bloom_filter::~bloom_filter() noexcept {
-    _stats.memory_size -= memory_size();
+    _shard_stats.memory_size -= memory_size();
 }
 
 bool bloom_filter::is_present(hashed_key key) {

--- a/utils/bloom_filter.hh
+++ b/utils/bloom_filter.hh
@@ -29,7 +29,6 @@ private:
     static thread_local struct stats {
         uint64_t memory_size = 0;
     } _shard_stats;
-    stats& _stats = _shard_stats;
 
 public:
     int num_hashes() { return _hash_count; }


### PR DESCRIPTION
Every `bloom_filter` held a `stats& _stats = _shard_stats` member -- an 8-byte reference bound at construction to the thread-local per-shard `_shard_stats`.
Since all instances on a shard reference the same shard-global object, the reference carried no information: it was 8 bytes per `bloom_filter` plus an extra indirection on each constructor/destructor stats update.

Remove the member and use `_shard_stats` directly in the two places that touch it (the constructor and destructor, which add and subtract `memory_size()`). There is one `bloom_filter` per sstable's filter component, so this trims 8 bytes per open sstable.

No functional change: the stats accounting is identical, and `get_shard_stats()` already exposed `_shard_stats` directly.

Backport: no, improvement, benign.
AI-Assisted: Yes.