### PR TITLE
install-dependencies: install requests/setuptools via pip to fix CVEs

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -170,14 +170,16 @@ fedora_python3_packages=(
     python3-pyyaml
     python3-urwid
     python3-pyparsing
-    python3-requests
-    python3-setuptools
     python3-psutil
     python3-distro
     python3-click
     python3-six
     python3-pyudev
 )
+# NOTE: requests and setuptools are intentionally NOT taken from Fedora RPMs.
+# The Fedora packages lag upstream and ship versions with known CVEs (requests
+# pulls vulnerable urllib3/idna; setuptools vendors vulnerable jaraco.context and
+# wheel). They are installed via pip below with CVE-fixed version floors instead.
 
 # an associative array from packages to constrains
 declare -A pip_packages=(
@@ -192,6 +194,18 @@ declare -A pip_packages=(
     [universalasync]=""
     [boto3-stubs[dynamodb]]=""
     [setuptools_scm]=""
+    # Security floors (replace the formerly RPM-provided packages). pip's default
+    # --upgrade-strategy is only-if-needed, so transitive deps are NOT bumped unless
+    # named explicitly here.
+    #   requests >=2.33.0  -> CVE-2026-25645
+    #   urllib3  >=2.7.0   -> CVE-2026-44431, CVE-2026-44432 (transitive of requests)
+    #   idna     >=3.15    -> CVE-2026-45409 (transitive of requests)
+    #   setuptools >=81.0.0 -> vendors jaraco.context 6.1.0 (CVE-2026-23949, since 80.10.0)
+    #                          and wheel 0.46.3 (CVE-2026-24049, since 81.0.0)
+    [requests]=">=2.33.0"
+    [urllib3]=">=2.7.0"
+    [idna]=">=3.15"
+    [setuptools]=">=81.0.0"
 )
 
 pip_symlinks=(


### PR DESCRIPTION
## Problem

A Trivy scan of `docker.io/scylladb/scylla-nightly:latest` reports 6 fixable CVEs (4 HIGH, 2 MEDIUM). The RHEL base OS layer is clean — all findings are in the bundled relocatable Python at `/opt/scylladb/python3/.../site-packages/`.

| Package | Installed | Fixed in | CVE(s) | Severity |
|---|---|---|---|---|
| urllib3 | 2.6.3 | 2.7.0 | CVE-2026-44431, CVE-2026-44432 | HIGH |
| jaraco.context | 5.3.0 | 6.1.0 | CVE-2026-23949 | HIGH |
| wheel | 0.45.1 | 0.46.2 | CVE-2026-24049 | HIGH |
| requests | 2.32.5 | 2.33.0 | CVE-2026-25645 | MEDIUM |
| idna | 3.10 | 3.15 | CVE-2026-45409 | MEDIUM |

## Root cause

These packages come from **Fedora RPMs** (`python3-requests`, `python3-setuptools`), not pip:
- `requests` (RPM) pulls vulnerable `urllib3` / `idna` as transitive RPM deps.
- `setuptools` (RPM) vendors vulnerable `jaraco.context` and `wheel` under `_vendor/`.

Because they are RPM-provided, the existing `pip install --upgrade` step never touches them (pip's default `--upgrade-strategy` is `only-if-needed`), so rebuilding the nightly does **not** pick up the fixes.

## Fix

Move `requests` and `setuptools` off Fedora RPMs and install them via pip with CVE-fixed version floors. `setuptools >= 81.0.0` is the first release that vendors `jaraco.context 6.1.0` and `wheel 0.46.3`.

## Verification

Not yet built/scanned. After build, re-run:
```
trivy image docker.io/scylladb/scylla-nightly:<new> --scanners vuln --ignore-unfixed
```
Expect 0 findings.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2502
