### PR TITLE
tablets: move repair/migration task_info to tablet_map side maps (shrink tablet_info 448B->112B)

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -220,20 +220,20 @@ bool tablet_has_excluded_node(const locator::topology& topo, const tablet_info& 
     return false;
 }
 
-tablet_info::tablet_info(tablet_replica_set replicas, db_clock::time_point repair_time, tablet_task_info repair_task_info, tablet_task_info migration_task_info, int64_t sstables_repaired_at)
+tablet_info::tablet_info(tablet_replica_set replicas, db_clock::time_point repair_time, int64_t sstables_repaired_at)
     : replicas(std::move(replicas))
     , repair_time(repair_time)
-    , repair_task_info(std::move(repair_task_info))
-    , migration_task_info(std::move(migration_task_info))
     , sstables_repaired_at(sstables_repaired_at)
 {}
 
 tablet_info::tablet_info(tablet_replica_set replicas)
-    : tablet_info(std::move(replicas), db_clock::time_point{}, tablet_task_info{}, tablet_task_info{}, int64_t(0))
+    : tablet_info(std::move(replicas), db_clock::time_point{}, int64_t(0))
 {}
 
-std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b) {
-    auto repair_task_info = tablet_task_info::merge_repair_tasks(a.repair_task_info, b.repair_task_info);
+std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b,
+        const tablet_task_info& a_repair, const tablet_task_info& b_repair,
+        tablet_task_info* merged_repair_out) {
+    auto repair_task_info = tablet_task_info::merge_repair_tasks(a_repair, b_repair);
     if (!repair_task_info) {
         return {};
     }
@@ -248,7 +248,10 @@ std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b) {
 
     auto repair_time = std::max(a.repair_time, b.repair_time);
     int64_t sstables_repaired_at = std::max(a.sstables_repaired_at, b.sstables_repaired_at);
-    auto info = tablet_info(std::move(a.replicas), repair_time, *repair_task_info, a.migration_task_info, sstables_repaired_at);
+    auto info = tablet_info(std::move(a.replicas), repair_time, sstables_repaired_at);
+    if (merged_repair_out) {
+        *merged_repair_out = std::move(*repair_task_info);
+    }
     return info;
 }
 
@@ -551,7 +554,8 @@ tablet_layout tablet_map::get_layout() const {
 }
 
 tablet_map tablet_map::clone() const {
-    return tablet_map(_tablet_ids, _tablets, _transitions, _resize_decision, _resize_task_info,
+    return tablet_map(_tablet_ids, _tablets, _transitions, _repair_task_infos, _migration_task_infos,
+                      _resize_decision, _resize_task_info,
                       _repair_scheduler_config, _raft_info);
 }
 
@@ -572,6 +576,20 @@ future<tablet_map> tablet_map::clone_gently() const {
         co_await coroutine::maybe_yield();
     }
 
+    task_info_map repair_task_infos;
+    repair_task_infos.reserve(_repair_task_infos.size());
+    for (const auto& [id, ti] : _repair_task_infos) {
+        repair_task_infos.emplace(id, ti);
+        co_await coroutine::maybe_yield();
+    }
+
+    task_info_map migration_task_infos;
+    migration_task_infos.reserve(_migration_task_infos.size());
+    for (const auto& [id, ti] : _migration_task_infos) {
+        migration_task_infos.emplace(id, ti);
+        co_await coroutine::maybe_yield();
+    }
+
     raft_info_container raft_info;
     raft_info.reserve(_raft_info.size());
     for (const auto& i: _raft_info) {
@@ -580,6 +598,7 @@ future<tablet_map> tablet_map::clone_gently() const {
     }
 
     co_return tablet_map(std::move(ids), std::move(tablets), std::move(transitions),
+                         std::move(repair_task_infos), std::move(migration_task_infos),
                          _resize_decision, _resize_task_info, _repair_scheduler_config, std::move(raft_info));
 }
 
@@ -739,6 +758,24 @@ void tablet_map::set_tablet_transition_info(tablet_id id, tablet_transition_info
     _transitions.insert_or_assign(id, std::move(info));
 }
 
+void tablet_map::set_repair_task_info(tablet_id id, tablet_task_info info) {
+    check_tablet_id(id);
+    if (info.is_valid()) {
+        _repair_task_infos.insert_or_assign(id, std::move(info));
+    } else {
+        _repair_task_infos.erase(id);
+    }
+}
+
+void tablet_map::set_migration_task_info(tablet_id id, tablet_task_info info) {
+    check_tablet_id(id);
+    if (info.is_valid()) {
+        _migration_task_infos.insert_or_assign(id, std::move(info));
+    } else {
+        _migration_task_infos.erase(id);
+    }
+}
+
 void tablet_map::set_resize_decision(locator::resize_decision decision) {
     _resize_decision = std::move(decision);
 }
@@ -754,6 +791,16 @@ void tablet_map::set_repair_scheduler_config(std::optional<locator::repair_sched
 void tablet_map::clear_tablet_transition_info(tablet_id id) {
     check_tablet_id(id);
     _transitions.erase(id);
+}
+
+void tablet_map::clear_repair_task_info(tablet_id id) {
+    check_tablet_id(id);
+    _repair_task_infos.erase(id);
+}
+
+void tablet_map::clear_migration_task_info(tablet_id id) {
+    check_tablet_id(id);
+    _migration_task_infos.erase(id);
 }
 
 future<> tablet_map::for_each_tablet(seastar::noncopyable_function<future<>(tablet_id, const tablet_info&)> func) const {
@@ -826,6 +873,34 @@ const tablet_transition_info* tablet_map::get_tablet_transition_info(tablet_id i
         return nullptr;
     }
     return &i->second;
+}
+
+const tablet_task_info* tablet_map::get_repair_task_info_ptr(tablet_id id) const {
+    auto i = _repair_task_infos.find(id);
+    if (i == _repair_task_infos.end()) {
+        return nullptr;
+    }
+    return &i->second;
+}
+
+const tablet_task_info& tablet_map::get_repair_task_info(tablet_id id) const {
+    static const tablet_task_info empty;
+    auto* p = get_repair_task_info_ptr(id);
+    return p ? *p : empty;
+}
+
+const tablet_task_info* tablet_map::get_migration_task_info_ptr(tablet_id id) const {
+    auto i = _migration_task_infos.find(id);
+    if (i == _migration_task_infos.end()) {
+        return nullptr;
+    }
+    return &i->second;
+}
+
+const tablet_task_info& tablet_map::get_migration_task_info(tablet_id id) const {
+    static const tablet_task_info empty;
+    auto* p = get_migration_task_info_ptr(id);
+    return p ? *p : empty;
 }
 
 const tablet_raft_info& tablet_map::get_tablet_raft_info(tablet_id id) const {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -276,15 +276,15 @@ struct restore_config {
 };
 
 /// Stores information about a single tablet.
+/// Rarely-set repair/migration task infos are kept in tablet_map side maps
+/// (like tablet_transition_info), not here, to keep tablet_info small.
 struct tablet_info {
     tablet_replica_set replicas;
     db_clock::time_point repair_time;
-    locator::tablet_task_info repair_task_info;
-    locator::tablet_task_info migration_task_info;
-    int64_t sstables_repaired_at;
+    int64_t sstables_repaired_at = 0;
 
     tablet_info() = default;
-    tablet_info(tablet_replica_set, db_clock::time_point, tablet_task_info, tablet_task_info, int64_t sstables_repaired_at);
+    tablet_info(tablet_replica_set, db_clock::time_point, int64_t sstables_repaired_at);
     tablet_info(tablet_replica_set);
 
     bool operator==(const tablet_info&) const = default;
@@ -301,7 +301,11 @@ struct tablet_raft_info {
 //  - they cannot have active repair task, since each task has a different id
 //  - their replicas must be all co-located.
 // If tablet infos are mergeable, merged info is returned. Otherwise, nullopt.
-std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b);
+// Repair task infos live in tablet_map side maps, so they are passed in
+// (a_repair/b_repair) and the merged one is written to *merged_repair_out (if set).
+std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b,
+        const tablet_task_info& a_repair, const tablet_task_info& b_repair,
+        tablet_task_info* merged_repair_out);
 
 /// Represents states of the tablet migration state machine.
 ///
@@ -697,9 +701,13 @@ public:
     struct initialized_later {};
 private:
     using transitions_map = std::unordered_map<tablet_id, tablet_transition_info>;
+    // Rarely-set per-tablet task infos, kept out of tablet_info (SCYLLADB-1976).
+    using task_info_map = std::unordered_map<tablet_id, tablet_task_info>;
     tablet_id_map _tablet_ids;
     tablet_container _tablets;
     transitions_map _transitions;
+    task_info_map _repair_task_infos;
+    task_info_map _migration_task_infos;
     resize_decision _resize_decision;
     tablet_task_info _resize_task_info;
     std::optional<repair_scheduler_config> _repair_scheduler_config;
@@ -709,6 +717,8 @@ private:
     tablet_map(tablet_id_map ids,
                tablet_container tablets,
                transitions_map transitions,
+               task_info_map repair_task_infos,
+               task_info_map migration_task_infos,
                resize_decision resize_decision,
                tablet_task_info resize_task_info,
                std::optional<repair_scheduler_config> repair_scheduler_config,
@@ -716,6 +726,8 @@ private:
         : _tablet_ids(std::move(ids))
         , _tablets(std::move(tablets))
         , _transitions(std::move(transitions))
+        , _repair_task_infos(std::move(repair_task_infos))
+        , _migration_task_infos(std::move(migration_task_infos))
         , _resize_decision(resize_decision)
         , _resize_task_info(std::move(resize_task_info))
         , _repair_scheduler_config(std::move(repair_scheduler_config))
@@ -774,6 +786,15 @@ public:
     /// If there is no transition for a given tablet, returns nullptr.
     /// \throws std::logic_error If the given id does not belong to this instance.
     const tablet_transition_info* get_tablet_transition_info(tablet_id) const;
+
+    /// Returns the repair task info for a tablet, or a default (invalid) one if
+    /// it has no active repair task. Use get_repair_task_info_ptr() to tell them apart.
+    const tablet_task_info& get_repair_task_info(tablet_id) const;
+    const tablet_task_info* get_repair_task_info_ptr(tablet_id) const;
+
+    /// Like get_repair_task_info(), for migration tasks.
+    const tablet_task_info& get_migration_task_info(tablet_id) const;
+    const tablet_task_info* get_migration_task_info_ptr(tablet_id) const;
 
     /// Returns true for strongly-consistent tablets.
     /// Use get_tablet_raft_info() to retrieve Raft info for a specific tablet_id.
@@ -901,6 +922,11 @@ public:
     void emplace_tablet(tablet_id, dht::token last_token, tablet_info);
     void set_tablet(tablet_id, tablet_info);
     void set_tablet_transition_info(tablet_id, tablet_transition_info);
+    // Set/clear per-tablet repair/migration task infos; setting an invalid one clears it.
+    void set_repair_task_info(tablet_id, tablet_task_info);
+    void set_migration_task_info(tablet_id, tablet_task_info);
+    void clear_repair_task_info(tablet_id);
+    void clear_migration_task_info(tablet_id);
     void set_resize_decision(locator::resize_decision);
     void set_resize_task_info(tablet_task_info);
     void set_repair_scheduler_config(std::optional<locator::repair_scheduler_config> config);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2283,15 +2283,16 @@ future<gc_clock::time_point> repair_service::repair_tablet(gms::gossip_address_m
     std::vector<shard_id> shards;
     std::optional<shard_id> master_shard_id;
     auto& topology = guard.get_token_metadata()->get_topology();
-    auto hosts_filter = info.repair_task_info.repair_hosts_filter;
-    auto dcs_filter = info.repair_task_info.repair_dcs_filter;
-    auto incremental_mode = info.repair_task_info.repair_incremental_mode;
+    auto& repair_task_info = tmap.get_repair_task_info(tablet_id);
+    auto hosts_filter = repair_task_info.repair_hosts_filter;
+    auto dcs_filter = repair_task_info.repair_dcs_filter;
+    auto incremental_mode = repair_task_info.repair_incremental_mode;
     for (auto& r : replicas) {
         auto shard = r.shard;
         if (r.host != myhostid) {
             if (!hosts_filter.empty() || !dcs_filter.empty()) {
                 auto dc = topology.get_datacenter(r.host);
-                if (!info.repair_task_info.selected_by_filters(r, topology)) {
+                if (!repair_task_info.selected_by_filters(r, topology)) {
                     rlogger.debug("repair[{}]: Check node={} from dc={} hosts_filter={} dcs_filter={} skipped",
                         id.uuid(), r.host, dc, hosts_filter, dcs_filter);
                     continue;

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -301,14 +301,18 @@ tablet_map_to_mutations(const tablet_map& tablets, table_id id, const sstring& k
         auto last_token = tablets.get_last_token(tid);
         auto ck = clustering_key::from_single_value(*s, data_value(dht::token::to_int64(last_token)).serialize_nonnull());
         m.set_clustered_cell(ck, "replicas", make_list_value(replica_set_type, replicas_to_data_value(tablet.replicas)), ts);
-        if (features.tablet_migration_virtual_task && tablet.migration_task_info.is_valid()) {
-            m.set_clustered_cell(ck, "migration_task_info", tablet_task_info_to_data_value(tablet.migration_task_info), ts);
+        if (features.tablet_migration_virtual_task) {
+            auto& migration_task_info = tablets.get_migration_task_info(tid);
+            if (migration_task_info.is_valid()) {
+                m.set_clustered_cell(ck, "migration_task_info", tablet_task_info_to_data_value(migration_task_info), ts);
+            }
         }
         if (features.tablet_repair_scheduler) {
-            if (tablet.repair_task_info.is_valid()) {
-                m.set_clustered_cell(ck, "repair_task_info", tablet_task_info_to_data_value(tablet.repair_task_info), ts);
+            auto& repair_task_info = tablets.get_repair_task_info(tid);
+            if (repair_task_info.is_valid()) {
+                m.set_clustered_cell(ck, "repair_task_info", tablet_task_info_to_data_value(repair_task_info), ts);
                 if (features.tablet_incremental_repair) {
-                    m.set_clustered_cell(ck, "repair_incremental_mode", locator::tablet_repair_incremental_mode_to_string(tablet.repair_task_info.repair_incremental_mode), ts);
+                    m.set_clustered_cell(ck, "repair_incremental_mode", locator::tablet_repair_incremental_mode_to_string(repair_task_info.repair_incremental_mode), ts);
                 }
             }
             if (tablet.repair_time != db_clock::time_point{}) {
@@ -834,7 +838,7 @@ tablet_id process_one_row(replica::database* db, table_id table, tablet_map& map
     tablet_logger.debug("Set sstables_repaired_at={} table={} tablet={}", sstables_repaired_at, table, tid);
 
     auto last_token = dht::token::from_int64(row.get_as<int64_t>("last_token"));
-    auto info = tablet_info{std::move(tablet_replicas), repair_time, repair_task_info, migration_task_info, sstables_repaired_at};
+    auto info = tablet_info{std::move(tablet_replicas), repair_time, sstables_repaired_at};
     if (is_updating) {
         auto old_last_token = map.get_last_token(tid);
         if (last_token != old_last_token) {
@@ -846,6 +850,10 @@ tablet_id process_one_row(replica::database* db, table_id table, tablet_map& map
     } else {
         map.emplace_tablet(tid, last_token, std::move(info));
     }
+    // Task infos live in tablet_map side maps. Always (re)set so an update that
+    // drops the column clears the entry (set_*_task_info() clears on invalid).
+    map.set_repair_task_info(tid, std::move(repair_task_info));
+    map.set_migration_task_info(tid, std::move(migration_task_info));
 
     if (row.has("raft_group_id")) {
         if (!map.has_raft_info()) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4949,7 +4949,7 @@ future<service::tablet_operation_repair_result> storage_service::repair_tablet(l
         tasks::task_info global_tablet_repair_task_info;
         std::optional<locator::tablet_replica_set> replicas = std::nullopt;
         if (trinfo->stage == locator::tablet_transition_stage::repair) {
-            global_tablet_repair_task_info = {tasks::task_id{tmap.get_tablet_info(tablet.tablet).repair_task_info.tablet_task_id.uuid()}, 0};
+            global_tablet_repair_task_info = {tasks::task_id{tmap.get_repair_task_info(tablet.tablet).tablet_task_id.uuid()}, 0};
         } else {
             auto migration_streaming_info = get_migration_streaming_info(get_token_metadata_ptr()->get_topology(), tmap.get_tablet_info(tablet.tablet), *trinfo);
             replicas = locator::tablet_replica_set{migration_streaming_info.read_from.begin(), migration_streaming_info.read_from.end()};
@@ -5360,8 +5360,7 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
         auto ts = db_clock::now();
         for (const auto& token : tokens) {
             auto tid = tmap.get_tablet_id(token);
-            auto& tinfo = tmap.get_tablet_info(tid);
-            auto& req_id = tinfo.repair_task_info.tablet_task_id;
+            auto& req_id = tmap.get_repair_task_info(tid).tablet_task_id;
             if (req_id) {
                 throw std::runtime_error(fmt::format("Tablet {} is already in repair by tablet_task_id={}",
                         locator::global_tablet_id{table, tid}, req_id));
@@ -5404,7 +5403,7 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
         return std::all_of(tokens.begin(), tokens.end(), [&] (const dht::token& token) {
             auto id = tmap.get_tablet_id(token);
-            return tmap.get_tablet_info(id).repair_task_info.tablet_task_id != repair_task_info.tablet_task_id;
+            return tmap.get_repair_task_info(id).tablet_task_id != repair_task_info.tablet_task_id;
         });
     });
 
@@ -5449,9 +5448,8 @@ future<> storage_service::del_repair_tablet_request(table_id table, locator::tab
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
         utils::chunked_vector<canonical_mutation> updates;
 
-        co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) -> future<> {
-            auto& tinfo = tmap.get_tablet_info(tid);
-            auto& req_id = tinfo.repair_task_info.tablet_task_id;
+        co_await tmap.for_each_tablet([&] (locator::tablet_id tid, [[maybe_unused]] const locator::tablet_info& info) -> future<> {
+            auto& req_id = tmap.get_repair_task_info(tid).tablet_task_id;
             if (req_id != tablet_task_id) {
                 co_return;
             }

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1332,13 +1332,14 @@ public:
                 // Avoid rescheduling a failed tablet repair in a loop
                 // TODO: Allow user to config
                 const auto min_reschedule_time = std::chrono::seconds(5);
-                if (now - info.repair_task_info.sched_time < min_reschedule_time) {
+                auto& repair_task_info = tmap.get_repair_task_info(id);
+                if (now - repair_task_info.sched_time < min_reschedule_time) {
                     lblogger.debug("Skipped tablet repair for tablet={} which is scheduled too frequently", gid);
                     co_return;
                 }
 
                 db_clock::duration diff;
-                auto is_user_reuqest = info.repair_task_info.is_user_repair_request();
+                auto is_user_reuqest = repair_task_info.is_user_repair_request();
                 if (is_user_reuqest) {
                     // This means the user has issued a repair request manually. Select it for repair scheduling.
                 } else {
@@ -1908,7 +1909,8 @@ public:
 
             // Sibling tablets cannot be considered co-located if their tablet info is temporarily unmergeable.
             // It can happen if either has an active repair task, for example.
-            all_colocated &= bool(merge_tablet_info(with_optimistic_replicas(t1), with_optimistic_replicas(t2)));
+            all_colocated &= bool(merge_tablet_info(with_optimistic_replicas(t1), with_optimistic_replicas(t2),
+                    tmap.get_repair_task_info(t1.tid), tmap.get_repair_task_info(t2.tid), nullptr));
             return make_ready_future<>();
         });
         if (all_colocated) {
@@ -4685,6 +4687,13 @@ private:
 
             new_tablets.emplace_tablet(new_left_tid, tablets.get_split_token(tid), tablet_info);
             new_tablets.emplace_tablet(new_right_tid, tablets.get_last_token(tid), tablet_info);
+            // Propagate side-map task infos to both split halves (as before, when inline).
+            const auto& repair_ti = tablets.get_repair_task_info(tid);
+            const auto& migration_ti = tablets.get_migration_task_info(tid);
+            new_tablets.set_repair_task_info(new_left_tid, repair_ti);
+            new_tablets.set_repair_task_info(new_right_tid, repair_ti);
+            new_tablets.set_migration_task_info(new_left_tid, migration_ti);
+            new_tablets.set_migration_task_info(new_right_tid, migration_ti);
         }
 
         lblogger.info("Split tablets for table {}, increasing tablet count from {} to {}",
@@ -4705,6 +4714,9 @@ private:
 
             if (!right) {
                 new_tablets.emplace_tablet(*new_tid, tablets.get_last_token(left.tid), *left.info);
+                // Carry over side-map task infos.
+                new_tablets.set_repair_task_info(*new_tid, tablets.get_repair_task_info(left.tid));
+                new_tablets.set_migration_task_info(*new_tid, tablets.get_migration_task_info(left.tid));
                 new_tid = new_tablets.next_tablet(*new_tid);
                 return make_ready_future<>();
             }
@@ -4725,7 +4737,10 @@ private:
                 throw std::runtime_error(format("Sibling tablets {} (r: {}) and {} (r: {}) are not colocated.",
                                                 old_left_tid, left_tablet_replicas, old_right_tid, right_tablet_replicas));
             }
-            auto merged_tablet_info = locator::merge_tablet_info(left_tablet_info, right_tablet_info);
+            tablet_task_info merged_repair_task_info;
+            auto merged_tablet_info = locator::merge_tablet_info(left_tablet_info, right_tablet_info,
+                    tablets.get_repair_task_info(old_left_tid), tablets.get_repair_task_info(old_right_tid),
+                    &merged_repair_task_info);
             if (!merged_tablet_info) {
                 throw std::runtime_error(format("Unable to merge tablet info of sibling tablets {} (r: {}) and {} (r: {}).",
                                                 old_left_tid, left_tablet_replicas, old_right_tid, right_tablet_replicas));
@@ -4733,6 +4748,9 @@ private:
             lblogger.debug("Got merged_tablet_info with sstables_repaired_at={}", merged_tablet_info->sstables_repaired_at);
 
             new_tablets.emplace_tablet(*new_tid, tablets.get_last_token(old_right_tid), *merged_tablet_info);
+            new_tablets.set_repair_task_info(*new_tid, std::move(merged_repair_task_info));
+            // Migration task infos aren't merged; carry over the left tablet's, if any.
+            new_tablets.set_migration_task_info(*new_tid, tablets.get_migration_task_info(old_left_tid));
             new_tid = new_tablets.next_tablet(*new_tid);
             return make_ready_future<>();
         });

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -96,9 +96,9 @@ future<std::optional<tasks::virtual_task_hint>> tablet_virtual_task::contains(ta
             };
         }
         std::optional<locator::tablet_id> tid = tmap.first_tablet();
-        for (const locator::tablet_info& info : tmap.tablets()) {
-            auto task_type = maybe_get_task_type(info.repair_task_info, task_id).or_else([&] () {
-                return maybe_get_task_type(info.migration_task_info, task_id);
+        for ([[maybe_unused]] const locator::tablet_info& info : tmap.tablets()) {
+            auto task_type = maybe_get_task_type(tmap.get_repair_task_info(*tid), task_id).or_else([&] () {
+                return maybe_get_task_type(tmap.get_migration_task_info(*tid), task_id);
             });
             if (task_type.has_value()) {
                 co_return tasks::virtual_task_hint{
@@ -159,8 +159,9 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::wait(tasks::task_
         auto& tmap = tmptr->tablets().get_tablet_map(table);
         if (is_repair_task(task_type)) {
             bool running = false;
-            co_await tmap.for_each_tablet([&] (locator::tablet_id, const locator::tablet_info& info) {
-                if (info.repair_task_info.is_valid() && info.repair_task_info.tablet_task_id.uuid() == id.uuid()) {
+            co_await tmap.for_each_tablet([&] (locator::tablet_id tid, [[maybe_unused]] const locator::tablet_info& info) {
+                auto& rti = tmap.get_repair_task_info(tid);
+                if (rti.is_valid() && rti.tablet_task_id.uuid() == id.uuid()) {
                     running = true;
                 }
                 return make_ready_future();
@@ -171,7 +172,7 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::wait(tasks::task_
             co_return tmap.resize_task_info().tablet_task_id.uuid() != id.uuid();
         }
         if (is_migration_task(task_type)) {
-            co_return tmap.get_tablet_info(tablet_id_opt.value()).migration_task_info.tablet_task_id.uuid() != id.uuid();
+            co_return tmap.get_migration_task_info(tablet_id_opt.value()).tablet_task_id.uuid() != id.uuid();
         }
         on_internal_error(tasks::tmlogger, fmt::format("tablet_virtual_task::wait: unhandled tablet task type {}", task_type));
     };
@@ -238,20 +239,21 @@ future<std::vector<tasks::task_stats>> tablet_virtual_task::get_stats() {
         if (resize_stats) {
             res.push_back(std::move(resize_stats.value()));
         }
-        co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) {
-            auto repair_stats = maybe_make_task_stats(info.repair_task_info, schema);
+        co_await tmap.for_each_tablet([&] (locator::tablet_id tid, [[maybe_unused]] const locator::tablet_info& info) {
+            auto& rti = tmap.get_repair_task_info(tid);
+            auto repair_stats = maybe_make_task_stats(rti, schema);
             if (repair_stats) {
-                if (info.repair_task_info.is_user_repair_request()) {
+                if (rti.is_user_repair_request()) {
                     // User requested repair may encompass more that one tablet.
-                    auto task_id = tasks::task_id{info.repair_task_info.tablet_task_id.uuid()};
+                    auto task_id = tasks::task_id{rti.tablet_task_id.uuid()};
                     user_requests[task_id] = std::move(repair_stats.value());
-                    sched_num_sum[task_id] += info.repair_task_info.sched_nr;
+                    sched_num_sum[task_id] += rti.sched_nr;
                 } else {
                     res.push_back(std::move(repair_stats.value()));
                 }
             }
 
-            auto migration_stats = maybe_make_task_stats(info.migration_task_info, schema);
+            auto migration_stats = maybe_make_task_stats(tmap.get_migration_task_info(tid), schema);
             if (migration_stats) {
                 res.push_back(std::move(migration_stats.value()));
             }
@@ -317,8 +319,8 @@ future<std::optional<status_helper>> tablet_virtual_task::get_status_helper(task
                 repair_task_pending = true;
             }
         }
-        co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) {
-            auto& task_info = info.repair_task_info;
+        co_await tmap.for_each_tablet([&] (locator::tablet_id tid, [[maybe_unused]] const locator::tablet_info& info) {
+            auto& task_info = tmap.get_repair_task_info(tid);
             if (task_info.tablet_task_id.uuid() == id.uuid()) {
                 update_status(task_info, res.status, sched_nr);
                 no_tablets_processed = false;
@@ -329,7 +331,7 @@ future<std::optional<status_helper>> tablet_virtual_task::get_status_helper(task
     } else if (is_migration_task(task_type)) {    // Migration task.
         auto tablet_id = hint.get_tablet_id();
         res.pending_replica = tmap.get_tablet_transition_info(tablet_id)->pending_replica;
-        auto& task_info = tmap.get_tablet_info(tablet_id).migration_task_info;
+        auto& task_info = tmap.get_migration_task_info(tablet_id);
         if (task_info.tablet_task_id.uuid() == id.uuid()) {
             update_status(task_info, res.status, sched_nr);
             no_tablets_processed = false;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1655,8 +1655,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             rtlogger.warn("Tablet already in transition, ignoring repair: {}", gid);
             return;
         }
-        auto& info = tmap.get_tablet_info(gid.tablet);
-        auto repair_task_info = info.repair_task_info;
+        auto repair_task_info = tmap.get_repair_task_info(gid.tablet);
         if (!repair_task_info.is_user_repair_request()) {
             repair_task_info = locator::tablet_task_info::make_auto_repair_request();
         }
@@ -2219,8 +2218,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     bool fail_repair = utils::get_local_injector().enter("handle_tablet_migration_repair_fail");
                     if (fail_repair || action_failed(tablet_state.repair)) {
                         if (do_barrier()) {
-                            auto& tinfo = tmap.get_tablet_info(gid.tablet);
-                            _tablet_ops_metrics.inc_failed(tinfo.repair_task_info.request_type);
+                            _tablet_ops_metrics.inc_failed(tmap.get_repair_task_info(gid.tablet).request_type);
                             updates.emplace_back(get_mutation_builder()
                                     .set_stage(last_token, locator::tablet_transition_stage::end_repair)
                                     .del_session(last_token)
@@ -2229,8 +2227,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         break;
                     }
                     if (advance_in_background(gid, tablet_state.repair, "repair", [&] () -> future<> {
-                        auto& tinfo = tmap.get_tablet_info(gid.tablet);
-                        bool valid = tinfo.repair_task_info.is_valid();
+                        auto& repair_task_info = tmap.get_repair_task_info(gid.tablet);
+                        bool valid = repair_task_info.is_valid();
                         if (!valid) {
                             rtlogger.info("Skipping tablet repair for tablet={} which is cancelled by user", gid);
                             co_return;
@@ -2239,17 +2237,17 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         if (trinfo) {
                             tablet_state.session_id = trinfo->session_id;
                         }
-                        auto sched_time = tinfo.repair_task_info.sched_time;
+                        auto sched_time = repair_task_info.sched_time;
                         auto tablet = gid;
-                        auto hosts_filter = tinfo.repair_task_info.repair_hosts_filter;
-                        auto dcs_filter = tinfo.repair_task_info.repair_dcs_filter;
+                        auto hosts_filter = repair_task_info.repair_hosts_filter;
+                        auto dcs_filter = repair_task_info.repair_dcs_filter;
                         const auto& topo = _db.get_token_metadata().get_topology();
                         locator::host_id dst;
                         if (hosts_filter.empty() && dcs_filter.empty()) {
                             auto primary = tmap.get_primary_replica(gid.tablet, topo);
                             dst = primary.host;
                         } else {
-                            auto dst_opt = tmap.maybe_get_selected_replica(gid.tablet, topo, tinfo.repair_task_info);
+                            auto dst_opt = tmap.maybe_get_selected_replica(gid.tablet, topo, repair_task_info);
                             if (!dst_opt) {
                                 co_return;
                             }
@@ -2257,13 +2255,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         }
                         // Update repair task
                         db::system_keyspace::repair_task_entry entry{
-                            .task_uuid   = tasks::task_id(tinfo.repair_task_info.tablet_task_id.uuid()),
+                            .task_uuid   = tasks::task_id(repair_task_info.tablet_task_id.uuid()),
                             .operation   = db::system_keyspace::repair_task_operation::finished,
                             .first_token = dht::token::to_int64(tmap.get_first_token(gid.tablet)),
                             .last_token  = dht::token::to_int64(tmap.get_last_token(gid.tablet)),
                             .table_uuid  = gid.table,
                         };
-                        auto request_type = tinfo.repair_task_info.request_type;
+                        auto request_type = repair_task_info.request_type;
                         rtlogger.info("Initiating tablet repair host={} tablet={} request_type={}", dst, gid, request_type);
                         auto session_id = utils::get_local_injector().enter("handle_tablet_migration_repair_random_session") ?
                             service::session_id::create_random_id() : trinfo->session_id;
@@ -2284,10 +2282,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         }
 
                         auto& tinfo = tmap.get_tablet_info(gid.tablet);
-                        bool valid = tinfo.repair_task_info.is_valid();
-                        auto hosts_filter = tinfo.repair_task_info.repair_hosts_filter;
-                        auto dcs_filter = tinfo.repair_task_info.repair_dcs_filter;
-                        auto incremental = tinfo.repair_task_info.repair_incremental_mode != locator::tablet_repair_incremental_mode::disabled;
+                        auto& repair_task_info = tmap.get_repair_task_info(gid.tablet);
+                        bool valid = repair_task_info.is_valid();
+                        auto hosts_filter = repair_task_info.repair_hosts_filter;
+                        auto dcs_filter = repair_task_info.repair_dcs_filter;
+                        auto incremental = repair_task_info.repair_incremental_mode != locator::tablet_repair_incremental_mode::disabled;
                         bool is_filter_off = hosts_filter.empty() && dcs_filter.empty();
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::end_repair);
                         auto update = get_mutation_builder()
@@ -2299,7 +2298,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         }
                         // Skip update repair time in case hosts filter or dcs filter is set.
                         if (valid && is_filter_off) {
-                            auto sched_time = tinfo.repair_task_info.sched_time;
+                            auto sched_time = repair_task_info.sched_time;
                             auto time = tablet_state.repair_time;
                             update.set_repair_time(last_token, time);
                             auto repaired_at = sstring("None");
@@ -2316,7 +2315,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                     sched_time, time, repaired_at, last_token);
                         }
                         updates.emplace_back(update.build());
-                        _tablet_ops_metrics.inc_succeeded(tinfo.repair_task_info.request_type);
+                        _tablet_ops_metrics.inc_succeeded(repair_task_info.request_type);
                     }
                 }
                     break;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -371,10 +371,10 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                         tablet_replica {h3, 1},
                     },
                     db_clock::now(),
-                    locator::tablet_task_info::make_auto_repair_request({}, {"dc1", "dc2"}),
-                    locator::tablet_task_info::make_intranode_migration_request(),
                     0
                 });
+                tmap.set_repair_task_info(tmap.first_tablet(), locator::tablet_task_info::make_auto_repair_request({}, {"dc1", "dc2"}));
+                tmap.set_migration_task_info(tmap.first_tablet(), locator::tablet_task_info::make_intranode_migration_request());
                 tm.set_tablet_map(table1, std::move(tmap));
             }
 
@@ -387,12 +387,9 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tmap.set_tablet(tb, tablet_info {
                     tablet_replica_set {
                         tablet_replica {h1, 0},
-                    },
-                    {},
-                    {},
-                    locator::tablet_task_info::make_migration_request(),
-                    0
+                    }
                 });
+                tmap.set_migration_task_info(tb, locator::tablet_task_info::make_migration_request());
                 tb = *tmap.next_tablet(tb);
                 tmap.set_tablet(tb, tablet_info {
                     tablet_replica_set {
@@ -403,12 +400,9 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                 tmap.set_tablet(tb, tablet_info {
                     tablet_replica_set {
                         tablet_replica {h2, 2},
-                    },
-                    {},
-                    {},
-                    locator::tablet_task_info::make_migration_request(),
-                    0
+                    }
                 });
+                tmap.set_migration_task_info(tb, locator::tablet_task_info::make_migration_request());
                 tb = *tmap.next_tablet(tb);
                 tmap.set_tablet(tb, tablet_info {
                     tablet_replica_set {
@@ -805,10 +799,10 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence_with_colocated_tables) {
                         tablet_replica {h3, 1},
                     },
                     db_clock::now(),
-                    locator::tablet_task_info::make_auto_repair_request({}, {"dc1", "dc2"}),
-                    locator::tablet_task_info::make_intranode_migration_request(),
                     0
                 });
+                tmap.set_repair_task_info(tmap.first_tablet(), locator::tablet_task_info::make_auto_repair_request({}, {"dc1", "dc2"}));
+                tmap.set_migration_task_info(tmap.first_tablet(), locator::tablet_task_info::make_intranode_migration_request());
                 tm.set_tablet_map(table1, std::move(tmap));
             }
 
@@ -6864,8 +6858,8 @@ void run_tablet_manual_repair_rf1(cql_test_env& e) {
                 tablet_replica{host1, 0},
             }
         };
-        ti.repair_task_info = ti.repair_task_info.make_user_repair_request();
         tmap.set_tablet(tid, std::move(ti));
+        tmap.set_repair_task_info(tid, locator::tablet_task_info::make_user_repair_request());
         tmeta.set_tablet_map(table1, std::move(tmap));
         co_return;
     });


### PR DESCRIPTION
## Motivation
`tablet_info` embedded two `locator::tablet_task_info` members — `repair_task_info` and `migration_task_info` — each **168B**, that are almost always unset.
They inflated every `tablet_info` to **448B** even though the vast majority of tablets have no active repair or migration task at any given time. With thousands of tablets per node, that is hundreds of KB of resident memory spent on empty structs.

## Nature of change
Move the two task infos out of `tablet_info` and into side maps on `tablet_map` (`_repair_task_infos`, `_migration_task_infos`), keyed by `tablet_id` — exactly the way `tablet_transition_info` is already stored (`_transitions`).
`tablet_info` keeps only `replicas`, `repair_time` and `sstables_repaired_at`.

This is the approach suggested in the ticket ("kept separately, like `tablet_transition_info`").

### API
- `tablet_map::get_repair_task_info(id)` / `get_migration_task_info(id)` return a `const tablet_task_info&` (a static empty/invalid default when absent, so read sites need no null checks); `*_ptr()` variants return `nullptr` when absent.
- `set_*` / `clear_*` mutators mirror `set_tablet_transition_info`; setting an invalid (default) task info clears the entry.
- `merge_tablet_info()` no longer reads/writes task infos from `tablet_info`; the repair task infos are passed in and the merged one returned out, since they now live in the map.

Deserialization, serialization, split/merge and all read sites are updated to go through the map accessors.

## Memory savings
- **`sizeof(tablet_info)`: 448B → 112B (75% reduction)** (verified via compile-time probe).
- Cache lines per `tablet_info`: **7 → 2** (448B / 64 = 7, 112B / 64 = 2), reducing cache pressure on hot tablet-map scans.
- Zero per-tablet overhead for the task infos in the common (no-task) case — no inline members and no per-tablet `unique_ptr`/heap allocation.
- `tablet_info` also stays trivially copyable with a defaulted `operator==`.

## Mixed-version safety
This change is safe in a mixed-version cluster (one node upgraded to this patch, another not yet), including while tablets migrate between them:
- `tablet_info` / `tablet_map` / `tablet_task_info` are **not** serialized over RPC (not in any IDL). Tablet metadata crosses nodes only via the `system.tablets` table (group0/Raft).
- The `system.tablets` schema is **unchanged**, and the per-column (de)serialization helpers (`tablet_task_info_to_data_value` / `tablet_task_info_from_cell`) are byte-for-byte identical to master. Only the in-memory home of two fields changed.
- During migration, the coordinator (which may run on either version) writes `migration_task_info` via `tablet_mutation_builder::set_migration_task_info` (unchanged) → group0 → every node deserializes the **same column bytes** into its own layout
(side map on upgraded nodes, inline field on old nodes).
- The in-memory layout is private to each node and never observed across the wire, so the change is forward/backward compatible at both the persistence and RPC layers.

## Tests
`tablets_test` passes **107/107** in dev mode, including the metadata persistence round-trip (which exercises side-map serialization/deserialization of the task infos), repair scheduling, and split/merge.

Fixes: SCYLLADB-1976

Backport: no, improvement

