### PR TITLE
sstables: unified object storage layout with sstable_id-based prefix

### DIFF
--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -435,9 +435,8 @@ storage_options storage_options::append_to_object_storage_prefix(const sstring& 
     }
 
     object_storage options = std::get<object_storage>(value);
-    SCYLLA_ASSERT(std::holds_alternative<sstring>(options.location));
-    sstring prefix = std::get<sstring>(options.location);
-    options.location = seastar::format("{}/{}", prefix, s);
+    SCYLLA_ASSERT(options.location);
+    options.location = seastar::format("{}/{}", *options.location, s);
     ret.value = std::move(options);
     return ret;
 }
@@ -673,14 +672,10 @@ auto fmt::formatter<data_dictionary::storage_options>::format(const data_diction
             return fmt::format_to(ctx.out(), "{}", so.dir);
         },
         [&ctx, &type] (const data_dictionary::storage_options::object_storage& so) -> decltype(ctx.out()) {
-            return std::visit(overloaded_functor {
-                [&] (const sstring& prefix) -> decltype(ctx.out()) {
-                    return fmt::format_to(ctx.out(), "{}://{}/{}", type, so.bucket, prefix);
-                },
-                [&] (const table_id& owner) -> decltype(ctx.out()) {
-                    return fmt::format_to(ctx.out(), "{}://{} (owner {})", type, so.bucket, owner);
-                }
-            }, so.location);
+            if (so.location) {
+                return fmt::format_to(ctx.out(), "{}://{}/{}", type, so.bucket, *so.location);
+            }
+            return fmt::format_to(ctx.out(), "{}://{}", type, so.bucket);
         }
     }, so.value);
 }

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -32,7 +32,7 @@ struct storage_options {
     struct object_storage {
         std::string bucket;
         std::string endpoint;
-        std::variant<sstring, table_id> location;
+        std::optional<sstring> location;
         seastar::abort_source* abort_source = nullptr;
 
         std::string type;

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1152,6 +1152,7 @@ schema_ptr system_keyspace::sstables_registry() {
             .with_column("node_owner", uuid_type, column_kind::partition_key)
             .with_column("generation", timeuuid_type, column_kind::clustering_key)
             .with_column("status", utf8_type)
+            .with_column("sstable_id", uuid_type)
             .with_column("state", utf8_type)
             .with_column("version", utf8_type)
             .with_column("format", utf8_type)
@@ -3480,9 +3481,9 @@ system_keyspace::read_cdc_generation_opt(utils::UUID id) {
 }
 
 future<> system_keyspace::sstables_registry_create_entry(table_id tid, locator::host_id node_owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) {
-    static const auto req = format("INSERT INTO system.{} (table_id, node_owner, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
+    static const auto req = format("INSERT INTO system.{} (table_id, node_owner, generation, status, sstable_id, state, version, format) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
     slogger.trace("Inserting {}.{}.{} into {}", tid, node_owner, desc.generation, SSTABLES_REGISTRY);
-    co_await execute_cql(req, tid.id, node_owner.uuid(), desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
+    co_await execute_cql(req, tid.id, node_owner.uuid(), desc.generation, status, desc.sstable_identifier.id, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
 
 future<> system_keyspace::sstables_registry_update_entry_status(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstring status) {
@@ -3524,14 +3525,16 @@ future<> system_keyspace::sstables_registry_delete_entry(table_id tid, locator::
 }
 
 future<> system_keyspace::sstables_registry_list(table_id tid, locator::host_id node_owner, sstable_registry_entry_consumer consumer) {
-    static const auto req = format("SELECT status, state, generation, version, format FROM system.{} WHERE table_id = ? AND node_owner = ?", SSTABLES_REGISTRY);
+    static const auto req = format("SELECT status, sstable_id, state, generation, version, format FROM system.{} WHERE table_id = ? AND node_owner = ?", SSTABLES_REGISTRY);
     slogger.trace("Listing {}.{} entries from {}", tid, node_owner, SSTABLES_REGISTRY);
 
     co_await _qp.query_internal(req, db::consistency_level::ONE, { tid.id, node_owner.uuid() }, 1000, [ consumer = std::move(consumer) ] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {
         auto status = row.get_as<sstring>("status");
         auto state = sstables::state_from_dir(row.get_as<sstring>("state"));
         auto gen = sstables::generation_type(row.get_as<utils::UUID>("generation"));
-        optimized_optional<sstables::sstable_id> sid = std::nullopt;  // FIXME: for now
+        auto sid = row.has("sstable_id")
+            ? sstables::sstable_id(row.get_as<utils::UUID>("sstable_id"))
+            : sstables::sstable_id(gen.as_uuid());
         auto ver = sstables::version_from_string(row.get_as<sstring>("version"));
         auto fmt = sstables::format_from_string(row.get_as<sstring>("format"));
         sstables::entry_descriptor desc(gen, sid, ver, fmt, sstables::component_type::TOC);

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3531,9 +3531,10 @@ future<> system_keyspace::sstables_registry_list(table_id tid, locator::host_id 
         auto status = row.get_as<sstring>("status");
         auto state = sstables::state_from_dir(row.get_as<sstring>("state"));
         auto gen = sstables::generation_type(row.get_as<utils::UUID>("generation"));
+        optimized_optional<sstables::sstable_id> sid = std::nullopt;  // FIXME: for now
         auto ver = sstables::version_from_string(row.get_as<sstring>("version"));
         auto fmt = sstables::format_from_string(row.get_as<sstring>("format"));
-        sstables::entry_descriptor desc(gen, ver, fmt, sstables::component_type::TOC);
+        sstables::entry_descriptor desc(gen, sid, ver, fmt, sstables::component_type::TOC);
         co_await consumer(std::move(status), std::move(state), std::move(desc));
         co_return stop_iteration::no;
     });

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -1397,6 +1397,7 @@ CREATE TABLE system.sstables (
     owner uuid,
     generation timeuuid,
     status text,
+    sstable_id uuid,
     state text,
     version text,
     format text,
@@ -1408,6 +1409,7 @@ CREATE TABLE system.sstables (
 - `owner`: UUID of the owning table
 - `generation`: SSTable generation identifier
 - `status`: Current status of the SSTable
+- `sstable_id`: Unique identifier of the SSTable, derived from its generation for new SSTables
 - `state`: State of the SSTable
 - `version`: SSTable format version
 - `format`: SSTable format

--- a/idl/sstables.idl.hh
+++ b/idl/sstables.idl.hh
@@ -7,6 +7,8 @@
  */
 
 
+#include "sstables/types.hh"
+
 namespace sstables {
 
 enum class sstable_state : uint8_t {
@@ -14,6 +16,10 @@ enum class sstable_state : uint8_t {
     staging,
     quarantine,
     upload,
+};
+
+class sstable_id final {
+    utils::UUID uuid();
 };
 
 }

--- a/idl/streaming.idl.hh
+++ b/idl/streaming.idl.hh
@@ -103,6 +103,7 @@ class stream_blob_meta {
     streaming::file_ops fops;
     service::frozen_topology_guard topo_guard;
     std::optional<sstables::sstable_state> sstable_state;
+    std::optional<sstables::sstable_id> sstable_id;
 };
 
 class node_and_shard {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -192,8 +192,9 @@ distributed_loader::process_upload_dir(sharded<replica::database>& db, sharded<d
             auto& sstm = global_table->get_sstables_manager();
             auto& gen = global_table->get_sstable_generation_generator();
             auto generation = gen();
+            auto sid = sstables::sstable_id(generation.as_uuid());
             return sstm.make_sstable(global_table->schema(), global_table->get_storage_options(),
-                                     generation, sstables::sstable_state::upload, sstm.get_preferred_sstable_version(),
+                                     generation, sid, sstables::sstable_state::upload, sstm.get_preferred_sstable_version(),
                                      sstables::sstable_format_types::big, db_clock::now(), &error_handler_gen_for_upload_dir);
         };
         // Pass owned_ranges_ptr to reshard to piggy-back cleanup on the resharding compaction.
@@ -396,7 +397,8 @@ future<> table_populator::process_subdir(sharded<sstables::sstable_directory>& d
 }
 
 sstables::shared_sstable make_sstable(replica::table& table, sstables::sstable_state state, sstables::generation_type generation, sstables::sstable_version_types v) {
-    return table.get_sstables_manager().make_sstable(table.schema(), table.get_storage_options(), generation, state, v, sstables::sstable_format_types::big);
+    auto sid = sstables::sstable_id(generation.as_uuid());
+    return table.get_sstables_manager().make_sstable(table.schema(), table.get_storage_options(), generation, sid, state, v, sstables::sstable_format_types::big);
 }
 
 future<> table_populator::populate_subdir(sharded<sstables::sstable_directory>& directory) {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -498,7 +498,9 @@ sstables::shared_sstable table::make_sstable(sstables::sstable_state state) {
 
 sstables::shared_sstable table::make_sstable(sstables::sstable_state state, sstables::sstable_version_types version) {
     auto& sstm = get_sstables_manager();
-    return sstm.make_sstable(_schema, *_storage_opts, calculate_generation_for_new_table(), state, version, sstables::sstable::format_types::big);
+    auto gen = calculate_generation_for_new_table();
+    auto sid = sstables::sstable_id(gen.as_uuid());
+    return sstm.make_sstable(_schema, *_storage_opts, gen, sid, state, version, sstables::sstable::format_types::big);
 }
 
 sstables::shared_sstable table::make_sstable() {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4993,7 +4993,7 @@ future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id
 
     auto load_sstable = [leave_unsealed] (const dht::sharder& sharder, replica::table& t, sstables::entry_descriptor d) -> future<sstables::shared_sstable> {
         auto& mng = t.get_sstables_manager();
-        auto sst = mng.make_sstable(t.schema(), t.get_storage_options(), d.generation, d.state.value_or(sstables::sstable_state::normal),
+        auto sst = mng.make_sstable(t.schema(), t.get_storage_options(), d.generation, d.sid, d.state.value_or(sstables::sstable_state::normal),
                                     d.version, d.format, db_clock::now(), default_io_error_handler_gen());
         // The loader will consider current shard as sstable owner, despite the tablet sharder
         // will still point to leaving replica at this stage in migration. If node goes down,

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -41,8 +41,8 @@ sstables::object_name::object_name(std::string_view bucket, std::string_view pre
     : _name(fmt::format("/{}/{}/{}", bucket, prefix, type))
 {}
 
-sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, const generation_type& gen, std::string_view type)
-    : _name(fmt::format("/{}/{}/{}/{}", bucket, prefix, gen, type))
+sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, const sstable_id& sid, std::string_view type)
+    : _name(fmt::format("/{}/{}/{}/{}", bucket, prefix, sid, type))
 {}
 sstables::object_name::object_name(std::string_view bucket, std::string_view object) 
     : _name(fmt::format("/{}/{}", bucket, object))

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -41,8 +41,8 @@ sstables::object_name::object_name(std::string_view bucket, std::string_view pre
     : _name(fmt::format("/{}/{}/{}", bucket, prefix, type))
 {}
 
-sstables::object_name::object_name(std::string_view bucket, const generation_type& gen, std::string_view type) 
-    : _name(fmt::format("/{}/{}/{}", bucket, gen, type))
+sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, const generation_type& gen, std::string_view type)
+    : _name(fmt::format("/{}/{}/{}/{}", bucket, prefix, gen, type))
 {}
 sstables::object_name::object_name(std::string_view bucket, std::string_view object) 
     : _name(fmt::format("/{}/{}", bucket, object))

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -50,7 +50,7 @@ public:
     object_name(const object_name&);
     object_name(object_name&&);
     object_name(std::string_view bucket, std::string_view prefix, std::string_view type);
-    object_name(std::string_view bucket, const generation_type&, std::string_view type);
+    object_name(std::string_view bucket, std::string_view prefix, const generation_type&, std::string_view type);
     object_name(std::string_view bucket, std::string_view object);
 
     std::string_view bucket() const;

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -18,6 +18,7 @@
 
 #include "utils/lister.hh"
 #include "utils/s3/creds.hh"
+#include "sstables/types.hh"
 
 namespace seastar {
 class abort_source;
@@ -42,15 +43,13 @@ class abstract_lister;
 
 namespace sstables {
 
-class generation_type;
-
 class object_name {
     std::string _name;
 public:
     object_name(const object_name&);
     object_name(object_name&&);
     object_name(std::string_view bucket, std::string_view prefix, std::string_view type);
-    object_name(std::string_view bucket, std::string_view prefix, const generation_type&, std::string_view type);
+    object_name(std::string_view bucket, std::string_view prefix, const sstable_id&, std::string_view type);
     object_name(std::string_view bucket, std::string_view object);
 
     std::string_view bucket() const;

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -18,6 +18,7 @@
 #include "sstables/component_type.hh"
 #include "sstables/shareable_components.hh"
 #include "sstables/generation_type.hh"
+#include "sstables/types.hh"
 #include <seastar/core/shared_ptr.hh>
 
 namespace sstables {
@@ -31,15 +32,16 @@ enum class sstable_state {
 
 struct entry_descriptor {
     generation_type generation;
+    optimized_optional<sstable_id> sid;
     sstable_version_types version;
     sstable_format_types format;
     component_type component;
     std::optional<sstable_state> state;
 
-    entry_descriptor(generation_type generation,
+    entry_descriptor(generation_type generation, optimized_optional<sstable_id> sid,
                      sstable_version_types version, sstable_format_types format,
                      component_type component, std::optional<sstable_state> state = {})
-        : generation(generation), version(version), format(format), component(component), state(state) {}
+        : generation(generation), sid(sid), version(version), format(format), component(component), state(state) {}
 };
 
 // Parses sstable file path extracting entry_descriptor from it. Returns the descriptor

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -36,6 +36,7 @@ struct entry_descriptor {
     sstable_version_types version;
     sstable_format_types format;
     component_type component;
+    sstable_id sstable_identifier;
     std::optional<sstable_state> state;
 
     entry_descriptor(generation_type generation, optimized_optional<sstable_id> sid,

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -621,7 +621,7 @@ sstable_directory::retrieve_shared_sstables() {
     return std::exchange(_shared_sstable_info, {});
 }
 
-bool sstable_directory::compare_sstable_storage_prefix(const sstring& prefix_a, const sstring& prefix_b) noexcept {
+bool sstable_directory::compare_sstable_storage_prefix(std::string_view prefix_a, std::string_view prefix_b) noexcept {
     size_t size_a = prefix_a.size();
     if (prefix_a.back() == '/') {
         size_a--;

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -229,7 +229,7 @@ void sstable_directory::validate(sstables::shared_sstable sst, process_flags fla
 
 future<sstables::shared_sstable> sstable_directory::load_sstable(sstables::entry_descriptor desc,
         const data_dictionary::storage_options& storage_opts, sstables::sstable_open_config cfg) const {
-    shared_sstable sst = _manager.make_sstable(_schema, storage_opts, desc.generation, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
+    shared_sstable sst = _manager.make_sstable(_schema, storage_opts, desc.generation, desc.sid, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
     co_await sst->load(_sharder, cfg);
     co_return sst;
 }
@@ -263,7 +263,9 @@ sstable_directory::process_descriptor(sstables::entry_descriptor desc,
             new_sst.mutate_sstable_level(0);
         };
         auto sst_creator = [&](shared_sstable) {
-            return _manager.make_sstable(_schema, storage_opts, sstables::sstable_generation_generator{}(), _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
+            auto gen = sstable_generation_generator{}();
+            auto sid = storage_opts.is_object_storage_type() ? sstable_id(gen.as_uuid()) : sst->get_sstable_identifier();
+            return _manager.make_sstable(_schema, storage_opts, gen, sid, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
         };
         auto new_sst = co_await sst->link_with_rewritten_component(std::move(sst_creator), component_type::Statistics, std::move(modifier), false);
         co_await sst->unlink();
@@ -510,7 +512,8 @@ sstable_directory::move_foreign_sstables(sharded<sstable_directory>& source_dire
 }
 
 future<shared_sstable> sstable_directory::load_foreign_sstable(foreign_sstable_open_info& info) {
-    auto sst = _manager.make_sstable(_schema, *_storage_opts, info.generation, _state, info.version, info.format, db_clock::now(), _error_handler_gen);
+    auto sid = sstable_id{utils::UUID_gen::get_time_UUID()};
+    auto sst = _manager.make_sstable(_schema, *_storage_opts, info.generation, sid, _state, info.version, info.format, db_clock::now(), _error_handler_gen);
     co_await sst->load(std::move(info));
     co_return sst;
 }
@@ -527,7 +530,7 @@ sstable_directory::load_foreign_sstables(sstable_entry_descriptor_vector info_ve
 
 future<std::vector<shard_id>> sstable_directory::get_shards_for_this_sstable(
         const sstables::entry_descriptor& desc, const data_dictionary::storage_options& storage_opts, process_flags flags) const {
-    auto sst = _manager.make_sstable(_schema, storage_opts, desc.generation, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
+    auto sst = _manager.make_sstable(_schema, storage_opts, desc.generation, std::nullopt, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
     co_await sst->load_owner_shards(_sharder);
     validate(sst, flags);
     co_return sst->get_shards_for_this_sstable();

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -133,7 +133,7 @@ sstable_directory::sstable_directory(replica::table& table,
     , _storage_opts(std::move(storage_opts))
     , _state(sstable_state::upload)
     , _error_handler_gen(error_handler_gen)
-    , _storage(make_storage(_manager, *_storage_opts, _state))
+    , _storage(make_storage(_manager, _schema, *_storage_opts, _state))
     , _lister(std::make_unique<sstable_directory::restore_components_lister>(_storage_opts->value,
                                                                              std::move(sstables)))
     , _sharder_ptr(std::make_unique<dht::auto_refreshing_sharder>(table.shared_from_this()))
@@ -170,7 +170,7 @@ sstable_directory::sstable_directory(sstables_manager& manager,
     , _storage_opts(std::move(storage_opts))
     , _state(state)
     , _error_handler_gen(error_handler_gen)
-    , _storage(make_storage(_manager, *_storage_opts, _state))
+    , _storage(make_storage(_manager, _schema, *_storage_opts, _state))
     , _lister(make_components_lister())
     , _sharder_ptr(std::holds_alternative<unique_sharder_ptr>(sharder) ? std::move(std::get<unique_sharder_ptr>(sharder)) : nullptr)
     , _sharder(_sharder_ptr ? *_sharder_ptr : *std::get<const dht::sharder*>(sharder))

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -79,20 +79,10 @@ sstable_directory::make_components_lister() {
             return std::make_unique<sstable_directory::filesystem_components_lister>(make_path(loc.dir.native(), _state));
         },
         [this] (const data_dictionary::storage_options::object_storage& os) mutable -> std::unique_ptr<sstable_directory::components_lister> {
-            return std::visit(overloaded_functor {
-                [this, &os] (const sstring& prefix) -> std::unique_ptr<sstable_directory::components_lister> {
-                    if (prefix.empty()) {
-                        on_internal_error(sstlog, fmt::format("{} storage options is missing 'prefix'", os.type));
-                    }
-                    return std::make_unique<sstable_directory::filesystem_components_lister>(fs::path(prefix), _manager, os);
-                },
-                [this, &os] (const table_id& owner) -> std::unique_ptr<sstable_directory::components_lister> {
-                    if (owner.id.is_null()) {
-                        on_internal_error(sstlog, fmt::format("{} storage options is missing 'owner'", os.type));
-                    }
-                    return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), owner, _manager.get_local_host_id());
-                }
-            }, os.location);
+            if (os.location) {
+                return std::make_unique<sstable_directory::filesystem_components_lister>(fs::path(*os.location), _manager, os);
+            }
+            return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), _schema->id(), _manager.get_local_host_id());
         }
     }, _storage_opts->value);
 }

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -319,7 +319,7 @@ public:
     // Returns the name of the pending_delete_log and an unordered_set of sstable prefixes.
     static future<sstring> create_pending_deletion_log(opened_directory& base_dir, const std::vector<shared_sstable>& ssts);
 
-    static bool compare_sstable_storage_prefix(const sstring& a, const sstring& b) noexcept;
+    static bool compare_sstable_storage_prefix(std::string_view a, std::string_view b) noexcept;
     sstable_state state() const noexcept { return _state; }
 };
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -4428,7 +4428,7 @@ generation_type::from_string(const std::string& s) {
 }
 
 sstring component_name::format() const {
-    return sst._storage->prefix() + "/" + sst.component_basename(component);
+    return fmt::format("{}/{}", sst._storage->prefix(), sst.component_basename(component));
 }
 
 future<data_sink> file_io_extension::wrap_sink(const sstable& sst, component_type c, data_sink sink) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -989,8 +989,7 @@ future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_
 }
 
 future<entry_descriptor> sstable::clone(generation_type new_generation, bool leave_unsealed) const {
-    co_await _storage->clone(*this, new_generation, leave_unsealed);
-    co_return entry_descriptor(new_generation, _version, _format, component_type::TOC, _state);
+    co_return co_await _storage->clone(*this, new_generation, leave_unsealed);
 }
 
 file_writer::~file_writer() {
@@ -2134,7 +2133,7 @@ future<foreign_sstable_open_info> sstable::get_open_info() & {
 }
 
 entry_descriptor sstable::get_descriptor(component_type c) const {
-    return entry_descriptor(_generation, _version, _format, c);
+    return entry_descriptor(_generation, _sstable_identifier, _version, _format, c);
 }
 
 future<>
@@ -3020,7 +3019,7 @@ static std::expected<std::tuple<entry_descriptor, sstring, sstring>, sstring> ma
         return std::unexpected{seastar::format("invalid version for file {}. Name doesn't match any known version.", fname)};
     }
     try {
-        return std::make_tuple(entry_descriptor(generation_type::from_string(generation), version, format_from_string(format), sstable::component_from_sstring(version, component)), ks, cf);
+        return std::make_tuple(entry_descriptor(generation_type::from_string(generation), std::nullopt, version, format_from_string(format), sstable::component_from_sstring(version, component)), ks, cf);
     } catch (const std::exception& e) {
         return std::unexpected{seastar::format("failed to parse sstable filename {}: {}", fname, e.what())};
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1805,7 +1805,6 @@ sstable_id sstable::get_sstable_identifier() const {
     if (_sstable_identifier) {
         return *_sstable_identifier;
     }
-    sstlog.warn("sstable {} has no identifier, deriving from generation", get_filename());
     return sstable_id(_generation.as_uuid());
 }
 
@@ -2425,7 +2424,9 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
     }
 
     sstable_id sid;
-    if (generation().is_uuid_based()) {
+    if (_sstable_identifier) {
+        sid = *_sstable_identifier;
+    } else if (generation().is_uuid_based()) {
         sid = sstable_id(generation().as_uuid());
     } else {
         sid = sstable_id(utils::UUID_gen::get_time_UUID());
@@ -3972,6 +3973,7 @@ mutation_source sstable::as_mutation_source() {
 sstable::sstable(schema_ptr schema,
         const data_dictionary::storage_options& storage,
         generation_type generation,
+        optimized_optional<sstable_id> sstable_identifier,
         sstable_state state,
         version_types v,
         format_types f,
@@ -3996,6 +3998,7 @@ sstable::sstable(schema_ptr schema,
     , _large_data_handler(large_data_handler)
     , _corrupt_data_handler(corrupt_data_handler)
     , _manager(manager)
+    , _sstable_identifier(std::move(sstable_identifier))
     , _ignore_component_digest_mismatch(_manager.get_config().ignore_component_digest_mismatch)
 {
     manager.add(this);
@@ -4387,13 +4390,13 @@ public:
     }
 };
 
-std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr schema, sstables_manager& sstm, const data_dictionary::storage_options& s_opts, sstable_state state, std::string_view component_filename, sstable_stream_sink_cfg cfg) {
+std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr schema, sstables_manager& sstm, const data_dictionary::storage_options& s_opts, sstable_state state, std::string_view component_filename, optimized_optional<sstable_id> sid, sstable_stream_sink_cfg cfg) {
     auto desc_result = parse_path(component_filename, schema->ks_name(), schema->cf_name());
     if (!desc_result) {
         throw_malformed_sstable_exception(desc_result.error());
     }
     auto desc = std::move(*desc_result);
-    auto sst = sstm.make_sstable(schema, s_opts, desc.generation, state, desc.version, desc.format);
+    auto sst = sstm.make_sstable(schema, s_opts, desc.generation, sid, state, desc.version, desc.format);
 
     auto type = desc.component;
     // Don't write actual TOC. Write temp, if successful, storage::seal will rename this to actual

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1626,7 +1626,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         scylla_metadata metadata;
         read_simple<component_type::Scylla>(metadata).get();
         if (update_sstable_id) {
-            metadata.set_sstable_identifier();
+            metadata.set_sstable_identifier(sstable_id(generation.as_uuid()));
         }
 
         new_sst->write_component_with_metadata(component, std::move(metadata));

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1607,6 +1607,11 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         on_internal_error(sstlog, "SSTable must have Scylla component to rewrite Statistics component.");
     }
 
+    if (_storage->is_object_storage()) {
+        // Always update the sstable_id for object storage, since sstables may be shared globally
+        update_sstable_id = true;
+    }
+
     return seastar::async([this, creator = std::move(sstable_creator), component, modifier = std::move(modifier), update_sstable_id] {
         auto new_sst = creator(shared_from_this());
         auto generation = new_sst->generation();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3973,7 +3973,7 @@ sstable::sstable(schema_ptr schema,
     , _schema(std::move(schema))
     , _generation(generation)
     , _state(state)
-    , _storage(make_storage(manager, storage, _state))
+    , _storage(make_storage(manager, _schema, storage, _state))
     , _version(v)
     , _format(f)
     , _index_cache(std::make_unique<partition_index_cache>(

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1801,6 +1801,14 @@ future<> sstable::update_info_for_opened_data(sstable_open_config cfg) {
     }
 }
 
+sstable_id sstable::get_sstable_identifier() const {
+    if (_sstable_identifier) {
+        return *_sstable_identifier;
+    }
+    sstlog.warn("sstable {} has no identifier, deriving from generation", get_filename());
+    return sstable_id(_generation.as_uuid());
+}
+
 future<> sstable::create_data() noexcept {
     auto oflags = sstable_write_open_flags;
     file_open_options opt;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -210,6 +210,7 @@ public:
     sstable(schema_ptr schema,
             const data_dictionary::storage_options& storage,
             generation_type generation,
+            optimized_optional<sstable_id> sstable_identifier,
             sstable_state state,
             version_types v,
             format_types f,
@@ -1330,7 +1331,7 @@ struct sstable_stream_sink_cfg {
 
 // Creates a sink object which can receive a component file sourced from above source object data.
 
-std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr, sstables_manager&, const data_dictionary::storage_options&, sstable_state, std::string_view component_filename, sstable_stream_sink_cfg cfg);
+std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr, sstables_manager&, const data_dictionary::storage_options&, sstable_state, std::string_view component_filename, optimized_optional<sstable_id> sid, sstable_stream_sink_cfg cfg);
 
 } // namespace sstables
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1123,6 +1123,9 @@ public:
         return _sstable_identifier;
     }
 
+    // Returns the sstable identifier, falling back to deriving it from the generation.
+    sstable_id get_sstable_identifier() const;
+
     // Drops all evictable in-memory caches of on-disk content.
     future<> drop_caches();
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -238,13 +238,14 @@ locator::host_id sstables_manager::get_local_host_id() const {
 shared_sstable sstables_manager::make_sstable(schema_ptr schema,
         const data_dictionary::storage_options& storage,
         generation_type generation,
+        optimized_optional<sstable_id> sid,
         sstable_state state,
         sstable_version_types v,
         sstable_format_types f,
         db_clock::time_point now,
         io_error_handler_gen error_handler_gen,
         size_t buffer_size) {
-    return make_lw_shared<sstable>(std::move(schema), storage, generation, state, v, f, get_large_data_handler(), get_corrupt_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
+    return make_lw_shared<sstable>(std::move(schema), storage, generation, sid, state, v, f, get_large_data_handler(), get_corrupt_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
 }
 
 sstable_writer_config sstables_manager::configure_writer(sstring origin) const {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -197,6 +197,7 @@ public:
     shared_sstable make_sstable(schema_ptr schema,
             const data_dictionary::storage_options& storage,
             generation_type generation,
+            optimized_optional<sstable_id> sstable_identifier,
             sstable_state state = sstable_state::normal,
             sstable_version_types v = get_highest_sstable_version(),
             sstable_format_types f = sstable_format_types::big,

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -648,12 +648,12 @@ protected:
     object_name make_object_name(const sstable& sst, component_type type) const;
     object_name make_object_name(const sstable& sst, sstring comp, generation_type gen) const;
 
-    // Construct the object name for a reference: {prefix}/{gen}/refs/node-{host_id}/{gen}
+    // Construct the object name for a reference: {prefix}/{sstable_id}/refs/node-{host_id}/{gen}
     object_name make_ref_object_name(const sstable& sst, generation_type gen, locator::host_id host_id) const {
         return make_object_name(sst, fmt::format("refs/node-{}/{}", host_id, gen), gen);
     }
-    // Check if any reference objects exist for the given generation
-    future<bool> has_references(generation_type gen) const;
+    // Check if any reference objects exist for the given sstable_id
+    future<bool> has_references(sstable_id sid) const;
 
     table_id owner() const {
         if (_location) {
@@ -756,13 +756,13 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
 
     auto ret = _location
             ? object_name(_bucket, *_location, sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp))
-            : object_name(_bucket, _prefix, gen, comp);
+            : object_name(_bucket, _prefix, sst.get_sstable_identifier(), comp);
     sstlog.debug("make_object_name: sstable_id={} generation={} comp={}: {}", sst.sstable_identifier(), gen, comp, ret.str());
     return ret;
 }
 
-future<bool> object_storage_base::has_references(generation_type gen) const {
-    auto refs_prefix = fmt::format("{}/{}/refs/", _prefix, gen);
+future<bool> object_storage_base::has_references(sstable_id sid) const {
+    auto refs_prefix = fmt::format("{}/{}/refs/", _prefix, sid);
     auto lister = _client->make_object_lister(_bucket, refs_prefix, nullptr);
     co_return co_await with_closeable(std::move(lister), [] (abstract_lister& lister) -> future<bool> {
         auto entry = co_await lister.get();
@@ -894,7 +894,7 @@ future<> object_storage_base::wipe(const sstable& sst, const atomic_delete_conte
     co_await delete_object(make_ref_object_name(sst, sst.generation(), node_owner));
 
     // Only delete components if no references remain
-    if (!co_await has_references(sst.generation())) {
+    if (!co_await has_references(sst.get_sstable_identifier())) {
         co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
             co_await delete_object(make_object_name(sst, type));
         });
@@ -921,7 +921,7 @@ future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc) {
     std::vector<sstring> components;
 
     try {
-        auto f = make_readable_file(object_name(_bucket, _prefix, desc.generation, sstable_version_constants::get_component_map(desc.version).at(component_type::TOC)));
+        auto f = make_readable_file(object_name(_bucket, _prefix, desc.sstable_identifier, sstable_version_constants::get_component_map(desc.version).at(component_type::TOC)));
         auto [components, digest] = co_await with_closeable(std::move(f), [] (file& f) {
             return sstable::read_and_parse_toc(f);
         });
@@ -933,10 +933,10 @@ future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc) {
 
     co_await coroutine::parallel_for_each(components, [this, &desc] (sstring comp) -> future<> {
         if (comp != sstable_version_constants::TOC_SUFFIX) {
-            co_await delete_object(object_name(_bucket, _prefix, desc.generation, comp));
+            co_await delete_object(object_name(_bucket, _prefix, desc.sstable_identifier, comp));
         }
     });
-    co_await delete_object(object_name(_bucket, _prefix, desc.generation, sstable_version_constants::TOC_SUFFIX));
+    co_await delete_object(object_name(_bucket, _prefix, desc.sstable_identifier, sstable_version_constants::TOC_SUFFIX));
 }
 
 future<> object_storage_base::unlink_component(const sstable& sst, component_type type) noexcept {
@@ -956,20 +956,15 @@ future<> object_storage_base::snapshot(const sstable& sst, sstring name) const {
 future<entry_descriptor> object_storage_base::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
     sstlog.trace("clone sst: {} generation={} leave_unsealed={}", sst.get_filename(), gen, leave_unsealed);
 
-    // Register the cloned sstable as "creating" in the registry
+    // The clone shares the same sstable_id as the source, so the objects are
+    // already at the right path. Just register a new entry and add a reference.
     entry_descriptor desc(gen, sst.get_sstable_identifier(), sst.get_version(), sst.get_format(), component_type::TOC);
     auto node_owner = sst.manager().get_local_host_id();
     co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
 
     co_await _client->put_object(make_ref_object_name(sst, gen, node_owner), memory_data_sink_buffers(), abort_source());
 
-    // Copy all component objects from the source to the destination generation.
-    co_await coroutine::parallel_for_each(sst.all_components(), [this, &sst, &gen] (const std::pair<component_type, sstring>& p) -> future<> {
-        co_await copy_object(make_object_name(sst, p.second, sst.generation()), make_object_name(sst, p.second, gen));
-    });
-
     if (!leave_unsealed) {
-        // Mark the cloned sstable as sealed in the registry
         co_await sst.manager().sstables_registry().update_entry_status(owner(), node_owner, gen, status_sealed);
     }
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -662,6 +662,9 @@ public:
         , _as(as)
     {}
 
+    virtual bool is_object_storage() const noexcept override {
+        return true;
+    }
     future<> seal(const sstable& sst) override;
     future<> snapshot(const sstable& sst, sstring name) const override;
     future<> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -949,15 +949,11 @@ std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schem
             return std::make_unique<sstables::filesystem_storage>(loc.dir.native(), state);
         },
         [&] (const data_dictionary::storage_options::object_storage& os) mutable -> std::unique_ptr<sstables::storage> {
-            auto loc = std::visit(overloaded_functor {
-                        [] (const sstring& prefix) { return std::optional<sstring>(prefix); },
-                        [] (const table_id&) { return std::optional<sstring>(); }
-                    }, os.location);
             if (s_opts.is_s3_type()) {
-                return std::make_unique<sstables::s3_storage>(schema, manager.get_endpoint_client(os.endpoint), os.bucket, std::move(loc), os.abort_source);
+                return std::make_unique<sstables::s3_storage>(schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
             }
             if (s_opts.is_gs_type()) {
-                return std::make_unique<sstables::object_storage_base>("GS", schema, manager.get_endpoint_client(os.endpoint), os.bucket, std::move(loc), os.abort_source);
+                return std::make_unique<sstables::object_storage_base>("GS", schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
             }
             throw std::runtime_error(fmt::format("Not implemented: '{}'", os.type));
         }
@@ -1000,7 +996,6 @@ static future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_
     nopts.value = data_dictionary::storage_options::object_storage {
         .bucket = so.bucket,
         .endpoint = so.endpoint,
-        .location = s.id(),
         .type = so.type
     };
     co_return make_lw_shared<const data_dictionary::storage_options>(std::move(nopts));

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -633,7 +633,7 @@ protected:
     schema_ptr _schema;
     shared_ptr<sstables::object_storage_client> _client;
     sstring _bucket;
-    std::variant<sstring, table_id> _location;
+    std::optional<sstring> _location;
     seastar::abort_source* _as;
 
     static constexpr auto status_creating = "creating";
@@ -644,16 +644,16 @@ protected:
     object_name make_object_name(const sstable& sst, sstring comp, generation_type gen) const;
 
     table_id owner() const {
-        if (std::holds_alternative<sstring>(_location)) {
-            on_internal_error(sstlog, format("Storage holds {} prefix, but registry owner is expected", std::get<sstring>(_location)));
+        if (_location) {
+            on_internal_error(sstlog, format("Storage holds '{}' prefix, but registry owner is expected", *_location));
         }
-        return std::get<table_id>(_location);
+        return _schema->id();
     }
     seastar::abort_source* abort_source() const {
         return _as;
     }
 public:
-    object_storage_base(sstring type, schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
+    object_storage_base(sstring type, schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::optional<sstring> loc, seastar::abort_source* as)
         : _type(type) 
         , _schema(std::move(schema))
         , _client(std::move(client))
@@ -688,7 +688,10 @@ public:
     future<> unlink_component(const sstable& sst, component_type) noexcept override;
 
     sstring prefix() const override { 
-        return std::visit([] (const auto& v) { return fmt::to_string(v); }, _location); 
+        if (_location) {
+            return *_location;
+        }
+        return fmt::to_string(_schema->id());
     }
 
     future<bool> exists(const sstable& sst, component_type type) const override {
@@ -717,7 +720,7 @@ public:
 
 class s3_storage : public object_storage_base {
 public:
-    s3_storage(schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
+    s3_storage(schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::optional<sstring> loc, seastar::abort_source* as)
         : object_storage_base("S3", std::move(schema), std::move(client), std::move(bucket), std::move(loc), as)
     {}
 
@@ -735,15 +738,11 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
         throw std::runtime_error(fmt::format("'{}' STORAGE only works with uuid_sstable_identifier enabled", _type));
     }
 
-    return std::visit(overloaded_functor {
-        [&] (const sstring& prefix) {
-            return object_name(_bucket, prefix,
-                sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp));
-        },
-        [&] (const table_id&) {
-            return object_name(_bucket, gen, comp);
-        }
-    }, _location);
+    if (!_location) {
+        return object_name(_bucket, gen, comp);
+    }
+    return object_name(_bucket, *_location,
+        sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp));
 }
 
 void object_storage_base::open(sstable& sst) {
@@ -950,17 +949,15 @@ std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schem
             return std::make_unique<sstables::filesystem_storage>(loc.dir.native(), state);
         },
         [&] (const data_dictionary::storage_options::object_storage& os) mutable -> std::unique_ptr<sstables::storage> {
-            if (std::visit(overloaded_functor {
-                        [] (const sstring& prefix) { return prefix.empty(); },
-                        [] (const table_id& owner) { return owner.id.is_null(); }
-                    }, os.location)) {
-                on_internal_error(sstlog, fmt::format("{} storage options is missing 'location'", os.name()));
-            }
+            auto loc = std::visit(overloaded_functor {
+                        [] (const sstring& prefix) { return std::optional<sstring>(prefix); },
+                        [] (const table_id&) { return std::optional<sstring>(); }
+                    }, os.location);
             if (s_opts.is_s3_type()) {
-                return std::make_unique<sstables::s3_storage>(schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
+                return std::make_unique<sstables::s3_storage>(schema, manager.get_endpoint_client(os.endpoint), os.bucket, std::move(loc), os.abort_source);
             }
             if (s_opts.is_gs_type()) {
-                return std::make_unique<sstables::object_storage_base>("GS", schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
+                return std::make_unique<sstables::object_storage_base>("GS", schema, manager.get_endpoint_client(os.endpoint), os.bucket, std::move(loc), os.abort_source);
             }
             throw std::runtime_error(fmt::format("Not implemented: '{}'", os.type));
         }

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -89,7 +89,7 @@ public:
 
     virtual future<> seal(const sstable& sst) override;
     virtual future<> snapshot(const sstable& sst, sstring name) const override;
-    virtual future<> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;
+    virtual future<entry_descriptor> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;
     virtual future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     virtual void open(sstable& sst) override;
@@ -448,9 +448,12 @@ future<> filesystem_storage::snapshot(const sstable& sst, sstring name) const {
     co_await sst.sstable_touch_directory_io_check(snapshot_dir);
     co_await create_links_common(sst, snapshot_dir.native(), sst._generation, link_mode::default_mode);
 }
-future<> filesystem_storage::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
+future<entry_descriptor> filesystem_storage::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
     sstlog.debug("Cloning {} dir={} generation={} leave_unsealed={}", sst.get_filename(), _dir.path().native(), gen, leave_unsealed);
     co_await create_links_common(sst, _dir.path().native(), std::move(gen), leave_unsealed ? link_mode::leave_unsealed : link_mode::default_mode);
+    auto desc = sst.get_descriptor(component_type::TOC);
+    desc.generation = gen;
+    co_return desc;
 }
 
 future<> filesystem_storage::move(const sstable& sst, sstring new_dir, generation_type new_generation, delayed_commit_changes* delay_commit) {
@@ -680,7 +683,7 @@ public:
     }
     future<> seal(const sstable& sst) override;
     future<> snapshot(const sstable& sst, sstring name) const override;
-    future<> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;
+    future<entry_descriptor> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;
     future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     void open(sstable& sst) override;
@@ -768,7 +771,7 @@ future<bool> object_storage_base::has_references(generation_type gen) const {
 }
 
 void object_storage_base::open(sstable& sst) {
-    entry_descriptor desc(sst._generation, sst._version, sst._format, component_type::TOC);
+    entry_descriptor desc(sst._generation, sst._sstable_identifier, sst._version, sst._format, component_type::TOC);
     auto host_id = sst.manager().get_local_host_id();
     sst.manager().sstables_registry().create_entry(owner(), host_id, status_creating, sst._state, std::move(desc)).get();
 
@@ -950,11 +953,11 @@ future<> object_storage_base::snapshot(const sstable& sst, sstring name) const {
     co_return;
 }
 
-future<> object_storage_base::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
+future<entry_descriptor> object_storage_base::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
     sstlog.trace("clone sst: {} generation={} leave_unsealed={}", sst.get_filename(), gen, leave_unsealed);
 
     // Register the cloned sstable as "creating" in the registry
-    entry_descriptor desc(gen, sst.get_version(), sst.get_format(), component_type::TOC);
+    entry_descriptor desc(gen, sst.sstable_identifier(), sst.get_version(), sst.get_format(), component_type::TOC);
     auto node_owner = sst.manager().get_local_host_id();
     co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
 
@@ -971,6 +974,7 @@ future<> object_storage_base::clone(const sstable& sst, generation_type gen, boo
     }
 
     sstlog.debug("clone sst: {} generation={}: done", sst.get_filename(), gen);
+    co_return desc;
 }
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schema_ptr schema, const data_dictionary::storage_options& s_opts, sstable_state state) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -108,7 +108,7 @@ public:
     }
     virtual future<> unlink_component(const sstable& sst, component_type) noexcept override;
 
-    virtual sstring prefix() const override { return _dir.native(); }
+    virtual std::string_view prefix() const override { return _dir.native(); }
     future<bool> exists(const sstable& sst, component_type type) const override {
         return file_exists(sst.get_filename(type).format());
     }
@@ -584,7 +584,7 @@ future<atomic_delete_context> filesystem_storage::atomic_delete_prepare(const st
 
     for (const auto& sst : ssts) {
         auto prefix = sst->_storage->prefix();
-        res.prefixes.insert(prefix);
+        res.prefixes.emplace(prefix);
     }
 
     res.pending_delete_log = co_await sstable_directory::create_pending_deletion_log(_base_dir, ssts);
@@ -634,6 +634,8 @@ protected:
     shared_ptr<sstables::object_storage_client> _client;
     sstring _bucket;
     std::optional<sstring> _location;
+    sstring _sstables_prefix;
+    std::string_view _prefix;
     seastar::abort_source* _as;
 
     static constexpr auto status_creating = "creating";
@@ -659,6 +661,8 @@ public:
         , _client(std::move(client))
         , _bucket(std::move(bucket))
         , _location(std::move(loc))
+        , _sstables_prefix(_location ? "" : fmt::to_string(_schema->id()))
+        , _prefix(_location ? *_location : _sstables_prefix)
         , _as(as)
     {
         sstlog.debug("Object storage type={} keyspace={} table={} table_id={} bucket={} loc={}", _type, _schema->ks_name(), _schema->cf_name(), _schema->id(), _bucket, _location ? *_location : "<none>");
@@ -692,11 +696,8 @@ public:
     }
     future<> unlink_component(const sstable& sst, component_type) noexcept override;
 
-    sstring prefix() const override { 
-        if (_location) {
-            return *_location;
-        }
-        return fmt::to_string(_schema->id());
+    std::string_view prefix() const override {
+        return _prefix;
     }
 
     future<bool> exists(const sstable& sst, component_type type) const override {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -661,7 +661,7 @@ public:
         , _client(std::move(client))
         , _bucket(std::move(bucket))
         , _location(std::move(loc))
-        , _sstables_prefix(_location ? "" : fmt::to_string(_schema->id()))
+        , _sstables_prefix(_location ? "" : format("sstables/{}/{}-{}", _schema->ks_name(), _schema->cf_name(), _schema->id()))
         , _prefix(_location ? *_location : _sstables_prefix)
         , _as(as)
     {
@@ -746,7 +746,7 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
 
     auto ret = _location
             ? object_name(_bucket, *_location, sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp))
-            : object_name(_bucket, gen, comp);
+            : object_name(_bucket, _prefix, gen, comp);
     sstlog.debug("make_object_name: sstable_id={} generation={} comp={}: {}", sst.sstable_identifier(), gen, comp, ret.str());
     return ret;
 }
@@ -893,7 +893,7 @@ future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc) {
     std::vector<sstring> components;
 
     try {
-        auto f = make_readable_file(object_name(_bucket, desc.generation, sstable_version_constants::get_component_map(desc.version).at(component_type::TOC)));
+        auto f = make_readable_file(object_name(_bucket, _prefix, desc.generation, sstable_version_constants::get_component_map(desc.version).at(component_type::TOC)));
         auto [components, digest] = co_await with_closeable(std::move(f), [] (file& f) {
             return sstable::read_and_parse_toc(f);
         });
@@ -905,10 +905,10 @@ future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc) {
 
     co_await coroutine::parallel_for_each(components, [this, &desc] (sstring comp) -> future<> {
         if (comp != sstable_version_constants::TOC_SUFFIX) {
-            co_await delete_object(object_name(_bucket, desc.generation, comp));
+            co_await delete_object(object_name(_bucket, _prefix, desc.generation, comp));
         }
     });
-    co_await delete_object(object_name(_bucket, desc.generation, sstable_version_constants::TOC_SUFFIX));
+    co_await delete_object(object_name(_bucket, _prefix, desc.generation, sstable_version_constants::TOC_SUFFIX));
 }
 
 future<> object_storage_base::unlink_component(const sstable& sst, component_type type) noexcept {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -660,7 +660,9 @@ public:
         , _bucket(std::move(bucket))
         , _location(std::move(loc))
         , _as(as)
-    {}
+    {
+        sstlog.debug("Object storage type={} keyspace={} table={} table_id={} bucket={} loc={}", _type, _schema->ks_name(), _schema->cf_name(), _schema->id(), _bucket, _location ? *_location : "<none>");
+    }
 
     virtual bool is_object_storage() const noexcept override {
         return true;
@@ -741,11 +743,11 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
         throw std::runtime_error(fmt::format("'{}' STORAGE only works with uuid_sstable_identifier enabled", _type));
     }
 
-    if (!_location) {
-        return object_name(_bucket, gen, comp);
-    }
-    return object_name(_bucket, *_location,
-        sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp));
+    auto ret = _location
+            ? object_name(_bucket, *_location, sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp))
+            : object_name(_bucket, gen, comp);
+    sstlog.debug("make_object_name: sstable_id={} generation={} comp={}: {}", sst.sstable_identifier(), gen, comp, ret.str());
+    return ret;
 }
 
 void object_storage_base::open(sstable& sst) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -645,6 +645,13 @@ protected:
     object_name make_object_name(const sstable& sst, component_type type) const;
     object_name make_object_name(const sstable& sst, sstring comp, generation_type gen) const;
 
+    // Construct the object name for a reference: {prefix}/{gen}/refs/node-{host_id}/{gen}
+    object_name make_ref_object_name(const sstable& sst, generation_type gen, locator::host_id host_id) const {
+        return make_object_name(sst, fmt::format("refs/node-{}/{}", host_id, gen), gen);
+    }
+    // Check if any reference objects exist for the given generation
+    future<bool> has_references(generation_type gen) const;
+
     table_id owner() const {
         if (_location) {
             on_internal_error(sstlog, format("Storage holds '{}' prefix, but registry owner is expected", *_location));
@@ -751,9 +758,21 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
     return ret;
 }
 
+future<bool> object_storage_base::has_references(generation_type gen) const {
+    auto refs_prefix = fmt::format("{}/{}/refs/", _prefix, gen);
+    auto lister = _client->make_object_lister(_bucket, refs_prefix, nullptr);
+    co_return co_await with_closeable(std::move(lister), [] (abstract_lister& lister) -> future<bool> {
+        auto entry = co_await lister.get();
+        co_return entry.has_value();
+    });
+}
+
 void object_storage_base::open(sstable& sst) {
     entry_descriptor desc(sst._generation, sst._version, sst._format, component_type::TOC);
-    sst.manager().sstables_registry().create_entry(owner(), sst.manager().get_local_host_id(), status_creating, sst._state, std::move(desc)).get();
+    auto host_id = sst.manager().get_local_host_id();
+    sst.manager().sstables_registry().create_entry(owner(), host_id, status_creating, sst._state, std::move(desc)).get();
+
+    put_object(make_ref_object_name(sst, sst._generation, host_id), memory_data_sink_buffers()).get();
 
     memory_data_sink_buffers bufs;
     auto out = data_sink(std::make_unique<memory_data_sink>(bufs));
@@ -868,9 +887,15 @@ future<> object_storage_base::wipe(const sstable& sst, const atomic_delete_conte
         co_await sstables_registry.update_entry_status(owner(), node_owner, sst.generation(), status_removing);
     }
 
-    co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
-        co_await delete_object(make_object_name(sst, type));
-    });
+    // Remove this node's reference to the sstable
+    co_await delete_object(make_ref_object_name(sst, sst.generation(), node_owner));
+
+    // Only delete components if no references remain
+    if (!co_await has_references(sst.generation())) {
+        co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
+            co_await delete_object(make_object_name(sst, type));
+        });
+    }
 
     co_await sstables_registry.delete_entry(owner(), node_owner, sst.generation());
 }
@@ -932,6 +957,8 @@ future<> object_storage_base::clone(const sstable& sst, generation_type gen, boo
     entry_descriptor desc(gen, sst.get_version(), sst.get_format(), component_type::TOC);
     auto node_owner = sst.manager().get_local_host_id();
     co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
+
+    co_await _client->put_object(make_ref_object_name(sst, gen, node_owner), memory_data_sink_buffers(), abort_source());
 
     // Copy all component objects from the source to the destination generation.
     co_await coroutine::parallel_for_each(sst.all_components(), [this, &sst, &gen] (const std::pair<component_type, sstring>& p) -> future<> {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -771,7 +771,7 @@ future<bool> object_storage_base::has_references(generation_type gen) const {
 }
 
 void object_storage_base::open(sstable& sst) {
-    entry_descriptor desc(sst._generation, sst._sstable_identifier, sst._version, sst._format, component_type::TOC);
+    entry_descriptor desc(sst._generation, sst.get_sstable_identifier(), sst._version, sst._format, component_type::TOC);
     auto host_id = sst.manager().get_local_host_id();
     sst.manager().sstables_registry().create_entry(owner(), host_id, status_creating, sst._state, std::move(desc)).get();
 
@@ -957,7 +957,7 @@ future<entry_descriptor> object_storage_base::clone(const sstable& sst, generati
     sstlog.trace("clone sst: {} generation={} leave_unsealed={}", sst.get_filename(), gen, leave_unsealed);
 
     // Register the cloned sstable as "creating" in the registry
-    entry_descriptor desc(gen, sst.sstable_identifier(), sst.get_version(), sst.get_format(), component_type::TOC);
+    entry_descriptor desc(gen, sst.get_sstable_identifier(), sst.get_version(), sst.get_format(), component_type::TOC);
     auto node_owner = sst.manager().get_local_host_id();
     co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -630,6 +630,7 @@ future<> filesystem_storage::unlink_component(const sstable& sst, component_type
 class object_storage_base : public sstables::storage {
 protected:
     sstring _type;
+    schema_ptr _schema;
     shared_ptr<sstables::object_storage_client> _client;
     sstring _bucket;
     std::variant<sstring, table_id> _location;
@@ -652,8 +653,9 @@ protected:
         return _as;
     }
 public:
-    object_storage_base(sstring type, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
+    object_storage_base(sstring type, schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
         : _type(type) 
+        , _schema(std::move(schema))
         , _client(std::move(client))
         , _bucket(std::move(bucket))
         , _location(std::move(loc))
@@ -715,8 +717,8 @@ public:
 
 class s3_storage : public object_storage_base {
 public:
-    s3_storage(shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
-        : object_storage_base("S3", std::move(client), std::move(bucket), std::move(loc), as)
+    s3_storage(schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
+        : object_storage_base("S3", std::move(schema), std::move(client), std::move(bucket), std::move(loc), as)
     {}
 
     future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
@@ -939,7 +941,7 @@ future<> object_storage_base::clone(const sstable& sst, generation_type gen, boo
     sstlog.debug("clone sst: {} generation={}: done", sst.get_filename(), gen);
 }
 
-std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state) {
+std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schema_ptr schema, const data_dictionary::storage_options& s_opts, sstable_state state) {
     return std::visit(overloaded_functor {
         [state] (const data_dictionary::storage_options::local& loc) mutable -> std::unique_ptr<sstables::storage> {
             if (loc.dir.empty()) {
@@ -955,10 +957,10 @@ std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const
                 on_internal_error(sstlog, fmt::format("{} storage options is missing 'location'", os.name()));
             }
             if (s_opts.is_s3_type()) {
-                return std::make_unique<sstables::s3_storage>(manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
+                return std::make_unique<sstables::s3_storage>(schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
             }
             if (s_opts.is_gs_type()) {
-                return std::make_unique<sstables::object_storage_base>("GS", manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
+                return std::make_unique<sstables::object_storage_base>("GS", schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
             }
             throw std::runtime_error(fmt::format("Not implemented: '{}'", os.type));
         }

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -107,7 +107,7 @@ public:
     }
     virtual future<> seal(const sstable& sst) = 0;
     virtual future<> snapshot(const sstable& sst, sstring name) const = 0;
-    virtual future<> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const = 0;
+    virtual future<entry_descriptor> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const = 0;
     virtual future<> change_state(const sstable& sst, sstable_state to, generation_type generation, delayed_commit_changes* delay) = 0;
     // runs in async context
     virtual void open(sstable& sst) = 0;

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -127,7 +127,7 @@ public:
     virtual future<uint64_t> free_space() const = 0;
     virtual future<> unlink_component(const sstable& sst, component_type) noexcept = 0;
 
-    virtual sstring prefix() const  = 0;
+    virtual std::string_view prefix() const  = 0;
     virtual future<bool> exists(const sstable& sst, component_type type) const = 0;
 };
 

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -18,13 +18,12 @@
 #include <seastar/core/reactor.hh>
 
 #include "data_dictionary/storage_options.hh"
+#include "schema/schema_fwd.hh"
 #include "seastarx.hh"
 #include "sstables/shared_sstable.hh"
 #include "sstables/component_type.hh"
 #include "sstables/generation_type.hh"
 #include "utils/disk-error-handler.hh"
-
-class schema;
 
 namespace data_dictionary {
 class storage_options;
@@ -129,7 +128,7 @@ public:
     virtual future<bool> exists(const sstable& sst, component_type type) const = 0;
 };
 
-std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state);
+std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schema_ptr schema, const data_dictionary::storage_options& s_opts, sstable_state state);
 future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const sstables_manager&, const schema&, const data_dictionary::storage_options& so);
 future<> destroy_table_storage(const data_dictionary::storage_options& so);
 future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring ks_name);

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -102,6 +102,9 @@ public:
 
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage
 
+    virtual bool is_object_storage() const noexcept {
+        return false;
+    }
     virtual future<> seal(const sstable& sst) = 0;
     virtual future<> snapshot(const sstable& sst, sstring name) const = 0;
     virtual future<> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const = 0;

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -736,7 +736,7 @@ struct scylla_metadata {
         auto* sid = data.get<scylla_metadata_type::SSTableIdentifier, scylla_metadata::sstable_identifier>();
         return sid ? sid->value : sstable_id::create_null_id();
     }
-    void set_sstable_identifier(sstable_id sid = sstable_id{utils::UUID_gen::get_time_UUID()}) {
+    void set_sstable_identifier(sstable_id sid) {
         data.set<scylla_metadata_type::SSTableIdentifier>(scylla_metadata::sstable_identifier{sid});
     }
     components_digests& get_or_create_components_digests() {

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -222,7 +222,7 @@ private:
         auto& table = db.find_column_family(ks, cf);
         auto& sst_manager = table.get_sstables_manager();
         auto sst = sst_manager.make_sstable(
-            table.schema(), table.get_storage_options(), min_info.generation, sstables::sstable_state::normal, min_info.version, min_info.format);
+            table.schema(), table.get_storage_options(), min_info.generation, min_info.sid, sstables::sstable_state::normal, min_info.version, min_info.format);
         sst->set_sstable_level(0);
         auto units = co_await sst_manager.dir_semaphore().get_units(1);
         sstables::sstable_open_config cfg {
@@ -933,7 +933,7 @@ future<sstables::shared_sstable> sstables_loader::attach_sstable(table_id tid, c
     llog.debug("Adding downloaded SSTables to the table {} on shard {}", table.schema()->cf_name(), this_shard_id());
     auto& sst_manager = table.get_sstables_manager();
     auto sst = sst_manager.make_sstable(
-        table.schema(), table.get_storage_options(), min_info.generation, sstables::sstable_state::normal, min_info.version, min_info.format);
+        table.schema(), table.get_storage_options(), min_info.generation, min_info.sid, sstables::sstable_state::normal, min_info.version, min_info.format);
     sst->set_sstable_level(0);
     auto erm = table.get_effective_replication_map();
     sstables::sstable_open_config cfg {

--- a/sstables_loader_helpers.cc
+++ b/sstables_loader_helpers.cc
@@ -53,7 +53,10 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
         swap(*scylla_it, *std::next(components.begin()));
     }
 
+    // For now, use new gen/sid for the downloaded SSTable.
+    // In the future, cosidering using the same gen/sid as the source SSTable.
     auto gen = table.get_sstable_generation_generator()();
+    auto sid = sstables::sstable_id(gen.as_uuid());
     auto files = co_await sstable->readable_file_for_all_components();
     for (auto it = components.cbegin(); it != components.cend(); ++it) {
         try {
@@ -65,6 +68,7 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
                                              sstables::sstable_state::normal,
                                              sstables::sstable::component_basename(
                                                  table.schema()->ks_name(), table.schema()->cf_name(), descriptor.version, gen, descriptor.format, it->first),
+                                             sid,
                                              sstables::sstable_stream_sink_cfg{.last_component = std::next(it) == components.cend(), .leave_unsealed = true});
             auto out = co_await sstable_sink->output(foptions, stream_options);
 
@@ -101,7 +105,7 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
                     on_internal_error(logger, "Fully-contained sstable must belong to one shard only");
                 }
                 logger.debug("SSTable shards {}", fmt::join(shards, ", "));
-                co_return minimal_sst_info{shards.front(), gen, descriptor.version, descriptor.format};
+                co_return minimal_sst_info{shards.front(), gen, sid, descriptor.version, descriptor.format};
             }
         } catch (...) {
             logger.info("Error downloading SSTable component {}. Reason: {}", it->first, std::current_exception());

--- a/sstables_loader_helpers.hh
+++ b/sstables_loader_helpers.hh
@@ -15,6 +15,7 @@
 #include "sstables/generation_type.hh"
 #include "sstables/shared_sstable.hh"
 #include "sstables/version.hh"
+#include "sstables/types.hh"
 #include "utils/log.hh"
 
 #include <vector>
@@ -27,6 +28,7 @@ class database;
 struct minimal_sst_info {
     shard_id shard;
     sstables::generation_type generation;
+    optimized_optional<sstables::sstable_id> sid;
     sstables::sstable_version_types version;
     sstables::sstable_format_types format;
 };

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -553,6 +553,7 @@ tablet_stream_files(netw::messaging_service& ms, std::list<stream_blob_info> sou
             meta.fops = info.fops;
             meta.filename = info.filename;
             meta.sstable_state = info.sstable_state;
+            meta.sstable_id = info.sstable_id;
             fstream = co_await info.source(stream_options);
         } catch (...) {
             blogger.warn("fstream[{}] Master failed sources={} targets={} error={}",
@@ -779,6 +780,10 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
             auto& sst = sst_snapshot.sst;
             // stable state (across files) is a must for load to work on destination
             auto sst_state = sst->state();
+            auto sst_id = sst->sstable_identifier();
+            if (!sst_id) {
+                on_internal_error(blogger, format("sstable {} has no identifier", sst->get_filename()));
+            }
 
             auto sources = co_await create_stream_sources(sst_snapshot, reader);
             auto newgen = fmt::to_string(sst_gen());
@@ -792,6 +797,7 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
                 auto& info = files.emplace_back();
                 info.fops = file_ops::stream_sstables;
                 info.sstable_state = sst_state;
+                info.sstable_id = *sst_id;
                 info.filename = std::move(newname);
                 info.source = [s = std::move(s)](const file_input_stream_options& options) {
                     return s->input(options);

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -52,7 +52,7 @@ static future<> load_sstable_for_tablet(const file_stream_id& ops_id, replica::d
         replica::table& t = db.find_column_family(id);
         auto erm = t.get_effective_replication_map();
         auto& sstm = t.get_sstables_manager();
-        auto sst = sstm.make_sstable(t.schema(), t.get_storage_options(), desc.generation, state, desc.version, desc.format);
+        auto sst = sstm.make_sstable(t.schema(), t.get_storage_options(), desc.generation, desc.sid, state, desc.version, desc.format);
         sstables::sstable_open_config cfg { .unsealed_sstable = true };
         co_await sst->load(erm->get_sharder(*t.schema()), cfg);
         auto on_add = [sst, &sstm] (sstables::shared_sstable loading_sst) -> future<> {
@@ -438,7 +438,8 @@ future<> stream_blob_handler(replica::database& db, db::view::view_building_work
             // left sealed on the table directory.
             sstables::sstable_stream_sink_cfg cfg { .last_component = meta.fops == file_ops::load_sstables,
                                                     .leave_unsealed = true };
-            auto sstable_sink = sstables::create_stream_sink(table.schema(), sstm, table.get_storage_options(), sstable_state(meta), meta.filename, cfg);
+            auto sid = optimized_optional<sstables::sstable_id>{};  // FIXME: pass sstable_id in stream_blob_meta
+            auto sstable_sink = sstables::create_stream_sink(table.schema(), sstm, table.get_storage_options(), sstable_state(meta), meta.filename, sid, cfg);
             auto out = co_await sstable_sink->output(foptions, stream_options);
             co_return output_result{
                 [sstable_sink = std::move(sstable_sink), &meta, &db, &vbw](store_result res) -> future<> {

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -438,7 +438,7 @@ future<> stream_blob_handler(replica::database& db, db::view::view_building_work
             // left sealed on the table directory.
             sstables::sstable_stream_sink_cfg cfg { .last_component = meta.fops == file_ops::load_sstables,
                                                     .leave_unsealed = true };
-            auto sid = optimized_optional<sstables::sstable_id>{};  // FIXME: pass sstable_id in stream_blob_meta
+            auto sid = meta.sstable_id ? optimized_optional<sstables::sstable_id>(*meta.sstable_id) : optimized_optional<sstables::sstable_id>{};
             auto sstable_sink = sstables::create_stream_sink(table.schema(), sstm, table.get_storage_options(), sstable_state(meta), meta.filename, sid, cfg);
             auto out = co_await sstable_sink->output(foptions, stream_options);
             co_return output_result{

--- a/streaming/stream_blob.hh
+++ b/streaming/stream_blob.hh
@@ -99,6 +99,7 @@ public:
     streaming::file_ops fops;
     service::frozen_topology_guard topo_guard;
     std::optional<sstables::sstable_state> sstable_state;
+    std::optional<sstables::sstable_id> sstable_id;
     // We can extend this verb to send arbitrary blob of data
 };
 
@@ -115,6 +116,7 @@ struct stream_blob_info {
     sstring filename;
     streaming::file_ops fops;
     std::optional<sstables::sstable_state> sstable_state;
+    std::optional<sstables::sstable_id> sstable_id;
     stream_blob_source_fn source;
 
     friend inline std::ostream& operator<<(std::ostream& os, const stream_blob_info& x) {

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -558,7 +558,7 @@ static future<> test_stream_sink_write(sstables::test_env_config cfg) {
 
         auto version = get_highest_sstable_version();
         auto format = sstable::format_types::big;
-        auto generation = env.new_generation();
+        auto [generation, sid] = env.new_generation_and_sid();
         auto& mgr = env.manager();
         auto s_opts = env.get_storage_options();
 
@@ -570,7 +570,7 @@ static future<> test_stream_sink_write(sstables::test_env_config cfg) {
         auto toc_basename = sstable::component_basename(
                 s->ks_name(), s->cf_name(), version, generation, format, component_type::TOC);
 
-        auto sink = create_stream_sink(s, mgr, s_opts, sstable_state::normal, toc_basename, {});
+        auto sink = create_stream_sink(s, mgr, s_opts, sstable_state::normal, toc_basename, sid, {});
 
         // output() would succeed before the fix (wrapping the read-only file into a stream),
         // but the write below would throw std::logic_error("unsupported operation on s3 readable file").

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -564,7 +564,7 @@ static future<> test_stream_sink_write(sstables::test_env_config cfg) {
 
         std::visit(overloaded_functor {
             [&env] (data_dictionary::storage_options::local& o) { o.dir = env.tempdir().path().native(); },
-            [&s] (data_dictionary::storage_options::object_storage& o) { o.location = s->id(); },
+            [] (data_dictionary::storage_options::object_storage& o) { o.location = std::nullopt; },
         }, s_opts.value);
 
         auto toc_basename = sstable::component_basename(

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -78,7 +78,8 @@ SEASTAR_TEST_CASE(incremental_compaction_test) {
 
         auto tmp = make_lw_shared<tmpdir>();
         auto sst_gen = [&env, s, tmp] () mutable {
-            auto sst = env.make_sstable(s, tmp->path().string(), env.new_generation(), sstable_version_types::md, big);
+            auto [gen, sid] = env.new_generation_and_sid();
+            auto sst = env.make_sstable(s, tmp->path().string(), gen, sid, sstable_version_types::md, big);
             return sst;
         };
 
@@ -234,7 +235,8 @@ SEASTAR_THREAD_TEST_CASE(incremental_compaction_sag_test) {
         }
 
         shared_sstable make_sstable_with_size(size_t sstable_data_size) {
-            auto sst = _env.make_sstable(_cf->schema(), "/nowhere/in/particular", _env.new_generation(), sstable_version_types::md, big);
+            auto [gen, sid] = _env.new_generation_and_sid();
+            auto sst = _env.make_sstable(_cf->schema(), "/nowhere/in/particular", gen, sid, sstable_version_types::md, big);
             auto keys = tests::generate_partition_keys(2, _cf->schema(), local_shard_only::yes);
             sstables::test(sst).set_values(keys[0].key(), keys[1].key(), stats_metadata{}, sstable_data_size);
             return sst;
@@ -335,7 +337,8 @@ SEASTAR_TEST_CASE(basic_garbage_collection_test) {
         auto close_cf = deferred_stop(cf);
 
         auto creator = [&] {
-            auto sst = env.make_sstable(s, tmp.path().string(), env.new_generation(), sstables::get_highest_sstable_version(), big);
+            auto [gen, sid] = env.new_generation_and_sid();
+            auto sst = env.make_sstable(s, tmp.path().string(), gen, sid, sstables::get_highest_sstable_version(), big);
             return sst;
         };
         auto sst = make_sstable_containing(creator, std::move(mutations)).get();
@@ -436,7 +439,8 @@ SEASTAR_TEST_CASE(ics_reshape_test) {
         auto tmp = tmpdir();
 
         auto sst_gen = [&env, s, &tmp]() {
-            return env.make_sstable(s, tmp.path().string(), env.new_generation(), sstables::sstable::version_types::md, big);
+            auto [gen, sid] = env.new_generation_and_sid();
+            return env.make_sstable(s, tmp.path().string(), gen, sid, sstables::sstable::version_types::md, big);
         };
 
         {

--- a/test/boost/schema_loader_test.cc
+++ b/test/boost/schema_loader_test.cc
@@ -333,7 +333,7 @@ void check_sstable_schema(sstables::test_env& env, std::filesystem::path sst_pat
 
     const auto ed = sstables::parse_path(sst_path, "ks", "tbl").value();
     const auto dir_path = sst_path.parent_path();
-    auto sst = env.make_sstable(schema, dir_path.c_str(), ed.generation, ed.version, ed.format);
+    auto sst = env.make_sstable(schema, dir_path.c_str(), ed.generation, ed.sid, ed.version, ed.format);
 
     sst->load(schema->get_sharder()).get();
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -55,6 +55,7 @@ class sstable_assertions final : public sstables::test {
         : test(env.make_sstable(std::move(schema),
                             path,
                             generation,
+                            std::nullopt,
                             version,
                             sstable_format_types::big,
                             1))

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7359,7 +7359,7 @@ void sstable_clone_leaving_unsealed_dest_sstable_fn(test_env& env) {
     bool leave_unsealed = true;
     auto d = sst->clone(gen_generator(), leave_unsealed).get();
 
-    auto sst2 = env.make_sstable(s, d.generation, d.version, d.format);
+    auto sst2 = env.make_sstable(s, d.generation, d.sid, d.version, d.format);
     sst2->load(s->get_sharder(), sstable_open_config{ .unsealed_sstable = leave_unsealed }).get();
     BOOST_REQUIRE(!sst2->get_storage().exists(*sst2, sstables::component_type::TOC).get());
     BOOST_REQUIRE(sst2->get_storage().exists(*sst2, sstables::component_type::TemporaryTOC).get());
@@ -7367,7 +7367,7 @@ void sstable_clone_leaving_unsealed_dest_sstable_fn(test_env& env) {
     leave_unsealed = false;
     d = sst->clone(gen_generator(), leave_unsealed).get();
 
-    auto sst3 = env.make_sstable(s, d.generation, d.version, d.format);
+    auto sst3 = env.make_sstable(s, d.generation, d.sid, d.version, d.format);
     sst3->load(s->get_sharder(), sstable_open_config{ .unsealed_sstable = leave_unsealed }).get();
     BOOST_REQUIRE(sst3->get_storage().exists(*sst3, sstables::component_type::TOC).get());
     BOOST_REQUIRE(!sst3->get_storage().exists(*sst3, sstables::component_type::TemporaryTOC).get());
@@ -7394,7 +7394,7 @@ void object_storage_sstable_clone_leaving_unsealed_dest_sstable(test_env& env) {
     bool leave_unsealed = true;
     auto d = sst->clone(gen_generator(), leave_unsealed).get();
 
-    auto sst2 = env.make_sstable(s, d.generation, d.version, d.format);
+    auto sst2 = env.make_sstable(s, d.generation, d.sid, d.version, d.format);
     {
         bool checked = false;
         env.manager()
@@ -7416,7 +7416,7 @@ void object_storage_sstable_clone_leaving_unsealed_dest_sstable(test_env& env) {
     leave_unsealed = false;
     d = sst->clone(gen_generator(), leave_unsealed).get();
 
-    auto sst3 = env.make_sstable(s, d.generation, d.version, d.format);
+    auto sst3 = env.make_sstable(s, d.generation, d.sid, d.version, d.format);
     {
         bool checked = false;
         env.manager()

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -32,7 +32,8 @@ static db_clock::time_point to_db_clock(gc_clock::time_point tp) {
 static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, sstring dir, utils::chunked_vector<mutation> mutations,
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    auto sst = env.make_sstable(s, dir, env.new_generation(), version, sstable_format_types::big, default_sstable_buffer_size, to_db_clock(query_time));
+    auto [gen, sid] = env.new_generation_and_sid();
+    auto sst = env.make_sstable(s, dir, gen, sid, version, sstable_format_types::big, default_sstable_buffer_size, to_db_clock(query_time));
     auto mt = make_memtable(s, mutations).get();
     auto mr = mt->make_mutation_reader(s, env.make_reader_permit());
     sst->write_components(std::move(mr), mutations.size(), s, cfg, mt->get_encoding_stats()).get();

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2228,7 +2228,7 @@ SEASTAR_TEST_CASE(test_broken_promoted_index_is_skipped) {
                 .with_column("v", int32_type)
                 .build(schema_builder::compact_storage::yes);
 
-        auto sst = env.make_sstable(s, get_test_dir("broken_non_compound_pi_and_range_tombstone", s), sstables::generation_type(1), version);
+        auto sst = env.make_sstable(s, get_test_dir("broken_non_compound_pi_and_range_tombstone", s), sstables::generation_type(1), std::nullopt, version);
         try {
             sst->load(sst->get_schema()->get_sharder()).get();
         } catch (...) {

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -86,7 +86,8 @@ make_sstable_for_all_shards(replica::table& table, sstables::sstable_state state
         m.set_clustered_cell(clustering_key::make_empty(), bytes("c"), data_value(int32_t(0)), api::timestamp_type(0));
         mt->apply(std::move(m));
     }
-    auto sst = table.get_sstables_manager().make_sstable(s, table.get_storage_options(), generation, state);
+    auto sid = sstables::sstable_id(generation.as_uuid());
+    auto sst = table.get_sstables_manager().make_sstable(s, table.get_storage_options(), generation, sid, state);
     write_memtable_to_sstable(*mt, sst).get();
     mt->clear_gently().get();
     // We can't write an SSTable with bad sharding, so pretend
@@ -99,7 +100,8 @@ make_sstable_for_all_shards(replica::table& table, sstables::sstable_state state
 
 sstables::shared_sstable new_sstable(sstables::test_env& env, sstables::generation_type gen) {
     testlog.debug("new_sstable: dir={} gen={}", env.tempdir().path(), gen);
-    return env.make_sstable(test_table_schema(), gen);
+    auto sid = gen.is_uuid_based() ? sstables::sstable_id(gen.as_uuid()) : sstables::sstable_id{utils::UUID_gen::get_time_UUID()};
+    return env.make_sstable(test_table_schema(), gen, sid);
 }
 
 sstables::shared_sstable new_env_sstable(sstables::test_env& env) {
@@ -582,8 +584,9 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
             auto generation = sharded_gen.invoke_on(shard, [] (auto& gen) {
                 return gen();
             }).get();
+            auto sid = sstable_id(generation.as_uuid());
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sid, sstables::sstable_state::upload);
         };
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable)).get();
         verify_that_all_sstables_are_local(sstdir, this_smp_shard_count() * this_smp_shard_count()).get();
@@ -632,8 +635,9 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly_with_owned
             auto generation = sharded_gen.invoke_on(shard, [] (auto& gen) {
                 return gen();
             }).get();
+            auto sid = sstables::sstable_id(generation.as_uuid());
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sid, sstables::sstable_state::upload);
         };
         const auto& erm = e.db().local().find_keyspace("ks").get_static_effective_replication_map();
         auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(e.db().local().get_keyspace_local_ranges(erm).get());
@@ -685,7 +689,8 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_distributes_well_eve
                 return gen();
             }).get();
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+            auto sid = sstables::sstable_id(generation.as_uuid());
+            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sid, sstables::sstable_state::upload);
         };
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable)).get();
         verify_that_all_sstables_are_local(sstdir, this_smp_shard_count() * this_smp_shard_count()).get();
@@ -734,7 +739,8 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_respect_max_threshol
                 return gen();
             }).get();
             auto& cf = e.local_db().find_column_family("ks", "cf");
-            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+            auto sid = sstables::sstable_id(generation.as_uuid());
+            return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sid, sstables::sstable_state::upload);
         };
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable)).get();
         verify_that_all_sstables_are_local(sstdir, 2 * this_smp_shard_count() * this_smp_shard_count()).get();
@@ -949,8 +955,9 @@ SEASTAR_TEST_CASE(sstable_directory_test_reshard_vnodes) {
                 auto generation = sharded_gen.invoke_on(shard, [] (auto& gen) {
                     return gen();
                 }).get();
+                auto sid = sstables::sstable_id(generation.as_uuid());
                 auto& cf = e.local_db().find_column_family("ks", "cf");
-                return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+                return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sid, sstables::sstable_state::upload);
             };
 
             const auto& erm = e.local_db().find_keyspace("ks").get_static_effective_replication_map();

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -67,7 +67,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_idempotent) {
     auto stop_env = defer([&env] { env.stop().get(); });
 
     auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), sstables::generation_type(1));
-    sstring old_path = sst->get_storage().prefix();
+    auto old_path = sst->get_storage().prefix();
     touch_directory(format("{}/{}", old_path, sstables::staging_dir)).get();
     sst->change_state(sstables::sstable_state::staging).get();
     sst->change_state(sstables::sstable_state::normal).get();
@@ -171,7 +171,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_clone_preserves_staging_state) {
     // Load the cloned sstable from the staging directory.  We use the storage
     // prefix of the source (which is the staging sub-directory) so that the
     // loader can find the files, mirroring what distributed_loader does.
-    auto staging_dir = sst->get_storage().prefix();
+    auto staging_dir = sstring(sst->get_storage().prefix());
     auto cloned_sst = env.reusable_sst(schema, staging_dir, clone_gen).get();
 
     // Assert that the cloned sstable preserves the staging state.

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -106,8 +106,9 @@ void run_sstable_resharding_test(sstables::test_env& env) {
         auto gen = smp::submit_to(shard, [&cf] () {
             return column_family_test::calculate_generation_for_new_table(*cf);
         }).get();
+        auto sid = sstables::sstable_id(gen.as_uuid());
 
-        return env.make_sstable(cf->schema(), gen, version);
+        return env.make_sstable(cf->schema(), gen, sid, version);
     };
     auto cdata = compaction::compaction_manager::create_compaction_data();
     compaction::compaction_progress_monitor progress_monitor;

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -963,7 +963,7 @@ static future<> test_component_digest_persistence(component_type component, ssta
 
         sst_original = nullptr;
 
-        auto sst_reopened = env.make_sstable(schema, dir_path, entry_desc.generation, entry_desc.version, entry_desc.format);
+        auto sst_reopened = env.make_sstable(schema, dir_path, entry_desc.generation, entry_desc.sid, entry_desc.version, entry_desc.format);
         sst_reopened->load(schema->get_sharder()).get();
 
         auto loaded_digest = sst_reopened->get_component_digest(component);
@@ -1074,7 +1074,7 @@ static future<> test_component_digest_validation(component_type component, sstab
         corrupt_sstable(sst, component);
 
         // Loading the sstable should detect the digest mismatch
-        auto sst_corrupted = env.make_sstable(schema, dir_path, entry_desc.generation, entry_desc.version, entry_desc.format);
+        auto sst_corrupted = env.make_sstable(schema, dir_path, entry_desc.generation, entry_desc.sid, entry_desc.version, entry_desc.format);
         BOOST_REQUIRE_EXCEPTION(sst_corrupted->load(schema->get_sharder()).get(), malformed_sstable_exception,
             exception_predicate::message_contains(expected_message));
     });

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -804,6 +804,20 @@ BOOST_AUTO_TEST_CASE(test_empty_key_view_comparison) {
     BOOST_CHECK(lf.begin() == lf.end());
 }
 
+static sstables::entry_descriptor make_entry_descriptor(sstables::generation_type gen, sstables::sstable_version_types version, sstables::sstable_format_types format, sstables::component_type component) {
+    optimized_optional<sstables::sstable_id> sid;
+    if (gen.is_uuid_based()) {
+        sid = sstables::sstable_id(gen.as_uuid());
+    }
+    return entry_descriptor{
+        gen,
+        sid,
+        version,
+        format,
+        component
+    };
+}
+
 // Test that sstables::parse_path is able to parse the paths of sstables
 BOOST_AUTO_TEST_CASE(test_parse_path_good) {
     struct sstable_case {
@@ -817,56 +831,56 @@ BOOST_AUTO_TEST_CASE(test_parse_path_good) {
             "/scylla/system/truncated-38c19fd0fb863310a4b70d0cc66628aa/mc-2-big-Data.db",
             "system",
             "truncated",
-            entry_descriptor{
+            make_entry_descriptor(
                 generation_type{2},
                 sstable_version_types::mc,
                 sstable_format_types::big,
                 component_type::Data
-            }
+            )
         },
         {
             "/scylla/system/scylla_local-2972ec7ffb2038ddaac1d876f2e3fcbd/mc-3-big-Summary.db",
             "system",
             "scylla_local",
-            entry_descriptor{
+            make_entry_descriptor(
                 generation_type{3},
                 sstable_version_types::mc,
                 sstable_format_types::big,
                 component_type::Summary
-            }
+            )
         },
         {
             "/scylla/system_distributed/cdc_generation_timestamps-fdf455c4cfec3e009719d7a45436c89d/me-3g9p_0938_0ecz429c6f019i7yuf-big-Index.db",
             "system_distributed",
             "cdc_generation_timestamps",
-            entry_descriptor{
+            make_entry_descriptor(
                 generation_type::from_string("3g9p_0938_0ecz429c6f019i7yuf"),
                 sstable_version_types::me,
                 sstable_format_types::big,
                 component_type::Index
-            }
+            )
          },
          {
             "/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/md-3g9r_04ux_4be4w2d7t8bg6u7nok-big-Statistics.db",
             "system_schema",
             "columns",
-            entry_descriptor{
+            make_entry_descriptor(
                 generation_type::from_string("3g9r_04ux_4be4w2d7t8bg6u7nok"),
                 sstable_version_types::md,
                 sstable_format_types::big,
                 component_type::Statistics
-            }
+            )
         },
         {
             "/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/md-3g9r_04ux_4be4w2d7t8bg6u7nok-big-ReallyBigData.db",
             "system_schema",
             "columns",
-            entry_descriptor{
+            make_entry_descriptor(
                 generation_type::from_string("3g9r_04ux_4be4w2d7t8bg6u7nok"),
                 sstable_version_types::md,
                 sstable_format_types::big,
                 component_type::Unknown
-            }
+            )
         }
     };
     for (auto& [path, expected_ks, expected_cf, expected_desc] : sstables) {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -117,14 +117,15 @@ public:
     future<> stop();
 
     sstables::generation_type new_generation() noexcept;
+    std::pair<sstables::generation_type, sstables::sstable_id> new_generation_and_sid() noexcept;
 
-    shared_sstable make_sstable(schema_ptr schema, sstring dir, sstables::generation_type generation,
+    shared_sstable make_sstable(schema_ptr schema, sstring dir, sstables::generation_type generation, optimized_optional<sstables::sstable_id> sid = {},
             sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
             size_t buffer_size = default_sstable_buffer_size, db_clock::time_point now = db_clock::now());
 
     shared_sstable make_sstable(schema_ptr schema, sstring dir, sstable::version_types v = sstables::get_highest_sstable_version());
 
-    shared_sstable make_sstable(schema_ptr schema, sstables::generation_type generation,
+    shared_sstable make_sstable(schema_ptr schema, sstables::generation_type generation, optimized_optional<sstables::sstable_id> sid = {},
             sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
             size_t buffer_size = default_sstable_buffer_size, db_clock::time_point now = db_clock::now());
 

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -94,17 +94,17 @@ future<sstables::shared_sstable> make_sstable_containing(std::function<sstables:
 }
 
 shared_sstable make_sstable_easy(test_env& env, mutation_reader rd, sstable_writer_config cfg,
-        sstables::generation_type gen, const sstables::sstable::version_types version, int expected_partition, db_clock::time_point query_time) {
+        sstables::generation_type gen, optimized_optional<sstables::sstable_id> sid, const sstables::sstable::version_types version, int expected_partition, db_clock::time_point query_time) {
     auto s = rd.schema();
-    auto sst = env.make_sstable(s, gen, version, sstable_format_types::big, default_sstable_buffer_size, query_time);
+    auto sst = env.make_sstable(s, gen, sid, version, sstable_format_types::big, default_sstable_buffer_size, query_time);
     sst->write_components(std::move(rd), expected_partition, s, cfg, encoding_stats{}).get();
     sst->load(s->get_sharder()).get();
     return sst;
 }
 
 shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable> mt, sstable_writer_config cfg,
-        sstables::generation_type gen, const sstable::version_types v, int estimated_partitions, db_clock::time_point query_time) {
-    return make_sstable_easy(env, mt->make_mutation_reader(mt->schema(), env.make_reader_permit()), std::move(cfg), gen, v, estimated_partitions, query_time);
+        sstables::generation_type gen, optimized_optional<sstables::sstable_id> sid, const sstable::version_types v, int estimated_partitions, db_clock::time_point query_time) {
+    return make_sstable_easy(env, mt->make_mutation_reader(mt->schema(), env.make_reader_permit()), std::move(cfg), gen, sid, v, estimated_partitions, query_time);
 }
 
 future<compaction::compaction_result> compact_sstables(test_env& env, compaction::compaction_descriptor descriptor, table_for_tests t,

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -259,18 +259,22 @@ future<compaction::compaction_result> compact_sstables(test_env& env, compaction
                  can_purge_tombstones can_purge = can_purge_tombstones::yes);
 
 shared_sstable make_sstable_easy(test_env& env, mutation_reader rd, sstable_writer_config cfg,
-        sstables::generation_type gen, const sstable::version_types version = sstables::get_highest_sstable_version(), int expected_partition = 1, db_clock::time_point = db_clock::now());
+        sstables::generation_type gen, optimized_optional<sstables::sstable_id> sid,
+        const sstable::version_types version = sstables::get_highest_sstable_version(), int expected_partition = 1, db_clock::time_point = db_clock::now());
 shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable> mt, sstable_writer_config cfg,
-        sstables::generation_type gen, const sstable::version_types v = sstables::get_highest_sstable_version(), int estimated_partitions = 1, db_clock::time_point = db_clock::now());
+        sstables::generation_type gen, optimized_optional<sstables::sstable_id> sid,
+        const sstable::version_types v = sstables::get_highest_sstable_version(), int estimated_partitions = 1, db_clock::time_point = db_clock::now());
 
 
 inline shared_sstable make_sstable_easy(test_env& env, mutation_reader rd, sstable_writer_config cfg,
         const sstable::version_types version = sstables::get_highest_sstable_version(), int expected_partition = 1) {
-    return make_sstable_easy(env, std::move(rd), std::move(cfg), env.new_generation(), version, expected_partition);
+    auto [gen, sid] = env.new_generation_and_sid();
+    return make_sstable_easy(env, std::move(rd), std::move(cfg), gen, sid, version, expected_partition);
 }
 inline shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable> mt, sstable_writer_config cfg,
         const sstable::version_types version = sstables::get_highest_sstable_version(), int estimated_partitions = 1, db_clock::time_point query_time = db_clock::now()) {
-    return make_sstable_easy(env, std::move(mt), std::move(cfg), env.new_generation(), version, estimated_partitions, query_time);
+    auto [gen, sid] = env.new_generation_and_sid();
+    return make_sstable_easy(env, std::move(mt), std::move(cfg), gen, sid, version, estimated_partitions, query_time);
 }
 
 future<lw_shared_ptr<replica::memtable>> make_memtable(schema_ptr s, const utils::chunked_vector<mutation>& muts);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -242,6 +242,11 @@ struct test_env::impl {
     sstables::generation_type new_generation() noexcept {
         return gen();
     }
+    std::pair<sstables::generation_type, sstables::sstable_id> new_generation_and_sid() noexcept {
+        auto generation = gen();
+        auto sid = sstables::sstable_id(generation.as_uuid());
+        return {generation, sid};
+    }
 };
 
 test_env::impl::impl(test_env_config cfg, sstable_compressor_factory& scfarg, sstables::storage_manager* sstm, tmpdir* tdir)
@@ -394,8 +399,14 @@ test_env::new_generation() noexcept {
     return _impl->new_generation();
 }
 
+std::pair<sstables::generation_type, sstables::sstable_id>
+test_env::new_generation_and_sid() noexcept {
+    return _impl->new_generation_and_sid();
+}
+
 shared_sstable
 test_env::make_sstable(schema_ptr schema, sstring dir, sstables::generation_type generation,
+        optimized_optional<sstables::sstable_id> sid,
         sstable::version_types v, sstable::format_types f,
         size_t buffer_size, db_clock::time_point now) {
     // FIXME -- most of the callers work with _impl->dir's path, so
@@ -417,44 +428,49 @@ test_env::make_sstable(schema_ptr schema, sstring dir, sstables::generation_type
         [&dir] (data_dictionary::storage_options::local& o) { o.dir = dir; },
         [] (data_dictionary::storage_options::object_storage& o) { o.location = std::nullopt; },
     }, storage.value);
-    return _impl->mgr.make_sstable(std::move(schema), storage, generation, state, v, f, now, default_io_error_handler_gen(), buffer_size);
+    return _impl->mgr.make_sstable(std::move(schema), storage, generation, sid, state, v, f, now, default_io_error_handler_gen(), buffer_size);
 }
 
 shared_sstable
 test_env::make_sstable(schema_ptr schema, sstring dir, sstable::version_types v) {
-    return make_sstable(std::move(schema), std::move(dir), new_generation(), std::move(v));
+    auto [gen, sid] = new_generation_and_sid();
+    return make_sstable(std::move(schema), std::move(dir), gen, sid, std::move(v));
 }
 
 shared_sstable
 test_env::make_sstable(schema_ptr schema, sstables::generation_type generation,
+        optimized_optional<sstables::sstable_id> sid,
         sstable::version_types v, sstable::format_types f,
         size_t buffer_size, db_clock::time_point now) {
-    return make_sstable(std::move(schema), _impl->dir.path().native(), generation, std::move(v), std::move(f), buffer_size, now);
+    return make_sstable(std::move(schema), _impl->dir.path().native(), generation, std::move(sid), std::move(v), std::move(f), buffer_size, now);
 }
 
 shared_sstable
 test_env::make_sstable(schema_ptr schema, sstable::version_types v) {
-    return make_sstable(std::move(schema), _impl->dir.path().native(), std::move(v));
+    auto [gen, sid] = new_generation_and_sid();
+    return make_sstable(std::move(schema), _impl->dir.path().native(), gen, sid, std::move(v));
 }
 
 std::function<shared_sstable()>
 test_env::make_sst_factory(schema_ptr s) {
     return [this, s = std::move(s)] {
-        return make_sstable(s, new_generation());
+        auto [gen, sid] = new_generation_and_sid();
+        return make_sstable(s, gen, sid);
     };
 }
 
 std::function<shared_sstable()>
 test_env::make_sst_factory(schema_ptr s, sstable::version_types version) {
     return [this, s = std::move(s), version] {
-        return make_sstable(s, new_generation(), version);
+        auto [gen, sid] = new_generation_and_sid();
+        return make_sstable(s, gen, sid, version);
     };
 }
 
 future<shared_sstable>
 test_env::reusable_sst(schema_ptr schema, sstring dir, sstables::generation_type generation,
         sstable::version_types version, sstable::format_types f, sstable_open_config cfg) {
-    auto sst = make_sstable(std::move(schema), dir, generation, version, f);
+    auto sst = make_sstable(std::move(schema), dir, generation, std::nullopt, version, f);
     return sst->load(sst->get_schema()->get_sharder(), cfg).then([sst = std::move(sst)] {
         return make_ready_future<shared_sstable>(std::move(sst));
     });

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -415,7 +415,7 @@ test_env::make_sstable(schema_ptr schema, sstring dir, sstables::generation_type
     auto storage = _impl->storage;
     std::visit(overloaded_functor {
         [&dir] (data_dictionary::storage_options::local& o) { o.dir = dir; },
-        [&schema] (data_dictionary::storage_options::object_storage& o) { o.location = schema->id(); },
+        [] (data_dictionary::storage_options::object_storage& o) { o.location = std::nullopt; },
     }, storage.value);
     return _impl->mgr.make_sstable(std::move(schema), storage, generation, state, v, f, now, default_io_error_handler_gen(), buffer_size);
 }
@@ -552,7 +552,7 @@ test_env::make_table_for_tests(schema_ptr s, sstring dir) {
     auto storage = _impl->storage;
     std::visit(overloaded_functor {
         [&dir] (data_dictionary::storage_options::local& o) { o.dir = dir; },
-        [&s] (data_dictionary::storage_options::object_storage& o) { o.location = s->id(); },
+        [] (data_dictionary::storage_options::object_storage& o) { o.location = std::nullopt; },
     }, storage.value);
     return table_for_tests(manager(), _impl->cmgr->get_compaction_manager(), s, std::move(cfg), std::move(storage));
 }

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -474,7 +474,7 @@ test_env::reusable_sst(schema_ptr schema, sstables::generation_type generation,
 
 future<shared_sstable>
 test_env::reusable_sst(schema_ptr schema, shared_sstable sst) {
-    return reusable_sst(std::move(schema), sst->get_storage().prefix(), sst->generation(), sst->get_version());
+    return reusable_sst(std::move(schema), sstring(sst->get_storage().prefix()), sst->generation(), sst->get_version());
 }
 
 future<shared_sstable>

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -229,7 +229,7 @@ public:
             std::filesystem::path sst_path = sst_dir_path / de.name.begin();
             auto entry = parse_path(sst_path, s->ks_name(), s->cf_name()).value();
             if (entry.component == component_type::TOC) {
-                auto sst = _env.make_sstable(s, this->dir(), entry.generation, entry.version);
+                auto sst = _env.make_sstable(s, this->dir(), entry.generation, entry.sid, entry.version);
                 co_await sst->load(s->get_sharder());
                 _sst.push_back(sst);
             }
@@ -243,7 +243,7 @@ public:
             size_t partitions = _mt->partition_count();
 
             test_setup::create_empty_test_dir(dir()).get();
-            auto sst = _env.make_sstable(s, dir(), sstables::generation_type(idx), sstables::get_highest_sstable_version(), sstable::format_types::big, _cfg.buffer_size);
+            auto sst = _env.make_sstable(s, dir(), sstables::generation_type(idx), std::nullopt, sstables::get_highest_sstable_version(), sstable::format_types::big, _cfg.buffer_size);
 
             auto start = perf_sstable_test_env::now();
             write_memtable_to_sstable(*_mt, sst).get();
@@ -260,7 +260,9 @@ public:
         return test_setup::create_empty_test_dir(dir()).then([this] {
             return sstables::test_env::do_with_async_returning<double>([this] (sstables::test_env& env) {
                 auto sst_gen = [this] () mutable {
-                    return _env.make_sstable(s, dir(), _env.new_generation(), sstables::get_highest_sstable_version(), sstable::format_types::big, _cfg.buffer_size);
+                    auto gen = _env.new_generation();
+                    auto sid = sstables::sstable_id(gen.as_uuid());
+                    return _env.make_sstable(s, dir(), gen, sid, sstables::get_highest_sstable_version(), sstable::format_types::big, _cfg.buffer_size);
                 };
 
                 std::vector<shared_sstable> ssts;

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -622,7 +622,7 @@ schema_ptr do_load_schema_from_sstable(const db::config& dbcfg, std::filesystem:
     const auto ed = std::move(*ed_result);
     const auto dir_path = sstable_path.parent_path();
     auto local = data_dictionary::make_local_options(dir_path);
-    auto bootstrap_sst = sst_man.make_sstable(bootstrap_schema, local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
+    auto bootstrap_sst = sst_man.make_sstable(bootstrap_schema, local, ed.generation, ed.sid, sstables::sstable_state::normal, ed.version, ed.format);
 
     bootstrap_sst->load_metadata().get();
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -370,7 +370,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
             const auto dir_path = sst_path.parent_path();
             options = data_dictionary::make_local_options(dir_path);
         }
-        auto sst = sst_man.make_sstable(schema, options, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
+        auto sst = sst_man.make_sstable(schema, options, ed.generation, ed.sid, sstables::sstable_state::normal, ed.version, ed.format);
 
         try {
             auto open_cfg = sstables::sstable_open_config{
@@ -773,12 +773,13 @@ private:
         const auto format = sstables::sstable_format_types::big;
         const auto version = _sst_man.get_preferred_sstable_version();
         auto generation = _generation_generator();
+        auto sid = sstables::sstable_id(generation.as_uuid());
         auto sst_name = sstables::sstable::filename(_output_dir, _schema->ks_name(), _schema->cf_name(), version, generation, format, component_type::Data);
         if (file_exists(sst_name).get()) {
             throw std::runtime_error(fmt::format("cannot create output sstable {}, file already exists", sst_name));
         }
         auto local = data_dictionary::make_local_options(_output_dir);
-        return _sst_man.make_sstable(_schema, local, generation, sstables::sstable_state::normal, version, format);
+        return _sst_man.make_sstable(_schema, local, generation, sid, sstables::sstable_state::normal, version, format);
     }
     sstables::sstable_writer_config do_configure_writer(sstring origin) const {
         return _sst_man.configure_writer(std::move(origin));
@@ -1846,6 +1847,7 @@ void write_operation(schema_ptr schema, reader_permit permit, const std::vector<
 
     auto consume_reader = [&] (mutation_reader reader, size_t partition_count_estimate) -> future<> {
         auto generation = sstables::generation_type(utils::UUID_gen::get_time_UUID());
+        auto sid = sstables::sstable_id(generation.as_uuid());
 
         {
             auto sst_name = sstables::sstable::filename(output_dir, schema->ks_name(), schema->cf_name(), version, generation, format, component_type::Data);
@@ -1857,7 +1859,7 @@ void write_operation(schema_ptr schema, reader_permit permit, const std::vector<
         auto writer_cfg = manager.configure_writer("scylla-sstable");
         writer_cfg.validation_level = validation_level;
         auto local = data_dictionary::make_local_options(output_dir);
-        auto sst = manager.make_sstable(schema, local, generation, sstables::sstable_state::normal, version, format);
+        auto sst = manager.make_sstable(schema, local, generation, sid, sstables::sstable_state::normal, version, format);
 
         co_await sst->write_components(std::move(reader), partition_count_estimate, schema, writer_cfg, encoding_stats{});
 
@@ -1975,6 +1977,7 @@ void shard_of_with_vnodes(const std::vector<sstables::shared_sstable>& sstables,
             schema,
             data_dictionary::make_local_options(fs::path(sst->get_storage().prefix())),
             sst->generation(),
+            sst->sstable_identifier(),
             sstable_state::normal,
             sst->get_version());
         new_sst->load_owner_shards(schema->get_sharder()).get();
@@ -2178,9 +2181,10 @@ void upgrade_operation(schema_ptr schema, reader_permit permit, const std::vecto
         }
 
         const auto new_generation = sstables::generation_type(utils::UUID_gen::get_time_UUID());
+        auto sid = sstables::sstable_id(new_generation.as_uuid());
 
         auto writer_cfg = sst_man.configure_writer("scylla-sstable");
-        auto new_sst = sst_man.make_sstable(schema, local, new_generation, sstables::sstable_state::normal, new_version, new_format);
+        auto new_sst = sst_man.make_sstable(schema, local, new_generation, sid, sstables::sstable_state::normal, new_version, new_format);
 
         new_sst->write_components(
                 sst->make_full_scan_reader(schema, permit),
@@ -2271,9 +2275,10 @@ void filter_operation(schema_ptr schema, reader_permit permit, const std::vector
         }
 
         const auto new_generation = sstables::generation_type(utils::UUID_gen::get_time_UUID());
+        auto sid = sstables::sstable_id(new_generation.as_uuid());
 
         auto writer_cfg = sst_man.configure_writer("scylla-sstable");
-        auto new_sst = sst_man.make_sstable(schema, local, new_generation, sstables::sstable_state::normal, new_version, new_format);
+        auto new_sst = sst_man.make_sstable(schema, local, new_generation, sid, sstables::sstable_state::normal, new_version, new_format);
 
         new_sst->write_components(
                 std::move(reader),
@@ -2342,7 +2347,8 @@ void split_operation(schema_ptr schema, reader_permit permit, const std::vector<
 
         auto consumer = [&] (mutation_reader reader) -> future<> {
             const auto new_generation = sstables::generation_type(utils::UUID_gen::get_time_UUID());
-            auto new_sst = sst_man.make_sstable(schema, local, new_generation, sstables::sstable_state::normal, new_version, new_format);
+            const auto sid = sstables::sstable_id(new_generation.as_uuid());
+            auto new_sst = sst_man.make_sstable(schema, local, new_generation, sid, sstables::sstable_state::normal, new_version, new_format);
 
             auto writer_cfg = sst_man.configure_writer("scylla-sstable");
 

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -138,7 +138,7 @@ public:
         auto total = std::accumulate(_buffers.begin(), _buffers.end(), size_t{}, [](size_t s, auto& buf) {
             return s + buf.size();
         });
-        if (total == 0) {
+        if (total == 0 && !force) {
             co_return;
         }
 


### PR DESCRIPTION
## Summary

- Restructure the object storage prefix to use `sstables/{ks}/{table}-{table_id}/{sstable_id}/{component}` instead of `{table_id}/{generation}/{component}`
- Implement reference objects (`refs/node-{host_id}/{generation}`) for sstable lifecycle management — components are only deleted when no references remain
- Simplify `clone()` to just add a reference instead of copying objects, since cloned sstables share the same `sstable_id`
- Pass `sstable_id` through streaming (`stream_blob_meta`) so receiving nodes can reference shared sstables
- Add `sstable_id` column to `system.sstables` registry
- Fix GCS resumable upload sink for zero-length objects

Fixes: SCYLLADB-2559

--

This is a new feature/improvement for the unified object storage layout. No backport needed.