### PR TITLE
logstor: support changing disk size

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -974,6 +974,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Total size in megabytes allocated for logstor storage on disk.")
     , logstor_file_size_in_mb(this, "logstor_file_size_in_mb", value_status::Used, 32,
         "Total size in megabytes allocated for each logstor data file on disk.")
+    , logstor_format_on_startup(this, "logstor_format_on_startup", value_status::Used, true,
+        "Controls when logstor data files are formatted. When enabled, all logstor files are formatted during node startup, which increases startup time but ensures optimal write performance immediately after startup. "
+        "When disabled, logstor files are formatted lazily on first write, which reduces startup time but may cause slightly degraded write performance on first access to each file.")
     , logstor_separator_delay_limit_ms(this, "logstor_separator_delay_limit_ms", value_status::Used, 100,
         "Maximum delay in milliseconds for logstor separator debt control.")
     , logstor_separator_max_memory_in_mb(this, "logstor_separator_max_memory_in_mb", value_status::Used, 256,

--- a/db/config.hh
+++ b/db/config.hh
@@ -273,6 +273,7 @@ public:
     named_value<double> memtable_cleanup_threshold;
     named_value<uint32_t> logstor_disk_size_in_mb;
     named_value<uint32_t> logstor_file_size_in_mb;
+    named_value<bool> logstor_format_on_startup;
     named_value<uint32_t> logstor_separator_delay_limit_ms;
     named_value<uint32_t> logstor_separator_max_memory_in_mb;
     named_value<uint32_t> file_cache_size_in_mb;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -964,6 +964,7 @@ database::init_logstor() {
             .base_dir = std::filesystem::path(_cfg.logstor_directory()),
             .file_size = _cfg.logstor_file_size_in_mb() * 1024ull * 1024ull,
             .disk_size = _cfg.logstor_disk_size_in_mb() * 1024ull * 1024ull,
+            .format_on_startup = _cfg.logstor_format_on_startup(),
             .compaction_sg = _dbcfg.compaction_scheduling_group,
             .compaction_static_shares = _cfg.compaction_static_shares,
             .separator_sg = _dbcfg.memtable_scheduling_group,

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -44,15 +44,17 @@
 
 namespace replica::logstor {
 
+using file_id_t = uint64_t;
+
 class segment {
 protected:
     log_segment_id _id;
     seastar::file _file;
     uint64_t _file_offset; // Offset within the shared file where this segment starts
-    size_t _max_size;
+    uint64_t _max_size;
 
 public:
-    segment(log_segment_id id, seastar::file file, uint64_t file_offset, size_t max_size);
+    segment(log_segment_id id, seastar::file file, uint64_t file_offset, uint64_t max_size);
 
     virtual ~segment() = default;
 
@@ -108,7 +110,7 @@ public:
     }
 };
 
-segment::segment(log_segment_id id, seastar::file file, uint64_t file_offset, size_t max_size)
+segment::segment(log_segment_id id, seastar::file file, uint64_t file_offset, uint64_t max_size)
     : _id(id)
     , _file(std::move(file))
     , _file_offset(file_offset)
@@ -158,9 +160,9 @@ future<log_location> writeable_segment::append(bytes_view data) {
 
 future<> writeable_segment::do_write(log_location loc, bytes_view data) {
     const auto alignment = _file.disk_write_dma_alignment();
-    const auto total = data.size();
+    const uint64_t total = data.size();
     auto offset = absolute_offset(loc.offset);
-    size_t written = 0;
+    uint64_t written = 0;
 
     while (written < total) {
         auto new_written = co_await _file.dma_write(
@@ -179,7 +181,7 @@ future<> writeable_segment::do_write(log_location loc, bytes_view data) {
 using seg_ptr = lw_shared_ptr<writeable_segment>;
 
 class file_manager {
-    size_t _segments_per_file;
+    uint64_t _segments_per_file;
 
     // configured: file count allowed by the current configuration; new file ids
     // are allocated only below this limit.
@@ -193,12 +195,12 @@ class file_manager {
         uint64_t actual;
     } _max_files;
 
-    size_t _file_size;
+    uint64_t _file_size;
     std::filesystem::path _base_dir;
     seastar::scheduling_group _sched_group;
     bool _format_on_startup;
 
-    size_t _next_file_id{0};
+    file_id_t _next_file_id{0};
 
     seastar::gate _async_gate;
     shared_future<> _next_file_formatter{make_ready_future<>()};
@@ -216,24 +218,24 @@ public:
         , _base_dir(cfg.base_dir)
         , _sched_group(cfg.compaction_sg)
         , _format_on_startup(cfg.format_on_startup)
-        , _open_read_files(_max_files.actual)
+        , _open_read_files(static_cast<size_t>(_max_files.actual))
     {}
 
     future<> start();
     future<> stop();
 
-    future<seastar::file> get_file_for_write(size_t file_id);
-    future<seastar::file> get_file_for_read(size_t file_id);
+    future<seastar::file> get_file_for_write(file_id_t);
+    future<seastar::file> get_file_for_read(file_id_t);
 
-    future<> format_file_region(seastar::file file, uint64_t offset, size_t size);
-    future<> format_file(size_t file_id);
-    future<> recover_next_file(size_t next_file_id);
-    future<> remove_file(size_t file_id);
+    future<> format_file_region(seastar::file file, uint64_t offset, uint64_t size);
+    future<> format_file(file_id_t);
+    future<> recover_next_file(file_id_t);
+    future<> remove_file(file_id_t);
     void set_actual_max_files(uint64_t actual_max_files);
 
-    size_t allocated_file_count() const noexcept { return _next_file_id; }
+    uint64_t allocated_file_count() const noexcept { return _next_file_id; }
 
-    size_t segments_per_file() const noexcept { return _segments_per_file; }
+    uint64_t segments_per_file() const noexcept { return _segments_per_file; }
     uint64_t configured_max_files() const noexcept { return _max_files.configured; }
     uint64_t actual_max_files() const noexcept { return _max_files.actual; }
 
@@ -242,12 +244,12 @@ public:
         return fmt::format("ls_{}-", this_shard_id());
     }
 
-    std::filesystem::path get_file_path(size_t file_id) const {
+    std::filesystem::path get_file_path(file_id_t file_id) const {
         auto fname = fmt::format("{}{}-Data.db", get_file_name_prefix(), file_id);
         return _base_dir / fname;
     }
 
-    std::optional<size_t> file_name_to_file_id(const std::string& fname) const;
+    std::optional<file_id_t> file_name_to_file_id(const std::string& fname) const;
 };
 
 future<> file_manager::start() {
@@ -264,7 +266,7 @@ future<> file_manager::stop() {
     co_await _async_gate.close();
 }
 
-future<> file_manager::format_file(size_t file_id) {
+future<> file_manager::format_file(file_id_t file_id) {
     auto file_path = get_file_path(file_id).string();
     bool file_exists = co_await seastar::file_exists(file_path);
     if (!file_exists) {
@@ -281,15 +283,15 @@ future<> file_manager::format_file(size_t file_id) {
     }
 }
 
-future<> file_manager::recover_next_file(size_t next_file_id) {
+future<> file_manager::recover_next_file(file_id_t next_file_id) {
     _next_file_id = next_file_id;
 
     if (_format_on_startup) {
         auto holder = _async_gate.hold();
-        auto next_file_id = _next_file_id;
+        file_id_t next_file_id = _next_file_id;
         co_await with_scheduling_group(_sched_group, [this, next_file_id] -> future<> {
             logstor_logger.info("Formatting {} logstor files", _max_files.configured);
-            for (size_t file_id = next_file_id; file_id < _max_files.configured; ++file_id) {
+            for (file_id_t file_id = next_file_id; file_id < _max_files.configured; ++file_id) {
                 co_await format_file(file_id);
                 _next_file_id = file_id + 1;
             }
@@ -307,7 +309,7 @@ future<> file_manager::recover_next_file(size_t next_file_id) {
     }
 }
 
-future<> file_manager::remove_file(size_t file_id) {
+future<> file_manager::remove_file(file_id_t file_id) {
     if (file_id != _max_files.actual - 1) {
         on_internal_error(logstor_logger, fmt::format("Attempted to remove file {} that is not the last allocated file", file_id));
     }
@@ -335,10 +337,10 @@ void file_manager::set_actual_max_files(uint64_t actual_max_files) {
         on_internal_error(logstor_logger, fmt::format("Attempted to reduce actual max files from {} to {}", _max_files.actual, actual_max_files));
     }
     _max_files.actual = actual_max_files;
-    _open_read_files.resize(_max_files.actual);
+    _open_read_files.resize(static_cast<size_t>(_max_files.actual));
 }
 
-future<seastar::file> file_manager::get_file_for_write(size_t file_id) {
+future<seastar::file> file_manager::get_file_for_write(file_id_t file_id) {
     if (file_id >= _max_files.actual) {
         on_internal_error(logstor_logger, "Attempted to access file beyond actual disk capacity");
     }
@@ -376,7 +378,7 @@ future<seastar::file> file_manager::get_file_for_write(size_t file_id) {
     co_return file;
 }
 
-future<seastar::file> file_manager::get_file_for_read(size_t file_id) {
+future<seastar::file> file_manager::get_file_for_read(file_id_t file_id) {
     if (file_id >= _open_read_files.size()) {
         on_internal_error(logstor_logger, "Attempted to access file beyond actual disk capacity");
     }
@@ -396,13 +398,13 @@ future<seastar::file> file_manager::get_file_for_read(size_t file_id) {
     co_return std::move(file);
 }
 
-future<> file_manager::format_file_region(seastar::file file, uint64_t offset, size_t size) {
+future<> file_manager::format_file_region(seastar::file file, uint64_t offset, uint64_t size) {
     // Write zeros to entire region using the pre-allocated zero buffer
-    size_t remaining = size;
+    uint64_t remaining = size;
     uint64_t current_offset = offset;
 
     while (remaining > 0) {
-        auto write_size = std::min(remaining, _zero_buf_size);
+        auto write_size = std::min<uint64_t>(remaining, _zero_buf_size);
         auto written = co_await file.dma_write(current_offset, _zero_buf.get(), write_size);
 
         current_offset += written;
@@ -410,7 +412,7 @@ future<> file_manager::format_file_region(seastar::file file, uint64_t offset, s
     }
 }
 
-std::optional<size_t> file_manager::file_name_to_file_id(const std::string& fname) const {
+std::optional<file_id_t> file_manager::file_name_to_file_id(const std::string& fname) const {
     std::string prefix = get_file_name_prefix();
     std::string suffix = "-Data.db";
     if (fname.starts_with(prefix) && fname.ends_with(suffix)) {
@@ -419,7 +421,7 @@ std::optional<size_t> file_manager::file_name_to_file_id(const std::string& fnam
         size_t end = fname.size() - suffix.size();
         std::string file_id_str = fname.substr(start, end - start);
         try {
-            return std::stoull(file_id_str);
+            return static_cast<file_id_t>(std::stoull(file_id_str));
         } catch (...) {
             return std::nullopt;
         }
@@ -456,7 +458,7 @@ private:
     struct controller {
         float _compaction_overhead{1.0}; // running average ratio
 
-        void update(size_t segment_write_count, size_t new_segments);
+        void update(size_t segment_write_count, uint64_t new_segments);
     };
     controller _controller;
     timer<lowres_clock> _adjust_shares_timer;
@@ -642,7 +644,7 @@ class segment_manager_impl {
     compaction_manager_impl _compaction_mgr;
 
     segment_manager_config _cfg;
-    size_t _segments_per_file;
+    uint64_t _segments_per_file;
 
     // configured: segment count allowed by the current configuration; new
     // segment ids are allocated only below this limit.
@@ -655,7 +657,7 @@ class segment_manager_impl {
         uint64_t actual;
     } _max_segments;
 
-    size_t _next_new_segment_id{0};
+    uint64_t _next_new_segment_id{0};
 
     stats _stats;
     seastar::metrics::metric_groups _metrics;
@@ -759,7 +761,7 @@ public:
         _trigger_separator_flush_fn = std::move(fn);
     }
 
-    size_t get_segment_size() const noexcept {
+    uint64_t get_segment_size() const noexcept {
         return _cfg.segment_size;
     }
 
@@ -778,17 +780,17 @@ public:
     future<seastar::input_stream<char>> create_segment_input_stream(log_segment_id segment_id, const seastar::file_input_stream_options& opts);
     future<std::unique_ptr<segment_stream_sink>> create_segment_output_stream(replica::database&);
 
-    size_t available_segment_count() const noexcept {
+    uint64_t available_segment_count() const noexcept {
         const auto allocatable_new_segment_count =
                 _next_new_segment_id < _max_segments.configured ? _max_segments.configured - _next_new_segment_id : 0;
 
-        return _free_segments.size() + _segment_pool.size() + allocatable_new_segment_count;
+        return static_cast<uint64_t>(_free_segments.size()) + static_cast<uint64_t>(_segment_pool.size()) + allocatable_new_segment_count;
     }
 
     void set_actual_max_segments(uint64_t actual_max_segments) {
         _max_segments.actual = actual_max_segments;
-        _segment_descs.resize(_max_segments.actual);
-        _free_segments.reserve(_max_segments.actual);
+        _segment_descs.resize(static_cast<size_t>(_max_segments.actual));
+        _free_segments.reserve(static_cast<size_t>(_max_segments.actual));
     }
 
 private:
@@ -855,32 +857,32 @@ private:
     }
 
     log_segment_id desc_to_segment_id(const segment_descriptor& desc) const noexcept {
-        size_t index = &desc - &_segment_descs[0];
+        uint64_t index = &desc - &_segment_descs[0];
         return log_segment_id(index);
     }
 
     struct segment_location {
-        size_t file_id;
-        size_t file_offset;
+        file_id_t file_id;
+        uint64_t file_offset;
     };
 
-    size_t file_offset_to_segment_index(size_t file_offset) const noexcept {
+    uint64_t file_offset_to_segment_index(uint64_t file_offset) const noexcept {
         return file_offset / _cfg.segment_size;
     }
 
-    size_t segment_index_to_file_offset(size_t segment_index) const noexcept {
+    uint64_t segment_index_to_file_offset(uint64_t segment_index) const noexcept {
         return segment_index * _cfg.segment_size;
     }
 
     segment_location segment_id_to_file_location(log_segment_id segment_id) const noexcept {
-        size_t file_id = segment_id.value / _segments_per_file;
-        size_t file_offset = (segment_id.value % _segments_per_file) * _cfg.segment_size;
+        file_id_t file_id = segment_id.value / _segments_per_file;
+        uint64_t file_offset = (segment_id.value % _segments_per_file) * _cfg.segment_size;
         return segment_location{file_id, file_offset};
     }
 
-    auto segments_in_file(size_t file_id) const noexcept {
+    auto segments_in_file(file_id_t file_id) const noexcept {
         return std::views::iota(file_id * _segments_per_file, (file_id + 1) * _segments_per_file)
-            | std::views::transform([] (size_t i) {
+            | std::views::transform([] (uint64_t i) {
                 return log_segment_id(i);
             });
     }
@@ -903,7 +905,7 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
     , _segments_per_file(config.file_size / config.segment_size)
     , _max_segments{(config.disk_size / config.file_size) * _segments_per_file, (config.disk_size / config.file_size) * _segments_per_file}
     , _segment_pool(segment_pool_size, config.max_segments_per_compaction)
-    , _segment_descs(_max_segments.actual)
+    , _segment_descs(static_cast<size_t>(_max_segments.actual))
     {
 
     if (_segments_per_file == 0) {
@@ -914,7 +916,7 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
         throw exceptions::configuration_exception(fmt::format("Disk size {} must be greater than or equal to file size {}", config.disk_size, config.file_size));
     }
 
-    _free_segments.reserve(_max_segments.actual);
+    _free_segments.reserve(static_cast<size_t>(_max_segments.actual));
 
     // pre-allocate write buffers for compaction
     // at most a single compaction/split running at a time
@@ -1401,10 +1403,10 @@ compaction_reenabler compaction_manager_impl::disable_compaction_no_wait(compact
 }
 
 std::vector<log_segment_id> compaction_manager_impl::select_segments_for_compaction(const segment_descriptor_hist& segments) {
-    size_t accum_net_data_size = 0;
-    size_t accum_record_count = 0;
-    ssize_t max_gain = 0;
-    size_t best_count = 0;
+    uint64_t accum_net_data_size = 0;
+    uint64_t accum_record_count = 0;
+    int64_t max_gain = 0;
+    uint64_t best_count = 0;
     std::vector<log_segment_id> candidates;
     const auto segment_size = _sm.get_segment_size();
 
@@ -1425,7 +1427,7 @@ std::vector<log_segment_id> compaction_manager_impl::select_segments_for_compact
         logstor_logger.trace("Evaluating compaction candidate {} with net data size {} accumulated {} required segments {}",
                            seg_id, desc.net_data_size(segment_size), accum_net_data_size, required_segments);
 
-        auto gain = ssize_t(candidates.size()) - ssize_t(required_segments);
+        auto gain = static_cast<int64_t>(candidates.size()) - static_cast<int64_t>(required_segments);
         if (gain > max_gain) {
             max_gain = gain;
             best_count = candidates.size();
@@ -1585,7 +1587,7 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
         }
     }
 
-    size_t new_segments = segments.size() > cb.stats.flush_count ? segments.size() - cb.stats.flush_count : 0;
+    uint64_t new_segments = segments.size() > cb.stats.flush_count ? segments.size() - cb.stats.flush_count : 0;
     _stats.segments_compacted += segments.size();
     _stats.compaction_segments_freed += new_segments;
     _stats.compaction_records_rewritten += cb.stats.records_rewritten;
@@ -1594,8 +1596,8 @@ future<> compaction_manager_impl::compact_segments(compaction_group& cg, std::ve
     _controller.update(cb.stats.flush_count, new_segments);
 }
 
-void compaction_manager_impl::controller::update(size_t segment_write_count, size_t new_segments) {
-    float new_overhead = static_cast<float>(segment_write_count) / std::max<size_t>(1, new_segments);
+void compaction_manager_impl::controller::update(size_t segment_write_count, uint64_t new_segments) {
+    float new_overhead = static_cast<float>(segment_write_count) / std::max<uint64_t>(1, new_segments);
     _compaction_overhead = 0.8 * _compaction_overhead + 0.2 * new_overhead;
 }
 
@@ -1805,7 +1807,7 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
     co_await _file_mgr.start();
 
     // Scan the base directory for all files belonging to this shard.
-    std::set<size_t> found_file_ids;
+    std::set<file_id_t> found_file_ids;
     std::vector<sstring> files_for_removal;
     std::string file_prefix = _file_mgr.get_file_name_prefix();
     co_await lister::scan_dir(_cfg.base_dir, lister::dir_entry_types::of<directory_entry_type::regular>(),
@@ -1833,7 +1835,7 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
     );
 
     // Verify all files are present
-    size_t next_file_id = 0;
+    file_id_t next_file_id = 0;
     for (auto file_id : found_file_ids) {
         if (file_id != next_file_id) {
             throw std::runtime_error(fmt::format("Missing log segment file(s) detected during recovery: file {} missing", _file_mgr.get_file_path(next_file_id).string()));
@@ -1841,12 +1843,12 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
         next_file_id++;
     }
 
-    size_t allocated_segment_count = next_file_id * _segments_per_file;
+    uint64_t allocated_segment_count = next_file_id * _segments_per_file;
 
     _file_mgr.set_actual_max_files(std::max(_file_mgr.configured_max_files(), next_file_id));
     set_actual_max_segments(std::max(_max_segments.configured, allocated_segment_count));
 
-    std::vector<segment_sequence> segment_seqs(allocated_segment_count, segment_sequence(0));
+    std::vector<segment_sequence> segment_seqs(static_cast<size_t>(allocated_segment_count), segment_sequence(0));
     segment_sequence max_segment_seq = segment_sequence(0);
 
     // Populate the index from all segments. Keep the latest record for each key.
@@ -1877,7 +1879,7 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
     }
 
     // go over the index and mark all segments that have live data as used.
-    utils::dynamic_bitset used_segments(allocated_segment_count);
+    utils::dynamic_bitset used_segments(static_cast<size_t>(allocated_segment_count));
 
     co_await db.get_tables_metadata().for_each_table_gently([&] (table_id tid, lw_shared_ptr<table> tp) -> future<> {
         if (!tp->uses_logstor()) {
@@ -1891,10 +1893,10 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
     });
 
     // put used segments in compaction groups, and put the rest in the free list.
-    size_t free_segment_count = 0;
-    size_t used_segment_count = 0;
-    size_t max_used_seg_idx = 0;
-    for (size_t seg_idx = 0; seg_idx < allocated_segment_count; ++seg_idx) {
+    uint64_t free_segment_count = 0;
+    uint64_t used_segment_count = 0;
+    uint64_t max_used_seg_idx = 0;
+    for (uint64_t seg_idx = 0; seg_idx < allocated_segment_count; ++seg_idx) {
         co_await coroutine::maybe_yield();
         log_segment_id seg_id(seg_idx);
         if (!used_segments.test(seg_idx)) {
@@ -1919,7 +1921,7 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
     allocated_segment_count = next_file_id * _segments_per_file;
     set_actual_max_segments(std::max(_max_segments.configured, allocated_segment_count));
 
-    size_t recovered_used_segment_count = 0;
+    uint64_t recovered_used_segment_count = 0;
     if (used_segments.size() > 0) {
         for (auto seg_idx = used_segments.find_first_set(); seg_idx != utils::dynamic_bitset::npos; seg_idx = used_segments.find_next_set(seg_idx)) {
             co_await coroutine::maybe_yield();
@@ -2119,7 +2121,7 @@ const compaction_manager& segment_manager::get_compaction_manager() const noexce
     return _impl->get_compaction_manager();
 }
 
-size_t segment_manager::get_segment_size() const noexcept {
+uint64_t segment_manager::get_segment_size() const noexcept {
     return _impl->get_segment_size();
 }
 

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -571,7 +571,6 @@ public:
 class segment_manager_impl {
 
     struct stats {
-        uint64_t segments_in_use{0};
         std::array<uint64_t, write_source_count> bytes_written{0};
         std::array<uint64_t, write_source_count> data_bytes_written{0};
         uint64_t bytes_read{0};
@@ -713,6 +712,10 @@ public:
     future<seastar::input_stream<char>> create_segment_input_stream(log_segment_id segment_id, const seastar::file_input_stream_options& opts);
     future<std::unique_ptr<segment_stream_sink>> create_segment_output_stream(replica::database&);
 
+    size_t available_segment_count() const noexcept {
+        return _free_segments.size() + _segment_pool.size() + (_max_segments - _next_new_segment_id);
+    }
+
 private:
 
     future<> replenish_reserve();
@@ -763,7 +766,6 @@ private:
     future<seg_ptr> get_segment(write_source src) {
         seg_ptr seg = co_await _segment_pool.get_segment(src);
         seg->start(make_segment_ref(seg->id()), allocate_segment_seq());
-        _stats.segments_in_use++;
         co_return seg;
     }
 
@@ -854,9 +856,9 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
     namespace sm = seastar::metrics;
 
     _metrics.add_group("logstor_sm", {
-        sm::make_gauge("segments_in_use", _stats.segments_in_use,
+        sm::make_gauge("segments_in_use", [this] { return _max_segments - available_segment_count(); },
                        sm::description("Counts number of segments currently in use.")),
-        sm::make_gauge("free_segments", [this] { return _free_segments.size(); },
+        sm::make_gauge("free_segments", [this] { return available_segment_count(); },
                        sm::description("Counts number of free segments currently available.")),
         sm::make_gauge("segment_pool_size", [this] { return _segment_pool.size(); },
                        sm::description("Counts number of segments in the segment pool.")),
@@ -1183,7 +1185,6 @@ void segment_manager_impl::free_segment(log_segment_id segment_id) noexcept {
     _segment_freed_cv.signal();
 
     _stats.segments_freed++;
-    _stats.segments_in_use--;
 }
 
 future<> segment_manager_impl::discard_segments(segment_set& ss) {
@@ -1827,7 +1828,6 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
                 logstor_logger.info("Recovering used segments: {}%", 100 * recovered_used_segment_count / used_segment_count);
             }
             co_await add_segment_to_compaction_group(db, desc);
-            _stats.segments_in_use++;
             recovered_used_segment_count++;
         }
     }

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -183,6 +183,7 @@ class file_manager {
     size_t _file_size;
     std::filesystem::path _base_dir;
     seastar::scheduling_group _sched_group;
+    bool _format_on_startup;
 
     size_t _next_file_id{0};
 
@@ -201,6 +202,7 @@ public:
         , _file_size(cfg.file_size)
         , _base_dir(cfg.base_dir)
         , _sched_group(cfg.compaction_sg)
+        , _format_on_startup(cfg.format_on_startup)
         , _open_read_files(_max_files)
     {}
 
@@ -212,7 +214,7 @@ public:
 
     future<> format_file_region(seastar::file file, uint64_t offset, size_t size);
     future<> format_file(size_t file_id);
-    void recover_next_file_id(size_t next_file_id);
+    future<> recover_next_file(size_t next_file_id);
 
     size_t allocated_file_count() const noexcept { return _next_file_id; }
 
@@ -263,8 +265,22 @@ future<> file_manager::format_file(size_t file_id) {
     }
 }
 
-void file_manager::recover_next_file_id(size_t next_file_id) {
+future<> file_manager::recover_next_file(size_t next_file_id) {
     _next_file_id = next_file_id;
+
+    if (_format_on_startup) {
+        auto holder = _async_gate.hold();
+        auto next_file_id = _next_file_id;
+        co_await with_scheduling_group(_sched_group, [this, next_file_id] -> future<> {
+            logstor_logger.info("Formatting {} logstor files", _max_files);
+            for (size_t file_id = next_file_id; file_id < _max_files; ++file_id) {
+                co_await format_file(file_id);
+                _next_file_id = file_id + 1;
+            }
+        });
+        _next_file_formatter = make_ready_future<>();
+        co_return;
+    }
 
     if (_next_file_id < _max_files) {
         _next_file_formatter = with_gate(_async_gate, [this] {
@@ -1819,7 +1835,7 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
     _next_new_segment_id = allocated_segment_count;
     _next_segment_seq = max_segment_seq + 1;
 
-    _file_mgr.recover_next_file_id(next_file_id);
+    co_await _file_mgr.recover_next_file(next_file_id);
 
     logstor_logger.info("Recovery complete");
 }

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -8,6 +8,7 @@
 #include "replica/logstor/segment_manager.hh"
 #include "replica/logstor/ondisk.hh"
 #include "replica/logstor/segment_io.hh"
+#include "exceptions/exceptions.hh"
 #include "replica/logstor/index.hh"
 #include "replica/logstor/logstor.hh"
 #include "replica/logstor/types.hh"
@@ -179,7 +180,19 @@ using seg_ptr = lw_shared_ptr<writeable_segment>;
 
 class file_manager {
     size_t _segments_per_file;
-    size_t _max_files;
+
+    // configured: file count allowed by the current configuration; new file ids
+    // are allocated only below this limit.
+    // actual: file count currently present on disk. Recovery may raise this
+    // above configured if it finds existing files beyond the configured limit.
+    // Such files remain readable and their live segments remain usable until
+    // freed, but new files are never allocated beyond configured. Fully retired
+    // files may be deleted from the end.
+    struct {
+        uint64_t configured;
+        uint64_t actual;
+    } _max_files;
+
     size_t _file_size;
     std::filesystem::path _base_dir;
     seastar::scheduling_group _sched_group;
@@ -198,12 +211,12 @@ class file_manager {
 public:
     file_manager(segment_manager_config cfg)
         : _segments_per_file(cfg.file_size / cfg.segment_size)
-        , _max_files(cfg.disk_size / cfg.file_size)
+        , _max_files{cfg.disk_size / cfg.file_size, cfg.disk_size / cfg.file_size}
         , _file_size(cfg.file_size)
         , _base_dir(cfg.base_dir)
         , _sched_group(cfg.compaction_sg)
         , _format_on_startup(cfg.format_on_startup)
-        , _open_read_files(_max_files)
+        , _open_read_files(_max_files.actual)
     {}
 
     future<> start();
@@ -215,11 +228,14 @@ public:
     future<> format_file_region(seastar::file file, uint64_t offset, size_t size);
     future<> format_file(size_t file_id);
     future<> recover_next_file(size_t next_file_id);
+    future<> remove_file(size_t file_id);
+    void set_actual_max_files(uint64_t actual_max_files);
 
     size_t allocated_file_count() const noexcept { return _next_file_id; }
 
     size_t segments_per_file() const noexcept { return _segments_per_file; }
-    size_t max_files() const noexcept { return _max_files; }
+    uint64_t configured_max_files() const noexcept { return _max_files.configured; }
+    uint64_t actual_max_files() const noexcept { return _max_files.actual; }
 
     // the file names are ls_{shard_id}-{file_id}-Data.db
     static const sstring get_file_name_prefix() {
@@ -272,8 +288,8 @@ future<> file_manager::recover_next_file(size_t next_file_id) {
         auto holder = _async_gate.hold();
         auto next_file_id = _next_file_id;
         co_await with_scheduling_group(_sched_group, [this, next_file_id] -> future<> {
-            logstor_logger.info("Formatting {} logstor files", _max_files);
-            for (size_t file_id = next_file_id; file_id < _max_files; ++file_id) {
+            logstor_logger.info("Formatting {} logstor files", _max_files.configured);
+            for (size_t file_id = next_file_id; file_id < _max_files.configured; ++file_id) {
                 co_await format_file(file_id);
                 _next_file_id = file_id + 1;
             }
@@ -282,7 +298,7 @@ future<> file_manager::recover_next_file(size_t next_file_id) {
         co_return;
     }
 
-    if (_next_file_id < _max_files) {
+    if (_next_file_id < _max_files.configured) {
         _next_file_formatter = with_gate(_async_gate, [this] {
             return with_scheduling_group(_sched_group, [this] {
                 return format_file(_next_file_id);
@@ -291,8 +307,43 @@ future<> file_manager::recover_next_file(size_t next_file_id) {
     }
 }
 
+future<> file_manager::remove_file(size_t file_id) {
+    if (file_id != _max_files.actual - 1) {
+        on_internal_error(logstor_logger, fmt::format("Attempted to remove file {} that is not the last allocated file", file_id));
+    }
+    if (_max_files.actual <= _max_files.configured) {
+        on_internal_error(logstor_logger, fmt::format("Attempted to remove file {} while actual max files {} is not above configured max files {}", file_id, _max_files.actual, _max_files.configured));
+    }
+    if (file_id < _open_read_files.size()) {
+        if (file_id + 1 != _open_read_files.size()) {
+            on_internal_error(logstor_logger, fmt::format("Attempted to remove file {} while higher file {} is still allocated", file_id, file_id + 1));
+        }
+        if (_open_read_files[file_id]) {
+            co_await _open_read_files[file_id].close();
+        }
+        _open_read_files.pop_back();
+    }
+    co_await seastar::remove_file(get_file_path(file_id).string());
+    _max_files.actual--;
+}
+
+void file_manager::set_actual_max_files(uint64_t actual_max_files) {
+    if (actual_max_files < _max_files.configured) {
+        on_internal_error(logstor_logger, fmt::format("Attempted to set actual max files {} below configured max files {}", actual_max_files, _max_files.configured));
+    }
+    if (actual_max_files < _max_files.actual) {
+        on_internal_error(logstor_logger, fmt::format("Attempted to reduce actual max files from {} to {}", _max_files.actual, actual_max_files));
+    }
+    _max_files.actual = actual_max_files;
+    _open_read_files.resize(_max_files.actual);
+}
+
 future<seastar::file> file_manager::get_file_for_write(size_t file_id) {
-    if (file_id == _next_file_id && file_id < _max_files) {
+    if (file_id >= _max_files.actual) {
+        on_internal_error(logstor_logger, "Attempted to access file beyond actual disk capacity");
+    }
+
+    if (file_id == _next_file_id && file_id < _max_files.configured) {
         // allocate file_id and wait for it to be formatted, and start formatting
         // the next file in background
         co_await _next_file_formatter.get_future();
@@ -300,7 +351,7 @@ future<seastar::file> file_manager::get_file_for_write(size_t file_id) {
         if (file_id == _next_file_id) {
             _next_file_id++;
 
-            if (_next_file_id < _max_files) {
+            if (_next_file_id < _max_files.configured) {
                 _next_file_formatter = with_gate(_async_gate, [this] {
                     return with_scheduling_group(_sched_group, [this] {
                         return format_file(_next_file_id);
@@ -308,7 +359,7 @@ future<seastar::file> file_manager::get_file_for_write(size_t file_id) {
                 });
             }
         }
-    } else if (file_id >= _max_files) {
+    } else if (file_id >= _max_files.configured && file_id >= _next_file_id) {
         on_internal_error(logstor_logger, "Disk size limit reached, cannot allocate more files");
     } else if (file_id > _next_file_id) {
         on_internal_error(logstor_logger, "files must be allocated in sequential order");
@@ -326,6 +377,10 @@ future<seastar::file> file_manager::get_file_for_write(size_t file_id) {
 }
 
 future<seastar::file> file_manager::get_file_for_read(size_t file_id) {
+    if (file_id >= _open_read_files.size()) {
+        on_internal_error(logstor_logger, "Attempted to access file beyond actual disk capacity");
+    }
+
     auto& cached_file = _open_read_files[file_id];
     if (cached_file) {
         co_return cached_file;
@@ -588,7 +643,18 @@ class segment_manager_impl {
 
     segment_manager_config _cfg;
     size_t _segments_per_file;
-    size_t _max_segments;
+
+    // configured: segment count allowed by the current configuration; new
+    // segment ids are allocated only below this limit.
+    // actual: segment slots currently present on disk. Recovery may raise this
+    // above configured if it finds existing segments beyond the configured
+    // limit. Those segments remain usable until freed; once freed, beyond-
+    // configured segments become retired and are not allocated again.
+    struct {
+        uint64_t configured;
+        uint64_t actual;
+    } _max_segments;
+
     size_t _next_new_segment_id{0};
 
     stats _stats;
@@ -713,7 +779,16 @@ public:
     future<std::unique_ptr<segment_stream_sink>> create_segment_output_stream(replica::database&);
 
     size_t available_segment_count() const noexcept {
-        return _free_segments.size() + _segment_pool.size() + (_max_segments - _next_new_segment_id);
+        const auto allocatable_new_segment_count =
+                _next_new_segment_id < _max_segments.configured ? _max_segments.configured - _next_new_segment_id : 0;
+
+        return _free_segments.size() + _segment_pool.size() + allocatable_new_segment_count;
+    }
+
+    void set_actual_max_segments(uint64_t actual_max_segments) {
+        _max_segments.actual = actual_max_segments;
+        _segment_descs.resize(_max_segments.actual);
+        _free_segments.reserve(_max_segments.actual);
     }
 
 private:
@@ -826,12 +901,20 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
         })
     , _cfg(config)
     , _segments_per_file(config.file_size / config.segment_size)
-    , _max_segments((config.disk_size / config.file_size) * _segments_per_file)
+    , _max_segments{(config.disk_size / config.file_size) * _segments_per_file, (config.disk_size / config.file_size) * _segments_per_file}
     , _segment_pool(segment_pool_size, config.max_segments_per_compaction)
-    , _segment_descs(_max_segments)
+    , _segment_descs(_max_segments.actual)
     {
 
-    _free_segments.reserve(_max_segments);
+    if (_segments_per_file == 0) {
+        throw exceptions::configuration_exception(fmt::format("Segment size {} must be less than or equal to file size {}", config.segment_size, config.file_size));
+    }
+
+    if (_max_segments.configured == 0) {
+        throw exceptions::configuration_exception(fmt::format("Disk size {} must be greater than or equal to file size {}", config.disk_size, config.file_size));
+    }
+
+    _free_segments.reserve(_max_segments.actual);
 
     // pre-allocate write buffers for compaction
     // at most a single compaction/split running at a time
@@ -856,7 +939,7 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
     namespace sm = seastar::metrics;
 
     _metrics.add_group("logstor_sm", {
-        sm::make_gauge("segments_in_use", [this] { return _max_segments - available_segment_count(); },
+        sm::make_gauge("segments_in_use", [this] { return _max_segments.actual - available_segment_count(); },
                        sm::description("Counts number of segments currently in use.")),
         sm::make_gauge("free_segments", [this] { return available_segment_count(); },
                        sm::description("Counts number of free segments currently available.")),
@@ -1094,7 +1177,7 @@ future<> segment_manager_impl::switch_active_segment() {
     }
 
     // trigger separator flush for separator buffers that hold old segments
-    auto u = std::max<size_t>(1, _max_segments / 100);
+    auto u = std::max<size_t>(1, _max_segments.configured / 100);
     if (_next_segment_seq.value % u == 0 && _next_segment_seq.value > 5*u) {
         trigger_separator_flush(segment_sequence(_next_segment_seq.value - 5*u));
     }
@@ -1146,12 +1229,12 @@ future<seg_ptr> segment_manager_impl::allocate_segment() {
 
     while (true) {
         // first, allocate all new segments sequentially
-        if (_next_new_segment_id < _max_segments) {
+        if (_next_new_segment_id < _max_segments.configured) {
             auto seg_id = log_segment_id(_next_new_segment_id++);
             co_return co_await make_segment(seg_id);
         }
 
-        if (_free_segments.size() < _max_segments * trigger_compaction_threshold / 100) {
+        if (_free_segments.size() < _max_segments.configured * trigger_compaction_threshold / 100) {
             trigger_compaction();
         }
 
@@ -1181,8 +1264,10 @@ void segment_manager_impl::free_segment(log_segment_id segment_id) noexcept {
     if (desc.ref_count != 0) {
         on_internal_error(logstor_logger, format("Freeing segment {} with non-zero reference count", segment_id));
     }
-    _free_segments.push_back(segment_id);
-    _segment_freed_cv.signal();
+    if (segment_id.value < _max_segments.configured) {
+        _free_segments.push_back(segment_id);
+        _segment_freed_cv.signal();
+    }
 
     _stats.segments_freed++;
 }
@@ -1758,6 +1843,9 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
 
     size_t allocated_segment_count = next_file_id * _segments_per_file;
 
+    _file_mgr.set_actual_max_files(std::max(_file_mgr.configured_max_files(), next_file_id));
+    set_actual_max_segments(std::max(_max_segments.configured, allocated_segment_count));
+
     std::vector<segment_sequence> segment_seqs(allocated_segment_count, segment_sequence(0));
     segment_sequence max_segment_seq = segment_sequence(0);
 
@@ -1805,24 +1893,38 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
     // put used segments in compaction groups, and put the rest in the free list.
     size_t free_segment_count = 0;
     size_t used_segment_count = 0;
+    size_t max_used_seg_idx = 0;
     for (size_t seg_idx = 0; seg_idx < allocated_segment_count; ++seg_idx) {
         co_await coroutine::maybe_yield();
         log_segment_id seg_id(seg_idx);
         if (!used_segments.test(seg_idx)) {
-            _free_segments.push_back(seg_id);
-            free_segment_count++;
+            if (seg_idx < _max_segments.configured) {
+                _free_segments.push_back(seg_id);
+                free_segment_count++;
+            }
         } else {
             used_segment_count++;
+            max_used_seg_idx = seg_idx;
         }
     }
     logstor_logger.info("Found {} used segments and {} free segments", used_segment_count, free_segment_count);
 
+    auto target_file_count = std::max(max_used_seg_idx / _segments_per_file + 1, _file_mgr.configured_max_files());
+    for (; next_file_id > target_file_count; next_file_id--) {
+        auto file_id = next_file_id - 1;
+        logstor_logger.info("Recovery: removing retired file {}", _file_mgr.get_file_path(file_id).string());
+        co_await _file_mgr.remove_file(file_id);
+    }
+
+    allocated_segment_count = next_file_id * _segments_per_file;
+    set_actual_max_segments(std::max(_max_segments.configured, allocated_segment_count));
+
     size_t recovered_used_segment_count = 0;
-    for (size_t seg_idx = 0; seg_idx < allocated_segment_count; ++seg_idx) {
-        co_await coroutine::maybe_yield();
-        log_segment_id seg_id(seg_idx);
-        auto& desc = get_segment_descriptor(seg_id);
-        if (used_segments.test(seg_idx)) {
+    if (used_segments.size() > 0) {
+        for (auto seg_idx = used_segments.find_first_set(); seg_idx != utils::dynamic_bitset::npos; seg_idx = used_segments.find_next_set(seg_idx)) {
+            co_await coroutine::maybe_yield();
+            log_segment_id seg_id(seg_idx);
+            auto& desc = get_segment_descriptor(seg_id);
             logstor_logger.trace("Recovering used segment {}", seg_id);
             if (recovered_used_segment_count % 1000 == 0) {
                 logstor_logger.info("Recovering used segments: {}%", 100 * recovered_used_segment_count / used_segment_count);

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -36,15 +36,15 @@ class compaction_manager;
 class segment_set;
 class primary_index;
 
-static constexpr size_t default_segment_size = 128 * 1024;
-static constexpr size_t default_file_size = 32 * 1024 * 1024;
+static constexpr uint64_t default_segment_size = 128 * 1024;
+static constexpr uint64_t default_file_size = 32 * 1024 * 1024;
 
 /// Configuration for the segment manager
 struct segment_manager_config {
     std::filesystem::path base_dir;
-    size_t segment_size = default_segment_size;
-    size_t file_size = default_file_size;
-    size_t disk_size;
+    uint64_t segment_size = default_segment_size;
+    uint64_t file_size = default_file_size;
+    uint64_t disk_size;
     bool format_on_startup = true;
     bool compaction_enabled = true;
     size_t max_segments_per_compaction = 8;
@@ -130,7 +130,7 @@ public:
     void set_trigger_compaction_hook(std::function<void()> fn);
     void set_trigger_separator_flush_hook(std::function<void(segment_sequence)> fn);
 
-    size_t get_segment_size() const noexcept;
+    uint64_t get_segment_size() const noexcept;
 
     future<> discard_segments(segment_set&);
 

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -45,6 +45,7 @@ struct segment_manager_config {
     size_t segment_size = default_segment_size;
     size_t file_size = default_file_size;
     size_t disk_size;
+    bool format_on_startup = true;
     bool compaction_enabled = true;
     size_t max_segments_per_compaction = 8;
     seastar::scheduling_group compaction_sg;

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -7,6 +7,7 @@
 import asyncio
 import random
 import time
+from pathlib import Path
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import new_test_keyspace
 from cassandra.protocol import ConfigurationException
@@ -16,6 +17,12 @@ from test.pylib.tablets import get_tablet_count, get_tablet_replica
 from test.pylib.util import wait_for
 
 logger = logging.getLogger(__name__)
+
+segment_size = 128 * 1024
+
+async def count_logstor_data_files(manager: ManagerClient, server_id: int, shard: int) -> int:
+    workdir = await manager.server_get_workdir(server_id)
+    return len(list((Path(workdir) / "logstor").glob(f"ls_{shard}-*-Data.db")))
 
 async def test_property(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
@@ -355,6 +362,212 @@ async def test_recovery_with_segment_reuse(manager: ManagerClient):
             rows = await cql.run_async(f"SELECT v FROM {ks}.test WHERE pk = {pk}")
             assert len(rows) == 1, f"Key {pk} not found after recovery"
             assert rows[0].v == expected_v, f"Key {pk} value mismatch after recovery"
+
+async def test_grow_logstor_disk_size(manager: ManagerClient):
+    """
+    Test that increasing the configured logstor disk size works correctly.
+
+    This test starts a node with a smaller logstor disk size, verifies the
+    initial file count, restarts the node with a larger configured size, and
+    checks that new files are created and the number of free segments grows.
+    """
+    old_disk_size_mb = 4
+    new_disk_size_mb = 8
+    file_size_mb = 1
+
+    cmdline = ['--logger-log-level', 'logstor=debug', '--smp=1']
+    cfg = {
+        'logstor_disk_size_in_mb': old_disk_size_mb,
+        'logstor_file_size_in_mb': file_size_mb,
+        'logstor_format_on_startup': True,
+        'experimental_features': ['logstor'],
+    }
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH tablets={'initial':1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        files_before_restart = await count_logstor_data_files(manager, servers[0].server_id, 0)
+        assert files_before_restart == old_disk_size_mb // file_size_mb
+
+        metrics = await manager.metrics.query(servers[0].ip_addr)
+        old_free_segments = metrics.get("scylla_logstor_sm_free_segments") or 0
+
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_update_config(servers[0].server_id, 'logstor_disk_size_in_mb', new_disk_size_mb)
+        await manager.server_start(servers[0].server_id)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        files_after_growth = await count_logstor_data_files(manager, servers[0].server_id, 0)
+        assert files_after_growth == new_disk_size_mb // file_size_mb
+
+        metrics = await manager.metrics.query(servers[0].ip_addr)
+        new_free_segments = metrics.get("scylla_logstor_sm_free_segments") or 0
+
+        assert new_free_segments >= old_free_segments + ((new_disk_size_mb - old_disk_size_mb) * 1024 * 1024) // segment_size, \
+            "Free segments should increase after growing disk size"
+
+async def test_shrink_logstor_disk_size_no_data(manager: ManagerClient):
+    """
+    Test that shrinking the configured logstor disk size works correctly when
+    there is no live data to preserve the extra capacity.
+
+    This test starts a node with a larger logstor disk size, verifies the
+    initial file count, restarts the node with a smaller configured size, and
+    checks that the extra file is removed and the free segment count stays
+    within the new capacity.
+    """
+    old_disk_size_mb = 8
+    new_disk_size_mb = 4
+    file_size_mb = 1
+
+    cmdline = ['--logger-log-level', 'logstor=debug', '--smp=1']
+    cfg = {
+        'logstor_disk_size_in_mb': old_disk_size_mb,
+        'logstor_file_size_in_mb': file_size_mb,
+        'logstor_format_on_startup': True,
+        'experimental_features': ['logstor'],
+    }
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH tablets={'initial':1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        files_before_restart = await count_logstor_data_files(manager, servers[0].server_id, 0)
+        assert files_before_restart == old_disk_size_mb // file_size_mb
+
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_update_config(servers[0].server_id, 'logstor_disk_size_in_mb', new_disk_size_mb)
+        await manager.server_start(servers[0].server_id)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        files_after_restart = await count_logstor_data_files(manager, servers[0].server_id, 0)
+        assert files_after_restart == new_disk_size_mb // file_size_mb
+
+        metrics = await manager.metrics.query(servers[0].ip_addr)
+        free_segments = metrics.get("scylla_logstor_sm_free_segments") or 0
+        assert free_segments <= new_disk_size_mb * 1024 * 1024 // segment_size, "Free segments should not exceed total segments after shrinking disk size"
+
+
+async def test_shrink_logstor_disk_size_dead_data(manager: ManagerClient):
+    """
+    Test that shrinking the configured logstor disk size can remove a file when
+    all data in that file is dead.
+
+    This test starts with two files, writes enough segment-sized data to use
+    both files, drops the table so all data becomes dead, restarts with a
+    smaller configured disk size, and checks that the extra file disappears and
+    the remaining segment accounting matches the new capacity.
+    """
+    old_disk_size_mb = 8
+    new_disk_size_mb = 4
+    file_size_mb = 4
+    segments_per_file = (file_size_mb * 1024 * 1024) // segment_size
+
+    cmdline = ['--logger-log-level', 'logstor=trace', '--smp=1']
+    cfg = {
+        'logstor_disk_size_in_mb': old_disk_size_mb,
+        'logstor_file_size_in_mb': file_size_mb,
+        'logstor_format_on_startup': True,
+        'experimental_features': ['logstor'],
+    }
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH tablets={'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        files_before = await count_logstor_data_files(manager, servers[0].server_id, 0)
+        assert files_before == old_disk_size_mb // file_size_mb
+
+        # Fill segments in both files by writing segments_per_file+1 segment-sized values to unique keys.
+        # Since there are only two files, this ensure each file has at least one segment with data.
+        value_size = 120 * 1024  # ~120 KB fills approximately one 128 KB segment
+        value = 'x' * value_size
+        for i in range(segments_per_file + 1):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{value}')")
+
+        # Drop the table to mark all data as dead
+        await cql.run_async(f"DROP TABLE {ks}.test")
+
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_update_config(servers[0].server_id, 'logstor_disk_size_in_mb', new_disk_size_mb)
+        await manager.server_start(servers[0].server_id)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        files_after_shrink = await count_logstor_data_files(manager, servers[0].server_id, 0)
+        assert files_after_shrink == new_disk_size_mb // file_size_mb, \
+            f"Expected {new_disk_size_mb // file_size_mb} file(s) after shrink with dead data, got {files_after_shrink}"
+
+        metrics = await manager.metrics.query(servers[0].ip_addr)
+        free_segments = metrics.get("scylla_logstor_sm_free_segments") or 0
+        segments_in_use = metrics.get("scylla_logstor_sm_segments_in_use") or 0
+        configured_segments = new_disk_size_mb * 1024 * 1024 // segment_size
+        # The segment manager allocates one empty active segment on startup, so
+        # after recovery with no live data all configured segments should be
+        # accounted for by free segments plus that active segment.
+        assert free_segments + segments_in_use == configured_segments, \
+            f"Expected all configured segments to be accounted for after shrink with dead data, got free={free_segments}, in_use={segments_in_use}"
+        assert segments_in_use <= 1, \
+            f"Expected at most one active segment after shrink with dead data, got {segments_in_use}"
+
+
+async def test_shrink_logstor_disk_size_live_data(manager: ManagerClient):
+    """
+    Test that shrinking the configured logstor disk size preserves files that
+    still contain live data.
+
+    This test starts with two files, writes enough unique segment-sized values
+    to place live data in the second file, restarts with a smaller configured
+    disk size, and checks that the file is kept and the data remains readable.
+    """
+    old_disk_size_mb = 8
+    new_disk_size_mb = 4
+    file_size_mb = 4
+    segments_per_file = (file_size_mb * 1024 * 1024) // segment_size
+
+    cmdline = ['--logger-log-level', 'logstor=debug', '--smp=1']
+    cfg = {
+        'logstor_disk_size_in_mb': old_disk_size_mb,
+        'logstor_file_size_in_mb': file_size_mb,
+        'logstor_format_on_startup': True,
+        'experimental_features': ['logstor'],
+    }
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH tablets={'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        files_before = await count_logstor_data_files(manager, servers[0].server_id, 0)
+        assert files_before == old_disk_size_mb // file_size_mb
+
+        # Fill segments in both files by writing segments_per_file+1 segment-sized values to unique keys.
+        # Since there are only two files, this ensure each file has at least one segment with live data.
+        num_keys = segments_per_file + 1
+        value_size = 120 * 1024  # ~120 KB fills approximately one 128 KB segment
+        value = 'x' * value_size
+        for i in range(num_keys):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{value}')")
+
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_update_config(servers[0].server_id, 'logstor_disk_size_in_mb', new_disk_size_mb)
+        await manager.server_start(servers[0].server_id)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        # The second file must not be removed because it contains live data
+        files_after_shrink = await count_logstor_data_files(manager, servers[0].server_id, 0)
+        assert files_after_shrink == old_disk_size_mb // file_size_mb, \
+            f"Expected {old_disk_size_mb // file_size_mb} files (live data prevents removal of second file), got {files_after_shrink}"
+
+        # Verify all data is still accessible
+        for i in range(num_keys):
+            rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test WHERE pk = {i}")
+            assert len(rows) == 1, f"Key {i} not found after attempted shrink with live data"
+            assert rows[0].v == value, f"Wrong value for key {i} after attempted shrink with live data"
+
 
 async def test_compaction(manager: ManagerClient):
     """


### PR DESCRIPTION
The config parameter logstor_disk_size_in_mb determines how much disk
space we allocate for logstor files. Now we add support for changing the
allocated disk size by restarting the node with a different value than
what was used previously.

If the disk_size value is greater than what's used currently, we will
allocate new files and segments up to the new limit and they can be used
normally.

If the disk_value is smaller than the previous value, and during
recovery we find there are more files than the configured value, then we
will attempt to shrink the used capacity gradually. We will stop
allocating new segments from the above configured range, and segments
that are freed from this range will become retired and not used anymore.
Eventually these files will become unused (a compaction step can be
added to enforce this), then we can remove the files starting from the
end.

Fixes [SCYLLADB-2516](https://scylladb.atlassian.net/browse/SCYLLADB-2516)

[SCYLLADB-2516]: https://scylladb.atlassian.net/browse/SCYLLADB-2516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

no backport - new feature