### PR TITLE
sstables: await unlink completion in close_files()

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3495,7 +3495,7 @@ int sstable::compare_by_max_timestamp(const sstable& other) const {
 }
 
 future<> sstable::close_files() {
-    utils::small_vector<future<>, 4> close_futures;
+    utils::small_vector<future<>, 5> close_futures;
     if (_index_file) {
         close_futures.push_back(_index_file.close().handle_exception([me = shared_from_this()] (auto ep) {
             sstlog.warn("sstable close index_file failed: {}", ep);
@@ -3521,7 +3521,6 @@ future<> sstable::close_files() {
         }));
     }
 
-    auto unlinked = make_ready_future<>();
     if (_marked_for_deletion != mark_for_deletion::none && !_unlinked_at) {
         // If a deletion fails for some reason we
         // log and ignore this failure, because on startup we'll again try to
@@ -3529,14 +3528,14 @@ future<> sstable::close_files() {
         // generation number anyway.
         sstlog.debug("Deleting sstable that is {}marked for deletion", _marked_for_deletion == mark_for_deletion::implicit ? "implicitly " : "");
         try {
-            unlinked = unlink().handle_exception(
+            close_futures.push_back(unlink().handle_exception(
                         [me = shared_from_this()] (std::exception_ptr eptr) {
                             try {
                                 std::rethrow_exception(eptr);
                             } catch (...) {
                                 sstlog.warn("Exception when deleting sstable file: {}", eptr);
                             }
-                        });
+                        }));
         } catch (...) {
             sstlog.warn("Exception when deleting sstable file: {}", std::current_exception());
         }


### PR DESCRIPTION
Commit cdcf34b3a0 ("sstables: create and open BTI index files, when enabled") refactored close_files() from named futures passed to when_all_succeed() to a small_vector of futures.  In the process, the `unlinked` future was accidentally left out of the vector, turning the SSTable deletion into a fire-and-forget background task.

This means callers of close_files() can observe stale temporary files (.tmp, .sstable dir) on disk after the call returns, because wipe() is still running in the background.

Fix by pushing the unlink future into close_futures so when_all_succeed() awaits it, restoring the pre-cdcf34b3a0 behavior.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2438

Backport to 2025.4 onwards in needed. This is where the regression was introduced.