### PR TITLE
locator: reduce tablet_info memory footprint with optional task_info

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -223,17 +223,51 @@ bool tablet_has_excluded_node(const locator::topology& topo, const tablet_info& 
 tablet_info::tablet_info(tablet_replica_set replicas, db_clock::time_point repair_time, tablet_task_info repair_task_info, tablet_task_info migration_task_info, int64_t sstables_repaired_at)
     : replicas(std::move(replicas))
     , repair_time(repair_time)
-    , repair_task_info(std::move(repair_task_info))
-    , migration_task_info(std::move(migration_task_info))
+    , repair_task_info(repair_task_info.is_valid() ? std::make_unique<tablet_task_info>(std::move(repair_task_info)) : nullptr)
+    , migration_task_info(migration_task_info.is_valid() ? std::make_unique<tablet_task_info>(std::move(migration_task_info)) : nullptr)
     , sstables_repaired_at(sstables_repaired_at)
 {}
 
 tablet_info::tablet_info(tablet_replica_set replicas)
-    : tablet_info(std::move(replicas), db_clock::time_point{}, tablet_task_info{}, tablet_task_info{}, int64_t(0))
+    : replicas(std::move(replicas))
+    , sstables_repaired_at(0)
 {}
 
+tablet_info::tablet_info(const tablet_info& o)
+    : replicas(o.replicas)
+    , repair_time(o.repair_time)
+    , repair_task_info(o.repair_task_info ? std::make_unique<tablet_task_info>(*o.repair_task_info) : nullptr)
+    , migration_task_info(o.migration_task_info ? std::make_unique<tablet_task_info>(*o.migration_task_info) : nullptr)
+    , sstables_repaired_at(o.sstables_repaired_at)
+{}
+
+tablet_info& tablet_info::operator=(const tablet_info& o) {
+    if (this != &o) {
+        replicas = o.replicas;
+        repair_time = o.repair_time;
+        repair_task_info = o.repair_task_info ? std::make_unique<tablet_task_info>(*o.repair_task_info) : nullptr;
+        migration_task_info = o.migration_task_info ? std::make_unique<tablet_task_info>(*o.migration_task_info) : nullptr;
+        sstables_repaired_at = o.sstables_repaired_at;
+    }
+    return *this;
+}
+
+bool tablet_info::operator==(const tablet_info& o) const {
+    auto eq = [](const std::unique_ptr<tablet_task_info>& a, const std::unique_ptr<tablet_task_info>& b) {
+        return (!a && !b) || (a && b && *a == *b);
+    };
+    return replicas == o.replicas
+        && repair_time == o.repair_time
+        && eq(repair_task_info, o.repair_task_info)
+        && eq(migration_task_info, o.migration_task_info)
+        && sstables_repaired_at == o.sstables_repaired_at;
+}
+
 std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b) {
-    auto repair_task_info = tablet_task_info::merge_repair_tasks(a.repair_task_info, b.repair_task_info);
+    static const tablet_task_info empty_task_info;
+    auto repair_task_info = tablet_task_info::merge_repair_tasks(
+        a.repair_task_info ? *a.repair_task_info : empty_task_info,
+        b.repair_task_info ? *b.repair_task_info : empty_task_info);
     if (!repair_task_info) {
         return {};
     }
@@ -248,7 +282,8 @@ std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b) {
 
     auto repair_time = std::max(a.repair_time, b.repair_time);
     int64_t sstables_repaired_at = std::max(a.sstables_repaired_at, b.sstables_repaired_at);
-    auto info = tablet_info(std::move(a.replicas), repair_time, *repair_task_info, a.migration_task_info, sstables_repaired_at);
+    auto info = tablet_info(std::move(a.replicas), repair_time, *repair_task_info,
+        a.migration_task_info ? *a.migration_task_info : empty_task_info, sstables_repaired_at);
     return info;
 }
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -220,11 +220,11 @@ bool tablet_has_excluded_node(const locator::topology& topo, const tablet_info& 
     return false;
 }
 
-tablet_info::tablet_info(tablet_replica_set replicas, db_clock::time_point repair_time, tablet_task_info repair_task_info, tablet_task_info migration_task_info, int64_t sstables_repaired_at)
+tablet_info::tablet_info(tablet_replica_set replicas, db_clock::time_point repair_time, std::unique_ptr<tablet_task_info> repair_task_info, std::unique_ptr<tablet_task_info> migration_task_info, int64_t sstables_repaired_at)
     : replicas(std::move(replicas))
     , repair_time(repair_time)
-    , repair_task_info(repair_task_info.is_valid() ? std::make_unique<tablet_task_info>(std::move(repair_task_info)) : nullptr)
-    , migration_task_info(migration_task_info.is_valid() ? std::make_unique<tablet_task_info>(std::move(migration_task_info)) : nullptr)
+    , repair_task_info(std::move(repair_task_info))
+    , migration_task_info(std::move(migration_task_info))
     , sstables_repaired_at(sstables_repaired_at)
 {}
 
@@ -282,8 +282,8 @@ std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b) {
 
     auto repair_time = std::max(a.repair_time, b.repair_time);
     int64_t sstables_repaired_at = std::max(a.sstables_repaired_at, b.sstables_repaired_at);
-    auto info = tablet_info(std::move(a.replicas), repair_time, *repair_task_info,
-        a.migration_task_info ? *a.migration_task_info : empty_task_info, sstables_repaired_at);
+    auto info = tablet_info(std::move(a.replicas), repair_time, std::make_unique<tablet_task_info>(*repair_task_info),
+        a.migration_task_info ? std::make_unique<tablet_task_info>(*a.migration_task_info) : nullptr, sstables_repaired_at);
     return info;
 }
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -285,7 +285,7 @@ struct tablet_info {
     int64_t sstables_repaired_at;
 
     tablet_info() = default;
-    tablet_info(tablet_replica_set, db_clock::time_point, tablet_task_info, tablet_task_info, int64_t sstables_repaired_at);
+    tablet_info(tablet_replica_set, db_clock::time_point, std::unique_ptr<tablet_task_info> repair_task_info, std::unique_ptr<tablet_task_info> migration_task_info, int64_t sstables_repaired_at);
     tablet_info(tablet_replica_set);
 
     tablet_info(const tablet_info&);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -23,6 +23,7 @@
 #include "utils/UUID.hh"
 #include "raft/raft.hh"
 
+#include <memory>
 #include <ranges>
 #include <seastar/core/reactor.hh>
 #include <seastar/util/log.hh>
@@ -279,15 +280,20 @@ struct restore_config {
 struct tablet_info {
     tablet_replica_set replicas;
     db_clock::time_point repair_time;
-    locator::tablet_task_info repair_task_info;
-    locator::tablet_task_info migration_task_info;
+    std::unique_ptr<tablet_task_info> repair_task_info;
+    std::unique_ptr<tablet_task_info> migration_task_info;
     int64_t sstables_repaired_at;
 
     tablet_info() = default;
     tablet_info(tablet_replica_set, db_clock::time_point, tablet_task_info, tablet_task_info, int64_t sstables_repaired_at);
     tablet_info(tablet_replica_set);
 
-    bool operator==(const tablet_info&) const = default;
+    tablet_info(const tablet_info&);
+    tablet_info& operator=(const tablet_info&);
+    tablet_info(tablet_info&&) noexcept = default;
+    tablet_info& operator=(tablet_info&&) noexcept = default;
+
+    bool operator==(const tablet_info&) const;
 };
 
 /// Reft-related information for strongly-consistent tablets.

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2283,15 +2283,15 @@ future<gc_clock::time_point> repair_service::repair_tablet(gms::gossip_address_m
     std::vector<shard_id> shards;
     std::optional<shard_id> master_shard_id;
     auto& topology = guard.get_token_metadata()->get_topology();
-    auto hosts_filter = info.repair_task_info.repair_hosts_filter;
-    auto dcs_filter = info.repair_task_info.repair_dcs_filter;
-    auto incremental_mode = info.repair_task_info.repair_incremental_mode;
+    auto hosts_filter = info.repair_task_info ? info.repair_task_info->repair_hosts_filter : std::unordered_set<locator::host_id>{};
+    auto dcs_filter = info.repair_task_info ? info.repair_task_info->repair_dcs_filter : std::unordered_set<sstring>{};
+    auto incremental_mode = info.repair_task_info ? info.repair_task_info->repair_incremental_mode : locator::tablet_repair_incremental_mode::disabled;
     for (auto& r : replicas) {
         auto shard = r.shard;
         if (r.host != myhostid) {
             if (!hosts_filter.empty() || !dcs_filter.empty()) {
                 auto dc = topology.get_datacenter(r.host);
-                if (!info.repair_task_info.selected_by_filters(r, topology)) {
+                if (!info.repair_task_info || !info.repair_task_info->selected_by_filters(r, topology)) {
                     rlogger.debug("repair[{}]: Check node={} from dc={} hosts_filter={} dcs_filter={} skipped",
                         id.uuid(), r.host, dc, hosts_filter, dcs_filter);
                     continue;

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -834,7 +834,10 @@ tablet_id process_one_row(replica::database* db, table_id table, tablet_map& map
     tablet_logger.debug("Set sstables_repaired_at={} table={} tablet={}", sstables_repaired_at, table, tid);
 
     auto last_token = dht::token::from_int64(row.get_as<int64_t>("last_token"));
-    auto info = tablet_info{std::move(tablet_replicas), repair_time, repair_task_info, migration_task_info, sstables_repaired_at};
+    auto info = tablet_info{std::move(tablet_replicas), repair_time,
+            repair_task_info.is_valid() ? std::make_unique<locator::tablet_task_info>(std::move(repair_task_info)) : nullptr,
+            migration_task_info.is_valid() ? std::make_unique<locator::tablet_task_info>(std::move(migration_task_info)) : nullptr,
+            sstables_repaired_at};
     if (is_updating) {
         auto old_last_token = map.get_last_token(tid);
         if (last_token != old_last_token) {

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -301,14 +301,14 @@ tablet_map_to_mutations(const tablet_map& tablets, table_id id, const sstring& k
         auto last_token = tablets.get_last_token(tid);
         auto ck = clustering_key::from_single_value(*s, data_value(dht::token::to_int64(last_token)).serialize_nonnull());
         m.set_clustered_cell(ck, "replicas", make_list_value(replica_set_type, replicas_to_data_value(tablet.replicas)), ts);
-        if (features.tablet_migration_virtual_task && tablet.migration_task_info.is_valid()) {
-            m.set_clustered_cell(ck, "migration_task_info", tablet_task_info_to_data_value(tablet.migration_task_info), ts);
+        if (features.tablet_migration_virtual_task && tablet.migration_task_info) {
+            m.set_clustered_cell(ck, "migration_task_info", tablet_task_info_to_data_value(*tablet.migration_task_info), ts);
         }
         if (features.tablet_repair_scheduler) {
-            if (tablet.repair_task_info.is_valid()) {
-                m.set_clustered_cell(ck, "repair_task_info", tablet_task_info_to_data_value(tablet.repair_task_info), ts);
+            if (tablet.repair_task_info) {
+                m.set_clustered_cell(ck, "repair_task_info", tablet_task_info_to_data_value(*tablet.repair_task_info), ts);
                 if (features.tablet_incremental_repair) {
-                    m.set_clustered_cell(ck, "repair_incremental_mode", locator::tablet_repair_incremental_mode_to_string(tablet.repair_task_info.repair_incremental_mode), ts);
+                    m.set_clustered_cell(ck, "repair_incremental_mode", locator::tablet_repair_incremental_mode_to_string(tablet.repair_task_info->repair_incremental_mode), ts);
                 }
             }
             if (tablet.repair_time != db_clock::time_point{}) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4949,7 +4949,7 @@ future<service::tablet_operation_repair_result> storage_service::repair_tablet(l
         tasks::task_info global_tablet_repair_task_info;
         std::optional<locator::tablet_replica_set> replicas = std::nullopt;
         if (trinfo->stage == locator::tablet_transition_stage::repair) {
-            global_tablet_repair_task_info = {tasks::task_id{tmap.get_tablet_info(tablet.tablet).repair_task_info.tablet_task_id.uuid()}, 0};
+            global_tablet_repair_task_info = {tasks::task_id{tmap.get_tablet_info(tablet.tablet).repair_task_info->tablet_task_id.uuid()}, 0};
         } else {
             auto migration_streaming_info = get_migration_streaming_info(get_token_metadata_ptr()->get_topology(), tmap.get_tablet_info(tablet.tablet), *trinfo);
             replicas = locator::tablet_replica_set{migration_streaming_info.read_from.begin(), migration_streaming_info.read_from.end()};
@@ -5361,8 +5361,8 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
         for (const auto& token : tokens) {
             auto tid = tmap.get_tablet_id(token);
             auto& tinfo = tmap.get_tablet_info(tid);
-            auto& req_id = tinfo.repair_task_info.tablet_task_id;
-            if (req_id) {
+            if (tinfo.repair_task_info && tinfo.repair_task_info->tablet_task_id) {
+                auto& req_id = tinfo.repair_task_info->tablet_task_id;
                 throw std::runtime_error(fmt::format("Tablet {} is already in repair by tablet_task_id={}",
                         locator::global_tablet_id{table, tid}, req_id));
             }
@@ -5404,7 +5404,8 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
         return std::all_of(tokens.begin(), tokens.end(), [&] (const dht::token& token) {
             auto id = tmap.get_tablet_id(token);
-            return tmap.get_tablet_info(id).repair_task_info.tablet_task_id != repair_task_info.tablet_task_id;
+            return tmap.get_tablet_info(id).repair_task_info == nullptr
+                || tmap.get_tablet_info(id).repair_task_info->tablet_task_id != repair_task_info.tablet_task_id;
         });
     });
 
@@ -5451,8 +5452,7 @@ future<> storage_service::del_repair_tablet_request(table_id table, locator::tab
 
         co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) -> future<> {
             auto& tinfo = tmap.get_tablet_info(tid);
-            auto& req_id = tinfo.repair_task_info.tablet_task_id;
-            if (req_id != tablet_task_id) {
+            if (!tinfo.repair_task_info || tinfo.repair_task_info->tablet_task_id != tablet_task_id) {
                 co_return;
             }
             auto last_token = tmap.get_last_token(tid);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1332,13 +1332,13 @@ public:
                 // Avoid rescheduling a failed tablet repair in a loop
                 // TODO: Allow user to config
                 const auto min_reschedule_time = std::chrono::seconds(5);
-                if (now - info.repair_task_info.sched_time < min_reschedule_time) {
+                if (info.repair_task_info && now - info.repair_task_info->sched_time < min_reschedule_time) {
                     lblogger.debug("Skipped tablet repair for tablet={} which is scheduled too frequently", gid);
                     co_return;
                 }
 
                 db_clock::duration diff;
-                auto is_user_reuqest = info.repair_task_info.is_user_repair_request();
+                auto is_user_reuqest = info.repair_task_info && info.repair_task_info->is_user_repair_request();
                 if (is_user_reuqest) {
                     // This means the user has issued a repair request manually. Select it for repair scheduling.
                 } else {

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -97,8 +97,9 @@ future<std::optional<tasks::virtual_task_hint>> tablet_virtual_task::contains(ta
         }
         std::optional<locator::tablet_id> tid = tmap.first_tablet();
         for (const locator::tablet_info& info : tmap.tablets()) {
-            auto task_type = maybe_get_task_type(info.repair_task_info, task_id).or_else([&] () {
-                return maybe_get_task_type(info.migration_task_info, task_id);
+            static const locator::tablet_task_info empty_task_info;
+            auto task_type = maybe_get_task_type(info.repair_task_info ? *info.repair_task_info : empty_task_info, task_id).or_else([&] () {
+                return maybe_get_task_type(info.migration_task_info ? *info.migration_task_info : empty_task_info, task_id);
             });
             if (task_type.has_value()) {
                 co_return tasks::virtual_task_hint{
@@ -160,7 +161,7 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::wait(tasks::task_
         if (is_repair_task(task_type)) {
             bool running = false;
             co_await tmap.for_each_tablet([&] (locator::tablet_id, const locator::tablet_info& info) {
-                if (info.repair_task_info.is_valid() && info.repair_task_info.tablet_task_id.uuid() == id.uuid()) {
+                if (info.repair_task_info && info.repair_task_info->tablet_task_id.uuid() == id.uuid()) {
                     running = true;
                 }
                 return make_ready_future();
@@ -171,7 +172,8 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::wait(tasks::task_
             co_return tmap.resize_task_info().tablet_task_id.uuid() != id.uuid();
         }
         if (is_migration_task(task_type)) {
-            co_return tmap.get_tablet_info(tablet_id_opt.value()).migration_task_info.tablet_task_id.uuid() != id.uuid();
+            auto& mti = tmap.get_tablet_info(tablet_id_opt.value()).migration_task_info;
+            co_return !mti || mti->tablet_task_id.uuid() != id.uuid();
         }
         on_internal_error(tasks::tmlogger, fmt::format("tablet_virtual_task::wait: unhandled tablet task type {}", task_type));
     };
@@ -239,19 +241,20 @@ future<std::vector<tasks::task_stats>> tablet_virtual_task::get_stats() {
             res.push_back(std::move(resize_stats.value()));
         }
         co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) {
-            auto repair_stats = maybe_make_task_stats(info.repair_task_info, schema);
+            static const locator::tablet_task_info empty_task_info;
+            auto repair_stats = maybe_make_task_stats(info.repair_task_info ? *info.repair_task_info : empty_task_info, schema);
             if (repair_stats) {
-                if (info.repair_task_info.is_user_repair_request()) {
+                if (info.repair_task_info && info.repair_task_info->is_user_repair_request()) {
                     // User requested repair may encompass more that one tablet.
-                    auto task_id = tasks::task_id{info.repair_task_info.tablet_task_id.uuid()};
+                    auto task_id = tasks::task_id{info.repair_task_info->tablet_task_id.uuid()};
                     user_requests[task_id] = std::move(repair_stats.value());
-                    sched_num_sum[task_id] += info.repair_task_info.sched_nr;
+                    sched_num_sum[task_id] += info.repair_task_info->sched_nr;
                 } else {
                     res.push_back(std::move(repair_stats.value()));
                 }
             }
 
-            auto migration_stats = maybe_make_task_stats(info.migration_task_info, schema);
+            auto migration_stats = maybe_make_task_stats(info.migration_task_info ? *info.migration_task_info : empty_task_info, schema);
             if (migration_stats) {
                 res.push_back(std::move(migration_stats.value()));
             }
@@ -318,9 +321,8 @@ future<std::optional<status_helper>> tablet_virtual_task::get_status_helper(task
             }
         }
         co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) {
-            auto& task_info = info.repair_task_info;
-            if (task_info.tablet_task_id.uuid() == id.uuid()) {
-                update_status(task_info, res.status, sched_nr);
+            if (info.repair_task_info && info.repair_task_info->tablet_task_id.uuid() == id.uuid()) {
+                update_status(*info.repair_task_info, res.status, sched_nr);
                 no_tablets_processed = false;
             }
             return make_ready_future();
@@ -330,8 +332,8 @@ future<std::optional<status_helper>> tablet_virtual_task::get_status_helper(task
         auto tablet_id = hint.get_tablet_id();
         res.pending_replica = tmap.get_tablet_transition_info(tablet_id)->pending_replica;
         auto& task_info = tmap.get_tablet_info(tablet_id).migration_task_info;
-        if (task_info.tablet_task_id.uuid() == id.uuid()) {
-            update_status(task_info, res.status, sched_nr);
+        if (task_info && task_info->tablet_task_id.uuid() == id.uuid()) {
+            update_status(*task_info, res.status, sched_nr);
             no_tablets_processed = false;
         }
     } else {    // Resize task.

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1656,10 +1656,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             return;
         }
         auto& info = tmap.get_tablet_info(gid.tablet);
-        auto repair_task_info = info.repair_task_info;
-        if (!repair_task_info.is_user_repair_request()) {
-            repair_task_info = locator::tablet_task_info::make_auto_repair_request();
-        }
+        auto repair_task_info = (info.repair_task_info && info.repair_task_info->is_user_repair_request())
+            ? *info.repair_task_info
+            : locator::tablet_task_info::make_auto_repair_request();
         repair_task_info.sched_nr++;
         repair_task_info.sched_time = db_clock::now();
         out.emplace_back(
@@ -2220,7 +2219,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     if (fail_repair || action_failed(tablet_state.repair)) {
                         if (do_barrier()) {
                             auto& tinfo = tmap.get_tablet_info(gid.tablet);
-                            _tablet_ops_metrics.inc_failed(tinfo.repair_task_info.request_type);
+                            _tablet_ops_metrics.inc_failed(tinfo.repair_task_info ? tinfo.repair_task_info->request_type : locator::tablet_task_type::none);
                             updates.emplace_back(get_mutation_builder()
                                     .set_stage(last_token, locator::tablet_transition_stage::end_repair)
                                     .del_session(last_token)
@@ -2230,7 +2229,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     }
                     if (advance_in_background(gid, tablet_state.repair, "repair", [&] () -> future<> {
                         auto& tinfo = tmap.get_tablet_info(gid.tablet);
-                        bool valid = tinfo.repair_task_info.is_valid();
+                        bool valid = tinfo.repair_task_info != nullptr;
                         if (!valid) {
                             rtlogger.info("Skipping tablet repair for tablet={} which is cancelled by user", gid);
                             co_return;
@@ -2239,17 +2238,17 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         if (trinfo) {
                             tablet_state.session_id = trinfo->session_id;
                         }
-                        auto sched_time = tinfo.repair_task_info.sched_time;
+                        auto sched_time = tinfo.repair_task_info->sched_time;
                         auto tablet = gid;
-                        auto hosts_filter = tinfo.repair_task_info.repair_hosts_filter;
-                        auto dcs_filter = tinfo.repair_task_info.repair_dcs_filter;
+                        auto hosts_filter = tinfo.repair_task_info->repair_hosts_filter;
+                        auto dcs_filter = tinfo.repair_task_info->repair_dcs_filter;
                         const auto& topo = _db.get_token_metadata().get_topology();
                         locator::host_id dst;
                         if (hosts_filter.empty() && dcs_filter.empty()) {
                             auto primary = tmap.get_primary_replica(gid.tablet, topo);
                             dst = primary.host;
                         } else {
-                            auto dst_opt = tmap.maybe_get_selected_replica(gid.tablet, topo, tinfo.repair_task_info);
+                            auto dst_opt = tmap.maybe_get_selected_replica(gid.tablet, topo, *tinfo.repair_task_info);
                             if (!dst_opt) {
                                 co_return;
                             }
@@ -2257,13 +2256,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         }
                         // Update repair task
                         db::system_keyspace::repair_task_entry entry{
-                            .task_uuid   = tasks::task_id(tinfo.repair_task_info.tablet_task_id.uuid()),
+                            .task_uuid   = tasks::task_id(tinfo.repair_task_info->tablet_task_id.uuid()),
                             .operation   = db::system_keyspace::repair_task_operation::finished,
                             .first_token = dht::token::to_int64(tmap.get_first_token(gid.tablet)),
                             .last_token  = dht::token::to_int64(tmap.get_last_token(gid.tablet)),
                             .table_uuid  = gid.table,
                         };
-                        auto request_type = tinfo.repair_task_info.request_type;
+                        auto request_type = tinfo.repair_task_info->request_type;
                         rtlogger.info("Initiating tablet repair host={} tablet={} request_type={}", dst, gid, request_type);
                         auto session_id = utils::get_local_injector().enter("handle_tablet_migration_repair_random_session") ?
                             service::session_id::create_random_id() : trinfo->session_id;
@@ -2284,10 +2283,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         }
 
                         auto& tinfo = tmap.get_tablet_info(gid.tablet);
-                        bool valid = tinfo.repair_task_info.is_valid();
-                        auto hosts_filter = tinfo.repair_task_info.repair_hosts_filter;
-                        auto dcs_filter = tinfo.repair_task_info.repair_dcs_filter;
-                        auto incremental = tinfo.repair_task_info.repair_incremental_mode != locator::tablet_repair_incremental_mode::disabled;
+                        bool valid = tinfo.repair_task_info != nullptr;
+                        auto hosts_filter = valid ? tinfo.repair_task_info->repair_hosts_filter : std::unordered_set<locator::host_id>{};
+                        auto dcs_filter = valid ? tinfo.repair_task_info->repair_dcs_filter : std::unordered_set<sstring>{};
+                        auto incremental = valid && tinfo.repair_task_info->repair_incremental_mode != locator::tablet_repair_incremental_mode::disabled;
                         bool is_filter_off = hosts_filter.empty() && dcs_filter.empty();
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::end_repair);
                         auto update = get_mutation_builder()
@@ -2299,7 +2298,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         }
                         // Skip update repair time in case hosts filter or dcs filter is set.
                         if (valid && is_filter_off) {
-                            auto sched_time = tinfo.repair_task_info.sched_time;
+                            auto sched_time = tinfo.repair_task_info->sched_time;
                             auto time = tablet_state.repair_time;
                             update.set_repair_time(last_token, time);
                             auto repaired_at = sstring("None");
@@ -2316,7 +2315,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                     sched_time, time, repaired_at, last_token);
                         }
                         updates.emplace_back(update.build());
-                        _tablet_ops_metrics.inc_succeeded(tinfo.repair_task_info.request_type);
+                        _tablet_ops_metrics.inc_succeeded(tinfo.repair_task_info ? tinfo.repair_task_info->request_type : locator::tablet_task_type::none);
                     }
                 }
                     break;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -6864,7 +6864,7 @@ void run_tablet_manual_repair_rf1(cql_test_env& e) {
                 tablet_replica{host1, 0},
             }
         };
-        ti.repair_task_info = ti.repair_task_info.make_user_repair_request();
+        ti.repair_task_info = std::make_unique<locator::tablet_task_info>(locator::tablet_task_info::make_user_repair_request());
         tmap.set_tablet(tid, std::move(ti));
         tmeta.set_tablet_map(table1, std::move(tmap));
         co_return;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -371,8 +371,8 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                         tablet_replica {h3, 1},
                     },
                     db_clock::now(),
-                    locator::tablet_task_info::make_auto_repair_request({}, {"dc1", "dc2"}),
-                    locator::tablet_task_info::make_intranode_migration_request(),
+                    std::make_unique<locator::tablet_task_info>(locator::tablet_task_info::make_auto_repair_request({}, {"dc1", "dc2"})),
+                    std::make_unique<locator::tablet_task_info>(locator::tablet_task_info::make_intranode_migration_request()),
                     0
                 });
                 tm.set_tablet_map(table1, std::move(tmap));
@@ -390,7 +390,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                     },
                     {},
                     {},
-                    locator::tablet_task_info::make_migration_request(),
+                    std::make_unique<locator::tablet_task_info>(locator::tablet_task_info::make_migration_request()),
                     0
                 });
                 tb = *tmap.next_tablet(tb);
@@ -406,7 +406,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                     },
                     {},
                     {},
-                    locator::tablet_task_info::make_migration_request(),
+                    std::make_unique<locator::tablet_task_info>(locator::tablet_task_info::make_migration_request()),
                     0
                 });
                 tb = *tmap.next_tablet(tb);
@@ -805,8 +805,8 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence_with_colocated_tables) {
                         tablet_replica {h3, 1},
                     },
                     db_clock::now(),
-                    locator::tablet_task_info::make_auto_repair_request({}, {"dc1", "dc2"}),
-                    locator::tablet_task_info::make_intranode_migration_request(),
+                    std::make_unique<locator::tablet_task_info>(locator::tablet_task_info::make_auto_repair_request({}, {"dc1", "dc2"})),
+                    std::make_unique<locator::tablet_task_info>(locator::tablet_task_info::make_intranode_migration_request()),
                     0
                 });
                 tm.set_tablet_map(table1, std::move(tmap));


### PR DESCRIPTION
## Summary

- Convert `tablet_info::repair_task_info` and `migration_task_info` from inline 168-byte structs to `std::unique_ptr<tablet_task_info>`, only allocated when a task is active.
- Simplify the `tablet_info` constructor to accept `std::unique_ptr` directly with default arguments.

## Result

`sizeof(tablet_info)`: **448 → 128 bytes** (71% reduction, -320 bytes per tablet)

Zero per-tablet heap allocation in the common case (no active task).

## Context

Alternative approach to #30252, in response to [this review comment](https://github.com/scylladb/scylladb/pull/30252#issuecomment-4641769783) — uses `std::unique_ptr` rather than side maps or `std::optional` to avoid always reserving space for the embedded structs.

Fixes: SCYLLADB-1976

--

Improvement. No backport required