### PR TITLE
raft: fix `_messages` oversized allocations by using `chunked_vector`

### DIFF
--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -10,6 +10,7 @@
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/on_internal_error.hh>
 #include "utils/assert.hh"
+#include "utils/chunked_vector.hh"
 #include "utils/small_vector.hh"
 #include "raft.hh"
 #include "tracker.hh"
@@ -28,7 +29,7 @@ struct fsm_output {
     };
     std::optional<std::pair<term_t, server_id>> term_and_vote;
     std::vector<log_entry_ptr> log_entries;
-    std::vector<std::pair<server_id, rpc_message>> messages;
+    utils::chunked_vector<std::pair<server_id, rpc_message>> messages;
     // Entries to apply.
     std::vector<log_entry_ptr> committed;
     std::optional<applied_snapshot> snp;
@@ -228,7 +229,7 @@ private:
     // If a server receives a request with a stale term number, it
     // rejects the request.
     // TLA+ line 328
-    std::vector<std::pair<server_id, rpc_message>> _messages;
+    utils::chunked_vector<std::pair<server_id, rpc_message>> _messages;
 
     // Signaled when there is a IO event to process.
     seastar::condition_variable& _sm_events;

--- a/test/raft/helpers.cc
+++ b/test/raft/helpers.cc
@@ -80,7 +80,7 @@ bool deliver(raft_routing_map& routes, raft::server_id from,
     return true;
 }
 
-void deliver(raft_routing_map& routes, raft::server_id from, std::vector<std::pair<raft::server_id, raft::rpc_message>> msgs) {
+void deliver(raft_routing_map& routes, raft::server_id from, utils::chunked_vector<std::pair<raft::server_id, raft::rpc_message>> msgs) {
     for (auto& m: msgs) {
         deliver(routes, from, std::move(m));
     }

--- a/test/raft/helpers.hh
+++ b/test/raft/helpers.hh
@@ -103,7 +103,7 @@ using raft_routing_map = std::unordered_map<raft::server_id, raft::fsm*>;
 bool deliver(raft_routing_map& routes, raft::server_id from,
         std::pair<raft::server_id, raft::rpc_message> m);
 void deliver(raft_routing_map& routes, raft::server_id from,
-        std::vector<std::pair<raft::server_id, raft::rpc_message>> msgs);
+        utils::chunked_vector<std::pair<raft::server_id, raft::rpc_message>> msgs);
 
 void
 communicate_impl(std::function<bool()> stop_pred, raft_routing_map& map);


### PR DESCRIPTION
Replace `_messages` `std::vector` with `chunked_vector` to avoid oversized allocations.

Replace both `std::vector` declarations with `utils::chunked_vector`, which stores data in ≤128 KB chunks. At 2,252 elements the container uses 3 chunks of 81,920 bytes each — no single allocation exceeds the threshold.

`utils::chunked_vector` provides `push_back()`, `empty()`, `size()`, `noexcept swap()`, and full iterator support, so no call sites in fsm.cc or server.cc require changes.

Fixes: SCYLLADB-473

Backport: Yes — the 180,224-byte allocation has been observed on the released 2025.4.9.0 build (Argus 84ad419f), making all active maintained branches affected. The fix is a 3-line header-only change with no ABI or API impact, making it safe to backport to all active branches.