### PR TITLE
storage_service: fix use-after-free in merge_topology_snapshot

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -864,9 +864,11 @@ future<> storage_service::merge_topology_snapshot(raft_snapshot snp) {
                 if (m.representation().size() <= max_size) {
                     frozen_muts_to_apply.push_back(co_await freeze_gently(mut));
                 } else {
-                    co_await for_each_split_mutation(std::move(mut), max_size, [&] (mutation m) -> future<> {
+                    utils::chunked_vector<mutation> split_muts;
+                    co_await split_mutation(std::move(mut), split_muts, max_size);
+                    for (auto& m : split_muts) {
                         frozen_muts_to_apply.push_back(co_await freeze_gently(m));
-                    });
+                    }
                 }
             }
         }


### PR DESCRIPTION
A coroutine lambda returning future<> was passed to for_each_split_mutation() which accepts std::function<void(mutation)>. The future was silently discarded, causing the coroutine's post-co_await code to run asynchronously after frozen_muts_to_apply was already gone.

Revert to the pre-regression approach: collect split mutations into a vector with split_mutation(), then freeze them one by one with proper co_await.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2714
Regression introduced in faa0ee984463 ("mutation: add for_each_split_mutation")

Regression was introduced in 2026.1. Needs a backport to 2026.1+