### PR TITLE
Relax repair+batchlog replay error injections

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -484,7 +484,6 @@ future<db::all_batches_replayed> db::batchlog_manager::replay_all_failed_batches
 
     co_await with_gate(_gate, [this, &all_replayed, batch = std::move(batch)] () mutable -> future<> {
         blogger.debug("Started replayAllFailedBatches");
-        co_await utils::get_local_injector().inject("add_delay_to_batch_replay", std::chrono::milliseconds(1000));
 
         auto schema = _qp.db().find_schema(system_keyspace::NAME, system_keyspace::BATCHLOG);
 
@@ -525,7 +524,6 @@ future<db::all_batches_replayed> db::batchlog_manager::replay_all_failed_batches
 
     co_await with_gate(_gate, [this, cleanup, &all_replayed, batch = std::move(batch), now, &replay_stats_per_shard] () mutable -> future<> {
         blogger.debug("Started replayAllFailedBatches with cleanup: {}", cleanup);
-        co_await utils::get_local_injector().inject("add_delay_to_batch_replay", std::chrono::milliseconds(1000));
 
         auto schema = _qp.db().find_schema(system_keyspace::NAME, system_keyspace::BATCHLOG_V2);
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2722,8 +2722,8 @@ future<repair_flush_hints_batchlog_response> repair_service::repair_flush_hints_
                         }
                     }
                     if (issue_flush) {
+                        utils::get_local_injector().enter("repair_flush_hints_batchlog_handler");
                         all_replayed = co_await _bm.local().do_batch_log_replay(db::batchlog_manager::post_replay_cleanup::no);
-                        utils::get_local_injector().set_parameter("repair_flush_hints_batchlog_handler", "issue_flush", fmt::to_string(flush_time));
                     }
                     rlogger.info("repair[{}]: Finished to flush batchlog for repair_flush_hints_batchlog_request from node={}, flushed={} all_replayed={}", req.repair_uuid, from, issue_flush, all_replayed);
                 }
@@ -2740,8 +2740,6 @@ future<repair_flush_hints_batchlog_response> repair_service::repair_flush_hints_
             rs._flush_hints_batchlog_time = flush_time;
         });
         updated = true;
-    } else {
-        utils::get_local_injector().set_parameter("repair_flush_hints_batchlog_handler", "skip_flush", fmt::to_string(flush_time));
     }
     auto duration = std::chrono::duration<float>(gc_clock::now() - now);
     rlogger.info("repair[{}]: Finished to process repair_flush_hints_batchlog_request from node={} updated={} flush_hints_batchlog_time={} flush_cache_time={} flush_duration={}",

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2707,7 +2707,6 @@ future<repair_flush_hints_batchlog_response> repair_service::repair_flush_hints_
                     } else {
                         if (now < last_replay) {
                             flush_time = now;
-                            utils::get_local_injector().set_parameter("repair_flush_hints_batchlog_handler", "skip_flush_use_now", fmt::to_string(flush_time));
                         } else if (now - last_replay < cache_time) {
                             // Skip the replay request since last_replay is already
                             // updated since last _flush_hints_batchlog_time
@@ -2715,7 +2714,6 @@ future<repair_flush_hints_batchlog_response> repair_service::repair_flush_hints_
                             // flush time because last_replay (batchlog replay
                             // time) is smaller than now (hint flush time).
                             flush_time = last_replay;
-                            utils::get_local_injector().set_parameter("repair_flush_hints_batchlog_handler", "skip_flush_use_last_replay", fmt::to_string(flush_time));
                         } else {
                             // Issue the replay so the last_replay will be updated
                             // to bigger than now after the call.

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -183,9 +183,6 @@ async def do_batchlog_flush_in_repair(manager, cache_time_in_ms):
         await manager.api.enable_injection(node.ip_addr, "repair_flush_hints_batchlog_handler", one_shot=False)
         await manager.api.enable_injection(node.ip_addr, "add_delay_to_batch_replay", one_shot=False)
 
-    for node in (node1, node2):
-        assert (await get_injection_params(manager, node.ip_addr, "repair_flush_hints_batchlog_handler")) == {}
-
     async def do_repair(node):
         await manager.api.repair(node.ip_addr, "ks", "tbl")
 
@@ -193,23 +190,23 @@ async def do_batchlog_flush_in_repair(manager, cache_time_in_ms):
         start = time.time()
         await asyncio.gather(*(do_repair(node) for x in range(nr_repairs_per_node) for node in [node1, node2]))
         duration = time.time() - start
-        params = await get_injection_params(manager, node1.ip_addr, "repair_flush_hints_batchlog_handler")
-        logger.debug(f"After {label} repair cache_time_in_ms={cache_time_in_ms} injection_params={params} repair_duration={duration}")
-        return (params, duration)
+        logger.debug(f"After {label} repair cache_time_in_ms={cache_time_in_ms} repair_duration={duration}")
+        return duration
 
-    params, duration = await repair("First")
+    duration = await repair("First")
     total_repair_duration += duration
 
     await asyncio.sleep(1 + (cache_time_in_ms / 1000))
 
-    params, duration = await repair("Second")
+    count_before = await manager.api.get_injection_enter_count(node1.ip_addr, "repair_flush_hints_batchlog_handler")
+    duration = await repair("Second")
     total_repair_duration += duration
+    count_after = await manager.api.get_injection_enter_count(node1.ip_addr, "repair_flush_hints_batchlog_handler")
 
-    assert (int(params['issue_flush']) > 0)
-    if cache_time_in_ms > 0:
-        assert (int(params['skip_flush']) > 0)
-    else:
-        assert (not 'skip_flush' in params)
+    # Each repair sends flush requests to all nodes, so node1 receives nr_repairs
+    # requests per round. With cache, only the first triggers an actual replay.
+    replays_per_round = 1 if cache_time_in_ms > 0 else nr_repairs
+    assert count_after - count_before == replays_per_round
 
     logger.debug(f"Repair nr_repairs={nr_repairs} cache_time_in_ms={cache_time_in_ms} total_repair_duration={total_repair_duration}")
 

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -181,7 +181,6 @@ async def do_batchlog_flush_in_repair(manager, cache_time_in_ms):
 
     for node in (node1, node2):
         await manager.api.enable_injection(node.ip_addr, "repair_flush_hints_batchlog_handler", one_shot=False)
-        await manager.api.enable_injection(node.ip_addr, "add_delay_to_batch_replay", one_shot=False)
 
     async def do_repair(node):
         await manager.api.repair(node.ip_addr, "ks", "tbl")

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -371,6 +371,12 @@ class ScyllaRESTAPIClient:
     async def message_injection(self, node_ip: str, injection: str) -> None:
         await self.client.post(f"/v2/error_injection/injection/{quote(injection, safe='')}/message", host=node_ip)
 
+    async def get_injection_enter_count(self, node_ip: str, injection: str) -> int:
+        """Return the current enter count for the given injection."""
+        return await self.client.get_json(
+            f"/v2/error_injection/injection/{quote(injection, safe='')}/enters",
+            host=node_ip)
+
     async def wait_for_injection_enter(self, node_ip: str, injection: str, threshold: int = 1, deadline: float | None = None) -> None:
         """Poll until the injection's enter count reaches the threshold.
            Default threshold=1 waits for at least one enter.
@@ -380,9 +386,7 @@ class ScyllaRESTAPIClient:
             deadline = time.time() + 60.0
 
         async def _check():
-            count = await self.client.get_json(
-                f"/v2/error_injection/injection/{quote(injection, safe='')}/enters",
-                host=node_ip)
+            count = await self.get_injection_enter_count(node_ip, injection)
             return count if count >= threshold else None
 
         await wait_for(_check, deadline, label=f"injection_enter({injection})")


### PR DESCRIPTION
This PR fixes two injections used by the batchlog_flush_in_repair test.

The add_delay_to_batch_replay injection was placed at the start of batchlog replay to slow it down, hoping concurrent repair-triggered flush requests would overlap the replay window and exercise the cache-skip path. This was never necessary: all incoming flush requests are serialized by _flush_hints_batchlog_sem before any replay decision is made, so the second request always sees a freshly-updated cache timestamp and hits the skip path regardless of replay speed.

The repair_flush_hints_batchlog_handler injection was used as a telemetry channel: C++ would call set_parameter() with named values (issue_flush, skip_flush, skip_flush_use_now, skip_flush_use_last_replay) and the test would read them back to determine which code path was taken. Two of the four parameters were never read by any test. The remaining two are overly complex, the test just needs to know the number of times batchlog flush was issued, not the skip/not-skip decision with the exact timing passed with the parameter.

Overall the test becomes shorter, and the core code less polluted with error injections.

Improving test and error-injection subsystem, no need to backport