### PR TITLE
[Backport 2025.1] ci: pin GitHub Actions to commit SHAs and migrate to Node.js 24

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -10,6 +10,9 @@ on:
     types: [labeled]
     branches: [master, next, enterprise]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check-commit:
     runs-on: ubuntu-latest
@@ -30,7 +33,7 @@ jobs:
             echo "DEFAULT_BRANCH=master" >> $GITHUB_ENV
           fi
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ github.repository }}
           ref: ${{ env.DEFAULT_BRANCH }}

--- a/.github/workflows/backport-pr-fixes-validation.yaml
+++ b/.github/workflows/backport-pr-fixes-validation.yaml
@@ -5,12 +5,15 @@ on:
     types: [opened, reopened, edited]
     branches: [branch-*]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check-fixes-prefix:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR body for "Fixes" prefix patterns
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const body = context.payload.pull_request.body;

--- a/.github/workflows/build-scylla.yaml
+++ b/.github/workflows/build-scylla.yaml
@@ -12,6 +12,9 @@ on:
         description: 'the md5sum for scylla executable'
         value: ${{ jobs.build.outputs.md5sum }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   read-toolchain:
     uses: ./.github/workflows/read-toolchain.yaml
@@ -24,7 +27,7 @@ jobs:
     outputs:
       md5sum: ${{ steps.checksum.outputs.md5sum }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - name: Generate the building system

--- a/.github/workflows/check-license-header.yaml
+++ b/.github/workflows/check-license-header.yaml
@@ -1,0 +1,53 @@
+name: License Header Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [master]
+
+env:
+  HEADER_CHECK_LINES: 10
+  LICENSE: "LicenseRef-ScyllaDB-Source-Available-1.0"
+  CHECKED_EXTENSIONS: ".cc .hh .py"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  check-license-headers:
+    name: Check License Headers
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        run: |
+          # Get list of added files comparing with base branch
+          echo "files=$(git diff --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
+      - name: Check license headers
+        if: steps.changed-files.outputs.files != ''
+        run: |
+          .github/scripts/check-license.py \
+            --files ${{ steps.changed-files.outputs.files }} \
+            --license "${{ env.LICENSE }}" \
+            --check-lines "${{ env.HEADER_CHECK_LINES }}" \
+            --extensions ${{ env.CHECKED_EXTENSIONS }}
+
+      - name: Comment on PR if check fails
+        if: failure()
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const license = '${{ env.LICENSE }}';
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `❌ License header check failed. Please ensure all new files include the header within the first ${{ env.HEADER_CHECK_LINES }} lines:\n\`\`\`\n${license}\n\`\`\`\nSee action logs for details.`
+            });

--- a/.github/workflows/clang-nightly.yaml
+++ b/.github/workflows/clang-nightly.yaml
@@ -9,6 +9,7 @@ env:
   # use the development branch explicitly
   CLANG_VERSION: 20
   BUILD_DIR: build
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions: {}
 
@@ -32,7 +33,7 @@ jobs:
     steps:
       - run: |
           sudo dnf -y install git
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
       - name: Install build dependencies

--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -18,6 +18,7 @@ env:
   BUILD_TYPE: RelWithDebInfo
   BUILD_DIR: build
   CLANG_TIDY_CHECKS: '-*,bugprone-use-after-move'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions: {}
 
@@ -41,7 +42,7 @@ jobs:
           IMAGE: ${{ needs.read-toolchain.image }}
         run: |
           echo ${{ needs.read-toolchain.image }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
       - run: |

--- a/.github/workflows/codespell.yaml
+++ b/.github/workflows/codespell.yaml
@@ -4,13 +4,15 @@ on:
     branches:
       - master
 permissions: {}
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   codespell:
     name: Check for spelling errors
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: codespell-project/actions-codespell@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           only_warn: 1
           ignore_words_list: "ans,datas,fo,ser,ue,crate,nd,reenable,strat,stap,te,raison"

--- a/.github/workflows/conflict_reminder.yaml
+++ b/.github/workflows/conflict_reminder.yaml
@@ -5,13 +5,16 @@ on:
     - cron: '0 10 * * 1,4'  # Runs every Monday and Thursday at 10:00am
   workflow_dispatch:      # Manual trigger for testing
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   notify_conflict_prs:
     runs-on: ubuntu-latest
 
     steps:
       - name: Notify PR Authors of Conflicts
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const prs = await github.paginate(github.rest.pulls.list, {

--- a/.github/workflows/differential-shellcheck.yaml
+++ b/.github/workflows/differential-shellcheck.yaml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -21,12 +24,12 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        uses: redhat-plumbers-in-action/differential-shellcheck@d965e66ec0b3b2f821f75c8eff9b12442d9a7d1e # v5.5.6
         with:
           severity: warning
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -5,6 +5,7 @@ name: "Docs / Publish"
 env:
   FLAG: ${{ github.repository == 'scylladb/scylla-enterprise' && 'enterprise' || 'opensource' }}
   DEFAULT_BRANCH: ${{ github.repository == 'scylladb/scylla-enterprise' && 'enterprise' || 'master' }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
   push:
@@ -21,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.DEFAULT_BRANCH }}
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
       - name: Set up env

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -4,6 +4,7 @@ name: "Docs / Build PR"
 
 env:
   FLAG: ${{ github.repository == 'scylladb/scylla-enterprise' && 'enterprise' || 'opensource' }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
   pull_request:
@@ -19,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.10"
       - name: Set up env

--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -11,7 +11,16 @@ env:
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
   # the "idl" subdirectory does not contain C++ source code. the .hh files in it are
   # supposed to be processed by idl-compiler.py, so we don't check them using the cleaner
+<<<<<<< HEAD
   CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang message mutation mutation_writer node_ops redis replica
+||||||| parent of 99f4121cd8 (ci: pin GitHub Actions to commit SHAs and migrate to Node.js 24)
+  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang message mutation mutation_writer node_ops raft redis replica service
+  SEASTAR_BAD_INCLUDE_OUTPUT_PATH: build/seastar-bad-include.log
+=======
+  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang message mutation mutation_writer node_ops raft redis replica service
+  SEASTAR_BAD_INCLUDE_OUTPUT_PATH: build/seastar-bad-include.log
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+>>>>>>> 99f4121cd8 (ci: pin GitHub Actions to commit SHAs and migrate to Node.js 24)
 
 permissions: {}
 
@@ -30,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ needs.read-toolchain.outputs.image }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
       - run: |
@@ -80,7 +89,31 @@ jobs:
           done
       - run: |
           echo "::remove-matcher owner=clang-include-cleaner::"
+<<<<<<< HEAD
       - uses: actions/upload-artifact@v4
+||||||| parent of 99f4121cd8 (ci: pin GitHub Actions to commit SHAs and migrate to Node.js 24)
+      - run: |
+          echo "::add-matcher::.github/seastar-bad-include.json"
+      - name: check for seastar includes
+        run: |
+          git -c safe.directory="$PWD"    \
+            grep -nE '#include +"seastar/' \
+            | tee "$SEASTAR_BAD_INCLUDE_OUTPUT_PATH"
+      - run: |
+          echo "::remove-matcher owner=seastar-bad-include::"
+      - uses: actions/upload-artifact@v4
+=======
+      - run: |
+          echo "::add-matcher::.github/seastar-bad-include.json"
+      - name: check for seastar includes
+        run: |
+          git -c safe.directory="$PWD"    \
+            grep -nE '#include +"seastar/' \
+            | tee "$SEASTAR_BAD_INCLUDE_OUTPUT_PATH"
+      - run: |
+          echo "::remove-matcher owner=seastar-bad-include::"
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+>>>>>>> 99f4121cd8 (ci: pin GitHub Actions to commit SHAs and migrate to Node.js 24)
         with:
           name: Logs (clang-include-cleaner)
           path: "./${{ env.CLEANER_OUTPUT_PATH }}"

--- a/.github/workflows/make-pr-ready-for-review.yaml
+++ b/.github/workflows/make-pr-ready-for-review.yaml
@@ -7,6 +7,7 @@ on:
 
 env:
   DEFAULT_BRANCH: 'master'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   mark-ready:
@@ -15,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ github.repository }}
           ref: ${{ env.DEFAULT_BRANCH }}

--- a/.github/workflows/pr-require-backport-label.yaml
+++ b/.github/workflows/pr-require-backport-label.yaml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
       - next
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   label:
     if: github.event.pull_request.draft == false
@@ -13,7 +15,17 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+<<<<<<< HEAD
       - uses: mheap/github-action-required-labels@v5
+||||||| parent of 99f4121cd8 (ci: pin GitHub Actions to commit SHAs and migrate to Node.js 24)
+      - name: Wait for label to be added
+        run: sleep 1m
+      - uses: mheap/github-action-required-labels@v5
+=======
+      - name: Wait for label to be added
+        run: sleep 1m
+      - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5.5.2
+>>>>>>> 99f4121cd8 (ci: pin GitHub Actions to commit SHAs and migrate to Node.js 24)
         with:
           mode: minimum
           count: 1

--- a/.github/workflows/read-toolchain.yaml
+++ b/.github/workflows/read-toolchain.yaml
@@ -7,13 +7,16 @@ on:
         description: "the toolchain docker image"
         value: ${{ jobs.read-toolchain.outputs.image }}
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   read-toolchain:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.read.outputs.image }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: tools/toolchain/image
           sparse-checkout-cone-mode: false

--- a/.github/workflows/seastar.yaml
+++ b/.github/workflows/seastar.yaml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   BUILD_DIR: build
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   read-toolchain:
@@ -29,12 +30,12 @@ jobs:
           - RelWithDebInfo
           - Dev
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: true
       - run: |
           rm -rf seastar
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: scylladb/seastar
           submodules: true

--- a/.github/workflows/sync-labels.yaml
+++ b/.github/workflows/sync-labels.yaml
@@ -7,6 +7,9 @@ on:
   issues:
     types: [labeled, unlabeled]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   label-sync:
     if: ${{ github.repository == 'scylladb/scylladb' }}
@@ -21,7 +24,7 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             .github/scripts/sync_labels.py

--- a/.github/workflows/urgent_issue_reminder.yml
+++ b/.github/workflows/urgent_issue_reminder.yml
@@ -4,13 +4,16 @@ on:
   schedule:
     - cron: '10 8 * * 1' # Runs every Monday at 8 AM
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   reminder:
     runs-on: ubuntu-latest
 
     steps:
     - name: Send reminders
-      uses: actions/github-script@v7
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
           const labelFilters = ['P0', 'P1', 'Field-Tier1','status/release blocker', 'status/regression']; 


### PR DESCRIPTION
Rebased version of #30293 on top of current branch-2025.1.

## Summary
- Pin all external GitHub Actions to full commit SHAs to reduce supply chain attack surface
- Upgrade outdated actions to their latest versions
- Set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true

**This PR was generated automatically. Please verify that GitHub Actions work as expected with these changes before merging.**

Reference: https://github.com/scylladb/scylladb/pull/29421
Closes: #30293