### PR TITLE
test/lib: fix wrong scheduling group and comment typos in cql_test_env

### DIFF
--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -582,7 +582,7 @@ private:
 
             auto scheduling_groups = get_scheduling_groups().get();
             debug::streaming_scheduling_group = scheduling_groups.streaming_scheduling_group;
-            debug::gossip_scheduling_group = scheduling_groups.streaming_scheduling_group;
+            debug::gossip_scheduling_group = scheduling_groups.gossip_scheduling_group;
 
             auto notify_set = init_configurables
                 ? configurable::init_all(*cfg, init_configurables->extensions, service_set(
@@ -863,7 +863,7 @@ private:
                         // FIXME: should not need to do this - it makes this whole thing unsafe. But
                         // reactor::posix_reuseport_detect() currently always returns false, thus
                         // trying to grab a port and reusing it properly here does _not_ work at all.
-                        // Once the seastar issue is fixed, we can just keep the tmp socket aliva across
+                        // Once the seastar issue is fixed, we can just keep the tmp socket alive across
                         // the listen invoke below.
                         tmp = {};
                         _ms.invoke_on_all(&netw::messaging_service::start_listen, std::ref(_token_metadata), [host_id] (gms::inet_address ip) {return host_id; }).get();
@@ -938,7 +938,7 @@ private:
             _mapreduce_service.start(std::ref(_ms), std::ref(_proxy), std::ref(_db), std::ref(abort_sources)).get();
             auto stop_mapreduce_service =  defer_verbose_shutdown("mapreduce service", [this] { _mapreduce_service.stop().get(); });
 
-            // gropu0 client exists only on shard 0
+            // group0 client exists only on shard 0
             service::raft_group0_client group0_client(_group0_registry.local(), _gossiper.local(), _sys_ks.local(), _token_metadata.local(), maintenance_mode_enabled::no);
 
             _mm.start(std::ref(_mnotifier), std::ref(_feature_service), std::ref(_ms), std::ref(_proxy), std::ref(_gossiper), std::ref(group0_client), std::ref(_sys_ks)).get();


### PR DESCRIPTION
## What

Fixes in `test/lib/cql_test_env.cc`:

1. **Wrong scheduling group (bug).** `single_node_cql_env` assigned the **streaming** scheduling group to `debug::gossip_scheduling_group`:

   ```cpp
   debug::gossip_scheduling_group = scheduling_groups.streaming_scheduling_group; // wrong
   ```

   `get_scheduling_groups()` already creates a dedicated `gossip_scheduling_group` (and `dbcfg.gossip_scheduling_group` is set from it a few lines later). With the wrong assignment, `check_raft_rpc_scheduling_group()` in `service/storage_service.cc` — which asserts that Raft group0 RPCs run in the gossip scheduling group — compared `current_scheduling_group()` against the **streaming** group under tests. Now it assigns the gossip group, matching production (`main.cc`).

2. **Comment typo:** `aliva` → `alive`.
3. **Comment typo:** `gropu0` → `group0`.

## Why

The scheduling-group mix-up meant the test environment did not faithfully reproduce the production scheduling-group setup for Raft group0 RPC verification, so `check_raft_rpc_scheduling_group()` could pass/fail against the wrong group in tests.

## Test

- Dev build of `test/boost/combined_tests` (recompiles `cql_test_env.cc`).
- Ran `./test.py --mode=dev test/boost/aggregate_fcts_test.cc` → **7 passed**. This exercises full `cql_test_env` startup, including the corrected scheduling-group assignment and group0 client setup.

Backport: yes, worth backporting - correctness fix for test.
