### PR TITLE
test/alternator: fix test_table_naming failing through test/alternator/run

### DIFF
--- a/test/alternator/test_encoding.py
+++ b/test/alternator/test_encoding.py
@@ -247,8 +247,7 @@ def test_table_naming(cql, test_table_s):
     ks = 'alternator_' + table_name
     # Verify we can query the underlying CQL table using the expected keyspace
     # and table name. The query will succeed only if naming is as expected.
-    rows = list(cql.execute(f'SELECT p FROM "{ks}"."{table_name}"'))
-    assert rows == []
+    cql.execute(f'SELECT p FROM "{ks}"."{table_name}"')
 
 # Test that GSI and LSI view names in the underlying CQL schema follow the
 # expected naming convention:


### PR DESCRIPTION
The Alternator test test_encoding.py::test_table_naming tests how the underlying CQL table is named. The test had a silly bug: It used a shared table for finding its name, and tried to SELECT it to verify its name in CQL, but incorrectly asserted that the SELECT return nothing. This check passed when this test file was run alone (as CI always does), but when a developer runs the entire test suite via test/alternator/run, other test files cause the shared table to not be empty, and the check failed.

The fix is trivial - just test that the SELECT didn't fail - not what it's output should be.