### PR TITLE
Fix flaky test_tombstone_gc_correctness_during_tablet_split

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -878,6 +878,9 @@ class load_balancer {
             if (utils::get_local_injector().enter("force_resize_cancellation")) {
                 return true;
             }
+            if (utils::get_local_injector().enter("skip_resize_cancellation")) {
+                return false;
+            }
             return d.resize_decision.split_or_merge() && to_resize_decision(d).way != d.resize_decision.way;
         }
 

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -1276,6 +1276,13 @@ async def test_tombstone_gc_correctness_during_tablet_split(manager: ManagerClie
         s1_mark = await s1_log.mark()
 
         logger.info("Force compaction of split sstable containing expired tombstone")
+        # The forced compaction can empty the tablet (gc_grace_seconds=0 purges the
+        # co-located inserts and their tombstones) while the split is in flight. An empty
+        # tablet drives avg_tablet_size to 0, which would otherwise make the load balancer
+        # revoke the already split-ready split instead of finalizing it. Suppress that
+        # cancellation so the split finalizes.
+        await manager.api.enable_injection(servers[0].ip_addr, "skip_resize_cancellation", one_shot=False)
+
         await manager.api.stop_compaction(servers[0].ip_addr, "SPLIT")
         compaction_task = asyncio.create_task(manager.api.keyspace_compaction(servers[0].ip_addr, ks))
 


### PR DESCRIPTION
### Summary
- This test was flaky: its forced major compaction (gc_grace_seconds=0) can empty the tablet while the tablet split is still in flight, driving avg_tablet_size to 0 and causing the load balancer to revoke the split-ready split instead of finalizing it — after which the test's detected tablet split wait never completes.
- Adds a skip_resize_cancellation error injection to the load balancer and enables it in the test so the in-flight split finalizes regardless of when the compaction empties the tablet.
### Root cause
The test deliberately holds split finalization open with tablet_split_finalization_postpone (disabled only at the end), while tablet_load_stats_refresh_before_rebalancing keeps the balancer re-evaluating against freshly refreshed load stats every pass.
The postpone gates only the finalize transition, not cancellation: in produce_resize_plan(), table_needs_resize_cancellation() is checked before the finalize branch. So while finalization is held back, once the forced compaction empties the tablet a rebalance pass recomputes avg_tablet_size=0, flips the decision to "merge", and revokes the still-unfinalized split (the loop then continues past the finalize branch). When the test finally disables the postpone, there is no split left to finalize.
The failure was intermittent because it depends on the forced compaction actually purging the tombstoned data to an empty tablet - and a rebalance pass observing it - before the split is finalized.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2416