### PR TITLE
test: Teach S3 creds test to use faster retry strategy

### DIFF
--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -928,21 +928,21 @@ SEASTAR_THREAD_TEST_CASE(test_creds) {
     auto port = std::stoul(tests::getenv_safe("MOCK_S3_SERVER_PORT"));
     tmpdir tmp;
 
-    auto sts_provider = std::make_unique<aws::sts_assume_role_credentials_provider>(host, port, false);
+    auto sts_provider = std::make_unique<aws::sts_assume_role_credentials_provider>(host, port, false, make_test_retry_strategy);
     auto creds = sts_provider->get_aws_credentials().get();
     BOOST_REQUIRE_EQUAL(creds.access_key_id, "STS_EXAMPLE_ACCESS_KEY_ID");
     BOOST_REQUIRE_EQUAL(creds.secret_access_key, "STS_EXAMPLE_SECRET_ACCESS_KEY");
     BOOST_REQUIRE_EQUAL(creds.session_token.contains("STS_SESSIONTOKEN"), true);
 
-    auto md_provider = std::make_unique<aws::instance_profile_credentials_provider>(host, port);
+    auto md_provider = std::make_unique<aws::instance_profile_credentials_provider>(host, port, make_test_retry_strategy);
     creds = md_provider->get_aws_credentials().get();
     BOOST_REQUIRE_EQUAL(creds.access_key_id, "INSTANCE_FROFILE_EXAMPLE_ACCESS_KEY_ID");
     BOOST_REQUIRE_EQUAL(creds.secret_access_key, "INSTANCE_FROFILE_EXAMPLE_SECRET_ACCESS_KEY");
     BOOST_REQUIRE_EQUAL(creds.session_token.contains("INSTANCE_FROFILE_SESSIONTOKEN"), true);
 
     aws::aws_credentials_provider_chain provider_chain;
-    provider_chain.add_credentials_provider(std::make_unique<aws::sts_assume_role_credentials_provider>(host, port, false))
-        .add_credentials_provider(std::make_unique<aws::instance_profile_credentials_provider>(host, port));
+    provider_chain.add_credentials_provider(std::make_unique<aws::sts_assume_role_credentials_provider>(host, port, false, make_test_retry_strategy))
+        .add_credentials_provider(std::make_unique<aws::instance_profile_credentials_provider>(host, port, make_test_retry_strategy));
     creds = provider_chain.get_aws_credentials().get();
     BOOST_REQUIRE_EQUAL(creds.access_key_id, "STS_EXAMPLE_ACCESS_KEY_ID");
     BOOST_REQUIRE_EQUAL(creds.secret_access_key, "STS_EXAMPLE_SECRET_ACCESS_KEY");
@@ -952,8 +952,8 @@ SEASTAR_THREAD_TEST_CASE(test_creds) {
     BOOST_REQUIRE(creds1.expires_at - creds.expires_at >= 1s);
 
     provider_chain = {};
-    provider_chain.add_credentials_provider(std::make_unique<aws::sts_assume_role_credentials_provider>("0.0.0.0", 0, false))
-        .add_credentials_provider(std::make_unique<aws::instance_profile_credentials_provider>(host, port));
+    provider_chain.add_credentials_provider(std::make_unique<aws::sts_assume_role_credentials_provider>("0.0.0.0", 0, false, [] { return std::make_unique<test_retry_strategy>(1); }))
+        .add_credentials_provider(std::make_unique<aws::instance_profile_credentials_provider>(host, port, make_test_retry_strategy));
     creds = provider_chain.get_aws_credentials().get();
     BOOST_REQUIRE_EQUAL(creds.access_key_id, "INSTANCE_FROFILE_EXAMPLE_ACCESS_KEY_ID");
     BOOST_REQUIRE_EQUAL(creds.secret_access_key, "INSTANCE_FROFILE_EXAMPLE_SECRET_ACCESS_KEY");
@@ -963,8 +963,8 @@ SEASTAR_THREAD_TEST_CASE(test_creds) {
     BOOST_REQUIRE(creds1.expires_at - creds.expires_at >= 1s);
 
     provider_chain = {};
-    provider_chain.add_credentials_provider(std::make_unique<aws::sts_assume_role_credentials_provider>("0.0.0.0", 0, false))
-        .add_credentials_provider(std::make_unique<aws::instance_profile_credentials_provider>("0.0.0.0", 0));
+    provider_chain.add_credentials_provider(std::make_unique<aws::sts_assume_role_credentials_provider>("0.0.0.0", 0, false, [] { return std::make_unique<test_retry_strategy>(1); }))
+        .add_credentials_provider(std::make_unique<aws::instance_profile_credentials_provider>("0.0.0.0", 0, [] { return std::make_unique<test_retry_strategy>(1); }));
     creds = provider_chain.get_aws_credentials().get();
     BOOST_REQUIRE_EQUAL(creds.access_key_id, "");
     BOOST_REQUIRE_EQUAL(creds.secret_access_key, "");

--- a/utils/s3/credentials_providers/aws_credentials_provider.hh
+++ b/utils/s3/credentials_providers/aws_credentials_provider.hh
@@ -8,9 +8,16 @@
 
 #pragma once
 #include "utils/s3/creds.hh"
+#include <functional>
+#include <memory>
 #include <seastar/core/future.hh>
 
+namespace seastar::http { class retry_strategy; }
+
 namespace aws {
+
+using retry_strategy_factory = std::function<std::unique_ptr<seastar::http::retry_strategy>()>;
+
 /*
  * Abstract class for retrieving AWS credentials. Create a derived class from this to allow various methods of retrieving credentials.
  */

--- a/utils/s3/credentials_providers/instance_profile_credentials_provider.cc
+++ b/utils/s3/credentials_providers/instance_profile_credentials_provider.cc
@@ -22,7 +22,13 @@ namespace aws {
 
 static logging::logger ec2_md_logger("ec2_metadata");
 
-instance_profile_credentials_provider::instance_profile_credentials_provider(const std::string& _host, unsigned _port) : ec2_metadata_ip(_host), port(_port) {
+instance_profile_credentials_provider::instance_profile_credentials_provider()
+    : _retry_factory([] { return std::make_unique<default_aws_retry_strategy>(); }) {
+}
+
+instance_profile_credentials_provider::instance_profile_credentials_provider(const std::string& _host, unsigned _port,
+        retry_strategy_factory retry_factory)
+    : ec2_metadata_ip(_host), port(_port), _retry_factory(std::move(retry_factory)) {
 }
 
 future<> instance_profile_credentials_provider::reload() {
@@ -35,7 +41,7 @@ future<> instance_profile_credentials_provider::update_credentials() {
     http::client http_client(std::make_unique<utils::http::dns_connection_factory>(ec2_metadata_ip, port, false, ec2_md_logger),
                                            1,
                                            1_MiB,
-                                           std::make_unique<default_aws_retry_strategy>());
+                                           _retry_factory());
     auto req = http::request::make("PUT", ec2_metadata_ip, "/latest/api/token");
     req._headers["x-aws-ec2-metadata-token-ttl-seconds"] = format("{}", session_duration);
 

--- a/utils/s3/credentials_providers/instance_profile_credentials_provider.hh
+++ b/utils/s3/credentials_providers/instance_profile_credentials_provider.hh
@@ -16,8 +16,9 @@ namespace aws {
  */
 class instance_profile_credentials_provider final : public aws_credentials_provider {
 public:
-    instance_profile_credentials_provider() = default;
-    instance_profile_credentials_provider(const std::string& _host, unsigned _port); // For tests
+    instance_profile_credentials_provider();
+    instance_profile_credentials_provider(const std::string& _host, unsigned _port,
+            retry_strategy_factory retry_factory); // For tests
     [[nodiscard]] const char* get_name() const override { return "instance_profile_credentials_provider"; }
 
 protected:
@@ -30,6 +31,7 @@ private:
     std::string ec2_metadata_ip{"169.254.169.254"};
     unsigned port{80};
     static constexpr unsigned session_duration{21600};
+    retry_strategy_factory _retry_factory;
 };
 
 } // namespace aws

--- a/utils/s3/credentials_providers/sts_assume_role_credentials_provider.cc
+++ b/utils/s3/credentials_providers/sts_assume_role_credentials_provider.cc
@@ -23,12 +23,14 @@ namespace aws {
 
 static logging::logger sts_logger("sts");
 
-sts_assume_role_credentials_provider::sts_assume_role_credentials_provider(const std::string& _host, unsigned _port, bool _is_secured)
-    : sts_host(_host), port(_port), is_secured(_is_secured) {
+sts_assume_role_credentials_provider::sts_assume_role_credentials_provider(const std::string& _host, unsigned _port, bool _is_secured,
+        retry_strategy_factory retry_factory)
+    : sts_host(_host), port(_port), is_secured(_is_secured), _retry_factory(std::move(retry_factory)) {
 }
 
 sts_assume_role_credentials_provider::sts_assume_role_credentials_provider(const std::string& _region, const std::string& _role_arn)
-    : sts_host(seastar::format("sts.{}.amazonaws.com", _region)), role_arn(_role_arn) {
+    : sts_host(seastar::format("sts.{}.amazonaws.com", _region)), role_arn(_role_arn)
+    , _retry_factory([] { return std::make_unique<default_aws_retry_strategy>(); }) {
 }
 
 future<> sts_assume_role_credentials_provider::reload() {
@@ -45,7 +47,7 @@ future<> sts_assume_role_credentials_provider::update_credentials() {
     req.set_query_param("RoleSessionName", format("{}", utils::make_random_uuid()));
     req.set_query_param("RoleArn", role_arn);
     http::client http_client(
-        std::make_unique<utils::http::dns_connection_factory>(sts_host, port, is_secured, sts_logger), 1, 1024, std::make_unique<default_aws_retry_strategy>());
+        std::make_unique<utils::http::dns_connection_factory>(sts_host, port, is_secured, sts_logger), 1, 1024, _retry_factory());
     co_await http_client.make_request(
         std::move(req),
         [this](const http::reply&, input_stream<char>&& in) -> future<> {

--- a/utils/s3/credentials_providers/sts_assume_role_credentials_provider.hh
+++ b/utils/s3/credentials_providers/sts_assume_role_credentials_provider.hh
@@ -16,7 +16,8 @@ namespace aws {
  */
 class sts_assume_role_credentials_provider final : public aws_credentials_provider {
 public:
-    sts_assume_role_credentials_provider(const std::string& _host, unsigned _port, bool _is_secured); // For tests
+    sts_assume_role_credentials_provider(const std::string& _host, unsigned _port, bool _is_secured,
+            retry_strategy_factory retry_factory); // For tests
     sts_assume_role_credentials_provider(const std::string& _region, const std::string& _role_arn);
     [[nodiscard]] const char* get_name() const override { return "sts_assume_role_credentials_provider"; }
 
@@ -32,6 +33,7 @@ private:
     unsigned port{443};
     static constexpr unsigned session_duration{43200};
     bool is_secured{true};
+    retry_strategy_factory _retry_factory;
 };
 
 } // namespace aws


### PR DESCRIPTION
There's a part of S3 creds test that deliberately connects to an invalid address. Since the creds provideds all use default retry strategies, this all ends up in several exponential retries and the test spends a lot of time just waiting.

By using a single short retry shortens the test greatly: 108.6s -> 6.0s

Fixes SCYLLADB-2255

Improving tests, not backporting