### PR TITLE
alternator: add export scan helper for S3 export

### DIFF
--- a/alternator/export.cc
+++ b/alternator/export.cc
@@ -8,12 +8,28 @@
 
 #include "alternator/export.hh"
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+#include "alternator/executor.hh"
+#include "alternator/executor_util.hh"
+#include "alternator/serialization.hh"
+#include "cql3/selection/selection.hh"
+#include "cql3/result_set.hh"
+#include "query/query-request.hh"
+#include "schema/schema.hh"
+#include "service/client_state.hh"
+#include "service/pager/query_pagers.hh"
+#include "service/storage_proxy.hh"
+#include "service_permit.hh"
 #include "utils/rjson.hh"
+
 #include <algorithm>
+#include <ranges>
 #include <string>
 #include <string_view>
 
 namespace alternator {
+
+static logging::logger elogger("alternator-export");
 
 // Interfaces for `sink` / `source` pipelines.
 // The `sink` pipeline consists of 3 stages:
@@ -206,6 +222,106 @@ std::unique_ptr<import_pipeline_interface> create_in_memory_source_pipeline(in_m
     auto parser = std::make_unique<json_parser>(std::move(on_item));
     auto decompressor = std::make_unique<noop_decompressor>(std::move(parser));
     return std::make_unique<in_memory_source>(storage, std::move(decompressor));
+}
+
+
+seastar::future<> scan_table(
+    service::storage_proxy& proxy,
+    schema_ptr schema,
+    abort_source& as,
+    service_permit permit,
+    seastar::noncopyable_function<seastar::future<>(rjson::value)> cb)
+{
+    as.check();
+
+    // Build a wildcard selection (SELECT *) for all columns.
+    auto selection = cql3::selection::selection::wildcard(schema);
+
+    // Collect all regular column IDs to read.
+    // We're only interested in regular columns (that contain user data), not static columns.
+    // We also ignore timestamp columns, which are not part of the user data.
+    auto regular_columns =
+        schema->regular_columns()
+        | std::views::transform(&column_definition::id)
+        | std::ranges::to<query::column_id_vector>();
+
+    // Set up query options: allow short reads and bypass cache.
+    query::partition_slice::option_set opts = selection->get_query_options();
+    opts.set<query::partition_slice::option::allow_short_read>();
+    opts.set<query::partition_slice::option::bypass_cache>();
+
+    // Scan all clustering ranges (no restriction).
+    std::vector<query::clustering_range> ck_bounds{
+        query::clustering_range::make_open_ended_both_sides()};
+
+    auto partition_slice = query::partition_slice(
+        std::move(ck_bounds), {}, std::move(regular_columns), opts);
+
+    auto command = ::make_lw_shared<query::read_command>(
+        schema->id(), schema->version(), partition_slice,
+        proxy.get_max_result_size(partition_slice),
+        query::tombstone_limit(proxy.get_tombstone_limit()));
+
+    // Use an internal client state - no authorization checks needed for
+    // this internal scan operation. The caller should verify, if user has permission to perform the scan.
+    auto& client_state = service::client_state::for_internal_calls();
+    tracing::trace_state_ptr trace_state;
+    auto query_state_ptr = std::make_unique<service::query_state>(
+        client_state, trace_state, std::move(permit));
+
+    db::consistency_level cl = db::consistency_level::LOCAL_QUORUM;
+    auto query_options = std::make_unique<cql3::query_options>(
+        cl, std::vector<cql3::raw_value>{});
+    lw_shared_ptr<service::pager::paging_state> paging_state = nullptr;
+    query_options = std::make_unique<cql3::query_options>(
+        std::move(query_options), std::move(paging_state));
+
+    // Scan the full token ring.
+    dht::partition_range_vector partition_ranges{
+        dht::partition_range::make_open_ended_both_sides()};
+
+    auto p = service::pager::query_pagers::pager(
+        proxy, schema, selection, *query_state_ptr, *query_options,
+        command, std::move(partition_ranges), nullptr);
+
+    while (!p->is_exhausted()) {
+        as.check();
+        std::unique_ptr<cql3::result_set> rs;
+
+        // We will retry reading a page 10 times (nothing special about 10 itself).
+        static constexpr const int max_retries = 10;
+
+        // We will try to read a page several times to avoid accidental timeout aborting
+        // whole scan. We will still abort on any other error.
+        for (int retries = 0; ; ++retries) {
+            try {
+                rs = co_await p->fetch_page(scan_table_page_size, gc_clock::now(), executor::default_timeout());
+                break;
+            } catch(exceptions::read_timeout_exception&) {
+                elogger.warn("S3 export scanner read timed out, will retry: {}", std::current_exception());
+            }
+            // If we didn't break out of this loop, add a minimal sleep
+            if (retries >= max_retries) {
+                // Don't get stuck forever asking the same page, maybe there's
+                // a bug or a real problem in several replicas. We're giving up here -
+                // the caller must catch and handle the exception.
+                throw runtime_exception("scanner thread failed after too many timeouts for the same page");
+            }
+            // Timeout happen for a reason - we don't want to retry too fast, so we wait a bit before retrying.
+            co_await seastar::sleep_abortable(std::chrono::seconds(1), as);
+        }
+
+        co_await coroutine::maybe_yield();
+        for (const auto& row : rs->rows()) {
+            as.check();
+            rjson::value item = rjson::empty_object();
+            // Convert each row to a DynamoDB-style JSON item using the
+            // same logic as describe_single_item() from executor_util.
+            describe_single_item(*selection, row, std::nullopt, item);
+            co_await cb(std::move(item));
+            co_await coroutine::maybe_yield();
+        }
+    }
 }
 
 } // namespace alternator

--- a/alternator/export.hh
+++ b/alternator/export.hh
@@ -13,8 +13,16 @@
 #include <memory>
 #include <span>
 #include <vector>
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
+#include <seastar/util/noncopyable_function.hh>
+#include "schema/schema_fwd.hh"
+#include "service_permit.hh"
 #include "utils/rjson.hh"
+
+namespace service {
+class storage_proxy;
+}
 
 namespace alternator {
 
@@ -92,5 +100,32 @@ std::unique_ptr<export_pipeline_interface> create_in_memory_sink_pipeline(in_mem
 // You should not use the same in_memory_test_storage object for sink and source pipeline simultaneously -
 // you need to complete sink pipeline first, then create and run source pipeline.
 std::unique_ptr<import_pipeline_interface> create_in_memory_source_pipeline(in_memory_test_storage &, std::function<seastar::future<>(rjson::value)> on_item);
+
+/// Perform a full table scan over an Alternator table, calling `cb` for
+/// every item found. The callback receives an `rjson::value` representing
+/// one DynamoDB-style item (JSON object with typed attribute values).
+///
+/// Guarantees:
+///  - Every item in the table is visited exactly once as long as table is not modified during the scan -
+///    it's unspecified if newly added items during the scan are visited or not.
+///    Similarly it's unspecified if deleted items during the scan are visited or not.
+///  - Calls to `cb` are sequential (never parallel).
+///  - Items may be visited in any order (not necessarily sort-key order).
+///  - Aborting `as` stops the scan by throwing `abort_requested_exception`.
+///
+/// The function underneath performs global scan over whole table, using single-threaded query_pager.
+/// The scan uses LOCAL_QUORUM consistency and bypasses the cache to avoid polluting it.
+/// The scan takes ownership of `permit` and holds it for the duration of the scan.
+
+seastar::future<> scan_table(
+    service::storage_proxy& proxy,
+    schema_ptr schema,
+    seastar::abort_source& as,
+    service_permit permit,
+    seastar::noncopyable_function<seastar::future<>(rjson::value)> cb);
+
+/// Hardcoded page size for scan_table - nothing special about the number itself, but it's hardcoded.
+/// The number is public so tests could use it to verify pagination works.
+static constexpr uint32_t scan_table_page_size = 4096u;
 
 } // namespace alternator

--- a/configure.py
+++ b/configure.py
@@ -533,6 +533,7 @@ scylla_tests = set([
     'test/boost/allocation_strategy_test',
     'test/boost/alternator_unit_test',
     'test/boost/alternator_export_test',
+    'test/boost/alternator_table_scan_test',
     'test/boost/anchorless_list_test',
     'test/boost/auth_passwords_test',
     'test/boost/audit_rule_test',

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -12,6 +12,9 @@ add_scylla_test(alternator_export_test
 add_scylla_test(alternator_unit_test
   KIND SEASTAR
   LIBRARIES alternator)
+add_scylla_test(alternator_table_scan_test
+  KIND SEASTAR
+  LIBRARIES alternator)
 add_scylla_test(anchorless_list_test
   KIND BOOST)
 add_scylla_test(audit_rule_test

--- a/test/boost/alternator_table_scan_test.cc
+++ b/test/boost/alternator_table_scan_test.cc
@@ -1,0 +1,668 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+// Test for alternator::scan_table() - full table scan functionality.
+// Tables and items are created through the Alternator executor API
+// (CreateTable / PutItem) rather than raw CQL.
+// See SCYLLADB-1888.
+
+#include "test/lib/scylla_test_case.hh"
+#include "test/lib/cql_test_env.hh"
+
+#include "alternator/export.hh"
+#include "alternator/executor.hh"
+#include "alternator/error.hh"
+#include "alternator/rmw_operation.hh"
+#include "cdc/metadata.hh"
+#include "service/storage_proxy.hh"
+#include "service/client_state.hh"
+#include "service_permit.hh"
+#include "utils/rjson.hh"
+
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/util/defer.hh>
+
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+namespace {
+// Wraps a sharded<alternator::executor> for use in tests. Provides
+// create_table() and put_item() methods that accept DynamoDB-style
+// JSON requests, just like the real Alternator HTTP API would.
+class alternator_test_executor {
+    cdc::metadata _cdc_md;
+    sharded<alternator::executor> _exec;
+    alternator::rmw_operation::write_isolation _saved_write_isolation;
+public:
+    void start(cql_test_env& e) {
+        // Save and override the default write isolation. The default
+        // LWT_ALWAYS uses proxy.cas() which requires need_remote_proxy
+        // in the test env. FORBID_RMW uses direct quorum writes which
+        // work without a remote proxy - sufficient for our unconditional
+        // PutItem calls.
+        _saved_write_isolation = alternator::rmw_operation::default_write_isolation;
+        alternator::rmw_operation::set_default_write_isolation("forbid_rmw");
+        _exec.start(
+            std::ref(e.gossiper().local()),
+            std::ref(e.get_storage_proxy().local()),
+            std::ref(e.get_storage_service().local()),
+            std::ref(e.migration_manager().local()),
+            std::ref(e.get_system_distributed_keyspace().local()),
+            std::ref(e.get_system_keyspace().local()),
+            std::ref(_cdc_md),
+            std::ref(e.vector_store_client().local()),
+            default_smp_service_group(),
+            utils::updateable_value<uint32_t>(10000)).get();
+    }
+
+    void stop() {
+        _exec.stop().get();
+        alternator::rmw_operation::default_write_isolation = _saved_write_isolation;
+    }
+
+    // Call CreateTable with a DynamoDB-style JSON request.
+    void create_table(rjson::value request) {
+        service::client_state cs(service::client_state::internal_tag{});
+        tracing::trace_state_ptr ts;
+        std::unique_ptr<audit::audit_info_alternator> ai;
+        auto result = _exec.local().create_table(cs, ts, empty_service_permit(),
+            std::move(request), ai).get();
+        if (auto* err = std::get_if<alternator::api_error>(&result)) {
+            BOOST_FAIL(fmt::format("CreateTable failed: {}", err->what()));
+        }
+    }
+
+    // Call PutItem with a DynamoDB-style JSON request.
+    void put_item(rjson::value request) {
+        service::client_state cs(service::client_state::internal_tag{});
+        tracing::trace_state_ptr ts;
+        std::unique_ptr<audit::audit_info_alternator> ai;
+        auto result = _exec.local().put_item(cs, ts, empty_service_permit(),
+            std::move(request), ai).get();
+        if (auto* err = std::get_if<alternator::api_error>(&result)) {
+            BOOST_FAIL(fmt::format("PutItem failed: {}", err->what()));
+        }
+    }
+};
+
+// Build a PutItem request JSON for a table with hash key "p" (string),
+// sort key "c" (string - optional), and a single extra string attribute (optional).
+rjson::value make_put_item_request(std::string_view table_name,
+    std::string_view pk, std::optional<std::string_view> ck,
+    std::optional<std::string_view> attr_name = std::nullopt, std::optional<std::string_view> attr_value = std::nullopt)
+{
+    rjson::value req = rjson::empty_object();
+    rjson::add(req, "TableName", rjson::from_string(table_name));
+
+    rjson::value item = rjson::empty_object();
+
+    rjson::value pk_val = rjson::empty_object();
+    rjson::add(pk_val, "S", rjson::from_string(pk));
+    rjson::add(item, "p", std::move(pk_val));
+    if (ck) {
+        rjson::value ck_val = rjson::empty_object();
+        rjson::add(ck_val, "S", rjson::from_string(*ck));
+        rjson::add(item, "c", std::move(ck_val));
+    }
+
+    if (attr_name && attr_value) {
+        rjson::value attr_val = rjson::empty_object();
+        rjson::add(attr_val, "S", rjson::from_string(*attr_value));
+        rjson::add_with_string_name(item, *attr_name, std::move(attr_val));
+    }
+
+    rjson::add(req, "Item", std::move(item));
+    return req;
+}
+
+// Build a PutItem request JSON for a table with hash key "p" (string) and extra attributes (optional) -
+// those will be moved into the "Item" object of the request.
+rjson::value make_put_item_request(std::string_view table_name, std::string_view pk, rjson::value attrs)
+{
+    rjson::value req = rjson::empty_object();
+    rjson::add(req, "TableName", rjson::from_string(table_name));
+
+    rjson::value item = rjson::empty_object();
+    rjson::value pk_val = rjson::empty_object();
+    rjson::add(pk_val, "S", rjson::from_string(pk));
+    rjson::add(item, "p", std::move(pk_val));
+
+    for (auto it = attrs.MemberBegin(); it != attrs.MemberEnd(); ++it) {
+        rjson::add_with_string_name(item, rjson::to_string_view(it->name), std::move(it->value));
+    }
+
+    rjson::add(req, "Item", std::move(item));
+    return req;
+}
+
+// Extract a string attribute value from a DynamoDB-style JSON item.
+// Item format: {"attr_name": {"S": "value"}}
+std::string get_string_attr(const rjson::value& item, const char* attr_name) {
+    BOOST_REQUIRE(item.IsObject());
+    BOOST_REQUIRE(item.HasMember(attr_name));
+    const auto& typed_val = item[attr_name];
+    BOOST_REQUIRE(typed_val.IsObject());
+    BOOST_REQUIRE(typed_val.HasMember("S"));
+    return std::string(rjson::to_string_view(typed_val["S"]));
+}
+
+service_permit make_test_service_permit(seastar::semaphore& sem) {
+    return make_service_permit(seastar::get_units(sem, 1).get());
+}
+
+struct executor_fixture {
+  executor_fixture() {
+      BOOST_TEST_MESSAGE( "ctor fixture" );
+  }
+  void setup() {
+  }
+  void teardown() {
+  }
+  ~executor_fixture() {
+      BOOST_TEST_MESSAGE( "dtor fixture" );
+  }
+  static int i;
+};
+int executor_fixture::i = 0;
+
+BOOST_TEST_GLOBAL_FIXTURE( executor_fixture );
+} // anonymous namespace
+
+// Basic test: create an Alternator table with a hash key and sort key via
+// the Alternator API, insert a few items via PutItem, then verify that
+// scan_table visits all items exactly once.
+SEASTAR_TEST_CASE(test_scan_table_basic) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        alternator_test_executor exec;
+        exec.start(e);
+        auto stop_exec = defer([&] { exec.stop(); });
+
+        // CreateTable with hash key "p" and sort key "c", both strings.
+        exec.create_table(rjson::parse(R"({
+            "TableName": "testtbl",
+            "BillingMode": "PAY_PER_REQUEST",
+            "AttributeDefinitions": [
+                {"AttributeName": "p", "AttributeType": "S"},
+                {"AttributeName": "c", "AttributeType": "S"}
+            ],
+            "KeySchema": [
+                {"AttributeName": "p", "KeyType": "HASH"},
+                {"AttributeName": "c", "KeyType": "RANGE"}
+            ]
+        })"));
+
+        std::multiset<std::tuple<std::string, std::string, std::string>> scanned_set, expected_set;
+        expected_set = {
+            {"user1", "order1", "item_a"},
+            {"user1", "order2", "item_b"},
+            {"user2", "order1", "item_c"},
+            {"user3", "order1", "item_d"},
+            {"user3", "order2", "item_e"},
+        };
+
+        // PutItem for each item.
+        for (const auto& ti : expected_set) {
+            exec.put_item(make_put_item_request("testtbl", std::get<0>(ti), std::get<1>(ti), "data", std::get<2>(ti)));
+        }
+
+        // Run the full table scan.
+        auto& proxy = e.get_storage_proxy().local();
+        auto schema = e.local_db().find_schema("alternator_testtbl", "testtbl");
+
+        abort_source as;
+        seastar::semaphore scan_permit_sem{1};
+        alternator::scan_table(proxy, schema, as,
+            make_test_service_permit(scan_permit_sem),
+            [&scanned_set] (rjson::value item) -> future<> {
+                BOOST_REQUIRE(item.IsObject());
+                std::multiset<std::string_view> expected_keys = {"p", "c", "data"};
+                std::multiset<std::string_view> actual_keys;
+                for (auto it = item.MemberBegin(); it != item.MemberEnd(); ++it) {
+                    actual_keys.insert(rjson::to_string_view(it->name));
+                }
+                BOOST_REQUIRE_EQUAL_COLLECTIONS(expected_keys.begin(), expected_keys.end(),
+                    actual_keys.begin(), actual_keys.end());
+                scanned_set.emplace(get_string_attr(item, "p"),
+                                    get_string_attr(item, "c"),
+                                    get_string_attr(item, "data"));
+                return make_ready_future<>();
+            }).get();
+
+        BOOST_REQUIRE_EQUAL(scanned_set.size(), expected_set.size());
+        BOOST_REQUIRE(scanned_set == expected_set);
+    });
+}
+
+
+// Test: scan an empty table returns no items.
+SEASTAR_TEST_CASE(test_scan_table_empty) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        alternator_test_executor exec;
+        exec.start(e);
+        auto stop_exec = defer([&] { exec.stop(); });
+
+        exec.create_table(rjson::parse(R"({
+            "TableName": "emptytbl",
+            "BillingMode": "PAY_PER_REQUEST",
+            "AttributeDefinitions": [
+                {"AttributeName": "p", "AttributeType": "S"}
+            ],
+            "KeySchema": [
+                {"AttributeName": "p", "KeyType": "HASH"}
+            ]
+        })"));
+
+        auto& proxy = e.get_storage_proxy().local();
+        auto schema = e.local_db().find_schema("alternator_emptytbl", "emptytbl");
+
+        size_t count = 0;
+        abort_source as;
+        seastar::semaphore scan_permit_sem{1};
+        alternator::scan_table(proxy, schema, as,
+            make_test_service_permit(scan_permit_sem),
+            [&count] (rjson::value) -> future<> {
+                ++count;
+                return make_ready_future<>();
+            }).get();
+
+        BOOST_REQUIRE_EQUAL(count, 0);
+    });
+}
+
+// Test: scan a table with only a hash key (no sort key).
+SEASTAR_TEST_CASE(test_scan_table_hash_only) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        alternator_test_executor exec;
+        exec.start(e);
+        auto stop_exec = defer([&] { exec.stop(); });
+
+        exec.create_table(rjson::parse(R"({
+            "TableName": "hashonly",
+            "BillingMode": "PAY_PER_REQUEST",
+            "AttributeDefinitions": [
+                {"AttributeName": "p", "AttributeType": "S"}
+            ],
+            "KeySchema": [
+                {"AttributeName": "p", "KeyType": "HASH"}
+            ]
+        })"));
+
+        std::multiset<std::tuple<std::string, std::string>> scanned_set, expected_set;
+
+        // Insert 10 items with numeric "score" attributes.
+        for (int i = 0; i < 10; i++) {
+            exec.put_item(make_put_item_request("hashonly", format("key{}", i), std::nullopt, "score", format("{}", i * 10)));
+            expected_set.emplace(format("key{}", i), format("{}", i * 10));
+        }
+
+        auto& proxy = e.get_storage_proxy().local();
+        auto schema = e.local_db().find_schema("alternator_hashonly", "hashonly");
+
+        abort_source as;
+        seastar::semaphore scan_permit_sem{1};
+        alternator::scan_table(proxy, schema, as,
+            make_test_service_permit(scan_permit_sem),
+            [&scanned_set] (rjson::value item) -> future<> {
+                BOOST_REQUIRE(item.IsObject());
+                std::multiset<std::string_view> expected_keys = {"p", "score"};
+                std::multiset<std::string_view> actual_keys;
+                for (auto it = item.MemberBegin(); it != item.MemberEnd(); ++it) {
+                    actual_keys.insert(rjson::to_string_view(it->name));
+                }
+                BOOST_REQUIRE_EQUAL_COLLECTIONS(expected_keys.begin(), expected_keys.end(), actual_keys.begin(), actual_keys.end());
+                scanned_set.emplace(get_string_attr(item, "p"),
+                                    get_string_attr(item, "score"));
+                return make_ready_future<>();
+            }).get();
+
+        BOOST_REQUIRE_EQUAL(scanned_set.size(), expected_set.size());
+        BOOST_REQUIRE(scanned_set == expected_set);
+    });
+}
+
+// Test: scan a table with only a hash key (no sort key) and without any additional attributes whatsoever.
+SEASTAR_TEST_CASE(test_scan_table_hash_only_no_additional_attrs) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        alternator_test_executor exec;
+        exec.start(e);
+        auto stop_exec = defer([&] { exec.stop(); });
+
+        exec.create_table(rjson::parse(R"({
+            "TableName": "hashonly",
+            "BillingMode": "PAY_PER_REQUEST",
+            "AttributeDefinitions": [
+                {"AttributeName": "p", "AttributeType": "S"}
+            ],
+            "KeySchema": [
+                {"AttributeName": "p", "KeyType": "HASH"}
+            ]
+        })"));
+
+        std::multiset<std::string> scanned_set, expected_set;
+
+        // Insert 10 items with no additional attributes.
+        for (int i = 0; i < 10; i++) {
+            exec.put_item(make_put_item_request("hashonly", format("key{}", i), std::nullopt));
+            expected_set.insert(format("key{}", i));
+        }
+
+        auto& proxy = e.get_storage_proxy().local();
+        auto schema = e.local_db().find_schema("alternator_hashonly", "hashonly");
+
+        abort_source as;
+        seastar::semaphore scan_permit_sem{1};
+        alternator::scan_table(proxy, schema, as,
+            make_test_service_permit(scan_permit_sem),
+            [&scanned_set] (rjson::value item) -> future<> {
+                BOOST_REQUIRE(item.IsObject());
+                std::multiset<std::string_view> expected_keys = { "p" };
+                std::multiset<std::string_view> actual_keys;
+                for (auto it = item.MemberBegin(); it != item.MemberEnd(); ++it) {
+                    actual_keys.insert(rjson::to_string_view(it->name));
+                }
+                BOOST_REQUIRE(actual_keys == expected_keys);
+                scanned_set.insert(get_string_attr(item, "p"));
+                return make_ready_future<>();
+            }).get();
+
+        BOOST_REQUIRE_EQUAL(scanned_set.size(), expected_set.size());
+        BOOST_REQUIRE(scanned_set == expected_set);
+    });
+}
+
+// Test: non-string DynamoDB attribute values survive the row-to-item conversion.
+SEASTAR_TEST_CASE(test_scan_table_non_string_attributes) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        alternator_test_executor exec;
+        exec.start(e);
+        auto stop_exec = defer([&] { exec.stop(); });
+
+        exec.create_table(rjson::parse(R"({
+            "TableName": "typedattrs",
+            "BillingMode": "PAY_PER_REQUEST",
+            "AttributeDefinitions": [
+                {"AttributeName": "p", "AttributeType": "S"}
+            ],
+            "KeySchema": [
+                {"AttributeName": "p", "KeyType": "HASH"}
+            ]
+        })"));
+
+        exec.put_item(make_put_item_request("typedattrs", "key", rjson::parse(R"({
+            "score": {"N": "42"},
+            "enabled": {"BOOL": true},
+            "payload": {"B": "aGVsbG8="},
+            "missing": {"NULL": true},
+            "string_set": {"SS": ["blue", "green"]},
+            "number_set": {"NS": ["1", "2.5"]},
+            "binary_set": {"BS": ["Zmlyc3Q=", "c2Vjb25k"]},
+            "nested": {"M": {"child": {"S": "value"}}},
+            "items": {"L": [{"S": "first"}, {"N": "7"}]}
+        })")));
+
+        auto& proxy = e.get_storage_proxy().local();
+        auto schema = e.local_db().find_schema("alternator_typedattrs", "typedattrs");
+
+        size_t callbacks = 0;
+        abort_source as;
+        auto compare_set = [](std::set<std::string_view> expected, const rjson::value& actual_array) {
+            BOOST_REQUIRE(actual_array.IsArray());
+            std::set<std::string_view> actual;
+            for (const auto& val : actual_array.GetArray()) {
+                actual.insert(rjson::to_string_view(val));
+            }
+            BOOST_REQUIRE_EQUAL_COLLECTIONS(expected.begin(), expected.end(), actual.begin(), actual.end());
+        };
+        seastar::semaphore scan_permit_sem{1};
+        alternator::scan_table(proxy, schema, as,
+            make_test_service_permit(scan_permit_sem),
+            [&] (rjson::value item) -> future<> {
+                ++callbacks;
+                BOOST_REQUIRE_EQUAL(get_string_attr(item, "p"), "key");
+
+                BOOST_REQUIRE(item.HasMember("score"));
+                BOOST_REQUIRE(item["score"].HasMember("N"));
+                BOOST_REQUIRE_EQUAL(rjson::to_string_view(item["score"]["N"]), "42");
+
+                BOOST_REQUIRE(item.HasMember("enabled"));
+                BOOST_REQUIRE(item["enabled"].HasMember("BOOL"));
+                BOOST_REQUIRE(item["enabled"]["BOOL"].GetBool());
+
+                BOOST_REQUIRE(item.HasMember("payload"));
+                BOOST_REQUIRE(item["payload"].HasMember("B"));
+                BOOST_REQUIRE_EQUAL(rjson::to_string_view(item["payload"]["B"]), "aGVsbG8=");
+
+                BOOST_REQUIRE(item.HasMember("missing"));
+                BOOST_REQUIRE(item["missing"].HasMember("NULL"));
+                BOOST_REQUIRE(item["missing"]["NULL"].GetBool());
+
+                BOOST_REQUIRE(item.HasMember("string_set"));
+                BOOST_REQUIRE(item["string_set"].HasMember("SS"));
+                const auto& string_set = item["string_set"]["SS"];
+                BOOST_REQUIRE(string_set.IsArray());
+                compare_set({"blue", "green"}, string_set);
+
+                BOOST_REQUIRE(item.HasMember("number_set"));
+                BOOST_REQUIRE(item["number_set"].HasMember("NS"));
+                const auto& number_set = item["number_set"]["NS"];
+                BOOST_REQUIRE(number_set.IsArray());
+                compare_set({"1", "2.5"}, number_set);
+
+                BOOST_REQUIRE(item.HasMember("binary_set"));
+                BOOST_REQUIRE(item["binary_set"].HasMember("BS"));
+                const auto& binary_set = item["binary_set"]["BS"];
+                BOOST_REQUIRE(binary_set.IsArray());
+                compare_set({"Zmlyc3Q=", "c2Vjb25k"}, binary_set);
+
+                BOOST_REQUIRE(item.HasMember("nested"));
+                BOOST_REQUIRE(item["nested"].HasMember("M"));
+                const auto& nested = item["nested"]["M"];
+                BOOST_REQUIRE(nested.HasMember("child"));
+                BOOST_REQUIRE(nested["child"].HasMember("S"));
+                BOOST_REQUIRE_EQUAL(rjson::to_string_view(nested["child"]["S"]), "value");
+
+                BOOST_REQUIRE(item.HasMember("items"));
+                BOOST_REQUIRE(item["items"].HasMember("L"));
+                const auto& items = item["items"]["L"];
+                BOOST_REQUIRE(items.IsArray());
+                BOOST_REQUIRE_EQUAL(items.Size(), 2);
+                BOOST_REQUIRE(items[0].HasMember("S"));
+                BOOST_REQUIRE_EQUAL(rjson::to_string_view(items[0]["S"]), "first");
+                BOOST_REQUIRE(items[1].HasMember("N"));
+                BOOST_REQUIRE_EQUAL(rjson::to_string_view(items[1]["N"]), "7");
+
+                return make_ready_future<>();
+            }).get();
+
+        BOOST_REQUIRE_EQUAL(callbacks, 1);
+    });
+}
+
+// Test: callback failures are propagated and stop the scan.
+SEASTAR_TEST_CASE(test_scan_table_callback_exception) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        alternator_test_executor exec;
+        exec.start(e);
+        auto stop_exec = defer([&] { exec.stop(); });
+
+        exec.create_table(rjson::parse(R"({
+            "TableName": "failtbl",
+            "BillingMode": "PAY_PER_REQUEST",
+            "AttributeDefinitions": [
+                {"AttributeName": "p", "AttributeType": "S"}
+            ],
+            "KeySchema": [
+                {"AttributeName": "p", "KeyType": "HASH"}
+            ]
+        })"));
+
+        for (int i = 0; i < 3; ++i) {
+            exec.put_item(make_put_item_request("failtbl", format("key{}", i), std::nullopt));
+        }
+
+        auto& proxy = e.get_storage_proxy().local();
+        auto schema = e.local_db().find_schema("alternator_failtbl", "failtbl");
+
+        size_t callbacks = 0;
+        abort_source as;
+        seastar::semaphore scan_permit_sem{1};
+        BOOST_REQUIRE_THROW(alternator::scan_table(proxy, schema, as,
+            make_test_service_permit(scan_permit_sem),
+            [&callbacks] (rjson::value) -> future<> {
+                ++callbacks;
+                return make_exception_future<>(std::runtime_error("expected scan callback failure"));
+            }).get(), std::runtime_error);
+        BOOST_REQUIRE_EQUAL(callbacks, 1);
+    });
+}
+
+// Test: abort requests are propagated and stop the scan.
+SEASTAR_TEST_CASE(test_scan_table_abort) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        alternator_test_executor exec;
+        exec.start(e);
+        auto stop_exec = defer([&] { exec.stop(); });
+
+        exec.create_table(rjson::parse(R"({
+            "TableName": "aborttbl",
+            "BillingMode": "PAY_PER_REQUEST",
+            "AttributeDefinitions": [
+                {"AttributeName": "p", "AttributeType": "S"}
+            ],
+            "KeySchema": [
+                {"AttributeName": "p", "KeyType": "HASH"}
+            ]
+        })"));
+
+        for (int i = 0; i < 3; ++i) {
+            exec.put_item(make_put_item_request("aborttbl", format("key{}", i), std::nullopt));
+        }
+
+        auto& proxy = e.get_storage_proxy().local();
+        auto schema = e.local_db().find_schema("alternator_aborttbl", "aborttbl");
+
+        seastar::semaphore scan_permit_sem{1};
+        abort_source already_aborted;
+        already_aborted.request_abort();
+        BOOST_REQUIRE_THROW(alternator::scan_table(proxy, schema, already_aborted,
+            make_test_service_permit(scan_permit_sem),
+            [] (rjson::value) -> future<> {
+                BOOST_FAIL("callback should not be called after aborting before scan start");
+                return make_ready_future<>();
+            }).get(), abort_requested_exception);
+
+        size_t callbacks = 0;
+        abort_source abort_during_scan;
+        BOOST_REQUIRE_THROW(alternator::scan_table(proxy, schema, abort_during_scan,
+            make_test_service_permit(scan_permit_sem),
+            [&callbacks, &abort_during_scan] (rjson::value) -> future<> {
+                ++callbacks;
+                abort_during_scan.request_abort();
+                return make_ready_future<>();
+            }).get(), abort_requested_exception);
+        BOOST_REQUIRE_EQUAL(callbacks, 1);
+    });
+}
+
+// Test: scan_table waits for each callback before invoking the next one.
+SEASTAR_TEST_CASE(test_scan_table_callback_is_awaited_sequentially) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        alternator_test_executor exec;
+        exec.start(e);
+        auto stop_exec = defer([&] { exec.stop(); });
+
+        exec.create_table(rjson::parse(R"({
+            "TableName": "sequencedtbl",
+            "BillingMode": "PAY_PER_REQUEST",
+            "AttributeDefinitions": [
+                {"AttributeName": "p", "AttributeType": "S"}
+            ],
+            "KeySchema": [
+                {"AttributeName": "p", "KeyType": "HASH"}
+            ]
+        })"));
+
+        for (int i = 0; i < 3; ++i) {
+            exec.put_item(make_put_item_request("sequencedtbl", format("key{}", i), std::nullopt));
+        }
+
+        auto& proxy = e.get_storage_proxy().local();
+        auto schema = e.local_db().find_schema("alternator_sequencedtbl", "sequencedtbl");
+
+        bool callback_in_progress = false;
+        size_t callbacks = 0;
+        abort_source as;
+        seastar::semaphore scan_permit_sem{1};
+        alternator::scan_table(proxy, schema, as,
+            make_test_service_permit(scan_permit_sem),
+            [&callback_in_progress, &callbacks] (rjson::value) -> future<> {
+                BOOST_REQUIRE(!callback_in_progress);
+                callback_in_progress = true;
+                ++callbacks;
+                return seastar::yield().then([&callback_in_progress] {
+                    BOOST_REQUIRE(callback_in_progress);
+                    callback_in_progress = false;
+                });
+            }).get();
+
+        BOOST_REQUIRE_EQUAL(callbacks, 3);
+        BOOST_REQUIRE(!callback_in_progress);
+    });
+}
+
+// Test: scan a table with lot of items to ensure paging works correctly. We insert 10000 items and verify that all are scanned.
+// Nothing special about 10000 itself, the number must be bigger than 4096, as scan_table() explicitly sets 4096 page size limit.
+SEASTAR_TEST_CASE(test_scan_table_lot_of_items) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        alternator_test_executor exec;
+        exec.start(e);
+        auto stop_exec = defer([&] { exec.stop(); });
+
+        exec.create_table(rjson::parse(R"({
+            "TableName": "hashonly",
+            "BillingMode": "PAY_PER_REQUEST",
+            "AttributeDefinitions": [
+                {"AttributeName": "p", "AttributeType": "S"}
+            ],
+            "KeySchema": [
+                {"AttributeName": "p", "KeyType": "HASH"}
+            ]
+        })"));
+
+        // Insert items with "score" attribute, so we could force paging. We know the page size
+        // so insert enough items to require 4 pages just to be safe.
+        constexpr size_t item_count = alternator::scan_table_page_size * 3 + 1;
+        for (size_t i = 0; i < item_count; i++) {
+            exec.put_item(make_put_item_request("hashonly", format("key{}", i), std::nullopt, "score", format("{}", i * 10)));
+        }
+
+        auto& proxy = e.get_storage_proxy().local();
+        auto schema = e.local_db().find_schema("alternator_hashonly", "hashonly");
+
+        std::multiset<std::string> scanned_keys;
+        abort_source as;
+        seastar::semaphore scan_permit_sem{1};
+        alternator::scan_table(proxy, schema, as,
+            make_test_service_permit(scan_permit_sem),
+            [&scanned_keys] (rjson::value item) -> future<> {
+                scanned_keys.insert(get_string_attr(item, "p"));
+                return make_ready_future<>();
+            }).get();
+
+        BOOST_REQUIRE_EQUAL(scanned_keys.size(), item_count);
+        for (size_t i = 0; i < item_count; i++) {
+            BOOST_REQUIRE(scanned_keys.count(format("key{}", i)) == 1);
+        }
+    });
+}


### PR DESCRIPTION
The export to S3 functionality implementation is splited into separate PRs, which are grouped into three separate sections:
- sink - takes a row representation (as `rjson::value`), processes it and stores it into it's final destination (we add `source` part as well, to simplify debugging),
- scan - produces content of the table as single `rjson::value` object for each row (in random order, but not repeating),
- orchestration - the logic that constructs sink / scan objects and manage them.

This patch implements full table scan function helper for orchestration section. The function creates a scanner, that reads whole table and calls a passed in callback with each item it reads.

Fixes: SCYLLADB-1888

Backport: none, new feature.