### PR TITLE
streaming: synchronously unlink partial sstable on write failure

### DIFF
--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -70,6 +70,15 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
                 return sst->write_components(std::move(reader), adjusted_estimated_partitions, s,
                                              cfg, encoding_stats{}).then([sst] {
                     return sst->open_data();
+                }).handle_exception([sst] (std::exception_ptr ep) -> future<> {
+                    // Synchronously remove partial SSTable files before the
+                    // error propagates.  Without this, the shared_sstable
+                    // destructor triggers sstables_manager::deactivate() which
+                    // runs destroy() as a fire-and-forget background task,
+                    // leaving temporary files visible to callers that check the
+                    // filesystem right after the operation fails.
+                    co_await sst->unlink();
+                    std::rethrow_exception(ep);
                 }).then([cf, sst, offstrategy, origin, on_sstable_written, cfg] -> future<std::vector<sstables::shared_sstable>> {
                     auto on_add = [sst, origin, on_sstable_written, cfg] (sstables::shared_sstable loading_sst) -> future<> {
                         if (on_sstable_written) {


### PR DESCRIPTION
When write_components() or open_data() fails on the receiver side (e.g. due to critical disk utilization rejecting a streamed mutation fragment), the shared_sstable goes out of scope and triggers sstables_manager::deactivate(), which runs destroy() as a fire-and-forget background task:

    (void)sst->destroy().finally([ptr] { ... });

This means the API response can return before the partial SSTable files (.tmp, .sstable dir, component files) are removed from disk.

Add an explicit co_await sst->unlink() in the streaming consumer's error path so that cleanup completes before the exception propagates to the caller.  This matches the pattern established by 784127c40b ("sstables_loader: synchronously unlink streamed sstables before returning") for source-side SSTables.  When deactivate() later fires in the background, unlink() is a no-op since _unlinked is already set.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2644

Improvement, no need to backport. The test is flaky on CI.  