### PR TITLE
service: strong_consistency: Add support for tablets-routing-v2-experimental

### DIFF
--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -21,6 +21,7 @@
 #include "utils/result.hh"
 #include "utils/small_vector.hh"
 #include "service/storage_proxy_fwd.hh"
+#include "locator/tablets.hh"
 
 namespace cql3 {
 
@@ -86,6 +87,7 @@ private:
     std::vector<cql3::raw_value_view> _value_views;
     unset_bind_variable_vector _unset;
     const bool _skip_metadata;
+    std::optional<locator::tablet_version_block> _tablet_version_block;
     const specific_options _options;
     std::optional<std::vector<query_options>> _batch_options;
     // We must use the same microsecond-precision timestamp for
@@ -214,6 +216,15 @@ public:
 
     const query_options::specific_options& get_specific_options() const {
         return _options;
+    }
+
+    // Set the tablet_version_block received in an EXECUTE request (TABLETS_ROUTING_V2).
+    void set_tablet_version_block(locator::tablet_version_block block) noexcept {
+        _tablet_version_block = block;
+    }
+
+    std::optional<locator::tablet_version_block> get_tablet_version_block() const noexcept {
+        return _tablet_version_block;
     }
 
     // Mainly for the sake of BatchQueryOptions

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -317,9 +317,11 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
     if (auto warning = db::large_data_soft_violation_warning(violations); !warning.empty()) [[unlikely]] {
         result->add_warning(std::move(warning));
     }
-    if (keys_size_one) {
-        auto&& table = s->table();
-        if (_may_use_token_aware_routing && table.uses_tablets() && qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
+
+    auto&& table = s->table();
+
+    if (keys_size_one && _may_use_token_aware_routing && table.uses_tablets()) {
+        if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
             auto erm = table.get_effective_replication_map();
             auto tablet_info = erm->check_locality(token, qs.get_client_state().get_original_shard());
             if (tablet_info.has_value()) {

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: (LicenseRef-ScyllaDB-Source-Available-1.1 and Apache-2.0)
  */
 
+#include "transport/cql_protocol_extension.hh"
 #include "utils/assert.hh"
 #include "cql3/cql_statement.hh"
 #include "cql3/statements/modification_statement.hh"
@@ -321,8 +322,23 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
     auto&& table = s->table();
 
     if (keys_size_one && _may_use_token_aware_routing && table.uses_tablets()) {
-        if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
-            auto erm = table.get_effective_replication_map();
+        auto erm = table.get_effective_replication_map();
+        if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
+            if (!options.get_tablet_version_block().has_value()) {
+                // V2 is negotiated but no block was parsed. process_execute_internal()
+                // reads the block unconditionally whenever the V2 extension is set and
+                // rejects the request with a protocol_exception if the byte is missing,
+                // so the block is guaranteed present here. Reaching this point is a
+                // server-side invariant violation, not a client error, hence on_internal_error.
+                utils::on_internal_error(
+                    "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
+                    "carry a tablet_version_block");
+            }
+            auto tablet_info_v2 = erm->check_tablet_version(token, *options.get_tablet_version_block());
+            if (tablet_info_v2) {
+                result->add_tablet_info_v2(std::move(*tablet_info_v2));
+            }
+        } else if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
             auto tablet_info = erm->check_locality(token, qs.get_client_state().get_original_shard());
             if (tablet_info.has_value()) {
                 result->add_tablet_info(std::move(*tablet_info));

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -26,8 +26,10 @@
 #include <seastar/core/future.hh>
 #include <seastar/coroutine/exception.hh>
 #include "index/vector_index.hh"
+#include "locator/tablets.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
 #include "service/qos/qos_common.hh"
+#include "transport/cql_protocol_extension.hh"
 #include "transport/messages/result_message.hh"
 #include "cql3/functions/functions.hh"
 #include "cql3/functions/as_json_function.hh"
@@ -484,14 +486,27 @@ select_statement::do_execute(query_processor& qp,
 
     auto token = dht::token();
     std::optional<locator::tablet_routing_info> tablet_info = {};
+    std::optional<locator::tablet_routing_info_v2> tablet_info_v2 = {};
 
     auto&& table = _schema->table();
     if (_may_use_token_aware_routing && table.uses_tablets()
             && key_ranges.size() == 1 && query::is_single_partition(key_ranges.front())) {
-        if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
-            token = key_ranges[0].start()->value().as_decorated_key().token();
+        token = key_ranges[0].start()->value().as_decorated_key().token();
+        auto erm = table.get_effective_replication_map();
 
-            auto erm = table.get_effective_replication_map();
+        if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
+            if (!options.get_tablet_version_block().has_value()) {
+                // V2 is negotiated but no block was parsed. process_execute_internal()
+                // reads the block unconditionally whenever the V2 extension is set and
+                // rejects the request with a protocol_exception if the byte is missing,
+                // so the block is guaranteed present here. Reaching this point is a
+                // server-side invariant violation, not a client error, hence on_internal_error.
+                utils::on_internal_error(
+                    "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
+                    "carry a tablet_version_block");
+            }
+            tablet_info_v2 = erm->check_tablet_version(token, *options.get_tablet_version_block());
+        } else if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
             tablet_info = erm->check_locality(token, state.get_client_state().get_original_shard());
         }
     }
@@ -524,8 +539,15 @@ select_statement::do_execute(query_processor& qp,
             nonpaged_filtering, parsed_limit, std::move(cas_shard));
     }
 
-    if (!tablet_info.has_value()) {
+    if (!tablet_info.has_value() && !tablet_info_v2.has_value()) {
         return f;
+    }
+
+    if (tablet_info_v2.has_value()) {
+        return f.then([tablet_info_v2 = std::move(*tablet_info_v2)] (auto res) mutable {
+            res->add_tablet_info_v2(std::move(tablet_info_v2));
+            return res;
+        });
     }
 
     return f.then([tablet_info = std::move(*tablet_info)] (auto res) mutable {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -486,8 +486,9 @@ select_statement::do_execute(query_processor& qp,
     std::optional<locator::tablet_routing_info> tablet_info = {};
 
     auto&& table = _schema->table();
-    if (_may_use_token_aware_routing && table.uses_tablets() && state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
-        if (key_ranges.size() == 1 && query::is_single_partition(key_ranges.front())) {
+    if (_may_use_token_aware_routing && table.uses_tablets()
+            && key_ranges.size() == 1 && query::is_single_partition(key_ranges.front())) {
+        if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
             token = key_ranges[0].start()->value().as_decorated_key().token();
 
             auto erm = table.get_effective_replication_map();

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -10,6 +10,7 @@
 
 #include "db/consistency_level_type.hh"
 #include "db/timeout_clock.hh"
+#include "service/strong_consistency/groups_manager.hh"
 #include "transport/messages/result_message.hh"
 #include "cql3/query_processor.hh"
 #include "service/strong_consistency/coordinator.hh"
@@ -61,9 +62,10 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
     }
 
     auto [coordinator, holder] = qp.acquire_strongly_consistent_coordinator();
+    const auto token = keys[0].start()->value().token();
 
     auto mutate_result = co_await coordinator.get().mutate(_statement->s,
-        keys[0].start()->value().token(),
+        token,
         [&](api::timestamp_type ts) {
             const auto prefetch_data = update_parameters::prefetch_data(_statement->s);
             const auto ttl = _statement->get_time_to_live(options);
@@ -86,7 +88,30 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
         throw exceptions::mutation_write_timeout_exception{"", "", options.get_consistency(), 0, 0, db::write_type::SIMPLE};
     });
 
-    co_return seastar::make_shared<result_message::void_message>();
+    auto result = seastar::make_shared<result_message::void_message>();
+
+    if (qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
+        if (!options.get_tablet_version_block().has_value()) {
+            // V2 is negotiated but no block was parsed. process_execute_internal()
+            // reads the block unconditionally whenever the V2 extension is set and
+            // rejects the request with a protocol_exception if the byte is missing,
+            // so the block is guaranteed present here. Reaching this point is a
+            // server-side invariant violation, not a client error, hence on_internal_error.
+            utils::on_internal_error(
+                "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
+                "carry a tablet_version_block");
+        }
+
+        const auto& groups_manager = coordinator.get().get_groups_manager();
+        const auto& table = _statement->s->table();
+
+        auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, *options.get_tablet_version_block());
+        if (maybe_routing_info_v2) {
+            result->add_tablet_info_v2(std::move(*maybe_routing_info_v2));
+        }
+    }
+
+    co_return std::move(result);
 }
 
 future<> modification_statement::check_access(query_processor& qp, const service::client_state& state) const {

--- a/cql3/statements/strong_consistency/select_statement.cc
+++ b/cql3/statements/strong_consistency/select_statement.cc
@@ -11,8 +11,10 @@
 #include "db/consistency_level_type.hh"
 #include "query/query-request.hh"
 #include "cql3/query_processor.hh"
+#include "replica/database.hh"
 #include "service/strong_consistency/coordinator.hh"
 #include "cql3/statements/strong_consistency/statement_helpers.hh"
+#include "service/strong_consistency/groups_manager.hh"
 
 namespace cql3::statements::strong_consistency {
 
@@ -66,8 +68,32 @@ future<::shared_ptr<result_message>> select_statement::do_execute(query_processo
         co_return co_await redirect_statement(qp, options, redirect->target, timeout, is_write, coordinator.get().get_stats(), std::move(redirect->on_forwarding_finished));
     }
 
-    co_return co_await process_results(get<lw_shared_ptr<query::result>>(std::move(query_result)),
+    auto result = co_await process_results(get<lw_shared_ptr<query::result>>(std::move(query_result)),
         read_command, options, now);
+
+    if (state.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
+        if (!options.get_tablet_version_block().has_value()) {
+            // V2 is negotiated but no block was parsed. process_execute_internal()
+            // reads the block unconditionally whenever the V2 extension is set and
+            // rejects the request with a protocol_exception if the byte is missing,
+            // so the block is guaranteed present here. Reaching this point is a
+            // server-side invariant violation, not a client error, hence on_internal_error.
+            utils::on_internal_error(
+                "The protocol extension tablets-routing-v2 requires that every EXECUTE request "
+                "carry a tablet_version_block");
+        }
+
+        const auto& groups_manager = coordinator.get().get_groups_manager();
+        const auto& table = _query_schema->table();
+        const auto& token = key_ranges[0].start()->value().token();
+
+        auto maybe_routing_info_v2 = groups_manager.check_tablet_version(table, token, *options.get_tablet_version_block());
+        if (maybe_routing_info_v2) {
+            result->add_tablet_info_v2(std::move(*maybe_routing_info_v2));
+        }
+    }
+
+    co_return std::move(result);
 }
 
 }

--- a/docs/dev/protocol-extensions.md
+++ b/docs/dev/protocol-extensions.md
@@ -203,7 +203,7 @@ The string map in the SUPPORTED response will contain the following parameters:
   - `ERROR_CODE`: a 32-bit signed decimal integer which Scylla
     will use as the error code for the rate limit exception.
 
-## Sending tablet info to the drivers
+## Tablets routing v1
 
 This extension adds support for sending tablet info to the drivers if the 
 request was routed to the wrong node/shard.
@@ -236,7 +236,7 @@ the previously received tablets has an overlapping token range.
 The group of tablets that meets this criterion has to be deleted, and the new
 tablet should replace them.
 
-## Negotiate sending tablets info to the drivers
+### Negotiating tablets-routing-v1 extension
 
 This extension allows the driver to inform the database that it is aware of
 tablets and is able to interpret the tablet information sent in `custom_payload`.

--- a/docs/dev/protocol-extensions.md
+++ b/docs/dev/protocol-extensions.md
@@ -247,6 +247,106 @@ Having a designated flag gives the ability to skip tablet metadata generation
 The feature is identified by the `TABLETS_ROUTING_V1` key, which is meant to be sent
 in the SUPPORTED message.
 
+## Tablets routing v2
+
+The `tablets-routing-v1` payload described above is only sent when a request is
+routed to the wrong node or shard, and it is never produced for strongly
+consistent (SC) tables. This leaves two gaps:
+
+  - A driver whose cached replica set has gone stale is not corrected as long as
+    its requests keep reaching a node that is still a replica (so no misrouting
+    is observed).
+  - Although it should technically be possible to adjust the protocol to cover
+    strongly consistent tables, any solution would come with its own set of
+    problems.
+
+`tablets-routing-v2` closes both gaps by associating every tablet with a
+`tablet_version`: an opaque 64-bit value the server derives from the tablet's
+current replica set (and, for strongly consistent tablets, from the tablet's Raft
+leader). Whenever a tablet's routing changes, its version changes. The driver
+echoes a small fingerprint of the version it currently holds on every request,
+and the server returns up-to-date routing information whenever the fingerprints
+disagree.
+
+More information on TABLETS_ROUTING_V2 can be found in [tablets-routing-v2.md](tablets-routing-v2.md).
+
+### Presenting the version on a request
+
+When `tablets-routing-v2` is negotiated, the driver appends one extra byte — the
+`tablet_version_block` — to the body of every EXECUTE request, immediately after
+the regular query parameters:
+
+```
+<id><query_parameters><tablet_version_block>
+```
+
+`tablet_version_block` is a `[byte]` carrying a single 4-bit slice of the 64-bit
+`tablet_version` the driver currently holds for the target tablet:
+
+  - the high nibble (bits 4-7) is the *block index* (`0..15`), selecting which
+    4-bit slice of the version is being presented (blocks are indexed from the
+    least significant bits towards the most significant ones);
+  - the low nibble (bits 0-3) is the value of that slice.
+
+Example: 0xA3 corresponds to the block of index 0xA and its value: 0x3.
+
+Only one block is sent per request, keeping the overhead at a single byte. A
+driver is expected to rotate the block index across requests so that, over time,
+the whole 64-bit version is checked; any single mismatching block is enough to
+trigger a refresh. A driver that holds no version yet for a tablet should still
+send a byte — the resulting mismatch makes the server return the current routing.
+
+### Receiving the refreshed routing info
+
+The server takes the tablet's current `tablet_version`, extracts the same block
+the driver presented, and compares the two 4-bit values:
+
+  - if they match, the routing is considered current and nothing is added to the
+    response;
+  - otherwise the server attaches a `tablets-routing-v2` entry to the RESULT
+    message `custom_payload`.
+
+The driver has to be able to deserialize the `tablets-routing-v2` field from
+`bytes` to:
+
+  - `TupleType(LongType, LongType, ListType(TupleType(UUIDType, Int32Type)), LongType)`
+
+whose elements are:
+
+  - two `LongType`s — the first and last token of the tablet's token range, in the
+    form `(first_token, last_token]`;
+  - `ListType(TupleType(UUIDType, Int32Type))` — the ordered replica set, one
+    `(host_id, shard)` tuple per replica;
+  - a trailing `LongType` — the new 64-bit `tablet_version`, which the driver
+    should remember and fingerprint on subsequent requests.
+
+This is a superset of the `tablets-routing-v1` tuple, which has the same first
+three elements but no version. As with `tablets-routing-v1`, on receiving this
+payload the driver must drop every cached tablet whose token range overlaps the
+new one and replace it with the received tablet.
+
+The order of the returned replicas is deterministic. Moreover, for strongly-consistent
+tables, the replicas are shifted so that the leader of the corresponding Raft
+group is always the first in the list.
+
+### Negotiating tablets-routing-v2 extension
+
+This extension tells the database that the driver understands the
+`tablets-routing-v2` mechanism described above: that it will present a
+`tablet_version_block` on EXECUTE requests and can interpret the
+`tablets-routing-v2` `custom_payload`.
+
+The feature is identified by the `TABLETS_ROUTING_V2_EXPERIMENTAL` key, which is
+meant to be sent in the SUPPORTED message.
+
+Unlike `TABLETS_ROUTING_V1`, the server advertises
+`TABLETS_ROUTING_V2_EXPERIMENTAL` only once the `STRONGLY_CONSISTENT_TABLES`
+cluster feature is enabled — that is, once every node in the cluster supports it.
+Gating on the cluster feature rather than on a single node's local configuration
+ensures that, during a rolling upgrade, connections to different nodes cannot
+negotiate the extension inconsistently. The `_EXPERIMENTAL` suffix indicates the
+feature is still under development and its format may change.
+
 ## Negotiate sending metadata id
 
 This extension allows the driver to inform the database that it is aware of

--- a/docs/dev/tablets-routing-v2.md
+++ b/docs/dev/tablets-routing-v2.md
@@ -1,0 +1,204 @@
+# Tablets routing v2
+
+Although the document covers both `global` and `local` consistency for strongly consistent
+tables, note that `local` is **not** supported yet.
+
+## Terminology
+
+For convenience, we introduce a few new terms that we’ll use for the remainder of this document:
+
+* Routing information comprises of a list of replicas and their distinguished leader. For more details, see section [“Tablet version”](#tablet-version) below.
+* A leader hint is part of routing information and corresponds to the identity of the leader.
+* The processing node is the node that executes a request. Nodes that forward it are not processing. (Note: In the case of eventual consistency, the processing node is always the coordinator.)
+* The processing shard is the shard that executes a request. Shards that bounce it are not processing.
+
+In some places, to avoid overly complex and wordy sentences, we might use the term “processing node” to mean “processing node or processing shard” or simply “processing shard”. Rely on context when interpreting it.
+
+## Summary
+
+The driver includes its cached tablet_version in each `EXECUTE` request. Upon a mismatch with the server’s tablet version, the server returns routing information corresponding to the tablet. The driver then caches this information and routes subsequent queries directly to the leader.
+
+Request processing paths
+* The tablet version matches. The response doesn’t contain any additional payload.
+* The tablet version is mismatched. The server includes information about the current replica set and also information about the current Raft leader. The driver updates its cache.
+
+Note that it’s possible that a request doesn’t arrive at the leader and yet the tablet_version matches. In that case, no additional payload is returned, and this is an acceptable situation.
+
+## Tablet version
+
+A tablet_version is a 64-bit hash produced based on an ordered list of replicas. The order of the replicas is chosen by a deterministic sorting algorithm.
+
+1. Eventually consistent tablets: the replica list consists of all replicas of the tablet:
+```cpp
+// Fetch ALL of the replicas of the tablet and sort them.
+replica_list = sort(tablet.replica_list)
+
+tablet_version = hash(replica_list)
+```
+2. Strongly consistent tablets:
+    - Global consistency: the replica list consists of all replicas of the tablet. The list is shifted so that the leader of the Raft group is the first replica in the list:
+    ```cpp
+    // Fetch ALL of the replicas of the tablet and sort them.
+    replica_list = sort(tablet.replica_list)
+
+    // Shift the replica list so that the leader is the first in list.
+    replica_list = shift_for_leader(replica_list, tablet.leader)
+
+    tablet_version = hash(replica_list)
+    ```
+    - Local consistency: the replica list consists of the replicas in the local DC only. The list is shifted so that the leader of the Raft group is the first replica in the list:
+    ```cpp
+    // Fetch the list of replicas in the local DC ONLY.
+    dc_replica_list = tablet.dcs[local_dc].replica_list
+
+    // Sort the replicas.
+    dc_replica_list = sort(dc_replica_list)
+
+    // Shift the replica list so that the leader is the first in list.
+    dc_replica_list = shift_for_leader(dc_replica_list, tablet.dcs[local_dc].leader)
+
+    tablet_version = hash(dc_replica_list)
+    ```
+
+**Note:** In the case of `local` consistency, a single tablet can have multiple tablet_versions, depending on which DC it’s computed in (because `tablet_version` depends on the identity of the leader).
+
+**Note:** Because a locally-consistent tablet may have multiple tablet_versions, one for each DC, it makes sense to reduce the number of arguments that `tablet_version` depends on to only the replicas in the local DC. This will reduce the number of tablet version mismatches: changes in one DC don’t affect any other DC.
+
+### Tablet version block
+
+We divide a 64-bit tablet_version into 16 blocks, each consisting of 4 bits. We then encode a given block with 8 bits in the following way:
+* The index of the block in the hash (0-15): 4 bits.
+* The contents of the block: 4 bits.
+
+Blocks are indexed from the least significant bits to the most significant ones, so block `i` occupies bits `[i*4, i*4 + 4)` of the hash. The bit positions refer to the tablet_version as a 64-bit integer (bit 0 is the least significant bit); they are independent of endianness.
+
+**Example:** If the 13-th block is equal to 0xC, then the block is encoded by the byte 0xDC (because the hex representation of 13 is 0xD).
+
+We refer to this representation with the term: **tablet version block**. The driver uses this construct instead of the full tablet_version when sending requests to the server to reduce network usage (cf. section [“Server-side changes”](#server-side-changes) below).
+
+## Protocol format and negotiation
+
+During connection setup, the driver and server negotiate `TABLETS_ROUTING_V2` support:
+1. The server advertises `TABLETS_ROUTING_V2` in the `SUPPORTED` response (as a key in the options multimap with an empty value), alongside the existing `TABLETS_ROUTING_V1`.
+2. During `STARTUP`, the driver echoes back `TABLETS_ROUTING_V2` in its options map to opt in.
+3. The server records the extension on the connection’s client state via `set_protocol_extensions()`.
+
+`TABLETS_ROUTING_V2` subsumes `TABLETS_ROUTING_V1`. A driver that negotiates v2 **does not** negotiate v1. If a driver only negotiates v1, the server falls back to the existing v1 behavior.
+
+The extension is gated behind the cluster feature `STRONGLY_CONSISTENT_TABLES`.
+
+**Note:** We temporarily use a different name for the protocol extension: `TABLETS_ROUTING_V2_EXPERIMENTAL`.
+The name explicitly conveys that the feature is still experimental and may be modified.
+
+### EXECUTE request extension
+
+The `tablet_version` is not transmitted directly. Instead, an arbitrarily chosen tablet version block (cf. section [“Tablet version”](#tablet-version)) is carried as part of the `EXECUTE` request body, right after the `query_parameters`:
+```
+EXECUTE (pre-TABLETS_ROUTING_V2):
+  <id><query_parameters>
+
+EXECUTE (post-TABLETS_ROUTING_V2):
+  <id><query_parameters><tablet_version_block>
+
+where <tablet_version_block> is a byte.
+```
+
+The `tablet_version_block` is associated with the target table of the prepared statement and the specific token being accessed. The driver fetches the `tablet_version` it has cached for the tablet covering the request’s partition token, chooses an arbitrary tablet version block, and sends it as part of the `EXECUTE` request.
+
+For requests that are not single-partition (e.g. range scans), the driver sends an arbitrary `tablet_version_block`. It will be ignored and no routing information will be returned (cf. section [“Server-side changes”](#server-side-changes) below).
+
+### Response payload
+
+The routing information is carried as a custom payload in the `RESULT` frame under the key `"tablets-routing-v2"`. The frame’s custom_payload flag (bit 2, 0x04) is set in the frame header.
+
+The payload value is serialized using CQL type serialization as a tuple:
+```
+TupleType(
+  u64,                    // first_token (exclusive)
+  u64,                    // last_token (inclusive)
+  List<Tuple<UUID, u32>>, // replicas [(host_id, shard_id), ...]
+  u64,                    // tablet_version, big-endian
+)
+```
+
+The replica list corresponds to the same order that was used for computing the tablet_version (cf. section [“Tablet version”](#tablet-version) above). In particular, for strongly consistent tables, the first replica in the list is always the leader of the Raft group.
+
+For tables using the `local` consistency mode, the returned replica list only consists of the replicas in the local DC (as specified in the section [“Tablet version”](#tablet-version)). For all other tables, the replica list consists of all replicas of the tablet.
+
+### Interaction with TABLETS_ROUTING_V1
+
+If the driver negotiated `TABLETS_ROUTING_V2`, the server only uses the v2 key (`"tablets-routing-v2"`) in responses. The v1 key (`"tablets-routing-v1"`) is never sent alongside v2 for the same response. If the driver only negotiated v1, the behavior remains as in v1.
+
+## Server-side changes
+
+**Computing tablet version.** The `tablet_version` hash is computed according to the algorithm specified in section [“Tablet version”](#tablet-version).
+
+Note that for strongly consistent tablets computing the `tablet_version` is only possible for the members of the Raft group because only they know the identity of the leader. Moreover, a single tablet can have multiple `tablet_version`s associated with it if the table uses the `local` consistency mode. Due to that, for strongly-consistent tablets, this information can only be computed on the members of the Raft group and corresponds to the tablet_version of that specific Raft group.
+
+**Example:** Consider nodes A, B, C in two DCs: DC1: {A, B}, DC2: {C}. Consider a tablet T whose replicas are A and C.
+* T is eventually consistent:
+    - A: tablet_version = 0x11111111
+    - B: tablet_version = 0x11111111
+    - C: tablet_version = 0x11111111
+* T is strongly consistent and uses global consistency mode:
+    - A: tablet_version = 0x11111111
+    - B: tablet_version = \<unknown\>
+    - C: tablet_version = 0x11111111
+* T is strongly consistent and uses local consistency mode:
+    - A: tablet_version = 0x11111111
+    - B: tablet_version = \<unknown\>
+    - C: tablet_version = 0x23232323 (different Raft group -> different tablet version)
+
+**Returning routing information.** When a request arrives and the attached `tablet_version_block` doesn’t match the actual `tablet_version`, the server includes the full routing information in a **successful** response. Errors don’t carry any additional payload as we usually cannot predict what happened. For instance, if the driver gets a server timeout error, it’s not clear if it’s because the node is overloaded, partitioned, or if other replicas don’t respond to it. Any routing information returned in such circumstances would ultimately be unreliable.
+
+If the target table is vnode-based, the passed `tablet_version_block` is ignored and no routing information is returned in the response.
+
+**Raft group member status.** The driver may send a read to a strongly-consistent table using consistency level `ONE` or `LOCAL_ONE`. In that case, the processing node can be a non-leader replica. If the Raft status of the processing node is a candidate, that means it’s observing an ongoing election. In that case, the provided `tablet_version_block` is ignored and no routing information is returned. Because there’s no leader, computing the `tablet_version` is not possible. Moreover, that could be a sign of a network partition.
+
+### Who provides routing information
+
+The node attaching routing information is always the processing node. It’s attached to the result by the statement execution code.
+1. **Eventual consistency.** The coordinator uses `storage_proxy::mutate_*()` and `storage_proxy::query()`, which internally contact replicas via dedicated RPC verbs. These RPCs return raw data, not CQL results. The coordinator assembles the final CQL result and is the one that attaches `tablets-routing-v1` payload today. This means that for eventually-consistent tables, the coordinator is the processing node.
+
+    The tablet version comparison and payload attachment happen locally on the coordinator. No changes to the existing forwarding infrastructure are needed. The coordinator can compute the tablet_version because every node has access to the list of replicas of every tablet.
+2. **Strong consistency.** The statement code may produce a bounce that will redirect the statement to a replica via CQL forwarding. This forwards the raw CQL request bytes to the target node, which runs the full statement execution and produces a complete CQL result (including any custom payloads). Finally, it returns the raw serialised response body and flags to the coordinator. The coordinator reconstructs a response from the raw bytes and sends it to the client without inspecting or modifying the response body. Custom payloads attached by the processing node are passed to the driver transparently. No forwarding infrastructure changes are needed.
+
+**Note:** It may happen that there are two bounces: the coordinator passes a request to a replica but not the leader of the tablet. The forwarding code returns redirect information containing the new target. The coordinator follows it. No result is produced at the redirect step, and no routing information is attached. Only the successful execution on the processing node attaches routing information.
+
+### Pseudocode (on the processing shard; simplified)
+```cpp
+// The cluster has not enabled the cluster feature yet.
+// Fall back to TABLETS_ROUTING_V1.
+if (!connection.uses_tablets_routing_v2()) {
+    return handle_v1();
+}
+
+// The driver thought the table was tablet-based, but it uses vnodes.
+// No routing information returned.
+if (!table.uses_tablets()) {
+    return handle_vnodes();
+}
+
+tablet_version = compute_tablet_version(tablet)
+tablet_version_block = extract_tablet_version_block(tablet_version)
+
+// Version mismatch. Provide the driver with the updated routing information.
+if (status() != raft::candidate
+        && request.is_single_partition()
+        && request.tablet_version_block != tablet_version_block
+) {
+    replica_list = tablet.get_replica_list()
+    // Shift the replica list so that the leader
+    // is the first in the list.
+    shifted_replica_list = shift_replica_list(replica_list, tablet.leader)
+
+    response->set_tablets_routing_v2(
+        tablet.token_begin,
+        tablet.token_end,
+        shifted_replica_list,
+        tablet_version
+    );
+}
+
+// No additional payload attached.
+```

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -116,6 +116,10 @@ std::optional<tablet_routing_info> vnode_effective_replication_map::check_locali
     return {};
 }
 
+std::optional<tablet_routing_info_v2> vnode_effective_replication_map::check_tablet_version(const token&, tablet_version_block) const {
+    return {};
+}
+
 bool vnode_effective_replication_map::has_pending_ranges(locator::host_id endpoint) const {
     for (const auto& item : *_pending_endpoints) {
         const auto& nodes = item.second;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -314,6 +314,9 @@ public:
     ///          so the client can learn the correct tablet map
     virtual std::optional<tablet_routing_info> check_locality(const token& token, unsigned original_shard) const = 0;
 
+    /// Checks whether a tablet_version_block matches the tablet_version corresponding to token.
+    /// \returns std::nullopt if there's a match; tablet_routing_info_v2 otherwise.
+    virtual std::optional<tablet_routing_info_v2> check_tablet_version(const token&, tablet_version_block) const = 0;
 
     /// Returns true if there are any pending ranges for this endpoint.
     /// This operation is expensive, for vnode_erm it iterates
@@ -505,6 +508,7 @@ public: // effective_replication_map
     host_id_vector_replica_set get_replicas_for_reading(const token& token, bool is_vnode = false) const override;
     host_id_vector_replica_set get_replicas(const token& search_token, bool is_vnode = false) const override;
     std::optional<tablet_routing_info> check_locality(const token& token, unsigned original_shard) const override;
+    std::optional<tablet_routing_info_v2> check_tablet_version(const token&, tablet_version_block) const override;
     bool has_pending_ranges(locator::host_id endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
     const dht::sharder& get_sharder(const schema& s) const override;
@@ -617,6 +621,7 @@ public:
     host_id_vector_replica_set get_replicas_for_reading(const token& token, bool is_vnode = false) const override;
     host_id_vector_replica_set get_replicas(const token& search_token, bool is_vnode = false) const override;
     std::optional<tablet_routing_info> check_locality(const token& token, unsigned original_shard) const override;
+    std::optional<tablet_routing_info_v2> check_tablet_version(const token&, tablet_version_block) const override;
     bool has_pending_ranges(locator::host_id endpoint) const override;
     std::unique_ptr<token_range_splitter> make_splitter() const override;
     const dht::sharder& get_sharder(const schema& s) const override;

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -65,6 +65,10 @@ std::optional<tablet_routing_info> local_effective_replication_map::check_locali
     return std::nullopt;
 }
 
+std::optional<tablet_routing_info_v2> local_effective_replication_map::check_tablet_version(const token&, tablet_version_block) const {
+    return std::nullopt;
+}
+
 bool local_effective_replication_map::has_pending_ranges(locator::host_id endpoint) const {
     return false;
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -54,7 +54,6 @@ tablet_version hash_replica_list(const tablet_replica_set& replicas) noexcept {
 
 } // namespace internal
 
-[[maybe_unused]]
 static tablet_replica_set prepare_replicas_for_ec_tablet_version(tablet_replica_set replicas) {
     std::ranges::sort(replicas);
     return replicas;
@@ -1606,6 +1605,30 @@ public:
         }
 
         return make_tablet_routing_info();
+    }
+
+    std::optional<tablet_routing_info_v2> check_tablet_version(const token& search_token, tablet_version_block block) const override {
+        const auto& tablet_map = get_tablet_map();
+        const auto tid = tablet_map.get_tablet_id(search_token);
+        const auto& tablet_info = tablet_map.get_tablet_info(tid);
+
+        tablet_replica_set prepared_replicas = prepare_replicas_for_ec_tablet_version(tablet_info.replicas);
+        const auto tablet_version = internal::hash_replica_list(prepared_replicas);
+
+        if (compare_tablet_version_block(tablet_version, block)) [[likely]] {
+            return std::nullopt;
+        }
+
+        const dht::token first_token = (tid == tablet_map.first_tablet())
+                ? dht::minimum_token()
+                : tablet_map.get_last_token(tablet_id(size_t(tid) - 1));
+        const dht::token last_token = tablet_map.get_last_token(tid);
+
+        return tablet_routing_info_v2 {
+            .tablet_replicas = std::move(prepared_replicas),
+            .token_range = std::make_pair(first_token, last_token),
+            .hash = tablet_version
+        };
     }
 
     virtual bool has_pending_ranges(locator::host_id host_id) const override {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -19,8 +19,10 @@
 #include "utils/rjson.hh"
 #include "utils/div_ceil.hh"
 #include "gms/feature_service.hh"
+#include "utils/xx_hasher.hh"
 
 #include <algorithm>
+#include <cstring>
 #include <flat_set>
 #include <iterator>
 #include <chrono>
@@ -34,6 +36,29 @@
 namespace locator {
 
 seastar::logger tablet_logger("tablets");
+
+
+
+namespace internal {
+
+tablet_version hash_replica_list(const tablet_replica_set& replicas) noexcept {
+    xx_hasher hasher{0};
+
+    for (const auto& replica : replicas) {
+        feed_hash(hasher, replica.host);
+        feed_hash(hasher, replica.shard);
+    }
+
+    return tablet_version{hasher.finalize_uint64()};
+}
+
+} // namespace internal
+
+[[maybe_unused]]
+static tablet_replica_set prepare_replicas_for_ec_tablet_version(tablet_replica_set replicas) {
+    std::ranges::sort(replicas);
+    return replicas;
+}
 
 std::pair<tablet_id, std::optional<tablet_id>> tablet_map::sibling_tablets(tablet_id t) const {
     check_tablet_id(t);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -116,7 +116,7 @@ using tablet_replica_set = utils::small_vector<tablet_replica, 3>;
 /// Used by TABLETS_ROUTING_V2 to detect when a driver's cached routing is stale.
 ///
 /// Tablet version is computed differently for eventually-consistent and
-/// strongly-consistent tablets.
+/// strongly-consistent tablets. For more details, see: docs/dev/tablets-routing-v2.md.
 using tablet_version = utils::tagged_integer<struct tablet_version_tag, uint64_t>;
 
 /// A single-byte encoding of one 4-bit block of a tablet_version.
@@ -124,6 +124,7 @@ using tablet_version = utils::tagged_integer<struct tablet_version_tag, uint64_t
 /// Used in EXECUTE requests to minimize network usage.
 ///
 /// Blocks are indexed from the least significant bits to the most significant ones.
+/// For more details, see: docs/dev/tablets-routing-v2.md.
 using tablet_version_block = utils::tagged_integer<struct tablet_version_block_tag, uint8_t>;
 
 inline bool compare_tablet_version_block(tablet_version hash, tablet_version_block block) noexcept {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -112,7 +112,45 @@ struct tablet_replica {
 
 using tablet_replica_set = utils::small_vector<tablet_replica, 3>;
 
+/// A 64-bit hash computed from a tablet's replica list after ordering it.
+/// Used by TABLETS_ROUTING_V2 to detect when a driver's cached routing is stale.
+///
+/// Tablet version is computed differently for eventually-consistent and
+/// strongly-consistent tablets.
+using tablet_version = utils::tagged_integer<struct tablet_version_tag, uint64_t>;
+
+/// A single-byte encoding of one 4-bit block of a tablet_version.
+/// The high nibble is the block index (0-15), the low nibble is the block's value.
+/// Used in EXECUTE requests to minimize network usage.
+///
+/// Blocks are indexed from the least significant bits to the most significant ones.
+using tablet_version_block = utils::tagged_integer<struct tablet_version_block_tag, uint8_t>;
+
+inline bool compare_tablet_version_block(tablet_version hash, tablet_version_block block) noexcept {
+    uint64_t hash_value = hash.value();
+
+    // Extract the value of the block.
+    const uint8_t block_value = block.value() & 0x0F;
+
+    // Extract the index of the block.
+    const uint8_t block_index = (block.value() & 0xF0) >> 4;
+
+    // Shift the hash so that the block corresponds to the 4 least significant bits.
+    hash_value >>= (block_index * 4);
+
+    // Extract the block value.
+    const uint8_t hash_block = static_cast<uint8_t>(hash_value & 0x0F);
+
+    return hash_block == block_value;
 }
+
+namespace internal {
+
+tablet_version hash_replica_list(const tablet_replica_set&) noexcept;
+
+} // namespace internal
+
+} // namespace locator
 
 namespace std {
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -1071,6 +1071,12 @@ struct tablet_routing_info {
     std::pair<dht::token, dht::token> token_range;
 };
 
+struct tablet_routing_info_v2 {
+    tablet_replica_set tablet_replicas;
+    std::pair<dht::token, dht::token> token_range;
+    tablet_version hash;
+};
+
 /// Split a list of ranges, such that conceptually each input range is
 /// intersected with each tablet range.
 /// Tablets are pre-filtered, selecting only tablets that have a replica on the

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -40,6 +40,7 @@ static thread_local auto tablet_task_info_type = user_type_impl::get_instance(
 static thread_local auto replica_type = tuple_type_impl::get_instance({uuid_type, int32_type});
 static thread_local auto replica_set_type = list_type_impl::get_instance(replica_type, false);
 static thread_local auto tablet_info_type = tuple_type_impl::get_instance({long_type, long_type, replica_set_type});
+static thread_local auto tablet_info_v2_type = tuple_type_impl::get_instance({long_type, long_type, replica_set_type, long_type});
 
 data_type get_replica_set_type() {
     return replica_set_type;
@@ -47,6 +48,10 @@ data_type get_replica_set_type() {
 
 data_type get_tablet_info_type() {
     return tablet_info_type;
+}
+
+data_type get_tablet_info_v2_type() {
+    return tablet_info_v2_type;
 }
 
 void tablet_add_repair_scheduler_user_types(const sstring& ks, replica::database& db) {

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -38,6 +38,7 @@ namespace replica {
 data_type get_replica_set_type();
 
 data_type get_tablet_info_type();
+data_type get_tablet_info_v2_type();
 
 void set_strongly_consistent_tables_enabled(bool enabled);
 

--- a/service/strong_consistency/coordinator.hh
+++ b/service/strong_consistency/coordinator.hh
@@ -105,6 +105,10 @@ public:
     // until the raft groups for those tablets are started and ready to serve queries.
     // For the local node, waits directly without an RPC.
     future<> wait_for_table_raft_groups_on_all_hosts(table_id table, lowres_clock::time_point timeout);
+
+    const groups_manager& get_groups_manager() const noexcept {
+        return _groups_manager;
+    }
 };
 
 }

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -37,7 +37,6 @@ static raft::server_id to_server_id(host_id host_id) {
     return raft::server_id{host_id.uuid()};
 };
 
-[[maybe_unused]]
 static std::optional<locator::tablet_replica_set> prepare_replicas_for_sc_tablet_version(locator::tablet_replica_set replicas, raft::server_id group_leader) {
     std::ranges::sort(replicas);
     const auto leader_host_id = locator::host_id{group_leader.uuid()};
@@ -525,6 +524,55 @@ future<> groups_manager::stop() {
     }
 
     logger.info("stop() completed");
+}
+
+std::optional<locator::tablet_routing_info_v2> groups_manager::check_tablet_version(
+        const replica::table& table,
+        const dht::token& token,
+        const locator::tablet_version_block block) const
+{
+    const auto& erm = table.get_effective_replication_map();
+    const auto& tablet_map = erm->get_token_metadata().tablets().get_tablet_map(table.schema()->id());
+    const auto tablet_id = tablet_map.get_tablet_id(token);
+    const auto& raft_info = tablet_map.get_tablet_raft_info(tablet_id);
+    const auto group_id = raft_info.group_id;
+
+    auto group_it = _raft_groups.find(group_id);
+    if (group_it == _raft_groups.end()) [[unlikely]] {
+        return std::nullopt;
+    }
+
+    const raft_group_state& state = group_it->second;
+    if (!state.server) [[unlikely]] {
+        // We don't know who the leader is, so we cannot compute routing information.
+        return std::nullopt;
+    }
+
+    const raft::server_id group_leader = state.server->current_leader();
+    const auto& tablet_info = tablet_map.get_tablet_info(tablet_id);
+    auto maybe_replicas = prepare_replicas_for_sc_tablet_version(tablet_info.replicas, group_leader);
+
+    if (!maybe_replicas) [[unlikely]] {
+        // The leader is not present in the replica set.
+        return std::nullopt;
+    }
+
+    const auto hash = locator::internal::hash_replica_list(*maybe_replicas);
+
+    if (locator::compare_tablet_version_block(hash, block)) [[likely]] {
+        return std::nullopt;
+    }
+
+    const dht::token first_token = (tablet_id == tablet_map.first_tablet())
+            ? dht::minimum_token()
+            : tablet_map.get_last_token(locator::tablet_id(size_t(tablet_id) - 1));
+    const dht::token last_token = tablet_map.get_last_token(tablet_id);
+
+    return locator::tablet_routing_info_v2 {
+        .tablet_replicas = std::move(*maybe_replicas),
+        .token_range = std::make_pair(first_token, last_token),
+        .hash = hash
+    };
 }
 
 }

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -8,6 +8,8 @@
 
 #include "groups_manager.hh"
 
+#include "locator/tablets.hh"
+#include "raft/raft.hh"
 #include "service/migration_manager.hh"
 #include "service/strong_consistency/state_machine.hh"
 #include "service/strong_consistency/raft_groups_storage.hh"
@@ -34,6 +36,19 @@ static logging::logger logger("sc_groups_manager");
 static raft::server_id to_server_id(host_id host_id) {
     return raft::server_id{host_id.uuid()};
 };
+
+[[maybe_unused]]
+static std::optional<locator::tablet_replica_set> prepare_replicas_for_sc_tablet_version(locator::tablet_replica_set replicas, raft::server_id group_leader) {
+    std::ranges::sort(replicas);
+    const auto leader_host_id = locator::host_id{group_leader.uuid()};
+    auto leader_it = std::ranges::find(replicas, leader_host_id, &tablet_replica::host);
+    if (leader_it == replicas.end()) [[unlikely]] {
+        on_internal_error(logger, seastar::format("Leader ({}) is not among the replicas: {}",
+                leader_host_id, replicas));
+    }
+    std::ranges::rotate(replicas, leader_it);
+    return std::make_optional(std::move(replicas));
+}
 
 class groups_manager::rpc_impl: public service::raft_rpc {
 public:

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -241,4 +241,4 @@ public:
     begin_read_result begin_read(abort_source&);
 };
 
-}
+} // namespace service::strong_consistency

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "locator/abstract_replication_strategy.hh"
+#include "locator/tablets.hh"
 #include "message/messaging_service.hh"
 #include "service/raft/raft_group_registry.hh"
 #include "cql3/query_processor.hh"
@@ -190,6 +191,11 @@ public:
     future<> wait_for_table_raft_groups_on_all_hosts(table_id table, lowres_clock::time_point timeout);
 
     tablet_group_leader_cache& leader_cache() { return _leader_cache; }
+
+    std::optional<locator::tablet_routing_info_v2> check_tablet_version(
+        const replica::table&,
+        const dht::token&,
+        const locator::tablet_version_block) const;
 };
 
 /// A temporary, RAII-style handle to an active Raft group server instance,

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -7,6 +7,9 @@
  */
 
 
+#include "locator/abstract_replication_strategy.hh"
+#include "locator/tablets.hh"
+#include "replica/tablets.hh"
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 
@@ -22,6 +25,7 @@
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/log.hh"
 #include "test/lib/test_utils.hh"
+#include "test/lib/eventually.hh"
 
 #include <seastar/core/future-util.hh>
 #include <seastar/core/sleep.hh>
@@ -56,6 +60,8 @@
 #include "compaction/compaction_manager.hh"
 #include "service/query_state.hh"
 #include "service_permit.hh"
+#include "service/strong_consistency/coordinator.hh"
+#include "service/strong_consistency/groups_manager.hh"
 
 
 BOOST_AUTO_TEST_SUITE(cql_query_test)
@@ -6309,6 +6315,524 @@ SEASTAR_TEST_CASE(test_sstable_load_mixed_generation_type) {
                 {int32_type->decompose(2), int32_type->decompose(2)}
             });
     });
+}
+
+static
+cql_test_config tablet_v2_cql_test_config() {
+    auto c = tablet_cql_test_config();
+    c.db_config->experimental_features(
+        {db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES},
+        db::config::config_source::CommandLine
+    );
+    return c;
+}
+
+static
+bool has_tablets_routing_v2(::shared_ptr<cql_transport::messages::result_message> result) {
+    auto custom_payload = result->custom_payload();
+    return custom_payload.has_value() && custom_payload->contains("tablets-routing-v2");
+}
+
+static
+locator::tablet_version_block extract_tablet_version_block(locator::tablet_version hash, uint8_t block_idx) {
+    uint64_t hash_value = hash.value();
+    hash_value >>= (block_idx * 4);
+    uint8_t block_index = block_idx << 4;
+    uint8_t block_value = static_cast<uint8_t>(hash_value & 0x0F);
+    return locator::tablet_version_block{block_index | block_value};
+}
+
+static
+locator::tablet_version get_eventually_consistent_tablet_version(
+        const locator::effective_replication_map& erm,
+        const dht::token& token)
+{
+    const locator::tablet_version_block blocks[2] = {
+        locator::tablet_version_block{0x00}, locator::tablet_version_block{0x01}
+    };
+    for (auto block : blocks) {
+        auto result = erm.check_tablet_version(token, block);
+        if (result) {
+            return result->hash;
+        }
+    }
+    throw std::runtime_error("Couldn't obtain tablet version");
+}
+
+// Verify that when a TABLETS_ROUTING_V2 connection sends:
+// (A) a matching tablet version block, the response doesn't contain
+//     "tablets-routing-v2" payload;
+// (B) a mismatching tablet version block, the response does contain
+//     "tablets-routing-v2" payload with the correct format and contents.
+SEASTAR_TEST_CASE(test_tablets_routing_v2_match_and_mismatch) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE KEYSPACE ks_tablet WITH replication = "
+            "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+            "AND tablets = {'initial': 1}").get();
+        e.execute_cql("CREATE TABLE ks_tablet.tbl (pk int PRIMARY KEY, v int)").get();
+
+        const auto schema = e.local_db().find_schema("ks_tablet", "tbl");
+        const auto erm = schema->table().get_effective_replication_map();
+
+        // Get the actual tablet version for the partition token.
+        const auto pk = partition_key::from_singular(*schema, int32_t{1});
+        const auto token = dht::get_token(*schema, pk.view());
+        const auto tv = get_eventually_consistent_tablet_version(*erm, token);
+
+        const auto correct_tvb = extract_tablet_version_block(tv, 0);
+        // Keep the same index of the block, but change its value.
+        const auto wrong_tvb = locator::tablet_version_block{correct_tvb.value() ^ 0x0F};
+
+        const auto local_shard = schema->table().shard_for_reads(token);
+
+        smp::submit_to(local_shard, [&e, correct_tvb, wrong_tvb] {
+            return seastar::async([=, &e] {
+                // Set up V2 protocol extension on client state.
+                cql_transport::cql_protocol_extension_enum_set exts = e.local_client_state().get_protocol_extensions();
+                exts.remove(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1);
+                exts.set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
+                e.local_client_state().set_protocol_extensions(std::move(exts));
+
+                e.execute_cql("INSERT INTO ks_tablet.tbl (pk, v) VALUES (1, 100)").get();
+
+                const auto insert_id = e.prepare("INSERT INTO ks_tablet.tbl (pk, v) VALUES (?, ?)").get();
+                const auto select_id = e.prepare("SELECT v FROM ks_tablet.tbl WHERE pk = ?").get();
+
+                /* INSERT */ {
+                    const auto make_insert_options = [] {
+                        return std::make_unique<cql3::query_options>(
+                            db::consistency_level::ONE,
+                            cql3::raw_value_vector_with_unset({
+                                cql3::raw_value::make_value(int32_type->decompose(int32_t{1})),
+                                cql3::raw_value::make_value(int32_type->decompose(int32_t{42})),
+                            }),
+                            cql3::query_options::specific_options::DEFAULT);
+                    };
+
+                    // Case 1. Pass a correct tablet version block. Tablets-routing-v2 information
+                    //         should NOT be returned.
+                    auto correct_insert_options = make_insert_options();
+                    correct_insert_options->set_tablet_version_block(correct_tvb);
+
+                    const auto ok_result = e.execute_prepared_with_qo(insert_id, std::move(correct_insert_options)).get();
+                    BOOST_REQUIRE_MESSAGE(!has_tablets_routing_v2(ok_result),
+                        "Tablets-routing-v2 payload was not expected to be returned (INSERT)");
+
+                    // Case 2. Pass the wrong tablet version block. Tablets-routing-v2 information
+                    //         SHOULD be returned.
+                    auto wrong_insert_options = make_insert_options();
+                    wrong_insert_options->set_tablet_version_block(wrong_tvb);
+
+                    const auto bad_result = e.execute_prepared_with_qo(insert_id, std::move(wrong_insert_options)).get();
+                    BOOST_REQUIRE_MESSAGE(has_tablets_routing_v2(bad_result),
+                        "Expected tablets-routing-v2 payload on version mismatch (INSERT)");
+
+                    // Verify the payload can be deserialized.
+                    const auto& payload = bad_result->custom_payload().value().at("tablets-routing-v2");
+                    const auto type = replica::get_tablet_info_v2_type();
+                    // Deserialize the tuple: (u64, u64, List<Tuple<UUID, u32>>, u64).
+                    const auto val = type->deserialize(payload);
+                    BOOST_REQUIRE(!val.is_null());
+                }
+
+                /* SELECT */ {
+                    // Case 1. Pass a correct tablet version block. Tablets-routing-v2 information
+                    //         should NOT be returned.
+                    const auto make_select_options = [] {
+                        return std::make_unique<cql3::query_options>(
+                            db::consistency_level::ONE,
+                            cql3::raw_value_vector_with_unset({
+                                cql3::raw_value::make_value(int32_type->decompose(int32_t{1})),
+                            }),
+                            cql3::query_options::specific_options::DEFAULT);
+                    };
+
+                    auto correct_select_options = make_select_options();
+                    correct_select_options->set_tablet_version_block(correct_tvb);
+
+                    const auto ok_result = e.execute_prepared_with_qo(select_id, std::move(correct_select_options)).get();
+                    BOOST_REQUIRE_MESSAGE(!has_tablets_routing_v2(ok_result),
+                        "Tablets-routing-v2 payload was not expected to be returned (SELECT)");
+
+                    // Case 2. Pass the wrong tablet version block. Tablets-routing-v2 information
+                    //         SHOULD be returned.
+                    auto wrong_select_options = make_select_options();
+                    wrong_select_options->set_tablet_version_block(wrong_tvb);
+
+                    const auto bad_result = e.execute_prepared_with_qo(select_id, std::move(wrong_select_options)).get();
+                    BOOST_REQUIRE_MESSAGE(has_tablets_routing_v2(bad_result),
+                        "Expected tablets-routing-v2 payload on version mismatch (SELECT)");
+
+                    // Verify the payload can be deserialized.
+                    const auto& payload = bad_result->custom_payload().value().at("tablets-routing-v2");
+                    const auto type = replica::get_tablet_info_v2_type();
+                    // Deserialize the tuple: (u64, u64, List<Tuple<UUID, u32>>, u64).
+                    const auto val = type->deserialize(payload);
+                    BOOST_REQUIRE(!val.is_null());
+                }
+            });
+        }).get();
+    }, tablet_v2_cql_test_config());
+}
+
+// Test the interaction between tablets-routing versions.
+//
+// (A) (V1, V2) = (enabled, disabled):
+//     We should fall back to the old protocol for tablet awareness.
+// (B) (V1, V2) = (disabled, enabled):
+//     We should ONLY use the new protocol. Even when hitting
+//     the wrong shard, tablets-routing-v1 payload should NOT be returned.
+//
+// We also test the pathological situation when both V1 and V2 are enabled.
+// In that case, the server should behave as if V1 were disabled.
+SEASTAR_TEST_CASE(test_tablets_routing_v1_v2_interaction) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE KEYSPACE ks_tablet WITH replication = "
+            "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+            "AND tablets = {'initial': 1}").get();
+        e.execute_cql("CREATE TABLE ks_tablet.tbl (pk int PRIMARY KEY, v int)").get();
+
+        const auto schema = e.local_db().find_schema("ks_tablet", "tbl");
+        const auto erm = schema->table().get_effective_replication_map();
+
+        // Get the actual tablet version for the partition token.
+        const auto pk = partition_key::from_singular(*schema, int32_t{1});
+        const auto token = dht::get_token(*schema, pk.view());
+        const auto tv = get_eventually_consistent_tablet_version(*erm, token);
+
+        const auto correct_tvb = extract_tablet_version_block(tv, 0);
+        // Keep the same index of the block, but change its value.
+        const auto wrong_tvb = locator::tablet_version_block{correct_tvb.value() ^ 0x0F};
+
+        const auto local_shard = schema->table().shard_for_reads(token);
+        const auto foreign_shard = (local_shard + 1) % this_smp_shard_count();
+        BOOST_REQUIRE(local_shard != foreign_shard);
+
+        smp::submit_to(foreign_shard, [&e, correct_tvb, wrong_tvb] {
+            return seastar::async([=, &e] {
+                const auto insert_id = e.prepare("INSERT INTO ks_tablet.tbl (pk, v) VALUES (?, ?)").get();
+
+                /* (V1, V2) = (enabled, disabled) */ {
+                    cql_transport::cql_protocol_extension_enum_set exts = e.local_client_state().get_protocol_extensions();
+                    exts.set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1);
+                    exts.remove(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
+                    e.local_client_state().set_protocol_extensions(std::move(exts));
+
+                    std::vector<cql3::raw_value> raw_values;
+                    raw_values.emplace_back(cql3::raw_value::make_value(int32_type->decompose(int32_t{2})));
+                    raw_values.emplace_back(cql3::raw_value::make_value(int32_type->decompose(int32_t{99})));
+
+
+                    const auto result = e.execute_prepared(insert_id, std::move(raw_values)).get();
+                    // V1 should fire (cross-shard).
+                    BOOST_REQUIRE_MESSAGE(has_tablet_routing(result),
+                        "Expected tablets-routing-v1 payload on cross-shard request");
+                    // V2 should NOT be present.
+                    BOOST_REQUIRE_MESSAGE(!has_tablets_routing_v2(result),
+                        "V1-only connection must not receive tablets-routing-v2 payload");
+                }
+
+                /* (V1, V2) = (enabled, enabled) */ {
+                    // Both tablets-routing versions should NOT be enabled
+                    // simultaneously, but let's test it! V1 should be ignored.
+                    cql_transport::cql_protocol_extension_enum_set exts = e.local_client_state().get_protocol_extensions();
+                    exts.set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1);
+                    exts.set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
+                    e.local_client_state().set_protocol_extensions(std::move(exts));
+
+                    const auto options = std::make_unique<cql3::query_options>(
+                        db::consistency_level::ONE,
+                        cql3::raw_value_vector_with_unset({
+                            cql3::raw_value::make_value(int32_type->decompose(int32_t{1})),
+                            cql3::raw_value::make_value(int32_type->decompose(int32_t{42})),
+                        }),
+                        cql3::query_options::specific_options::DEFAULT);
+
+                    auto bad_options = std::make_unique<cql3::query_options>(*options);
+                    bad_options->set_tablet_version_block(wrong_tvb);
+
+                    auto bad_result = e.execute_prepared_with_qo(insert_id, std::move(bad_options)).get();
+                    BOOST_REQUIRE_MESSAGE(!has_tablet_routing(bad_result),
+                        "Expected tablets-routing-v2 payload only");
+                    BOOST_REQUIRE_MESSAGE(has_tablets_routing_v2(bad_result),
+                        "Expected tablets-routing-v2 payload");
+
+                    // With a match, no payload should be returned.
+                    auto ok_options = std::make_unique<cql3::query_options>(*options);
+                    ok_options->set_tablet_version_block(correct_tvb);
+
+                    auto ok_result = e.execute_prepared_with_qo(insert_id, std::move(ok_options)).get();
+                    BOOST_REQUIRE_MESSAGE(!has_tablet_routing(ok_result),
+                        "Didn't expect tablets-routing-v1 payload");
+                    BOOST_REQUIRE_MESSAGE(!has_tablets_routing_v2(ok_result),
+                        "Didn't expect tablets-routing-v2 payload");
+                }
+
+                /* (V1, V2) = (disabled, enabled) */ {
+                    // Even though we target the wrong shard (foreign shard),
+                    // tablets-routing-v1 information should NOT be returned.
+                    cql_transport::cql_protocol_extension_enum_set exts = e.local_client_state().get_protocol_extensions();
+                    exts.remove(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1);
+                    exts.set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
+                    e.local_client_state().set_protocol_extensions(std::move(exts));
+
+                    const auto make_options = [] {
+                        return std::make_unique<cql3::query_options>(
+                            db::consistency_level::ONE,
+                            cql3::raw_value_vector_with_unset({
+                                cql3::raw_value::make_value(int32_type->decompose(int32_t{1})),
+                                cql3::raw_value::make_value(int32_type->decompose(int32_t{42})),
+                            }),
+                            cql3::query_options::specific_options::DEFAULT);
+                    };
+
+                    auto bad_options = make_options();
+                    bad_options->set_tablet_version_block(wrong_tvb);
+
+                    auto bad_result = e.execute_prepared_with_qo(insert_id, std::move(bad_options)).get();
+                    BOOST_REQUIRE_MESSAGE(!has_tablet_routing(bad_result),
+                        "Expected tablets-routing-v2 payload only");
+                    BOOST_REQUIRE_MESSAGE(has_tablets_routing_v2(bad_result),
+                        "Expected tablets-routing-v2 payload");
+
+                    // With a match, no payload should be returned.
+                    auto ok_options = make_options();
+                    ok_options->set_tablet_version_block(correct_tvb);
+
+                    auto ok_result = e.execute_prepared_with_qo(insert_id, std::move(ok_options)).get();
+                    BOOST_REQUIRE_MESSAGE(!has_tablet_routing(ok_result),
+                        "Didn't expect tablets-routing-v1 payload");
+                    BOOST_REQUIRE_MESSAGE(!has_tablets_routing_v2(ok_result),
+                        "Didn't expect tablets-routing-v2 payload");
+                }
+            });
+        }).get();
+    }, tablet_v2_cql_test_config());
+}
+
+// Verifies the format of the "tablets-routing-v2" payload:
+// TupleType(u64, u64, List<Tuple<UUID, u32>>, u64)
+// containing (first_token, last_token, replicas, tablet_version).
+SEASTAR_TEST_CASE(test_tablets_routing_v2_payload_format) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE KEYSPACE ks_tablet WITH replication = "
+            "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+            "AND tablets = {'initial': 1}").get();
+        e.execute_cql("CREATE TABLE ks_tablet.tbl (pk int PRIMARY KEY, v int)").get();
+
+        const auto schema = e.local_db().find_schema("ks_tablet", "tbl");
+        const auto erm = schema->table().get_effective_replication_map();
+        const auto& tablet_map = erm->get_token_metadata().tablets().get_tablet_map(schema->id());
+
+        // Get the actual tablet version for the partition token.
+        const auto pk = partition_key::from_singular(*schema, int32_t{1});
+        const auto token = dht::get_token(*schema, pk.view());
+        const auto tid = tablet_map.get_tablet_id(token);
+        const auto tv = get_eventually_consistent_tablet_version(*erm, token);
+
+        const auto correct_tvb = extract_tablet_version_block(tv, 0);
+        // Keep the same index of the block, but change its value.
+        const auto wrong_tvb = locator::tablet_version_block{correct_tvb.value() ^ 0x0F};
+
+        // Get expected values from the tablet_map.
+        const auto& info = tablet_map.get_tablet_info(tid);
+        const auto last_token = tablet_map.get_last_token(tid);
+        const auto first_token = (tid == tablet_map.first_tablet())
+            ? dht::minimum_token()
+            : tablet_map.get_last_token(locator::tablet_id(size_t(tid) - 1));
+
+        const auto local_shard = schema->table().shard_for_reads(token);
+
+        smp::submit_to(local_shard, [&] {
+            return seastar::async([&] {
+                // Set up V2 protocol extension on client state.
+                cql_transport::cql_protocol_extension_enum_set exts = e.local_client_state().get_protocol_extensions();
+                exts.remove(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1);
+                exts.set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
+                e.local_client_state().set_protocol_extensions(std::move(exts));
+
+                const auto insert_id = e.prepare("INSERT INTO ks_tablet.tbl (pk, v) VALUES (?, ?)").get();
+
+                // Send a mismatching block to trigger V2 payload.
+                auto options = std::make_unique<cql3::query_options>(
+                    db::consistency_level::ONE,
+                    cql3::raw_value_vector_with_unset({
+                        cql3::raw_value::make_value(int32_type->decompose(int32_t{1})),
+                        cql3::raw_value::make_value(int32_type->decompose(int32_t{1})),
+                    }),
+                    cql3::query_options::specific_options::DEFAULT);
+                options->set_tablet_version_block(wrong_tvb);
+
+                auto result = e.execute_prepared_with_qo(insert_id, std::move(options)).get();
+                BOOST_REQUIRE(has_tablets_routing_v2(result));
+
+                // Deserialize the payload.
+                auto& payload_bytes = result->custom_payload().value().at("tablets-routing-v2");
+                auto type = replica::get_tablet_info_v2_type();
+                auto val = type->deserialize(payload_bytes);
+                BOOST_REQUIRE(!val.is_null());
+
+                // Extract tuple elements: (first_token, last_token, replicas, version).
+                auto tuple_val = value_cast<tuple_type_impl::native_type>(val);
+                BOOST_REQUIRE_EQUAL(tuple_val.size(), 4u);
+
+                // Element 0: first_token.
+                auto returned_first = value_cast<int64_t>(tuple_val[0]);
+                BOOST_REQUIRE_EQUAL(returned_first, dht::token::to_int64(first_token));
+
+                // Element 1: last_token.
+                auto returned_last = value_cast<int64_t>(tuple_val[1]);
+                BOOST_REQUIRE_EQUAL(returned_last, dht::token::to_int64(last_token));
+
+                // Element 2: replicas list.
+                auto replicas_list = value_cast<list_type_impl::native_type>(tuple_val[2]);
+                BOOST_REQUIRE_EQUAL(replicas_list.size(), info.replicas.size());
+
+                // Element 3: tablet_version (int64 serialized).
+                auto returned_version = static_cast<locator::tablet_version>(
+                    value_cast<int64_t>(tuple_val[3]));
+                BOOST_REQUIRE_EQUAL(returned_version, tv);
+            });
+        }).get();
+    }, tablet_v2_cql_test_config());
+}
+
+// Test the basic interaction between a strongly consistent table
+// and tablets-routing protocols.
+// We verify that the table is "immune" to tablets-routing-v1, i.e.
+// we will never get the corresponding payload, even if a request targets
+// the wrong shard.
+// We also verify tablets-routing-v2: a request carrying a mismatching tablet
+// version block must receive the "tablets-routing-v2" payload, and a matching
+// one must not.
+SEASTAR_TEST_CASE(test_tablets_routing_strong_consistency) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE KEYSPACE ks_tablet WITH replication = "
+            "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+            "AND tablets = {'initial': 1} "
+            "AND consistency = 'global'").get();
+        e.execute_cql("CREATE TABLE ks_tablet.tbl (pk int PRIMARY KEY, v int)").get();
+
+        const auto schema = e.local_db().find_schema("ks_tablet", "tbl");
+        const auto pk = partition_key::from_singular(*schema, int32_t{1});
+        const auto token = dht::get_token(*schema, pk.view());
+
+        const auto local_shard = schema->table().shard_for_reads(token);
+        const auto foreign_shard = (local_shard + 1) % this_smp_shard_count();
+        BOOST_REQUIRE(local_shard != foreign_shard);
+
+        // Part 1 (cross-shard): a strongly consistent table must be immune to
+        // tablets-routing-v1 even when the request hits the wrong shard.
+        smp::submit_to(foreign_shard, [&e] {
+            return seastar::async([&e] {
+                cql_transport::cql_protocol_extension_enum_set exts = e.local_client_state().get_protocol_extensions();
+                exts.set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1);
+                exts.remove(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
+                e.local_client_state().set_protocol_extensions(std::move(exts));
+
+                const auto insert_id = e.prepare("INSERT INTO ks_tablet.tbl (pk, v) VALUES (?, ?)").get();
+                auto options = std::make_unique<cql3::query_options>(
+                    db::consistency_level::QUORUM,
+                    cql3::raw_value_vector_with_unset({
+                        cql3::raw_value::make_value(int32_type->decompose(int32_t{1})),
+                        cql3::raw_value::make_value(int32_type->decompose(int32_t{42})),
+                    }),
+                    cql3::query_options::specific_options::DEFAULT);
+
+                const auto result = e.execute_prepared_with_qo(insert_id, std::move(options)).get();
+                // Even though we target the wrong shard (foreign shard),
+                // tablets-routing-v1 information should NOT be returned.
+                BOOST_REQUIRE_MESSAGE(!has_tablet_routing(result),
+                    "Did not expect tablets-routing-v1 payload on cross-shard request for strongly consistent table");
+                BOOST_REQUIRE_MESSAGE(!has_tablets_routing_v2(result),
+                    "V1-only connection must not receive tablets-routing-v2 payload");
+            });
+        }).get();
+
+        // Part 2 (replica shard): with V2 enabled, a mismatching tablet version
+        // block must yield a tablets-routing-v2 payload, and a matching one must
+        // not. The check only runs on the shard that hosts the tablet replica;
+        // a request to any other shard is redirected before the version check.
+        smp::submit_to(local_shard, [&e, token] {
+            return seastar::async([&e, token] {
+                cql_transport::cql_protocol_extension_enum_set exts = e.local_client_state().get_protocol_extensions();
+                exts.remove(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1);
+                exts.set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
+                e.local_client_state().set_protocol_extensions(std::move(exts));
+
+                const auto local_schema = e.local_db().find_schema("ks_tablet", "tbl");
+                const auto& [coordinator_ref, _] = e.local_qp().acquire_strongly_consistent_coordinator();
+                const auto& groups_manager = coordinator_ref.get().get_groups_manager();
+
+                const auto get_tablet_version = [&] (const replica::table& table, const dht::token& token) -> std::optional<locator::tablet_version> {
+                    const locator::tablet_version_block blocks[] = {
+                        locator::tablet_version_block{0x00}, locator::tablet_version_block{0x01}
+                    };
+                    for (auto block : blocks) {
+                        auto result = groups_manager.check_tablet_version(table, token, block);
+                        if (result) {
+                            return std::make_optional(result->hash);
+                        }
+                    }
+                    return std::nullopt;
+                };
+
+                // Leader might not be available instantly, so poll until we can compute the tablet version.
+                locator::tablet_version version{0};
+                const bool version_ready = eventually_true([&] {
+                    if (const auto v = get_tablet_version(local_schema->table(), token)) {
+                        version = *v;
+                        return true;
+                    }
+                    return false;
+                });
+                BOOST_REQUIRE_MESSAGE(version_ready,
+                    "Strongly consistent tablet version was not computed in time");
+
+                const auto correct_tvb = extract_tablet_version_block(version, 0);
+                // Keep the same block index, but change its value to force a mismatch.
+                const auto wrong_tvb = locator::tablet_version_block{correct_tvb.value() ^ 0x0F};
+
+                const auto insert_id = e.prepare("INSERT INTO ks_tablet.tbl (pk, v) VALUES (?, ?)").get();
+                const auto make_options = [] {
+                    return std::make_unique<cql3::query_options>(
+                        db::consistency_level::QUORUM,
+                        cql3::raw_value_vector_with_unset({
+                            cql3::raw_value::make_value(int32_type->decompose(int32_t{1})),
+                            cql3::raw_value::make_value(int32_type->decompose(int32_t{42})),
+                        }),
+                        cql3::query_options::specific_options::DEFAULT);
+                };
+
+                // Mismatching block: tablets-routing-v2 payload SHOULD be returned.
+                auto wrong_options = make_options();
+                wrong_options->set_tablet_version_block(wrong_tvb);
+
+                const auto bad_result = e.execute_prepared_with_qo(insert_id, std::move(wrong_options)).get();
+                BOOST_REQUIRE_MESSAGE(!has_tablet_routing(bad_result),
+                    "Did not expect tablets-routing-v1 payload");
+                BOOST_REQUIRE_MESSAGE(has_tablets_routing_v2(bad_result),
+                    "Expected tablets-routing-v2 payload on version mismatch");
+
+                // Verify the payload can be deserialized.
+                const auto& payload = bad_result->custom_payload().value().at("tablets-routing-v2");
+                const auto type = replica::get_tablet_info_v2_type();
+                // Deserialize the tuple: (u64, u64, List<Tuple<UUID, u32>>, u64).
+                const auto val = type->deserialize(payload);
+                BOOST_REQUIRE(!val.is_null());
+
+                // Matching block: no payload should be returned.
+                auto ok_options = make_options();
+                ok_options->set_tablet_version_block(correct_tvb);
+
+                const auto ok_result = e.execute_prepared_with_qo(insert_id, std::move(ok_options)).get();
+                BOOST_REQUIRE_MESSAGE(!has_tablet_routing(ok_result),
+                    "Did not expect tablets-routing-v1 payload");
+                BOOST_REQUIRE_MESSAGE(!has_tablets_routing_v2(ok_result),
+                    "Did not expect tablets-routing-v2 payload on version match");
+            });
+        }).get();
+    }, tablet_v2_cql_test_config());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -7747,4 +7747,119 @@ SEASTAR_THREAD_TEST_CASE(test_pow2_convergence_does_not_trigger_scale_down) {
     }, std::move(cfg)).get();
 }
 
+static
+locator::tablet_version_block extract_tablet_version_block(locator::tablet_version hash, uint8_t block_idx) {
+    uint64_t hash_value = hash.value();
+    hash_value >>= (block_idx * 4);
+    uint8_t block_index = block_idx << 4;
+    uint8_t block_value = static_cast<uint8_t>(hash_value & 0x0F);
+    return locator::tablet_version_block{block_index | block_value};
+}
+
+SEASTAR_THREAD_TEST_CASE(test_tablet_version_block_matches) {
+    tablet_version version{0xABCD1234DEADBEEFULL};
+
+    // All 16 blocks should match when extracted from the same version.
+    for (unsigned i = 0; i < 16; ++i) {
+        auto block = extract_tablet_version_block(version, i);
+        BOOST_REQUIRE(compare_tablet_version_block(version, block));
+    }
+
+    // A block from a different version should not match.
+    tablet_version other{0x1111111111111111ULL};
+    bool found_mismatch = false;
+    for (unsigned i = 0; i < 16; ++i) {
+        auto block = extract_tablet_version_block(other, i);
+        if (!compare_tablet_version_block(version, block)) {
+            found_mismatch = true;
+            break;
+        }
+    }
+    BOOST_REQUIRE_MESSAGE(found_mismatch, "All 16 blocks matched between two different versions -- unexpected");
+
+    size_t counter = 0;
+    for (unsigned value = 0; value < 1 << 8; ++value) {
+        const auto block = tablet_version_block{value};
+        if (compare_tablet_version_block(version, block)) {
+            ++counter;
+        }
+    }
+    // There are 16 blocks we can match.
+    BOOST_REQUIRE_MESSAGE(counter == 16, "We should get exactly 16 matches");
+
+    // A manually crafted wrong block should not match.
+    auto correct_block_0 = extract_tablet_version_block(version, 0);
+    // Flip the value nibble.
+    auto wrong_block_0 = tablet_version_block{correct_block_0.value() ^ 0x0F};
+    BOOST_REQUIRE(!compare_tablet_version_block(version, wrong_block_0));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_tablet_version_changes_after_tablet_migration) {
+    cql_test_config cfg = tablet_cql_test_config();
+    cfg.db_config->experimental_features(
+        {db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES},
+        db::config::config_source::CommandLine
+    );
+
+    do_with_cql_env_thread([] (cql_test_env& e) {
+        topology_builder topo(e);
+
+        const unsigned shard_count = 1;
+        const auto dc = topo.dc();
+        const auto rack = topo.rack();
+        // Let's be extra careful with adding the nodes to the SAME rack.
+        // That's necessary because we're going to be migrating the tablet
+        // from one to the other.
+        const auto host1 = topo.add_node(node_state::normal, shard_count, rack);
+        const auto host2 = topo.add_node(node_state::normal, shard_count, rack);
+
+        testlog.info("DC: {}, hosts: host1={}, host2={}", dc, host1, host2);
+
+        const auto ks = add_keyspace(e, {{dc, 1}}, 1);
+        const auto table = add_table(e, ks).get();
+
+        const auto move_tablet = [&] (const locator::host_id host_id) {
+            mutate_tablets(e, [&](tablet_metadata& tmeta) -> future<> {
+                auto boundaries = dht::get_uniform_tokens(1);
+                tablet_map tmap(std::move(boundaries));
+                for (auto tid : tmap.tablet_ids()) {
+                    tmap.set_tablet(tid, tablet_info{tablet_replica_set{{{host_id, 0}}}});
+                }
+                tmeta.set_tablet_map(table, std::move(tmap));
+                co_return;
+            });
+            auto aoe = abort_on_expiry(lowres_clock::now() + std::chrono::seconds(60));
+            auto guard = e.get_raft_group0_client().start_operation(aoe.abort_source()).get();
+            save_token_metadata(e, std::move(guard)).get();
+        };
+
+        const auto get_tablet_version = [&] {
+            const auto schema = e.local_db().as_data_dictionary().find_schema(table);
+            const auto erm = schema->table().get_effective_replication_map();
+            // The table has just one tablet, so we can use an arbitrary token.
+            const auto token = dht::token{0};
+
+            const tablet_version_block blocks[2] = {tablet_version_block{0x00}, tablet_version_block{0x01}};
+            for (const auto block : blocks) {
+                auto result = erm->check_tablet_version(token, block);
+                if (result) {
+                    return result->hash;
+                }
+            }
+
+            throw std::runtime_error(fmt::format("Couldn't obtain tablet version for {}.{}", schema->ks_name(), schema->cf_name()));
+        };
+
+        move_tablet(host1);
+        const auto tv1 = get_tablet_version();
+        move_tablet(host2);
+        const auto tv2 = get_tablet_version();
+
+        testlog.info("Comparing versions: tv1={:016x} vs. tv2={:016x}", tv1.value(), tv2.value());
+        // Technically, it's possible that these two versions will be the same even after tablet migration.
+        // However, that's a highly unlikely scenario.
+        BOOST_REQUIRE_MESSAGE(tv1 != tv2, "Tablet version was supposed to change after tablet migration");
+    }, std::move(cfg)).get();
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -66,6 +66,7 @@
 #include "db/system_keyspace.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "repair/row_level.hh"
+#include "transport/cql_protocol_extension.hh"
 #include "utils/assert.hh"
 #include "utils/only_on_shard0.hh"
 #include "utils/cross-shard-barrier.hh"
@@ -204,6 +205,9 @@ private:
             : client_state(service::client_state::external_tag{}, auth_service, &sl_controller, timeout,
                     socket_address(), false, &as)
         {
+            auto exts = client_state.get_protocol_extensions();
+            exts.set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1);
+            client_state.set_protocol_extensions(std::move(exts));
             client_state.set_login(auth::authenticated_user(testing_superuser));
         }
 
@@ -223,9 +227,6 @@ private:
     auto make_query_state() {
         if (_db.local().has_keyspace(ks_name)) {
             _core_local.local().client_state.set_keyspace(_db.local(), ks_name);
-            cql_transport::cql_protocol_extension_enum_set cql_proto_exts;
-            cql_proto_exts.set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1);
-            _core_local.local().client_state.set_protocol_extensions(std::move(cql_proto_exts));
         }
         return ::make_shared<service::query_state>(_core_local.local().client_state, empty_service_permit());
     }

--- a/transport/cql_protocol_extension.cc
+++ b/transport/cql_protocol_extension.cc
@@ -19,12 +19,9 @@ static const std::map<cql_protocol_extension, seastar::sstring> EXTENSION_NAMES 
     {cql_protocol_extension::LWT_ADD_METADATA_MARK, "SCYLLA_LWT_ADD_METADATA_MARK"},
     {cql_protocol_extension::RATE_LIMIT_ERROR, "SCYLLA_RATE_LIMIT_ERROR"},
     {cql_protocol_extension::TABLETS_ROUTING_V1, "TABLETS_ROUTING_V1"},
-    {cql_protocol_extension::USE_METADATA_ID, "SCYLLA_USE_METADATA_ID"}
+    {cql_protocol_extension::USE_METADATA_ID, "SCYLLA_USE_METADATA_ID"},
+    {cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL, "TABLETS_ROUTING_V2_EXPERIMENTAL"}
 };
-
-cql_protocol_extension_enum_set supported_cql_protocol_extensions() {
-    return cql_protocol_extension_enum_set::full();
-} 
 
 const seastar::sstring& protocol_extension_name(cql_protocol_extension ext) {
     return EXTENSION_NAMES.at(ext);

--- a/transport/cql_protocol_extension.hh
+++ b/transport/cql_protocol_extension.hh
@@ -29,18 +29,18 @@ enum class cql_protocol_extension {
     LWT_ADD_METADATA_MARK,
     RATE_LIMIT_ERROR,
     TABLETS_ROUTING_V1,
-    USE_METADATA_ID
+    USE_METADATA_ID,
+    TABLETS_ROUTING_V2_EXPERIMENTAL
 };
 
 using cql_protocol_extension_enum = super_enum<cql_protocol_extension,
     cql_protocol_extension::LWT_ADD_METADATA_MARK,
     cql_protocol_extension::RATE_LIMIT_ERROR,
     cql_protocol_extension::TABLETS_ROUTING_V1,
-    cql_protocol_extension::USE_METADATA_ID>;
+    cql_protocol_extension::USE_METADATA_ID,
+    cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL>;
 
 using cql_protocol_extension_enum_set = enum_set<cql_protocol_extension_enum>;
-
-cql_protocol_extension_enum_set supported_cql_protocol_extensions();
 
 /**
  * Returns the name of extension to be used in SUPPORTED/STARTUP feature negotiation.

--- a/transport/messages/result_message.cc
+++ b/transport/messages/result_message.cc
@@ -11,6 +11,7 @@
 #include "cql3/cql_statement.hh"
 #include "replica/tablets.hh"
 #include "types/tuple.hh"
+#include <bit>
 #include <seastar/core/format.hh>
 #include <fmt/std.h>
 
@@ -23,6 +24,19 @@ void result_message::add_tablet_info(locator::tablet_routing_info info) {
 
     auto tablets_routing = make_tuple_value(replica::get_tablet_info_type(), {v1, v2, replicas_values});
     add_custom_payload("tablets-routing-v1", tablets_routing.serialize_nonnull());
+}
+
+void result_message::add_tablet_info_v2(locator::tablet_routing_info_v2 info) {
+    auto replica_values = make_list_value(replica::get_replica_set_type(), replica::replicas_to_data_value(info.tablet_replicas));
+    auto v1 = data_value(dht::token::to_int64(info.token_range.first));
+    auto v2 = data_value(dht::token::to_int64(info.token_range.second));
+    auto hash = data_value(std::bit_cast<int64_t>(info.hash.value()));
+
+    auto tablets_routing_v2 = make_tuple_value(
+        replica::get_tablet_info_v2_type(),
+        {v1, v2, replica_values, hash}
+    );
+    add_custom_payload("tablets-routing-v2", tablets_routing_v2.serialize_nonnull());
 }
 
 std::ostream& operator<<(std::ostream& os, const result_message::void_message& msg) {

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -55,6 +55,7 @@ public:
     }
 
     void add_tablet_info(locator::tablet_routing_info info);
+    void add_tablet_info_v2(locator::tablet_routing_info_v2);
 
     const std::optional<std::unordered_map<sstring, bytes>>& custom_payload() const {
         return _custom_payload;

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1707,6 +1707,16 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
     if (!cached_pk_fn_calls.empty()) {
         options.set_cached_pk_function_calls(std::move(cached_pk_fn_calls));
     }
+
+    if (client_state.is_protocol_extension_set(cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL)) {
+        auto tablet_version_byte = in.read_byte();
+        if (!tablet_version_byte) {
+            return make_exception_future<cql_server::process_fn_return_type>(std::move(tablet_version_byte).assume_error());
+        }
+        const uint8_t block = tablet_version_byte.assume_value();
+        options.set_tablet_version_block(locator::tablet_version_block{block});
+    }
+
     auto skip_metadata = options.skip_metadata();
 
     if (init_trace && trace_state) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -24,6 +24,7 @@
 #include "service/storage_service.hh"
 #include "service/memory_limiter.hh"
 #include "service/storage_proxy.hh"
+#include "gms/feature_service.hh"
 #include "service/qos/service_level_controller.hh"
 #include "db/consistency_level_type.hh"
 #include "db/write_type.hh"
@@ -967,6 +968,16 @@ std::unique_ptr<cql_server::response> cql_server::handle_exception(int16_t strea
         return make_error(stream, exceptions::exception_code::SERVER_ERROR, "unknown error", trace_state);
     }
 }
+
+cql_protocol_extension_enum_set cql_server::connection::supported_cql_protocol_extensions() const {
+    auto exts = cql_protocol_extension_enum_set::full();
+    const bool strongly_consistent_tables = _server._query_processor.local().proxy().features().strongly_consistent_tables;
+    if (!strongly_consistent_tables) {
+        exts.remove(cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
+    }
+    return exts;
+}
+
 future<foreign_ptr<std::unique_ptr<cql_server::response>>>
     cql_server::connection::process_request_one(fragmented_temporary_buffer::istream fbuf, uint8_t op, uint16_t stream, uint8_t flags, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit, api::timestamp_type request_start_timestamp) {
     using auth_state = service::client_state::auth_state;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -344,6 +344,7 @@ private:
         service::client_state& get_client_state() { return _client_state; }
         scheduling_group get_scheduling_group() const { return _current_scheduling_group; }
     private:
+        cql_protocol_extension_enum_set supported_cql_protocol_extensions() const;
         friend class process_request_executor;
 
         future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_request_one(fragmented_temporary_buffer::istream buf, uint8_t op, uint16_t stream, uint8_t flags, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit, api::timestamp_type request_start_timestamp);


### PR DESCRIPTION
In scylladb/scylladb@b06a007, we introduced tablet awareness. Thanks to
it, the driver was finally able to learn about the replicas of a given
tablet and successfully route requests to the right nodes and shards.
Unfortunately, the feature isn't sufficient to handle strongly
consistent tables.

Just like an eventually consistent tablet, a strongly consistent one
has a set of replicas that own it. The difference is that the latter
also has a distinguished replica called the leader that coordinates all
of the writes and (almost) all reads to the tablet. That creates a need
for the driver to route its requests to the leader instead of an
arbitrary replica. However, the current tablet awareness doesn't allow
the driver to learn about the identity of the leader.

To solve that problem, we devise a new protocol extension that will
effectively function as a new version of tablet awareness. It affects
both eventually and strongly consistent tablets. This PR implements it
in the server.

---

We introduce the notion of a tablet version -- a 64-bit hash that
corresponds to the replicas of a tablet and (in the case of strongly
consistent tablets) its leader.

With every EXECUTE request, the driver provides information about the
tablet version it knows. If the server detects a mismatch, the response
to the request will contain full routing information: the boundary
tokens of the tablet, the list of its replicas, and the tablet version.
The driver then updates its cache and routes subsequent requests to the
right replicas.

For more details, see the documentation added in this PR.

---

Tests have been provided to verify that the implementation is correct.
Because the driver-side isn't implemented yet, the scope of what we can
properly test is limited, but we still cover most of the important
parts of the implementation.

---

Fixes: SCYLLADB-288
Refs: SCYLLADB-291

Backport: no, new feature.