### PR TITLE
repair: Stabilize incremental repair race-window test

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2263,6 +2263,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             .table_uuid  = gid.table,
                         };
                         auto request_type = tinfo.repair_task_info->request_type;
+                        if (utils::get_local_injector().enter("skip_tablet_repair_rpc")) {
+                            rtlogger.info("Skipped tablet repair host={} tablet={} request_type={} due to error injection", dst, gid, request_type);
+                            tablet_state.repair_time = db_clock::now();
+                            co_return;
+                        }
                         rtlogger.info("Initiating tablet repair host={} tablet={} request_type={}", dst, gid, request_type);
                         auto session_id = utils::get_local_injector().enter("handle_tablet_migration_repair_random_session") ?
                             service::session_id::create_random_id() : trinfo->session_id;

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -965,7 +965,7 @@ async def test_tablet_incremental_repair_table_drop_compaction_group_gone(manage
 # on the affected replica leading to data resurrection.
 
 class _LeadershipTransferred(Exception):
-    """Raised when leadership transferred to servers[1] during the test, requiring a retry."""
+    """Raised when coordinator interference requires retrying the race-window test."""
     pass
 
 async def _setup_table_for_race_window(manager, servers, cql):
@@ -1035,8 +1035,10 @@ async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, to
     coord_mark = await coord_log.mark()
 
     # Hold the race window open: prevent the coordinator from committing
-    # end_repair + sstables_repaired_at=2 to Raft.
-    await manager.api.enable_injection(coord_serv.ip_addr, "delay_end_repair_update", one_shot=False)
+    # end_repair + sstables_repaired_at=2 to Raft.  Enable the injection on
+    # every node so the window remains held even if leadership changes while
+    # servers[1] is restarted.
+    await inject_error_on(manager, "delay_end_repair_update", servers)
 
     repair_response = await manager.api.tablet_repair(
         servers[0].ip_addr, ks, "test", token,
@@ -1066,6 +1068,13 @@ async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, to
     pos, _ = await coord_log.wait_for("Finished tablet repair host=", from_mark=coord_mark)
     post_marks_pos, _ = await coord_log.wait_for("Finished tablet repair host=", from_mark=pos)
 
+    # From this point on, any additional tablet repair RPC for this repair stage
+    # is a residual re-repair.  Skip it deterministically so it cannot flush
+    # post-repair memtables and contaminate the repaired set while this test is
+    # exercising the compaction race window.  Enable it everywhere so a new
+    # coordinator after servers[1] restarts is covered too.
+    await inject_error_on(manager, "skip_tablet_repair_rpc", servers)
+
     # --- Race window is open ---
     # Write post-repair keys 20-29.  All nodes receive the writes into their memtables
     # (RF=3, hinted handoff disabled).
@@ -1090,20 +1099,25 @@ async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, to
     # With the classifier fix: S1' has repaired_at==sstables_repaired_at+1 and the tablet
     # is still in the `repair` stage, so it is classified REPAIRING (compaction disabled),
     # and the merge never happens.
+    await manager.server_update_config(target.server_id, "error_injections_at_startup",
+                                       ["delay_end_repair_update", "skip_tablet_repair_rpc"])
     await manager.server_stop_gracefully(target.server_id)
     await manager.server_start(target.server_id)
+    await manager.server_remove_config_option(target.server_id, "error_injections_at_startup")
     await manager.servers_see_each_other(servers)
 
-    # Check if leadership transferred during the restart.  Any coordinator
-    # change (not just to servers[1]) can trigger a residual re-repair that
-    # flushes memtables on all replicas and marks post-repair data as repaired,
-    # masking the bug this test detects.
+    # Check if leadership transferred during the restart.  This used to make
+    # the attempt invalid because a new coordinator could close the race window
+    # or re-run the repair RPC.  The test now enables delay_end_repair_update
+    # and skip_tablet_repair_rpc on all nodes, so a new coordinator remains
+    # under the same controls.  Keep tracking the current coordinator for logs.
     new_coord = await get_topology_coordinator(manager)
     if new_coord != coord:
-        await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
-        await manager.api.wait_task(servers[0].ip_addr, task_id)
-        raise _LeadershipTransferred(
-            f"topology coordinator changed from {coord} to {new_coord} after restart")
+        logger.warning(f"Topology coordinator changed from {coord} to {new_coord} after restart")
+        coord = new_coord
+        coord_serv = await find_server_by_host_id(manager, servers, coord)
+        coord_log = await manager.server_open_log(coord_serv.server_id)
+        post_marks_pos = await coord_log.mark()
 
     # Even without a coordinator change, check if the coordinator initiated a
     # residual re-repair (e.g. after seeing tablets stuck in the repair stage
@@ -1112,7 +1126,8 @@ async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, to
     rerepair_matches = await coord_log.grep("Initiating tablet repair host=", from_mark=post_marks_pos)
     if rerepair_matches:
         logger.warning(f"Coordinator initiated residual re-repair post-restart: {rerepair_matches[0][1]}")
-        await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
+        await inject_error_off(manager, "delay_end_repair_update", servers)
+        await inject_error_off(manager, "skip_tablet_repair_rpc", servers)
         await manager.api.wait_task(servers[0].ip_addr, task_id)
         raise _LeadershipTransferred(
             "coordinator initiated residual re-repair after restart")
@@ -1134,15 +1149,17 @@ async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, to
         rerepair_matches = await coord_log.grep("Initiating tablet repair host=", from_mark=post_marks_pos)
         if rerepair_matches:
             logger.warning(f"Coordinator initiated residual re-repair during poll: {rerepair_matches[0][1]}")
-            await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
+            await inject_error_off(manager, "delay_end_repair_update", servers)
+            await inject_error_off(manager, "skip_tablet_repair_rpc", servers)
             await manager.api.wait_task(servers[0].ip_addr, task_id)
             raise _LeadershipTransferred(
                 "coordinator initiated residual re-repair during compaction poll")
         await asyncio.sleep(1)
 
     # --- Release the race window ---
-    await manager.api.disable_injection(coord_serv.ip_addr, "delay_end_repair_update")
+    await inject_error_off(manager, "delay_end_repair_update", servers)
     await manager.api.wait_task(servers[0].ip_addr, task_id)
+    await inject_error_off(manager, "skip_tablet_repair_rpc", servers)
 
     # Final re-repair check after injection release: the coordinator may have
     # queued a re-repair that only executes once the injection is lifted.
@@ -1225,17 +1242,19 @@ async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: 
     # coordinator check and the restart, the coordinator change masks the bug.
     # Detect and retry with a fresh keyspace.
     max_attempts = 5
+    retry_reasons = []
     for attempt in range(1, max_attempts + 1):
         try:
             current_key = await _do_race_window_promotes_unrepaired_data(
                 manager, servers, cql, ks, 'all', scylla_path, current_key)
             return
         except _LeadershipTransferred as e:
+            retry_reasons.append(str(e))
             logger.warning(f"Attempt {attempt}/{max_attempts}: {e}.  Retrying.")
             ks, current_key = await _setup_table_for_race_window(manager, servers, cql)
 
-    pytest.fail(f"Leadership kept transferring to servers[1] after {max_attempts} attempts; "
-                "could not run the test without coordinator interference.")
+    pytest.fail(f"Could not run the test without coordinator interference after {max_attempts} attempts. "
+                f"Retry reasons: {retry_reasons}")
 
 # ----------------------------------------------------------------------------
 # Tombstone GC safety tests


### PR DESCRIPTION
The race-window test can become flaky when the topology coordinator changes while the test keeps the tablet in repair stage.  A new coordinator may reconstruct the persistent repair state and run another tablet repair RPC.  That residual repair can flush and mark the post-repair writes as repaired, contaminating the scenario the test is trying to isolate.

Add a test-only skip_tablet_repair_rpc injection in the topology coordinator, checked immediately before send_tablet_repair().  The test enables it only after the intended repair RPCs have completed, so the core repair work still happens normally while later residual repair RPCs are skipped.

Enable both delay_end_repair_update and skip_tablet_repair_rpc on all nodes so coordinator changes remain under the same controls.  Also set the same injections through error_injections_at_startup before restarting
servers[1], since runtime injections do not survive process restart. This covers the case where the restarted node becomes the new topology coordinator.

With those controls in place, a coordinator change is no longer treated as an automatic invalid attempt.  The test logs the change, switches log tracking to the new coordinator, and keeps the direct check for an unexpected "Initiating tablet repair host=" message.

Also improve the retry failure message by recording the exact retry reasons.

Tests:
./test.py --mode=dev test_incremental_repair_race_window_promotes_unrepaired_data -v --repeat 200 --max-failures 1

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1478

Backport to 2026.1  and 2026.2 (where the previous fix test: fix flaky test_incremental_repair_race_window_promotes_unrepaired_data is present)