### PR TITLE
sstables: remove dead try-catch around noexcept unlink() in close_files()

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3527,18 +3527,13 @@ future<> sstable::close_files() {
         // clean up unused sstables, and because we'll never reuse the same
         // generation number anyway.
         sstlog.debug("Deleting sstable that is {}marked for deletion", _marked_for_deletion == mark_for_deletion::implicit ? "implicitly " : "");
-        try {
-            close_futures.push_back(unlink().handle_exception(
-                        [me = shared_from_this()] (std::exception_ptr eptr) {
-                            try {
-                                std::rethrow_exception(eptr);
-                            } catch (...) {
-                                sstlog.warn("Exception when deleting sstable file: {}", eptr);
-                            }
-                        }));
-        } catch (...) {
-            sstlog.warn("Exception when deleting sstable file: {}", std::current_exception());
-        }
+        close_futures.push_back(unlink().handle_exception([me = shared_from_this()] (std::exception_ptr eptr) {
+            try {
+                std::rethrow_exception(eptr);
+            } catch (...) {
+                sstlog.warn("Exception when deleting sstable file: {}", eptr);
+            }
+        }));
     }
 
     _on_closed(*this);


### PR DESCRIPTION
unlink() has been noexcept since 7130e2e7ff ("sstables: harden unlink", 2021), so wrapping it in try-catch is dead code.  Remove it and flatten the indentation.

Cleanup. No backport required.