### PR TITLE
Refactor `BM25()` function to localize interception logic

### DIFF
--- a/cql3/expr/expr-utils.hh
+++ b/cql3/expr/expr-utils.hh
@@ -135,19 +135,13 @@ inline bool has_partition_token(const expression& e, const schema& table_schema)
     return find_binop(e, [&] (const binary_operator& o) { return is_partition_token_for_schema(o.lhs, table_schema); });
 }
 
-// Check whether the given expression represents
-// a call to the BM25() scoring function.
-bool is_bm25_function_call(const function_call&);
-bool is_bm25_function_call(const expression&);
+// Check whether the given function_call is a call to the native function with the given name.
+bool is_native_function_call(const function_call&, std::string_view name);
 
-inline bool has_bm25_function(const expression& e) {
-    return find_binop(e, [](const binary_operator& o) {
-        return is_bm25_function_call(o.lhs);
-    });
+inline bool is_native_function_call(const expression& e, std::string_view name) {
+    const function_call* fc = as_if<function_call>(&e);
+    return fc && is_native_function_call(*fc, name);
 }
-
-// Check whether the given function_call is a call to any scoring function.
-bool is_scoring_function_call(const function_call&);
 
 inline bool is_clustering_order(const binary_operator& op) {
     return op.order == comparison_order::clustering;

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2349,7 +2349,7 @@ adjust_for_collection_as_maps(const expression& e) {
     });
 }
 
-static bool is_native_function_call(const function_call& fc, const functions::function_name& native_name) {
+static bool is_function_call_name_equal(const function_call& fc, const functions::function_name& native_name) {
     const functions::function_name& fun_name =
         std::visit(overloaded_functor{[](const functions::function_name& fname) -> const functions::function_name& { return fname; },
                                       [](const shared_ptr<functions::function>& fun) -> const functions::function_name& { return fun->name(); }},
@@ -2360,7 +2360,11 @@ static bool is_native_function_call(const function_call& fc, const functions::fu
 bool is_token_function(const function_call& fun_call) {
     static thread_local const functions::function_name token_function_name =
         functions::function_name::native_function("token");
-    return is_native_function_call(fun_call, token_function_name);
+    return is_function_call_name_equal(fun_call, token_function_name);
+}
+
+bool is_native_function_call(const function_call& fc, std::string_view name) {
+    return is_function_call_name_equal(fc, functions::function_name::native_function(sstring(name)));
 }
 
 bool is_token_function(const expression& e) {
@@ -2413,24 +2417,6 @@ bool is_partition_token_for_schema(const expression& maybe_token, const schema& 
     }
 
     return is_partition_token_for_schema(*fun_call, table_schema);
-}
-
-bool is_bm25_function_call(const function_call& fc) {
-    static thread_local const functions::function_name bm25_function_name =
-        functions::function_name::native_function("bm25");
-    return is_native_function_call(fc, bm25_function_name);
-}
-
-bool is_bm25_function_call(const expression& e) {
-    const function_call* fc = as_if<function_call>(&e);
-    if (fc == nullptr) {
-        return false;
-    }
-    return is_bm25_function_call(*fc);
-}
-
-bool is_scoring_function_call(const function_call& fc) {
-    return is_bm25_function_call(fc);
 }
 
 void

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -254,26 +254,9 @@ binary_operator validate_and_prepare_new_restriction(const binary_operator& rest
         // Token restriction
         std::vector<const column_definition*> column_defs = to_column_definitions(as<function_call>(prepared_binop.lhs).args);
         validate_token_relation(column_defs, prepared_binop.op, *schema);
-    } else if (auto function = as_if<function_call>(&prepared_binop.lhs)) {
-        // Function call restriction (e.g., BM25(column, query_term) > 0).
-        // Note: the token() function is handled by the previous branch, 
-        // so the only function-call restrictions allowed here are scoring functions.
-        if (!is_scoring_function_call(*function)) {
-            throw exceptions::invalid_request_exception("Only the token function and scoring functions are supported in function-call restrictions");
-        }
-        if (function->args.empty() || !as_if<column_value>(&function->args[0])) {
-            throw exceptions::invalid_request_exception("First argument to a scoring function must be a column");
-        }
-        if (prepared_binop.op != oper_t::GT) {
-            throw exceptions::invalid_request_exception(format("Unsupported \"{}\" relation for scoring function restriction, only \">\" is supported", prepared_binop.op));
-        }
-
-        // Only BM25(col, query) > 0 is supported; reject non-zero thresholds and bind markers
-        auto* rhs_const = as_if<constant>(&prepared_binop.rhs);
-        if (!rhs_const || rhs_const->is_null()
-                || rhs_const->view().deserialize<float>(*float_type) != 0.0f) {
-            throw exceptions::invalid_request_exception("Scoring function comparison value must be the literal 0");
-        }
+    } else if (is<function_call>(prepared_binop.lhs)) {
+        // Non-token function-call restrictions (e.g. BM25(col, term) > 0)
+        // Validated in statement_restrictions
     } else {
         // Anything else
         throw exceptions::invalid_request_exception(

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -837,7 +837,7 @@ statement_restrictions::statement_restrictions(private_tag,
             // BM25 restrictions are purely declarative.
             // They signal full-text search intent but do not filter rows or select an index.
             // Intercept them so they never enter the generic restriction/index/filtering machinery.
-            if (expr::is_bm25_function_call(*fc)) {
+            if (expr::is_native_function_call(*fc, "bm25")) {
                 _scoring_function_restrictions.push_back(std::move(prepared_restriction));
                 continue;
             }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -254,35 +254,6 @@ is_null_constant(const expression& e) {
 }
 
 static std::optional<std::vector<predicate>>
-try_make_scoring_function_predicate(const function_call& fc, const binary_operator& oper) {
-    if (!is_scoring_function_call(fc)) {
-        return std::nullopt;
-    }
-    if (fc.args.empty()) {
-        throw exceptions::invalid_request_exception("Scoring function requires at least one argument");
-    }
-    const auto* col = as_if<column_value>(&fc.args[0]);
-    if (!col) {
-        return std::nullopt;
-    }
-    auto solve = [oper] (const query_options& options) {
-        managed_bytes_opt val = evaluate(oper.rhs, options).to_managed_bytes_opt();
-        if (!val) {
-            return empty_value_set;
-        }
-        return value_set(value_list{*val});
-    };
-    return std::vector<predicate>{predicate{
-        .solve_for = std::move(solve),
-        .filter = oper,
-        .on = on_column{col->col},
-        .is_singleton = false,
-        .order = oper.order,
-        .op = oper.op,
-    }};
-}
-
-static std::optional<std::vector<predicate>>
 try_make_token_predicate(const function_call& fc, const binary_operator& oper, const schema* table_schema_opt) {
     if (!table_schema_opt || !is_partition_token_for_schema(fc, *table_schema_opt)) {
         return std::nullopt;
@@ -538,9 +509,6 @@ to_predicates(
                             });
                         },
                         [&] (const function_call& fun_call) -> std::vector<predicate> {
-                            if (auto preds = try_make_scoring_function_predicate(fun_call, oper)) {
-                                return std::move(*preds);
-                            }
                             if (auto preds = try_make_token_predicate(fun_call, oper, table_schema_opt)) {
                                 return std::move(*preds);
                             }
@@ -710,9 +678,6 @@ is_predicate_supported_by(const predicate& pred, const secondary_index::index& i
     }
     return std::visit(overloaded_functor{
         [&] (const on_column& oc) -> ret_t {
-            if (expr::has_bm25_function(pred.filter)) {
-                return idx.supports_bm25_expression(*oc.column);
-            }
             if (pred.is_subscript) {
                 return idx.supports_subscript_expression(*oc.column, *pred.op);
             }
@@ -868,6 +833,21 @@ statement_restrictions::statement_restrictions(private_tag,
 
     std::vector<predicate> predicates;
     for (auto& prepared_restriction : prepared_where_clause) {
+        if (const auto* fc = expr::as_if<expr::function_call>(&prepared_restriction.lhs)) {
+            // BM25 restrictions are purely declarative.
+            // They signal full-text search intent but do not filter rows or select an index.
+            // Intercept them so they never enter the generic restriction/index/filtering machinery.
+            if (expr::is_bm25_function_call(*fc)) {
+                _scoring_function_restrictions.push_back(std::move(prepared_restriction));
+                continue;
+            }
+            // token() is the only other allowed function-call restriction.
+            // It is handled separately by `try_make_token_predicate()`.
+            if (!expr::is_token_function(prepared_restriction.lhs)) {
+                throw exceptions::invalid_request_exception(
+                    "Only the token function and scoring functions are supported in function-call restrictions");
+            }
+        }
         auto preds = to_predicates(prepared_restriction, _schema.get());
         predicates.insert(predicates.end(), std::make_move_iterator(preds.begin()), std::make_move_iterator(preds.end()));
     }
@@ -1131,7 +1111,6 @@ statement_restrictions::statement_restrictions(private_tag,
     _ck_is_all_eq = ck_is_all_eq;
     _pk_is_all_eq = pk_is_all_eq;
     _pk_has_slice_or_needs_filtering = pk_has_slice_or_needs_filtering;
-    bool has_queriable_fulltext_index = false;
     if (_check_indexes) {
         auto cf = db.find_column_family(schema);
         auto& sim = cf.get_index_manager();
@@ -1149,16 +1128,6 @@ statement_restrictions::statement_restrictions(private_tag,
                 && index_supports_some_column(sc_pk_pred_vectors, sim, allow_local)
                 && !type.is_delete();
         _has_queriable_regular_index = index_supports_some_column(sc_nonpk_pred_vectors, sim, allow_local)
-                && !type.is_delete();
-        single_column_predicate_vectors sc_nonpk_match_pred_vectors;
-        for (const auto& [col, preds] : sc_nonpk_pred_vectors) {
-            for (const auto& pred : preds) {
-                if (expr::has_bm25_function(pred.filter)) {
-                    sc_nonpk_match_pred_vectors[col].push_back(pred);
-                }
-            }
-        }
-        has_queriable_fulltext_index = index_supports_some_column(sc_nonpk_match_pred_vectors, sim, allow_local)
                 && !type.is_delete();
     } else {
         _has_queriable_ck_index = false;
@@ -1213,10 +1182,6 @@ statement_restrictions::statement_restrictions(private_tag,
     }
 
     if (!is_empty_restriction(_nonprimary_key_restrictions)) {
-        if (has_bm25_restriction() && !has_queriable_fulltext_index) {
-            throw exceptions::invalid_request_exception(
-                "No fulltext index found for full-text search query");
-        }
         if (_has_queriable_regular_index && _partition_range_is_simple) {
             _uses_secondary_indexing = true;
         } else if (!allow_filtering && !type.is_delete() && !type.is_update()) {
@@ -1338,13 +1303,6 @@ statement_restrictions::clustering_key_restrictions_has_only_eq() const {
 bool
 statement_restrictions::has_token_restrictions() const {
     return std::holds_alternative<token_range_restrictions>(_partition_range_restrictions);
-}
-
-bool
-statement_restrictions::has_bm25_restriction() const {
-    return expr::has_bm25_function(_nonprimary_key_restrictions)
-        || expr::has_bm25_function(_clustering_columns_restrictions)
-        || expr::has_bm25_function(_partition_key_restrictions);
 }
 
 bool

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -838,6 +838,9 @@ statement_restrictions::statement_restrictions(private_tag,
             // They signal full-text search intent but do not filter rows or select an index.
             // Intercept them so they never enter the generic restriction/index/filtering machinery.
             if (expr::is_native_function_call(*fc, "bm25")) {
+                if (!type.is_select()) {
+                    throw exceptions::invalid_request_exception("BM25() is only supported in SELECT statements");
+                }
                 _scoring_function_restrictions.push_back(std::move(prepared_restriction));
                 continue;
             }

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -158,6 +158,15 @@ private:
 
     expr::expression _regular_columns_filter = expr::conjunction({});
 
+    /**
+     * Scoring-function restrictions, e.g. WHERE BM25(col, 'term') > 0.
+     *
+     * Purely declarative. They express full-text matching intent,
+     * but neither filter rows nor drive index selection themselves.
+     * Extracted early and forwarded to the FTS layer as-is.
+     */
+    std::vector<expr::binary_operator> _scoring_function_restrictions;
+
 
     std::unordered_set<const column_definition*> _not_null_columns;
 
@@ -311,7 +320,9 @@ public:
         return _uses_secondary_indexing;
     }
 
-    bool has_bm25_restriction() const;
+    const std::vector<expr::binary_operator>& get_scoring_function_restrictions() const {
+        return _scoring_function_restrictions;
+    }
 
     const expr::expression& get_partition_key_restrictions() const {
         return _partition_key_restrictions;

--- a/cql3/statements/external_search/fulltext_indexed_table_select_statement.cc
+++ b/cql3/statements/external_search/fulltext_indexed_table_select_statement.cc
@@ -49,10 +49,10 @@ expr::expression extract_search_term_from_second_argument(const expr::function_c
 
 namespace {
 
-void validate_bm25_where_restriction(const expr::binary_operator& binop, const std::string& order_col) {
+void validate_bm25_where_restriction(const expr::binary_operator& binop, const bm25_ordering_info& ordering_info) {
     const auto& fc = expr::as<expr::function_call>(binop.lhs);
     const auto& col = extract_column_from_first_argument(fc);
-    if (col->name_as_text() != order_col) {
+    if (col->name_as_text() != ordering_info.index.target_column()) {
         throw exceptions::invalid_request_exception("Full-text search queries must reference the same column in both WHERE and ORDER BY clauses");
     }
 
@@ -63,6 +63,17 @@ void validate_bm25_where_restriction(const expr::binary_operator& binop, const s
     const auto* rhs_const = expr::as_if<expr::constant>(&binop.rhs);
     if (!rhs_const || rhs_const->is_null() || rhs_const->view().deserialize<float>(*float_type) != 0.0f) {
         throw exceptions::invalid_request_exception("BM25 function comparison value must be the literal 0");
+    }
+
+    const auto where_search_term = extract_search_term_from_second_argument(fc);
+
+    // If both query terms are literals, reject mismatches at prepare time.
+    // Bind-marker cases are caught at execute time.
+    const auto* where_const = expr::as_if<expr::constant>(&where_search_term);
+    const auto* order_const = expr::as_if<expr::constant>(&ordering_info.search_term);
+    if (where_const && order_const && *where_const != *order_const) {
+        throw exceptions::invalid_request_exception(
+                "Full-text search queries must use the same search term in both WHERE and ORDER BY clauses");
     }
 }
 
@@ -146,8 +157,7 @@ std::optional<bm25_ordering_info> get_bm25_ordering_info(
         throw exceptions::invalid_request_exception("Full-text search queries support only one WHERE BM25() restriction");
     }
 
-    const auto& order_col = ordering_info->index.target_column();
-    validate_bm25_where_restriction(scoring_restrictions.front(), order_col);
+    validate_bm25_where_restriction(scoring_restrictions.front(), *ordering_info);
 
     // Reject any WHERE restrictions beyond the single BM25 clause.
     // BM25 restrictions are excluded from `restrictions`.

--- a/cql3/statements/external_search/fulltext_indexed_table_select_statement.cc
+++ b/cql3/statements/external_search/fulltext_indexed_table_select_statement.cc
@@ -47,6 +47,27 @@ expr::expression extract_search_term_from_second_argument(const expr::function_c
 
 } // anonymous namespace
 
+namespace {
+
+void validate_bm25_where_restriction(const expr::binary_operator& binop, const std::string& order_col) {
+    const auto& fc = expr::as<expr::function_call>(binop.lhs);
+    const auto& col = extract_column_from_first_argument(fc);
+    if (col->name_as_text() != order_col) {
+        throw exceptions::invalid_request_exception("Full-text search queries must reference the same column in both WHERE and ORDER BY clauses");
+    }
+
+    if (binop.op != expr::oper_t::GT) {
+        throw exceptions::invalid_request_exception(
+                seastar::format("Unsupported \"{}\" relation for BM25 function restriction, only \">\" is supported", binop.op));
+    }
+    const auto* rhs_const = expr::as_if<expr::constant>(&binop.rhs);
+    if (!rhs_const || rhs_const->is_null() || rhs_const->view().deserialize<float>(*float_type) != 0.0f) {
+        throw exceptions::invalid_request_exception("BM25 function comparison value must be the literal 0");
+    }
+}
+
+} // anonymous namespace
+
 std::optional<bm25_ordering_info> get_bm25_ordering_info(
         data_dictionary::database db,
         schema_ptr schema,
@@ -117,37 +138,22 @@ std::optional<bm25_ordering_info> get_bm25_ordering_info(
         throw exceptions::invalid_request_exception("Full-text search queries require an ORDER BY BM25() clause");
     }
 
-    const auto bm25_where_pred = [&](const expr::binary_operator& o) {
-        if (!expr::is_bm25_function_call(o.lhs)) {
-            return false;
-        }
-        const auto* fc = expr::as_if<expr::function_call>(&o.lhs);
-        if (!fc || fc->args.empty()) {
-            return false;
-        }
-        const auto* col_val = expr::as_if<expr::column_value>(&fc->args[0]);
-        return col_val && ordering_info->index.supports_bm25_expression(*col_val->col);
-    };
-    const auto* where_bm25_binop = expr::find_binop(restrictions->get_nonprimary_key_restrictions(), bm25_where_pred)
-                                           ?: expr::find_binop(restrictions->get_clustering_columns_restrictions(), bm25_where_pred);
-    if (!where_bm25_binop) {
-        throw exceptions::invalid_request_exception("Full-text search queries require a WHERE BM25() clause on the same column used in ORDER BY BM25()");
+    const auto& scoring_restrictions = restrictions->get_scoring_function_restrictions();
+    if (scoring_restrictions.empty()) {
+        throw exceptions::invalid_request_exception("Full-text search queries require a WHERE BM25() > 0 clause");
+    }
+    if (scoring_restrictions.size() > 1) {
+        throw exceptions::invalid_request_exception("Full-text search queries support only one WHERE BM25() restriction");
     }
 
-    // Validate that the WHERE BM25 second argument is not a column reference.
-    const auto& where_fc = expr::as<expr::function_call>(where_bm25_binop->lhs);
-    if (where_fc.args.size() != 2) {
-        throw exceptions::invalid_request_exception("BM25() requires both a column and a query term argument");
-    }
-    extract_search_term_from_second_argument(where_fc);
+    const auto& order_col = ordering_info->index.target_column();
+    validate_bm25_where_restriction(scoring_restrictions.front(), order_col);
 
-    // Reject any WHERE restrictions beyond the BM25 clause itself.
-    const auto is_non_bm25_binop = [](const expr::binary_operator& o) {
-        return !expr::is_bm25_function_call(o.lhs);
-    };
+    // Reject any WHERE restrictions beyond the single BM25 clause.
+    // BM25 restrictions are excluded from `restrictions`.
     if (!restrictions->partition_key_restrictions_is_empty()
-            || expr::find_binop(restrictions->get_clustering_columns_restrictions(), is_non_bm25_binop)
-            || expr::find_binop(restrictions->get_nonprimary_key_restrictions(), is_non_bm25_binop)) {
+            || !restrictions::is_empty_restriction(restrictions->get_clustering_columns_restrictions())
+            || !restrictions::is_empty_restriction(restrictions->get_nonprimary_key_restrictions())) {
         throw exceptions::invalid_request_exception(
                 "Full-text search queries do not support additional WHERE restrictions");
     }
@@ -199,15 +205,12 @@ future<shared_ptr<cql_transport::messages::result_message>> fulltext_indexed_tab
         co_await coroutine::return_exception(exceptions::invalid_request_exception("Full-text search query term must not be null"));
     }
 
-    const auto has_bm25_lhs = [](const expr::binary_operator& o) {
-        return expr::is_bm25_function_call(o.lhs);
-    };
-    const auto* where_binop = expr::find_binop(_restrictions->get_nonprimary_key_restrictions(), has_bm25_lhs)
-                                      ?: expr::find_binop(_restrictions->get_clustering_columns_restrictions(), has_bm25_lhs);
-    const auto& fc = expr::as<expr::function_call>(where_binop->lhs);
-    const auto where_search_term_val = expr::evaluate(fc.args[1], options);
-    if (where_search_term_val != search_term_val) {
-        throw exceptions::invalid_request_exception("Full-text search queries must use the same search term in both WHERE and ORDER BY clauses");
+    const auto& where_restriction = _restrictions->get_scoring_function_restrictions().front();
+    const auto& fc = expr::as<expr::function_call>(where_restriction.lhs);
+    const auto where_val = expr::evaluate(fc.args[1], options);
+    if (where_val != search_term_val) {
+        throw exceptions::invalid_request_exception(
+                "Full-text search queries must use the same search term in both WHERE and ORDER BY clauses");
     }
 
     auto search_term_bytes = std::move(search_term_val).to_bytes();

--- a/cql3/statements/external_search/fulltext_indexed_table_select_statement.cc
+++ b/cql3/statements/external_search/fulltext_indexed_table_select_statement.cc
@@ -90,7 +90,7 @@ std::optional<bm25_ordering_info> get_bm25_ordering_info(
 
     // Verify this is a BM25 function call
     auto* fc = expr::as_if<expr::function_call>(&prepared_expr);
-    if (!fc || !expr::is_bm25_function_call(*fc)) {
+    if (!fc || !expr::is_native_function_call(*fc, "bm25")) {
         throw exceptions::invalid_request_exception("Only BM25 scoring function is supported in ORDER BY");
     }
 

--- a/cql3/statements/external_search/fulltext_indexed_table_select_statement.cc
+++ b/cql3/statements/external_search/fulltext_indexed_table_select_statement.cc
@@ -105,9 +105,7 @@ std::optional<bm25_ordering_info> get_bm25_ordering_info(
         throw exceptions::invalid_request_exception("Only BM25 scoring function is supported in ORDER BY");
     }
 
-    if (fc->args.size() != 2) {
-        throw exceptions::invalid_request_exception("BM25 requires both a column and a query term argument");
-    }
+    throwing_assert(fc->args.size() == 2);
 
     const auto* column = extract_column_from_first_argument(*fc);
     auto search_term = extract_search_term_from_second_argument(*fc);

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2064,7 +2064,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     }
 
     for (auto& ps : prepared_selectors) {
-        if (expr::is_bm25_function_call(ps.expr)) {
+        if (expr::is_native_function_call(ps.expr, "bm25")) {
             throw exceptions::invalid_request_exception("BM25() is not supported in the SELECT clause");
         }
         expr::fill_prepare_context(ps.expr, ctx);
@@ -2116,7 +2116,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     const auto& scoring_restrictions = restrictions->get_scoring_function_restrictions();
 
     bool has_bm25_restriction = std::ranges::any_of(scoring_restrictions, [](const expr::binary_operator& binop) {
-        return expr::is_bm25_function_call(binop.lhs);
+        return expr::is_native_function_call(binop.lhs, "bm25");
     });
     bool is_fts_query = has_bm25_restriction || has_bm25_ordering;
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2113,7 +2113,16 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     auto restrictions = prepare_restrictions(db, schema, ctx, selection, for_view, _parameters->allow_filtering() || is_ann_query || has_bm25_ordering,
             restrictions::check_indexes(!_parameters->is_mutation_fragments()));
 
-    bool is_fts_query = restrictions->has_bm25_restriction() || has_bm25_ordering;
+    const auto& scoring_restrictions = restrictions->get_scoring_function_restrictions();
+
+    bool has_bm25_restriction = std::ranges::any_of(scoring_restrictions, [](const expr::binary_operator& binop) {
+        return expr::is_bm25_function_call(binop.lhs);
+    });
+    bool is_fts_query = has_bm25_restriction || has_bm25_ordering;
+
+    if (is_ann_query && is_fts_query) {
+        throw exceptions::invalid_request_exception("BM25 and ANN cannot be combined in the same query");
+    }
 
     if (_parameters->is_distinct()) {
         validate_distinct_selection(*schema, *selection, *restrictions);

--- a/test/cqlpy/test_fulltext_index.py
+++ b/test/cqlpy/test_fulltext_index.py
@@ -12,13 +12,15 @@
 
 import pytest
 import re
+from test.pylib.skip_types import skip_env
 from .util import new_test_table, new_test_keyspace, new_function, unique_name
 from cassandra.protocol import InvalidRequest, SyntaxException
 
 # Fulltext search is not allowed in tables using vnodes, so all tests in this file need tablets
-@pytest.fixture(scope="function", autouse=True)
-def all_tests_are_tablets_and_scylla_only(skip_without_tablets, scylla_only):
-    pass
+@pytest.fixture(scope="module", autouse=True)
+def all_tests_are_tablets_and_scylla_only(scylla_only, has_tablets):
+    if not has_tablets:
+        skip_env("Full-Text Search needs tablets enabled")
 
 
 @pytest.mark.parametrize("column_type", ["text", "varchar", "ascii"])

--- a/test/cqlpy/test_fulltext_index.py
+++ b/test/cqlpy/test_fulltext_index.py
@@ -689,3 +689,11 @@ def test_udf_named_bm25_coexists_with_system_bm25(cql, test_keyspace, fulltext_t
             cql.execute(f"SELECT * FROM {fulltext_table} WHERE BM25(content, 'hello') > 0 ORDER BY BM25(content, 'hello') LIMIT 10")
         # The system BM25 operator is reachable via system. qualification
         cql.prepare(f"SELECT * FROM {fulltext_table} WHERE system.bm25(content, 'hello') > 0 ORDER BY system.bm25(content, 'hello') LIMIT 10")
+
+
+def test_bm25_rejected_in_non_select_statements(cql, fulltext_table):
+    """BM25 must be rejected in non-SELECT statements."""
+    with pytest.raises(InvalidRequest, match="only supported in SELECT statements"):
+        cql.execute(f"UPDATE {fulltext_table} SET content = 'x' WHERE p = 1 AND BM25(content, 'hello') > 0")
+    with pytest.raises(InvalidRequest, match="only supported in SELECT statements"):
+        cql.execute(f"DELETE FROM {fulltext_table} WHERE p = 1 AND BM25(content, 'hello') > 0")

--- a/test/cqlpy/test_fulltext_index.py
+++ b/test/cqlpy/test_fulltext_index.py
@@ -475,7 +475,7 @@ def test_bm25_only_gt_allowed(cql, fulltext_table):
     """BM25 restrictions should reject all operators other than >."""
     for operator in ["=", "<", "<=", "!=", ">="]:
         with pytest.raises(InvalidRequest, match=fr'Unsupported "{operator}" relation'):
-            cql.execute(f"SELECT * FROM {fulltext_table} WHERE BM25(content, 'hello') {operator} 0 LIMIT 1")
+            cql.execute(f"SELECT * FROM {fulltext_table} WHERE BM25(content, 'hello') {operator} 0 ORDER BY BM25(content, 'hello') LIMIT 1")
 
 
 def test_bm25_like_operator_rejected(cql, fulltext_table):
@@ -508,6 +508,16 @@ def test_bm25_where_only_rejected(cql, fulltext_table):
         cql.execute(f"SELECT * FROM {fulltext_table} WHERE BM25(content, 'hello') > 0 LIMIT 1")
 
 
+def test_bm25_multiple_where_restrictions_rejected(cql, test_keyspace):
+    """More than one WHERE BM25() restriction must be rejected."""
+    schema = 'p int primary key, col1 text, col2 text'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(col1) USING 'fulltext_index'")
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(col2) USING 'fulltext_index'")
+        with pytest.raises(InvalidRequest, match="only one WHERE BM25"):
+            cql.execute(f"SELECT * FROM {table} WHERE BM25(col1, 'hello') > 0 AND BM25(col2, 'hello') > 0 ORDER BY BM25(col1, 'hello') LIMIT 1")
+
+
 def test_bm25_order_by_only_rejected(cql, fulltext_table):
     """ORDER BY BM25 without a WHERE BM25() > 0 clause must be rejected."""
     with pytest.raises(InvalidRequest, match="require a WHERE BM25"):
@@ -522,6 +532,16 @@ def test_order_by_ann_then_bm25_rejected(cql, test_keyspace):
         cql.execute(f"CREATE CUSTOM INDEX ON {table}(vec) USING 'vector_index'")
         with pytest.raises(InvalidRequest, match="does not support any other ordering"):
             cql.execute(f"SELECT * FROM {table} WHERE BM25(content, 'hello') > 0 ORDER BY vec ANN OF [1.0, 2.0], BM25(content, 'hello') LIMIT 1")
+
+
+def test_bm25_where_with_ann_order_by_rejected(cql, test_keyspace):
+    """BM25 WHERE restriction combined with an ANN ORDER BY must be rejected."""
+    schema = 'p int primary key, content text, vec vector<float, 2>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(content) USING 'fulltext_index'")
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(vec) USING 'vector_index'")
+        with pytest.raises(InvalidRequest, match="BM25 and ANN cannot be combined in the same query"):
+            cql.execute(f"SELECT * FROM {table} WHERE BM25(content, 'hello') > 0 ORDER BY vec ANN OF [1.0, 2.0] LIMIT 1")
 
 
 def test_order_by_bm25_then_ann_rejected(cql, test_keyspace):
@@ -598,7 +618,7 @@ def test_bm25_different_columns_rejected(cql, test_keyspace):
         cql.execute(f"CREATE CUSTOM INDEX ON {table}(col1) USING 'fulltext_index'")
         cql.execute(f"CREATE CUSTOM INDEX ON {table}(col2) USING 'fulltext_index'")
         with pytest.raises(InvalidRequest, match="same column"):
-            cql.execute(f"SELECT * FROM {table} WHERE BM25(col1, 'hello') > 0 ORDER BY BM25(col2, 'world') LIMIT 1")
+            cql.execute(f"SELECT * FROM {table} WHERE BM25(col1, 'hello') > 0 ORDER BY BM25(col2, 'hello') LIMIT 1")
 
 
 def test_bm25_different_search_terms_rejected(cql, fulltext_table):


### PR DESCRIPTION
PR #30016 introduced the `BM25()` scoring operator for Full-Text Search queries. As a consequence of the initial design, the knowledge that `bm25()` must be intercepted before evaluation ended up scattered across several unrelated layers:
- `cql3/expr/restrictions.cc` - BM25-specific validation (operator type, threshold, column arg check)
- `statement_restrictions.cc` - routing BM25 WHERE restrictions via `try_make_scoring_function_predicate()` and `has_bm25_restriction()`
- `fulltext_indexed_table_select_statement.cc` - fulltext index lookup from the ORDER BY expression
- `scoring_fcts.cc` - defensive `on_internal_error` backstop
- `cql3/expr/expr-utils.hh` - BM25-specific predicates (`is_bm25_function_call()`, `is_scoring_function_call()`) exposed as general expression utilities

This PR consolidates all BM25 interception so that adding a new scoring function in the future requires touching exactly one layer.

The single authoritative interception point for BM25 is now `statement_restrictions` (early extraction into `_scoring_function_restrictions`) and `fulltext_indexed_table_select_statement` (validation and routing). Generic layers (`expr/`, `restrictions/`) are free of BM25-specific knowledge. The `scoring_fcts.cc` backstop exception provides an additional safety net if a BM25 call somehow reaches evaluation.

Follow-up to: https://github.com/scylladb/scylladb/pull/30016
Fixes: SCYLLADB-2558