### PR TITLE
Add progress tracking to tablet restore task

### DIFF
--- a/db/snapshot_types.hh
+++ b/db/snapshot_types.hh
@@ -46,6 +46,11 @@ struct snapshot_sstable_entry {
     int64_t index_size;
 };
 
+struct snapshot_sstables_progress {
+    size_t nr_sstables;
+    size_t nr_downloaded_sstables;
+};
+
 // A single cluster level snapshot
 struct snapshot_entry {
     std::string name;

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -619,6 +619,21 @@ future<> snapshot_table_helper::insert_snapshot_sstable(sstring snapshot_name, s
             cql3::query_processor::cache_internal::yes).discard_result();
 }
 
+future<snapshot_sstables_progress> snapshot_table_helper::get_snapshot_sstables_progress(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl) const {
+    static const sstring query = format("SELECT downloaded FROM {}.{}"
+        " WHERE snapshot_name = ? AND \"keyspace\" = ? AND \"table\" = ? AND datacenter = ? AND rack = ?",
+        system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_SSTABLES);
+    snapshot_sstables_progress progress = {};
+    co_await _qp.query_internal(query, cl, { snapshot_name, ks, table, dc, rack }, 1000, [&] (const cql3::untyped_result_set_row& row) {
+        progress.nr_sstables++;
+        if (row.get_or<bool>("downloaded", false)) {
+            progress.nr_downloaded_sstables++;
+        }
+        return make_ready_future<stop_iteration>(stop_iteration::no);
+    });
+    co_return progress;
+}
+
 future<utils::chunked_vector<snapshot_sstable_entry>>
 snapshot_table_helper::get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl, std::optional<dht::token> start_token, std::optional<dht::token> end_token) const {
     utils::chunked_vector<snapshot_sstable_entry> sstables;

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -148,6 +148,9 @@ public:
      * `toc_name`, and `prefix`. Uses consistency level `LOCAL_QUORUM` by default. */
     future<utils::chunked_vector<snapshot_sstable_entry>> get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM, std::optional<dht::token> start_token = std::nullopt, std::optional<dht::token> end_token = std::nullopt) const;
 
+    /* Retrieves download progress for a given snapshot, keyspace, table, datacenter, and rack */
+    future<snapshot_sstables_progress> get_snapshot_sstables_progress(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM) const;
+
     future<> update_sstable_download_status(sstring snapshot_name,
                                             sstring ks,
                                             sstring table,

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/map_reduce.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/shared_mutex.hh>
+#include <seastar/core/timer.hh>
 #include <seastar/core/units.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/switch_to.hh>
@@ -1192,6 +1193,31 @@ class sstables_loader::tablet_restore_task_impl : public tasks::task_manager::ta
     table_id _tid;
     sstring _snap_name;
     size_t _tablet_count;
+    tasks::task_manager::task::progress _progress;
+    seastar::named_gate _gate{"progress_updater"};
+    timer<seastar::lowres_clock> _progress_update_timer;
+
+    future<> update_progress() {
+        auto& loader = _loader.local();
+        auto& db = loader._db.local();
+        auto s = db.find_schema(_tid);
+        auto md = db.get_token_metadata_ptr();
+        const auto& topo = md->get_topology();
+        auto dc = topo.get_datacenter();
+        auto dc_racks_it = topo.get_datacenter_racks().find(dc);
+        if (dc_racks_it == topo.get_datacenter_racks().end()) {
+            co_return;
+        }
+
+        db::snapshot_table_helper sth(loader._sys_dist_ks.qp());
+        tasks::task_manager::task::progress progress = {};
+        co_await max_concurrent_for_each(dc_racks_it->second, 16, [&](const auto& rack_entry) -> future<> {
+            auto p = co_await sth.get_snapshot_sstables_progress(_snap_name, s->ks_name(), s->cf_name(), dc, rack_entry.first);
+            progress.total += p.nr_sstables;
+            progress.completed += p.nr_downloaded_sstables;
+        });
+        _progress = progress;
+    }
 
 public:
     tablet_restore_task_impl(tasks::task_manager::module_ptr module, sharded<sstables_loader>& loader, sstring ks,
@@ -1201,8 +1227,19 @@ public:
         , _tid(std::move(tid))
         , _snap_name(std::move(snap_name))
         , _tablet_count(ms.tablet_count)
+        , _progress_update_timer([this] {
+            if (auto gh = _gate.try_hold()) {
+                std::ignore = update_progress().finally([this, gh = std::move(*gh)] {
+                    if (!_gate.is_closed()) {
+                        _progress_update_timer.rearm(lowres_clock::now() + 5s);
+                    }
+                });
+            }
+        })
     {
-        _status.progress_units = "batches";
+        _status.progress_units = "sstables";
+        _progress.total = ms.nr_sstables;
+        _progress_update_timer.arm(lowres_clock::now());
     }
 
     virtual std::string type() const override {
@@ -1219,6 +1256,15 @@ public:
 
     tasks::is_abortable is_abortable() const noexcept override {
         return tasks::is_abortable::no;
+    }
+
+    future<tasks::task_manager::task::progress> get_progress() const override {
+        co_return _progress;
+    }
+
+    future<> release_resources() noexcept override {
+        _progress_update_timer.cancel();
+        co_await _gate.close();
     }
 
 protected:
@@ -1248,6 +1294,11 @@ protected:
         if (eptr) {
             std::rethrow_exception(eptr);
         }
+
+        // Restore complete. The total was known upfront from manifest parsing.
+        // Mark all progress as complete and stop the background update timer.
+        _progress_update_timer.cancel();
+        _progress.completed = _progress.total;
     }
 };
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1080,7 +1080,7 @@ future<std::vector<tablet_sstable_collection>> get_sstables_for_tablets_for_test
     return tablet_sstable_streamer::get_sstables_for_tablets(sstables, std::move(tablets_ranges));
 }
 
-static future<size_t> process_manifest(input_stream<char>& is, sstring keyspace, sstring table,
+static future<manifest_summary> process_manifest(input_stream<char>& is, sstring keyspace, sstring table,
                                  const sstring& expected_snapshot_name,
                                  const sstring& manifest_prefix, db::system_distributed_keyspace& sys_dist_ks,
                                  db::consistency_level cl) {
@@ -1119,7 +1119,7 @@ static future<size_t> process_manifest(input_stream<char>& is, sstring keyspace,
     // FIXME: cleanup of the snapshot-related rows is needed in case anything throws in here.
     auto sstables = rjson::find(parsed, "sstables");
     if (!sstables) {
-        co_return tablet_count;
+        co_return manifest_summary{tablet_count, 0};
     }
     if (!sstables->IsArray()) {
         throw std::runtime_error("Malformed manifest, 'sstables' is not array");
@@ -1148,10 +1148,10 @@ static future<size_t> process_manifest(input_stream<char>& is, sstring keyspace,
                                              repaired_at, data_size, index_size, cl);
     }
 
-    co_return tablet_count;
+    co_return manifest_summary{tablet_count, sstables->Size()};
 }
 
-future<size_t> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl) {
+future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl) {
     if (manifest_prefixes.empty()) {
         throw std::invalid_argument("manifest prefixes list must not be empty");
     }
@@ -1162,23 +1162,29 @@ future<size_t> populate_snapshot_sstables_from_manifests(sstables::storage_manag
 
     // tablet_count to be returned by this function, we also validate that all manifests passed contain the same tablet count
     std::optional<size_t> tablet_count;
+    size_t nr_sstables = 0;
 
     co_await seastar::max_concurrent_for_each(manifest_prefixes, 16, [&] (const sstring& manifest_prefix) {
         // Download the manifest JSON file
         sstables::object_name name(bucket, manifest_prefix);
         auto source = client->make_download_source(name);
         return seastar::with_closeable(input_stream<char>(std::move(source)), [&] (input_stream<char>& is) {
-            return process_manifest(is, keyspace, table, expected_snapshot_name, manifest_prefix, sys_dist_ks, cl).then([&](size_t count) {
+            return process_manifest(is, keyspace, table, expected_snapshot_name, manifest_prefix, sys_dist_ks, cl).then([&](manifest_summary ms) {
+                size_t count = ms.tablet_count;
                 if (!tablet_count) {
                     tablet_count = count;
                 } else if (*tablet_count != count) {
                     throw std::runtime_error(fmt::format("Inconsistent tablet_count values in manifest {}: expected {}, got {}", manifest_prefix, *tablet_count, count));
                 }
+                nr_sstables += ms.nr_sstables;
             });
         });
     });
 
-    co_return *tablet_count;
+    co_return manifest_summary{
+        .tablet_count = *tablet_count,
+        .nr_sstables = nr_sstables,
+    };
 }
 
 class sstables_loader::tablet_restore_task_impl : public tasks::task_manager::task::impl {
@@ -1189,12 +1195,12 @@ class sstables_loader::tablet_restore_task_impl : public tasks::task_manager::ta
 
 public:
     tablet_restore_task_impl(tasks::task_manager::module_ptr module, sharded<sstables_loader>& loader, sstring ks,
-            table_id tid, sstring snap_name, size_t tablet_count) noexcept
+            table_id tid, sstring snap_name, manifest_summary ms) noexcept
         : tasks::task_manager::task::impl(module, tasks::task_id::create_random_id(), 0, "node", ks, "", "", tasks::task_id::create_null_id())
         , _loader(loader)
         , _tid(std::move(tid))
         , _snap_name(std::move(snap_name))
-        , _tablet_count(tablet_count)
+        , _tablet_count(ms.tablet_count)
     {
         _status.progress_units = "batches";
     }
@@ -1246,7 +1252,7 @@ protected:
 };
 
 future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, sstring prefix, utils::chunked_vector<sstring> manifests) {
-    auto tablet_count = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
+    auto summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
 
     auto datacenter = _db.local().get_token_metadata().get_topology().get_datacenter();
 
@@ -1254,6 +1260,6 @@ future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring ke
     // TODO: update state when all restored...
     co_await sth.insert_snapshot_remote_location(snap_name, datacenter, endpoint, bucket, prefix, db::snapshot_state::remote);
 
-    auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name), tablet_count);
+    auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name), summary);
     co_return task->id();
 }

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -194,4 +194,9 @@ struct tablet_sstable_collection {
 future<std::vector<tablet_sstable_collection>> get_sstables_for_tablets_for_tests(const std::vector<sstables::shared_sstable>& sstables,
                                                                                   std::vector<dht::token_range>&& tablets_ranges);
 
-future<size_t> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+struct manifest_summary {
+    size_t tablet_count;
+    size_t nr_sstables;
+};
+
+future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl = db::consistency_level::EACH_QUORUM);

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -765,6 +765,8 @@ async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_s
         tid = await manager.api.restore_tablets(servers[1].ip_addr, ks, 'test', snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
         status = await manager.api.wait_task(servers[1].ip_addr, tid)
         assert (status is not None) and (status['state'] == 'done')
+        assert status['progress_total'] > 0
+        assert status['progress_completed'] == status['progress_total']
 
         await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
 
@@ -852,6 +854,9 @@ async def test_restore_tablets_download_failure(build_mode: str, manager: Manage
         status = await manager.api.wait_task(servers[0].ip_addr, tid)
         assert 'state' in status and status['state'] == 'failed'
         assert 'error' in status and 'Failing sstable download' in status['error']
+        # Partial progress: some SSTables were downloaded before the failure
+        assert status['progress_total'] > 0
+        assert status['progress_completed'] < status['progress_total']
 
 
 @pytest.mark.parametrize("target", ['coordinator', 'replica', 'api'])


### PR DESCRIPTION
This patch adds per-SSTable progress tracking to the tablet restore task,
enabling monitoring of how far along a restore operation is. Previously,
progress_total and progress_completed were always zero, making large
restore operations impossible to track.

A periodic timer (5s interval) queries `system_distributed.snapshot_sstables`
to count downloaded vs total SSTables, updating progress incrementally.
Respectively, the progress units is "sstables".

By the time run() finishes (without exceptions) the update timer is canceled
and the progress is reset to 100% by hand. Since there's a small chance that
by that time the timer didn't do background update, the initial `total`
counters is initialized from the manifests parsing.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-986

New feature, not backporting