### PR TITLE
service/storage_proxy: reduce padding in read-path executor/resolver

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4836,9 +4836,9 @@ protected:
         RATE_LIMIT,
     };
     db::consistency_level _cl;
+    bool _request_failed = false; // will be true if request fails or timeouts
     size_t _targets_count;
     promise<result<>> _done_promise; // all target responded
-    bool _request_failed = false; // will be true if request fails or timeouts
     timer<storage_proxy::clock_type> _timeout;
     schema_ptr _schema;
     size_t _failed = 0;
@@ -5576,7 +5576,6 @@ protected:
     lw_shared_ptr<query::read_command> _cmd;
     lw_shared_ptr<query::read_command> _retry_cmd;
     dht::partition_range _partition_range;
-    db::consistency_level _cl;
     size_t _block_for;
     host_id_vector_replica_set _targets;
     // Targets that were successfully used for a data or digest request
@@ -5584,13 +5583,10 @@ protected:
     promise<result<foreign_ptr<lw_shared_ptr<query::result>>>> _result_promise;
     tracing::trace_state_ptr _trace_state;
     lw_shared_ptr<replica::column_family> _cf;
-    bool _foreground = true;
     service_permit _permit; // holds admission permit until operation completes
     db::per_partition_rate_limit::info _rate_limit_info;
 
 private:
-    const bool _native_reversed_queries_enabled;
-
     void on_read_resolved() noexcept {
         // We could have !_foreground if this is called on behalf of background reconciliation.
         _proxy->get_stats().foreground_reads -= int(_foreground);
@@ -5608,8 +5604,8 @@ public:
             host_id_vector_replica_set targets, tracing::trace_state_ptr trace_state, service_permit permit, db::per_partition_rate_limit::info rate_limit_info) :
                            _schema(std::move(s)), _proxy(std::move(proxy))
                          , _effective_replication_map_ptr(std::move(ermp))
-                         , _cmd(std::move(cmd)), _partition_range(std::move(pr)), _cl(cl), _block_for(block_for), _targets(std::move(targets)), _trace_state(std::move(trace_state)),
-                           _cf(std::move(cf)), _permit(std::move(permit)), _rate_limit_info(rate_limit_info),
+                         , _cmd(std::move(cmd)), _partition_range(std::move(pr)), _block_for(block_for), _targets(std::move(targets)), _trace_state(std::move(trace_state)),
+                           _cf(std::move(cf)), _permit(std::move(permit)), _rate_limit_info(rate_limit_info), _cl(cl),
                            _native_reversed_queries_enabled(_proxy->features().native_reverse_queries) {
         _proxy->get_stats().reads++;
         _proxy->get_stats().foreground_reads++;
@@ -6022,6 +6018,12 @@ private:
 
     static constexpr latency_clock::duration NO_LATENCY{-1};
     latency_clock::duration _max_request_latency{NO_LATENCY};
+
+protected:
+    db::consistency_level _cl;
+    bool _foreground = true;
+private:
+    const bool _native_reversed_queries_enabled;
 };
 
 class never_speculating_read_executor : public abstract_read_executor {


### PR DESCRIPTION
Motivation:
abstract_read_executor and abstract_read_resolver are allocated once per read request. Both had scattered small scalar members that left alignment holes between larger 8-byte-aligned members:

  - abstract_read_executor: _cl (4B enum), _foreground (1B) and  _native_reversed_queries_enabled (1B const) sat between pointers and wide members (sizeof == 448).
  - abstract_read_resolver: _request_failed (1B) sat between _done_promise and _timeout (sizeof == 200).

Group these small scalars together so the compiler packs them into a single alignment slot. No behavioural change: member access levels are preserved and the constructor initialiser list is reordered to match the new declaration order.

Results (sizes from -fdump-record-layouts, independent of build mode):
  - abstract_read_executor: 448 -> 432 bytes (-16B, all recovered padding). Derived never_/always_/speculating_read_executor inherit the gain.
  - abstract_read_resolver: 200 -> 192 bytes (-8B, all recovered padding), which drops it from 4 to 3 64-byte cache lines (192 == 3 x 64).

Tests: built service/storage_proxy.o via dbuild; struct sizes verified with -fdump-record-layouts.

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
AI-assisted: Yes
Backport: no, improvement
