### PR TITLE
test: add sstables registry tests for object-storage keyspaces

### DIFF
--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -6,20 +6,85 @@ import pytest
 import shutil
 import logging
 import json
+import time
+import uuid
 
 from test.pylib.minio_server import MinioServer
 from cassandra.protocol import ConfigurationException
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 from test.cluster.util import reconnect_driver
 from test.pylib.object_storage import format_tuples, keyspace_options
 from test.cqlpy.rest_api import scylla_inject_error
 from test.cluster.test_config import wait_for_config
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, wait_for_token_ring_and_group0_consistency
 from test.pylib.tablets import get_all_tablet_replicas
 from test.pylib.skip_types import skip_bug
 
 logger = logging.getLogger(__name__)
+
+
+async def assert_registry_entries_on_all_nodes(cql, hosts, table_id, action):
+    """Verify that the sstables registry has entries for the given table_id on all nodes passed as arg."""
+    for h in hosts:
+        res = await cql.run_async(
+            SimpleStatement(f"SELECT * FROM system.sstables WHERE table_id = {table_id} ALLOW FILTERING",
+                            consistency_level=ConsistencyLevel.ONE), host=h)
+        assert res, f'Expected registry entries on {h.address} before {action}'
+
+
+async def assert_registry_empty_on_all_nodes(cql, hosts, table_id, action):
+    """Verify that the sstables registry has no entries for the given table_id on all nodes passed as arg.
+
+    system.sstables is a node-local table, so each node only stores entries for
+    the tablets it owns. Querying every node verifies each one cleaned up its own
+    registry after the operation.
+
+    Object-storage SSTables are deleted in two phases: unlink() (awaited by
+    TRUNCATE/DROP) only transitions the registry entry to the 'removing' state via
+    wipe(), while the row itself is deleted later by destroy(), which runs
+    fire-and-forget when the last SSTable reference is dropped. The operation can
+    therefore return before the entries are gone, so poll each node until its
+    registry is empty instead of asserting immediately.
+    """
+    async def registry_empty_on(h):
+        res = await cql.run_async(
+            SimpleStatement(f"SELECT * FROM system.sstables WHERE table_id = {table_id} ALLOW FILTERING",
+                            consistency_level=ConsistencyLevel.ONE), host=h)
+        return True if not res else None
+
+    for h in hosts:
+        try:
+            await wait_for(lambda h=h: registry_empty_on(h), time.time() + 30)
+        except AssertionError:
+            raise AssertionError(f'Unexpected entries in registry on {h.address} after {action}')
+
+
+async def get_table_id(cql, ks, table_name):
+    """Get the table UUID from system_schema."""
+    rows = await cql.run_async(
+        f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = '{table_name}'")
+    return rows[0].id
+
+
+async def get_registry_entries(cql, table_id, node_owner, host):
+    """Get sstables registry entries for a specific (table_id, node_owner) partition.
+
+    system.sstables is a node-local table: entries with node_owner=N only exist in
+    node N's own system.sstables. The query must therefore be routed to that node
+    via the `host` parameter, otherwise it hits the coordinator's local table and
+    returns nothing.
+    """
+    if isinstance(node_owner, str):
+        node_owner = uuid.UUID(node_owner)
+    rows = await cql.run_async(
+        SimpleStatement(
+            "SELECT generation, status FROM system.sstables"
+            " WHERE table_id = %s AND node_owner = %s",
+            consistency_level=ConsistencyLevel.ONE),
+        parameters=[table_id, node_owner], host=host)
+    return rows
 
 
 @pytest.mark.parametrize('replication_factor', [1, 3])
@@ -99,25 +164,6 @@ async def test_basic(manager: ManagerClient, object_storage, tmp_path, mode, rep
         res = cql.execute(stmt)
         have_res = {x.name: x.value for x in res}
         assert have_res == rows, f'Unexpected table content: {have_res}'
-
-        print('Drop table')
-        cql.execute(f"DROP TABLE {ks}.test;")
-        # Check that the ownership table is de-populated.
-        # With two-phase deletion for object-storage SSTables, wipe() transitions
-        # registry entries to "removing" state and defers the actual registry
-        # entry deletion to destroy() (runs when the last shared_sstable ref is
-        # dropped).  So entries still in "removing" state are expected — they
-        # confirm that wipe() ran correctly.
-        res = cql.execute("SELECT * FROM system.sstables;")
-        unexpected = [row for row in res if row.status != 'removing']
-        assert not unexpected, \
-            f'Unexpected entries in registry: {[(row.table_id, row.status) for row in unexpected]}'
-        # Make sure objects also disappeared
-        await asyncio.gather(*(manager.server_restart(s.server_id) for s in servers))
-        cql = await reconnect_driver(manager)
-        objects = object_storage.get_resource().Bucket(object_storage.bucket_name).objects.all()
-        print(f'Found objects: {[ objects ]}')
-        assert not list(objects), 'Expected no objects in object storage after table drop'
 
 async def test_garbage_collect(manager: ManagerClient, object_storage):
     '''verify ownership table is garbage-collected on boot'''
@@ -362,4 +408,327 @@ async def test_create_keyspace_after_config_update(manager: ManagerClient, objec
     print('Verify all data is intact')
     rows = {r.name: r.value for r in cql.execute(f'SELECT * FROM random_ks.test;')}
     assert rows == {'test_key': 123, 'after_reconfig': 456}, f'Unexpected table content: {rows}'
+
+
+async def test_tablet_move_updates_registry(manager: ManagerClient, s3_storage):
+    """
+    Verify that moving a tablet from one node to another correctly
+    updates the (node-local) sstables registry: the destination node
+    creates new entries (status=sealed) in its own system.sstables and
+    the source node's entries are cleaned up.
+
+    Uses a 2-node cluster with RF=1 and a single tablet to ensure
+    deterministic placement and movement.
+
+    S3-only: the fake-gcs-server mock breaks tablet
+    streaming over object storage (ifGenerationMatch ignored, SCYLLADB-2044).
+    """
+    cfg = {
+        'object_storage_endpoints': s3_storage.create_endpoint_conf(),
+        'experimental_features': ['keyspace-storage-options']
+    }
+    servers = await manager.servers_add(2, config=cfg)
+    await manager.disable_tablet_balancing()
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 30)
+    host_by_ip = {h.address: h for h in hosts}
+
+    host_ids = {}
+    driver_host = {}
+    for s in servers:
+        host_ids[s] = await manager.get_host_id(s.server_id)
+        driver_host[s] = host_by_ip[str(s.rpc_address)]
+
+    ks_opts = keyspace_options(s3_storage, rf=1)
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, v int) WITH tablets = {{'max_tablet_count': 1}}")
+        for i in range(10):
+            await cql.run_async(f"INSERT INTO {ks}.t1 (pk, v) VALUES ({i}, {i})")
+
+        for srv in servers:
+            await manager.api.flush_keyspace(srv.ip_addr, ks)
+
+        table_id = await get_table_id(cql, ks, 't1')
+
+        # Find which node owns the tablet
+        replicas = await get_all_tablet_replicas(manager, servers[0], ks, 't1')
+        assert len(replicas) == 1, f"Expected 1 tablet, got {len(replicas)}"
+        assert len(replicas[0].replicas) == 1, f"Expected RF=1, got {len(replicas[0].replicas)}"
+        src_host_id, src_shard = replicas[0].replicas[0]
+        token = replicas[0].last_token
+
+        # Determine source and destination servers
+        src_server = None
+        dst_server = None
+        for s in servers:
+            if host_ids[s] == src_host_id:
+                src_server = s
+            else:
+                dst_server = s
+        assert src_server and dst_server, f"Could not match host_ids: tablet src={src_host_id}, servers={host_ids}"
+
+        dst_host_id = host_ids[dst_server]
+
+        # Verify source has registry entries before move
+        src_entries = await get_registry_entries(cql, table_id, src_host_id, host=driver_host[src_server])
+        assert len(src_entries) > 0, "Source should have registry entries before move"
+        logger.info(f"Source {src_host_id} has {len(src_entries)} registry entries before move")
+
+        # Move the tablet
+        logger.info(f"Moving tablet from {src_host_id} (shard {src_shard}) to {dst_host_id} (shard 0)")
+        await manager.api.move_tablet(servers[0].ip_addr, ks, "t1",
+                                      src_host_id, src_shard,
+                                      dst_host_id, 0, token)
+
+        # Verify data is still readable
+        rows = await cql.run_async(f"SELECT * FROM {ks}.t1")
+        assert len(rows) == 10, f"Expected 10 rows after move, got {len(rows)}"
+
+        # Verify destination's local registry has entries (status=sealed)
+        dst_entries = await get_registry_entries(cql, table_id, dst_host_id, host=driver_host[dst_server])
+        assert len(dst_entries) > 0, \
+            f"Destination {dst_host_id} should have registry entries after move"
+        for entry in dst_entries:
+            assert entry.status == 'sealed', \
+                f"Destination entry {entry.generation} has status '{entry.status}', expected 'sealed'"
+        logger.info(f"Destination {dst_host_id} has {len(dst_entries)} sealed registry entries")
+
+        # Verify source entries are cleaned up
+        src_entries_after = await get_registry_entries(cql, table_id, src_host_id, host=driver_host[src_server])
+        assert len(src_entries_after) == 0, \
+            f"Source {src_host_id} should have no registry entries after move, got {len(src_entries_after)}"
+        logger.info("Source registry entries cleaned up successfully")
+
+
+async def test_decommission_migrates_registry(manager: ManagerClient, s3_storage):
+    """
+    Verify registry behavior around decommission.
+    This test checks that the tablet owned by the decommissioned node is migrated to the surviving node,
+    which then builds its own local registry entries (status=sealed).
+
+    Uses a 2-node cluster with RF=1 and a single tablet so the owner is unambiguous; the
+    owner is decommissioned to force a migration.
+
+    S3-only: the fake-gcs-server mock breaks tablet
+    streaming over object storage (ifGenerationMatch ignored, SCYLLADB-2044).
+    """
+    cfg = {
+        'object_storage_endpoints': s3_storage.create_endpoint_conf(),
+        'experimental_features': ['keyspace-storage-options']
+    }
+    servers = await manager.servers_add(2, config=cfg)
+    # Avoid racing with the pre-decommission registry check below.
+    # Decommission still drains the tablet to the survivor regardless.
+    await manager.disable_tablet_balancing()
+
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 30)
+    host_by_ip = {h.address: h for h in hosts}
+
+    host_ids = {}
+    for s in servers:
+        host_ids[s] = await manager.get_host_id(s.server_id)
+
+    ks_opts = keyspace_options(s3_storage, rf=1)
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, v int) WITH tablets = {{'max_tablet_count': 1}}")
+        for i in range(10):
+            await cql.run_async(f"INSERT INTO {ks}.t1 (pk, v) VALUES ({i}, {i})")
+
+        for srv in servers:
+            await manager.api.flush_keyspace(srv.ip_addr, ks)
+
+        table_id = await get_table_id(cql, ks, 't1')
+
+        # Identify the tablet owner and decommission it, forcing the tablet to migrate
+        # to the surviving node.
+        replicas = await get_all_tablet_replicas(manager, servers[0], ks, 't1')
+        assert len(replicas) == 1, f"Expected 1 tablet, got {len(replicas)}"
+        assert len(replicas[0].replicas) == 1, f"Expected RF=1, got {len(replicas[0].replicas)}"
+        owner_host_id = replicas[0].replicas[0][0]
+        decom_server = next(s for s in servers if host_ids[s] == owner_host_id)
+        remaining_server = next(s for s in servers if s is not decom_server)
+        remaining_host_id = host_ids[remaining_server]
+
+        # The owner has local registry entries before decommission.
+        owner_entries = await get_registry_entries(cql, table_id, owner_host_id,
+                                                    host=host_by_ip[str(decom_server.rpc_address)])
+        assert len(owner_entries) > 0, "Owner should have registry entries before decommission"
+        logger.info(f"Owner {owner_host_id} has {len(owner_entries)} registry entries before decommission")
+
+        # Decommission the owner node
+        logger.info(f"Decommissioning owner {decom_server} (host_id={owner_host_id})")
+        await manager.decommission_node(decom_server.server_id)
+        await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+        # Re-resolve the surviving node's CQL host after the topology change.
+        remaining_hosts = await wait_for_cql_and_get_hosts(cql, [remaining_server], time.time() + 30)
+        remaining_host = remaining_hosts[0]
+
+        # The tablet migrated to the surviving node, which must have built its own
+        # local registry entries (status=sealed).
+        entries = await get_registry_entries(cql, table_id, remaining_host_id, host=remaining_host)
+        assert len(entries) > 0, \
+            f"Surviving node {remaining_host_id} should have registry entries after migration"
+        for e in entries:
+            assert e.status == 'sealed', \
+                f"Entry {e.generation} has status '{e.status}', expected 'sealed'"
+        logger.info(f"Surviving node {remaining_host_id} has {len(entries)} sealed registry entries")
+
+        # Data remains readable from the surviving node.
+        rows = await cql.run_async(
+            SimpleStatement(f"SELECT * FROM {ks}.t1", consistency_level=ConsistencyLevel.ONE),
+            host=remaining_host)
+        assert len(rows) == 10, f"Expected 10 rows, got {len(rows)}"
+
+
+async def test_repair_creates_registry_entries(manager: ManagerClient, s3_storage):
+    """
+    Verify that non-incremental (tablet) repair on an object-storage keyspace
+    creates sstables registry entries on the repaired node via streaming.
+
+    To attribute the new entries to repair -- and not to a memtable flush of
+    data the node already had -- the destination must genuinely lack the data
+    before repair:
+
+      * dst is stopped while the rows are written (at CL=ONE to src) and src
+        is flushed, so the data lives only in src's SSTables;
+      * hinted handoff is disabled so dst is not silently repopulated when it
+        restarts;
+      * after dst restarts, its local system.sstables is empty.
+
+    Repair on dst then streams the data from src, writing a new sealed SSTable
+    on dst, which must appear in dst's registry *without any flush*. If repair
+    were a no-op, dst's registry would stay empty.
+
+    FIXME: incremental repair is not supported on object-storage keyspaces
+    because object_storage_base does not implement link_with_excluded_components().
+    Regular tablet repair uses streaming which works correctly.
+
+    S3-only: the fake-gcs-server mock breaks tablet
+    streaming over object storage (ifGenerationMatch ignored, SCYLLADB-2044).
+    """
+    cfg = {
+        'object_storage_endpoints': s3_storage.create_endpoint_conf(),
+        'experimental_features': ['keyspace-storage-options'],
+        'rf_rack_valid_keyspaces': False,
+        'hinted_handoff_enabled': False,
+    }
+
+    servers = await manager.servers_add(2, config=cfg)
+    # Keep tablet placement deterministic so dst's missing replica is only
+    # filled in by the explicit repair below, not by background balancing.
+    await manager.disable_tablet_balancing()
+
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 30)
+    host_by_ip = {h.address: h for h in hosts}
+
+    src_node = servers[0]
+    dst_node = servers[1]
+    src_host_id = await manager.get_host_id(src_node.server_id)
+    dst_host_id = await manager.get_host_id(dst_node.server_id)
+    src_host = host_by_ip[str(src_node.rpc_address)]
+
+    ks_opts = keyspace_options(s3_storage, rf=2)
+    async with new_test_keyspace(manager, ks_opts) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, v int)")
+        table_id = await get_table_id(cql, ks, 't1')
+
+        # Stop dst so the writes land only on src. With hinted handoff disabled,
+        # dst will not be repopulated on restart, so the only way it can later
+        # obtain the data (and a registry entry) is through repair streaming.
+        await manager.server_stop_gracefully(dst_node.server_id)
+
+        for i in range(10):
+            await cql.run_async(
+                SimpleStatement(f"INSERT INTO {ks}.t1 (pk, v) VALUES ({i}, {i})",
+                                consistency_level=ConsistencyLevel.ONE),
+                host=src_host)
+        await manager.api.flush_keyspace(src_node.ip_addr, ks)
+
+        # Bring dst back and refresh its CQL host handle.
+        await manager.server_start(dst_node.server_id, wait_others=1)
+        hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+        host_by_ip = {h.address: h for h in hosts}
+        dst_host = host_by_ip[str(dst_node.rpc_address)]
+
+        src_entries = await get_registry_entries(cql, table_id, src_host_id, host=src_host)
+        assert len(src_entries) > 0, "Source should have registry entries after flush"
+        logger.info(f"Source {src_host_id} has {len(src_entries)} registry entries")
+
+        # dst was down during the writes (hints disabled), so it has no SSTables
+        # and therefore no local registry entries.
+        dst_entries_before = await get_registry_entries(cql, table_id, dst_host_id, host=dst_host)
+        assert len(dst_entries_before) == 0, \
+            f"Destination should have no registry entries before repair, got {len(dst_entries_before)}"
+
+        # Run non-incremental tablet repair on dst. This streams the missing data
+        # from src and writes a new sealed SSTable on dst.
+        logger.info(f"Running repair on {dst_host_id} ({dst_node.ip_addr})")
+        params = {
+            "ks": ks,
+            "table": "t1",
+            "tokens": "all",
+            "await_completion": "true",
+            "incremental_mode": "disabled",
+        }
+        await manager.api.client.post_json(
+            "/storage_service/tablets/repair", host=dst_node.ip_addr, params=params)
+
+        # Repair streams a complete sealed SSTable, so the registry entry must
+        # appear on dst.
+        dst_entries = await get_registry_entries(cql, table_id, dst_host_id, host=dst_host)
+        assert len(dst_entries) > 0, \
+            f"Destination {dst_host_id} should have registry entries created by repair"
+        for e in dst_entries:
+            assert e.status == 'sealed', \
+                f"Entry {e.generation} has status '{e.status}', expected 'sealed'"
+        logger.info(f"Destination {dst_host_id} has {len(dst_entries)} sealed entries after repair")
+
+        # Verify data consistency
+        rows = await cql.run_async(f"SELECT * FROM {ks}.t1")
+        assert len(rows) == 10, f"Expected 10 rows, got {len(rows)}"
+
+
+@pytest.mark.parametrize('operation', ['truncate', 'drop_table', 'drop_keyspace'])
+async def test_registry_cleanup_on_all_nodes(manager: ManagerClient, object_storage, operation):
+    """
+    Verify that TRUNCATE, DROP TABLE and DROP KEYSPACE on an object-storage
+    backed table clean up the sstables registry entries on all nodes.
+
+    Uses a 2-node RF=2 cluster so both nodes own the data
+    and therefore both have local system.sstables entries that the operation
+    must remove.
+    """
+    cfg = {
+        'object_storage_endpoints': object_storage.create_endpoint_conf(),
+        'experimental_features': ['keyspace-storage-options'],
+    }
+    servers = await manager.servers_add(2, config=cfg,
+                                        property_file=[{"dc": "dc1", "rack": "r0"},
+                                                       {"dc": "dc1", "rack": "r1"}])
+
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage, rf=2)) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int)")
+        for k in range(4):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({k}, {k})")
+        for server in servers:
+            await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        table_id = await get_table_id(cql, ks, 'test')
+
+        await assert_registry_entries_on_all_nodes(cql, hosts, table_id, operation)
+
+        if operation == 'truncate':
+            await cql.run_async(f"TRUNCATE {ks}.test")
+        elif operation == 'drop_table':
+            await cql.run_async(f"DROP TABLE {ks}.test")
+        else:
+            await cql.run_async(f"DROP KEYSPACE {ks}")
+
+        await assert_registry_empty_on_all_nodes(cql, hosts, table_id, operation)
 


### PR DESCRIPTION
Add tests covering system.sstables registry state for object-storage-backed keyspaces during various operations.

- test_tablet_move_updates_registry: moving a tablet creates sealed entries on the destination's registry and removes them from the source.
- test_decommission_migrates_registry: decommissioning the tablet owner migrates the tablet to the surviving node, which builds its own sealed entries.
- test_repair_creates_registry_entries: non-incremental tablet repair on a node kept empty (writes go to the other replica while it is down, hinted handoff disabled) streams the data in and registers a sealed entry, so the entry is attributable to repair rather than a memtable flush.
- test_registry_cleanup_on_all_nodes: TRUNCATE, DROP TABLE and DROP KEYSPACE remove registry entries on all nodes, parametrized over the three operations on a 2-node RF=2 cluster.

The previous inline DROP TABLE registry check in test_basic is dropped; it is now covered, on all nodes, by the new parametrized test.

GCS variants of the streaming-based tests are skipped due to a fake-gcs-server bug where ifGenerationMatch is ignored (SCYLLADB-2044).

Extending test coverage, no need for backport.

Fixes SCYLLADB-3199