### PR TITLE
vector_index: Disable post filtering in ANN queries

### DIFF
--- a/cql3/statements/external_search/vector_indexed_table_select_statement.hh
+++ b/cql3/statements/external_search/vector_indexed_table_select_statement.hh
@@ -85,6 +85,10 @@ private:
     future<coordinator_result<foreign_ptr<lw_shared_ptr<query::result>>>> query_base_table(query_processor& qp, service::query_state& state,
             const query_options& options, lw_shared_ptr<query::read_command> command, lowres_clock::time_point timeout,
             std::vector<dht::partition_range> partition_ranges) const;
+
+    bool needs_post_filtering() const override {
+        return false; // All filtering is done by the index query, so no post-filtering is allowed.
+    }
 };
 
 } // namespace cql3::statements

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -436,7 +436,7 @@ select_statement::do_execute(query_processor& qp,
     const uint64_t inner_loop_limit = get_inner_loop_limit(parsed_limit, _selection->is_aggregate());
     auto now = gc_clock::now();
 
-    _stats.filtered_reads += _restrictions_need_filtering;
+    _stats.filtered_reads += needs_post_filtering();
 
     const source_selector src_sel = state.get_client_state().is_internal()
             ? source_selector::INTERNAL : source_selector::USER;
@@ -475,7 +475,7 @@ select_statement::do_execute(query_processor& qp,
     // If the user provided a page_size we'll use that to page internally (because why not), otherwise we use our default
     // Also note: all GROUP BY queries are considered aggregation.
     const bool aggregate = _selection->is_aggregate() || has_group_by();
-    const bool nonpaged_filtering = _restrictions_need_filtering && page_size <= 0;
+    const bool nonpaged_filtering = needs_post_filtering() && page_size <= 0;
     if (aggregate || nonpaged_filtering) {
         page_size = page_size <= 0 ? qp.get_cql_config().select_internal_page_size : page_size;
     }
@@ -513,7 +513,7 @@ select_statement::do_execute(query_processor& qp,
 
     auto f = make_ready_future<shared_ptr<cql_transport::messages::result_message>>();
 
-    if (!aggregate && !_restrictions_need_filtering && (page_size <= 0
+    if (!aggregate && !needs_post_filtering() && (page_size <= 0
             || !service::pager::query_pagers::may_need_paging(*_query_schema, page_size,
                     *command, key_ranges))) {
         f = execute_without_checking_exception_message_non_aggregate_unpaged(qp, command, std::move(key_ranges), state, options, now, std::move(cas_shard));
@@ -542,7 +542,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
     auto timeout_duration = get_timeout(state.get_client_state(), options);
     auto timeout = db::timeout_clock::now() + timeout_duration;
     auto p = service::pager::query_pagers::pager(qp.proxy(), _query_schema, _selection,
-            state, options, command, std::move(key_ranges), _restrictions_need_filtering ? _restrictions : nullptr, std::move(cas_shard));
+            state, options, command, std::move(key_ranges), needs_post_filtering() ? _restrictions : nullptr, std::move(cas_shard));
 
     auto per_partition_limit = get_limit(options, _per_partition_limit, true);
 
@@ -561,7 +561,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
         }
         co_return co_await builder.with_thread_if_needed([this, &p, &builder] {
             auto rs = builder.build();
-            if (_restrictions_need_filtering) {
+            if (needs_post_filtering()) {
                 _stats.filtered_rows_read_total += p->stats().rows_read_total;
                 _stats.filtered_rows_matched_total += rs->size();
             }
@@ -577,7 +577,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
                         " you must either remove the ORDER BY or the IN and sort client side, or disable paging for this query");
     }
 
-    if (_selection->is_trivial() && !_restrictions_need_filtering && !_per_partition_limit) {
+    if (_selection->is_trivial() && !needs_post_filtering() && !_per_partition_limit) {
         coordinator_result<result_generator> result_gen = co_await p->fetch_page_generator_result(page_size, now, timeout, _stats);
         if (result_gen.has_error()) {
             co_return failed_result_to_result_message(std::move(result_gen));
@@ -607,7 +607,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
         rs->get_metadata().set_paging_state(p->state());
     }
 
-    if (_restrictions_need_filtering) {
+    if (needs_post_filtering()) {
         _stats.filtered_rows_read_total += p->stats().rows_read_total;
         _stats.filtered_rows_matched_total += rs->size();
     }
@@ -951,7 +951,7 @@ select_statement::process_results(foreign_ptr<lw_shared_ptr<query::result>> resu
                                   const query_options& options,
                                   gc_clock::time_point now) const
 {
-    const bool fast_path = !needs_post_query_ordering() && _selection->is_trivial() && !_restrictions_need_filtering;
+    const bool fast_path = !needs_post_query_ordering() && _selection->is_trivial() && !needs_post_filtering();
     if (fast_path) {
         return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(make_shared<cql_transport::messages::result_message::rows>(result(
             result_generator(_query_schema, std::move(results), std::move(cmd), _selection, _stats),
@@ -968,7 +968,7 @@ select_statement::process_results_complex(foreign_ptr<lw_shared_ptr<query::resul
                                   gc_clock::time_point now) const {
     cql3::selection::result_set_builder builder(*_selection, now, &options);
     co_return co_await builder.with_thread_if_needed([&] {
-        if (_restrictions_need_filtering) {
+        if (needs_post_filtering()) {
             results->ensure_counts();
             _stats.filtered_rows_read_total += *results->row_count();
             query::result_view::consume(*results, cmd->slice,
@@ -989,7 +989,7 @@ select_statement::process_results_complex(foreign_ptr<lw_shared_ptr<query::resul
             rs->trim(cmd->get_row_limit());
         }
         update_stats_rows_read(rs->size());
-        _stats.filtered_rows_matched_total += _restrictions_need_filtering ? rs->size() : 0;
+        _stats.filtered_rows_matched_total += needs_post_filtering() ? rs->size() : 0;
         return shared_ptr<cql_transport::messages::result_message>(::make_shared<cql_transport::messages::result_message::rows>(result(std::move(rs))));
     });
 }
@@ -1266,7 +1266,7 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
                     paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options, internal_page_size);
                 }
                 internal_options.reset(new cql3::query_options(std::move(internal_options), paging_state ? make_lw_shared<service::pager::paging_state>(*paging_state) : nullptr));
-                if (_restrictions_need_filtering) {
+                if (needs_post_filtering()) {
                     _stats.filtered_rows_read_total += *results->row_count();
                     query::result_view::consume(*results, cmd->slice, cql3::selection::result_set_builder::visitor(builder, *_schema, *_selection,
                             cql3::selection::result_set_builder::restrictions_filter(_restrictions, options, cmd->get_row_limit(), _schema, cmd->slice.partition_row_limit())));
@@ -1308,7 +1308,7 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
 
         auto rs = builder.build();
         update_stats_rows_read(rs->size());
-        _stats.filtered_rows_matched_total += _restrictions_need_filtering ? rs->size() : 0;
+        _stats.filtered_rows_matched_total += needs_post_filtering() ? rs->size() : 0;
         auto msg = ::make_shared<cql_transport::messages::result_message::rows>(result(std::move(rs)));
         co_return shared_ptr<cql_transport::messages::result_message>(std::move(msg));
     }
@@ -1824,7 +1824,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
     const uint64_t limit = get_inner_loop_limit(get_limit(options, _limit), _selection->is_aggregate());
     auto now = gc_clock::now();
 
-    _stats.filtered_reads += _restrictions_need_filtering;
+    _stats.filtered_reads += needs_post_filtering();
 
     const source_selector src_sel = state.get_client_state().is_internal()
             ? source_selector::INTERNAL : source_selector::USER;
@@ -1861,7 +1861,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
     // Note that if there are some nodes in the cluster with a version less than 2.0, we can't use paging (CASSANDRA-6707).
     // Also note: all GROUP BY queries are considered aggregation.
     const bool aggregate = _selection->is_aggregate() || has_group_by();
-    const bool nonpaged_filtering = _restrictions_need_filtering && page_size <= 0;
+    const bool nonpaged_filtering = needs_post_filtering() && page_size <= 0;
     if (aggregate || nonpaged_filtering) {
         page_size = qp.get_cql_config().select_internal_page_size;
     }
@@ -1876,7 +1876,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
     // Since this query doesn't go through storage-proxy, we have to take care of pinning erm here.
     auto erm_keepalive = tbl.get_effective_replication_map();
 
-    if (!aggregate && !_restrictions_need_filtering && (page_size <= 0
+    if (!aggregate && !needs_post_filtering() && (page_size <= 0
             || !service::pager::query_pagers::may_need_paging(*_schema, page_size,
                     *command, key_ranges))) {
         return do_query(erm_keepalive, {}, qp.proxy(), _schema, command, std::move(key_ranges), cl,
@@ -1916,14 +1916,14 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
             options,
             command,
             std::move(key_ranges),
-            _restrictions_need_filtering ? _restrictions : nullptr,
+            needs_post_filtering() ? _restrictions : nullptr,
             std::nullopt,
             [this, erm_keepalive, this_node] (service::storage_proxy& sp, schema_ptr schema, lw_shared_ptr<query::read_command> cmd, dht::partition_range_vector partition_ranges,
                     db::consistency_level cl, service::storage_proxy_coordinator_query_options optional_params, std::optional<service::cas_shard>) mutable {
                 return do_query(std::move(erm_keepalive), this_node, sp, std::move(schema), std::move(cmd), std::move(partition_ranges), cl, std::move(optional_params));
             });
 
-    if (_selection->is_trivial() && !_restrictions_need_filtering && !_per_partition_limit) {
+    if (_selection->is_trivial() && !needs_post_filtering() && !_per_partition_limit) {
         return p->fetch_page_generator_result(page_size, now, timeout, _stats).then(wrap_result_to_error_message([this, p = std::move(p)] (result_generator&& generator) {
             auto meta = [&] () -> shared_ptr<const cql3::metadata> {
                 if (!p->is_exhausted()) {
@@ -1947,7 +1947,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
                     rs->get_metadata().set_paging_state(p->state());
                 }
 
-                if (_restrictions_need_filtering) {
+                if (needs_post_filtering()) {
                     _stats.filtered_rows_read_total += p->stats().rows_read_total;
                     _stats.filtered_rows_matched_total += rs->size();
                 }

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -72,7 +72,9 @@ protected:
     lw_shared_ptr<const parameters> _parameters;
     ::shared_ptr<selection::selection> _selection;
     const ::shared_ptr<const restrictions::statement_restrictions> _restrictions;
-    const bool _restrictions_need_filtering;
+private:
+    const bool _restrictions_need_filtering; // Access via needs_post_filtering()
+protected:
     ::shared_ptr<std::vector<size_t>> _group_by_cell_indices; ///< Indices in result row of cells holding GROUP BY values.
     bool _is_reversed;
     expr::unset_bind_variable_guard _limit_unset_guard;
@@ -161,6 +163,10 @@ public:
 protected:
     uint64_t get_limit(const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit = false) const;
     static uint64_t get_inner_loop_limit(uint64_t limit, bool is_aggregate);
+
+    virtual bool needs_post_filtering() const {
+        return _restrictions_need_filtering;
+    }
 
     bool needs_post_query_ordering() const;
     virtual void update_stats_rows_read(int64_t rows_read) const {

--- a/test/cqlpy/test_vector_search_with_vector_store_mock.py
+++ b/test/cqlpy/test_vector_search_with_vector_store_mock.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from http import HTTPStatus
 from http.server import HTTPServer, BaseHTTPRequestHandler
+from itertools import combinations
 import json
 import threading
 
@@ -256,3 +257,46 @@ def test_vector_search_no_paging_warning_when_limit_less_than_page_size(cql, tes
             f"SELECT * FROM {table} ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 5", fetch_size=100))
 
         assert not result.response_future.warnings
+
+# Vector Search allows filtering on partition and clustering key columns in any combination.
+# It also assumes responsibility for filtering, so post-filtering in the coordinator is not allowed:
+# only selected columns are retrieved from the base table, and remaining columns are unavailable for filtering.
+# 
+# This test verifies all the combinations of partition key and clustering key columns filtering.
+# It reproduces bugs from when post filtering was not disabled in general and the normal filtering logic was used.
+# In that case some combinations triggered post-filtering, which failed or crashed (on primary key columns)
+# due to missing columns in the SELECT result set.
+#
+# Reproduces SCYLLADB-2737 (all cases without pk1 or pk2)
+def test_vector_search_ann_with_restricted_key_column_not_selected(cql, test_keyspace, vector_store_mock, skip_without_tablets):
+
+    schema = "pk1 tinyint, pk2 tinyint, ck1 tinyint, ck2 tinyint, category int, embedding vector<float, 3>, PRIMARY KEY ((pk1, pk2), ck1, ck2)"
+
+    with new_test_table(cql, test_keyspace, schema) as table:
+        index_name = unique_name()
+        cql.execute(
+            f"CREATE CUSTOM INDEX {index_name} ON {table}(embedding) USING 'vector_index'")
+        cql.execute(
+            f"INSERT INTO {table} (pk1, pk2, ck1, ck2, category, embedding) VALUES (5, 7, 9, 1, 7, [0.1, 0.2, 0.3])")
+        cql.execute(
+            f"INSERT INTO {table} (pk1, pk2, ck1, ck2, category, embedding) VALUES (5, 7, 9, 2, 8, [0.1, 0.2, 0.3])")
+        vector_store_mock.set_next_ann_response(200, json.dumps({
+            "primary_keys": {"pk1": [5, 5], "pk2": [7, 7], "ck1": [9, 9], "ck2": [2, 1]},
+            "similarity_scores": [0.2, 0.1],
+        }))
+
+        restriction_tokens = [
+            "pk1 = 5",
+            "pk2 = 7",
+            "ck1 = 9",
+            "ck2 IN (1, 2)",
+        ]
+
+        for size in range(1, len(restriction_tokens) + 1):
+            for subset in combinations(restriction_tokens, size):
+                where_clause = " AND ".join(subset)
+                print(f"Testing ANN query with restrictions: {where_clause}")
+                result = cql.execute(
+                    f"SELECT category FROM {table} WHERE {where_clause} ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 2")
+
+                assert list(result) == [(8,), (7,)]


### PR DESCRIPTION
ANN queries can use filtering only on columns that are stored in the vector index. Currently these are only primary key columns.
All the filtering is handled inside Vector Store - filter definition is passed in JSON request and Vector Store rejects request it cannot filter. Post filtering in scylla after retreval of results is not expected. Especially the code to ensure all necessary columns would be retrieved is omitted. However it was not disabled - normal result processing path is used, which includes post filtering, depending on restrictions. It is neccesary for non-prefix key columns or partial partition columns. In such case post filtering tried to access columns that were not retreived and specifically for partition key it ended with scylla crash due to out of bound memeory access.

With this patch post filtering is disabled for all ANN queries. It also includes test that reproduced the problem - crashing scylla before this patch.

Fixes: SCYLLADB-2737

Needs backport - fixes crashes observed in production