### PR TITLE
view_building_coordinator: don't use raft timeout when starting group0 operation

### DIFF
--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -55,7 +55,7 @@ view_building_coordinator::view_building_coordinator(replica::database& db, raft
     , _as(as) {}
 
 future<service::group0_guard> view_building_coordinator::start_operation() {
-    auto guard = co_await _group0.client().start_operation(_as, service::raft_timeout{});
+    auto guard = co_await _group0.client().start_operation(_as);
     vbc_logger.debug("starting new operation");
     if (_term != _raft.get_current_term()) {
         throw service::term_changed_error{};


### PR DESCRIPTION
The coordinator is working on raft leader, it doesn't need to use timeout when starting group0 operation.
Using the timeout may lead to issues like SCYLLADB-2114, where `finished_task_gc_fiber` timed out on read barrier because it took ~90 seconds on highly loaded node.

Fixes SCYLLADB-2114

This fix should be backported to all versions with view building coordinator (2025.4 and newer).