### PR TITLE
test.py: fix maintenance socket dir cleanup race on cluster recycle

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -347,7 +347,8 @@ class ScyllaServer:
         xdist_worker_id = get_xdist_worker_id()
         # this variable needed to make a cleanup after server is not needed anymore
         self.maintenance_socket_dir = tempfile.TemporaryDirectory(
-            prefix=f"scylladb-{f'{xdist_worker_id}-' if xdist_worker_id else ''}{self.server_id}-test.py-"
+            prefix=f"scylladb-{f'{xdist_worker_id}-' if xdist_worker_id else ''}{self.server_id}-test.py-",
+            ignore_cleanup_errors=True,
         )
         self.maintenance_socket_path = f"{self.maintenance_socket_dir.name}/cql.m"
         # Unix socket for receiving sd_notify messages from Scylla

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -52,11 +52,11 @@ class PythonTestSuite(TestSuite):
                which would delete the log file and directory - we might want to preserve
                these if it came from a failed test.
             """
+            await cluster.stop()
             for srv in cluster.servers.values():
                 if srv.log_file is not None:
                     srv.log_file.close()
                 srv.maintenance_socket_dir.cleanup()
-            await cluster.stop()
             # Close API client to release connector resources
             if cluster.api is not None:
                 cluster.api.close()


### PR DESCRIPTION
When a dirty cluster was recycled, recycle_cluster() cleaned up each server's maintenance_socket_dir before stopping the servers. Since cluster.servers includes running servers, the live Scylla process could (re)create files such as the cql.m maintenance socket in the directory while shutil was removing it, between its scandir snapshot and the final rmdir. This made TemporaryDirectory.cleanup() fail with ENOTEMPTY ("Directory not empty"), surfacing as an HTTP 500 on the next test's before-test request.

Stop the servers before cleaning up the directories, and construct the TemporaryDirectory with ignore_cleanup_errors=True as an additional safeguard.

Fixes SCYLLADB-2645