### PR TITLE
test/alternator: add an easy way to run an Alternator server

### DIFF
--- a/test/alternator/README.md
+++ b/test/alternator/README.md
@@ -76,6 +76,18 @@ The `--release` option supports various version specifiers, such as 5.4.7
 5.4.0~rc2 (a pre-release), or Enterprise releases such as 2021.1.9 or 2023.1
 (the latest in that branch).
 
+The `--vs` option (the double minus is important, `-vs` is different) tells
+`test/alternator/run` to also run a vector store in addition to Scylla. This
+is needed for tests for the vector index feature (test_vector.py).
+
+If you like the ability of `test/alternator/run` to easily and quickly start
+Alternator for you, but want to interactively run your own code against it
+instead of the standard tests, then use `test/alternator/run --interactive`.
+With `--interactive`, `run` will start Alternator, tell you the URL where it
+is listening, and then just wait until interrupted - without running tests.
+You can combine the `--interactive` option with `--release` or `--vs`, but no
+other options are allowed.
+
 ## HTTPS support
 
 In order to run tests over HTTPS instead of the default HTTP, run

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -7,6 +7,7 @@ import run
 import os
 import requests
 import glob
+import signal
 
 # When tests are to be run against AWS (the "--aws" option), it is not
 # necessary to start Scylla at all. All we need to do is to run pytest.
@@ -49,6 +50,11 @@ if '--vnodes' in sys.argv:
     remove_scylla_options.append('--enable-tablets=true')
     # Tablets are now enabled by default on some releases, it is not enough to remove the enable above.
     extra_scylla_options.append('--enable-tablets=false')
+# test/alternator/run --interactive will not run any test. It will instead
+# leave the server running and allow the user to connect to it. This server
+# will be more practical to use if we do NOT enforce authorization.
+if '--interactive' in sys.argv:
+    remove_scylla_options.append('--alternator-enforce-authorization=1')
 
 if "-h" in sys.argv or "--help" in sys.argv:
     run.run_pytest(sys.path[0], sys.argv)
@@ -62,7 +68,7 @@ def run_alternator_cmd(pid, dir):
     ip = run.pid_to_ip(pid)
     cmd += [
         '--alternator-address', ip,
-        '--alternator-enforce-authorization', '1',
+        '--alternator-enforce-authorization=1',
         '--alternator-write-isolation', 'only_rmw_uses_lwt',
         '--alternator-streams-time-window-s', '0',
         '--alternator-timeout-in-ms', '30000',
@@ -100,9 +106,10 @@ def run_alternator_cmd(pid, dir):
     if 'release' in globals():
         version = release.split('~')[0].split('.')
         major = [int(version[0]), int(version[1])]
-        print(major)
         if major < [2025,4]:
             cmd.remove('--alternator-allow-system-table-write=1')
+        if major < [2026,3]:
+            cmd.remove('--tablet-load-stats-refresh-interval-in-seconds=1')
 
     return (cmd, env)
 
@@ -134,6 +141,7 @@ def run_vector_store_cmd(pid, dir):
         vector_store_executable
     ]
     return (cmd, env)
+
 if '--vs' in sys.argv:
     sys.argv.remove('--vs')
     # Find the vector-store executable. We look for it in the vector-store/
@@ -171,6 +179,16 @@ run.wait_for_services(pid, [
     lambda: run.check_cql(ip),
     lambda: check_alternator(alternator_url),
 ])
+
+# test/alternator/run --interactive will not run any test. It will instead
+# leave the server running and allow the user to interact with it. The user
+# should interrupt this process (e.g., control-C) to kill the server.
+if '--interactive' in sys.argv:
+    if len(sys.argv) != 2:
+        print('The "--interactive" option can be combined with "--release" or "--vs", but no other options.')
+        exit(1)
+    print(f'Scylla with Alternator is running without authorization enforced.\nConnect at: {alternator_url}\nPress Ctrl-C to stop.')
+    signal.pause()
 
 # Finally run pytest:
 success = run.run_pytest(sys.path[0], ['--url', alternator_url] + sys.argv[1:])

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -411,6 +411,11 @@ def run_precompiled_scylla_cmd(exe, pid, dir):
         cmd.remove('--rf-rack-valid-keyspaces=1')
     if major < [2025,2]:
         cmd.remove('--group0-raft-op-timeout-in-ms=300000')
+    if major < [2026,2]:
+        cmd.remove('--experimental-features=logstor')
+        cmd.remove('--logstor-disk-size-in-mb=8')
+        cmd.remove('--logstor-file-size-in-mb=4')
+        cmd.remove('--logstor-separator-max-memory-in-mb=8')
     return (cmd, env)
 
 # Get a Cluster object to connect to CQL at the given IP address (and with


### PR DESCRIPTION
test/alternator/run has made it very easy to run a Scylla server and run tests against it. But sometimes you just want to run a Scylla server and leave it running - without starting any test. For example, to run some external or manual test against this server.

So this patch adds to test/alternator/run the option "--interactive". With this option, "run --interactive" doesn't run any test - it just runs the server *without authorization* and waits until interrupted.

For example to run tests written by the "extenddb" project against Alternator, one can run:

	$ test/alternator/run --interactive
	Scylla is: /home/nyh/scylla/build/dev/scylla.
	Booting Scylla on 127.8.225.32 in /tmp/scylla-test-516384...
	Boot successful (0.4 seconds).
	Scylla with Alternator is running without authorization enforced.
	Connect at: http://127.8.225.32:8000
	Press Ctrl-C to stop.

And then in another window, in the extenddb/tests/python directory run:

	DYNAMODB_ENDPOINT=http://127.8.225.32:8000 \
	pytest test_streams.py::TestStreamRecords

Where the URL was taken from the "run --interactive" output. In the output of "run --interactive" you can also find the temporary directory which contains, among other things, the log file of the running server.