### PR TITLE
Significantly speed up Alternator Streams tests

### DIFF
--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -115,9 +115,7 @@ def wait_for_active_stream(dynamodbstreams, table, timeout=60):
             desc = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
             if not 'StreamStatus' in desc or desc.get('StreamStatus') == 'ENABLED':
                 return (arn, stream['StreamLabel']);
-        # real dynamo takes some time until a stream is usable
-        print("Stream not available. Sleep 5s...")
-        time.sleep(5)
+        time.sleep(5 if is_aws(table) else 0.05)
     assert False
 
 # Local java dynamodb server version behaves differently from 

--- a/test/alternator/test_streams_tablets.py
+++ b/test/alternator/test_streams_tablets.py
@@ -61,16 +61,16 @@ def get_tablet_count_for_base_table_of_table(rest_api, cql, keyspace_name: str, 
 # modify tablet count for given cdc_log table and wait until the change is applied
 # this calls alter table with new `min_tablet_count`, which requires additional scylla options to work reliably
 # (--tablet-load-stats-refresh-interval-in-seconds=1 and --tablets-initial-scale-factor=1)
-def set_tablet_count_and_wait(rest_api, cql, ks, table_name, cdc_log_table_name, expected_tablet_count):
+def set_tablet_count_and_wait(rest_api, cql, ks, table_name, cdc_log_table_name, expected_tablet_count, timeout=10):
     assert_number_of_streams_is_equal_to_number_of_tablets(rest_api, cql, ks, table_name, cdc_log_table_name)
     cql.execute(f"ALTER TABLE \"{ks}\".\"{cdc_log_table_name}\" WITH tablets = {{'min_tablet_count': {expected_tablet_count}}};")
     start = time.time()
-    while time.time() < start + 10:
+    while time.time() < start + timeout:
         if get_tablet_count_for_base_table_of_table(rest_api, cql, ks, cdc_log_table_name) == expected_tablet_count:
             break
         time.sleep(0.1)
     else:
-        pytest.fail(f'Tablet count did not reach expected value {expected_tablet_count} within timeout')
+        pytest.fail(f'Tablet count did not reach expected value {expected_tablet_count} within {timeout}s timeout')
 
 def iterate_over_describe_stream(dynamodbstreams, arn, end_ts, filter_shard_id=None):
     params = {
@@ -102,7 +102,7 @@ def iterate_over_describe_stream(dynamodbstreams, arn, end_ts, filter_shard_id=N
 #  - wait for expected number of stream shards to be created
 #  - build parent map (shard -> parent) and children map (shard -> list of children) between stream shards
 #  - call the callback with the data
-def run_parent_children_relationship_test(dynamodb, dynamodbstreams, rest_api, cql, tablet_multipliers, callback):
+def run_parent_children_relationship_test(dynamodb, dynamodbstreams, rest_api, cql, tablet_multipliers, callback, timeout=10):
     with create_stream_test_table(dynamodb, StreamViewType='NEW_AND_OLD_IMAGES', Tags=TABLET_TAGS) as table:
         (arn, label) = wait_for_active_stream(dynamodbstreams, table)
 
@@ -119,7 +119,7 @@ def run_parent_children_relationship_test(dynamodb, dynamodbstreams, rest_api, c
         for tablet_mult in tablet_multipliers:
             tablet_count = int(init_table_count * tablet_mult)
             assert tablet_count >= 1
-            set_tablet_count_and_wait(rest_api, cql, ks, table_name, cdc_log_table_name, tablet_count)
+            set_tablet_count_and_wait(rest_api, cql, ks, table_name, cdc_log_table_name, tablet_count, timeout=timeout)
 
         # Strip multipliers that don't change the tablet count from the
         # previous state. The table starts with a multiplier of 1 (i.e.
@@ -219,7 +219,7 @@ def test_parent_children_merge(dynamodb, dynamodbstreams, rest_api, cql):
                 existence_count[child] += 1
         assert all(count == 2 for count in existence_count.values())
 
-    run_parent_children_relationship_test(dynamodb, dynamodbstreams, rest_api, cql, [0.5], verify_parent_children_relationship_merge)
+    run_parent_children_relationship_test(dynamodb, dynamodbstreams, rest_api, cql, [0.5], verify_parent_children_relationship_merge, timeout=1)
 
 # run a test, where we create two cdc log generations (parent and children)
 # and children count is double of parents (thus parents are splited into children)


### PR DESCRIPTION
Before this patch, a complete unparallelized run of the Alternator test suite (`test/alternator/run`) takes 140 seconds. Some may say "That's not bad for 1400 tests in 35,000 lines of code!" , or "Wow, that's faster than a single dtest". But I'm not one of these "some". I thought 140 seconds was too much, and the following two trivial patches shave of 32 seconds of that time, more than 20%  of the (unparallelized) time of the entire test suite.

Both patches just fix unnecessarily-large sleeps in test for Alternator Streams.