### PR TITLE
ci: scylla-ci-route: run only scylla_gdb suite for gdb-only PRs

### DIFF
--- a/.github/workflows/scylla-ci-route.yaml
+++ b/.github/workflows/scylla-ci-route.yaml
@@ -255,14 +255,28 @@ jobs:
             ARTIFACTS_REQUIRED=false
           fi
 
-          # scylla_gdb: required if any file matches scylla-gdb.py or test/scylla_gdb/*
+          # scylla_gdb: run ONLY the scylla_gdb suite if EVERY changed file matches
+          # scylla-gdb.py or test/scylla_gdb/* (RELENG-638). A PR changing only
+          # scylla-gdb.py is treated the same as one changing only test/scylla_gdb.
           GDB_REQUIRED=false
+          GDB_HAS_FILES=false
+          GDB_ONLY=true
           while IFS= read -r FILE; do
-            if echo "$FILE" | grep -qE '^(scylla-gdb\.py|test/scylla_gdb/)'; then
-              GDB_REQUIRED=true
+            [ -z "$FILE" ] && continue
+            GDB_HAS_FILES=true
+            if ! echo "$FILE" | grep -qE '^(scylla-gdb\.py|test/scylla_gdb/)'; then
+              GDB_ONLY=false
               break
             fi
           done <<< "$ALL_FILES"
+          if [ "$GDB_HAS_FILES" = "true" ] && [ "$GDB_ONLY" = "true" ]; then
+            GDB_REQUIRED=true
+            # Run only the scylla_gdb suite: RUN_UNIT_TEST must be false so scylla-ci
+            # restricts the run to includeTests=scylla_gdb instead of all unit tests.
+            DTEST_REQUIRED=false
+            UNITTEST_REQUIRED=false
+            ARTIFACTS_REQUIRED=false
+          fi
 
           echo "build_required=$BUILD_REQUIRED" >> "$GITHUB_OUTPUT"
           echo "dtest_required=$DTEST_REQUIRED" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The gdb detection used "any file matches" semantics and set
RUN_ONLY_SCYLLA_GDB whenever a PR merely touched scylla-gdb.py or
test/scylla_gdb/, even alongside other source changes. It also still
passed dtest/unittest/artifacts as required, so the downstream job ran
the full matrix instead of only the scylla_gdb suite.

Set RUN_ONLY_SCYLLA_GDB only when EVERY changed file is gdb-related, and
suppress dtest/unittest/artifacts in that case so scylla-ci runs only the
scylla_gdb suite. A PR changing only scylla-gdb.py is now treated the
same as one changing only test/scylla_gdb.

Fixes: https://scylladb.atlassian.net/browse/RELENG-638

**The scylla-ci-route.yaml is not yet activate, we need to backport to all releases so once we activate it will work**