### PR TITLE
sstables: prevent clearing sstables vector on failed atomic deletion

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -124,6 +124,7 @@ enum class sstable_state;
 class sstable;
 class storage_manager;
 class sstables_manager;
+class atomic_deletion;
 class sstable_set;
 class directory_semaphore;
 struct sstable_files_snapshot;
@@ -652,6 +653,7 @@ public:
 
     void notify_bootstrap_or_replace_end();
 
+private:
     // Ensures that concurrent preemptible mutations to sstable lists will produce correct results.
     // User will hold this permit until done with all updates. As soon as it's released, another concurrent
     // attempt to update the lists will be able to proceed.
@@ -693,8 +695,13 @@ public:
     };
     // NOTE: Always use this interface for deleting SSTables in the table, since it guarantees
     // synchronization with concurrent iterations.
+    // Returns an object that lets callers control the commit point explicitly:
+    // commit() makes deletion durable, and execute() performs best-effort physical deletion.
+    sstables::atomic_deletion make_atomic_deletion(std::vector<sstables::shared_sstable> sstables_to_remove);
+    // Ignores all errors. Use make_atomic_deletion() for fine-grained error handling.
     future<> delete_sstables_atomically(const sstable_list_permit&, std::vector<sstables::shared_sstable> sstables_to_remove);
 
+public:
     // Precondition: table needs tablet splitting.
     // Returns true if all storage of table is ready for splitting.
     bool all_storage_groups_split();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1170,6 +1170,8 @@ public:
     const sstables::sstable_set& get_sstable_set() const;
     lw_shared_ptr<const sstable_list> get_sstables() const;
     lw_shared_ptr<const sstable_list> get_sstables_including_compacted_undeleted() const;
+    // For tests only.
+    bool tablet_has_compacted_undeleted_sstables(locator::tablet_id) const;
     std::vector<sstables::shared_sstable> select_sstables(const dht::partition_range& range) const;
     future<> drop_quarantined_sstables();
     size_t sstables_count() const;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5567,11 +5567,11 @@ future<> compaction_group::cleanup() {
     }
 
     if (!_sstables_compacted_but_not_deleted.empty()) {
-        co_await _t.delete_sstables_atomically(permit, _sstables_compacted_but_not_deleted);
-        // delete_sstables_atomically swallows exceptions, so this always runs.
-        // Any SSTables that failed to delete will eventually be re-compacted
-        // and re-deleted.
+        auto gh = _t._sstable_deletion_gate.hold();
+        auto deletion = _t.make_atomic_deletion(_sstables_compacted_but_not_deleted);
+        co_await deletion.commit();
         _sstables_compacted_but_not_deleted.clear();
+        co_await deletion.execute();
         _t.rebuild_statistics();
     }
     if (utils::get_local_injector().enter("tablet_cleanup_failure_post_deletion")) {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2406,15 +2406,22 @@ table::sstable_list_builder::build_new_list(const sstables::sstable_set& current
         make_lw_shared<sstables::sstable_set>(std::move(new_sstable_list)), std::move(removed_sstables)};
 }
 
+sstables::atomic_deletion
+table::make_atomic_deletion(std::vector<sstables::shared_sstable> sstables_to_remove) {
+    return get_sstables_manager().make_atomic_deletion(std::move(sstables_to_remove));
+}
+
 future<>
 table::delete_sstables_atomically(const sstable_list_permit&, std::vector<sstables::shared_sstable> sstables_to_remove) {
     try {
         auto gh = _sstable_deletion_gate.hold();
-        co_await get_sstables_manager().delete_atomically(std::move(sstables_to_remove));
+        auto deletion = make_atomic_deletion(std::move(sstables_to_remove));
+        co_await deletion.commit();
+        co_await deletion.execute();
     } catch (...) {
         // There is nothing more we can do here.
         // Any remaining SSTables will eventually be re-compacted and re-deleted.
-        tlogger.error("Compacted SSTables deletion failed: {}. Ignored.", std::current_exception());
+        tlogger.error("SSTables deletion failed: {}. Ignored.", std::current_exception());
     }
 }
 
@@ -3018,7 +3025,7 @@ bool storage_group::no_compacted_sstable_undeleted() const {
 
 // Gets the list of all sstables in the column family, including ones that are
 // not used for active queries because they have already been compacted, but are
-// waiting for delete_atomically() to return.
+// waiting for atomic deletion to complete.
 //
 // As long as we haven't deleted them, compaction needs to ensure it doesn't
 // garbage-collect a tombstone that covers data in an sstable that may not be

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2936,6 +2936,7 @@ future<> table::drop_quarantined_sstables() {
     class quarantine_removal_updater : public row_cache::external_updater_impl {
         table& _t;
         std::vector<sstables::shared_sstable>& _removed;
+        std::optional<sstables::atomic_deletion>& _deletion;
         struct compaction_group_update {
             lw_shared_ptr<sstables::sstable_set> new_main_sstables;
             lw_shared_ptr<sstables::sstable_set> new_maintenance_sstables;
@@ -2944,8 +2945,10 @@ future<> table::drop_quarantined_sstables() {
         std::unordered_map<compaction_group*, compaction_group_update> _cg_updates;
 
     public:
-        explicit quarantine_removal_updater(table& t, std::vector<sstables::shared_sstable>& removed)
-            : _t(t), _removed(removed) {}
+        // Note: \c deletion is an output parameter filled by prepare() for the committed atomic_deletion object.
+        // If engaged after co_await prepare(), the user should co_await deletion->execute() to complete the atomic deletion process.
+        explicit quarantine_removal_updater(table& t, std::vector<sstables::shared_sstable>& removed, std::optional<sstables::atomic_deletion>& deletion)
+            : _t(t), _removed(removed), _deletion(deletion) {}
 
         virtual future<> prepare() override {
             _t.for_each_compaction_group([&] (compaction_group& cg) {
@@ -2978,7 +2981,10 @@ future<> table::drop_quarantined_sstables() {
                     .removed_main_sstables = std::move(removed_main)
                 };
             });
-            co_return;
+            if (!_removed.empty()) {
+                _deletion.emplace(_t.make_atomic_deletion(_removed));
+                co_await _deletion->commit();
+            }
         }
 
         virtual void execute() override {
@@ -2992,8 +2998,9 @@ future<> table::drop_quarantined_sstables() {
             }
         }
 
-        static std::unique_ptr<row_cache::external_updater_impl> make(table& t, std::vector<sstables::shared_sstable>& removed) {
-            return std::make_unique<quarantine_removal_updater>(t, removed);
+        static std::unique_ptr<row_cache::external_updater_impl> make(table& t, std::vector<sstables::shared_sstable>& removed,
+                                                                       std::optional<sstables::atomic_deletion>& deletion) {
+            return std::make_unique<quarantine_removal_updater>(t, removed, deletion);
         }
     };
 
@@ -3006,13 +3013,17 @@ future<> table::drop_quarantined_sstables() {
     auto permit = co_await get_sstable_list_permit();
 
     std::vector<sstables::shared_sstable> removed;
-    auto updater = row_cache::external_updater(quarantine_removal_updater::make(*this, removed));
+    std::optional<sstables::atomic_deletion> deletion;
+    auto gh = _sstable_deletion_gate.hold();
+    auto updater = row_cache::external_updater(quarantine_removal_updater::make(*this, removed, deletion));
     co_await _cache.invalidate(std::move(updater));
 
     _cache.refresh_snapshot();
     rebuild_statistics();
 
-    co_await delete_sstables_atomically(permit, std::move(removed));
+    if (deletion) {
+        co_await deletion->execute();
+    }
 }
 
 bool storage_group::no_compacted_sstable_undeleted() const {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3060,6 +3060,16 @@ const std::vector<sstables::shared_sstable>& compaction_group::compacted_undelet
     return _sstables_compacted_but_not_deleted;
 }
 
+bool table::tablet_has_compacted_undeleted_sstables(locator::tablet_id tid) const {
+    auto* sg = _sg_manager->maybe_storage_group_for_id(_schema, tid.value());
+    if (!sg) {
+        return false;
+    }
+    return std::ranges::any_of(sg->compaction_groups_immediate(), [] (const auto& cg) {
+        return !cg->compacted_undeleted_sstables().empty();
+    });
+}
+
 lw_shared_ptr<memtable_list>
 table::make_memory_only_memtable_list() {
     auto get_schema = [this] { return schema(); };

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -652,6 +652,7 @@ future<sstring> sstable_directory::create_pending_deletion_log(opened_directory&
         sstring tmp_pending_delete_log = pending_delete_log + ".tmp";
         dirlog.trace("Writing {}", tmp_pending_delete_log);
 
+        try {
             touch_directory(pending_delete_dir).get();
             auto oflags = sstable_write_open_flags;
             // Create temporary pending_delete log file.
@@ -660,7 +661,6 @@ future<sstring> sstable_directory::create_pending_deletion_log(opened_directory&
             auto out = make_file_output_stream(std::move(f), 4096).get();
             auto close_out = deferred_close(out);
 
-        try {
             auto trim_size = base_dir.native().size() + 1; // Account for the '/' delimiter
             for (const auto& sst : ssts) {
                 sstring toc = seastar::to_sstring(sst->toc_filename());
@@ -674,9 +674,6 @@ future<sstring> sstable_directory::create_pending_deletion_log(opened_directory&
 
             out.flush().get();
             close_out.close_now();
-        } catch (...) {
-            dirlog.warn("Error while writing {}: {}. Ignoring.", tmp_pending_delete_log, std::current_exception());
-        }
 
             // Once flushed and closed, the temporary log file can be renamed.
             io_check(rename_file, tmp_pending_delete_log, pending_delete_log, rename_flags::none).get();
@@ -684,6 +681,9 @@ future<sstring> sstable_directory::create_pending_deletion_log(opened_directory&
             // Guarantee that the changes above reached the disk.
             base_dir.sync(general_disk_error_handler).get();
             dirlog.debug("{} written successfully.", pending_delete_log);
+        } catch (...) {
+            dirlog.warn("Error creating {}: {}. Ignoring.", pending_delete_log, std::current_exception());
+        }
 
         return pending_delete_log;
     });

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -682,7 +682,8 @@ future<sstring> sstable_directory::create_pending_deletion_log(opened_directory&
             base_dir.sync(general_disk_error_handler).get();
             dirlog.debug("{} written successfully.", pending_delete_log);
         } catch (...) {
-            dirlog.warn("Error creating {}: {}. Ignoring.", pending_delete_log, std::current_exception());
+            dirlog.warn("Error creating {}: {}.", pending_delete_log, std::current_exception());
+            throw;
         }
 
         return pending_delete_log;

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -315,9 +315,9 @@ public:
     //
     // This function only solves the second problem for now.
 
-    // Creates the deletion log for atomic deletion of sstables at `base_dir` (helper for the
-    // above function that's also used by tests)
-    // Returns the name of the pending_delete_log and an unordered_set of sstable prefixes.
+    // Creates and commits the deletion log for atomic deletion of sstables at `base_dir`.
+    // On success, all sstables listed in the log will eventually be deleted.
+    // Returns the name of the pending_delete_log.
     static future<sstring> create_pending_deletion_log(opened_directory& base_dir, const std::vector<shared_sstable>& ssts);
 
     static bool compare_sstable_storage_prefix(std::string_view a, std::string_view b) noexcept;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3925,7 +3925,7 @@ utils::hashed_key sstable::make_hashed_key(const schema& s, const partition_key&
 }
 
 future<>
-sstable::unlink(const atomic_delete_context* ctx) noexcept {
+sstable::unlink(const atomic_deletion* deletion) noexcept {
     // Serialize with other calls to unlink or potentially ongoing mutations.
     auto lock = co_await get_units(_mutate_sem, 1);
     if (_unlinked_at) {
@@ -3935,7 +3935,7 @@ sstable::unlink(const atomic_delete_context* ctx) noexcept {
     _unlinked_at = db_clock::now();
     _on_delete(*this);
 
-    auto remove_fut = _storage->wipe(*this, ctx);
+    auto remove_fut = _storage->wipe(*this, deletion);
 
     try {
         if (_cloned_to_sstable_filename) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -460,9 +460,9 @@ public:
 
     // Delete the sstable by unlinking all sstable files
     // Ignores all errors.
-    // When ctx is provided, it indicates the call is part of an atomic
+    // When deletion is provided, it indicates the call is part of an atomic
     // deletion sequence where atomic_delete_prepare has already been called.
-    future<> unlink(const atomic_delete_context* ctx = nullptr) noexcept;
+    future<> unlink(const atomic_deletion* deletion = nullptr) noexcept;
 
     db::large_data_handler& get_large_data_handler() {
         return _large_data_handler;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -461,7 +461,7 @@ public:
     // Delete the sstable by unlinking all sstable files
     // Ignores all errors.
     // When deletion is provided, it indicates the call is part of an atomic
-    // deletion sequence where atomic_delete_prepare has already been called.
+    // deletion sequence that has already been committed.
     future<> unlink(const atomic_deletion* deletion = nullptr) noexcept;
 
     db::large_data_handler& get_large_data_handler() {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -54,6 +54,9 @@ future<> atomic_deletion::commit() {
     if (empty()) {
         co_return;
     }
+    if (utils::get_local_injector().enter("delete_atomically_before_prepare")) {
+        throw std::runtime_error("delete_atomically_before_prepare");
+    }
     co_await _impl->commit(_ssts);
     utils::get_local_injector().inject("delete_atomically_after_prepare",
             [] { throw std::runtime_error("delete_atomically_after_prepare"); });

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -30,6 +30,52 @@ namespace sstables {
 
 logging::logger smlogger("sstables_manager");
 
+const storage& atomic_deletion::get_storage(const std::vector<shared_sstable>& ssts) {
+    auto& storage = ssts.front()->get_storage();
+    for (const auto& sst : ssts | std::views::drop(1)) {
+        auto& other_storage = sst->get_storage();
+        if (storage != other_storage) {
+            on_internal_error(smlogger, fmt::format(
+                    "atomic_deletion created with SSTables from different storage contexts: front={} front_storage={} offending={} offending_storage={}",
+                    ssts.front()->get_filename(), storage.prefix(),
+                    sst->get_filename(), other_storage.prefix()));
+        }
+    }
+    return storage;
+}
+
+atomic_deletion::atomic_deletion(std::vector<shared_sstable> ssts)
+    : _ssts(std::move(ssts))
+    , _storage(_ssts.empty() ? nullptr : &get_storage(_ssts))
+    , _impl(_storage ? _storage->make_atomic_deletion_impl() : nullptr) {
+}
+
+future<> atomic_deletion::commit() {
+    if (empty()) {
+        co_return;
+    }
+    co_await _impl->commit(_ssts);
+    utils::get_local_injector().inject("delete_atomically_after_prepare",
+            [] { throw std::runtime_error("delete_atomically_after_prepare"); });
+}
+
+future<> atomic_deletion::execute() noexcept {
+    if (empty()) {
+        co_return;
+    }
+    try {
+        co_await coroutine::parallel_for_each(_ssts, [this] (shared_sstable sst) {
+            return sst->unlink(this);
+        });
+        utils::get_local_injector().inject("delete_atomically_after_unlink",
+                [] { throw std::runtime_error("delete_atomically_after_unlink"); });
+        co_await _impl->finalize();
+    } catch (...) {
+        // After commit(), the SSTables will be deleted even after a crash.
+        smlogger.warn("SSTables deletion failed after commit: {}. Will be retried on restart.", std::current_exception());
+    }
+}
+
 sstables_manager::sstables_manager(
     sstring name, db::large_data_handler& large_data_handler, db::corrupt_data_handler& corrupt_data_handler, struct config cfg, gms::feature_service& feat, cache_tracker& ct, directory_semaphore& dir_sem,
     noncopyable_function<locator::host_id()>&& resolve_host_id, sstable_compressor_factory& compressor_factory, const abort_source& abort, std::vector<file_io_extension*> file_io_extensions, scheduling_group maintenance_sg, storage_manager* shared)
@@ -409,29 +455,8 @@ void sstables_manager::maybe_done() {
     }
 }
 
-future<> sstables_manager::delete_atomically(std::vector<shared_sstable> ssts) {
-    if (ssts.empty()) {
-        co_return;
-    }
-
-    // All sstables here belong to the same table, thus they do live
-    // in the same storage so it's OK to get the deleter from _signal_mana
-    // front element. The deleter implementation is welcome to check
-    // that sstables from the vector really live in it.
-    auto& storage = ssts.front()->get_storage();
-    auto ctx = co_await storage.atomic_delete_prepare(ssts);
-
-    utils::get_local_injector().inject("delete_atomically_after_prepare",
-            [] { throw std::runtime_error("delete_atomically_after_prepare"); });
-
-    co_await coroutine::parallel_for_each(ssts, [&ctx] (shared_sstable sst) {
-        return sst->unlink(&ctx);
-    });
-
-    utils::get_local_injector().inject("delete_atomically_after_unlink",
-            [] { throw std::runtime_error("delete_atomically_after_unlink"); });
-
-    co_await storage.atomic_delete_complete(std::move(ctx));
+atomic_deletion sstables_manager::make_atomic_deletion(std::vector<shared_sstable> ssts) {
+    return atomic_deletion(std::move(ssts));
 }
 
 future<utils::chunked_vector<sstable_snapshot_metadata>> sstables_manager::take_snapshot(std::vector<shared_sstable> ssts, sstring name) {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -46,6 +46,7 @@ namespace sstables {
 
 class object_storage_client;
 class directory_semaphore;
+class storage;
 using schema_ptr = lw_shared_ptr<const schema>;
 using shareable_components_ptr = lw_shared_ptr<shareable_components>;
 
@@ -60,6 +61,27 @@ struct sstable_snapshot_metadata {
     int64_t last_token;
     int64_t repaired_at;
     std::optional<size_t> tablet_id;
+};
+
+class atomic_deletion {
+    std::vector<shared_sstable> _ssts;
+    const storage* _storage = nullptr;
+    std::unique_ptr<atomic_deletion_impl> _impl;
+
+    static const storage& get_storage(const std::vector<shared_sstable>& ssts);
+
+public:
+    explicit atomic_deletion(std::vector<shared_sstable> ssts);
+
+    std::vector<shared_sstable>& sstables() noexcept { return _ssts; }
+    const std::vector<shared_sstable>& sstables() const noexcept { return _ssts; }
+    bool empty() const noexcept { return _ssts.empty(); }
+
+    // On success, all sstables are ensured to be eventually deleted.
+    // On failure, either all or none of the sstables will be deleted,
+    // but never only some of them.
+    future<> commit();
+    future<> execute() noexcept;
 };
 
 class storage_manager : public peering_sharded_service<storage_manager> {
@@ -286,7 +308,7 @@ public:
         return *_sstables_registry;
     }
 
-    future<> delete_atomically(std::vector<shared_sstable> ssts);
+    atomic_deletion make_atomic_deletion(std::vector<shared_sstable> ssts);
     future<utils::chunked_vector<sstable_snapshot_metadata>> take_snapshot(std::vector<shared_sstable> ssts, sstring jsondir);
     future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const schema& s, const data_dictionary::storage_options& so);
     future<> destroy_table_storage(const data_dictionary::storage_options& so);

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -96,15 +96,15 @@ public:
     virtual future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     virtual void open(sstable& sst) override;
-    virtual future<> wipe(sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept override;
+    virtual future<> wipe(sstable& sst, const atomic_deletion* deletion = nullptr) noexcept override;
     virtual future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) override;
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) override;
     future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
     future<data_source> make_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) override;
     virtual future<> destroy(const sstable& sst) override { return make_ready_future<>(); }
-    virtual future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
-    virtual future<> atomic_delete_complete(atomic_delete_context ctx) const override;
+    virtual future<atomic_deletion> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
+    virtual future<> atomic_delete_complete(atomic_deletion ctx) const override;
     virtual future<> remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) override;
     virtual future<uint64_t> free_space() const override {
         return seastar::fs_avail(prefix());
@@ -518,8 +518,8 @@ static inline fs::path parent_path(const sstring& fname) {
     return fs::canonical(fs::path(fname)).parent_path();
 }
 
-future<> filesystem_storage::wipe(sstable& sst, const atomic_delete_context* ctx) noexcept {
-    auto sync = ctx ? sync_dir::no : sync_dir::yes;
+future<> filesystem_storage::wipe(sstable& sst, const atomic_deletion* deletion) noexcept {
+    auto sync = deletion ? sync_dir::no : sync_dir::yes;
     // We must be able to generate toc_filename()
     // in order to delete the sstable.
     // Running out of memory here will terminate.
@@ -589,8 +589,8 @@ future<> filesystem_storage::wipe(sstable& sst, const atomic_delete_context* ctx
     }
 }
 
-future<atomic_delete_context> filesystem_storage::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
-    atomic_delete_context res;
+future<atomic_deletion> filesystem_storage::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
+    atomic_deletion res;
 
     for (const auto& sst : ssts) {
         auto prefix = sst->_storage->prefix();
@@ -601,15 +601,15 @@ future<atomic_delete_context> filesystem_storage::atomic_delete_prepare(const st
     co_return std::move(res);
 }
 
-future<> filesystem_storage::atomic_delete_complete(atomic_delete_context ctx) const {
-    co_await coroutine::parallel_for_each(ctx.prefixes, [] (const auto& dir) -> future<> {
+future<> filesystem_storage::atomic_delete_complete(atomic_deletion deletion) const {
+    co_await coroutine::parallel_for_each(deletion.prefixes, [] (const auto& dir) -> future<> {
         co_await sync_directory(dir);
     });
 
         // Once all sstables are deleted, the log file can be removed.
         // Note: the log file will be removed also if unlink failed to remove
         // any sstable and ignored the error.
-        const auto& log = ctx.pending_delete_log;
+        const auto& log = deletion.pending_delete_log;
         try {
             co_await remove_file(log);
             sstlog.debug("{} removed.", log);
@@ -692,7 +692,7 @@ public:
     future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     void open(sstable& sst) override;
-    future<> wipe(sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept override;
+    future<> wipe(sstable& sst, const atomic_deletion* deletion = nullptr) noexcept override;
     future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) override;
     future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) override;
     future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
@@ -700,8 +700,8 @@ public:
 
     future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) override;
     future<> destroy(const sstable& sst) override;
-    future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
-    future<> atomic_delete_complete(atomic_delete_context ctx) const override;
+    future<atomic_deletion> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
+    future<> atomic_delete_complete(atomic_deletion ctx) const override;
     future<> remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) override;
     future<uint64_t> free_space() const override {
         // assumes infinite space on s3/gs (https://aws.amazon.com/s3/faqs/#How_much_data_can_I_store).
@@ -955,7 +955,7 @@ future<> object_storage_base::change_state(const sstable& sst, sstable_state sta
     co_await sst.manager().sstables_registry().update_entry_state(owner(), sst.manager().get_local_host_id(), sst.generation(), state);
 }
 
-future<> object_storage_base::wipe(sstable& sst, const atomic_delete_context* ctx) noexcept {
+future<> object_storage_base::wipe(sstable& sst, const atomic_deletion* deletion) noexcept {
     // Mark the sstable for deletion so that destroy() — called when the
     // last shared_sstable reference is dropped — will delete the cloud
     // objects.
@@ -975,7 +975,7 @@ future<> object_storage_base::wipe(sstable& sst, const atomic_delete_context* ct
     // FIXME: unlike filesystem_storage::wipe, this implementation does not
     // catch exceptions from sstables_registry calls and may return an
     // exceptional future, breaking the contract documented on storage::wipe.
-    if (!ctx) {
+    if (!deletion) {
         co_await sst.manager().sstables_registry().update_entry_status(owner(), sst.manager().get_local_host_id(), sst.generation(), status_removing);
     }
 }
@@ -1031,17 +1031,17 @@ future<> object_storage_base::destroy(const sstable& sst) {
     sstlog.debug("Deleted reference {} remaining_refs={}", ref_name.str(), remaining_refs);
 }
 
-future<atomic_delete_context> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
+future<atomic_deletion> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
     std::vector<generation_type> gens;
     gens.reserve(ssts.size());
     for (auto& sst : ssts) {
         gens.push_back(sst->generation());
     }
     co_await ssts.front()->manager().sstables_registry().batch_update_entry_status(owner(), ssts.front()->manager().get_local_host_id(), gens, status_removing);
-    co_return atomic_delete_context{};
+    co_return atomic_deletion{};
 }
 
-future<> object_storage_base::atomic_delete_complete(atomic_delete_context ctx) const {
+future<> object_storage_base::atomic_delete_complete(atomic_deletion deletion) const {
     co_return;
 }
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -103,8 +103,8 @@ public:
     future<data_source> make_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) override;
     virtual future<> destroy(const sstable& sst) override { return make_ready_future<>(); }
-    virtual future<atomic_deletion> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
-    virtual future<> atomic_delete_complete(atomic_deletion ctx) const override;
+    virtual std::unique_ptr<atomic_deletion_impl> make_atomic_deletion_impl() const override;
+    virtual bool operator==(const storage&) const noexcept override;
     virtual future<> remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) override;
     virtual future<uint64_t> free_space() const override {
         return seastar::fs_avail(prefix());
@@ -589,33 +589,50 @@ future<> filesystem_storage::wipe(sstable& sst, const atomic_deletion* deletion)
     }
 }
 
-future<atomic_deletion> filesystem_storage::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
-    atomic_deletion res;
+class filesystem_atomic_deletion_impl : public atomic_deletion_impl {
+    opened_directory& _base_dir;
+    sstring _pending_delete_log;
+    std::unordered_set<sstring> _prefixes;
 
-    for (const auto& sst : ssts) {
-        auto prefix = sst->_storage->prefix();
-        res.prefixes.emplace(prefix);
+public:
+    filesystem_atomic_deletion_impl(opened_directory& base_dir)
+        : _base_dir(base_dir)
+    {
     }
 
-    res.pending_delete_log = co_await sstable_directory::create_pending_deletion_log(_base_dir, ssts);
-    co_return std::move(res);
-}
+    future<> commit(const std::vector<shared_sstable>& ssts) override {
+        for (const auto& sst : ssts) {
+            auto prefix = sst->get_storage().prefix();
+            _prefixes.emplace(prefix);
+        }
 
-future<> filesystem_storage::atomic_delete_complete(atomic_deletion deletion) const {
-    co_await coroutine::parallel_for_each(deletion.prefixes, [] (const auto& dir) -> future<> {
-        co_await sync_directory(dir);
-    });
+        _pending_delete_log = co_await sstable_directory::create_pending_deletion_log(_base_dir, ssts);
+    }
+
+    future<> finalize() override {
+        co_await coroutine::parallel_for_each(_prefixes, [] (const auto& dir) -> future<> {
+            co_await sync_directory(dir);
+        });
 
         // Once all sstables are deleted, the log file can be removed.
         // Note: the log file will be removed also if unlink failed to remove
         // any sstable and ignored the error.
-        const auto& log = deletion.pending_delete_log;
         try {
-            co_await remove_file(log);
-            sstlog.debug("{} removed.", log);
+            co_await remove_file(_pending_delete_log);
+            sstlog.debug("{} removed.", _pending_delete_log);
         } catch (...) {
-            sstlog.warn("Error removing {}: {}. Ignoring.", log, std::current_exception());
+            sstlog.warn("Error removing {}: {}. Ignoring.", _pending_delete_log, std::current_exception());
         }
+    }
+};
+
+std::unique_ptr<atomic_deletion_impl> filesystem_storage::make_atomic_deletion_impl() const {
+    return std::make_unique<filesystem_atomic_deletion_impl>(_base_dir);
+}
+
+bool filesystem_storage::operator==(const storage& other) const noexcept {
+    auto* other_fs = dynamic_cast<const filesystem_storage*>(&other);
+    return other_fs && sstable_directory::compare_sstable_storage_prefix(_base_dir.native(), other_fs->_base_dir.native());
 }
 
 future<> filesystem_storage::remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) {
@@ -700,8 +717,8 @@ public:
 
     future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) override;
     future<> destroy(const sstable& sst) override;
-    future<atomic_deletion> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
-    future<> atomic_delete_complete(atomic_deletion ctx) const override;
+    std::unique_ptr<atomic_deletion_impl> make_atomic_deletion_impl() const override;
+    bool operator==(const storage&) const noexcept override;
     future<> remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) override;
     future<uint64_t> free_space() const override {
         // assumes infinite space on s3/gs (https://aws.amazon.com/s3/faqs/#How_much_data_can_I_store).
@@ -1031,18 +1048,47 @@ future<> object_storage_base::destroy(const sstable& sst) {
     sstlog.debug("Deleted reference {} remaining_refs={}", ref_name.str(), remaining_refs);
 }
 
-future<atomic_deletion> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
-    std::vector<generation_type> gens;
-    gens.reserve(ssts.size());
-    for (auto& sst : ssts) {
-        gens.push_back(sst->generation());
+class object_storage_atomic_deletion_impl : public atomic_deletion_impl {
+    table_id _owner;
+    const char* _status_removing;
+    std::vector<generation_type> _generations;
+
+public:
+    object_storage_atomic_deletion_impl(table_id owner, const char* status_removing)
+        : _owner(owner)
+        , _status_removing(status_removing)
+    {
     }
-    co_await ssts.front()->manager().sstables_registry().batch_update_entry_status(owner(), ssts.front()->manager().get_local_host_id(), gens, status_removing);
-    co_return atomic_deletion{};
+
+    future<> commit(const std::vector<shared_sstable>& ssts) override {
+        _generations.reserve(ssts.size());
+        for (auto& sst : ssts) {
+            _generations.push_back(sst->generation());
+        }
+        co_await ssts.front()->manager().sstables_registry().batch_update_entry_status(_owner, ssts.front()->manager().get_local_host_id(), _generations, _status_removing);
+    }
+
+    future<> finalize() override {
+        // commit() marks all SSTables as removing in the registry. During
+        // atomic_deletion::execute(), each sstable::unlink() calls wipe(),
+        // which deletes the object-storage components and removes the registry
+        // entry for that SSTable. There is no batch-level state left to clean up.
+        return make_ready_future<>();
+    }
+};
+
+std::unique_ptr<atomic_deletion_impl> object_storage_base::make_atomic_deletion_impl() const {
+    return std::make_unique<object_storage_atomic_deletion_impl>(owner(), status_removing);
 }
 
-future<> object_storage_base::atomic_delete_complete(atomic_deletion deletion) const {
-    co_return;
+bool object_storage_base::operator==(const storage& other) const noexcept {
+    auto* other_object = dynamic_cast<const object_storage_base*>(&other);
+    return other_object
+            && _type == other_object->_type
+            && _schema->id() == other_object->_schema->id()
+            && _client.get() == other_object->_client.get()
+            && _uses_foreign_location == other_object->_uses_foreign_location
+            && _prefix == other_object->_prefix;
 }
 
 future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) {

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -43,11 +43,20 @@ class delayed_commit_changes;
 class object_storage_client;
 class sstable;
 class sstables_manager;
+class atomic_deletion;
 class entry_descriptor;
 
-struct atomic_deletion {
-    sstring pending_delete_log;
-    std::unordered_set<sstring> prefixes;
+class atomic_deletion_impl {
+public:
+    virtual ~atomic_deletion_impl() = default;
+    // Commit the atomic deletion intent to stable storage. On success, all
+    // SSTables in the deletion are guaranteed to be eventually deleted. On
+    // failure, either all or none of them will be deleted, but never only some
+    // of them.
+    virtual future<> commit(const std::vector<shared_sstable>&) = 0;
+    // Clean up any pending state created by commit() after the physical
+    // SSTable deletion has completed.
+    virtual future<> finalize() = 0;
 };
 
 using object_storage_reference_names = utils::small_vector<sstring, 3>;
@@ -125,8 +134,8 @@ public:
     virtual future<data_source> make_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const = 0;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;
     virtual future<> destroy(const sstable& sst) = 0;
-    virtual future<atomic_deletion> atomic_delete_prepare(const std::vector<shared_sstable>&) const = 0;
-    virtual future<> atomic_delete_complete(atomic_deletion ctx) const = 0;
+    virtual std::unique_ptr<atomic_deletion_impl> make_atomic_deletion_impl() const = 0;
+    virtual bool operator==(const storage&) const noexcept = 0;
     virtual future<> remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) = 0;
     // Free space available in the underlying storage.
     virtual future<uint64_t> free_space() const = 0;

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -45,7 +45,7 @@ class sstable;
 class sstables_manager;
 class entry_descriptor;
 
-struct atomic_delete_context {
+struct atomic_deletion {
     sstring pending_delete_log;
     std::unordered_set<sstring> prefixes;
 };
@@ -118,15 +118,15 @@ public:
     virtual void open(sstable& sst) = 0;
     // Must never return an exceptional future: implementations are expected
     // to catch and log any errors internally.
-    virtual future<> wipe(sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept = 0;
+    virtual future<> wipe(sstable& sst, const atomic_deletion* deletion = nullptr) noexcept = 0;
     virtual future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) = 0;
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) = 0;
     virtual future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const = 0;
     virtual future<data_source> make_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const = 0;
     virtual future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) = 0;
     virtual future<> destroy(const sstable& sst) = 0;
-    virtual future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const = 0;
-    virtual future<> atomic_delete_complete(atomic_delete_context ctx) const = 0;
+    virtual future<atomic_deletion> atomic_delete_prepare(const std::vector<shared_sstable>&) const = 0;
+    virtual future<> atomic_delete_complete(atomic_deletion ctx) const = 0;
     virtual future<> remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) = 0;
     // Free space available in the underlying storage.
     virtual future<uint64_t> free_space() const = 0;

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -1828,7 +1828,7 @@ SEASTAR_TEST_CASE(test_unknown_component) {
         BOOST_REQUIRE(file_exists(env.tempdir().path().string() + "/la-1-big-UNKNOWN.txt").get());
 
         sstp = env.reusable_sst(uncompressed_schema(), generation_type{1}).get();
-        env.manager().delete_atomically({sstp}).get();
+        sstp->unlink().get();
         // assure unknown component is deleted
         BOOST_REQUIRE(!file_exists(env.tempdir().path().string() + "/la-1-big-UNKNOWN.txt").get());
     });

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -6715,6 +6715,60 @@ SEASTAR_TEST_CASE(test_cleanup_of_deallocated_tablet) {
     }, cfg);
 }
 
+// Regression test for cleanup failures before the atomic deletion commit point:
+// compacted-but-not-deleted SSTables must stay tracked so cleanup can retry.
+SEASTAR_TEST_CASE(test_tablet_cleanup_retries_compacted_sstable_deletion) {
+    auto cfg = tablet_cql_test_config();
+    cfg.initial_tablets = 1;
+
+    return do_with_cql_env_thread([](cql_test_env& e) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+        fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+        return;
+#endif
+        e.execute_cql("create table ks.cf (pk int, ck int, v text, primary key (pk, ck))").get();
+
+        for (int i = 0; i < 100; i++) {
+            e.execute_cql(format("INSERT INTO ks.cf (pk, ck, v) VALUES ({}, {}, '{}')",
+                                 i, i, "payload_to_ensure_sstable_creation")).get();
+        }
+        replica::database::flush_table_on_all_shards(e.db(), "ks", "cf").get();
+
+        auto saw_failed_cleanup = e.db().map_reduce0([&] (replica::database& db) -> future<bool> {
+            auto& cf = db.find_column_family("ks", "cf");
+            auto& sys_ks = e.get_system_keyspace().local();
+            if (cf.get_stats().tablet_count == 0 || cf.get_sstables()->empty()) {
+                co_return false;
+            }
+
+            utils::get_local_injector().enable("delete_atomically_before_prepare", true);
+            auto disable_injection = seastar::defer([] {
+                utils::get_local_injector().disable("delete_atomically_before_prepare");
+            });
+            try {
+                co_await cf.cleanup_tablet(db, sys_ks, locator::tablet_id(0));
+                BOOST_FAIL("cleanup_tablet should fail before atomic deletion is committed");
+            } catch (const std::runtime_error& e) {
+                BOOST_REQUIRE_EQUAL(std::string(e.what()), "delete_atomically_before_prepare");
+            }
+
+            BOOST_REQUIRE(cf.tablet_has_compacted_undeleted_sstables(locator::tablet_id(0)));
+            co_return true;
+        }, false, std::logical_or<bool>()).get();
+        BOOST_REQUIRE(saw_failed_cleanup);
+
+        e.db().invoke_on_all([&] (replica::database& db) -> future<> {
+            auto& cf = db.find_column_family("ks", "cf");
+            if (cf.get_stats().tablet_count > 0) {
+                auto& sys_ks = e.get_system_keyspace().local();
+                co_await cf.cleanup_tablet(db, sys_ks, locator::tablet_id(0));
+                BOOST_REQUIRE(!cf.tablet_has_compacted_undeleted_sstables(locator::tablet_id(0)));
+            }
+            co_return;
+        }).get();
+    }, cfg);
+}
+
 // Reproduces https://github.com/scylladb/scylladb/issues/24134
 // tablet cleanup used subtract_compaction_group_from_stats() which is a
 // non-self-healing decrement. It double-counts total_disk_space_used because


### PR DESCRIPTION
## The problem

As discussed in https://github.com/scylladb/scylladb/pull/30266#discussion_r3373348447, `delete_sstables_atomically` swallows all exceptions.  That means that `_sstables_compacted_but_not_deleted` will always be cleared after the call to `delete_sstables_atomically` even though the intention was to clear only if `delete_sstables_atomically` was successful.

This is a preexisting issue, where `delete_sstables_atomically` may leak deleted sstables if it’s not able to write the pending_delete log.  It’s kind of correct since the contract is that it would delete either all sstable or none of them, but still we want `_sstables_compacted_but_not_deleted` to remain intact in case `delete_sstables_atomically` failed so we can retry their deletion.

## Solution summary
- Introduce a staged `sstables::atomic_deletion` abstraction for atomic SSTable deletion, with 2 stages:
  - commit: Commit the atomic deletion intent to stable storage. On success, all SSTables in the deletion are guaranteed to be eventually deleted. On failure, either all or none of them will be deleted, but never only some of them.
    - Failures in commit generate an exception.
  - finalize: Clean up any pending state created by commit() after the physical SSTable deletion has completed.

## Implementation details
- Keep `table::delete_sstables_atomically()` as the simple best-effort API that ignores errors, while allowing callers that need precise recovery behavior to use `table::make_atomic_deletion()` directly.
- In `compaction_group::cleanup()`, preserve `_sstables_compacted_but_not_deleted` if atomic deletion fails before commit, and clear it only after `prepare_and_commit()` succeeds.
- In `drop_quarantined_sstables()`, prepare and commit atomic deletion in `row_cache::external_updater_impl::prepare()` before cache/table state is modified, then complete deletion after the cache update commits.
- Make pending-delete log creation propagate failures instead of publishing a possibly incomplete log.
- Keep truncate/discard behavior unchanged; it continues to use best-effort chunked deletion.
- Simplify `test_unknown_component` to use plain SSTable unlink instead of atomic deletion.

Fixes [SCYLLADB-2515](https://scylladb.atlassian.net/browse/SCYLLADB-2515)

Follows up on https://github.com/scylladb/scylladb/pull/30266

--

Improvement, no backport required.


[SCYLLADB-2515]: https://scylladb.atlassian.net/browse/SCYLLADB-2515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ