### PR TITLE
test: multi-table multi-node tablet restore testing and parallelism verification

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -791,6 +791,72 @@ async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_s
 
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_restore_tablets_parallel(build_mode: str, manager: ManagerClient, object_storage):
+    '''Verify that the tablets of a single table are restored in parallel, not one by one.
+    Pause one tablet download per node with a one-shot injection and assert that the remaining
+    tablets keep downloading (restore progress advances above zero) while those are blocked.
+    If tablet downloads were serialized, a blocked tablet would stall all progress.'''
+
+    topology = topo(rf = 1, nodes = 2, racks = 1, dcs = 1)
+    servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
+
+    cql = manager.get_cql()
+
+    # Enough keys to populate a few tablets across the nodes: we need at least two
+    # tablets with sstables so that pausing one still leaves others to make progress.
+    num_keys = 500
+    tablet_count = 4
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count}}};")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, value) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
+        snap_name, _ = await take_snapshot(ks, servers, manager, logger)
+        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, 'test', object_storage, manager, logger) for s in servers))
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count}, 'max_tablet_count': {tablet_count}}};")
+
+        # Pause the first tablet download to reach the injection on each node; the
+        # remaining tablets proceed (one_shot consumes the injection after one pause).
+        await asyncio.gather(*(manager.api.enable_injection(s.ip_addr, "pause_tablet_restore", one_shot=True) for s in servers))
+
+        manifests = [f'{s.server_id}/{snap_name}/manifest.json' for s in servers]
+        tid = await manager.api.restore_tablets(servers[0].ip_addr, ks, 'test', snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
+
+        # Wait until a tablet download is parked on at least one node.
+        waiters = [asyncio.create_task(manager.api.wait_for_injection_enter(s.ip_addr, "pause_tablet_restore")) for s in servers]
+        done, pending = await asyncio.wait(waiters, timeout=30, return_when=asyncio.FIRST_COMPLETED)
+        for t in pending:
+            t.cancel()
+        assert done, "Restore did not reach the tablet-download pause on any node"
+
+        # While that tablet is blocked, the others must keep downloading: restore
+        # progress advances above zero without reaching completion (the blocked tablet's
+        # sstables stay pending). Progress refreshes on a 5s timer.
+        st = None
+        deadline = time.time() + 30
+        while time.time() < deadline:
+            st = await manager.api.get_task_status(servers[0].ip_addr, tid)
+            if 0 < st['progress_completed'] < st['progress_total']:
+                break
+            await asyncio.sleep(1)
+        assert st is not None and 0 < st['progress_completed'] < st['progress_total'], \
+            f"Expected other tablets to download while one was paused, got progress {st}"
+        logger.info(f"Cross-tablet parallelism confirmed: {st['progress_completed']}/{st['progress_total']} "
+                    f"sstables downloaded while a tablet was paused")
+
+        # Release the paused tablet and let the restore finish.
+        await asyncio.gather(*(manager.api.message_injection(s.ip_addr, "pause_tablet_restore") for s in servers))
+
+        status = await manager.api.wait_task(servers[0].ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done'), f"Restore failed: {status}"
+        assert status['progress_completed'] == status['progress_total']
+
+        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_vs_migration(build_mode: str, manager: ManagerClient, object_storage):
     '''Check that restore handles tablets migrating around'''
 

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -734,13 +734,17 @@ async def do_test_streaming_scopes(build_mode: str, manager: ManagerClient, topo
 
             await cql.run_async(f"DROP TABLE {ks}.test")
 
-
 @pytest.mark.parametrize("topology", [
-        topo(rf = 1, nodes = 3, racks = 1, dcs = 1),
+        topo(rf = 1, nodes = 2, racks = 1, dcs = 1),
         topo(rf = 2, nodes = 2, racks = 2, dcs = 1),
     ])
-async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_storage, topology):
-    '''Check that restoring of a cluster using tablet-aware restore works'''
+@pytest.mark.parametrize("num_tables, num_restore_nodes", [
+        (1, 1),  # single table via a single node
+        (2, 1),  # multiple tables via a single node
+        (2, 2),  # multiple tables dispatched from multiple nodes
+    ])
+async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_storage, topology, num_tables, num_restore_nodes):
+    '''Check that tablet-aware restore works for multiple tables backed up from multiple nodes'''
 
     servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
 
@@ -748,27 +752,42 @@ async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_s
 
     num_keys = 10
     tablet_count=5
+    tables = [f'test{i}' for i in range(num_tables)]
 
+    # Create the keyspace, populate multiple tables, and back them all up
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count}}};")
-        insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, value) VALUES (?, ?)")
-        insert_stmt.consistency_level = ConsistencyLevel.ALL
-        await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
-        snap_name, sstables = await take_snapshot(ks, servers, manager, logger)
-        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, 'test', object_storage, manager, logger) for s in servers))
+        async def create_table(cf):
+            await cql.run_async(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count}}};")
+            insert_stmt = cql.prepare(f"INSERT INTO {ks}.{cf} (pk, value) VALUES (?, ?)")
+            insert_stmt.consistency_level = ConsistencyLevel.ALL
+            await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
 
+        await asyncio.gather(*(create_table(cf) for cf in tables))
+
+        snap_name, _ = await take_snapshot(ks, servers, manager, logger)
+
+        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}/{cf}', ks, cf, object_storage, manager, logger) for cf in tables for s in servers))
+
+    # Restore all tables into a fresh keyspace, distributing restore calls
+    # round-robin across num_restore_nodes nodes.
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int );")
+        await asyncio.gather(*(cql.run_async(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int );") for cf in tables))
 
-        logger.info(f'Restore cluster via {servers[1].ip_addr}')
-        manifests = [ f'{s.server_id}/{snap_name}/manifest.json' for s in servers ]
-        tid = await manager.api.restore_tablets(servers[1].ip_addr, ks, 'test', snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
-        status = await manager.api.wait_task(servers[1].ip_addr, tid)
-        assert (status is not None) and (status['state'] == 'done')
-        assert status['progress_total'] > 0
-        assert status['progress_completed'] == status['progress_total']
+        restore_nodes = servers[:num_restore_nodes]
 
-        await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
+        async def restore_table(idx, cf):
+            node = restore_nodes[idx % len(restore_nodes)]
+            logger.info(f'Restore table {cf} via {node.ip_addr}')
+            manifests = [f'{s.server_id}/{snap_name}/{cf}/manifest.json' for s in servers]
+            tid = await manager.api.restore_tablets(node.ip_addr, ks, cf, snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
+            status = await manager.api.wait_task(node.ip_addr, tid)
+            assert (status is not None) and (status['state'] == 'done'), f"Restore of {cf} via {node.ip_addr} failed: {status}"
+            assert status['progress_total'] > 0
+            assert status['progress_completed'] == status['progress_total']
+
+        await asyncio.gather(*(restore_table(i, cf) for i, cf in enumerate(tables)))
+
+        await asyncio.gather(*(check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, cf) for cf in tables))
 
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')


### PR DESCRIPTION
This PR extends the tablet restore test coverage to verify that
restoring multiple tables works correctly, both from a single API node
and from multiple API nodes simultaneously. It also adds a dedicated
test that proves restore tasks for different tables execute in parallel.

The first commit reworks `test_restore_tablets` to be parametrized over
`(topology, num_tables, num_restore_nodes)`. Restore API calls are 
distributed round-robin across `num_restore_nodes` nodes, covering:
- single table, single node (baseline, rf=1 and rf=2)
- multiple tables, single node (rf=1 and rf=2)
- multiple tables, multiple nodes (rf=1 and rf=2)

The second commit adds `test_restore_tablets_parallel`, which uses the 
existing `pause_tablet_restore` injection point to block one table's
restore and verify that a second table's restore completes independently.
If restores ran sequentially, the test would timeout (30s deadline on
`wait_task`).

Fixes SCYLLADB-981

No backport needed, extends test coverage