### PR TITLE
compaction: refresh ICS backlog on flush, not only on compaction completion

### DIFF
--- a/compaction/incremental_backlog_tracker.cc
+++ b/compaction/incremental_backlog_tracker.cc
@@ -55,6 +55,14 @@ incremental_backlog_tracker::calculate_sstables_backlog_contribution(const std::
 incremental_backlog_tracker::incremental_backlog_tracker(incremental_compaction_strategy_options options) : _options(std::move(options)) {}
 
 double incremental_backlog_tracker::backlog(const compaction_backlog_tracker::ongoing_writes& ow, const compaction_backlog_tracker::ongoing_compactions& oc) const {
+    if (_backlog_dirty) {
+        auto result = calculate_sstables_backlog_contribution(_all, _options, _threshold);
+        _total_backlog_bytes = result.total_backlog_bytes;
+        _sstables_backlog_contribution = result.sstables_backlog_contribution;
+        _sstable_runs_contributing_backlog = std::move(result.sstable_runs_contributing_backlog);
+        _backlog_dirty = false;
+    }
+
     inflight_component compacted = compacted_backlog(oc);
 
     // Bail out if effective backlog is zero
@@ -83,7 +91,6 @@ void incremental_backlog_tracker::replace_sstables(const std::vector<sstables::s
     auto all = _all;
     auto total_bytes = _total_bytes;
     auto threshold = _threshold;
-    auto backlog_calculation_result = incremental_backlog_tracker::backlog_calculation_result{};
     for (auto&& sst : new_ssts) {
     if (sst->data_size() > 0) {
         // note: we don't expect failed insertions since each sstable will be inserted once
@@ -94,23 +101,15 @@ void incremental_backlog_tracker::replace_sstables(const std::vector<sstables::s
     }
     }
 
-    bool exhausted_input_run = false;
     for (auto&& sst : old_ssts) {
     if (sst->data_size() > 0) {
         auto run_identifier = sst->run_identifier();
         all[run_identifier].erase(sst);
         if (all[run_identifier].all().empty()) {
             all.erase(run_identifier);
-            exhausted_input_run = true;
         }
         total_bytes -= sst->data_size();
     }
-    }
-    // Backlog contribution will only be refreshed when an input SSTable run was exhausted by
-    // compaction, so to avoid doing it for each exhausted fragment, which would be both
-    // overkill and expensive.
-    if (exhausted_input_run) {
-        backlog_calculation_result = calculate_sstables_backlog_contribution(all, _options, threshold);
     }
 
     // commit calculations
@@ -118,12 +117,9 @@ void incremental_backlog_tracker::replace_sstables(const std::vector<sstables::s
         _all = std::move(all);
         _total_bytes = total_bytes;
         _threshold = threshold;
-
-        if (exhausted_input_run) {
-            _total_backlog_bytes = backlog_calculation_result.total_backlog_bytes;
-            _sstables_backlog_contribution = backlog_calculation_result.sstables_backlog_contribution;
-            _sstable_runs_contributing_backlog = std::move(backlog_calculation_result.sstable_runs_contributing_backlog);
-        }
+        // Defer backlog contribution recalculation to the next backlog() call,
+        // avoiding O(N^2) cost when many sstables are added in a batch (e.g. boot).
+        _backlog_dirty = true;
     });
 }
 

--- a/compaction/incremental_backlog_tracker.hh
+++ b/compaction/incremental_backlog_tracker.hh
@@ -19,11 +19,15 @@ namespace compaction {
 class incremental_backlog_tracker final : public compaction_backlog_tracker::impl {
     incremental_compaction_strategy_options _options;
     int64_t _total_bytes = 0;
-    int64_t _total_backlog_bytes = 0;
     unsigned _threshold = 0;
-    double _sstables_backlog_contribution = 0.0f;
-    std::unordered_set<sstables::run_id> _sstable_runs_contributing_backlog;
     std::unordered_map<sstables::run_id, sstables::sstable_run> _all;
+
+    // Cached backlog contribution fields, recalculated lazily when _backlog_dirty is set.
+    // Marked mutable because they are caches updated on first backlog() call after a change.
+    mutable bool _backlog_dirty = true;
+    mutable int64_t _total_backlog_bytes = 0;
+    mutable double _sstables_backlog_contribution = 0.0f;
+    mutable std::unordered_set<sstables::run_id> _sstable_runs_contributing_backlog;
 
     struct inflight_component {
         int64_t total_bytes = 0;


### PR DESCRIPTION
The incremental backlog tracker only recalculated its backlog contribution fields (_total_backlog_bytes, _sstables_backlog_contribution, and _sstable_runs_contributing_backlog) when compaction exhausted an input sstable run. When a memtable flush produced a new sstable, replace_sstables was called with an empty old_ssts list, so exhausted_input_run stayed false and the backlog contribution remained stale.

This meant the compaction controller saw an outdated (lower) backlog and allocated fewer CPU shares to compaction than warranted. If the system was already in a bad state with low shares, unaccounted L0 backlog could grow unboundedly while a large compaction was in progress, degrading read performance and causing memory pressure.

Fix by deferring backlog contribution recalculation to the next backlog() call using a dirty flag, rather than computing it eagerly in replace_sstables(). This ensures:
 - Backlog is always up-to-date when the controller samples it (every 250ms)
 - No O(N^2) cost during boot: replace_sstables() just sets the dirty flag (O(1)), and calculate_sstables_backlog_contribution() runs only on the next backlog() call, which is driven by the controller timer, not by per-sstable additions.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2659

Yes, can be backport to vulnerable versions (2026.2 and 2026.1)