### PR TITLE
replica: make reads abortable

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -170,6 +170,9 @@ private:
     // Lazily allocated: only needed for memory-wait or inactive-read paths.
     std::unique_ptr<auxiliary_data> _aux_data;
 
+    // Subscription to an external abort_source, set via set_abort_source().
+    optimized_optional<abort_source::subscription> _abort_sub;
+
     uint64_t _need_cpu_branches = 0;
     uint64_t _awaits_branches = 0;
     uint64_t _sstables_read = 0;
@@ -411,6 +414,52 @@ public:
         _state = reader_permit::state::preemptive_aborted;
         _pr.set_exception(ex);
         _semaphore.on_permit_preemptive_aborted();
+    }
+
+    // Called (synchronously, inline) when the associated abort_source fires.
+    // Must be noexcept because it runs from abort_source::request_abort().
+    void on_abort(std::exception_ptr ex) noexcept {
+        if (_ex) {
+            return; // already failed (e.g. timed out), nothing to do
+        }
+        _ex = std::move(ex);
+        _ttl_timer.cancel();
+        ++_semaphore._stats.reads_aborted;
+
+        switch (_state) {
+            case state::waiting_for_admission:
+            case state::waiting_for_memory:
+            case state::waiting_for_execution:
+                // Dequeue the permit and unblock the waiting coroutine.
+                _pr.set_exception(_ex);
+                _semaphore.dequeue_permit(*this);
+                on_permit_inactive(reader_permit::state::preemptive_aborted);
+                break;
+            case state::inactive:
+                // Evict the inactive reader so the permit can be destroyed.
+                // After evict() returns *this may already be destroyed via the
+                // notify_handler / close path, so we must not access any member.
+                _semaphore.evict(*this, reader_concurrency_semaphore::evict_reason::permit);
+                return;
+            case state::active:
+            case state::active_need_cpu:
+            case state::active_await:
+                // _ex is set; the reader will propagate it at the next
+                // permit check-point (cache_mutation_reader, partition_snapshot_reader, etc.)
+                break;
+            case state::evicted:
+            case state::preemptive_aborted:
+                break;
+        }
+    }
+
+    void set_abort_source(abort_source& as) {
+        auto do_abort = [this, &as] () noexcept { on_abort(as.abort_requested_exception_ptr()); };
+        if (as.abort_requested()) {
+            do_abort();
+        } else {
+            _abort_sub = as.subscribe(std::move(do_abort));
+        }
     }
 
     void on_register_as_inactive() {
@@ -1567,6 +1616,12 @@ bool reader_concurrency_semaphore::should_evict_inactive_read() const noexcept {
 }
 
 future<> reader_concurrency_semaphore::do_wait_admission(reader_permit::impl& permit) {
+    // Abort_source may have already fired (or the source was already aborted
+    // when set_abort_source() was called) — fail fast without touching queues.
+    if (permit.aborted()) [[unlikely]] {
+        return make_exception_future<>(permit.get_abort_exception());
+    }
+
     if (!_execution_loop_future) {
         _execution_loop_future.emplace(execution_loop());
     }
@@ -1792,6 +1847,9 @@ void reader_concurrency_semaphore::on_permit_not_awaits() noexcept {
 future<reader_permit> reader_concurrency_semaphore::obtain_permit(schema_ptr schema, const char* const op_name, size_t memory,
         db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr, abort_source* as) {
     auto permit = reader_permit(*this, std::move(schema), std::string_view(op_name), {1, static_cast<ssize_t>(memory)}, timeout, std::move(trace_ptr));
+    if (as) {
+        permit->set_abort_source(*as);
+    }
     return do_wait_admission(*permit).then([permit] () mutable {
         return std::move(permit);
     });
@@ -1800,6 +1858,9 @@ future<reader_permit> reader_concurrency_semaphore::obtain_permit(schema_ptr sch
 future<reader_permit> reader_concurrency_semaphore::obtain_permit(schema_ptr schema, sstring&& op_name, size_t memory,
         db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr, abort_source* as) {
     auto permit = reader_permit(*this, std::move(schema), std::move(op_name), {1, static_cast<ssize_t>(memory)}, timeout, std::move(trace_ptr));
+    if (as) {
+        permit->set_abort_source(*as);
+    }
     return do_wait_admission(*permit).then([permit] () mutable {
         return std::move(permit);
     });
@@ -1820,6 +1881,9 @@ future<> reader_concurrency_semaphore::with_permit(schema_ptr schema, const char
     permit_holder = reader_permit(*this, std::move(schema), std::string_view(op_name), {1, static_cast<ssize_t>(memory)}, timeout, std::move(trace_ptr));
     auto permit = *permit_holder;
     permit->func() = std::move(func);
+    if (as) {
+        permit->set_abort_source(*as);
+    }
     return do_wait_admission(*permit);
 }
 
@@ -1838,6 +1902,12 @@ future<> reader_concurrency_semaphore::with_ready_permit(reader_permit::impl& pe
 }
 
 future<> reader_concurrency_semaphore::with_ready_permit(reader_permit permit, abort_source* as, read_func func) {
+    if (as) {
+        permit->set_abort_source(*as);
+    }
+    if (permit->aborted()) [[unlikely]] {
+        return make_exception_future<>(permit->get_abort_exception());
+    }
     permit->func() = std::move(func);
     return with_ready_permit(*permit);
 }

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1901,7 +1901,8 @@ future<> reader_concurrency_semaphore::with_ready_permit(reader_permit::impl& pe
     return fut;
 }
 
-future<> reader_concurrency_semaphore::with_ready_permit(reader_permit permit, abort_source* as, read_func func) {
+future<> reader_concurrency_semaphore::with_ready_permit(reader_permit permit, tracing::trace_state_ptr trace_ptr, abort_source* as, read_func func) {
+    permit->set_trace_state(std::move(trace_ptr));
     if (as) {
         permit->set_abort_source(*as);
     }

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1790,7 +1790,7 @@ void reader_concurrency_semaphore::on_permit_not_awaits() noexcept {
 }
 
 future<reader_permit> reader_concurrency_semaphore::obtain_permit(schema_ptr schema, const char* const op_name, size_t memory,
-        db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr) {
+        db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr, abort_source* as) {
     auto permit = reader_permit(*this, std::move(schema), std::string_view(op_name), {1, static_cast<ssize_t>(memory)}, timeout, std::move(trace_ptr));
     return do_wait_admission(*permit).then([permit] () mutable {
         return std::move(permit);
@@ -1798,7 +1798,7 @@ future<reader_permit> reader_concurrency_semaphore::obtain_permit(schema_ptr sch
 }
 
 future<reader_permit> reader_concurrency_semaphore::obtain_permit(schema_ptr schema, sstring&& op_name, size_t memory,
-        db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr) {
+        db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr, abort_source* as) {
     auto permit = reader_permit(*this, std::move(schema), std::move(op_name), {1, static_cast<ssize_t>(memory)}, timeout, std::move(trace_ptr));
     return do_wait_admission(*permit).then([permit] () mutable {
         return std::move(permit);
@@ -1816,7 +1816,7 @@ reader_permit reader_concurrency_semaphore::make_tracking_only_permit(schema_ptr
 }
 
 future<> reader_concurrency_semaphore::with_permit(schema_ptr schema, const char* const op_name, size_t memory,
-        db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr, reader_permit_opt& permit_holder, read_func func) {
+        db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr, abort_source* as, reader_permit_opt& permit_holder, read_func func) {
     permit_holder = reader_permit(*this, std::move(schema), std::string_view(op_name), {1, static_cast<ssize_t>(memory)}, timeout, std::move(trace_ptr));
     auto permit = *permit_holder;
     permit->func() = std::move(func);
@@ -1837,7 +1837,7 @@ future<> reader_concurrency_semaphore::with_ready_permit(reader_permit::impl& pe
     return fut;
 }
 
-future<> reader_concurrency_semaphore::with_ready_permit(reader_permit permit, read_func func) {
+future<> reader_concurrency_semaphore::with_ready_permit(reader_permit permit, abort_source* as, read_func func) {
     permit->func() = std::move(func);
     return with_ready_permit(*permit);
 }

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -20,6 +20,10 @@
 #include "utils/updateable_value.hh"
 #include "dht/i_partitioner_fwd.hh"
 
+namespace seastar {
+class abort_source;
+}
+
 namespace bi = boost::intrusive;
 
 using namespace seastar;
@@ -548,8 +552,15 @@ public:
     ///
     /// Some permits cannot be associated with any table, so passing nullptr as
     /// the schema parameter is allowed.
-    future<reader_permit> obtain_permit(schema_ptr schema, const char* const op_name, size_t memory, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr);
-    future<reader_permit> obtain_permit(schema_ptr schema, sstring&& op_name, size_t memory, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr);
+    ///
+    /// If \c as is provided, the admission wait can be cancelled early by
+    /// calling \c as->request_abort(), which causes the returned future to
+    /// resolve with \c abort_requested_exception.  After admission the
+    /// subscription remains active: callers may check
+    /// \c reader_permit::get_abort_exception() at yield points to propagate
+    /// the abort through their read logic.
+    future<reader_permit> obtain_permit(schema_ptr schema, const char* const op_name, size_t memory, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr, abort_source* as);
+    future<reader_permit> obtain_permit(schema_ptr schema, sstring&& op_name, size_t memory, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr, abort_source* as);
 
     /// Make a tracking only permit
     ///
@@ -586,8 +597,13 @@ public:
     ///
     /// Some permits cannot be associated with any table, so passing nullptr as
     /// the schema parameter is allowed.
+    ///
+    /// If \c as is provided, the read can be cancelled early by calling
+    /// \c as->request_abort(). Reads waiting in the admission queue are
+    /// removed immediately; active reads see the abort exception at the next
+    /// permit check-point inside the reader.
     future<> with_permit(schema_ptr schema, const char* const op_name, size_t memory, db::timeout_clock::time_point timeout,
-            tracing::trace_state_ptr trace_ptr, reader_permit_opt& permit_holder, read_func func);
+            tracing::trace_state_ptr trace_ptr, abort_source* as, reader_permit_opt& permit_holder, read_func func);
 
     /// Run the function through the semaphore's execution stage with a pre-admitted permit
     ///
@@ -596,7 +612,7 @@ public:
     /// available, e.g. when resuming a saved read. Using
     /// \ref obtain_permit(), then \ref with_ready_permit() is less
     /// optimal then just using \ref with_permit().
-    future<> with_ready_permit(reader_permit permit, read_func func);
+    future<> with_ready_permit(reader_permit permit, abort_source* as, read_func func);
 
     /// Set the total resources of the semaphore to \p r.
     ///

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -614,7 +614,7 @@ public:
     /// available, e.g. when resuming a saved read. Using
     /// \ref obtain_permit(), then \ref with_ready_permit() is less
     /// optimal then just using \ref with_permit().
-    future<> with_ready_permit(reader_permit permit, abort_source* as, read_func func);
+    future<> with_ready_permit(reader_permit permit, tracing::trace_state_ptr trace_ptr, abort_source* as, read_func func);
 
     /// Set the total resources of the semaphore to \p r.
     ///

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -206,6 +206,8 @@ public:
         uint64_t total_reads_killed_due_to_kill_limit = 0;
         // Total number of reads admitted, via all admission paths.
         uint64_t reads_admitted = 0;
+        // Total number of reads aborted by the user (via the abort_source param)
+        uint64_t reads_aborted = 0;
         // Total number of reads enqueued to wait for admission.
         uint64_t reads_enqueued_for_admission = 0;
         // Total number of reads enqueued to wait for memory.

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1859,7 +1859,7 @@ static db::rate_limiter::can_proceed account_singular_ranges_to_rate_limit(
 
 future<std::tuple<lw_shared_ptr<query::result>, cache_temperature>>
 database::query(schema_ptr query_schema, const query::read_command& cmd, query::result_options opts, const dht::partition_range_vector& ranges,
-                tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info) {
+                tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info, abort_source* as) {
     column_family& cf = find_column_family(cmd.cf_id);
 
     if (account_singular_ranges_to_rate_limit(_rate_limiter, cf, ranges, _dbcfg, rate_limit_info) == db::rate_limiter::can_proceed::no) {
@@ -1893,11 +1893,11 @@ database::query(schema_ptr query_schema, const query::read_command& cmd, query::
         future<> f = make_ready_future<>();
         if (querier_opt) {
             querier_opt->permit().set_trace_state(trace_state);
-            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), read_func));
+            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), as, read_func));
         } else {
             reader_permit_opt permit_holder;
             f = co_await coroutine::as_future(semaphore.with_permit(query_schema, "data-query", cf.estimate_read_memory_cost(), timeout,
-                        trace_state, permit_holder, read_func));
+                        trace_state, as, permit_holder, read_func));
         }
 
         if (!f.failed()) {
@@ -1927,7 +1927,7 @@ database::query(schema_ptr query_schema, const query::read_command& cmd, query::
 
 future<std::tuple<reconcilable_result, cache_temperature>>
 database::query_mutations(schema_ptr query_schema, const query::read_command& cmd, const dht::partition_range& range,
-                          tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, bool tombstone_gc_enabled) {
+                          tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, bool tombstone_gc_enabled, abort_source* as) {
     const auto short_read_allwoed = query::short_read(cmd.slice.options.contains<query::partition_slice::option::allow_short_read>());
     auto& semaphore = get_reader_concurrency_semaphore();
     auto max_result_size = cmd.max_result_size ? *cmd.max_result_size : get_query_max_result_size();
@@ -1958,11 +1958,11 @@ database::query_mutations(schema_ptr query_schema, const query::read_command& cm
         future<> f = make_ready_future<>();
         if (querier_opt) {
             querier_opt->permit().set_trace_state(trace_state);
-            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), read_func));
+            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), as, read_func));
         } else {
             reader_permit_opt permit_holder;
             f = co_await coroutine::as_future(semaphore.with_permit(query_schema, "mutation-query", cf.estimate_read_memory_cost(), timeout,
-                        trace_state, permit_holder, read_func));
+                        trace_state, as, permit_holder, read_func));
         }
 
         if (!f.failed()) {
@@ -2027,7 +2027,7 @@ db::timeout_semaphore& database::get_view_update_concurrency_sem() {
 }
 
 future<reader_permit> database::obtain_reader_permit(table& tbl, const char* const op_name, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr) {
-    return get_reader_concurrency_semaphore().obtain_permit(tbl.schema(), op_name, tbl.estimate_read_memory_cost(), timeout, std::move(trace_ptr));
+    return get_reader_concurrency_semaphore().obtain_permit(tbl.schema(), op_name, tbl.estimate_read_memory_cost(), timeout, std::move(trace_ptr), {});
 }
 
 future<reader_permit> database::obtain_reader_permit(schema_ptr schema, const char* const op_name, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr) {
@@ -4092,7 +4092,7 @@ future<utils::chunked_vector<temporary_buffer<char>>> database::sample_data_file
                 coroutine::lambda([&] (int) -> future<>
             {
                 auto permit = co_await local_db._system_read_concurrency_sem.obtain_permit(
-                    local_state.schema, "sample_data_files", chunk_size, no_timeout, nullptr);
+                    local_state.schema, "sample_data_files", chunk_size, no_timeout, nullptr, {});
                 auto [sst, offset] = get_next_chunk();
                 auto sample = co_await sst->data_read(offset, chunk_size, permit);
                 auto& out_buf = *out_it++;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1892,8 +1892,7 @@ database::query(schema_ptr query_schema, const query::read_command& cmd, query::
 
         future<> f = make_ready_future<>();
         if (querier_opt) {
-            querier_opt->permit().set_trace_state(trace_state);
-            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), as, read_func));
+            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), trace_state, as, read_func));
         } else {
             reader_permit_opt permit_holder;
             f = co_await coroutine::as_future(semaphore.with_permit(query_schema, "data-query", cf.estimate_read_memory_cost(), timeout,
@@ -1957,8 +1956,7 @@ database::query_mutations(schema_ptr query_schema, const query::read_command& cm
 
         future<> f = make_ready_future<>();
         if (querier_opt) {
-            querier_opt->permit().set_trace_state(trace_state);
-            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), as, read_func));
+            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), trace_state, as, read_func));
         } else {
             reader_permit_opt permit_holder;
             f = co_await coroutine::as_future(semaphore.with_permit(query_schema, "mutation-query", cf.estimate_read_memory_cost(), timeout,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1869,7 +1869,7 @@ static db::rate_limiter::can_proceed account_singular_ranges_to_rate_limit(
 
 future<std::tuple<lw_shared_ptr<query::result>, cache_temperature>>
 database::query(schema_ptr query_schema, const query::read_command& cmd, query::result_options opts, const dht::partition_range_vector& ranges,
-                tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info) {
+                tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info, abort_source* as) {
     column_family& cf = find_column_family(cmd.cf_id);
 
     if (account_singular_ranges_to_rate_limit(_rate_limiter, cf, ranges, _dbcfg, rate_limit_info) == db::rate_limiter::can_proceed::no) {
@@ -1903,11 +1903,11 @@ database::query(schema_ptr query_schema, const query::read_command& cmd, query::
         future<> f = make_ready_future<>();
         if (querier_opt) {
             querier_opt->permit().set_trace_state(trace_state);
-            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), read_func));
+            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), as, read_func));
         } else {
             reader_permit_opt permit_holder;
             f = co_await coroutine::as_future(semaphore.with_permit(query_schema, "data-query", cf.estimate_read_memory_cost(), timeout,
-                        trace_state, permit_holder, read_func));
+                        trace_state, as, permit_holder, read_func));
         }
 
         if (!f.failed()) {
@@ -1937,7 +1937,7 @@ database::query(schema_ptr query_schema, const query::read_command& cmd, query::
 
 future<std::tuple<reconcilable_result, cache_temperature>>
 database::query_mutations(schema_ptr query_schema, const query::read_command& cmd, const dht::partition_range& range,
-                          tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, bool tombstone_gc_enabled) {
+                          tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, bool tombstone_gc_enabled, abort_source* as) {
     const auto short_read_allwoed = query::short_read(cmd.slice.options.contains<query::partition_slice::option::allow_short_read>());
     auto& semaphore = get_reader_concurrency_semaphore();
     auto max_result_size = cmd.max_result_size ? *cmd.max_result_size : get_query_max_result_size();
@@ -1968,11 +1968,11 @@ database::query_mutations(schema_ptr query_schema, const query::read_command& cm
         future<> f = make_ready_future<>();
         if (querier_opt) {
             querier_opt->permit().set_trace_state(trace_state);
-            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), read_func));
+            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), as, read_func));
         } else {
             reader_permit_opt permit_holder;
             f = co_await coroutine::as_future(semaphore.with_permit(query_schema, "mutation-query", cf.estimate_read_memory_cost(), timeout,
-                        trace_state, permit_holder, read_func));
+                        trace_state, as, permit_holder, read_func));
         }
 
         if (!f.failed()) {
@@ -2037,7 +2037,7 @@ db::timeout_semaphore& database::get_view_update_concurrency_sem() {
 }
 
 future<reader_permit> database::obtain_reader_permit(table& tbl, const char* const op_name, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr) {
-    return get_reader_concurrency_semaphore().obtain_permit(tbl.schema(), op_name, tbl.estimate_read_memory_cost(), timeout, std::move(trace_ptr));
+    return get_reader_concurrency_semaphore().obtain_permit(tbl.schema(), op_name, tbl.estimate_read_memory_cost(), timeout, std::move(trace_ptr), {});
 }
 
 future<reader_permit> database::obtain_reader_permit(schema_ptr schema, const char* const op_name, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr) {
@@ -4134,7 +4134,7 @@ future<utils::chunked_vector<temporary_buffer<char>>> database::sample_data_file
                 coroutine::lambda([&] (int) -> future<>
             {
                 auto permit = co_await local_db._system_read_concurrency_sem.obtain_permit(
-                    local_state.schema, "sample_data_files", chunk_size, no_timeout, nullptr);
+                    local_state.schema, "sample_data_files", chunk_size, no_timeout, nullptr, {});
                 auto [sst, offset] = get_next_chunk();
                 auto sample = co_await sst->data_read(offset, chunk_size, permit);
                 auto& out_buf = *out_it++;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1902,8 +1902,7 @@ database::query(schema_ptr query_schema, const query::read_command& cmd, query::
 
         future<> f = make_ready_future<>();
         if (querier_opt) {
-            querier_opt->permit().set_trace_state(trace_state);
-            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), as, read_func));
+            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), trace_state, as, read_func));
         } else {
             reader_permit_opt permit_holder;
             f = co_await coroutine::as_future(semaphore.with_permit(query_schema, "data-query", cf.estimate_read_memory_cost(), timeout,
@@ -1967,8 +1966,7 @@ database::query_mutations(schema_ptr query_schema, const query::read_command& cm
 
         future<> f = make_ready_future<>();
         if (querier_opt) {
-            querier_opt->permit().set_trace_state(trace_state);
-            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), as, read_func));
+            f = co_await coroutine::as_future(semaphore.with_ready_permit(querier_opt->permit(), trace_state, as, read_func));
         } else {
             reader_permit_opt permit_holder;
             f = co_await coroutine::as_future(semaphore.with_permit(query_schema, "mutation-query", cf.estimate_read_memory_cost(), timeout,

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -2021,9 +2021,11 @@ public:
 
     future<std::tuple<lw_shared_ptr<query::result>, cache_temperature>> query(schema_ptr query_schema, const query::read_command& cmd, query::result_options opts,
                                                                   const dht::partition_range_vector& ranges, tracing::trace_state_ptr trace_state,
-                                                                  db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info = std::monostate{});
+                                                                  db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info = std::monostate{},
+                                                                  abort_source* as = nullptr);
     future<std::tuple<reconcilable_result, cache_temperature>> query_mutations(schema_ptr query_schema, const query::read_command& cmd, const dht::partition_range& range,
-                                                tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, bool tombstone_gc_enabled = true);
+                                                tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, bool tombstone_gc_enabled = true,
+                                                abort_source* as = nullptr);
     // Apply the mutation atomically.
     // Throws timed_out_error when timeout is reached.
     future<db::large_data_violation_type> apply(schema_ptr, const frozen_mutation&, tracing::trace_state_ptr tr_state, db::commitlog_force_sync sync, db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info = std::monostate{}, bool skip_large_data_guardrails = false);
@@ -2395,6 +2397,6 @@ public:
     }
     virtual future<reader_permit> obtain_reader_permit(schema_ptr schema, const char* const description, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr) override {
         auto& cf = _db.local().find_column_family(_table_id);
-        return semaphore().obtain_permit(schema, description, cf.estimate_read_memory_cost(), timeout, std::move(trace_ptr));
+        return semaphore().obtain_permit(schema, description, cf.estimate_read_memory_cost(), timeout, std::move(trace_ptr), nullptr);
     }
 };

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -2032,9 +2032,11 @@ public:
 
     future<std::tuple<lw_shared_ptr<query::result>, cache_temperature>> query(schema_ptr query_schema, const query::read_command& cmd, query::result_options opts,
                                                                   const dht::partition_range_vector& ranges, tracing::trace_state_ptr trace_state,
-                                                                  db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info = std::monostate{});
+                                                                  db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info = std::monostate{},
+                                                                  abort_source* as = nullptr);
     future<std::tuple<reconcilable_result, cache_temperature>> query_mutations(schema_ptr query_schema, const query::read_command& cmd, const dht::partition_range& range,
-                                                tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, bool tombstone_gc_enabled = true);
+                                                tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, bool tombstone_gc_enabled = true,
+                                                abort_source* as = nullptr);
     // Apply the mutation atomically.
     // Throws timed_out_error when timeout is reached.
     future<db::large_data_violation_type> apply(schema_ptr, const frozen_mutation&, tracing::trace_state_ptr tr_state, db::commitlog_force_sync sync, db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info = std::monostate{}, bool skip_large_data_guardrails = false);
@@ -2414,6 +2416,6 @@ public:
     }
     virtual future<reader_permit> obtain_reader_permit(schema_ptr schema, const char* const description, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr) override {
         auto& cf = _db.local().find_column_family(_table_id);
-        return semaphore().obtain_permit(schema, description, cf.estimate_read_memory_cost(), timeout, std::move(trace_ptr));
+        return semaphore().obtain_permit(schema, description, cf.estimate_read_memory_cost(), timeout, std::move(trace_ptr), nullptr);
     }
 };

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5356,7 +5356,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     future<row_locker::lock_holder> lockf = local_base_lock(base, m.decorated_key(), slice.default_row_ranges(), timeout);
     auto lock = co_await std::move(lockf);
     auto pk = dht::partition_range::make_singular(m.decorated_key());
-    auto permit = co_await sem.obtain_permit(base, "push-view-updates-read-before-write", estimate_read_memory_cost(), timeout, tr_state);
+    auto permit = co_await sem.obtain_permit(base, "push-view-updates-read-before-write", estimate_read_memory_cost(), timeout, tr_state, {});
     auto reader = source.make_mutation_reader(base, permit, pk, slice, tr_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
     co_await gen->generate_and_propagate_view_updates(*this, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now, timeout);
     tracing::trace(tr_state, "View updates for {}.{} were generated and propagated", base->ks_name(), base->cf_name());

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5047,6 +5047,7 @@ table::query(schema_ptr query_schema,
         if (table_name && *table_name == _schema->cf_name()) {
             tlogger.info("replica_query_wait: waiting");
             co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes(5));
+            tlogger.info("replica_query_wait: done");
         }
     });
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5264,6 +5264,7 @@ table::query(schema_ptr query_schema,
         if (table_name && *table_name == _schema->cf_name()) {
             tlogger.info("replica_query_wait: waiting");
             co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes(5));
+            tlogger.info("replica_query_wait: done");
         }
     });
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5571,7 +5571,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     future<row_locker::lock_holder> lockf = local_base_lock(base, m.decorated_key(), slice.default_row_ranges(), timeout);
     auto lock = co_await std::move(lockf);
     auto pk = dht::partition_range::make_singular(m.decorated_key());
-    auto permit = co_await sem.obtain_permit(base, "push-view-updates-read-before-write", estimate_read_memory_cost(), timeout, tr_state);
+    auto permit = co_await sem.obtain_permit(base, "push-view-updates-read-before-write", estimate_read_memory_cost(), timeout, tr_state, {});
     auto reader = source.make_mutation_reader(base, permit, pk, slice, tr_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
     co_await gen->generate_and_propagate_view_updates(*this, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now, timeout);
     tracing::trace(tr_state, "View updates for {}.{} were generated and propagated", base->ks_name(), base->cf_name());

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1566,7 +1566,7 @@ future<> sstable::load_first_and_last_position_in_partition() {
     }
 
     auto& sem = _manager.sstable_metadata_concurrency_sem();
-    reader_permit permit = co_await sem.obtain_permit(_schema, "sstable::load_first_and_last_position_range", sstable_buffer_size, db::no_timeout, {});
+    reader_permit permit = co_await sem.obtain_permit(_schema, "sstable::load_first_and_last_position_range", sstable_buffer_size, db::no_timeout, {}, {});
     auto first_pos_opt = co_await find_first_position_in_partition(permit, get_first_decorated_key(), false);
     auto last_pos_opt = co_await find_first_position_in_partition(permit, get_last_decorated_key(), true);
 
@@ -3815,7 +3815,7 @@ future<uint64_t> sstable::estimated_keys_for_range(const dht::token_range& range
 
     auto& sem = _manager.sstable_metadata_concurrency_sem();
     uint64_t estimated_memory = 16 * 1024; // Value pulled from thin air
-    reader_permit permit = co_await sem.obtain_permit(_schema, "sstable::estimated_keys_for_range", estimated_memory, db::no_timeout, {});
+    reader_permit permit = co_await sem.obtain_permit(_schema, "sstable::estimated_keys_for_range", estimated_memory, db::no_timeout, {}, {});
     auto ir = make_index_reader(std::move(permit));
 
     std::exception_ptr ex;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1551,7 +1551,7 @@ future<> sstable::load_first_and_last_position_in_partition() {
     }
 
     auto& sem = _manager.sstable_metadata_concurrency_sem();
-    reader_permit permit = co_await sem.obtain_permit(_schema, "sstable::load_first_and_last_position_range", sstable_buffer_size, db::no_timeout, {});
+    reader_permit permit = co_await sem.obtain_permit(_schema, "sstable::load_first_and_last_position_range", sstable_buffer_size, db::no_timeout, {}, {});
     auto first_pos_opt = co_await find_first_position_in_partition(permit, get_first_decorated_key(), false);
     auto last_pos_opt = co_await find_first_position_in_partition(permit, get_last_decorated_key(), true);
 
@@ -3874,7 +3874,7 @@ future<uint64_t> sstable::estimated_keys_for_range(const dht::token_range& range
 
     auto& sem = _manager.sstable_metadata_concurrency_sem();
     uint64_t estimated_memory = 16 * 1024; // Value pulled from thin air
-    reader_permit permit = co_await sem.obtain_permit(_schema, "sstable::estimated_keys_for_range", estimated_memory, db::no_timeout, {});
+    reader_permit permit = co_await sem.obtain_permit(_schema, "sstable::estimated_keys_for_range", estimated_memory, db::no_timeout, {}, {});
     auto ir = make_index_reader(std::move(permit));
 
     std::exception_ptr ex;

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -2437,4 +2437,202 @@ SEASTAR_TEST_CASE(replica_read_timeout_no_exception) {
     }, cfg);
 }
 
+// Test that reads can be aborted via the abort_source* parameter, in all phases of the read.
+SEASTAR_TEST_CASE(replica_read_abort) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    testlog.debug("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+    return make_ready_future();
+#endif
+    cql_test_config cfg;
+    cfg.db_config->reader_concurrency_semaphore_preemptive_abort_factor.set(0.0);
+
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        const sstring ks_name = get_name();
+        const sstring tbl_name = "tbl";
+
+        e.execute_cql(format("CREATE KEYSPACE {} WITH"
+                    " replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND"
+                    " tablets = {{'enabled': 'true'}}", ks_name)).get();
+
+        e.execute_cql(format("CREATE TABLE {}.{} (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH compaction = {{'class': 'NullCompactionStrategy'}}", ks_name, tbl_name)).get();
+
+        auto& db = e.local_db();
+        auto& tbl = db.find_column_family(ks_name, tbl_name);
+        auto schema = tbl.schema();
+
+        auto& semaphore = db.get_reader_concurrency_semaphore();
+        const auto& semaphore_stats = semaphore.get_stats();
+
+        const auto& querier_cache_stats = db.get_querier_cache_stats();
+
+        auto& error_injection = utils::get_local_injector();
+        const auto error_injection_name = "replica_query_wait";
+
+        const auto dk = tests::generate_partition_key(tbl);
+
+        // Insert data
+        {
+            auto insert_id = e.prepare(format("INSERT INTO {}.{} (pk, ck, v) VALUES (?, ?, 0)", ks_name, tbl_name)).get();
+            const auto cql3_pk = cql3::raw_value::make_value(dk.key().explode().front());
+            for (int32_t ck = 0; ck < 30; ++ck) {
+                e.execute_prepared(insert_id, {cql3_pk, cql3::raw_value::make_value(serialized(ck))}).get();
+            }
+            replica::database::flush_table_on_all_shards(e.db(), ks_name, tbl_name).get();
+        }
+
+        auto execute_read = [&] (abort_source& as, std::optional<query_id> query_uuid = {}) -> future<query_id> {
+            auto first_page_slice = schema->full_slice();
+            first_page_slice.options.set<query::partition_slice::option::allow_short_read>();
+
+            auto ck = clustering_key::from_single_value(*schema, serialized(10));
+            auto second_page_slice = partition_slice_builder(*schema)
+                .set_specific_ranges(query::specific_ranges(dk.key(), {query::clustering_range::make_starting_with(query::clustering_range::bound(ck, false))}))
+                .build();
+
+            auto max_size = std::numeric_limits<uint64_t>::max();
+
+            auto cmd = query::read_command(
+                    schema->id(),
+                    schema->version(),
+                    query_uuid ? second_page_slice : first_page_slice,
+                    query::max_result_size(max_size, max_size, 10),
+                    query::tombstone_limit::max,
+                    query::row_limit::max,
+                    query::partition_limit::max,
+                    gc_clock::now(),
+                    {},
+                    query_uuid ? *query_uuid : query_id::create_random_id(),
+                    query_uuid ? query::is_first_page::no : query::is_first_page::yes);
+
+            dht::partition_range_vector ranges;
+            ranges.push_back(dht::partition_range::make_singular(dk));
+
+            const auto inserts_before = querier_cache_stats.inserts;
+
+            try {
+                co_await db.query(schema, cmd, query::result_options::only_result(), ranges, {}, db::no_timeout, std::monostate{}, &as);
+
+                BOOST_REQUIRE_EQUAL(querier_cache_stats.inserts, inserts_before + 1);
+                BOOST_REQUIRE_EQUAL(querier_cache_stats.population, 1);
+            } catch (abort_requested_exception) {
+                BOOST_REQUIRE_EQUAL(querier_cache_stats.inserts, inserts_before);
+                BOOST_REQUIRE_EQUAL(querier_cache_stats.population, 0);
+                throw;
+            } catch (...) {
+                BOOST_FAIL(format("Unexpected exception from db.query(): {}", std::current_exception()));
+            }
+
+            co_return cmd.query_uuid;
+        };
+
+        testlog.info("abort read before started");
+        {
+            abort_source as;
+            as.request_abort();
+
+            BOOST_REQUIRE_THROW(execute_read(as).get(), abort_requested_exception);
+        }
+
+        testlog.info("abort read while in queue");
+        {
+            auto permit = semaphore.make_tracking_only_permit(schema, "soak", db::no_timeout, {});
+            auto resources = permit.consume_resources(semaphore.available_resources());
+
+            abort_source as;
+
+            BOOST_REQUIRE_EQUAL(semaphore_stats.waiters, 0);
+
+            auto fut = execute_read(as);
+
+            BOOST_REQUIRE(eventually_true([&] { return semaphore_stats.waiters > 0; }));
+
+            as.request_abort();
+
+            BOOST_REQUIRE_THROW(fut.get(), abort_requested_exception);
+        }
+
+        testlog.info("abort read after admission");
+        {
+            error_injection.enable(error_injection_name, false, {{"table", tbl_name}});
+
+            abort_source as;
+
+            const auto reads_admitted_before = semaphore_stats.reads_admitted;
+
+            auto fut = execute_read(as);
+
+            BOOST_REQUIRE(eventually_true([&] { return semaphore_stats.reads_admitted > reads_admitted_before; }));
+            BOOST_REQUIRE(eventually_true([&] { return error_injection.waiters(error_injection_name) > 0; }));
+
+            as.request_abort();
+
+            error_injection.receive_message(error_injection_name);
+            error_injection.disable(error_injection_name);
+
+            BOOST_REQUIRE_THROW(fut.get(), abort_requested_exception);
+        }
+
+        testlog.info("abort read on second page before start");
+        {
+            abort_source as_firs_page;
+            const auto query_uuid = execute_read(as_firs_page).get();
+
+            abort_source as_second_page;
+            as_second_page.request_abort();
+
+            const auto misses_before = querier_cache_stats.misses;
+
+            BOOST_REQUIRE_THROW(execute_read(as_second_page, query_uuid).get(), abort_requested_exception);
+            BOOST_REQUIRE_EQUAL(querier_cache_stats.misses, misses_before);
+        }
+
+        testlog.info("abort read on second page while queued");
+        {
+            abort_source as_firs_page;
+            const auto query_uuid = execute_read(as_firs_page).get();
+
+            BOOST_REQUIRE(semaphore.try_evict_one_inactive_read());
+            auto permit = semaphore.make_tracking_only_permit(schema, "soak", db::no_timeout, {});
+            auto resources = permit.consume_resources(semaphore.available_resources());
+
+            abort_source as_second_page;
+
+            const auto misses_before = querier_cache_stats.misses;
+
+            auto fut = execute_read(as_second_page, query_uuid);
+
+            BOOST_REQUIRE(eventually_true([&] { return semaphore_stats.waiters > 0; }));
+
+            as_second_page.request_abort();
+
+            BOOST_REQUIRE_THROW(fut.get(), abort_requested_exception);
+            BOOST_REQUIRE_EQUAL(querier_cache_stats.misses, misses_before + 1);
+        }
+
+        testlog.info("abort read on second page after admission");
+        {
+            abort_source as_firs_page;
+            const auto query_uuid = execute_read(as_firs_page).get();
+
+            error_injection.enable(error_injection_name, false, {{"table", tbl_name}});
+
+            abort_source as_second_page;
+
+            const auto reads_admitted_before = semaphore_stats.reads_admitted;
+
+            auto fut = execute_read(as_second_page, query_uuid);
+
+            BOOST_REQUIRE(eventually_true([&] { return semaphore_stats.reads_admitted > reads_admitted_before; }));
+            BOOST_REQUIRE(eventually_true([&] { return error_injection.waiters(error_injection_name) > 0; }));
+
+            as_second_page.request_abort();
+
+            error_injection.receive_message(error_injection_name);
+            error_injection.disable(error_injection_name);
+
+            BOOST_REQUIRE_THROW(fut.get(), abort_requested_exception);
+        }
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -2488,4 +2488,202 @@ SEASTAR_THREAD_TEST_CASE(test_full_position_cmp_ring_order) {
     BOOST_REQUIRE(is_sorted_by_full_position);
 }
 
+// Test that reads can be aborted via the abort_source* parameter, in all phases of the read.
+SEASTAR_TEST_CASE(replica_read_abort) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    testlog.debug("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+    return make_ready_future();
+#endif
+    cql_test_config cfg;
+    cfg.db_config->reader_concurrency_semaphore_preemptive_abort_factor.set(0.0);
+
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        const sstring ks_name = get_name();
+        const sstring tbl_name = "tbl";
+
+        e.execute_cql(format("CREATE KEYSPACE {} WITH"
+                    " replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND"
+                    " tablets = {{'enabled': 'true'}}", ks_name)).get();
+
+        e.execute_cql(format("CREATE TABLE {}.{} (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH compaction = {{'class': 'NullCompactionStrategy'}}", ks_name, tbl_name)).get();
+
+        auto& db = e.local_db();
+        auto& tbl = db.find_column_family(ks_name, tbl_name);
+        auto schema = tbl.schema();
+
+        auto& semaphore = db.get_reader_concurrency_semaphore();
+        const auto& semaphore_stats = semaphore.get_stats();
+
+        const auto& querier_cache_stats = db.get_querier_cache_stats();
+
+        auto& error_injection = utils::get_local_injector();
+        const auto error_injection_name = "replica_query_wait";
+
+        const auto dk = tests::generate_partition_key(tbl);
+
+        // Insert data
+        {
+            auto insert_id = e.prepare(format("INSERT INTO {}.{} (pk, ck, v) VALUES (?, ?, 0)", ks_name, tbl_name)).get();
+            const auto cql3_pk = cql3::raw_value::make_value(dk.key().explode().front());
+            for (int32_t ck = 0; ck < 30; ++ck) {
+                e.execute_prepared(insert_id, {cql3_pk, cql3::raw_value::make_value(serialized(ck))}).get();
+            }
+            replica::database::flush_table_on_all_shards(e.db(), ks_name, tbl_name).get();
+        }
+
+        auto execute_read = [&] (abort_source& as, std::optional<query_id> query_uuid = {}) -> future<query_id> {
+            auto first_page_slice = schema->full_slice();
+            first_page_slice.options.set<query::partition_slice::option::allow_short_read>();
+
+            auto ck = clustering_key::from_single_value(*schema, serialized(10));
+            auto second_page_slice = partition_slice_builder(*schema)
+                .set_specific_ranges(query::specific_ranges(dk.key(), {query::clustering_range::make_starting_with(query::clustering_range::bound(ck, false))}))
+                .build();
+
+            auto max_size = std::numeric_limits<uint64_t>::max();
+
+            auto cmd = query::read_command(
+                    schema->id(),
+                    schema->version(),
+                    query_uuid ? second_page_slice : first_page_slice,
+                    query::max_result_size(max_size, max_size, 10),
+                    query::tombstone_limit::max,
+                    query::row_limit::max,
+                    query::partition_limit::max,
+                    gc_clock::now(),
+                    {},
+                    query_uuid ? *query_uuid : query_id::create_random_id(),
+                    query_uuid ? query::is_first_page::no : query::is_first_page::yes);
+
+            dht::partition_range_vector ranges;
+            ranges.push_back(dht::partition_range::make_singular(dk));
+
+            const auto inserts_before = querier_cache_stats.inserts;
+
+            try {
+                co_await db.query(schema, cmd, query::result_options::only_result(), ranges, {}, db::no_timeout, std::monostate{}, &as);
+
+                BOOST_REQUIRE_EQUAL(querier_cache_stats.inserts, inserts_before + 1);
+                BOOST_REQUIRE_EQUAL(querier_cache_stats.population, 1);
+            } catch (abort_requested_exception) {
+                BOOST_REQUIRE_EQUAL(querier_cache_stats.inserts, inserts_before);
+                BOOST_REQUIRE_EQUAL(querier_cache_stats.population, 0);
+                throw;
+            } catch (...) {
+                BOOST_FAIL(format("Unexpected exception from db.query(): {}", std::current_exception()));
+            }
+
+            co_return cmd.query_uuid;
+        };
+
+        testlog.info("abort read before started");
+        {
+            abort_source as;
+            as.request_abort();
+
+            BOOST_REQUIRE_THROW(execute_read(as).get(), abort_requested_exception);
+        }
+
+        testlog.info("abort read while in queue");
+        {
+            auto permit = semaphore.make_tracking_only_permit(schema, "soak", db::no_timeout, {});
+            auto resources = permit.consume_resources(semaphore.available_resources());
+
+            abort_source as;
+
+            BOOST_REQUIRE_EQUAL(semaphore_stats.waiters, 0);
+
+            auto fut = execute_read(as);
+
+            BOOST_REQUIRE(eventually_true([&] { return semaphore_stats.waiters > 0; }));
+
+            as.request_abort();
+
+            BOOST_REQUIRE_THROW(fut.get(), abort_requested_exception);
+        }
+
+        testlog.info("abort read after admission");
+        {
+            error_injection.enable(error_injection_name, false, {{"table", tbl_name}});
+
+            abort_source as;
+
+            const auto reads_admitted_before = semaphore_stats.reads_admitted;
+
+            auto fut = execute_read(as);
+
+            BOOST_REQUIRE(eventually_true([&] { return semaphore_stats.reads_admitted > reads_admitted_before; }));
+            BOOST_REQUIRE(eventually_true([&] { return error_injection.waiters(error_injection_name) > 0; }));
+
+            as.request_abort();
+
+            error_injection.receive_message(error_injection_name);
+            error_injection.disable(error_injection_name);
+
+            BOOST_REQUIRE_THROW(fut.get(), abort_requested_exception);
+        }
+
+        testlog.info("abort read on second page before start");
+        {
+            abort_source as_firs_page;
+            const auto query_uuid = execute_read(as_firs_page).get();
+
+            abort_source as_second_page;
+            as_second_page.request_abort();
+
+            const auto misses_before = querier_cache_stats.misses;
+
+            BOOST_REQUIRE_THROW(execute_read(as_second_page, query_uuid).get(), abort_requested_exception);
+            BOOST_REQUIRE_EQUAL(querier_cache_stats.misses, misses_before);
+        }
+
+        testlog.info("abort read on second page while queued");
+        {
+            abort_source as_firs_page;
+            const auto query_uuid = execute_read(as_firs_page).get();
+
+            BOOST_REQUIRE(semaphore.try_evict_one_inactive_read());
+            auto permit = semaphore.make_tracking_only_permit(schema, "soak", db::no_timeout, {});
+            auto resources = permit.consume_resources(semaphore.available_resources());
+
+            abort_source as_second_page;
+
+            const auto misses_before = querier_cache_stats.misses;
+
+            auto fut = execute_read(as_second_page, query_uuid);
+
+            BOOST_REQUIRE(eventually_true([&] { return semaphore_stats.waiters > 0; }));
+
+            as_second_page.request_abort();
+
+            BOOST_REQUIRE_THROW(fut.get(), abort_requested_exception);
+            BOOST_REQUIRE_EQUAL(querier_cache_stats.misses, misses_before + 1);
+        }
+
+        testlog.info("abort read on second page after admission");
+        {
+            abort_source as_firs_page;
+            const auto query_uuid = execute_read(as_firs_page).get();
+
+            error_injection.enable(error_injection_name, false, {{"table", tbl_name}});
+
+            abort_source as_second_page;
+
+            const auto reads_admitted_before = semaphore_stats.reads_admitted;
+
+            auto fut = execute_read(as_second_page, query_uuid);
+
+            BOOST_REQUIRE(eventually_true([&] { return semaphore_stats.reads_admitted > reads_admitted_before; }));
+            BOOST_REQUIRE(eventually_true([&] { return error_injection.waiters(error_injection_name) > 0; }));
+
+            as_second_page.request_abort();
+
+            error_injection.receive_message(error_injection_name);
+            error_injection.disable(error_injection_name);
+
+            BOOST_REQUIRE_THROW(fut.get(), abort_requested_exception);
+        }
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -2427,6 +2427,7 @@ SEASTAR_TEST_CASE(replica_read_timeout_no_exception) {
                     "dummy",
                     1,
                     db::no_timeout,
+                    {},
                     {}));
             }).get();
 

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -2453,6 +2453,7 @@ SEASTAR_TEST_CASE(replica_read_timeout_no_exception) {
                     "dummy",
                     1,
                     db::no_timeout,
+                    {},
                     {}));
             }).get();
 

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -4448,7 +4448,7 @@ SEASTAR_TEST_CASE(test_multishard_reader_safe_to_create_with_admitted_permit) {
         };
 
         // timeout is used to break the deadlock in case this test fails
-        auto permit = semaphores.at(this_shard_id())->obtain_permit(s.schema(), "multishard_reader", 128 * 1024, db::timeout_clock::now() + 60s, {}).get();
+        auto permit = semaphores.at(this_shard_id())->obtain_permit(s.schema(), "multishard_reader", 128 * 1024, db::timeout_clock::now() + 60s, {}, {}).get();
         auto lifecycle_policy = seastar::make_shared<test_reader_lifecycle_policy>(reader_factory, std::make_unique<semaphore_factory>(semaphores));
 
         auto reader = make_multishard_combining_reader_for_tests(*sharder, std::move(lifecycle_policy), s.schema(), std::move(permit),

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -749,13 +749,13 @@ SEASTAR_THREAD_TEST_CASE(test_immediate_evict_on_insert) {
     test_querier_cache t;
 
     auto& sem = t.get_semaphore();
-    auto permit1 = sem.obtain_permit(t.get_schema(), get_name(), 0, db::no_timeout, {}).get();
+    auto permit1 = sem.obtain_permit(t.get_schema(), get_name(), 0, db::no_timeout, {}, {}).get();
 
     auto resources = permit1.consume_resources(reader_resources(sem.available_resources().count, 0));
 
     BOOST_CHECK_EQUAL(sem.available_resources().count, 0);
 
-    auto fut = sem.obtain_permit(t.get_schema(), get_name(), 1, db::no_timeout, {});
+    auto fut = sem.obtain_permit(t.get_schema(), get_name(), 1, db::no_timeout, {}, {});
 
     BOOST_CHECK_EQUAL(sem.get_stats().waiters, 1);
 
@@ -869,7 +869,7 @@ SEASTAR_THREAD_TEST_CASE(test_ttl_not_sticky_on_lookup) {
     test_querier_cache t(ttl_timeout_test_timeout);
 
     auto& sem = t.get_semaphore();
-    auto permit1 = sem.obtain_permit(t.get_schema(), get_name(), 1024, db::no_timeout, {}).get();
+    auto permit1 = sem.obtain_permit(t.get_schema(), get_name(), 1024, db::no_timeout, {}, {}).get();
 
     const auto entry = t.produce_first_page_and_save_mutation_querier();
 
@@ -892,7 +892,7 @@ SEASTAR_THREAD_TEST_CASE(test_timeout_is_applied_on_lookup) {
     test_querier_cache t;
 
     auto& sem = t.get_semaphore();
-    auto permit1 = sem.obtain_permit(t.get_schema(), get_name(), 1024, db::no_timeout, {}).get();
+    auto permit1 = sem.obtain_permit(t.get_schema(), get_name(), 1024, db::no_timeout, {}, {}).get();
 
     const auto entry = t.produce_first_page_and_save_mutation_querier();
 

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -3139,4 +3139,283 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_signal_detects_negati
     BOOST_REQUIRE_EQUAL(semaphore.consumed_resources(), reader_resources{});
 }
 
+// Verify that with_permit() returns abort_requested_exception immediately
+// (without queuing and without calling the read function) when the
+// abort_source has already been fired before with_permit() is called.
+SEASTAR_THREAD_TEST_CASE(test_with_permit_pre_aborted) {
+    simple_schema s;
+    const auto schema = s.schema();
+    const std::string test_name = get_name();
+
+    reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, test_name);
+    auto stop_sem = deferred_stop(semaphore);
+
+    abort_source as;
+    as.request_abort(); // fire before with_permit is even called
+
+    reader_permit_opt permit_holder;
+    bool lambda_called = false;
+    auto fut = semaphore.with_permit(schema, test_name.c_str(), 1024, db::no_timeout, {}, &as, permit_holder,
+            [&] (reader_permit) {
+                lambda_called = true;
+                return make_ready_future<>();
+            });
+
+    fut.wait();
+
+    BOOST_REQUIRE(fut.failed());
+    BOOST_CHECK_THROW(fut.get(), abort_requested_exception);
+    BOOST_REQUIRE(!lambda_called);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 0);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_admission, 0);
+}
+
+// Verify that with_permit() returns abort_requested_exception when the
+// abort_source fires while the permit is waiting in the admission queue.
+SEASTAR_THREAD_TEST_CASE(test_with_permit_abort_in_queue) {
+    simple_schema s;
+    const auto schema = s.schema();
+    const std::string test_name = get_name();
+
+    // count=1 so the second permit must queue
+    reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, test_name, 1);
+    auto stop_sem = deferred_stop(semaphore);
+
+    // Occupy the single admission slot
+    reader_permit_opt permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, {}).get();
+
+    // with_permit will queue because count=1 is exhausted
+    abort_source as;
+    reader_permit_opt permit2_holder;
+    bool lambda_called = false;
+    auto permit2_fut = semaphore.with_permit(schema, test_name.c_str(), 1024, db::no_timeout, {}, &as, permit2_holder,
+            [&] (reader_permit) {
+                lambda_called = true;
+                return make_ready_future<>();
+            });
+
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_queued_because_count_resources, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 0);
+    BOOST_REQUIRE(!permit2_fut.available());
+
+    as.request_abort();
+
+    permit2_fut.wait();
+
+    BOOST_REQUIRE(!lambda_called);
+    BOOST_REQUIRE(permit2_fut.failed());
+    BOOST_CHECK_THROW(permit2_fut.get(), abort_requested_exception);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 0);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 1);
+}
+
+// Verify that aborting a permit while the read function is executing sets the
+// abort exception on the permit.
+SEASTAR_THREAD_TEST_CASE(test_with_permit_abort_after_admission) {
+    simple_schema s;
+    const auto schema = s.schema();
+    const std::string test_name = get_name();
+
+    // Semaphore with unlimited resources so the permit is admitted immediately
+    reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, test_name);
+    auto stop_sem = deferred_stop(semaphore);
+
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 0);
+
+    abort_source as;
+    reader_permit_opt permit_holder;
+    bool lambda_called = false;
+
+    auto permit_fut = semaphore.with_permit(schema, test_name.c_str(), 1024, db::no_timeout, {}, &as, permit_holder,
+            [&lambda_called] (reader_permit p) -> future<> {
+                lambda_called = true;
+                // Infinite loop on purpose, testing that abort works.
+                while (true) {
+                    if (auto ex = p.get_abort_exception(); ex) {
+                        std::rethrow_exception(ex);
+                    }
+                    co_await yield();
+                }
+            });
+
+    BOOST_REQUIRE(eventually_true([&] { return lambda_called; }));
+
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 0);
+
+    as.request_abort();
+
+    permit_fut.wait();
+
+    BOOST_REQUIRE(permit_fut.failed());
+    BOOST_CHECK_THROW(permit_fut.get(), abort_requested_exception);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 1);
+}
+
+// Verify that with_ready_permit() returns abort_requested_exception
+// immediately (without calling the read function) when the
+// abort_source has already been fired before with_permit() is called.
+SEASTAR_THREAD_TEST_CASE(test_with_ready_permit_pre_aborted) {
+    simple_schema s;
+    const auto schema = s.schema();
+    const std::string test_name = get_name();
+
+    reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, test_name);
+    auto stop_sem = deferred_stop(semaphore);
+
+    auto permit = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, {}).get();
+
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 0);
+
+    abort_source as;
+    as.request_abort(); // fire before with_read_permit is even called
+
+    bool lambda_called = false;
+    auto fut = semaphore.with_ready_permit(permit, &as,
+            [&] (reader_permit) {
+                lambda_called = true;
+                return make_ready_future<>();
+            });
+
+    fut.wait();
+
+    BOOST_REQUIRE(fut.failed());
+    BOOST_CHECK_THROW(fut.get(), abort_requested_exception);
+    BOOST_REQUIRE(!lambda_called);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_admission, 0);
+}
+
+// Verify that aborting a permit while the read function is executing sets the
+// abort exception on the permit.
+SEASTAR_THREAD_TEST_CASE(test_with_ready_permit_abort) {
+    simple_schema s;
+    const auto schema = s.schema();
+    const std::string test_name = get_name();
+
+    // Semaphore with unlimited resources so the permit is admitted immediately
+    reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, test_name);
+    auto stop_sem = deferred_stop(semaphore);
+
+    auto permit = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, {}).get();
+
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 0);
+
+    abort_source as;
+    bool lambda_called = false;
+
+    auto permit_fut = semaphore.with_ready_permit(permit, &as,
+            [&lambda_called] (reader_permit p) -> future<> {
+                lambda_called = true;
+                // Infinite loop on purpose, testing that abort works.
+                while (true) {
+                    if (auto ex = p.get_abort_exception(); ex) {
+                        std::rethrow_exception(ex);
+                    }
+                    co_await yield();
+                }
+            });
+
+    BOOST_REQUIRE(eventually_true([&] { return lambda_called; }));
+
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 0);
+
+    as.request_abort();
+
+    permit_fut.wait();
+
+    BOOST_REQUIRE(permit_fut.failed());
+    BOOST_CHECK_THROW(permit_fut.get(), abort_requested_exception);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 1);
+}
+
+// Verify that obtain_permit() returns abort_requested_exception immediately
+// (without queuing) when the abort_source has already been fired before
+// obtain_permit() is called.
+SEASTAR_THREAD_TEST_CASE(test_obtain_permit_pre_aborted) {
+    simple_schema s;
+    const auto schema = s.schema();
+    const std::string test_name = get_name();
+
+    reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, test_name);
+    auto stop_sem = deferred_stop(semaphore);
+
+    abort_source as;
+    as.request_abort();
+
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 0);
+
+    auto permit_fut = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, &as);
+
+    permit_fut.wait();
+
+    BOOST_REQUIRE(permit_fut.failed());
+    BOOST_CHECK_THROW(permit_fut.get(), abort_requested_exception);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 0);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 0);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 1);
+}
+
+// Verify that obtain_permit() returns abort_requested_exception when the
+// abort_source fires while the permit is waiting in the admission queue.
+SEASTAR_THREAD_TEST_CASE(test_obtain_permit_abort_in_queue) {
+    simple_schema s;
+    const auto schema = s.schema();
+    const std::string test_name = get_name();
+
+    // count=1 so the second permit must queue
+    reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, test_name, 1);
+    auto stop_sem = deferred_stop(semaphore);
+
+    // Occupy the single admission slot
+    reader_permit_opt permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, {}).get();
+
+    // obtain_permit will queue because count=1 is exhausted
+    abort_source as;
+    auto permit2_fut = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, &as);
+
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 0);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_queued_because_count_resources, 1);
+    BOOST_REQUIRE(!permit2_fut.available());
+
+    as.request_abort();
+
+    permit2_fut.wait();
+
+    BOOST_REQUIRE(permit2_fut.failed());
+    BOOST_CHECK_THROW(permit2_fut.get(), abort_requested_exception);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 0);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 1);
+}
+
+// Verify that aborting a permit after admission sets the
+// abort exception on the permit.
+SEASTAR_THREAD_TEST_CASE(test_obtain_permit_aborted_after_admission) {
+    simple_schema s;
+    const auto schema = s.schema();
+    const std::string test_name = get_name();
+
+    reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, test_name);
+    auto stop_sem = deferred_stop(semaphore);
+
+    abort_source as;
+
+    auto permit = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, &as).get();
+
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 0);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
+    BOOST_REQUIRE(!permit.get_abort_exception());
+
+    as.request_abort();
+
+    BOOST_REQUIRE(permit.get_abort_exception());
+    BOOST_CHECK_THROW(std::rethrow_exception(permit.get_abort_exception()), abort_requested_exception);
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_aborted, 1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1185,7 +1185,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
 
     auto p2 = semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {}, {}).get();
     read rd2(p2);
-    auto fut2 = semaphore.with_ready_permit(p2, {}, rd2.get_read_func());
+    auto fut2 = semaphore.with_ready_permit(p2, {}, {}, rd2.get_read_func());
 
     // At this point we expect to have:
     // * 1 inactive read (not evicted)
@@ -2690,7 +2690,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_execution_stage_wakeu
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted_immediately, 1);
 
     bool func_called = false;
-    auto func_fut = semaphore.with_ready_permit(permit1, {}, [&] (reader_permit permit) {
+    auto func_fut = semaphore.with_ready_permit(permit1, {}, {}, [&] (reader_permit permit) {
         func_called = true;
         return sleep(std::chrono::milliseconds(1));
     });
@@ -3273,7 +3273,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_ready_permit_pre_aborted) {
     as.request_abort(); // fire before with_read_permit is even called
 
     bool lambda_called = false;
-    auto fut = semaphore.with_ready_permit(permit, &as,
+    auto fut = semaphore.with_ready_permit(permit, {}, &as,
             [&] (reader_permit) {
                 lambda_called = true;
                 return make_ready_future<>();
@@ -3307,7 +3307,7 @@ SEASTAR_THREAD_TEST_CASE(test_with_ready_permit_abort) {
     abort_source as;
     bool lambda_called = false;
 
-    auto permit_fut = semaphore.with_ready_permit(permit, &as,
+    auto permit_fut = semaphore.with_ready_permit(permit, {}, &as,
             [&lambda_called] (reader_permit p) -> future<> {
                 lambda_called = true;
                 // Infinite loop on purpose, testing that abort works.

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -113,14 +113,14 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_destroyed_permit_rele
 
     // Admitted, active
     {
-        auto permit = semaphore.obtain_permit(s.schema(), get_name(), 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(s.schema(), get_name(), 1024, db::no_timeout, {}, {}).get();
         auto units1 = permit.consume_memory(1024);
     }
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), initial_resources);
 
     // Admitted, inactive
     {
-        auto permit = semaphore.obtain_permit(s.schema(), get_name(), 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(s.schema(), get_name(), 1024, db::no_timeout, {}, {}).get();
         auto units1 = permit.consume_memory(1024);
 
         auto handle = semaphore.register_inactive_read(make_empty_mutation_reader(s.schema(), permit));
@@ -155,7 +155,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_readmission_preserves
 
     auto stop_sem = deferred_stop(semaphore);
 
-    reader_permit_opt permit = semaphore.obtain_permit(s.schema(), get_name(), 1024, db::no_timeout, {}).get();
+    reader_permit_opt permit = semaphore.obtain_permit(s.schema(), get_name(), 1024, db::no_timeout, {}, {}).get();
     BOOST_REQUIRE_EQUAL(permit->consumed_resources(), base_resources);
 
     std::optional<reader_permit::resource_units> residue_units;
@@ -288,7 +288,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_forward_progress) {
             if (_memory_only) {
                 _permit = _semaphore.make_tracking_only_permit(_schema, "reader_m", db::no_timeout, {});
             } else {
-                _permit = co_await _semaphore.obtain_permit(_schema, fmt::format("reader_{}", _evictable ? 'e' : 'a'), 1024, db::no_timeout, {});
+                _permit = co_await _semaphore.obtain_permit(_schema, fmt::format("reader_{}", _evictable ? 'e' : 'a'), 1024, db::no_timeout, {}, {});
             }
             _units = _permit->consume_memory(tests::random::get_int(128, 1024));
         }
@@ -433,7 +433,7 @@ SEASTAR_TEST_CASE(reader_restriction_file_tracking) {
     return async([&] {
         reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, get_name(), 100, 4 * 1024);
         auto stop_sem = deferred_stop(semaphore);
-        auto permit = semaphore.obtain_permit(nullptr, get_name(), 0, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(nullptr, get_name(), 0, db::no_timeout, {}, {}).get();
 
         {
             auto tracked_file = make_tracked_file(file(shared_ptr<file_impl>(make_shared<dummy_file_impl>())), permit);
@@ -493,11 +493,11 @@ SEASTAR_TEST_CASE(reader_concurrency_semaphore_timeout) {
         {
             auto timeout = db::timeout_clock::now() + std::chrono::duration_cast<db::timeout_clock::time_point::duration>(std::chrono::milliseconds{1});
 
-            reader_permit_opt permit1 = semaphore.obtain_permit(nullptr, "permit1", replica::new_reader_base_cost, timeout, {}).get();
+            reader_permit_opt permit1 = semaphore.obtain_permit(nullptr, "permit1", replica::new_reader_base_cost, timeout, {}, {}).get();
 
-            auto permit2_fut = semaphore.obtain_permit(nullptr, "permit2", replica::new_reader_base_cost, timeout, {});
+            auto permit2_fut = semaphore.obtain_permit(nullptr, "permit2", replica::new_reader_base_cost, timeout, {}, {});
 
-            auto permit3_fut = semaphore.obtain_permit(nullptr, "permit3", replica::new_reader_base_cost, timeout, {});
+            auto permit3_fut = semaphore.obtain_permit(nullptr, "permit3", replica::new_reader_base_cost, timeout, {}, {});
 
             BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 2);
 
@@ -541,9 +541,9 @@ SEASTAR_THREAD_TEST_CASE(reader_concurrency_semaphore_abort) {
 
         auto timeout = db::timeout_clock::now() + 60min;
 
-        reader_permit_opt permit1 = semaphore.obtain_permit(nullptr, "permit1", replica::new_reader_base_cost, timeout, {}).get();
+        reader_permit_opt permit1 = semaphore.obtain_permit(nullptr, "permit1", replica::new_reader_base_cost, timeout, {}, {}).get();
 
-        auto permit2_fut = semaphore.obtain_permit(nullptr, "permit2", replica::new_reader_base_cost, timeout, {});
+        auto permit2_fut = semaphore.obtain_permit(nullptr, "permit2", replica::new_reader_base_cost, timeout, {}, {});
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_admission, 1);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_memory, 0);
@@ -567,15 +567,15 @@ SEASTAR_TEST_CASE(reader_concurrency_semaphore_max_queue_length) {
         auto stop_sem = deferred_stop(semaphore);
 
         {
-            reader_permit_opt permit1 = semaphore.obtain_permit(nullptr, "permit1", replica::new_reader_base_cost, db::no_timeout, {}).get();
+            reader_permit_opt permit1 = semaphore.obtain_permit(nullptr, "permit1", replica::new_reader_base_cost, db::no_timeout, {}, {}).get();
 
-            auto permit2_fut = semaphore.obtain_permit(nullptr, "permit2", replica::new_reader_base_cost, db::no_timeout, {});
+            auto permit2_fut = semaphore.obtain_permit(nullptr, "permit2", replica::new_reader_base_cost, db::no_timeout, {}, {});
 
-            auto permit3_fut = semaphore.obtain_permit(nullptr, "permit3", replica::new_reader_base_cost, db::no_timeout, {});
+            auto permit3_fut = semaphore.obtain_permit(nullptr, "permit3", replica::new_reader_base_cost, db::no_timeout, {}, {});
 
             BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 2);
 
-            auto permit4_fut = semaphore.obtain_permit(nullptr, "permit4", replica::new_reader_base_cost, db::no_timeout, {});
+            auto permit4_fut = semaphore.obtain_permit(nullptr, "permit4", replica::new_reader_base_cost, db::no_timeout, {}, {});
 
             // The queue should now be full.
             BOOST_REQUIRE_THROW(permit4_fut.get(), std::runtime_error);
@@ -649,6 +649,7 @@ SEASTAR_THREAD_TEST_CASE(reader_concurrency_semaphore_dump_reader_diganostics) {
                         regular_permit_op_names.at(tests::random::get_int<unsigned>(0, regular_permit_op_names.size() - 1)),
                         1024,
                         db::timeout_clock::now() + std::chrono::seconds(timeout_seconds),
+                        {},
                         {});
 
                 if (!permit.permit_fut->available()) {
@@ -740,7 +741,7 @@ static void require_can_admit(schema_ptr schema, reader_concurrency_semaphore& s
             expected_can_admit, semaphore.available_resources());
     const auto stats_before = semaphore.get_stats();
 
-    auto admit_fut = semaphore.obtain_permit(schema, "require_can_admit", 1024, db::timeout_clock::now(), {});
+    auto admit_fut = semaphore.obtain_permit(schema, "require_can_admit", 1024, db::timeout_clock::now(), {}, {});
     admit_fut.wait();
     const bool can_admit = !admit_fut.failed();
     if (can_admit) {
@@ -781,13 +782,13 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
 
     // resources and waitlist
     {
-        reader_permit_opt permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}).get();
+        reader_permit_opt permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}, {}).get();
 
         require_can_admit(true, "enough resources");
 
         const auto stats_before = semaphore.get_stats();
 
-        auto enqueued_permit_fut = semaphore.obtain_permit(schema, get_name(), 2 * 1024, db::no_timeout, {});
+        auto enqueued_permit_fut = semaphore.obtain_permit(schema, get_name(), 2 * 1024, db::no_timeout, {}, {});
         {
             const auto stats_after = semaphore.get_stats();
             BOOST_REQUIRE(!enqueued_permit_fut.available());
@@ -809,7 +810,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
 
     // need_cpu and awaits
     {
-        auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}, {}).get();
 
         require_can_admit(true, "!need_cpu");
         {
@@ -838,7 +839,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
 
     // forward progress -- readmission
     {
-        auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}, {}).get();
 
         auto irh = semaphore.register_inactive_read(make_empty_mutation_reader(s.schema(), permit));
         BOOST_REQUIRE(semaphore.try_evict_one_inactive_read());
@@ -864,7 +865,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
 
     // inactive readers
     {
-        auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}, {}).get();
 
         require_can_admit(true, "!need_cpu");
         {
@@ -892,10 +893,10 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
 
     // evicting inactive readers for admission
     {
-        auto permit1 = semaphore.obtain_permit(schema, get_name(), 1024, db::timeout_clock::now(), {}).get();
+        auto permit1 = semaphore.obtain_permit(schema, get_name(), 1024, db::timeout_clock::now(), {}, {}).get();
         auto irh1 = semaphore.register_inactive_read(make_empty_mutation_reader(s.schema(), permit1));
 
-        auto permit2 = semaphore.obtain_permit(schema, get_name(), 1024, db::timeout_clock::now(), {}).get();
+        auto permit2 = semaphore.obtain_permit(schema, get_name(), 1024, db::timeout_clock::now(), {}, {}).get();
         auto irh2 = semaphore.register_inactive_read(make_empty_mutation_reader(s.schema(), permit2));
 
         BOOST_REQUIRE(eventually_true([&] { return !irh1 || !irh2; }));
@@ -911,7 +912,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
 
         const auto stats_before = semaphore.get_stats();
 
-        auto permit2_fut = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {});
+        auto permit2_fut = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}, {});
 
         const auto stats_after = semaphore.get_stats();
         BOOST_REQUIRE_EQUAL(stats_after.reads_admitted, stats_before.reads_admitted);
@@ -932,7 +933,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     {
         check_admitting_enqueued_read(
             [&] {
-                return reader_permit_opt(semaphore.obtain_permit(schema, get_name(), 2 * 1024, db::no_timeout, {}).get());
+                return reader_permit_opt(semaphore.obtain_permit(schema, get_name(), 2 * 1024, db::no_timeout, {}, {}).get());
             },
             [] (reader_permit_opt& permit1) {
                 permit1 = {};
@@ -947,7 +948,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     {
         check_admitting_enqueued_read(
             [&] {
-                return reader_permit_opt(semaphore.obtain_permit(schema, get_name(), 2 * 1024, db::no_timeout, {}).get());
+                return reader_permit_opt(semaphore.obtain_permit(schema, get_name(), 2 * 1024, db::no_timeout, {}, {}).get());
             },
             [&] (reader_permit_opt& permit1) {
                 return semaphore.register_inactive_read(make_empty_mutation_reader(s.schema(), *permit1));
@@ -961,7 +962,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     {
         check_admitting_enqueued_read(
             [&] {
-                auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}).get();
+                auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}, {}).get();
                 require_can_admit(true, "enough resources");
                 return std::pair(permit, std::optional<reader_permit::need_cpu_guard>{permit});
             }, [&] (std::pair<reader_permit, std::optional<reader_permit::need_cpu_guard>>& permit_and_need_cpu_guard) {
@@ -977,7 +978,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_admission) {
     {
         check_admitting_enqueued_read(
             [&] {
-                auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}).get();
+                auto permit = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}, {}).get();
                 require_can_admit(true, "enough resources");
                 return std::pair(permit, reader_permit::need_cpu_guard{permit});
             }, [&] (std::pair<reader_permit, reader_permit::need_cpu_guard>& permit_and_need_cpu_guard) {
@@ -998,7 +999,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_need_cpu_awaits) {
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 0);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, 0);
 
-    auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+    auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
     for (auto scenario = 0; scenario < 5; ++scenario) {
         testlog.info("Running scenario {}", scenario);
@@ -1179,19 +1180,19 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
         }
     };
 
-    auto p1 = semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {}).get();
+    auto p1 = semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {}, {}).get();
     auto irh1 = semaphore.register_inactive_read(make_empty_mutation_reader(ss.schema(), p1));
 
-    auto p2 = semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {}).get();
+    auto p2 = semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {}, {}).get();
     read rd2(p2);
-    auto fut2 = semaphore.with_ready_permit(p2, rd2.get_read_func());
+    auto fut2 = semaphore.with_ready_permit(p2, {}, rd2.get_read_func());
 
     // At this point we expect to have:
     // * 1 inactive read (not evicted)
     // * 1 need_cpu (but not awaiting) read on the ready list
     // * 1 waiter
     // * no more count resources left
-    auto p3_fut = semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {});
+    auto p3_fut = semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {}, {});
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 2); // (waiters includes _ready_list entries)
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_admission, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 0); // permit looses need_cpu status while waiting for execution
@@ -1234,8 +1235,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_set_resources) {
 
     BOOST_REQUIRE_EQUAL(semaphore.unreduced_memory(), 0);
 
-    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
-    auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
+    auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), reader_resources(2, 2 * 1024));
     BOOST_REQUIRE_EQUAL(semaphore.initial_resources(), reader_resources(4, 4 * 1024));
 
@@ -1256,7 +1257,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_set_resources) {
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), reader_resources(-1, 1024));
     BOOST_REQUIRE_EQUAL(semaphore.initial_resources(), reader_resources(1, 3 * 1024));
 
-    auto permit3_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
+    auto permit3_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {});
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_admission, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
 
@@ -1419,7 +1420,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_shared_pool) {
     BOOST_CHECK_LE(std::abs(sem1.available_resources().memory - expected_ded_per_sg), 2);
 
     // 2. Verify borrowing and returning
-    auto permit = sem1.obtain_permit(nullptr, "test", 0, db::no_timeout, {}).get();
+    auto permit = sem1.obtain_permit(nullptr, "test", 0, db::no_timeout, {}, {}).get();
     const ssize_t dedicated_mem = sem1.initial_resources().memory;
 
     {
@@ -1478,8 +1479,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_multiple_borrow
     const ssize_t dedicated2 = sem2.initial_resources().memory;
     const ssize_t shared_memory = shared_pool.total_memory();
 
-    auto permit1 = sem1.obtain_permit(nullptr, "test1", 0, db::no_timeout, {}).get();
-    auto permit2 = sem2.obtain_permit(nullptr, "test2", 0, db::no_timeout, {}).get();
+    auto permit1 = sem1.obtain_permit(nullptr, "test1", 0, db::no_timeout, {}, {}).get();
+    auto permit2 = sem2.obtain_permit(nullptr, "test2", 0, db::no_timeout, {}, {}).get();
 
     {
         // Both semaphores exhaust their dedicated memory
@@ -1602,8 +1603,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_shared_pool_raises_se
             shared_pool);
     auto stop_sem = deferred_stop(semaphore);
 
-    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 0, db::no_timeout, {}).get();
-    auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 0, db::no_timeout, {}).get();
+    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 0, db::no_timeout, {}, {}).get();
+    auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 0, db::no_timeout, {}, {}).get();
 
     std::vector<reader_permit::resource_units> res;
 
@@ -1666,13 +1667,13 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_shared_pool_no_starva
             shared_pool);
     auto stop_sem2 = deferred_stop(sem2);
 
-    auto sem1_active = reader_permit_opt(sem1.obtain_permit(nullptr, "sem1_active", dedicated, db::no_timeout, {}).get());
-    auto sem2_active = reader_permit_opt(sem2.obtain_permit(nullptr, "sem2_active", dedicated, db::no_timeout, {}).get());
+    auto sem1_active = reader_permit_opt(sem1.obtain_permit(nullptr, "sem1_active", dedicated, db::no_timeout, {}, {}).get());
+    auto sem2_active = reader_permit_opt(sem2.obtain_permit(nullptr, "sem2_active", dedicated, db::no_timeout, {}, {}).get());
 
     // sem1's head waiter needs more than the whole shared pool can hold; sem2's
     // head waiter would fit in what gets returned. sem1 registers first.
-    auto sem1_waiter = sem1.obtain_permit(nullptr, "sem1_waiter", dedicated, db::no_timeout, {});
-    auto sem2_waiter = sem2.obtain_permit(nullptr, "sem2_waiter", shared, db::no_timeout, {});
+    auto sem1_waiter = sem1.obtain_permit(nullptr, "sem1_waiter", dedicated, db::no_timeout, {}, {});
+    auto sem2_waiter = sem2.obtain_permit(nullptr, "sem2_waiter", shared, db::no_timeout, {}, {});
     BOOST_REQUIRE(!sem1_waiter.available());
     BOOST_REQUIRE(!sem2_waiter.available());
 
@@ -1751,8 +1752,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_shared_pool_wakes_mul
         auto& sem = *sems[i];
         // Active permit consumes all dedicated memory, so the waiter below has
         // to borrow from the shared pool to be admitted.
-        actives.emplace_back(sem.obtain_permit(nullptr, "active", dedicated, db::no_timeout, {}).get());
-        waiters.push_back(sem.obtain_permit(nullptr, "waiter", waiter_memory, db::no_timeout, {}));
+        actives.emplace_back(sem.obtain_permit(nullptr, "active", dedicated, db::no_timeout, {}, {}).get());
+        waiters.push_back(sem.obtain_permit(nullptr, "waiter", waiter_memory, db::no_timeout, {}, {}));
     }
 
     for (int i = 0; i < num_sems; ++i) {
@@ -1905,7 +1906,7 @@ private:
 public:
     explicit allocating_reader(reader_concurrency_semaphore& sem) : _sem(sem) {
         testlog.debug("[{}] allocating_reader created", fmt::ptr(this));
-        _admission_fut = sem.obtain_permit(nullptr, "reader", admission_cost, db::no_timeout, {}).then_wrapped([this] (future<reader_permit>&& permit_fut) {
+        _admission_fut = sem.obtain_permit(nullptr, "reader", admission_cost, db::no_timeout, {}, {}).then_wrapped([this] (future<reader_permit>&& permit_fut) {
             try {
                 _permit = std::move(permit_fut.get());
                 _state = state::request_memory;
@@ -2272,7 +2273,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_request_memory_preser
             initial_resources.memory, 100, utils::updateable_value<uint32_t>(serialize_multiplier));
     auto stop_sem = deferred_stop(semaphore);
 
-    auto sponge_permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+    auto sponge_permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
     uint64_t reads_enqueued_for_memory = 0;
 
@@ -2307,20 +2308,20 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_request_memory_preser
 
     // active
     {
-        auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
         do_check(permit, 0, 0, std::source_location::current());
     }
 
     // need_cpu
     {
-        auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
         reader_permit::need_cpu_guard ncpu_guard{permit};
         do_check(permit, 1, 0, std::source_location::current());
     }
 
     // awaits
     {
-        auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
         reader_permit::need_cpu_guard ncpu_guard{permit};
         reader_permit::awaits_guard awaits_guard{permit};
         do_check(permit, 1, 1, std::source_location::current());
@@ -2337,7 +2338,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_blessed_read_goes_ina
     simple_schema ss;
     auto s = ss.schema();
 
-    auto permit = semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {}).get();
+    auto permit = semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {}, {}).get();
 
     std::vector<reader_permit::resource_units> permit_res;
 
@@ -2366,7 +2367,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_stop_with_inactive_re
     simple_schema ss;
     auto s = ss.schema();
 
-    auto permit = reader_permit_opt(semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {}).get());
+    auto permit = reader_permit_opt(semaphore.obtain_permit(s, get_name(), 1024, db::no_timeout, {}, {}).get());
 
     auto handle = semaphore.register_inactive_read(make_empty_mutation_reader(s, *permit));
 
@@ -2395,8 +2396,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_permit_waiting_for_me
             initial_resources.memory, 100, utils::updateable_value<uint32_t>(serialize_multiplier));
     auto stop_sem = deferred_stop(semaphore);
 
-    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
-    auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
+    auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
     std::vector<reader_permit::resource_units> res;
 
@@ -2442,7 +2443,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_no_unnecessary_evicti
     simple_schema ss;
     auto s = ss.schema();
 
-    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
     // There are available resources
     {
@@ -2462,7 +2463,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_no_unnecessary_evicti
 
     // Count resources are on the limit but no one wants more
     {
-        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 0);
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 2 * 1024);
@@ -2496,13 +2497,13 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_no_unnecessary_evicti
 
     // There are waiters but they are not blocked on resources
     {
-        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
-        auto permit3 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
+        auto permit3 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
         std::optional<reader_permit::need_cpu_guard> ncpu_guard1{permit1};
         std::optional<reader_permit::need_cpu_guard> ncpu_guard2{permit2};
 
-        auto permit4_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
+        auto permit4_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {});
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_queued_because_need_cpu_permits, 1);
 
@@ -2534,11 +2535,11 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
 
     uint64_t evicted_reads = 0;
 
-    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
     // No count resources - obtaining new permit
     {
-        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 0);
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 2 * 1024);
@@ -2547,7 +2548,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
         BOOST_REQUIRE(handle);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
 
-        auto new_permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto new_permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
         BOOST_REQUIRE(!handle);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
@@ -2558,12 +2559,12 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
 
     // No count resources - waiter
     {
-        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 0);
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 2 * 1024);
 
-        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
+        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {});
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
 
         auto handle = semaphore.register_inactive_read(make_empty_mutation_reader(s, permit1));
@@ -2588,7 +2589,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
         BOOST_REQUIRE(handle);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
 
-        auto new_permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto new_permit = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
         BOOST_REQUIRE(!handle);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
@@ -2604,7 +2605,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 1);
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 0);
 
-        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
+        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {});
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
 
         auto handle = semaphore.register_inactive_read(make_empty_mutation_reader(s, permit1));
@@ -2620,14 +2621,14 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
 
     // No count resources - waiter blocked on something else too
     {
-        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 0);
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 2 * 1024);
 
         std::optional<reader_permit::need_cpu_guard> ncpu_guard{permit2};
 
-        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
+        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {});
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
 
         auto handle = semaphore.register_inactive_read(make_empty_mutation_reader(s, permit1));
@@ -2648,7 +2649,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
     // No memory resources - waiter blocked on something else too
     {
         semaphore.set_resources({initial_resources.count + 1, initial_resources.memory});
-        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
         auto units = permit1.consume_memory(2 * 1024);
 
         BOOST_REQUIRE_EQUAL(semaphore.available_resources().count, 1);
@@ -2656,7 +2657,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
 
         std::optional<reader_permit::need_cpu_guard> ncpu_guard{permit2};
 
-        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
+        auto new_permit_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {});
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
 
         auto handle = semaphore.register_inactive_read(make_empty_mutation_reader(s, permit1));
@@ -2683,13 +2684,13 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_execution_stage_wakeu
     reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, get_name(), initial_resources.count, initial_resources.memory, 100);
     auto stop_sem = deferred_stop(semaphore);
 
-    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
+    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {}).get();
 
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted_immediately, 1);
 
     bool func_called = false;
-    auto func_fut = semaphore.with_ready_permit(permit1, [&] (reader_permit permit) {
+    auto func_fut = semaphore.with_ready_permit(permit1, {}, [&] (reader_permit permit) {
         func_called = true;
         return sleep(std::chrono::milliseconds(1));
     });
@@ -2698,7 +2699,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_execution_stage_wakeu
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
 
     // trying to obtain a second permit should block on the _ready_list
-    auto permit2_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {});
+    auto permit2_fut = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}, {});
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_queued_because_ready_list, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 2);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
@@ -2768,7 +2769,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_live_update_cpu_concu
         ::require_can_admit(schema, semaphore, expected_can_admit, description, sl);
     };
 
-    auto permit1 = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}).get();
+    auto permit1 = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}, {}).get();
 
     require_can_admit(true, "!need_cpu");
     {
@@ -2776,7 +2777,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_live_update_cpu_concu
 
         require_can_admit(true, "need_cpu < cpu_concurrency");
 
-        auto permit2 = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}).get();
+        auto permit2 = semaphore.obtain_permit(schema, get_name(), 1024, db::no_timeout, {}, {}).get();
 
         // no change
         require_can_admit(true, "need_cpu < cpu_concurrency");
@@ -2817,14 +2818,14 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_wait_queue_overload_c
             reader_concurrency_semaphore_shared_pool::empty_pool());
     auto stop_sem = deferred_stop(semaphore);
 
-    reader_permit_opt permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}).get();
+    reader_permit_opt permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, {}).get();
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted_immediately, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 0);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().total_reads_shed_due_to_overload, 0);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().current_permits, 1);
 
-    auto permit2_fut = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {});
+    auto permit2_fut = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, {});
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted_immediately, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
@@ -2833,7 +2834,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_wait_queue_overload_c
 
     {
         reader_permit_opt permit_holder;
-        auto permit3_fut = semaphore.with_permit(schema, test_name.c_str(), 1024, db::no_timeout, {}, permit_holder, [] (reader_permit) {
+        auto permit3_fut = semaphore.with_permit(schema, test_name.c_str(), 1024, db::no_timeout, {}, {}, permit_holder, [] (reader_permit) {
             BOOST_FAIL("unexpected call to with permit lambda");
             return make_ready_future<>();
         });
@@ -2872,12 +2873,12 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_double_permit_abort) 
             reader_concurrency_semaphore_shared_pool::empty_pool());
     auto stop_sem = deferred_stop(semaphore);
 
-    reader_permit_opt permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}).get();
+    reader_permit_opt permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, {}).get();
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted_immediately, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 0);
 
-    reader_permit_opt permit2 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}).get();
+    reader_permit_opt permit2 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, {}).get();
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted, 2);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_admitted_immediately, 2);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 0);
@@ -2935,11 +2936,11 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_abort_preemptively_ab
 
     // Set a ridiculously long timeout to ensure permit will not be rejected due to timeout
     auto timeout = db::timeout_clock::now() + 60min;
-    auto permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}).get();
+    auto permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, {}).get();
     auto units1 = permit1.request_memory(2024).get();
 
     reader_permit_opt permit2_holder;
-    auto permit2_fut = semaphore.with_permit(schema, test_name.c_str(), 1024, timeout, {}, permit2_holder, [] (reader_permit) {
+    auto permit2_fut = semaphore.with_permit(schema, test_name.c_str(), 1024, timeout, {}, {}, permit2_holder, [] (reader_permit) {
         BOOST_FAIL("unexpected call to with permit lambda");
         return make_ready_future<>();
     });
@@ -2985,7 +2986,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_always_admit_one_perm
 
     // Scenario2: all memory use used by evicted permit (recouped count resource)
     {
-        auto permit = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}, {}).get();
         auto res = permit.consume_memory(4096);
 
         require_can_admit(schema, semaphore, false, "all memory used, cannot admit");
@@ -3023,7 +3024,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_release_base_resource
     const auto expected_consumed_resources = expected_base_resources;
 
     {
-        auto permit = semaphore.obtain_permit(s.schema(), get_name(), 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(s.schema(), get_name(), 1024, db::no_timeout, {}, {}).get();
 
         BOOST_REQUIRE_EQUAL(permit.base_resources(), expected_base_resources);
         BOOST_REQUIRE_EQUAL(permit.consumed_resources(), permit.base_resources());
@@ -3042,7 +3043,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_release_base_resource
     }
 
     {
-        auto permit = semaphore.obtain_permit(s.schema(), get_name(), 1024, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(s.schema(), get_name(), 1024, db::no_timeout, {}, {}).get();
 
         auto irh = semaphore.register_inactive_read(make_empty_mutation_reader(s.schema(), permit));
         BOOST_REQUIRE(irh);
@@ -3083,8 +3084,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_preemptive_abort_requ
             utils::updateable_value<float>(1.0f)); // preemptive abort factor
     auto stop_sem = deferred_stop(semaphore);
 
-    auto permit1 = semaphore.obtain_permit(nullptr, "permit1", memory/2, db::no_timeout, {}).get();
-    reader_permit_opt permit2 = semaphore.obtain_permit(nullptr, "permit2", memory/2, db::timeout_clock::now() + 60s, {}).get();
+    auto permit1 = semaphore.obtain_permit(nullptr, "permit1", memory/2, db::no_timeout, {}, {}).get();
+    reader_permit_opt permit2 = semaphore.obtain_permit(nullptr, "permit2", memory/2, db::timeout_clock::now() + 60s, {}, {}).get();
 
     auto units1 = permit1.request_memory(memory * serialize_limit_multiplier).get();
     auto mem_fut = permit2->request_memory(1024);

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -4864,7 +4864,7 @@ SEASTAR_THREAD_TEST_CASE(test_cache_reader_semaphore_oom_kill) {
     // Check different amounts of memory consumed before the read, so the OOM kill is triggered in different places.
     for (unsigned memory = 1; memory <= 512; memory *= 2) {
         semaphore.set_resources({1, memory});
-        auto permit = semaphore.obtain_permit(s.schema(), "read", 0, db::no_timeout, {}).get();
+        auto permit = semaphore.obtain_permit(s.schema(), "read", 0, db::no_timeout, {}, {}).get();
         auto create_reader_and_read_all = [&] {
             auto rd = cache.make_reader(s.schema(), permit, pr, gc_state);
             auto close_rd = deferred_close(rd);

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -776,7 +776,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
         void check(mutation mut) {
             // First we check that we would be able to create a reader, even
             // though the staging reader consumed all resources.
-            auto permit = _semaphore.obtain_permit(_schema, "consumer_verifier", replica::new_reader_base_cost, db::timeout_clock::now(), {}).get();
+            auto permit = _semaphore.obtain_permit(_schema, "consumer_verifier", replica::new_reader_base_cost, db::timeout_clock::now(), {}, {}).get();
 
             const size_t current_rows = rows_in_mut(mut);
             const auto total_rows = _partition_rows.at(mut.decorated_key());
@@ -885,7 +885,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
             return less(a.decorated_key(), b.decorated_key());
         });
 
-        auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get();
+        auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}, {}).get();
 
         auto mt = make_memtable(schema, muts).get();
         auto p = make_manually_paused_evictable_reader(
@@ -988,7 +988,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering_with_random_mutati
     auto stop_sem = deferred_stop(sem);
     const abort_source as;
     auto mt = make_memtable(schema, {mut}).get();
-    auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get();
+    auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}, {}).get();
     auto p = make_manually_paused_evictable_reader(
             mt->as_data_source(),
             schema,

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -774,7 +774,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
         void check(mutation mut) {
             // First we check that we would be able to create a reader, even
             // though the staging reader consumed all resources.
-            auto permit = _semaphore.obtain_permit(_schema, "consumer_verifier", replica::new_reader_base_cost, db::timeout_clock::now(), {}).get();
+            auto permit = _semaphore.obtain_permit(_schema, "consumer_verifier", replica::new_reader_base_cost, db::timeout_clock::now(), {}, {}).get();
 
             const size_t current_rows = rows_in_mut(mut);
             const auto total_rows = _partition_rows.at(mut.decorated_key());
@@ -883,7 +883,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
             return less(a.decorated_key(), b.decorated_key());
         });
 
-        auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get();
+        auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}, {}).get();
 
         auto mt = make_memtable(schema, muts).get();
         auto p = make_manually_paused_evictable_reader(
@@ -986,7 +986,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering_with_random_mutati
     auto stop_sem = deferred_stop(sem);
     const abort_source as;
     auto mt = make_memtable(schema, {mut}).get();
-    auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get();
+    auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}, {}).get();
     auto p = make_manually_paused_evictable_reader(
             mt->as_data_source(),
             schema,

--- a/test/lib/key_utils.cc
+++ b/test/lib/key_utils.cc
@@ -10,6 +10,7 @@
 #include "test/lib/random_schema.hh"
 #include "test/lib/random_utils.hh"
 #include "dht/i_partitioner.hh"
+#include "replica/database.hh"
 
 namespace tests {
 
@@ -88,6 +89,32 @@ dht::decorated_key generate_partition_key(schema_ptr s, std::optional<shard_id> 
 
 dht::decorated_key generate_partition_key(schema_ptr s, local_shard_only lso, std::optional<key_size> size) {
     return generate_partition_key(std::move(s), lso == local_shard_only::yes ? std::optional(this_shard_id()) : std::nullopt, size);
+}
+
+std::vector<dht::decorated_key> generate_partition_keys(size_t n, replica::table& tbl, std::optional<shard_id> shard, std::optional<key_size> size) {
+    auto s = tbl.schema();
+    return generate_keys<partition_key, dht::decorated_key, dht::decorated_key::less_comparator>(
+            n,
+            s,
+            dht::decorated_key::less_comparator(s),
+            s->partition_key_type()->types(),
+            [&tbl, shard, tokens = std::set<dht::token>()] (const partition_key& pkey) mutable -> std::optional<dht::decorated_key> {
+                auto dkey = dht::decorate_key(*tbl.schema(), pkey);
+                if (shard && *shard != tbl.shard_for_reads(dkey.token())) {
+                    return {};
+                }
+                if (!tokens.insert(dkey.token()).second) {
+                    return {};
+                }
+                return dkey;
+            },
+            false,
+            size);
+}
+
+dht::decorated_key generate_partition_key(replica::table& tbl, std::optional<shard_id> shard, std::optional<key_size> size) {
+    auto&& keys = generate_partition_keys(1, tbl, shard, size);
+    return std::move(keys.front());
 }
 
 std::vector<clustering_key> generate_clustering_keys(size_t n, schema_ptr s, bool allow_prefixes, std::optional<key_size> size) {

--- a/test/lib/key_utils.hh
+++ b/test/lib/key_utils.hh
@@ -39,6 +39,10 @@ std::vector<dht::decorated_key> generate_partition_keys(size_t n, schema_ptr s, 
 dht::decorated_key generate_partition_key(schema_ptr s, std::optional<shard_id> shard = this_shard_id(), std::optional<key_size> size = {});
 dht::decorated_key generate_partition_key(schema_ptr s, local_shard_only lso, std::optional<key_size> size = {});
 
+// Works with both tablets and vnodes. Uses replica::table::shard_for_reads() to match keys against shard.
+std::vector<dht::decorated_key> generate_partition_keys(size_t n, replica::table& tbl, std::optional<shard_id> shard = this_shard_id(), std::optional<key_size> size = {});
+dht::decorated_key generate_partition_key(replica::table& tbl, std::optional<shard_id> shard = this_shard_id(), std::optional<key_size> size = {});
+
 // Generate n clustering keys
 //
 // Returned keys are unique, ordered and never empty.

--- a/test/lib/reader_lifecycle_policy.hh
+++ b/test/lib/reader_lifecycle_policy.hh
@@ -108,7 +108,7 @@ public:
         return *_contexts[shard]->semaphore;
     }
     virtual future<reader_permit> obtain_reader_permit(schema_ptr schema, const char* const description, db::timeout_clock::time_point timeout, tracing::trace_state_ptr trace_ptr) override {
-        return semaphore().obtain_permit(schema, description, 128 * 1024, timeout, std::move(trace_ptr));
+        return semaphore().obtain_permit(schema, description, 128 * 1024, timeout, std::move(trace_ptr), {});
     }
 };
 

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -174,7 +174,7 @@ void execute_reads(const schema_ptr& schema, reader_concurrency_semaphore& sem, 
 
         if (sem.get_stats().waiters) {
             testlog.trace("Waiting for queue to drain");
-            sem.obtain_permit(schema, "drain", 1, db::no_timeout, {}).get();
+            sem.obtain_permit(schema, "drain", 1, db::no_timeout, {}, {}).get();
         }
     }
 


### PR DESCRIPTION
Add `abort_source*` parameter to `database::query()` and propagate it down to `reader_concurrency_semaphore`. Wire up the abort-source in the latter to the reader-permit, so it is abortable in any phase of the read.
Fixes: SCYLLADB-2456

Backport: new feature, no backport