### PR TITLE
raft: fix node bootstrap crash due to transfer_snapshot/enable_in_memory_state_machine race

### DIFF
--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -56,12 +56,12 @@ namespace service {
 static logging::logger slogger("group0_raft_sm");
 
 group0_state_machine::group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss,
-        gms::gossiper& gossiper, gms::feature_service& feat)
+        gms::gossiper& gossiper, gms::feature_service& feat, bool enable_immediately)
     : _client(client), _mm(mm), _sp(sp), _ss(ss)
     , _gate("group0_state_machine")
     , _state_id_handler(ss._topology_state_machine, sp.local_db(), gossiper)
     , _feature_service(feat)
-    , _in_memory_state_machine_enabled(utils::get_local_injector().is_enabled("group0_enable_sm_immediately")) {
+    , _in_memory_state_machine_enabled(enable_immediately || utils::get_local_injector().is_enabled("group0_enable_sm_immediately")) {
     _state_id_handler.run();
 }
 

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -475,6 +475,8 @@ future<> group0_state_machine::load_snapshot(raft::snapshot_id id) {
 future<> group0_state_machine::enable_in_memory_state_machine() {
     co_await utils::get_local_injector().inject("group0_state_machine_enable_in_memory_fail",
             [] { return std::make_exception_ptr(std::runtime_error("injected failure in enable_in_memory_state_machine")); });
+    co_await utils::get_local_injector().inject("delay_before_enable_in_memory_state_machine",
+            utils::wait_for_message(300s));
     auto read_apply_mutex_holder = co_await _client.hold_read_apply_mutex(_abort_source);
     if (!_in_memory_state_machine_enabled) {
         _in_memory_state_machine_enabled = true;
@@ -602,6 +604,8 @@ future<> group0_state_machine::transfer_snapshot(raft::server_id from_id, raft::
     co_await notify_client_route_change_if_needed(_ss, client_routes_update);
 
     co_await _sp.mutate_locally({std::move(history_mut)}, nullptr);
+
+    slogger.info("transfer snapshot from {} index {} snp id {} completed", hid, snp.idx, snp.id);
   } catch (const abort_requested_exception&) {
     throw raft::request_aborted(fmt::format(
         "Abort requested while transferring snapshot from ID: {}, snapshot descriptor id: {}, snapshot index: {}", from_id, snp.id, snp.idx));

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -141,7 +141,7 @@ class group0_state_machine : public raft_state_machine {
     future<> sync_audit_known_entities();
 public:
     group0_state_machine(raft_group0_client& client, migration_manager& mm, storage_proxy& sp, storage_service& ss,
-            gms::gossiper& gossiper, gms::feature_service& feat);
+            gms::gossiper& gossiper, gms::feature_service& feat, bool enable_immediately);
     future<> apply(raft::log_entry_ptr_list commands) override;
     future<raft::snapshot_id> take_snapshot() override;
     void drop_snapshot(raft::snapshot_id id) override;

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -220,9 +220,9 @@ const raft::server_id& raft_group0::load_my_id() {
 }
 
 raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, raft::server_id my_id, service::storage_service& ss, cql3::query_processor& qp,
-                                                            service::migration_manager& mm) {
+                                                            service::migration_manager& mm, bool enable_sm_immediately) {
     auto state_machine = std::make_unique<group0_state_machine>(
-            _client, mm, qp.proxy(), ss, _gossiper, _feat);
+            _client, mm, qp.proxy(), ss, _gossiper, _feat, enable_sm_immediately);
     auto& state_machine_ref = *state_machine;
     auto rpc = std::make_unique<group0_rpc>(_raft_gr.direct_fd(), *state_machine, _ms.local(), _raft_gr.failure_detector(), gid, my_id);
     // Keep a reference to a specific RPC class.
@@ -443,13 +443,13 @@ void raft_group0::destroy() {
     }
 }
 
-future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm) {
+future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, bool enable_sm_immediately) {
     SCYLLA_ASSERT(group0_id != raft::group_id{});
     // The address map may miss our own id in case we connect
     // to an existing Raft Group 0 leader.
     auto my_id = load_my_id();
     group0_log.info("Server {} is starting group 0 with id {}", my_id, group0_id);
-    auto srv_for_group0 = create_server_for_group0(group0_id, my_id, ss, qp, mm);
+    auto srv_for_group0 = create_server_for_group0(group0_id, my_id, ss, qp, mm, enable_sm_immediately);
     auto& persistence = srv_for_group0.persistence;
     auto& server = *srv_for_group0.server;
     co_await with_scheduling_group(_sg, [this, &srv_for_group0, group0_id] (this auto self) -> future<> {
@@ -521,7 +521,7 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, shared_p
     auto group0_id = raft::group_id{co_await sys_ks.get_raft_group0_id()};
     if (group0_id) {
         // Group 0 ID present means we've already joined group 0 before.
-        co_await start_server_for_group0(group0_id, ss, qp, mm);
+        co_await start_server_for_group0(group0_id, ss, qp, mm, true);
         co_await enable_group0_state_machine();
         co_return;
     }
@@ -591,7 +591,7 @@ future<> raft_group0::join_group0(std::vector<gms::inet_address> seeds, shared_p
             utils::get_local_injector().inject("stop_after_bootstrapping_initial_raft_configuration",
                 [] { std::raise(SIGSTOP); });
 
-            co_await start_server_for_group0(group0_id, ss, qp, mm);
+            co_await start_server_for_group0(group0_id, ss, qp, mm, true);
             co_await enable_group0_state_machine();
             server = &_raft_gr.group0();
             // FIXME if we crash now or after getting added to the config but before storing group 0 ID,
@@ -694,7 +694,7 @@ future<> raft_group0::setup_group0_if_exist(db::system_keyspace& sys_ks, service
     if (group0_id) {
         // Group 0 ID is present => we've already joined group 0 earlier.
         group0_log.info("setup_group0: group 0 ID present. Starting existing Raft server.");
-        co_await start_server_for_group0(group0_id, ss, qp, mm);
+        co_await start_server_for_group0(group0_id, ss, qp, mm, false);
 
         // Start group 0 leadership monitor fiber.
         _leadership_monitor = leadership_monitor_fiber();

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -288,7 +288,7 @@ private:
     future<group0_peer_exchange> peer_exchange(discovery::peer_list peers);
 
     raft_server_for_group create_server_for_group0(raft::group_id id, raft::server_id my_id, service::storage_service& ss, cql3::query_processor& qp,
-        service::migration_manager& mm);
+        service::migration_manager& mm, bool enable_sm_immediately);
 
     // Start a Raft server for the cluster-wide group 0 and join it to the group.
     // Called during bootstrap or upgrade.
@@ -331,7 +331,7 @@ private:
     // XXX: perhaps it would be good to make this function callable multiple times,
     // if we want to handle crashes of the group 0 server without crashing the entire Scylla process
     // (we could then try restarting the server internally).
-    future<> start_server_for_group0(raft::group_id group0_id, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm);
+    future<> start_server_for_group0(raft::group_id group0_id, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, bool enable_sm_immediately);
 
     // Modify the given server voter status in Raft group 0 configuration.
     // Retries on raft::commit_status_unknown.

--- a/test/cluster/test_group0_snapshot_schema_race.py
+++ b/test/cluster/test_group0_snapshot_schema_race.py
@@ -13,9 +13,6 @@ from test.pylib.manager_client import ManagerClient
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.xfail(reason="transfer_snapshot with _in_memory_state_machine_enabled=false "
-                          "writes schema to disk but reload_state() does not reload it, "
-                          "causing subsequent apply() to fail with no_such_keyspace")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_snapshot_transfer_before_enable_sm_causes_no_such_keyspace(manager: ManagerClient) -> None:
     """Verify that a joining node handles schema correctly when transfer_snapshot()

--- a/test/cluster/test_group0_snapshot_schema_race.py
+++ b/test/cluster/test_group0_snapshot_schema_race.py
@@ -1,0 +1,72 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import logging
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.xfail(reason="transfer_snapshot with _in_memory_state_machine_enabled=false "
+                          "writes schema to disk but reload_state() does not reload it, "
+                          "causing subsequent apply() to fail with no_such_keyspace")
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_snapshot_transfer_before_enable_sm_causes_no_such_keyspace(manager: ManagerClient) -> None:
+    """Verify that a joining node handles schema correctly when transfer_snapshot()
+    runs before enable_in_memory_state_machine().
+
+    Reproduces a race condition where:
+    1. Raft server starts on the joining node (_in_memory_state_machine_enabled = false)
+    2. Leader sends install_snapshot, triggering transfer_snapshot()
+    3. transfer_snapshot() acquires _read_apply_mutex before enable_in_memory_state_machine
+    4. Since the flag is false, schema is written to system_schema tables via
+       write_mutations_to_database() but NOT loaded into memory
+    5. enable_in_memory_state_machine() sets flag=true, calls reload_state() which
+       does NOT reload schema
+    6. Next Raft apply() with flag=true tries to ALTER system_distributed via
+       merge_schema_from() -> merge_keyspaces() -> prepare_update_keyspace_on_all_shards()
+       -> find_keyspace() which fails because the keyspace is on disk but not in
+       the in-memory _keyspaces map
+    """
+    # Start node 1 -- it creates system_distributed during its normal startup
+    srv1 = await manager.server_add()
+    logger.info("Leader node %s started", srv1.server_id)
+
+    # Create node 2 with injection that will delay enable_in_memory_state_machine.
+    # This forces transfer_snapshot() to run first with the flag=false.
+    injection = "delay_before_enable_in_memory_state_machine"
+    srv2 = await manager.server_add(start=False,
+                                    config={'error_injections_at_startup': [injection]})
+    logger.info("Created node %s, starting with injection", srv2.server_id)
+
+    # Start node 2 as a background task.
+    # We expect it to join successfully (after the fix).
+    # Without the fix it will crash with no_such_keyspace.
+    task = asyncio.create_task(manager.server_start(srv2.server_id))
+
+    # Open node 2's log and wait for the injection to fire
+    log = await manager.server_open_log(srv2.server_id)
+    await log.wait_for(f"{injection}: waiting for message", timeout=60)
+    logger.info("Node %s hit the injection, transfer_snapshot should run now", srv2.server_id)
+
+    # Wait for transfer_snapshot to complete. The INFO-level log message
+    # "transfer snapshot from <id> index <N> snp id <id> completed" is emitted
+    # at the very end of transfer_snapshot() after all data (schema, topology,
+    # auth) has been persisted locally.
+    await log.wait_for("transfer snapshot from .* completed", timeout=60)
+    logger.info("transfer_snapshot completed on node %s, releasing injection", srv2.server_id)
+
+    # Release the injection -- enable_in_memory_state_machine() will now proceed
+    await manager.api.message_injection(srv2.ip_addr, injection)
+
+    # Wait for node 2 to finish joining.
+    # Without the fix: crashes with "no_such_keyspace (Can't find a keyspace system_distributed)"
+    # With the fix: joins successfully
+    await task
+    logger.info("Node %s joined successfully", srv2.server_id)


### PR DESCRIPTION
When a node joins a cluster, `start_server_for_group0()` starts the Raft server while the messaging port is already open. The leader can immediately send an `install_snapshot` RPC, triggering `transfer_snapshot()` on the joining node. If `transfer_snapshot()` acquires `_read_apply_mutex` before `enable_group0_state_machine()` does, it sees `_in_memory_state_machine_enabled=false` and writes schema to `system_schema` tables via `write_mutations_to_database()` without creating in-memory keyspace representations.

When `enable_in_memory_state_machine()` subsequently sets the flag to true and calls `reload_state()`, schema is not reloaded (`reload_state` covers topology, auth, service levels, etc. but not schema). The next Raft `apply()` with the flag=true attempts to ALTER `system_distributed` via `merge_schema_from()` → `merge_keyspaces()` → `prepare_update_keyspace_on_all_shards()` → `find_keyspace()`, which throws `no_such_keyspace` because the keyspace exists on disk but not in the in-memory `_keyspaces` map. The node crashes during bootstrap.

The fix enables the in-memory state machine at construction time on the join path by passing `enable_immediately=true` to the `group0_state_machine` constructor. This is safe because on a fresh join there is no prior persisted state that could be partially applied — the crash-safety concern that motivates the two-phase flag does not apply here. On the restart path (`setup_group0_if_exist`), the flag remains false since log replay happens before `init_non_system_keyspaces`.

The first commit adds a regression test that deterministically reproduces the race using a `wait_for_message` error injection to delay `enable_in_memory_state_machine()`. The second commit contains the fix.

Fixes SCYLLADB-2498

No backport needed since this is a recent regression.