### PR TITLE
tablet_allocator: consolidate resize cancellation injection points

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -875,11 +875,8 @@ class load_balancer {
         // If we cancel a split, that's because average size dropped so much a merge would be
         // required post completion, and vice-versa.
         bool table_needs_resize_cancellation(const table_size_desc& d) const {
-            if (utils::get_local_injector().enter("force_resize_cancellation")) {
-                return true;
-            }
-            if (utils::get_local_injector().enter("skip_resize_cancellation")) {
-                return false;
+            if (auto value = utils::get_local_injector().inject_parameter("resize_cancellation")) {
+                return *value == "force";  // any other value (e.g. "skip") suppresses cancellation
             }
             return d.resize_decision.split_or_merge() && to_resize_decision(d).way != d.resize_decision.way;
         }

--- a/test/cluster/tasks/test_tablet_tasks.py
+++ b/test/cluster/tasks/test_tablet_tasks.py
@@ -595,8 +595,8 @@ async def test_tablet_resize_revoked(manager: ManagerClient):
 
         async def revoke_resize(log, mark):
             await log.wait_for('tablet_virtual_task: wait until tablet operation is finished', from_mark=mark)
-            revoke_injection = "force_resize_cancellation"
-            await enable_injection(manager, servers, revoke_injection)
+            for server in servers:
+                await manager.api.enable_injection(server.ip_addr, "resize_cancellation", one_shot=False, parameters={"value": "force"})
 
         async def wait_for_task(task_id):
             status = await tm.wait_for_task(servers[0].ip_addr, task_id)

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -1281,7 +1281,7 @@ async def test_tombstone_gc_correctness_during_tablet_split(manager: ManagerClie
         # tablet drives avg_tablet_size to 0, which would otherwise make the load balancer
         # revoke the already split-ready split instead of finalizing it. Suppress that
         # cancellation so the split finalizes.
-        await manager.api.enable_injection(servers[0].ip_addr, "skip_resize_cancellation", one_shot=False)
+        await manager.api.enable_injection(servers[0].ip_addr, "resize_cancellation", one_shot=False, parameters={"value": "skip"})
 
         await manager.api.stop_compaction(servers[0].ip_addr, "SPLIT")
         compaction_task = asyncio.create_task(manager.api.keyspace_compaction(servers[0].ip_addr, ks))


### PR DESCRIPTION
Replace the two separate "force_resize_cancellation" and "skip_resize_cancellation" error injections with a single "resize_cancellation" injection parameterized by value: "force" cancels an ongoing resize, any other value (e.g. "skip") suppresses cancellation. Update the affected tests accordingly.

Backport is not required, it is refactoring change