### PR TITLE
object store: add tiering option for hybrid NVMe/S3 sstable storage

### DIFF
--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -26,6 +26,7 @@
 #include "auth/service.hh"
 #include "schema/schema_builder.hh"
 #include "data_dictionary/data_dictionary.hh"
+#include "data_dictionary/keyspace_metadata.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "types/user.hh"
 #include "gms/feature_service.hh"
@@ -217,7 +218,29 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
 
     bool ks_uses_tablets;
     try {
-        ks_uses_tablets = db.find_keyspace(keyspace()).get_replication_strategy().uses_tablets();
+        const auto ks = db.find_keyspace(keyspace());
+        ks_uses_tablets = ks.get_replication_strategy().uses_tablets();
+        auto& storage_opts = ks.metadata()->get_storage_options();
+        if (auto* obj = std::get_if<data_dictionary::storage_options::object_storage>(&storage_opts.value)) {
+            if (obj->tiering != data_dictionary::storage_options::tiering_mode::none) {
+                auto compression_opts = _properties.properties()->get_compression_options();
+                // compression_opts == nullopt means "use default" which has
+                // compression enabled. Compression is disabled in two ways:
+                // WITH compression = {}  -> compression_opts is an empty map)
+                // WITH compression = {'sstable_compression': ''} -> map with empty value
+                const sstring sstable_compression_key = "sstable_compression";
+                bool compression_disabled =
+                    compression_opts &&
+                    (compression_opts->empty() ||
+                     (compression_opts->count(sstable_compression_key) &&
+                      compression_opts->at(sstable_compression_key).empty()));
+                if (compression_disabled) {
+                    throw exceptions::invalid_request_exception(
+                        "Tables in a keyspace with tiering=data_page_cache must have compression enabled. "
+                        "The page cache uses compressed-chunk offsets as cache keys, which require compression.");
+                }
+            }
+        }
     } catch (const data_dictionary::no_such_keyspace& e) {
         throw exceptions::invalid_request_exception("Cannot create a table in a non-existent keyspace: " + keyspace());
     }

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -337,18 +337,28 @@ static storage_options::object_storage object_storage_from_map(std::string_view 
             throw std::runtime_error(fmt::format("Missing {} option: {}", type, option.first));
         }
     }
-    if (values.size() > allowed_options.size()) {
-        throw std::runtime_error(fmt::format("Extraneous options for {}: {}; allowed: {}",
-            type, fmt::join(values | std::views::keys, ","),
-            fmt::join(allowed_options | std::views::keys, ",")));
+    if (auto it = values.find("tiering"); it != values.end()) {
+        if (it->second == "data_page_cache") {
+            options.tiering = storage_options::tiering_mode::data_page_cache;
+        } else {
+            throw std::runtime_error(fmt::format("Unknown tiering value '{}'; allowed: data_page_cache", it->second));
+        }
+    }
+    const size_t known_options = allowed_options.size() + (values.contains("tiering") ? 1 : 0);
+    if (values.size() > known_options) {
+        throw std::runtime_error(fmt::format("Extraneous options for {}: {}; allowed: bucket, endpoint, tiering",
+            type, fmt::join(values | std::views::keys, ",")));
     }
     options.type = std::string(type);
     return options;
 }
 
 std::map<sstring, sstring> storage_options::object_storage::to_map() const {
-    return {{"bucket", bucket},
-            {"endpoint", endpoint}};
+    std::map<sstring, sstring> result{{"bucket", bucket}, {"endpoint", endpoint}};
+    if (tiering == storage_options::tiering_mode::data_page_cache) {
+        result["tiering"] = "data_page_cache";
+    }
+    return result;
 }
 
 std::string_view storage_options::object_storage::name() const {

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -29,11 +29,19 @@ struct storage_options {
         std::string_view name() const;
         bool operator==(const local&) const = default;
     };
+    // Tiering scheme for object-storage keyspaces.
+    // data_page_cache: Data component lives on object store with an in-DB page cache;
+    //   all other components (index structures) are stored on local NVMe disk.
+    enum class tiering_mode { none, data_page_cache };
+
     struct object_storage {
         std::string bucket;
         std::string endpoint;
         std::variant<sstring, table_id> location;
         seastar::abort_source* abort_source = nullptr;
+        tiering_mode tiering = tiering_mode::none;
+        // Non-persisted: when tiering != none, non-Data components are stored here locally.
+        sstring local_dir;
 
         std::string type;
 

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -38,7 +38,9 @@
 #include "mutation_query.hh"
 #include "db/timeout_clock.hh"
 #include "sstables/sstables.hh"
+#include "sstables/sstables_manager.hh"
 #include "db/schema_tables.hh"
+#include "sstables/page_cache.hh"
 #include "gms/generation-number.hh"
 #include "service/storage_service.hh"
 #include "service/storage_proxy.hh"
@@ -1166,6 +1168,41 @@ schema_ptr system_keyspace::tablets() {
     return schema;
 }
 
+schema_ptr system_keyspace::pagecache() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(NAME, PAGECACHE);
+        return schema_builder(this_smp_shard_count(), NAME, PAGECACHE, id)
+            .with_column("sstable", timeuuid_type, column_kind::partition_key)
+            .with_column("offset", long_type, column_kind::clustering_key)
+            .with_column("page", bytes_type)
+            .set_comment("Object-storage page cache: stores raw bytes fetched from object storage keyed by (sstable generation, file offset)")
+            .with_hash_version()
+            .build();
+    }();
+    return schema;
+}
+
+schema_ptr system_keyspace::pagecache_hits() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(NAME, PAGECACHE_HITS);
+        return schema_builder(this_smp_shard_count(), NAME, PAGECACHE_HITS, id)
+            .with_column("sstable", timeuuid_type, column_kind::partition_key)
+            .with_column("offset", long_type, column_kind::clustering_key)
+            .with_column("last_hit", timestamp_type)
+            // This is intentionally a separate table from system.pagecache, which stores the
+            // raw page data (large blobs, written once, rarely updated).  Access tracking is
+            // kept separate because its write pattern is the opposite: small rows, updated on
+            // every cache hit.  Mixing the two would create compaction pressure from the
+            // high-churn hit timestamps against the large, stable page blobs.  The separation
+            // also lets a future eviction daemon scan only the small hits table to find
+            // least-recently-used pages, without touching the bulky page data at all.
+            .set_comment("Object-storage page cache access tracking: records the last time each cached page was accessed")
+            .with_hash_version()
+            .build();
+    }();
+    return schema;
+}
+
 schema_ptr system_keyspace::service_levels_v2() {
     static thread_local auto schema = [] {
         auto id = generate_legacy_id(NAME, SERVICE_LEVELS_V2);
@@ -2278,7 +2315,7 @@ std::vector<schema_ptr> system_keyspace::all_tables(const db::config& cfg) {
     r.insert(r.end(), {tablets()});
 
     if (cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
-        r.insert(r.end(), {sstables_registry()});
+        r.insert(r.end(), {sstables_registry(), pagecache(), pagecache_hits()});
     }
 
     if (cfg.check_experimental(db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES)) {
@@ -2309,6 +2346,10 @@ future<> system_keyspace::make(
 
     replica::tablet_add_repair_scheduler_user_types(NAME, db);
     db.find_keyspace(NAME).add_user_type(sstableinfo_type);
+
+    if (db.get_config().check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
+        db.get_user_sstables_manager().set_page_cache(make_page_cache());
+    }
 }
 
 void system_keyspace::mark_writable() {
@@ -3518,6 +3559,67 @@ future<> system_keyspace::sstables_registry_list(table_id tid, locator::host_id 
         co_await consumer(std::move(status), std::move(state), std::move(desc));
         co_return stop_iteration::no;
     });
+}
+
+future<std::optional<temporary_buffer<char>>> system_keyspace::pagecache_get(utils::UUID sstable_gen, int64_t offset) {
+    static const auto req = format("SELECT page FROM system.{} WHERE sstable = ? AND offset = ?", PAGECACHE);
+    auto rs = co_await execute_cql(req, sstable_gen, offset);
+    if (!rs || rs->empty()) {
+        co_return std::nullopt;
+    }
+    auto& row = rs->one();
+    if (!row.has("page")) {
+        co_return std::nullopt;
+    }
+    auto blob = row.get_blob_unfragmented("page");
+    temporary_buffer<char> buf(blob.size());
+    std::copy(blob.begin(), blob.end(), buf.get_write());
+
+    // Update last_hit timestamp asynchronously (fire and forget).
+    // Exceptions are ignored - best-effort for eviction tracking.
+    static const auto hit_req = format("INSERT INTO system.{} (sstable, offset, last_hit) VALUES (?, ?, ?)", PAGECACHE_HITS);
+    (void)execute_cql(hit_req, sstable_gen, offset, db_clock::now()).discard_result().handle_exception([] (std::exception_ptr) {});
+
+    co_return std::move(buf);
+}
+
+future<> system_keyspace::pagecache_put(utils::UUID sstable_gen, int64_t offset, temporary_buffer<char> data) {
+    static const auto req = format("INSERT INTO system.{} (sstable, offset, page) VALUES (?, ?, ?)", PAGECACHE);
+    bytes blob(reinterpret_cast<const int8_t*>(data.get()), data.size());
+    co_await execute_cql(req, sstable_gen, offset, std::move(blob)).discard_result();
+}
+
+future<> system_keyspace::pagecache_evict_sstable(utils::UUID sstable_gen) {
+    static const auto req = fmt::format("DELETE FROM system.{} WHERE sstable = ?", PAGECACHE);
+    static const auto hits_req = fmt::format("DELETE FROM system.{} WHERE sstable = ?", PAGECACHE_HITS);
+    co_await execute_cql(req, sstable_gen).discard_result();
+    co_await execute_cql(hits_req, sstable_gen).discard_result();
+}
+
+namespace {
+
+class system_page_cache : public sstables::page_cache {
+    system_keyspace& _sys_ks;
+public:
+    explicit system_page_cache(system_keyspace& sys_ks) : _sys_ks(sys_ks) {}
+
+    future<std::optional<temporary_buffer<char>>> get_page(utils::UUID sstable_gen, int64_t offset) override {
+        return _sys_ks.pagecache_get(sstable_gen, offset);
+    }
+
+    future<> put_page(utils::UUID sstable_gen, int64_t offset, temporary_buffer<char> data) override {
+        return _sys_ks.pagecache_put(sstable_gen, offset, std::move(data));
+    }
+
+    future<> evict_sstable(utils::UUID sstable_gen) override {
+        return _sys_ks.pagecache_evict_sstable(sstable_gen);
+    }
+};
+
+} // anonymous namespace
+
+shared_ptr<sstables::page_cache> system_keyspace::make_page_cache() {
+    return make_shared<system_page_cache>(*this);
 }
 
 future<service::topology_request_state> system_keyspace::get_topology_request_state(utils::UUID id, bool require_entry) {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -42,6 +42,10 @@ namespace sstables {
     enum class sstable_state;
 }
 
+namespace sstables {
+    class page_cache;
+}
+
 namespace service {
 
 class storage_service;
@@ -202,6 +206,8 @@ public:
     static constexpr auto TOPOLOGY = "topology";
     static constexpr auto TOPOLOGY_REQUESTS = "topology_requests";
     static constexpr auto SSTABLES_REGISTRY = "sstables";
+    static constexpr auto PAGECACHE = "pagecache";
+    static constexpr auto PAGECACHE_HITS = "pagecache_hits";
     static constexpr auto CDC_GENERATIONS_V3 = "cdc_generations_v3";
     static constexpr auto CDC_STREAMS_STATE = "cdc_streams_state";
     static constexpr auto CDC_STREAMS_HISTORY = "cdc_streams_history";
@@ -258,6 +264,8 @@ public:
     static schema_ptr topology();
     static schema_ptr topology_requests();
     static schema_ptr sstables_registry();
+    static schema_ptr pagecache();
+    static schema_ptr pagecache_hits();
     static schema_ptr cdc_generations_v3();
     static schema_ptr cdc_streams_state();
     static schema_ptr cdc_streams_history();
@@ -675,6 +683,12 @@ public:
     future<> sstables_registry_delete_entry(table_id tid, locator::host_id node_owner, sstables::generation_type gen);
     using sstable_registry_entry_consumer = sstables::sstables_registry::entry_consumer;
     future<> sstables_registry_list(table_id tid, locator::host_id node_owner, sstable_registry_entry_consumer consumer);
+
+    // Object-storage page cache operations (backed by system.pagecache and system.pagecache_hits)
+    future<std::optional<temporary_buffer<char>>> pagecache_get(utils::UUID sstable_gen, int64_t offset);
+    future<> pagecache_put(utils::UUID sstable_gen, int64_t offset, temporary_buffer<char> data);
+    future<> pagecache_evict_sstable(utils::UUID sstable_gen);
+    seastar::shared_ptr<sstables::page_cache> make_page_cache();
 
     future<std::optional<sstring>> load_group0_upgrade_state();
     future<> save_group0_upgrade_state(sstring);

--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -481,3 +481,63 @@ It's important to re-iterate that the per-cell TTL and per-row TTL features
 are separate and distinct, use a different CQL syntax, have a different
 implementation and provide different guarantees. It is possible to use
 both features in the same table, or even the same row.
+
+## Keyspace storage options
+
+The `STORAGE` option on `CREATE KEYSPACE` allows storing SSTable files on object
+storage (S3-compatible or Google Cloud Storage) instead of local disk.
+
+This feature is experimental and must be enabled in `scylla.yaml`:
+
+```yaml
+experimental_features:
+  - keyspace-storage-options
+```
+
+### Syntax
+
+```cql
+CREATE KEYSPACE ks
+  WITH REPLICATION = { ... }
+  AND STORAGE = {
+    'type'    : '<S3|GS>',
+    'endpoint': '<endpoint_name>',
+    'bucket'  : '<bucket_name>'
+    [, 'tiering' : '<tiering_mode>' ]
+  };
+```
+
+The endpoint must be configured in `scylla.yaml` under `object_storage_endpoints`.
+See the [object storage developer guide](../dev/object_storage.md) for endpoint
+configuration details.
+
+### Tiering option
+
+The optional `tiering` parameter controls how SSTable components are distributed
+between object storage and local disk.
+
+| Value | Description |
+|---|---|
+| *(absent)* | All SSTable components are stored on object storage. |
+| `data_page_cache` | Only the `Data` component is stored on object storage, served through an in-database page cache. All structural/index components (`Rows.db`, `Partitions.db`, `Summary.db`, etc.) are stored on local NVMe disk for low-latency access. |
+
+The `data_page_cache` tiering mode is designed for read-heavy workloads: the bulk of
+the data stays in cheap object storage, frequently-read data pages are cached in
+memory, and the index structures that are consulted on every read remain on fast
+local disk.
+
+Example:
+
+```cql
+CREATE KEYSPACE ks
+  WITH REPLICATION = {
+    'class' : 'NetworkTopologyStrategy',
+    'replication_factor' : 1
+  }
+  AND STORAGE = {
+    'type'    : 'S3',
+    'endpoint': 's3.us-east-2.amazonaws.com',
+    'bucket'  : 'my-bucket',
+    'tiering' : 'data_page_cache'
+  };
+```

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -116,6 +116,48 @@ CREATE KEYSPACE ks
 ```
 
 
+## Tiering option
+
+Both S3 and GS keyspaces support an optional `tiering` parameter in the `STORAGE` clause.
+Currently the only supported value is `data_page_cache`.
+
+### `tiering = 'data_page_cache'`
+
+When `tiering = 'data_page_cache'` is set, ScyllaDB uses a **hybrid storage** scheme for SSTables:
+
+- The **Data component** (`Data.db`) and the **TOC** (`TOC.txt`) are stored on object storage
+  (S3 or GS).  Reads of `Data.db` are served through an **in-database page cache** backed by the
+  `system.pagecache` and `system.pagecache_hits` system tables.  Once a page is fetched from object
+  storage it is stored in the cache, so subsequent reads of the same page require no
+  object-storage GET requests.  The TOC is kept in the bucket because it is needed for SSTable
+  lifecycle operations (cloning, deletion) that run without access to local disk state.
+- All other **non-Data components** (`Rows.db`, `Partitions.db`, `Index.db`, `Summary.db`, etc.)
+  are stored on local NVMe disk.  These components are accessed on every read and keeping them
+  local avoids the latency of object-storage round-trips on the read hot path.
+
+This combination is intended for workloads where reads are common and data is large: the bulk of the
+data stays in cheap object storage while the index structures that guide every read stay on fast
+local disk, and frequently-accessed data pages are cached in memory.
+
+Example (S3):
+
+```cql
+CREATE KEYSPACE ks
+  WITH REPLICATION = {
+   'class' : 'NetworkTopologyStrategy',
+   'replication_factor' : 1
+  }
+  AND STORAGE = {
+   'type' : 'S3',
+   'endpoint' : 's3.us-east-2.amazonaws.com',
+   'bucket' : 'bucket-for-testing',
+   'tiering' : 'data_page_cache'
+  };
+```
+
+The local index component files are stored under the first configured `data_file_directories` path
+(from `scylla.yaml`), in a subdirectory named `<keyspace>/<table>-<table_uuid_no_dashes>`.
+
 ## Creating keyspace with GS
 
 This mirrors AWS S3 config.
@@ -312,7 +354,7 @@ The optional `files` member may contain a list of non-SSTable files included in 
 
 When creating a keyspace with S3/GS storage, the data is stored under the bucket passed as argument to the `CREATE KEYSPACE` statement.  
 Once the statement is issued, Scylla will transparently use the S3/GS bucket as the location of the SSTables for that keyspace.  
-Like in the case above, there is no hierarchy for the data, *all SSTables components are stored flat within the bucket*.
+By default, *all SSTable components are stored flat within the bucket*:
 ```perl
 scylla-sstables-bucket/
 │
@@ -330,6 +372,10 @@ scylla-sstables-bucket/
 │
 └── ... (other SSTable folders)
 ```
+
+When the `tiering = 'data_page_cache'` option is used (see [Tiering option](#tiering-option)),
+only `Data.db` and `TOC.txt` are stored in the bucket.  All other non-Data components
+(`Rows.db`, `Partitions.db`, `Index.db`, `Summary.db`, etc.) are stored on local NVMe disk instead.
 
 ## Downloading, deleting, uploading SSTables
 

--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -304,7 +304,12 @@ enum class compressed_checksum_mode {
 
 template <ChecksumUtils ChecksumType, bool check_digest, compressed_checksum_mode mode>
 class compressed_file_data_source_impl : public data_source_impl {
-    std::function<future<input_stream<char>>()> _stream_creator;
+    // _stream_creator opens the underlying S3/file stream starting at a given
+    // compressed offset.  It is stored as the original stream_creator_fn so that
+    // skip() can defer the open until get() actually needs the data.
+    sstables::stream_creator_fn _stream_creator;
+    uint64_t _compressed_end_pos = 0; // compressed end of the last chunk we may need
+    file_input_stream_options _stream_options;
     std::optional<input_stream<char>> _input_stream;
     sstables::compression* _compression_metadata;
     sstables::compression::segmented_offsets::accessor _offsets;
@@ -314,13 +319,16 @@ class compressed_file_data_source_impl : public data_source_impl {
     uint64_t _pos;
     uint64_t _beg_pos;
     uint64_t _end_pos;
+    std::optional<sstables::chunk_page_cache> _chunk_cache;
 public:
     compressed_file_data_source_impl(sstables::stream_creator_fn stream_creator, sstables::compression* cm,
                 uint64_t pos, size_t len, file_input_stream_options options,
-                reader_permit permit, std::optional<uint32_t> digest)
+                reader_permit permit, std::optional<uint32_t> digest,
+                std::optional<sstables::chunk_page_cache> chunk_cache = std::nullopt)
             : _compression_metadata(cm)
             , _offsets(_compression_metadata->offsets.get_accessor())
             , _permit(std::move(permit))
+            , _chunk_cache(std::move(chunk_cache))
     {
         _pos = _beg_pos = pos;
         if (pos > _compression_metadata->uncompressed_file_length()) {
@@ -353,19 +361,17 @@ public:
         // and open a file_input_stream to read that range.
         auto start = _compression_metadata->locate(_beg_pos, _offsets);
         auto end = _compression_metadata->locate(_end_pos - 1, _offsets);
-        _stream_creator = [stream_creator{std::move(stream_creator)}, start = start.chunk_start, length = end.chunk_start + end.chunk_len - start.chunk_start, options] mutable {
-            return stream_creator(start, length, std::move(options));
-        };
+        _stream_creator = std::move(stream_creator);
+        _compressed_end_pos = end.chunk_start + end.chunk_len;
+        _stream_options = std::move(options);
         _underlying_pos = start.chunk_start;
     }
+public:
     virtual future<temporary_buffer<char>> get() override {
         if (_pos >= _end_pos) {
             co_return temporary_buffer<char>();
         }
 
-        if (!_input_stream) {
-            _input_stream = co_await _stream_creator();
-        }
         auto addr = _compression_metadata->locate(_pos, _offsets);
         // Uncompress the next chunk. We need to skip part of the first
         // chunk, but then continue to read from beginning of chunks.
@@ -375,10 +381,40 @@ public:
         if (!addr.chunk_len) {
             sstables::throw_malformed_sstable_exception(format("compressed chunk_len must be greater than zero, chunk_start={}", addr.chunk_start));
         }
-        auto buf = co_await _input_stream->read_exactly(addr.chunk_len);
-        if (buf.size() != addr.chunk_len) {
-            sstables::throw_malformed_sstable_exception(format("compressed reader hit premature end-of-file at file offset {}, expected chunk_len={}, actual={}", _underlying_pos, addr.chunk_len, buf.size()));
+
+        // Check the per-chunk page cache.  We always check, even when the
+        // underlying stream is already open: a skip() may have seeked past
+        // chunks that were since cached by another reader.  On a hit we still
+        // advance the open stream by chunk_len so its position stays correct.
+        temporary_buffer<char> buf;
+        if (_chunk_cache) {
+            auto cached = co_await _chunk_cache->get(addr.chunk_start);
+            if (cached && cached->size() >= addr.chunk_len) {
+                buf = temporary_buffer<char>(cached->get(), addr.chunk_len);
+                if (_input_stream) {
+                    co_await _input_stream->skip(addr.chunk_len);
+                }
+            }
         }
+        if (buf.empty()) {
+            if (!_input_stream) {
+                // Open the stream at addr.chunk_start, the exact compressed
+                // offset of the chunk we need.
+                _input_stream = co_await _stream_creator(addr.chunk_start,
+                        _compressed_end_pos - addr.chunk_start,
+                        std::move(_stream_options));
+            }
+            buf = co_await _input_stream->read_exactly(addr.chunk_len);
+            if (buf.size() != addr.chunk_len) {
+                sstables::throw_malformed_sstable_exception(format("compressed reader hit premature end-of-file at file offset {}, expected chunk_len={}, actual={}", addr.chunk_start, addr.chunk_len, buf.size()));
+            }
+            // Cache at exact chunk offset so scans and point reads share entries.
+            if (_chunk_cache) {
+                co_await _chunk_cache->put(addr.chunk_start,
+                        temporary_buffer<char>(buf.get(), addr.chunk_len));
+            }
+        }
+
         auto res_units = co_await _permit.request_memory(_compression_metadata->uncompressed_chunk_length());
         // The last 4 bytes of the chunk are the adler32/crc32 checksum
         // of the rest of the (compressed) chunk.
@@ -451,10 +487,12 @@ public:
         auto underlying_n = addr.chunk_start - _underlying_pos;
         _underlying_pos = addr.chunk_start;
         _beg_pos = _pos;
-        if (!_input_stream) {
-            _input_stream = co_await _stream_creator();
+        if (_input_stream) {
+            // Stream is open: advance it past the skipped region.
+            co_await _input_stream->skip(underlying_n);
         }
-        co_await _input_stream->skip(underlying_n);
+        // If the stream is not open, get() will open it lazily at addr.chunk_start
+        // when the next chunk is actually needed.
         co_return temporary_buffer<char>();
     }
 };
@@ -577,23 +615,23 @@ class compressed_file_data_source : public data_source {
 public:
     compressed_file_data_source(sstables::stream_creator_fn stream_creator, sstables::compression* cm,
             uint64_t offset, size_t len, file_input_stream_options options, reader_permit permit,
-            std::optional<uint32_t> digest)
+            std::optional<uint32_t> digest, std::optional<sstables::chunk_page_cache> chunk_cache = std::nullopt)
         : data_source(std::make_unique<compressed_file_data_source_impl<ChecksumType, check_digest, mode>>(
-                std::move(stream_creator), cm, offset, len, std::move(options), std::move(permit), digest))
+                std::move(stream_creator), cm, offset, len, std::move(options), std::move(permit), digest, std::move(chunk_cache)))
         {}
 };
 
 template <ChecksumUtils ChecksumType, compressed_checksum_mode mode>
 inline input_stream<char> make_compressed_file_input_stream(sstables::stream_creator_fn stream_creator, sstables::compression *cm, uint64_t offset, size_t len,
         file_input_stream_options options, reader_permit permit,
-        std::optional<uint32_t> digest)
+        std::optional<uint32_t> digest, std::optional<sstables::chunk_page_cache> chunk_cache = std::nullopt)
 {
     if (digest) [[unlikely]] {
         return input_stream<char>(compressed_file_data_source<ChecksumType, true, mode>(
-                std::move(stream_creator), cm, offset, len, std::move(options), std::move(permit), digest));
+                std::move(stream_creator), cm, offset, len, std::move(options), std::move(permit), digest, std::move(chunk_cache)));
     }
     return input_stream<char>(compressed_file_data_source<ChecksumType, false, mode>(
-            std::move(stream_creator), cm, offset, len, std::move(options), std::move(permit), digest));
+            std::move(stream_creator), cm, offset, len, std::move(options), std::move(permit), digest, std::move(chunk_cache)));
 }
 
 // compressed_file_data_sink_impl works as a filter for a file output stream,
@@ -702,18 +740,18 @@ inline output_stream<char> make_compressed_file_output_stream(output_stream<char
 input_stream<char> sstables::make_compressed_file_k_l_format_input_stream(stream_creator_fn stream_creator,
         sstables::compression* cm, uint64_t offset, size_t len,
         class file_input_stream_options options, reader_permit permit,
-        std::optional<uint32_t> digest)
+        std::optional<uint32_t> digest, std::optional<sstables::chunk_page_cache> chunk_cache)
 {
     return make_compressed_file_input_stream<adler32_utils, compressed_checksum_mode::checksum_chunks_only>(
-            std::move(stream_creator), cm, offset, len, std::move(options), std::move(permit), digest);
+            std::move(stream_creator), cm, offset, len, std::move(options), std::move(permit), digest, std::move(chunk_cache));
 }
 
 input_stream<char> sstables::make_compressed_file_m_format_input_stream(stream_creator_fn stream_creator,
         sstables::compression *cm, uint64_t offset, size_t len,
         class file_input_stream_options options, reader_permit permit,
-        std::optional<uint32_t> digest) {
+        std::optional<uint32_t> digest, std::optional<sstables::chunk_page_cache> chunk_cache) {
     return make_compressed_file_input_stream<crc32_utils, compressed_checksum_mode::checksum_all>(
-            std::move(stream_creator), cm, offset, len, std::move(options), std::move(permit), digest);
+            std::move(stream_creator), cm, offset, len, std::move(options), std::move(permit), digest, std::move(chunk_cache));
 }
 
 output_stream<char> sstables::make_compressed_file_m_format_output_stream(output_stream<char> out,

--- a/sstables/compress.hh
+++ b/sstables/compress.hh
@@ -13,7 +13,7 @@
 //
 // To allow reasonably-efficient seeking in the compressed file, the file
 // is not compressed as a whole, but rather divided into chunks of a known
-// size (by default, 64 KB), where each chunk is compressed individually.
+// size (by default, 4 KB), where each chunk is compressed individually.
 // The compressed size of each chunk is different, so for allowing seeking
 // to a particular position in the uncompressed data, we need to also know
 // the position of each chunk. This offset vector is supplied externally as
@@ -362,6 +362,19 @@ public:
 
 using stream_creator_fn = std::function<future<input_stream<char>>(uint64_t, uint64_t, file_input_stream_options)>;
 
+/// Per-chunk page cache for compressed SSTable Data reads.
+///
+/// When supplied to compressed_file_data_source_impl, each compressed chunk is
+/// looked up and stored in the cache at its exact compressed-file offset before
+/// and after reading from the underlying stream.  This ensures cache entries are
+/// keyed at chunk boundaries rather than at file_input_stream buffer-aligned
+/// positions, making them reusable across both sequential scans (offset=0) and
+/// random-access point reads (offset=chunk_k.start).
+struct chunk_page_cache {
+    std::function<future<std::optional<temporary_buffer<char>>>(uint64_t offset)> get;
+    std::function<future<>(uint64_t offset, temporary_buffer<char>)> put;
+};
+
 // Note: compression_metadata is passed by reference; The caller is
 // responsible for keeping the compression_metadata alive as long as there
 // are open streams on it. This should happen naturally on a higher level -
@@ -370,12 +383,14 @@ using stream_creator_fn = std::function<future<input_stream<char>>(uint64_t, uin
 input_stream<char> make_compressed_file_k_l_format_input_stream(stream_creator_fn stream_creator,
                 sstables::compression* cm, uint64_t offset, size_t len,
                 class file_input_stream_options options, reader_permit permit,
-                std::optional<uint32_t> digest);
+                std::optional<uint32_t> digest,
+                std::optional<chunk_page_cache> chunk_cache = std::nullopt);
 
 input_stream<char> make_compressed_file_m_format_input_stream(stream_creator_fn stream_creator,
                 sstables::compression* cm, uint64_t offset, size_t len,
                 class file_input_stream_options options, reader_permit permit,
-                std::optional<uint32_t> digest);
+                std::optional<uint32_t> digest,
+                std::optional<chunk_page_cache> chunk_cache = std::nullopt);
 
 // Raw compressed data stream function that return compressed chunks without decompression
 // while still calculating digests and verifying checksums. Compatible with SSTables version 3.x and later.

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -801,6 +801,10 @@ public:
         return _out_of_range;
     }
 
+    bool bypass_cache() const {
+        return _slice.options.contains(query::partition_slice::option::bypass_cache);
+    }
+
     // See the RowConsumer concept
     void push_ready_fragments() {
         if (_ready) {

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -217,6 +217,10 @@ public:
 
     ~mp_row_consumer_m() {}
 
+    bool bypass_cache() const {
+        return _slice.options.contains(query::partition_slice::option::bypass_cache);
+    }
+
     // See the RowConsumer concept
     void push_ready_fragments() {
         if (auto rto = std::move(_stored_tombstone)) {
@@ -2106,6 +2110,7 @@ public:
 
     const reader_permit& permit() const { return _permit; }
     tracing::trace_state_ptr trace_state() { return {}; }
+    bool bypass_cache() const { return true; }
     uint64_t error_count() const { return _error_count; }
     position_in_partition_view current_position() const { return _current_pos; }
 

--- a/sstables/page_cache.hh
+++ b/sstables/page_cache.hh
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <optional>
+#include <seastar/core/future.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/core/shared_ptr.hh>
+#include "utils/UUID.hh"
+
+namespace sstables {
+
+/// Abstract interface for an object-storage page cache.
+///
+/// Caches the raw bytes fetched from object storage by (sstable generation UUID, file offset).
+/// Implementations store and retrieve cached pages; on a miss the caller is
+/// expected to fall back to the real object-storage request.
+class page_cache {
+public:
+    virtual ~page_cache() = default;
+
+    /// Return cached bytes for the read at (sstable_gen, offset), or nullopt on a miss.
+    virtual seastar::future<std::optional<seastar::temporary_buffer<char>>>
+    get_page(utils::UUID sstable_gen, int64_t offset) = 0;
+
+    /// Store bytes read at (sstable_gen, offset) in the cache.
+    virtual seastar::future<>
+    put_page(utils::UUID sstable_gen, int64_t offset, seastar::temporary_buffer<char> data) = 0;
+
+    /// Evict all cached entries for the given SSTable (e.g. after it is deleted).
+    virtual seastar::future<>
+    evict_sstable(utils::UUID sstable_gen) = 0;
+};
+
+using page_cache_ptr = seastar::shared_ptr<page_cache>;
+
+} // namespace sstables

--- a/sstables/sstable_mutation_reader.hh
+++ b/sstables/sstable_mutation_reader.hh
@@ -128,7 +128,8 @@ inline future<std::unique_ptr<DataConsumeRowsContext>> data_consume_rows(const s
     // can be beneficial if the user wants to fast_forward_to() on the
     // returned context, and may make small skips.
     auto input = co_await sst->data_stream(toread.start, last_end - toread.start,
-            consumer.permit(), consumer.trace_state(), sst->_partition_range_history, sstable::raw_stream::no, integrity);
+            consumer.permit(), consumer.trace_state(), sst->_partition_range_history, sstable::raw_stream::no, integrity,
+            throwing_integrity_error_handler, consumer.bypass_cache());
     co_return std::make_unique<DataConsumeRowsContext>(s, std::move(sst), consumer, std::move(input), toread.start, toread.end - toread.start);
 }
 
@@ -163,7 +164,8 @@ template <typename DataConsumeRowsContext>
 inline future<std::unique_ptr<DataConsumeRowsContext>> data_consume_single_partition(const schema& s, shared_sstable sst, typename DataConsumeRowsContext::consumer& consumer,
         sstable::disk_read_range toread, integrity_check integrity) {
     auto input = co_await sst->data_stream(toread.start, toread.end - toread.start,
-            consumer.permit(), consumer.trace_state(), sst->_single_partition_history, sstable::raw_stream::no, integrity);
+            consumer.permit(), consumer.trace_state(), sst->_single_partition_history, sstable::raw_stream::no, integrity,
+            throwing_integrity_error_handler, consumer.bypass_cache());
     co_return std::make_unique<DataConsumeRowsContext>(s, std::move(sst), consumer, std::move(input), toread.start, toread.end - toread.start);
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3069,19 +3069,19 @@ component_type sstable::component_from_sstring(version_types v, const sstring &s
 
 future<input_stream<char>> sstable::data_stream(uint64_t pos, size_t len,
         reader_permit permit, tracing::trace_state_ptr trace_state, lw_shared_ptr<file_input_stream_history> history, raw_stream raw,
-        integrity_check integrity, integrity_error_handler error_handler) {
+        integrity_check integrity, integrity_error_handler error_handler, bool bypass_cache) {
     file_input_stream_options options;
     options.buffer_size = sstable_buffer_size;
     options.read_ahead = 4;
     options.dynamic_adjustments = std::move(history);
-    return data_stream(pos, len, permit, std::move(trace_state), history, std::move(options), raw, integrity, std::move(error_handler));
+    return data_stream(pos, len, permit, std::move(trace_state), history, std::move(options), raw, integrity, std::move(error_handler), bypass_cache);
 }
 
 future<input_stream<char>> sstable::data_stream(uint64_t pos, size_t len,
         reader_permit permit, tracing::trace_state_ptr trace_state, lw_shared_ptr<file_input_stream_history> history,
         file_input_stream_options options,
         raw_stream raw, integrity_check integrity,
-        integrity_error_handler error_handler) {
+        integrity_error_handler error_handler, bool bypass_cache) {
 
     file f = make_tracked_file(_data_file, permit);
     if (trace_state) {
@@ -3102,7 +3102,7 @@ future<input_stream<char>> sstable::data_stream(uint64_t pos, size_t len,
         // across both sequential scans and random-access point reads.
         auto [pcache, pcache_uuid] = _storage->data_page_cache_info(*this);
         std::optional<sstables::chunk_page_cache> chunk_cache;
-        if (pcache) {
+        if (pcache && !bypass_cache) {
             chunk_cache = sstables::chunk_page_cache{
                 .get = [pcache, pcache_uuid](uint64_t off) {
                     return pcache->get_page(pcache_uuid, static_cast<int64_t>(off));

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -43,6 +43,7 @@
 #include "utils/to_string.hh"
 #include "data_dictionary/storage_options.hh"
 #include "dht/sharder.hh"
+#include "page_cache.hh"
 #include "writer.hh"
 #include "m_format_read_helpers.hh"
 #include "open_info.hh"
@@ -3095,12 +3096,28 @@ future<input_stream<char>> sstable::data_stream(uint64_t pos, size_t len,
         co_return input_stream<char>(co_await _storage->make_data_or_index_source(*this, component_type::Data, std::move(f), pos, len, std::move(options)));
     };
     if (_components->compression && raw == raw_stream::no) {
+        // Build a per-chunk page cache accessor if the storage backend supports it.
+        // This ensures compressed chunks are cached at their exact file offsets
+        // rather than at buffer-aligned positions, making cache entries reusable
+        // across both sequential scans and random-access point reads.
+        auto [pcache, pcache_uuid] = _storage->data_page_cache_info(*this);
+        std::optional<sstables::chunk_page_cache> chunk_cache;
+        if (pcache) {
+            chunk_cache = sstables::chunk_page_cache{
+                .get = [pcache, pcache_uuid](uint64_t off) {
+                    return pcache->get_page(pcache_uuid, static_cast<int64_t>(off));
+                },
+                .put = [pcache, pcache_uuid](uint64_t off, temporary_buffer<char> data) {
+                    return pcache->put_page(pcache_uuid, static_cast<int64_t>(off), std::move(data));
+                }
+            };
+        }
         if (_version >= sstable_version_types::mc) {
             co_return make_compressed_file_m_format_input_stream(stream_creator, &_components->compression,
-               pos, len, std::move(options), permit, digest);
+               pos, len, std::move(options), permit, digest, std::move(chunk_cache));
         } else {
             co_return make_compressed_file_k_l_format_input_stream(stream_creator, &_components->compression,
-                pos, len, std::move(options), permit, digest);
+                pos, len, std::move(options), permit, digest, std::move(chunk_cache));
         }
     }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -825,13 +825,15 @@ public:
     future<input_stream<char>> data_stream(uint64_t pos, size_t len,
             reader_permit permit, tracing::trace_state_ptr trace_state, lw_shared_ptr<file_input_stream_history> history,
             raw_stream raw = raw_stream::no, integrity_check integrity = integrity_check::no,
-            integrity_error_handler error_handler = throwing_integrity_error_handler);
+            integrity_error_handler error_handler = throwing_integrity_error_handler,
+            bool bypass_cache = false);
 
     future<input_stream<char>> data_stream(uint64_t pos, size_t len,
         reader_permit permit, tracing::trace_state_ptr trace_state, lw_shared_ptr<file_input_stream_history> history,
         file_input_stream_options options,
         raw_stream raw = raw_stream::no, integrity_check integrity = integrity_check::no,
-        integrity_error_handler error_handler = throwing_integrity_error_handler);
+        integrity_error_handler error_handler = throwing_integrity_error_handler,
+        bool bypass_cache = false);
 
     // Read exactly the specific byte range from the data file (after
     // uncompression, if the file is compressed). This can be used to read

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -39,6 +39,7 @@ class config;
 }   // namespace db
 
 namespace s3 { class client; }
+namespace sstables { class page_cache; }
 
 namespace gms { class feature_service; }
 
@@ -173,6 +174,8 @@ private:
 
     const abort_source& _abort;
 
+    shared_ptr<sstables::page_cache> _page_cache;
+
     named_gate _signal_gate;
     signal_type _signal_source;
 
@@ -206,6 +209,13 @@ public:
     shared_ptr<object_storage_client> get_endpoint_client(sstring endpoint) const {
         SCYLLA_ASSERT(_storage != nullptr);
         return _storage->get_endpoint_client(std::move(endpoint));
+    }
+
+    void set_page_cache(shared_ptr<sstables::page_cache> cache) noexcept {
+        _page_cache = std::move(cache);
+    }
+    shared_ptr<sstables::page_cache> get_page_cache() const noexcept {
+        return _page_cache;
     }
 
     bool is_known_endpoint(sstring endpoint) const {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -879,9 +879,10 @@ future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc) {
 
     try {
         auto f = make_readable_file(object_name(_bucket, desc.generation, sstable_version_constants::get_component_map(desc.version).at(component_type::TOC)));
-        auto [components, digest] = co_await with_closeable(std::move(f), [] (file& f) {
+        auto [toc_components, digest] = co_await with_closeable(std::move(f), [] (file& f) {
             return sstable::read_and_parse_toc(f);
         });
+        components = std::move(toc_components);
     } catch (const storage_io_error& e) {
         if (e.code().value() != ENOENT) {
             throw;

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -35,6 +35,7 @@
 #include "utils/overloaded_functor.hh"
 #include "utils/memory_data_sink.hh"
 #include "utils/s3/client.hh"
+#include "sstables/page_cache.hh"
 #include "utils/exceptions.hh"
 #include "utils/to_string.hh"
 #include "utils/checked-file-impl.hh"
@@ -633,7 +634,19 @@ protected:
     sstring _bucket;
     std::variant<sstring, table_id> _location;
     seastar::abort_source* _as;
+    shared_ptr<sstables::page_cache> _page_cache;
+    // When page_cache is enabled, non-Data components are stored locally here.
+    sstring _local_dir;
 
+public:
+    bool uses_page_cache() const noexcept override { return _page_cache != nullptr; }
+
+    std::pair<seastar::shared_ptr<sstables::page_cache>, utils::UUID>
+    data_page_cache_info(const sstable& sst) const override {
+        return {_page_cache, sst.generation().as_uuid()};
+    }
+
+protected:
     static constexpr auto status_creating = "creating";
     static constexpr auto status_sealed = "sealed";
     static constexpr auto status_removing = "removing";
@@ -651,12 +664,14 @@ protected:
         return _as;
     }
 public:
-    object_storage_base(sstring type, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
+    object_storage_base(sstring type, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as, shared_ptr<sstables::page_cache> page_cache = nullptr, sstring local_dir = {})
         : _type(type) 
         , _client(std::move(client))
         , _bucket(std::move(bucket))
         , _location(std::move(loc))
         , _as(as)
+        , _page_cache(std::move(page_cache))
+        , _local_dir(std::move(local_dir))
     {}
 
     future<> seal(const sstable& sst) override;
@@ -712,15 +727,7 @@ public:
     }
 };
 
-class s3_storage : public object_storage_base {
-public:
-    s3_storage(shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
-        : object_storage_base("S3", std::move(client), std::move(bucket), std::move(loc), as)
-    {}
 
-    future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
-    future<data_source> make_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
-};
 
 object_name object_storage_base::make_object_name(const sstable& sst, component_type type) const {
     auto comp = sstable_version_constants::get_component_map(sst.get_version()).at(type);
@@ -756,7 +763,17 @@ void object_storage_base::open(sstable& sst) {
 }
 
 future<file> object_storage_base::open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) {
-    return maybe_wrap_file(sst, type, flags, make_readable_file(make_object_name(sst, type)));
+    // When page_cache is enabled, non-Data components (except TOC/TemporaryTOC) live on local disk.
+    // TOC and TemporaryTOC are always in object storage (written there by open() via put_object).
+    if (!_local_dir.empty() && type != component_type::Data
+            && type != component_type::TOC && type != component_type::TemporaryTOC) {
+        auto dir = sstring(make_path(_local_dir, sst._state).native());
+        auto name = std::filesystem::path(dir) / sst.component_basename(type);
+        auto f = open_sstable_component_file_non_checked(name.native(), flags, options, check_integrity);
+        return maybe_wrap_file(sst, type, flags, std::move(f));
+    }
+    auto f = make_readable_file(make_object_name(sst, type));
+    return maybe_wrap_file(sst, type, flags, std::move(f));
 }
 
 static future<data_sink> maybe_wrap_sink(const sstable& sst, component_type type, data_sink sink) {
@@ -800,37 +817,68 @@ future<data_sink> object_storage_base::make_data_or_index_sink(sstable& sst, com
         || type == component_type::Index
         || type == component_type::Rows
         || type == component_type::Partitions);
+    if (!_local_dir.empty() && type != component_type::Data) {
+        // Non-Data components go to local disk when page cache is enabled.
+        // Mirror filesystem_storage::make_data_or_index_sink: move the file handle
+        // that create_data() stored in _index_file/_rows_file/_partitions_file into
+        // the data sink.  This leaves those fields null, so open_data() will
+        // re-open them as read-only.
+        file_output_stream_options fopts;
+        fopts.buffer_size = sst.sstable_buffer_size;
+        fopts.write_behind = 10;
+        file f;
+        switch (type) {
+        case component_type::Index:
+            f = std::move(sst._index_file);
+            break;
+        case component_type::Rows:
+            f = std::move(sst._rows_file);
+            break;
+        case component_type::Partitions:
+            f = std::move(sst._partitions_file);
+            break;
+        default:
+            // unreachable due to the assert at the top of the function.
+            abort();
+        }
+        return make_file_data_sink(std::move(f), fopts).then([&sst, type] (data_sink sink) {
+            return maybe_wrap_sink(sst, type, std::move(sink));
+        });
+    }
     // FIXME: if we have file size upper bound upfront, it's better to use make_upload_sink() instead
     return maybe_wrap_sink(sst, type, make_data_upload_sink(make_object_name(sst, type), std::nullopt));
 }
 
 future<data_source>
 object_storage_base::make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options options) const {
-    co_return co_await make_source(sst, type, f, offset, len, options);
-}
-
-future<data_source>
-object_storage_base::make_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options) const {
-    co_return co_await maybe_wrap_source(sst, type, _client->make_download_source(make_object_name(sst, type), abort_source()), offset, len);
-}
-
-future<data_source>
-s3_storage::make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options options) const {
+    // In tiering mode, non-Data components (e.g. Index.db for non-BTI format) live on
+    // local disk.  Use the passed-in file directly rather than routing through the S3
+    // download path, which make_source() would do at offset == 0.
+    if (!_local_dir.empty() && type != component_type::Data) {
+        co_return make_file_data_source(std::move(f), offset, len, std::move(options));
+    }
     co_return co_await make_source(sst, type, std::move(f), offset, len, std::move(options));
 }
 
 future<data_source>
-s3_storage::make_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options options) const {
+object_storage_base::make_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options options) const {
     if (offset == 0) {
-        co_return co_await object_storage_base::make_source(sst, type, std::move(f), offset, len, std::move(options));
+        co_return co_await maybe_wrap_source(sst, type, _client->make_download_source(make_object_name(sst, type), abort_source()), offset, len);
     }
-    // Reuse the file passed in by the caller.The file is already wrapped with
+    // Reuse the file passed in by the caller. The file is already wrapped with
     // the configured file_io_extensions (applied at open_component time), so
     // no further wrapping is needed.
     co_return make_file_data_source(std::move(f), offset, len, std::move(options));
 }
 
 future<data_sink> object_storage_base::make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) {
+    // TOC is written to object storage directly by open(); never route it to local disk.
+    if (!_local_dir.empty() && type != component_type::Data
+            && type != component_type::TOC && type != component_type::TemporaryTOC) {
+        return sst.new_sstable_component_file(sst._write_error_handler, type, oflags).then([options = std::move(options)] (file f) mutable {
+            return make_file_data_sink(std::move(f), std::move(options));
+        });
+    }
     return maybe_wrap_sink(sst, type, make_upload_sink(make_object_name(sst, type)));
 }
 
@@ -859,10 +907,28 @@ future<> object_storage_base::wipe(const sstable& sst, sync_dir) noexcept {
     co_await sstables_registry.update_entry_status(owner(), node_owner, sst.generation(), status_removing);
 
     co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
+        if (!_local_dir.empty() && type != component_type::Data
+                && type != component_type::TOC && type != component_type::TemporaryTOC) {
+            // Non-Data, non-TOC components are local; delete from local disk.
+            auto dir = sstring(make_path(_local_dir, sst._state).native());
+            auto name = (std::filesystem::path(dir) / sst.component_basename(type)).native();
+            try {
+                co_await remove_file(name);
+            } catch (...) {
+                if (!is_system_error_errno(ENOENT)) {
+                    throw;
+                }
+            }
+            co_return;
+        }
         co_await delete_object(make_object_name(sst, type));
     });
 
     co_await sstables_registry.delete_entry(owner(), node_owner, sst.generation());
+
+    if (_page_cache) {
+        co_await _page_cache->evict_sstable(sst.generation().as_uuid());
+    }
 }
 
 future<atomic_delete_context> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>&) const {
@@ -889,10 +955,33 @@ future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc) {
         }
     }
 
-    co_await coroutine::parallel_for_each(components, [this, &desc] (sstring comp) -> future<> {
-        if (comp != sstable_version_constants::TOC_SUFFIX) {
-            co_await delete_object(object_name(_bucket, desc.generation, comp));
+    // In tiering mode only the Data component lives in object storage; all others
+    // are on local disk.  Delete them now using the generation, version, format,
+    // and state from the entry_descriptor.  For mc+ versions (the only ones used
+    // with object storage), the component basename is v-g-f-component and does
+    // not include ks/cf, so empty strings suffice.
+    const auto data_suffix = sstable_version_constants::get_component_map(desc.version).at(component_type::Data);
+
+    co_await coroutine::parallel_for_each(components, [this, &desc, &data_suffix] (sstring comp) -> future<> {
+        if (comp == sstable_version_constants::TOC_SUFFIX) {
+            co_return; // handled separately below
         }
+        if (!_local_dir.empty() && comp != data_suffix) {
+            // This component lives on local disk in tiering mode; delete it there.
+            auto state = desc.state.value_or(sstable_state::normal);
+            auto dir = make_path(_local_dir, state);
+            auto basename = sstable::component_basename("", "", desc.version, desc.generation, desc.format, comp);
+            auto name = (dir / basename).native();
+            try {
+                co_await remove_file(name);
+            } catch (...) {
+                if (!is_system_error_errno(ENOENT)) {
+                    sstlog.warn("Failed to delete local tiering component {}: {}. Ignoring.", name, std::current_exception());
+                }
+            }
+            co_return;
+        }
+        co_await delete_object(object_name(_bucket, desc.generation, comp));
     });
     co_await delete_object(object_name(_bucket, desc.generation, sstable_version_constants::TOC_SUFFIX));
 }
@@ -919,8 +1008,22 @@ future<> object_storage_base::clone(const sstable& sst, generation_type gen, boo
     auto node_owner = sst.manager().get_local_host_id();
     co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
 
-    // Copy all component objects from the source to the destination generation.
+    // Copy all components: in tiering mode, non-Data components live on local disk
+    // and must be linked there rather than copied via object storage.
     co_await coroutine::parallel_for_each(sst.all_components(), [this, &sst, &gen] (const std::pair<component_type, sstring>& p) -> future<> {
+        if (!_local_dir.empty() && p.first != component_type::Data && p.first != component_type::TOC
+                && p.first != component_type::TemporaryTOC) {
+            auto state_dir = make_path(_local_dir, sst._state);
+            auto src = (state_dir / sst.component_basename(p.first)).native();
+            auto dst_basename = sstable::component_basename(
+                    sst.get_schema()->ks_name(), sst.get_schema()->cf_name(),
+                    sst.get_version(), gen, sst.get_format(), p.second);
+            auto dst = (state_dir / dst_basename).native();
+            // Use idempotent_link_file to match filesystem_storage::clone() behaviour:
+            // if the link already exists and points to the same inode (crash replay), succeed.
+            co_await idempotent_link_file(src, dst);
+            co_return;
+        }
         co_await copy_object(make_object_name(sst, p.second, sst.generation()), make_object_name(sst, p.second, gen));
     });
 
@@ -947,13 +1050,9 @@ std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const
                     }, os.location)) {
                 on_internal_error(sstlog, fmt::format("{} storage options is missing 'location'", os.name()));
             }
-            if (s_opts.is_s3_type()) {
-                return std::make_unique<sstables::s3_storage>(manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
-            }
-            if (s_opts.is_gs_type()) {
-                return std::make_unique<sstables::object_storage_base>("GS", manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
-            }
-            throw std::runtime_error(fmt::format("Not implemented: '{}'", os.type));
+            auto page_cache = os.tiering != data_dictionary::storage_options::tiering_mode::none ? manager.get_page_cache() : nullptr;
+            auto type_name = s_opts.is_s3_type() ? "S3" : "GS";
+            return std::make_unique<sstables::object_storage_base>(type_name, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source, std::move(page_cache), os.local_dir);
         }
     }, s_opts.value);
 }
@@ -990,11 +1089,23 @@ std::vector<std::filesystem::path> get_local_directories(const std::vector<sstri
 }
 
 static future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const sstables_manager& mgr, const schema& s, const data_dictionary::storage_options::object_storage& so) {
+    sstring local_dir;
+    if (so.tiering != data_dictionary::storage_options::tiering_mode::none && !mgr.get_config().data_file_directories.empty()) {
+        auto uuid_sstring = s.id().to_sstring();
+        boost::erase_all(uuid_sstring, "-");
+        local_dir = format("{}/{}/{}-{}", mgr.get_config().data_file_directories[0],
+            s.ks_name(), s.cf_name(), uuid_sstring);
+        // Ensure the local directories exist.
+        co_await io_check([&local_dir] { return recursive_touch_directory(local_dir); });
+        co_await io_check([&local_dir] { return touch_directory(local_dir + "/" + staging_dir); });
+    }
     data_dictionary::storage_options nopts;
     nopts.value = data_dictionary::storage_options::object_storage {
         .bucket = so.bucket,
         .endpoint = so.endpoint,
         .location = s.id(),
+        .tiering = so.tiering,
+        .local_dir = std::move(local_dir),
         .type = so.type
     };
     co_return make_lw_shared<const data_dictionary::storage_options>(std::move(nopts));

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -39,6 +39,7 @@ class delayed_commit_changes;
 class sstable;
 class sstables_manager;
 class entry_descriptor;
+class page_cache;
 
 struct atomic_delete_context {
     sstring pending_delete_log;
@@ -127,6 +128,19 @@ public:
 
     virtual sstring prefix() const  = 0;
     virtual future<bool> exists(const sstable& sst, component_type type) const = 0;
+
+    // Returns true if this storage uses a page cache for Data reads.
+    // When true, the table must use compression: the cache keys are
+    // (sstable_generation, chunk_offset) and chunks are variable-size
+    // compressed blocks, so each offset uniquely identifies one chunk.
+    // Uncompressed SSTables have no chunk boundaries and variable read
+    // sizes, making offset alone an ambiguous cache key.
+    virtual bool uses_page_cache() const noexcept { return false; }
+
+    /// Returns the page cache and per-sstable cache key used for Data-component
+    /// chunk caching, or {nullptr, {}} if this storage does not cache Data reads.
+    virtual std::pair<seastar::shared_ptr<sstables::page_cache>, utils::UUID>
+    data_page_cache_info(const sstable&) const { return {nullptr, {}}; }
 };
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state);

--- a/sstables/writer.cc
+++ b/sstables/writer.cc
@@ -10,6 +10,7 @@
 #include "sstable_writer.hh"
 #include "writer.hh"
 #include "mx/writer.hh"
+#include "compressor.hh"
 
 namespace sstables {
 
@@ -17,6 +18,11 @@ sstable_writer::sstable_writer(sstable& sst, const schema& s, uint64_t estimated
         const sstable_writer_config& cfg, encoding_stats enc_stats, shard_id shard) {
     if (sst.get_version() < oldest_writable_sstable_format) {
         on_internal_error(sstlog, format("writing sstables with too old format: {}", static_cast<int>(sst.get_version())));
+    }
+    if (sst.get_storage().uses_page_cache() && !s.get_compressor_params().compression_enabled()) {
+        on_internal_error(sstlog, format("Table {}.{} uses tiering=data_page_cache but has no compression. "
+            "This should have been rejected at CREATE TABLE time.",
+            s.ks_name(), s.cf_name()));
     }
     _impl = mc::make_writer(sst, s, estimated_partitions, cfg, enc_stats, shard);
     if (cfg.replay_position) {

--- a/test/cluster/object_store/test_page_cache.py
+++ b/test/cluster/object_store/test_page_cache.py
@@ -1,0 +1,746 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+import asyncio
+import pytest
+
+from cassandra import InvalidRequest
+from test.pylib.manager_client import ManagerClient
+from test.pylib.object_storage import format_tuples
+from test.cluster.util import new_test_keyspace
+
+
+async def test_s3_page_cache(manager: ManagerClient, s3_storage):
+    '''Verify that a point read served from S3 populates the S3 page cache, so
+    that after dropping the row cache the same point read requires zero new S3 GET
+    requests.
+
+    We use a point read (WHERE pk = ?) rather than a full-table scan because
+    the caching policy for scans may in theory differ - e.g. a full-table scan
+    might avoid caching the entire table. So scans have their separate tests
+    below.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text);")
+
+        # Insert a few rows so the flush produces an SSTable with a known key we can point-read.
+        n_rows = 10
+        row_value = 'x' * 100
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{row_value}');") for i in range(n_rows)])
+
+        # Flush to S3 so the data lives entirely in an SSTable object (not in the memtable).
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Drop the row cache before the first read so that the read is guaranteed to go to
+        # S3 and warm the S3 page cache, rather than possibly being served from an
+        # already-populated row cache.
+        await manager.api.drop_sstable_caches(ip)
+
+        metrics_before_first = await manager.metrics.query(ip)
+        gets_before_first = metrics_before_first.get('scylla_s3_total_read_requests') or 0.0
+
+        # First read: goes to S3, warming the S3 page cache (and the row cache).
+        row = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0;").one()
+        assert row is not None and row.v == row_value
+
+        # Sanity check: the first read must have issued at least one S3 GET
+        # (otherwise the metric is broken or the data was somehow already cached).
+        metrics_after_first = await manager.metrics.query(ip)
+        gets_after_first = metrics_after_first.get('scylla_s3_total_read_requests') or 0.0
+        assert gets_after_first > gets_before_first
+
+        # Drop the row cache so the next read cannot be served from decoded-row cache.
+        await manager.api.drop_sstable_caches(ip)
+
+        # Second read (same point read): with a page cache the data page is
+        # still cached, so zero new S3 GETs are needed. Without a page cache,
+        # new GETs are issued and the metrics would increase.
+        row2 = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0;").one()
+        assert row2 is not None and row2.v == row_value
+
+        metrics_after = await manager.metrics.query(ip)
+        gets_after = metrics_after.get('scylla_s3_total_read_requests') or 0.0
+
+        assert 0 == gets_after - gets_after_first
+
+
+async def test_tiering_requires_compression(manager: ManagerClient, s3_storage):
+    '''Verify that creating a table without compression in a keyspace with
+    tiering=data_page_cache is rejected. The page cache uses compressed-chunk
+    offsets as cache keys, which are only well-defined for compressed SSTables.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        with pytest.raises(InvalidRequest, match="tiering=data_page_cache"):
+            await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH compression = {{}};")
+        # An empty sstable_compression value also disables compression (maps to algorithm::none)
+        # and must be rejected with the same error.
+        with pytest.raises(InvalidRequest, match="tiering=data_page_cache"):
+            await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH compression = {{'sstable_compression': ''}};")
+
+
+async def test_s3_page_cache_scan_populates_cache_for_point_reads(manager: ManagerClient, s3_storage):
+    '''Verify that a full-table scan populates the S3 page cache at compressed
+    chunk offsets, so that subsequent point reads require zero new S3 GET requests.
+
+    If we don't pay special attention to this case, the scan can cache data at
+    file_input_stream buffer-aligned positions (0, 128 KB, 256 KB, ...) while
+    point reads looked up the cache at compressed chunk-boundary offsets (e.g.
+    ~2 KB for the second chunk).  Because these offsets never coincide for
+    chunks past the first, point reads after a scan could result in spurious
+    cache misses and extra S3 GET requests.
+
+    The correct implementation should store compressed chunks at their exact
+    compressed-file offsets, so scan-populated entries are reusable for all
+    subsequent point reads.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text);")
+
+        # Insert enough rows to guarantee the SSTable spans at least two
+        # compressed chunks (the default chunk size is 4 KB of uncompressed data).
+        # 20 rows x 5000 bytes ~= 100 KB uncompressed -> ~25 compressed chunks.
+        n_rows = 20
+        row_value = 'x' * 5000
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{row_value}');") for i in range(n_rows)])
+
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Drop the row cache so the scan definitely reads from S3.
+        await manager.api.drop_sstable_caches(ip)
+
+        metrics_before_scan = await manager.metrics.query(ip)
+        gets_before_scan = metrics_before_scan.get('scylla_s3_total_read_requests') or 0.0
+
+        # Full-table scan: reads all compressed chunks from S3 and caches each
+        # at its exact compressed-file offset via chunk_page_cache.
+        rows = list(cql.execute(f"SELECT * FROM {ks}.test;"))
+        assert len(rows) == n_rows
+
+        # Sanity check: the scan must have issued at least one S3 GET.
+        metrics_after_scan = await manager.metrics.query(ip)
+        gets_after_scan = metrics_after_scan.get('scylla_s3_total_read_requests') or 0.0
+        assert gets_after_scan > gets_before_scan
+
+        # Drop the row cache so the next reads go to the SSTable layer.
+        await manager.api.drop_sstable_caches(ip)
+
+        # Point reads for every partition: all compressed chunks are already in
+        # the S3 page cache, so zero new S3 GETs should be issued.
+        for pk in range(n_rows):
+            row = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = {pk};").one()
+            assert row is not None and row.v == row_value
+
+        metrics_after_reads = await manager.metrics.query(ip)
+        gets_after_reads = metrics_after_reads.get('scylla_s3_total_read_requests') or 0.0
+
+        assert gets_after_reads == gets_after_scan
+
+
+async def test_s3_page_cache_single_partition_multi_chunk(manager: ManagerClient, s3_storage):
+    '''Verify page cache behaviour for a single wide partition spread across
+    multiple compressed chunks.
+
+    A single partition is written with enough large clustering rows to fill
+    more than one compressed chunk (4 KB each by default).  Then:
+
+    1. A partition scan warms the S3 page cache.  Because the whole partition
+       is fetched via a single streaming S3 GET, the download issues exactly
+       one new S3 GET.
+    2. After the scan, system.pagecache contains multiple rows for the SSTable
+       (one per cached compressed chunk).
+    3. Point reads for each individual clustering row afterwards require zero
+       new S3 GETs - all chunks are already cached.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int, ck int, v text, PRIMARY KEY (pk, ck));")
+
+        # Write enough data to a single partition to span more than one
+        # compressed chunks.  The default chunk size is 4 KB of uncompressed
+        # data, so 20 rows x 5000 bytes ~= 100 KB -> ~25 chunks.
+        n_rows = 20
+        row_value = 'x' * 5000
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, ck, v) VALUES (0, {i}, '{row_value}');") for i in range(n_rows)])
+
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Drop the row cache so the partition scan goes to S3.
+        await manager.api.drop_sstable_caches(ip)
+
+        metrics_before_scan = await manager.metrics.query(ip)
+        gets_before_scan = metrics_before_scan.get('scylla_s3_total_read_requests') or 0.0
+
+        # Scan the whole partition.
+        rows = list(cql.execute(f"SELECT ck, v FROM {ks}.test WHERE pk = 0;"))
+        assert len(rows) == n_rows
+
+        metrics_after_scan = await manager.metrics.query(ip)
+        gets_after_scan = metrics_after_scan.get('scylla_s3_total_read_requests') or 0.0
+
+        # The whole partition lives in one Data.db range; one streaming GET
+        # suffices to read it end-to-end.
+        assert gets_after_scan - gets_before_scan == 1
+
+        # The system.pagecache table must contain more than one entry for this
+        # SSTable - at least one row per compressed chunk.
+        cached_rows = list(cql.execute("SELECT sstable, offset FROM system.pagecache;"))
+        assert len(cached_rows) > 1
+
+        # Drop the row cache so individual reads go to the SSTable layer.
+        await manager.api.drop_sstable_caches(ip)
+
+        # Point reads for each clustering row must not trigger new S3 GETs.
+        for ck in range(n_rows):
+            row = cql.execute(f"SELECT v FROM {ks}.test WHERE pk = 0 AND ck = {ck};").one()
+            assert row is not None and row.v == row_value
+
+        metrics_after_reads = await manager.metrics.query(ip)
+        gets_after_reads = metrics_after_reads.get('scylla_s3_total_read_requests') or 0.0
+
+        assert gets_after_reads == gets_after_scan
+
+        # If we drop the row cache again and re-scan the entire partition,
+        # we still won't issue any new S3 GETs since all chunks are cached.
+        await manager.api.drop_sstable_caches(ip)
+
+        rows2 = list(cql.execute(f"SELECT ck, v FROM {ks}.test WHERE pk = 0;"))
+        assert len(rows2) == n_rows
+
+        metrics_after_rescan = await manager.metrics.query(ip)
+        gets_after_rescan = metrics_after_rescan.get('scylla_s3_total_read_requests') or 0.0
+        assert gets_after_rescan == gets_after_reads
+
+
+async def test_s3_page_cache_point_reads_populate_cache_for_scan(manager: ManagerClient, s3_storage):
+    '''Verify that point reads populate the S3 page cache so that a subsequent
+    partition scan requires zero new S3 GET requests.
+
+    This is the reverse of test_s3_page_cache_single_partition_multi_chunk: instead
+    of a scan warming the cache for later point reads, here individual point reads
+    warm the cache chunk by chunk, and the subsequent scan finds all chunks already
+    cached.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int, ck int, v text, PRIMARY KEY (pk, ck));")
+
+        # Write enough data to span more than one compressed chunk (4 KB each).
+        # 20 rows x 5000 bytes ~= 100 KB -> ~25 chunks.
+        n_rows = 20
+        row_value = 'x' * 5000
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, ck, v) VALUES (0, {i}, '{row_value}');") for i in range(n_rows)])
+
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Drop the row cache so the point reads go to S3.
+        await manager.api.drop_sstable_caches(ip)
+
+        # Point reads for every clustering row: each read fetches the chunks it
+        # needs from S3 and caches them.
+        for ck in range(n_rows):
+            row = cql.execute(f"SELECT v FROM {ks}.test WHERE pk = 0 AND ck = {ck};").one()
+            assert row is not None and row.v == row_value
+
+        metrics_after_reads = await manager.metrics.query(ip)
+        gets_after_reads = metrics_after_reads.get('scylla_s3_total_read_requests') or 0.0
+
+        # Sanity check: the point reads must have issued at least one S3 GET.
+        assert gets_after_reads > 0
+
+        # Drop the row cache so the scan goes to the SSTable layer.
+        await manager.api.drop_sstable_caches(ip)
+
+        # Full partition scan: all chunks are already in the S3 page cache from
+        # the point reads above, so zero new S3 GETs should be issued.
+        rows = list(cql.execute(f"SELECT ck, v FROM {ks}.test WHERE pk = 0;"))
+        assert len(rows) == n_rows
+
+        metrics_after_scan = await manager.metrics.query(ip)
+        gets_after_scan = metrics_after_scan.get('scylla_s3_total_read_requests') or 0.0
+        assert gets_after_scan == gets_after_reads
+
+
+async def test_s3_page_cache_partial_reads_then_scan(manager: ManagerClient, s3_storage):
+    '''Verify correctness and cache behaviour when only a few rows of a wide
+    partition are point-read before a full partition scan.
+
+    Point reads for ck=0 and one middle clustering row warm a subset of the
+    compressed chunks.  The subsequent full scan must still return all 20 rows
+    correctly (the un-cached chunks are fetched from S3 on demand).  After the
+    scan all chunks are in the page cache, so a second scan (after dropping the
+    row cache) issues zero new S3 GETs.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int, ck int, v text, PRIMARY KEY (pk, ck));")
+
+        # Write enough data to span many compressed chunks (4 KB each by default).
+        # 20 rows x 5000 bytes ~= 100 KB -> ~25 chunks.
+        n_rows = 20
+        row_value = 'x' * 5000
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, ck, v) VALUES (0, {i}, '{row_value}');") for i in range(n_rows)])
+
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Drop the row cache so the point reads definitely go to S3.
+        await manager.api.drop_sstable_caches(ip)
+
+        # Read only two rows: the first clustering row and one from the middle.
+        # This warms only the subset of chunks that contain those rows.
+        for ck in [0, n_rows // 2]:
+            row = cql.execute(f"SELECT v FROM {ks}.test WHERE pk = 0 AND ck = {ck};").one()
+            assert row is not None and row.v == row_value
+
+        # Drop the row cache so the scan goes to the SSTable layer.
+        await manager.api.drop_sstable_caches(ip)
+
+        # Full partition scan: must return all rows correctly even though only
+        # some chunks are cached.  Un-cached chunks are fetched from S3.
+        rows = list(cql.execute(f"SELECT ck, v FROM {ks}.test WHERE pk = 0;"))
+        assert len(rows) == n_rows
+        assert all(r.v == row_value for r in rows)
+
+        metrics_after_scan = await manager.metrics.query(ip)
+        gets_after_scan = metrics_after_scan.get('scylla_s3_total_read_requests') or 0.0
+
+        # Drop the row cache again: all chunks are now cached (the scan just
+        # fetched any that were missing), so a second scan must issue zero new
+        # S3 GETs.
+        await manager.api.drop_sstable_caches(ip)
+
+        rows2 = list(cql.execute(f"SELECT ck, v FROM {ks}.test WHERE pk = 0;"))
+        assert len(rows2) == n_rows
+
+        metrics_after_rescan = await manager.metrics.query(ip)
+        gets_after_rescan = metrics_after_rescan.get('scylla_s3_total_read_requests') or 0.0
+        assert gets_after_rescan == gets_after_scan
+
+
+async def test_tiered_compaction(manager: ManagerClient, s3_storage):
+    '''Verify that compaction works correctly for tiered (data_page_cache) tables.
+
+    Flush two separate SSTables, compact them together, then read back and
+    verify that the merged result is correct: overwrites from the second flush
+    are visible and deleted keys are gone.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text);")
+
+        # First flush: rows 0..9 with value 'first'
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, 'first');") for i in range(10)])
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Second flush: overwrite rows 0..4 with 'second', delete rows 5..9
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, 'second');") for i in range(5)])
+        await asyncio.gather(*[cql.run_async(f"DELETE FROM {ks}.test WHERE pk = {i};") for i in range(5, 10)])
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Compact both SSTables into one.
+        await manager.api.keyspace_compaction(ip, ks)
+
+        # Read back and verify merged result.
+        rows = {row.pk: row.v for row in cql.execute(f"SELECT pk, v FROM {ks}.test;")}
+
+        # Rows 0..4 should have the value from the second flush.
+        for pk in range(5):
+            assert rows.get(pk) == 'second'
+
+        # Rows 5..9 should have been deleted.
+        for pk in range(5, 10):
+            assert pk not in rows
+
+
+async def test_s3_page_cache_eviction_on_compaction(manager: ManagerClient, s3_storage):
+    '''Verify that compaction evicts the page cache entries for the input SSTables
+    and that the compacted SSTable gets its own entries when subsequently read.
+
+    Two SSTables are flushed.  A full scan populates system.pagecache with entries
+    under two distinct SSTable UUIDs.  After compaction the two original UUIDs must
+    be gone from system.pagecache (the cache entries for deleted SSTables are
+    useless and should be cleaned up).  A second scan then repopulates the cache
+    under the single new (compacted) SSTable UUID.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int, ck int, v text, PRIMARY KEY (pk, ck));")
+
+        # Write enough data per flush to produce multiple compressed chunks.
+        # 20 rows x 5000 bytes ~= 100 KB -> ~25 chunks per SSTable.
+        n_rows = 20
+        row_value = 'x' * 5000
+
+        # Disable auto-compaction so we can check things before compaction
+        # happens and not worry about auto-compaction happening before that.
+        await manager.api.disable_autocompaction(ip, ks)
+
+        # First sstable: ck=0..n_rows-1 in partition pk=0.
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, ck, v) VALUES (0, {i}, '{row_value}');") for i in range(n_rows)])
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Second sstable: ck=n_rows..2*n_rows-1 in the same partition pk=0.
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, ck, v) VALUES (0, {n_rows + i}, '{row_value}');") for i in range(n_rows)])
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Drop the row cache and scan the partition to warm system.pagecache for both SSTables.
+        await manager.api.drop_sstable_caches(ip)
+        rows = list(cql.execute(f"SELECT ck FROM {ks}.test WHERE pk = 0;"))
+        assert len(rows) == 2 * n_rows
+
+        # system.pagecache must now contain entries under at least 2 distinct UUIDs
+        # (one per SSTable).  We look up only the UUIDs that belong to our table
+        # via system.sstables so we don't pick up entries from other tests.
+        table_id_row = cql.execute(f"SELECT id FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='test';").one()
+        table_id = table_id_row.id
+        node_owner = cql.execute("SELECT host_id FROM system.local;").one().host_id
+        uuids_before = {row.generation for row in cql.execute(f"SELECT generation FROM system.sstables WHERE table_id={table_id} AND node_owner={node_owner};")}
+        assert len(uuids_before) >= 2
+        # Sanity check: all of those UUIDs must already be present in pagecache.
+        uuids_in_pagecache = {row.sstable for row in cql.execute("SELECT sstable FROM system.pagecache;")}
+        assert uuids_before <= uuids_in_pagecache
+        # pagecache_hits is written only on a cache hit, not on the initial put.
+        # Do a second scan (after dropping the row cache) to generate hits and
+        # populate pagecache_hits before checking it.
+        await manager.api.drop_sstable_caches(ip)
+        rows_rehit = list(cql.execute(f"SELECT ck FROM {ks}.test WHERE pk = 0;"))
+        assert len(rows_rehit) == 2 * n_rows
+        uuids_in_pagecache_hits = {row.sstable for row in cql.execute("SELECT sstable FROM system.pagecache_hits;")}
+        assert uuids_before <= uuids_in_pagecache_hits
+
+        # Compact both SSTables into one.
+        await manager.api.keyspace_compaction(ip, ks)
+
+        # After compaction the two original SSTables are deleted; their page cache
+        # entries must have been evicted from both pagecache and pagecache_hits.
+        uuids_in_pagecache_after_compaction = {row.sstable for row in cql.execute("SELECT sstable FROM system.pagecache;")}
+        assert uuids_before.isdisjoint(uuids_in_pagecache_after_compaction)
+        uuids_in_pagecache_hits_after_compaction = {row.sstable for row in cql.execute("SELECT sstable FROM system.pagecache_hits;")}
+        assert uuids_before.isdisjoint(uuids_in_pagecache_hits_after_compaction)
+
+        # Scan again to warm the cache for the new compacted SSTable.
+        await manager.api.drop_sstable_caches(ip)
+        rows2 = list(cql.execute(f"SELECT ck FROM {ks}.test WHERE pk = 0;"))
+        assert len(rows2) == 2 * n_rows
+
+        # After compaction there is exactly one SSTable; its UUID must be in pagecache.
+        uuids_after_compaction = {row.generation for row in cql.execute(f"SELECT generation FROM system.sstables WHERE table_id={table_id} AND node_owner={node_owner};")}
+        assert len(uuids_after_compaction) == 1
+        uuids_in_pagecache_after_scan = {row.sstable for row in cql.execute("SELECT sstable FROM system.pagecache;")}
+        assert uuids_after_compaction <= uuids_in_pagecache_after_scan
+
+
+async def test_s3_page_cache_eviction_on_table_drop(manager: ManagerClient, s3_storage):
+    '''Verify that dropping a table evicts all its page cache entries from
+    system.pagecache and system.pagecache_hits.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text);")
+        await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES (0, 'hello');")
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Warm the page cache with a point read.
+        await manager.api.drop_sstable_caches(ip)
+        row = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0;").one()
+        assert row is not None and row.v == 'hello'
+
+        # Record the SSTable UUID(s) for this table, then verify they are in the cache.
+        table_id_row = cql.execute(f"SELECT id FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='test';").one()
+        table_id = table_id_row.id
+        node_owner = cql.execute("SELECT host_id FROM system.local;").one().host_id
+        uuids = {row.generation for row in cql.execute(f"SELECT generation FROM system.sstables WHERE table_id={table_id} AND node_owner={node_owner};")}
+        assert len(uuids) >= 1
+
+        uuids_in_pagecache = {row.sstable for row in cql.execute("SELECT sstable FROM system.pagecache;")}
+        assert uuids <= uuids_in_pagecache
+        # pagecache_hits is written only on a cache hit, not on the initial put.
+        # Re-read the row (after dropping the row cache) to generate a hit and
+        # populate pagecache_hits before checking it.
+        await manager.api.drop_sstable_caches(ip)
+        row2 = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0;").one()
+        assert row2 is not None and row2.v == 'hello'
+        uuids_in_pagecache_hits = {row.sstable for row in cql.execute("SELECT sstable FROM system.pagecache_hits;")}
+        assert uuids <= uuids_in_pagecache_hits
+
+        # Drop the table; this must evict all its entries from the page cache.
+        await cql.run_async(f"DROP TABLE {ks}.test;")
+
+        uuids_in_pagecache_after_drop = {row.sstable for row in cql.execute("SELECT sstable FROM system.pagecache;")}
+        assert uuids.isdisjoint(uuids_in_pagecache_after_drop)
+        uuids_in_pagecache_hits_after_drop = {row.sstable for row in cql.execute("SELECT sstable FROM system.pagecache_hits;")}
+        assert uuids.isdisjoint(uuids_in_pagecache_hits_after_drop)
+
+
+async def test_s3_page_cache_non_bti_index_write(manager: ManagerClient, s3_storage):
+    '''Verify that writing an SSTable with tiering=data_page_cache using the
+    non-BTI "me" sstable format works.
+
+    Non-BTI sstables use component_type::Index (Index.db) rather than BTI's
+    Rows.db + Partitions.db pair.  Some code paths are different in this case,
+    and during the development we saw crashes and errors in this code path
+    (both read and write paths), so it's worth continuing to check this code
+    path. All other tests in this file use the default sstable format with
+    BTI, so don't exercise the non-BTI code paths.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options'],
+           'sstable_format': 'me'}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text);")
+        await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES (0, 'hello');")
+
+        # Flush to S3, exercising the write to S3 path
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Read the row back to confirm the write completed successfully and
+        # exercising the read path..
+        await manager.api.drop_sstable_caches(ip)
+        row = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0;").one()
+        assert row is not None and row.v == 'hello'
+
+
+async def test_s3_pagecache_hits_tracking(manager: ManagerClient, s3_storage):
+    '''Verify the write pattern of system.pagecache_hits.
+
+    system.pagecache_hits records the last time a cached page was *accessed*
+    (i.e. served from the cache on a hit), not the time it was first stored.
+    This is intentional: the table is used by the eviction daemon to find
+    least-recently-used pages.  A page that was put into the cache but never
+    re-read should look *old* to the eviction daemon - writing a fresh
+    timestamp on the initial put would make it appear recently used and
+    suppress eviction, which is wrong.
+
+    The expected sequence is:
+      1st read  (cache miss)  -> page stored in system.pagecache,
+                                 system.pagecache_hits has NO entry yet.
+      2nd read  (cache hit)   -> system.pagecache_hits gets an entry with
+                                 last_hit = now.
+      3rd read  (cache hit)   -> system.pagecache_hits entry updated to a
+                                 newer last_hit timestamp.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text);")
+        await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES (0, 'hello');")
+        await manager.api.flush_keyspace(ip, ks)
+
+        table_id_row = cql.execute(f"SELECT id FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='test';").one()
+        table_id = table_id_row.id
+        node_owner = cql.execute("SELECT host_id FROM system.local;").one().host_id
+
+        def sstable_uuids():
+            return {row.generation for row in cql.execute(f"SELECT generation FROM system.sstables WHERE table_id={table_id} AND node_owner={node_owner};")}
+
+        def pagecache_uuids():
+            return {row.sstable for row in cql.execute("SELECT sstable FROM system.pagecache;")}
+
+        def pagecache_hits_rows():
+            return {(row.sstable, row.offset): row.last_hit for row in cql.execute("SELECT sstable, offset, last_hit FROM system.pagecache_hits;")}
+
+        # 1st read: cache miss - the page is fetched from S3 and stored in
+        # system.pagecache.  system.pagecache_hits must NOT be written yet.
+        await manager.api.drop_sstable_caches(ip)
+        row = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0;").one()
+        assert row is not None and row.v == 'hello'
+
+        uuids = sstable_uuids()
+        assert len(uuids) >= 1
+        assert uuids <= pagecache_uuids()
+        assert not any(k[0] in uuids for k in pagecache_hits_rows())
+
+        # 2nd read: cache hit - the page is served from system.pagecache.
+        # system.pagecache_hits must now contain an entry for our SSTable.
+        await manager.api.drop_sstable_caches(ip)
+        row2 = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0;").one()
+        assert row2 is not None and row2.v == 'hello'
+
+        hits_after_second = pagecache_hits_rows()
+        our_hits_after_second = {k: v for k, v in hits_after_second.items() if k[0] in uuids}
+        assert len(our_hits_after_second) >= 1
+
+        # 3rd read: another cache hit - last_hit must be newer than after the
+        # 2nd read.  Sleep 2 ms first to ensure db_clock (millisecond precision)
+        # advances, so we can assert > rather than >=.
+        await asyncio.sleep(0.002)
+        await manager.api.drop_sstable_caches(ip)
+        row3 = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0;").one()
+        assert row3 is not None and row3.v == 'hello'
+
+        hits_after_third = pagecache_hits_rows()
+        our_hits_after_third = {k: v for k, v in hits_after_third.items() if k[0] in uuids}
+        assert len(our_hits_after_third) >= 1
+        for key in our_hits_after_second:
+            if key in our_hits_after_third:
+                assert our_hits_after_third[key] > our_hits_after_second[key]
+
+
+async def test_s3_bypass_cache_does_not_populate_page_cache(manager: ManagerClient, s3_storage):
+    '''Verify that reads with BYPASS CACHE do not populate the S3 page cache.
+
+    A normal read warms the page cache (entries appear in system.pagecache).
+    A subsequent read with BYPASS CACHE must still return correct data by
+    fetching directly from S3, and must not add any new entries to
+    system.pagecache.
+    '''
+    objconf = s3_storage.create_endpoint_conf()
+    cfg = {'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    server = await manager.server_add(config=cfg)
+    ip = server.ip_addr
+
+    cql = manager.get_cql()
+    storage_opts = format_tuples(type=s3_storage.type, endpoint=s3_storage.address, bucket=s3_storage.bucket_name, tiering='data_page_cache')
+    ks_opts = f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND STORAGE = {storage_opts}"
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text);")
+
+        n_rows = 10
+        row_value = 'x' * 100
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({i}, '{row_value}');") for i in range(n_rows)])
+
+        await manager.api.flush_keyspace(ip, ks)
+
+        # Drop the row cache so the first read goes to the SSTable layer.
+        await manager.api.drop_sstable_caches(ip)
+
+        # BYPASS CACHE read: must return correct data but must NOT populate the
+        # page cache.  Check that system.pagecache has no entries for our table
+        # after the read.
+        table_id = cql.execute(f"SELECT id FROM system_schema.tables WHERE keyspace_name='{ks}' AND table_name='test';").one().id
+        node_owner = cql.execute("SELECT host_id FROM system.local;").one().host_id
+
+        def our_sstable_uuids():
+            return {row.generation for row in cql.execute(f"SELECT generation FROM system.sstables WHERE table_id={table_id} AND node_owner={node_owner};")}
+
+        def our_pagecache_entries():
+            return [row for row in cql.execute("SELECT sstable FROM system.pagecache;") if row.sstable in our_sstable_uuids()]
+
+        def our_pagecache_hits_timestamps():
+            uuids = our_sstable_uuids()
+            return {(row.sstable, row.offset): row.last_hit for row in cql.execute("SELECT sstable, offset, last_hit FROM system.pagecache_hits;") if row.sstable in uuids}
+
+        row = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0 BYPASS CACHE;").one()
+        assert row is not None and row.v == row_value
+
+        # The page cache must remain empty for our table after a BYPASS CACHE read.
+        assert our_pagecache_entries() == []
+
+        # First normal read: warms the page cache (cache miss, so pagecache_hits is not written yet).
+        row2 = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0;").one()
+        assert row2 is not None and row2.v == row_value
+
+        entries_after_normal_read = our_pagecache_entries()
+        assert len(entries_after_normal_read) >= 1
+
+        # Second normal read (after dropping the row cache): cache hit, so pagecache_hits is now written.
+        await manager.api.drop_sstable_caches(ip)
+        row3 = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0;").one()
+        assert row3 is not None and row3.v == row_value
+
+        hits_before_bypass = our_pagecache_hits_timestamps()
+        assert len(hits_before_bypass) >= 1
+
+        # BYPASS CACHE read must not add new pagecache entries, and must not
+        # update the last_hit timestamps in pagecache_hits.  Sleep 2 ms first
+        # so that any spurious timestamp update would be detectable.
+        await asyncio.sleep(0.002)
+        row4 = cql.execute(f"SELECT * FROM {ks}.test WHERE pk = 0 BYPASS CACHE;").one()
+        assert row4 is not None and row4.v == row_value
+
+        entries_after_bypass = our_pagecache_entries()
+        assert len(entries_after_bypass) == len(entries_after_normal_read)
+
+        hits_after_bypass = our_pagecache_hits_timestamps()
+        assert hits_after_bypass == hits_before_bypass


### PR DESCRIPTION
Today, ScyllaDB provides users with two distinct options on where to store their data: Either all of it is stored on the ScyllaDB nodes (on NVMe) or all of it on object storage (S3 or GCS). The first option is very expensive for large amounts of data, and the second option is very expensive for large number of requests, and also introduces high latency.
    
This PR introduces a new "tiered storage" option for storing part of the data locally and part on object storage, aiming to achieve a reasonable balance between the two existing approaches, in other words: Achieve a reasonably low cost for both massive storage and massive number of requests.
    
We'll probably have multiple tiering options in the future, making different tradeoffs between local storage and object storage suitable for different workloads. This PR introduces one tiering mode: `data_page_cache`. It is chosen by a parameter in the keyspace STORAGE clause:
    
```
        AND STORAGE = { 'type': 'S3', ..., 'tiering': 'data_page_cache' }
```
    
With `tiering='data_page_cache'`, ScyllaDB uses the following hybrid storage layout:
    
* The Data component is stored on S3/GCS, but reads are served through an in-database page cache backed by the new system.pagecache and system.pagecache_hits system tables.  The page cache holds compressed chunks (only compressed tables are supported). A chunk fetched from object storage is stored in the cache, so subsequent reads of the same page require no network requests.
    
* All other sstable components, including index components (Index.db, Rows.db, Partitions.db) are stored on local NVMe disk. These components are small relative to the data but potentially consulted on every read, so on cache misses keeping indexes local halves the request cost.

As mentioned above, `tiering=data_page_cache` requires that the table uses compression, which is the default anyway (and strongly recommended). All reads are done in granularity of these compressed chunks, and these compressed chunks are individually stored in the cache and each is addressed by its offset (the length of each chunk is already known, but not the same for each chunk). The implementation can also cache chunks read during a scan of a partition or even a whole table, and reuse it in later scans or even reads of individual rows.

Cached pages (compressed chunks) for an sstable are deleted when the sstable is deleted - this happens during compaction and also when a table is deleted. We will also have a cache eviction background thread to limit the amount of cached data and evict least-recently-used cached chunks, but this is not yet implemented.
 
This scheme is aimed at read-heavy workloads with large datasets: the bulk of the data lives in cheap, elastic object storage while the hot read path stays on fast local hardware.

**NOTE YET IMPLEMENTED IN THIS VERSION CAUSING IT TO BE A DRAFT**:
1. Cache eviction when the cache reaches a certain size limit - is not yet implemented. We already evict cache entries when an sstable is deleted (e.g., on compaction).
2. Read-ahead - S3 makes larger reads cost the same as smaller reads, so we might want to read more compressed chunks (but store them separately in the cache table). Remember which chunk was used when so we can delete unused chunks sooner. (We do already read larger chunks for scans, but read-ahead asks to do this also for point reads, I'm not sure it's even a good idea).