### PR TITLE
 view_building_worker: create only one `process_staging` task per tablet replica

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -283,14 +283,50 @@ future<> view_building_worker::create_staging_sstable_tasks() {
     auto uuid_gen = _vb_state_machine.building_state.make_task_uuid_generator(guard.write_timestamp());
     view_building_task_mutation_builder builder(guard.write_timestamp(), std::move(uuid_gen));
     auto my_host_id = _db.get_token_metadata().get_topology().my_host_id();
+    auto started_tasks_lock = co_await get_units(_started_staging_tasks_mutex, 1, _as);
     for (auto& [table_id, sst_infos]: _sstables_to_register) {
+        std::set<std::pair<shard_id, dht::token>> new_tasks;
+        auto task_exists = [&, this] (shard_id shard, dht::token last_token) {
+            if (new_tasks.contains({shard, last_token})) {
+                // We're already creating a task for this tablet replica
+                return true;
+            }
+
+            if (!_vb_state_machine.building_state.tasks_state.contains(table_id)) {
+                return false;
+            }
+            auto& tasks_for_table = _vb_state_machine.building_state.tasks_state.at(table_id);
+            for (auto& [replica, tasks]: tasks_for_table) {
+                if (replica.host != my_host_id || replica.shard != shard) {
+                    continue;
+                }
+                for (auto& staging_task: tasks.staging_tasks) {
+                    if (_started_staging_tasks[replica].contains(std::make_pair(table_id, staging_task.first))) {
+                        // This view building tasks is already started, we cannot attach this staging sstable to it
+                        continue;
+                    }
+                    if (staging_task.second.last_token == last_token && !staging_task.second.aborted) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        };
+
+
         for (auto& sst_info: sst_infos) {
+            if (task_exists(sst_info.shard, sst_info.last_token)) {
+                vbw_logger.debug("Process staging task for replica {} already exists, skipping...", locator::tablet_replica{my_host_id, sst_info.shard});
+                continue;
+            }
+
             view_building_task task {
                 builder.new_id(), view_building_task::task_type::process_staging, false,
                 table_id, ::table_id{}, {my_host_id, sst_info.shard}, sst_info.last_token
             };
             builder.set_task(task);
-            vbw_logger.trace("Creating process staging task: {} with ID: {} for replica: {}", task, task.id, task.replica);
+            vbw_logger.debug("Creating process staging task: {} with ID: {} for replica: {}", task, task.id, task.replica);
+            new_tasks.insert({sst_info.shard, sst_info.last_token});
         }
     }
 

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -157,6 +157,8 @@ future<> view_building_worker::do_drain() {
     }
     co_await _staging_sstables_mutex.wait();
     _staging_sstables_mutex.broken();
+    co_await _started_staging_tasks_mutex.wait();
+    _started_staging_tasks_mutex.broken();
     _sstables_to_register_event.broken();
     if (this_shard_id() == 0) {
         auto sstable_registrator = std::exchange(_staging_sstables_registrator, make_ready_future<>());
@@ -402,6 +404,7 @@ future<> view_building_worker::run_view_building_state_observer() {
 
             co_await update_built_views();
             co_await check_for_aborted_tasks();
+            co_await clear_started_staging_tasks();
             _as.check();
 
             read_apply_mutex_holder.return_all();
@@ -422,6 +425,30 @@ future<> view_building_worker::run_view_building_state_observer() {
             }
         }
     }
+}
+
+// Removes entries from `_started_staging_tasks` which are already removed from view building state machine
+future<> view_building_worker::clear_started_staging_tasks() {
+    auto lock = co_await get_units(_started_staging_tasks_mutex, 1, _as);
+    for (auto it = _started_staging_tasks.begin(); it != _started_staging_tasks.end(); ) {
+        auto& replica = it->first;
+        auto& ids = it->second;
+        for (auto ids_it = ids.begin(); ids_it != ids.end(); ) {
+            if (_vb_state_machine.building_state.get_task(ids_it->first, replica, ids_it->second)) {
+                ++ids_it;
+            } else {
+                ids_it = ids.erase(ids_it);
+            }
+        }
+
+        if (ids.empty()) {
+            it = _started_staging_tasks.erase(it);
+        } else {
+            ++it;
+        }
+        co_await coroutine::maybe_yield();
+    }
+
 }
 
 // Compares tablet-based views entries in `system.view_build_status_v2`(group0 table)
@@ -600,6 +627,19 @@ future<> view_building_worker::batch::abort() {
     });
 }
 
+future<> view_building_worker::batch::log_started_process_staging_tasks() {
+    if (tasks.begin()->second.type != view_building_task::task_type::process_staging) {
+        co_return;
+    }
+
+    auto replica = tasks.begin()->second.replica;
+    auto ids = tasks | std::views::values | std::views::transform([] (auto& task) { return std::make_pair(task.base_id, task.id); }) | std::ranges::to<std::vector>();
+    co_await _vbw.invoke_on(0, [ids = std::move(ids), replica] (view_building_worker& shard0_vbw) -> future<> {
+        auto lock = co_await get_units(shard0_vbw._started_staging_tasks_mutex, 1, shard0_vbw._as);
+        shard0_vbw._started_staging_tasks[replica].insert_range(ids);
+    });
+}
+
 future<> view_building_worker::batch::do_work() {
     if (this_shard_id() != replica.shard) {
         on_internal_error(vbw_logger, fmt::format("view_building_worker::batch::do_work() should be executed on tasks shard "));
@@ -634,6 +674,7 @@ future<> view_building_worker::batch::do_work() {
                 co_await _vbw.local().do_build_range(base_id, views_ids, last_token, as);
                 break;
             case view_building_task::task_type::process_staging:
+                co_await log_started_process_staging_tasks();
                 co_await _vbw.local().do_process_staging(base_id, last_token);
                 break;
             }

--- a/db/view/view_building_worker.hh
+++ b/db/view/view_building_worker.hh
@@ -88,6 +88,7 @@ class view_building_worker : public seastar::peering_sharded_service<view_buildi
         sharded<view_building_worker>& _vbw;
 
         future<> do_work();
+        future<> log_started_process_staging_tasks();
     };
 
     friend class batch;
@@ -139,6 +140,8 @@ private:
     semaphore _staging_sstables_mutex = semaphore(1);
     std::unordered_map<table_id, std::vector<staging_sstable_task_info>> _sstables_to_register;
     std::unordered_map<table_id, std::vector<sstables::shared_sstable>> _staging_sstables;
+    semaphore _started_staging_tasks_mutex = semaphore(1);
+    std::unordered_map<locator::tablet_replica, std::set<std::pair<table_id, utils::UUID>>> _started_staging_tasks;
     future<> _staging_sstables_registrator = make_ready_future<>();
 
 public:
@@ -167,6 +170,7 @@ private:
 
     future<> run_view_building_state_observer();
     future<> update_built_views();
+    future<> clear_started_staging_tasks();
 
     dht::token_range get_tablet_token_range(table_id table_id, dht::token last_token);
     future<> do_build_range(table_id base_id, std::vector<table_id> views_ids, dht::token last_token, abort_source& as);


### PR DESCRIPTION
Currently view building worker is creating one `process_staging` view
building task per new staging sstable.
But this can lead to big number of tasks and may hit `command_is_too_big_error`
in scenario with high tablet count and tablet operations like tablet drain.

However, it is enough to have 1 task per tablet replica for some table.
`do_process_staging()` is already processing all staging sstables for
task's tablet replica.

Fixes SCYLLADB-2434

This fix should be backported to all versions with view building coordinator (2025.4 and newer).