### PR TITLE
message/messaging_service: cleanup stale _host_connection entries

### DIFF
--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -537,6 +537,27 @@ messaging_service::messaging_service(config cfg, scheduling_config scfg, std::sh
             ci.attach_auxiliary("baddr", broadcast_address);
             ci.attach_auxiliary("src_cpu_id", src_cpu_id);
             ci.attach_auxiliary("max_result_size", max_result_size.value_or(query::result_memory_limiter::maximum_result_size));
+            // Erase stale entries for this peer before inserting the new one.
+            // Connections are removed from rpc::server::_conns on natural TCP teardown,
+            // but _host_connections has no such hook, so stale entries accumulate and
+            // trigger oversized rehash allocations in large clusters (SCYLLADB-2532).
+            {
+                auto [b, e] = _host_connections.equal_range(peer_host_id);
+                while (b != e) {
+                    const auto& conn_ref = b->second;
+                    bool is_live = false;
+                    conn_ref.server.foreach_connection([&](const rpc::server::connection& c) {
+                        if (c.get_connection_id() == conn_ref.conn_id) {
+                            is_live = true;
+                        }
+                    });
+                    if (!is_live) {
+                        b = _host_connections.erase(b);
+                    } else {
+                        ++b;
+                    }
+                }
+            }
             _host_connections.emplace(peer_host_id, connection_ref {
                 .server = ci.server,
                 .conn_id = ci.conn_id,


### PR DESCRIPTION
_host_connections is std::multimap<host_id, connection_ref>, to support multiple connections per host. On disconnect-reconnect cycles, entries in this map are never cleared, so with a lot of such cycles the map can get really large. This was observed to happen in testing, where the map got so bit that it triggered oversized-allocation warning on emplace(). When adding a new connection, first check the existing entries in the map an drop any stale ones to prevent onbounded growth.

Fixes: SCYLLADB-2532

Bug affects all versions, but it is rare, I propose not to backport, at least not immediately