### PR TITLE
mv/row_locker: increase load factor to avoid oversized allocations

### DIFF
--- a/db/view/row_locking.cc
+++ b/db/view/row_locking.cc
@@ -16,6 +16,8 @@ row_locker::row_locker(schema_ptr s)
     : _schema(s)
     , _two_level_locks(1, decorated_key_hash(), decorated_key_equals_comparator(this))
 {
+    // Increase max load factor to allow up to ~128K concurrent requests without oversized allocations.
+    _two_level_locks.max_load_factor(8);
 }
 
 void row_locker::upgrade(schema_ptr new_schema) {


### PR DESCRIPTION
In the row_locker structure, held by each table, we have an unordered_map of locks for each locked partition. We've seen in tests that the number of concurrently locked partitions may exceed 16K, which results in rehashing of the map and performing an oversized allocation. In this patch we avoid this by increasing the max_load_factor of the map with locks. This should effectively decrease the number of buckets in the map by 8x, so the array with bucket references should also decrease 8x in size. The performance loss incurred here should be negligible - we lock partitions when we do a read-before-write for a view update, which dominates the time for generating the view update.

Fixes: SCYLLADB-1580
