### PR TITLE
Large data guardrail cql warnings - Coordinator side

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2996,8 +2996,8 @@ future<executor::request_return_type> rmw_operation::execute(service::storage_pr
             nullptr;
     return proxy.cas(schema(), std::move(*cas_shard), *this, read_command, to_partition_ranges(*schema(), _pk),
             {timeout, std::move(permit), client_state, trace_state},
-            db::consistency_level::LOCAL_SERIAL, db::consistency_level::LOCAL_QUORUM, timeout, timeout, true, std::move(cdc_opts)).then([this, read_command, &wcu_total] (bool is_applied) mutable {
-        if (!is_applied) {
+            db::consistency_level::LOCAL_SERIAL, db::consistency_level::LOCAL_QUORUM, timeout, timeout, true, std::move(cdc_opts)).then([this, read_command, &wcu_total] (service::storage_proxy::cas_result cas_result) mutable {
+        if (!cas_result.is_applied) {
             return make_ready_future<executor::request_return_type>(api_error::conditional_check_failed("The conditional request failed", std::move(_return_attributes)));
         }
         return make_ready_future<executor::request_return_type>(rmw_operation_return(std::move(_return_attributes), _consumed_capacity, wcu_total));

--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -452,6 +452,11 @@ large_row_fail_threshold_mb: 20
 # Set to 0 to disable.
 large_cell_fail_threshold_mb: 2
 
+# When true, soft limit violations detected by the coordinator-side large data
+# guardrail check are reported to the client as CQL warnings in the response
+# frame. When false, only server-side logging is performed.
+large_data_cql_warnings: true
+
 # Log a warning when row number is larger than this value
 # compaction_rows_count_warning_threshold: 100000
 

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -17,6 +17,7 @@
 #include "cas_request.hh"
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
+#include "db/large_data_handler.hh"
 #include "tracing/trace_state.hh"
 #include "utils/unique_view.hh"
 
@@ -294,7 +295,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::do_
     return get_mutations(qp, options, timeout, local, now, query_state).then([this, &qp, cl, timeout, tr_state = query_state.get_trace_state(),
                                                                                                                                permit = query_state.get_permit()] (utils::chunked_vector<mutation> ms) mutable {
         return execute_without_conditions(qp, std::move(ms), cl, timeout, std::move(tr_state), std::move(permit));
-    }).then([guardrail_state, cl] (coordinator_result<> res) {
+    }).then([guardrail_state, cl] (coordinator_result<db::large_data_violation_type> res) {
         if (!res) {
             return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(
                     seastar::make_shared<cql_transport::messages::result_message::exception>(std::move(res).assume_error()));
@@ -304,11 +305,14 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::do_
             result->add_warning(format("Using write consistency level {} listed on the "
                                        "write_consistency_levels_warned is not recommended.", cl));
         }
+        if (auto warning = db::large_data_soft_violation_warning(res.value()); !warning.empty()) {
+            result->add_warning(std::move(warning));
+        }
         return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(std::move(result));
     });
 }
 
-future<coordinator_result<>> batch_statement::execute_without_conditions(
+future<coordinator_result<db::large_data_violation_type>> batch_statement::execute_without_conditions(
         query_processor& qp,
         utils::chunked_vector<mutation> mutations,
         db::consistency_level cl,
@@ -403,8 +407,14 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
     auto* request_ptr = request.get();
     return qp.proxy().cas(schema, std::move(cas_shard), *request_ptr, request->read_command(qp), request->key(),
             {read_timeout, qs.get_permit(), qs.get_client_state(), qs.get_trace_state()},
-            std::move(cl_for_paxos).assume_value(), cl_for_learn, batch_timeout, cas_timeout).then([this, request = std::move(request)] (bool is_applied) {
-        return request->build_cas_result_set(_metadata, _columns_of_cas_result_set, is_applied);
+            std::move(cl_for_paxos).assume_value(), cl_for_learn, batch_timeout, cas_timeout).then([this, request = std::move(request)] (service::storage_proxy::cas_result cas_result) {
+        auto result = request->build_cas_result_set(_metadata, _columns_of_cas_result_set, cas_result.is_applied);
+        // Surface any coordinator-side large data guardrail soft limit violations
+        // detected during the LWT to the client as a CQL warning.
+        if (auto warning = db::large_data_soft_violation_warning(cas_result.large_data_violations); !warning.empty()) {
+            result->add_warning(std::move(warning));
+        }
+        return result;
     });
 }
 

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -20,6 +20,10 @@ namespace cql_transport::messages {
     class result_message;
 }
 
+namespace db {
+enum class large_data_violation_type : uint8_t;
+}
+
 namespace cql3 {
 
 class query_processor;
@@ -134,7 +138,7 @@ private:
             service::query_state& query_state, const query_options& options,
             bool local, api::timestamp_type now) const;
 
-    future<exceptions::coordinator_result<>> execute_without_conditions(
+    future<exceptions::coordinator_result<db::large_data_violation_type>> execute_without_conditions(
             query_processor& qp,
             utils::chunked_vector<mutation> mutations,
             db::consistency_level cl,

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -28,6 +28,7 @@
 #include "cas_request.hh"
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
+#include "db/large_data_handler.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
 #include "cql3/statements/strong_consistency/modification_statement.hh"
 #include "cql3/statements/strong_consistency/statement_helpers.hh"
@@ -310,6 +311,11 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
         result->add_warning(format("Using write consistency level {} listed on the "
                                    "write_consistency_levels_warned is not recommended.", cl));
     }
+    // Surface any coordinator-side large data guardrail soft limit violations
+    // detected during the write to the client as a CQL warning.
+    if (auto warning = db::large_data_soft_violation_warning(res.value()); !warning.empty()) {
+        result->add_warning(std::move(warning));
+    }
     if (keys_size_one) {
         auto&& table = s->table();
         if (_may_use_token_aware_routing && table.uses_tablets() && qs.get_client_state().is_protocol_extension_set(cql_transport::cql_protocol_extension::TABLETS_ROUTING_V1)) {
@@ -324,13 +330,13 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
     co_return std::move(result);
 }
 
-future<coordinator_result<>>
+future<coordinator_result<db::large_data_violation_type>>
 modification_statement::execute_without_condition(query_processor& qp, service::query_state& qs, const query_options& options, json_cache_opt& json_cache, std::vector<dht::partition_range> keys) const {
     auto cl = options.get_consistency();
     auto timeout = db::timeout_clock::now() + get_timeout(qs.get_client_state(), options);
     return get_mutations(qp, options, timeout, false, options.get_timestamp(qs), qs, json_cache, std::move(keys)).then([this, cl, timeout, &qp, &qs, &options] (auto mutations) {
         if (mutations.empty()) {
-            return make_ready_future<coordinator_result<>>(bo::success());
+            return make_ready_future<coordinator_result<db::large_data_violation_type>>(db::large_data_violation_type::none);
         }
 
         return qp.proxy().mutate_with_triggers(std::move(mutations), cl, timeout, false, qs.get_trace_state(), qs.get_permit(), db::allow_per_partition_rate_limit::yes, this->is_raw_counter_shard_write(), {
@@ -453,10 +459,15 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
     return qp.proxy().cas(s, std::move(cas_shard), *request_ptr, request->read_command(qp), request->key(),
             {read_timeout, qs.get_permit(), qs.get_client_state(), qs.get_trace_state()},
             std::move(cl_for_paxos).assume_value(), cl_for_learn, statement_timeout, cas_timeout, true, {},
-            attrs->is_bypass_large_data_guardrails()).then([this, request = std::move(request), tablet_info = std::move(tablet_info)] (bool is_applied) mutable {
-        auto result = request->build_cas_result_set(_metadata, _columns_of_cas_result_set, is_applied);
+            attrs->is_bypass_large_data_guardrails()).then([this, request = std::move(request), tablet_info = std::move(tablet_info)] (service::storage_proxy::cas_result cas_result) mutable {
+        auto result = request->build_cas_result_set(_metadata, _columns_of_cas_result_set, cas_result.is_applied);
         if (tablet_info) {
             result->add_tablet_info(std::move(*tablet_info));
+        }
+        // Surface any coordinator-side large data guardrail soft limit violations
+        // detected during the LWT to the client as a CQL warning.
+        if (auto warning = db::large_data_soft_violation_warning(cas_result.large_data_violations); !warning.empty()) {
+            result->add_warning(std::move(warning));
         }
         return result;
     });

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -22,6 +22,10 @@
 #include <memory>
 #include <optional>
 
+namespace db {
+enum class large_data_violation_type : uint8_t;
+}
+
 namespace cql3 {
 
 class query_processor;
@@ -241,7 +245,7 @@ public:
     execute_without_checking_exception_message(query_processor& qp, service::query_state& qs, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
 private:
-    future<exceptions::coordinator_result<>>
+    future<exceptions::coordinator_result<db::large_data_violation_type>>
     execute_without_condition(query_processor& qp, service::query_state& qs, const query_options& options, json_cache_opt& json_cache, std::vector<dht::partition_range> keys) const;
 
     future<::shared_ptr<cql_transport::messages::result_message>>

--- a/db/config.cc
+++ b/db/config.cc
@@ -844,6 +844,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Log a warning when writing cells larger than this value.")
     , large_cell_fail_threshold_mb(this, "large_cell_fail_threshold_mb", liveness::LiveUpdate, value_status::Used, 0,
         "Reject writes with cell value size exceeding this threshold in MB. Set to 0 to disable.")
+    , large_data_cql_warnings(this, "large_data_cql_warnings", liveness::LiveUpdate, value_status::Used, false,
+        "When true, soft limit violations detected by the coordinator-side large data guardrail check are reported to the "
+        "client as CQL warnings in the response frame. When false, this behavior is suppressed (only server-side logging is "
+        "performed).")
     , large_partition_fail_threshold_mb(this, "large_partition_fail_threshold_mb", liveness::LiveUpdate, value_status::Used, 0,
         "Reject writes targeting a partition whose on-disk size already exceeds this threshold in MB, as recorded in any SSTable's large data records. "
         "Set to 0 to disable.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -234,6 +234,7 @@ public:
     named_value<uint32_t> compaction_large_row_warning_threshold_mb;
     named_value<uint32_t> compaction_large_cell_warning_threshold_mb;
     named_value<uint32_t> large_cell_fail_threshold_mb;
+    named_value<bool> large_data_cql_warnings;
     named_value<uint32_t> large_partition_fail_threshold_mb;
     named_value<uint32_t> rows_count_fail_threshold;
     named_value<uint32_t> large_row_fail_threshold_mb;

--- a/db/large_data_cache_tracker.hh
+++ b/db/large_data_cache_tracker.hh
@@ -60,6 +60,9 @@ struct guardrail_config {
     // Cell thresholds (coordinator-side only — checked from mutation content)
     utils::updateable_value<uint32_t> cell_size_fail_threshold_mb;
     utils::updateable_value<uint32_t> cell_size_warn_threshold_mb;
+    // When true, coordinator-side soft limit violations are surfaced to the
+    // client as CQL warnings in the response frame (see large_data_cql_warnings).
+    utils::updateable_value<bool> cql_warnings_enabled;
 };
 
 // Tracker for mutation_partition_v2::apply_monotonically().

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -48,7 +48,7 @@ constexpr uint64_t MB = 1024 * 1024;
 enum class guardrail_source { replica, coordinator };
 
 template <guardrail_source Source, typename ContextFn>
-void enforce_threshold(const schema& s, uint64_t value,
+bool enforce_threshold(const schema& s, uint64_t value,
         uint64_t fail_threshold, uint64_t warn_threshold,
         std::string_view metric, ContextFn&& make_context) {
     if (fail_threshold > 0 && value > fail_threshold) [[unlikely]] {
@@ -66,9 +66,30 @@ void enforce_threshold(const schema& s, uint64_t value,
         large_data_logger.warn("Large data guardrail: {} {} exceeds soft limit {} "
             "(keyspace={}, table={}, {})",
             metric, value, warn_threshold, s.ks_name(), s.cf_name(), make_context());
+        return true;
     }
+    return false;
 }
 } // anonymous namespace
+
+sstring large_data_soft_violation_warning(large_data_violation_type violations) {
+    if (violations == large_data_violation_type::none) {
+        return {};
+    }
+    // List categories in a stable row, cell, collection order.
+    static constexpr std::pair<large_data_violation_type, std::string_view> categories[] = {
+        {large_data_violation_type::row, "row"},
+        {large_data_violation_type::cell, "cell"},
+        {large_data_violation_type::collection, "collection"},
+    };
+    std::vector<std::string_view> listed;
+    for (const auto& [category, name] : categories) {
+        if ((violations & category) != large_data_violation_type::none) {
+            listed.push_back(name);
+        }
+    }
+    return seastar::format("Large data guardrail: Soft limit violation for {}", fmt::join(listed, ", "));
+}
 
 nop_large_data_handler::nop_large_data_handler()
     : large_data_handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(),
@@ -309,7 +330,7 @@ void large_data_guardrail::check_collection_element_count(const schema& s, bytes
             ck ? seastar::format("{}", ck->with_schema(s)) : sstring()); });
 }
 
-void large_data_guardrail::check_coordinator(const schema& s, const mutation_partition& mp,
+large_data_violation_type large_data_guardrail::check_coordinator(const schema& s, const mutation_partition& mp,
         partition_key_view pk) const {
     const uint64_t cell_fail = uint64_t(_cfg.cell_size_fail_threshold_mb()) * MB;
     const uint64_t cell_warn = uint64_t(_cfg.cell_size_warn_threshold_mb()) * MB;
@@ -317,6 +338,17 @@ void large_data_guardrail::check_coordinator(const schema& s, const mutation_par
     const uint64_t row_warn = uint64_t(_cfg.row_size_warn_threshold_mb()) * MB;
     const uint64_t coll_fail = uint64_t(_cfg.collection_elements_fail_threshold());
     const uint64_t coll_warn = uint64_t(_cfg.collection_elements_warn_threshold());
+
+    // Only accumulate soft violations when CQL warnings are enabled by
+    // configuration.  Hard limit enforcement and server-side soft limit logging
+    // are unaffected.
+    const bool track = _cfg.cql_warnings_enabled();
+    large_data_violation_type violations = large_data_violation_type::none;
+    auto note = [&] (large_data_violation_type category, bool warned) {
+        if (track && warned) {
+            violations |= category;
+        }
+    };
 
     auto check_cell = [&](const column_definition& cdef, const atomic_cell_or_collection& cell) {
         if (!cdef.is_atomic()) {
@@ -326,25 +358,25 @@ void large_data_guardrail::check_coordinator(const schema& s, const mutation_par
         if (!acv.is_live()) {
             return;
         }
-        enforce_threshold<guardrail_source::coordinator>(s, acv.value_size(),
+        note(large_data_violation_type::cell, enforce_threshold<guardrail_source::coordinator>(s, acv.value_size(),
             cell_fail, cell_warn, "cell value size",
-            [&] { return seastar::format("column={}", cdef.name_as_text()); });
+            [&] { return seastar::format("column={}", cdef.name_as_text()); }));
     };
 
     auto check_collection = [&](const column_definition& cdef, const atomic_cell_or_collection& cell) {
         if (cdef.is_atomic()) {
             return;
         }
-        enforce_threshold<guardrail_source::coordinator>(s, cell.as_collection_mutation().size(),
+        note(large_data_violation_type::collection, enforce_threshold<guardrail_source::coordinator>(s, cell.as_collection_mutation().size(),
             coll_fail, coll_warn, "collection element count",
-            [&] { return seastar::format("column={}", cdef.name_as_text()); });
+            [&] { return seastar::format("column={}", cdef.name_as_text()); }));
     };
 
     if (!mp.static_row().empty()) {
         auto static_size = mp.static_row().external_memory_usage(s, column_kind::static_column);
-        enforce_threshold<guardrail_source::coordinator>(s, static_size,
+        note(large_data_violation_type::row, enforce_threshold<guardrail_source::coordinator>(s, static_size,
             row_fail, row_warn, "static row size",
-            [&] { return seastar::format("partition_key={}", pk); });
+            [&] { return seastar::format("partition_key={}", pk); }));
         mp.static_row().for_each_cell([&](column_id id, const atomic_cell_or_collection& cell) {
             const column_definition& cdef = s.static_column_at(id);
             check_cell(cdef, cell);
@@ -356,15 +388,16 @@ void large_data_guardrail::check_coordinator(const schema& s, const mutation_par
         if (e.dummy()) {
             continue;
         }
-        enforce_threshold<guardrail_source::coordinator>(s, e.memory_usage(s),
+        note(large_data_violation_type::row, enforce_threshold<guardrail_source::coordinator>(s, e.memory_usage(s),
             row_fail, row_warn, "row size",
-            [&] { return seastar::format("clustering_key={}", e.key().with_schema(s)); });
+            [&] { return seastar::format("clustering_key={}", e.key().with_schema(s)); }));
         e.row().cells().for_each_cell([&](column_id id, const atomic_cell_or_collection& cell) {
             const column_definition& cdef = s.regular_column_at(id);
             check_cell(cdef, cell);
             check_collection(cdef, cell);
         });
     }
+    return violations;
 }
 
 void large_data_cache_tracker::on_row_merged(const schema& s, const rows_entry& row) noexcept {

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -11,6 +11,7 @@
 #include <concepts>
 #include <cstdint>
 #include <optional>
+#include <type_traits>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/future.hh>
 #include <boost/intrusive/set.hpp>
@@ -115,6 +116,34 @@ private:
     record_set<record_type::collection> _collections;
 };
 
+// Coordinator-side soft limit violation categories.  Used as a set of bit
+// flags so a single write can accumulate violations across all of its rows,
+// cells, and collections (see the operators below).
+enum class large_data_violation_type : uint8_t {
+    none       = 0,
+    row        = 1 << 0,
+    cell       = 1 << 1,
+    collection = 1 << 2,
+};
+
+inline constexpr large_data_violation_type operator|(large_data_violation_type a, large_data_violation_type b) {
+    return large_data_violation_type(std::underlying_type_t<large_data_violation_type>(a) | std::underlying_type_t<large_data_violation_type>(b));
+}
+
+inline constexpr void operator|=(large_data_violation_type& a, large_data_violation_type b) {
+    a = a | b;
+}
+
+inline constexpr large_data_violation_type operator&(large_data_violation_type a, large_data_violation_type b) {
+    return large_data_violation_type(std::underlying_type_t<large_data_violation_type>(a) & std::underlying_type_t<large_data_violation_type>(b));
+}
+
+// Translate a set of soft-limit violation categories into the client-facing CQL
+// warning string, or an empty string when no categories are set.  The message
+// lists the violated categories in row, cell, collection order, e.g.
+//   "Large data guardrail: Soft limit violation for cell, collection"
+sstring large_data_soft_violation_warning(large_data_violation_type violations);
+
 // Each replica::table holds a shared_ptr to either a real guardrail or a
 // noop.  The guardrail owns the per-table large_data_record_index, so
 // noop tables pay no index-maintenance cost.
@@ -131,7 +160,10 @@ public:
             partition_key_view pk) const = 0;
     // Coordinator-side check: inspects the mutation content directly
     // (cell value sizes, row memory usage, collection element counts).
-    virtual void check_coordinator(const schema& s, const mutation_partition& mp,
+    // Hard limit violations throw; soft limit violations are logged and, when
+    // CQL warnings are enabled, returned as the set of violated categories so
+    // the CQL layer can surface them to the client as a response warning.
+    virtual large_data_violation_type check_coordinator(const schema& s, const mutation_partition& mp,
             partition_key_view pk) const = 0;
     // Returns a tracker to pass to partition_entry::apply(), or nullptr
     // when no memtable-level tracking is needed.  The returned pointer
@@ -155,8 +187,8 @@ public:
     }
     void check(const schema&, const mutation_partition&,
             partition_key_view) const override {}
-    void check_coordinator(const schema&, const mutation_partition&,
-            partition_key_view) const override {}
+    large_data_violation_type check_coordinator(const schema&, const mutation_partition&,
+            partition_key_view) const override { return large_data_violation_type::none; }
     large_data_cache_tracker* get_memtable_cache_tracker(const schema&,
             partition_key_view) override { return nullptr; }
     void on_flush() override {}
@@ -172,7 +204,7 @@ public:
 
     void check(const schema& s, const mutation_partition& mp,
             partition_key_view pk) const override;
-    void check_coordinator(const schema& s, const mutation_partition& mp,
+    large_data_violation_type check_coordinator(const schema& s, const mutation_partition& mp,
             partition_key_view pk) const override;
     large_data_cache_tracker* get_memtable_cache_tracker(const schema& s,
             partition_key_view pk) override;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1649,6 +1649,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
         .collection_elements_warn_threshold = db_config.compaction_collection_elements_count_warning_threshold,
         .cell_size_fail_threshold_mb = db_config.large_cell_fail_threshold_mb,
         .cell_size_warn_threshold_mb = db_config.compaction_large_cell_warning_threshold_mb,
+        .cql_warnings_enabled = db_config.large_data_cql_warnings,
     };
 
     return cfg;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4293,23 +4293,31 @@ storage_proxy::mutate_internal(Range mutations, db::consistency_level cl, tracin
     });
 }
 
-future<result<>>
+future<result<db::large_data_violation_type>>
 storage_proxy::mutate_with_triggers(utils::chunked_vector<mutation> mutations, db::consistency_level cl,
     clock_type::time_point timeout,
     bool should_mutate_atomically, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, bool raw_counters, coordinator_mutate_options options) {
     warn(unimplemented::cause::TRIGGERS);
 
+    db::large_data_violation_type large_data_violations = db::large_data_violation_type::none;
     if (!options.bypass_large_data_guardrails) {
         for (const mutation& m : mutations) {
-            m.schema()->table().get_large_data_guardrail()->check_coordinator(*m.schema(), m.partition(), m.key());
+            large_data_violations |= m.schema()->table().get_large_data_guardrail()->check_coordinator(*m.schema(), m.partition(), m.key());
         }
     }
 
+    auto carry_violations = [large_data_violations] (result<> res) -> result<db::large_data_violation_type> {
+        if (!res) {
+            return std::move(res).as_failure();
+        }
+        return large_data_violations;
+    };
+
     if (should_mutate_atomically) {
         SCYLLA_ASSERT(!raw_counters);
-        return mutate_atomically_result(std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), std::move(options));
+        return mutate_atomically_result(std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), std::move(options)).then(carry_violations);
     }
-    return mutate_result(std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), allow_limit, raw_counters, std::move(options));
+    return mutate_result(std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), allow_limit, raw_counters, std::move(options)).then(carry_violations);
 }
 
 /**
@@ -6836,7 +6844,7 @@ storage_proxy::do_query_with_paxos(schema_ptr s,
     auto* request_ptr = request.get();
 
     return cas(std::move(s), std::move(cas_shard), *request_ptr, cmd, std::move(partition_ranges), std::move(query_options),
-            cl, db::consistency_level::ANY, timeout, cas_timeout, false).then([request = std::move(request)] (bool is_applied) mutable {
+            cl, db::consistency_level::ANY, timeout, cas_timeout, false).then([request = std::move(request)] (cas_result) mutable {
         return make_ready_future<coordinator_query_result>(std::move(request->res));
     });
 }
@@ -6905,7 +6913,7 @@ static mutation_write_failure_exception read_failure_to_write(read_failure_excep
  * The cas_shard must be created *before* selecting the shard, to protect against
  * concurrent tablet migrations.
  */
-future<bool> storage_proxy::cas(schema_ptr schema, cas_shard cas_shard, cas_request& request, lw_shared_ptr<query::read_command> cmd,
+future<storage_proxy::cas_result> storage_proxy::cas(schema_ptr schema, cas_shard cas_shard, cas_request& request, lw_shared_ptr<query::read_command> cmd,
         dht::partition_range_vector partition_ranges, storage_proxy::coordinator_query_options query_options,
         db::consistency_level cl_for_paxos, db::consistency_level cl_for_learn,
         clock_type::time_point write_timeout, clock_type::time_point cas_timeout, bool write, cdc::per_request_options cdc_opts,
@@ -6972,6 +6980,10 @@ future<bool> storage_proxy::cas(schema_ptr schema, cas_shard cas_shard, cas_requ
     lc.start();
 
     bool condition_met;
+    // Accumulates coordinator-side large data guardrail soft limit violations
+    // detected while proposing the client-requested mutation, returned to the
+    // CQL layer so it can surface them to the client as a response warning.
+    db::large_data_violation_type large_data_violations = db::large_data_violation_type::none;
 
     try {
         auto update_stats = seastar::defer ([&] {
@@ -7025,7 +7037,7 @@ future<bool> storage_proxy::cas(schema_ptr schema, cas_shard cas_shard, cas_requ
                 // since the value we are writing is dummy we may use minimal consistency level for learn
                 handler->set_cl_for_learn(db::consistency_level::ANY);
             } else {
-                ld_guardrail->check_coordinator(
+                large_data_violations |= ld_guardrail->check_coordinator(
                         *schema, mutation->partition(), mutation->key());
                 paxos::paxos_state::logger.debug("CAS[{}] precondition is met; proposing client-requested updates for {}",
                         handler->id(), ballot);
@@ -7106,7 +7118,7 @@ future<bool> storage_proxy::cas(schema_ptr schema, cas_shard cas_shard, cas_requ
         }
     }
 
-    co_return condition_met;
+    co_return cas_result{condition_met, large_data_violations};
 }
 
 host_id_vector_replica_set storage_proxy::get_live_endpoints(const locator::effective_replication_map& erm, const dht::token& token) const {

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -75,6 +75,7 @@ class feature_service;
 namespace db {
 class system_keyspace;
 struct snapshot_options;
+enum class large_data_violation_type : uint8_t;
 
 namespace view {
 struct view_building_state_machine;
@@ -174,6 +175,15 @@ struct storage_proxy_coordinator_mutate_options {
     bool bypass_large_data_guardrails = false;
 };
 
+// Result of a CAS (LWT) operation: whether the conditional update was applied,
+// plus any coordinator-side large data guardrail soft limit violations detected
+// while proposing the client-requested mutation, so the CQL layer can surface
+// them to the client as a response warning.
+struct storage_proxy_cas_result {
+    bool is_applied = false;
+    db::large_data_violation_type large_data_violations = {};
+};
+
 class cas_request;
 
 class storage_proxy : public seastar::async_sharded_service<storage_proxy>, public peering_sharded_service<storage_proxy>, public service::endpoint_lifecycle_subscriber  {
@@ -231,6 +241,7 @@ public:
     using coordinator_query_options = storage_proxy_coordinator_query_options;
     using coordinator_query_result = storage_proxy_coordinator_query_result;
     using coordinator_mutate_options = storage_proxy_coordinator_mutate_options;
+    using cas_result = storage_proxy_cas_result;
 
     // Holds  a list of endpoints participating in CAS request, for a given
     // consistency level, token, and state of joining/leaving nodes.
@@ -746,7 +757,7 @@ public:
     future<> replicate_counter_from_leader(mutation m, db::consistency_level cl, tracing::trace_state_ptr tr_state,
                                            clock_type::time_point timeout, service_permit permit);
 
-    future<result<>> mutate_with_triggers(utils::chunked_vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout,
+    future<result<db::large_data_violation_type>> mutate_with_triggers(utils::chunked_vector<mutation> mutations, db::consistency_level cl, clock_type::time_point timeout,
                                           bool should_mutate_atomically, tracing::trace_state_ptr tr_state, service_permit permit,
                                           db::allow_per_partition_rate_limit allow_limit, bool raw_counters = false,
                                           coordinator_mutate_options options = {});
@@ -842,7 +853,7 @@ public:
         clock_type::time_point timeout,
         tracing::trace_state_ptr trace_state = nullptr);
 
-    future<bool> cas(schema_ptr schema, cas_shard cas_shard, cas_request& request, lw_shared_ptr<query::read_command> cmd,
+    future<cas_result> cas(schema_ptr schema, cas_shard cas_shard, cas_request& request, lw_shared_ptr<query::read_command> cmd,
             dht::partition_range_vector partition_ranges, coordinator_query_options query_options,
             db::consistency_level cl_for_paxos, db::consistency_level cl_for_learn,
             clock_type::time_point write_timeout, clock_type::time_point cas_timeout, bool write = true, cdc::per_request_options cdc_opts = {},

--- a/test/boost/large_data_guardrail_test.cc
+++ b/test/boost/large_data_guardrail_test.cc
@@ -295,7 +295,8 @@ mutation make_mutation_with_tombstone(schema_ptr s) {
 db::guardrail_config make_coordinator_config(
         uint32_t cell_fail_mb = 0, uint32_t cell_warn_mb = 0,
         uint32_t row_fail_mb = 0, uint32_t row_warn_mb = 0,
-        uint32_t collection_fail = 0, uint32_t collection_warn = 0) {
+        uint32_t collection_fail = 0, uint32_t collection_warn = 0,
+        bool cql_warnings_enabled = false) {
     return db::guardrail_config{
         .partition_size_fail_threshold_mb = utils::updateable_value<uint32_t>(0),
         .partition_size_warn_threshold_mb = utils::updateable_value<uint32_t>(0),
@@ -307,11 +308,17 @@ db::guardrail_config make_coordinator_config(
         .collection_elements_warn_threshold = utils::updateable_value<uint32_t>(collection_warn),
         .cell_size_fail_threshold_mb = utils::updateable_value<uint32_t>(cell_fail_mb),
         .cell_size_warn_threshold_mb = utils::updateable_value<uint32_t>(cell_warn_mb),
+        .cql_warnings_enabled = utils::updateable_value<bool>(cql_warnings_enabled),
     };
 }
 
 void coordinator_check(const db::large_data_guardrail& g, const mutation& m) {
     g.check_coordinator(*m.schema(), m.partition(), m.key());
+}
+
+// Runs the coordinator check collecting soft limit violations.
+db::large_data_violation_type coordinator_soft_violations(const db::large_data_guardrail& g, const mutation& m) {
+    return g.check_coordinator(*m.schema(), m.partition(), m.key());
 }
 
 schema_ptr make_set_schema() {
@@ -561,6 +568,109 @@ BOOST_AUTO_TEST_CASE(test_per_table_guardrails_disabled_by_default) {
         .with_column("v", bytes_type)
         .build();
     BOOST_REQUIRE(!s->large_data_guardrails_enabled());
+}
+
+// ---------------------------------------------------------------------------
+// CQL warning (soft limit) tests
+// ---------------------------------------------------------------------------
+
+// Warning string builder
+
+BOOST_AUTO_TEST_CASE(test_soft_violation_warning_empty_when_no_bits) {
+    BOOST_REQUIRE(db::large_data_soft_violation_warning(db::large_data_violation_type::none).empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_soft_violation_warning_single_category) {
+    BOOST_REQUIRE_EQUAL(
+        db::large_data_soft_violation_warning(db::large_data_violation_type::row),
+        "Large data guardrail: Soft limit violation for row");
+    BOOST_REQUIRE_EQUAL(
+        db::large_data_soft_violation_warning(db::large_data_violation_type::cell),
+        "Large data guardrail: Soft limit violation for cell");
+    BOOST_REQUIRE_EQUAL(
+        db::large_data_soft_violation_warning(db::large_data_violation_type::collection),
+        "Large data guardrail: Soft limit violation for collection");
+}
+
+BOOST_AUTO_TEST_CASE(test_soft_violation_warning_multiple_categories_in_order) {
+    // Regardless of how the categories were combined, the listed order is
+    // row, cell, collection.
+    auto cell_and_collection = db::large_data_violation_type::collection | db::large_data_violation_type::cell;
+    BOOST_REQUIRE_EQUAL(
+        db::large_data_soft_violation_warning(cell_and_collection),
+        "Large data guardrail: Soft limit violation for cell, collection");
+
+    auto all = db::large_data_violation_type::row | db::large_data_violation_type::cell
+        | db::large_data_violation_type::collection;
+    BOOST_REQUIRE_EQUAL(
+        db::large_data_soft_violation_warning(all),
+        "Large data guardrail: Soft limit violation for row, cell, collection");
+}
+
+// Soft limit bitmask tracking
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_cell_soft_limit_sets_bit) {
+    auto s = make_simple_schema();
+    // cell warn at 1MB, no hard limit; warnings enabled.
+    auto cfg = make_coordinator_config(0, 1 /* cell_warn_mb */, 0, 0, 0, 0, true);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, MB + 1);
+    BOOST_REQUIRE(coordinator_soft_violations(g, m) == db::large_data_violation_type::cell);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_row_soft_limit_sets_bit) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(0, 0, 0, 1 /* row_warn_mb */, 0, 0, true);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, MB + 1);
+    auto violations = coordinator_soft_violations(g, m);
+    BOOST_REQUIRE((violations & db::large_data_violation_type::row) == db::large_data_violation_type::row);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_collection_soft_limit_sets_bit) {
+    auto s = make_set_schema();
+    auto cfg = make_coordinator_config(0, 0, 0, 0, 0, 100 /* collection_warn */, true);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_set(s, 101);
+    BOOST_REQUIRE(coordinator_soft_violations(g, m) == db::large_data_violation_type::collection);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_soft_limit_below_threshold_sets_no_bit) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(0, 1 /* cell_warn_mb */, 0, 0, 0, 0, true);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, 100);
+    BOOST_REQUIRE(coordinator_soft_violations(g, m) == db::large_data_violation_type::none);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_soft_limit_suppressed_when_warnings_disabled) {
+    auto s = make_simple_schema();
+    // Soft cell limit is crossed but CQL warnings are disabled -> nothing set.
+    auto cfg = make_coordinator_config(0, 1 /* cell_warn_mb */, 0, 0, 0, 0, false);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, MB + 1);
+    BOOST_REQUIRE(coordinator_soft_violations(g, m) == db::large_data_violation_type::none);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_soft_limit_accumulates_multiple_categories) {
+    auto s = make_set_schema();
+    // Both the row (the set's serialized size) and the collection element count
+    // cross their soft limits in a single mutation.
+    auto cfg = make_coordinator_config(0, 0, 0, 1 /* row_warn_mb */, 0, 100 /* collection_warn */, true);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_set(s, 101);
+    auto violations = coordinator_soft_violations(g, m);
+    BOOST_REQUIRE((violations & db::large_data_violation_type::collection) == db::large_data_violation_type::collection);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_soft_limit_hard_limit_still_throws) {
+    auto s = make_simple_schema();
+    // Hard cell limit set; warnings enabled. Hard limit must still throw.
+    auto cfg = make_coordinator_config(1 /* cell_fail_mb */, 0, 0, 0, 0, 0, true);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, MB + 1);
+    BOOST_REQUIRE_THROW(g.check_coordinator(*m.schema(), m.partition(), m.key()),
+            exceptions::invalid_request_exception);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cqlpy/test_coordinator_guardrail_cql_warnings.py
+++ b/test/cqlpy/test_coordinator_guardrail_cql_warnings.py
@@ -1,0 +1,264 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+import re
+from contextlib import ExitStack
+
+import pytest
+
+from cassandra.protocol import InvalidRequest
+
+from .util import config_value_context, new_test_table
+
+
+WARNING_RE = re.compile(r"(?i)large data guardrail.*soft limit violation")
+
+
+@pytest.fixture(scope="function", autouse=True)
+def all_tests_are_scylla_only(scylla_only):
+    pass
+
+
+def make_blob(size_bytes):
+    return bytes(size_bytes)
+
+
+def make_set(n):
+    """Create a set with n elements."""
+    return set(range(n))
+
+
+def get_warnings(result):
+    """Extract CQL protocol warnings from a result set, or empty list."""
+    warnings = result.response_future.warnings
+    return warnings if warnings else []
+
+
+# --- Row soft limit CQL warnings ---
+
+
+def test_row_soft_limit_returns_cql_warning(cql, test_keyspace):
+    """A write exceeding the row soft limit returns a CQL warning."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_row_fail_threshold_mb", "0"))
+            result = cql.execute(insert, [1, make_blob(1048576 + 1)])
+            warnings = get_warnings(result)
+            assert len(warnings) > 0, "Expected a CQL warning for row soft limit violation"
+            assert any(WARNING_RE.search(w) for w in warnings)
+            assert any("row" in w.lower() for w in warnings)
+
+
+def test_row_soft_limit_no_warning_when_below_threshold(cql, test_keyspace):
+    """A write within the row soft limit produces no CQL warning."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_row_fail_threshold_mb", "0"))
+            result = cql.execute(insert, [1, b"\x00"])
+            warnings = get_warnings(result)
+            assert not any(WARNING_RE.search(w) for w in warnings), \
+                f"Unexpected CQL warning: {warnings}"
+
+
+# --- Cell soft limit CQL warnings ---
+
+
+def test_cell_soft_limit_returns_cql_warning(cql, test_keyspace):
+    """A write exceeding the cell soft limit returns a CQL warning."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_cell_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_cell_fail_threshold_mb", "0"))
+            result = cql.execute(insert, [1, make_blob(1048576 + 1)])
+            warnings = get_warnings(result)
+            assert len(warnings) > 0, "Expected a CQL warning for cell soft limit violation"
+            assert any(WARNING_RE.search(w) for w in warnings)
+            assert any("cell" in w.lower() for w in warnings)
+
+
+def test_cell_soft_limit_no_warning_when_below_threshold(cql, test_keyspace):
+    """A write within the cell soft limit produces no CQL warning."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_cell_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_cell_fail_threshold_mb", "0"))
+            result = cql.execute(insert, [1, b"\x00"])
+            warnings = get_warnings(result)
+            assert not any(WARNING_RE.search(w) for w in warnings), \
+                f"Unexpected CQL warning: {warnings}"
+
+
+# --- Collection soft limit CQL warnings ---
+
+
+def test_collection_soft_limit_returns_cql_warning(cql, test_keyspace):
+    """A write exceeding the collection element count soft limit returns a CQL warning."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v set<int>",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_collection_elements_count_warning_threshold", "5"))
+            cfg.enter_context(config_value_context(cql, "large_collection_elements_fail_threshold", "0"))
+            result = cql.execute(insert, [1, make_set(6)])
+            warnings = get_warnings(result)
+            assert len(warnings) > 0, "Expected a CQL warning for collection soft limit violation"
+            assert any(WARNING_RE.search(w) for w in warnings)
+            assert any("collection" in w.lower() for w in warnings)
+
+
+def test_collection_soft_limit_no_warning_when_below_threshold(cql, test_keyspace):
+    """A write within the collection element count soft limit produces no CQL warning."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v set<int>",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_collection_elements_count_warning_threshold", "5"))
+            cfg.enter_context(config_value_context(cql, "large_collection_elements_fail_threshold", "0"))
+            result = cql.execute(insert, [1, make_set(3)])
+            warnings = get_warnings(result)
+            assert not any(WARNING_RE.search(w) for w in warnings), \
+                f"Unexpected CQL warning: {warnings}"
+
+
+# --- Multi-category violations ---
+
+
+def test_row_and_cell_combined_warning(cql, test_keyspace):
+    """A single write exceeding both row and cell soft limits returns a CQL
+    warning listing both categories."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_row_fail_threshold_mb", "0"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_cell_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_cell_fail_threshold_mb", "0"))
+            result = cql.execute(insert, [1, make_blob(1048576 + 1)])
+            warnings = get_warnings(result)
+            assert len(warnings) > 0
+            warning_text = "\n".join(warnings).lower()
+            assert "row" in warning_text
+            assert "cell" in warning_text
+
+
+# --- Feature flag disabled ---
+
+
+def test_no_cql_warning_when_flag_disabled(cql, test_keyspace):
+    """No CQL warning is returned when large_data_cql_warnings is disabled,
+    even if the soft limit is exceeded."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "false"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_row_fail_threshold_mb", "0"))
+            result = cql.execute(insert, [1, make_blob(1048576 + 1)])
+            warnings = get_warnings(result)
+            assert not any(WARNING_RE.search(w) for w in warnings), \
+                f"CQL warning should not appear when feature is disabled: {warnings}"
+
+
+def test_no_cql_warning_when_guardrails_disabled_on_table(cql, test_keyspace):
+    """No CQL warning when large_data_guardrails_enabled is false on the table,
+    even if the global flag is on and the soft limit is exceeded."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = false") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_row_fail_threshold_mb", "0"))
+            result = cql.execute(insert, [1, make_blob(1048576 + 1)])
+            warnings = get_warnings(result)
+            assert not any(WARNING_RE.search(w) for w in warnings), \
+                f"CQL warning should not appear when table guardrails are disabled: {warnings}"
+
+
+# --- Batch statement CQL warnings ---
+
+
+def test_batch_row_soft_limit_returns_cql_warning(cql, test_keyspace):
+    """A batch write exceeding the row soft limit returns a CQL warning."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        batch = cql.prepare(f"BEGIN BATCH INSERT INTO {table} (pk, v) VALUES (1, ?) APPLY BATCH")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_row_fail_threshold_mb", "0"))
+            result = cql.execute(batch, [make_blob(1048576 + 1)])
+            warnings = get_warnings(result)
+            assert len(warnings) > 0, "Expected a CQL warning for batch row soft limit violation"
+            assert any(WARNING_RE.search(w) for w in warnings)
+
+
+# --- LWT CQL warnings ---
+
+
+def test_lwt_insert_soft_limit_returns_cql_warning(cql, test_keyspace):
+    """An LWT INSERT exceeding the row soft limit returns a CQL warning."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert_if = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?) IF NOT EXISTS")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_row_fail_threshold_mb", "0"))
+            result = cql.execute(insert_if, [1, make_blob(1048576 + 1)])
+            warnings = get_warnings(result)
+            assert len(warnings) > 0, "Expected a CQL warning for LWT soft limit violation"
+            assert any(WARNING_RE.search(w) for w in warnings)
+
+
+def test_lwt_update_soft_limit_returns_cql_warning(cql, test_keyspace):
+    """An LWT UPDATE exceeding the row soft limit returns a CQL warning."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        update_if = cql.prepare(f"UPDATE {table} SET v = ? WHERE pk = ? IF v != null")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"))
+            cfg.enter_context(config_value_context(cql, "large_row_fail_threshold_mb", "0"))
+            cql.execute(insert, [1, b"\x00"])
+            result = cql.execute(update_if, [make_blob(1048576 + 1), 1])
+            warnings = get_warnings(result)
+            assert len(warnings) > 0, "Expected a CQL warning for LWT UPDATE soft limit violation"
+            assert any(WARNING_RE.search(w) for w in warnings)
+
+
+# --- Hard limit still rejects even with CQL warnings enabled ---
+
+
+def test_hard_limit_still_rejects_with_cql_warnings_enabled(cql, test_keyspace):
+    """Hard limit rejection takes precedence; enabling CQL warnings does not
+    suppress hard limit enforcement."""
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with ExitStack() as cfg:
+            cfg.enter_context(config_value_context(cql, "large_data_cql_warnings", "true"))
+            cfg.enter_context(config_value_context(cql, "large_row_fail_threshold_mb", "1"))
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [1, make_blob(1048576 + 1)])


### PR DESCRIPTION
Until now, soft-limit violations were only logged on the server side.
This PR adds an opt-in mechanism to surface coordinator-side soft-limit violations as CQL warnings returned directly in the query response. The coordinator checks the size of the mutation it is about to send, and if a soft limit is breached, a warning is included in the response listing which categories were affected (row, cell, and/or collection). 
This lets client applications observe violations on writes that pass through the coordinator without having to scrape server logs.
The feature is controlled by a new large_data_cql_warnings config option.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1824.
No backport is required