### PR TITLE
config: enable TLS 1.3 session tickets by default

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -515,7 +515,7 @@ large_collection_elements_fail_threshold: 20000
 #    certficate_revocation_list: <not set>
 #    require_client_auth: False
 #    priority_string: <not set, use default>
-#    enable_session_tickets: <default false>
+#    enable_session_tickets: <default true>
 
 # internode_compression controls whether traffic between nodes is
 # compressed.

--- a/db/config.cc
+++ b/db/config.cc
@@ -1385,7 +1385,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "\n"
         "* priority_string: (Default: not set, use default) GnuTLS priority string controlling TLS algorithms used/allowed.\n"
         "* require_client_auth: (Default: false) Enables or disables certificate authentication.\n"
-        "* enable_session_tickets: (Default: false) Enables or disables TLS1.3 session tickets.\n"
+        "* enable_session_tickets: (Default: true) Enables or disables TLS1.3 session tickets.\n"
         "\n"
         "Related information: Client-to-node encryption")
     , alternator_encryption_options(this, "alternator_encryption_options", value_status::Used, {/*none*/},
@@ -1396,7 +1396,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "The advanced settings are:\n"
         "\n"
         "* priority_string: GnuTLS priority string controlling TLS algorithms used/allowed.\n"
-        "* enable_session_tickets: (Default: false) Enables or disables TLS1.3 session tickets.")
+        "* enable_session_tickets: (Default: true) Enables or disables TLS1.3 session tickets.")
     , alternator_force_read_before_write(this, "alternator_force_read_before_write", liveness::LiveUpdate, value_status::Used, false, "Forces Alternator to perform Read Before Write. Used for better DynamoDB compatibility in WCU calculation")
     , ssl_storage_port(this, "ssl_storage_port", value_status::Used, 7001,
         "The SSL port for encrypted communication. Unused unless enabled in encryption_options.")
@@ -2190,7 +2190,7 @@ future<> configure_tls_creds_builder(seastar::tls::credentials_builder& creds, d
     if (is_true(get_or_default(options, "require_client_auth", "false"))) {
         creds.set_client_auth(seastar::tls::client_auth::REQUIRE);
     }
-    if (is_true(get_or_default(options, "enable_session_tickets", "false"))) {
+    if (is_true(get_or_default(options, "enable_session_tickets", "true"))) {
         creds.set_session_resume_mode(seastar::tls::session_resume_mode::TLS13_SESSION_TICKET);
     }
 


### PR DESCRIPTION
TLS 1.3 session tickets reduce stalls due to TLS handshakes by reusing authentication across different connections to the same client.

GNUTLS enables session tickets by default [1], indicating it is suitable for a default configuration.

[1] https://gnutls.org/manual/html_node/Session-initialization.html

Not fixing a regression, so not backporting.