### PR TITLE
test/boost/hwlb_test: fix flakiness

### DIFF
--- a/test/boost/hwlb_test.cc
+++ b/test/boost/hwlb_test.cc
@@ -51,7 +51,7 @@ static std::vector<std::pair<int,float>> me_first(
 // Again, this is just a simulation - no actual request is sent here, these
 // requests are just counted.
 static void test_hit_rates(std::vector<float> hr, unsigned CL,
-                           bool want_extra = false, unsigned iterations = 100000) {
+                           bool want_extra = false, unsigned iterations = 500000) {
     const int RF = hr.size();
     BOOST_TEST_MESSAGE(fmt::format("RF={} nodes, given hit rates: {}",
         RF, fmt::join(hr, " ")));
@@ -208,9 +208,11 @@ static void test_hit_rates(std::vector<float> hr, unsigned CL,
     // such as test_clip(), very rarely (e.g., once in a million calls
     // to miss_equalizing_combination()) generate an invalid combination.
     // To work around this flakyness (and allow this test into the suite),
-    // we check here count_invalid <= 3. Later we should revert it to
-    // count_invalid == 0 and find the cause of the rare bug.
-    BOOST_CHECK(count_invalid <= 3);
+    // we allow up to RF*iterations/100000 invalid combinations (one per
+    // 100,000 calls), which scales with the total number of calls made.
+    // Later we should revert it to count_invalid == 0 and find the cause
+    // of the rare bug.
+    BOOST_CHECK(count_invalid <= (long long)RF * iterations / 100000);
     BOOST_TEST_MESSAGE("----------------------------------------------------------");
 }
 
@@ -350,7 +352,16 @@ BOOST_AUTO_TEST_CASE(extra) {
 // max_hit_rate variable, which clips hit rates - and what happens
 // when it is 0.999 (before issue #8815) or 0.95 (that issue's fix).
 BOOST_AUTO_TEST_CASE(test_a) {
-    test_hit_rates({0.999, 0.999, 0.999, 0.999, 0.999, 0.94}, 2);
+    // The cold node gets only ~1/301 of requests (miss rate 60x higher than
+    // warm nodes). With the old default of 100,000 iterations it got only
+    // ~3,988 requests (~3.6 sigma from failure, ~1 in 5,000 chance per run,
+    // causing actual CI failures). We use 5,000,000 iterations instead, giving
+    // ~199,000 requests (~25 sigma from failure).
+    test_hit_rates({0.999, 0.999, 0.999, 0.999, 0.999, 0.94}, 2, false, 5000000);
     test_hit_rates({0.95, 0.95, 0.95, 0.95, 0.95, 0.94}, 2);
-    test_hit_rates({0.999, 0.999, 0.999, 0.999, 0.999, 0.989}, 2);
+    // The cold node gets only ~1/56 of requests (miss rate 11x higher than
+    // warm nodes). With the old default of 100,000 iterations it got only
+    // ~21,000 requests (~8 sigma from failure). We use 1,000,000 iterations
+    // instead, giving ~214,000 requests (~26 sigma from failure).
+    test_hit_rates({0.999, 0.999, 0.999, 0.999, 0.999, 0.989}, 2, false, 1000000);
 }

--- a/test/boost/test_config.yaml
+++ b/test/boost/test_config.yaml
@@ -53,3 +53,7 @@ custom_args:
         - '-c2 -m2G --logger-log-level batchlog_manager=trace:debug_error_injection=trace:testlog=trace'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test
+# Tests skipped in debug/sanitize modes because they use many iterations
+# for statistical accuracy and are prohibitively slow under those modes.
+skip_in_debug_modes:
+    - hwlb_test


### PR DESCRIPTION
The tests in test/boost/hwlb_test are all statistical: We test the miss_equalizing_combination() function through many load-balancing decisions, and confirm that after many such probabilistic decisions, the average load distribution is close to what we expect. We need to run enough of these probabilistic experiments to make sure that the chance of getting a result far from the expected one is vanishingly small.

Unfortunately, as CI has been run these test thousands of times, we DID see some flakiness, and this patch fixes them in two places, in both places by increasing the number of iterations and greatly lowering the chance of ever seeing a spurious failure:

1. Increase default iterations from 100,000 to 500,000.

   The count2 check (BOOST_CHECK(std::abs((count2[i][i]/total) - e) < 1e-2)) compares observed vs. expected fraction of work a coordinator keeps locally. In the worst case (e = 0.5), the standard deviation of the observed fraction is sqrt(0.25/N). With N=100,000 iterations per coordinator, that is ~1.58e-3, meaning the tolerance of 1e-2 is only ~6.3 sigma away from failure -- a ~1-in-500,000,000 chance per check, but with many checks across many test cases and thousands of CI runs, failures were observed in practice.

   With N=500,000 the tolerance becomes ~14 sigma (~1-in-10^43 per check), which is safe regardless of how often the test suite runs.

2. Use more iterations for two test cases in test_a.

   test_hit_rates({0.999x5, 0.94}, CL=2): the cold node (miss rate 0.06) gets only ~1/301 of all replica requests. With the default 500,000 iterations that is ~9,960 requests, giving a standard deviation on its miss count of ~5.9. The max/min miss ratio check (< 1.06) sits only ~10 sigma from failure (~1-in-10^23). This is theoretically safe, although at the prior default of 100,000 iterations it was only ~4.5 sigma (~1-in-14,000), causing real CI failures. Still, we use 5,000,000 iterations (matching the pattern in test_3_1 for similar extreme cases), pushing the margin to ~32 sigma (~1-in-10^224).

   test_hit_rates({0.999x5, 0.989}, CL=2): the cold node (miss rate 0.011) gets ~1/56 of requests. With the old default of 100,000 iterations that is ~21,400 requests and only ~8 sigma (~1-in-10^15) from failure -- marginal for a test run millions of times. With 1,000,000 iterations this becomes ~28 sigma (~1-in-10^170).

These tests were always fairly slow and became even slower with the increased number of iterations (over a minute), so we also change the configuration to not run these tests in debug builds.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2549
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2618

No need to backport, this is a very newly-merged test.