### PR TITLE
test: test_audit: fix tablet migration race in test_insert_failure_standalone

### DIFF
--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -1482,6 +1482,10 @@ class CQLAuditTester(AuditTester):
         with self.assert_exactly_n_audit_entries_were_added(session, 1):
             conn.execute(stmt)
 
+        # Disable tablet balancing before sampling so the chosen tablet can't
+        # be migrated out from under the CL=THREE insert below (SCYLLADB-2527).
+        await self.manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
         audit_partition_servers, insert_server, server_to_stop, query_to_fail, query_fail_count = await self._test_insert_failure_doesnt_report_success_assign_nodes(session=session)
 
         # TODO: remove the loop when scylladb#24473 is fixed
@@ -1491,6 +1495,7 @@ class CQLAuditTester(AuditTester):
                 await self.manager.get_host_id(srv.server_id)
 
         if len(audit_partition_servers) != 3 or server_to_stop is None or insert_server is None:
+            logger.warning("test_insert_failure: no disjoint data/audit replica set found; skipping")
             skip_env("Failed to assign nodes for insert failure test")
 
         for srv in audit_partition_servers:


### PR DESCRIPTION
The test samples replica placement via describe_ring and assumes it stays stable until its CL=THREE insert. A tablet load balancer migration landing in between routes the insert to the new, fully-alive replicas and it succeeds instead of failing.

After node assignment, disable tablet balancing, quiesce the topology and re-verify the sampled placement; skip if it changed. Balancing must stay enabled during the assignment itself — the initial allocation may not give enough replica-set diversity for a disjoint assignment to exist. No read barriers are needed on the other nodes before the re-check: quiesce_topology read-barriers the queried node, so the describe_ring union always contains the final placement — a lagging node can only inflate the union past 3 endpoints, which is also treated as a skip.

Verified by temporarily injecting a rack-preserving move_tablet of the chosen key's tablet into the window: without the fix it reproduces 'Expected insert to fail' deterministically, with the fix the re-verification skips.

Fixes: SCYLLADB-2527

Reported once on master. Exceptionally rare. No need to backport.