### PR TITLE
test/cluster/mv/test_mv_building: check if any view builder isn't finished

### DIFF
--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -365,7 +365,7 @@ async def test_do_not_finish_view_builder_with_nodes_down(manager: ManagerClient
         build_status = await cql.run_async(
             f"SELECT * FROM system.view_build_status_v2 WHERE keyspace_name = '{ks}' AND view_name = 'mv_cf_view'",
             host=cql.cluster.metadata.get_host(servers[0].ip_addr))
-        assert len(build_status) > 0 and build_status[0].status != 'SUCCESS', \
+        assert len(build_status) > 0 and any(bs.status != 'SUCCESS' for bs in build_status), \
             "View builder should still be in progress while nodes are down"
 
         # Restart the stopped nodes


### PR DESCRIPTION
test_do_not_finish_view_builder_with_nodes_down is assuming that not finished build status is on the first row, which is completely false assumption.

This patch changes this check to validate if at least one view builder isn't finished.

Fixes SCYLLADB-2639

This test is also present in 2026.2, so this patch should be backported there.