### PR TITLE
utils: lsa: avoid large allocations in chunked_managed_vector

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -899,6 +899,25 @@ class managed_vector:
             yield self._ref['_data'][i]
 
 
+class managed_chunk_directory:
+    def __init__(self, ref):
+        self._ref = ref
+
+    def __len__(self):
+        return int(self._ref['_size'])
+
+    def __nonzero__(self):
+        return self.__len__() > 0
+
+    def __bool__(self):
+        return self.__len__() > 0
+
+    def __iter__(self):
+        for block in managed_vector(self._ref['_blocks']):
+            for chunk in managed_vector(block):
+                yield chunk
+
+
 class chunked_managed_vector:
     def __init__(self, ref):
         self._ref = ref
@@ -913,7 +932,13 @@ class chunked_managed_vector:
         return self.__len__() > 0
 
     def __iter__(self):
-        for chunk in managed_vector(self._ref['_chunks']):
+        chunks = self._ref['_chunks']
+        try:
+            chunks['_blocks']
+            chunk_iter = managed_chunk_directory(chunks)
+        except gdb.error:
+            chunk_iter = managed_vector(chunks)
+        for chunk in chunk_iter:
             for e in managed_vector(chunk):
                 yield e
 

--- a/test/boost/chunked_managed_vector_test.cc
+++ b/test/boost/chunked_managed_vector_test.cc
@@ -209,6 +209,151 @@ SEASTAR_TEST_CASE(tests_reserve_partial) {
   return make_ready_future<>();
 }
 
+SEASTAR_TEST_CASE(test_reserve_many_chunks) {
+    region region;
+    allocating_section as;
+    with_allocator(region.allocator(), [&] {
+        as(region, [&] {
+            lsa::chunked_managed_vector<uint8_t> v;
+            auto size = lsa::chunked_managed_vector<uint8_t>::max_chunk_capacity() * 1024;
+
+            v.reserve(size);
+            BOOST_REQUIRE_EQUAL(v.capacity(), size);
+
+            v.emplace_back(1);
+            BOOST_REQUIRE_EQUAL(v.front(), 1);
+            v.clear_and_release();
+        });
+    });
+    return make_ready_future<>();
+}
+
+// A value sized so that exactly one element fits in a chunk, i.e.
+// chunked_managed_vector<one_per_chunk_value>::max_chunk_capacity() == 1,
+// regardless of logalloc's max managed object size or managed_vector's metadata
+// size. This lets a handful of elements span many chunks (and therefore multiple
+// directory blocks), exercising the chunk directory -- a private implementation
+// detail of chunked_managed_vector -- through the public API.
+//
+// A chunk keeps its elements in a managed_vector<T> whose contiguous allocation
+// must stay within logalloc::max_managed_object_size, leaving
+// max_managed_object_size - metadata_size() bytes of payload. Sizing the element
+// to that payload (rounded down to its alignment) yields one element per chunk
+// and keeps the test stable if those limits change. metadata_size() is taken
+// from managed_vector<uint64_t> to avoid referring to the still-incomplete
+// one_per_chunk_value; the static_asserts below confirm the proxy is exact.
+constexpr size_t one_per_chunk_value_size =
+        (logalloc::max_managed_object_size - managed_vector<uint64_t>::metadata_size())
+        / alignof(uint64_t) * alignof(uint64_t);
+struct one_per_chunk_value {
+    uint64_t tag;
+    char padding[one_per_chunk_value_size - sizeof(uint64_t)];
+};
+static_assert(sizeof(one_per_chunk_value) == one_per_chunk_value_size);
+static_assert(managed_vector<one_per_chunk_value>::metadata_size() == managed_vector<uint64_t>::metadata_size());
+// This expression is chunked_managed_vector::max_chunk_capacity() evaluated at compile time.
+static_assert((logalloc::max_managed_object_size - managed_vector<one_per_chunk_value>::metadata_size()) / sizeof(one_per_chunk_value) == 1);
+
+// The chunk directory is stored as a two-level managed structure so that no
+// single allocation exceeds logalloc's contiguous allocation limit.
+// This exercises element access and shrinking across a directory block boundary,
+// i.e. when the directory holds more chunk pointers than fit in one directory block.
+SEASTAR_TEST_CASE(test_directory_block_boundary) {
+    region region;
+    allocating_section as;
+    with_allocator(region.allocator(), [&] {
+        as(region, [&] {
+            using vector_type = lsa::chunked_managed_vector<one_per_chunk_value>;
+
+            // More chunks than fit in a single directory block.
+            constexpr size_t count = 700;
+            vector_type v;
+            BOOST_REQUIRE_EQUAL(vector_type::max_chunk_capacity(), 1u);
+            for (size_t i = 0; i < count; ++i) {
+                v.emplace_back(one_per_chunk_value{.tag = i});
+            }
+            BOOST_REQUIRE_EQUAL(v.size(), count);
+
+            // Random access must be correct across directory block boundaries.
+            for (size_t i = 0; i < count; ++i) {
+                BOOST_REQUIRE_EQUAL(v[i].tag, i);
+            }
+
+            // Shrinking releases directory blocks; surviving elements stay intact.
+            constexpr size_t kept = 100;
+            v.resize(kept);
+            BOOST_REQUIRE_EQUAL(v.size(), kept);
+            BOOST_REQUIRE_EQUAL(v.capacity(), kept);
+            for (size_t i = 0; i < kept; ++i) {
+                BOOST_REQUIRE_EQUAL(v[i].tag, i);
+            }
+
+            v.clear_and_release();
+        });
+    });
+    return make_ready_future<>();
+}
+
+// After chunked_managed_vector::reserve(n), the following n emplace_back()s must
+// not allocate. external_memory_usage() accounts for reserved capacity, so if any
+// chunk, directory block, or the top-level block array reallocated to grow, it
+// would change. Spanning several directory blocks exercises the two-level
+// directory's reserve() path.
+SEASTAR_TEST_CASE(test_directory_reserve_avoids_push_back_allocation) {
+    region region;
+    allocating_section as;
+    with_allocator(region.allocator(), [&] {
+        as(region, [&] {
+            using vector_type = lsa::chunked_managed_vector<one_per_chunk_value>;
+            BOOST_REQUIRE_EQUAL(vector_type::max_chunk_capacity(), 1u);
+            // More chunks than fit in a single directory block.
+            constexpr size_t n = 700;
+            vector_type v;
+            v.reserve(n);
+            auto reserved_mem = v.external_memory_usage();
+            for (size_t i = 0; i < n; ++i) {
+                v.emplace_back(one_per_chunk_value{.tag = i});
+                // No reallocation: reserved capacity is unchanged.
+                BOOST_REQUIRE_EQUAL(v.external_memory_usage(), reserved_mem);
+            }
+            BOOST_REQUIRE_EQUAL(v.size(), n);
+            for (size_t i = 0; i < n; ++i) {
+                BOOST_REQUIRE_EQUAL(v[i].tag, i);
+            }
+            v.clear_and_release();
+        });
+    });
+    return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_directory_pop_back_preserves_reserved_blocks) {
+    region region;
+    allocating_section as;
+    with_allocator(region.allocator(), [&] {
+        as(region, [&] {
+            using vector_type = lsa::chunked_managed_vector<one_per_chunk_value>;
+            constexpr size_t n = 700;
+            vector_type v;
+            v.reserve(n);
+            auto reserved_mem = v.external_memory_usage();
+
+            v.emplace_back(one_per_chunk_value{.tag = 1});
+            v.pop_back();
+
+            BOOST_REQUIRE_EQUAL(v.size(), 0u);
+            BOOST_REQUIRE_EQUAL(v.external_memory_usage(), reserved_mem);
+
+            for (size_t i = 0; i < n; ++i) {
+                v.emplace_back(one_per_chunk_value{.tag = i});
+                BOOST_REQUIRE_EQUAL(v.external_memory_usage(), reserved_mem);
+            }
+
+            v.clear_and_release();
+        });
+    });
+    return make_ready_future<>();
+}
+
 SEASTAR_TEST_CASE(test_clear_and_release) {
     region region;
     allocating_section as;

--- a/utils/lsa/chunked_managed_vector.hh
+++ b/utils/lsa/chunked_managed_vector.hh
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <utility>
 #include <algorithm>
+#include <bit>
 #include <stdexcept>
 
 namespace lsa {
@@ -29,8 +30,109 @@ class chunked_managed_vector {
     using chunk_ptr = managed_vector<T>;
     static constexpr size_t max_contiguous_allocation = logalloc::max_managed_object_size - chunk_ptr::metadata_size();
     static_assert(std::is_nothrow_move_constructible<T>::value, "T must be nothrow move constructible");
+    // Internal detail: the two-level directory of chunk pointers, kept
+    // entirely in LSA memory. This is NOT a general-purpose container and
+    // must not be used outside chunked_managed_vector. It exists only because
+    // chunked_managed_vector cannot store its own directory: doing so would
+    // nest the same large-allocation problem one level down (infinite
+    // regress), and the directory needs a compile-time power-of-two block
+    // size so operator[] compiles to shifts and masks (O(1) indexing), which
+    // chunked_managed_vector's runtime max_chunk_capacity() does not provide.
+    //
+    // Storing the whole directory in a single managed_vector would, for large
+    // vectors, require a contiguous LSA allocation exceeding logalloc's max
+    // managed object size. Splitting it into fixed-size blocks keeps each
+    // block's allocation within the limit. All storage stays in LSA (and thus
+    // relocatable); only the top-level block array approaches the limit, which
+    // happens once the vector grows into the multi-GB range (~1.3 GB of
+    // payload), well beyond any realistic single-vector size.
+    class chunk_directory {
+        using block = managed_vector<chunk_ptr>;
+        // Keep each block's allocation within logalloc's limit, rounded down to a
+        // power of two so that operator[] uses shifts and masks instead of division
+        // and remainder.
+        static constexpr size_t block_capacity = std::bit_floor((logalloc::max_managed_object_size - block::metadata_size()) / sizeof(chunk_ptr));
+        static_assert(block_capacity >= 1);
+        managed_vector<block, 1> _blocks;
+        size_t _size = 0;
+    public:
+        size_t size() const { return _size; }
+        bool empty() const { return _size == 0; }
+        chunk_ptr& operator[](size_t i) { return _blocks[i / block_capacity][i % block_capacity]; }
+        const chunk_ptr& operator[](size_t i) const { return _blocks[i / block_capacity][i % block_capacity]; }
+        chunk_ptr& back() { return (*this)[_size - 1]; }
+        // Ensure the directory can hold n entries without further allocation.
+        // Interior blocks are always filled to block_capacity, so only the last
+        // needed block may be partially reserved. By materializing the blocks and
+        // reserving storage within them, subsequent push_back()s up to n don't
+        // allocate.
+        void reserve(size_t n) {
+            size_t nblocks = (n + block_capacity - 1) / block_capacity;
+            if (nblocks <= _blocks.size()) {
+                // Already have the blocks; top up the last needed one if n grew
+                // within it.
+                if (nblocks > 0) {
+                    size_t bi = nblocks - 1;
+                    _blocks[bi].reserve(std::min(block_capacity, n - bi * block_capacity));
+                }
+                return;
+            }
+            _blocks.reserve(nblocks);
+            // The current last block becomes an interior block, so reserve it fully.
+            if (!_blocks.empty()) {
+                _blocks.back().reserve(block_capacity);
+            }
+            while (_blocks.size() < nblocks) {
+                size_t bi = _blocks.size();
+                _blocks.emplace_back();
+                _blocks.back().reserve(std::min(block_capacity, n - bi * block_capacity));
+            }
+        }
+        void push_back(chunk_ptr value) {
+            size_t bi = _size / block_capacity;
+            // reserve() may have materialized this block already.
+            if (bi == _blocks.size()) {
+                _blocks.emplace_back();
+            }
+            auto& b = _blocks[bi];
+            if (b.size() == b.capacity()) {
+                // Not reserved ahead: grow geometrically but never past
+                // block_capacity, so managed_vector's own growth can't overshoot
+                // the block and exceed logalloc's limit.
+                b.reserve(std::min(block_capacity, std::max<size_t>(b.capacity() * 2, 1)));
+            }
+            b.emplace_back(std::move(value));
+            ++_size;
+        }
+        void pop_back() {
+            size_t bi = (_size - 1) / block_capacity;
+            _blocks[bi].pop_back();
+            --_size;
+        }
+        void shrink_to_fit() {
+            size_t nblocks = (_size + block_capacity - 1) / block_capacity;
+            while (_blocks.size() > nblocks) {
+                _blocks.pop_back();
+            }
+        }
+        // Clears the directory and releases all memory so it can be destroyed under any allocator.
+        void clear_and_release() noexcept {
+            for (auto& b : _blocks) {
+                b.clear_and_release();
+            }
+            _blocks.clear_and_release();
+            _size = 0;
+        }
+        size_t external_memory_usage() const {
+            size_t n = _blocks.external_memory_usage();
+            for (const auto& b : _blocks) {
+                n += b.external_memory_usage();
+            }
+            return n;
+        }
+    };
     // Each chunk holds max_chunk_capacity() items, except possibly the last
-    managed_vector<chunk_ptr, 1> _chunks;
+    chunk_directory _chunks;
     size_t _size = 0;
     size_t _capacity = 0;
 public:
@@ -170,7 +272,13 @@ public:
 public:
     template <class ValueType>
     class iterator_type {
-        const chunk_ptr* _chunks;
+        // The owner pointer's constness follows ValueType, so a const_iterator
+        // holds a const owner and a mutable iterator a mutable one. addr() then
+        // delegates to chunked_managed_vector::addr(), whose const/non-const
+        // overloads produce the correctly-qualified pointer without a const_cast
+        // and keep the directory-indexing logic in a single place.
+        using owner_ptr = std::conditional_t<std::is_const_v<ValueType>, const chunked_managed_vector*, chunked_managed_vector*>;
+        owner_ptr _owner = nullptr;
         size_t _i;
     public:
         using iterator_category = std::random_access_iterator_tag;
@@ -180,12 +288,12 @@ public:
         using reference = ValueType&;
     private:
         pointer addr() const {
-            return &const_cast<chunk_ptr*>(_chunks)[_i / max_chunk_capacity()][_i % max_chunk_capacity()];
+            return _owner->addr(_i);
         }
-        iterator_type(const chunk_ptr* chunks, size_t i) : _chunks(chunks), _i(i) {}
+        iterator_type(owner_ptr owner, size_t i) : _owner(owner), _i(i) {}
     public:
         iterator_type() = default;
-        iterator_type(const iterator_type<std::remove_const_t<ValueType>>& x) : _chunks(x._chunks), _i(x._i) {} // needed for iterator->const_iterator conversion
+        iterator_type(const iterator_type<std::remove_const_t<ValueType>>& x) : _owner(x._owner), _i(x._i) {} // needed for iterator->const_iterator conversion
         reference operator*() const {
             return *addr();
         }
@@ -248,12 +356,12 @@ public:
 public:
     const T& front() const { return *cbegin(); }
     T& front() { return *begin(); }
-    iterator begin() { return iterator(_chunks.data(), 0); }
-    iterator end() { return iterator(_chunks.data(), _size); }
-    const_iterator begin() const { return const_iterator(_chunks.data(), 0); }
-    const_iterator end() const { return const_iterator(_chunks.data(), _size); }
-    const_iterator cbegin() const { return const_iterator(_chunks.data(), 0); }
-    const_iterator cend() const { return const_iterator(_chunks.data(), _size); }
+    iterator begin() { return iterator(this, 0); }
+    iterator end() { return iterator(this, _size); }
+    const_iterator begin() const { return const_iterator(this, 0); }
+    const_iterator end() const { return const_iterator(this, _size); }
+    const_iterator cbegin() const { return const_iterator(this, 0); }
+    const_iterator cend() const { return const_iterator(this, _size); }
     std::reverse_iterator<iterator> rbegin() { return std::reverse_iterator(end()); }
     std::reverse_iterator<iterator> rend() { return std::reverse_iterator(begin()); }
     std::reverse_iterator<const_iterator> rbegin() const { return std::reverse_iterator(end()); }
@@ -430,6 +538,7 @@ chunked_managed_vector<T>::shrink_to_fit() {
         _chunks.pop_back();
         _capacity = _chunks.size() * max_chunk_capacity();
     }
+    _chunks.shrink_to_fit();
 
     auto overcapacity = _size - _capacity;
     if (overcapacity) {


### PR DESCRIPTION
chunked_managed_vector stores its elements in LSA-managed chunks, but kept the chunk directory itself in a single managed_vector. With enough chunks, that directory grows into a large contiguous LSA allocation and trips logalloc's max managed object size limit.

This can happen when reading large SSTable partition index pages: the partition_index_page entries are chunked, but reserving enough chunks for the page can make the chunk directory exceed logalloc's limit, aborting with errors like:

    Contiguous allocation of size 13320 exceeds logalloc's limit of 13107

In the old layout, each directory entry was a managed chunk pointer. On this build that pointer object is 32 bytes, so the single managed_vector directory hit logalloc's 13107-byte limit at about 409 chunks. Each chunk holds about 13 KB of payload regardless of element type, so the old layout could overflow once the vector reached only about 5 MB of payload.

Split the chunk directory into a two-level structure (`managed_chunk_directory`): a top-level managed_vector of fixed-size directory blocks, each itself a managed_vector bounded so its allocation stays within logalloc's limit. **All storage remains LSA-managed and relocatable** (both levels are `managed_vector`); nothing falls back to the standard allocator, so LSA memory accounting and compaction are unaffected. No single directory-block allocation can exceed the limit. With 256 entries per directory block and about 409 top-level block entries, the top-level block array only approaches the limit once the vector grows to roughly 104K chunks, or about 1.3 GB of payload.

block_capacity is rounded down to a power of two so that per-element operator[] can be compiled as shifts and masks instead of division and remainder.

The directory's reserve() materializes the needed blocks and reserves storage within them: interior blocks to block_capacity, and only the last block partially. A following sequence of push_back()s up to the reserved size therefore performs no allocation. push_back() and pop_back() address their target block by index rather than using back(), so reserved-but-empty trailing blocks are valid.

Update scylla-gdb.py to walk the new two-level directory so the chunked_managed_vector pretty-printer keeps working, falling back to the old single-managed_vector layout for older binaries/cores.

Add regression tests:
- test_reserve_many_chunks reserves enough chunks to reproduce the original failure.
- test_directory_block_boundary exercises element access and shrinking across a directory block boundary.
- test_directory_reserve_avoids_push_back_allocation verifies that push_back() after reserve() does not allocate.
- test_directory_pop_back_preserves_reserved_blocks verifies that popping entries does not discard reserved directory blocks.

Tests:
./test.py --mode=dev test/boost/chunked_managed_vector_test.cc

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2679

Improvement. No backport for now unless requested explicitly.
