### PR TITLE
transport: support reclassifying a misbehaving control connection

### DIFF
--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -116,6 +116,18 @@ public:
         return false;
     }
 
+    // A driver's control connection runs in a dedicated scheduling group and is
+    // only meant to issue the system queries the driver needs to manage itself,
+    // never user load. Returns true when executing this statement means the
+    // connection is being misused for user load, so the CQL server can reclassify
+    // it as a regular user connection and stop using the driver scheduling group.
+    //
+    // There is deliberately no default implementation: every statement type must
+    // classify itself, so a newly introduced statement cannot silently fall
+    // through with the wrong classification. Intermediate classes may implement it
+    // once on behalf of all their sub-classes.
+    virtual bool should_reclassify_control_connection() const = 0;
+
     audit::audit_info* get_audit_info() { return _audit_info.get(); }
     void set_audit_info(audit::audit_info_ptr&& info) { _audit_info = std::move(info); }
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -630,6 +630,11 @@ query_processor::execute_direct_without_checking_exception_message(utils::chunke
     log.trace("execute_direct: \"{}\"", query_string);
     tracing::trace(query_state.get_trace_state(), "Parsing a statement");
     auto p = get_statement(query_string, query_state.get_client_state(), d);
+    return execute_direct_statement_without_checking_exception_message(std::move(p), query_state, options);
+}
+
+future<::shared_ptr<result_message>>
+query_processor::execute_direct_statement_without_checking_exception_message(std::unique_ptr<statements::prepared_statement> p, service::query_state& query_state, query_options& options) {
     auto statement = p->statement;
     if (statement->get_bound_terms() != options.get_values_count()) {
         const auto msg = format("Invalid amount of bind variables: expected {:d} received {:d}",

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -330,6 +330,15 @@ public:
             dialect d,
             query_options& options);
 
+    // Like execute_direct_without_checking_exception_message, but takes an already
+    // prepared statement. The CQL server prepares the statement before calling this
+    // so it can inspect it (e.g. to reclassify a control connection running user load).
+    future<::shared_ptr<cql_transport::messages::result_message>>
+    execute_direct_statement_without_checking_exception_message(
+            std::unique_ptr<statements::prepared_statement> statement,
+            service::query_state& query_state,
+            query_options& options);
+
     future<::shared_ptr<cql_transport::messages::result_message>>
     do_execute_direct(
             service::query_state& query_state,

--- a/cql3/statements/authentication_statement.hh
+++ b/cql3/statements/authentication_statement.hh
@@ -25,6 +25,11 @@ public:
 
     bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
+    // Manages roles/authentication, not user data.
+    bool should_reclassify_control_connection() const override {
+        return false;
+    }
+
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
 protected:
     virtual audit::statement_category category() const override;

--- a/cql3/statements/authorization_statement.hh
+++ b/cql3/statements/authorization_statement.hh
@@ -29,6 +29,11 @@ public:
 
     bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
+    // Manages permissions, not user data.
+    bool should_reclassify_control_connection() const override {
+        return false;
+    }
+
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
 protected:

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -99,6 +99,12 @@ public:
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
+    // A control connection never has a legitimate reason to run a batch, so any
+    // batch arriving on one means it is being used for user load.
+    bool should_reclassify_control_connection() const override {
+        return true;
+    }
+
     virtual uint32_t get_bound_terms() const override;
 
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;

--- a/cql3/statements/broadcast_modification_statement.hh
+++ b/cql3/statements/broadcast_modification_statement.hh
@@ -46,6 +46,11 @@ public:
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+
+    // Operates only on the internal broadcast table, never on user data.
+    bool should_reclassify_control_connection() const override {
+        return false;
+    }
 };
 
 

--- a/cql3/statements/describe_statement.hh
+++ b/cql3/statements/describe_statement.hh
@@ -54,6 +54,11 @@ public:
     virtual seastar::future<> check_access(query_processor& qp, const service::client_state& state) const override;
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
 
+    // DESCRIBE only introspects schema metadata, it is not user load.
+    bool should_reclassify_control_connection() const override {
+        return false;
+    }
+
     virtual seastar::future<seastar::shared_ptr<cql_transport::messages::result_message>>
     execute(cql3::query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 };

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -80,6 +80,12 @@ const sstring& modification_statement::keyspace() const {
     return s->ks_name();
 }
 
+bool modification_statement::should_reclassify_control_connection() const {
+    // A control connection legitimately writes only to system tables; writing any
+    // other keyspace means it is being used for user load.
+    return _ks_sel == ks_selector::NONSYSTEM;
+}
+
 const sstring& modification_statement::column_family() const {
     return s->cf_name();
 }

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -143,6 +143,8 @@ public:
 
     bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
+    bool should_reclassify_control_connection() const override;
+
     void add_operation(std::unique_ptr<operation> op);
 
     void inc_cql_stats(bool is_internal) const;

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -55,6 +55,11 @@ protected:
 
     virtual audit::statement_category category() const override;
 
+    // DDL manages schema objects, it is not a user load reclassification target.
+    bool should_reclassify_control_connection() const override {
+        return false;
+    }
+
 public:
     /**
      * When a new data_dictionary::database object (keyspace, table) is created, the creator needs to be granted all applicable

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -302,6 +302,12 @@ const sstring& select_statement::keyspace() const {
     return _schema->ks_name();
 }
 
+bool select_statement::should_reclassify_control_connection() const {
+    // A control connection legitimately reads system tables; reading any other
+    // keyspace means it is being used for user load.
+    return _ks_sel == ks_selector::NONSYSTEM;
+}
+
 const sstring& select_statement::column_family() const {
     return _schema->cf_name();
 }

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -125,6 +125,8 @@ public:
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
+    virtual bool should_reclassify_control_connection() const override;
+
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor& qp,
         service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 

--- a/cql3/statements/service_level_statement.hh
+++ b/cql3/statements/service_level_statement.hh
@@ -49,6 +49,11 @@ public:
 
     bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
+    // Manages service levels, not user data.
+    bool should_reclassify_control_connection() const override {
+        return false;
+    }
+
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
 protected:
     virtual audit::statement_category category() const override;

--- a/cql3/statements/strong_consistency/modification_statement.hh
+++ b/cql3/statements/strong_consistency/modification_statement.hh
@@ -34,6 +34,12 @@ public:
     uint32_t get_bound_terms() const override;
 
     bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
+
+    // Wraps a regular modification, so it carries user load exactly when the
+    // wrapped statement does.
+    bool should_reclassify_control_connection() const override {
+        return _statement->should_reclassify_control_connection();
+    }
 };
 
 }

--- a/cql3/statements/truncate_statement.hh
+++ b/cql3/statements/truncate_statement.hh
@@ -35,6 +35,12 @@ public:
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
+    // TRUNCATE is an administrative operation a driver never runs on its control
+    // connection, so we should reclassify on it.
+    bool should_reclassify_control_connection() const override {
+        return true;
+    }
+
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
     virtual void validate(query_processor&, const service::client_state& state) const override;

--- a/cql3/statements/use_statement.hh
+++ b/cql3/statements/use_statement.hh
@@ -30,6 +30,11 @@ public:
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
+    // Only selects the active keyspace, it does not touch user data.
+    bool should_reclassify_control_connection() const override {
+        return false;
+    }
+
     virtual seastar::future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
     virtual seastar::future<seastar::shared_ptr<cql_transport::messages::result_message>>

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -88,6 +88,7 @@ private:
             : _keyspace(cs->_keyspace)
             , _user(cs->_user)
             , _auth_state(cs->_auth_state)
+            , _user_connection(cs->_user_connection)
             , _is_internal(cs->_is_internal)
             , _bypass_auth_checks(cs->_bypass_auth_checks)
             , _remote_address(cs->_remote_address)
@@ -129,7 +130,18 @@ private:
 	std::list<client_option_key_value_cached_entry> _client_options;
 
     auth_state _auth_state = auth_state::UNINITIALIZED;
-    bool _control_connection = false;
+    // A connection is treated as a driver control connection by default: it is
+    // meant to issue only the system queries a driver needs to manage itself.
+    // Once it is observed running user (non-system) load it is multiplexed with
+    // user load by the driver and is reclassified as a regular user connection.
+    // The reclassification is sticky so the connection is never turned back into
+    // a control connection. Whether a non-reclassified connection actually runs
+    // in the driver scheduling group additionally depends on sl:driver existing.
+    bool _user_connection = false;
+    // Set together with _user_connection and cleared once the CQL server has
+    // switched the connection to the user scheduling group, so the switch happens
+    // exactly once.
+    bool _reclassification_pending = false;
 
     // isInternal is used to mark ClientState as used by some internal component
     // that should have an ability to modify system keyspace.
@@ -177,12 +189,21 @@ public:
         _auth_state = new_state;
     }
 
-    bool is_control_connection() const noexcept {
-        return _control_connection;
+    bool is_user_connection() const noexcept {
+        return _user_connection;
     }
 
-    bool set_control_connection() noexcept {
-        return _control_connection = true;
+    void reclassify_as_user_connection() noexcept {
+        _user_connection = true;
+        _reclassification_pending = true;
+    }
+
+    bool needs_scheduling_group_reclassification() const noexcept {
+        return _reclassification_pending;
+    }
+
+    void mark_reclassification_applied() noexcept {
+        _reclassification_pending = false;
     }
 
     std::optional<client_options_cache_entry_type> get_driver_name() const {

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -534,6 +534,9 @@ future<>  service_level_controller::notify_service_level_added(sstring name, ser
             unsigned sl_idx = internal::scheduling_group_index(sl_data.sg);
             _sl_lookup[sl_idx].first = &(result.first->first);
             _sl_lookup[sl_idx].second = &(result.first->second);
+            if (name == driver_service_level_name) {
+                _driver_scheduling_group = sl_data.sg;
+            }
             register_metrics();
         }
     });
@@ -588,6 +591,9 @@ future<> service_level_controller::notify_service_level_removed(sstring name) {
             .sg = sl_it->second.sg,
         };
         _service_levels_db.erase(sl_it);
+        if (name == driver_service_level_name) {
+            _driver_scheduling_group = std::nullopt;
+        }
         register_metrics();
         co_return co_await seastar::async( [this, name, sl_info] {
             _subscribers.thread_for_each([name, sl_info] (qos_configuration_change_subscriber* subscriber) {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -210,6 +210,7 @@ private:
     std::pair<const sstring*, service_level*> _sl_lookup[max_scheduling_groups()];
     service_level _default_service_level;
     seastar::metrics::metric_groups _metrics;
+    std::optional<scheduling_group> _driver_scheduling_group = std::nullopt;
     service_level_distributed_data_accessor_ptr _sl_data_accessor;
     sharded<auth::service>& _auth_service;
     locator::shared_token_metadata& _token_metadata;
@@ -319,6 +320,9 @@ public:
      * get_scheduling_group("default")
      */
     scheduling_group get_scheduling_group(sstring service_level_name);
+    std::optional<scheduling_group> get_driver_scheduling_group() const noexcept {
+        return _driver_scheduling_group;
+    }
     /**
      * Get the scheduling group of a specific user for the service level cache
      * @param user - the user for determining the service level

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -158,9 +158,9 @@ public:
                         ? *maybe_sl_opts->shares_name
                         : service_level_controller::default_service_level_name;
 
-                co_return co_await _sl_controller.with_service_level(sl_name, std::forward<Func>(func));
+                return _sl_controller.with_service_level(sl_name, std::forward<Func>(func));
             } else {
-                co_return co_await _sl_controller.with_service_level(service_level_controller::default_service_level_name, std::forward<Func>(func));
+                return _sl_controller.with_service_level(service_level_controller::default_service_level_name, std::forward<Func>(func));
             }
         }
 

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -16,8 +16,8 @@ from test.cluster.util import trigger_snapshot, reconnect_driver, \
         find_server_by_host_id
 from test.cqlpy.test_service_levels import MAX_USER_SERVICE_LEVELS
 from cassandra import ConsistencyLevel
-from cassandra.query import SimpleStatement
-from cassandra.protocol import InvalidRequest, QueryMessage
+from cassandra.query import SimpleStatement, BatchType
+from cassandra.protocol import InvalidRequest, QueryMessage, PrepareMessage, ExecuteMessage, BatchMessage
 from cassandra.auth import PlainTextAuthProvider
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
@@ -499,6 +499,114 @@ async def test_driver_service_level_used_for_driver_queries(manager: ManagerClie
     await cql.run_async(f"CREATE SERVICE LEVEL driver", host=h)
     cql, func = await get_control_connection_query_function(manager)
     await _verify_requests_count_metrics(manager, server, 'sl:driver', 'sl:test', func)
+
+# Some drivers multiplex the control connection with user load, which would leak
+# user queries into sl:driver. Verify that issuing a user statement on the control
+# connection permanently reclassifies it as a regular user connection, regardless
+# of whether the statement arrives as a read or write QUERY, an EXECUTE or a BATCH.
+# Reproduces SCYLLADB-2458.
+async def test_control_connection_reclassified_by_user_load(manager: ManagerClient) -> None:
+    server = await manager.server_add(config=auth_config)
+
+    cql = manager.get_cql()
+    [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+
+    await cql.run_async("CREATE KEYSPACE demo WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}", host=h)
+    await cql.run_async("CREATE TABLE demo.events (id int PRIMARY KEY, payload text)", host=h)
+
+    def query_trigger(control_connection):
+        control_connection.wait_for_response(QueryMessage("SELECT * FROM demo.events", ConsistencyLevel.ONE))
+
+    def execute_trigger(control_connection):
+        prepared = control_connection.wait_for_response(PrepareMessage("SELECT * FROM demo.events"))
+        control_connection.wait_for_response(ExecuteMessage(prepared.query_id, [], ConsistencyLevel.ONE,
+            result_metadata_id=getattr(prepared, "result_metadata_id", None)))
+
+    def batch_trigger(control_connection):
+        control_connection.wait_for_response(BatchMessage(BatchType.LOGGED,
+            [(False, "INSERT INTO demo.events (id, payload) VALUES (1, 'x')", [])], ConsistencyLevel.ONE))
+
+    def insert_trigger(control_connection):
+        control_connection.wait_for_response(QueryMessage(
+            "INSERT INTO demo.events (id, payload) VALUES (2, 'y')", ConsistencyLevel.ONE))
+
+    # Each statement kind that can leak user load onto a control connection must
+    # reclassify it on its own. A single (non-batch) write and a BATCH take
+    # different code paths, so both are exercised here. Reuse a single cluster and
+    # open a fresh control connection per trigger.
+    for trigger in (query_trigger, execute_trigger, batch_trigger, insert_trigger):
+        await manager.driver_connect() # restart control connection
+        cql = manager.get_cql()
+        control_connection = cql.cluster.control_connection._connection
+
+        logger.info("A fresh control connection serves driver queries in sl:driver")
+        system_query = QueryMessage("SELECT * FROM system.peers", 1)
+        system_func = lambda: control_connection.wait_for_response(system_query)
+        await _verify_requests_count_metrics(manager, server, 'sl:driver', 'sl:default', system_func)
+
+        logger.info("Issuing a user statement on the control connection reclassifies it")
+        await asyncio.to_thread(trigger, control_connection)
+
+        logger.info("The reclassified connection serves further queries in sl:default, not sl:driver")
+        await _verify_requests_count_metrics(manager, server, 'sl:default', 'sl:driver', system_func)
+
+# A well-behaved driver only ever queries system tables on its control connection.
+# Run the queries that the ScyllaDB-supported drivers send on theirs (see
+# https://docs.scylladb.com/stable/versioning/driver-support.html) and verify the
+# connection keeps running in sl:driver - none of them must trigger a reclassification.
+async def test_control_connection_not_reclassified_by_driver_queries(manager: ManagerClient) -> None:
+    server = await manager.server_add(config=auth_config)
+
+    cql = manager.get_cql()
+    [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+    await manager.driver_connect() # restart control connection
+    cql = manager.get_cql()
+    control_connection = cql.cluster.control_connection._connection
+
+    control_connection_queries = [
+        # Local node metadata, read by every supported driver (Python, Java, Go,
+        # Rust, C#, CPP-RS, Node.js) right after opening the control connection.
+        "SELECT * FROM system.local WHERE key='local'",
+        # Peer/topology discovery, read by every supported driver. ScyllaDB has no
+        # system.peers_v2, so all drivers fall back to system.peers.
+        "SELECT * FROM system.peers",
+        # Keyspace metadata, read by every schema-aware driver (Python, Java, Go,
+        # Rust, C#, Node.js).
+        "SELECT * FROM system_schema.keyspaces",
+        # Table metadata, read by every schema-aware driver (Python, Java, Go,
+        # Rust, C#, Node.js).
+        "SELECT * FROM system_schema.tables",
+        # Column metadata, read by every schema-aware driver (Python, Java, Go,
+        # Rust, C#, Node.js).
+        "SELECT * FROM system_schema.columns",
+        # User-defined type metadata (Python, Java, Go, Rust, C#).
+        "SELECT * FROM system_schema.types",
+        # User-defined function metadata (Python, Java, C#).
+        "SELECT * FROM system_schema.functions",
+        # User-defined aggregate metadata (Python, Java, C#).
+        "SELECT * FROM system_schema.aggregates",
+        # Materialized view metadata (Python, Java, Go, C#).
+        "SELECT * FROM system_schema.views",
+        # Secondary index metadata (Python, Java, Go, C#).
+        "SELECT * FROM system_schema.indexes",
+        # Token-range size estimates, read by the Go driver (gocql) for token-aware
+        # range planning.
+        "SELECT * FROM system.size_estimates",
+    ]
+
+    def run_control_connection_queries():
+        for query in control_connection_queries:
+            control_connection.wait_for_response(QueryMessage(query, ConsistencyLevel.ONE))
+
+    logger.info("Running the queries that supported drivers send on the control connection")
+    await asyncio.to_thread(run_control_connection_queries)
+
+    logger.info("The control connection still serves driver queries in sl:driver")
+    system_query = QueryMessage("SELECT * FROM system.peers", 1)
+    system_func = lambda: control_connection.wait_for_response(system_query)
+    await _verify_requests_count_metrics(manager, server, 'sl:driver', 'sl:default', system_func)
 
 # Reproduces scylladb/scylladb#26040
 async def test_anonymous_user(manager: ManagerClient) -> None:

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -457,13 +457,19 @@ async def test_driver_service_level_not_used_for_user_queries(manager: ManagerCl
     [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
-    func = lambda: cql.execute(f"SELECT * from system.peers")
+    await cql.run_async("CREATE KEYSPACE demo WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}", host=h)
+    await cql.run_async("CREATE TABLE demo.events (id int PRIMARY KEY)", host=h)
+
+    # A connection starts in sl:driver and is reclassified to the user's service
+    # level the moment it runs user load, so querying a user table moves it out of
+    # sl:driver into sl:default.
+    func = lambda: cql.execute("SELECT * from demo.events")
     await _verify_requests_count_metrics(manager, server, 'sl:default', 'sl:driver', func)
 
     await cql.run_async(f"CREATE SERVICE LEVEL test", host=h)
     await cql.run_async(f"ATTACH SERVICE LEVEL test TO cassandra", host=h)
 
-    func = lambda: cql.execute(f"SELECT * from system.peers")
+    func = lambda: cql.execute("SELECT * from demo.events")
     await _verify_requests_count_metrics(manager, server, 'sl:test', 'sl:driver', func)
 
 async def test_driver_service_level_used_for_driver_queries(manager: ManagerClient) -> None:
@@ -501,23 +507,33 @@ async def test_anonymous_user(manager: ManagerClient) -> None:
     cql = manager.get_cql()
     [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
 
-    async def connections_ready():
+    # Every connection starts in sl:driver and only moves to its user scheduling
+    # group once it runs user (non-system) load. Run a query on a user table so
+    # the anonymous user's connection is reclassified to sl:default - without it
+    # the connection would stay in sl:driver and never expose the #26040 bug,
+    # where sl:default was previously confused with the main scheduling group.
+    await cql.run_async("CREATE KEYSPACE demo WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+    await cql.run_async("CREATE TABLE demo.events (id int PRIMARY KEY)")
+    for _ in range(10):
+        await cql.run_async("SELECT * FROM demo.events")
+
+    async def anonymous_connection_uses_sl_default():
         rows = list(cql.execute("SELECT connection_stage, username, scheduling_group FROM system.clients"))
         if len(rows) == 0:
             return None
+        if any(row.connection_stage != "READY" for row in rows):
+            return None
         for row in rows:
-            if row.connection_stage != "READY":
-                return None
-        return rows
+            assert row.username == 'anonymous'
+            assert row.scheduling_group in ['sl:default', 'sl:driver']
+        if any(row.scheduling_group == 'sl:default' for row in rows):
+            return rows
+        return None
 
-    rows = await wait_for(connections_ready, time.time() + 60)
-    for r in rows:
-        assert r.username == 'anonymous'
-        assert r.scheduling_group in ['sl:default', 'sl:driver']
-        if r.scheduling_group == 'sl:default':
-            return
-
-    assert False, f"None of clients use sl:default, rows={rows}"
+    # Retry: the user-table load above reclassifies a connection to sl:default,
+    # but the switch takes effect only after the triggering query finishes, so
+    # system.clients may briefly still report the old group.
+    await wait_for(anonymous_connection_uses_sl_default, time.time() + 60)
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_per_service_level_cql_requests_serving(manager: ManagerClient) -> None:
@@ -540,6 +556,21 @@ async def test_per_service_level_cql_requests_serving(manager: ManagerClient) ->
     await cql.run_async(f"CREATE ROLE user_a WITH PASSWORD = 'pass_a' AND LOGIN = true")
     await cql.run_async(f"ATTACH SERVICE LEVEL {sl_a} TO user_a")
 
+    # Drop sl:driver to make all connections start directly in their user
+    # service level (sl:sl_a or sl:default), avoiding the connection-pool
+    # warm-up race where some pooled connections remain in sl:driver.
+    await cql.run_async("DROP SERVICE LEVEL driver")
+
+    # Wait for the drop to propagate: poll until a probe connection no longer
+    # reports any user as being in sl:driver.
+    async def driver_sl_dropped():
+        clients = await cql.run_async("SELECT scheduling_group FROM system.clients")
+        for row in clients:
+            if 'sl:driver' in row.scheduling_group:
+                return None  # Still have sl:driver connections, retry
+        return True  # All connections are out of sl:driver
+    await wait_for(driver_sl_dropped, deadline=time.time() + 10, period=0.5)
+
     # Open dedicated driver sessions for user_a and the cassandra superuser.
     # Disable schema and token metadata refresh on both to prevent background
     # driver queries from interfering with the error injection and metrics.
@@ -556,12 +587,6 @@ async def test_per_service_level_cql_requests_serving(manager: ManagerClient) ->
     session_default = cluster_default.connect()
 
     try:
-        # Warm up both sessions to ensure the driver has established connections
-        # before enabling injection. Without this, execute() may fail with
-        # NoHostAvailable and the query never reaches the server.
-        session_a.execute("SELECT key FROM system.local")
-        session_default.execute("SELECT key FROM system.local")
-
         # Enable error injection to pause CQL requests.
         await manager.api.enable_injection(server.ip_addr, "transport_cql_request_pause", False)
 
@@ -645,6 +670,20 @@ async def test_per_service_level_cql_request_latency_histogram(manager: ManagerC
     await cql.run_async(f"CREATE ROLE user_a WITH PASSWORD = 'pass_a' AND LOGIN = true")
     await cql.run_async(f"ATTACH SERVICE LEVEL {sl_a} TO user_a")
 
+    # Drop sl:driver to make all connections start directly in their user
+    # service level (sl:sl_a), avoiding the connection-pool warm-up race
+    # where some pooled connections remain in sl:driver.
+    await cql.run_async("DROP SERVICE LEVEL driver")
+
+    # Wait for the drop to propagate.
+    async def driver_sl_dropped():
+        clients = await cql.run_async("SELECT scheduling_group FROM system.clients")
+        for row in clients:
+            if 'sl:driver' in row.scheduling_group:
+                return None
+        return True
+    await wait_for(driver_sl_dropped, deadline=time.time() + 10, period=0.5)
+
     cluster_a = manager.con_gen([server.ip_addr],
         manager.port, manager.use_ssl, PlainTextAuthProvider(username='user_a', password='pass_a'))
     cluster_a.schema_metadata_enabled = False
@@ -658,10 +697,6 @@ async def test_per_service_level_cql_request_latency_histogram(manager: ManagerC
         return 0 if value is None else value
 
     try:
-        # Warm up the session before enabling the injection, so the paused query
-        # is not mixed with connection initialization.
-        session_a.execute("SELECT key FROM system.local")
-
         metrics = await manager.metrics.query(server.ip_addr)
         baseline_count = metric_value(metrics, "count")
         baseline_sum = metric_value(metrics, "sum")
@@ -669,7 +704,7 @@ async def test_per_service_level_cql_request_latency_histogram(manager: ManagerC
         await manager.api.enable_injection(server.ip_addr, "transport_cql_request_pause", False)
         log = await manager.server_open_log(server.server_id)
         mark = await log.mark()
-        query_task = asyncio.ensure_future(asyncio.to_thread(session_a.execute, "SELECT key FROM system.local"))
+        query_task = asyncio.ensure_future(asyncio.to_thread(session_a.execute, "SELECT * FROM system.local"))
         await log.wait_for("transport_cql_request_pause: waiting for message", from_mark=mark)
 
         metrics = await manager.metrics.query(server.ip_addr)

--- a/test/cqlpy/test_service_level_api.py
+++ b/test/cqlpy/test_service_level_api.py
@@ -8,8 +8,10 @@
 ########################################
 
 import pytest
+from cassandra import ConsistencyLevel
+from cassandra.protocol import QueryMessage
 from .rest_api import get_request, post_request
-from .util import new_session, unique_name
+from .util import new_session, new_test_table, unique_name
 import time
 
 # All tests in this file check the Scylla-only service levels feature,
@@ -71,41 +73,73 @@ def wait_until_all_connections_authenticated(cql, wait_s = 1, timeout_s = 30):
     raise RuntimeError(f"Awaiting for connections authentication timed out.")
 
 # The driver creates 1 connection per shard plus 1 control connection.
-# This function validates that all connections execept the control one use correct scheduling group.
-def verify_scheduling_group_assignment(cql, user, target_scheduling_group, shard_count):
+# This function returns the set of shards whose per-shard connection of `user`
+# runs under `target_scheduling_group`.
+def shards_in_scheduling_group(cql, user, target_scheduling_group):
     shards_with_correct_sg = set()
     connections = cql.execute(f"SELECT username, scheduling_group, shard_id FROM system.clients WHERE client_type='cql' AND username='{user}' ALLOW FILTERING")
 
     for conn in connections:
         if target_scheduling_group in conn.scheduling_group:
             shards_with_correct_sg.add(conn.shard_id)
-    
-    assert len(shards_with_correct_sg) == shard_count, (f"Not all user '{user}' connections are working under target scheduling group '{target_scheduling_group}'."
-                                                        f"Shards with correct scehduling group: {shards_with_correct_sg}, shard")
+
+    return shards_with_correct_sg
+
+# A connection starts in sl:driver and is reclassified to its user's service level
+# only once it runs user (non-system) load. Send a user-table query on every
+# per-shard connection of `session` so each of them gets reclassified.
+def reclassify_user_connections(session, user_table):
+    query = QueryMessage(f"SELECT * FROM {user_table}", ConsistencyLevel.ONE)
+    for pool in list(session._pools.values()):
+        for conn in list(pool._connections.values()):
+            conn.wait_for_response(query)
+
+# The scheduling-group switch takes effect only after the query that triggered the
+# reclassification finishes, so system.clients may briefly still report sl:driver.
+# Re-trigger reclassification and poll until all per-shard connections of `user`
+# run under `target_scheduling_group`.
+def wait_for_scheduling_group_assignment(cql, session, user, user_table, target_scheduling_group, shard_count, wait_s = 1, timeout_s = 30):
+    start_time = time.time()
+    shards_with_correct_sg = set()
+    while time.time() - start_time < timeout_s:
+        reclassify_user_connections(session, user_table)
+        shards_with_correct_sg = shards_in_scheduling_group(cql, user, target_scheduling_group)
+        if len(shards_with_correct_sg) == shard_count:
+            return
+        time.sleep(wait_s)
+
+    raise RuntimeError(f"Not all user '{user}' connections are working under target scheduling group "
+                       f"'{target_scheduling_group}'. Shards with correct scheduling group: {shards_with_correct_sg}, "
+                       f"expected {shard_count} shards.")
 
 # Test if `/service_levels/count_connections` prints counted CQL connections
 # per scheduling group per user.
-def test_count_opened_cql_connections(cql):
+def test_count_opened_cql_connections(cql, test_keyspace):
     user = f"test_user_{unique_name()}"
     sl = f"sl_{unique_name()}"
 
     cql.execute(f"CREATE ROLE {user} WITH login = true AND password='{user}'")
     cql.execute(f"CREATE SERVICE LEVEL {sl} WITH shares = 100")
     cql.execute(f"ATTACH SERVICE LEVEL {sl} TO {user}")
-    read_barrier(cql)
 
     try:
-        with new_session(cql, user):
-            wait_for_clients(cql, user, 3) # 3 from smp=2 + control connection
-            wait_until_all_connections_authenticated(cql)
-            verify_scheduling_group_assignment(cql, user, sl, get_shard_count(cql))
+        with new_test_table(cql, test_keyspace, "id int PRIMARY KEY") as user_table:
+            cql.execute(f"GRANT SELECT ON {user_table} TO {user}")
+            read_barrier(cql)
 
-            api_response = count_opened_connections(cql)
-            assert f"sl:{sl}" in api_response
-            assert user in api_response[f"sl:{sl}"]
+            with new_session(cql, user) as session:
+                wait_for_clients(cql, user, 3) # 3 from smp=2 + control connection
+                wait_until_all_connections_authenticated(cql)
+                # The connections start in sl:driver and only move to sl:{sl} once
+                # they run user load, so issue a user-table query on each of them.
+                wait_for_scheduling_group_assignment(cql, session, user, user_table, sl, get_shard_count(cql))
 
-            table_response = count_opened_connections_from_table(cql)
-            assert api_response == table_response
+                api_response = count_opened_connections(cql)
+                assert f"sl:{sl}" in api_response
+                assert user in api_response[f"sl:{sl}"]
+
+                table_response = count_opened_connections_from_table(cql)
+                assert api_response == table_response
     finally:
         cql.execute(f"DETACH SERVICE LEVEL FROM {user}")
         cql.execute(f"DROP ROLE {user}")

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1344,6 +1344,7 @@ future<> cql_server::connection::process_request() {
                     clogger.error("{}: request processing failed: {}",
                                   _client_state.get_remote_address(), std::current_exception());
                 }
+                maybe_update_scheduling_group_after_reclassification();
             });
 
             if (should_paralelize) {
@@ -1517,10 +1518,17 @@ void cql_server::connection::update_control_connection_scheduling_group() {
 }
 
 void cql_server::connection::update_scheduling_group() {
-    if (_client_state.is_control_connection()) {
+    if (!_client_state.is_user_connection() && _server._sl_controller.get_driver_scheduling_group()) {
         update_control_connection_scheduling_group();
     } else {
         update_user_scheduling_group(_client_state.user());
+    }
+}
+
+void cql_server::connection::maybe_update_scheduling_group_after_reclassification() {
+    if (_client_state.needs_scheduling_group_reclassification()) {
+        _client_state.mark_reclassification_applied();
+        update_scheduling_group();
     }
 }
 
@@ -1576,6 +1584,25 @@ static void record_client_timestamp_drift(cql_sg_stats& sg_stats, bool init_trac
     sg_stats._client_timestamp_drift.add_micro(drift);
 }
 
+// Runs user statements under the user service level. The connection's scheduling
+// group is only re-evaluated after the request finishes, and the connection loop
+// may already be waiting for the next frame under the old tenant. Keep wrapping
+// requests after reclassification so a stale sl:driver tenant cannot leak into a
+// reclassified connection's paged requests.
+static bool reclassifying_control_connection_needs_user_service_level(
+        const cql3::cql_statement& statement, service::query_state& query_state) {
+    auto& client_state = query_state.get_client_state();
+    if (!client_state.is_user_connection()) {
+        if (client_state.is_internal() || !statement.should_reclassify_control_connection()) {
+            return false;
+        }
+        client_state.reclassify_as_user_connection();
+    }
+
+    const auto driver_sg = query_state.get_service_level_controller().get_driver_scheduling_group();
+    return driver_sg && driver_sg->active();
+}
+
 static future<cql_server::process_fn_return_type>
 process_query_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
@@ -1608,7 +1635,16 @@ process_query_internal(service::client_state& client_state, sharded<cql3::query_
         tracing::begin(trace_state, "Execute CQL3 query", client_state.get_client_address());
     }
 
-    return qp.local().execute_direct_without_checking_exception_message(query.assume_value(), query_state, dialect, options).then([q_state = std::move(q_state), stream, skip_metadata, version] (auto msg) {
+    tracing::trace(trace_state, "Parsing a statement");
+    auto prepared = qp.local().get_statement(query.assume_value(), client_state, dialect);
+    auto& statement = *prepared->statement;
+    auto execute_fut = reclassifying_control_connection_needs_user_service_level(statement, query_state)
+            ? query_state.get_service_level_controller().with_user_service_level(query_state.get_client_state().user(),
+                    [&qp, &query_state, &options, prepared = std::move(prepared)] () mutable {
+                return qp.local().execute_direct_statement_without_checking_exception_message(std::move(prepared), query_state, options);
+            })
+            : qp.local().execute_direct_statement_without_checking_exception_message(std::move(prepared), query_state, options);
+    return std::move(execute_fut).then([q_state = std::move(q_state), stream, skip_metadata, version] (auto msg) {
         if (msg->as_bounce()) {
             return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {
@@ -1726,8 +1762,14 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
     }
 
     tracing::trace(trace_state, "Processing a statement");
-    return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization)
-            .then([trace_state = query_state.get_trace_state(), skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id)] (auto msg) mutable {
+    auto& statement = *stmt;
+    auto execute_fut = reclassifying_control_connection_needs_user_service_level(statement, query_state)
+            ? query_state.get_service_level_controller().with_user_service_level(query_state.get_client_state().user(),
+                    [&qp, &query_state, &options, stmt = std::move(stmt), prepared = std::move(prepared), cache_key = std::move(cache_key), needs_authorization] () mutable {
+                return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
+            })
+            : qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
+    return std::move(execute_fut).then([trace_state = query_state.get_trace_state(), skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id)] (auto msg) mutable {
         if (msg->as_bounce()) {
             return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {
@@ -1867,8 +1909,13 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
 
     auto batch = ::make_shared<cql3::statements::batch_statement>(cql3::statements::batch_statement::type(type.assume_value()), std::move(modifications), cql3::attributes::none(), qp.local().get_cql_stats());
     batch->set_audit_info(batch->audit_info());
-    return qp.local().execute_batch_without_checking_exception_message(batch, query_state, options, std::move(pending_authorization_entries))
-            .then([stream, batch, q_state = std::move(q_state), trace_state = query_state.get_trace_state(), version] (auto msg) {
+    auto execute_fut = reclassifying_control_connection_needs_user_service_level(*batch, query_state)
+            ? query_state.get_service_level_controller().with_user_service_level(query_state.get_client_state().user(),
+                    [&qp, &query_state, &options, batch, pending_authorization_entries = std::move(pending_authorization_entries)] () mutable {
+                return qp.local().execute_batch_without_checking_exception_message(batch, query_state, options, std::move(pending_authorization_entries));
+            })
+            : qp.local().execute_batch_without_checking_exception_message(batch, query_state, options, std::move(pending_authorization_entries));
+    return std::move(execute_fut).then([stream, batch, q_state = std::move(q_state), trace_state = query_state.get_trace_state(), version] (auto msg) {
         if (msg->as_bounce()) {
             return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {
@@ -1983,13 +2030,6 @@ future<std::unique_ptr<cql_server::response>>
 cql_server::connection::process_register(uint16_t stream, request_reader in, service::client_state& client_state,
         tracing::trace_state_ptr trace_state) {
     using ret_type = std::unique_ptr<cql_server::response>;
-
-    if (!_client_state.is_control_connection()) {
-        if (_server._sl_controller.has_service_level(qos::service_level_controller::driver_service_level_name)) {
-            _client_state.set_control_connection();
-            update_scheduling_group();
-        }
-    }
 
     std::vector<sstring> event_types;
     auto sl = in.read_string_list(event_types);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1509,7 +1509,7 @@ void cql_server::connection::update_user_scheduling_group(const std::optional<au
 }
 
 void cql_server::connection::update_control_connection_scheduling_group() {
-    auto shg_grp = _server._sl_controller.get_scheduling_group(qos::service_level_controller::driver_service_level_name);
+    auto shg_grp = _server._sl_controller.get_driver_scheduling_group().value_or(_server._sl_controller.get_default_scheduling_group());
     _current_scheduling_group = shg_grp;
     switch_tenant([this] (this auto self, noncopyable_function<future<> ()> process_loop) -> future<> {
         co_return co_await _server._sl_controller.with_service_level(qos::service_level_controller::driver_service_level_name, std::move(process_loop));

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -341,6 +341,7 @@ private:
         client_data make_client_data() const;
         const service::client_state& get_client_state() const { return _client_state; }
         void update_scheduling_group();
+        void maybe_update_scheduling_group_after_reclassification();
         service::client_state& get_client_state() { return _client_state; }
         scheduling_group get_scheduling_group() const { return _current_scheduling_group; }
     private:
@@ -398,8 +399,8 @@ private:
 
     virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override;
     scheduling_group get_scheduling_group_for_new_connection() const override {
-        if (_sl_controller.get_driver_scheduling_group()) {
-            return *_sl_controller.get_driver_scheduling_group();
+        if (auto sg = _sl_controller.get_driver_scheduling_group(); sg) {
+            return *sg;
         }
         return default_scheduling_group();
     }

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -398,8 +398,8 @@ private:
 
     virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override;
     scheduling_group get_scheduling_group_for_new_connection() const override {
-        if (_sl_controller.has_service_level(qos::service_level_controller::driver_service_level_name)) {
-            return _sl_controller.get_scheduling_group(qos::service_level_controller::driver_service_level_name);
+        if (_sl_controller.get_driver_scheduling_group()) {
+            return *_sl_controller.get_driver_scheduling_group();
         }
         return default_scheduling_group();
     }


### PR DESCRIPTION
A connection that is registered as a control connection runs in the dedicated driver scheduling group. Before this commit, that classification was based on the REGISTER command alone and never revisited. Drivers may also reuse the control connection for user load, which would let user requests run in the driver scheduling group they are not meant to use.

This commit revisits the classification on every request. The CQL server inspects every authorized query, prepared-statement execution and batch and reclassifies the connection as a regular user connection once the statement counts as user load. A batch always counts as user load; single queries count only when they touch a non-system keyspace.

To keep this logic in one place, the CQL server now prepares the statement for the QUERY path too (it already had the prepared statement for EXECUTE and BATCH), so the query processor stays unaware of the reclassification.

Results from `perf-cql-raw --workload read --use-prepared true --duration 20 --memory 2G --smp 1 --partitions 1000`:

Before this patch series:
```
236170.13 tps ( 78.2 allocs/op,   0.0 logallocs/op,  23.2 tasks/op,   47754 insns/op,   18903 cycles/op,        0 errors)
throughput:
        mean=   234648.38 standard-deviation=3283.78
        median= 235821.73 median-absolute-deviation=1521.75
        maximum=236488.60 minimum=222346.56
instructions_per_op:
        mean=   47756.96 standard-deviation=6.87
        median= 47757.73 median-absolute-deviation=6.23
        maximum=47767.51 minimum=47744.03
cpu_cycles_per_op:
        mean=   18927.34 standard-deviation=41.46
        median= 18934.40 median-absolute-deviation=39.35
        maximum=19009.47 minimum=18872.26

```

After this patch series:
```
237452.16 tps ( 78.2 allocs/op,   0.0 logallocs/op,  23.2 tasks/op,   47758 insns/op,   18750 cycles/op,        0 errors)
throughput:
        mean=   236796.87 standard-deviation=1603.11
        median= 237452.16 median-absolute-deviation=970.25
        maximum=238078.11 minimum=231447.78
instructions_per_op:
        mean=   47750.04 standard-deviation=9.90
        median= 47752.50 median-absolute-deviation=8.40
        maximum=47769.44 minimum=47731.99
cpu_cycles_per_op:
        mean=   18782.42 standard-deviation=76.62
        median= 18750.29 median-absolute-deviation=42.34
        maximum=18976.26 minimum=18703.89
```

Fixes SCYLLADB-2458

Backport: Should be backported to 2026.1 and 2026.2 to avoid performance issues for customers that use misbehaving drivers.