### PR TITLE
test/cluster: stabilize concurrent tablet migration test

### DIFF
--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -591,6 +591,7 @@ async def test_concurrent_tablet_migrations(manager: ManagerClient):
     for property_file in rack_property_files:
         servers.append(await manager.server_add(property_file=property_file, cmdline=cmdline_loggers))
 
+    await manager.servers_see_each_other(servers)
     await manager.disable_tablet_balancing()
     await pause_view_building_tasks(manager)
 


### PR DESCRIPTION
This test depends on the initial nodes having a complete and consistent view of each other before tablet balancing is disabled and tablets are created with multi-DC/rack placement.

Previously, the test relied on server_add() as an implicit readiness barrier. However, server_add() only guarantees that the added server is already serving requests; it does not guarantee that cluster-wide discovery has completed. As a result, tablet placement could be evaluated before all initial nodes had discovered each other, making the test timing-sensitive.

In this test unlike in other tests where get_ready_cql(servers) is used. Using servers_see_each_other is better use because its not only verifying CQL readiness, it also waits for the servers to see each other, ensuring the topology is fully established before the test proceeds.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2433

backport: not required, test fails only in master
