### PR TITLE
api/raft: fix trigger_stepdown to read group_id from query parameter

### DIFF
--- a/api/raft.cc
+++ b/api/raft.cc
@@ -139,7 +139,7 @@ void set_raft(http_context&, httpd::routes& r, sharded<service::raft_group_regis
             });
             co_return json_void{};
         }
-        raft::group_id gid{utils::UUID{req->get_path_param("group_id")}};
+        raft::group_id gid{utils::UUID{req->get_query_param("group_id")}};
 
         std::atomic<bool> found_srv{false};
         co_await raft_gr.invoke_on_all([gid, timeout_dur, &found_srv] (service::raft_group_registry& raft_gr) -> future<> {


### PR DESCRIPTION
get_query_param is checked to detect a targeted stepdown, but the value is then read via get_path_param which always returns empty since the route has no path placeholder. Use get_query_param consistently.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2542.

Needs backport to all live versions as they all use get_path_param