### PR TITLE
Use managed_bytes for clustering keys in memtable large-data guardrail caches

### DIFF
--- a/db/large_data_cache_tracker.hh
+++ b/db/large_data_cache_tracker.hh
@@ -23,27 +23,73 @@ class atomic_cell_or_collection;
 
 namespace db {
 
+// Memtable-level guardrail cache keys.
+//
+// Each key has two flavours:
+//   *_key       — owns the data stored in the cache.
+//   *_key_view  — non-owning view used for allocation-free heterogeneous lookup.
+//
+// Hashing and equality are defined on the view types; owning keys expose view()
+// so the transparent functors (cache_key_hash / cache_key_eq) treat an owning
+// key and a matching view as equal.
+
+struct row_key_view {
+    bytes_view pk;
+    bytes_view ck;
+    bool operator==(const row_key_view&) const noexcept = default;
+    size_t hash() const noexcept {
+        return utils::hash_combine(
+            std::hash<bytes_view>{}(pk),
+            std::hash<bytes_view>{}(ck));
+    }
+};
+
+struct collection_key_view {
+    bytes_view pk;
+    bytes_view ck;
+    column_id col;
+    bool operator==(const collection_key_view&) const noexcept = default;
+    size_t hash() const noexcept {
+        return utils::hash_combine(
+            row_key_view{pk, ck}.hash(),
+            std::hash<column_id>{}(col));
+    }
+};
+
 struct row_key {
     bytes pk;
     bytes ck;
-    bool operator==(const row_key&) const = default;
-    struct hash {
-        size_t operator()(const row_key& k) const noexcept;
-    };
+    row_key_view view() const noexcept { return {bytes_view(pk), bytes_view(ck)}; }
 };
 
 struct collection_key {
     bytes pk;
     bytes ck;
     column_id col;
-    bool operator==(const collection_key&) const = default;
-    struct hash {
-        size_t operator()(const collection_key& k) const noexcept;
-    };
+    collection_key_view view() const noexcept { return {bytes_view(pk), bytes_view(ck), col}; }
 };
 
-using memtable_row_cache = std::unordered_map<row_key, uint64_t, row_key::hash>;
-using memtable_collection_cache = std::unordered_map<collection_key, uint64_t, collection_key::hash>;
+inline row_key_view as_key_view(const row_key& k) noexcept { return k.view(); }
+inline row_key_view as_key_view(const row_key_view& k) noexcept { return k; }
+inline collection_key_view as_key_view(const collection_key& k) noexcept { return k.view(); }
+inline collection_key_view as_key_view(const collection_key_view& k) noexcept { return k; }
+
+// Transparent hash/equality shared by both caches; heterogeneous lookups with
+// a *_key_view are allocation-free.
+struct cache_key_hash {
+    using is_transparent = void;
+    template <typename K>
+    size_t operator()(const K& k) const noexcept { return as_key_view(k).hash(); }
+};
+
+struct cache_key_eq {
+    using is_transparent = void;
+    template <typename A, typename B>
+    bool operator()(const A& a, const B& b) const noexcept { return as_key_view(a) == as_key_view(b); }
+};
+
+using memtable_row_cache = std::unordered_map<row_key, uint64_t, cache_key_hash, cache_key_eq>;
+using memtable_collection_cache = std::unordered_map<collection_key, uint64_t, cache_key_hash, cache_key_eq>;
 
 struct guardrail_config {
     // Partition thresholds (replica-side only — checked via SSTable metadata index)

--- a/db/large_data_cache_tracker.hh
+++ b/db/large_data_cache_tracker.hh
@@ -11,6 +11,7 @@
 #include <cstdint>
 #include <unordered_map>
 #include "bytes.hh"
+#include "utils/managed_bytes.hh"
 #include "schema/schema_fwd.hh"
 #include "utils/hash.hh"
 #include "utils/updateable_value.hh"
@@ -26,27 +27,40 @@ namespace db {
 // Memtable-level guardrail cache keys.
 //
 // Each key has two flavours:
-//   *_key       — owns the data stored in the cache.
-//   *_key_view  — non-owning view used for allocation-free heterogeneous lookup.
+//   *_key       — owns its clustering key as a (possibly fragmented)
+//                 managed_bytes, stored in the cache.
+//   *_key_view  — non-owning views into the keys of the mutation being
+//                 checked, used for heterogeneous, allocation-free lookups.
 //
-// Hashing and equality are defined on the view types; owning keys expose view()
-// so the transparent functors (cache_key_hash / cache_key_eq) treat an owning
-// key and a matching view as equal.
+// Hashing and equality are defined once, on the view types, in terms of their
+// fields; the owning keys expose view() so the shared transparent functors
+// (cache_key_hash / cache_key_eq) treat an owning key and a view with the same
+// content as equal.
+//
+// IMPORTANT (allocator safety): these caches are plain std::unordered_maps that
+// outlive the LSA allocator context in which they are populated (on_row_merged()
+// runs inside the memtable's allocating_section) and are cleared in
+// on_flush()/rebuild() under the standard allocator.  managed_bytes picks its
+// allocator from current_allocator(), so every construction and destruction of
+// an *owning* key (inserts and clears) MUST happen under
+// with_allocator(standard_allocator(), ...); otherwise an LSA-allocated key
+// would be freed under the wrong allocator and corrupt memory.  Lookups use the
+// non-owning views and so neither copy nor allocate.
 
 struct row_key_view {
     bytes_view pk;
-    bytes_view ck;
+    managed_bytes_view ck;
     bool operator==(const row_key_view&) const noexcept = default;
     size_t hash() const noexcept {
         return utils::hash_combine(
             std::hash<bytes_view>{}(pk),
-            std::hash<bytes_view>{}(ck));
+            std::hash<managed_bytes_view>{}(ck));
     }
 };
 
 struct collection_key_view {
     bytes_view pk;
-    bytes_view ck;
+    managed_bytes_view ck;
     column_id col;
     bool operator==(const collection_key_view&) const noexcept = default;
     size_t hash() const noexcept {
@@ -58,15 +72,15 @@ struct collection_key_view {
 
 struct row_key {
     bytes pk;
-    bytes ck;
-    row_key_view view() const noexcept { return {bytes_view(pk), bytes_view(ck)}; }
+    managed_bytes ck;
+    row_key_view view() const noexcept { return { bytes_view(pk), managed_bytes_view(ck)}; }
 };
 
 struct collection_key {
     bytes pk;
-    bytes ck;
+    managed_bytes ck;
     column_id col;
-    collection_key_view view() const noexcept { return {bytes_view(pk), bytes_view(ck), col}; }
+    collection_key_view view() const noexcept { return { bytes_view(pk), managed_bytes_view(ck), col}; }
 };
 
 inline row_key_view as_key_view(const row_key& k) noexcept { return k.view(); }

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -10,6 +10,7 @@
 #include <seastar/core/format.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/when_all.hh>
+#include "utils/allocation_strategy.hh"
 #include "db/system_keyspace.hh"
 #include "db/large_data_handler.hh"
 #include "keys/keys.hh"
@@ -27,6 +28,11 @@
 static logging::logger large_data_logger("large_data");
 
 namespace db {
+
+template <typename Func>
+static decltype(auto) with_standard_allocator(Func&& f) {
+    return with_allocator(standard_allocator(), std::forward<Func>(f));
+}
 
 namespace {
 constexpr uint64_t MB = 1024 * 1024;
@@ -182,7 +188,7 @@ large_data_record_index::lookup_partition(bytes_view pk_bytes) const {
 }
 
 std::optional<uint64_t> large_data_record_index::lookup_row(bytes_view pk_bytes,
-        bytes_view ck_bytes) const {
+        managed_bytes_view ck_bytes) const {
     lookup_key lk{pk_bytes, ck_bytes, {}};
     auto [begin, end] = _rows.equal_range(lk, _rows.key_comp());
     if (begin == end) {
@@ -196,7 +202,7 @@ std::optional<uint64_t> large_data_record_index::lookup_row(bytes_view pk_bytes,
 }
 
 std::optional<uint64_t> large_data_record_index::lookup_collection(bytes_view pk_bytes,
-        bytes_view ck_bytes, bytes_view column_name) const {
+        managed_bytes_view ck_bytes, bytes_view column_name) const {
     lookup_key lk{pk_bytes, ck_bytes, column_name};
     auto [begin, end] = _collections.equal_range(lk, _collections.key_comp());
     if (begin == end) {
@@ -213,15 +219,29 @@ void large_data_guardrail::register_sstable(sstables::shared_sstable sst) {
     _index.register_sstable(std::move(sst));
 }
 
+void large_data_guardrail::clear_memtable_caches() noexcept {
+    // Clearing destroys the owned managed_bytes keys; do it under the standard
+    // allocator they were allocated from (see with_standard_allocator()).
+    with_standard_allocator([&] {
+        _memtable_row_cache.clear();
+        _memtable_collection_cache.clear();
+    });
+}
+
 void large_data_guardrail::on_flush() {
-    _memtable_row_cache.clear();
-    _memtable_collection_cache.clear();
+    clear_memtable_caches();
 }
 
 void large_data_guardrail::rebuild(const std::unordered_set<sstables::shared_sstable>& sstables) {
     _index.rebuild(sstables);
-    _memtable_row_cache.clear();
-    _memtable_collection_cache.clear();
+    clear_memtable_caches();
+}
+
+large_data_guardrail::~large_data_guardrail() {
+    // Empty the caches before the maps themselves are destroyed, so the owned
+    // managed_bytes keys are freed from the heap they were allocated on and the
+    // maps are then destroyed empty (and so allocate/free nothing).
+    clear_memtable_caches();
 }
 
 void large_data_guardrail::check(const schema& s, const mutation_partition& mp,
@@ -410,21 +430,27 @@ void large_data_cache_tracker::on_row_merged(const schema& s, const rows_entry& 
         const uint64_t row_warn = uint64_t(_cfg.row_size_warn_threshold_mb()) * MB;
         const uint64_t row_fail = uint64_t(_cfg.row_size_fail_threshold_mb()) * MB;
 
-        auto ck_bytes = row.key().view().representation().linearize();
+        // The cache keys own a managed_bytes clustering key.  on_row_merged()
+        // runs under the memtable's LSA allocator, so build the key and insert
+        // (which copies it into the cache) under the standard allocator the
+        // caches are torn down with (see with_standard_allocator()).
+        with_standard_allocator([&] {
+            auto ck_bytes_view = row.key().view().representation();
 
-        if (row_warn > 0 || row_fail > 0) {
-            size_t row_size = row.memory_usage(s);
-            uint64_t threshold = row_warn > 0 ? row_warn : row_fail;
-            if (row_size >= threshold) {
-                _row_cache.insert_or_assign(row_key{_pk_bytes, ck_bytes}, row_size);
+            if (row_warn > 0 || row_fail > 0) {
+                size_t row_size = row.memory_usage(s);
+                uint64_t threshold = row_warn > 0 ? row_warn : row_fail;
+                if (row_size >= threshold) {
+                    _row_cache.insert_or_assign(row_key{_pk_bytes, managed_bytes(ck_bytes_view)}, row_size);
+                }
             }
-        }
 
-        // Flush buffered collection observations from on_collection_merged().
-        for (auto& pc : _pending_collections) {
-            _collection_cache.insert_or_assign(
-                collection_key{_pk_bytes, ck_bytes, pc.id}, pc.count);
-        }
+            // Flush buffered collection observations from on_collection_merged().
+            for (auto& pc : _pending_collections) {
+                _collection_cache.insert_or_assign(
+                    collection_key{_pk_bytes, managed_bytes(ck_bytes_view), pc.id}, pc.count);
+            }
+        });
         _pending_collections.clear();
     } catch (...) {
         // noexcept: a failure here only means the memtable-level cache is not

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -28,20 +28,6 @@ static logging::logger large_data_logger("large_data");
 
 namespace db {
 
-size_t row_key::hash::operator()(const row_key& k) const noexcept {
-    return utils::hash_combine(
-        std::hash<bytes_view>{}(bytes_view(k.pk)),
-        std::hash<bytes_view>{}(bytes_view(k.ck)));
-}
-
-size_t collection_key::hash::operator()(const collection_key& k) const noexcept {
-    return utils::hash_combine(
-        utils::hash_combine(
-            std::hash<bytes_view>{}(bytes_view(k.pk)),
-            std::hash<bytes_view>{}(bytes_view(k.ck))),
-        std::hash<column_id>{}(k.col));
-}
-
 namespace {
 constexpr uint64_t MB = 1024 * 1024;
 
@@ -301,7 +287,7 @@ large_data_violation_type large_data_guardrail::check_row_size(const schema& s, 
     auto row_size_opt = _index.lookup_row(pk_bytes, ck_bytes);
     uint64_t row_size = row_size_opt.value_or(0);
     if (ck) {
-        auto it = _memtable_row_cache.find(row_key{bytes(pk_bytes), bytes(ck_bytes)});
+        auto it = _memtable_row_cache.find(row_key_view{pk_bytes, ck_bytes});
         if (it != _memtable_row_cache.end()) {
             row_size = std::max(row_size, it->second);
         }
@@ -327,7 +313,7 @@ large_data_violation_type large_data_guardrail::check_collection_element_count(c
     uint64_t count = count_opt.value_or(0);
     if (ck) {
         auto it = _memtable_collection_cache.find(
-            collection_key{bytes(pk_bytes), bytes(ck_bytes), cdef.id});
+            collection_key_view{pk_bytes, ck_bytes, cdef.id});
         if (it != _memtable_collection_cache.end()) {
             count = std::max(count, it->second);
         }

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -16,6 +16,8 @@
 #include <seastar/core/future.hh>
 #include <boost/intrusive/set.hpp>
 #include "bytes.hh"
+#include "utils/managed_bytes.hh"
+#include "utils/fragment_range.hh"
 #include "schema/schema_fwd.hh"
 #include "system_keyspace.hh"
 #include "sstables/shared_sstable.hh"
@@ -42,7 +44,7 @@ using sstables::large_data_record;
 
 struct lookup_key {
     bytes_view pk;
-    bytes_view ck;
+    managed_bytes_view ck;
     bytes_view column_name;
 };
 
@@ -57,8 +59,8 @@ struct record_compare {
 private:
     static bytes_view get_pk(const large_data_record& r) noexcept { return bytes_view(r.partition_key.value); }
     static bytes_view get_pk(const lookup_key& k) noexcept { return k.pk; }
-    static bytes_view get_ck(const large_data_record& r) noexcept { return bytes_view(r.clustering_key.value); }
-    static bytes_view get_ck(const lookup_key& k) noexcept { return k.ck; }
+    static single_fragmented_view get_ck(const large_data_record& r) noexcept { return single_fragmented_view(bytes_view(r.clustering_key.value)); }
+    static managed_bytes_view get_ck(const lookup_key& k) noexcept { return k.ck; }
     static bytes_view get_col(const large_data_record& r) noexcept { return bytes_view(r.column_name.value); }
     static bytes_view get_col(const lookup_key& k) noexcept { return k.column_name; }
 public:
@@ -72,9 +74,8 @@ public:
         if constexpr (Depth == record_type::partition) {
             return false;
         }
-        auto l_ck = get_ck(a), r_ck = get_ck(b);
-        if (l_ck != r_ck) {
-            return l_ck < r_ck;
+        if (auto c = compare_unsigned(get_ck(a), get_ck(b)); c != 0) {
+            return c < 0;
         }
         if constexpr (Depth == record_type::row) {
             return false;
@@ -106,9 +107,9 @@ public:
     void rebuild(const std::unordered_set<sstables::shared_sstable>& sstables);
 
     std::optional<partition_entry> lookup_partition(bytes_view pk_bytes) const;
-    std::optional<uint64_t> lookup_row(bytes_view pk_bytes, bytes_view ck_bytes) const;
+    std::optional<uint64_t> lookup_row(bytes_view pk_bytes, managed_bytes_view ck_bytes) const;
     std::optional<uint64_t> lookup_collection(bytes_view pk_bytes,
-            bytes_view ck_bytes, bytes_view column_name) const;
+            managed_bytes_view ck_bytes, bytes_view column_name) const;
 
 private:
     record_set<record_type::partition> _partitions;
@@ -201,6 +202,11 @@ public:
         : _cfg(std::move(cfg))
         , _tracker(_cfg, _memtable_row_cache, _memtable_collection_cache) {}
 
+    // The memtable caches own managed_bytes keys allocated on the standard
+    // heap (see with_standard_allocator() in the .cc).  Empty them under the
+    // standard allocator before the maps themselves are destroyed.
+    virtual ~large_data_guardrail() override;
+
     void check(const schema& s, const mutation_partition& mp,
             partition_key_view pk, db::large_data_violation_type* violations_out) const override;
     void check_coordinator(const schema& s, const mutation_partition& mp,
@@ -219,6 +225,9 @@ private:
     large_data_violation_type check_collection_element_count(const schema& s, bytes_view pk_bytes, partition_key_view pk,
             const column_definition& cdef, bytes_view ck_bytes,
             const clustering_key_prefix* ck) const;
+    // Empties the memtable caches, destroying their owning managed_bytes keys
+    // under the standard allocator (see large_data_cache_tracker.hh).
+    void clear_memtable_caches() noexcept;
 
     guardrail_config _cfg;
     large_data_record_index _index;


### PR DESCRIPTION
The memtable-level guardrail caches previously stored clustering keys as contiguous bytes, requiring a linearize() call on every write even when the key was already in a single fragment. This removes that allocation by storing keys as managed_bytes (fragmented-aware) and passing managed_bytes_view directly from representation() on all lookup and insert paths.
To keep the change reviewable the work is split into two commits:
1. Refactor the cache key hash/eq boilerplate into shared transparent functors (cache_key_hash/cache_key_eq) via non-owning *_key_view types, switching cache lookups to heterogeneous find() 
2. Switch *_key::ck to managed_bytes, *_key_view::ck to managed_bytes_view, update record_compare to use single_fragmented_view + compare_unsigned for heterogeneous SSTable-metadata vs. live-key comparison, and drop all linearize() calls.

Backport is not required