### PR TITLE
[Backport 2026.2] db/view/view_building: replace system keyspace functions with mutation builder

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -9,6 +9,7 @@
 
 #include "db/schema_tables.hh"
 
+#include "db/view/view_building_task_mutation_builder.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
 #include "gms/feature_service.hh"
@@ -1800,7 +1801,8 @@ static void make_update_indices_mutations(
         utils::chunked_vector<mutation>& mutations)
 {
     mutation indices_mutation(indexes(), partition_key::from_singular(*indexes(), old_table->ks_name()));
-    std::vector<mutation> view_building_muts;
+    view::view_building_task_mutation_builder vb_mut_builder(timestamp);
+    std::vector<mutation> view_status_muts;
 
     auto diff = difference(old_table->all_indices(), new_table->all_indices());
     auto& db = sp.local_db();
@@ -1835,8 +1837,7 @@ static void make_update_indices_mutations(
                     }
 
                     for (auto& [id, _]: replica_tasks.view_tasks.at(view->id())) {
-                        auto mut = sys_ks.make_remove_view_building_task_mutation(timestamp, id).get();
-                        view_building_muts.push_back(std::move(mut));
+                        vb_mut_builder.del_task(id);
                         slogger.trace("Aborting view building task with ID: {} because the index is being dropped", id);
                     }
                 }
@@ -1844,7 +1845,7 @@ static void make_update_indices_mutations(
 
             // Remove entries from `system.view_build_status_v2`
             auto build_status_mut = sys_ks.make_remove_view_build_status_mutation(timestamp, {view->ks_name(), view->cf_name()}).get();
-            view_building_muts.push_back(std::move(build_status_mut));
+            view_status_muts.push_back(std::move(build_status_mut));
         }
     }
 
@@ -1863,7 +1864,8 @@ static void make_update_indices_mutations(
     }
 
     mutations.emplace_back(std::move(indices_mutation));
-    mutations.insert(mutations.end(), std::make_move_iterator(view_building_muts.begin()), std::make_move_iterator(view_building_muts.end()));
+    mutations.emplace_back(vb_mut_builder.build());
+    mutations.insert(mutations.end(), std::make_move_iterator(view_status_muts.begin()), std::make_move_iterator(view_status_muts.end()));
 }
 
 static void add_drop_column_to_mutations(schema_ptr table, const sstring& name, const schema::dropped_column& dc, api::timestamp_type timestamp, utils::chunked_vector<mutation>& mutations) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2783,16 +2783,6 @@ future<db::view::building_tasks> system_keyspace::get_view_building_tasks() {
     co_return tasks;
 }
 
-future<mutation> system_keyspace::make_remove_view_building_task_mutation(api::timestamp_type ts, utils::UUID id) {
-    static const sstring stmt = format("DELETE FROM {}.{} WHERE key = '{}' AND id = ?", NAME, VIEW_BUILDING_TASKS, VIEW_BUILDING_KEY);
-
-    auto muts = co_await _qp.get_mutations_internal(stmt, internal_system_query_state(), ts, {id});
-    if (muts.size() != 1) {
-        on_internal_error(slogger, fmt::format("expected 1 mutation got {}", muts.size()));
-    }
-    co_return std::move(muts[0]);
-}
-
 static constexpr auto VIEW_BUILDING_PROCESSING_BASE_ID_KEY = "view_building_processing_base_id";
 
 future<std::optional<table_id>> system_keyspace::get_view_building_processing_base_id() {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2783,28 +2783,6 @@ future<db::view::building_tasks> system_keyspace::get_view_building_tasks() {
     co_return tasks;
 }
 
-future<mutation> system_keyspace::make_view_building_task_mutation(api::timestamp_type ts, const db::view::view_building_task& task) {
-    static const sstring stmt = format("INSERT INTO {}.{}(key, id, type, aborted, base_id, view_id, last_token, host_id, shard) VALUES ('{}', ?, ?, ?, ?, ?, ?, ?, ?)", NAME, VIEW_BUILDING_TASKS, VIEW_BUILDING_KEY);
-    using namespace db::view;
-
-    data_value_or_unset view_id = unset_value{};
-    if (task.type == db::view::view_building_task::task_type::build_range) {
-        if (!task.view_id) {
-            on_internal_error(slogger, fmt::format("view_id is not set for build_range task with id: {}", task.id));
-        }
-        view_id = data_value(task.view_id->uuid());
-    }
-    auto muts = co_await _qp.get_mutations_internal(stmt, internal_system_query_state(), ts, {
-            task.id, task_type_to_sstring(task.type), task.aborted,
-            task.base_id.uuid(), view_id, dht::token::to_int64(task.last_token),
-            task.replica.host.uuid(), int32_t(task.replica.shard)
-    });
-    if (muts.size() != 1) {
-        on_internal_error(slogger, fmt::format("expected 1 mutation got {}", muts.size()));
-    }
-    co_return std::move(muts[0]);
-}
-
 future<mutation> system_keyspace::make_remove_view_building_task_mutation(api::timestamp_type ts, utils::UUID id) {
     static const sstring stmt = format("DELETE FROM {}.{} WHERE key = '{}' AND id = ?", NAME, VIEW_BUILDING_TASKS, VIEW_BUILDING_KEY);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -573,7 +573,6 @@ public:
 
     // system.view_building_tasks
     future<db::view::building_tasks> get_view_building_tasks();
-    future<mutation> make_remove_view_building_task_mutation(api::timestamp_type ts, utils::UUID id);
 
     // system.scylla_local, view_building_processing_base key
     future<std::optional<table_id>> get_view_building_processing_base_id();

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -573,7 +573,6 @@ public:
 
     // system.view_building_tasks
     future<db::view::building_tasks> get_view_building_tasks();
-    future<mutation> make_view_building_task_mutation(api::timestamp_type ts, const db::view::view_building_task& task);
     future<mutation> make_remove_view_building_task_mutation(api::timestamp_type ts, utils::UUID id);
 
     // system.scylla_local, view_building_processing_base key

--- a/db/view/view_building_task_mutation_builder.cc
+++ b/db/view/view_building_task_mutation_builder.cc
@@ -52,6 +52,19 @@ view_building_task_mutation_builder& view_building_task_mutation_builder::del_ta
     return *this;
 }
 
+view_building_task_mutation_builder& view_building_task_mutation_builder::set_task(db::view::view_building_task& task) {
+    auto id = task.id;
+    set_type(id, task.type);
+    set_aborted(id, task.aborted);
+    set_base_id(id, task.base_id);
+    if (task.view_id) {
+        set_view_id(id, *task.view_id);
+    }
+    set_last_token(id, task.last_token);
+    set_replica(id, task.replica);
+    return *this;
+}
+
 }
 
 }

--- a/db/view/view_building_task_mutation_builder.hh
+++ b/db/view/view_building_task_mutation_builder.hh
@@ -38,6 +38,7 @@ public:
     view_building_task_mutation_builder& set_last_token(utils::UUID id, dht::token last_token);
     view_building_task_mutation_builder& set_replica(utils::UUID id, const locator::tablet_replica& replica);
     view_building_task_mutation_builder& del_task(utils::UUID id);
+    view_building_task_mutation_builder& set_task(db::view::view_building_task& task);
 
     mutation build() {
         return std::move(_m);

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "db/view/view_building_worker.hh"
+#include "db/view/view_building_task_mutation_builder.hh"
 #include "db/view/view_consumer.hh"
 #include "dht/token.hh"
 #include "replica/database.hh"
@@ -273,8 +274,8 @@ future<> view_building_worker::create_staging_sstable_tasks() {
     shards.erase(0); // We're already holding shard0 lock
     auto locks = co_await lock_staging_mutex_on_multiple_shards(std::move(shards));
 
-    utils::chunked_vector<canonical_mutation> cmuts;
     auto guard = co_await _group0.client().start_operation(_as);
+    view_building_task_mutation_builder builder(guard.write_timestamp());
     auto my_host_id = _db.get_token_metadata().get_topology().my_host_id();
     for (auto& [table_id, sst_infos]: _sstables_to_register) {
         for (auto& sst_info: sst_infos) {
@@ -282,12 +283,13 @@ future<> view_building_worker::create_staging_sstable_tasks() {
                 utils::UUID_gen::get_time_UUID(), view_building_task::task_type::process_staging, false,
                 table_id, ::table_id{}, {my_host_id, sst_info.shard}, sst_info.last_token
             };
-            auto mut = co_await _sys_ks.make_view_building_task_mutation(guard.write_timestamp(), task);
-            cmuts.emplace_back(std::move(mut));
+            builder.set_task(task);
+            vbw_logger.trace("Creating process staging task: {} with ID: {} for replica: {}", task, task.id, task.replica);
         }
     }
 
-    vbw_logger.debug("Creating {} process_staging view_building_tasks", cmuts.size());
+    utils::chunked_vector<canonical_mutation> cmuts;
+    cmuts.emplace_back(builder.build());
     auto cmd = _group0.client().prepare_command(service::write_mutations{std::move(cmuts)}, guard, "create view building tasks");
     co_await _group0.client().add_entry(std::move(cmd), std::move(guard), _as);
 

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -17,6 +17,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "auth/resource.hh"
+#include "db/view/view_building_task_mutation_builder.hh"
 #include "locator/host_id.hh"
 #include "schema/schema_registry.hh"
 #include "service/migration_manager.hh"
@@ -794,12 +795,12 @@ static future<> add_view_building_tasks_mutations(storage_proxy& sp, view_ptr vi
     using namespace db::view;
 
     auto& db = sp.local_db();
-    auto& sys_ks = sp.system_keyspace();
 
     auto base_id = view->view_info()->base_id();
     auto& base_cf = db.find_column_family(base_id);
     auto erm = base_cf.get_effective_replication_map();
     auto& tablet_map = erm->get_token_metadata().tablets().get_tablet_map(base_id);
+    db::view::view_building_task_mutation_builder builder(ts);
 
     co_await tablet_map.for_each_tablet([&] (auto tid, const auto& tablet_info) -> future<> {
         auto last_token = tablet_map.get_last_token(tid);
@@ -810,11 +811,12 @@ static future<> add_view_building_tasks_mutations(storage_proxy& sp, view_ptr vi
                 base_id, view->id(), replica, last_token
             };
 
-            auto mut = co_await sys_ks.make_view_building_task_mutation(ts, task);
-            out.push_back(std::move(mut));
+            builder.set_task(task);
             mlogger.trace("Creating view building task: {} with ID: {} for replica: {}", task, id, replica);
         }
+        co_return;
     });
+    out.emplace_back(builder.build());
 }
 
 future<utils::chunked_vector<mutation>> prepare_new_view_announcement(storage_proxy& sp, view_ptr view, api::timestamp_type ts) {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -676,13 +676,13 @@ static future<> add_cleanup_view_building_state_drop_keyspace_mutations(storage_
     using namespace db::view;
     mlogger.info("Cleaning view building state for all views in keyspace {} ", ks_meta->name());
 
+    db::view::view_building_task_mutation_builder builder(ts);
     auto& sys_ks = sp.system_keyspace();
     auto& vb_state_machine = sp.view_building_state_machine();
 
-    auto drop_all_tasks_in_task_map = [&] (const task_map& task_map) -> future<> {
+    auto drop_all_tasks_in_task_map = [&] (const task_map& task_map) {
         for (auto& [id, _]: task_map) {
-            auto mut = co_await sys_ks.make_remove_view_building_task_mutation(ts, id);
-            out.push_back(std::move(mut));
+            builder.del_task(id);
             mlogger.trace("Aborting view building task with ID: {} because the keyspace is being dropped", id);
         }
     };
@@ -696,9 +696,9 @@ static future<> add_cleanup_view_building_state_drop_keyspace_mutations(storage_
 
         for (auto [_, replica_tasks]: vb_state_machine.building_state.tasks_state.at(tid)) {
             for (auto& [_, views_tasks]: replica_tasks.view_tasks) {
-                co_await drop_all_tasks_in_task_map(views_tasks);
+                drop_all_tasks_in_task_map(views_tasks);
             }
-            co_await drop_all_tasks_in_task_map(replica_tasks.staging_tasks);
+            drop_all_tasks_in_task_map(replica_tasks.staging_tasks);
         }
     }
 
@@ -707,6 +707,7 @@ static future<> add_cleanup_view_building_state_drop_keyspace_mutations(storage_
         auto build_status_mut = co_await sys_ks.make_remove_view_build_status_mutation(ts, {view->ks_name(), view->cf_name()});
         out.push_back(std::move(build_status_mut));
     }
+    out.emplace_back(builder.build());
 }
 
 future<utils::chunked_vector<mutation>> prepare_keyspace_drop_announcement(storage_proxy& sp, const sstring& ks_name, api::timestamp_type ts) {
@@ -871,6 +872,7 @@ static future<> add_cleanup_view_building_state_drop_view_mutations(storage_prox
     using namespace db::view;
     mlogger.info("Cleaning view building state for view {} ({}.{})", view->id(), view->ks_name(), view->cf_name());
 
+    db::view::view_building_task_mutation_builder builder(ts);
     auto& sys_ks = sp.system_keyspace();
     auto& vb_state_machine = sp.view_building_state_machine();
 
@@ -884,8 +886,7 @@ static future<> add_cleanup_view_building_state_drop_view_mutations(storage_prox
 
             // Abort all view building tasks for this view
             for (auto& [id, _]: replica_tasks.view_tasks.at(view->id())) {
-                auto mut = co_await sys_ks.make_remove_view_building_task_mutation(ts, id);
-                out.push_back(std::move(mut));
+                builder.del_task(id);
                 mlogger.trace("Aborting view building task with ID: {} because the view is being dropped", id);
             }
         }
@@ -894,6 +895,7 @@ static future<> add_cleanup_view_building_state_drop_view_mutations(storage_prox
     // Remove entries from `system.view_build_status_v2`
     auto build_status_mut = co_await sys_ks.make_remove_view_build_status_mutation(ts, {view->ks_name(), view->cf_name()});
     out.push_back(std::move(build_status_mut));
+    out.emplace_back(builder.build());
 }
 
 future<utils::chunked_vector<mutation>> prepare_view_drop_announcement(storage_proxy& sp, const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts) {


### PR DESCRIPTION
`system.view_building_tasks` is a single partition table, so it makes more sense to use a mutation builder and generate 1 mutation per group0 command instead of generating multiple mutations.

This PR removes all `make_..._mutation()` system keyspace functions related to view building tasks and replaces them with mutation builder.

Refs https://github.com/scylladb/scylladb/issues/25929
Fixes SCYLLADB-2647

This patch reduces size of changes to `system.view_building_tasks` significantly, so we should backport it. 

- (cherry picked from commit https://github.com/scylladb/scylladb/commit/4227cab5cbbe85a1aa9d6baba5ef31930157a164)
- (cherry picked from commit https://github.com/scylladb/scylladb/commit/e002665aa706ae04f16325bda80f65c92063a818)
- (skipped commit https://github.com/scylladb/scylladb/commit/2561cc154677eb2533ba6f7cb7519799d4679e54 - not required)
- (cherry picked from commit https://github.com/scylladb/scylladb/commit/1a32ccd8f66b68ebc8d3fc2ea53ab1017dad7631)

Parent PR: https://github.com/scylladb/scylladb/pull/26557