### PR TITLE
test: marking tests as nightly

### DIFF
--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -131,8 +131,7 @@ async def run_random_resizes(
     }
 
 
-@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-@pytest.mark.skip_mode(mode='debug', reason='debug mode is too slow for this test')
+@pytest.mark.nightly
 async def test_multi_column_lwt_during_split_merge(manager: ManagerClient, scale_timeout):
     """
     Test scenario:

--- a/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
+++ b/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
@@ -292,8 +292,7 @@ async def run_random_resizes(
         "seen_merge": merge_count,
     }
 
-
-@pytest.mark.skip_mode("debug", "debug mode is too slow for this test")
+@pytest.mark.nightly
 async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClient, scale_timeout):
 
     cfg = {


### PR DESCRIPTION
The test was taking about 170s in dev mode, exceeding the 60s threshold by 2.9x. 
Reduce resource usage by marking tests as nightly 



Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2282
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3191
