### PR TITLE
sstables_loader: avoid rjson asserts whilst processing backup manifest during tablet aware restore

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1080,26 +1080,30 @@ static future<size_t> process_manifest(input_stream<char>& is, sstring keyspace,
     rjson::value parsed = rjson::parse(std::move(content));
 
     // Basic validation that tablet_count is a power of 2, as expected by our restore process
-    size_t tablet_count = parsed["table"]["tablet_count"].GetUint64();
+    auto& table_obj = rjson::get(parsed, "table");
+    size_t tablet_count = rjson::get<uint64_t>(table_obj, "tablet_count");
+
     if (!std::has_single_bit(tablet_count)) {
         on_internal_error(llog, fmt::format("Invalid tablet_count {} in manifest {}, expected a power of 2", tablet_count, manifest_prefix));
     }
 
     // Extract the necessary fields from the manifest
     // Expected JSON structure documented in docs/dev/object_storage.md
-    auto snapshot_name = rjson::to_sstring(parsed["snapshot"]["name"]);
+    auto& snapshot_obj = rjson::get(parsed, "snapshot");
+    auto snapshot_name = rjson::get<std::string>(snapshot_obj, "name");
     if (snapshot_name != expected_snapshot_name) {
         throw std::runtime_error(fmt::format("Manifest {} belongs to snapshot '{}', expected '{}'",
             manifest_prefix, snapshot_name, expected_snapshot_name));
     }
     if (keyspace.empty()) {
-        keyspace = rjson::to_sstring(parsed["table"]["keyspace_name"]);
+        keyspace = rjson::get<std::string>(table_obj, "keyspace_name");
     }
     if (table.empty()) {
-        table = rjson::to_sstring(parsed["table"]["table_name"]);
+        table = rjson::get<std::string>(table_obj, "table_name");
     }
-    auto datacenter = rjson::to_sstring(parsed["node"]["datacenter"]);
-    auto rack = rjson::to_sstring(parsed["node"]["rack"]);
+    auto& node_obj = rjson::get(parsed, "node");
+    auto datacenter = rjson::get<std::string>(node_obj, "datacenter");
+    auto rack = rjson::get<std::string>(node_obj, "rack");
 
     // Process each sstable entry in the manifest
     // FIXME: cleanup of the snapshot-related rows is needed in case anything throws in here.
@@ -1112,10 +1116,14 @@ static future<size_t> process_manifest(input_stream<char>& is, sstring keyspace,
     }
 
     for (auto& sstable_entry : sstables->GetArray()) {
-        auto id = rjson::to_sstable_id(sstable_entry["id"]);
-        auto first_token = rjson::to_token(sstable_entry["first_token"]);
-        auto last_token = rjson::to_token(sstable_entry["last_token"]);
-        auto toc_name = rjson::to_sstring(sstable_entry["toc_name"]);
+        // rjson::get functions assert if the passed value is not an object
+        if (!sstable_entry.IsObject()) {
+            throw std::runtime_error("Malformed manifest, the entry in the 'sstables' array is not an object");
+        }
+        auto id = rjson::to_sstable_id(rjson::get(sstable_entry, "id"));
+        auto first_token = rjson::to_token(rjson::get(sstable_entry, "first_token"));
+        auto last_token = rjson::to_token(rjson::get(sstable_entry, "last_token"));
+        auto toc_name = rjson::to_sstring(rjson::get(sstable_entry, "toc_name"));
         auto prefix = sstring(std::filesystem::path(manifest_prefix).parent_path().string());
         // Insert the snapshot sstable metadata into system_distributed.snapshot_sstables with a TTL of 3 days, that should be enough
         // for any snapshot restore operation to complete, and after that the metadata will be automatically cleaned up from the table

--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -204,6 +204,20 @@ public:
     }
 };
 
+// Returns a human-readable name for the given rjson type.
+inline std::string_view type_name(rjson::type t) {
+    switch (t) {
+    case rapidjson::kNullType: return "kNullType";
+    case rapidjson::kFalseType: return "kFalseType";
+    case rapidjson::kTrueType: return "kTrueType";
+    case rapidjson::kObjectType: return "kObjectType";
+    case rapidjson::kArrayType: return "kArrayType";
+    case rapidjson::kStringType: return "kStringType";
+    case rapidjson::kNumberType: return "kNumberType";
+    }
+    throw std::runtime_error("unknown rjson type provided");
+}
+
 // Parses a JSON value from given string or raw character array.
 // The string/char array liveness does not need to be persisted,
 // as parse() will allocate member names and values.
@@ -233,10 +247,13 @@ rjson::value parse_yieldable(chunked_content&&, size_t max_nested_level = defaul
 rjson::value from_string(const char* str, size_t size);
 rjson::value from_string(std::string_view view);
 
-// Returns a string_view to the string held in a JSON value (which is
-// assumed to hold a string, i.e., v.IsString() == true). This is a view
-// to the existing data - no copying is done.
+// Returns a string_view to the string held in a JSON value.
+// Throws if the value does not hold a string.
+// This is a view to the existing data - no copying is done.
 inline std::string_view to_string_view(const rjson::value& v) {
+    if (!v.IsString()) {
+        throw std::runtime_error(fmt::format("rjson::to_string_view expects a string value, got: {}", type_name(v.GetType())));
+    }
     return std::string_view(v.GetString(), v.GetStringLength());
 }
 
@@ -248,17 +265,29 @@ inline std::string_view to_string_view(const rjson::value& v) {
 // for string conversion because it needs to scan the string
 // unnecessarily and GetStringLength could be used to avoid that.
 inline sstring to_sstring(const rjson::value& str) {
+    if (!str.IsString()) {
+        throw std::runtime_error(fmt::format("rjson::to_sstring expects a string value, got: {}", type_name(str.GetType())));
+    }
     return sstring(str.GetString(), str.GetStringLength());
 }
 inline std::string to_string(const rjson::value& str) {
+    if (!str.IsString()) {
+        throw std::runtime_error(fmt::format("rjson::to_string expects a string value, got: {}", type_name(str.GetType())));
+    }
     return std::string(str.GetString(), str.GetStringLength());
 }
 // Helper for conversion to dht::token
 inline dht::token to_token(const rjson::value& v) {
+    if (!v.IsInt64()) {
+        throw std::runtime_error(fmt::format("rjson::to_token expects a 64-bit signed integer value, got: {}", type_name(v.GetType())));
+    }
     return dht::token::from_int64(v.GetInt64());
 }
 // Helper for conversion to sstables::sstable_id
 inline sstables::sstable_id to_sstable_id(const rjson::value& v) {
+    if (!v.IsString()) {
+        throw std::runtime_error(fmt::format("rjson::to_sstable_id expects a string value, got: {}", type_name(v.GetType())));
+    }
     return sstables::sstable_id(utils::UUID(rjson::to_string_view(v)));
 }
 // Returns a pointer to JSON member if it exists, nullptr otherwise


### PR DESCRIPTION
Several rjson accessor functions (to_sstring, to_token, to_sstable_id)
call rapidjson getters that assert on type mismatch rather than
throwing. Added type checks that throw std::runtime_error, consistent
with other rjson utilities.
 
process_manifest() used direct JSON access
which asserts on missing keys. Replaced with rjson::get() calls and 
added an explicit IsObject() check on sstable array entries, so a
malformed backup manifest produces an exception instead of crashing
the node.

Fixes SCYLLADB-2437
 
No backport needed — tablet-aware restore is a new feature.