### PR TITLE
scylla-gdb: add missing `e` in exception clause

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -6544,8 +6544,8 @@ class scylla_prepared_statements(gdb.Command):
         def try_decode(raw_stmt: bytes):
             try:
                 return raw_stmt.decode("utf-8", "replace")
-            except Exception:
-                gdb.write("try_decode(): failed to decode raw statement: {}\n".format(e))
+            except Exception as e:
+                gdb.write("try_decode(): falied to decode raw statement: {}\n".format(e))
                 return str(raw_stmt)
 
         qp = sharded(gdb.parse_and_eval("debug::the_query_processor").dereference()).local()


### PR DESCRIPTION
Add missing `e` parameter to an exception clause, as the exception object (via `e`) is later used in `gdb.write` call.

Backport: none, the error was recent (commit 6c3f104b67adc3d667cca756b245cb61bfaeeafb).