### PR TITLE
Add more snapshot tables to system_distributed

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -867,7 +867,7 @@ std::pair<std::reference_wrapper<struct query_processor::remote>, gate::holder> 
 
 query_options query_processor::make_internal_options(
         const statements::prepared_statement::checked_weak_ptr& p,
-        const std::vector<data_value_or_unset>& values,
+        const query_data_params& values,
         db::consistency_level cl,
         int32_t page_size,
         service::node_local_only node_local_only) const {
@@ -930,7 +930,7 @@ struct internal_query_state {
 internal_query_state query_processor::create_paged_state(
         const sstring& query_string,
         db::consistency_level cl,
-        const data_value_list& values,
+        const query_data_params& values,
         int32_t page_size,
         std::optional<service::query_state> qs) {
     auto p = prepare_internal(query_string);
@@ -1001,7 +1001,7 @@ future<::shared_ptr<untyped_result_set>>
 query_processor::execute_internal(
         const sstring& query_string,
         db::consistency_level cl,
-        const data_value_list& values,
+        const query_data_params& values,
         cache_internal cache) {
     auto qs = query_state_for_internal_call();
     co_return co_await execute_internal(query_string, cl, qs, values, cache);
@@ -1012,7 +1012,7 @@ query_processor::execute_internal(
         const sstring& query_string,
         db::consistency_level cl,
         service::query_state& query_state,
-        const data_value_list& values,
+        const query_data_params& values,
         cache_internal cache) {
 
     if (log.is_enabled(logging::log_level::trace)) {
@@ -1057,7 +1057,7 @@ query_processor::execute_with_params(
         statements::prepared_statement::checked_weak_ptr p,
         db::consistency_level cl,
         service::query_state& query_state,
-        const data_value_list& values) {
+        const query_data_params& values) {
     auto opts = make_internal_options(p, values, cl);
     auto statement = p->statement;
 
@@ -1272,7 +1272,7 @@ bool query_processor::migration_subscriber::should_invalidate(
 future<> query_processor::query_internal(
         const sstring& query_string,
         db::consistency_level cl,
-        const data_value_list& values,
+        const query_data_params& values,
         int32_t page_size,
         noncopyable_function<future<stop_iteration>(const cql3::untyped_result_set_row&)> f,
         std::optional<service::query_state> qs) {

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -375,7 +375,7 @@ public:
     future<> query_internal(
             const sstring& query_string,
             db::consistency_level cl,
-            const data_value_list& values,
+            const query_data_params& values,
             int32_t page_size,
             noncopyable_function<future<stop_iteration>(const cql3::untyped_result_set_row&)> f,
             std::optional<service::query_state> qs = std::nullopt);
@@ -409,13 +409,13 @@ public:
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
             db::consistency_level,
-            const data_value_list&,
+            const query_data_params&,
             cache_internal cache);
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
             db::consistency_level,
             service::query_state& query_state,
-            const data_value_list& values,
+            const query_data_params& values,
             cache_internal cache);
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
@@ -431,7 +431,7 @@ public:
         return execute_internal(query_string, cl, query_state, {}, cache);
     }
     future<::shared_ptr<untyped_result_set>>
-    execute_internal(const sstring& query_string, const data_value_list& values, cache_internal cache) {
+    execute_internal(const sstring& query_string, const query_data_params& values, cache_internal cache) {
         return execute_internal(query_string, db::consistency_level::ONE, values, cache);
     }
     future<::shared_ptr<untyped_result_set>>
@@ -454,7 +454,7 @@ public:
             statements::prepared_statement::checked_weak_ptr p,
             db::consistency_level,
             service::query_state& query_state,
-            const data_value_list& values = { });
+            const query_data_params& values = { });
 
     future<::shared_ptr<cql_transport::messages::result_message>> do_execute_with_params(
             service::query_state& query_state,
@@ -537,7 +537,7 @@ public:
 
     query_options make_internal_options(
             const statements::prepared_statement::checked_weak_ptr& p,
-            const std::vector<data_value_or_unset>& values,
+            const query_data_params& values,
             db::consistency_level,
             int32_t page_size = -1,
             service::node_local_only node_local_only = service::node_local_only::no) const;
@@ -572,7 +572,7 @@ private:
     internal_query_state create_paged_state(
             const sstring& query_string,
             db::consistency_level,
-            const data_value_list& values,
+            const query_data_params& values,
             int32_t page_size,
             std::optional<service::query_state> qs = std::nullopt);
 

--- a/db/snapshot_types.hh
+++ b/db/snapshot_types.hh
@@ -46,10 +46,84 @@ struct snapshot_sstable_entry {
     int64_t index_size;
 };
 
+// A single cluster level snapshot
+struct snapshot_entry {
+    std::string name;
+
+    db_clock::time_point created_at;
+    db_clock::time_point expires_at;
+
+    std::string namespace_version;
+    std::string manifest_version;
+
+    constexpr bool operator==(const snapshot_entry& o) const noexcept = default;
+};
+
+// Backup location for a snapshot for a given dc
 struct snapshot_remote_location_entry {
-    sstring endpoint;
-    sstring bucket;
-    sstring prefix;
+    std::string snapshot_name;
+    std::string datacenter;
+
+    // reference to named endpoint in scylla conf.
+    // note: need to be consistent across creation
+    // and usage of this info. 
+    std::string endpoint;
+    std::string bucket;
+    std::string prefix;
+
+    snapshot_state state;
+
+    constexpr bool operator==(const snapshot_remote_location_entry& o) const noexcept = default;
+};
+
+// Keyspace as of the time of snapshot
+struct snapshot_keyspace_entry {
+    std::string snapshot_name;
+    std::string keyspace_name;
+    std::string keyspace_schema;
+
+    constexpr bool operator==(const snapshot_keyspace_entry& o) const noexcept = default;
+};
+
+// Table as of the time of snapshot
+struct snapshot_table_entry {
+    std::string snapshot_name;
+    std::string keyspace_name;
+    std::string table_name;
+
+    ::table_id table_id;
+    snapshot_table_type type;
+
+    ::table_id base_table_id;
+
+    std::string table_schema;
+
+    std::string tablet_layout;
+
+    constexpr bool operator==(const snapshot_table_entry& o) const noexcept = default;
+};
+
+// Tablet as of the time of snapshot
+struct snapshot_tablet_entry {
+    size_t tablet_id;
+
+    // Token range of tablet, equivalent
+    // to tablet_manager::get_first_token/get_last_token
+    dht::token first_token;
+    dht::token last_token;
+    db_clock::time_point repair_time;
+    int64_t repaired_at;
+
+    constexpr bool operator==(const snapshot_tablet_entry& o) const noexcept = default;
+};
+
+// Node as of the time of snapshot
+struct snapshot_node_entry {
+    std::string datacenter;
+    std::string rack;
+    locator::host_id node;
+
+    constexpr bool operator==(const snapshot_node_entry& o) const noexcept = default;
 };
 
 } // namespace db

--- a/db/snapshot_types.hh
+++ b/db/snapshot_types.hh
@@ -10,11 +10,26 @@
 
 #include "schema/schema_fwd.hh"
 #include "dht/token.hh"
+#include "locator/host_id.hh"
 #include "sstables/types.hh"
 
 namespace db {
 
 using is_downloaded = bool_class<class is_downloaded_tag>;
+
+enum class snapshot_state : uint8_t {
+    unknown,
+    local,
+    being_backed_up,
+    remote_and_local,
+    remote,
+};
+
+enum class snapshot_table_type : uint32_t {
+    cql_table,
+    cql_view,
+    alternator_table,
+};
 
 struct snapshot_sstable_entry {
     sstables::sstable_id sstable_id;
@@ -23,6 +38,12 @@ struct snapshot_sstable_entry {
     sstring toc_name;
     sstring prefix;
     is_downloaded downloaded{is_downloaded::no};
+    locator::host_id node;
+    size_t tablet_id;
+    snapshot_state state;
+    int64_t repaired_at;
+    int64_t data_size;
+    int64_t index_size;
 };
 
 struct snapshot_remote_location_entry {

--- a/db/snapshot_types.hh
+++ b/db/snapshot_types.hh
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include "schema/schema_fwd.hh"
+#include "dht/token.hh"
+#include "sstables/types.hh"
+
+namespace db {
+
+using is_downloaded = bool_class<class is_downloaded_tag>;
+
+struct snapshot_sstable_entry {
+    sstables::sstable_id sstable_id;
+    dht::token first_token;
+    dht::token last_token;
+    sstring toc_name;
+    sstring prefix;
+    is_downloaded downloaded{is_downloaded::no};
+};
+
+struct snapshot_remote_location_entry {
+    sstring endpoint;
+    sstring bucket;
+    sstring prefix;
+};
+
+} // namespace db

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -122,6 +122,18 @@ schema_ptr snapshot_sstables() {
                 .with_column("prefix", utf8_type)
                 // Flag if the SSTable was downloaded already
                 .with_column("downloaded", boolean_type)
+                // Node ID where sstable resides (optional)
+                .with_column("node", uuid_type)
+                // Tablet to which the sstable belonged at time of snapshot
+                .with_column("tablet", long_type)
+                // State - local, being_backed_up, remote_and_local, remote
+                .with_column("state", int32_type)
+                // Repair time
+                .with_column("repaired_at", long_type)
+                // Data size 
+                .with_column("data_size", long_type)
+                // Index size 
+                .with_column("index_size", long_type)
                 .with_hash_version()
                 .build();
     }();
@@ -459,9 +471,11 @@ snapshot_table_helper::snapshot_table_helper(cql3::query_processor& qp)
 
 future<> snapshot_table_helper::insert_snapshot_sstable(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack
     , sstables::sstable_id sstable_id, dht::token first_token, dht::token last_token, sstring toc_name, sstring prefix
+    , locator::host_id node, size_t tablet_id, snapshot_state state, int64_t repaired_at
+    , int64_t data_size, int64_t index_size
     , db::consistency_level cl) 
 {
-    static const sstring query = format("INSERT INTO {}.{} (snapshot_name, \"keyspace\", \"table\", datacenter, rack, first_token, sstable_id, last_token, toc_name, prefix) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TTL {}"
+    static const sstring query = format("INSERT INTO {}.{} (snapshot_name, \"keyspace\", \"table\", datacenter, rack, first_token, sstable_id, last_token, toc_name, prefix, node, tablet, state, repaired_at, data_size, index_size) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TTL {}"
         , system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_SSTABLES
         , snapshot_table_ttl_seconds
     );
@@ -471,7 +485,10 @@ future<> snapshot_table_helper::insert_snapshot_sstable(sstring snapshot_name, s
             cl,
             internal_distributed_query_state(),
             { std::move(snapshot_name), std::move(ks), std::move(table), std::move(dc), std::move(rack),
-              dht::token::to_int64(first_token), sstable_id.uuid(), dht::token::to_int64(last_token), std::move(toc_name), std::move(prefix) },
+              dht::token::to_int64(first_token), sstable_id.uuid(), dht::token::to_int64(last_token), std::move(toc_name), std::move(prefix),
+              node.uuid(), int64_t(tablet_id), int32_t(state), repaired_at,
+              data_size, index_size,
+            },
             cql3::query_processor::cache_internal::yes).discard_result();
 }
 
@@ -479,13 +496,25 @@ future<utils::chunked_vector<snapshot_sstable_entry>>
 snapshot_table_helper::get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl, std::optional<dht::token> start_token, std::optional<dht::token> end_token) const {
     utils::chunked_vector<snapshot_sstable_entry> sstables;
 
-    static const sstring base_query = format("SELECT toc_name, prefix, sstable_id, first_token, last_token, downloaded FROM {}.{}"
+    static const sstring base_query = format("SELECT toc_name, prefix, sstable_id, first_token, last_token, downloaded, node, tablet, state, repaired_at, data_size, index_size FROM {}.{}"
         " WHERE snapshot_name = ? AND \"keyspace\" = ? AND \"table\" = ? AND datacenter = ? AND rack = ?"
         , system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_SSTABLES
     );
 
     auto read_row = [&] (const cql3::untyped_result_set_row& row) {
-            sstables.emplace_back(sstables::sstable_id(row.get_as<utils::UUID>("sstable_id")), dht::token::from_int64(row.get_as<int64_t>("first_token")), dht::token::from_int64(row.get_as<int64_t>("last_token")), row.get_as<sstring>("toc_name"), row.get_as<sstring>("prefix"), is_downloaded(row.get_or<bool>("downloaded", false)));
+            sstables.emplace_back(sstables::sstable_id(row.get_as<utils::UUID>("sstable_id"))
+                , dht::token::from_int64(row.get_as<int64_t>("first_token"))
+                , dht::token::from_int64(row.get_as<int64_t>("last_token"))
+                , row.get_as<sstring>("toc_name")
+                , row.get_as<sstring>("prefix")
+                , is_downloaded(row.get_or<bool>("downloaded", false))
+                , locator::host_id(row.get_or<utils::UUID>("node", utils::UUID{}))
+                , row.get_or<int64_t>("tablet", 0)
+                , snapshot_state(row.get_or<int32_t>("state", 0))
+                , row.get_or<int64_t>("repaired_at", 0)
+                , row.get_or<int64_t>("data_size", 0)
+                , row.get_or<int64_t>("index_size", 0)
+            );
             return make_ready_future<stop_iteration>(stop_iteration::no);
     };
 

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -96,6 +96,113 @@ schema_ptr cdc_timestamps() {
 
 static const sstring CDC_TIMESTAMPS_KEY = "timestamps";
 
+schema_ptr snapshots() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOTS);
+        return schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOTS, std::make_optional(id))
+                // Name of the snapshot
+                .with_column("name", utf8_type, column_kind::partition_key)
+                // When snapshot was created
+                .with_column("created_at", timestamp_type)
+                // When snapshot expires
+                .with_column("expires_at", timestamp_type)
+                .with_column("namespace_version", utf8_type)
+                .with_column("manifest_version", utf8_type)
+                .with_hash_version()
+                .build();
+    }();
+    return schema;
+}
+
+schema_ptr snapshot_keyspaces() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_KEYSPACES);
+        return schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_KEYSPACES, std::make_optional(id))
+                // Name of the snapshot
+                .with_column("snapshot_name", utf8_type, column_kind::partition_key)
+                // The name of keyspace
+                .with_column("keyspace_name", utf8_type, column_kind::clustering_key)
+                // Keyspace schema
+                .with_column("keyspace_schema", utf8_type)
+                .with_hash_version()
+                .build();
+    }();
+    return schema;
+}
+
+schema_ptr snapshot_tables() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_TABLES);
+        return schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_TABLES, std::make_optional(id))
+                // Name of the snapshot
+                .with_column("snapshot_name", utf8_type, column_kind::partition_key)
+                // The name of keyspace
+                .with_column("keyspace_name", utf8_type, column_kind::clustering_key)
+                // The name of table
+                .with_column("table_name", utf8_type, column_kind::clustering_key)
+                // Table ID
+                .with_column("table_id", uuid_type)
+                // Table type
+                .with_column("type", int32_type)
+                // Optional base table
+                .with_column("base_table_id", uuid_type)
+                // Table schema
+                .with_column("table_schema", utf8_type)
+                .with_column("tablet_layout", utf8_type)
+                .with_hash_version()
+                .build();
+    }();
+    return schema;
+}
+
+
+schema_ptr snapshot_tablets() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_TABLETS);
+        return schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_TABLETS, std::make_optional(id))
+                // Name of the snapshot
+                .with_column("snapshot_name", utf8_type, column_kind::partition_key)
+                // The name of keyspace
+                .with_column("keyspace_name", utf8_type, column_kind::partition_key)
+                // The name of table
+                .with_column("table_name", utf8_type, column_kind::partition_key)
+                // The datacenter for which the tablet mapping was active
+                .with_column("datacenter", utf8_type, column_kind::partition_key)
+                // First token in the token range covered by this tablet
+                .with_column("first_token", long_type, column_kind::clustering_key)
+                // Tablet ID
+                .with_column("tablet_id", long_type)
+                // Last token in the token range covered by this tablet
+                .with_column("last_token", long_type)
+                // Repair time
+                .with_column("repair_time", timestamp_type)
+                // Repaired at
+                .with_column("repaired_at", long_type)
+
+                .with_hash_version()
+                .build();
+    }();
+    return schema;
+}
+
+schema_ptr snapshot_nodes() {
+    static thread_local auto schema = [] {
+        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_NODES);
+        return schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_NODES, std::make_optional(id))
+                // Name of the snapshot
+                .with_column("snapshot_name", utf8_type, column_kind::partition_key)
+                // Datacenter of the node (at snapshot)
+                .with_column("datacenter", utf8_type, column_kind::clustering_key)
+                // The rack of the node (at snapshot)
+                .with_column("rack", utf8_type, column_kind::clustering_key)
+                // Actual node
+                .with_column("node", uuid_type, column_kind::clustering_key)
+                .with_hash_version()
+                .build();
+    }();
+    return schema;
+}
+
 schema_ptr snapshot_sstables() {
     static thread_local auto schema = [] {
         auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_SSTABLES);
@@ -144,11 +251,17 @@ schema_ptr snapshot_remote_locations() {
     static thread_local auto schema = [] {
         auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS);
         return schema_builder(this_smp_shard_count(), system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS, std::make_optional(id))
+                // Name of the snapshot
                 .with_column("snapshot_name", utf8_type, column_kind::partition_key)
+                // The datacenter for which the location is used
                 .with_column("datacenter", utf8_type, column_kind::clustering_key)
+                // The endpoint of the location 
                 .with_column("endpoint", utf8_type)
+                // Storage bucket
                 .with_column("bucket", utf8_type)
+                // Storage prefix
                 .with_column("prefix", utf8_type)
+                // State - local, being_backed_up, remote_and_local, remote
                 .with_column("state", int32_type)
                 .with_hash_version()
                 .build();
@@ -171,13 +284,27 @@ static std::vector<schema_ptr> ensured_tables() {
         view_build_status(),
         cdc_desc(),
         cdc_timestamps(),
+        snapshots(),
+        snapshot_remote_locations(),
+        snapshot_keyspaces(),
+        snapshot_tables(),
+        snapshot_tablets(),
+        snapshot_nodes(),
         snapshot_sstables(),
         snapshot_remote_locations(),
     };
 }
 
 std::vector<schema_ptr> system_distributed_keyspace::all_distributed_tables() {
-    return {view_build_status(), cdc_desc(), cdc_timestamps(), snapshot_sstables(), snapshot_remote_locations()};
+    return {view_build_status(), cdc_desc(), cdc_timestamps(),
+        snapshots(),
+        snapshot_remote_locations(),
+        snapshot_keyspaces(),
+        snapshot_tables(),
+        snapshot_tablets(),
+        snapshot_nodes(),
+        snapshot_sstables()
+    };
 }
 
 system_distributed_keyspace::system_distributed_keyspace(cql3::query_processor& qp, service::migration_manager& mm, service::storage_proxy& sp)
@@ -571,23 +698,394 @@ future<> snapshot_table_helper::update_sstable_download_status(sstring snapshot_
                                   cql3::query_processor::cache_internal::no);
 }
 
-future<> snapshot_table_helper::insert_snapshot_remote_location(sstring snapshot_name, sstring datacenter, sstring endpoint, sstring bucket, sstring prefix, db::consistency_level cl) {
-    static const sstring query = format("INSERT INTO {}.{} (snapshot_name, datacenter, endpoint, bucket, prefix, state) VALUES (?, ?, ?, ?, ?, ?) USING TTL {}",
-                                        system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS, snapshot_table_ttl_seconds);
-    // State 4 = snapshot_state::remote (data exists only in object storage)
-    co_await _qp.execute_internal(query, cl, internal_distributed_query_state(),
-                                  {std::move(snapshot_name), std::move(datacenter), std::move(endpoint), std::move(bucket), std::move(prefix), int32_t(4)},
-                                  cql3::query_processor::cache_internal::yes);
+future<> snapshot_table_helper::insert_snapshot_remote_location(sstring snapshot_name, sstring datacenter, sstring endpoint, sstring bucket, sstring prefix, snapshot_state state, db::consistency_level cl) {
+    co_await insert_snapshot_remote_locations(std::span<const snapshot_remote_location_entry>({
+        snapshot_remote_location_entry{
+            .snapshot_name = std::move(snapshot_name),
+            .datacenter = std::move(datacenter),
+            .endpoint = std::move(endpoint),
+            .bucket = std::move(bucket),
+            .prefix = std::move(prefix),
+            .state = state,
+        }
+    }), cl);
 }
 
 future<snapshot_remote_location_entry> snapshot_table_helper::get_snapshot_remote_location(sstring snapshot_name, sstring datacenter, db::consistency_level cl) const {
-    static const sstring query = format("SELECT endpoint, bucket, prefix FROM {}.{} WHERE snapshot_name = ? AND datacenter = ?", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS);
+    static const sstring query = format("SELECT endpoint, bucket, prefix, state FROM {}.{} WHERE snapshot_name = ? AND datacenter = ?", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS);
     auto rs = co_await _qp.execute_internal(query, cl, internal_distributed_query_state(), {snapshot_name, datacenter}, cql3::query_processor::cache_internal::yes);
     if (rs->empty()) {
         throw std::runtime_error(format("No snapshot remote location found for snapshot '{}' in datacenter '{}'", snapshot_name, datacenter));
     }
     auto& row = rs->one();
-    co_return snapshot_remote_location_entry{row.get_as<sstring>("endpoint"), row.get_as<sstring>("bucket"), row.get_as<sstring>("prefix")};
+    co_return snapshot_remote_location_entry{snapshot_name, datacenter
+        , row.get_as<sstring>("endpoint")
+        , row.get_as<sstring>("bucket")
+        , row.get_as<sstring>("prefix")
+        , snapshot_state(row.get_as<int32_t>("state"))
+    };
+}
+
+/**
+* Inserts a snapshot into system.dist table
+*/
+future<> snapshot_table_helper::insert_snapshot(const snapshot_entry& e, db::consistency_level cl) {
+    static const sstring query = format(
+        R"foo(INSERT INTO {}.{} (
+            name, created_at, expires_at, namespace_version, manifest_version
+        ) VALUES (
+            ?, ?, ?, ?, ?
+        ) USING TTL {})foo", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOTS, snapshot_table_ttl_seconds
+        );
+
+    return _qp.execute_internal(
+            query,
+            cl,
+            internal_distributed_query_state(),
+            { e.name, e.created_at, e.expires_at, e.namespace_version, e.manifest_version },
+            cql3::query_processor::cache_internal::yes).discard_result();
+}
+
+/**
+* Find a snapshot entry. 
+*/
+future<std::optional<snapshot_entry>> snapshot_table_helper::get_snapshot(std::string_view snapshot_name, db::consistency_level cl) {
+    std::optional<snapshot_entry> res;
+
+    static const sstring query = format(R"foo(SELECT 
+        name, created_at, expires_at, namespace_version, manifest_version
+        FROM {}.{} 
+        WHERE name = ?
+        )foo", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOTS
+    );
+
+    co_await _qp.query_internal(query, cl,
+        { snapshot_name },
+        10, [&](const cql3::untyped_result_set_row& row) {
+            res = snapshot_entry {
+                .name = row.get_as<sstring>("name"),
+                .created_at = row.get_as<db_clock::time_point>("created_at"), 
+                .expires_at = row.get_as<db_clock::time_point>("expires_at"), 
+                .namespace_version = row.get_as<sstring>("namespace_version"), 
+                .manifest_version = row.get_as<sstring>("manifest_version"), 
+            };
+            return make_ready_future<stop_iteration>(stop_iteration::yes);
+        }
+    );
+    co_return res;
+}
+
+static constexpr size_t snapshot_max_parallel = 10;
+
+/**
+* Add remote locations to a snapshot
+*/
+future<> snapshot_table_helper::insert_snapshot_remote_locations(std::span<const snapshot_remote_location_entry> locations, db::consistency_level cl) {
+    static const sstring query = format(
+        R"foo(INSERT INTO {}.{} (
+            snapshot_name, datacenter, endpoint, bucket, prefix, state
+        ) VALUES (
+            ?, ?, ?, ?, ?, ?
+        ) USING TTL {})foo", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS, snapshot_table_ttl_seconds
+        );
+
+    for (auto chunk : locations | std::views::chunk(snapshot_max_parallel)) {
+        co_await coroutine::parallel_for_each(chunk.begin(), chunk.end(), [&](const snapshot_remote_location_entry& e) {
+            return _qp.execute_internal(
+                        query, cl,
+                        internal_distributed_query_state(),
+                        { e.snapshot_name, e.datacenter, e.endpoint, e.bucket, e.prefix, int32_t(e.state) },
+                        cql3::query_processor::cache_internal::yes).discard_result();
+        });
+    }
+}
+
+/**
+* Get all remote locations in snapshot
+*/
+future<utils::chunked_vector<snapshot_remote_location_entry>> 
+snapshot_table_helper::get_snapshot_remote_locations(std::string_view snapshot_name, db::consistency_level cl) {
+    utils::chunked_vector<snapshot_remote_location_entry> entries;
+
+    static const sstring query = format("SELECT snapshot_name, datacenter, endpoint, bucket, prefix, state FROM {}.{}"
+        " WHERE snapshot_name = ?", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS
+    );
+
+    co_await _qp.query_internal(
+        query, cl,
+        { snapshot_name },
+        1000, [&] (const cql3::untyped_result_set_row& row) {
+            entries.emplace_back(row.get_as<sstring>("snapshot_name")
+                , row.get_as<sstring>("datacenter")
+                , row.get_as<sstring>("endpoint")
+                , row.get_as<sstring>("bucket")
+                , row.get_as<sstring>("prefix")
+                , snapshot_state(row.get_as<int32_t>("state")) 
+            );
+            return make_ready_future<stop_iteration>(stop_iteration::no);
+        }
+    );
+
+    co_return entries;
+}
+
+/**
+* Add keyspaces to a snapshot
+*/
+future<> snapshot_table_helper::insert_snapshot_keyspaces(std::span<const snapshot_keyspace_entry> keyspaces, db::consistency_level cl) {
+    static const sstring query = format(
+        R"foo(INSERT INTO {}.{} (
+            snapshot_name, keyspace_name, keyspace_schema
+        ) VALUES (
+            ?, ?, ?
+        ) USING TTL {})foo", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_KEYSPACES, snapshot_table_ttl_seconds
+        );
+
+    for (auto chunk : keyspaces | std::views::chunk(snapshot_max_parallel)) {
+        co_await coroutine::parallel_for_each(chunk.begin(), chunk.end(), [&](const snapshot_keyspace_entry& e) {
+            return _qp.execute_internal(
+                        query, cl,
+                        internal_distributed_query_state(),
+                        { e.snapshot_name, e.keyspace_name, e.keyspace_schema },
+                        cql3::query_processor::cache_internal::yes).discard_result();
+        });
+    }
+}
+
+/**
+* Get all keyspaces in snapshot
+*/
+future<utils::chunked_vector<snapshot_keyspace_entry>> 
+snapshot_table_helper::get_snapshot_keyspaces(std::string_view snapshot_name, db::consistency_level cl) {
+    utils::chunked_vector<snapshot_keyspace_entry> entries;
+
+    static const sstring query = format("SELECT snapshot_name, keyspace_name, keyspace_schema FROM {}.{}"
+        " WHERE snapshot_name = ?", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_KEYSPACES
+    );
+
+    co_await _qp.query_internal(
+        query, cl,
+        { snapshot_name },
+        1000, [&] (const cql3::untyped_result_set_row& row) {
+            entries.emplace_back(row.get_as<sstring>("snapshot_name")
+                , row.get_as<sstring>("keyspace_name")
+                , row.get_as<sstring>("keyspace_schema")
+            );
+            return make_ready_future<stop_iteration>(stop_iteration::no);
+        }
+    );
+
+    co_return entries;
+}
+
+/**
+* Add tables to a snapshot
+*/
+future<> snapshot_table_helper::insert_snapshot_tables(std::span<const snapshot_table_entry> tables, db::consistency_level cl) {
+    static const sstring query = format(
+        R"foo(INSERT INTO {}.{} (
+            snapshot_name, keyspace_name, table_name, table_id, type, base_table_id, table_schema, tablet_layout
+        ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?
+        ) USING TTL {})foo", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_TABLES, snapshot_table_ttl_seconds
+        );
+
+    for (auto chunk : tables | std::views::chunk(snapshot_max_parallel)) {
+        co_await coroutine::parallel_for_each(chunk.begin(), chunk.end(), [&](const snapshot_table_entry& e) {
+            return _qp.execute_internal(
+                        query, cl,
+                        internal_distributed_query_state(),
+                        { 
+                            e.snapshot_name, e.keyspace_name, e.table_name, e.table_id.uuid(),
+                            int32_t(e.type), e.base_table_id.uuid(), e.table_schema, e.tablet_layout
+                        },
+                        cql3::query_processor::cache_internal::yes).discard_result();
+        });
+    }
+}
+
+
+/**
+* Get all tables in snapshot, optionally restricted by keyspace
+*/
+future<utils::chunked_vector<snapshot_table_entry>> 
+snapshot_table_helper::get_snapshot_tables(std::string_view snapshot_name, std::string_view keyspace, std::string_view table, db::consistency_level cl) {
+    utils::chunked_vector<snapshot_table_entry> entries;
+
+    static const sstring base_query = format(R"foo(SELECT 
+        snapshot_name, keyspace_name, table_name, table_id, type, base_table_id, table_schema, tablet_layout
+        FROM {}.{} WHERE snapshot_name = ?)foo", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_TABLES
+    );
+
+    auto read_row = [&] (const cql3::untyped_result_set_row& row) {
+        entries.emplace_back(row.get_as<sstring>("snapshot_name")
+            , row.get_as<sstring>("keyspace_name")
+            , row.get_as<sstring>("table_name")
+            , table_id(row.get_as<utils::UUID>("table_id"))
+            , snapshot_table_type(row.get_as<int32_t>("type"))
+            , table_id(row.get_as<utils::UUID>("base_table_id"))
+            , row.get_as<sstring>("table_schema")
+            , row.get_as<sstring>("tablet_layout")
+        );
+        return make_ready_future<stop_iteration>(stop_iteration::no);
+    };
+
+    auto query = base_query;
+    query_data_vector params = {
+        sstring(snapshot_name)
+    };
+
+    if (!keyspace.empty()) {
+        query += " AND keyspace_name = ?";
+        params.emplace_back(keyspace);
+    }
+    if (!table.empty()) {
+        query += " AND table_name = ?";
+        params.emplace_back(table);
+    }
+    co_await _qp.query_internal(query, cl, params, 1000, read_row);
+    co_return entries;
+}
+
+/**
+ * Add tablets to a snapshot
+ */
+future<> snapshot_table_helper::insert_snapshot_tablets(std::string_view snapshot_name
+        , std::string_view keyspace, std::string_view table, std::string_view datacenter
+        , std::span<const snapshot_tablet_entry> tablets, db::consistency_level cl
+    ) 
+{
+    static const sstring query = format(
+        R"foo(INSERT INTO {}.{} (
+            snapshot_name, keyspace_name, table_name, datacenter, first_token, tablet_id, last_token, repair_time, repaired_at
+        ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?
+        ) USING TTL {})foo", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_TABLETS, snapshot_table_ttl_seconds
+        );
+
+    for (auto chunk : tablets | std::views::chunk(snapshot_max_parallel)) {
+        co_await coroutine::parallel_for_each(chunk.begin(), chunk.end(), [&](const snapshot_tablet_entry& e) {
+            return _qp.execute_internal(
+                        query, cl,
+                        internal_distributed_query_state(),
+                        { 
+                            sstring(snapshot_name), sstring(keyspace), sstring(table), sstring(datacenter), 
+                            dht::token::to_int64(e.first_token), int64_t(e.tablet_id), dht::token::to_int64(e.last_token),
+                            e.repair_time, e.repaired_at
+                        },
+                        cql3::query_processor::cache_internal::yes).discard_result();
+        });
+    }
+}
+
+
+/**
+* Get all tables in snapshot, optionally restricted by keyspace
+*/
+future<utils::chunked_vector<snapshot_tablet_entry>> snapshot_table_helper::get_snapshot_tablets(std::string_view snapshot_name
+        , std::string_view keyspace, std::string_view table, std::string_view datacenter
+        , db::consistency_level cl
+    ) 
+{
+    utils::chunked_vector<snapshot_tablet_entry> entries;
+
+    static const sstring query = format(R"foo(SELECT 
+        first_token, tablet_id, last_token, repair_time, repaired_at 
+        FROM {}.{} WHERE snapshot_name = ? AND keyspace_name = ? AND table_name = ? AND datacenter = ?)foo", 
+        system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_TABLETS
+    );
+
+    co_await _qp.query_internal(
+        query, cl,
+        { sstring(snapshot_name), sstring(keyspace), sstring(table), sstring(datacenter) },
+        1000, [&] (const cql3::untyped_result_set_row& row) {
+            entries.emplace_back(row.get_as<int64_t>("tablet_id")
+                , dht::token::from_int64(row.get_as<int64_t>("first_token"))
+                , dht::token::from_int64(row.get_as<int64_t>("last_token"))
+                , row.get_as<db_clock::time_point>("repair_time")
+                , row.get_as<int64_t>("repaired_at")
+            );
+            return make_ready_future<stop_iteration>(stop_iteration::no);
+        }
+    );
+
+    co_return entries;
+}
+
+/**
+ * Add nodes to a snapshot
+ */
+future<> snapshot_table_helper::insert_snapshot_nodes(std::string_view snapshot_name
+    , std::span<const snapshot_node_entry> nodes
+    , db::consistency_level cl
+)
+{
+    static const sstring query = format(
+        R"foo(INSERT INTO {}.{} (
+            snapshot_name, datacenter, rack, node
+        ) VALUES (
+            ?, ?, ?, ?
+        ) USING TTL {})foo", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_NODES, snapshot_table_ttl_seconds
+        );
+
+    for (auto chunk : nodes | std::views::chunk(snapshot_max_parallel)) {
+        co_await coroutine::parallel_for_each(chunk.begin(), chunk.end(), [&](const snapshot_node_entry& e) {
+            return _qp.execute_internal(
+                        query, cl,
+                        internal_distributed_query_state(),
+                        { 
+                            sstring(snapshot_name), sstring(e.datacenter), sstring(e.rack), e.node.uuid()
+                        },
+                        cql3::query_processor::cache_internal::yes).discard_result();
+        });
+    }
+}
+
+/**
+ * Get all nodes in snapshot for a given datacenter and optionally rack
+ */
+future<utils::chunked_vector<snapshot_node_entry>> snapshot_table_helper::get_snapshot_nodes(std::string_view snapshot_name
+    , std::string_view datacenter
+    , std::string_view rack
+    , db::consistency_level cl
+)
+{
+    utils::chunked_vector<snapshot_node_entry> entries;
+
+    static const sstring base_query = format(R"foo(SELECT 
+        datacenter, rack, node 
+        FROM {}.{} WHERE snapshot_name = ?)foo", 
+        system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_NODES
+    );
+
+    auto query = base_query;
+    query_data_vector params = {
+        sstring(snapshot_name)
+    };
+
+    if (!datacenter.empty()) {
+        query += " AND datacenter = ?";
+        params.emplace_back(sstring(datacenter));
+    }
+
+    if (!rack.empty()) {
+        query += " AND rack = ?";
+        params.emplace_back(sstring(rack));
+    }
+
+    co_await _qp.query_internal(
+        query, cl,
+        params,
+        1000, [&] (const cql3::untyped_result_set_row& row) {
+            entries.emplace_back(row.get_as<sstring>("datacenter"), row.get_as<sstring>("rack")
+                , locator::host_id(row.get_as<utils::UUID>("node"))
+            );
+            return make_ready_future<stop_iteration>(stop_iteration::no);
+        }
+    );
+
+    co_return entries;
+
 }
 
 } // namespace db

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -450,10 +450,21 @@ system_distributed_keyspace::cdc_current_generation_timestamp(context ctx) {
     co_return timestamp_cql->one().get_as<db_clock::time_point>("time");
 }
 
-future<> system_distributed_keyspace::insert_snapshot_sstable(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, sstables::sstable_id sstable_id, dht::token first_token, dht::token last_token, sstring toc_name, sstring prefix, db::consistency_level cl) {
-    // Not inserting the downloaded column so that re-populating on restore
-    // retry doesn't overwrite downloaded=true set by a previous attempt
-    static const sstring query = format("INSERT INTO {}.{} (snapshot_name, \"keyspace\", \"table\", datacenter, rack, first_token, sstable_id, last_token, toc_name, prefix) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TTL {}", NAME, SNAPSHOT_SSTABLES, SNAPSHOT_SSTABLES_TTL_SECONDS);
+// TODO: this is very hardcoded.
+static constexpr uint64_t snapshot_table_ttl_seconds = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::days(3)).count();
+
+snapshot_table_helper::snapshot_table_helper(cql3::query_processor& qp)
+    : _qp(qp)
+{}
+
+future<> snapshot_table_helper::insert_snapshot_sstable(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack
+    , sstables::sstable_id sstable_id, dht::token first_token, dht::token last_token, sstring toc_name, sstring prefix
+    , db::consistency_level cl) 
+{
+    static const sstring query = format("INSERT INTO {}.{} (snapshot_name, \"keyspace\", \"table\", datacenter, rack, first_token, sstable_id, last_token, toc_name, prefix) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) USING TTL {}"
+        , system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_SSTABLES
+        , snapshot_table_ttl_seconds
+    );
 
     return _qp.execute_internal(
             query,
@@ -465,11 +476,13 @@ future<> system_distributed_keyspace::insert_snapshot_sstable(sstring snapshot_n
 }
 
 future<utils::chunked_vector<snapshot_sstable_entry>>
-system_distributed_keyspace::get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl, std::optional<dht::token> start_token, std::optional<dht::token> end_token) const {
+snapshot_table_helper::get_snapshot_sstables(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, db::consistency_level cl, std::optional<dht::token> start_token, std::optional<dht::token> end_token) const {
     utils::chunked_vector<snapshot_sstable_entry> sstables;
 
     static const sstring base_query = format("SELECT toc_name, prefix, sstable_id, first_token, last_token, downloaded FROM {}.{}"
-        " WHERE snapshot_name = ? AND \"keyspace\" = ? AND \"table\" = ? AND datacenter = ? AND rack = ?", NAME, SNAPSHOT_SSTABLES);
+        " WHERE snapshot_name = ? AND \"keyspace\" = ? AND \"table\" = ? AND datacenter = ? AND rack = ?"
+        , system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_SSTABLES
+    );
 
     auto read_row = [&] (const cql3::untyped_result_set_row& row) {
             sstables.emplace_back(sstables::sstable_id(row.get_as<utils::UUID>("sstable_id")), dht::token::from_int64(row.get_as<int64_t>("first_token")), dht::token::from_int64(row.get_as<int64_t>("last_token")), row.get_as<sstring>("toc_name"), row.get_as<sstring>("prefix"), is_downloaded(row.get_or<bool>("downloaded", false)));
@@ -509,19 +522,19 @@ system_distributed_keyspace::get_snapshot_sstables(sstring snapshot_name, sstrin
     co_return sstables;
 }
 
-future<> system_distributed_keyspace::update_sstable_download_status(sstring snapshot_name,
-                                                                     sstring ks,
-                                                                     sstring table,
-                                                                     sstring dc,
-                                                                     sstring rack,
-                                                                     sstables::sstable_id sstable_id,
-                                                                     dht::token start_token,
-                                                                     is_downloaded downloaded) const {
+future<> snapshot_table_helper::update_sstable_download_status(sstring snapshot_name,
+                                                               sstring ks,
+                                                               sstring table,
+                                                               sstring dc,
+                                                               sstring rack,
+                                                               sstables::sstable_id sstable_id,
+                                                               dht::token start_token,
+                                                               is_downloaded downloaded) const {
     static const sstring update_query = format("UPDATE {}.{} USING TTL {} SET downloaded = ? WHERE snapshot_name = ? AND \"keyspace\" = ? AND \"table\" = ? AND "
                                                "datacenter = ? AND rack = ? AND first_token = ? AND sstable_id = ?",
-                                               NAME,
-                                               SNAPSHOT_SSTABLES,
-                                               SNAPSHOT_SSTABLES_TTL_SECONDS);
+                                               system_distributed_keyspace::NAME,
+                                               system_distributed_keyspace::SNAPSHOT_SSTABLES,
+                                               snapshot_table_ttl_seconds);
     co_await _qp.execute_internal(update_query,
                                   consistency_level::ONE,
                                   internal_distributed_query_state(),
@@ -529,17 +542,17 @@ future<> system_distributed_keyspace::update_sstable_download_status(sstring sna
                                   cql3::query_processor::cache_internal::no);
 }
 
-future<> system_distributed_keyspace::insert_snapshot_remote_location(sstring snapshot_name, sstring datacenter, sstring endpoint, sstring bucket, sstring prefix, db::consistency_level cl) {
+future<> snapshot_table_helper::insert_snapshot_remote_location(sstring snapshot_name, sstring datacenter, sstring endpoint, sstring bucket, sstring prefix, db::consistency_level cl) {
     static const sstring query = format("INSERT INTO {}.{} (snapshot_name, datacenter, endpoint, bucket, prefix, state) VALUES (?, ?, ?, ?, ?, ?) USING TTL {}",
-                                        NAME, SNAPSHOT_REMOTE_LOCATIONS, SNAPSHOT_SSTABLES_TTL_SECONDS);
+                                        system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS, snapshot_table_ttl_seconds);
     // State 4 = snapshot_state::remote (data exists only in object storage)
     co_await _qp.execute_internal(query, cl, internal_distributed_query_state(),
                                   {std::move(snapshot_name), std::move(datacenter), std::move(endpoint), std::move(bucket), std::move(prefix), int32_t(4)},
                                   cql3::query_processor::cache_internal::yes);
 }
 
-future<system_distributed_keyspace::snapshot_remote_location_entry> system_distributed_keyspace::get_snapshot_remote_location(sstring snapshot_name, sstring datacenter, db::consistency_level cl) const {
-    static const sstring query = format("SELECT endpoint, bucket, prefix FROM {}.{} WHERE snapshot_name = ? AND datacenter = ?", NAME, SNAPSHOT_REMOTE_LOCATIONS);
+future<snapshot_remote_location_entry> snapshot_table_helper::get_snapshot_remote_location(sstring snapshot_name, sstring datacenter, db::consistency_level cl) const {
+    static const sstring query = format("SELECT endpoint, bucket, prefix FROM {}.{} WHERE snapshot_name = ? AND datacenter = ?", system_distributed_keyspace::NAME, system_distributed_keyspace::SNAPSHOT_REMOTE_LOCATIONS);
     auto rs = co_await _qp.execute_internal(query, cl, internal_distributed_query_state(), {snapshot_name, datacenter}, cql3::query_processor::cache_internal::yes);
     if (rs->empty()) {
         throw std::runtime_error(format("No snapshot remote location found for snapshot '{}' in datacenter '{}'", snapshot_name, datacenter));

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -50,6 +50,12 @@ struct snapshot_sstable_entry {
     is_downloaded downloaded{is_downloaded::no};
 };
 
+struct snapshot_remote_location_entry {
+    sstring endpoint;
+    sstring bucket;
+    sstring prefix;
+};
+
 class system_distributed_keyspace {
 public:
     static constexpr auto NAME = "system_distributed";
@@ -82,6 +88,10 @@ public:
         /* How many different token owners (endpoints) are there in the token ring? */
         size_t num_token_owners;
     };
+
+    cql3::query_processor& qp() const {
+        return _qp;
+    }
 private:
     cql3::query_processor& _qp;
     service::migration_manager& _mm;
@@ -115,6 +125,15 @@ public:
     // NOTE: currently used only by alternator
     future<db_clock::time_point> cdc_current_generation_timestamp(context);
 
+private:
+    future<> create_tables(std::vector<schema_ptr> tables);
+};
+
+class snapshot_table_helper {
+    cql3::query_processor& _qp;
+public:
+    snapshot_table_helper(cql3::query_processor&);
+
     /* Inserts a single SSTable entry for a given snapshot, keyspace, table, datacenter,
      * and rack. The row is written with the specified TTL (in seconds). Uses consistency
      * level `EACH_QUORUM` by default.*/
@@ -135,17 +154,8 @@ public:
                                             dht::token start_token,
                                             is_downloaded downloaded) const;
 
-    struct snapshot_remote_location_entry {
-        sstring endpoint;
-        sstring bucket;
-        sstring prefix;
-    };
-
     future<> insert_snapshot_remote_location(sstring snapshot_name, sstring datacenter, sstring endpoint, sstring bucket, sstring prefix, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
     future<snapshot_remote_location_entry> get_snapshot_remote_location(sstring snapshot_name, sstring datacenter, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM) const;
-
-private:
-    future<> create_tables(std::vector<schema_ptr> tables);
 };
 
 }

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "snapshot_types.hh"
 #include "schema/schema_fwd.hh"
 #include "utils/chunked_vector.hh"
 #include "db/consistency_level_type.hh"
@@ -38,23 +39,6 @@ namespace service {
 
 
 namespace db {
-
-using is_downloaded = bool_class<class is_downloaded_tag>;
-
-struct snapshot_sstable_entry {
-    sstables::sstable_id sstable_id;
-    dht::token first_token;
-    dht::token last_token;
-    sstring toc_name;
-    sstring prefix;
-    is_downloaded downloaded{is_downloaded::no};
-};
-
-struct snapshot_remote_location_entry {
-    sstring endpoint;
-    sstring bucket;
-    sstring prefix;
-};
 
 class system_distributed_keyspace {
 public:

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -121,7 +121,11 @@ public:
     /* Inserts a single SSTable entry for a given snapshot, keyspace, table, datacenter,
      * and rack. The row is written with the specified TTL (in seconds). Uses consistency
      * level `EACH_QUORUM` by default.*/
-    future<> insert_snapshot_sstable(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack, sstables::sstable_id sstable_id, dht::token first_token, dht::token last_token, sstring toc_name, sstring prefix, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+    future<> insert_snapshot_sstable(sstring snapshot_name, sstring ks, sstring table, sstring dc, sstring rack
+        , sstables::sstable_id sstable_id, dht::token first_token, dht::token last_token, sstring toc_name, sstring prefix
+        , locator::host_id node, size_t tablet_id, snapshot_state, int64_t repaired_at = {}
+        , int64_t data_size = 0, int64_t index_size = 0
+        , db::consistency_level cl = db::consistency_level::EACH_QUORUM);
 
     /* Retrieves all SSTable entries for a given snapshot, keyspace, table, datacenter, and rack.
      * If `start_token` and `end_token` are provided, only entries whose `first_token` is in the range [`start_token`, `end_token`] will be returned.

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -57,6 +57,21 @@ public:
      * in the old table also appear in the new table, if necessary. */
     static constexpr auto CDC_DESC_V1 = "cdc_streams_descriptions";
 
+    /* This table is used by the backup and restore code to store snapshot metadata. */
+    static constexpr auto SNAPSHOTS = "snapshots";
+
+    /* This table is used by the backup and restore code to store snapshot keyspaces. */
+    static constexpr auto SNAPSHOT_KEYSPACES = "snapshot_keyspaces";
+
+    /* This table is used by the backup and restore code to store snapshot tables. */
+    static constexpr auto SNAPSHOT_TABLES = "snapshot_tables";
+
+    /* This table is used by the backup and restore code to store snapshot tablets. */
+    static constexpr auto SNAPSHOT_TABLETS = "snapshot_tablets";
+
+    /* This table is used by the backup and restore code to store snapshot nodes. */
+    static constexpr auto SNAPSHOT_NODES = "snapshot_nodes";
+
     /* This table is used by the backup and restore code to store per-sstable metadata.
      * The data the coordinator node puts in this table comes from the snapshot manifests. */
     static constexpr auto SNAPSHOT_SSTABLES = "snapshot_sstables";
@@ -142,8 +157,79 @@ public:
                                             dht::token start_token,
                                             is_downloaded downloaded) const;
 
-    future<> insert_snapshot_remote_location(sstring snapshot_name, sstring datacenter, sstring endpoint, sstring bucket, sstring prefix, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+    future<> insert_snapshot_remote_location(sstring snapshot_name, sstring datacenter, sstring endpoint, sstring bucket, sstring prefix, snapshot_state, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
     future<snapshot_remote_location_entry> get_snapshot_remote_location(sstring snapshot_name, sstring datacenter, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM) const;
+
+    /**
+     * Inserts a snapshot into system.dist table
+     */
+    future<> insert_snapshot(const snapshot_entry&, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+    /**
+     * Find a snapshot entry. 
+     */
+    future<std::optional<snapshot_entry>> get_snapshot(std::string_view snapshot_name, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM);
+
+    /**
+     * Add backup locations to a snapshot
+     */
+    future<> insert_snapshot_remote_locations(std::span<const snapshot_remote_location_entry> keyspaces, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+
+    /**
+     * Get all remote locations for snapshot
+     */
+    future<utils::chunked_vector<snapshot_remote_location_entry>> get_snapshot_remote_locations(std::string_view snapshot_name, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM);
+
+    /**
+     * Add keyspaces to a snapshot
+     */
+    future<> insert_snapshot_keyspaces(std::span<const snapshot_keyspace_entry> keyspaces, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+
+    /**
+     * Get all keyspaces in snapshot
+     */
+    future<utils::chunked_vector<snapshot_keyspace_entry>> get_snapshot_keyspaces(std::string_view snapshot_name, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM);
+
+    /**
+     * Add tables to a snapshot
+     */
+    future<> insert_snapshot_tables(std::span<const snapshot_table_entry> tables, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+
+    /**
+     * Get all tables in snapshot, optionally restricted by keyspace
+     */
+    future<utils::chunked_vector<snapshot_table_entry>> get_snapshot_tables(std::string_view snapshot_name, std::string_view keyspace = {}, std::string_view table = {}, db::consistency_level cl = db::consistency_level::LOCAL_QUORUM);
+
+    /**
+     * Add tablets to a snapshot
+     */
+    future<> insert_snapshot_tablets(std::string_view snapshot_name
+        , std::string_view keyspace, std::string_view table, std::string_view datacenter
+        , std::span<const snapshot_tablet_entry> tables
+        , db::consistency_level cl = db::consistency_level::EACH_QUORUM
+    );
+
+    /**
+     * Get all tablets in snapshot for a given keyspace + table in datacenter
+     * TODO: query by range?
+     */
+    future<utils::chunked_vector<snapshot_tablet_entry>> get_snapshot_tablets(std::string_view snapshot_name
+        , std::string_view keyspace, std::string_view table, std::string_view datacenter
+        , db::consistency_level cl = db::consistency_level::LOCAL_QUORUM
+    );
+
+    future<> insert_snapshot_nodes(std::string_view snapshot_name
+        , std::span<const snapshot_node_entry> nodes
+        , db::consistency_level cl = db::consistency_level::EACH_QUORUM
+    );
+
+    /**
+     * Get all nodes in snapshot for a given datacenter and optionally rack
+     */
+    future<utils::chunked_vector<snapshot_node_entry>> get_snapshot_nodes(std::string_view snapshot_name
+        , std::string_view datacenter = {}
+        , std::string_view rack = {}
+        , db::consistency_level cl = db::consistency_level::LOCAL_QUORUM
+    );
 };
 
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3793,7 +3793,7 @@ future<> system_keyspace::stop() {
     co_await shutdown();
 }
 
-future<::shared_ptr<cql3::untyped_result_set>> system_keyspace::execute_cql(const sstring& query_string, const data_value_list& values) {
+future<::shared_ptr<cql3::untyped_result_set>> system_keyspace::execute_cql(const sstring& query_string, const query_data_params& values) {
     return _qp.execute_internal(query_string, values, cql3::query_processor::cache_internal::yes);
 }
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -723,7 +723,7 @@ public:
 
     virtual_tables_registry& get_virtual_tables_registry() { return _virtual_tables_registry; }
 private:
-    future<::shared_ptr<cql3::untyped_result_set>> execute_cql(const sstring& query_string, const data_value_list& values);
+    future<::shared_ptr<cql3::untyped_result_set>> execute_cql(const sstring& query_string, const query_data_params& values);
     template <typename... Args>
     future<::shared_ptr<cql3::untyped_result_set>> execute_cql_with_timeout(sstring req, db::timeout_clock::time_point timeout, Args&&... args);
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4001,6 +4001,7 @@ struct manifest_json : public json::json_base {
         json::json_element<int64_t> first_token;
         json::json_element<int64_t> last_token;
         json::json_element<uint64_t> tablet_id;
+        json::json_element<int64_t> repaired_at;
 
         sstable_info() {
             register_params();
@@ -4013,6 +4014,7 @@ struct manifest_json : public json::json_base {
             index_size = e.index_size;
             first_token = e.first_token;
             last_token = e.last_token;
+            repaired_at = e.repaired_at;
             if (e.tablet_id) {
                 tablet_id = *e.tablet_id;
             }
@@ -4026,6 +4028,7 @@ struct manifest_json : public json::json_base {
             first_token = e.first_token;
             last_token = e.last_token;
             tablet_id = e.tablet_id;
+            repaired_at = e.repaired_at;
         }
         sstable_info(sstable_info&& e) {
             register_params();
@@ -4036,6 +4039,7 @@ struct manifest_json : public json::json_base {
             first_token = e.first_token;
             last_token = e.last_token;
             tablet_id = e.tablet_id;
+            repaired_at = e.repaired_at;
         }
         sstable_info& operator=(sstable_info&& e) {
             id = e.id;
@@ -4045,6 +4049,7 @@ struct manifest_json : public json::json_base {
             first_token = e.first_token;
             last_token = e.last_token;
             tablet_id = e.tablet_id;
+            repaired_at = e.repaired_at;
             return *this;
         }
     private:
@@ -4056,6 +4061,7 @@ struct manifest_json : public json::json_base {
             add(&first_token, "first_token");
             add(&last_token, "last_token");
             add(&tablet_id, "tablet_id");
+            add(&repaired_at, "repaired_at");
         }
     };
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -435,6 +435,7 @@ future<utils::chunked_vector<sstable_snapshot_metadata>> sstables_manager::take_
     utils::chunked_vector<sstable_snapshot_metadata> sstables_metadata;
 
     co_await _dir_semaphore.parallel_for_each(ssts, [&] (sstables::shared_sstable sstable) {
+        auto& sst_stats = sstable->get_stats_metadata();
         sstable_snapshot_metadata md = {
             .id = sstable->sstable_identifier()->uuid(),
             .toc_name = sstable->component_basename(sstables::component_type::TOC),
@@ -442,6 +443,7 @@ future<utils::chunked_vector<sstable_snapshot_metadata>> sstables_manager::take_
             .index_size = sstable->index_size(),
             .first_token = dht::token::to_int64(sstable->get_first_decorated_key().token()),
             .last_token = dht::token::to_int64(sstable->get_last_decorated_key().token()),
+            .repaired_at = sst_stats.repaired_at, 
         };
         sstables_metadata.push_back(std::move(md));
         return io_check([sstable, &name] {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -58,6 +58,7 @@ struct sstable_snapshot_metadata {
     uint64_t index_size;
     int64_t first_token;
     int64_t last_token;
+    int64_t repaired_at;
     std::optional<size_t> tablet_id;
 };
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -973,10 +973,11 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
     auto datacenter = topo.get_datacenter();
     auto rack = topo.get_rack();
 
-    auto snapshot_info = co_await _sys_dist_ks.get_snapshot_remote_location(snapshot_name, datacenter);
-    llog.info("Downloading sstables for tablet {} from {}@{}/{}", tid, snapshot_name, snapshot_info.endpoint, snapshot_info.bucket);
+    db::snapshot_table_helper sth(_sys_dist_ks.qp());
 
-    auto sst_infos = co_await _sys_dist_ks.get_snapshot_sstables(snapshot_name, keyspace_name, table_name, datacenter, rack,
+    auto snapshot_info = co_await sth.get_snapshot_remote_location(snapshot_name, datacenter);
+    llog.info("Downloading sstables for tablet {} from {}@{}/{}", tid, snapshot_name, snapshot_info.endpoint, snapshot_info.bucket);
+    auto sst_infos = co_await sth.get_snapshot_sstables(snapshot_name, keyspace_name, table_name, datacenter, rack,
             db::consistency_level::LOCAL_QUORUM, tablet_range.start().transform([] (auto& v) { return v.value(); }), tablet_range.end().transform([] (auto& v) { return v.value(); }));
     llog.debug("{} SSTables found for tablet {}", sst_infos.size(), tid);
     if (sst_infos.empty()) {
@@ -1056,16 +1057,17 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
 
     co_await container().invoke_on_all([tid, &downloaded_ssts, snap_name = snapshot_name, keyspace_name, table_name, datacenter, rack] (auto& loader) -> future<> {
         auto shard_ssts = std::move(downloaded_ssts[this_shard_id()]);
-        co_await max_concurrent_for_each(shard_ssts, 16, [&loader, tid, snap_name, keyspace_name, table_name, datacenter, rack](const auto& min_info) -> future<> {
+        db::snapshot_table_helper sth(loader._sys_dist_ks.qp());
+        co_await max_concurrent_for_each(shard_ssts, 16, [&sth, &loader, tid, snap_name, keyspace_name, table_name, datacenter, rack](const auto& min_info) -> future<> {
             sstables::shared_sstable attached_sst = co_await loader.attach_sstable(tid.table, min_info);
-            co_await loader._sys_dist_ks.update_sstable_download_status(snap_name,
-                                                                         keyspace_name,
-                                                                         table_name,
-                                                                         datacenter,
-                                                                         rack,
-                                                                         *attached_sst->sstable_identifier(),
-                                                                         attached_sst->get_first_decorated_key().token(),
-                                                                         db::is_downloaded::yes);
+            co_await sth.update_sstable_download_status(snap_name,
+                                                        keyspace_name,
+                                                        table_name,
+                                                        datacenter,
+                                                        rack,
+                                                        *attached_sst->sstable_identifier(),
+                                                        attached_sst->get_first_decorated_key().token(),
+                                                        db::is_downloaded::yes);
         });
     });
 }
@@ -1120,6 +1122,8 @@ static future<size_t> process_manifest(input_stream<char>& is, sstring keyspace,
         throw std::runtime_error("Malformed manifest, 'sstables' is not array");
     }
 
+    db::snapshot_table_helper sth(sys_dist_ks.qp());
+
     for (auto& sstable_entry : sstables->GetArray()) {
         // rjson::get functions assert if the passed value is not an object
         if (!sstable_entry.IsObject()) {
@@ -1132,8 +1136,8 @@ static future<size_t> process_manifest(input_stream<char>& is, sstring keyspace,
         auto prefix = sstring(std::filesystem::path(manifest_prefix).parent_path().string());
         // Insert the snapshot sstable metadata into system_distributed.snapshot_sstables with a TTL of 3 days, that should be enough
         // for any snapshot restore operation to complete, and after that the metadata will be automatically cleaned up from the table
-        co_await sys_dist_ks.insert_snapshot_sstable(snapshot_name, keyspace, table, datacenter, rack, id, first_token, last_token,
-                                                    toc_name, prefix, cl);
+        co_await sth.insert_snapshot_sstable(snapshot_name, keyspace, table, datacenter, rack, id, first_token, last_token,
+                                             toc_name, prefix, cl);
     }
 
     co_return tablet_count;
@@ -1212,7 +1216,9 @@ future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring ke
     auto tablet_count = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
 
     auto datacenter = _db.local().get_token_metadata().get_topology().get_datacenter();
-    co_await _sys_dist_ks.insert_snapshot_remote_location(snap_name, datacenter, endpoint, bucket, prefix);
+
+    db::snapshot_table_helper sth(_sys_dist_ks.qp());
+    co_await sth.insert_snapshot_remote_location(snap_name, datacenter, endpoint, bucket, prefix);
 
     co_await container().invoke_on(0, [tid, tablet_count] (auto& sl) -> future<> {
         co_await sl._ss.local().alter_table_with_tablet_hints(tid, tablet_count, tablet_count);

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1133,11 +1133,16 @@ static future<size_t> process_manifest(input_stream<char>& is, sstring keyspace,
         auto first_token = rjson::to_token(rjson::get(sstable_entry, "first_token"));
         auto last_token = rjson::to_token(rjson::get(sstable_entry, "last_token"));
         auto toc_name = rjson::to_sstring(rjson::get(sstable_entry, "toc_name"));
+        auto tablet_id = rjson::get<size_t>(sstable_entry, "tablet_id");
+        auto repaired_at = rjson::get<int64_t>(sstable_entry, "repaired_at");
+        auto data_size = rjson::get<int64_t>(sstable_entry, "data_size");
+        auto index_size = rjson::get<int64_t>(sstable_entry, "index_size");
         auto prefix = sstring(std::filesystem::path(manifest_prefix).parent_path().string());
         // Insert the snapshot sstable metadata into system_distributed.snapshot_sstables with a TTL of 3 days, that should be enough
         // for any snapshot restore operation to complete, and after that the metadata will be automatically cleaned up from the table
         co_await sth.insert_snapshot_sstable(snapshot_name, keyspace, table, datacenter, rack, id, first_token, last_token,
-                                             toc_name, prefix, cl);
+                                             toc_name, prefix, locator::host_id::create_null_id(), tablet_id, db::snapshot_state::remote, 
+                                             repaired_at, data_size, index_size, cl);
     }
 
     co_return tablet_count;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1223,7 +1223,8 @@ future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring ke
     auto datacenter = _db.local().get_token_metadata().get_topology().get_datacenter();
 
     db::snapshot_table_helper sth(_sys_dist_ks.qp());
-    co_await sth.insert_snapshot_remote_location(snap_name, datacenter, endpoint, bucket, prefix);
+    // TODO: update state when all restored...
+    co_await sth.insert_snapshot_remote_location(snap_name, datacenter, endpoint, bucket, prefix, db::snapshot_state::remote);
 
     co_await container().invoke_on(0, [tid, tablet_count] (auto& sl) -> future<> {
         co_await sl._ss.local().alter_table_with_tablet_hints(tid, tablet_count, tablet_count);

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -43,53 +43,53 @@ SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works, *boost::unit_test::pr
     auto db_cfg_ptr = make_shared<db::config>();
 
     return do_with_cql_env([] (cql_test_env& env) -> future<> {
-            auto snapshot_name = "snapshot";
-            auto ks = "ks";
-            auto table = "cf";
-            auto dc = "dc1";
-            auto rack = "r1";
-            auto sstable_id = utils::UUID_gen::get_time_UUID();
-            auto last_token = dht::token::from_int64(100);
-            auto toc_name = "me-3gdq_0bki_2cvk01yl83nj0tp5gh-big-TOC.txt";
-            auto prefix = "some/prefix";
-            auto num_iter = 5;
+        auto snapshot_name = "snapshot";
+        auto ks = "ks";
+        auto table = "cf";
+        auto dc = "dc1";
+        auto rack = "r1";
+        auto sstable_id = utils::UUID_gen::get_time_UUID();
+        auto last_token = dht::token::from_int64(100);
+        auto toc_name = "me-3gdq_0bki_2cvk01yl83nj0tp5gh-big-TOC.txt";
+        auto prefix = "some/prefix";
+        auto num_iter = 5;
 
-            for (int i = num_iter - 1; i >= 0; --i) {
-                // insert some test data into snapshot_sstables table
-                auto first_token = dht::token::from_int64(i);
-                co_await env.get_system_distributed_keyspace().local().insert_snapshot_sstable(snapshot_name, ks, table, dc, rack, sstables::sstable_id(sstable_id), first_token, last_token, toc_name, prefix, db::consistency_level::ONE);
-            }
-            // read it back and check if it is correct
-            auto sstables = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(snapshot_name, ks, table, dc, rack, db::consistency_level::ONE);
+        for (int i = num_iter - 1; i >= 0; --i) {
+            // insert some test data into snapshot_sstables table
+            auto first_token = dht::token::from_int64(i);
+            co_await env.get_system_distributed_keyspace().local().insert_snapshot_sstable(snapshot_name, ks, table, dc, rack, sstables::sstable_id(sstable_id), first_token, last_token, toc_name, prefix, db::consistency_level::ONE);
+        }
+        // read it back and check if it is correct
+        auto sstables = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(snapshot_name, ks, table, dc, rack, db::consistency_level::ONE);
 
-            BOOST_CHECK_EQUAL(sstables.size(), num_iter);
+        BOOST_CHECK_EQUAL(sstables.size(), num_iter);
 
-            for (int i = 0; i < num_iter; ++i) {
-                const auto& sstable = sstables[i];
-                BOOST_CHECK_EQUAL(sstable.toc_name, toc_name);
-                BOOST_CHECK_EQUAL(sstable.prefix, prefix);
-                BOOST_CHECK_EQUAL(sstable.first_token, dht::token::from_int64(i));
-                BOOST_CHECK_EQUAL(sstable.last_token, last_token);
-                BOOST_CHECK_EQUAL(sstable.sstable_id.uuid(), sstable_id);
-            }
+        for (int i = 0; i < num_iter; ++i) {
+            const auto& sstable = sstables[i];
+            BOOST_CHECK_EQUAL(sstable.toc_name, toc_name);
+            BOOST_CHECK_EQUAL(sstable.prefix, prefix);
+            BOOST_CHECK_EQUAL(sstable.first_token, dht::token::from_int64(i));
+            BOOST_CHECK_EQUAL(sstable.last_token, last_token);
+            BOOST_CHECK_EQUAL(sstable.sstable_id.uuid(), sstable_id);
+        }
 
-            // test token range filtering: matching range should return the sstable
-            auto filtered = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(
-                    snapshot_name, ks, table, dc, rack, db::consistency_level::ONE,
-                    dht::token::from_int64(-10), dht::token::from_int64(num_iter + 1));
-            BOOST_CHECK_EQUAL(filtered.size(), num_iter);
+        // test token range filtering: matching range should return the sstable
+        auto filtered = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(
+            snapshot_name, ks, table, dc, rack, db::consistency_level::ONE,
+            dht::token::from_int64(-10), dht::token::from_int64(num_iter + 1));
+        BOOST_CHECK_EQUAL(filtered.size(), num_iter);
 
-            // test token range filtering: the interval is inclusive, if start and end are equal to first_token, it should return one sstable 
-            filtered = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(
-                    snapshot_name, ks, table, dc, rack, db::consistency_level::ONE,
-                    dht::token::from_int64(0), dht::token::from_int64(0));
-            BOOST_CHECK_EQUAL(filtered.size(), 1);
+        // test token range filtering: the interval is inclusive, if start and end are equal to first_token, it should return one sstable 
+        filtered = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(
+            snapshot_name, ks, table, dc, rack, db::consistency_level::ONE,
+            dht::token::from_int64(0), dht::token::from_int64(0));
+        BOOST_CHECK_EQUAL(filtered.size(), 1);
 
-            // test token range filtering: non-matching range should return nothing
-            auto empty = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(
-                    snapshot_name, ks, table, dc, rack, db::consistency_level::ONE,
-                    dht::token::from_int64(num_iter + 10), dht::token::from_int64(num_iter + 20));
-            BOOST_CHECK_EQUAL(empty.size(), 0);
+        // test token range filtering: non-matching range should return nothing
+        auto empty = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(
+            snapshot_name, ks, table, dc, rack, db::consistency_level::ONE,
+            dht::token::from_int64(num_iter + 10), dht::token::from_int64(num_iter + 20));
+        BOOST_CHECK_EQUAL(empty.size(), 0);
     }, db_cfg_ptr);
 }
 

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -39,7 +39,7 @@
 #include "test/boost/database_test.hh"
 
 
-SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works) {
     auto db_cfg_ptr = make_shared<db::config>();
 
     return do_with_cql_env([] (cql_test_env& env) -> future<> {
@@ -54,13 +54,18 @@ SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works, *boost::unit_test::pr
         auto prefix = "some/prefix";
         auto num_iter = 5;
 
+        db::snapshot_table_helper sdk(env.qp().local());
+        constexpr auto cl = db::consistency_level::ONE;
+
         for (int i = num_iter - 1; i >= 0; --i) {
             // insert some test data into snapshot_sstables table
             auto first_token = dht::token::from_int64(i);
-            co_await env.get_system_distributed_keyspace().local().insert_snapshot_sstable(snapshot_name, ks, table, dc, rack, sstables::sstable_id(sstable_id), first_token, last_token, toc_name, prefix, db::consistency_level::ONE);
+            co_await sdk.insert_snapshot_sstable(snapshot_name, ks, table, dc, rack
+                , sstables::sstable_id(sstable_id), first_token, last_token, toc_name, prefix
+                , cl);
         }
         // read it back and check if it is correct
-        auto sstables = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(snapshot_name, ks, table, dc, rack, db::consistency_level::ONE);
+        auto sstables = co_await sdk.get_snapshot_sstables(snapshot_name, ks, table, dc, rack, cl);
 
         BOOST_CHECK_EQUAL(sstables.size(), num_iter);
 
@@ -74,19 +79,19 @@ SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works, *boost::unit_test::pr
         }
 
         // test token range filtering: matching range should return the sstable
-        auto filtered = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(
+        auto filtered = co_await sdk.get_snapshot_sstables(
             snapshot_name, ks, table, dc, rack, db::consistency_level::ONE,
             dht::token::from_int64(-10), dht::token::from_int64(num_iter + 1));
         BOOST_CHECK_EQUAL(filtered.size(), num_iter);
 
         // test token range filtering: the interval is inclusive, if start and end are equal to first_token, it should return one sstable 
-        filtered = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(
+        filtered = co_await sdk.get_snapshot_sstables(
             snapshot_name, ks, table, dc, rack, db::consistency_level::ONE,
             dht::token::from_int64(0), dht::token::from_int64(0));
         BOOST_CHECK_EQUAL(filtered.size(), 1);
 
         // test token range filtering: non-matching range should return nothing
-        auto empty = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables(
+        auto empty = co_await sdk.get_snapshot_sstables(
             snapshot_name, ks, table, dc, rack, db::consistency_level::ONE,
             dht::token::from_int64(num_iter + 10), dht::token::from_int64(num_iter + 20));
         BOOST_CHECK_EQUAL(empty.size(), 0);
@@ -113,7 +118,9 @@ future<> check_snapshot_sstables(cql_test_env& env) {
     auto& topology = env.get_storage_proxy().local().get_token_metadata_ptr()->get_topology();
     auto dc = topology.get_datacenter();
     auto rack = topology.get_rack();
-    auto sstables = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables("snapshot", "ks", "cf", dc, rack, db::consistency_level::ONE);
+
+    db::snapshot_table_helper sth(env.local_qp());
+    auto sstables = co_await sth.get_snapshot_sstables("snapshot", "ks", "cf", dc, rack, db::consistency_level::ONE);
 
     // Check that the sstables in system_distributed.snapshot_sstables match the sstables in the snapshot directory on disk
     auto& cf = env.local_db().find_column_family("ks", "cf");

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -49,6 +49,7 @@ SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works) {
         auto dc = "dc1";
         auto rack = "r1";
         auto sstable_id = utils::UUID_gen::get_time_UUID();
+        auto host_id = locator::host_id::create_random_id();
         auto last_token = dht::token::from_int64(100);
         auto toc_name = "me-3gdq_0bki_2cvk01yl83nj0tp5gh-big-TOC.txt";
         auto prefix = "some/prefix";
@@ -62,6 +63,7 @@ SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works) {
             auto first_token = dht::token::from_int64(i);
             co_await sdk.insert_snapshot_sstable(snapshot_name, ks, table, dc, rack
                 , sstables::sstable_id(sstable_id), first_token, last_token, toc_name, prefix
+                , host_id, i, db::snapshot_state::local, 0, 0, 0
                 , cl);
         }
         // read it back and check if it is correct

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -38,21 +38,107 @@
 #include "test/lib/sstable_test_env.hh"
 #include "test/boost/database_test.hh"
 
+using namespace std::string_literals;
+
+template <>
+struct fmt::formatter<db::snapshot_state> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const db::snapshot_state& e, FormatContext& ctx) const {
+        switch (e) {
+        case db::snapshot_state::unknown: return formatter<string_view>::format("unknown", ctx);
+        case db::snapshot_state::local: return formatter<string_view>::format("local", ctx);
+        case db::snapshot_state::being_backed_up: return formatter<string_view>::format("being_backed_up", ctx);
+        case db::snapshot_state::remote_and_local: return formatter<string_view>::format("remote_and_local", ctx);
+        case db::snapshot_state::remote: return formatter<string_view>::format("remote", ctx);
+        default: throw std::invalid_argument(fmt::format("Unhandled snapshot_state {}", int(e)));
+        }
+    }
+};
+
+template <>
+struct fmt::formatter<db::snapshot_table_type> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const db::snapshot_table_type& e, FormatContext& ctx) const {
+        switch (e) {
+        case db::snapshot_table_type::cql_table: return formatter<string_view>::format("cql_table", ctx);
+        case db::snapshot_table_type::cql_view: return formatter<string_view>::format("cql_view", ctx);
+        case db::snapshot_table_type::alternator_table: return formatter<string_view>::format("alternator_table", ctx);
+        default: throw std::invalid_argument(fmt::format("Unhandled snapshot_table_type {}", int(e)));
+        }
+    }
+};
+
+template <>
+struct fmt::formatter<db::snapshot_entry> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const db::snapshot_entry& e, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), 
+            "{{ {}, {}, {}, {}, {} }}",
+            e.name, e.created_at, e.expires_at, 
+            e.namespace_version, e.manifest_version
+        );
+    }
+};
+
+template <>
+struct fmt::formatter<db::snapshot_remote_location_entry> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const db::snapshot_remote_location_entry& e, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), 
+            "{{ {}, {}, {}, {}, {}, {} }}",
+            e.snapshot_name, e.datacenter, e.endpoint, e.bucket, e.prefix, e.state
+        );
+    }
+};
+
+template <>
+struct fmt::formatter<db::snapshot_keyspace_entry> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const db::snapshot_keyspace_entry& e, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), 
+            "{{ {}, {}, {} }}",
+            e.snapshot_name, e.keyspace_name, e.keyspace_schema
+        );
+    }
+};
+
+template <>
+struct fmt::formatter<db::snapshot_table_entry> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const db::snapshot_table_entry& e, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), 
+            "{{ {}, {}, {}, {}, {}, {}, {} }}",
+            e.snapshot_name, e.keyspace_name, e.table_name, e.table_id,
+            e.type, e.base_table_id, e.table_schema
+        );
+    }
+};
+
+template <>
+struct fmt::formatter<db::snapshot_node_entry> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const db::snapshot_node_entry& e, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), 
+            "{{ {}, {}, {} }}",
+            e.datacenter, e.rack, e.node
+        );
+    }
+};
 
 SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works) {
     auto db_cfg_ptr = make_shared<db::config>();
 
     return do_with_cql_env([] (cql_test_env& env) -> future<> {
-        auto snapshot_name = "snapshot";
-        auto ks = "ks";
-        auto table = "cf";
-        auto dc = "dc1";
-        auto rack = "r1";
+        auto snapshot_name = "snapshot"s;
+        auto ks = "ks"s;
+        auto table = "cf"s;
+        auto dc = "dc1"s;
+        auto rack = "r1"s;
         auto sstable_id = utils::UUID_gen::get_time_UUID();
         auto host_id = locator::host_id::create_random_id();
         auto last_token = dht::token::from_int64(100);
-        auto toc_name = "me-3gdq_0bki_2cvk01yl83nj0tp5gh-big-TOC.txt";
-        auto prefix = "some/prefix";
+        auto toc_name = "me-3gdq_0bki_2cvk01yl83nj0tp5gh-big-TOC.txt"s;
+        auto prefix = "some/prefix"s;
         auto num_iter = 5;
 
         db::snapshot_table_helper sdk(env.qp().local());
@@ -97,6 +183,117 @@ SEASTAR_TEST_CASE(test_snapshot_manifests_table_api_works) {
             snapshot_name, ks, table, dc, rack, db::consistency_level::ONE,
             dht::token::from_int64(num_iter + 10), dht::token::from_int64(num_iter + 20));
         BOOST_CHECK_EQUAL(empty.size(), 0);
+
+        db::snapshot_entry sse {
+            .name = snapshot_name,
+            .created_at = db_clock::now(),
+            .expires_at = db_clock::now() + 10000s,
+            .namespace_version = "Moose and Bear",
+            .manifest_version = "Wingdings",
+        };
+
+        db::snapshot_remote_location_entry rle {
+            .snapshot_name = snapshot_name,
+            .datacenter = dc,
+            .endpoint = "The end of all things",
+            .bucket = "A_bucket_for_fun",
+            .prefix = prefix,
+            .state = db::snapshot_state::local,
+        };
+
+        co_await sdk.insert_snapshot(sse, cl);
+
+        auto q_sse = co_await sdk.get_snapshot(snapshot_name, cl);
+
+        BOOST_CHECK(bool(q_sse));
+        BOOST_CHECK_EQUAL(*q_sse, sse);
+
+        co_await sdk.insert_snapshot_remote_locations(std::span<const db::snapshot_remote_location_entry>({ rle }), cl);
+
+        auto q_rle = co_await sdk.get_snapshot_remote_locations(snapshot_name, cl);
+
+        BOOST_CHECK_EQUAL(q_rle.size(), 1);
+        BOOST_CHECK_EQUAL(q_rle[0], rle);
+
+        auto keyspaces = std::views::iota(1, 4) | std::views::transform([&](int i) {
+            auto name = fmt::format("{}_{}", ks, i);
+            return db::snapshot_keyspace_entry {
+                .snapshot_name = snapshot_name,
+                .keyspace_name = name,
+                .keyspace_schema = "CREATE KEYSPACE " + name,
+            };
+        }) | std::ranges::to<std::vector>();
+
+        co_await sdk.insert_snapshot_keyspaces(keyspaces, cl);
+        auto q_keyspaces = co_await sdk.get_snapshot_keyspaces(snapshot_name, cl);
+
+        std::ranges::sort(q_keyspaces, {}, &db::snapshot_keyspace_entry::keyspace_name);
+
+        BOOST_CHECK(std::ranges::equal(keyspaces, q_keyspaces));
+
+        auto ks_1 = ks + "_1";
+        auto tables = std::views::iota(1, 10) | std::views::transform([&](int i) {
+            auto name = fmt::format("{}_{}", table, i);
+            return db::snapshot_table_entry {
+                .snapshot_name = snapshot_name,
+                .keyspace_name = (i & 1) ? ks : ks_1,
+                .table_name = name,
+                .table_id = ::table_id::create_random_id(),
+                .type = db::snapshot_table_type::cql_table,
+            };
+        }) | std::ranges::to<std::vector>();
+
+        co_await sdk.insert_snapshot_tables(tables, cl);
+        auto q_tables1 = co_await sdk.get_snapshot_tables(snapshot_name, {}, {}, cl);
+
+        std::ranges::sort(q_tables1, {}, &db::snapshot_table_entry::table_name);
+
+        BOOST_CHECK(std::ranges::equal(tables, q_tables1));
+
+        for (auto k : { ks, ks_1 }) {
+            auto q_tables2 = co_await sdk.get_snapshot_tables(snapshot_name, k, {}, cl);
+            auto filtered = tables | std::views::filter([&](auto& e) {
+                return e.keyspace_name == k;
+            });
+
+            std::ranges::sort(q_tables2, {}, &db::snapshot_table_entry::table_name);
+
+            BOOST_CHECK(std::ranges::equal(filtered, q_tables2));
+        }
+
+        auto tablets = std::views::iota(1u, 100u) | std::views::transform([&](unsigned i) {
+            return db::snapshot_tablet_entry {
+                .tablet_id = i,
+                .first_token = dht::token::from_int64(i * 1000),
+                .last_token = dht::token::from_int64(i * 1000 + 999),
+                .repair_time = db_clock::now(),
+                .repaired_at = i
+            };
+        }) | std::ranges::to<std::vector>();
+
+        co_await sdk.insert_snapshot_tablets(snapshot_name, ks, table, dc, tablets, cl);
+        auto q_tablets = co_await sdk.get_snapshot_tablets(snapshot_name, ks, table, dc, cl);
+
+        std::ranges::sort(q_tablets, {}, &db::snapshot_tablet_entry::tablet_id);
+        BOOST_CHECK(std::ranges::equal(tablets, q_tablets));
+
+auto nodes = std::views::iota(1u, 20u) | std::views::transform([&](unsigned i) {
+            return db::snapshot_node_entry {
+                .datacenter = dc,
+                .rack = rack,
+                .node = locator::host_id::create_random_id()
+            };
+        }) | std::ranges::to<std::vector>();
+
+        co_await sdk.insert_snapshot_nodes(snapshot_name, nodes, cl);
+        auto q_nodes = co_await sdk.get_snapshot_nodes(snapshot_name, dc, rack, cl);
+
+        BOOST_TEST_MESSAGE(fmt::format("Baba {} | {}", nodes, q_nodes));
+        std::ranges::sort(nodes, {}, &db::snapshot_node_entry::node);
+        std::ranges::sort(q_nodes, {}, &db::snapshot_node_entry::node);
+
+        BOOST_CHECK(std::ranges::equal(nodes, q_nodes));
+
     }, db_cfg_ptr);
 }
 

--- a/types/types.hh
+++ b/types/types.hh
@@ -1155,3 +1155,14 @@ template <> struct fmt::formatter<data_value> {
 };
 
 using data_value_list = std::initializer_list<data_value_or_unset>;
+using query_data_values = std::span<const data_value_or_unset>;
+using query_data_vector = std::vector<data_value_or_unset>;
+
+class query_data_params : public query_data_values {
+public:
+    using query_data_values::query_data_values;
+    query_data_params(const data_value_list& params)
+        : query_data_values(params)
+    {}
+};
+


### PR DESCRIPTION
Cherry-picked from #29580

Refs: SCYLLADB-783
Refs: SCYLLADB-2378
Refs: #30023

Adds snapshots, keyspaces, tables, tablets, and nodes to the set of sys_dist snapshot tables, as well as some
fields to sstables. 
Includes breaking out into serparate header and op interface.

