### PR TITLE
replica: make tablet cleanup stats self-healing

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -789,7 +789,6 @@ private:
     sstables::generation_type calculate_generation_for_new_table();
 private:
     void rebuild_statistics();
-    void subtract_compaction_group_from_stats(const compaction_group& cg) noexcept;
 private:
     mutation_source_opt _virtual_reader;
     std::optional<noncopyable_function<future<>(const frozen_mutation&)>> _virtual_writer;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2277,12 +2277,6 @@ void table::rebuild_large_data_index() {
     _large_data_guardrail->rebuild(sstables);
 }
 
-void table::subtract_compaction_group_from_stats(const compaction_group& cg) noexcept {
-    _stats.live_disk_space_used -= cg.live_disk_space_used_full_stats();
-    _stats.total_disk_space_used -= cg.total_disk_space_used_full_stats();
-    _stats.live_sstable_count -= cg.live_sstable_count();
-}
-
 future<table::sstable_list_permit>
 table::get_sstable_list_permit() {
     co_return sstable_list_permit(co_await seastar::get_units(_sstable_set_mutation_sem, 1));
@@ -5653,7 +5647,6 @@ future<> compaction_group::cleanup() {
         }
 
         virtual void execute() override {
-            _t.subtract_compaction_group_from_stats(_cg);
             _cg.set_main_sstables(std::move(_empty_main_set));
             _cg.set_maintenance_sstables(std::move(_empty_maintenance_set));
             _t.refresh_compound_sstable_set();
@@ -5669,17 +5662,21 @@ future<> compaction_group::cleanup() {
     // Since permit is still held, all actions below will be executed atomically:
     co_await _t._cache.invalidate(std::move(updater), p_range);
     _t._cache.refresh_snapshot();
+    _t.rebuild_statistics();
 
     if (_t.uses_logstor()) {
         co_await _t.logstor_index().erase(p_range);
         co_await discard_logstor_segments();
     }
 
-    co_await _t.delete_sstables_atomically(permit, _sstables_compacted_but_not_deleted);
-    // Clearing sstables_compacted_but_not_deleted only on success allows a retry caused
-    // by a failure during deletion to still find the sstables, despite they were removed
-    // from the sstable sets.
-    _sstables_compacted_but_not_deleted.clear();
+    if (!_sstables_compacted_but_not_deleted.empty()) {
+        co_await _t.delete_sstables_atomically(permit, _sstables_compacted_but_not_deleted);
+        // delete_sstables_atomically swallows exceptions, so this always runs.
+        // Any SSTables that failed to delete will eventually be re-compacted
+        // and re-deleted.
+        _sstables_compacted_but_not_deleted.clear();
+        _t.rebuild_statistics();
+    }
     if (utils::get_local_injector().enter("tablet_cleanup_failure_post_deletion")) {
         tlogger.info("Cleanup failed for tablet {}", group_id());
         throw std::runtime_error("tablet cleanup failure");

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -6652,6 +6652,82 @@ SEASTAR_TEST_CASE(test_cleanup_of_deallocated_tablet) {
     }, cfg);
 }
 
+// Reproduces https://github.com/scylladb/scylladb/issues/24134
+// tablet cleanup used subtract_compaction_group_from_stats() which is a
+// non-self-healing decrement. It double-counts total_disk_space_used because
+// prepare() pushes sstables into _sstables_compacted_but_not_deleted before
+// execute() subtracts total_disk_space_used_full_stats() which includes both
+// the live and the compacted-but-not-deleted terms.
+SEASTAR_TEST_CASE(test_tablet_cleanup_stats_non_negative) {
+    auto cfg = tablet_cql_test_config();
+    cfg.initial_tablets = 1;
+
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        e.execute_cql("create table ks.cf (pk int, ck int, v text, primary key (pk, ck))").get();
+
+        // Insert data and flush to create sstables with non-trivial disk usage.
+        for (int i = 0; i < 100; i++) {
+            e.execute_cql(format("INSERT INTO ks.cf (pk, ck, v) VALUES ({}, {}, '{}')",
+                                 i, i, "payload_to_ensure_nonzero_disk_usage")).get();
+        }
+
+        replica::database::flush_table_on_all_shards(e.db(), "ks", "cf").get();
+
+        // Verify stats are positive before cleanup on at least one shard.
+        auto has_data = e.db().map_reduce0([] (replica::database& db) {
+            auto& cf = db.find_column_family("ks", "cf");
+            auto& stats = cf.get_stats();
+            if (stats.live_sstable_count > 0) {
+                testlog.info("Before cleanup: live_disk_space_used={} total_disk_space_used={} live_sstable_count={}",
+                             stats.live_disk_space_used.on_disk, stats.total_disk_space_used.on_disk, stats.live_sstable_count);
+                BOOST_REQUIRE_GT(stats.live_disk_space_used.on_disk, 0);
+                BOOST_REQUIRE_GT(stats.total_disk_space_used.on_disk, 0);
+                return true;
+            }
+            return false;
+        }, false, std::logical_or<bool>()).get();
+        BOOST_REQUIRE(has_data);
+
+        // Cleanup the tablet. On HEAD this causes total_disk_space_used to go
+        // negative due to double-counting in subtract_compaction_group_from_stats.
+        e.db().invoke_on_all([&] (replica::database& db) -> future<> {
+            auto& cf = db.find_column_family("ks", "cf");
+            auto& sys_ks = e.get_system_keyspace().local();
+            if (cf.get_stats().tablet_count > 0) {
+                co_await cf.cleanup_tablet(db, sys_ks, locator::tablet_id(0));
+            }
+        }).get();
+
+        // After cleanup, all stats must be non-negative.
+        e.db().invoke_on_all([] (replica::database& db) {
+            auto& cf = db.find_column_family("ks", "cf");
+            auto& stats = cf.get_stats();
+            testlog.info("After cleanup: live_disk_space_used={} total_disk_space_used={} live_sstable_count={}",
+                         stats.live_disk_space_used.on_disk, stats.total_disk_space_used.on_disk, stats.live_sstable_count);
+            BOOST_REQUIRE_GE(stats.live_disk_space_used.on_disk, 0);
+            BOOST_REQUIRE_GE(stats.total_disk_space_used.on_disk, 0);
+            BOOST_REQUIRE_GE(stats.live_sstable_count, 0);
+        }).get();
+
+        // Double cleanup must also leave stats non-negative.
+        e.db().invoke_on_all([&] (replica::database& db) -> future<> {
+            auto& cf = db.find_column_family("ks", "cf");
+            auto& sys_ks = e.get_system_keyspace().local();
+            if (cf.get_stats().tablet_count > 0) {
+                co_await cf.cleanup_tablet(db, sys_ks, locator::tablet_id(0));
+            }
+        }).get();
+
+        e.db().invoke_on_all([] (replica::database& db) {
+            auto& cf = db.find_column_family("ks", "cf");
+            auto& stats = cf.get_stats();
+            BOOST_REQUIRE_GE(stats.live_disk_space_used.on_disk, 0);
+            BOOST_REQUIRE_GE(stats.total_disk_space_used.on_disk, 0);
+            BOOST_REQUIRE_GE(stats.live_sstable_count, 0);
+        }).get();
+    }, cfg);
+}
+
 namespace {
 
 future<> test_create_keyspace(sstring ks_name, std::optional<bool> tablets_opt, const cql_test_config& cfg, uint64_t initial_tablets = 0, sstring replication_strategy = "NetworkTopologyStrategy") {


### PR DESCRIPTION
tablet cleanup used subtract_compaction_group_from_stats() which is a non-self-healing decrement that can produce negative stats values.

The total_disk_space_used double-counts because prepare() pushes sstables into _sstables_compacted_but_not_deleted before execute() subtracts total_disk_space_used_full_stats() which includes both the live and the compacted-but-not-deleted terms.

Additionally, live_disk_space_used can go negative when a concurrent rebuild_statistics() (triggered by compaction on another CG) runs while the tablet's compaction group gate is closed: the rebuild skips the closed-gate CG, then subtract_compaction_group_from_stats() double-subtracts its contribution.

Fix by removing the non-self-healing subtract_compaction_group_from_stats() and replacing it with rebuild_statistics() calls after the sstable sets are cleared — the same self-healing pattern used by compaction completion.

Refs #24134
Fixes SCYLLADB-2377

--

The issue exists since 893ee68251 (Scylla 5.4), so it should be backported to all live releases in principle, but since fixing #24134 hardened scylla-nodetool, I'd recommend backporting only up to 2026.1