### PR TITLE
scrub --mode=validate: document quarantine and allow opt-out

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1232,6 +1232,14 @@
                      "paramType":"query"
                   },
                   {
+                     "name":"quarantine_invalid_sstables",
+                     "description":"Controls whether invalid sstable identified by scrub (validate-mode) should be quarantined (default true)",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"boolean",
+                     "paramType":"query"
+                  },
+                  {
                      "name":"keyspace",
                      "description":"The keyspace to query about",
                      "required":true,

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -285,6 +285,13 @@ scrub_info parse_scrub_options(const http_context& ctx, std::unique_ptr<http::re
         info.opts.drop_unfixable = compaction::compaction_type_options::scrub::drop_unfixable_sstables::yes;
     }
 
+    if (req->get_query_param("quarantine_invalid_sstables") != "") {
+        if (scrub_mode != compaction::compaction_type_options::scrub::mode::validate) {
+            throw httpd::bad_param_exception("The 'quarantine_invalid_sstables' parameter is only valid when 'scrub_mode' is 'VALIDATE'");
+        }
+        info.opts.quarantine_sstables = compaction::compaction_type_options::scrub::quarantine_invalid_sstables(req_param<bool>(*req, "quarantine_invalid_sstables", true));
+    }
+
     return info;
 }
 

--- a/docs/operating-scylla/nodetool-commands/scrub.rst
+++ b/docs/operating-scylla/nodetool-commands/scrub.rst
@@ -42,6 +42,8 @@ Parameter                                                             Descriptio
 ``-q <quarantine_mode>`` / ``--quarantine-mode <quarantine_mode>``    How to handle quarantined SSTables (one of: INCLUDE|EXCLUDE|ONLY, default INCLUDE)
 --------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------
 ``--drop-unfixable-sstables``                                         Drop unfixable SSTables instead of aborting the entire scrub (only valid with ``--mode=SEGREGATE``)
+--------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------
+``--quarantine-invalid-sstables <true|false>``                        Should corrupt sstables be quarantined (default true, only valid with ``--mode=VALIDATE``)
 ====================================================================  ==================================================================================================================
 
 ``--`` This option can be used to separate command-line options from the list of argument, (useful when arguments might be mistaken for command-line options.
@@ -130,6 +132,18 @@ Method 1: Quarantine and Drop
 
 This will move corrupted SSTables to a ``quarantine`` directory.
 The ``quarantine`` directory is a sub-directory of the table's respective data directory.
+Quarantined SSTables are handled distinctly:
+
+* They participate in reads.
+* They participate in streaming and data migration.
+* They participate in repairs.
+* They do not participate in compaction, but participate in overlap checks for
+  the purpose of tombstone-gc.
+
+The purpose of the quarantine is to keep corrupt SSTables out of compaction, which can spread the compaction or can get in a fail-retry loop. It also makes corrupt SSTables easy to find and retrieve for investigation.
+
+It is possible to opt-out from quarantining SSTables by passing ``--quarantine-invalid-sstables=false`` to nodetool.
+
 
 **Step 2** (Optional): Preserve quarantined SSTables for analysis:
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2928,7 +2928,9 @@ public:
     }
 };
 
-void scrub_validate_corrupted_content(compress_sstable compress) {
+void scrub_validate_corrupted_content(compress_sstable compress,
+        compaction::compaction_type_options::scrub::quarantine_invalid_sstables quarantine_sstables
+            = compaction::compaction_type_options::scrub::quarantine_invalid_sstables::yes) {
     scrub_test_framework<random_schema::yes> test(compress);
 
     auto schema = test.schema();
@@ -2940,23 +2942,32 @@ void scrub_validate_corrupted_content(compress_sstable compress) {
             std::uniform_int_distribution<size_t>(10, 10)).get();
     std::swap(*muts.begin(), *(muts.begin() + 1));
 
-    test.run(schema, muts, [] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
+    test.run(schema, muts, [quarantine_sstables] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
         BOOST_REQUIRE(sstables.size() == 1);
         auto sst = sstables.front();
 
         compaction::compaction_type_options::scrub opts = {
             .operation_mode = compaction::compaction_type_options::scrub::mode::validate,
+            .quarantine_sstables = quarantine_sstables,
         };
         auto stats = table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
         BOOST_REQUIRE(stats.has_value());
         BOOST_REQUIRE_GT(stats->validation_errors, 0);
-        BOOST_REQUIRE(sst->is_quarantined());
-        BOOST_REQUIRE(in_strategy_sstables(ts).get().empty());
+        const bool expect_quarantined = quarantine_sstables == compaction::compaction_type_options::scrub::quarantine_invalid_sstables::yes;
+        BOOST_REQUIRE_EQUAL(sst->is_quarantined(), expect_quarantined);
+        if (expect_quarantined) {
+            BOOST_REQUIRE(in_strategy_sstables(ts).get().empty());
+        } else {
+            BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).get().size(), 1);
+            BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).get().front(), sst);
+        }
     });
 }
 
-void scrub_validate_corrupted_file(compress_sstable compress, component_type component = component_type::Data) {
+void scrub_validate_corrupted_file(compress_sstable compress, component_type component = component_type::Data,
+        compaction::compaction_type_options::scrub::quarantine_invalid_sstables quarantine_sstables
+            = compaction::compaction_type_options::scrub::quarantine_invalid_sstables::yes) {
     scrub_test_framework<random_schema::yes> test(compress);
 
     auto schema = test.schema();
@@ -2967,7 +2978,7 @@ void scrub_validate_corrupted_file(compress_sstable compress, component_type com
             tests::no_expiry_expiry_generator(),
             std::uniform_int_distribution<size_t>(10, 10)).get();
 
-    test.run(schema, muts, [component] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
+    test.run(schema, muts, [component, quarantine_sstables] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
         BOOST_REQUIRE(sstables.size() == 1);
         auto sst = sstables.front();
 
@@ -2976,17 +2987,26 @@ void scrub_validate_corrupted_file(compress_sstable compress, component_type com
 
         compaction::compaction_type_options::scrub opts = {
             .operation_mode = compaction::compaction_type_options::scrub::mode::validate,
+            .quarantine_sstables = quarantine_sstables,
         };
         auto stats = table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
         BOOST_REQUIRE(stats.has_value());
         BOOST_REQUIRE_GT(stats->validation_errors, 0);
-        BOOST_REQUIRE(sst->is_quarantined());
-        BOOST_REQUIRE(in_strategy_sstables(ts).get().empty());
+        const bool expect_quarantined = quarantine_sstables == compaction::compaction_type_options::scrub::quarantine_invalid_sstables::yes;
+        BOOST_REQUIRE_EQUAL(sst->is_quarantined(), expect_quarantined);
+        if (expect_quarantined) {
+            BOOST_REQUIRE(in_strategy_sstables(ts).get().empty());
+        } else {
+            BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).get().size(), 1);
+            BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).get().front(), sst);
+        }
     });
 }
 
-void scrub_validate_corrupted_digest(compress_sstable compress) {
+void scrub_validate_corrupted_digest(compress_sstable compress,
+        compaction::compaction_type_options::scrub::quarantine_invalid_sstables quarantine_sstables
+            = compaction::compaction_type_options::scrub::quarantine_invalid_sstables::yes) {
     scrub_test_framework<random_schema::yes> test(compress);
 
     auto schema = test.schema();
@@ -2997,7 +3017,7 @@ void scrub_validate_corrupted_digest(compress_sstable compress) {
             tests::no_expiry_expiry_generator(),
             std::uniform_int_distribution<size_t>(10, 10)).get();
 
-    test.run(schema, muts, [] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
+    test.run(schema, muts, [quarantine_sstables] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
         BOOST_REQUIRE(sstables.size() == 1);
         auto sst = sstables.front();
 
@@ -3017,24 +3037,33 @@ void scrub_validate_corrupted_digest(compress_sstable compress) {
 
         compaction::compaction_type_options::scrub opts = {
             .operation_mode = compaction::compaction_type_options::scrub::mode::validate,
+            .quarantine_sstables = quarantine_sstables,
         };
         auto stats = table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
         BOOST_REQUIRE(stats.has_value());
         BOOST_REQUIRE_GT(stats->validation_errors, 0);
-        BOOST_REQUIRE(sst->is_quarantined());
-        BOOST_REQUIRE(in_strategy_sstables(ts).get().empty());
+        const bool expect_quarantined = quarantine_sstables == compaction::compaction_type_options::scrub::quarantine_invalid_sstables::yes;
+        BOOST_REQUIRE_EQUAL(sst->is_quarantined(), expect_quarantined);
+        if (expect_quarantined) {
+            BOOST_REQUIRE(in_strategy_sstables(ts).get().empty());
+        } else {
+            BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).get().size(), 1);
+            BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).get().front(), sst);
+        }
     });
 }
 
-void scrub_validate_no_digest(compress_sstable compress) {
+void scrub_validate_no_digest(compress_sstable compress,
+        compaction::compaction_type_options::scrub::quarantine_invalid_sstables quarantine_sstables
+            = compaction::compaction_type_options::scrub::quarantine_invalid_sstables::yes) {
     scrub_test_framework<random_schema::yes> test(compress);
 
     auto schema = test.schema();
 
     auto muts = tests::generate_random_mutations(test.random_schema()).get();
 
-    test.run(schema, muts, [] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
+    test.run(schema, muts, [quarantine_sstables] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
         BOOST_REQUIRE(sstables.size() == 1);
         auto sst = sstables.front();
 
@@ -3044,6 +3073,7 @@ void scrub_validate_no_digest(compress_sstable compress) {
 
         compaction::compaction_type_options::scrub opts = {
             .operation_mode = compaction::compaction_type_options::scrub::mode::validate,
+            .quarantine_sstables = quarantine_sstables,
         };
         auto stats = table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
@@ -3061,29 +3091,39 @@ void scrub_validate_no_digest(compress_sstable compress) {
 
         BOOST_REQUIRE(stats.has_value());
         BOOST_REQUIRE_GT(stats->validation_errors, 0);
-        BOOST_REQUIRE(sst->is_quarantined());
-        BOOST_REQUIRE(in_strategy_sstables(ts).get().empty());
+        const bool expect_quarantined = quarantine_sstables == compaction::compaction_type_options::scrub::quarantine_invalid_sstables::yes;
+        BOOST_REQUIRE_EQUAL(sst->is_quarantined(), expect_quarantined);
+        if (expect_quarantined) {
+            BOOST_REQUIRE(in_strategy_sstables(ts).get().empty());
+        } else {
+            BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).get().size(), 1);
+            BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).get().front(), sst);
+        }
     });
 }
 
-void scrub_validate_valid(compress_sstable compress) {
+void scrub_validate_valid(compress_sstable compress,
+        compaction::compaction_type_options::scrub::quarantine_invalid_sstables quarantine_sstables
+            = compaction::compaction_type_options::scrub::quarantine_invalid_sstables::yes) {
     scrub_test_framework<random_schema::yes> test(compress);
 
     auto schema = test.schema();
 
     auto muts = tests::generate_random_mutations(test.random_schema()).get();
 
-    test.run(schema, muts, [] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
+    test.run(schema, muts, [quarantine_sstables] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
         BOOST_REQUIRE(sstables.size() == 1);
         auto sst = sstables.front();
 
         compaction::compaction_type_options::scrub opts = {
             .operation_mode = compaction::compaction_type_options::scrub::mode::validate,
+            .quarantine_sstables = quarantine_sstables,
         };
         auto stats = table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
 
         BOOST_REQUIRE(stats.has_value());
         BOOST_REQUIRE_EQUAL(stats->validation_errors, 0);
+        // A valid sstable is never quarantined regardless of the quarantine_sstables flag.
         BOOST_REQUIRE(!sst->is_quarantined());
         BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).get().size(), 1);
         BOOST_REQUIRE_EQUAL(in_strategy_sstables(ts).get().front(), sst);
@@ -3097,10 +3137,24 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_corrupted_content) {
     }
 }
 
+SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_corrupted_content_no_quarantine) {
+    for (const auto& compress : {compress_sstable::no, compress_sstable::yes}) {
+        testlog.info("Validating {}compressed SSTable with content-level corruption (no quarantine)...", compress == compress_sstable::no ? "un" : "");
+        scrub_validate_corrupted_content(compress, compaction::compaction_type_options::scrub::quarantine_invalid_sstables::no);
+    }
+}
+
 SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_corrupted_file) {
     for (const auto& compress : {compress_sstable::no, compress_sstable::yes}) {
         testlog.info("Validating {}compressed SSTable with invalid checksums...", compress == compress_sstable::no ? "un" : "");
         scrub_validate_corrupted_file(compress);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_corrupted_file_no_quarantine) {
+    for (const auto& compress : {compress_sstable::no, compress_sstable::yes}) {
+        testlog.info("Validating {}compressed SSTable with invalid checksums (no quarantine)...", compress == compress_sstable::no ? "un" : "");
+        scrub_validate_corrupted_file(compress, component_type::Data, compaction::compaction_type_options::scrub::quarantine_invalid_sstables::no);
     }
 }
 
@@ -3111,10 +3165,24 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_corrupted_index) {
     }
 }
 
+SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_corrupted_index_no_quarantine) {
+    for (const auto& compress : {compress_sstable::no, compress_sstable::yes}) {
+        testlog.info("Validating {}compressed SSTable with corrupted index (no quarantine)...", compress == compress_sstable::no ? "un" : "");
+        scrub_validate_corrupted_file(compress, component_type::Index, compaction::compaction_type_options::scrub::quarantine_invalid_sstables::no);
+    }
+}
+
 SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_corrupted_file_digest) {
     for (const auto& compress : {compress_sstable::no, compress_sstable::yes}) {
         testlog.info("Validating {}compressed SSTable with invalid digest...", compress == compress_sstable::no ? "un" : "");
         scrub_validate_corrupted_digest(compress);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_corrupted_file_digest_no_quarantine) {
+    for (const auto& compress : {compress_sstable::no, compress_sstable::yes}) {
+        testlog.info("Validating {}compressed SSTable with invalid digest (no quarantine)...", compress == compress_sstable::no ? "un" : "");
+        scrub_validate_corrupted_digest(compress, compaction::compaction_type_options::scrub::quarantine_invalid_sstables::no);
     }
 }
 
@@ -3125,10 +3193,24 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_no_digest) {
     }
 }
 
+SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_no_digest_no_quarantine) {
+    for (const auto& compress : {compress_sstable::no, compress_sstable::yes}) {
+        testlog.info("Validating {}compressed SSTable with no digest (no quarantine)...", compress == compress_sstable::no ? "un" : "");
+        scrub_validate_no_digest(compress, compaction::compaction_type_options::scrub::quarantine_invalid_sstables::no);
+    }
+}
+
 SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_valid_sstable) {
     for (const auto& compress : {compress_sstable::no, compress_sstable::yes}) {
         testlog.info("Validating {}compressed SSTable...", compress == compress_sstable::no ? "un" : "");
         scrub_validate_valid(compress);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(sstable_scrub_validate_mode_test_valid_sstable_no_quarantine) {
+    for (const auto& compress : {compress_sstable::no, compress_sstable::yes}) {
+        testlog.info("Validating {}compressed SSTable (no quarantine)...", compress == compress_sstable::no ? "un" : "");
+        scrub_validate_valid(compress, compaction::compaction_type_options::scrub::quarantine_invalid_sstables::no);
     }
 }
 

--- a/test/nodetool/test_scrub.py
+++ b/test/nodetool/test_scrub.py
@@ -205,3 +205,33 @@ def test_scrub_drop_unfixable_sstables_option(nodetool):
             ("scrub", "ks", "tbl1", "--mode=ABORT", "--drop-unfixable-sstables"),
             {"expected_requests": [expected_request("GET", "/storage_service/keyspaces", response=["ks"])]},
             ["error processing arguments: --drop-unfixable-sstables is only valid with --mode=SEGREGATE"])
+
+
+def test_scrub_no_quarantine_option(nodetool, scylla_only):
+    # --quarantine-invalid-sstables=false with --mode=VALIDATE passes quarantine_invalid_sstables=false to the API
+    nodetool("scrub", "ks", "tbl1", "--mode=VALIDATE", "--quarantine-invalid-sstables=false", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks",
+                         params={"cf": "tbl1", "scrub_mode": "VALIDATE", "quarantine_invalid_sstables": "false"},
+                         response=scrub_status.successful.value)])
+
+    # --quarantine-invalid-sstables=true is the default but can be passed explicitly
+    nodetool("scrub", "ks", "tbl1", "--mode=VALIDATE", "--quarantine-invalid-sstables=true", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks"]),
+        expected_request("GET", "/storage_service/keyspace_scrub/ks",
+                         params={"cf": "tbl1", "scrub_mode": "VALIDATE", "quarantine_invalid_sstables": "true"},
+                         response=scrub_status.successful.value)])
+
+    # --quarantine-invalid-sstables without --mode=VALIDATE is rejected
+    check_nodetool_fails_with(
+            nodetool,
+            ("scrub", "ks", "tbl1", "--mode=ABORT", "--quarantine-invalid-sstables=false"),
+            {"expected_requests": [expected_request("GET", "/storage_service/keyspaces", response=["ks"])]},
+            ["error processing arguments: --quarantine-invalid-sstables is only valid with --mode=VALIDATE"])
+
+    # --quarantine-invalid-sstables without any --mode is also rejected
+    check_nodetool_fails_with(
+            nodetool,
+            ("scrub", "ks", "tbl1", "--quarantine-invalid-sstables=false"),
+            {"expected_requests": [expected_request("GET", "/storage_service/keyspaces", response=["ks"])]},
+            ["error processing arguments: --quarantine-invalid-sstables is only valid with --mode=VALIDATE"])

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -210,6 +210,40 @@ def test_storage_service_keyspace_scrub_mode(cql, this_dc, rest_api):
                 resp = rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}", { "cf": f"{test_tables[0]}", "quarantine_mode": "YYY" })
                 assert resp.status_code == requests.codes.bad_request
 
+def test_storage_service_keyspace_scrub_no_quarantine(cql, this_dc, rest_api):
+    """Test that the quarantine_invalid_sstables parameter is accepted for VALIDATE mode and
+    rejected for other scrub modes."""
+    with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
+        with new_test_table(cql, keyspace, "a int, PRIMARY KEY (a)") as t0:
+            table = t0.split('.')[1]
+
+            # quarantine_invalid_sstables=false is valid with scrub_mode=VALIDATE
+            resp = rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}",
+                                 { "cf": table, "scrub_mode": "VALIDATE", "quarantine_invalid_sstables": "false" })
+            resp.raise_for_status()
+
+            # quarantine_invalid_sstables=true is the default but also valid explicitly
+            resp = rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}",
+                                 { "cf": table, "scrub_mode": "VALIDATE", "quarantine_invalid_sstables": "true" })
+            resp.raise_for_status()
+
+            # quarantine_invalid_sstables with an unknown value is rejected
+            resp = rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}",
+                                 { "cf": table, "scrub_mode": "VALIDATE", "quarantine_invalid_sstables": "maybe" })
+            assert resp.status_code == requests.codes.bad_request
+
+            # quarantine_invalid_sstables=false is rejected when scrub_mode is not VALIDATE
+            for mode in ["ABORT", "SKIP", "SEGREGATE"]:
+                resp = rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}",
+                                     { "cf": table, "scrub_mode": mode, "quarantine_invalid_sstables": "false" })
+                assert resp.status_code == requests.codes.bad_request, \
+                    f"Expected 400 for scrub_mode={mode} with quarantine_invalid_sstables=false"
+
+            # quarantine_invalid_sstables=false is valid with the default VALIDATE mode
+            resp = rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace}",
+                                 { "cf": table, "quarantine_invalid_sstables": "false" })
+            resp.raise_for_status()
+
 def test_storage_service_keyspace_bad_param(cql, this_dc, rest_api):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}") as keyspace:
         # Url must include the keyspace param.

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -4940,6 +4940,39 @@ For more information, see: {}
                 "scrub",
                 "Scrub the SSTable files in the specified keyspace or table(s)",
 fmt::format(R"(
+The main use-case of scrub is to find corrupt sstables.
+
+This can be achieved with `nodetool scrub --mode=VALIDATE`. Validate is also the
+default mode.
+
+Validate-mode scrub does not rewrite sstables like the other scrub modes. The
+following are validated:
+* Checksums and digests for data component and any other component if available.
+* Partition, row and mutation-fragment kind order.
+* index<->data consistency (only for sstable formats mc to me).
+
+Any problem found during validating an sstable are logged by ScyllaDB via the
+compaction logger (error level).
+
+If validate completed successfully, nodetool will exit with exit code 0. If
+nodetool completed successfully but found invalid sstables, it exits with exit
+code 3 (and a message about invalid sstables).
+
+By default, validate-mode scrub quarantines invalid sstables. Quarantined
+sstables are handled distinctly:
+* They participate in reads.
+* They participate in streaming and tablet migration (file streaming).
+* They participate in repair.
+* They do not participate in compaction, but participate in overlap checks for
+  the purpose of tombstone-gc.
+
+The purpose of the quarantine is to keep corrupt sstables out of compaction,
+which can spread the compaction or can get in a fail-retry loop. It also makes
+corrupt sstables easy to find and retrieve for investigation.
+
+It is possible to opt-out from quarantining sstables by passing
+--quarantine-invalid-sstables=false to scrub.
+
 For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/scrub.html")),
                 {

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -2255,6 +2255,7 @@ void scrub_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     const bool has_skip_corrupted = vm.contains("skip-corrupted");
     const bool has_mode = vm.contains("mode");
     const bool has_drop_unfixable = vm.contains("drop-unfixable-sstables");
+    const bool has_quarantine_invalid_sstables = vm.contains("quarantine-invalid-sstables");
 
     const sstring mode = has_mode ? vm["mode"].as<sstring>() : "";
 
@@ -2264,6 +2265,10 @@ void scrub_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
 
     if (has_drop_unfixable && (!has_mode || mode != "SEGREGATE")) {
         throw std::invalid_argument("--drop-unfixable-sstables is only valid with --mode=SEGREGATE");
+    }
+
+    if (has_quarantine_invalid_sstables && (!has_mode || mode != "VALIDATE")) {
+        throw std::invalid_argument("--quarantine-invalid-sstables is only valid with --mode=VALIDATE");
     }
 
     std::unordered_map<sstring, sstring> params;
@@ -2288,6 +2293,10 @@ void scrub_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
 
     if (has_drop_unfixable) {
         params["drop_unfixable_sstables"] = "true";
+    }
+
+    if (has_quarantine_invalid_sstables) {
+        params["quarantine_invalid_sstables"] = fmt::to_string(vm["quarantine-invalid-sstables"].as<bool>());
     }
 
     std::vector<api::scrub_status> statuses;
@@ -4942,6 +4951,7 @@ For more information, see: {}
                     typed_option<>("reinsert-overflowed-ttl,r", "Rewrites rows with overflowed expiration date (unused)"),
                     typed_option<int64_t>("jobs,j", "The number of sstables to be scrubbed concurrently (unused)"),
                     typed_option<>("drop-unfixable-sstables", "Drop unfixed sstables instead of aborting the entire scrub (only with --mode=SEGREGATE)"),
+                    typed_option<bool>("quarantine-invalid-sstables", "Whether to quarantine invalid sstables found during scrub (yes or no, default yes; only with --mode=VALIDATE)"),
                 },
                 {
                     typed_option<sstring>("keyspace", "The keyspace to scrub", 1),


### PR DESCRIPTION
Add `quarantine_invalid_sstables=<true|false>` to the `keyspace_scrub` REST API and `--quarantine-invalid-sstables=<true|false>` to `nodetool scrub` to allow users to opt-out from quarantining sstables. Default is still to quarantine sstables.
Add help text to scrub, describing the most mainstream use-case (validate) as well as the quarantine semantics. Improve the online documentation as well, add description of quarantine and document the new flag.

Fixes: SCYLLADB-2422

Backport: improvement, no backport