### PR TITLE
sstables: reduce per-sstable memory: -16B/sstable (padding holes) + 1 fewer heap alloc/sstable (column_translation)

### DIFF
--- a/sstables/column_translation.hh
+++ b/sstables/column_translation.hh
@@ -88,7 +88,21 @@ private:
         {}
     };
 
-    lw_shared_ptr<const state> _state = make_lw_shared<const state>();
+    // The initial state is an empty, immutable default-constructed state shared
+    // by all column_translation instances on the same shard. It is replaced
+    // (copy-on-write, by reassigning the pointer) the first time get_for_schema()
+    // is called with a matching format, so sharing the default avoids a heap
+    // allocation per sstable that, in practice, is almost always immediately
+    // overwritten or never used.
+    //
+    // thread_local (per-shard): lw_shared_ptr refcounting is not thread-safe, so
+    // the shared default must not be touched from more than one shard.
+    static const lw_shared_ptr<const state>& default_state() {
+        static thread_local const lw_shared_ptr<const state> s = make_lw_shared<const state>();
+        return s;
+    }
+
+    lw_shared_ptr<const state> _state = default_state();
 
 public:
     // Use for formats >= mc.

--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -280,7 +280,7 @@ compression::locate(uint64_t position, const compression::segmented_offsets::acc
 std::map<sstring, sstring> options_from_compression(const compression& c) {
     std::map<sstring, sstring> result;
     result.emplace(compression_parameters::SSTABLE_COMPRESSION, sstring(c.name.value.begin(), c.name.value.end()));
-    result.emplace(compression_parameters::CHUNK_LENGTH_KB, to_sstring(c.chunk_len / 1024));
+    result.emplace(compression_parameters::CHUNK_LENGTH_KB, to_sstring(c.uncompressed_chunk_length() / 1024));
     for (const auto& [k, v] : c.options.elements) {
         auto k_str = sstring(k.value.begin(), k.value.end());
         auto v_str = sstring(v.value.begin(), v.value.end());

--- a/sstables/compress.hh
+++ b/sstables/compress.hh
@@ -289,13 +289,16 @@ struct compression {
 
     disk_string<uint16_t> name;
     disk_array<uint32_t, option> options;
-    uint32_t chunk_len = 0;
     uint64_t data_len = 0;
     segmented_offsets offsets;
 
 private:
     // Variables *not* found in the "Compression Info" file (added by update()):
     uint64_t _compressed_file_length = 0;
+    // chunk_len and _full_checksum are grouped here so the two uint32_t pack
+    // into a single 8-byte slot (avoids padding holes). chunk_len is only
+    // accessed via uncompressed_chunk_length()/set_uncompressed_chunk_length().
+    uint32_t chunk_len = 0;
     uint32_t _full_checksum = 0;
     compressor_ptr _compressor;
 public:

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -304,29 +304,33 @@ struct compaction_metadata : public metadata_base<compaction_metadata> {
 };
 
 struct stats_metadata : public metadata_base<stats_metadata> {
+    // NOTE: on-disk serialization order is defined by describe_type() below and
+    // is independent of this declaration order. Fields are grouped here to pack
+    // the sub-8-byte scalars together and avoid padding holes.
     utils::estimated_histogram estimated_partition_size;
     utils::estimated_histogram estimated_cells_count;
+    utils::streaming_histogram estimated_tombstone_drop_time;
     db::replay_position position;
+    db::replay_position commitlog_lower_bound; // 3_x only
     int64_t min_timestamp;
     int64_t max_timestamp;
-    int32_t min_local_deletion_time; // 3_x only
-    int32_t max_local_deletion_time;
-    int32_t min_ttl; // 3_x only
-    int32_t max_ttl; // 3_x only
     double compression_ratio;
-    utils::streaming_histogram estimated_tombstone_drop_time;
-    uint32_t sstable_level;
     // There is not meaningful value to put in this field, since we have no
     // incremental repair. Before we have it, let's set it to 0.
     // According to architecture/sstable/sstable3/sstables-3-statistics.rst,
     // the repaired_at is a int64_t value.
     int64_t repaired_at = 0;
-    disk_array<uint32_t, disk_string<uint16_t>> min_column_names;
-    disk_array<uint32_t, disk_string<uint16_t>> max_column_names;
-    bool has_legacy_counter_shards;
     int64_t columns_count; // 3_x only
     int64_t rows_count; // 3_x only
-    db::replay_position commitlog_lower_bound; // 3_x only
+    // Sub-8-byte scalars grouped together to avoid padding holes.
+    int32_t min_local_deletion_time; // 3_x only
+    int32_t max_local_deletion_time;
+    int32_t min_ttl; // 3_x only
+    int32_t max_ttl; // 3_x only
+    uint32_t sstable_level;
+    bool has_legacy_counter_shards;
+    disk_array<uint32_t, disk_string<uint16_t>> min_column_names;
+    disk_array<uint32_t, disk_string<uint16_t>> max_column_names;
     disk_array<uint32_t, commitlog_interval> commitlog_intervals; // 3_x only
     std::optional<locator::host_id> originating_host_id; // 3_11_11 and later (me format)
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -970,7 +970,7 @@ void dump_compression_info_operation(schema_ptr schema, reader_permit permit, co
         }
         writer.EndObject();
         writer.Key("chunk_len");
-        writer.Uint(compression.chunk_len);
+        writer.Uint(compression.uncompressed_chunk_length());
         writer.Key("data_len");
         writer.Uint64(compression.data_len);
         writer.Key("offsets");


### PR DESCRIPTION
## Motivation

Two small, independent per-sstable memory improvements that target structures *other* than the inline `sstable` fields (those are handled separately in #30131), so they compose cleanly with it:

1. `stats_metadata` and `compression` (one of each lives inside the per-sstable `shareable_components`) carry padding holes from sub-8-byte scalars being scattered among 8-byte-aligned members.
2. Every `column_translation` (one per sstable) eagerly heap-allocates its own empty, immutable default state, even though that state is almost always immediately overwritten or never used.

## Nature of change

### 1. Reorder `stats_metadata` and `compression` fields to close padding holes
Group the sub-8-byte scalars together so they pack without holes. Pure in-memory layout change.

On-disk serialization order is defined by `describe_type()` (for `stats_metadata`) and by explicit field-by-field `parse()`/`write()` calls (for `compression`), both independent of declaration order, so **the persisted bytes are unchanged** 
— verified by `sstable_3_x_test`, which asserts exact on-disk layouts.

To enable grouping, `compression::chunk_len` is moved next to `_full_checksum` (two `uint32_t` packed into one 8-byte slot), and the two direct `c.chunk_len` accesses (in `options_from_compression()` and the `scylla-sstable` dump tool) are replaced with the existing `c.uncompressed_chunk_length()` accessor.

Measured (dev build, x86-64, via `sizeof` probes):
- `sizeof(stats_metadata)`: 472 → 464 B (−8)
- `sizeof(compression)`:    232 → 224 B (−8)

### 2. Share the empty default `column_translation` state per shard 
Replace the per-instance `make_lw_shared<const state>()` initializer with a `thread_local` (per-shard) shared default. The state is `const` (immutable) and is only ever pointed-to, never mutated; it is replaced (copy-on-write, by reassigning the `lw_shared_ptr`) the first time `get_for_schema()` runs.
This removes one heap allocation per sstable, collapsing N allocations (N = sstables on the shard) into one.

`thread_local` (not a plain `static`) because `lw_shared_ptr` refcounting is not thread-safe; this is sound because an sstable and its `column_translation` have a single-shard lifecycle — `sstable` is non-copyable and non-movable, the `sstables_manager` is per-shard, and `shared_sstable` is a non-atomic
`lw_shared_ptr<sstable>` — so the shared default is only ever reference-counted on its own shard. (Same idiom as `utils/logalloc.cc`.)

No change to `sizeof(sstable)`; this is an allocation-count / allocator-pressure improvement.

## Relationship to #30131

This intentionally does **not** touch the inline fields of the `sstable` struct itself (`_mutate_sem`, `_components_digests`, field reordering, recognized components) — those are handled in #30131.
The two changes here are disjoint from it (`stats_metadata`/`compression` live in `shareable_components`; `column_translation`'s state is separate heap state), so they can land independently in either order.

## Tests

`sstable_3_x_test` (exact on-disk format), `sstable_datafile_test`, `sstable_test` (221), `sstable_compaction_test` (269) pass in dev; full scylla build links; cqlpy `test_compaction` and `test_bloom_filter` pass on a multi-shard node (exercising the shared `column_translation` default across shards).

Backport: no, benign improvement
