### PR TITLE
service: session: get abort_source via the guard

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -866,6 +866,11 @@ public:
     void clear_session_abort_subscription() {
         _session_abort_sub = {};
     }
+    // Returns the abort_source of the topology session this repair_meta belongs to.
+    // Safe because _topology_guard keeps the session alive for the lifetime of this repair_meta.
+    seastar::abort_source& session_abort_source() const {
+        return _topology_guard.abort_source();
+    }
     const std::optional<repair_sync_boundary>& current_sync_boundary() const {
         return _current_sync_boundary;
     }
@@ -3900,7 +3905,10 @@ repair_service::insert_repair_meta(
         rlogger.debug("insert_repair_meta: Inserted repair_meta_id {} for node {}", id.repair_meta_id, id.ip);
     }
     if (topo_guard != service::null_topology_guard) {
-        auto& session_as = service::get_topology_session_manager().get_session_abort_source(topo_guard);
+        // Obtain the session's abort_source through the guard that rm already
+        // holds (rm->_topology_guard). The guard keeps the session alive, so the
+        // returned reference is safe to use here.
+        auto& session_as = rm->session_abort_source();
         auto sub = session_as.subscribe([this, id, topo_guard] () noexcept {
             auto it = repair_meta_map().find(id);
             if (it == repair_meta_map().end()) {

--- a/service/session.cc
+++ b/service/session.cc
@@ -38,14 +38,6 @@ session::guard session_manager::enter_session(session_id id) {
     return guard;
 }
 
-seastar::abort_source& session_manager::get_session_abort_source(session_id id) {
-    auto i = _sessions.find(id);
-    if (i == _sessions.end()) {
-        throw std::runtime_error(fmt::format("Session not found: {}", id));
-    }
-    return i->second->abort_source();
-}
-
 void session_manager::create_session(session_id id) {
     auto [i, created] = _sessions.emplace(id, std::make_unique<session>(id));
     if (created) {

--- a/service/session.hh
+++ b/service/session.hh
@@ -71,6 +71,12 @@ public:
         [[nodiscard]] bool valid() const {
             return !_session->_closed;
         }
+
+        /// Returns the abort_source of the session this guard belongs to.
+        /// Safe because the guard keeps the session alive.
+        seastar::abort_source& abort_source() const noexcept {
+            return _session->abort_source();
+        }
     };
 
     explicit session(session_id id) : _id(id), _gate("session") {}
@@ -123,10 +129,6 @@ public:
     session_manager();
 
     session::guard enter_session(session_id id);
-
-    /// Returns the abort_source associated with a session.
-    /// Throws if the session does not exist.
-    seastar::abort_source& get_session_abort_source(session_id id);
 
     /// Creates a session on this shard if it doesn't exist yet.
     /// If the session already exists does nothing.

--- a/service/topology_guard.hh
+++ b/service/topology_guard.hh
@@ -64,6 +64,12 @@ public:
     void check() {
         return _guard.check();
     }
+
+    /// Returns the abort_source of the session backing this guard.
+    /// Safe because the guard keeps the session alive.
+    seastar::abort_source& abort_source() const noexcept {
+        return _guard.abort_source();
+    }
 };
 
 static_assert(TopologyGuard<session_topology_guard>);

--- a/test/boost/sessions_test.cc
+++ b/test/boost/sessions_test.cc
@@ -112,7 +112,7 @@ SEASTAR_TEST_CASE(test_session_abort_source_unblocks_drain) {
         BOOST_REQUIRE(guard->valid());
 
         // Subscribe to the session's abort_source (as insert_repair_meta does)
-        auto& session_as = mgr.get_session_abort_source(id);
+        auto& session_as = guard->abort_source();
         BOOST_REQUIRE(!session_as.abort_requested());
 
         bool aborted = false;
@@ -143,9 +143,12 @@ SEASTAR_TEST_CASE(test_session_abort_source_already_closed) {
         auto id = session_id(utils::make_random_uuid());
         mgr.create_session(id);
 
-        mgr.initiate_close_of_sessions_except({});
+        // Hold a guard so we can access the abort_source; the guard keeps the
+        // session alive, which is the precondition for abort_source() access.
+        auto guard = std::make_optional<session::guard>(mgr.enter_session(id));
+        auto& session_as = guard->abort_source();
 
-        auto& session_as = mgr.get_session_abort_source(id);
+        mgr.initiate_close_of_sessions_except({});
         BOOST_REQUIRE(session_as.abort_requested());
 
         // Subscribing after abort returns empty subscription
@@ -156,6 +159,8 @@ SEASTAR_TEST_CASE(test_session_abort_source_already_closed) {
         BOOST_REQUIRE(!sub);
         BOOST_REQUIRE(!called);
 
+        // Release the guard so drain can complete.
+        guard.reset();
         mgr.drain_closing_sessions().get();
     });
 }
@@ -174,7 +179,7 @@ SEASTAR_TEST_CASE(test_session_abort_source_already_closed_requires_immediate_cl
 
         mgr.initiate_close_of_sessions_except({});
 
-        auto& session_as = mgr.get_session_abort_source(id);
+        auto& session_as = guard->abort_source();
         BOOST_REQUIRE(session_as.abort_requested());
 
         bool called = false;
@@ -205,7 +210,7 @@ SEASTAR_TEST_CASE(test_session_abort_source_drain_blocks_without_release) {
         auto guard = std::make_optional<session::guard>(mgr.enter_session(id));
 
         // Subscribe but do NOT release the guard in the callback
-        auto& session_as = mgr.get_session_abort_source(id);
+        auto& session_as = guard->abort_source();
         bool aborted = false;
         auto sub = session_as.subscribe([&] () noexcept {
             aborted = true;


### PR DESCRIPTION
get_session_abort_source(session_id) returned a bare abort_source& looked up by id. The reference is only valid while the session exists, and the session is kept alive by a session::guard, not by the id. Without a guard the reference can dangle once the session closes.

Expose abort_source() on session::guard and session_topology_guard instead, and drop the id-based lookup. insert_repair_meta() now gets it from the guard the repair_meta already holds (rm->_topology_guard), so the object that pins the session is the same one that subscribes to its abort_source.

No functional change. Follow-up to "repair: Abort follower repair_meta on session close".

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1805

Backports to 2026.1 and 2026.2.