### PR TITLE
init: size object storage clients memory as a fraction of shard memory

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1731,6 +1731,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , object_storage_connections_per_shard(this, "object_storage_connections_per_shard", liveness::LiveUpdate, value_status::Used, 128,
         "Maximum number of object storage connections per shard. "
         "Connections are distributed proportionally across scheduling groups based on their shares.")
+    , object_storage_clients_memory_fraction(this, "object_storage_clients_memory_fraction", value_status::Unused, 0.01,
+        "Fraction of shard memory used as the buffer budget shared by all object storage clients.")
     , error_injections_at_startup(this, "error_injections_at_startup", error_injection_value_status, {}, "List of error injections that should be enabled on startup.")
     , topology_barrier_stall_detector_threshold_seconds(this, "topology_barrier_stall_detector_threshold_seconds", value_status::Used, 2, "Report sites blocking topology barrier if it takes longer than this.")
     , enable_tablets(this, "enable_tablets", value_status::Used, false, "Enable tablets for newly created keyspaces. (deprecated)")

--- a/db/config.hh
+++ b/db/config.hh
@@ -617,6 +617,7 @@ public:
 
     named_value<std::vector<object_storage_endpoint_param>> object_storage_endpoints;
     named_value<unsigned> object_storage_connections_per_shard;
+    named_value<double> object_storage_clients_memory_fraction;
 
     named_value<std::vector<error_injection_at_startup>> error_injections_at_startup;
     named_value<double> topology_barrier_stall_detector_threshold_seconds;

--- a/main.cc
+++ b/main.cc
@@ -1308,7 +1308,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             checkpoint(stop_signal, "starting storage manager");
             sstables::storage_manager::config stm_cfg;
-            stm_cfg.object_storage_clients_memory = std::clamp<size_t>(memory::stats().total_memory() * 0.01, 10 << 20, 100 << 20);
+            stm_cfg.object_storage_clients_memory = std::max<size_t>(10 << 20, memory::stats().total_memory() * cfg->object_storage_clients_memory_fraction());
+            startlog.info("Object storage clients memory budget: {} bytes ({}% of shard memory)",
+                          stm_cfg.object_storage_clients_memory,
+                          cfg->object_storage_clients_memory_fraction() * 100);
             sstm.start(std::ref(*cfg), stm_cfg).get();
             auto stop_sstm = defer_verbose_shutdown("sstables storage manager", [&sstm] {
                 sstm.stop().get();


### PR DESCRIPTION
### Problem

The buffer budget shared by all object storage clients was computed with a hard-coded formula: 1% of shard memory, clamped to the range `[10 MiB, 100 MiB]`. This is inflexible — it cannot be tuned per deployment, and the fixed ceiling does not scale with shard size on large machines.

### Changes

A new config option `object_storage_clients_memory_fraction` (a `double`, default `0.01`) controls the fraction of shard memory used as the object storage clients' buffer budget. At startup, the budget is computed as `shard_memory * fraction` instead of the old clamped formula, and the resulting budget is logged at `info` level.

This option is intentionally **not** live-updateable — the budget is consumed when the storage manager starts.

Note: the previous `[10 MiB, 100 MiB]` clamp is removed; the budget is now a pure percentage of shard memory that scales with shard size. For the sake of tests to pass (constrained memory) the minimum s3 client memory size is set to 10MiB

### Backport

No backport needed — this is a configuration enhancement for KS on object storage, not operational yet
