### PR TITLE
fix performance issues in bypass_cache write tests

### DIFF
--- a/test/cluster/dtest/bypass_cache_test.py
+++ b/test/cluster/dtest/bypass_cache_test.py
@@ -342,7 +342,8 @@ class TestBypassCache(Tester):
         metric = ["scylla_cache_bytes_used"]
         for _ in range(NUM_OF_QUERY_EXECUTIONS):
             cache_bytes_used_before_write = self.get_scylla_cache_reads_metrics(node=node, metrics=metric)[metric[0]]
-            insert_c1c2(session, keys=list(range(self.first_key + 10)), cf=self.table_name, ks=self.keyspace_name)
+            insert_c1c2(session, keys=list(range(self.first_key, self.first_key + 10)), cf=self.table_name,
+                        ks=self.keyspace_name)
             self.cluster.nodetool(f"flush -- {self.keyspace_name} {self.table_name}")
             cache_bytes_used_after_write = self.get_scylla_cache_reads_metrics(node=node, metrics=metric)[metric[0]]
             if cache_bytes_used_before_write < cache_bytes_used_after_write:

--- a/test/cluster/dtest/bypass_cache_test.py
+++ b/test/cluster/dtest/bypass_cache_test.py
@@ -344,7 +344,7 @@ class TestBypassCache(Tester):
             cache_bytes_used_before_write = self.get_scylla_cache_reads_metrics(node=node, metrics=metric)[metric[0]]
             insert_c1c2(session, keys=list(range(self.first_key, self.first_key + 10)), cf=self.table_name,
                         ks=self.keyspace_name)
-            self.cluster.nodetool(f"flush -- {self.keyspace_name} {self.table_name}")
+            node.flush(ks=self.keyspace_name, table=self.table_name)
             cache_bytes_used_after_write = self.get_scylla_cache_reads_metrics(node=node, metrics=metric)[metric[0]]
             if cache_bytes_used_before_write < cache_bytes_used_after_write:
                 grew += 1

--- a/test/cluster/dtest/ccmlib/scylla_cluster.py
+++ b/test/cluster/dtest/ccmlib/scylla_cluster.py
@@ -228,7 +228,9 @@ class ScyllaCluster:
         return self
 
     def flush(self) -> None:
-        self.nodetool("flush")
+        for node in self.nodelist():
+            if node.is_running():
+                node.flush()
 
     @staticmethod
     def debug(message: str) -> None:

--- a/test/cluster/dtest/ccmlib/scylla_node.py
+++ b/test/cluster/dtest/ccmlib/scylla_node.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 import logging
 
+
 from test.cluster.dtest.ccmlib.common import ArgumentError, wait_for, BIN_DIR
 from test.pylib.internal_types import ServerUpState
 from test.pylib.manager_client import NoSuchProcess
@@ -651,12 +652,15 @@ class ScyllaNode:
 
 
     def flush(self, ks: str | None = None, table: str | None = None, **kwargs) -> None:
-        cmd = ["flush"]
+        """Flush memtables to sstables via the REST API.
+
+        Uses ScyllaRESTAPIClient (same as test/pylib/nodetool.py) which is
+        much faster than spawning a nodetool subprocess.
+        """
         if ks:
-            cmd.append(ks)
-        if table:
-            cmd.append(table)
-        self.nodetool(" ".join(cmd), **kwargs)
+            self.cluster.manager.api.keyspace_flush(node_ip=self.address(), keyspace=ks, table=table)
+        else:
+            self.cluster.manager.api.flush_all_keyspaces(node_ip=self.address())
 
     def compact(self, keyspace: str = "", tables: str | None = ()) -> None:
         compact_cmd = ["compact"]


### PR DESCRIPTION
Two independent fixes for `test_writes_caching_enabled` and 
`test_writes_caching_disabled` which were exceeding the 60s CI threshold
(observed 92s in dev mode).

**Commit 1: fix quadratic insert growth**

`insert_c1c2(keys=list(range(self.first_key + 10)))` always started from 0,
inserting all keys from 0 to first_key+9 instead of just 10 new keys per
iteration. Over 200 iterations this produced 201,000 INSERT operations
instead of the intended 2,000.

Fix to insert exactly 10 new unique keys per iteration

**Commit 2 (global for ported dtests): use REST API for flush instead of nodetool subprocess**

`ScyllaNode.flush()` spawned a subprocess (`exec scylla nodetool flush`)
which internally just does an HTTP POST to the REST API. With 200 flush
calls in a tight loop, subprocess overhead dominated at ~146ms per call
(~29s total).

Replaced subprocess-based `node.nodetool("flush ...")` with a direct
REST API call via `requests.post()`, matching the approach already used
in the main pytest framework. The nodetool flush command internally calls
the same REST endpoint, but through a full subprocess spawn of the
Scylla binary in nodetool mode (~146ms overhead per call).

Updated `ScyllaNode.flush()` and `ScyllaCluster.flush()` accordingly.

Fixes: SCYLLADB-2258