### PR TITLE
Fixes on top of group0 initialization movement

### DIFF
--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -598,10 +598,6 @@ future<> group0_state_machine::transfer_snapshot(raft::server_id from_id, raft::
         co_await mutate_locally(std::move(raft_snp->mutations), _sp);
     }
 
-    co_await _ss.auth_cache().load_all();
-
-    co_await sync_audit_known_entities();
-
     co_await notify_client_route_change_if_needed(_ss, client_routes_update);
 
     co_await _sp.mutate_locally({std::move(history_mut)}, nullptr);

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -314,7 +314,15 @@ future<> group0_state_machine::merge_and_apply(group0_state_machine_merger& merg
     co_await std::visit(make_visitor(
     [&] (schema_change& chng) -> future<> {
         modules_to_reload = get_modules_to_reload(chng.mutations);
-        co_await _mm.merge_schema_from(locator::host_id{cmd.creator_id.uuid()}, std::move(chng.mutations));
+        if (_in_memory_state_machine_enabled) {
+            co_await _mm.merge_schema_from(locator::host_id{cmd.creator_id.uuid()}, std::move(chng.mutations));
+        } else {
+            // Just write the mutations to system_schema tables without
+            // creating in-memory keyspace/table representations.
+            // This is used during early raft log replay before non-system
+            // keyspaces are loaded.
+            co_await write_mutations_to_database(_ss, _sp, cmd.creator_addr, std::move(chng.mutations));
+        }
     },
     [&] (broadcast_table_query& query) -> future<> {
         auto result = co_await service::broadcast_tables::execute_broadcast_table_query(_sp, query.query, cmd.new_state_id);
@@ -328,7 +336,11 @@ future<> group0_state_machine::merge_and_apply(group0_state_machine_merger& merg
     [&] (mixed_change& chng) -> future<> {
         modules_to_reload = get_modules_to_reload(chng.mutations);
         topology_state_change_hint.emplace();
-        co_await _mm.merge_schema_from(locator::host_id{cmd.creator_id.uuid()}, std::move(chng.mutations));
+        if (_in_memory_state_machine_enabled) {
+            co_await _mm.merge_schema_from(locator::host_id{cmd.creator_id.uuid()}, std::move(chng.mutations));
+        } else {
+            co_await write_mutations_to_database(_ss, _sp, cmd.creator_addr, std::move(chng.mutations));
+        }
     },
     [&] (write_mutations& muts) -> future<> {
         modules_to_reload = get_modules_to_reload(muts.mutations);
@@ -559,7 +571,11 @@ future<> group0_state_machine::transfer_snapshot(raft::server_id from_id, raft::
 
     auto read_apply_mutex_holder = co_await _client.hold_read_apply_mutex(as);
 
-    co_await _mm.merge_schema_from(hid, std::move(*cm));
+    if (_in_memory_state_machine_enabled) {
+        co_await _mm.merge_schema_from(hid, std::move(*cm));
+    } else {
+        co_await write_mutations_to_database(_ss, _sp, gms::inet_address{}, std::move(*cm));
+    }
 
     if (topology_snp && !topology_snp->mutations.empty()) {
         co_await _ss.merge_topology_snapshot(std::move(*topology_snp));

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -153,7 +153,10 @@ public:
 
 bool should_flush_system_topology_after_applying(const mutation& mut, const data_dictionary::database db);
 
-// Used to write data to topology and other tables except schema tables.
+// Used to write mutations directly to the database, bypassing in-memory
+// state machine processing. Used for topology tables during normal operation
+// and also for schema tables during early raft log replay (before
+// non-system keyspaces are loaded).
 future<> write_mutations_to_database(storage_service& storage_service, storage_proxy& proxy, gms::inet_address from, utils::chunked_vector<canonical_mutation> cms);
 
 } // end of namespace service

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -423,18 +423,28 @@ future<> raft_group_registry::abort_server(raft::group_id gid, sstring reason) {
     if (const auto it = _servers.find(gid); it != _servers.end()) {
         auto& [gid, s] = *it;
         if (!s.aborted) {
-            co_await container().invoke_on_all([is_group0 = (gid == _group0_id), gid] (raft_group_registry& rg) {
-                if (is_group0) {
-                    rg._group0_is_alive = false;
-                }
-                rg._group_shards.erase(gid);
-            });
-            s.aborted = s.server->abort(std::move(reason))
-                .handle_exception([gid] (std::exception_ptr ex) {
-                    rslog.warn("Failed to abort raft group server {}: {}", gid, ex);
-                });
+            // Set s.aborted immediately (before any co_await) to prevent
+            // concurrent calls from entering this block. This can happen
+            // when on_background_error fires abort_server concurrently with
+            // abort_and_drain's call to abort_server.
+            s.aborted = do_abort_server(gid, s, std::move(reason));
         }
         co_await s.aborted->get_future();
+    }
+}
+
+future<> raft_group_registry::do_abort_server(raft::group_id gid, raft_server_for_group& s, sstring reason) {
+    auto is_group0 = (gid == _group0_id);
+    try {
+        co_await container().invoke_on_all([is_group0, gid] (raft_group_registry& rg) {
+            if (is_group0) {
+                rg._group0_is_alive = false;
+            }
+            rg._group_shards.erase(gid);
+        });
+        co_await s.server->abort(std::move(reason));
+    } catch (...) {
+        rslog.warn("Failed to abort raft group server {}: {}", gid, std::current_exception());
     }
 }
 

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -146,6 +146,12 @@ public:
     // abort future is returned.
     future<> abort_server(raft::group_id gid, sstring reason = "");
 
+private:
+    // Helper for abort_server: performs the actual abort work.
+    future<> do_abort_server(raft::group_id gid, raft_server_for_group& s, sstring reason);
+
+public:
+
     // Destroys the server for the given group and removes it from the registry.
     // The server must be aborted before this function is called, see the abort_server function.
     // No further access to this server must occur after this point.


### PR DESCRIPTION
Fix a race in  `raft_group_registry::abort_server`  uncovered by previous change where concurrent abort is not handled correctly. Also fixes ` _in_memory_state_machine_enabled` flag handling bug where it is not respected during apply and snapshot transfer execution.

Fixes SCYLLADB-2420
Fixes SCYLLADB-2414
Fixes SCYLLADB-2419

No need to backport since the problem exists only on HEAD