### PR TITLE
Add Google KMS mock server to unit tests

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1558,6 +1558,7 @@ scylla_tests_dependencies = scylla_core + alternator + idls + scylla_tests_gener
     'test/lib/proc_utils.cc',
     'test/lib/gcs_fixture.cc',
     'test/lib/aws_kms_fixture.cc',
+    'test/lib/gcp_kms_fixture.cc',
     'test/lib/azure_kms_fixture.cc',
 ]
 

--- a/ent/encryption/gcp_host.cc
+++ b/ent/encryption/gcp_host.cc
@@ -43,6 +43,7 @@
 #include "utils/UUID_gen.hh"
 #include "utils/rjson.hh"
 #include "utils/gcp/gcp_credentials.hh"
+#include "utils/http.hh"
 #include "marshal_exception.hh"
 #include "db/config.hh"
 
@@ -53,7 +54,7 @@ logger gcp_log("gcp");
 
 namespace encryption {
 bool operator==(const gcp_host::credentials_source& k1, const gcp_host::credentials_source& k2) {
-    return k1.gcp_credentials_file == k2.gcp_credentials_file && k1.gcp_impersonate_service_account == k2.gcp_impersonate_service_account;
+    return k1.gcp_credentials_file == k2.gcp_credentials_file && k1.gcp_impersonate_service_account == k2.gcp_impersonate_service_account && k1.gcp_iam_endpoint_override == k2.gcp_iam_endpoint_override;
 }
 }
 
@@ -61,19 +62,21 @@ template<>
 struct fmt::formatter<encryption::gcp_host::credentials_source> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const encryption::gcp_host::credentials_source& d, fmt::format_context& ctxt) const {
-        return fmt::format_to(ctxt.out(), "{{ gcp_credentials_file = {}, gcp_impersonate_service_account = {} }}", d.gcp_credentials_file, d.gcp_impersonate_service_account);
+        return fmt::format_to(ctxt.out(), "{{ gcp_credentials_file = {}, gcp_impersonate_service_account = {}, gcp_iam_endpoint_override = {} }}", d.gcp_credentials_file, d.gcp_impersonate_service_account, d.gcp_iam_endpoint_override);
     }
 };
 
 template<> 
 struct std::hash<encryption::gcp_host::credentials_source> {
     size_t operator()(const encryption::gcp_host::credentials_source& a) const {
-        return utils::tuple_hash{}(std::tie(a.gcp_credentials_file, a.gcp_impersonate_service_account));
+        return utils::tuple_hash{}(std::tie(a.gcp_credentials_file, a.gcp_impersonate_service_account, a.gcp_iam_endpoint_override));
     }
 };
 
 using namespace utils::gcp;
 using namespace rest;
+
+static constexpr char GCP_KMS_DEFAULT_ENDPOINT[] = "https://cloudkms.googleapis.com";
 
 class encryption::gcp_host::impl {
 public:
@@ -95,7 +98,11 @@ public:
             .max_size = std::numeric_limits<size_t>::max(),
             .expiry = options.key_cache_expiry.value_or(default_expiry),
             .refresh = options.key_cache_refresh.value_or(default_refresh)}, gcp_log, std::bind_front(&impl::find_key, this))
-    {}
+    {
+        if (_options.endpoint.empty()) {
+            _options.endpoint = GCP_KMS_DEFAULT_ENDPOINT;
+        }
+    }
     ~impl() = default;
 
     future<> init();
@@ -155,7 +162,7 @@ private:
 
     shared_ptr<tls::certificate_credentials> _certs;
 
-    std::unordered_map<credentials_source, google_credentials> _cached_credentials;
+    std::unordered_map<credentials_source, std::optional<google_credentials>> _cached_credentials;
 
     utils::loading_cache<attr_cache_key, key_and_id_type, 2, utils::loading_cache_reload_enabled::yes,
         utils::simple_entry_size<key_and_id_type>, attr_cache_key_hash> _attr_cache;
@@ -181,6 +188,7 @@ future<std::tuple<shared_ptr<encryption::symmetric_key>, encryption::gcp_host::i
         .src = {
             .gcp_credentials_file = get_option(oov, &option_override::gcp_credentials_file, _options.gcp_credentials_file),
             .gcp_impersonate_service_account = get_option(oov, &option_override::gcp_impersonate_service_account, _options.gcp_impersonate_service_account),
+            .gcp_iam_endpoint_override = get_option(oov, &option_override::gcp_iam_endpoint_override, _options.gcp_iam_endpoint_override),
         },
         .master_key = get_option(oov, &option_override::master_key, _options.master_key),
         .info = info,
@@ -210,6 +218,7 @@ future<shared_ptr<encryption::symmetric_key>> encryption::gcp_host::impl::get_ke
         .src = {
             .gcp_credentials_file = get_option(oov, &option_override::gcp_credentials_file, _options.gcp_credentials_file),
             .gcp_impersonate_service_account = get_option(oov, &option_override::gcp_impersonate_service_account, _options.gcp_impersonate_service_account),
+            .gcp_iam_endpoint_override = get_option(oov, &option_override::gcp_iam_endpoint_override, _options.gcp_iam_endpoint_override),
         },
         .id = id,
     };
@@ -233,15 +242,18 @@ future<rjson::value> encryption::gcp_host::impl::gcp_auth_post_with_retry(std::s
     auto i = _cached_credentials.find(src);
     if (i == _cached_credentials.end()) {
         try {
-            auto c = !src.gcp_credentials_file.empty()
-                ? co_await google_credentials::from_file(src.gcp_credentials_file)
-                : co_await google_credentials::get_default_credentials()
-                ;
-            if (!src.gcp_credentials_file.empty()) {
+            std::optional<google_credentials> c;
+            if (src.gcp_credentials_file.empty()) {
+                c = co_await google_credentials::get_default_credentials();
+            } else if (src.gcp_credentials_file != "none") {
+                c = co_await google_credentials::from_file(src.gcp_credentials_file);
                 gcp_log.trace("Loaded credentials from {}", src.gcp_credentials_file);
             }
-            if (!src.gcp_impersonate_service_account.empty()) {
-                c = google_credentials(impersonated_service_account_credentials(src.gcp_impersonate_service_account, std::move(c)));
+            if (!src.gcp_impersonate_service_account.empty() && c) {
+                c = google_credentials(impersonated_service_account_credentials(src.gcp_impersonate_service_account
+                    , std::move(*c)
+                    , src.gcp_iam_endpoint_override
+                ));
             }
             i = _cached_credentials.emplace(src, std::move(c)).first;
         } catch (...) {
@@ -260,6 +272,9 @@ future<rjson::value> encryption::gcp_host::impl::gcp_auth_post_with_retry(std::s
     bool do_backoff = false;
     bool did_auth_retry = false;
 
+    std::vector<key_value> headers;
+    std::string bearer;
+
     for (int retry = 0; ; ++retry) {
         if (std::exchange(do_backoff, false)) {
             co_await exr.retry(_as);
@@ -268,12 +283,17 @@ future<rjson::value> encryption::gcp_host::impl::gcp_auth_post_with_retry(std::s
         bool refreshing = true;
 
         try {
-            co_await creds.refresh(KMS_SCOPE, _certs);
+            if (creds) {
+                bearer.clear();
+                co_await creds->refresh(KMS_SCOPE, _certs);
+                bearer = utils::gcp::format_bearer(creds->token);
+            }
             refreshing = false;
-
-            auto res = co_await send_request(uri, _certs, body, httpd::operation_type::POST, key_values({
-                { utils::gcp::AUTHORIZATION, utils::gcp::format_bearer(creds.token) },
-            }), &_as);
+            if (!bearer.empty()) {
+                headers.resize(1);
+                headers[0] = { utils::gcp::AUTHORIZATION, bearer };
+            }
+            auto res = co_await send_request(uri, _certs, body, httpd::operation_type::POST, headers, &_as);
             co_return res;
         } catch (httpd::unexpected_status_error& e) {
             gcp_log.debug("{}: Got unexpected response: {}", uri, e.status());
@@ -311,7 +331,7 @@ future<rjson::value> encryption::gcp_host::impl::gcp_auth_post_with_retry(std::s
     }
 }
 
-static constexpr char GCP_KMS_QUERY_TEMPLATE[] = "https://cloudkms.googleapis.com/v1/projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}:{}";
+static constexpr char GCP_KMS_QUERY_TEMPLATE[] = "{}/v1/projects/{}/locations/{}/keyRings/{}/cryptoKeys/{}:{}";
 
 future<> encryption::gcp_host::impl::init() {
     if (_initialized) {
@@ -420,6 +440,7 @@ future<encryption::gcp_host::impl::key_and_id_type> encryption::gcp_host::impl::
 
     auto key = make_shared<symmetric_key>(info);
     auto url = fmt::format(GCP_KMS_QUERY_TEMPLATE, 
+        _options.endpoint,
         _options.gcp_project_id,
         _options.gcp_location,
         keyring,
@@ -468,6 +489,7 @@ future<bytes> encryption::gcp_host::impl::find_key(const id_cache_key& k) {
     std::string enc(id.begin() + pos + 1, id.end());
 
     auto url = fmt::format(GCP_KMS_QUERY_TEMPLATE, 
+        _options.endpoint,
         _options.gcp_project_id,
         _options.gcp_location,
         keyring,
@@ -493,6 +515,7 @@ encryption::gcp_host::gcp_host(encryption_context& ctxt, const std::string& name
         host_options opts;
         map_wrapper<std::unordered_map<sstring, sstring>> m(map);
 
+        opts.endpoint = m("endpoint").value_or("");
         opts.master_key = m("master_key").value_or("");
 
         opts.gcp_project_id = m("gcp_project_id").value_or(""); 
@@ -500,6 +523,7 @@ encryption::gcp_host::gcp_host(encryption_context& ctxt, const std::string& name
 
         opts.gcp_credentials_file = m("gcp_credentials_file").value_or("");
         opts.gcp_impersonate_service_account = m("gcp_impersonate_service_account").value_or("");
+        opts.gcp_iam_endpoint_override = m("gcp_iam_endpoint_override").value_or("");
 
         opts.certfile = m("certfile").value_or("");
         opts.keyfile = m("keyfile").value_or("");
@@ -539,7 +563,7 @@ template<>
 struct fmt::formatter<encryption::gcp_host::impl::attr_cache_key> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const encryption::gcp_host::impl::attr_cache_key& d, fmt::format_context& ctxt) const {
-        return fmt::format_to(ctxt.out(), "{},{},{}", d.master_key, d.src.gcp_credentials_file, d.src.gcp_impersonate_service_account);
+        return fmt::format_to(ctxt.out(), "{},{},{},{}", d.master_key, d.src.gcp_credentials_file, d.src.gcp_impersonate_service_account, d.src.gcp_iam_endpoint_override);
     }
 };
 
@@ -547,6 +571,6 @@ template<>
 struct fmt::formatter<encryption::gcp_host::impl::id_cache_key> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(const encryption::gcp_host::impl::id_cache_key& d, fmt::format_context& ctxt) const {
-        return fmt::format_to(ctxt.out(), "{},{},{}", d.id, d.src.gcp_credentials_file, d.src.gcp_impersonate_service_account);
+        return fmt::format_to(ctxt.out(), "{},{},{},{}", d.id, d.src.gcp_credentials_file, d.src.gcp_impersonate_service_account, d.src.gcp_iam_endpoint_override);
     }
 };

--- a/ent/encryption/gcp_host.hh
+++ b/ent/encryption/gcp_host.hh
@@ -35,6 +35,8 @@ public:
         T gcp_credentials_file;
         // Optional service account (email address) to impersonate
         T gcp_impersonate_service_account;
+        // Optional service account iam_endpoint_override
+        T gcp_iam_endpoint_override;
     };
 
     using credentials_source = t_credentials_source<std::string>;
@@ -42,6 +44,10 @@ public:
     struct host_options : public credentials_source {
         std::string gcp_project_id;
         std::string gcp_location;
+
+        // Optional. Mainly for mock testing.
+        // Default is the official google base service url for KMS
+        std::string endpoint;
 
         // GCP KMS Key to encrypt data keys with. Format: <keychain>/<keyname>
         std::string master_key;

--- a/ent/encryption/gcp_key_provider.cc
+++ b/ent/encryption/gcp_key_provider.cc
@@ -52,6 +52,7 @@ shared_ptr<key_provider> gcp_key_provider_factory::get_provider(encryption_conte
 
     oov.gcp_credentials_file = opts("gcp_credentials_file");
     oov.gcp_impersonate_service_account = opts("gcp_impersonate_service_account");
+    oov.gcp_iam_endpoint_override = opts("gcp_iam_endpoint_override");
 
     if (!gcp_host) {
         throw std::invalid_argument("gcp_host must be provided");

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -957,7 +957,7 @@ SEASTAR_FIXTURE_TEST_CASE(test_kms_provider, local_aws_kms_wrapper, *check_run_t
                 master_key: {0}
                 aws_region: {1}
                 aws_profile: {2}
-                endpoint: {3}
+                endpoint: '{3}'
                 )foo"
         , kms_key_alias, kms_aws_region, kms_aws_profile, endpoint
     );
@@ -976,7 +976,7 @@ SEASTAR_FIXTURE_TEST_CASE(test_kms_provider_with_master_key_in_cf, local_aws_kms
             kms_test:
                 aws_region: {1}
                 aws_profile: {2}
-                endpoint: {3}
+                endpoint: '{3}'
                 )foo"
         , kms_key_alias, kms_aws_region, kms_aws_profile, endpoint
     );
@@ -1015,7 +1015,7 @@ SEASTAR_FIXTURE_TEST_CASE(test_kms_provider_with_broken_algo, local_aws_kms_wrap
                 master_key: {0}
                 aws_region: {1}
                 aws_profile: {2}
-                endpoint: {3}
+                endpoint: '{3}'
                 )foo"
         , kms_key_alias, kms_aws_region, kms_aws_profile, endpoint
     );
@@ -1040,7 +1040,7 @@ SEASTAR_FIXTURE_TEST_CASE(test_commitlog_kms_encryption_with_slow_key_resolve, l
                 master_key: {0}
                 aws_region: {1}
                 aws_profile: {2}
-                endpoint: {3}
+                endpoint: '{3}'
                 )foo"
         , kms_key_alias, kms_aws_region, kms_aws_profile, endpoint
     );

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -317,21 +317,28 @@ class fake_proxy {
     bool _do_proxy = true;
     future<> _f;
 
-    future<> run(std::string dst_addr) {
-        uint16_t port = 443u;
-        auto i = dst_addr.find_last_of(':');
-        if (i != std::string::npos && i > 0 && dst_addr[i - 1] != ':') { // just check against ipv6...
-            port = std::stoul(dst_addr.substr(i + 1));
-            dst_addr = dst_addr.substr(0, i);
-        }
-
-        auto addr = co_await seastar::net::dns::resolve_name(dst_addr);
+    future<> run(std::string dst_endpoint) {
+        auto info = utils::http::parse_simple_url(dst_endpoint);
+        auto port = info.port;
+        auto dst_addr = info.host;
+        auto addr = co_await seastar::net::dns::resolve_name(dst_addr, seastar::net::inet_address::family::INET);
         std::vector<future<>> work;
+
+        testlog.debug("Proxy {} -> {} ({}:{}/{}:{})", _address, dst_endpoint, dst_addr, port, addr, port);
+
+        shared_ptr<seastar::tls::certificate_credentials> creds;
+        if (info.is_https()) {
+            creds = make_shared<seastar::tls::certificate_credentials>();
+            co_await creds->set_system_trust();
+        }
 
         while (_go_on) {
             try {
                 auto client = co_await _socket.accept();
-                auto dst = co_await seastar::connect(socket_address(addr, port));
+                auto dst = co_await (info.is_https()
+                    ? seastar::tls::connect(creds, socket_address(addr, port), seastar::tls::tls_options{ .server_name = info.host })
+                    : seastar::connect(socket_address(addr, port))
+                );
 
                 testlog.debug("Got proxy connection: {}->{}:{} ({})", client.remote_address, dst_addr, port, _do_proxy);
 
@@ -389,10 +396,10 @@ class fake_proxy {
         }
     }
 public:
-    fake_proxy(std::string dst)
+    fake_proxy(std::string endpoint)
         : _socket(seastar::listen(socket_address(0x7f000001, 0)))
         , _address(_socket.local_address())
-        , _f(run(std::move(dst)))
+        , _f(run(std::move(endpoint)))
     {}
 
     const socket_address& address() const {
@@ -415,8 +422,8 @@ public:
  * Tests that a network error in key resolution (in commitlog in this case) results in a non-fatal, non-isolating
  * exception, i.e. an eventual write error.
  */
-static future<> network_error_test_helper(const tmpdir& tmp, const std::string& host, std::function<std::tuple<scopts_map, std::string>(const fake_proxy&)> make_opts) {
-    fake_proxy proxy(host);
+static future<> network_error_test_helper(const tmpdir& tmp, const std::string& endpoint, std::function<std::tuple<scopts_map, std::string>(const fake_proxy&)> make_opts) {
+    fake_proxy proxy(endpoint);
     std::exception_ptr p;
     try {
         auto [scopts, yaml] = make_opts(proxy);
@@ -755,7 +762,7 @@ SEASTAR_TEST_CASE(test_kmip_provider_multiple_hosts, *check_run_test_decorator("
      * Pretend to have failover by using a local proxy.
     */
     co_await kmip_test_helper([](const kmip_test_info& info, const tmpdir& tmp) -> future<> {
-        fake_proxy proxy(info.host);
+        fake_proxy proxy("kmip://" + info.host);
 
         auto host2 = boost::lexical_cast<std::string>(proxy.address());
 
@@ -806,7 +813,8 @@ SEASTAR_TEST_CASE(test_commitlog_kmip_encryption_with_slow_key_resolve, *check_r
 
 SEASTAR_TEST_CASE(test_kmip_network_error, *check_run_test_decorator("ENABLE_KMIP_TEST")) {
     co_await kmip_test_helper([](const kmip_test_info& info, const tmpdir& tmp) -> future<> {
-        co_await network_error_test_helper(tmp, info.host, [&](const auto& proxy) {
+        // fake an URI here. 
+        co_await network_error_test_helper(tmp, "kmip://" + info.host, [&](const auto& proxy) {
             auto yaml = fmt::format(R"foo(
                 kmip_hosts:
                     kmip_test:
@@ -1042,15 +1050,17 @@ SEASTAR_FIXTURE_TEST_CASE(test_commitlog_kms_encryption_with_slow_key_resolve, l
 
 SEASTAR_FIXTURE_TEST_CASE(test_kms_network_error, local_aws_kms_wrapper, *check_run_test_decorator("ENABLE_KMS_TEST", true)) {
     tmpdir tmp;
-    std::string host, scheme;
+    std::string host;
 
     if (endpoint.empty()) { 
-        host = make_aws_host(kms_aws_region, "kms");
-        scheme = "https://";
+        host = "https://" + make_aws_host(kms_aws_region, "kms");
+        // TODO: cannot run a proxy here, because REST calls to
+        // AWS are dependent on proper HTTP host headers (for virt host resolve)
+        // Need to build a real http proxy for this to work
+        BOOST_TEST_MESSAGE("Cannot run network proxy for actual AWS endpoint. Skipping test.");
+        co_return;
     } else {
-        auto info = utils::http::parse_simple_url(endpoint);
-        host = info.host + ":" + std::to_string(info.port);
-        scheme = info.scheme;
+        host = endpoint;
     }
 
     co_await network_error_test_helper(tmp, host, [&](const auto& proxy) {
@@ -1060,10 +1070,10 @@ SEASTAR_FIXTURE_TEST_CASE(test_kms_network_error, local_aws_kms_wrapper, *check_
                     master_key: {0}
                     aws_region: {1}
                     aws_profile: {2}
-                    endpoint: {3}://{4}
+                    endpoint: http://{3}
                     key_cache_expiry: 1ms
                     )foo"
-            , kms_key_alias, kms_aws_region, kms_aws_profile, scheme, proxy.address()
+            , kms_key_alias, kms_aws_region, kms_aws_profile, proxy.address()
         );
         return std::make_tuple(scopts_map({ { "key_provider", "KmsKeyProviderFactory" }, { "kms_host", "kms_test" } }), yaml);
     });
@@ -1600,10 +1610,8 @@ SEASTAR_FIXTURE_TEST_CASE(test_azure_provider_with_both_secret_and_cert_real, re
 
 SEASTAR_FIXTURE_TEST_CASE(test_azure_network_error, fake_azure, *check_azure_mock_test_decorator()) {
     tmpdir tmp;
-    auto info = utils::http::parse_simple_url(imds_endpoint);
-    auto host_endpoint = fmt::format("{}:{}", info.host, info.port);
     auto key = key_name.substr(key_name.find_last_of('/') + 1);
-    co_await network_error_test_helper(tmp, host_endpoint, [&](const auto& proxy) {
+    co_await network_error_test_helper(tmp, imds_endpoint, [&](const auto& proxy) {
         auto yaml = fmt::format(R"foo(
             azure_hosts:
                 azure_test:

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -39,6 +39,7 @@
 #include "test/lib/proc_utils.hh"
 #include "test/lib/aws_kms_fixture.hh"
 #include "test/lib/azure_kms_fixture.hh"
+#include "test/lib/gcp_kms_fixture.hh"
 #include "db/config.hh"
 #include "db/extensions.hh"
 #include "db/system_keyspace.hh"
@@ -1165,37 +1166,9 @@ SEASTAR_TEST_CASE(test_user_info_encryption_dont_allow_per_table_encryption) {
     * GCP_LOCATION - set to test location
 */
 
-struct gcp_test_env {
-    std::string key_name;
-    std::string location;
-    std::string project_id; 
-    std::string user_1_creds;
-    std::string user_2_creds;
-};
-
-static future<> gcp_test_helper(std::function<future<>(const tmpdir&, const gcp_test_env&)> f) {
-    gcp_test_env env {
-        .key_name = get_var_or_default("GCP_KEY_NAME", "test_ring/test_key"),
-        .location = get_var_or_default("GCP_LOCATION", "global"),
-        .project_id = get_var_or_default("GCP_PROJECT_ID", "scylla-kms-test"),
-        .user_1_creds = get_var_or_default("GCP_USER_1_CREDENTIALS", ""),
-        .user_2_creds = get_var_or_default("GCP_USER_2_CREDENTIALS", ""),
-    };
-
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_provider, local_gcp_kms_wrapper, *check_run_test_decorator("ENABLE_GCP_TEST", true)) {
     tmpdir tmp;
-
-    if (env.user_1_creds.empty()) {
-        BOOST_ERROR("No 'GCP_USER_1_CREDENTIALS' provided");
-    }
-    if (env.user_2_creds.empty()) {
-        BOOST_ERROR("No 'GCP_USER_2_CREDENTIALS' provided");
-    }
-
-    co_await f(tmp, env);
-}
-
-SEASTAR_TEST_CASE(test_gcp_provider, *check_run_test_decorator("ENABLE_GCP_TEST")) {
-    co_await gcp_test_helper([](const tmpdir& tmp, const gcp_test_env& gcp) -> future<> {
+    {
         auto yaml = fmt::format(R"foo(
             gcp_hosts:
                 gcp_test:
@@ -1203,24 +1176,27 @@ SEASTAR_TEST_CASE(test_gcp_provider, *check_run_test_decorator("ENABLE_GCP_TEST"
                     gcp_project_id: {1}
                     gcp_location: {2}
                     gcp_credentials_file: {3}
+                    endpoint: '{4}'
                     )foo"
-            , gcp.key_name, gcp.project_id, gcp.location, gcp.user_1_creds
+            , gcp_key_name, gcp_project_id, gcp_location, gcp_user_1_credentials, endpoint
         );
 
         co_await test_provider("'key_provider': 'GcpKeyProviderFactory', 'gcp_host': 'gcp_test', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", tmp, yaml);
-    });
+    }
 }
 
-SEASTAR_TEST_CASE(test_gcp_provider_with_master_key_in_cf, *check_run_test_decorator("ENABLE_GCP_TEST")) {
-    co_await gcp_test_helper([](const tmpdir& tmp, const gcp_test_env& gcp) -> future<> {
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_provider_with_master_key_in_cf, local_gcp_kms_wrapper, *check_run_test_decorator("ENABLE_GCP_TEST", true)) {
+    tmpdir tmp;
+    {
         auto yaml = fmt::format(R"foo(
             gcp_hosts:
                 gcp_test:
                     gcp_project_id: {1}
                     gcp_location: {2}
                     gcp_credentials_file: {3}
+                    endpoint: '{4}'
                     )foo"
-            , gcp.key_name, gcp.project_id, gcp.location, gcp.user_1_creds
+            , gcp_key_name, gcp_project_id, gcp_location, gcp_user_1_credentials, endpoint
         );
 
         // should fail
@@ -1241,18 +1217,19 @@ SEASTAR_TEST_CASE(test_gcp_provider_with_master_key_in_cf, *check_run_test_decor
         }
 
         // should be ok
-        co_await test_provider(fmt::format("'key_provider': 'GcpKeyProviderFactory', 'gcp_host': 'gcp_test', 'master_key': '{}', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", gcp.key_name)
+        co_await test_provider(fmt::format("'key_provider': 'GcpKeyProviderFactory', 'gcp_host': 'gcp_test', 'master_key': '{}', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", gcp_key_name)
             , tmp, yaml
             );
-    });
+    }
 }
 
 /**
  * Verify that trying to access key materials with a user w/o permissions to encrypt/decrypt using cloudkms
  * fails.
 */
-SEASTAR_TEST_CASE(test_gcp_provider_with_invalid_user, *check_run_test_decorator("ENABLE_GCP_TEST")) {
-    co_await gcp_test_helper([](const tmpdir& tmp, const gcp_test_env& gcp) -> future<> {
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_provider_with_invalid_user, local_gcp_kms_wrapper, *check_run_test_decorator("ENABLE_GCP_TEST", true)) {
+    tmpdir tmp;
+    {
         auto yaml = fmt::format(R"foo(
             gcp_hosts:
                 gcp_test:
@@ -1260,8 +1237,9 @@ SEASTAR_TEST_CASE(test_gcp_provider_with_invalid_user, *check_run_test_decorator
                     gcp_project_id: {1}
                     gcp_location: {2}
                     gcp_credentials_file: {3}
+                    endpoint: '{4}'
                     )foo"
-            , gcp.key_name, gcp.project_id, gcp.location, gcp.user_2_creds
+            , gcp_key_name, gcp_project_id, gcp_location, gcp_user_2_credentials, endpoint
         );
 
         // should fail
@@ -1269,16 +1247,17 @@ SEASTAR_TEST_CASE(test_gcp_provider_with_invalid_user, *check_run_test_decorator
             co_await test_provider("'key_provider': 'GcpKeyProviderFactory', 'gcp_host': 'gcp_test', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", tmp, yaml)
             , std::exception
         );
-    });
+    }
 }
 
 /**
  * Verify that impersonation of an allowed service account works. User1 can encrypt, but we run 
  * as User2. However, impersonating user1 will allow us do it ourselves.
 */
-SEASTAR_TEST_CASE(test_gcp_provider_with_impersonated_user, *check_run_test_decorator("ENABLE_GCP_TEST")) {
-    co_await gcp_test_helper([](const tmpdir& tmp, const gcp_test_env& gcp) -> future<> {
-        auto buf = co_await read_text_file_fully(sstring(gcp.user_1_creds));
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_provider_with_impersonated_user, local_gcp_kms_wrapper, *check_run_test_decorator("ENABLE_GCP_TEST", true)) {
+    tmpdir tmp;
+    {
+        auto buf = co_await read_text_file_fully(sstring(gcp_user_1_credentials));
         auto json = rjson::parse(std::string_view(buf.begin(), buf.end()));
         auto user1 = rjson::get<std::string>(json, "client_email");
 
@@ -1290,12 +1269,14 @@ SEASTAR_TEST_CASE(test_gcp_provider_with_impersonated_user, *check_run_test_deco
                     gcp_location: {2}
                     gcp_credentials_file: {3}
                     gcp_impersonate_service_account: {4}
+                    gcp_iam_endpoint_override: '{5}'
+                    endpoint: '{6}'
                     )foo"
-            , gcp.key_name, gcp.project_id, gcp.location, gcp.user_2_creds, user1
+            , gcp_key_name, gcp_project_id, gcp_location, gcp_user_2_credentials, user1, gcp_iam_endpoint_override, endpoint
         );
 
         co_await test_provider("'key_provider': 'GcpKeyProviderFactory', 'gcp_host': 'gcp_test', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", tmp, yaml);
-    });
+    }
 }
 
 // Note: cannot do the above test for gcp, because we can't use false endpoints there. Could mess with address resolution,

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -1289,6 +1289,38 @@ SEASTAR_FIXTURE_TEST_CASE(test_gcp_provider_with_impersonated_user, local_gcp_km
     }
 }
 
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_network_error, local_gcp_kms_wrapper, *check_run_test_decorator("ENABLE_GCP_TEST", true)) {
+    tmpdir tmp;
+    std::string host;
+
+    if (endpoint.empty()) { 
+        host = "https://cloudkms.googleapis.com";
+        // TODO: cannot run a proxy here, because REST calls to
+        // GCP are dependent on proper HTTP host headers (for virt host resolve)
+        // Need to build a real http proxy for this to work
+        BOOST_TEST_MESSAGE("Cannot run network proxy for actual GCP endpoint. Skipping test.");
+        co_return;
+    } else {
+        host = endpoint;
+    }
+
+    co_await network_error_test_helper(tmp, host, [&](const auto& proxy) {
+        auto yaml = fmt::format(R"foo(
+            gcp_hosts:
+                gcp_test:
+                    master_key: {0}
+                    gcp_project_id: {1}
+                    gcp_location: {2}
+                    gcp_credentials_file: {3}
+                    endpoint: http://{4}
+                    key_cache_expiry: 1ms
+                    )foo"
+            , gcp_key_name, gcp_project_id, gcp_location, gcp_user_1_credentials, proxy.address()
+        );
+        return std::make_tuple(scopts_map({ { "key_provider", "GcpKeyProviderFactory" }, { "gcp_host", "gcp_test" } }), yaml);
+    });
+}
+
 // Note: cannot do the above test for gcp, because we can't use false endpoints there. Could mess with address resolution,
 // but there is no infrastructure for that atm.
 

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(test-lib
     gcs_fixture.cc
     aws_kms_fixture.cc
     azure_kms_fixture.cc
+    gcp_kms_fixture.cc
     limiting_data_source.cc
     )
 target_include_directories(test-lib

--- a/test/lib/gcp_kms_fixture.cc
+++ b/test/lib/gcp_kms_fixture.cc
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include <string>
+#include <memory>
+#include <regex>
+
+#include <seastar/core/with_timeout.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/net/inet_address.hh>
+
+#include "gcp_kms_fixture.hh"
+#include "tmpdir.hh"
+#include "proc_utils.hh"
+#include "test_utils.hh"
+#include "ent/encryption/encryption.hh"
+
+namespace fs = std::filesystem;
+namespace tp = tests::proc;
+
+using namespace tests;
+using namespace std::chrono_literals;
+using namespace std::string_view_literals;
+
+static future<std::tuple<tp::process_fixture, int>> start_fake_kms_server(const tmpdir& tmp, const fs::path& seed) {
+    auto pyexec = tests::proc::find_file_in_path("python");
+
+    promise<int> port_promise;
+    auto port_future = port_promise.get_future();
+
+    auto python = co_await tests::proc::process_fixture::create(pyexec, 
+        { // args
+            pyexec.string(),
+            "test/pylib/gcp_kms_server_mock.py",
+            "--seed", seed.string(),
+            "--log-level", "DEBUG",
+        }
+        ,{} // env
+        // stdout handler
+        , tests::proc::process_fixture::create_copy_handler(std::cout)
+        // stderr handler
+        , [port_promise = std::move(port_promise), b = false](std::string_view line) mutable -> future<consumption_result<char>> {
+            static std::regex port_ex(R"foo(Starting GCP KMS mock server on \('[^']+', (\d+)\))foo");
+
+            std::match_results<typename std::string_view::const_iterator> m;
+            if (!b && std::regex_search(line.begin(), line.end(), m, port_ex)) {
+                port_promise.set_value(std::stoi(m[1].str()));
+                BOOST_TEST_MESSAGE("Matched Mock GCP KMS port: " + m[1].str());
+                b = true;
+            }
+            co_return continue_consuming{};
+        }
+    );
+
+    // arbitrary timeout of 20s for the server to make some output. Very generous.
+    auto port = co_await with_timeout(std::chrono::steady_clock::now() + 20s, std::move(port_future));
+
+    if (port <= 0) {
+        throw std::runtime_error("Invalid port");
+    }
+
+    // wait for port.
+    for (size_t retry = 0; retry < 5; ++retry) {
+        try {
+            BOOST_TEST_MESSAGE(fmt::format("Attempting to connect to GCP KMS server at {}", port));
+            // TODO: seastar does not have a connect with timeout. That would be helpful here. But alas...
+            auto c = co_await with_timeout(std::chrono::steady_clock::now() + 20s, seastar::connect(socket_address(net::inet_address("127.0.0.1"), port)));
+            BOOST_TEST_MESSAGE("Mock GCP KMS server up and available"); // debug print. Why not.
+            c.shutdown_output();
+            break;
+        } catch (...) {
+        }
+        co_await sleep(100ms);
+    }
+
+    co_return std::make_tuple(std::move(python), port);
+}
+
+class gcp_kms_fixture::impl {
+public:
+    std::optional<tp::process_fixture> local_kms;
+
+    std::string endpoint;
+    std::string gcp_key_name;
+    std::string gcp_location;
+    std::string gcp_project_id;
+    std::string gcp_user_1_credentials;
+    std::string gcp_user_2_credentials;
+    std::string gcp_iam_endpoint_override;
+
+    tmpdir tmp;
+
+    bool created_master_key = false;
+
+    impl();
+
+    seastar::future<> setup();
+    seastar::future<> teardown();
+};
+
+gcp_kms_fixture::impl::impl()  
+    : gcp_key_name(getenv_or_default("GCP_KEY_NAME", "test_ring/test_key"))
+    , gcp_location(getenv_or_default("GCP_LOCATION", "global"))
+    , gcp_project_id(getenv_or_default("GCP_PROJECT_ID", "scylla-kms-test"))
+    , gcp_user_1_credentials(getenv_or_default("GCP_USER_1_CREDENTIALS"))
+    , gcp_user_2_credentials(getenv_or_default("GCP_USER_2_CREDENTIALS"))
+{}
+
+seastar::future<> gcp_kms_fixture::impl::setup() {
+    if (gcp_key_name.empty() || gcp_user_1_credentials.empty() || gcp_user_2_credentials.empty()) {
+        auto seed = tmp.path() / "seed.yaml";
+        auto cred1 = tmp.path() / "cred1.json";
+        auto cred2 = tmp.path() / "cred2.json";
+        auto user1 = "user1@apa.org";
+        auto user2 = "user2@apa.org";
+
+        co_await encryption::write_text_file_fully(seed.string(), fmt::format(R"foo(
+projects:
+  {}:
+    locations:
+      {}:
+        keyRings:
+          test-ring:
+            cryptoKeys:
+              test-key:
+                purpose: ENCRYPT_DECRYPT
+                labels:
+                  env: dev
+                versions:
+                  - {{}}   # creates version 1
+                users:
+                  - {}
+impersonators:
+  {}:
+    - {}
+)foo", gcp_project_id, gcp_location, user1, user2, user1
+        ));
+
+        auto [proc, port] = co_await start_fake_kms_server(tmp, seed);
+        local_kms.emplace(std::move(proc));
+
+        for (auto [user, cred] : { std::make_pair(user1, cred1), std::make_pair(user2, cred2) }) {
+            // create a fake service account file. the private key, id:s etc are ignored
+            // by the fake token endpoint. Only the actual email + token endpoint here matters.
+            // the mock server will give us a "Bearer" token that works as auth for the mock.
+            // nothing even close to actual gcp, but...
+            co_await encryption::write_text_file_fully(cred.string(), fmt::format(R"foo(
+{{
+        "type": "service_account",
+        "project_id": "{}",
+        "private_key_id": "c68de079f19d430a742bf18fed675a00caac13a2",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDCZ+yap8UNnxeR\nM1Ho10jx6JnpXdktDrBhF/vK/ENYmjiIjV1RsULtqJDHDrVJhK+k7chiA64M70XT\nOP/ABlvoNqPmX90WWroQd4HbEPnXMEMJYBiKg1vUtsUImB8soxKxCp0uY3sn+6cx\n8LNjvmI4waCclTTPIoLeh9s8USu5gr/ZrBQUjUlKLqSdoQfw4Tt1XRY0z4NDT3iX\naIrFeuwrXvnHKLFJ9j+jkdZm5qtjtBDR5C0tQbzUeD0xX0XTrPmgF8yt0JgmqUxs\nfp4/yGAOpuFpj5w11mRo6e4Kq2xvlxRJaBqoyd/70EgccwwBQ4gAN187CYp7PSuG\nFdD4MvAdAgMBAAECggEACVewNbB5VlG+crJqLcvmzAVXHDFv5evuSwQ5jAQ6glAL\nBnjwsqPXqQ8wQfixeqJ/RGhO+HLf0uxOyTtUgxhrI0o47zHNMK1UgsUTfwEeWJqP\npiwxkbqFV8Ae0O5qlR0TIWH2ssuCGCZOXyaHoHP+SWb4vn2nJ4srieEyhoAKH2SV\nOLlhB80QUd1xqVB9D6N6Ee13JQyWbDTqZPd8rSHJ3EmR9qxZtpxdtTKobpGNoFlH\nOXL26LAUMJ+N4A0Z6/RX5i/HJax5k2lrguawRzWibj8JtoH3V7iqpDmtSShpZdY4\n888EMePBo5AN0v01UYpOUQwUuMrPMp0EVUTjnDvnoQKBgQDon5tPo+axMvBImlA6\nZNoI5dnws3x4wZKHbhgGryU4kW9iGHKNU8sTVkvja40bJMNaPT+7wtuB+nOuLNjX\nZNOM4wRcqBgXPQ6elgrBwY5Pf2TVmiqdjvNLNWaI+3lRNiDg6Gf6TRQJ/0wa9IIt\nwlAgenpS1lI4I67oehjEwTYw0QKBgQDV8SWOFoAjNkWsN8/mCxxQZi1YwLS+xJsz\nlDYBlAAxVuyGJXCnJ7Q7AkKbIy365ZPh4sfFnLbfT5LNt//UUP87rpfcVeVuwUnP\nGM2+1Umo2j5ur9edlca97fMywj7c+3lOe/LBTkMP9KgnOAhAqLrsrOzSH77ChLtB\nmePcIER9jQKBgAMbFmzCyHK3NmQRw150OEEEKJvBGblXBEjQnHuCXSHbNzx9DRJ7\n+usgLNU1e2XQYNdUmAQ+vsWGfYLm0GJX00c/RLCkAeZVh1twr2YU2nyPO95qN4Vx\nAiiP5vWPPfhqm5fFIpZB7zGO+gomF5La1E0KtZVjjSd4un4aGziNR9bxAoGAFaB/\n/GIX5/dXibZGpOmgnhwGH3+zhclYKxmjb/tnHZW86T6lqbAgzwpGc2pV/pPwpBgJ\nu9dAwUhI/dTI3sylUIIwxcxFGjId5PqL6euju5b8UrIh6MM4SQDh4dKzCiG9vIpZ\nGuNvchB4YyaN5wNnif9dHUyqOv2x9Eq7NwhoBA0CgYEA1TeeQvYZgRK42jT5yC/R\nuPS+Eb8IhpeWHU52T+1SgSUFYmgNAbE7n0nHVzYE64IvsPmVZLrLhhXADjRHICvK\nhTtML1lBustG7Z9Tu66EZdQkvnJDwmVSZqVr2FmoOlXVS/qj4Tcc5kWvVp5ogI3u\npF0cRpeqEwY4dSWhiCznRkA=\n-----END PRIVATE KEY-----\n",
+        "client_email": "{}",
+        "client_id": "100849414604266807639",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "http://127.0.0.1:{}/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test1-262%40scylla-kms-test.iam.gserviceaccount.com",
+        "universe_domain": "googleapis.com"
+}})foo", gcp_project_id, user, port));
+        }
+
+        gcp_key_name = "test-ring/test-key";
+        gcp_user_1_credentials = cred1.string();
+        gcp_user_2_credentials = cred2.string();
+        endpoint = "http://127.0.0.1:" + std::to_string(port);
+        gcp_iam_endpoint_override = fmt::format("http://127.0.0.1:{}/v1/projects/-/serviceAccounts/{}:generateAccessToken", port, user1);
+        BOOST_TEST_MESSAGE(fmt::format("Test server endpoint {}, alias {}", endpoint, gcp_key_name));
+    }
+}
+
+seastar::future<> gcp_kms_fixture::impl::teardown() {
+    if (local_kms) {
+        local_kms->terminate();
+        co_await local_kms->wait();
+    }
+}
+
+static thread_local gcp_kms_fixture* active_gcp_kms_fixture = nullptr;
+
+gcp_kms_fixture::gcp_kms_fixture() 
+    : _impl(std::make_unique<impl>())
+{}
+
+gcp_kms_fixture::~gcp_kms_fixture() = default;
+
+const std::string& gcp_kms_fixture::endpoint() const {
+    return _impl->endpoint;
+}
+const std::string& gcp_kms_fixture::gcp_key_name() const {
+    return _impl->gcp_key_name;
+}
+const std::string& gcp_kms_fixture::gcp_location() const {
+    return _impl->gcp_location;
+}
+const std::string& gcp_kms_fixture::gcp_project_id() const {
+    return _impl->gcp_project_id;
+}
+const std::string& gcp_kms_fixture::gcp_user_1_credentials() const {
+    return _impl->gcp_user_1_credentials;
+}
+const std::string& gcp_kms_fixture::gcp_user_2_credentials() const {
+    return _impl->gcp_user_2_credentials;
+}
+const std::string& gcp_kms_fixture::gcp_iam_endpoint_override() const {
+    return _impl->gcp_iam_endpoint_override;
+}
+
+seastar::future<> gcp_kms_fixture::setup() {
+    co_await _impl->setup();
+    active_gcp_kms_fixture = this;
+}
+
+seastar::future<> gcp_kms_fixture::teardown() {
+    active_gcp_kms_fixture = nullptr;
+    return _impl->teardown();
+}
+
+gcp_kms_fixture* gcp_kms_fixture::active() {
+    return active_gcp_kms_fixture;
+}
+
+local_gcp_kms_wrapper::local_gcp_kms_wrapper() = default;
+local_gcp_kms_wrapper::~local_gcp_kms_wrapper() = default;
+
+seastar::future<> local_gcp_kms_wrapper::setup() {
+    auto f = gcp_kms_fixture::active();
+    if (!f) {
+        _local = std::make_unique<gcp_kms_fixture>();
+        co_await _local->setup();
+        f = gcp_kms_fixture::active();;
+    }
+
+    endpoint = f->endpoint();
+    gcp_key_name = f->gcp_key_name();
+    gcp_location = f->gcp_location();
+    gcp_project_id = f->gcp_project_id();
+    gcp_user_1_credentials = f->gcp_user_1_credentials();
+    gcp_user_2_credentials = f->gcp_user_2_credentials();
+    gcp_iam_endpoint_override = f->gcp_iam_endpoint_override();
+}
+
+seastar::future<> local_gcp_kms_wrapper::teardown() {
+    if (_local) {
+        co_await _local->teardown();
+        _local = {};
+    }
+}

--- a/test/lib/gcp_kms_fixture.hh
+++ b/test/lib/gcp_kms_fixture.hh
@@ -1,0 +1,84 @@
+
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <string>
+#include <memory>
+
+#include <seastar/core/future.hh>
+
+class tmpdir;
+
+/*
+    Simple GCP KMS mock/real provider. Uses either real or local, fake, endpoint.
+
+    Note: fake kms server does not have any credentials or permissions
+
+    This fixture is parameterized with env vars, if set we will just expose 
+    a real (we assume) KMS endpoint:
+
+    * GCP_KEY_NAME - set to name of key you have access to. If set, the fixture will assume we run real kms
+    * GCP_LOCATION - set to whatever location your key is in.
+    * GCP_PROJECT_ID
+    * GCP_USER_1_CREDENTIALS
+    * GCP_USER_2_CREDENTIALS
+
+    In CI, we provide the vars from jenkins, with working values
+
+*/
+
+class gcp_kms_fixture {
+    class impl;
+    std::unique_ptr<impl> _impl;
+public:
+    gcp_kms_fixture();
+    ~gcp_kms_fixture();
+
+    const std::string& gcp_key_name() const;
+    const std::string& gcp_location() const;
+    const std::string& gcp_project_id() const;
+    const std::string& gcp_user_1_credentials() const;
+    const std::string& gcp_user_2_credentials() const;
+    const std::string& gcp_iam_endpoint_override() const;
+
+    // this will be empty if using real KMS.
+    const std::string& endpoint() const;
+
+    seastar::future<> setup();
+    seastar::future<> teardown();
+
+    static gcp_kms_fixture* active();
+};
+
+/**
+ * Inheritance-only (intended at least) fixture
+ * for getting a suite-shared fixture above and
+ * also helping clean up test local objects.
+ * 
+ * If no suite-level aws_kms_fixture is active, it
+ * will create one in setup and kill it in teardown
+ */
+class local_gcp_kms_wrapper {
+    std::unique_ptr<gcp_kms_fixture> _local;
+public:
+    local_gcp_kms_wrapper();
+    ~local_gcp_kms_wrapper();
+
+    std::string endpoint;
+    std::string gcp_key_name;
+    std::string gcp_location;
+    std::string gcp_project_id;
+    std::string gcp_user_1_credentials;
+    std::string gcp_user_2_credentials;
+    std::string gcp_iam_endpoint_override;
+
+    seastar::future<> setup();
+    seastar::future<> teardown();
+};

--- a/test/pylib/encryption_provider.py
+++ b/test/pylib/encryption_provider.py
@@ -8,6 +8,9 @@ import os
 import asyncio
 import logging
 import threading
+import yaml
+import json
+
 from enum import Enum
 from functools import cached_property
 
@@ -15,6 +18,7 @@ from test import TEST_DIR
 from test.pylib.dockerized_service import DockerizedServer
 from test.pylib.kmip_wrapper import KMIPServerWrapper
 from test.pylib.azure_vault_server_mock import MockAzureVaultServer
+from test.pylib.gcp_kms_server_mock import MockGcpKmsServer
 
 import boto3
 
@@ -26,6 +30,7 @@ class KeyProvider(Enum):
     kmip = "KmipKeyProviderFactory"
     kms = "KmsKeyProviderFactory"
     azure = "AzureKeyProviderFactory"
+    gcp = "GcpKeyProviderFactory"
 
 class KeyProviderFactory:
     """Base class for provider factories"""
@@ -286,6 +291,93 @@ class AzureKeyProviderFactory(KeyProviderFactory):
     def require_restart(self):
         return True
 
+
+class GcpKeyProviderFactory(KeyProviderFactory):
+    gcp_project_id = "scylla-kms-test"
+    gcp_location = "global"
+    gcp_keyring = "test-ring"
+    gcp_keyname = "test-key"
+
+    """GcpKeyProviderFactory proxy"""
+    def __init__(self, tmpdir):
+        super(GcpKeyProviderFactory, self).__init__(KeyProvider.gcp, tmpdir)
+        self.tmpdir = tmpdir
+        self.gcp_server = None
+        self.gcp_host = "gcp_test"
+        self.gcp_port = 0
+        self.gcp_credentials_file = os.path.join(tmpdir, "creds.json")
+        self.gcp_server = None
+        self.gcp_user = "user1@apa.org"
+
+    def configuration_parameters(self) -> dict[str, str]:
+        """scylla.conf entries for provider"""
+        options = {
+            self.gcp_host: {
+                "master_key": f"{self.gcp_keyring}/{self.gcp_keyname}",
+                "gcp_project_id": self.gcp_project_id,
+                "gcp_location": self.gcp_location,
+                "gcp_credentials_file": self.gcp_credentials_file,
+                "endpoint": "http://127.0.0.1:" + str(self.gcp_port),
+            }
+        }
+        return super().configuration_parameters() | { "gcp_hosts": options } 
+
+    async def __aenter__(self):
+        self.gcp_server = MockGcpKmsServer("127.0.0.1", 0)
+        seed = { "projects":
+                { self.gcp_project_id:
+                 { "locations":
+                  { self.gcp_location:
+                   { "keyRings":
+                    { self.gcp_keyring:
+                     { "cryptoKeys":
+                      { self.gcp_keyname:
+                       { "purpose": 'ENCRYPT_DECRYPT',
+                         "versions": [{}],
+                         "users": [ self.gcp_user ]
+                       }
+                      }
+                     }
+                    }
+                   }
+                  }
+                 }
+                }
+            }
+        self.gcp_server.load_seed(yaml.safe_dump(seed))
+        self.gcp_port = self.gcp_server.server_address[1]
+        await self.gcp_server.start()
+
+        with open(self.gcp_credentials_file, "w", encoding='utf-8') as f:
+            creds = {
+                "type": "service_account",
+                "project_id": self.gcp_project_id,
+                "private_key_id": "c68de079f19d430a742bf18fed675a00caac13a2",
+                "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDCZ+yap8UNnxeR\nM1Ho10jx6JnpXdktDrBhF/vK/ENYmjiIjV1RsULtqJDHDrVJhK+k7chiA64M70XT\nOP/ABlvoNqPmX90WWroQd4HbEPnXMEMJYBiKg1vUtsUImB8soxKxCp0uY3sn+6cx\n8LNjvmI4waCclTTPIoLeh9s8USu5gr/ZrBQUjUlKLqSdoQfw4Tt1XRY0z4NDT3iX\naIrFeuwrXvnHKLFJ9j+jkdZm5qtjtBDR5C0tQbzUeD0xX0XTrPmgF8yt0JgmqUxs\nfp4/yGAOpuFpj5w11mRo6e4Kq2xvlxRJaBqoyd/70EgccwwBQ4gAN187CYp7PSuG\nFdD4MvAdAgMBAAECggEACVewNbB5VlG+crJqLcvmzAVXHDFv5evuSwQ5jAQ6glAL\nBnjwsqPXqQ8wQfixeqJ/RGhO+HLf0uxOyTtUgxhrI0o47zHNMK1UgsUTfwEeWJqP\npiwxkbqFV8Ae0O5qlR0TIWH2ssuCGCZOXyaHoHP+SWb4vn2nJ4srieEyhoAKH2SV\nOLlhB80QUd1xqVB9D6N6Ee13JQyWbDTqZPd8rSHJ3EmR9qxZtpxdtTKobpGNoFlH\nOXL26LAUMJ+N4A0Z6/RX5i/HJax5k2lrguawRzWibj8JtoH3V7iqpDmtSShpZdY4\n888EMePBo5AN0v01UYpOUQwUuMrPMp0EVUTjnDvnoQKBgQDon5tPo+axMvBImlA6\nZNoI5dnws3x4wZKHbhgGryU4kW9iGHKNU8sTVkvja40bJMNaPT+7wtuB+nOuLNjX\nZNOM4wRcqBgXPQ6elgrBwY5Pf2TVmiqdjvNLNWaI+3lRNiDg6Gf6TRQJ/0wa9IIt\nwlAgenpS1lI4I67oehjEwTYw0QKBgQDV8SWOFoAjNkWsN8/mCxxQZi1YwLS+xJsz\nlDYBlAAxVuyGJXCnJ7Q7AkKbIy365ZPh4sfFnLbfT5LNt//UUP87rpfcVeVuwUnP\nGM2+1Umo2j5ur9edlca97fMywj7c+3lOe/LBTkMP9KgnOAhAqLrsrOzSH77ChLtB\nmePcIER9jQKBgAMbFmzCyHK3NmQRw150OEEEKJvBGblXBEjQnHuCXSHbNzx9DRJ7\n+usgLNU1e2XQYNdUmAQ+vsWGfYLm0GJX00c/RLCkAeZVh1twr2YU2nyPO95qN4Vx\nAiiP5vWPPfhqm5fFIpZB7zGO+gomF5La1E0KtZVjjSd4un4aGziNR9bxAoGAFaB/\n/GIX5/dXibZGpOmgnhwGH3+zhclYKxmjb/tnHZW86T6lqbAgzwpGc2pV/pPwpBgJ\nu9dAwUhI/dTI3sylUIIwxcxFGjId5PqL6euju5b8UrIh6MM4SQDh4dKzCiG9vIpZ\nGuNvchB4YyaN5wNnif9dHUyqOv2x9Eq7NwhoBA0CgYEA1TeeQvYZgRK42jT5yC/R\nuPS+Eb8IhpeWHU52T+1SgSUFYmgNAbE7n0nHVzYE64IvsPmVZLrLhhXADjRHICvK\nhTtML1lBustG7Z9Tu66EZdQkvnJDwmVSZqVr2FmoOlXVS/qj4Tcc5kWvVp5ogI3u\npF0cRpeqEwY4dSWhiCznRkA=\n-----END PRIVATE KEY-----\n",
+                "client_email": self.gcp_user,
+                "client_id": "100849414604266807639",
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": f"http://127.0.0.1:{self.gcp_port}/token",
+                "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/test1-262%40scylla-kms-test.iam.gserviceaccount.com",
+                "universe_domain": "googleapis.com"
+            }
+            json.dump(creds, f)
+
+        return self
+
+    async def __aexit__(self, exception_type, exception_value, exception_traceback):
+        # pylint: disable=bare-except
+        if self.gcp_server is not None:
+            await self.gcp_server.stop()
+
+    def additional_cf_options(self):
+        return super().additional_cf_options() | {"gcp_host": self.gcp_host}
+
+    def require_restart(self):
+        return True
+
+
 def make_key_provider_factory(provider: KeyProvider, tmpdir, scylla_exe):
     """Create key provider factory for enum"""
     res = None
@@ -299,6 +391,8 @@ def make_key_provider_factory(provider: KeyProvider, tmpdir, scylla_exe):
         res = KMSKeyProviderFactory(tmpdir)
     elif provider == KeyProvider.azure:
         res = AzureKeyProviderFactory(tmpdir)
+    elif provider == KeyProvider.gcp:
+        res = GcpKeyProviderFactory(tmpdir)
     else:
         raise RuntimeError(f'Unknown key_provider: {provider}')
 

--- a/test/pylib/gcp_kms_server_mock.py
+++ b/test/pylib/gcp_kms_server_mock.py
@@ -1,0 +1,294 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+# Mock GCP KMS server for local testing.
+
+import re
+import json
+import yaml
+import uuid
+import time
+import base64
+import urllib
+import asyncio
+import logging
+import threading
+import argparse
+import signal
+import datetime as dt
+from functools import partial
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from cryptography.fernet import Fernet
+
+logger = logging.getLogger('fake_gcp_kms')
+
+class GcpKmsVault:
+    """
+    Fake KMS vault
+    """
+    class AESKey:
+        def __init__(self):
+            self.def_version = None
+            self.versions: dict[str,Fernet] = dict()
+            self.users = set()
+            self.create_version()
+
+        def get_version(self, version = None) -> tuple[bytes, Fernet]:
+            version = version or self.def_version
+            return (uuid.UUID(version).bytes, self.versions.get(version))
+
+        def create_version(self):
+            version = uuid.uuid4().hex
+            key = Fernet(Fernet.generate_key())
+            self.versions[version] = key
+            if not self.def_version:
+                self.def_version = version;
+            return version
+
+        def encrypt(self, message: bytes, version: str = None) -> bytes:
+            pfx, key = self.get_version(version)
+            return pfx + key.encrypt(message)
+
+        def decrypt(self, message: bytes) -> bytes:
+            pfx = message[:16]
+            msg = message[16:]
+            _, key = self.get_version(uuid.UUID(bytes=pfx).hex)
+            return key.decrypt(msg)
+
+        def add_user(self, user: str):
+            self.users.add(user)
+
+        def has_user(self, user: str):
+            return user in self.users
+
+    def __init__(self):
+        self.keys = dict()
+        self.impersonators: dict[str, list] = dict()
+        self.lock = threading.Lock()
+
+    def add_impersonator(self, user: str, principal: str):
+        self.impersonators.setdefault(user, list()).append(principal)
+
+    def can_impersonate(self, user:str, principal: str):
+        with self.lock:
+            return principal in self.impersonators.get(user, [])
+
+    def get_key(self, key_name: str) -> AESKey:
+        with self.lock:
+            return self.keys.get(key_name)
+    
+    def load_seed(self, seed):
+        root = yaml.safe_load(seed)
+        for proj,pd in root['projects'].items():
+            for loc,ld in pd['locations'].items():
+                for key_ring, krd in ld['keyRings'].items():
+                    for ck, ckd in krd['cryptoKeys'].items():
+                        kname = f"{proj}/{loc}/{key_ring}/{ck}"
+                        key = self.AESKey()
+                        for _ in ckd['versions'][1:]:
+                            key.create_version()
+                            logger.debug("Adding version to key %s", kname)
+                        for user in ckd['users']:
+                            key.add_user(user)
+                            logger.debug("Adding user %s to key %s", user, kname)
+                        logger.debug("Adding key %s", kname)
+                        with self.lock:
+                            self.keys[kname] = key
+        for imp,principals in root.get('impersonators', {}).items():
+            for p in principals:
+                logger.debug("Adding impersonator %s -> %s", imp, p)
+                self.add_impersonator(imp, p)
+
+class GcpKmsRequestHandler(BaseHTTPRequestHandler):
+    """
+    HTTP request handler
+
+    Supported endpoints:
+    - POST /v1/projects/{project}/locations/{location}/keyRings/{keyRing}/cryptoKeys/{keyName}:{action}";
+    - POST /token (fake oauth)
+    """
+    keyop_expression = re.compile(r'^/v1/projects/([^/]+)/locations/([^/]+)/keyRings/([^/]+)/cryptoKeys/([^/]+):(\w+)$')
+    oauth_path = "/token"
+    impersonate_expression = re.compile(r'^/v1/projects/-/serviceAccounts/([^:]+):generateAccessToken$')
+
+    TOKEN_DURATION = 86400  # 24 hours
+
+    def __init__(self, vault: GcpKmsVault, *args, **kwargs):
+        self.vault = vault
+        super().__init__(*args, **kwargs)
+
+    def extract_client_id(self):
+        """Extract client ID from Authorization header if present"""
+        auth_header = self.headers.get('Authorization', '')
+        if auth_header.startswith('Bearer '):
+            try:
+                token = auth_header[7:]
+                return base64.urlsafe_b64decode(token).decode()
+            except Exception:
+                pass
+        return None
+
+    def do_send_response(self, status_code, response):
+        s = json.dumps(response).encode()
+        self.send_response(status_code)
+        self.send_header('Content-Type', "application/json")
+        self.send_header('Content-Length', str(len(s)))
+        self.end_headers()
+        self.wfile.write(s)
+        logger.debug("response %s: %s", status_code, response)
+
+    def make_error_response(self, status, message):
+        self.do_send_response(status, { "status": status, "message": message })
+
+    def do_POST(self):
+        logger.debug("Request %s: %s", self.path, self.headers)
+
+        if self.path == self.oauth_path:
+            content_length = int(self.headers.get('Content-Length', 0))
+            body = self.rfile.read(content_length).decode('utf-8')
+            form_data = urllib.parse.parse_qs(body)
+            for param in ['grant_type', 'assertion']:
+                if not param in form_data:
+                    self.make_error_response(400, f"missing required parameter {param}")
+                    return
+
+            assertion=form_data['assertion'][0]
+            # jwt. we don't care about whether it is valid or not (probably not)
+            # just generate a bearer we can extract user from.
+            # note: this is _not even close_ to what actual gcp gives back.
+            # but this matters not for us; we just need a value than can be parsed.
+            try:
+                chunk = assertion.split('.')[1].encode()
+                # make sure we have padding
+                decoded = base64.b64decode(chunk + b'==')
+                data = json.loads(decoded)
+                email = data['iss']
+                self.do_send_response(200, {
+                    "token_type": "Bearer",
+                    "expires_in": self.TOKEN_DURATION,
+                    "access_token": base64.b64encode(email.encode()).decode()
+                })
+            except Exception as e:
+                self.make_error_response(400, f"error parsing auth token {e}")
+            return
+
+        match = self.impersonate_expression.match(self.path)
+        if match:
+            principal = match.groups()[0]
+            user = self.extract_client_id()
+            if self.vault.can_impersonate(user, principal):
+                self.do_send_response(200, {
+                    "expireTime": (dt.datetime.now() + dt.timedelta(seconds=self.TOKEN_DURATION)).strftime('%FT%TZ'),
+                    "accessToken": base64.b64encode(principal.encode()).decode()
+                })
+            else:
+                self.make_error_response(400, f"User {user} cannot impersonate {principal}")
+            return
+
+        match = self.keyop_expression.match(self.path)
+        if match:
+            project, location, key_ring, key_name, op = match.groups()
+            keyId = f"{project}/{location}/{key_ring}/{key_name}"
+            key = self.vault.get_key(keyId)
+
+            if not key:
+                self.make_error_response(404, f"Key {key_name} not found in {project}/{location}/{key_ring}")
+                return
+
+            content_length = self.headers['Content-Length']
+            data = self.rfile.read(int(content_length) if content_length else -1)
+            user = self.extract_client_id()
+
+            if not user:
+                self.make_error_response(400, "Missing auth")
+                return
+
+            if not key.has_user(user):
+                self.make_error_response(403, f"{user} cannot access {keyId}")
+                return
+
+            body = json.loads(data.decode())
+
+            if op == 'encrypt':
+                buf = key.encrypt(base64.b64decode(body['plaintext']))
+                self.do_send_response(200, { 'ciphertext': base64.b64encode(buf).decode() })
+                return 
+
+            if op == 'decrypt':
+                buf = key.decrypt(base64.b64decode(body['ciphertext']))
+                self.do_send_response(200, { 'plaintext': base64.b64encode(buf).decode() })
+                return
+
+            self.make_error_response(400, f"Unsupported op: {op}")
+            return
+
+        self.make_error_response(404, "Invalid path")
+
+class MockGcpKmsServer:
+    def __init__(self, host, port):
+        self.vault = GcpKmsVault()
+        handler = partial(GcpKmsRequestHandler, self.vault)
+        self.server = ThreadingHTTPServer((host, port), handler)
+        self.server_thread = None
+        self.server.request_queue_size = 10
+        self.is_stopped = asyncio.Event()
+        self.is_stopped.set()
+
+    @property
+    def server_address(self):
+        return self.server.server_address
+
+    def load_seed(self, seed: str):
+        self.vault.load_seed(seed)
+
+    async def start(self):
+        if self.is_stopped.is_set():
+            logger.info("Starting GCP KMS mock server on %s", self.server.server_address)
+            loop = asyncio.get_running_loop()
+            self.server_thread = loop.run_in_executor(None, self.server.serve_forever)
+            self.is_stopped.clear()
+
+    async def stop(self):
+        if not self.is_stopped.is_set():
+            logger.info("Stopping GCP KMS mock server")
+            self.server.shutdown()
+            self.server.server_close()
+            await self.server_thread
+            self.is_stopped.set()
+
+    async def run(self):
+        try:
+            await self.start()
+            await self.is_stopped.wait()
+        except (Exception, asyncio.CancelledError) as e:
+            logger.error("Server error: %s", e)
+            await self.stop()
+
+
+if __name__ == '__main__':
+    async def run():
+        parser = argparse.ArgumentParser(description="GCP KMS mock server")
+        parser.add_argument('--host', default='127.0.0.1')
+        parser.add_argument('--port', type=int, default=0)
+        parser.add_argument("--seed", help="Seed file")
+        parser.add_argument('--log-level', default=logging.INFO,
+                            choices=logging.getLevelNamesMapping().keys(),
+                            help="Set log level")
+
+        args = parser.parse_args()
+        logging.basicConfig(level=args.log_level, format='%(levelname)s  %(asctime)s - %(message)s')
+        server = MockGcpKmsServer(args.host, args.port)
+
+        if args.seed:
+            with open(args.seed, encoding='utf-8') as f:
+                server.load_seed(f)
+
+        await server.start()
+        signal.sigwait({signal.SIGINT, signal.SIGTERM})
+        await server.stop()
+
+    asyncio.run(run())

--- a/utils/gcp/gcp_credentials.cc
+++ b/utils/gcp/gcp_credentials.cc
@@ -93,8 +93,9 @@ utils::gcp::service_account_credentials::service_account_credentials(const rjson
     , quota_project_id(rjson::get_opt<std::string>(v, "refresh_token").value_or(""))
 {}
 
-utils::gcp::impersonated_service_account_credentials::impersonated_service_account_credentials(std::string principal, google_credentials&& c)
-    : target_principal(std::move(principal))
+utils::gcp::impersonated_service_account_credentials::impersonated_service_account_credentials(std::string principal, google_credentials&& c, std::string iam_endpoint_override_in)
+    : iam_endpoint_override(std::move(iam_endpoint_override_in))
+    , target_principal(std::move(principal))
     , source_credentials(std::make_unique<google_credentials>(std::move(c))) 
 {}
 

--- a/utils/gcp/gcp_credentials.hh
+++ b/utils/gcp/gcp_credentials.hh
@@ -72,7 +72,7 @@ namespace utils::gcp {
     };
 
     struct impersonated_service_account_credentials {
-        impersonated_service_account_credentials(std::string principal, google_credentials&&);
+        impersonated_service_account_credentials(std::string principal, google_credentials&&, std::string iam_endpoint_override = {});
         impersonated_service_account_credentials(const rjson::value&);
 
         std::vector<std::string> delegates;


### PR DESCRIPTION
Fixes: SCYLLADB-2529

Adds additional config params to GCP provider, to allow local endpoints etc.

Adds a minimal mock GCP KMS server written in python (inspired/partially stolen from mock azure, thank you).
Implements rudimentary operations and some oauth2 emulation to allow our tests to run against this.

Adds test fixtures for boost and pytest and changes tests to use said fixtures. 

Enhancement to tests. No backport needed.