### PR TITLE
group0: reduce history GC duration from 1 week to 1 hour

### DIFF
--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+#include <functional>
 #include <optional>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/when_any.hh>
@@ -27,6 +28,7 @@
 #include "utils/assert.hh"
 #include "utils/to_string.hh"
 #include "db/system_keyspace.hh"
+#include "mutation/timestamp.hh"
 #include "replica/tablets.hh"
 #include "gms/gossiper.hh"
 
@@ -202,11 +204,23 @@ future<> raft_group0_client::add_entry(group0_command group0_cmd, group0_guard g
         // on this node to proceed
     } ();
 
-    if (!(co_await _sys_ks.group0_history_contains(new_group0_state_id))) {
-        // The command was applied but the history table does not contain the new group 0 state ID.
-        // This means `apply` skipped the change due to previous state ID mismatch.
+    // If the row exists, the command was applied — done, regardless of elapsed time.
+    // Must check before any clock, or a slow add_entry() (e.g. stalled Raft leader) can misclassify success as timeout.
+    if (co_await _sys_ks.group0_history_contains(new_group0_state_id)) {
+        co_return;
+    }
+
+    // Row absent: classify by whether our state ID is still inside the GC window (`now_ts` taken here, right after
+    // the read, to keep this check as tight as possible):
+    // - not yet GC-eligible: row can't have been cleared, so it was never written (apply() skipped it) — retryable group0_concurrent_modification.
+    // - otherwise: ambiguous (written-then-GC'd vs never-written) — not safe to retry, group0_hard_timeout instead.
+    const auto gc_micros = std::chrono::duration_cast<std::chrono::microseconds>(_history_gc_duration).count();
+    const auto new_ts = utils::UUID_gen::micros_timestamp(new_group0_state_id);
+    const auto now_ts = api::new_timestamp();
+    if (new_ts > now_ts - gc_micros) {
         throw group0_concurrent_modification{};
     }
+    throw group0_hard_timeout{};
 }
 
 future<> raft_group0_client::add_entry_unguarded(group0_command group0_cmd, seastar::abort_source* as) {

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -157,6 +157,10 @@ semaphore& raft_group0_client::operation_mutex() {
     return _operation_mutex;
 }
 
+semaphore& raft_group0_client::read_apply_mutex() {
+    return _read_apply_mutex;
+}
+
 future<> raft_group0_client::add_entry(group0_command group0_cmd, group0_guard guard, seastar::abort_source& as,
         std::optional<raft_timeout> timeout)
 {

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -181,6 +181,7 @@ public:
     // for test only
     void set_history_gc_duration(gc_clock::duration d);
     semaphore& operation_mutex();
+    semaphore& read_apply_mutex();
 
     bool maintenance_mode() const;
 

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -80,6 +80,24 @@ public:
     {}
 };
 
+// Thrown when a guard's history entry may have been GC'd — apply status unknown.
+// Unlike group0_concurrent_modification ("definitely not applied, safe to retry"),
+// this exception signals UNKNOWN status — the command may or may not have been applied.
+// It is a std::runtime_error and is not caught specially by any caller: CQL callers let it
+// propagate to the transport layer, which reports it to the client as a generic server error
+// (same SERVER_ERROR code and message as exceptions::server_exception would produce); internal
+// callers (topology coordinator, migration manager, etc.) also don't catch it — each caller's
+// outer driving loop handles unexpected failures by restarting the operation.
+// See: https://github.com/scylladb/scylladb/issues/28082
+class group0_hard_timeout : public std::runtime_error {
+public:
+    group0_hard_timeout()
+        : std::runtime_error("The outcome of this statement is unknown. "
+                             "It may or may not have been applied. "
+                             "Retrying the statement may be necessary.")
+    {}
+};
+
 // Singleton that exists only on shard zero. Used to post commands to group zero
 class raft_group0_client {
     service::raft_group_registry& _raft_gr;
@@ -91,7 +109,7 @@ class raft_group0_client {
     semaphore _read_apply_mutex = semaphore(1);
     semaphore _operation_mutex = semaphore(1);
 
-    gc_clock::duration _history_gc_duration = gc_clock::duration{std::chrono::duration_cast<gc_clock::duration>(std::chrono::weeks{1})};
+    gc_clock::duration _history_gc_duration = gc_clock::duration{std::chrono::duration_cast<gc_clock::duration>(std::chrono::hours{1})};
 
     std::unordered_map<utils::UUID, std::optional<service::broadcast_tables::query_result>> _results;
 

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -10,15 +10,20 @@
 #include <seastar/testing/test_case.hh>
 #include "test/lib/cql_assertions.hh"
 #include <seastar/core/coroutine.hh>
+#include <seastar/util/defer.hh>
 
+#include "clocks-impl.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/log.hh"
 
+#include "db/system_keyspace.hh"
 #include "schema/schema_builder.hh"
+#include "tasks/task_manager.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/error_injection.hh"
 #include "transport/messages/result_message.hh"
 #include "service/migration_manager.hh"
+#include "service/raft/raft_group0_client.hh"
 #include <fmt/ranges.h>
 #include <seastar/core/metrics_api.hh>
 
@@ -367,6 +372,199 @@ SEASTAR_TEST_CASE(test_group0_tables_use_schema_commitlog) {
         BOOST_REQUIRE(!test_group0_tables_use_schema_commitlog2->static_props().use_schema_commitlog);
 
         return make_ready_future();
+    });
+}
+
+// Row present => success, regardless of elapsed time or gc_duration.
+// See: https://github.com/scylladb/scylladb/issues/28082
+SEASTAR_TEST_CASE(test_group0_hard_timeout_history_present_is_always_success) {
+    return do_with_cql_env([] (cql_test_env& e) -> future<> {
+        auto& rclient = e.get_raft_group0_client();
+        abort_source as;
+
+        schema_builder::register_schema_initializer([](schema_builder& builder) {
+            if (builder.cf_name() == "test_group0_hard_timeout") {
+                builder.set_is_group0_table();
+            }
+        });
+
+        co_await e.execute_cql("CREATE TABLE test_group0_hard_timeout (key int PRIMARY KEY)");
+
+        auto insert_mut = [&] (int key) -> future<mutation> {
+            auto muts = co_await e.get_modification_mutations(format("INSERT INTO test_group0_hard_timeout (key) VALUES ({})", key));
+            co_return muts[0];
+        };
+
+        auto commit_mutation = [&] (int key) -> future<> {
+            auto guard = co_await rclient.start_operation(as);
+            service::group0_batch mc(std::move(guard));
+            mc.add_mutation(co_await insert_mut(key));
+            co_await std::move(mc).commit(rclient, as, ::service::raft_timeout{});
+        };
+
+        co_await commit_mutation(1);
+
+        {
+            auto guard = co_await rclient.start_operation(as);
+            service::group0_batch mc(std::move(guard));
+            mc.add_mutation(co_await insert_mut(2));
+            // Jump past the GC window so the row for key=2 would be GC-eligible
+            // by time — but it is present in the history table, so commit must
+            // succeed regardless.
+            auto gc_dur = rclient.get_history_gc_duration();
+            forward_jump_clocks(gc_dur + std::chrono::seconds{1});
+            auto restore_clocks = defer([gc_dur] { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
+            // Row present => success, must not throw.
+            co_await std::move(mc).commit(rclient, as, ::service::raft_timeout{});
+        }
+
+        auto row = co_await e.execute_cql("SELECT key FROM test_group0_hard_timeout WHERE key = 2");
+        auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(row);
+        BOOST_REQUIRE(rows);
+        BOOST_REQUIRE_EQUAL(rows->rs().result_set().rows().size(), 1);
+    });
+}
+
+// Row absent, inside GC window => never applied (prev_state_id mismatch) =>
+// group0_concurrent_modification (retryable), not group0_hard_timeout.
+SEASTAR_TEST_CASE(test_group0_hard_timeout_history_absent_not_gc_eligible_is_concurrent_modification) {
+    return do_with_cql_env([] (cql_test_env& e) -> future<> {
+        auto& rclient = e.get_raft_group0_client();
+        abort_source as;
+
+        schema_builder::register_schema_initializer([](schema_builder& builder) {
+            if (builder.cf_name() == "test_group0_hard_timeout") {
+                builder.set_is_group0_table();
+            }
+        });
+
+        co_await e.execute_cql("CREATE TABLE test_group0_hard_timeout (key int PRIMARY KEY)");
+        rclient.set_history_gc_duration(std::chrono::hours{1});
+
+        // Extra unit so two start_operation()s can be held concurrently (mirrors
+        // test_concurrent_group0_modifications).
+        rclient.operation_mutex().signal(1);
+        rclient.read_apply_mutex().signal(1);
+
+        auto insert_mut = [&] (int key) -> future<mutation> {
+            auto muts = co_await e.get_modification_mutations(format("INSERT INTO test_group0_hard_timeout (key) VALUES ({})", key));
+            co_return muts[0];
+        };
+
+        // A observes state before B's change lands; committing B first makes A's
+        // prev_state_id stale => apply() skips it => row genuinely never written.
+        auto guard_a = co_await rclient.start_operation(as);
+        auto guard_b = co_await rclient.start_operation(as);
+
+        service::group0_batch mc_b(std::move(guard_b));
+        mc_b.add_mutation(co_await insert_mut(1));
+        co_await std::move(mc_b).commit(rclient, as, ::service::raft_timeout{});
+
+        service::group0_batch mc_a(std::move(guard_a));
+        mc_a.add_mutation(co_await insert_mut(2));
+        // gc_duration=1h, no time passed => not GC-eligible => absence means
+        // "never written".
+        BOOST_CHECK_EXCEPTION(co_await std::move(mc_a).commit(rclient, as, ::service::raft_timeout{}),
+                service::group0_concurrent_modification, [] (const service::group0_concurrent_modification&) { return true; });
+    });
+}
+
+// Row absent, past GC window => ambiguous (applied-then-GC'd vs never-applied)
+// => group0_hard_timeout, never a silent success or an unsafe retry.
+SEASTAR_TEST_CASE(test_group0_hard_timeout_history_absent_gc_eligible_is_hard_timeout) {
+    return do_with_cql_env([] (cql_test_env& e) -> future<> {
+        auto& rclient = e.get_raft_group0_client();
+        abort_source as;
+
+        schema_builder::register_schema_initializer([](schema_builder& builder) {
+            if (builder.cf_name() == "test_group0_hard_timeout") {
+                builder.set_is_group0_table();
+            }
+        });
+
+        co_await e.execute_cql("CREATE TABLE test_group0_hard_timeout (key int PRIMARY KEY)");
+
+        // Extra unit so two start_operation()s can be held concurrently (mirrors
+        // test_concurrent_group0_modifications). Both mutexes are acquired by
+        // start_operation(), so both need the extra unit.
+        rclient.operation_mutex().signal(1);
+        rclient.read_apply_mutex().signal(1);
+
+        auto insert_mut = [&] (int key) -> future<mutation> {
+            auto muts = co_await e.get_modification_mutations(format("INSERT INTO test_group0_hard_timeout (key) VALUES ({})", key));
+            co_return muts[0];
+        };
+
+        auto guard_a = co_await rclient.start_operation(as);
+        auto guard_b = co_await rclient.start_operation(as);
+
+        service::group0_batch mc_b(std::move(guard_b));
+        mc_b.add_mutation(co_await insert_mut(1));
+        co_await std::move(mc_b).commit(rclient, as, ::service::raft_timeout{});
+
+        service::group0_batch mc_a(std::move(guard_a));
+        mc_a.add_mutation(co_await insert_mut(2));
+        // Jump past the GC window: A's prev_state_id entry is absent (never
+        // applied due to prev_state_id mismatch) and now GC-eligible by time =>
+        // ambiguous => must throw group0_hard_timeout.
+        auto gc_dur = rclient.get_history_gc_duration();
+        forward_jump_clocks(gc_dur + std::chrono::seconds{1});
+        auto restore_clocks = defer([gc_dur] { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
+        BOOST_CHECK_EXCEPTION(co_await std::move(mc_a).commit(rclient, as, ::service::raft_timeout{}),
+                service::group0_hard_timeout, [] (const service::group0_hard_timeout&) { return true; });
+    });
+}
+
+// Row absent after real physical GC (flush + compaction purges tombstones) =>
+// still group0_hard_timeout, not silent success.
+SEASTAR_TEST_CASE(test_group0_hard_timeout_history_absent_after_real_gc_is_hard_timeout) {
+    return do_with_cql_env([] (cql_test_env& e) -> future<> {
+        auto& rclient = e.get_raft_group0_client();
+        abort_source as;
+
+        schema_builder::register_schema_initializer([](schema_builder& builder) {
+            if (builder.cf_name() == "test_group0_hard_timeout") {
+                builder.set_is_group0_table();
+            }
+        });
+
+        co_await e.execute_cql("CREATE TABLE test_group0_hard_timeout (key int PRIMARY KEY)");
+
+        // Extra unit so two start_operation()s can be held concurrently.
+        rclient.operation_mutex().signal(1);
+        rclient.read_apply_mutex().signal(1);
+
+        auto insert_mut = [&] (int key) -> future<mutation> {
+            auto muts = co_await e.get_modification_mutations(format("INSERT INTO test_group0_hard_timeout (key) VALUES ({})", key));
+            co_return muts[0];
+        };
+
+        // gc_duration=0: each commit emits a range tombstone covering all prior
+        // state IDs, so B's commit immediately makes A's state_id GC-eligible.
+        rclient.set_history_gc_duration(gc_clock::duration{0});
+
+        auto guard_a = co_await rclient.start_operation(as);
+        auto guard_b = co_await rclient.start_operation(as);
+
+        service::group0_batch mc_b(std::move(guard_b));
+        mc_b.add_mutation(co_await insert_mut(1));
+        co_await std::move(mc_b).commit(rclient, as, ::service::raft_timeout{});
+
+        // Flush and compact group0_history so tombstones are physically purged.
+        // gc_clock::now() includes clocks_offset, so gc_grace_seconds=0 makes
+        // tombstones immediately eligible once gc_clock advances.
+        forward_jump_clocks(std::chrono::seconds{1});
+        auto restore_clocks = defer([] { forward_jump_clocks(-std::chrono::seconds{1}); });
+        auto& history_cf = e.local_db().find_column_family("system", db::system_keyspace::GROUP0_HISTORY);
+        co_await history_cf.flush();
+        co_await history_cf.compact_all_sstables(tasks::task_info{});
+
+        // After real GC, A's prev_state_id row is physically absent (not just
+        // covered by a tombstone). Still ambiguous => must throw group0_hard_timeout.
+        service::group0_batch mc_a(std::move(guard_a));
+        mc_a.add_mutation(co_await insert_mut(2));
+        BOOST_CHECK_EXCEPTION(co_await std::move(mc_a).commit(rclient, as, ::service::raft_timeout{}),
+                service::group0_hard_timeout, [] (const service::group0_hard_timeout&) { return true; });
     });
 }
 

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -105,7 +105,7 @@ SEASTAR_TEST_CASE(test_group0_history_clearing_old_entries) {
         co_await perform_schema_change();
         BOOST_REQUIRE_EQUAL(co_await get_history_size(), 1);
 
-        rclient.set_history_gc_duration(duration_cast<gc_clock::duration>(weeks{1}));
+        rclient.set_history_gc_duration(duration_cast<gc_clock::duration>(hours{1}));
         co_await perform_schema_change();
         BOOST_REQUIRE_EQUAL(co_await get_history_size(), 2);
 


### PR DESCRIPTION
`system.group0_history` grows with every group0 command, including topology. With `_history_gc_duration` set to one week, clusters that scale in and out frequently can accumulate hundreds of MB of history, which later breaks snapshot transfer on the joining node: either the read exceeds `max_memory_for_unlimited_query_hard_limit` or the write exceeds `schema_commitlog_segment_size_in_mb/2`.

Reduce `_history_gc_duration` to one hour.

Also tighten `add_entry()` outcome classification when the Raft request does not return a definitive result. If the history row already exists, the command was applied and we return success regardless of elapsed time. If the row is absent, compare the generated `state_id` timestamp with the GC window: entries still inside the window were not applied and remain retryable via `group0_concurrent_modification`, while older entries are ambiguous (written-then-GC'd or never written) and must raise `group0_hard_timeout`.

1 hour GC duration reasoning: The window only needs to cover the max lifetime of a valid in-flight add_entry call: guard is stamped at creation, full round-trip bounded by group0_raft_op_timeout_in_ms (60s). No guard can be older than ~60s when group0_history_contains() runs. 1h = 60× the Raft op timeout. At peak churn: 1w → ~6M rows → hundreds of MB; 1h → ~36K rows → a few MB. Original 1-week had no documented motivation.

Fixes: SCYLLADB-2691
Fixes: #28082 

Backport: This is fixing a customer issue that has been identified in 2026.1, therefore it should be backported to all active branches.