### PR TITLE
test: rewrite `test_writes_caching_{disabled,enabled}` in C++

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1697,6 +1697,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/cql_query_large_test.cc',
     'test/boost/cql_query_like_test.cc',
     'test/boost/cql_query_test.cc',
+    'test/boost/cql_ddl_test.cc',
     'test/boost/database_test.cc',
     'test/boost/data_listeners_test.cc',
     'test/boost/disk_space_monitor_test.cc',

--- a/db/row_cache.hh
+++ b/db/row_cache.hh
@@ -409,6 +409,11 @@ public:
     mutation_reader make_nonpopulating_reader(schema_ptr s, reader_permit permit, const dht::partition_range& range,
             const query::partition_slice& slice, tracing::trace_state_ptr ts);
 
+    bool empty() const {
+        // Last entry is dummy one, used for continuity tracking
+        return _partitions.begin() == std::prev(_partitions.end());
+    }
+
     const stats& stats() const { return _stats; }
 public:
     // Populate cache from given mutation, which must be fully continuous.

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -350,6 +350,7 @@ add_scylla_test(combined_tests
     cql_query_large_test.cc
     cql_query_like_test.cc
     cql_query_test.cc
+    cql_ddl_test.cc
     database_test.cc
     data_listeners_test.cc
     disk_space_monitor_test.cc

--- a/test/boost/cql_ddl_test.cc
+++ b/test/boost/cql_ddl_test.cc
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+
+#include <boost/test/unit_test.hpp>
+
+#undef SEASTAR_TESTING_MAIN
+#include <seastar/testing/test_case.hh>
+
+BOOST_AUTO_TEST_SUITE(cql_ddl_test)
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/cql_ddl_test.cc
+++ b/test/boost/cql_ddl_test.cc
@@ -12,6 +12,68 @@
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>
 
+#include "test/lib/cql_test_env.hh"
+
 BOOST_AUTO_TEST_SUITE(cql_ddl_test)
+
+/// Check that writes interact with caching = {'enabled': X} as expected:
+/// * enable: true -> data is merged into cache on memtable flush [1]
+/// * enable: false -> data is not merged into cache on memtable flush
+///
+/// [1] Important: only partitions which are either already in the cache,
+///     or are not present in underlying (disk) are merged.
+future<> writes_with_caching_toggle(bool enabled) {
+    return do_with_cql_env_thread([enabled] (cql_test_env& e) {
+        e.execute_cql(format("CREATE TABLE ks.tbl (pk int PRIMARY KEY, v text) WITH CACHING = {{'enabled': '{}'}}", enabled)).get();
+
+        const auto& table = e.local_db().find_column_family("ks", "tbl");
+        const auto table_id = table.schema()->id();
+
+        auto write_rows = [&, first_pk = 0] () mutable {
+            sstring value(128, 'v');
+            const auto cql3_value = cql3::raw_value::make_value(serialized(value));
+
+            auto id = e.prepare("INSERT INTO ks.tbl (pk, v) VALUES (?, ?);").get();
+            for (int flushes = 0; flushes < 5; flushes++) {
+                for (int32_t pk = first_pk; pk < first_pk + 10; ++pk) {
+                    const auto cql3_pk = cql3::raw_value::make_value(serialized(pk));
+                    e.execute_prepared(id, {cql3_pk, cql3_value}).get();
+                }
+                replica::database::flush_table_on_all_shards(e.db(), table_id).get();
+            }
+            first_pk += 10;
+        };
+
+        auto check_expected_cache_content = [&] (bool cache_enabled) {
+            const auto get_cache_shards_with_content = e.db().map_reduce0([] (const replica::database& db) {
+                auto& t = db.find_column_family("ks", "tbl");
+                return uint64_t(!t.get_row_cache().empty());
+            }, uint64_t(0), std::plus<uint64_t>()).get();
+
+            if (cache_enabled) {
+                BOOST_REQUIRE_GT(get_cache_shards_with_content, 0);
+            } else {
+                BOOST_REQUIRE_EQUAL(get_cache_shards_with_content, 0);
+            }
+        };
+
+        write_rows();
+        check_expected_cache_content(enabled);
+
+        replica::database::drop_cache_for_table_on_all_shards(e.db(), table_id).get();
+        e.execute_cql(format("ALTER TABLE ks.tbl WITH CACHING = {{'enabled': '{}'}}", !enabled)).get();
+
+        write_rows();
+        check_expected_cache_content(!enabled);
+    });
+}
+
+SEASTAR_TEST_CASE(test_writes_with_caching_disabled) {
+    return writes_with_caching_toggle(false);
+}
+
+SEASTAR_TEST_CASE(test_writes_with_caching_enabled) {
+    return writes_with_caching_toggle(true);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cluster/dtest/bypass_cache_test.py
+++ b/test/cluster/dtest/bypass_cache_test.py
@@ -336,39 +336,3 @@ class TestBypassCache(Tester):
         # enabling caching for table and checking read comes from cache
         session.execute(f"ALTER TABLE {self.table_name} WITH caching = {{'enabled':true}}")
         self.verify_read_was_from_cache(node=node, query=query, session=session)
-
-    def verify_used_memory_grow(self, node, session):
-        grew = 0
-        metric = ["scylla_cache_bytes_used"]
-        for _ in range(NUM_OF_QUERY_EXECUTIONS):
-            cache_bytes_used_before_write = self.get_scylla_cache_reads_metrics(node=node, metrics=metric)[metric[0]]
-            insert_c1c2(session, keys=list(range(self.first_key, self.first_key + 10)), cf=self.table_name,
-                        ks=self.keyspace_name)
-            node.flush(ks=self.keyspace_name, table=self.table_name)
-            cache_bytes_used_after_write = self.get_scylla_cache_reads_metrics(node=node, metrics=metric)[metric[0]]
-            if cache_bytes_used_before_write < cache_bytes_used_after_write:
-                grew += 1
-            self.first_key += 10
-        return grew > NUM_OF_QUERY_EXECUTIONS / 2
-
-    def test_writes_caching_disabled(self):
-        session = self.prepare(insert_data=False)
-        node = self.cluster.nodelist()[0]
-        create_c1c2_table(session, cf=self.table_name, caching=False)
-        insert_c1c2(session, n=NUM_OF_QUERY_EXECUTIONS, cf=self.table_name, ks=self.keyspace_name)
-        self.first_key = 0
-        assert not self.verify_used_memory_grow(node=node, session=session), "expected to have writes without cache"
-        alter_cmd = f"ALTER TABLE {self.keyspace_name}.{self.table_name} WITH CACHING = {{'enabled': 'true'}}"
-        session.execute(alter_cmd)
-        assert self.verify_used_memory_grow(node=node, session=session), "expected to have writes through cache"
-
-    def test_writes_caching_enabled(self):
-        session = self.prepare(insert_data=False)
-        node = self.cluster.nodelist()[0]
-        create_c1c2_table(session, cf=self.table_name)
-        insert_c1c2(session, n=NUM_OF_QUERY_EXECUTIONS, cf=self.table_name, ks=self.keyspace_name)
-        self.first_key = 0
-        assert self.verify_used_memory_grow(node=node, session=session), "expected to have writes through cache"
-        alter_cmd = f"ALTER TABLE {self.keyspace_name}.{self.table_name} WITH CACHING = {{'enabled': 'false'}}"
-        session.execute(alter_cmd)
-        assert not self.verify_used_memory_grow(node=node, session=session), "expected to have writes without cache"


### PR DESCRIPTION
Migrate the tests from `test/cluster/dtest/test_bypass_cache.py` to `test/boost/cql_ddl_test.cc`.

The python variant of this test is flaky, because it doesn't have an accurate way to check whether cache has content for the table. The check can pick up activity in other (system) tables.

Rewriting this test in C++ allows for more targeted checks against the content of the cache via C++ API, resolving the flakyness. As a bonus, the test also runs faster.

Fixes: SCYLLADB-2636

Backport: test was observed to fail only on master, no backport for now