### PR TITLE
Remove racy view_building_worker_pause_before_consume error injection

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -714,7 +714,6 @@ future<> view_building_worker::do_build_range(table_id base_id, std::vector<tabl
                     co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes(5), &as);
                 }
             }).get();
-            utils::get_local_injector().inject("view_building_worker_pause_before_consume", 5min, as).get();
 
             vbw_logger.info("Starting range {} building for base table: {}.{}", range, base_cf->schema()->ks_name(), base_cf->schema()->cf_name());
             auto end_token = reader.consume_in_thread(std::move(consumer));

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1518,17 +1518,16 @@ async def test_tablet_streaming_with_staged_sstables(manager: ManagerClient):
         await manager.api.keyspace_flush(servers[0].ip_addr, ks, "test")
 
         logger.info("Create view")
-        # Pause view building
-        await manager.api.enable_injection(servers[0].ip_addr, "view_building_worker_pause_before_consume", one_shot=True)
+        # Pause view building worker at the range processing point
+        pause_build_injection = "view_building_worker_pause_build_range_task"
+        await manager.api.enable_injection(servers[0].ip_addr, pause_build_injection, one_shot=True)
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv1 AS \
                 SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL \
                 PRIMARY KEY (c, pk);")
         
-        # Check if view building was started
-        async def check_mv_status():
-            mv_status = await cql.run_async(f"SELECT status FROM system.view_build_status_v2 WHERE keyspace_name='{ks}' AND view_name='mv'")
-            return len(mv_status) == 1 and mv_status[0].status == "STARTED"
-        await wait_for(check_mv_status, time.time() + 30)
+        # Wait for view building worker to reach the injection point (deterministic synchronization)
+        logger.info("Waiting for view building worker to reach injection point")
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, pause_build_injection)
 
         logger.info("Generate an sstable and move it to upload directory of test table")
         # create an sstable using a dummy table

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1459,13 +1459,16 @@ async def test_tablet_streaming_with_unbuilt_view(manager: ManagerClient):
         s1_host_id = await manager.get_host_id(servers[1].server_id)
 
         logger.info("Inject error to make view building worker pause before processing the sstable")
-        injection_name = "view_building_worker_pause_before_consume"
+        injection_name = "view_building_worker_pause_build_range_task"
         await manager.api.enable_injection(servers[0].ip_addr, injection_name, one_shot=True)
 
         logger.info("Create view")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv1 AS \
                 SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL \
                 PRIMARY KEY (c, pk);")
+
+        logger.info("Wait for view building worker to reach the injection point")
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, injection_name)
 
         logger.info("Migrate the tablet to node 2")
         tablet_token = 0 # Doesn't matter since there is one tablet


### PR DESCRIPTION
The view_building_worker_pause_before_consume was a fixed-duration injection that slept for 5 minutes (abortable via the batch's abort_source). Two tests used it to pause the view building worker before it starts consuming sstables, so that they could perform some operation (tablet migration, staged sstable setup) while the worker was held.

The injection worked by several (implicit?) assumptions: the 5-minute sleep was not released by a test-controlled signal but by tablet migration aborting the batch's abort_source as a side-effect of moving the tablet off the source node. However,  unless the migration happens "promptly", the injection could just wake up in 5 minutes on its own. Seems reliable, but arbitrary magic timeouts are not nice.

Investigation of test_tablet_streaming_with_staged_sstables revealed a second, independent bug: its check_mv_status predicate was double-broken. It queried view_build_status_v2 for view name 'mv' while the actual view was 'mv1', and returned False instead of None thus making the wrapping wait_for() succeed. The test was effectively racing from the start.

There is already a better injection at the same code point: view_building_worker_pause_build_range_task, which uses wait_for_message() with the same abort_source. It supports the same migration-driven release, but also allows an explicit message_injection() wake-up for deterministic test synchronization.

Both tests are switched to pause_build_range_task with wait_for_injection_enter(), giving both a genuine guarantee that the worker is paused at the injection point before they proceed and is not woken up by a random delay. With no remaining users, pause_before_consume is removed from the production code.

Improving tests, not backporting (though the first fix, probably, could, up to reviewer)