### PR TITLE
build: fix compare_build_systems mismatch after Fedora 44 toolchain update

### DIFF
--- a/.github/workflows/compare-build-systems.yaml
+++ b/.github/workflows/compare-build-systems.yaml
@@ -9,6 +9,8 @@ on:
       - '**/CMakeLists.txt'
       - 'cmake/**'
       - 'scripts/compare_build_systems.py'
+      - 'tools/toolchain/**'
+      - 'install-dependencies.sh'
   workflow_dispatch:
 
 permissions:

--- a/configure.py
+++ b/configure.py
@@ -2323,6 +2323,7 @@ libs = ' '.join([maybe_static(args.staticyamlcpp, '-lyaml-cpp'), '-latomic', '-l
                  # experimental APIs that we use are only present there.
                  maybe_static(True, '-lzstd'),
                  maybe_static(True, '-llz4'),
+                 maybe_static(args.staticboost, '-lboost_container'),
                  maybe_static(args.staticboost, '-lboost_date_time -lboost_regex -licuuc -licui18n'),
                  '-lxxhash',
                  '-ldeflate',
@@ -2366,6 +2367,25 @@ kmipc_lib = f'{kmipc_dir}/lib/libkmip.a'
 if os.path.exists(kmipc_lib):
     libs += f' {kmipc_lib}'
     user_cflags += f' -I{kmipc_dir}/include -DHAVE_KMIP'
+
+cpp_jwt_encryption_sources = [
+    'ent/encryption/azure_host.cc',
+    'ent/encryption/azure_key_provider.cc',
+    'ent/encryption/encrypted_file_impl.cc',
+    'ent/encryption/encryption.cc',
+    'ent/encryption/encryption_config.cc',
+    'ent/encryption/gcp_host.cc',
+    'ent/encryption/gcp_key_provider.cc',
+    'ent/encryption/kmip_host.cc',
+    'ent/encryption/kmip_key_provider.cc',
+    'ent/encryption/kms_host.cc',
+    'ent/encryption/kms_key_provider.cc',
+    'ent/encryption/local_file_provider.cc',
+    'ent/encryption/replicated_key_provider.cc',
+    'ent/encryption/symmetric_key.cc',
+    'ent/encryption/system_key.cc',
+    'ent/encryption/utils.cc',
+]
 
 def get_extra_cxxflags(mode, mode_config, cxx, debuginfo):
     cxxflags = [
@@ -3092,6 +3112,8 @@ def create_build_system(args):
         mode_config['cxxflags'] += f' {extra_cxxflags}'
 
         mode_config['per_src_extra_cxxflags']['release.cc'] = ' '.join(get_release_cxxflags(scylla_product, scylla_version, scylla_release))
+        for src in cpp_jwt_encryption_sources:
+            mode_config['per_src_extra_cxxflags'][src] = '-DCPP_JWT_USE_VENDORED_NLOHMANN_JSON'
 
     prepare_advanced_optimizations(modes=modes, build_modes=build_modes, args=args)
 


### PR DESCRIPTION
### Problem
`compare_build_systems.py --ci` started failing after the Fedora 44 toolchain bump, with CMake-only deltas (`boost_container` link lib and `CPP_JWT_USE_VENDORED_NLOHMANN_JSON` define).

### Changes
- Trigger `.github/workflows/compare-build-systems.yaml` when toolchain inputs change (`tools/toolchain/**`, `install-dependencies.sh`), not only CMake/configure files.
- Align `configure.py` with CMake/toolchain behavior by:
  - adding `-lboost_container` to configure.py link libs, and
  - adding `-DCPP_JWT_USE_VENDORED_NLOHMANN_JSON` for `ent/encryption/*.cc` sources.

### Validation
- `scripts/compare_build_systems.py --ci` now reports `MATCH` across all modes.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2711
Refs: https://github.com/scylladb/scylladb/pull/30386

No backport needed (build/CI alignment only).