### PR TITLE
test/cluster: speedup test_multi_column_lwt_during_migration while keeping the same scenario

### DIFF
--- a/test/cluster/lwt/test_lwt_during_tablets_migration.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_migration.py
@@ -25,16 +25,16 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # Test constants
-NUM_MIGRATIONS = 20
-WARMUP_LWT_CNT = 100
-POST_LWT_CNT = 100
+NUM_MIGRATIONS = 10
+WARMUP_LWT_CNT = 30
+POST_LWT_CNT = 30
 PHASE_WARMUP = 'warmup'
 PHASE_POST = 'post'
 PHASE_MIGRATING = 'migrating'
 
 
 async def tablet_migration_ops(stop_event: asyncio.Event,
-        manager: ManagerClient, servers, tester, num_ops: int, pause_range=(0.5, 2.0)
+        manager: ManagerClient, servers, tester, num_ops: int, pause_range=(0.1, 0.5)
         ):
 
     """
@@ -116,11 +116,10 @@ async def test_multi_column_lwt_during_migration(manager: ManagerClient, scale_t
         "rf_rack_valid_keyspaces": False,
     }
 
-    servers = await manager.servers_add(6, config=cfg)
+    servers = await manager.servers_add(4, config=cfg)
     await manager.disable_tablet_balancing()
 
-    rf_max = len(servers) - 1
-    rf = random.randint(2, rf_max)
+    rf = 3
     logger.info("Using replication_factor=%d (servers=%d)", rf, len(servers))
 
     async with new_test_keyspace(
@@ -148,7 +147,7 @@ async def test_multi_column_lwt_during_migration(manager: ManagerClient, scale_t
                 NUM_MIGRATIONS,
             )
             await tester.start_workers(stop_event_)
-            # Phase 1: warmup LWT (100 applied CAS)
+            # Phase 1: warmup LWT (30 applied CAS)
             tester.set_phase(PHASE_WARMUP)
             logger.info("LWT warmup: waiting for %d applied CAS", WARMUP_LWT_CNT)
             await tester.wait_for_phase_ops(stop_event_, PHASE_WARMUP, WARMUP_LWT_CNT, timeout=60, poll=1.0)
@@ -162,7 +161,7 @@ async def test_multi_column_lwt_during_migration(manager: ManagerClient, scale_t
             )
             await asyncio.wait_for(
                 migration_task,
-                timeout=scale_timeout(NUM_MIGRATIONS * 2 + 15),  # 20*2+15 = 55s before scaling
+                timeout=scale_timeout(NUM_MIGRATIONS * 2 + 15),  # 10*2+15 = 35s before scaling
             )
             logger.info("LWT during migrating phase: %d ops", tester.get_phase_ops(PHASE_MIGRATING))
 


### PR DESCRIPTION
- Reduce NUM_MIGRATIONS from 20 to 10. The test still performs multiple tablet migrations, including the existing random mix of inter-node and intra-node moves, but avoids running this as a long stress test.
- Reduce WARMUP_LWT_CNT and POST_LWT_CNT from 100 to 30. Warmup and post phases still prove that the LWT workload is making progress before and after migrations. The lower count removes extra waiting that is not central to the migration coverage.
- Reduce migration pause range from 0.5-2.0s to 0.1-0.5s. The old random delay added significant wall-clock time between migrations. The shorter delay still leaves LWT workers running between migrations without dominating runtime.
- Reduce cluster size from 6 nodes to 4 nodes. RF=3 only needs one non-replica target for internode moves, so 4 nodes are sufficient. This lowers cluster startup and migration overhead.
- Replace random RF with fixed RF=3. This removes runtime variance and keeps the topology predictable. With 4 nodes and RF=3, internode migrations remain possible because there is always one non-replica node.

This reduced the test run time from ~61 seconds to ~26 seconds with minimal impact of what the test should do.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2271

backport: none this is just a test enhancement