### PR TITLE
strong_consistency: persist snapshot config during commitlog replay

### DIFF
--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -172,6 +172,9 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
 
         // Track the term of the last committed entry to update the snapshot descriptor.
         std::optional<raft::term_t> last_committed_term;
+        // Track the latest committed configuration entry, so we can persist it
+        // alongside the snapshot index (required by load_snapshot_descriptor).
+        raft::configuration last_committed_config;
 
         for (auto& entry : filtered.entries) {
             // Apply committed command entries to the memtables. It is safe not to append them
@@ -189,6 +192,9 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
 
             if (entry->idx <= commit_idx) {
                 last_committed_term = entry->term;
+                if (std::holds_alternative<raft::configuration>(entry->data)) {
+                    last_committed_config = std::get<raft::configuration>(entry->data);
+                }
             }
 
             // Rewrite uncommitted entries to the new commitlog to obtain rp_handles
@@ -225,6 +231,7 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
                     qp, group_id, this_shard_id(), raft::snapshot_descriptor{
                         .idx = commit_idx,
                         .term = *last_committed_term,
+                        .config = last_committed_config,
                         .id = raft::snapshot_id(utils::make_random_uuid()),
                     });
             logger.debug("group {}: advanced snapshot to idx={}, term={}", group_id, commit_idx, *last_committed_term);

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -136,35 +136,9 @@ future<raft::snapshot_descriptor> raft_groups_storage::load_snapshot_descriptor(
 future<> raft_groups_storage::store_snapshot_descriptor(const raft::snapshot_descriptor& snap, size_t preserve_log_entries) {
     // TODO: check that snap.idx refers to an already persisted entry
     return execute_with_linearization_point([this, &snap, preserve_log_entries] () -> future<> {
-        static const auto store_snp_cql = format("INSERT INTO system.{} (shard, group_id, snapshot_id, idx, term) VALUES (?, ?, ?, ?, ?)",
-            db::system_keyspace::RAFT_GROUPS_SNAPSHOTS);
-        co_await _qp.execute_internal(
-            store_snp_cql,
-            {int16_t(_shard), _group_id.id, snap.id.id, int64_t(snap.idx.value()), int64_t(snap.term.value())},
-            cql3::query_processor::cache_internal::yes
-        );
-        // remove old configs
-        static const auto delete_raft_cfg_cql = format("DELETE FROM system.{} WHERE shard = ? AND group_id = ?", db::system_keyspace::RAFT_GROUPS_SNAPSHOT_CONFIG);
-        co_await _qp.execute_internal(delete_raft_cfg_cql, {int16_t(_shard), _group_id.id}, cql3::query_processor::cache_internal::yes);
-        // store current and previous raft configurations
-        static const auto store_raft_cfg_cql = format("INSERT INTO system.{} (shard, group_id, disposition, server_id, can_vote) VALUES (?, ?, ?, ?, ?)",
-            db::system_keyspace::RAFT_GROUPS_SNAPSHOT_CONFIG);
-        for (const raft::config_member& srv : snap.config.current) {
-            co_await _qp.execute_internal(store_raft_cfg_cql,
-                {int16_t(_shard), _group_id.id, "CURRENT", srv.addr.id.id, srv.can_vote},
-                    cql3::query_processor::cache_internal::yes);
-        }
-        for (const raft::config_member& srv : snap.config.previous) {
-            co_await _qp.execute_internal(store_raft_cfg_cql,
-                {int16_t(_shard), _group_id.id, "PREVIOUS", srv.addr.id.id, srv.can_vote},
-                    cql3::query_processor::cache_internal::yes);
-        }
-
-        co_await update_snapshot(snap);
-        // Release replay position handles for entries covered by the snapshot.
-        // state_machine::apply() only acquires handles for command entries;
-        // configuration and dummy entries retain their handles in the map
-        // and are cleaned up here.
+        co_await persist_snapshot_descriptor(_qp, _group_id, _shard, snap);
+        // Also remove the corresponding replay position handles from raft_commitlog
+        // so that commitlog segments can be reclaimed.
         raft::index_t log_tail_index(snap.idx.value() - preserve_log_entries);
         _raft_commitlog.truncate_log_tail(log_tail_index);
     });
@@ -185,15 +159,50 @@ future<> raft_groups_storage::abort() {
     return std::move(_pending_op_fut);
 }
 
-future<> raft_groups_storage::update_snapshot(const raft::snapshot_descriptor &snap) {
+future<> raft_groups_storage::persist_snapshot_descriptor(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap) {
+    // Persist the snapshot configuration if present.
+    // Written before idx/term so that on crash-retry the guard in store_snapshot_index
+    // won't consider the operation complete when config hasn't been persisted yet.
+    if (!snap.config.current.empty()) {
+        // Remove old configs.
+        static const auto delete_cfg_cql = format("DELETE FROM system.{} WHERE shard = ? AND group_id = ?",
+            db::system_keyspace::RAFT_GROUPS_SNAPSHOT_CONFIG);
+        co_await qp.execute_internal(delete_cfg_cql, {int16_t(shard), gid.id}, cql3::query_processor::cache_internal::yes);
+
+        // Store current and previous raft configurations.
+        static const auto store_cfg_cql = format("INSERT INTO system.{} (shard, group_id, disposition, server_id, can_vote) VALUES (?, ?, ?, ?, ?)",
+            db::system_keyspace::RAFT_GROUPS_SNAPSHOT_CONFIG);
+        for (const raft::config_member& srv : snap.config.current) {
+            co_await qp.execute_internal(store_cfg_cql,
+                {int16_t(shard), gid.id, "CURRENT", srv.addr.id.id, srv.can_vote},
+                cql3::query_processor::cache_internal::yes);
+        }
+        for (const raft::config_member& srv : snap.config.previous) {
+            co_await qp.execute_internal(store_cfg_cql,
+                {int16_t(shard), gid.id, "PREVIOUS", srv.addr.id.id, srv.can_vote},
+                cql3::query_processor::cache_internal::yes);
+        }
+    }
+
+    // Write snapshot_id reference to RAFT_GROUPS.
     static const auto update_snapshot_cql = format(
         "INSERT INTO system.{} (shard, group_id, snapshot_id) VALUES (?, ?, ?)",
         db::system_keyspace::RAFT_GROUPS);
-    return _qp.execute_internal(
+    co_await qp.execute_internal(
         update_snapshot_cql,
-        {int16_t(_shard), _group_id.id, snap.id.id},
+        {int16_t(shard), gid.id, snap.id.id},
         cql3::query_processor::cache_internal::yes
-    ).discard_result();
+    );
+
+    // Write idx/term last — this is the "commit point" that store_snapshot_index's
+    // guard reads. Everything above must already be persisted by the time this succeeds.
+    static const auto store_snp_cql = format("INSERT INTO system.{} (shard, group_id, snapshot_id, idx, term) VALUES (?, ?, ?, ?, ?)",
+        db::system_keyspace::RAFT_GROUPS_SNAPSHOTS);
+    co_await qp.execute_internal(
+        store_snp_cql,
+        {int16_t(shard), gid.id, snap.id.id, int64_t(snap.idx.value()), int64_t(snap.term.value())},
+        cql3::query_processor::cache_internal::yes
+    );
 }
 
 future<> raft_groups_storage::store_snapshot_index(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap) {
@@ -209,20 +218,7 @@ future<> raft_groups_storage::store_snapshot_index(cql3::query_processor& qp, ra
         }
     }
 
-    // Update both tables atomically so a crash between writes cannot leave
-    // an inconsistent snapshot_id reference.
-    static const auto store_snapshot_batch_cql = format(
-        "BEGIN UNLOGGED BATCH"
-        "   INSERT INTO system.{} (shard, group_id, snapshot_id, idx, term) VALUES (?, ?, ?, ?, ?);"
-        "   INSERT INTO system.{} (shard, group_id, snapshot_id) VALUES (?, ?, ?);"
-        "APPLY BATCH",
-        db::system_keyspace::RAFT_GROUPS_SNAPSHOTS, db::system_keyspace::RAFT_GROUPS);
-    co_await qp.execute_internal(
-        store_snapshot_batch_cql,
-        {int16_t(shard), gid.id, snap.id.id, int64_t(snap.idx.value()), int64_t(snap.term.value()),
-         int16_t(shard), gid.id, snap.id.id},
-        cql3::query_processor::cache_internal::yes
-    );
+    co_await persist_snapshot_descriptor(qp, gid, shard, snap);
 }
 
 future<> raft_groups_storage::execute_with_linearization_point(std::function<future<>()> f) {

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -75,17 +75,20 @@ public:
     // Static version that doesn't require constructing a full raft_groups_storage object.
     // Useful during commitlog replay when only read access to metadata is needed.
     static future<raft::index_t> load_commit_idx(cql3::query_processor& qp, raft::group_id gid, shard_id shard);
-    // Store snapshot idx and term without updating the configuration.
+    // Store snapshot idx, term, and configuration.
     // Used to advance the persisted snapshot index so that raft does not
     // re-apply already applied entries on restart. Only writes if the new
     // index is higher than the existing one (safe to call on repeated replays).
+    // If snap.config is non-empty, also persists it to RAFT_GROUPS_SNAPSHOT_CONFIG.
     static future<> store_snapshot_index(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap);
 
     std::vector<index_and_replay_position> acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries);
 
 private:
 
-    future<> update_snapshot(const raft::snapshot_descriptor &snap);
+    // Shared implementation: persists snapshot idx, term, snapshot_id, and config
+    // to system tables (RAFT_GROUPS_SNAPSHOTS, RAFT_GROUPS, RAFT_GROUPS_SNAPSHOT_CONFIG).
+    static future<> persist_snapshot_descriptor(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap);
 
     future<> execute_with_linearization_point(std::function<future<>()> f);
 };

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -30,6 +30,10 @@
 #include "idl/commitlog.dist.impl.hh"
 #include "test/lib/mutation_source_test.hh"
 #include "service/strong_consistency/raft_commitlog.hh"
+#include "service/strong_consistency/raft_groups_storage.hh"
+#include "db/system_keyspace.hh"
+#include "locator/tablets.hh"
+#include "locator/token_metadata.hh"
 #include "idl/raft_storage.dist.hh"
 #include "idl/raft_storage.dist.impl.hh"
 
@@ -1808,6 +1812,97 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
         BOOST_REQUIRE(entries2.empty());
         co_return;
     });
+}
+
+// Test that process_raft_replayed_items tracks the last committed
+// configuration entry and persists it to the snapshot descriptor.
+// This exercises the commitlog replayer code path by:
+// 1. Setting up token metadata with a tablet that maps group_id -> table_id
+// 2. Inserting a commit_idx row in system.raft_groups
+// 3. Adding multiple config entries (some committed, some not) to the replay buffer
+// 4. Calling process_raft_replayed_items
+// 5. Verifying that load_snapshot_descriptor returns the last committed configuration
+SEASTAR_TEST_CASE(test_process_raft_replayed_items_persists_last_committed_config) {
+    auto db_cfg_ptr = make_shared<db::config>();
+    db_cfg_ptr->experimental_features({db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES});
+    return do_with_cql_env(
+            [](cql_test_env& env) -> future<> {
+                auto& qp = env.local_qp();
+                auto& db = env.local_db();
+
+                auto gid = make_group_id();
+                auto tid = make_table_id();
+
+                // Create distinguishable configurations with different member counts.
+                auto make_config = [](size_t num_members) {
+                    raft::configuration cfg;
+                    for (size_t i = 0; i < num_members; ++i) {
+                        cfg.current.insert(raft::config_member{
+                                raft::server_address{raft::server_id::create_random_id(), {}},
+                                raft::is_voter::yes});
+                    }
+                    return cfg;
+                };
+
+                auto cfg_2_members = make_config(2);
+                auto cfg_3_members = make_config(3);
+                auto cfg_5_members = make_config(5);
+
+                // Step 1: Set up token metadata so that our group_id maps to our table_id.
+                auto& stm = env.shared_token_metadata().local();
+                co_await stm.mutate_token_metadata([&](locator::token_metadata& tm) -> future<> {
+                    locator::tablet_map tmap(1, /*with_raft_info=*/true);
+                    auto tb = tmap.first_tablet();
+                    // Set raft info mapping this tablet to our group_id.
+                    tmap.set_tablet_raft_info(tb, locator::tablet_raft_info{.group_id = gid});
+                    // Assign a replica on shard 0 of the local host so that the tablet is considered local.
+                    auto local_host = tm.get_my_id();
+                    tmap.set_tablet(tb, locator::tablet_info{
+                            locator::tablet_replica_set{locator::tablet_replica{local_host, 0}}});
+                    tm.tablets().set_tablet_map(tid, std::move(tmap));
+                    return make_ready_future<>();
+                });
+
+                // Step 2: Insert commit_idx = 5 for the group (entries 1-5 are committed, 6+ are not).
+                raft::index_t commit_idx(5);
+                co_await qp.execute_internal(
+                        format("INSERT INTO system.{} (shard, group_id, commit_idx) VALUES (?, ?, ?)",
+                                db::system_keyspace::RAFT_GROUPS),
+                        {int16_t(0), gid.id, int64_t(commit_idx.value())},
+                        cql3::query_processor::cache_internal::yes);
+
+                // Step 3: Populate the replay buffer with entries.
+                // Use dummy and config entries only (no command entries, so no mutation
+                // deserialization is needed).
+                db::raft_commitlog_replay_buffer buffer;
+                buffer.add(gid, make_dummy_entry(raft::term_t(1), raft::index_t(1)));
+                // First committed config (2 members) — should be overwritten by the later one.
+                buffer.add(gid, make_lw_shared<raft::log_entry>(raft::log_entry{
+                        .term = raft::term_t(1), .idx = raft::index_t(2), .data = cfg_2_members}));
+                buffer.add(gid, make_dummy_entry(raft::term_t(1), raft::index_t(3)));
+                // Second committed config (3 members) — this is the LAST committed config.
+                buffer.add(gid, make_lw_shared<raft::log_entry>(raft::log_entry{
+                        .term = raft::term_t(2), .idx = raft::index_t(4), .data = cfg_3_members}));
+                buffer.add(gid, make_dummy_entry(raft::term_t(2), raft::index_t(5)));
+                // Uncommitted config (5 members) — must NOT be persisted.
+                buffer.add(gid, make_lw_shared<raft::log_entry>(raft::log_entry{
+                        .term = raft::term_t(2), .idx = raft::index_t(6), .data = cfg_5_members}));
+
+                // Step 4: Run the commitlog replayer.
+                co_await buffer.process_raft_replayed_items(db, qp, env.get_system_keyspace().local());
+
+                // Step 5: Verify that the persisted snapshot has the LAST committed config (3 members),
+                // not the earlier one (2 members) and not the uncommitted one (5 members).
+                auto& cl = *db.commitlog();
+                service::strong_consistency::raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(),
+                        0 /*shard*/, cl, tid, {});
+                auto snap = co_await storage.load_snapshot_descriptor();
+
+                BOOST_CHECK_EQUAL(snap.idx, commit_idx);
+                BOOST_CHECK_EQUAL(snap.term, raft::term_t(2));
+                BOOST_CHECK_EQUAL(snap.config.current.size(), 3);
+            },
+            std::move(db_cfg_ptr));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -1647,6 +1647,12 @@ async def test_data_survives_crash(manager: ManagerClient):
         assert len(snp_rows) == 1, f"Expected snapshot row for group {group_id}"
         assert snp_rows[0].idx > 0, f"Expected snapshot idx > 0 after replay, got {snp_rows[0].idx}"
 
+        # Verify that the configuration snapshot was also persisted during replay.
+        # Single-node cluster: exactly one voter member in the config.
+        cfg_rows = await cql.run_async(f"SELECT server_id, can_vote FROM system.raft_groups_snapshot_config WHERE shard = 0 AND group_id = {group_id}")
+        assert len(cfg_rows) == 1, f"Expected exactly 1 config member for single-node group {group_id}, got {len(cfg_rows)}"
+        assert cfg_rows[0].can_vote == True, f"Expected the sole member to be a voter"
+
     await manager.server_stop_gracefully(server.server_id)
 
 

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -511,6 +511,37 @@ SEASTAR_TEST_CASE(test_groups_store_snapshot_index) {
         auto snp4 = co_await storage.load_snapshot_descriptor();
         BOOST_CHECK_EQUAL(snp4.idx, raft::index_t(20));
         BOOST_CHECK_EQUAL(snp4.term, raft::term_t(4));
+
+        // Advance to 30 with a configuration — verify config is persisted
+        raft::server_id srv1 = raft::server_id::create_random_id();
+        raft::server_id srv2 = raft::server_id::create_random_id();
+        raft::configuration cfg;
+        cfg.current.insert(raft::config_member{raft::server_address{srv1, {}}, raft::is_voter::yes});
+        cfg.current.insert(raft::config_member{raft::server_address{srv2, {}}, raft::is_voter::no});
+
+        co_await raft_groups_storage::store_snapshot_index(qp, gid, test_shard, raft::snapshot_descriptor{
+            .idx = raft::index_t(30),
+            .term = raft::term_t(5),
+            .config = cfg,
+            .id = raft::snapshot_id(utils::make_random_uuid()),
+        });
+
+        auto snp5 = co_await storage.load_snapshot_descriptor();
+        BOOST_CHECK_EQUAL(snp5.idx, raft::index_t(30));
+        BOOST_CHECK_EQUAL(snp5.term, raft::term_t(5));
+        BOOST_CHECK_EQUAL(snp5.config.current.size(), 2);
+
+        // Advance to 40 without config — config from previous snapshot should remain
+        co_await raft_groups_storage::store_snapshot_index(qp, gid, test_shard, raft::snapshot_descriptor{
+            .idx = raft::index_t(40),
+            .term = raft::term_t(6),
+            .id = raft::snapshot_id(utils::make_random_uuid()),
+        });
+
+        auto snp6 = co_await storage.load_snapshot_descriptor();
+        BOOST_CHECK_EQUAL(snp6.idx, raft::index_t(40));
+        BOOST_CHECK_EQUAL(snp6.term, raft::term_t(6));
+        BOOST_CHECK_EQUAL(snp6.config.current.size(), 2);  // config preserved from idx=30
     });
 }
 


### PR DESCRIPTION
## Summary

- During commitlog replay, `store_snapshot_index` advances the persisted snapshot index but does not write the latest committed configuration to `RAFT_GROUPS_SNAPSHOT_CONFIG`
- This can cause `load_snapshot_descriptor` to return a stale/empty configuration on subsequent startup
- Fix: track the latest committed config entry during replay and persist it alongside the snapshot idx/term

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2365
Refs: https://github.com/scylladb/scylladb/pull/29005

Backport: No, this is a follow-up PR for a new feature that exists only on master.