### PR TITLE
[Backport 2025.4] scylla-gdb.py: scylla small-objects: make freelist traversal more robust

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -5102,10 +5102,15 @@ class scylla_small_objects(gdb.Command):
             span_end = int(span_start + span.size() * self._page_size)
 
             # span's free list
-            span_next_free = span.page['freelist']
-            while span_next_free:
-                self._free_in_span.add(int(span_next_free))
-                span_next_free = span_next_free.reinterpret_cast(self._free_object_ptr).dereference()
+            try:
+                span_next_free = span.page['freelist']
+                while span_next_free:
+                    self._free_in_span.add(int(span_next_free))
+                    span_next_free = span_next_free['next']
+            except gdb.error:
+                # This loop sometimes steps on "Cannot access memory at address", causing CI instability.
+                # Catch the exception and break the freelist traversal loop gracefully.
+                gdb.write(f"Warning: error traversing freelist of span [0x{span_start:x}, 0x{span_end:x}), some of the listed objects in this span may be free objects.\n")
 
             return span_start, span_end
 


### PR DESCRIPTION
Traversing the span's freelist is known to generate "Cannot access memory at address ..." errors, which is especially annoying when it results in failed CI. Make this loop more robust: catch gdb.error coming from it and just log a warning that some listed objects in the span may be free ones.

Fixes: #27681

Closes scylladb/scylladb#27805

(cherry picked from commit ebb101f8aeae3051d2f7f6ae203859607956304b)

This is a manual backport of https://github.com/scylladb/scylladb/pull/27805, because the automatic mechanism to create the backport PR has failed.
Fixes: SCYLLADB-2680