### PR TITLE
[Backport 2025.4] service: add missing replicas if tablet rebuild was rolled back

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -335,6 +335,34 @@ Modifying a keyspace with tablets enabled is possible and doesn't require any sp
 - The ``ALTER`` statement will fail if it would make the keyspace :term:`RF-rack-invalid <RF-rack-valid keyspace>`.
 - After the ``ALTER`` statement that increases the RF finishes, client applications should be restarted. Without a restart, drivers will not know about new replicas, which may cause request imbalance.
 
+Fixing invalid replica state with RF change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If a tablet rebuild fails during an RF change, the state of replicas will be invalid, even though the RF change is marked as successful. The missing replicas will be eventually added in the background. However, until then, the following RF changes will fail.
+
+To fix the state of replicas in the foreground, retry the previous ALTER KEYSPACE statement, i.e. update the replication factor to the same value it currently has.
+
+For example, if the following statement fails due to invalid replica state:
+
+.. code-block:: cql
+
+  ALTER KEYSPACE Excelsior WITH replication = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 3, 'dc2' : 1} AND tablets = { 'enabled': true };
+
+Check the current replication factor with DESCRIBE KEYSPACE:
+
+.. code-block:: cql
+
+  DESCRIBE KEYSPACE Excelsior;
+  CREATE KEYSPACE Excelsior WITH replication = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 3, 'dc2' : 2} AND tablets = { 'enabled': true };
+
+Ensure that reaching the valid replicas state is possible (e.g. there is enough non-excluded racks) and alter keyspace with the current replication factor:
+
+.. code-block:: cql
+
+  ALTER KEYSPACE Excelsior WITH replication = { 'class' : 'NetworkTopologyStrategy', 'dc1' : 3, 'dc2' : 2} AND tablets = { 'enabled': true };
+
+This should fix the state of replicas and allow future RF changes to succeed.
+
 .. _drop-keyspace-statement:
 
 DROP KEYSPACE

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1003,6 +1003,36 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
                         auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
                         new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, co_await old_tablets.clone_gently());
+
+                        replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id());
+                        co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
+                            auto last_token = new_tablet_map.get_last_token(tablet_id);
+                            auto old_tablet_info = old_tablets.get_tablet_info(last_token);
+                            auto abandoning_replicas = locator::substract_sets(old_tablet_info.replicas, tablet_info.replicas);
+                            auto new_replicas = locator::substract_sets(tablet_info.replicas, old_tablet_info.replicas);
+                            if (abandoning_replicas.size() + new_replicas.size() > 1) {
+                                throw std::runtime_error(fmt::format("Invalid state of a tablet {} of a table {}.{}. Expected replication factor: {}, but the tablet has replicas only on {}. "
+                                    "Try again later or use the \"Fixing invalid replica state with RF change\" procedure to fix the problem.", tablet_id, ks_name, table_or_mv->cf_name(),
+                                    ks.get_replication_strategy().get_replication_factor(*tmptr), old_tablet_info.replicas));
+                            }
+                            updates.emplace_back(co_await make_canonical_mutation_gently(
+                                    replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
+                                            .set_new_replicas(last_token, tablet_info.replicas)
+                                            .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+                                            .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
+                                            .build()
+                            ));
+
+                            // Calculate abandoning replica and abort view building tasks on them
+                            if (!abandoning_replicas.empty()) {
+                                if (abandoning_replicas.size() != 1) {
+                                    on_internal_error(rtlogger, fmt::format("Keyspace RF abandons {} replicas for table {} and tablet id {}", abandoning_replicas.size(), table_or_mv->id(), tablet_id));
+                                }
+                                _vb_coordinator->abort_tasks(updates, guard, table_or_mv->id(), *abandoning_replicas.begin(), last_token);
+                            }
+
+                            co_await coroutine::maybe_yield();
+                        });
                     } catch (const std::exception& e) {
                         error = e.what();
                         rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, error: {},"
@@ -1010,30 +1040,6 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         updates.clear(); // remove all tablets mutations ...
                         break;           // ... and only create mutations deleting the global req
                     }
-
-                    replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id());
-                    co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
-                        auto last_token = new_tablet_map.get_last_token(tablet_id);
-                        updates.emplace_back(co_await make_canonical_mutation_gently(
-                                replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
-                                        .set_new_replicas(last_token, tablet_info.replicas)
-                                        .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-                                        .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
-                                        .build()
-                        ));
-
-                        // Calculate abandoning replica and abort view building tasks on them
-                        auto old_tablet_info = old_tablets.get_tablet_info(last_token);
-                        auto abandoning_replicas = locator::substract_sets(old_tablet_info.replicas, tablet_info.replicas);
-                        if (!abandoning_replicas.empty()) {
-                            if (abandoning_replicas.size() != 1) {
-                                on_internal_error(rtlogger, fmt::format("Keyspace RF abandons {} replicas for table {} and tablet id {}", abandoning_replicas.size(), table_or_mv->id(), tablet_id));
-                            }
-                            _vb_coordinator->abort_tasks(updates, guard, table_or_mv->id(), *abandoning_replicas.begin(), last_token);
-                        }
-
-                        co_await coroutine::maybe_yield();
-                    });
                 }
             } else {
                 error = "Can't ALTER keyspace " + ks_name + ", keyspace doesn't exist";
@@ -2261,7 +2267,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             }
 
             // If there is no other work, evaluate load and start tablet migration if there is imbalance.
-            if (co_await maybe_start_tablet_migration(std::move(guard))) {
+            if (auto guard_opt = co_await maybe_start_tablet_migration(std::move(guard)); !guard_opt) {
+                co_return true;
+            } else {
+                guard = std::move(*guard_opt);
+            }
+
+            if (co_await maybe_retry_failed_rf_change_tablet_rebuilds(std::move(guard))) {
                 co_return true;
             }
             co_return false;
@@ -3248,11 +3260,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
     // Returns the guard if no work done. Otherwise, performs a table migration and consumes the guard.
     future<std::optional<group0_guard>> maybe_migrate_system_tables(group0_guard guard);
 
-    // Returns true if the state machine was transitioned into tablet migration path.
-    future<bool> maybe_start_tablet_migration(group0_guard);
+    // Returns the guard if no work done. Otherwise, transitions the state machine into tablet migration path.
+    future<std::optional<group0_guard>> maybe_start_tablet_migration(group0_guard);
 
-    // Returns true if the state machine was transitioned into tablet resize finalization path.
-    future<bool> maybe_start_tablet_resize_finalization(group0_guard, const table_resize_plan& plan);
+    // Returns the guard if no work done. Otherwise, transitions the state machine into tablet resize finalization path.
+    future<std::optional<group0_guard>> maybe_start_tablet_resize_finalization(group0_guard, const table_resize_plan& plan);
+
+    // Returns true if the state machine was transitioned into tablet migration path.
+    future<bool> maybe_retry_failed_rf_change_tablet_rebuilds(group0_guard guard);
 
     future<> refresh_tablet_load_stats();
     future<> start_tablet_load_stats_refresher();
@@ -3341,7 +3356,7 @@ future<std::optional<group0_guard>> topology_coordinator::maybe_migrate_system_t
     co_return std::move(guard);
 }
 
-future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard guard) {
+future<std::optional<group0_guard>> topology_coordinator::maybe_start_tablet_migration(group0_guard guard) {
     rtlogger.debug("Evaluating tablet balance");
 
     if (utils::get_local_injector().enter("tablet_load_stats_refresh_before_rebalancing")) {
@@ -3352,7 +3367,7 @@ future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard gua
     auto plan = co_await _tablet_allocator.balance_tablets(tm, {}, get_dead_nodes());
     if (plan.empty()) {
         rtlogger.debug("Tablet load balancer did not make any plan");
-        co_return false;
+        co_return std::move(guard);
     }
 
     utils::chunked_vector<canonical_mutation> updates;
@@ -3372,15 +3387,15 @@ future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard gua
             .build());
 
     co_await update_topology_state(std::move(guard), std::move(updates), "Starting tablet migration");
-    co_return true;
+    co_return std::nullopt;
 }
 
-future<bool> topology_coordinator::maybe_start_tablet_resize_finalization(group0_guard guard, const table_resize_plan& plan) {
+future<std::optional<group0_guard>> topology_coordinator::maybe_start_tablet_resize_finalization(group0_guard guard, const table_resize_plan& plan) {
     if (plan.finalize_resize.empty()) {
-        co_return false;
+        co_return std::move(guard);
     }
     if (utils::get_local_injector().enter("tablet_split_finalization_postpone")) {
-        co_return false;
+        co_return std::move(guard);
     }
 
     auto resize_finalization_transition_state = [this] {
@@ -3396,6 +3411,73 @@ future<bool> topology_coordinator::maybe_start_tablet_resize_finalization(group0
             .build());
 
     co_await update_topology_state(std::move(guard), std::move(updates), "Started tablet resize finalization");
+    co_return std::nullopt;
+}
+
+future<bool> topology_coordinator::maybe_retry_failed_rf_change_tablet_rebuilds(group0_guard guard) {
+    rtlogger.debug("Retrying failed rebuilds");
+
+    if (utils::get_local_injector().enter("maybe_retry_failed_rf_change_tablet_rebuilds_skip")) {
+        rtlogger.debug("Skipping retrying failed rebuilds due to error injection");
+        co_return false;
+    }
+
+    auto tmptr = get_token_metadata_ptr();
+    utils::chunked_vector<canonical_mutation> updates;
+    for (auto& ks_name : _db.get_tablets_keyspaces()) {
+        auto& ks = _db.find_keyspace(ks_name);
+        auto& strategy = ks.get_replication_strategy();
+        auto tables_with_mvs = ks.metadata()->tables();
+        auto views = ks.metadata()->views();
+        tables_with_mvs.insert(tables_with_mvs.end(), views.begin(), views.end());
+        for (const auto& table_or_mv : tables_with_mvs) {
+            if (!tmptr->tablets().is_base_table(table_or_mv->id())) {
+                continue;
+            }
+
+            auto& tablet_map = tmptr->tablets().get_tablet_map(table_or_mv->id());
+            auto new_tablet_map = co_await strategy.maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, co_await tablet_map.clone_gently());
+
+            replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id());
+            co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
+                auto& replicas = tablet_map.get_tablet_info(tablet_id).replicas;
+                auto it = std::find_if(tablet_info.replicas.begin(), tablet_info.replicas.end(), [&](const auto& replica) {
+                    return std::find(replicas.begin(), replicas.end(), replica) == replicas.end();
+                });
+                if (it == tablet_info.replicas.end()) {
+                    co_return;
+                }
+                auto new_replicas = replicas;
+                new_replicas.push_back(*it);
+                auto last_token = new_tablet_map.get_last_token(tablet_id);
+                updates.emplace_back(co_await make_canonical_mutation_gently(
+                        replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
+                                .set_new_replicas(last_token, new_replicas)
+                                .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+                                .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
+                                .build()
+                ));
+            });
+        }
+
+        if (!updates.empty()) {
+            break;
+        }
+    }
+
+    if (updates.empty()) {
+        rtlogger.debug("No failed RF change rebuilds to retry");
+        co_return false;
+    }
+
+    updates.emplace_back(
+        topology_mutation_builder(guard.write_timestamp())
+            .set_transition_state(topology::transition_state::tablet_migration)
+            .set_version(_topo_sm._topology.version + 1)
+            .build());
+
+    sstring reason = "Retry failed tablet rebuilds";
+    co_await update_topology_state(std::move(guard), std::move(updates), reason);
     co_return true;
 }
 

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -14,7 +14,7 @@ from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from test.pylib.util import unique_name, wait_for, wait_for_first_completed
 from test.cluster.conftest import skip_mode
-from test.cluster.util import wait_for_cql_and_get_hosts, create_new_test_keyspace, new_test_keyspace, reconnect_driver, get_topology_coordinator
+from test.cluster.util import wait_for_cql_and_get_hosts, create_new_test_keyspace, new_test_keyspace, reconnect_driver, get_topology_coordinator, find_server_by_host_id
 from contextlib import nullcontext as does_not_raise
 import time
 import pytest
@@ -350,6 +350,99 @@ async def test_multidc_alter_tablets_rf(request: pytest.FixtureRequest, manager:
         # check that we can remove all replicas from the cluster, i.e. change RF of dc1 from 1 to 0 as well:
         await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 0}}")
 
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_failed_tablet_rebuild_is_retried(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    async def alter_keyspace(new_rf):
+        await cql.run_async(f"alter keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', {new_rf}}};")
+
+    injection = "rebuild_repair_stage_fail"
+    config = {"tablets_mode_for_new_keyspaces": "enabled", "error_injections_at_startup": [injection], "rf_rack_valid_keyspaces": "false"}
+    cmdline = [
+        '--logger-log-level', 'load_balancer=debug',
+        '--smp=2',
+    ]
+
+    servers = [await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
+                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1c'})]
+
+    cql = manager.get_cql()
+
+    await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1}} and tablets = {{'initial': 4}};")
+    await cql.run_async("create table ks1.t (pk int primary key);")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk) VALUES ({pk});") for pk in range(16)])
+
+    coord = await get_topology_coordinator(manager)
+    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    log = await manager.server_open_log(coord_serv.server_id)
+    mark = await log.mark()
+
+    await alter_keyspace("'dc1': 2")
+
+    await log.wait_for('updating topology state: Retry failed tablet rebuilds', from_mark=mark)
+
+    failed = False
+    try:
+        await alter_keyspace("'dc1': 3")
+    except Exception:
+        failed = True
+    assert failed
+
+    [await manager.api.disable_injection(s.ip_addr, injection) for s in servers]
+
+    log1 = await manager.server_open_log(coord_serv.server_id)
+    mark1 = await log1.mark()
+
+    await log1.wait_for('No failed RF change rebuilds to retry', from_mark=mark1)
+
+    await manager.api.quiesce_topology(coord_serv.ip_addr)
+
+    await alter_keyspace("'dc1': 3")
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_failed_tablet_rebuild_is_retried_on_alter(manager: ManagerClient) -> None:
+    async def alter_keyspace(new_rf):
+        await cql.run_async(f"alter keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', {new_rf}}};")
+
+    fail_injection = "rebuild_repair_stage_fail"
+    skip_fix_injection = "maybe_retry_failed_rf_change_tablet_rebuilds_skip"
+    config = {
+        "tablets_mode_for_new_keyspaces": "enabled",
+        "error_injections_at_startup": [skip_fix_injection, fail_injection],
+        "rf_rack_valid_keyspaces": "false"
+    }
+    cmdline = [
+        '--logger-log-level', 'load_balancer=debug',
+        '--smp=2',
+    ]
+
+    servers = [await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+               await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'})]
+
+    cql = manager.get_cql()
+
+    await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1}} and tablets = {{'initial': 4}};")
+    await cql.run_async("create table ks1.t (pk int primary key);")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk) VALUES ({pk});") for pk in range(16)])
+
+    await alter_keyspace("'dc1': 2")
+
+    tablet_replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+    assert len(tablet_replicas) == 4
+    for r in tablet_replicas:
+        assert len(r.replicas) == 1
+
+    [await manager.api.disable_injection(s.ip_addr, fail_injection) for s in servers]
+
+    await alter_keyspace("'dc1': 2")
+
+    tablet_replicas = await get_all_tablet_replicas(manager, servers[0], "ks1", "t")
+    assert len(tablet_replicas) == 4
+    for r in tablet_replicas:
+        assert len(r.replicas) == 2
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/18110
 # Check that an existing cached read, will be cleaned up when the tablet it reads


### PR DESCRIPTION
RF change of tablet keyspace starts tablet rebuilds. Even if any of the rebuilds is rolled back (because pending replica was excluded), rf change request finishes successfully. In this case we end up with the state of the replicas that isn't compatible with the expected keyspace replication.

Modify topology coordinator so that if it were to be idle, it starts checking if there are any missing replicas. It moves to transition_state::tablet_migration and run required rebuilds.

If a new RF change request encounters invalid state of replicas it fails. The state will be fixed later and the analogical ALTER KEYSPACE statement will be allowed.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1566.

Requires backport to all versions with tablet keyspace rf change.

* github.com:scylladb/scylladb:
  test: add test_failed_tablet_rebuild_is_retried_on_alter
  test: add a test to ensure that failed rebuilds are retried
  service: fail ALTER KEYSPACE if replicas do not satisfy the replication
  service: retry failed tablet rebuilds
  service: maybe_start_tablet_migration returns std::optional<group0_guard>

(cherry picked from commit 5891efc2ca67b1fc1586e6bfbaa90ff18cb2c394)

Parent PR: #28709