### PR TITLE
doc: remove broken links to Cassandra

### DIFF
--- a/docs/architecture/sstable/sstable3/sstables-3-index.rst
+++ b/docs/architecture/sstable/sstable3/sstables-3-index.rst
@@ -120,9 +120,7 @@ In other words, that means that the block of ``unfiltereds`` in the data file th
 It is set for a range tombstone marker of either the ``INCL_START_BOUND`` or the ``EXCL_END_INCL_START_BOUNDARY`` kind and contains the open bound deletion time.
 
 The ``end_open_marker`` has to do with how range tombstones are organised in SSTables 3.0. and is closely connected with the merging logic of storage engine code. That code expects all the data it reads from SSTables to come strictly ordered and it expects range tombstone markers to always come in pairs (the combined "boundary" type marker is just treated as two markers - an end marker for the previous RT followed immediately by a start marker for a new RT.
-So when a slice of data is being read, it may contain an end RT marker without the corresponding start RT marker. In order to properly handle this, reader code returns a start RT marker corresponding to the slice start bound with the deletion time taken from the ``end_open_marker`` structure see: SSTableIterator.java.handlePreSliceData_ 
-
-.. _SSTableIterator.java.handlePreSliceData: https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/db/columniterator/SSTableIterator.java#L125
+So when a slice of data is being read, it may contain an end RT marker without the corresponding start RT marker. In order to properly handle this, reader code returns a start RT marker corresponding to the slice start bound with the deletion time taken from the ``end_open_marker`` structure. 
 
 The higher-level reason for this design is that C* 3.0 storage design aims to be as iterator-based as possible and as such doesn't re-arrange the data it reads (and without start RT marker, such re-arrangement would be due).
 

--- a/docs/architecture/sstable/sstable3/sstables-3-summary.rst
+++ b/docs/architecture/sstable/sstable3/sstables-3-summary.rst
@@ -94,15 +94,5 @@ The last two entries in the ``summary`` structure are  ``serialized_keys`` that 
 
 They store the first and the last keys in the index/data file.
 
-References
-
-* `IndexSummary.java`_ 
-
-* `SSTableReader.java, saveSummary`_ 
-
-.. _`IndexSummary.java`: https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/io/sstable/IndexSummary.java
-
-.. _`SSTableReader.java, saveSummary`: https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/io/sstable/format/SSTableReader.java
-
 
 .. include:: /rst_include/apache-copyrights.rst


### PR DESCRIPTION
Removes the broken and redundant links to Cassandra.

We should limit linking to Cassandra for a number of reasons; one of them is that the links tend to become dead sooner or later, without us knowing about it.

Also, most of them are now redundant.

Fixes https://github.com/scylladb/scylladb-docs-homepage/issues/212

--------
No backport needed. 
No advanced review needed (this PR only removes links).