### PR TITLE
test/tablets: Use scoped_logger_level for load_balancer log level cha…

### DIFF
--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2407,7 +2407,7 @@ SEASTAR_THREAD_TEST_CASE(test_no_conflicting_internode_and_intra_merge_colocatio
     cfg.db_config->rf_rack_valid_keyspaces.set(true);
 
     do_with_cql_env_thread([] (auto& e) {
-        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::trace);
+        scoped_logger_level lb_log("load_balancer", seastar::log_level::trace);
         topology_builder topo(e);
 
         // RackA: NodeA (overloaded), NodeB (underloaded)
@@ -3601,7 +3601,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_colocated_tablets) {
     // load balancing is expected to move one pair of co-located tablets to the
     // other host while maintaining co-location of each pair.
 
-    logging::logger_registry().set_logger_level("load_balancer", logging::log_level::trace);
+    scoped_logger_level lb_log("load_balancer", seastar::log_level::trace);
 
     unsigned shard_count = 2;
 
@@ -4194,7 +4194,7 @@ SEASTAR_THREAD_TEST_CASE(test_drain_with_forced_capacity_based_balancing_with_in
     cfg.db_config->force_capacity_based_balancing.set(true);
 
     do_with_cql_env_thread([] (auto& e) {
-        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::debug);
+        scoped_logger_level lb_log("load_balancer", seastar::log_level::debug);
         topology_builder topo(e);
 
         auto host1 = topo.add_node(node_state::removing, 8);
@@ -4808,7 +4808,7 @@ SEASTAR_THREAD_TEST_CASE(test_size_based_load_balancing_table_load) {
     //     1.2   |  10000 |          539
     auto cfg = tablet_cql_test_config();
     do_with_cql_env_thread([&] (auto& e) {
-        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::debug);
+        scoped_logger_level lb_log("load_balancer", seastar::log_level::debug);
 
         topology_builder topo(e);
 
@@ -5004,7 +5004,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_ignores_hosts_with_incomplete_stats)
     // This checks that nodes with incomplete stats are not included in load balancing.
     do_with_cql_env_thread([] (auto& e) {
 
-        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::debug);
+        scoped_logger_level lb_log("load_balancer", seastar::log_level::debug);
 
         topology_builder topo(e);
         auto host1 = topo.add_node(node_state::normal, 2);
@@ -5063,7 +5063,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_does_not_balance_with_missing_tablet
     // This checks that the balancer will not issue migrations with incomplete tablet sizes
     do_with_cql_env_thread([] (auto& e) {
 
-        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::debug);
+        scoped_logger_level lb_log("load_balancer", seastar::log_level::debug);
 
         topology_builder topo(e);
         auto host1 = topo.add_node(node_state::normal, 2);
@@ -5099,7 +5099,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_does_not_balance_with_missing_tablet
 
 SEASTAR_THREAD_TEST_CASE(test_split_and_merge_of_colocated_tables) {
     do_with_cql_env_thread([] (auto& e) {
-        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::trace);
+        scoped_logger_level lb_log("load_balancer", seastar::log_level::trace);
         topology_builder topo(e);
 
         unsigned shard_count = 2;
@@ -5935,7 +5935,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
 
 SEASTAR_THREAD_TEST_CASE(test_drain_node_without_capacity) {
     do_with_cql_env_thread([] (auto& e) {
-        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::debug);
+        scoped_logger_level lb_log("load_balancer", seastar::log_level::debug);
 
         topology_builder topo(e);
 
@@ -5976,7 +5976,7 @@ SEASTAR_THREAD_TEST_CASE(test_intranode_balance_threshold) {
     // Set the balance threshold explicitly
     cfg.db_config->size_based_balance_threshold_percentage.set(1.0);
     do_with_cql_env_thread([] (auto& e) {
-        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::debug);
+        scoped_logger_level lb_log("load_balancer", seastar::log_level::debug);
 
         topology_builder topo(e);
 
@@ -6386,7 +6386,7 @@ SEASTAR_THREAD_TEST_CASE(test_ensure_node_for_load_sketch) {
     // not have the larger node in its _nodes member hash map. This will cause an std::out_of_bounds
     // exception when load_sketch::pick() is called with the host_id of the larger node.
     do_with_cql_env_thread([] (auto& e) {
-        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::debug);
+        scoped_logger_level lb_log("load_balancer", seastar::log_level::debug);
 
         topology_builder topo(e);
 


### PR DESCRIPTION
…nges

Tests that set the load_balancer logger level via
logging::logger_registry().set_logger_level() never restored the previous level, causing log level pollution for all subsequently running tests in the same process (combined_tests binary runs all test cases in one process). Currently it's not a big deal, as test.py runs test in parallel with the help of --run_test option, so each test case pollutes only itself.

Replace all 10 call sites with scoped_logger_level RAII guard from test/lib/log.hh, which automatically restores the previous level on scope exit.

Minor test fixlet, not worth backporting