### PR TITLE
raft: add a preferred tablet group leader for strongly consistent keyspaces

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2708,17 +2708,13 @@ convert_extended_property_map(const collection_constructor& map, error_sink_fn a
             break;
         }
         auto right_str = expr::as_if<untyped_constant>(&entry_tuple->elements[1]);
+        const auto left_text = left->raw_text.linearize();
+        utils::property_value value;
         if (right_str) {
-            const auto left_text = left->raw_text.linearize();
-            const auto right_text = right_str->raw_text.linearize();
-            if (!res.emplace(left_text, right_text).second) {
-                sstring msg = fmt::format("Multiple definition for property {}", left_text);
-                add_recognition_error(msg);
-                break;
-            }
+            value = right_str->raw_text.linearize();
         } else {
-            auto right_vec = expr::as_if<collection_constructor>(&entry_tuple->elements[1]);
-            if (!right_vec) {
+            auto right_coll = expr::as_if<collection_constructor>(&entry_tuple->elements[1]);
+            if (!right_coll) {
                 sstring msg = fmt::format("Invalid property value: {} for property: {}", entry_tuple->elements[1], entry_tuple->elements[0]);
                 if (expr::is<bind_variable>(entry_tuple->elements[1])) {
                     msg += " (bind variables are not supported in DDL queries)";
@@ -2726,24 +2722,30 @@ convert_extended_property_map(const collection_constructor& map, error_sink_fn a
                 add_recognition_error(msg);
                 break;
             }
-            auto values = right_vec->elements | std::views::transform([&] (const auto& x) -> sstring {
-                auto elem = expr::as_if<untyped_constant>(&x);
-                if (!elem) {
-                    sstring msg = fmt::format("Invalid property vector value: {} for property: {}", x, entry_tuple->elements[0]);
-                    if (expr::is<bind_variable>(x)) {
-                        msg += " (bind variables are not supported in DDL queries)";
+            if (right_coll->style == collection_constructor::style_type::map) {
+                // Nested map value: convert inner map to map<sstring, sstring>
+                value = convert_property_map(*right_coll, add_recognition_error);
+            } else {
+                // List/vector value
+                value = right_coll->elements | std::views::transform([&] (const auto& x) -> sstring {
+                    auto elem = expr::as_if<untyped_constant>(&x);
+                    if (!elem) {
+                        sstring msg = fmt::format("Invalid property vector value: {} for property: {}", x, entry_tuple->elements[0]);
+                        if (expr::is<bind_variable>(x)) {
+                            msg += " (bind variables are not supported in DDL queries)";
+                        }
+                        add_recognition_error(msg);
+                        return "<invalid>";
                     }
-                    add_recognition_error(msg);
-                    return "<invalid>";
-                }
-                return elem->raw_text.linearize();
-            }) | std::ranges::to<utils::property_string_list>();
-            const auto left_text = left->raw_text.linearize();
-            if (!res.emplace(left_text, std::move(values)).second) {
-                sstring msg = fmt::format("Multiple definition for property {}", left_text);
-                add_recognition_error(msg);
-                break;
+                    return elem->raw_text.linearize();
+                }) | std::ranges::to<utils::property_string_list>();
             }
+        }
+
+        if (!res.emplace(left_text, std::move(value)).second) {
+            sstring msg = fmt::format("Multiple definition for property {}", left_text);
+            add_recognition_error(msg);
+            break;
         }
     }
     return res;

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2642,11 +2642,11 @@ split_aggregation(std::span<const expression> aggregation) {
     };
 }
 
-std::map<sstring, sstring> convert_property_map(const collection_constructor& map, error_sink_fn add_recognition_error) {
+::utils::property_string_map convert_property_map(const collection_constructor& map, error_sink_fn add_recognition_error) {
     if (map.elements.empty()) {
-        return std::map<sstring, sstring>{};
+        return utils::property_string_map{};
     }
-    std::map<sstring, sstring> res;
+    utils::property_string_map res;
     for (auto&& entry : map.elements) {
         auto entry_tuple = expr::as_if<tuple_constructor>(&entry);
         // Because the parser tries to be smart and recover on error (to
@@ -2684,12 +2684,12 @@ std::map<sstring, sstring> convert_property_map(const collection_constructor& ma
     return res;
 }
 
-std::map<sstring, std::variant<sstring, std::vector<sstring>>>
+::utils::extended_property_map
 convert_extended_property_map(const collection_constructor& map, error_sink_fn add_recognition_error) {
     if (map.elements.empty()) {
         return {};
     }
-    std::map<sstring, std::variant<sstring, std::vector<sstring>>> res;
+    utils::extended_property_map res;
     for (auto&& entry : map.elements) {
         auto entry_tuple = expr::as_if<tuple_constructor>(&entry);
         // Because the parser tries to be smart and recover on error (to
@@ -2737,7 +2737,7 @@ convert_extended_property_map(const collection_constructor& map, error_sink_fn a
                     return "<invalid>";
                 }
                 return elem->raw_text.linearize();
-            }) | std::ranges::to<std::vector<sstring>>();
+            }) | std::ranges::to<utils::property_string_list>();
             const auto left_text = left->raw_text.linearize();
             if (!res.emplace(left_text, std::move(values)).second) {
                 sstring msg = fmt::format("Multiple definition for property {}", left_text);

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -20,6 +20,7 @@
 #include "seastarx.hh"
 #include "cql3/values.hh"
 #include "utils/chunked_string.hh"
+#include "utils/property.hh"
 
 class row;
 
@@ -450,9 +451,9 @@ struct collection_constructor {
 // Called with error message string.
 using error_sink_fn = std::function<void(const std::string&)>;
 
-std::map<sstring, sstring> convert_property_map(const collection_constructor&, error_sink_fn);
+utils::property_string_map convert_property_map(const collection_constructor&, error_sink_fn);
 
-std::map<sstring, std::variant<sstring, std::vector<sstring>>>
+utils::extended_property_map
 convert_extended_property_map(const collection_constructor&, error_sink_fn);
 
 // Constructs an object of a user-defined type

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -20,6 +20,8 @@
 #include "exceptions/exceptions.hh"
 #include "gms/feature_service.hh"
 #include "db/config.hh"
+#include "utils/overloaded_functor.hh"
+#include "utils/on_internal_error.hh"
 #include <random>
 
 namespace cql3 {
@@ -322,10 +324,15 @@ void ks_prop_defs::validate() {
 
 locator::replication_strategy_config_options ks_prop_defs::get_replication_options() const {
     auto replication_options = get_extended_map(KW_REPLICATION);
-    if (replication_options) {
-        return replication_options.value();
+    if (!replication_options) {
+        return {};
     }
-    return {};
+    if (std::any_of(replication_options->begin(), replication_options->end(), [] (const auto& opt) {
+        return std::holds_alternative<map_type>(opt.second);
+    })) {
+        throw exceptions::configuration_exception("Cannot specify replication options as a map");
+    }
+    return *replication_options;
 }
 
 data_dictionary::storage_options ks_prop_defs::get_storage_options() const {

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -467,6 +467,15 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(s
 }
 
 lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm, const gms::feature_service& feat, const db::config& cfg) {
+    // Switching a keyspace to or from strong consistency would have to move the data it
+    // already holds between two write paths, so the consistency option cannot be altered.
+    // Restating the value the keyspace already has is allowed, so that a keyspace can be
+    // described and altered back.
+    if (const auto consistency = get_consistency_option();
+            consistency && *consistency != old->consistency_option().value_or(data_dictionary::consistency_config{})) {
+        throw exceptions::invalid_request_exception("Cannot alter consistency option of a keyspace");
+    }
+
     locator::replication_strategy_config_options options;
     const auto& old_options = old->strategy_options();
     // if tablets options have not been specified, inherit them if it's tablets-enabled KS
@@ -483,7 +492,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
         sc = old->strategy_name();
         options = old_options;
     }
-    return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_consistency_option(), get_boolean(KW_DURABLE_WRITES, true), get_storage_options(), {}, old->next_strategy_options_opt());
+    return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, old->consistency_option(), get_boolean(KW_DURABLE_WRITES, true), get_storage_options(), {}, old->next_strategy_options_opt());
 }
 
 namespace {

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -390,13 +390,49 @@ std::optional<unsigned> ks_prop_defs::get_initial_tablets(std::optional<unsigned
     return initial_count;
 }
 
-std::optional<data_dictionary::consistency_config_option> ks_prop_defs::get_consistency_option() const {
-    auto value = get_simple(KW_CONSISTENCY);
-    if (value) {
-        return data_dictionary::consistency_config_option_from_string(value.value());
-    } else {
+std::optional<data_dictionary::consistency_config> ks_prop_defs::get_consistency_option() const {
+    // Support both legacy simple string format: consistency = 'global'
+    // and new map format: consistency = {'type': 'global', 'dedicated_rack': {'dc1': 'rack1'}}
+    auto raw_value = get(KW_CONSISTENCY);
+    if (!raw_value) {
         return std::nullopt;
     }
+
+    return std::visit(overloaded_functor{
+        [](const sstring& str) -> data_dictionary::consistency_config {
+            data_dictionary::consistency_config config;
+            config.type = data_dictionary::consistency_config_option_from_string(str);
+            return config;
+        },
+        [](const extended_map_type& map_value) -> data_dictionary::consistency_config {
+            data_dictionary::consistency_config config;
+            std::optional<data_dictionary::consistency_config_option> consistency_type = std::nullopt;
+            for (const auto& [key, value] : map_value) {
+                if (key == "type") {
+                    if (!std::holds_alternative<sstring>(value)) {
+                        throw exceptions::configuration_exception("consistency 'type' must be a string value");
+                    }
+                    consistency_type = data_dictionary::consistency_config_option_from_string(std::get<sstring>(value));
+                    continue;
+                }
+                if (key == "dedicated_rack") {
+                    if (!std::holds_alternative<map_type>(value)) {
+                        throw exceptions::configuration_exception(
+                            "consistency 'dedicated_rack' must be a map of datacenter to rack name, e.g. {'dc1': 'rack1'}");
+                    }
+                    config.dedicated_rack = std::get<map_type>(value);
+                    continue;
+                }
+                throw exceptions::configuration_exception(
+                    fmt::format("Unrecognized consistency option '{}'. Valid options are: 'type', 'dedicated_rack'", key));
+            }
+            if (!consistency_type) {
+                throw exceptions::configuration_exception("consistency option requires a 'type' field");
+            }
+            config.type = *consistency_type;
+            return config;
+        }
+    }, *raw_value);
 }
 
 std::optional<sstring> ks_prop_defs::get_replication_strategy_class() const {

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -76,7 +76,7 @@ public:
     std::optional<sstring> get_replication_strategy_class() const;
     void set_default_replication_strategy_class_option();
     std::optional<unsigned> get_initial_tablets(std::optional<unsigned> default_value, bool enforce_tablets = false) const;
-    std::optional<data_dictionary::consistency_config_option> get_consistency_option() const;
+    std::optional<data_dictionary::consistency_config> get_consistency_option() const;
     data_dictionary::storage_options get_storage_options() const;
     bool get_durable_writes() const;
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&, const gms::feature_service&, const db::config&);

--- a/cql3/statements/property_definitions.cc
+++ b/cql3/statements/property_definitions.cc
@@ -85,13 +85,15 @@ std::optional<property_definitions::map_type> property_definitions::get_map(cons
 }
 
 property_definitions::map_type property_definitions::to_simple_map(const extended_map_type& xmap) {
-    return xmap | std::views::transform([](const auto& x) {
+    return xmap | std::views::transform([](const auto& x) -> std::pair<sstring, sstring> {
         // Convert each pair to a string key and value
-        try {
-            return std::make_pair(x.first, std::get<sstring>(x.second));
-        } catch (const std::bad_variant_access& e) {
+        if (auto* str = std::get_if<sstring>(&x.second)) {
+            return std::make_pair(x.first, *str);
+        }
+        if (std::holds_alternative<list_type>(x.second)) {
             throw exceptions::syntax_exception(seastar::format("Invalid map value '{}' for key '{}'. It should be a simple string.", std::get<list_type>(x.second), x.first));
         }
+        throw exceptions::syntax_exception(seastar::format("Invalid map value for key '{}'. It should be a simple string, not a nested map.", x.first));
     }) | std::ranges::to<map_type>();
 }
 
@@ -247,6 +249,9 @@ property_definitions::map_type to_flattened_map(const property_definitions::exte
                         out[fmt::format("{}:{}", in_key, i)] = v;
                     }
                 }
+            },
+            [&] (const property_definitions::map_type&) {
+                throw std::invalid_argument(fmt::format("key '{}' has a nested map value which cannot be flattened", in_key));
             }
         }, in_value);
     }

--- a/cql3/statements/property_definitions.hh
+++ b/cql3/statements/property_definitions.hh
@@ -19,6 +19,7 @@
 #include <variant>
 
 #include "seastarx.hh"
+#include "utils/property.hh"
 
 namespace cql3 {
 
@@ -26,9 +27,9 @@ namespace statements {
 
 class property_definitions {
 public:
-    using map_type = std::map<sstring, sstring>;
-    using list_type = std::vector<sstring>;
-    using extended_map_type = std::map<sstring, std::variant<sstring, list_type>>;
+    using map_type = utils::property_string_map;
+    using list_type = utils::property_string_list;
+    using extended_map_type = utils::extended_property_map;
     using value_type = std::variant<sstring, extended_map_type>;
     using properties_map_type = std::unordered_map<sstring, value_type>;
 protected:

--- a/data_dictionary/consistency_config_options.hh
+++ b/data_dictionary/consistency_config_options.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include <seastar/core/sstring.hh>
 
 namespace data_dictionary {
@@ -20,4 +21,16 @@ enum class consistency_config_option : uint8_t {
 
 consistency_config_option consistency_config_option_from_string(const seastar::sstring& str);
 seastar::sstring consistency_config_option_to_string(consistency_config_option option);
+
+struct consistency_config {
+    consistency_config_option type = consistency_config_option::eventual;
+    std::map<seastar::sstring, seastar::sstring> dedicated_rack;
+
+    bool has_dedicated_rack() const {
+        return !dedicated_rack.empty();
+    }
+
+    bool operator==(const consistency_config&) const = default;
+};
+
 }

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -221,7 +221,7 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
              std::string_view strategy_name,
              locator::replication_strategy_config_options strategy_options,
              std::optional<unsigned> initial_tablets,
-             std::optional<consistency_config_option> consistency_option,
+             std::optional<consistency_config> consistency_option,
              bool durable_writes,
              std::vector<schema_ptr> cf_defs,
              user_types_metadata user_types,
@@ -235,7 +235,7 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
     , _durable_writes{durable_writes}
     , _user_types{std::move(user_types)}
     , _storage_options(make_lw_shared<storage_options>(std::move(storage_opts)))
-    , _consistency_option(consistency_option)
+    , _consistency_option(std::move(consistency_option))
 {
     for (auto&& s : cf_defs) {
         _cf_meta_data.emplace(s->cf_name(), s);
@@ -247,14 +247,45 @@ void keyspace_metadata::validate(const gms::feature_service& fs, const locator::
     locator::replication_strategy_params params(strategy_options(), initial_tablets(), consistency_option());
     auto strategy = locator::abstract_replication_strategy::create_replication_strategy(strategy_name(), params, topology);
     strategy->validate_options(fs, topology);
-    if (!params.initial_tablets && params.consistency.value_or(data_dictionary::consistency_config_option::eventual) != data_dictionary::consistency_config_option::eventual) {
+    if (!params.initial_tablets && params.consistency && params.consistency->type != data_dictionary::consistency_config_option::eventual) {
         throw exceptions::configuration_exception("Only eventual consistency is supported for non-tablet keyspaces");
     }
     if (params.consistency && !fs.strongly_consistent_tables) {
         throw exceptions::configuration_exception("The strongly_consistent_tables feature must be enabled to use a consistency option");
     }
-    if (params.consistency && *params.consistency == data_dictionary::consistency_config_option::local) {
+    if (params.consistency && params.consistency->type == data_dictionary::consistency_config_option::local) {
         throw exceptions::configuration_exception("Local consistency is not supported yet");
+    }
+    // Validate dedicated_rack: if specified, the replication for that DC must be rack-based
+    // and must contain the dedicated rack in its rack list.
+    if (_consistency_option && _consistency_option->has_dedicated_rack()) {
+        if (_consistency_option->type == data_dictionary::consistency_config_option::eventual) {
+            throw exceptions::configuration_exception("dedicated_rack is not allowed with eventual consistency");
+        }
+        if (_consistency_option->type == data_dictionary::consistency_config_option::global
+                && _consistency_option->dedicated_rack.size() > 1) {
+            throw exceptions::configuration_exception("Only a single dedicated_rack entry is supported with global consistency");
+        }
+        if (!params.initial_tablets) {
+            throw exceptions::configuration_exception("dedicated_rack requires tablets to be enabled");
+        }
+        for (const auto& [dc, rack] : _consistency_option->dedicated_rack) {
+            auto it = strategy_options().find(dc);
+            if (it == strategy_options().end()) {
+                throw exceptions::configuration_exception(
+                    fmt::format("dedicated_rack references datacenter '{}' which is not in the replication options", dc));
+            }
+            auto rf = locator::abstract_replication_strategy::parse_replication_factor(it->second);
+            if (!rf.is_rack_based()) {
+                throw exceptions::configuration_exception(
+                    fmt::format("dedicated_rack requires rack-based replication for datacenter '{}', but replication factor is numeric", dc));
+            }
+            const auto& rack_list = rf.get_rack_list();
+            if (std::find(rack_list.begin(), rack_list.end(), rack) == rack_list.end()) {
+                throw exceptions::configuration_exception(
+                    fmt::format("dedicated_rack '{}' is not in the replication rack list for datacenter '{}': {}", rack, dc, rack_list));
+            }
+        }
     }
 }
 
@@ -273,7 +304,7 @@ keyspace_metadata::new_keyspace(std::string_view name,
                                 std::string_view strategy_name,
                                 locator::replication_strategy_config_options options,
                                 std::optional<unsigned> initial_tablets,
-                                std::optional<consistency_config_option> consistency_option,
+                                std::optional<consistency_config> consistency_option,
                                 bool durables_writes,
                                 storage_options storage_opts,
                                 std::vector<schema_ptr> cf_defs,
@@ -597,7 +628,22 @@ cql3::description keyspace_metadata::describe(const replica::database& db, cql3:
         os << "} AND durable_writes = " << fmt::to_string(_durable_writes);
         if (db.features().tablets) {
             if (_consistency_option) {
-                os << " AND consistency = " << cql3::util::single_quote(consistency_config_option_to_string(*_consistency_option));
+                if (_consistency_option->has_dedicated_rack()) {
+                    os << " AND consistency = {'type': "
+                       << cql3::util::single_quote(consistency_config_option_to_string(_consistency_option->type))
+                       << ", 'dedicated_rack': {";
+                    bool first = true;
+                    for (const auto& [dc, rack] : _consistency_option->dedicated_rack) {
+                        if (!first) {
+                            os << ", ";
+                        }
+                        os << cql3::util::single_quote(dc) << ": " << cql3::util::single_quote(rack);
+                        first = false;
+                    }
+                    os << "}}";
+                } else {
+                    os << " AND consistency = " << cql3::util::single_quote(consistency_config_option_to_string(_consistency_option->type));
+                }
             }
             if (!_initial_tablets.has_value()) {
                 os << " AND tablets = {'enabled': false}";

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -16,6 +16,7 @@
 #include "schema/schema.hh"
 #include "cql3/util.hh"
 #include "gms/feature_service.hh"
+#include "utils/on_internal_error.hh"
 #include <fmt/core.h>
 #include <fmt/ranges.h>
 #include <fmt/std.h>
@@ -581,6 +582,9 @@ cql3::description keyspace_metadata::describe(const replica::database& db, cql3:
                         os << cql3::util::single_quote(*it);
                     }
                     os << "]";
+                },
+                [] (const locator::replication_strategy_config_map&) {
+                    on_internal_error(locator::rslogger, "replication strategy configuration map used in keyspace metadata description");
                 }
             }, opt.second);
         }

--- a/data_dictionary/keyspace_metadata.hh
+++ b/data_dictionary/keyspace_metadata.hh
@@ -36,13 +36,13 @@ class keyspace_metadata final {
     bool _durable_writes;
     user_types_metadata _user_types;
     lw_shared_ptr<const storage_options> _storage_options;
-    std::optional<consistency_config_option> _consistency_option;
+    std::optional<consistency_config> _consistency_option;
 public:
     keyspace_metadata(std::string_view name,
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options strategy_options,
                  std::optional<unsigned> initial_tablets,
-                 std::optional<consistency_config_option> consistency_option,
+                 std::optional<consistency_config> consistency_option,
                  bool durable_writes,
                  std::vector<schema_ptr> cf_defs = std::vector<schema_ptr>{},
                  user_types_metadata user_types = user_types_metadata{},
@@ -53,7 +53,7 @@ public:
                  std::string_view strategy_name,
                  locator::replication_strategy_config_options options,
                  std::optional<unsigned> initial_tablets,
-                 std::optional<consistency_config_option> consistency_option,
+                 std::optional<consistency_config> consistency_option,
                  bool durables_writes = true,
                  storage_options storage_opts = {},
                  std::vector<schema_ptr> cf_defs = {},
@@ -86,8 +86,14 @@ public:
     std::optional<unsigned> initial_tablets() const {
         return _initial_tablets;
     }
-    std::optional<data_dictionary::consistency_config_option> consistency_option() const {
+    std::optional<data_dictionary::consistency_config> consistency_option() const {
         return _consistency_option;
+    }
+    std::optional<data_dictionary::consistency_config_option> consistency_type() const {
+        if (_consistency_option) {
+            return _consistency_option->type;
+        }
+        return std::nullopt;
     }
     bool uses_tablets() const noexcept {
         return _initial_tablets.has_value();

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -232,6 +232,7 @@ schema_ptr scylla_keyspaces() {
             {"storage_options", map_type_impl::get_instance(utf8_type, utf8_type, false)},
             {"initial_tablets", int32_type},
             {"consistency", utf8_type},
+            {"dedicated_rack", map_type_impl::get_instance(utf8_type, utf8_type, false)},
         },
         // static columns
         {},
@@ -1198,7 +1199,10 @@ utils::chunked_vector<mutation> make_create_keyspace_mutations(schema_features f
         }
         auto consistency = keyspace->consistency_option();
         if (consistency) {
-            scylla_m.set_cell(ckey, "consistency", data_dictionary::consistency_config_option_to_string(*consistency), timestamp);
+            scylla_m.set_cell(ckey, "consistency", data_dictionary::consistency_config_option_to_string(consistency->type), timestamp);
+            if (consistency->has_dedicated_rack()) {
+                store_map(scylla_m, ckey, "dedicated_rack", timestamp, consistency->dedicated_rack);
+            }
         }
         mutations.emplace_back(std::move(scylla_m));
     }
@@ -1278,7 +1282,7 @@ future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(
 
     data_dictionary::storage_options storage_opts;
     std::optional<unsigned> initial_tablets;
-    std::optional<data_dictionary::consistency_config_option> consistency;
+    std::optional<data_dictionary::consistency_config> consistency;
     // Scylla-specific row will only be present if SCYLLA_KEYSPACES schema feature is available in the cluster
     if (scylla_specific_rs) {
         if (!scylla_specific_rs->empty()) {
@@ -1295,7 +1299,15 @@ future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(
             initial_tablets = row.get<int>("initial_tablets");
             auto copt = row.get<sstring>("consistency");
             if (copt) {
-                consistency = data_dictionary::consistency_config_option_from_string(*copt);
+                data_dictionary::consistency_config cfg;
+                cfg.type = data_dictionary::consistency_config_option_from_string(*copt);
+                auto dr = row.get<map_type_impl::native_type>("dedicated_rack");
+                if (dr) {
+                    for (const auto& entry : *dr) {
+                        cfg.dedicated_rack.emplace(value_cast<sstring>(entry.first), value_cast<sstring>(entry.second));
+                    }
+                }
+                consistency = std::move(cfg);
             }
         }
     }

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -332,6 +332,37 @@ consistency is guaranteed for operations going to all DCs. Note that
 `local` or `global` consistencies are guaranteed only for requests that
 are going to the same partition.
 
+The option accepts either the consistency type alone (``consistency = 'global'``),
+or a map, which sets the type together with additional options::
+
+  CREATE KEYSPACE ks
+   WITH consistency = { 'type': 'global', 'dedicated_rack': { 'dc1': 'rack1' } }
+   AND replication = { 'class': 'NetworkTopologyStrategy', 'dc1': ['rack1', 'rack2', 'rack3'] };
+
+``dedicated_rack`` names the rack whose replicas should serve the keyspace's
+requests. A strongly consistent request is served by the leader of the tablet's
+Raft group, so the nodes of the dedicated rack are preferred as leaders: whenever
+a group holds an election, its replica in that rack is the first to stand for it and
+normally wins. This saves a cross-rack hop for the clients in the rack.
+
+The preference is also restored once it is lost. A group whose dedicated-rack replica was
+unavailable elects another replica, and that replica hands the leadership back once the
+dedicated-rack one is up again and has caught up, so leadership returns to the rack
+without an operator having to intervene.
+
+The ``consistency`` option cannot be changed after the keyspace is created - neither the
+type nor the dedicated rack - because the data the keyspace already holds would have to
+move between two write paths. An ``ALTER KEYSPACE`` which restates the current value is
+accepted; one which would change it is rejected.
+
+``dedicated_rack`` requires:
+
+- the `global` consistency type, and tablets;
+- exactly one entry - a single datacenter with a single rack in it;
+- a datacenter which is listed in the ``replication`` options, replicated with a
+  :ref:`rack list <rack_list_rf>` rather than a numeric replication factor, and
+  a rack which is in that list.
+
 .. _use-statement:        
         
 USE

--- a/docs/dev/strong_consistency.md
+++ b/docs/dev/strong_consistency.md
@@ -238,3 +238,90 @@ survive on disk, so uncommitted entries are still available for replay on the ne
 
 This is important: if we decremented the dirty count on shutdown, the commitlog might
 delete segments containing uncommitted Raft entries that we still need.
+
+# Leader placement
+
+Reads and writes for a strongly consistent tablet go through the leader of its Raft
+group, so which replica leads decides how many hops a request takes. A caller can name
+the replicas it would rather see leading: the sections below bias elections towards them
+and bootstrap a fresh group on one of them.
+
+## Preferred replicas
+
+`fsm_config::get_priority_members` names the servers which should win an election, best
+first. `fsm::reset_election_timeout()` gives each of them a reserved slot - the first
+named server times out one tick after `ELECTION_TIMEOUT`, the second two ticks after, and
+so on - while the servers which are not named randomize over the slots that are left. A
+named server therefore starts campaigning before an unnamed one, and, alone in its slot,
+cannot split the vote with it. It is a bias rather than a guarantee: election timers run
+independently on each node, so a slow node can still be beaten to it.
+
+`raft::reserved_election_slots()` turns the list into that slot order, dropping the
+servers which cannot vote in the current configuration - they cannot win an election, so
+a slot for them would only delay the ones which can.
+
+Two things to keep in mind when building such a list:
+
+- leaving a server out is how it is deprioritized, and it is a stronger demotion than
+  naming it last, because the free slots sit behind all the reserved ones and are spread
+  over the rest of the range;
+- the list has to be a property of the group, identical on all its replicas. If two
+  replicas disagree they can reserve the same slot and split a vote, which costs an
+  election round.
+
+The callback is invoked whenever the election timer is armed, so its answer may follow
+state which changes while the group runs. In exchange it runs in the fsm's synchronous
+context and must neither block nor throw.
+
+## The dedicated rack
+
+`groups_manager::dedicated_rack_replicas()` is the callback for tablet groups: if the
+keyspace sets `dedicated_rack` (see the `consistency` option in the CQL documentation),
+it names the tablet's replica in that rack, which is the cheapest one to serve a strongly
+consistent read from. There is at most one, because a rack list places one replica per
+rack. It is rebuilt on every arming, so a migrated tablet or a changed topology is picked
+up without restarting the group. Keyspaces without a dedicated rack name nobody and keep
+ordinary Raft, which spreads leadership over all the replicas.
+
+## Bootstrapping a fresh group
+
+A fresh group has no leader and no log, and waiting out an election timeout to get one is
+pure delay, so `raft::server` starts a single member as a candidate right away
+(`fsm_config::fast_bootstrap_seed`). That member is the holder of the first slot when the
+group has a preference - bootstrapping the leadership anywhere else would only make the
+group hand it over afterwards. Without a preference it is the voter at rank
+`seed % voters` in ascending `server_id` order, and `groups_manager` derives the seed from
+the group id, so that a table starting with many tablets spreads their initial leadership
+over its replicas instead of electing the smallest-id node everywhere.
+
+Note that a group is only bootstrapped this way while its log is empty, which a replica
+whose entries have all been applied also is - so a restarting replica may call an
+election and take the leadership from a healthy leader.
+
+## Handing the leadership over
+
+The slots steer elections, and a group holds an election only while it has no leader. Once
+it has one, nothing moves the leadership on its own: a follower which can see a live leader
+keeps resetting its election timer (`has_stable_leader()` in `fsm::tick()`) and never times
+out. A group which elected a leader outside the dedicated rack - because the replica there
+was down, behind, or just slower to campaign - would keep it for as long as it lives, since
+a healthy leader is never re-elected.
+
+So the leader settles it itself. Every `placement_check_interval` ticks
+`fsm::tick_leader()` looks for the first server which outranks it - one holding an earlier
+slot - and which the failure detector considers alive, and transfers the leadership there
+(`fsm::transfer_leadership_to()`). Passing over the ones which are gone matters once a
+caller names more than one server: the second choice should lead while the first is down.
+
+The transfer is aimed at that one server, which is what keeps it from making things worse:
+
+- nobody else is sent a `timeout_now`, so a group whose preferred server cannot take over
+  keeps its current leader instead of passing it to a third one - which would notice the
+  same thing and pass it on again, leaving the group churning;
+- a server which doesn't catch up before the timeout is given up on, as in any other
+  stepdown, and the next check tries again.
+
+Like any stepdown it holds the group's writes back while it waits for the target to catch
+up - which is also what lets the target catch up while the group is busy. That is why both
+the interval and the timeout are coarse: a group led from the wrong place is a latency
+problem, not a correctness one.

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -202,6 +202,9 @@ replication_factor_data::replication_factor_data(const replication_strategy_conf
             [&] (const std::vector<sstring>& racks) {
                 _data.emplace<std::vector<sstring>>(racks);
                 _count = racks.size();
+            },
+            [&] (const replication_strategy_config_map&) {
+                on_internal_error(rslogger, "replication strategy configuration map used as replication factor");
             }
     }, rf);
 }

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -19,6 +19,7 @@
 #include "utils/sequenced_set.hh"
 #include "utils/simple_hashers.hh"
 #include "utils/property.hh"
+#include "utils/on_internal_error.hh"
 #include "tablets.hh"
 #include "data_dictionary/consistency_config_options.hh"
 
@@ -46,6 +47,7 @@ enum class replication_strategy_type {
     everywhere_topology,
 };
 
+using replication_strategy_config_map = utils::property_string_map;
 using replication_strategy_config_option = utils::property_value;
 using replication_strategy_config_options = utils::extended_property_map;
 
@@ -660,6 +662,9 @@ struct appending_hash<locator::static_effective_replication_map::factory_key> {
                 },
                 [&h] (const std::vector<sstring>& vec) {
                     feed_hash(h, vec);
+                },
+                [] (const locator::replication_strategy_config_map&) {
+                    on_internal_error(locator::rslogger, "replication strategy configuration map used in replication map cache key");
                 }
             }, val);
         }
@@ -731,6 +736,10 @@ struct fmt::formatter<locator::replication_strategy_config_option> {
             },
             [&ctx] (const std::vector<sstring>& v) {
                 return fmt::format_to(ctx.out(), "[{}]", fmt::join(v | std::views::transform([] (auto& s) { return fmt::format("'{}'", s); }), ","));
+            },
+            [&ctx] (const locator::replication_strategy_config_map&) {
+                on_internal_error(locator::rslogger, "replication strategy configuration map formatted as replication option");
+                return fmt::format_to(ctx.out(), "{{}}");
             }
         }, opt);
     }

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -18,6 +18,7 @@
 #include "utils/maybe_yield.hh"
 #include "utils/sequenced_set.hh"
 #include "utils/simple_hashers.hh"
+#include "utils/property.hh"
 #include "tablets.hh"
 #include "data_dictionary/consistency_config_options.hh"
 
@@ -45,8 +46,8 @@ enum class replication_strategy_type {
     everywhere_topology,
 };
 
-using replication_strategy_config_option = std::variant<sstring, rack_list>;
-using replication_strategy_config_options = std::map<sstring, replication_strategy_config_option>;
+using replication_strategy_config_option = utils::property_value;
+using replication_strategy_config_options = utils::extended_property_map;
 
 // Returns the number of replicas inferred by the option.
 // Throws configuration_exception when option is not a valid replication factor specifier.

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -60,9 +60,9 @@ bool uses_rack_list_exclusively(const replication_strategy_config_options&);
 struct replication_strategy_params {
     const replication_strategy_config_options options;
     std::optional<unsigned> initial_tablets;
-    std::optional<data_dictionary::consistency_config_option> consistency;
+    std::optional<data_dictionary::consistency_config> consistency;
     explicit replication_strategy_params(const replication_strategy_config_options& o, std::optional<unsigned> it,
-        std::optional<data_dictionary::consistency_config_option> c) noexcept : options(o), initial_tablets(it), consistency(c) {}
+        std::optional<data_dictionary::consistency_config> c) noexcept : options(o), initial_tablets(it), consistency(std::move(c)) {}
 };
 
 using replication_map = std::unordered_map<token, host_id_vector_replica_set>;

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -26,7 +26,7 @@ class tablet_aware_replication_strategy : public per_table_replication_strategy 
 private:
     size_t _initial_tablets = 0;
     db::tablet_options _tablet_options;
-    data_dictionary::consistency_config_option _consistency;
+    data_dictionary::consistency_config _consistency;
 protected:
     void validate_tablet_options(const abstract_replication_strategy&, const gms::feature_service&, const replication_strategy_config_options&) const;
     void process_tablet_options(abstract_replication_strategy&, replication_strategy_config_options&, replication_strategy_params);
@@ -38,7 +38,8 @@ protected:
 public:
     size_t get_initial_tablets() const { return _initial_tablets; }
 
-    data_dictionary::consistency_config_option get_consistency() const { return _consistency; }
+    data_dictionary::consistency_config_option get_consistency() const { return _consistency.type; }
+    const data_dictionary::consistency_config& get_consistency_config() const { return _consistency; }
 
     /// Generates tablet_map for a new table.
     /// Runs under group0 guard.

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1757,7 +1757,7 @@ void tablet_aware_replication_strategy::process_tablet_options(abstract_replicat
                                                                replication_strategy_params params) {
     if (ars._uses_tablets) {
         _initial_tablets = params.initial_tablets.value_or(0);
-        _consistency = params.consistency.value_or(data_dictionary::consistency_config_option::eventual);
+        _consistency = params.consistency.value_or(data_dictionary::consistency_config{});
         mark_as_per_table(ars);
     }
 }

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -43,10 +43,11 @@ fsm::fsm(server_id id, sstring tag, term_t current_term, server_id voted_for, lo
     // enabled (fast_bootstrap_seed is set), for one deterministically chosen voter
     // of a fresh multi-node group (empty log, last_idx() == 0). Choosing a single
     // node avoids all nodes racing to call an election at once (wasting a term,
-    // risking split votes). The chosen one is the voter at rank (seed % num_voters)
-    // in ascending server_id order; every node derives the same rank without
-    // coordination. A caller managing many groups can vary the seed per group to
-    // rotate leadership across nodes; seed 0 picks the smallest-id voter. A bare
+    // risking split votes). The chosen one is the holder of the first election timeout
+    // slot if there is one, otherwise the voter at rank (seed % num_voters) in ascending
+    // server_id order; every node derives the same choice without coordination. A caller
+    // managing many groups can vary the seed per group to rotate leadership across nodes;
+    // seed 0 picks the smallest-id voter. A bare
     // fsm (e.g. in unit tests) leaves the seed unset and starts as a follower;
     // raft::server sets it. A multi-node node with a non-empty log has already
     // participated and takes the normal timeout path.
@@ -60,6 +61,14 @@ fsm::fsm(server_id id, sstring tag, term_t current_term, server_id voted_for, lo
         }
         if (!_config.fast_bootstrap_seed.has_value() || _log.last_idx() != index_t{0}) {
             return false;
+        }
+        // Bootstrap the leadership where it would end up anyway - on the holder of the
+        // first election timeout slot - instead of making the group hand it over later.
+        if (_config.get_priority_members) {
+            const auto slots = reserved_election_slots(cfg, _config.get_priority_members());
+            if (!slots.empty()) {
+                return slots.front() == _my_id;
+            }
         }
         unsigned voters = 0;
         unsigned rank = 0;

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -189,12 +189,32 @@ void fsm::update_current_term(term_t current_term)
 
 void fsm::reset_election_timeout() {
     static thread_local std::default_random_engine re{std::random_device{}()};
-    static thread_local std::uniform_int_distribution<> dist;
-    // Timeout within range of [1, conf size]
-    _randomized_election_timeout = ELECTION_TIMEOUT + logical_clock::duration{dist(re,
-            std::uniform_int_distribution<int>::param_type{1,
-                    std::max((size_t) ELECTION_TIMEOUT.count(),
-                            _log.get_configuration().current.size())})};
+    static thread_local std::uniform_int_distribution<logical_clock::rep> dist;
+
+    const configuration& cfg = _log.get_configuration();
+    const auto num_slots = std::max(ELECTION_TIMEOUT.count(),
+            static_cast<logical_clock::rep>(configuration::voter_count(cfg.current)));
+
+    // The position in the slot list is the slot, so slots are unique by construction.
+    std::vector<server_id> slots;
+    if (_config.get_priority_members) {
+        slots = reserved_election_slots(cfg, _config.get_priority_members());
+    }
+
+    logical_clock::rep offset;
+    const auto me = std::ranges::find(slots, _my_id);
+    if (me != slots.end()) {
+        // Our own reserved slot: deterministic, no randomness.
+        // First in the list -> ELECTION_TIMEOUT + 1, second -> +2, ...
+        offset = (me - slots.begin()) + 1;
+    } else {
+        // Ordinary member: randomize strictly after every reserved slot, so we
+        // can neither precede nor tie a priority member.
+        const auto first_free = static_cast<logical_clock::rep>(slots.size()) + 1;
+        const auto last_free = std::max(first_free, num_slots);
+        offset = dist(re, std::uniform_int_distribution<logical_clock::rep>::param_type{first_free, last_free});
+    }
+    _randomized_election_timeout = ELECTION_TIMEOUT + logical_clock::duration{offset};
 }
 
 void fsm::become_leader() {

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -14,6 +14,16 @@
 
 namespace raft {
 
+// How often a leader reconsiders whether a server it prefers should be leading instead of
+// it. Coarse on purpose: it costs a get_priority_members() call per leader, and a group
+// which is led from the wrong place is a latency problem, not a correctness one.
+static constexpr logical_clock::duration placement_check_interval = 5 * ELECTION_TIMEOUT;
+
+// How long such a handover holds writes back while it waits for the preferred server to
+// catch up. Short, because a server which doesn't make it costs the group these writes for
+// nothing - it is asked again at the next check.
+static constexpr logical_clock::duration placement_transfer_timeout = ELECTION_TIMEOUT;
+
 leader::~leader() {
     if (log_limiter_semaphore) {
         log_limiter_semaphore->broken(not_a_leader(fsm.current_leader()));
@@ -230,6 +240,7 @@ void fsm::become_leader() {
     SCYLLA_ASSERT(!std::holds_alternative<leader>(_state));
     _output.state_changed = true;
     _state.emplace<leader>(_config.max_log_size, *this);
+    leader_state().placement_check_at = _clock.now() + placement_check_interval;
 
     // The semaphore is not used on the follower, so the limit could
     // be temporarily exceeded here, and the value of
@@ -597,6 +608,28 @@ void fsm::maybe_commit() {
     }
 }
 
+void fsm::maybe_transfer_leadership_to_preferred() {
+    if (!_config.get_priority_members) {
+        return;
+    }
+    const auto slots = reserved_election_slots(_log.get_configuration(), _config.get_priority_members());
+    // Only a server ahead of us in the list outranks us - the ones behind it, and the ones
+    // which reserve no slot at all, do not. Take the first one which is alive: a server
+    // which is gone would not answer a timeout_now, and in an idle group its log looks up
+    // to date even then, so this is the only thing which tells us.
+    const auto me = std::ranges::find(slots, _my_id);
+    const auto target = std::find_if(slots.begin(), me, [this] (server_id id) {
+        const auto* progress = leader_state().tracker.find(id);
+        return progress != nullptr && progress->can_vote && _failure_detector.is_alive(id);
+    });
+    if (target == me) {
+        // Nobody outranks us here, or none of those who do is alive.
+        return;
+    }
+    logger.trace("maybe_transfer_leadership_to_preferred[{}]: handing over to {}", _tag, *target);
+    transfer_leadership_to(*target, placement_transfer_timeout);
+}
+
 void fsm::tick_leader() {
     if (election_elapsed() >= ELECTION_TIMEOUT) {
         // 6.2 Routing requests to the leader
@@ -661,6 +694,7 @@ void fsm::tick_leader() {
             // Cancel stepdown (only if the leader is part of the cluster)
             leader_state().log_limiter_semaphore->signal(_config.max_log_size);
             state.stepdown.reset();
+            state.stepdown_target.reset();
             state.timeout_now_sent.reset();
             _abort_leadership_transfer = true;
             _sm_events.signal(); // signal to handle aborting of leadership transfer
@@ -669,6 +703,13 @@ void fsm::tick_leader() {
             // resend timeout now in case it was lost
             send_to(*state.timeout_now_sent, timeout_now{_current_term});
         }
+    } else if (_clock.now() >= state.placement_check_at) {
+        // The election timeout slots only decide elections, and a group holds one only
+        // while it has no leader. Reconsider now and then, so that a server which was down
+        // or behind when we were elected still gets the leadership once it can take it.
+        // Note that this may make us a follower, so `state` must not be used afterwards.
+        state.placement_check_at = _clock.now() + placement_check_interval;
+        maybe_transfer_leadership_to_preferred();
     }
 }
 
@@ -781,7 +822,8 @@ void fsm::append_entries_reply(server_id from, append_reply&& reply) {
         // If a leader is stepping down, transfer the leadership
         // to a first voting node that has fully replicated log.
         if (leader_state().stepdown && !leader_state().timeout_now_sent &&
-                         progress.can_vote && progress.match_idx == _log.last_idx()) {
+                         progress.can_vote && progress.match_idx == _log.last_idx()
+                         && (!leader_state().stepdown_target || progress.id == *leader_state().stepdown_target)) {
             send_timeout_now(progress.id);
             // We may have resigned leadership if a stepdown process completed
             // while the leader is no longer part of the configuration.
@@ -1100,6 +1142,19 @@ bool fsm::apply_snapshot(snapshot_descriptor snp, size_t max_trailing_entries, s
 }
 
 void fsm::transfer_leadership(logical_clock::duration timeout) {
+    transfer_leadership_impl(timeout, std::nullopt);
+}
+
+void fsm::transfer_leadership_to(server_id target, logical_clock::duration timeout) {
+    check_is_leader();
+    const auto* progress = leader_state().tracker.find(target);
+    if (target == _my_id || progress == nullptr || !progress->can_vote) {
+        throw std::invalid_argument("raft::fsm: leadership can only be transferred to another voting member");
+    }
+    transfer_leadership_impl(timeout, target);
+}
+
+void fsm::transfer_leadership_impl(logical_clock::duration timeout, std::optional<server_id> target) {
     check_is_leader();
     auto leader = leader_state().tracker.find(_my_id);
     if (configuration::voter_count(get_configuration().current) == 1 && leader && leader->can_vote) {
@@ -1109,11 +1164,14 @@ void fsm::transfer_leadership(logical_clock::duration timeout) {
     }
 
     leader_state().stepdown = _clock.now() + timeout;
-    // Stop new requests from coming in
+    leader_state().stepdown_target = target;
+    // Stop new requests from coming in. This is also what lets a follower catch up with us
+    // under load, which it has to before it can win an election.
     leader_state().log_limiter_semaphore->consume(_config.max_log_size);
     // If there is a fully up-to-date voting replica make it start an election
     for (auto&& [_, p] : leader_state().tracker) {
-        if (p.id != _my_id && p.can_vote && p.match_idx == _log.last_idx()) {
+        if (p.id != _my_id && p.can_vote && p.match_idx == _log.last_idx()
+                && (!target || p.id == *target)) {
             send_timeout_now(p.id);
             break;
         }

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -67,8 +67,9 @@ struct fsm_config {
     // ascending server_id order. Callers that manage many groups (e.g. one per
     // tablet) can derive the seed from the group id so that leadership is spread
     // across nodes instead of always landing on the smallest-id one; a seed of 0
-    // selects the smallest-id voter. When unset (the default), fast bootstrap is
-    // disabled and a bare fsm starts as a follower; raft::server sets it.
+    // selects the smallest-id voter, and a priority member which can vote takes
+    // precedence over the seed. When unset (the default), fast bootstrap is disabled and
+    // a bare fsm starts as a follower; raft::server sets it.
     std::optional<uint64_t> fast_bootstrap_seed;
     // Servers to prefer as leader, in priority order: element 0 is the strongest
     // candidate, element k the (k+1)-th. Each listed server gets a unique,

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -76,9 +76,14 @@ struct fsm_config {
     // deterministic election-timeout slot ahead of every other server, so while a
     // listed server is alive it wins leadership. Servers not listed randomize
     // within the remaining slots and can never undercut a listed one. Listed servers
-    // which cannot vote are skipped, they cannot win an election anyway. The callback
-    // is invoked only when (re)arming the election timer, so it always reflects the
-    // current topology. Empty vector / unset => ordinary Raft.
+    // which cannot vote are skipped, they cannot win an election anyway. A leader which
+    // finds itself outranked hands the leadership over, so the preference also holds for a
+    // group which has already elected somebody else.
+    //
+    // The callback is invoked when (re)arming the election timer and, on a leader, every
+    // now and then, so it always reflects the current topology. It runs in the fsm's
+    // synchronous context and must neither block nor throw.
+    // Empty vector / unset => ordinary Raft.
     std::function<std::vector<server_id>()> get_priority_members;
 };
 
@@ -119,6 +124,11 @@ struct leader {
     // If timeout_now was already sent to one of the followers contains the id of the follower
     // it was sent to
     std::optional<server_id> timeout_now_sent;
+    // If the ongoing stepdown must hand the leadership to one particular server, contains
+    // that server; no other one is sent a timeout_now.
+    std::optional<server_id> stepdown_target;
+    // When to reconsider whether a preferred server should be leading instead of us.
+    logical_clock::time_point placement_check_at;
     // A source of read ids - a monotonically growing (in single term) identifiers of
     // reads issued by the state machine. Using monotonic ids allows the leader to
     // resolve all preceding read requests when a quorum of acks from followers arrive
@@ -489,6 +499,20 @@ public:
     // Can be used for leader stepdown if new configuration does not contain
     // current leader.
     void transfer_leadership(logical_clock::duration timeout = logical_clock::duration(0));
+
+    // Like transfer_leadership(), but hands the leadership to `target` and to nobody else:
+    // no other server is sent a timeout_now, so a caller which wants a particular leader
+    // gets that one or keeps the leadership. `target` has to be another voting member of
+    // the current configuration.
+    void transfer_leadership_to(server_id target, logical_clock::duration timeout);
+
+private:
+    void transfer_leadership_impl(logical_clock::duration timeout, std::optional<server_id> target);
+
+    // Hands the leadership to the first server which outranks us and is alive, if there is
+    // one. A leader calls this every placement_check_interval.
+    void maybe_transfer_leadership_to_preferred();
+public:
 
     void stop();
 

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -70,6 +70,15 @@ struct fsm_config {
     // selects the smallest-id voter. When unset (the default), fast bootstrap is
     // disabled and a bare fsm starts as a follower; raft::server sets it.
     std::optional<uint64_t> fast_bootstrap_seed;
+    // Servers to prefer as leader, in priority order: element 0 is the strongest
+    // candidate, element k the (k+1)-th. Each listed server gets a unique,
+    // deterministic election-timeout slot ahead of every other server, so while a
+    // listed server is alive it wins leadership. Servers not listed randomize
+    // within the remaining slots and can never undercut a listed one. Listed servers
+    // which cannot vote are skipped, they cannot win an election anyway. The callback
+    // is invoked only when (re)arming the election timer, so it always reflects the
+    // current topology. Empty vector / unset => ordinary Raft.
+    std::function<std::vector<server_id>()> get_priority_members;
 };
 
 class fsm;

--- a/raft/raft.cc
+++ b/raft/raft.cc
@@ -12,6 +12,18 @@ namespace raft {
 
 seastar::logger logger("raft");
 
+std::vector<server_id> reserved_election_slots(const configuration& cfg,
+        const std::vector<server_id>& preferred) {
+    std::vector<server_id> slots;
+    slots.reserve(preferred.size());
+    for (const auto& id : preferred) {
+        if (cfg.can_vote(id)) {
+            slots.push_back(id);
+        }
+    }
+    return slots;
+}
+
 size_t log_entry::get_size() const {
     struct overloaded {
         size_t operator()(const command& c) {

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -232,6 +232,13 @@ struct configuration {
     }
 };
 
+// The servers which reserve an election timeout slot, in the order of their slots: the
+// preferred servers, in the order they were given in, minus the ones which cannot vote in
+// this configuration and so cannot win an election anyway. The holder of the first slot
+// times out first and should end up the leader; see fsm_config::get_priority_members.
+std::vector<server_id> reserved_election_slots(const configuration& cfg,
+        const std::vector<server_id>& preferred);
+
 struct log_entry {
     // Dummy entry is used when a leader needs to commit an entry
     // (after leadership change for instance) but there is nothing

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -403,7 +403,8 @@ future<> server_impl::start() {
                                      .append_request_threshold = _config.append_request_threshold,
                                      .max_log_size = _config.max_log_size,
                                      .enable_prevoting = _config.enable_prevoting,
-                                     .fast_bootstrap_seed = _config.fast_bootstrap_seed
+                                     .fast_bootstrap_seed = _config.fast_bootstrap_seed,
+                                     .get_priority_members = _config.get_priority_members
                                  },
                                  _events);
 

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -74,7 +74,8 @@ public:
         // is spread across nodes instead of always landing on the smallest-id
         // one. The default of 0 selects the smallest-id voter. raft::server
         // always enables fast bootstrap (unlike a bare fsm, which disables it
-        // when no seed is provided).
+        // when no seed is provided). A priority member which can vote takes precedence
+        // over the seed.
         uint64_t fast_bootstrap_seed = 0;
         // Servers to prefer as leader, in priority order: element 0 is the strongest
         // candidate, element k the (k+1)-th. Each listed server gets a unique,

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -76,6 +76,15 @@ public:
         // always enables fast bootstrap (unlike a bare fsm, which disables it
         // when no seed is provided).
         uint64_t fast_bootstrap_seed = 0;
+        // Servers to prefer as leader, in priority order: element 0 is the strongest
+        // candidate, element k the (k+1)-th. Each listed server gets a unique,
+        // deterministic election-timeout slot ahead of every other server, so while a
+        // listed server is alive it wins leadership. Servers not listed randomize
+        // within the remaining slots and can never undercut a listed one. Listed servers
+        // which cannot vote are skipped, they cannot win an election anyway. The callback
+        // is invoked only when (re)arming the election timer, so it always reflects the
+        // current topology. Empty vector / unset => ordinary Raft.
+        std::function<std::vector<server_id>()> get_priority_members;
     };
 
     virtual ~server() {}

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2204,7 +2204,7 @@ future<token_metadata_change> storage_service::prepare_token_metadata_change(mut
                         // on startup after resharding (while the node is offline).
                         // It is determined on startup by the distributed loader.
                         auto old_tablet_rs = old_rs->maybe_as_tablet_aware();
-                        locator::replication_strategy_params params(rs->get_config_options(), old_tablet_rs->get_initial_tablets(), old_tablet_rs->get_consistency());
+                        locator::replication_strategy_params params(rs->get_config_options(), old_tablet_rs->get_initial_tablets(), old_tablet_rs->get_consistency_config());
                         auto& ks = ss.get_database().find_keyspace(table_schema->ks_name());
                         auto tablet_rs = locator::abstract_replication_strategy::create_replication_strategy(ks.metadata()->strategy_name(), params, tmptr->get_topology());
                         auto pt_rs = tablet_rs->maybe_as_per_table();

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -25,6 +25,7 @@
 #include "utils/error_injection.hh"
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/core/on_internal_error.hh>
 
 #include <seastar/core/abort_source.hh>
 
@@ -49,6 +50,54 @@ static std::optional<locator::tablet_replica_set> prepare_replicas_for_sc_tablet
     }
     std::ranges::rotate(replicas, leader_it);
     return std::make_optional(std::move(replicas));
+}
+
+// The replicas which should win the tablet group's leader election: the ones in the
+// dedicated rack of their datacenter, which is where a strongly consistent read is
+// cheapest to serve from. At most one - a rack list rejects duplicate racks, so a
+// tablet has a single replica per rack - and none if the keyspace has no dedicated one.
+static std::vector<raft::server_id> dedicated_rack_replicas(replica::database& db,
+        global_tablet_id tablet) {
+    // Nothing to prefer, or nothing left to read the preference from: leave the
+    // election to ordinary Raft, which spreads leadership across the replicas. Looked
+    // up without throwing - a dropped table is legitimate, and the caller must not
+    // throw.
+    const auto table_ptr = db.get_tables_metadata().get_table_if_exists(tablet.table);
+    if (!table_ptr) {
+        return {};
+    }
+    const auto schema = table_ptr->schema();
+    if (!db.has_keyspace(schema->ks_name())) {
+        return {};
+    }
+    const auto consistency = db.find_keyspace(schema->ks_name()).metadata()->consistency_option();
+    if (!consistency || !consistency->has_dedicated_rack()) {
+        return {};
+    }
+    const auto& tm = db.get_token_metadata();
+    if (!tm.tablets().has_tablet_map(tablet.table)) {
+        return {};
+    }
+    const auto& tablet_map = tm.tablets().get_tablet_map(tablet.table);
+    if (size_t(tablet.tablet) >= tablet_map.tablet_count()) {
+        // This map doesn't cover our tablet yet - we are one side of a split which
+        // hasn't been finalized. get_tablet_info() requires an id which belongs to it.
+        return {};
+    }
+    std::vector<raft::server_id> preferred;
+    const auto& topo = tm.get_topology();
+    for (const auto& replica : tablet_map.get_tablet_info(tablet.tablet).replicas) {
+        const auto* node = topo.find_node(replica.host);
+        if (!node) {
+            // Not in our topology (yet), so we can't tell which rack it is in.
+            continue;
+        }
+        const auto it = consistency->dedicated_rack.find(node->dc());
+        if (it != consistency->dedicated_rack.end() && it->second == node->rack()) {
+            preferred.push_back(to_server_id(replica.host));
+        }
+    }
+    return preferred;
 }
 
 class groups_manager::rpc_impl: public service::raft_rpc {
@@ -200,7 +249,15 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
         // groups pick different replicas instead of all electing the
         // smallest-id node (which would concentrate load on one node when a
         // table starts with many tablets).
-        .fast_bootstrap_seed = std::hash<raft::group_id>()(group_id)
+        .fast_bootstrap_seed = std::hash<raft::group_id>()(group_id),
+        // Recomputed on every arming of the election timer, because the keyspace, the
+        // tablet's replicas and the topology all change under a running group - hence
+        // `tm`, a snapshot, must not be captured. Capture the database, not `this`: raft
+        // servers are owned by the raft group registry, which outlives the groups
+        // manager. The tablet id is stable - a split or a merge builds new groups.
+        .get_priority_members = [&db = _db, tablet] {
+            return dedicated_rack_replicas(db, tablet);
+        }
     };
     auto server = raft::create_server(my_id, std::move(rpc), std::move(state_machine),
             std::move(storage), _raft_gr.failure_detector(), config);

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -1160,6 +1160,75 @@ SEASTAR_TEST_CASE(test_consistency_preserved_on_alter_keyspace) {
     }, cfg);
 }
 
+SEASTAR_TEST_CASE(test_create_keyspace_with_dedicated_rack) {
+    auto cfg = cql_test_config();
+    cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+    cfg.db_config->experimental_features({db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES});
+    cfg.db_config->rf_rack_valid_keyspaces.set(false);
+    return do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        unsigned shard_count = 2;
+        topo.start_new_dc({"dc1", "rack1"});
+        topo.add_node(service::node_state::normal, shard_count);
+        topo.start_new_rack("rack2");
+        topo.add_node(service::node_state::normal, shard_count);
+
+        // Basic creation with dedicated_rack works
+        e.execute_cql("CREATE KEYSPACE ks1 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', "
+                      "'dc1': ['rack1', 'rack2']} AND consistency = {'type': 'global', "
+                      "'dedicated_rack': {'dc1': 'rack1'}}").get();
+
+        auto ksm = e.local_db().find_keyspace("ks1").metadata();
+        auto consistency = ksm->consistency_option();
+        BOOST_REQUIRE(consistency.has_value());
+        BOOST_REQUIRE(consistency->type == data_dictionary::consistency_config_option::global);
+        BOOST_REQUIRE(consistency->has_dedicated_rack());
+        BOOST_REQUIRE_EQUAL(consistency->dedicated_rack.at("dc1"), sstring("rack1"));
+
+        // DESCRIBE round-trips correctly
+        auto desc = describe(e, "ks1");
+        BOOST_REQUIRE(desc.contains("'type': 'global'"));
+        BOOST_REQUIRE(desc.contains("'dedicated_rack': {'dc1': 'rack1'}"));
+
+        // Legacy string format still works
+        e.execute_cql("CREATE KEYSPACE ks_legacy WITH REPLICATION = {'class': 'NetworkTopologyStrategy', "
+                      "'dc1': ['rack1', 'rack2']} AND consistency = 'global'").get();
+        auto legacy = e.local_db().find_keyspace("ks_legacy").metadata()->consistency_option();
+        BOOST_REQUIRE(legacy.has_value());
+        BOOST_REQUIRE(legacy->type == data_dictionary::consistency_config_option::global);
+        BOOST_REQUIRE(!legacy->has_dedicated_rack());
+
+        // Error: dedicated_rack DC not in replication options
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "CREATE KEYSPACE fail1 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', "
+            "'dc1': ['rack1', 'rack2']} AND consistency = {'type': 'global', "
+            "'dedicated_rack': {'dc99': 'rack1'}}").get(),
+            exceptions::configuration_exception);
+
+        // Error: dedicated_rack requires rack-based replication
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "CREATE KEYSPACE fail2 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', "
+            "'dc1': 2} AND consistency = {'type': 'global', "
+            "'dedicated_rack': {'dc1': 'rack1'}}").get(),
+            exceptions::configuration_exception);
+
+        // Error: dedicated rack not in rack list
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "CREATE KEYSPACE fail3 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', "
+            "'dc1': ['rack1', 'rack2']} AND consistency = {'type': 'global', "
+            "'dedicated_rack': {'dc1': 'rack99'}}").get(),
+            exceptions::configuration_exception);
+
+        // Error: eventual + dedicated_rack
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "CREATE KEYSPACE fail4 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', "
+            "'dc1': ['rack1', 'rack2']} AND consistency = {'type': 'eventual', "
+            "'dedicated_rack': {'dc1': 'rack1'}}").get(),
+            exceptions::configuration_exception);
+    }, cfg);
+}
+
 } // namespace network_topology_strategy_test
 
 namespace locator {

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -1027,6 +1027,14 @@ SEASTAR_TEST_CASE(test_rack_list_rf) {
             "CREATE KEYSPACE fail WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1a']}").get(),
             exceptions::configuration_exception);
 
+        // Nested map value not allowed as RF
+        try {
+            e.execute_cql("CREATE KEYSPACE fail WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': {'rack1a': '1'}}").get();
+            BOOST_FAIL("Expected nested map replication factor to fail");
+        } catch (const exceptions::configuration_exception& ex) {
+            BOOST_REQUIRE(std::string_view(ex.what()).contains("Cannot specify replication options as a map"));
+        }
+
         // Alter to numeric with different count
         BOOST_REQUIRE_THROW(e.execute_cql(
             "ALTER KEYSPACE ks12 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 3}").get(),

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -47,6 +47,7 @@
 #include <seastar/core/coroutine.hh>
 #include "db/schema_tables.hh"
 #include "db/config.hh"
+#include "data_dictionary/consistency_config_options.hh"
 
 using namespace locator;
 

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -1116,6 +1116,50 @@ SEASTAR_TEST_CASE(test_rack_list_rejected_when_using_vnodes) {
     }, cfg);
 }
 
+SEASTAR_TEST_CASE(test_consistency_preserved_on_alter_keyspace) {
+    auto cfg = cql_test_config();
+    cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+    cfg.db_config->experimental_features({db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES});
+    return do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        unsigned shard_count = 2;
+        topo.start_new_dc({"dc1", "rack1"});
+        topo.add_node(service::node_state::normal, shard_count);
+
+        // Create keyspace with consistency and dedicated_rack
+        e.execute_cql("CREATE KEYSPACE ks_cons WITH REPLICATION = {'class': 'NetworkTopologyStrategy', "
+                      "'dc1': ['rack1']} AND consistency = {'type': 'global', 'dedicated_rack': {'dc1': 'rack1'}}").get();
+
+        auto check_consistency = [&] {
+            auto ksm = e.local_db().find_keyspace("ks_cons").metadata();
+            auto consistency = ksm->consistency_option();
+            BOOST_REQUIRE(consistency.has_value());
+            BOOST_REQUIRE(consistency->type == data_dictionary::consistency_config_option::global);
+            BOOST_REQUIRE(consistency->has_dedicated_rack());
+            BOOST_REQUIRE_EQUAL(consistency->dedicated_rack.at("dc1"), sstring("rack1"));
+        };
+        check_consistency();
+        BOOST_REQUIRE(describe(e, "ks_cons").contains("'type': 'global'"));
+        BOOST_REQUIRE(describe(e, "ks_cons").contains("'dedicated_rack'"));
+
+        // ALTER KEYSPACE without re-specifying consistency must preserve it
+        e.execute_cql("ALTER KEYSPACE ks_cons WITH DURABLE_WRITES = false").get();
+        check_consistency();
+
+        // Altering consistency is forbidden
+        try {
+            e.execute_cql("ALTER KEYSPACE ks_cons WITH consistency = {'type': 'eventual'}").get();
+            BOOST_FAIL("Expected ALTER KEYSPACE consistency update to fail");
+        } catch (const exceptions::invalid_request_exception& ex) {
+            BOOST_REQUIRE(std::string_view(ex.what()).contains("Cannot alter consistency option"));
+        }
+
+        // Consistency still intact after failed alter
+        check_consistency();
+    }, cfg);
+}
+
 } // namespace network_topology_strategy_test
 
 namespace locator {

--- a/test/cluster/test_dedicated_rack_leaders.py
+++ b/test/cluster/test_dedicated_rack_leaders.py
@@ -1,0 +1,283 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Measures how well the dedicated_rack leader preference holds in a real cluster.
+
+The election timeout only biases leadership towards the dedicated rack, so the
+guarantee is statistical rather than absolute: ticks fire independently on each node
+and a slower node can undercut a faster one. These tests disrupt leadership over and
+over and report, per round, in how many groups the dedicated rack won the election and
+how many terms were burnt getting there (extra terms mean split votes or retries).
+"""
+
+import asyncio
+import logging
+import time
+import uuid
+
+import pytest
+
+from test.cluster.util import new_test_keyspace
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import Host, gather_safely, wait_for
+
+logger = logging.getLogger(__name__)
+
+CONFIG = {'experimental_features': ['strongly-consistent-tables']}
+CMDLINE = ['--logger-log-level', 'sc_groups_manager=debug']
+
+DEDICATED_RACK = 'rack1'
+RACKS = [DEDICATED_RACK, 'rack2', 'rack3']
+TABLETS = 8
+# Rounds of disruption. Every round elects a leader for every group, so this is also
+# the number of samples per group.
+ROUNDS = 3
+# How often a leader reconsiders whether a preferred replica should be leading instead,
+# in seconds: 5 * ELECTION_TIMEOUT ticks of 100ms.
+PLACEMENT_INTERVAL = 5
+
+
+async def group_ids(manager: ManagerClient, ks: str, table: str) -> list[str]:
+    """Raft group ids of all the tablets of a table, one per tablet."""
+    table_id = await manager.get_table_id(ks, table)
+    rows = await manager.get_cql().run_async(
+        f"SELECT raft_group_id FROM system.tablets WHERE table_id = {table_id}")
+    return [str(row.raft_group_id) for row in rows]
+
+
+async def leader_of(manager: ManagerClient, ip: str, group_id: str) -> str | None:
+    """The group's leader as seen by the node at `ip`, or None during an election."""
+    leader = await manager.api.get_raft_leader(ip, group_id)
+    return None if uuid.UUID(leader).int == 0 else leader
+
+
+async def leaders(manager: ManagerClient, ip: str, groups: list[str]) -> dict[str, str | None]:
+    found = await gather_safely(*[leader_of(manager, ip, group) for group in groups])
+    return dict(zip(groups, found))
+
+
+async def terms(manager: ManagerClient, host: Host) -> dict[str, int]:
+    """vote_term of every group as persisted by one node."""
+    # DISTINCT requires the whole partition key, which is (shard, group_id).
+    rows = await manager.get_cql().run_async(
+        "SELECT DISTINCT shard, group_id, vote_term FROM system.raft_groups", host=host)
+    return {str(row.group_id): row.vote_term or 0 for row in rows}
+
+
+def report(round_name: str, groups: list[str], found: dict[str, str | None],
+           dedicated_host_id: str, term_deltas: dict[str, int]) -> int:
+    """Logs the outcome of one round and returns the number of groups led from the
+    dedicated rack."""
+    won = sum(1 for group in groups if found[group] == dedicated_host_id)
+    undecided = sum(1 for group in groups if found[group] is None)
+    burnt = [delta for delta in term_deltas.values() if delta > 1]
+    logger.info(f"{round_name}: dedicated rack leads {won}/{len(groups)} groups "
+                f"({100 * won // len(groups)}%), {undecided} undecided; "
+                f"groups needing more than one term: {len(burnt)}/{len(term_deltas)}, "
+                f"max terms burnt: {max(term_deltas.values(), default=0)}")
+    for group in groups:
+        logger.debug(f"{round_name}: group {group} leader {found[group]} "
+                     f"terms burnt {term_deltas.get(group)}")
+    return won
+
+
+async def wait_for_all_led_by(manager: ManagerClient, ip: str, groups: list[str],
+                              host_id: str, deadline: float) -> None:
+    async def all_led_by():
+        found = await leaders(manager, ip, groups)
+        missing = [group for group in groups if found[group] != host_id]
+        return True if not missing else None
+    await wait_for(all_led_by, deadline, label=f"all groups led by {host_id}")
+
+
+@pytest.mark.asyncio
+async def test_dedicated_rack_wins_elections(manager: ManagerClient):
+    """One node per rack, dedicated_rack = rack1. Restart the leading node repeatedly
+    and check that leadership goes back to the dedicated rack every time."""
+    servers = []
+    for rack in RACKS:
+        servers.append(await manager.server_add(config=CONFIG, cmdline=CMDLINE,
+                                                property_file={'dc': 'dc1', 'rack': rack}))
+    dedicated, other = servers[0], servers[1]
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
+    dedicated_host_id = host_ids[0]
+    # Ask a node which is never restarted, so that a stale view doesn't skew the counts.
+    observer = servers[2]
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', "
+            f"'dc1': ['{RACKS[0]}', '{RACKS[1]}', '{RACKS[2]}']}} "
+            f"AND tablets = {{'initial': {TABLETS}}} "
+            "AND consistency = {'type': 'global', "
+            f"'dedicated_rack': {{'dc1': '{DEDICATED_RACK}'}}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int)")
+        groups = await group_ids(manager, ks, 't')
+        assert len(groups) == TABLETS
+
+        # A fresh group bootstraps its leader on the preferred replica, so the rack
+        # leads from the start - without any election having happened yet.
+        await wait_for_all_led_by(manager, observer.ip_addr, groups, dedicated_host_id,
+                                  time.time() + 120)
+        before = await terms(manager, hosts[2])
+        found = await leaders(manager, observer.ip_addr, groups)
+        deltas = {group: 0 for group in groups}
+        assert report("initial", groups, found, dedicated_host_id, deltas) == len(groups)
+
+        for round_no in range(ROUNDS):
+            # Disrupt: take the dedicated replica away, so every group has to elect a
+            # leader outside the preferred rack, then bring it back.
+            await manager.server_stop_gracefully(dedicated.server_id)
+
+            # The surviving replicas have to elect a leader among themselves before the
+            # dedicated one comes back, or the round proves nothing: the assertion below
+            # would hold without the leadership ever having left the rack.
+            async def led_from_elsewhere():
+                found = await leaders(manager, observer.ip_addr, groups)
+                return True if all(found[group] not in (None, dedicated_host_id)
+                                   for group in groups) else None
+            await wait_for(led_from_elsewhere, time.time() + 120,
+                           label="every group led outside the dedicated rack")
+            logger.info(f"round {round_no}: the dedicated rack is down and leads nothing")
+
+            await manager.server_start(dedicated.server_id)
+            await manager.servers_see_each_other(servers)
+
+            # Once the dedicated replica is back it should take the leadership over: it
+            # holds the first election timeout slot, and a group led from another rack
+            # steps down for it.
+            await wait_for_all_led_by(manager, observer.ip_addr, groups, dedicated_host_id,
+                                      time.time() + 120)
+
+            after = await terms(manager, hosts[2])
+            deltas = {group: after.get(group, 0) - before.get(group, 0) for group in groups}
+            before = after
+            found = await leaders(manager, observer.ip_addr, groups)
+            won = report(f"round {round_no}", groups, found, dedicated_host_id, deltas)
+            assert won == len(groups)
+
+
+@pytest.mark.asyncio
+async def test_dedicated_rack_keeps_leadership(manager: ManagerClient):
+    """Restarting a node outside the dedicated rack must not move leadership out of
+    it."""
+    servers = []
+    for rack in RACKS:
+        servers.append(await manager.server_add(config=CONFIG, cmdline=CMDLINE,
+                                                property_file={'dc': 'dc1', 'rack': rack}))
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
+    dedicated_host_id = host_ids[0]
+    observer = servers[0]
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', "
+            f"'dc1': ['{RACKS[0]}', '{RACKS[1]}', '{RACKS[2]}']}} "
+            f"AND tablets = {{'initial': {TABLETS}}} "
+            "AND consistency = {'type': 'global', "
+            f"'dedicated_rack': {{'dc1': '{DEDICATED_RACK}'}}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int)")
+        groups = await group_ids(manager, ks, 't')
+
+        await wait_for_all_led_by(manager, observer.ip_addr, groups, dedicated_host_id,
+                                  time.time() + 120)
+
+        await manager.server_restart(servers[1].server_id)
+        await manager.servers_see_each_other(servers)
+
+        # Sample across more than one placement check: a single look right after the
+        # restart would also pass if the leadership were about to move away.
+        deadline = time.time() + 2 * PLACEMENT_INTERVAL + 1
+        while time.time() < deadline:
+            found = await leaders(manager, observer.ip_addr, groups)
+            assert all(found[group] == dedicated_host_id for group in groups), \
+                f"the leadership left the dedicated rack: {found}"
+        report("after restarting a non-dedicated replica", groups, found, dedicated_host_id,
+               {group: 0 for group in groups})
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_dedicated_rack_regains_leadership(manager: ManagerClient):
+    """A group which elected another replica while the dedicated-rack one was up and unable
+    to win must hand the leadership back to it once it can."""
+    # The dedicated replica cannot become a leader of anything while the injection is on,
+    # so it is added last - the first node has to lead group0 to form the cluster.
+    servers = [await manager.server_add(config=CONFIG, cmdline=CMDLINE,
+                                        property_file={'dc': 'dc1', 'rack': rack})
+               for rack in RACKS[1:]]
+    dedicated = await manager.server_add(
+            config=CONFIG | {'error_injections_at_startup': [{'name': 'avoid_being_raft_leader'}]},
+            cmdline=CMDLINE, property_file={'dc': 'dc1', 'rack': DEDICATED_RACK})
+    servers.append(dedicated)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
+    dedicated_host_id = host_ids[-1]
+    observer = servers[0]
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', "
+            f"'dc1': ['{RACKS[0]}', '{RACKS[1]}', '{RACKS[2]}']}} "
+            f"AND tablets = {{'initial': {TABLETS}}} "
+            "AND consistency = {'type': 'global', "
+            f"'dedicated_rack': {{'dc1': '{DEDICATED_RACK}'}}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int)")
+        groups = await group_ids(manager, ks, 't')
+
+        # Keep writing. A leader which replicates tells the followers who it is, so the
+        # preferred replica knows there is one and stays a follower even once it is allowed
+        # to campaign again - an idle group would instead get its leadership back for free,
+        # by that replica timing out first.
+        writing = True
+
+        async def writer():
+            insert = cql.prepare(f"INSERT INTO {ks}.t (pk, v) VALUES (?, ?)")
+            pk = 0
+            while writing:
+                try:
+                    # Awaiting the write is the pacing: the next one starts once this one
+                    # is answered.
+                    await cql.run_async(insert, [pk, pk])
+                except Exception as e:
+                    logger.debug(f"write of {pk} failed, most likely a leader change: {e}")
+                pk += 1
+
+        writer_task = asyncio.create_task(writer())
+        try:
+            # The preferred replica holds the first slot but refuses to campaign, so every
+            # group ends up led from another rack while it is up and healthy.
+            async def none_led_by_dedicated():
+                found = await leaders(manager, observer.ip_addr, groups)
+                return True if all(found[group] != dedicated_host_id for group in groups) else None
+            await wait_for(none_led_by_dedicated, time.time() + 120,
+                           label="no group led by the dedicated rack")
+
+            # The leadership must sit still while the preferred replica cannot take it over.
+            # Handing it to whoever is up to date instead would move it to another replica,
+            # which would hand it on in turn, and the group would keep churning.
+            settled = await leaders(manager, observer.ip_addr, groups)
+            # More than one placement check has to pass, so that the leaders had the chance
+            # to hand the leadership over and declined it.
+            deadline = time.time() + 2 * PLACEMENT_INTERVAL + 1
+            while time.time() < deadline:
+                again = await leaders(manager, observer.ip_addr, groups)
+                moved = {group: (settled[group], again[group]) for group in groups
+                         if settled[group] != again[group]}
+                assert not moved, \
+                    f"the leadership moved while the preferred replica could not take over: {moved}"
+
+            # Let it win again. Nothing announces that - it knows the leaders and stays a
+            # follower, and their own state doesn't change - so the leadership only comes
+            # back because they reconsider it themselves.
+            await manager.api.disable_injection(dedicated.ip_addr, 'avoid_being_raft_leader')
+            await wait_for_all_led_by(manager, observer.ip_addr, groups, dedicated_host_id,
+                                      time.time() + 120)
+        finally:
+            # Whichever way we leave, the keyspace is about to be dropped from under the
+            # writer.
+            writing = False
+            await writer_task

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2600,3 +2600,203 @@ BOOST_AUTO_TEST_CASE(test_no_resend_to_responded_peer) {
     }
     BOOST_CHECK(resent_to_c);
 }
+
+namespace {
+
+// The number of ticks it takes the fsm to call an election, i.e. the randomized
+// election timeout it currently has armed. Since a fresh fsm and a fsm which has
+// just called an election both start counting from the current tick, this can be
+// called repeatedly to sample consecutive timeouts. Returns 0 if no election was
+// called within `limit` ticks.
+logical_clock::rep ticks_until_election(fsm_debug& fsm, logical_clock::rep limit = 2 * ELECTION_TIMEOUT.count()) {
+    const auto term = fsm.get_current_term();
+    for (logical_clock::rep i = 1; i <= limit; i++) {
+        fsm.tick();
+        if (fsm.get_current_term() > term) {
+            return i;
+        }
+    }
+    return 0;
+}
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(test_election_priority_slots) {
+    const auto ET = ELECTION_TIMEOUT.count();
+    server_id A_id = id(), B_id = id(), C_id = id();
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    // A is the preferred leader, B the runner-up, C is an ordinary member.
+    auto priority_members = [A_id, B_id] { return std::vector<server_id>{A_id, B_id}; };
+    auto A = create_follower(A_id, raft::log(log), priority_members);
+    auto B = create_follower(B_id, raft::log(log), priority_members);
+
+    // Slots are deterministic and follow the list order, so the preferred member
+    // always calls an election first. Slot 0 is never handed out: nobody may call
+    // an election before ELECTION_TIMEOUT + 1.
+    BOOST_CHECK_EQUAL(ticks_until_election(A), ET + 1);
+    BOOST_CHECK_EQUAL(ticks_until_election(B), ET + 2);
+
+    // C randomizes strictly after both reserved slots, so it can neither precede
+    // nor tie a priority member no matter how the draw comes out.
+    for (int i = 0; i < 100; i++) {
+        auto C = create_follower(C_id, raft::log(log), priority_members);
+        const auto ticks = ticks_until_election(C);
+        BOOST_CHECK_GT(ticks, ET + 2);
+        BOOST_CHECK_LE(ticks, 2 * ET);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_election_priority_absent_means_ordinary_raft) {
+    const auto ET = ELECTION_TIMEOUT.count();
+    server_id A_id = id(), B_id = id(), C_id = id();
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    // No callback at all and a callback returning an empty list are equivalent:
+    // the timeout is randomized over the whole range, as in ordinary Raft.
+    for (int i = 0; i < 100; i++) {
+        auto A = create_follower(A_id, raft::log(log));
+        const auto ticks = ticks_until_election(A);
+        BOOST_CHECK_GE(ticks, ET + 1);
+        BOOST_CHECK_LE(ticks, 2 * ET);
+
+        auto B = create_follower(B_id, raft::log(log), [] { return std::vector<server_id>{}; });
+        const auto b_ticks = ticks_until_election(B);
+        BOOST_CHECK_GE(b_ticks, ET + 1);
+        BOOST_CHECK_LE(b_ticks, 2 * ET);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_election_priority_member_wins_election) {
+    server_id A_id = id(), B_id = id(), C_id = id();
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    // Only B is preferred; A and C are ordinary members.
+    auto priority_members = [B_id] { return std::vector<server_id>{B_id}; };
+    auto A = create_follower(A_id, raft::log(log), priority_members);
+    auto B = create_follower(B_id, raft::log(log), priority_members);
+    auto C = create_follower(C_id, raft::log(log), priority_members);
+
+    // Tick all the members at the same rate: B's reserved slot is the only one
+    // which can expire this early, so it is the only candidate.
+    for (int i = 0; i < ELECTION_TIMEOUT.count() + 1; i++) {
+        A.tick();
+        B.tick();
+        C.tick();
+    }
+    BOOST_CHECK(B.is_candidate());
+    BOOST_CHECK(A.is_follower());
+    BOOST_CHECK(C.is_follower());
+
+    // Nobody is campaigning against B, so it collects both votes.
+    communicate(A, B, C);
+    BOOST_CHECK(B.is_leader());
+}
+
+BOOST_AUTO_TEST_CASE(test_election_priority_list_is_reread) {
+    const auto ET = ELECTION_TIMEOUT.count();
+    server_id A_id = id(), B_id = id(), C_id = id();
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    // The list is a callback consulted on every arming of the election timer, so
+    // topology changes take effect without recreating the fsm.
+    std::vector<server_id> priority_members{A_id};
+    auto A = create_follower(A_id, raft::log(log), [&priority_members] { return priority_members; });
+
+    // Armed by the constructor, when A held the first slot.
+    BOOST_CHECK_EQUAL(ticks_until_election(A), ET + 1);
+    // Rearmed when A called the election above - still the first slot.
+    BOOST_CHECK_EQUAL(ticks_until_election(A), ET + 1);
+
+    // Demote A behind B. The timer armed before the change keeps the old slot,
+    // the one armed after it uses the new one.
+    priority_members = {B_id, A_id};
+    BOOST_CHECK_EQUAL(ticks_until_election(A), ET + 1);
+    BOOST_CHECK_EQUAL(ticks_until_election(A), ET + 2);
+
+    // Drop A from the list: it goes back to randomizing, now after B's slot.
+    priority_members = {B_id};
+    BOOST_CHECK_EQUAL(ticks_until_election(A), ET + 2);
+    const auto ticks = ticks_until_election(A);
+    BOOST_CHECK_GT(ticks, ET + 1);
+    BOOST_CHECK_LE(ticks, 2 * ET);
+}
+
+BOOST_AUTO_TEST_CASE(test_election_priority_list_longer_than_timeout) {
+    const auto ET = ELECTION_TIMEOUT.count();
+
+    // More members than there are ticks in the election timeout, all but the last
+    // one preferred, so the reserved slots alone exhaust the default range.
+    std::vector<server_id> ids;
+    for (logical_clock::rep i = 0; i < ET + 2; i++) {
+        ids.push_back(id());
+    }
+    raft::configuration cfg = config_from_ids(ids);
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    std::vector<server_id> priority_members(ids.begin(), std::prev(ids.end()));
+    auto get_priority_members = [priority_members] { return priority_members; };
+    const auto limit = 3 * ET;
+
+    // The range grows to fit the whole list: the last preferred member still gets
+    // its own slot, one tick ahead of...
+    auto last_priority = create_follower(priority_members.back(), raft::log(log), get_priority_members);
+    BOOST_CHECK_EQUAL(ticks_until_election(last_priority, limit),
+            ET + static_cast<logical_clock::rep>(priority_members.size()));
+
+    // ...the only member left to randomize, which has a single free slot to pick.
+    auto ordinary = create_follower(ids.back(), raft::log(log), get_priority_members);
+    BOOST_CHECK_EQUAL(ticks_until_election(ordinary, limit),
+            ET + static_cast<logical_clock::rep>(ids.size()));
+}
+
+BOOST_AUTO_TEST_CASE(test_election_priority_skips_non_voters) {
+    const auto ET = ELECTION_TIMEOUT.count();
+    server_id A_id = id(), B_id = id(), C_id = id(), removed_id = id();
+
+    // C is a member of the group but is not allowed to vote.
+    raft::configuration cfg(config_set({A_id, B_id}));
+    cfg.current.emplace(server_addr_from_id(C_id), raft::is_voter::no);
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    // The list names whole racks, so it may contain a server which is not a member of
+    // this group (removed_id) or one which cannot win an election (C); neither may
+    // consume a slot.
+    auto priority_members = [=] { return std::vector<server_id>{removed_id, C_id, A_id, B_id}; };
+    auto A = create_follower(A_id, raft::log(log), priority_members);
+    auto B = create_follower(B_id, raft::log(log), priority_members);
+
+    // A and B hold the first two slots, as if the list named only them.
+    BOOST_CHECK_EQUAL(ticks_until_election(A), ET + 1);
+    BOOST_CHECK_EQUAL(ticks_until_election(B), ET + 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_election_timeout_range_counts_voters_only) {
+    const auto ET = ELECTION_TIMEOUT.count();
+    server_id A_id = id();
+
+    // A group with many members, of which only three can vote - group 0 looks like
+    // this: its configuration holds every node of the cluster. The timeout range is
+    // spread over the servers which can call an election, so the non-voters must not
+    // widen it.
+    raft::configuration cfg(config_set({A_id, id(), id()}));
+    for (int i = 0; i < 3 * ET; i++) {
+        cfg.current.emplace(server_addr_from_id(id()), raft::is_voter::no);
+    }
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    for (int i = 0; i < 100; i++) {
+        auto A = create_follower(A_id, raft::log(log));
+        const auto ticks = ticks_until_election(A, 4 * ET);
+        BOOST_CHECK_GE(ticks, ET + 1);
+        BOOST_CHECK_LE(ticks, 2 * ET);
+    }
+}

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2840,3 +2840,175 @@ BOOST_AUTO_TEST_CASE(test_fast_bootstrap_falls_back_to_the_seed) {
     fsm_debug C(C_id, term_t{}, server_id{}, raft::log(log), trivial_failure_detector, fcfg);
     BOOST_CHECK(C.is_follower());
 }
+
+
+namespace {
+
+struct leader_ticks {
+    // The servers which were asked to take the leadership over, without repetitions.
+    std::vector<server_id> asked;
+    // Whether a handover was given up on.
+    bool transfer_aborted = false;
+};
+
+// Ticks a leader and collects what it did about handing the leadership over.
+leader_ticks tick_leader_for(fsm_debug& fsm, logical_clock::rep ticks) {
+    leader_ticks result;
+    for (logical_clock::rep i = 0; i < ticks; i++) {
+        fsm.tick();
+        const auto output = fsm.get_output();
+        result.transfer_aborted = result.transfer_aborted || output.abort_leadership_transfer;
+        for (const auto& [to, msg] : output.messages) {
+            if (std::holds_alternative<raft::timeout_now>(msg)
+                    && std::ranges::find(result.asked, to) == result.asked.end()) {
+                result.asked.push_back(to);
+            }
+        }
+    }
+    return result;
+}
+
+// Long enough for a leader to reconsider the leader placement and to give up on a handover.
+constexpr auto placement_ticks = 7 * ELECTION_TIMEOUT.count();
+
+} // anonymous namespace
+
+BOOST_AUTO_TEST_CASE(test_leader_hands_over_to_a_preferred_server) {
+    server_id A_id = id(), B_id = id(), C_id = id();
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    auto prefer_b = [B_id] { return std::vector<server_id>{B_id}; };
+    auto A = create_follower(A_id, raft::log(log), prefer_b);
+    auto B = create_follower(B_id, raft::log(log), prefer_b);
+    auto C = create_follower(C_id, raft::log(log), prefer_b);
+
+    // The slots only bias the election, so A can win it although B is preferred.
+    election_timeout(A);
+    communicate(A, B, C);
+    BOOST_CHECK(A.is_leader());
+    (void)A.get_output();
+
+    // A notices that B outranks it and asks B, and nobody else, to take over. It stays the
+    // leader until B wins the election.
+    const auto ticks = tick_leader_for(A, placement_ticks);
+    BOOST_CHECK_EQUAL(ticks.asked.size(), 1);
+    BOOST_CHECK_EQUAL(ticks.asked.front(), B_id);
+    BOOST_CHECK(A.is_leader());
+}
+
+BOOST_AUTO_TEST_CASE(test_preferred_leader_keeps_the_leadership) {
+    server_id A_id = id(), B_id = id(), C_id = id();
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    auto prefer_a = [A_id] { return std::vector<server_id>{A_id}; };
+    auto A = create_follower(A_id, raft::log(log), prefer_a);
+    auto B = create_follower(B_id, raft::log(log), prefer_a);
+    auto C = create_follower(C_id, raft::log(log), prefer_a);
+
+    election_timeout(A);
+    communicate(A, B, C);
+    BOOST_CHECK(A.is_leader());
+    (void)A.get_output();
+
+    // A is the preferred leader itself, so it has nobody to hand the group to.
+    const auto ticks = tick_leader_for(A, placement_ticks);
+    BOOST_CHECK(ticks.asked.empty());
+    BOOST_CHECK(A.is_leader());
+}
+
+BOOST_AUTO_TEST_CASE(test_leader_does_not_hand_over_to_a_dead_server) {
+    server_id A_id = id(), B_id = id(), C_id = id();
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    discrete_failure_detector fd;
+    auto prefer_b = [B_id] { return std::vector<server_id>{B_id}; };
+    auto A = create_follower(A_id, raft::log(log), prefer_b, fd);
+    auto B = create_follower(B_id, raft::log(log), prefer_b, fd);
+    auto C = create_follower(C_id, raft::log(log), prefer_b, fd);
+
+    election_timeout(A);
+    communicate(A, B, C);
+    BOOST_CHECK(A.is_leader());
+    (void)A.get_output();
+
+    // B is preferred but gone. Asking it would only hold the writes of the group back for
+    // nothing, so the handover isn't even started.
+    fd.mark_dead(B_id);
+    const auto ticks = tick_leader_for(A, placement_ticks);
+    BOOST_CHECK(ticks.asked.empty());
+    BOOST_CHECK(!A.leadership_transfer_active());
+    BOOST_CHECK(A.is_leader());
+
+    // Once it is back the leadership goes there, which is also what tells us that the
+    // checks above ran at all and declined for the right reason.
+    fd.mark_alive(B_id);
+    const auto after = tick_leader_for(A, placement_ticks);
+    BOOST_CHECK_EQUAL(after.asked.size(), 1);
+    BOOST_CHECK_EQUAL(after.asked.front(), B_id);
+}
+
+BOOST_AUTO_TEST_CASE(test_leader_gives_up_on_a_lagging_server) {
+    server_id A_id = id(), B_id = id(), C_id = id();
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    auto prefer_b = [B_id] { return std::vector<server_id>{B_id}; };
+    auto A = create_follower(A_id, raft::log(log), prefer_b);
+    auto B = create_follower(B_id, raft::log(log), prefer_b);
+    auto C = create_follower(C_id, raft::log(log), prefer_b);
+
+    election_timeout(A);
+    communicate(A, B, C);
+    BOOST_CHECK(A.is_leader());
+
+    // An entry which B has not replicated yet: it would lose an election, so it is not sent
+    // a timeout_now. The handover waits for it and is given up on when the timeout expires,
+    // which releases the writes again.
+    A.add_entry(raft::log_entry::dummy{});
+    (void)A.get_output();
+    const auto ticks = tick_leader_for(A, placement_ticks);
+    BOOST_CHECK(ticks.asked.empty());
+    BOOST_CHECK(ticks.transfer_aborted);
+    BOOST_CHECK(A.is_leader());
+    BOOST_CHECK(!A.leadership_transfer_active());
+
+    // Let B replicate the entry. The next check hands the leadership over, which is also
+    // what tells us that the one above ran and declined for the right reason.
+    A.tick();
+    communicate(A, B, C);
+    const auto after = tick_leader_for(A, placement_ticks);
+    BOOST_CHECK_EQUAL(after.asked.size(), 1);
+    BOOST_CHECK_EQUAL(after.asked.front(), B_id);
+}
+
+BOOST_AUTO_TEST_CASE(test_leader_hands_over_to_the_first_alive_preferred_server) {
+    server_id A_id = id(), B_id = id(), C_id = id();
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = cfg});
+
+    discrete_failure_detector fd;
+    auto prefer_b_then_c = [B_id, C_id] { return std::vector<server_id>{B_id, C_id}; };
+    auto A = create_follower(A_id, raft::log(log), prefer_b_then_c, fd);
+    auto B = create_follower(B_id, raft::log(log), prefer_b_then_c, fd);
+    auto C = create_follower(C_id, raft::log(log), prefer_b_then_c, fd);
+
+    election_timeout(A);
+    communicate(A, B, C);
+    BOOST_CHECK(A.is_leader());
+    (void)A.get_output();
+
+    // B holds the first slot but is gone, so the leadership goes to C - which outranks A
+    // too, and is there to take it.
+    fd.mark_dead(B_id);
+    const auto ticks = tick_leader_for(A, placement_ticks);
+    BOOST_CHECK_EQUAL(ticks.asked.size(), 1);
+    BOOST_CHECK_EQUAL(ticks.asked.front(), C_id);
+}

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2800,3 +2800,43 @@ BOOST_AUTO_TEST_CASE(test_election_timeout_range_counts_voters_only) {
         BOOST_CHECK_LE(ticks, 2 * ET);
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_fast_bootstrap_prefers_priority_member) {
+    server_id A_id = id(), B_id = id(), C_id = id();
+    BOOST_CHECK(A_id < B_id);
+    BOOST_CHECK(B_id < C_id);
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.config = cfg});
+
+    // The seed alone would bootstrap A, the smallest-id voter. C is the priority
+    // member, so it wins the election anyway - bootstrap it instead of handing the
+    // leadership over afterwards.
+    raft::fsm_config fcfg{.append_request_threshold = 1, .enable_prevoting = true,
+                          .fast_bootstrap_seed = 0,
+                          .get_priority_members = [C_id] { return std::vector<server_id>{C_id}; }};
+
+    fsm_debug C(C_id, term_t{}, server_id{}, raft::log(log), trivial_failure_detector, fcfg);
+    BOOST_CHECK(C.is_candidate());
+
+    fsm_debug A(A_id, term_t{}, server_id{}, raft::log(log), trivial_failure_detector, fcfg);
+    BOOST_CHECK(A.is_follower());
+}
+
+BOOST_AUTO_TEST_CASE(test_fast_bootstrap_falls_back_to_the_seed) {
+    server_id A_id = id(), B_id = id(), C_id = id(), removed_id = id();
+
+    raft::configuration cfg = config_from_ids({A_id, B_id, C_id});
+    raft::log log(raft::snapshot_descriptor{.config = cfg});
+
+    // No priority member can vote here, so the seed picks the leader as before.
+    raft::fsm_config fcfg{.append_request_threshold = 1, .enable_prevoting = true,
+                          .fast_bootstrap_seed = 0,
+                          .get_priority_members = [removed_id] { return std::vector<server_id>{removed_id}; }};
+
+    fsm_debug A(A_id, term_t{}, server_id{}, raft::log(log), trivial_failure_detector, fcfg);
+    BOOST_CHECK(A.is_candidate());
+
+    fsm_debug C(C_id, term_t{}, server_id{}, raft::log(log), trivial_failure_detector, fcfg);
+    BOOST_CHECK(C.is_follower());
+}

--- a/test/raft/helpers.cc
+++ b/test/raft/helpers.cc
@@ -137,6 +137,13 @@ fsm_debug create_follower(raft::server_id id, raft::log log, raft::failure_detec
     return fsm_debug(id, raft::term_t{}, raft::server_id{}, std::move(log), fd, fsm_cfg);
 }
 
+fsm_debug create_follower(raft::server_id id, raft::log log,
+        std::function<std::vector<raft::server_id>()> get_priority_members, raft::failure_detector& fd) {
+    auto fcfg = fsm_cfg;
+    fcfg.get_priority_members = std::move(get_priority_members);
+    return fsm_debug(id, raft::term_t{}, raft::server_id{}, std::move(log), fd, fcfg);
+}
+
 
 // Raft uses UUID 0 as special case.
 // Convert local 0-based integer id to raft +1 UUID

--- a/test/raft/helpers.hh
+++ b/test/raft/helpers.hh
@@ -142,6 +142,9 @@ raft::server_address_set address_set(std::vector<raft::server_id> ids);
 raft::config_member_set config_set(std::vector<raft::server_id> ids);
 fsm_debug create_follower(raft::server_id id, raft::log log,
         raft::failure_detector& fd = trivial_failure_detector);
+fsm_debug create_follower(raft::server_id id, raft::log log,
+        std::function<std::vector<raft::server_id>()> get_priority_members,
+        raft::failure_detector& fd = trivial_failure_detector);
 
 
 // Raft uses UUID 0 as special case.

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -167,7 +167,7 @@ private:
         return is_system_keyspace(unwrap(ks).metadata->name());
     }
     virtual const locator::abstract_replication_strategy& get_replication_strategy(data_dictionary::keyspace ks) const override {
-        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, {}, data_dictionary::consistency_config_option::eventual}, nullptr};
+        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, {}, data_dictionary::consistency_config{}}, nullptr};
         return strategy;
     }
     virtual const std::vector<view_ptr>& get_table_views(data_dictionary::table t) const override {

--- a/utils/property.hh
+++ b/utils/property.hh
@@ -24,7 +24,7 @@ namespace utils {
 
 using property_string_list = std::vector<sstring>;
 using property_string_map = std::map<sstring, sstring>;
-using property_value = std::variant<sstring, property_string_list>;
+using property_value = std::variant<sstring, property_string_list, property_string_map>;
 using extended_property_map = std::map<sstring, property_value>;
 
 }

--- a/utils/property.hh
+++ b/utils/property.hh
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <seastar/core/sstring.hh>
+
+#include <map>
+#include <vector>
+#include <variant>
+
+#include "seastarx.hh"
+
+// Shape shared by cql3::statements::property_definitions and
+// locator::replication_strategy_config_option: neither module may depend
+// on the other's headers, so the common type is defined here once instead
+// of being duplicated in both places.
+namespace utils {
+
+using property_string_list = std::vector<sstring>;
+using property_string_map = std::map<sstring, sstring>;
+using property_value = std::variant<sstring, property_string_list>;
+using extended_property_map = std::map<sstring, property_value>;
+
+}


### PR DESCRIPTION
In strongly-consistent keyspaces, all I/O goes through the tablet Raft group leader. This series adds a dedicated_rack option that biases leader election toward replicas in a specified rack, reducing cross-rack latency on the critical path:

CREATE KEYSPACE ks
WITH replication = {
  'class': 'NetworkTopologyStrategy',
  'dc1': ['rack1', 'rack2', 'rack3']
}
AND consistency = {
  'type': 'global',
  'dedicated_rack': {'dc1': 'rack1'}
};

Replicas in the dedicated rack get a deterministically lower Raft election timeout than all other replicas, so they always win leadership elections under normal operation. The setting is immutable after creation and validated against the replication topology.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3385.

New feature; no backport