### PR TITLE
test: fix test_unfinished_writes_during_shutdown decommission race

### DIFF
--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -176,6 +176,13 @@ async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest,
         logger.info(f"=== Run 1: target={target_server} (non-coordinator) ===")
         new_server = await do_test(target_server)
 
+        # Wait for all peers to see the restarted target_server as alive before
+        # starting decommission. Without this wait, the restarted node's gossip
+        # on_restart event may arrive at new_server mid-stream, causing
+        # stream_manager::fail_sessions to tear down the in-flight session and
+        # roll back the decommission (SCYLLADB-2417).
+        await manager.servers_see_each_other(await manager.running_servers())
+
         # Restore the cluster to its original state: decommission the added
         # node. do_test already restarted the target. This keeps 2 nodes with
         # RF=2, so both are replicas for every partition — same as run 1.


### PR DESCRIPTION
The cleanup decommission between Run 1 and Run 2 races with gossip propagation of the target node restart. Add a wait for the restarted node to be fully UP in gossip on all peers before starting decommission.

Without this wait, on slow test runs, the restarted node's on_restart event can arrive at the decommissioning node mid-stream, causing stream_manager::fail_sessions to tear down the in-flight session and roll back the decommission.

Fixes: SCYLLADB-2417

Backport: Should be backported to all active branches - the test is flaky in all branches. No production code change, only test change, so the risk is low.