### PR TITLE
replica: Fix multishard reads during vnodes-to-tablets migration

### DIFF
--- a/replica/multishard_query.cc
+++ b/replica/multishard_query.cc
@@ -857,8 +857,9 @@ static future<std::tuple<foreign_ptr<lw_shared_ptr<typename ResultBuilder::resul
     auto& stats = local_db.get_stats();
     const auto short_read_allowed = query::short_read(cmd.slice.options.contains<query::partition_slice::option::allow_short_read>());
 
-    const auto& keyspace = local_db.find_keyspace(s->ks_name());
-    auto query_method = keyspace.get_replication_strategy().uses_tablets() ? do_query_tablets<ResultBuilder> : do_query_vnodes<ResultBuilder>;
+    const auto& table = local_db.find_column_family(s);
+    const auto& erm = table.get_effective_replication_map();
+    auto query_method = erm->get_replication_strategy().uses_tablets() ? do_query_tablets<ResultBuilder> : do_query_vnodes<ResultBuilder>;
 
     auto account_failed_read = defer([&stats] {
         ++stats.total_reads_failed;

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -406,6 +406,7 @@ async def test_migration_rollback(manager: ManagerClient):
         await verify_data_integrity(cql, ks, "test", num_keys)
 
 
+@pytest.mark.xfail(reason="SCYLLADB-2207")
 async def test_migration_multinode(manager: ManagerClient):
     """Verify vnodes-to-tablets migration for a single table on a multi-node cluster with rolling restarts.
 
@@ -480,7 +481,8 @@ async def test_migration_multinode(manager: ManagerClient):
         await verify_data_integrity(cql, ks, "test", num_keys)
 
         logger.info("Starting rolling restarts: mark each node for upgrade, restart it, verify reads/writes at CL=QUORUM from every node")
-        for restart_idx, s in enumerate(servers):
+        expected_keys = num_keys
+        for s in servers:
             logger.info(f"Marking node {s.server_id} for tablets migration")
             await manager.api.upgrade_node_to_tablets(s.ip_addr)
 
@@ -501,23 +503,35 @@ async def test_migration_multinode(manager: ManagerClient):
             await reconnect_driver(manager)
             cql, _ = await manager.get_ready_cql(servers)
 
+            # Check for SCYLLADB-2207: issue a full-table scan from each node
+            # while the cluster is in semi-migrated state.
+            range_scan_stmt = SimpleStatement(f"SELECT * FROM {ks}.test")
+            range_scan_stmt.consistency_level = ConsistencyLevel.QUORUM
+            for node in servers:
+                logger.info(f"Running full-table scan with node {node.server_id} as coordinator after restarting node {s.server_id}")
+                host_obj = cql.cluster.metadata.get_host(node.ip_addr)
+                rows = await cql.run_async(range_scan_stmt, host=host_obj)
+                assert len(rows) == expected_keys, \
+                    f"Full-table scan verification failed: node {node.server_id}, expected {expected_keys} rows, got {len(rows)}"
+
             # Run 10 read/write queries from each node at CL=QUORUM to verify
             # correctness. The cluster is in a semi-migrated state, so some
             # nodes use a tablet ERM and some nodes use a vnode ERM.
-            logger.info(f"Running read/write verification from all nodes after restarting node {s.server_id}")
             insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
             insert_stmt.consistency_level = ConsistencyLevel.QUORUM
             select_stmt = cql.prepare(f"SELECT c FROM {ks}.test WHERE pk = ?")
             select_stmt.consistency_level = ConsistencyLevel.QUORUM
             for node_idx, node in enumerate(servers):
+                logger.info(f"Running read/write verification with node {node.server_id} as coordinator after restarting node {s.server_id}")
                 host_obj = cql.cluster.metadata.get_host(node.ip_addr)
-                base_key = num_keys + restart_idx * num_nodes * 10 + node_idx * 10
+                base_key = expected_keys + node_idx * 10
                 for i in range(10):
                     key = base_key + i
                     await cql.run_async(insert_stmt, [key, key], host=host_obj)
                     rows = await cql.run_async(select_stmt, [key], host=host_obj)
                     assert len(rows) == 1 and rows[0].c == key, \
                         f"Read/write verification failed: node {node.server_id}, key {key}"
+            expected_keys += num_nodes * 10
 
         logger.info("Verifying migration status after rolling restarts")
         await verify_migration_status(manager, servers[0], ks,
@@ -545,8 +559,7 @@ async def test_migration_multinode(manager: ManagerClient):
                 f"Expected intended_storage_mode=None for node {row.host_id} after finalization, got '{row.intended_storage_mode}'"
 
         logger.info("Final data integrity check")
-        total_keys = num_keys + num_nodes * num_nodes * 10 # original keys + 10 keys per node inserted during rolling restarts
-        await verify_data_integrity(cql, ks, "test", total_keys)
+        await verify_data_integrity(cql, ks, "test", expected_keys)
 
 
 async def setup_single_node(manager: ManagerClient):

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -406,7 +406,6 @@ async def test_migration_rollback(manager: ManagerClient):
         await verify_data_integrity(cql, ks, "test", num_keys)
 
 
-@pytest.mark.xfail(reason="SCYLLADB-2207")
 async def test_migration_multinode(manager: ManagerClient):
     """Verify vnodes-to-tablets migration for a single table on a multi-node cluster with rolling restarts.
 


### PR DESCRIPTION
During rolling restart in vnodes-to-tablets migration, a vnode-based coordinator may send a multishard read RPC to a tablet-based replica. The replica enters the multishard read path and incorrectly dispatches based on the keyspace replication strategy (still vnode-based) instead of the table's ERM (tablet-based), hitting an assertion failure:
```
ERROR multishard_query - multishard reader cannot be used on tables with non-static sharding
```

Fix the bug by checking the table's ERM and add range scans in `test_migration_multinode` for coverage.

Fixes SCYLLADB-2207.