### PR TITLE
storage_proxy: throttle cancel_write_handlers with count-based yield

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -7533,7 +7533,7 @@ future<> storage_proxy::cancel_write_handlers(noncopyable_function<bool(const ab
             }
         }
         it = next;
-        if (need_preempt() && it != _cancellable_write_handlers_list->end()) {
+        if (it != _cancellable_write_handlers_list->end() && need_preempt()) {
             // Save the iterator position. If the handler is destroyed during yield(),
             // the iterator will be updated to point to the next item in the list.
             //

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -15,6 +15,7 @@
 #include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/util/later.hh>
 #include <seastar/coroutine/try_future.hh>
 #include <seastar/util/defer.hh>
 #include "gms/inet_address.hh"
@@ -7518,6 +7519,13 @@ void storage_proxy::on_released(const locator::host_id& hid) {
 
 future<> storage_proxy::cancel_write_handlers(noncopyable_function<bool(const abstract_write_response_handler&)> filter_fun) {
     gate g;
+    // Each timeout_cb() schedules a task* into the reactor's circular_buffer<task*>
+    // (threshold: 16384 entries = 128 KB).  need_preempt() is time-based and doesn't
+    // track queue depth, so we yield unconditionally every max_cancellations_per_yield
+    // to let the reactor drain — 256 entries is well below the 16384-entry threshold.
+    // See SCYLLADB-2068.
+    constexpr size_t max_cancellations_per_yield = 256;
+    size_t since_yield = 0;
     auto it = _cancellable_write_handlers_list->begin();
     while (it != _cancellable_write_handlers_list->end()) {
         // timeout_cb() may destroy the current handler. Since the list uses
@@ -7530,10 +7538,11 @@ future<> storage_proxy::cancel_write_handlers(noncopyable_function<bool(const ab
             it->attach_to(g);
             if (_response_handlers.contains(it->id())) {
                 it->timeout_cb();
+                ++since_yield;
             }
         }
         it = next;
-        if (it != _cancellable_write_handlers_list->end() && need_preempt()) {
+        if (it != _cancellable_write_handlers_list->end() && (need_preempt() || since_yield >= max_cancellations_per_yield)) {
             // Save the iterator position. If the handler is destroyed during yield(),
             // the iterator will be updated to point to the next item in the list.
             //
@@ -7542,7 +7551,8 @@ future<> storage_proxy::cancel_write_handlers(noncopyable_function<bool(const ab
             // iterator_guard handles safe iterator updates while allowing prompt
             // handler destruction and client response.
             cancellable_write_handlers_list::iterator_guard ig{*_cancellable_write_handlers_list, it};
-            co_await coroutine::maybe_yield();
+            co_await seastar::yield();
+            since_yield = 0;
         }
     }
     co_await g.close();


### PR DESCRIPTION
Each `timeout_cb()` call schedules a task (via `promise::set_value` in the handler destructor). When thousands of handlers are cancelled at once, they all fire within a single reactor quantum, flooding `task_queue::_q` past 16384 entries (128 KB) and triggering an oversized allocation.

The existing `coroutine::maybe_yield()` guard is time-based and does not account for task-queue depth, so it does not prevent the burst.

Fix by yielding unconditionally every 256 cancellations using `seastar::yield()`, giving the reactor a chance to drain the task queue between batches. The existing `iterator_guard` is retained to handle safe iterator invalidation across the co_await point.

Fixes: SCYLLADB-2068
Backport: no — non-fatal CI improvement; does not meet the bar for backporting per current policy (not a regression or critical field issue).