### PR TITLE
Add coordinator-side guardrail check to LWT path

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -7009,6 +7009,8 @@ future<bool> storage_proxy::cas(schema_ptr schema, cas_shard cas_shard, cas_requ
                 // since the value we are writing is dummy we may use minimal consistency level for learn
                 handler->set_cl_for_learn(db::consistency_level::ANY);
             } else {
+                table.get_large_data_guardrail()->check_coordinator(
+                        *schema, mutation->partition(), mutation->key());
                 paxos::paxos_state::logger.debug("CAS[{}] precondition is met; proposing client-requested updates for {}",
                         handler->id(), ballot);
                 tracing::trace(handler->tr_state, "CAS precondition is met; proposing client-requested updates for {}", ballot);

--- a/test/cqlpy/test_coordinator_guardrail_large_cell.py
+++ b/test/cqlpy/test_coordinator_guardrail_large_cell.py
@@ -172,26 +172,25 @@ def test_at_hard_limit_succeeds(cql, test_table):
         cql.execute(insert, [1, make_blob(1048576)])
 
 
-# --- LWT exemption tests ---
-# LWT (Paxos) writes are exempt from coordinator-side guardrails because
-# the mutation is not available until after the Paxos prepare round, and
-# abandoning mid-round would violate linearizability (see issue #6299).
+# --- LWT rejection tests ---
 
 
-def test_lwt_insert_exempt_from_coordinator_guardrail(cql, test_table):
-    """LWT INSERT with large cell must not be rejected by coordinator guardrail."""
+def test_lwt_insert_rejected_by_coordinator_guardrail(cql, test_table):
+    """LWT INSERT with large cell must be rejected by coordinator guardrail."""
     insert_if = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?) IF NOT EXISTS")
     with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
-        cql.execute(insert_if, [100, make_blob(1048576 + 1)])
+        with pytest.raises(InvalidRequest, match="Large data guardrail"):
+            cql.execute(insert_if, [100, make_blob(1048576 + 1)])
 
 
-def test_lwt_update_exempt_from_coordinator_guardrail(cql, test_table):
-    """LWT UPDATE with large cell must not be rejected by coordinator guardrail."""
+def test_lwt_update_rejected_by_coordinator_guardrail(cql, test_table):
+    """LWT UPDATE with large cell must be rejected by coordinator guardrail."""
     insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
     update_if = cql.prepare(f"UPDATE {test_table} SET v = ? WHERE pk = ? IF v != null")
     with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
         cql.execute(insert, [102, b"\x00"])
-        cql.execute(update_if, [make_blob(1048576 + 1), 102])
+        with pytest.raises(InvalidRequest, match="Large data guardrail"):
+            cql.execute(update_if, [make_blob(1048576 + 1), 102])
 
 
 # --- Per-table guardrail toggle tests ---

--- a/test/cqlpy/test_coordinator_guardrail_large_collection.py
+++ b/test/cqlpy/test_coordinator_guardrail_large_collection.py
@@ -188,17 +188,14 @@ def test_delete_in_batch_always_allowed(cql, test_table_set):
         cql.execute(f"BEGIN BATCH DELETE FROM {test_table_set} WHERE pk = 1 APPLY BATCH")
 
 
-# --- LWT exemption tests ---
-# LWT (Paxos) writes are exempt from coordinator-side guardrails because
-# the mutation is not available until after the Paxos prepare round, and
-# abandoning mid-round would violate linearizability (see issue #6299).
+# --- LWT rejection tests ---
 
-
-def test_lwt_insert_exempt_from_coordinator_guardrail(cql, test_table_set):
-    """LWT INSERT with large collection must not be rejected by coordinator guardrail."""
+def test_lwt_insert_rejected_by_coordinator_guardrail(cql, test_table_set):
+    """LWT INSERT with large collection must be rejected by coordinator guardrail."""
     insert_if = cql.prepare(f"INSERT INTO {test_table_set} (pk, v) VALUES (?, ?) IF NOT EXISTS")
     with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
-        cql.execute(insert_if, [100, make_set(6)])
+        with pytest.raises(InvalidRequest, match="Large data guardrail"):
+            cql.execute(insert_if, [100, make_set(6)])
 
 
 # --- Per-table guardrail toggle tests ---

--- a/test/cqlpy/test_coordinator_guardrail_large_row.py
+++ b/test/cqlpy/test_coordinator_guardrail_large_row.py
@@ -163,26 +163,24 @@ def test_delete_in_batch_always_allowed(cql, test_table):
         cql.execute(f"BEGIN BATCH DELETE FROM {test_table} WHERE pk = 1 APPLY BATCH")
 
 
-# --- LWT exemption tests ---
-# LWT (Paxos) writes are exempt from coordinator-side guardrails because
-# the mutation is not available until after the Paxos prepare round, and
-# abandoning mid-round would violate linearizability (see issue #6299).
+# --- LWT rejection tests ---
 
-
-def test_lwt_insert_exempt_from_coordinator_guardrail(cql, test_table):
-    """LWT INSERT with large row must not be rejected by coordinator guardrail."""
+def test_lwt_insert_rejected_by_coordinator_guardrail(cql, test_table):
+    """LWT INSERT with large row must be rejected by coordinator guardrail."""
     insert_if = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?) IF NOT EXISTS")
     with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
-        cql.execute(insert_if, [100, make_blob(1048576 + 1)])
+        with pytest.raises(InvalidRequest, match="Large data guardrail"):
+            cql.execute(insert_if, [100, make_blob(1048576 + 1)])
 
 
-def test_lwt_update_exempt_from_coordinator_guardrail(cql, test_table):
-    """LWT UPDATE with large row must not be rejected by coordinator guardrail."""
+def test_lwt_update_rejected_by_coordinator_guardrail(cql, test_table):
+    """LWT UPDATE with large row must be rejected by coordinator guardrail."""
     insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
     update_if = cql.prepare(f"UPDATE {test_table} SET v = ? WHERE pk = ? IF v != null")
     with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
         cql.execute(insert, [102, b"\x00"])
-        cql.execute(update_if, [make_blob(1048576 + 1), 102])
+        with pytest.raises(InvalidRequest, match="Large data guardrail"):
+            cql.execute(update_if, [make_blob(1048576 + 1), 102])
 
 
 # --- Per-table guardrail toggle tests ---


### PR DESCRIPTION
Previously, LWT writes were fully exempt from coordinator-side guardrails. The mutation produced by request.apply() was never checked, allowing arbitrarily large cells, rows, and collections to pass through LWT writes unchecked.
Check coordinator guardrails after request.apply() produces the mutation, before proposing it to Paxos. Unlike the replica-side path, the coordinator has the mutation available before it enters the Paxos state machine, so it can check and catch violations before sending the mutation to replicas.

New feature, backport is not required

Depends on https://github.com/scylladb/scylladb/pull/29245

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2475