### PR TITLE
strong_consistency: handle no_such_keyspace in state_machine::apply

### DIFF
--- a/service/strong_consistency/state_machine.cc
+++ b/service/strong_consistency/state_machine.cc
@@ -97,6 +97,18 @@ public:
             // (see `schema_applier::commit_on_shard()` and `storage_service::commit_token_metadata_change()`).
             // In this case, we should just ignore mutations without throwing an error.
             logger.log(log_level::warn, rate_limit, "apply(): table {} was already dropped, ignoring mutations", _tablet.table);
+        } catch (replica::no_such_keyspace&) {
+            // Thrown when DROP KEYSPACE races with the raft applier fiber.
+            // The path: resolve_and_upgrade_mutations() calls
+            // local_schema_registry().get_or_null(schema_version), which may
+            // trigger lazy unfreezing of a cached frozen_schema. Unfreezing
+            // re-parses column types via cql_type_parser::parse(), which
+            // consults db_user_types_storage::get(ks_name), which calls
+            // database::find_keyspace() — and that throws no_such_keyspace
+            // if the keyspace was concurrently dropped.
+            // Safe to ignore: the table's raft group is about to be destroyed
+            // by schedule_raft_group_deletion() anyway.
+            logger.log(log_level::warn, rate_limit, "apply(): keyspace for table {} was already dropped, ignoring mutations", _tablet.table);
         } catch (const abort_requested_exception& ex) {
             // The exception can be thrown by get_schema_and_upgrade_mutations.
             // It means that the Raft group is being removed.
@@ -230,7 +242,8 @@ future<std::vector<schema_ptr>> resolve_and_upgrade_mutations(utils::chunked_vec
             // Old schema are TTLed after 10 days (see comment in `schema_applier::finalize_tables_and_views()`),
             // so this error theoretically may be triggered if a node is stuck longer than this.
             // But in practice we should do a snapshot much earlier, that's why `on_internal_error()` here.
-            // And if the table was already dropped, `no_such_column_family` will be thrown earlier.
+            // And if the table or keyspace was already dropped, `no_such_column_family`
+            // or `no_such_keyspace` will be thrown earlier.
             on_internal_error(logger, fmt::format("couldn't find schema for table {} and mutation schema version {}", table, m.schema_version()));
         }
         if (entry->second) {


### PR DESCRIPTION
DROP KEYSPACE can race with in-flight mutations being applied by the
raft applier fiber. When the keyspace is gone by the time we try to
resolve the schema or apply the mutation, `data_dictionary::no_such_keyspace`
is thrown. This exception was not caught by `state_machine::apply()`, so it
propagated to the `on_background_error` handler in `groups_manager`, which
calls `on_internal_error()` and aborts the node.

The `no_such_column_family` case was already handled (SCYLLADB-1450,
PR #29430). Apply the same treatment: catch `no_such_keyspace` next to
`no_such_column_family` and log a warning instead of aborting.

No separate test is added — the existing
`test_no_schema_when_apply_write` already exercises the DROP-races-with-
in-flight-DML scenario and is in fact the test that exposed this bug.
The new catch clause sits right next to the `no_such_column_family`
catch in the same `try` block and follows identical logic (log + ignore),
so it doesn't warrant a dedicated test of its own.

Fixes SCYLLADB-2363

backport: no need -- strong consistency is not GA