### PR TITLE
docs: bump starlette to 1.2.1 in uv.lock (CVE-2026-48710)

### DIFF
--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -840,15 +840,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Bump `starlette` from **1.0.0 → 1.2.1** in `docs/uv.lock`.

## Why

Resolves Dependabot alert: https://github.com/scylladb/scylladb/security/dependabot/60

- **CVE-2026-48710** / **GHSA-86qp-5c8j-p5mr** (severity: medium)
- Starlette `<= 1.0.0` is missing `Host` header validation, which poisons `request.url.path` and can bypass path-based security checks.
- First patched in **1.0.1**; this PR moves to the latest **1.2.1**.

`starlette` is a **transitive** dependency of `sphinx-autobuild` (the docs live-reload preview server, `make preview`); it is **not used by ScyllaDB itself** — it only appears in the documentation lockfile. `sphinx-autobuild` requires `starlette>=0.35`, so `1.2.1` is in range.

## Scope

- Lockfile-only change, regenerated with `uv lock --upgrade-package starlette`.
- Only the `starlette` entry changes (version + sdist/wheel hashes); `docs/pyproject.toml` is unchanged.
- `sphinx-autobuild` (2025.8.25) and `sphinx` (9.1.0) are already at their latest releases.

## Verification

- `uv sync` — resolver accepts the new lock; clean install (`starlette==1.2.1`).
- `make test` — strict Sphinx build (`-W --keep-going`) completes with exit 0.
- `sphinx-autobuild` preview server (the only consumer of `starlette`) serves `HTTP 200`.
