### PR TITLE
transport, service: shrink per-connection state from 1176 to 752 bytes (Seastar pool 1280 -> 768 B)

### DIFF
--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -75,6 +75,8 @@ private:
             , _user_connection(cs->_user_connection)
             , _is_internal(cs->_is_internal)
             , _bypass_auth_checks(cs->_bypass_auth_checks)
+            , _remote_port(cs->_remote_port)
+            , _original_shard(cs->_original_shard)
             , _remote_address(cs->_remote_address)
             , _auth_service(auth_service ? &auth_service->local() : nullptr)
             , _sl_controller(sl_controller ? &sl_controller->local() : nullptr)
@@ -82,7 +84,6 @@ private:
             , _timeout_config(cs->_timeout_config)
             , _as(as)
             , _enabled_protocol_extensions(cs->_enabled_protocol_extensions)
-            , _original_shard(cs->_original_shard)
     {}
     friend client_state_for_another_shard;
 private:
@@ -110,10 +111,12 @@ private:
     private volatile String keyspace;
 #endif
     std::optional<auth::authenticated_user> _user;
-    std::optional<client_options_cache_entry_type> _driver_name, _driver_version;
+    // entry_ptr is nullable itself; no std::optional needed around it.
+    client_options_cache_entry_type _driver_name, _driver_version;
 	std::list<client_option_key_value_cached_entry> _client_options;
 
-    auth_state _auth_state = auth_state::UNINITIALIZED;
+    // The flags and small enums below are bit-packed into one byte.
+    auth_state _auth_state : 2 = auth_state::UNINITIALIZED;
     // A connection is treated as a driver control connection by default: it is
     // meant to issue only the system queries a driver needs to manage itself.
     // Once it is observed running user (non-system) load it is multiplexed with
@@ -121,26 +124,33 @@ private:
     // The reclassification is sticky so the connection is never turned back into
     // a control connection. Whether a non-reclassified connection actually runs
     // in the driver scheduling group additionally depends on sl:driver existing.
-    bool _user_connection = false;
+    bool _user_connection : 1 = false;
     // Set together with _user_connection and cleared once the CQL server has
     // switched the connection to the user scheduling group, so the switch happens
     // exactly once.
-    bool _reclassification_pending = false;
+    bool _reclassification_pending : 1 = false;
 
     // isInternal is used to mark ClientState as used by some internal component
     // that should have an ability to modify system keyspace.
-    bool _is_internal;
+    bool _is_internal : 1;
 
     // bypass_auth_checks is used to skip authorization checks.
     // This is used by the maintenance socket to allow privileged access without
     // going through normal auth, while still treating queries as external.
-    bool _bypass_auth_checks;
+    bool _bypass_auth_checks : 1;
+
+    workload_type _workload_type : 2 = workload_type::unspecified;
 
     // The biggest timestamp that was returned by getTimestamp/assigned to a query
     static thread_local api::timestamp_type _last_timestamp_micros;
 
-    // Address of a client
-    socket_address _remote_address;
+    // Address of a client; kept apart (not as a socket_address, whose sockaddr_storage
+    // is 128 bytes) since there is one client_state per connection.
+    uint16_t _remote_port = 0;
+    // The shard where the current CQL request originally entered the node.
+    // After an internal CAS shard bounce this differs from this_shard_id().
+    unsigned _original_shard = this_shard_id();
+    gms::inet_address _remote_address;
 
     // Only populated for external client state.
     auth::service* _auth_service{nullptr};
@@ -149,8 +159,6 @@ private:
     // For restoring default values in the timeout config
     timeout_config _default_timeout_config;
     timeout_config _timeout_config;
-
-    workload_type _workload_type = workload_type::unspecified;
 
     // Used to communicate with the code executing user requests.
     // It's a way to indicate that we might abort processing the
@@ -191,7 +199,7 @@ public:
     }
 
     std::optional<client_options_cache_entry_type> get_driver_name() const {
-        return _driver_name;
+        return _driver_name ? std::optional(_driver_name) : std::nullopt;
     }
     future<> set_driver_name(client_options_cache_type& keys_and_values_cache, const sstring& driver_name) {
         _driver_name = co_await keys_and_values_cache.get_or_load(driver_name, [] (const client_options_cache_key_type&) {
@@ -208,7 +216,7 @@ public:
         const std::unordered_map<sstring, sstring>& client_options);
 
     std::optional<client_options_cache_entry_type> get_driver_version() const {
-        return _driver_version;
+        return _driver_version ? std::optional(_driver_version) : std::nullopt;
     }
     future<> set_driver_version(
         client_options_cache_type& keys_and_values_cache,
@@ -228,6 +236,7 @@ public:
                  abort_source* as = nullptr)
             : _is_internal(false)
             , _bypass_auth_checks(bypass_auth_checks)
+            , _remote_port(remote_address.port())
             , _remote_address(remote_address)
             , _auth_service(&auth_service)
             , _sl_controller(sl_controller)
@@ -240,15 +249,15 @@ public:
     }
 
     gms::inet_address get_client_address() const {
-        return gms::inet_address(_remote_address);
+        return _remote_address;
     }
 
     ::in_port_t get_client_port() const {
-        return _remote_address.port();
+        return _remote_port;
     }
 
-    const socket_address& get_remote_address() const {
-        return _remote_address;
+    socket_address get_remote_address() const {
+        return socket_address(_remote_address, _remote_port);
     }
 
     const timeout_config& get_timeout_config() const {
@@ -290,7 +299,8 @@ public:
             , _auth_state(auth_state::READY)
             , _is_internal(false)
             , _bypass_auth_checks(false)
-            , _remote_address(socket_address(forwarded_state.remote_address, forwarded_state.remote_port))
+            , _remote_port(forwarded_state.remote_port)
+            , _remote_address(forwarded_state.remote_address)
             , _auth_service(&auth_service)
             , _sl_controller(sl_controller)
             , _default_timeout_config(forwarded_state.timeout_config)
@@ -512,10 +522,6 @@ public:
 private:
 
     cql_transport::cql_protocol_extension_enum_set _enabled_protocol_extensions;
-
-    // The shard where the current CQL request originally entered the node.
-    // After an internal CAS shard bounce this differs from this_shard_id().
-    unsigned _original_shard = this_shard_id();
 
 public:
 

--- a/service/qos/qos_common.hh
+++ b/service/qos/qos_common.hh
@@ -56,7 +56,7 @@ struct service_level_options {
         bool operator==(const delete_marker&) const { return true; };
     };
 
-    enum class workload_type {
+    enum class workload_type : uint8_t {
         unspecified, batch, interactive, delete_marker
     };
 

--- a/transport/event_notifier.cc
+++ b/transport/event_notifier.cc
@@ -249,7 +249,7 @@ void cql_server::event_notifier::send_join_cluster(const gms::inet_address& endp
     for (auto&& conn : _topology_change_listeners) {
         using namespace cql_transport;
         if (!conn->_pending_requests_gate.is_closed()) {
-            conn->write_response(conn->make_topology_change_event(event::topology_change::new_node(endpoint, conn->_server_addr.port())));
+            conn->write_response(conn->make_topology_change_event(event::topology_change::new_node(endpoint, conn->_server_port)));
         };
     }
 }
@@ -259,7 +259,7 @@ void cql_server::event_notifier::on_leave_cluster(const gms::inet_address& endpo
     for (auto&& conn : _topology_change_listeners) {
         using namespace cql_transport;
         if (!conn->_pending_requests_gate.is_closed()) {
-            conn->write_response(conn->make_topology_change_event(event::topology_change::removed_node(endpoint, conn->_server_addr.port())));
+            conn->write_response(conn->make_topology_change_event(event::topology_change::removed_node(endpoint, conn->_server_port)));
         };
     }
 }
@@ -276,7 +276,7 @@ void cql_server::event_notifier::on_up(const gms::inet_address& endpoint, locato
         for (auto&& conn : _status_change_listeners) {
             using namespace cql_transport;
             if (!conn->_pending_requests_gate.is_closed()) {
-                conn->write_response(conn->make_status_change_event(event::status_change::node_up(endpoint, conn->_server_addr.port())));
+                conn->write_response(conn->make_status_change_event(event::status_change::node_up(endpoint, conn->_server_port)));
             };
         }
     }
@@ -290,7 +290,7 @@ void cql_server::event_notifier::on_down(const gms::inet_address& endpoint, loca
         for (auto&& conn : _status_change_listeners) {
             using namespace cql_transport;
             if (!conn->_pending_requests_gate.is_closed()) {
-                conn->write_response(conn->make_status_change_event(event::status_change::node_down(endpoint, conn->_server_addr.port())));
+                conn->write_response(conn->make_status_change_event(event::status_change::node_down(endpoint, conn->_server_port)));
             };
         }
     }

--- a/transport/generic_server.cc
+++ b/transport/generic_server.cc
@@ -408,15 +408,18 @@ future<> server::do_accepts(int which, bool keepalive, socket_address server_add
                 conn->shutdown();
                 continue;
             }
-            conn->_ssl_enabled = is_tls;
+            if (is_tls) {
+                // Allocate TLS metadata; protocol/cipher are filled in asynchronously below.
+                conn->_ssl_info = std::make_unique<connection::ssl_info>();
+            }
             // Move the processing into the background.
             (void)futurize_invoke([this, conn, is_tls] {
                 return (is_tls
                     ? tls::get_protocol_version(conn->_fd).then([conn](const sstring& protocol) {
                             return tls::get_cipher_suite(conn->_fd).then(
                                 [conn, protocol](const sstring& cipher_suite) mutable {
-                                    conn->_ssl_protocol = protocol;
-                                    conn->_ssl_cipher_suite = cipher_suite;
+                                    conn->_ssl_info->protocol = protocol;
+                                    conn->_ssl_info->cipher_suite = cipher_suite;
                                     return make_ready_future<bool>(true);
                                 });
                         }).handle_exception([conn](std::exception_ptr ep) {

--- a/transport/generic_server.hh
+++ b/transport/generic_server.hh
@@ -15,6 +15,8 @@
 #include "utils/scoped_item_list.hh"
 
 #include <cstdint>
+#include <memory>
+#include <optional>
 
 #include <seastar/core/file-types.hh>
 #include <seastar/core/future.hh>
@@ -61,9 +63,13 @@ protected:
     seastar::named_gate _pending_requests_gate;
     seastar::gate::holder _hold_server;
 
-    bool _ssl_enabled = false;
-    std::optional<sstring> _ssl_cipher_suite = std::nullopt;
-    std::optional<sstring> _ssl_protocol = std::nullopt;
+    // TLS metadata, allocated lazily only for TLS connections (non-null means
+    // TLS-enabled). The fields are filled in asynchronously after the handshake.
+    struct ssl_info {
+        std::optional<sstring> cipher_suite;
+        std::optional<sstring> protocol;
+    };
+    std::unique_ptr<ssl_info> _ssl_info;
 
 private:
     future<> process_until_tenant_switch();

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1115,7 +1115,7 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
 cql_server::connection::connection(cql_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units)
     : generic_server::connection{server, std::move(fd), sem, std::move(initial_sem_units)}
     , _server(server)
-    , _server_addr(server_addr)
+    , _server_port(server_addr.port())
     , _client_state(service::client_state::external_tag{}, server._auth_service, &server._sl_controller, server.timeout_config(), addr, bool(server._used_by_maintenance_socket), &server._abort_source)
     , _current_scheduling_group(server.get_scheduling_group_for_new_connection())
 {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1165,9 +1165,11 @@ client_data cql_server::connection::make_client_data() const {
     cd.scheduling_group_name = _current_scheduling_group.name();
     cd.client_options = _client_state.get_client_options();
 
-    cd.ssl_enabled = _ssl_enabled;
-    cd.ssl_protocol = _ssl_protocol;
-    cd.ssl_cipher_suite = _ssl_cipher_suite;
+    cd.ssl_enabled = bool(_ssl_info);
+    if (_ssl_info) {
+        cd.ssl_protocol = _ssl_info->protocol;
+        cd.ssl_cipher_suite = _ssl_info->cipher_suite;
+    }
 
     return cd;
 }
@@ -1482,7 +1484,7 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
     if (auto& a = client_state.get_auth_service()->underlying_authenticator(); a.require_authentication()) {
         _authenticating = true;
         auth::session_dn_func dn_func;
-        if (_ssl_enabled) {
+        if (_ssl_info) {
             dn_func = [this]() -> future<std::optional<auth::certificate_info>> {
                 auto dn_info = co_await tls::get_dn_information(this->_fd);
                 if (dn_info) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1119,7 +1119,7 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
 cql_server::connection::connection(cql_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units)
     : generic_server::connection{server, std::move(fd), sem, std::move(initial_sem_units)}
     , _server(server)
-    , _server_addr(server_addr)
+    , _server_port(server_addr.port())
     , _client_state(service::client_state::external_tag{}, server._auth_service, &server._sl_controller, server.timeout_config(), addr, bool(server._used_by_maintenance_socket), &server._abort_source)
     , _current_scheduling_group(server.get_scheduling_group_for_new_connection())
 {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1119,14 +1119,10 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
 cql_server::connection::connection(cql_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units)
     : generic_server::connection{server, std::move(fd), sem, std::move(initial_sem_units)}
     , _server(server)
+    , _current_scheduling_group(server.get_scheduling_group_for_new_connection())
     , _server_port(server_addr.port())
     , _client_state(service::client_state::external_tag{}, server._auth_service, &server._sl_controller, server.timeout_config(), addr, bool(server._used_by_maintenance_socket), &server._abort_source)
-    , _current_scheduling_group(server.get_scheduling_group_for_new_connection())
 {
-    _shedding_timer.set_callback([this] {
-        clogger.debug("Shedding all incoming requests due to overload");
-        _shed_incoming_requests = true;
-    });
     ++_server._stats.connects;
     ++_server._stats.connections;
     if (clogger.is_enabled(logging::log_level::trace)) {
@@ -1216,7 +1212,7 @@ future<> cql_server::connection::process_request() {
         auto request_start_timestamp = lowres_server_timestamp();
 
         const bool allow_shedding = _client_state.get_workload_type() == service::client_state::workload_type::interactive;
-        if (allow_shedding && _shed_incoming_requests) {
+        if (allow_shedding && lowres_clock::now() >= _shed_after) {
             ++_server._stats.requests_shed;
             return _read_buf.skip(f.length).then([this, stream = f.stream] {
                 const char* message = "request shed due to coordinator overload";
@@ -1276,7 +1272,7 @@ future<> cql_server::connection::process_request() {
                     } catch (semaphore_timed_out& sto) {
                         // Cancel shedding in case no more requests are going to do that on completion
                         if (_pending_requests_gate.get_count() == 0) {
-                            _shed_incoming_requests = false;
+                            _shed_after = lowres_clock::time_point::max();
                         }
                         return _read_buf.skip(length).then([sto = std::move(sto)] () mutable {
                             return make_exception_future<semaphore_units<>>(std::move(sto));
@@ -1285,8 +1281,8 @@ future<> cql_server::connection::process_request() {
                 })
                 : get_units(_server._memory_available, mem_estimate);
         if (_server._memory_available.waiters()) {
-            if (allow_shedding && !_shedding_timer.armed()) {
-                _shedding_timer.arm(shedding_timeout);
+            if (allow_shedding && _shed_after == lowres_clock::time_point::max()) {
+                _shed_after = lowres_clock::now() + shedding_timeout;
             }
             ++_server._stats.requests_blocked_memory;
         }
@@ -1309,8 +1305,7 @@ future<> cql_server::connection::process_request() {
             auto leave = defer([this, &sg_stats] noexcept {
                 --_server._stats.requests_serving;
                 --sg_stats._requests_serving;
-                _shedding_timer.cancel();
-                _shed_incoming_requests = false;
+                _shed_after = lowres_clock::time_point::max();
                 _pending_requests_gate.leave();
             });
             auto istream = buf.get_istream();

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -303,10 +303,10 @@ private:
 
     class connection : public generic_server::connection {
         cql_server& _server;
-        socket_address _server_addr;
         fragmented_temporary_buffer::reader _buffer_reader;
-        cql_protocol_version_type _version = 0;
         cql_compression _compression = cql_compression::none;
+        uint16_t _server_port = 0;
+        cql_protocol_version_type _version = 0;
         service::client_state _client_state;
         timer<lowres_clock> _shedding_timer;
         scheduling_group _current_scheduling_group;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -304,10 +304,10 @@ private:
 
     class connection : public generic_server::connection {
         cql_server& _server;
-        socket_address _server_addr;
         fragmented_temporary_buffer::reader _buffer_reader;
-        cql_protocol_version_type _version = 0;
         cql_compression _compression = cql_compression::none;
+        uint16_t _server_port = 0;
+        cql_protocol_version_type _version = 0;
         service::client_state _client_state;
         timer<lowres_clock> _shedding_timer;
         scheduling_group _current_scheduling_group;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -82,7 +82,7 @@ class request_reader;
 class response;
 enum class cql_binary_opcode : uint8_t;
 
-enum class cql_compression {
+enum class cql_compression : uint8_t {
     none,
     lz4,
     snappy,
@@ -305,16 +305,18 @@ private:
     class connection : public generic_server::connection {
         cql_server& _server;
         fragmented_temporary_buffer::reader _buffer_reader;
-        cql_compression _compression = cql_compression::none;
+        scheduling_group _current_scheduling_group;
         uint16_t _server_port = 0;
         cql_protocol_version_type _version = 0;
+        // Bit-packed with the flags: one byte for all of them.
+        cql_compression _compression : 2 = cql_compression::none;
+        bool _ready : 1 = false;
+        bool _authenticating : 1 = false;
         service::client_state _client_state;
-        timer<lowres_clock> _shedding_timer;
-        scheduling_group _current_scheduling_group;
-        bool _shed_incoming_requests = false;
-        bool _ready = false;
-        bool _authenticating = false;
-        bool _tenant_switch = false;
+        // Once a request has waited this long for memory, incoming requests are shed
+        // until a request completes. Replaces a 96-byte timer: the check only ever
+        // happens when the next frame arrives anyway.
+        lowres_clock::time_point _shed_after = lowres_clock::time_point::max();
 
         enum class tracing_request_type : uint8_t {
             not_requested,


### PR DESCRIPTION
## Motivation

One `cql_server::connection` object exists per live CQL client connection, and it carries a `service::client_state`. On master the connection is 1176 bytes, but what it stores is much smaller: two full `socket_address`es (136 bytes each, for a port and an IP), a 96-byte timer that is almost never armed, TLS metadata on non-TLS connections, and 4-byte enums holding 3 or 4 values.

Shrinking a struct only saves memory when the allocation crosses one of Seastar's small-pool size classes (..., 768, 896, 1024, 1280, 1536 bytes). Connections are `make_shared`'d (16-byte header), so master's 1176-byte connection is a 1192-byte allocation served from the 1280-byte pool. The first version of this PR (136 bytes, the server address) landed at 1056 bytes: still the 1280 pool, so it saved nothing measurable. This series was assembled so the object actually drops two classes.

## Changes

1. **transport/generic_server: lazily allocate TLS connection metadata** (was #30248). The two `std::optional<sstring>` for cipher suite and protocol move into a struct allocated only for TLS connections. 480 → 432 bytes for the base class.
2. **transport/cql: keep only the server port, not a full socket_address, per connection**. Only the port is ever read (by the event notifier for topology/status events). 136 → 2 bytes.
3. **transport/cql, service: compact the client address, shedding state, flags and enums in per-connection state**.
   - `client_state` kept the client address as a `socket_address`; only IP and port are read, so it is now `gms::inet_address` + `uint16_t`, and `get_remote_address()` rebuilds a `socket_address` by value for the log lines that format it.
   - The load-shedding `timer<lowres_clock>` (96 bytes) only ever raised a flag 50 ms after a request started waiting for memory, and the flag is consumed only when the next frame arrives. An 8-byte deadline compared at that point is equivalent and needs no allocation.
   - `cql_compression` (3 values), `workload_type` (4) and `auth_state` (3) become 2-bit fields; the bools around them 1-bit fields; so each class keeps its flags in one byte instead of an 8-byte slot.
   - `_driver_name`/`_driver_version` were `std::optional` around an already-nullable `entry_ptr`.
   - `cql_server::connection` had its own `_tenant_switch` shadowing the base-class member that `generic_server` actually uses; it was never read.

Nothing on the wire or on disk changes: `forwarded_client_state` already carried address and port separately, `workload_type` is persisted as a string, and the port delivered in topology/status events is unchanged.

## Results

Sizes (compiler-verified with `static_assert`, same for dev and release):

| | master | this PR |
|---|---:|---:|
| `generic_server::connection` | 480 B | 432 B |
| `cql_server::connection` (incl. base) | 1176 B | 752 B |
| `service::client_state` | 408 B | 264 B |
| `make_shared` allocation | 1192 B | 768 B |
| Seastar small-pool class | 1280 B | 768 B |

Measured: release build, one node, `--smp 2 -m 4G`, 40,000 idle CQL connections, scylla RSS before any query, master aa6f18a0b6 vs this PR, two interleaved rounds:

| round | master RSS | this PR | saved |
|---|---:|---:|---:|
| 1 | 304,432 kB | 285,956 kB | 18.0 MB |
| 2 | 305,472 kB | 286,328 kB | 18.7 MB |

Predicted from the pool classes: 512 B × 40K = 19.5 MB. For comparison, measured the same way: commit 2 alone saves 0 (same pool), commits 1+2 save ~10 MB (1024 pool), all three save ~18 MB (768 pool).

## Tests

- `test/boost/transport_test` passes.
- Under dbuild dev: `test/cqlpy/test_virtual_tables.py`, `test/cluster/test_proxy_protocol.py`, `test/cqlpy/test_service_levels.py`, `test/cqlpy/test_permissions.py`, `test/alternator/test_metrics.py`, `test/cqlpy/test_shedding.py`: 164 passed, 8 skipped, 2 xfailed.
- Manual: Python driver with lz4, snappy and no compression against a dev node, 5 KB round trip, and `system.clients` address/port/connection_stage; all correct, no errors logged. (The 2-bit `cql_compression` field has no automated coverage; the dbuild image lacks the lz4 module.)

Closes #30248 (folded in as the first commit).

Backport: no, improvement
