### PR TITLE
cql3: fix have_multiple_cfs misclassification in batch prepare

### DIFF
--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -456,7 +456,8 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
             first_ks = parsed->keyspace();
             first_cf = parsed->column_family();
         } else {
-            have_multiple_cfs = first_ks.value() != parsed->keyspace() || first_cf.value() != parsed->column_family();
+            have_multiple_cfs |= first_ks.value() != parsed->keyspace();
+            have_multiple_cfs |= first_cf.value() != parsed->column_family();
         }
         statements.emplace_back(parsed->prepare(db, meta, stats));
         auto audit_info = statements.back().statement->get_audit_info();

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -2661,6 +2661,45 @@ APPLY BATCH;)"
     });
 }
 
+// Regression test for SCYLLADB-2474: have_multiple_cfs misclassification in
+// batch_statement::prepare(): the flag was assigned with = instead of |=, so a
+// batch whose first and last sub-statements target the same table (e.g.
+// [ta, tb, ta]) had the flag cleared on the last sub-statement and was
+// misclassified as targeting a single table. A single-table batch is given a
+// routing key (partition_key_bind_indices) computed from its first
+// sub-statement, while a multi-table batch has no single partition key and must
+// have none. The misclassification therefore makes the prepared statement
+// advertise a bogus routing key.
+SEASTAR_TEST_CASE(test_batch_multi_table_has_no_partition_key_bind_indices) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("create table ta (pk int PRIMARY KEY, v int);").get();
+        e.execute_cql("create table tb (pk int PRIMARY KEY, v int);").get();
+        // A multi-table batch whose first and last sub-statements target the
+        // same table must not advertise a single routing key.
+        const auto multi_table_id = e.prepare(
+            "BEGIN BATCH "
+            "INSERT INTO ta (pk, v) VALUES (?, ?); "
+            "INSERT INTO tb (pk, v) VALUES (?, ?); "
+            "INSERT INTO ta (pk, v) VALUES (?, ?); "
+            "APPLY BATCH").get();
+        const auto multi_table_prepared = e.local_qp().get_prepared(multi_table_id);
+        BOOST_REQUIRE(multi_table_prepared);
+        BOOST_REQUIRE(multi_table_prepared->partition_key_bind_indices.empty());
+        // A single-table batch, on the other hand, must keep its routing key.
+        // This guards against the fix accidentally breaking the single-table
+        // case.
+        const auto single_table_id = e.prepare(
+            "BEGIN BATCH "
+            "INSERT INTO ta (pk, v) VALUES (?, ?); "
+            "INSERT INTO ta (pk, v) VALUES (?, ?); "
+            "INSERT INTO ta (pk, v) VALUES (?, ?); "
+            "APPLY BATCH").get();
+        const auto single_table_prepared = e.local_qp().get_prepared(single_table_id);
+        BOOST_REQUIRE(single_table_prepared);
+        BOOST_REQUIRE(!single_table_prepared->partition_key_bind_indices.empty());
+    });
+}
+
 SEASTAR_TEST_CASE(test_in_restriction) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table tir (p1 int, c1 int, r1 int, PRIMARY KEY (p1, c1));").get();


### PR DESCRIPTION
When preparing a batch, batch_statement::prepare() classifies the batch as single- or multi-table by comparing every sub-statement's table against the first one. The have_multiple_cfs flag was assigned with = instead of |=, so a later sub-statement that happens to match the first one's keyspace and table clears the flag again. A batch such as [ta, tb, ta] - whose first and last sub-statements target the same table - is therefore misclassified as single-table.

A single-table batch is given a routing key (partition_key_bind_indices) computed from its first sub-statement; a multi-table batch has no single partition key and must have none. The bug makes such a batch advertise a bogus routing key in its prepared metadata, so the coordinator routes the request using one sub-statement's partition key instead of treating the batch as un-routable.

Fix by accumulating the flag with |=. Add a unit test that prepares an [ta, tb, ta] batch and asserts the prepared statement has no partition_key_bind_indices; it fails before this change and passes after.

Fixes SCYLLADB-2474

Minor bugfix, no evidence it has caused troubles, so not backporting. 