### PR TITLE
transport/generic_server: lazily allocate TLS connection metadata (480 to 432 bytes (-48 bytes)  - one less cache line)

### DIFF
--- a/transport/generic_server.cc
+++ b/transport/generic_server.cc
@@ -408,15 +408,18 @@ future<> server::do_accepts(int which, bool keepalive, socket_address server_add
                 conn->shutdown();
                 continue;
             }
-            conn->_ssl_enabled = is_tls;
+            if (is_tls) {
+                // Allocate TLS metadata; protocol/cipher are filled in asynchronously below.
+                conn->_ssl_info = std::make_unique<connection::ssl_info>();
+            }
             // Move the processing into the background.
             (void)futurize_invoke([this, conn, is_tls] {
                 return (is_tls
                     ? tls::get_protocol_version(conn->_fd).then([conn](const sstring& protocol) {
                             return tls::get_cipher_suite(conn->_fd).then(
                                 [conn, protocol](const sstring& cipher_suite) mutable {
-                                    conn->_ssl_protocol = protocol;
-                                    conn->_ssl_cipher_suite = cipher_suite;
+                                    conn->_ssl_info->protocol = protocol;
+                                    conn->_ssl_info->cipher_suite = cipher_suite;
                                     return make_ready_future<bool>(true);
                                 });
                         }).handle_exception([conn](std::exception_ptr ep) {

--- a/transport/generic_server.hh
+++ b/transport/generic_server.hh
@@ -15,6 +15,8 @@
 #include "utils/scoped_item_list.hh"
 
 #include <cstdint>
+#include <memory>
+#include <optional>
 
 #include <seastar/core/file-types.hh>
 #include <seastar/core/future.hh>
@@ -61,9 +63,13 @@ protected:
     seastar::named_gate _pending_requests_gate;
     seastar::gate::holder _hold_server;
 
-    bool _ssl_enabled = false;
-    std::optional<sstring> _ssl_cipher_suite = std::nullopt;
-    std::optional<sstring> _ssl_protocol = std::nullopt;
+    // TLS metadata, allocated lazily only for TLS connections (non-null means
+    // TLS-enabled). The fields are filled in asynchronously after the handshake.
+    struct ssl_info {
+        std::optional<sstring> cipher_suite;
+        std::optional<sstring> protocol;
+    };
+    std::unique_ptr<ssl_info> _ssl_info;
 
 private:
     future<> process_until_tenant_switch();

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1161,9 +1161,11 @@ client_data cql_server::connection::make_client_data() const {
     cd.scheduling_group_name = _current_scheduling_group.name();
     cd.client_options = _client_state.get_client_options();
 
-    cd.ssl_enabled = _ssl_enabled;
-    cd.ssl_protocol = _ssl_protocol;
-    cd.ssl_cipher_suite = _ssl_cipher_suite;
+    cd.ssl_enabled = bool(_ssl_info);
+    if (_ssl_info) {
+        cd.ssl_protocol = _ssl_info->protocol;
+        cd.ssl_cipher_suite = _ssl_info->cipher_suite;
+    }
 
     return cd;
 }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1165,9 +1165,11 @@ client_data cql_server::connection::make_client_data() const {
     cd.scheduling_group_name = _current_scheduling_group.name();
     cd.client_options = _client_state.get_client_options();
 
-    cd.ssl_enabled = _ssl_enabled;
-    cd.ssl_protocol = _ssl_protocol;
-    cd.ssl_cipher_suite = _ssl_cipher_suite;
+    cd.ssl_enabled = bool(_ssl_info);
+    if (_ssl_info) {
+        cd.ssl_protocol = _ssl_info->protocol;
+        cd.ssl_cipher_suite = _ssl_info->cipher_suite;
+    }
 
     return cd;
 }
@@ -1482,7 +1484,7 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
     if (auto& a = client_state.get_auth_service()->underlying_authenticator(); a.require_authentication()) {
         _authenticating = true;
         auth::session_dn_func dn_func;
-        if (_ssl_enabled) {
+        if (_ssl_info) {
             dn_func = [this]() -> future<std::optional<auth::certificate_info>> {
                 auto dn_info = co_await tls::get_dn_information(this->_fd);
                 if (dn_info) {


### PR DESCRIPTION
Motivation:
generic_server::connection carried the TLS metadata of a connection inline:
a bool _ssl_enabled plus two std::optional<sstring> fields (_ssl_cipher_suite, _ssl_protocol). Together with alignment padding these occupy 56 bytes of every connection object, but they are only meaningful for TLS-encrypted connections.
Plaintext connections -- all unencrypted internode and client connections -- never use them, yet still pay the 56 bytes. One connection object exists per live client/internode connection, so this is pure per-connection waste.

Replace the three inline fields with a single, lazily-allocated holder:

    struct ssl_info {
        std::optional<sstring> cipher_suite;
        std::optional<sstring> protocol;
    };
    std::unique_ptr<ssl_info> _ssl_info;

The pointer is null for plaintext connections and is allocated once, at accept time, only when the connection is TLS-enabled. A non-null pointer therefore encodes "ssl_enabled == true"; the protocol/cipher optionals are
filled in asynchronously after the handshake is inspected (and may remain empty in the brief window before that completes, exactly as before).

This shrinks generic_server::connection from 480 to 432 bytes (-48 bytes) for every connection. TLS connections instead allocate a 48-byte ssl_info heap block (two optional<sstring>; the bool is encoded by the pointer being non-null), allocated only for them.

The fields are purely in-memory, runtime-populated state (reported via the system.clients virtual table); nothing here is serialized, so the change is wire-compatible.

Tests: built transport/generic_server.o and transport/server.o via dbuild.
Covered by test/cqlpy/test_ssl.py, which asserts that non-TLS connections report ssl_enabled=false with null ssl_protocol/ssl_cipher_suite and that TLS connections report ssl_enabled=true with the negotiated protocol and cipher (including the asynchronous-fill window). make_client_data() is
unchanged: cd.ssl_enabled = bool(_ssl_info) reproduces the previous always-engaged optional<bool>, and the cipher and protocol copies are identical.

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
AI-assisted: Yes
Backport: no, improvement
