### PR TITLE
sstables: unified object storage layout with sstable_id-based prefix

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -3370,6 +3370,41 @@
          ]
       },
       {
+         "path":"/storage_service/object_storage/sstables",
+         "operations":[
+            {
+               "method":"GET",
+               "summary":"List object-storage SSTables and references in a bucket",
+               "type":"array",
+               "items":{
+                  "type":"object_storage_sstable"
+               },
+               "nickname":"object_storage_sstables",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"endpoint",
+                     "description":"ID of the configured object storage endpoint",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"bucket",
+                     "description":"Object storage bucket name",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/sstable_info",
          "operations":[
             {
@@ -3621,6 +3656,27 @@
             "value":{
                "type":"double",
                "description":"The value"
+            }
+         }
+      },
+      "object_storage_sstable":{
+         "id":"object_storage_sstable",
+         "description":"Object-storage SSTable namespace entry",
+         "properties":{
+            "sstable_id":{
+               "type":"string",
+               "description":"The SSTable ID path component"
+            },
+            "num_references":{
+               "type":"long",
+               "description":"Number of reference objects under this SSTable ID"
+            },
+            "references":{
+               "type":"array",
+               "items":{
+                  "type":"string"
+               },
+               "description":"Reference object paths relative to the refs prefix"
             }
          }
       },

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -39,6 +39,7 @@
 #include "db/system_keyspace.hh"
 #include <seastar/http/exception.hh>
 #include <seastar/util/short_streams.hh>
+#include <seastar/util/closeable.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/exception.hh>
@@ -50,7 +51,9 @@
 #include "release.hh"
 #include "compaction/compaction_manager.hh"
 #include "compaction/task_manager_module.hh"
+#include "sstables/object_storage_client.hh"
 #include "sstables/sstables.hh"
+#include "sstables/storage.hh"
 #include "replica/database.hh"
 #include "db/extensions.hh"
 #include "db/snapshot-ctl.hh"
@@ -1439,6 +1442,74 @@ rest_retrain_dict(http_context& ctx, sharded<service::storage_service>& ss, serv
     co_return json_void();
 }
 
+static sstring require_query_param(const http::request& req, std::string_view name) {
+    auto value = req.get_query_param(std::string(name));
+    if (value.empty()) {
+        throw bad_param_exception(fmt::format("Missing required query parameter '{}'", name));
+    }
+    return value;
+}
+
+static const sstring object_storage_prefix = "sstables";
+
+static sstables::object_storage_client& get_object_storage_client(http_context& ctx, const http::request& req) {
+    auto endpoint = require_query_param(req, "endpoint");
+    return *ctx.db.local().get_user_sstables_manager().get_endpoint_client(std::move(endpoint));
+}
+
+static future<> collect_object_storage_entries(abstract_lister& lister, std::vector<sstring>& entries) {
+    while (auto entry = co_await lister.get()) {
+        entries.push_back(entry->name);
+    }
+}
+
+static future<std::vector<sstring>> list_object_storage_entries(sstables::object_storage_client& client, sstring bucket, sstring prefix) {
+    std::vector<sstring> entries;
+    auto lister = client.make_object_lister(std::move(bucket), std::move(prefix), [] (const std::filesystem::path&, const directory_entry&) { return true; });
+    co_await with_closeable(std::move(lister), [&entries] (abstract_lister& lister) {
+        return collect_object_storage_entries(lister, entries);
+    });
+    co_return entries;
+}
+
+static std::optional<sstring> first_path_component(std::string_view path) {
+    if (path.empty()) {
+        return std::nullopt;
+    }
+    auto pos = path.find('/');
+    return sstring(path.substr(0, pos));
+}
+
+static
+future<json::json_return_type>
+rest_object_storage_sstables(http_context& ctx, std::unique_ptr<http::request> req) {
+    auto bucket = require_query_param(*req, "bucket");
+    auto& client = get_object_storage_client(ctx, *req);
+    auto table_entries = co_await list_object_storage_entries(client, bucket, fmt::format("{}/", object_storage_prefix));
+    std::map<sstring, ss::object_storage_sstable> sstables;
+    for (const auto& entry : table_entries) {
+        auto sid = first_path_component(entry);
+        if (!sid) {
+            continue;
+        }
+        auto& sst = sstables[*sid];
+        sst.sstable_id = *sid;
+    }
+    for (auto& [sid_string, sst] : sstables) {
+        auto sid = sstables::sstable_id(utils::UUID(sid_string));
+        auto refs = co_await sstables::list_object_storage_references(client, bucket, object_storage_prefix, sid);
+        std::ranges::sort(refs);
+        sst.num_references = refs.size();
+        sst.references = std::move(refs);
+    }
+    std::vector<ss::object_storage_sstable> result;
+    result.reserve(sstables.size());
+    for (auto& sst : sstables | std::views::values) {
+        result.emplace_back(std::move(sst));
+    }
+    co_return result;
+}
+
 static
 future<json::json_return_type>
 rest_sstable_info(http_context& ctx, std::unique_ptr<http::request> req) {
@@ -2024,6 +2095,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::get_effective_ownership.set(r, gated(ss, rest_bind(rest_get_effective_ownership, ctx, ss)));
     ss::retrain_dict.set(r, gated(ss, rest_bind(rest_retrain_dict, ctx, ss, group0_client)));
     ss::estimate_compression_ratios.set(r, gated(ss, rest_bind(rest_estimate_compression_ratios, ctx, ss)));
+    ss::object_storage_sstables.set(r, gated(ss, rest_bind(rest_object_storage_sstables, ctx)));
     ss::sstable_info.set(r, gated(ss, rest_bind(rest_sstable_info, ctx)));
     ss::logstor_info.set(r, gated(ss, rest_bind(rest_logstor_info, ctx)));
     ss::reload_raft_topology_state.set(r, gated(ss, rest_bind(rest_reload_raft_topology_state, ss, group0_client)));
@@ -2107,6 +2179,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::get_total_hints.unset(r);
     ss::get_ownership.unset(r);
     ss::get_effective_ownership.unset(r);
+    ss::object_storage_sstables.unset(r);
     ss::sstable_info.unset(r);
     ss::logstor_info.unset(r);
     ss::reload_raft_topology_state.unset(r);

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -2207,7 +2207,6 @@ future<compaction_result> rewrite_sstables_component(compaction_descriptor descr
         };
 
         const auto& options = descriptor.options.as<compaction_type_options::component_rewrite>();
-        auto update_id = sstables::update_sstable_id(static_cast<bool>(options.update_id));
         // When rewriting a component, we cannot use the standard descriptor creator
         // because we must preserve the sstable version.
         auto creator = [&table_s] (sstables::shared_sstable sst) {
@@ -2215,7 +2214,7 @@ future<compaction_result> rewrite_sstables_component(compaction_descriptor descr
         };
         result.new_sstables.reserve(descriptor.sstables.size());
         for (auto& sst : descriptor.sstables) {
-            auto rewritten = sst->link_with_rewritten_component(creator, options.component_to_rewrite, options.modifier, update_id).get();
+            auto rewritten = sst->link_with_rewritten_component(creator, options.component_to_rewrite, options.modifier, options.update_id).get();
             result.new_sstables.push_back(rewritten);
         }
 

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -2207,7 +2207,7 @@ future<compaction_result> rewrite_sstables_component(compaction_descriptor descr
         };
 
         const auto& options = descriptor.options.as<compaction_type_options::component_rewrite>();
-        bool update_id = static_cast<bool>(options.update_id);
+        auto update_id = sstables::update_sstable_id(static_cast<bool>(options.update_id));
         // When rewriting a component, we cannot use the standard descriptor creator
         // because we must preserve the sstable version.
         auto creator = [&table_s] (sstables::shared_sstable sst) {

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -99,8 +99,7 @@ public:
         sstables::component_type component_to_rewrite;
         std::function<void(sstables::sstable&)> modifier;
 
-        using update_sstable_id = bool_class<class update_sstable_id_tag>;
-        update_sstable_id update_id = update_sstable_id::yes;
+        sstables::update_sstable_id update_id = sstables::update_sstable_id::yes;
     };
 private:
     using options_variant = std::variant<regular, cleanup, upgrade, scrub, reshard, reshape, split, major, component_rewrite>;
@@ -141,7 +140,7 @@ public:
         return compaction_type_options(scrub{.operation_mode = mode, .quarantine_sstables = quarantine_sstables, .drop_unfixable = drop_unfixable_sstables});
     }
 
-    static compaction_type_options make_component_rewrite(component_type component, std::function<void(sstables::sstable&)> modifier, component_rewrite::update_sstable_id update_id = component_rewrite::update_sstable_id::yes) {
+    static compaction_type_options make_component_rewrite(component_type component, std::function<void(sstables::sstable&)> modifier, sstables::update_sstable_id update_id = sstables::update_sstable_id::yes) {
         return compaction_type_options(component_rewrite{.component_to_rewrite = component, .modifier = std::move(modifier), .update_id = update_id});
     }
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -2430,7 +2430,7 @@ future<std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>> c
             std::function<bool(const sstables::shared_sstable&)> filter,
             sstables::component_type component,
             std::function<void(sstables::sstable&)> modifier,
-            compaction_type_options::component_rewrite::update_sstable_id update_id) {
+            sstables::update_sstable_id update_id) {
     std::unordered_map<sstables::shared_sstable, sstables::shared_sstable> rewritten_sstables;
     co_await rewrite_sstables_component(t, std::move(filter),
             compaction_type_options::make_component_rewrite(component, std::move(modifier), update_id),

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -388,7 +388,7 @@ public:
             std::function<bool(const sstables::shared_sstable&)> filter,
             sstables::component_type component,
             std::function<void(sstables::sstable&)> modifier,
-            compaction_type_options::component_rewrite::update_sstable_id update_id = compaction_type_options::component_rewrite::update_sstable_id::yes);
+            sstables::update_sstable_id update_id = sstables::update_sstable_id::yes);
 
     // Submit a table for major compaction.
     future<> perform_major_compaction(compaction::compaction_group_view& t, tasks::task_info info, bool consider_only_existing_data = false);

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -435,9 +435,8 @@ storage_options storage_options::append_to_object_storage_prefix(const sstring& 
     }
 
     object_storage options = std::get<object_storage>(value);
-    SCYLLA_ASSERT(std::holds_alternative<sstring>(options.location));
-    sstring prefix = std::get<sstring>(options.location);
-    options.location = seastar::format("{}/{}", prefix, s);
+    SCYLLA_ASSERT(options.location);
+    options.location = seastar::format("{}/{}", *options.location, s);
     ret.value = std::move(options);
     return ret;
 }
@@ -673,14 +672,10 @@ auto fmt::formatter<data_dictionary::storage_options>::format(const data_diction
             return fmt::format_to(ctx.out(), "{}", so.dir);
         },
         [&ctx, &type] (const data_dictionary::storage_options::object_storage& so) -> decltype(ctx.out()) {
-            return std::visit(overloaded_functor {
-                [&] (const sstring& prefix) -> decltype(ctx.out()) {
-                    return fmt::format_to(ctx.out(), "{}://{}/{}", type, so.bucket, prefix);
-                },
-                [&] (const table_id& owner) -> decltype(ctx.out()) {
-                    return fmt::format_to(ctx.out(), "{}://{} (owner {})", type, so.bucket, owner);
-                }
-            }, so.location);
+            if (so.location) {
+                return fmt::format_to(ctx.out(), "{}://{}/{}", type, so.bucket, *so.location);
+            }
+            return fmt::format_to(ctx.out(), "{}://{}", type, so.bucket);
         }
     }, so.value);
 }

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -32,7 +32,7 @@ struct storage_options {
     struct object_storage {
         std::string bucket;
         std::string endpoint;
-        std::variant<sstring, table_id> location;
+        std::optional<sstring> location;
         seastar::abort_source* abort_source = nullptr;
 
         std::string type;

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3542,9 +3542,10 @@ future<> system_keyspace::sstables_registry_list(table_id tid, locator::host_id 
         auto status = row.get_as<sstring>("status");
         auto state = sstables::state_from_dir(row.get_as<sstring>("state"));
         auto gen = sstables::generation_type(row.get_as<utils::UUID>("generation"));
+        optimized_optional<sstables::sstable_id> sid = std::nullopt;  // FIXME: for now
         auto ver = sstables::version_from_string(row.get_as<sstring>("version"));
         auto fmt = sstables::format_from_string(row.get_as<sstring>("format"));
-        sstables::entry_descriptor desc(gen, ver, fmt, sstables::component_type::TOC);
+        sstables::entry_descriptor desc(gen, sid, ver, fmt, sstables::component_type::TOC);
         co_await consumer(std::move(status), std::move(state), std::move(desc));
         co_return stop_iteration::no;
     });

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3498,7 +3498,7 @@ future<> system_keyspace::sstables_registry_create_entry(table_id tid, locator::
     if (desc.sid) {
         sid.emplace(desc.sid->id);
     } else {
-        slogger.warn("sstables_registry_create_entry: sstable with generation={} has no sstable_id", desc.generation);   // For now
+        on_internal_error(slogger, fmt::format("sstables_registry_create_entry: sstable with generation={} has no sstable_id", desc.generation));
     }
     co_await execute_cql(req, tid.id, node_owner.uuid(), desc.generation, status, sid, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
@@ -3553,7 +3553,7 @@ future<> system_keyspace::sstables_registry_list(table_id tid, locator::host_id 
         if (row.has("sstable_id")) {
             sid = sstables::sstable_id(row.get_as<utils::UUID>("sstable_id"));
         } else {
-            slogger.warn("sstables_registry_list: sstable with generation={} has no sstable_id", gen);   // For now
+            on_internal_error(slogger, fmt::format("sstables_registry_list: sstable with generation={} has no sstable_id", gen));
         }
         auto ver = sstables::version_from_string(row.get_as<sstring>("version"));
         auto fmt = sstables::format_from_string(row.get_as<sstring>("format"));

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1155,6 +1155,7 @@ schema_ptr system_keyspace::sstables_registry() {
             .with_column("node_owner", uuid_type, column_kind::partition_key)
             .with_column("generation", timeuuid_type, column_kind::clustering_key)
             .with_column("status", utf8_type)
+            .with_column("sstable_id", uuid_type)
             .with_column("state", utf8_type)
             .with_column("version", utf8_type)
             .with_column("format", utf8_type)
@@ -3491,9 +3492,15 @@ system_keyspace::read_cdc_generation_opt(utils::UUID id) {
 }
 
 future<> system_keyspace::sstables_registry_create_entry(table_id tid, locator::host_id node_owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) {
-    static const auto req = format("INSERT INTO system.{} (table_id, node_owner, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
+    static const auto req = format("INSERT INTO system.{} (table_id, node_owner, generation, status, sstable_id, state, version, format) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
     slogger.trace("Inserting {}.{}.{} into {}", tid, node_owner, desc.generation, SSTABLES_REGISTRY);
-    co_await execute_cql(req, tid.id, node_owner.uuid(), desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
+    std::optional<utils::UUID> sid = std::nullopt;
+    if (desc.sid) {
+        sid.emplace(desc.sid->id);
+    } else {
+        slogger.warn("sstables_registry_create_entry: sstable with generation={} has no sstable_id", desc.generation);   // For now
+    }
+    co_await execute_cql(req, tid.id, node_owner.uuid(), desc.generation, status, sid, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
 
 future<> system_keyspace::sstables_registry_update_entry_status(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstring status) {
@@ -3535,14 +3542,19 @@ future<> system_keyspace::sstables_registry_delete_entry(table_id tid, locator::
 }
 
 future<> system_keyspace::sstables_registry_list(table_id tid, locator::host_id node_owner, sstable_registry_entry_consumer consumer) {
-    static const auto req = format("SELECT status, state, generation, version, format FROM system.{} WHERE table_id = ? AND node_owner = ?", SSTABLES_REGISTRY);
+    static const auto req = format("SELECT status, sstable_id, state, generation, version, format FROM system.{} WHERE table_id = ? AND node_owner = ?", SSTABLES_REGISTRY);
     slogger.trace("Listing {}.{} entries from {}", tid, node_owner, SSTABLES_REGISTRY);
 
     co_await _qp.query_internal(req, db::consistency_level::ONE, { tid.id, node_owner.uuid() }, 1000, [ consumer = std::move(consumer) ] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {
         auto status = row.get_as<sstring>("status");
         auto state = sstables::state_from_dir(row.get_as<sstring>("state"));
         auto gen = sstables::generation_type(row.get_as<utils::UUID>("generation"));
-        optimized_optional<sstables::sstable_id> sid = std::nullopt;  // FIXME: for now
+        optimized_optional<sstables::sstable_id> sid = std::nullopt;
+        if (row.has("sstable_id")) {
+            sid = sstables::sstable_id(row.get_as<utils::UUID>("sstable_id"));
+        } else {
+            slogger.warn("sstables_registry_list: sstable with generation={} has no sstable_id", gen);   // For now
+        }
         auto ver = sstables::version_from_string(row.get_as<sstring>("version"));
         auto fmt = sstables::format_from_string(row.get_as<sstring>("format"));
         sstables::entry_descriptor desc(gen, sid, ver, fmt, sstables::component_type::TOC);

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -310,26 +310,71 @@ The optional `files` member may contain a list of non-SSTable files included in 
 
 3. `CREATE KEYSPACE` with S3/GS storage
 
-When creating a keyspace with S3/GS storage, the data is stored under the bucket passed as argument to the `CREATE KEYSPACE` statement.  
-Once the statement is issued, Scylla will transparently use the S3/GS bucket as the location of the SSTables for that keyspace.  
-Like in the case above, there is no hierarchy for the data, *all SSTables components are stored flat within the bucket*.
+When creating a keyspace with S3/GS storage, the data is stored under the bucket passed as argument to the `CREATE KEYSPACE` statement.
+Once the statement is issued, Scylla will transparently use the S3/GS bucket as the location of the SSTables for that keyspace.
+
+Automatically managed object-storage tables use a unified layout shared across S3 and GS. SSTable components are stored under a static `sstables/` prefix and grouped by the stable SSTable identifier (`sstable_id`), not by the node-local generation name:
+
 ```perl
 scylla-sstables-bucket/
 │
-├── 3gqe_1lnj_4sbpc2ezoscu9hhtor/
-│   ├── Data.db
-│   ├── Index.db
-│   ├── Summary.db
-│   └── ...
-│
-├── 1abx_k29m_9fyug3sdtjwj8krpqh/
-│   ├── Data.db
-│   ├── Index.db
-│   ├── Summary.db
-│   └── ...
-│
-└── ... (other SSTable folders)
+└── sstables/
+    ├── 4f4d0a90-d8c6-11f0-8b18-060de9f3bd1b/
+    │   ├── Data.db
+    │   ├── Index.db
+    │   ├── Summary.db
+    │   ├── TOC.txt
+    │   ├── ...
+    │   └── refs/
+    │       └── nodes/
+    │           ├── 7adf1ca2-6783-40ab-aa1f-ef1e0b5d98ba/
+    │           │   └── 3gqe_1lnj_4sbpc2ezoscu9hhtor
+    │           └── 10e68be1-d352-4173-bf34-2249dbb7329e/
+    │               └── 4c5s_0281_0v5kg2b4gri84iggoz
+    ├── 87a72290-d8c6-11f0-a5ea-060de9f3bd1b/
+    │   ├── Data.db
+    │   ├── Index.db
+    │   ├── Summary.db
+    │   ├── TOC.txt
+    │   ├── ...
+    │   └── refs/
+    │       └── nodes/
+    │           └── 7adf1ca2-6783-40ab-aa1f-ef1e0b5d98ba/
+    │               └── 5n8a_03tw_2jv4g2a4k2m33sq8ah
+    └── ...
 ```
+
+The managed SSTable prefix is:
+
+```text
+sstables/
+```
+
+Each SSTable lives under:
+
+```text
+sstables/{sstable_id}/
+```
+
+SSTable component object names are the component suffixes used by the local SSTable format, for example `Data.db`, `Index.db`, `Summary.db`, `Scylla.db`, and `TOC.txt`.
+
+Reference objects under `refs/nodes/` record which nodes still own a reference to the SSTable data:
+
+```text
+sstables/{sstable_id}/refs/nodes/{host_id}/{generation}
+```
+
+The reference object body is empty. Its name is the metadata: `{host_id}` identifies the node and `{generation}` is that node's local SSTable generation name for the shared SSTable.
+
+The `sstable_id` identifies the shared object-storage SSTable data. The local `generation` identifies a node-local SSTable entry in `system.sstables`. A newly created SSTable normally has an `sstable_id` derived from its generation. After tablet migration or reference sharing, multiple local SSTable entries can have different generations while pointing at the same object-storage data via the same `sstable_id`.
+
+Object-storage SSTable lifecycle:
+- Creation: Scylla uploads component objects under `{sstable_id}` and creates this node's `refs/nodes/{host_id}/{generation}` reference before sealing the local row in `system.sstables`.
+- Sharing: when tablet migration can share object-storage data, the receiving node creates a new local SSTable entry with its own generation and adds a node reference under the existing `{sstable_id}` prefix instead of copying all component objects.
+- Local removal: when a node removes its local SSTable, it first deletes its own reference object. If other references remain, component objects are left intact.
+- Final cleanup: component objects are deleted only after no reference objects remain for the `sstable_id`. This prevents one node from deleting shared data still referenced by another node.
+
+The `status` and `state` fields in `system.sstables` describe the local SSTable entry lifecycle. They do not describe a global lifecycle state for the object-storage component set identified by `sstable_id`.
 
 ## Downloading, deleting, uploading SSTables
 
@@ -397,7 +442,7 @@ There is high likelihood that a scrubbed SSTable results in different values for
 For the `storage_service/backup` REST API, in theory only removing an entire SSTable from the backup would require changing  
 the manifest file and remove the corresponding entry for the SSTable, in all other cases, no metadata changes needed.
 
-For the `CREATE KEYSPACE` on S3, there is no need to update any metadata as we currently don’t have any.
+For `CREATE KEYSPACE` on S3/GS storage, Scylla tracks object-storage SSTables in `system.sstables` and uses reference objects under the SSTable prefix to decide when component objects can be deleted. Manual changes to the objects under this layout should keep `system.sstables`, component objects, and `refs/nodes/{host_id}/{generation}` objects consistent.
 
 > **NOTE:**
 > It’s obvious to say that re-uploading a scrubbed SSTable means re-uploading all its components as it’s likely most of them were changed.

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -1389,7 +1389,7 @@ Implemented by `snapshots_table` in `db/system_keyspace.cc`.
 
 ## system.sstables
 
-The "ownership" table for non-local SSTables when using object storage (S3).
+The "ownership" table for non-local SSTables when using object storage (S3/GS).
 
 Schema:
 ```cql
@@ -1397,6 +1397,7 @@ CREATE TABLE system.sstables (
     owner uuid,
     generation timeuuid,
     status text,
+    sstable_id uuid,
     state text,
     version text,
     format text,
@@ -1406,13 +1407,20 @@ CREATE TABLE system.sstables (
 
 **Columns:**
 - `owner`: UUID of the owning table
-- `generation`: SSTable generation identifier
-- `status`: Current status of the SSTable
-- `state`: State of the SSTable
+- `generation`: Local SSTable generation identifier (clustering key)
+- `status`: Current lifecycle status of this node's local SSTable entry
+- `sstable_id`: Stable identifier of the SSTable data. For newly created SSTables it is derived from the generation, but it can survive local generation changes such as tablet migration.
+- `state`: State of this node's local SSTable entry
 - `version`: SSTable format version
 - `format`: SSTable format
 
-**Note:** When a user keyspace is created with S3 storage options, SSTables are put on remote object storage and the information about them is kept in this table.
+**Note:** When a user keyspace is created with S3/GS storage options, SSTable components are stored on remote object storage and local ownership information is kept in this table.
+
+`generation` and `sstable_id` identify related but different entities:
+- `generation` identifies the local SSTable entry on this node. It is part of the primary key and participates in local lifecycle state such as `status` and `state`.
+- `sstable_id` identifies the SSTable data object set. For object-storage tables, component objects are stored under a prefix containing `sstable_id`. The same `sstable_id` can be referenced by multiple local SSTable entries on different nodes, each with its own `generation`.
+
+This distinction matters for object-storage SSTable sharing. Tablet migration can create a new local SSTable entry with a new `generation` while continuing to reference the same object-storage SSTable data via the same `sstable_id`. The local row state applies to the local entry, not to the shared object-storage data itself.
 
 ---
 

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -432,19 +432,33 @@ bytes directly to disk and then loads the reconstructed SSTables into the table.
 
 For tables backed by object storage, the SSTable data already resides in the
 cloud — transferring the bytes over the network would be redundant and
-expensive. Instead, ScyllaDB uses a server-side copy (clone) approach:
+expensive. Instead, ScyllaDB shares object-storage SSTables by reference:
+
+Object-storage SSTable components are stored under a stable SSTable identifier,
+using a prefix of the form
+`sstables/{sstable_id}/{component}`. Each node
+or shard that owns the SSTable creates a zero-length reference object under that
+SSTable prefix: `.../{sstable_id}/refs/nodes/{host_id}/{generation}`. The
+`generation` identifies the local registry entry, while `sstable_id` identifies
+the shared component objects.
 
 1. The source node takes a storage snapshot of the tablet's SSTables, holding
    `shared_sstable` references that keep the original cloud objects alive even
    if concurrent compaction would otherwise delete them.
 
 2. For each SSTable, the source sends a `CLONE_SSTABLE` RPC to the destination
-   node. The request carries the SSTable identity (generation, version, format)
-   rather than raw bytes.
+   node. The request carries the SSTable metadata (SSTable ID, generation,
+   version, format, and state) rather than raw bytes.
 
-3. The destination node issues a server-side copy of every SSTable component
-   object (e.g. S3 `CopyObject`), writing the copies to a fresh generation
-   owned by the destination, and then loads the cloned SSTables.
+3. If the cluster supports SSTable reference sharing, the destination node
+   creates a new local registry entry and reference object that point at the
+   existing SSTable ID. No component objects are copied.
+
+4. During rolling upgrade, before all nodes support reference sharing, the
+   destination falls back to a server-side copy of each component object (e.g.
+   S3 `CopyObject`). In that path the destination uses a fresh SSTable ID
+   derived from the destination generation and rewrites `Scylla.db` metadata to
+   contain that ID.
 
 No SSTable bytes traverse the network between source and destination. Only the
 small `CLONE_SSTABLE` control messages are exchanged.

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -154,6 +154,7 @@ public:
     gms::feature cdc_block_tablet_merges_for_alternator_streams { *this, "CDC_BLOCK_TABLET_MERGES_FOR_ALTERNATOR_STREAMS"sv };
     gms::feature counters_with_tablets { *this, "COUNTERS_WITH_TABLETS"sv };
     gms::feature file_stream { *this, "FILE_STREAM"sv };
+    gms::feature sstable_reference_sharing { *this, "SSTABLE_REFERENCE_SHARING"sv };
     gms::feature compression_dicts { *this, "COMPRESSION_DICTS"sv };
     gms::feature tablet_options { *this, "TABLET_OPTIONS"sv };
     gms::feature tablet_load_stats_v2 { *this, "TABLET_LOAD_STATS_V2"sv };

--- a/idl/sstables.idl.hh
+++ b/idl/sstables.idl.hh
@@ -16,4 +16,8 @@ enum class sstable_state : uint8_t {
     upload,
 };
 
+class sstable_id final {
+    utils::UUID uuid();
+};
+
 }

--- a/idl/streaming.idl.hh
+++ b/idl/streaming.idl.hh
@@ -95,6 +95,14 @@ class stream_blob_cmd_data {
     std::optional<streaming::stream_blob_data> data;
 };
 
+class stream_sstable_meta {
+    sstables::sstable_id id;
+    utils::UUID generation;
+    int32_t version;
+    int32_t format;
+    sstables::sstable_state state;
+};
+
 class stream_blob_meta {
     streaming::file_stream_id ops_id;
     table_id table;
@@ -103,6 +111,7 @@ class stream_blob_meta {
     streaming::file_ops fops;
     service::frozen_topology_guard topo_guard;
     std::optional<sstables::sstable_state> sstable_state;
+    std::optional<streaming::stream_sstable_meta> sstable_meta;
 };
 
 class node_and_shard {
@@ -123,10 +132,7 @@ class stream_files_request {
 class clone_sstable_request {
     streaming::file_stream_id ops_id;
     table_id table;
-    utils::UUID generation;      // sstables::generation_type, encoded as its underlying UUID
-    int32_t version;             // cast from sstables::sstable_version_types
-    int32_t format;              // cast from sstables::sstable_format_types
-    int32_t sstable_state;
+    streaming::stream_sstable_meta sstable_meta;
     seastar::shard_id dst_shard_id;
     service::frozen_topology_guard topo_guard;
 };

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -770,7 +770,7 @@ private:
             std::function<bool(const sstables::shared_sstable&)> filter,
             sstables::component_type component,
             std::function<void(sstables::sstable&)> modifier,
-            compaction::compaction_type_options::component_rewrite::update_sstable_id update_id = compaction::compaction_type_options::component_rewrite::update_sstable_id::yes);
+            sstables::update_sstable_id update_id = sstables::update_sstable_id::yes);
 public:
     // Rewrite a component (e.g., Statistics) on all sstables matching `filter`
     // in every view of every compaction group in every storage group that
@@ -781,7 +781,7 @@ public:
             std::function<bool(const sstables::shared_sstable&)> filter,
             sstables::component_type component,
             std::function<void(sstables::sstable&)> modifier,
-            compaction::compaction_type_options::component_rewrite::update_sstable_id update_id = compaction::compaction_type_options::component_rewrite::update_sstable_id::yes);
+            sstables::update_sstable_id update_id = sstables::update_sstable_id::yes);
 private:
     // Returns a sstable set that can be safely used for purging any expired tombstone in a compaction group.
     // Only the sstables in the compaction group is not sufficient, since there might be other compaction

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -227,15 +227,19 @@ distributed_loader::process_upload_dir(sharded<replica::database>& db, sharded<d
 
 future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
 distributed_loader::get_sstables_from_upload_dir(sharded<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg) {
+    bool need_mutate_level = true;
     return get_sstables_from(db, ks, cf, cfg, [] (auto& global_table, auto& directory) {
         return directory.start(global_table.as_sharded_parameter(),
             sstables::sstable_state::upload, &error_handler_gen_for_upload_dir
         );
-    });
+    }, need_mutate_level);
 }
 
 future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
 distributed_loader::get_sstables_from_object_store(sharded<replica::database>& db, sstring ks, sstring cf, std::vector<sstring> sstables, sstring endpoint, sstring type, sstring bucket, sstring prefix, sstables::sstable_open_config cfg, std::function<seastar::abort_source*()> get_abort_src) {
+    // Do not mutate the source sstable's level.
+    // The sstable level would be mutated to 0, if needed, later on by download_sstable.
+    bool need_mutate_level = false;
     return get_sstables_from(db, ks, cf, cfg, [bucket, endpoint, type, prefix, sstables=std::move(sstables), get_abort_src] (auto& global_table, auto& directory) {
         return directory.start(global_table.as_sharded_parameter(),
             sharded_parameter([bucket, endpoint, type, prefix, get_abort_src] {
@@ -245,13 +249,14 @@ distributed_loader::get_sstables_from_object_store(sharded<replica::database>& d
             }),
             sstables,
             &error_handler_gen_for_upload_dir);
-    });
+    }, need_mutate_level);
 }
 
 future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
 distributed_loader::get_sstables_from(sharded<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg,
-        noncopyable_function<future<>(global_table_ptr&, sharded<sstables::sstable_directory>&)> start_dir) {
-    return seastar::async([&db, ks = std::move(ks), cf = std::move(cf), start_dir = std::move(start_dir), cfg] {
+        noncopyable_function<future<>(global_table_ptr&, sharded<sstables::sstable_directory>&)> start_dir,
+        bool need_mutate_level) {
+    return seastar::async([&db, ks = std::move(ks), cf = std::move(cf), start_dir = std::move(start_dir), cfg, need_mutate_level] {
         auto global_table = get_table_on_all_shards(db, ks, cf).get();
         auto table_id = global_table->schema()->id();
         auto allow_numerical_generations = !global_table->get_storage_options().is_object_storage_type();
@@ -263,7 +268,7 @@ distributed_loader::get_sstables_from(sharded<replica::database>& db, sstring ks
         std::vector<std::vector<sstables::shared_sstable>> sstables_on_shards(this_smp_shard_count());
         lock_table(global_table, directory).get();
         sstables::sstable_directory::process_flags flags {
-            .need_mutate_level = true,
+            .need_mutate_level = need_mutate_level,
             .allow_loading_materialized_view = false,
             .sort_sstables_according_to_owner = false,
             .allow_numerical_generations = allow_numerical_generations,

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -254,6 +254,7 @@ distributed_loader::get_sstables_from(sharded<replica::database>& db, sstring ks
     return seastar::async([&db, ks = std::move(ks), cf = std::move(cf), start_dir = std::move(start_dir), cfg] {
         auto global_table = get_table_on_all_shards(db, ks, cf).get();
         auto table_id = global_table->schema()->id();
+        auto allow_numerical_generations = !global_table->get_storage_options().is_object_storage_type();
 
         sharded<sstables::sstable_directory> directory;
         start_dir(global_table, directory).get();
@@ -265,6 +266,7 @@ distributed_loader::get_sstables_from(sharded<replica::database>& db, sstring ks
             .need_mutate_level = true,
             .allow_loading_materialized_view = false,
             .sort_sstables_according_to_owner = false,
+            .allow_numerical_generations = allow_numerical_generations,
             .sstable_open_config = cfg,
         };
         process_sstable_dir(directory, flags).get();
@@ -292,14 +294,16 @@ private:
     std::vector<lw_shared_ptr<sharded<sstables::sstable_directory>>> _sstable_directories;
     sstables::sstable_version_types _version_for_reshaping = sstables::oldest_writable_sstable_format;
     migration_direction _migration_direction;
+    bool _allow_numerical_generations;
 
 public:
-    table_populator(global_table_ptr& ptr, sharded<replica::database>& db, sstring ks, sstring cf, migration_direction md = migration_direction::none)
+    table_populator(global_table_ptr& ptr, sharded<replica::database>& db, sstring ks, sstring cf, migration_direction md, bool allow_numerical_generations)
         : _db(db)
         , _ks(std::move(ks))
         , _cf(std::move(cf))
         , _global_table(ptr)
         , _migration_direction(md)
+        , _allow_numerical_generations(allow_numerical_generations)
     {
     }
 
@@ -383,6 +387,7 @@ future<> table_populator::process_subdir(sharded<sstables::sstable_directory>& d
         .throw_on_missing_toc = true,
         .allow_loading_materialized_view = true,
         .garbage_collect = true,
+        .allow_numerical_generations = _allow_numerical_generations,
     };
     co_await distributed_loader::process_sstable_dir(directory, flags);
 
@@ -486,7 +491,8 @@ future<> distributed_loader::populate_keyspace(sharded<replica::database>& db,
             dblog.info("Keyspace {}: CF {} is in vnodes-to-tablets migration mode (direction: {})", ks_name, cfname, direction == md::forward ? "forward" : "rollback");
         }
 
-        auto metadata = table_populator(gtable, db, ks_name, cfname, direction);
+        auto allow_numerical_generations = !cf.get_storage_options().is_object_storage_type();
+        auto metadata = table_populator(gtable, db, ks_name, cfname, direction, allow_numerical_generations);
         std::exception_ptr ex;
 
         try {

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -80,7 +80,8 @@ class distributed_loader {
             std::optional<service::intended_storage_mode> storage_mode = std::nullopt);
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
         get_sstables_from(sharded<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg,
-        noncopyable_function<future<>(global_table_ptr&, sharded<sstables::sstable_directory>&)> start_dir);
+        noncopyable_function<future<>(global_table_ptr&, sharded<sstables::sstable_directory>&)> start_dir,
+        bool need_mutate_level);
 
 public:
     static future<> init_system_keyspace(sharded<db::system_keyspace>&, sharded<locator::effective_replication_map_factory>&, sharded<replica::database>&);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -498,7 +498,12 @@ sstables::shared_sstable table::make_sstable(sstables::sstable_state state) {
 
 sstables::shared_sstable table::make_sstable(sstables::sstable_state state, sstables::sstable_version_types version) {
     auto& sstm = get_sstables_manager();
-    return sstm.make_sstable(_schema, *_storage_opts, calculate_generation_for_new_table(), state, version, sstables::sstable::format_types::big);
+    auto gen = calculate_generation_for_new_table();
+    optimized_optional<sstables::sstable_id> sid_opt;
+    if (_storage_opts->is_object_storage_type()) {
+        sid_opt = sstables::sstable_id(gen.as_uuid());
+    }
+    return sstm.make_sstable(_schema, *_storage_opts, gen, sid_opt, state, version, sstables::sstable::format_types::big);
 }
 
 sstables::shared_sstable table::make_sstable() {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1436,7 +1436,7 @@ table::perform_component_rewrite(
         std::function<bool(const sstables::shared_sstable&)> filter,
         sstables::component_type component,
         std::function<void(sstables::sstable&)> modifier,
-        compaction::compaction_type_options::component_rewrite::update_sstable_id update_id) {
+        sstables::update_sstable_id update_id) {
     std::unordered_map<sstables::shared_sstable, sstables::shared_sstable> rewritten;
     auto cgs = sg.compaction_groups_immediate();
     auto& cm = get_compaction_manager();
@@ -1461,7 +1461,7 @@ table::perform_component_rewrite(
         std::function<bool(const sstables::shared_sstable&)> filter,
         sstables::component_type component,
         std::function<void(sstables::sstable&)> modifier,
-        compaction::compaction_type_options::component_rewrite::update_sstable_id update_id) {
+        sstables::update_sstable_id update_id) {
     std::unordered_map<sstables::shared_sstable, sstables::shared_sstable> rewritten;
     auto sgs = storage_groups_for_token_range(range);
     for (auto& sg : sgs) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5293,7 +5293,7 @@ future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id
 
     auto load_sstable = [leave_unsealed] (const dht::sharder& sharder, replica::table& t, sstables::entry_descriptor d) -> future<sstables::shared_sstable> {
         auto& mng = t.get_sstables_manager();
-        auto sst = mng.make_sstable(t.schema(), t.get_storage_options(), d.generation, d.state.value_or(sstables::sstable_state::normal),
+        auto sst = mng.make_sstable(t.schema(), t.get_storage_options(), d.generation, d.sid, d.state.value_or(sstables::sstable_state::normal),
                                     d.version, d.format, db_clock::now(), default_io_error_handler_gen());
         // The loader will consider current shard as sstable owner, despite the tablet sharder
         // will still point to leaving replica at this stage in migration. If node goes down,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6759,7 +6759,7 @@ void storage_service::init_messaging_service() {
     });
     ser::streaming_rpc_verbs::register_clone_sstable(&_messaging.local(),
             [this] (const rpc::client_info& cinfo, streaming::clone_sstable_request req) -> future<streaming::stream_files_response> {
-        co_return co_await streaming::clone_sstable_handler(_db.local(), _view_building_worker.local(), req);
+        co_return co_await streaming::clone_sstable_handler(_db.local(), _view_building_worker.local(), _feature_service, req);
     });
     ser::storage_service_rpc_verbs::register_raft_topology_cmd(&_messaging.local(), [this] (raft::server_id dst_id, raft::term_t term, uint64_t cmd_index, raft_topology_cmd cmd) {
         return handle_raft_rpc(dst_id, [cmd = std::move(cmd), term, cmd_index] (auto& ss) {

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -207,7 +207,7 @@ public:
                 , _bucket(std::move(bucket))
                 , _prefix(std::move(prefix))
                 , _filter(std::move(filter))
-                , _paging(100)
+                , _paging(1000)
                 , _pos(0)
             {}
             future<std::optional<directory_entry>> get() override {

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -40,8 +40,8 @@ sstables::object_name::object_name(std::string_view bucket, std::string_view pre
     : _name(fmt::format("/{}/{}/{}", bucket, prefix, type))
 {}
 
-sstables::object_name::object_name(std::string_view bucket, const generation_type& gen, std::string_view type) 
-    : _name(fmt::format("/{}/{}/{}", bucket, gen, type))
+sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, const generation_type& gen, std::string_view type)
+    : _name(fmt::format("/{}/{}/{}/{}", bucket, prefix, gen, type))
 {}
 sstables::object_name::object_name(std::string_view bucket, std::string_view object) 
     : _name(fmt::format("/{}/{}", bucket, object))

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -40,9 +40,13 @@ sstables::object_name::object_name(std::string_view bucket, std::string_view pre
     : _name(fmt::format("/{}/{}/{}", bucket, prefix, type))
 {}
 
-sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, const generation_type& gen, std::string_view type)
-    : _name(fmt::format("/{}/{}/{}/{}", bucket, prefix, gen, type))
-{}
+sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, const sstable_id& sid, std::string_view type)
+    : _name(fmt::format("/{}/{}/{}/{}", bucket, prefix, sid, type))
+{
+    if (!sid) {
+        on_internal_error(sstlog, fmt::format("SSTable identifier is required for object storage: bucket={} prefix={}", bucket, prefix));
+    }
+}
 sstables::object_name::object_name(std::string_view bucket, std::string_view object) 
     : _name(fmt::format("/{}/{}", bucket, object))
 {}

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -18,6 +18,7 @@
 
 #include "utils/lister.hh"
 #include "utils/s3/creds.hh"
+#include "sstables/storage.hh"
 
 namespace seastar {
 class abort_source;
@@ -49,8 +50,10 @@ class object_name {
 public:
     object_name(const object_name&);
     object_name(object_name&&);
+    // Used by native backup/restore with externally supplied prefixes
+    // following the foreign Scylla Manager bucket layout.
     object_name(std::string_view bucket, std::string_view prefix, std::string_view type);
-    object_name(std::string_view bucket, const generation_type&, std::string_view type);
+    object_name(std::string_view bucket, std::string_view prefix, const generation_type&, std::string_view type);
     object_name(std::string_view bucket, std::string_view object);
 
     std::string_view bucket() const;

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -19,6 +19,7 @@
 #include "utils/lister.hh"
 #include "utils/s3/creds.hh"
 #include "sstables/storage.hh"
+#include "sstables/types.hh"
 
 namespace seastar {
 class abort_source;
@@ -43,8 +44,6 @@ class abstract_lister;
 
 namespace sstables {
 
-class generation_type;
-
 class object_name {
     std::string _name;
 public:
@@ -53,7 +52,7 @@ public:
     // Used by native backup/restore with externally supplied prefixes
     // following the foreign Scylla Manager bucket layout.
     object_name(std::string_view bucket, std::string_view prefix, std::string_view type);
-    object_name(std::string_view bucket, std::string_view prefix, const generation_type&, std::string_view type);
+    object_name(std::string_view bucket, std::string_view prefix, const sstable_id&, std::string_view type);
     object_name(std::string_view bucket, std::string_view object);
 
     std::string_view bucket() const;

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -18,6 +18,7 @@
 #include "sstables/component_type.hh"
 #include "sstables/shareable_components.hh"
 #include "sstables/generation_type.hh"
+#include "sstables/types.hh"
 #include <seastar/core/shared_ptr.hh>
 
 namespace sstables {
@@ -31,15 +32,16 @@ enum class sstable_state {
 
 struct entry_descriptor {
     generation_type generation;
+    optimized_optional<sstable_id> sid;
     sstable_version_types version;
     sstable_format_types format;
     component_type component;
     std::optional<sstable_state> state;
 
-    entry_descriptor(generation_type generation,
+    entry_descriptor(generation_type generation, optimized_optional<sstable_id> sid,
                      sstable_version_types version, sstable_format_types format,
                      component_type component, std::optional<sstable_state> state = {})
-        : generation(generation), version(version), format(format), component(component), state(state) {}
+        : generation(generation), sid(sid), version(version), format(format), component(component), state(state) {}
 };
 
 // Parses sstable file path extracting entry_descriptor from it. Returns the descriptor

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -229,7 +229,7 @@ void sstable_directory::validate(sstables::shared_sstable sst, process_flags fla
 
 future<sstables::shared_sstable> sstable_directory::load_sstable(sstables::entry_descriptor desc,
         const data_dictionary::storage_options& storage_opts, sstables::sstable_open_config cfg) const {
-    shared_sstable sst = _manager.make_sstable(_schema, storage_opts, desc.generation, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
+    shared_sstable sst = _manager.make_sstable(_schema, storage_opts, desc.generation, desc.sid, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
     co_await sst->load(_sharder, cfg);
     co_return sst;
 }
@@ -532,7 +532,7 @@ sstable_directory::load_foreign_sstables(sstable_entry_descriptor_vector info_ve
 
 future<std::vector<shard_id>> sstable_directory::get_shards_for_this_sstable(
         const sstables::entry_descriptor& desc, const data_dictionary::storage_options& storage_opts, process_flags flags) const {
-    auto sst = _manager.make_sstable(_schema, storage_opts, desc.generation, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
+    auto sst = _manager.make_sstable(_schema, storage_opts, desc.generation, desc.sid, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
     co_await sst->load_owner_shards(_sharder);
     validate(sst, flags);
     co_return sst->get_shards_for_this_sstable();

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -486,14 +486,14 @@ future<> sstable_directory::restore_components_lister::commit() {
 
 future<> sstable_directory::sstables_registry_components_lister::garbage_collect(storage& st) {
     std::set<generation_type> gens_to_remove;
-    co_await _sstables_registry.sstables_registry_list(_table_id, _node_owner, coroutine::lambda([&st, &gens_to_remove] (sstring status, sstable_state state, entry_descriptor desc) -> future<> {
+    co_await _sstables_registry.sstables_registry_list(_table_id, _node_owner, coroutine::lambda([this, &st, &gens_to_remove] (sstring status, sstable_state state, entry_descriptor desc) -> future<> {
         if (status == "sealed") {
             co_return;
         }
 
         dirlog.info("Removing dangling {} {} entry", desc.generation, status);
         gens_to_remove.insert(desc.generation);
-        co_await st.remove_by_registry_entry(std::move(desc));
+        co_await st.remove_by_registry_entry(std::move(desc), _node_owner);
     }));
     co_await coroutine::parallel_for_each(gens_to_remove, [this] (auto gen) -> future<> {
         co_await _sstables_registry.delete_entry(_table_id, _node_owner, gen);

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -133,7 +133,7 @@ sstable_directory::sstable_directory(replica::table& table,
     , _storage_opts(std::move(storage_opts))
     , _state(sstable_state::upload)
     , _error_handler_gen(error_handler_gen)
-    , _storage(make_storage(_manager, *_storage_opts, _state))
+    , _storage(make_storage(_manager, _schema, *_storage_opts, _state))
     , _lister(std::make_unique<sstable_directory::restore_components_lister>(_storage_opts->value,
                                                                              std::move(sstables)))
     , _sharder_ptr(std::make_unique<dht::auto_refreshing_sharder>(table.shared_from_this()))
@@ -170,7 +170,7 @@ sstable_directory::sstable_directory(sstables_manager& manager,
     , _storage_opts(std::move(storage_opts))
     , _state(state)
     , _error_handler_gen(error_handler_gen)
-    , _storage(make_storage(_manager, *_storage_opts, _state))
+    , _storage(make_storage(_manager, _schema, *_storage_opts, _state))
     , _lister(make_components_lister())
     , _sharder_ptr(std::holds_alternative<unique_sharder_ptr>(sharder) ? std::move(std::get<unique_sharder_ptr>(sharder)) : nullptr)
     , _sharder(_sharder_ptr ? *_sharder_ptr : *std::get<const dht::sharder*>(sharder))

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -626,7 +626,7 @@ sstable_directory::retrieve_shared_sstables() {
     return std::exchange(_shared_sstable_info, {});
 }
 
-bool sstable_directory::compare_sstable_storage_prefix(const sstring& prefix_a, const sstring& prefix_b) noexcept {
+bool sstable_directory::compare_sstable_storage_prefix(std::string_view prefix_a, std::string_view prefix_b) noexcept {
     size_t size_a = prefix_a.size();
     if (prefix_a.back() == '/') {
         size_a--;

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -79,20 +79,10 @@ sstable_directory::make_components_lister() {
             return std::make_unique<sstable_directory::filesystem_components_lister>(make_path(loc.dir.native(), _state));
         },
         [this] (const data_dictionary::storage_options::object_storage& os) mutable -> std::unique_ptr<sstable_directory::components_lister> {
-            return std::visit(overloaded_functor {
-                [this, &os] (const sstring& prefix) -> std::unique_ptr<sstable_directory::components_lister> {
-                    if (prefix.empty()) {
-                        on_internal_error(sstlog, fmt::format("{} storage options is missing 'prefix'", os.type));
-                    }
-                    return std::make_unique<sstable_directory::filesystem_components_lister>(fs::path(prefix), _manager, os);
-                },
-                [this, &os] (const table_id& owner) -> std::unique_ptr<sstable_directory::components_lister> {
-                    if (owner.id.is_null()) {
-                        on_internal_error(sstlog, fmt::format("{} storage options is missing 'owner'", os.type));
-                    }
-                    return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), owner, _manager.get_local_host_id());
-                }
-            }, os.location);
+            if (os.location) {
+                return std::make_unique<sstable_directory::filesystem_components_lister>(fs::path(*os.location), _manager, os);
+            }
+            return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), _schema->id(), _manager.get_local_host_id());
         }
     }, _storage_opts->value);
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -242,6 +242,11 @@ sstable_directory::process_descriptor(sstables::entry_descriptor desc,
         _max_version_seen = desc.version;
     }
 
+    if (!flags.allow_numerical_generations && !desc.generation.is_uuid_based()) {
+        throw_malformed_sstable_exception(format("{}: numerical SSTable generations are not supported",
+                sstable::component_basename(_schema->ks_name(), _schema->cf_name(), desc.version, desc.generation, desc.format, desc.component)));
+    }
+
     auto storage_opts = get_storage_options();
     auto shards = co_await get_shards_for_this_sstable(desc, storage_opts, flags);
     if (flags.sort_sstables_according_to_owner && shards.size() == 1 && shards[0] != this_shard_id()) {

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -270,7 +270,7 @@ sstable_directory::process_descriptor(sstables::entry_descriptor desc,
         auto sst_creator = [&](shared_sstable) {
             return _manager.make_sstable(_schema, storage_opts, sstables::sstable_generation_generator{}(), _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
         };
-        auto new_sst = co_await sst->link_with_rewritten_component(std::move(sst_creator), component_type::Statistics, std::move(modifier), false);
+        auto new_sst = co_await sst->link_with_rewritten_component(std::move(sst_creator), component_type::Statistics, std::move(modifier), sstables::update_sstable_id::no);
         co_await sst->unlink();
         sst = std::move(new_sst);
         desc.generation = sst->generation();

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -83,6 +83,7 @@ public:
         bool allow_loading_materialized_view = false;
         bool sort_sstables_according_to_owner = true;
         bool garbage_collect = false;
+        bool allow_numerical_generations = true;
         sstables::sstable_open_config sstable_open_config;
     };
 

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -320,7 +320,7 @@ public:
     // Returns the name of the pending_delete_log and an unordered_set of sstable prefixes.
     static future<sstring> create_pending_deletion_log(opened_directory& base_dir, const std::vector<shared_sstable>& ssts);
 
-    static bool compare_sstable_storage_prefix(const sstring& a, const sstring& b) noexcept;
+    static bool compare_sstable_storage_prefix(std::string_view a, std::string_view b) noexcept;
     sstable_state state() const noexcept { return _state; }
 };
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -64,6 +64,7 @@
 #include "utils/cached_file.hh"
 #include "utils/stall_free.hh"
 #include "utils/checked-file-impl.hh"
+#include "utils/memory_data_sink.hh"
 #include "db/extensions.hh"
 #include "sstables/partition_index_cache.hh"
 #include "db/large_data_handler.hh"
@@ -988,8 +989,19 @@ future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_
     co_return std::move(files);
 }
 
-future<entry_descriptor> sstable::clone(generation_type new_generation, bool leave_unsealed) const {
-    return _storage->clone(*this, new_generation, leave_unsealed);
+future<entry_descriptor> sstable::clone(generation_type new_generation, bool leave_unsealed, bool may_use_reference_sharing) {
+    return _storage->clone(*this, new_generation, leave_unsealed, may_use_reference_sharing);
+}
+
+future<std::unique_ptr<scylla_metadata>> sstable::copy_scylla_metadata() {
+    if (_components->scylla_metadata) {
+        co_return std::make_unique<scylla_metadata>(*_components->scylla_metadata);
+    }
+    co_return co_await seastar::async([this] {
+        auto metadata = std::make_unique<sstables::scylla_metadata>();
+        read_simple<component_type::Scylla>(*metadata).get();
+        return metadata;
+    });
 }
 
 future<size_t> sstable::num_references() const {
@@ -1608,6 +1620,10 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
 
     if (!has_scylla_component()) {
         on_internal_error(sstlog, "SSTable must have Scylla component to rewrite Statistics component.");
+    }
+
+    if (_storage->is_object_storage() && !update_id) {
+        on_internal_error(sstlog, "Cannot keep sstable id when rewriting object-storage sstable component");
     }
 
     return seastar::async([this, creator = std::move(sstable_creator), component, modifier = std::move(modifier), update_id] {
@@ -2344,6 +2360,18 @@ sstable::read_scylla_metadata() noexcept {
             auto computed_digest = co_await compute_component_file_digest(component_type::Scylla);
             validate_component_digest(component_type::Scylla, computed_digest);
         });
+    });
+}
+
+future<std::unique_ptr<memory_data_sink_buffers>> sstable::serialize_scylla_metadata(scylla_metadata metadata) const {
+    co_return co_await seastar::async([this, metadata = std::move(metadata)] mutable {
+        metadata.digest = serialized_checksum(_version, metadata.data);
+        auto bufs = std::make_unique<memory_data_sink_buffers>();
+        auto out = data_sink(std::make_unique<memory_data_sink>(*bufs));
+        auto w = file_writer(output_stream<char>(std::move(out), sstable_buffer_size), component_name(*this, component_type::Scylla));
+        write(_version, w, metadata);
+        w.close();
+        return bufs;
     });
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3977,7 +3977,7 @@ sstable::sstable(schema_ptr schema,
     , _schema(std::move(schema))
     , _generation(generation)
     , _state(state)
-    , _storage(make_storage(manager, storage, _state))
+    , _storage(make_storage(manager, _schema, storage, _state))
     , _version(v)
     , _format(f)
     , _index_cache(std::make_unique<partition_index_cache>(

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2415,7 +2415,9 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
     }
 
     sstable_id sid;
-    if (generation().is_uuid_based()) {
+    if (_sstable_identifier) {
+        sid = *_sstable_identifier;
+    } else if (generation().is_uuid_based()) {
         sid = sstable_id(generation().as_uuid());
     } else {
         sid = sstable_id(utils::UUID_gen::get_time_UUID());
@@ -3963,6 +3965,7 @@ mutation_source sstable::as_mutation_source() {
 sstable::sstable(schema_ptr schema,
         const data_dictionary::storage_options& storage,
         generation_type generation,
+        optimized_optional<sstable_id> sstable_identifier,
         sstable_state state,
         version_types v,
         format_types f,
@@ -3987,6 +3990,7 @@ sstable::sstable(schema_ptr schema,
     , _large_data_handler(large_data_handler)
     , _corrupt_data_handler(corrupt_data_handler)
     , _manager(manager)
+    , _sstable_identifier(std::move(sstable_identifier))
     , _ignore_component_digest_mismatch(_manager.get_config().ignore_component_digest_mismatch)
 {
     manager.add(this);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -989,8 +989,7 @@ future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_
 }
 
 future<entry_descriptor> sstable::clone(generation_type new_generation, bool leave_unsealed) const {
-    co_await _storage->clone(*this, new_generation, leave_unsealed);
-    co_return entry_descriptor(new_generation, _version, _format, component_type::TOC, _state);
+    return _storage->clone(*this, new_generation, leave_unsealed);
 }
 
 file_writer::~file_writer() {
@@ -2129,7 +2128,7 @@ future<foreign_sstable_open_info> sstable::get_open_info() & {
 }
 
 entry_descriptor sstable::get_descriptor(component_type c) const {
-    return entry_descriptor(_generation, _version, _format, c);
+    return entry_descriptor(_generation, _sstable_identifier, _version, _format, c);
 }
 
 future<>
@@ -3019,7 +3018,7 @@ static std::expected<std::tuple<entry_descriptor, sstring, sstring>, sstring> ma
         return std::unexpected{seastar::format("invalid version for file {}. Name doesn't match any known version.", fname)};
     }
     try {
-        return std::make_tuple(entry_descriptor(generation_type::from_string(generation), version, format_from_string(format), sstable::component_from_sstring(version, component)), ks, cf);
+        return std::make_tuple(entry_descriptor(generation_type::from_string(generation), std::nullopt, version, format_from_string(format), sstable::component_from_sstring(version, component)), ks, cf);
     } catch (const std::exception& e) {
         return std::unexpected{seastar::format("failed to parse sstable filename {}: {}", fname, e.what())};
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -992,6 +992,10 @@ future<entry_descriptor> sstable::clone(generation_type new_generation, bool lea
     return _storage->clone(*this, new_generation, leave_unsealed);
 }
 
+future<size_t> sstable::num_references() const {
+    return _storage->num_references(*this);
+}
+
 file_writer::~file_writer() {
     if (_closed) {
         return;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -4426,7 +4426,7 @@ generation_type::from_string(const std::string& s) {
 }
 
 sstring component_name::format() const {
-    return sst._storage->prefix() + "/" + sst.component_basename(component);
+    return fmt::format("{}/{}", sst._storage->prefix(), sst.component_basename(component));
 }
 
 future<data_sink> file_io_extension::wrap_sink(const sstable& sst, component_type c, data_sink sink) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1593,7 +1593,7 @@ bool sstable::should_update_repaired_at(int64_t repaired_at) const {
 future<shared_sstable> sstable::link_with_rewritten_component(std::function<shared_sstable(shared_sstable)> sstable_creator,
         component_type component,
         std::function<void(sstable&)> modifier,
-        bool update_sstable_id) {
+        update_sstable_id update_id) {
     if (!is_component_rewrite_supported(component)) {
         on_internal_error(sstlog, "Only Statistics component can be rewritten.");
     }
@@ -1606,7 +1606,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         on_internal_error(sstlog, "SSTable must have Scylla component to rewrite Statistics component.");
     }
 
-    return seastar::async([this, creator = std::move(sstable_creator), component, modifier = std::move(modifier), update_sstable_id] {
+    return seastar::async([this, creator = std::move(sstable_creator), component, modifier = std::move(modifier), update_id] {
         auto new_sst = creator(shared_from_this());
         auto generation = new_sst->generation();
 
@@ -1619,7 +1619,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         // If unchanged, reuse the existing _components->scylla_metadata instead.
         scylla_metadata metadata;
         read_simple<component_type::Scylla>(metadata).get();
-        if (update_sstable_id) {
+        if (update_id) {
             metadata.set_sstable_identifier();
         }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -4308,7 +4308,9 @@ public:
         , _type(type)
         , _last_component(cfg.last_component)
         , _leave_unsealed(cfg.leave_unsealed)
-    {}
+    {
+        sstlog.debug("Creating stream sink for SSTable gen={} sid={} type={} last={} leave_unsealed={}", _sst->generation(), _sst->sstable_identifier(), _type, _last_component, _leave_unsealed);
+    }
 private:
     future<> load_metadata() const {
         if (!co_await _sst->_storage->exists(*_sst, component_type::Scylla)) {
@@ -4381,13 +4383,8 @@ public:
     }
 };
 
-std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr schema, sstables_manager& sstm, const data_dictionary::storage_options& s_opts, sstable_state state, std::string_view component_filename, sstable_stream_sink_cfg cfg) {
-    auto desc_result = parse_path(component_filename, schema->ks_name(), schema->cf_name());
-    if (!desc_result) {
-        throw_malformed_sstable_exception(desc_result.error());
-    }
-    auto desc = std::move(*desc_result);
-    auto sst = sstm.make_sstable(schema, s_opts, desc.generation, state, desc.version, desc.format);
+std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr schema, sstables_manager& sstm, const data_dictionary::storage_options& s_opts, sstable_state state, const entry_descriptor& desc, sstable_stream_sink_cfg cfg) {
+    auto sst = sstm.make_sstable(schema, s_opts, desc.generation, desc.sid, state, desc.version, desc.format);
 
     auto type = desc.component;
     // Don't write actual TOC. Write temp, if successful, storage::seal will rename this to actual

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1334,7 +1334,7 @@ struct sstable_stream_sink_cfg {
 
 // Creates a sink object which can receive a component file sourced from above source object data.
 
-std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr, sstables_manager&, const data_dictionary::storage_options&, sstable_state, std::string_view component_filename, sstable_stream_sink_cfg cfg);
+std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr, sstables_manager&, const data_dictionary::storage_options&, sstable_state, const entry_descriptor& desc, sstable_stream_sink_cfg cfg);
 
 } // namespace sstables
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -211,6 +211,7 @@ public:
     sstable(schema_ptr schema,
             const data_dictionary::storage_options& storage,
             generation_type generation,
+            optimized_optional<sstable_id> sstable_identifier,
             sstable_state state,
             version_types v,
             format_types f,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -289,6 +289,8 @@ public:
         return _generation;
     }
 
+    future<size_t> num_references() const;
+
     // Returns a mutation_reader for given range of partitions.
     //
     // Precondition: if the slice is reversed, the schema must be reversed as well.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1191,7 +1191,7 @@ public:
     future<shared_sstable> link_with_rewritten_component(std::function<shared_sstable(shared_sstable)> sstable_creator,
             component_type component,
             std::function<void(sstable&)> modifier,
-            bool update_sstable_id);
+            update_sstable_id);
     // Must be called in a seastar thread
     void write_component_with_metadata(component_type type, scylla_metadata metadata);
 };

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -53,6 +53,7 @@
 
 class sstable_assertions;
 class cached_file;
+class memory_data_sink_buffers;
 
 namespace data_dictionary {
 class storage_options;
@@ -711,6 +712,7 @@ private:
     void write_compression();
 
     future<> read_scylla_metadata() noexcept;
+    future<std::unique_ptr<memory_data_sink_buffers>> serialize_scylla_metadata(scylla_metadata metadata) const;
 
     void write_scylla_metadata(shard_id shard,
                                run_identifier identifier,
@@ -924,6 +926,7 @@ public:
     const scylla_metadata* get_scylla_metadata() const {
         return _components->scylla_metadata ? &*_components->scylla_metadata : nullptr;
     }
+    future<std::unique_ptr<scylla_metadata>> copy_scylla_metadata();
 
     run_id run_identifier() const {
         return _run_identifier;
@@ -1136,7 +1139,7 @@ public:
     // Clones this sstable with a new generation, under the same location as the original one.
     // If leave_unsealed is true, the destination sstable is left unsealed.
     // Implementation is underlying storage specific.
-    future<entry_descriptor> clone(generation_type new_generation, bool leave_unsealed = false) const;
+    future<entry_descriptor> clone(generation_type new_generation, bool leave_unsealed = false, bool may_use_reference_sharing = false);
 
     struct lesser_reclaimed_memory {
         // comparator class to be used by the _reclaimed set in sstables manager

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -239,13 +239,14 @@ locator::host_id sstables_manager::get_local_host_id() const {
 shared_sstable sstables_manager::make_sstable(schema_ptr schema,
         const data_dictionary::storage_options& storage,
         generation_type generation,
+        optimized_optional<sstable_id> sid,
         sstable_state state,
         sstable_version_types v,
         sstable_format_types f,
         db_clock::time_point now,
         io_error_handler_gen error_handler_gen,
         size_t buffer_size) {
-    return make_lw_shared<sstable>(std::move(schema), storage, generation, state, v, f, get_large_data_handler(), get_corrupt_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
+    return make_lw_shared<sstable>(std::move(schema), storage, generation, sid, state, v, f, get_large_data_handler(), get_corrupt_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);
 }
 
 sstable_writer_config sstables_manager::configure_writer(sstring origin) const {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -199,12 +199,24 @@ public:
     shared_sstable make_sstable(schema_ptr schema,
             const data_dictionary::storage_options& storage,
             generation_type generation,
+            optimized_optional<sstable_id> sstable_identifier,
             sstable_state state = sstable_state::normal,
             sstable_version_types v = get_highest_sstable_version(),
             sstable_format_types f = sstable_format_types::big,
             db_clock::time_point now = db_clock::now(),
             io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
             size_t buffer_size = default_sstable_buffer_size);
+    shared_sstable make_sstable(schema_ptr schema,
+            const data_dictionary::storage_options& storage,
+            generation_type generation,
+            sstable_state state = sstable_state::normal,
+            sstable_version_types v = get_highest_sstable_version(),
+            sstable_format_types f = sstable_format_types::big,
+            db_clock::time_point now = db_clock::now(),
+            io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
+            size_t buffer_size = default_sstable_buffer_size) {
+        return make_sstable(std::move(schema), storage, generation, std::nullopt, state, v, f, now, std::move(error_handler_gen), buffer_size);
+    }
 
     shared_ptr<object_storage_client> get_endpoint_client(sstring endpoint) const {
         SCYLLA_ASSERT(_storage != nullptr);

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -962,9 +962,10 @@ future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc) {
 
     try {
         auto f = make_readable_file(object_name(_bucket, prefix(), desc.generation, sstable_version_constants::get_component_map(desc.version).at(component_type::TOC)));
-        auto [components, digest] = co_await with_closeable(std::move(f), [] (file& f) {
+        auto [toc_components, digest] = co_await with_closeable(std::move(f), [] (file& f) {
             return sstable::read_and_parse_toc(f);
         });
+        components = std::move(toc_components);
     } catch (const storage_io_error& e) {
         if (e.code().value() != ENOENT) {
             throw;

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -89,7 +89,7 @@ public:
 
     virtual future<> seal(const sstable& sst) override;
     virtual future<> snapshot(const sstable& sst, sstring name) const override;
-    virtual future<> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;
+    virtual future<entry_descriptor> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;
     virtual future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     virtual void open(sstable& sst) override;
@@ -449,9 +449,13 @@ future<> filesystem_storage::snapshot(const sstable& sst, sstring name) const {
     co_await sst.sstable_touch_directory_io_check(snapshot_dir);
     co_await create_links_common(sst, snapshot_dir.native(), sst._generation, link_mode::default_mode);
 }
-future<> filesystem_storage::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
+future<entry_descriptor> filesystem_storage::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
     sstlog.debug("Cloning {} dir={} generation={} leave_unsealed={}", sst.get_filename(), _dir.path().native(), gen, leave_unsealed);
-    co_await create_links_common(sst, _dir.path().native(), std::move(gen), leave_unsealed ? link_mode::leave_unsealed : link_mode::default_mode);
+    co_await create_links_common(sst, _dir.path().native(), gen, leave_unsealed ? link_mode::leave_unsealed : link_mode::default_mode);
+    auto desc = sst.get_descriptor(component_type::TOC);
+    desc.generation = gen;
+    desc.state = sst.state();
+    co_return desc;
 }
 
 future<> filesystem_storage::move(const sstable& sst, sstring new_dir, generation_type new_generation, delayed_commit_changes* delay_commit) {
@@ -665,7 +669,7 @@ public:
 
     future<> seal(const sstable& sst) override;
     future<> snapshot(const sstable& sst, sstring name) const override;
-    future<> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;
+    future<entry_descriptor> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;
     future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     void open(sstable& sst) override;
@@ -747,7 +751,7 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
 }
 
 void object_storage_base::open(sstable& sst) {
-    entry_descriptor desc(sst._generation, sst._version, sst._format, component_type::TOC);
+    entry_descriptor desc(sst._generation, sst._sstable_identifier, sst._version, sst._format, component_type::TOC);
     sst.manager().sstables_registry().create_entry(owner(), sst.manager().get_local_host_id(), status_creating, sst._state, std::move(desc)).get();
 
     memory_data_sink_buffers bufs;
@@ -976,11 +980,12 @@ future<> object_storage_base::snapshot(const sstable& sst, sstring name) const {
     co_return;
 }
 
-future<> object_storage_base::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
+future<entry_descriptor> object_storage_base::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
     sstlog.trace("clone sst: {} generation={} leave_unsealed={}", sst.get_filename(), gen, leave_unsealed);
 
     // Register the cloned sstable as "creating" in the registry
-    entry_descriptor desc(gen, sst.get_version(), sst.get_format(), component_type::TOC);
+    entry_descriptor desc(gen, sst.sstable_identifier(), sst.get_version(), sst.get_format(), component_type::TOC);
+    desc.state = sst.state();
     auto node_owner = sst.manager().get_local_host_id();
     co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
 
@@ -995,6 +1000,7 @@ future<> object_storage_base::clone(const sstable& sst, generation_type gen, boo
     }
 
     sstlog.debug("clone sst: {} generation={}: done", sst.get_filename(), gen);
+    co_return desc;
 }
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schema_ptr schema, const data_dictionary::storage_options& s_opts, sstable_state state) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -665,7 +665,9 @@ public:
         , _bucket(std::move(bucket))
         , _location(std::move(loc))
         , _as(as)
-    {}
+    {
+        sstlog.debug("Object storage type={} keyspace={} table={} table_id={} bucket={} loc={}", _type, _schema->ks_name(), _schema->cf_name(), _schema->id(), _bucket, _location ? *_location : "<none>");
+    }
 
     future<> seal(const sstable& sst) override;
     future<> snapshot(const sstable& sst, sstring name) const override;
@@ -752,11 +754,11 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
         throw std::runtime_error(fmt::format("'{}' STORAGE only works with uuid_sstable_identifier enabled", _type));
     }
 
-    if (!_location) {
-        return object_name(_bucket, gen, comp);
-    }
-    return object_name(_bucket, *_location,
-        sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp));
+    auto ret = _location
+            ? object_name(_bucket, *_location, sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp))
+            : object_name(_bucket, gen, comp);
+    sstlog.trace("make_object_name: sstable_id={} generation={} comp={}: {}", sst.sstable_identifier(), gen, comp, ret.str());
+    return ret;
 }
 
 void object_storage_base::open(sstable& sst) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -9,6 +9,8 @@
 #include "storage.hh"
 
 #include <cerrno>
+#include <algorithm>
+#include <cctype>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/erase.hpp>
 
@@ -108,7 +110,7 @@ public:
     }
     virtual future<> unlink_component(const sstable& sst, component_type) noexcept override;
 
-    virtual sstring prefix() const override { return _dir.native(); }
+    virtual std::string_view prefix() const override { return _dir.native(); }
     bool is_object_storage() const override { return false; }
     future<bool> exists(const sstable& sst, component_type type) const override {
         return file_exists(sst.get_filename(type).format());
@@ -589,7 +591,7 @@ future<atomic_delete_context> filesystem_storage::atomic_delete_prepare(const st
 
     for (const auto& sst : ssts) {
         auto prefix = sst->_storage->prefix();
-        res.prefixes.insert(prefix);
+        res.prefixes.emplace(prefix);
     }
 
     res.pending_delete_log = co_await sstable_directory::create_pending_deletion_log(_base_dir, ssts);
@@ -638,7 +640,8 @@ protected:
     schema_ptr _schema;
     shared_ptr<sstables::object_storage_client> _client;
     sstring _bucket;
-    std::optional<sstring> _location;
+    bool _uses_foreign_location;
+    sstring _prefix;
     seastar::abort_source* _as;
 
     static constexpr auto status_creating = "creating";
@@ -649,8 +652,8 @@ protected:
     object_name make_object_name(const sstable& sst, sstring comp, generation_type gen) const;
 
     table_id owner() const {
-        if (_location) {
-            on_internal_error(sstlog, format("Storage holds '{}' prefix, but registry owner is expected", *_location));
+        if (_uses_foreign_location) {
+            on_internal_error(sstlog, format("Storage holds '{}' prefix, but registry owner is expected", prefix()));
         }
         return _schema->id();
     }
@@ -663,10 +666,11 @@ public:
         , _schema(std::move(schema))
         , _client(std::move(client))
         , _bucket(std::move(bucket))
-        , _location(std::move(loc))
+        , _uses_foreign_location(loc.has_value())
+        , _prefix(loc ? std::move(*loc) : "sstables")
         , _as(as)
     {
-        sstlog.debug("Object storage type={} keyspace={} table={} table_id={} bucket={} loc={}", _type, _schema->ks_name(), _schema->cf_name(), _schema->id(), _bucket, _location ? *_location : "<none>");
+        sstlog.debug("Object storage type={} keyspace={} table={} table_id={} bucket={} prefix={} uses_foreign_location={}", _type, _schema->ks_name(), _schema->cf_name(), _schema->id(), _bucket, _prefix, _uses_foreign_location);
     }
 
     future<> seal(const sstable& sst) override;
@@ -701,11 +705,8 @@ public:
         return *sid;
     }
 
-    sstring prefix() const override { 
-        if (_location) {
-            return *_location;
-        }
-        return fmt::to_string(_schema->id());
+    std::string_view prefix() const override {
+        return _prefix;
     }
 
     future<bool> exists(const sstable& sst, component_type type) const override {
@@ -754,9 +755,9 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
         throw std::runtime_error(fmt::format("'{}' STORAGE only works with uuid_sstable_identifier enabled", _type));
     }
 
-    auto ret = _location
-            ? object_name(_bucket, *_location, sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp))
-            : object_name(_bucket, gen, comp);
+    auto ret = _uses_foreign_location
+            ? object_name(_bucket, prefix(), sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp))
+            : object_name(_bucket, prefix(), gen, comp);
     sstlog.trace("make_object_name: sstable_id={} generation={} comp={}: {}", sst.sstable_identifier(), gen, comp, ret.str());
     return ret;
 }
@@ -960,7 +961,7 @@ future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc) {
     std::vector<sstring> components;
 
     try {
-        auto f = make_readable_file(object_name(_bucket, desc.generation, sstable_version_constants::get_component_map(desc.version).at(component_type::TOC)));
+        auto f = make_readable_file(object_name(_bucket, prefix(), desc.generation, sstable_version_constants::get_component_map(desc.version).at(component_type::TOC)));
         auto [components, digest] = co_await with_closeable(std::move(f), [] (file& f) {
             return sstable::read_and_parse_toc(f);
         });
@@ -972,10 +973,10 @@ future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc) {
 
     co_await coroutine::parallel_for_each(components, [this, &desc] (sstring comp) -> future<> {
         if (comp != sstable_version_constants::TOC_SUFFIX) {
-            co_await delete_object(object_name(_bucket, desc.generation, comp));
+            co_await delete_object(object_name(_bucket, prefix(), desc.generation, comp));
         }
     });
-    co_await delete_object(object_name(_bucket, desc.generation, sstable_version_constants::TOC_SUFFIX));
+    co_await delete_object(object_name(_bucket, prefix(), desc.generation, sstable_version_constants::TOC_SUFFIX));
 }
 
 future<> object_storage_base::unlink_component(const sstable& sst, component_type type) noexcept {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -1006,15 +1006,11 @@ std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schem
             return std::make_unique<sstables::filesystem_storage>(loc.dir.native(), state);
         },
         [&] (const data_dictionary::storage_options::object_storage& os) mutable -> std::unique_ptr<sstables::storage> {
-            auto loc = std::visit(overloaded_functor {
-                        [] (const sstring& prefix) { return std::optional<sstring>(prefix); },
-                        [] (const table_id&) { return std::optional<sstring>(); }
-                    }, os.location);
             if (s_opts.is_s3_type()) {
-                return std::make_unique<sstables::s3_storage>(schema, manager.get_endpoint_client(os.endpoint), os.bucket, std::move(loc), os.abort_source);
+                return std::make_unique<sstables::s3_storage>(schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
             }
             if (s_opts.is_gs_type()) {
-                return std::make_unique<sstables::object_storage_base>("GS", schema, manager.get_endpoint_client(os.endpoint), os.bucket, std::move(loc), os.abort_source);
+                return std::make_unique<sstables::object_storage_base>("GS", schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
             }
             throw std::runtime_error(fmt::format("Not implemented: '{}'", os.type));
         }
@@ -1057,7 +1053,6 @@ static future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_
     nopts.value = data_dictionary::storage_options::object_storage {
         .bucket = so.bucket,
         .endpoint = so.endpoint,
-        .location = s.id(),
         .type = so.type
     };
     co_return make_lw_shared<const data_dictionary::storage_options>(std::move(nopts));

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -634,7 +634,7 @@ protected:
     schema_ptr _schema;
     shared_ptr<sstables::object_storage_client> _client;
     sstring _bucket;
-    std::variant<sstring, table_id> _location;
+    std::optional<sstring> _location;
     seastar::abort_source* _as;
 
     static constexpr auto status_creating = "creating";
@@ -645,16 +645,16 @@ protected:
     object_name make_object_name(const sstable& sst, sstring comp, generation_type gen) const;
 
     table_id owner() const {
-        if (std::holds_alternative<sstring>(_location)) {
-            on_internal_error(sstlog, format("Storage holds {} prefix, but registry owner is expected", std::get<sstring>(_location)));
+        if (_location) {
+            on_internal_error(sstlog, format("Storage holds '{}' prefix, but registry owner is expected", *_location));
         }
-        return std::get<table_id>(_location);
+        return _schema->id();
     }
     seastar::abort_source* abort_source() const {
         return _as;
     }
 public:
-    object_storage_base(sstring type, schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
+    object_storage_base(sstring type, schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::optional<sstring> loc, seastar::abort_source* as)
         : _type(type) 
         , _schema(std::move(schema))
         , _client(std::move(client))
@@ -687,7 +687,10 @@ public:
     future<> unlink_component(const sstable& sst, component_type) noexcept override;
 
     sstring prefix() const override { 
-        return std::visit([] (const auto& v) { return fmt::to_string(v); }, _location); 
+        if (_location) {
+            return *_location;
+        }
+        return fmt::to_string(_schema->id());
     }
 
     future<bool> exists(const sstable& sst, component_type type) const override {
@@ -718,7 +721,7 @@ public:
 
 class s3_storage : public object_storage_base {
 public:
-    s3_storage(schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
+    s3_storage(schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::optional<sstring> loc, seastar::abort_source* as)
         : object_storage_base("S3", std::move(schema), std::move(client), std::move(bucket), std::move(loc), as)
     {}
 
@@ -736,15 +739,11 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
         throw std::runtime_error(fmt::format("'{}' STORAGE only works with uuid_sstable_identifier enabled", _type));
     }
 
-    return std::visit(overloaded_functor {
-        [&] (const sstring& prefix) {
-            return object_name(_bucket, prefix,
-                sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp));
-        },
-        [&] (const table_id&) {
-            return object_name(_bucket, gen, comp);
-        }
-    }, _location);
+    if (!_location) {
+        return object_name(_bucket, gen, comp);
+    }
+    return object_name(_bucket, *_location,
+        sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp));
 }
 
 void object_storage_base::open(sstable& sst) {
@@ -1007,17 +1006,15 @@ std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schem
             return std::make_unique<sstables::filesystem_storage>(loc.dir.native(), state);
         },
         [&] (const data_dictionary::storage_options::object_storage& os) mutable -> std::unique_ptr<sstables::storage> {
-            if (std::visit(overloaded_functor {
-                        [] (const sstring& prefix) { return prefix.empty(); },
-                        [] (const table_id& owner) { return owner.id.is_null(); }
-                    }, os.location)) {
-                on_internal_error(sstlog, fmt::format("{} storage options is missing 'location'", os.name()));
-            }
+            auto loc = std::visit(overloaded_functor {
+                        [] (const sstring& prefix) { return std::optional<sstring>(prefix); },
+                        [] (const table_id&) { return std::optional<sstring>(); }
+                    }, os.location);
             if (s_opts.is_s3_type()) {
-                return std::make_unique<sstables::s3_storage>(schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
+                return std::make_unique<sstables::s3_storage>(schema, manager.get_endpoint_client(os.endpoint), os.bucket, std::move(loc), os.abort_source);
             }
             if (s_opts.is_gs_type()) {
-                return std::make_unique<sstables::object_storage_base>("GS", schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
+                return std::make_unique<sstables::object_storage_base>("GS", schema, manager.get_endpoint_client(os.endpoint), os.bucket, std::move(loc), os.abort_source);
             }
             throw std::runtime_error(fmt::format("Not implemented: '{}'", os.type));
         }

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -631,6 +631,7 @@ future<> filesystem_storage::unlink_component(const sstable& sst, component_type
 class object_storage_base : public sstables::storage {
 protected:
     sstring _type;
+    schema_ptr _schema;
     shared_ptr<sstables::object_storage_client> _client;
     sstring _bucket;
     std::variant<sstring, table_id> _location;
@@ -653,8 +654,9 @@ protected:
         return _as;
     }
 public:
-    object_storage_base(sstring type, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
+    object_storage_base(sstring type, schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
         : _type(type) 
+        , _schema(std::move(schema))
         , _client(std::move(client))
         , _bucket(std::move(bucket))
         , _location(std::move(loc))
@@ -716,8 +718,8 @@ public:
 
 class s3_storage : public object_storage_base {
 public:
-    s3_storage(shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
-        : object_storage_base("S3", std::move(client), std::move(bucket), std::move(loc), as)
+    s3_storage(schema_ptr schema, shared_ptr<sstables::object_storage_client> client, sstring bucket, std::variant<sstring, table_id> loc, seastar::abort_source* as)
+        : object_storage_base("S3", std::move(schema), std::move(client), std::move(bucket), std::move(loc), as)
     {}
 
     future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
@@ -996,7 +998,7 @@ future<> object_storage_base::clone(const sstable& sst, generation_type gen, boo
     sstlog.debug("clone sst: {} generation={}: done", sst.get_filename(), gen);
 }
 
-std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state) {
+std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schema_ptr schema, const data_dictionary::storage_options& s_opts, sstable_state state) {
     return std::visit(overloaded_functor {
         [state] (const data_dictionary::storage_options::local& loc) mutable -> std::unique_ptr<sstables::storage> {
             if (loc.dir.empty()) {
@@ -1012,10 +1014,10 @@ std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const
                 on_internal_error(sstlog, fmt::format("{} storage options is missing 'location'", os.name()));
             }
             if (s_opts.is_s3_type()) {
-                return std::make_unique<sstables::s3_storage>(manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
+                return std::make_unique<sstables::s3_storage>(schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
             }
             if (s_opts.is_gs_type()) {
-                return std::make_unique<sstables::object_storage_base>("GS", manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
+                return std::make_unique<sstables::object_storage_base>("GS", schema, manager.get_endpoint_client(os.endpoint), os.bucket, os.location, os.abort_source);
             }
             throw std::runtime_error(fmt::format("Not implemented: '{}'", os.type));
         }

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -104,11 +104,12 @@ public:
     virtual future<> destroy(const sstable& sst) override { return make_ready_future<>(); }
     virtual future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
     virtual future<> atomic_delete_complete(atomic_delete_context ctx) const override;
-    virtual future<> remove_by_registry_entry(entry_descriptor desc) override;
+    virtual future<> remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) override;
     virtual future<uint64_t> free_space() const override {
         return seastar::fs_avail(prefix());
     }
     virtual future<> unlink_component(const sstable& sst, component_type) noexcept override;
+    future<size_t> num_references(const sstable& sst) const override;
 
     virtual std::string_view prefix() const override { return _dir.native(); }
     bool is_object_storage() const override { return false; }
@@ -615,8 +616,13 @@ future<> filesystem_storage::atomic_delete_complete(atomic_delete_context ctx) c
         }
 }
 
-future<> filesystem_storage::remove_by_registry_entry(entry_descriptor desc) {
+future<> filesystem_storage::remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) {
     on_internal_error(sstlog, "Filesystem storage doesn't keep its entries in registry");
+}
+
+future<size_t> filesystem_storage::num_references(const sstable& sst) const {
+    auto has_toc = co_await exists(sst, component_type::TOC);
+    co_return has_toc ? 1 : 0;
 }
 
 future<> filesystem_storage::unlink_component(const sstable& sst, component_type type) noexcept {
@@ -650,6 +656,11 @@ protected:
 
     object_name make_object_name(const sstable& sst, component_type type) const;
     object_name make_object_name(const sstable& sst, sstring comp, generation_type gen) const;
+
+    // Construct the object name for a reference: {prefix}/{gen}/refs/nodes/{host_id}/{gen}
+    object_name make_ref_object_name(generation_type gen, locator::host_id host_id) const {
+        return object_name(_bucket, prefix(), gen, fmt::format("refs/nodes/{}/{}", host_id, gen));
+    }
 
     table_id owner() const {
         if (_uses_foreign_location) {
@@ -689,12 +700,13 @@ public:
     future<> destroy(const sstable& sst) override;
     future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
     future<> atomic_delete_complete(atomic_delete_context ctx) const override;
-    future<> remove_by_registry_entry(entry_descriptor desc) override;
+    future<> remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) override;
     future<uint64_t> free_space() const override {
         // assumes infinite space on s3/gs (https://aws.amazon.com/s3/faqs/#How_much_data_can_I_store).
         return make_ready_future<uint64_t>(std::numeric_limits<uint64_t>::max());
     }
     future<> unlink_component(const sstable& sst, component_type) noexcept override;
+    future<size_t> num_references(const sstable& sst) const override;
 
     sstable_id get_sstable_identifier(const sstable& sst) const {
         auto sid = sst.sstable_identifier();
@@ -712,6 +724,12 @@ public:
     future<bool> exists(const sstable& sst, component_type type) const override {
         return _client->object_exists(make_object_name(sst, type), abort_source());
     }
+
+    // FIXME: pass sstable_id when reference sharing is introduced. At this point
+    // only this node's reference can exist, using the same generation as the
+    // object-storage prefix.
+    future<size_t> num_references(generation_type gen) const;
+    future<> delete_components(sstable_version_types version, generation_type gen, bool log_errors) const;
 
     bool is_object_storage() const override { return true; }
 
@@ -762,10 +780,70 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
     return ret;
 }
 
+static future<> collect_lister_entries(abstract_lister& lister, object_storage_reference_names& entries) {
+    while (auto entry = co_await lister.get()) {
+        entries.push_back(entry->name);
+    }
+}
+
+future<object_storage_reference_names> list_object_storage_references(object_storage_client& client, sstring bucket, std::string_view prefix, generation_type gen) {
+    object_storage_reference_names refs;
+    try {
+        auto refs_prefix = fmt::format("{}/{}/refs/", prefix, gen);
+        auto lister = client.make_object_lister(std::move(bucket), refs_prefix, [] (const std::filesystem::path&, const directory_entry&) { return true; });
+        co_await with_closeable(std::move(lister), [&refs] (abstract_lister& lister) {
+            return collect_lister_entries(lister, refs);
+        });
+    } catch (...) {
+        throw std::runtime_error(fmt::format("Failed to list references: prefix={} generation={}: {}", prefix, gen, std::current_exception()));
+    }
+    co_return refs;
+}
+
+future<size_t> object_storage_base::num_references(generation_type gen) const {
+    auto refs = co_await list_object_storage_references(*_client, _bucket, prefix(), gen);
+    co_return refs.size();
+}
+
+future<size_t> object_storage_base::num_references(const sstable& sst) const {
+    return num_references(sst.generation());
+}
+
+future<> object_storage_base::delete_components(sstable_version_types version, generation_type gen, bool log_errors) const {
+    auto prefix = this->prefix();
+    auto delete_component = [this, &prefix, &gen, log_errors] (std::string_view component) -> future<> {
+        try {
+            co_await delete_object(object_name(_bucket, prefix, gen, component));
+        } catch (const storage_io_error& e) {
+            if (e.code().value() != ENOENT) {
+                throw;
+            }
+        } catch (...) {
+            if (!log_errors) {
+                throw;
+            }
+            sstlog.warn("Failed to delete {} object {} for generation={}: {}", _type, component, gen, std::current_exception());
+        }
+    };
+
+    auto& component_map = sstable_version_constants::get_component_map(version);
+    co_await coroutine::parallel_for_each(component_map, [&delete_component] (const auto& entry) -> future<> {
+        if (entry.first == component_type::TOC) {
+            co_return;
+        }
+        co_await delete_component(entry.second);
+    });
+    co_await delete_component(sstable_version_constants::TOC_SUFFIX);
+}
+
 void object_storage_base::open(sstable& sst) {
     auto sid = get_sstable_identifier(sst);
     entry_descriptor desc(sst._generation, sid, sst._version, sst._format, component_type::TOC);
-    sst.manager().sstables_registry().create_entry(owner(), sst.manager().get_local_host_id(), status_creating, sst._state, std::move(desc)).get();
+    auto host_id = sst.manager().get_local_host_id();
+    sst.manager().sstables_registry().create_entry(owner(), host_id, status_creating, sst._state, std::move(desc)).get();
+
+    auto ref_name = make_ref_object_name(sst.generation(), host_id);
+    put_object(ref_name, memory_data_sink_buffers()).get();
 
     memory_data_sink_buffers bufs;
     auto out = data_sink(std::make_unique<memory_data_sink>(bufs));
@@ -773,6 +851,7 @@ void object_storage_base::open(sstable& sst) {
 
     sst.write_toc(std::move(w));
     put_object(make_object_name(sst, component_type::TOC), std::move(bufs)).get();
+    sstlog.debug("Created reference {}: {}", sst.get_filename(), ref_name);
 }
 
 future<file> object_storage_base::open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) {
@@ -910,17 +989,23 @@ future<> object_storage_base::destroy(const sstable& sst) {
     if (!sst.marked_for_deletion()) {
         co_return;
     }
-    // Delete the S3 objects. Errors are logged but not propagated because
-    // destroy() is called fire-and-forget from the shared_ptr deleter.
-    // Any objects that could not be deleted here will be retried on the
-    // next startup via garbage_collect() which handles "removing" entries.
-    co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
-        try {
-            co_await delete_object(make_object_name(sst, type));
-        } catch (...) {
-            sstlog.warn("Failed to delete {} object for {}: {}", _type, sst.toc_filename(), std::current_exception());
-        }
-    });
+
+    auto node_owner = sst.manager().get_local_host_id();
+
+    // Remove this node's reference to the sstable
+    auto ref_name = make_ref_object_name(sst.generation(), node_owner);
+    co_await delete_object(ref_name);
+
+    // Only delete components if no references remain
+    auto remaining_refs = co_await sst.num_references();
+    if (!remaining_refs) {
+        // Delete the S3 objects. Errors are logged but not propagated because
+        // destroy() is called fire-and-forget from the shared_ptr deleter.
+        // Any objects that could not be deleted here will be retried on the
+        // next startup via garbage_collect() which handles "removing" entries.
+        co_await delete_components(sst.get_version(), sst.generation(), true);
+    }
+
     // Remove the registry entry only after S3 objects are cleaned up.
     // If this fails, the "removing" entry survives and garbage_collect()
     // will delete the (already gone) objects tolerantly and retry deletion.
@@ -937,10 +1022,11 @@ future<> object_storage_base::destroy(const sstable& sst) {
             sstlog.warn("Skipping registry entry deletion for {}: sstables registry already unplugged (shutdown in progress)", sst.toc_filename());
             co_return;
         }
-        co_await sst.manager().sstables_registry().delete_entry(owner(), sst.manager().get_local_host_id(), sst.generation());
+        co_await sst.manager().sstables_registry().delete_entry(owner(), node_owner, sst.generation());
     } catch (...) {
         sstlog.warn("Failed to delete registry entry for {}: {}", sst.toc_filename(), std::current_exception());
     }
+    sstlog.debug("Deleted reference {} remaining_refs={}", ref_name.str(), remaining_refs);
 }
 
 future<atomic_delete_context> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
@@ -957,27 +1043,24 @@ future<> object_storage_base::atomic_delete_complete(atomic_delete_context ctx) 
     co_return;
 }
 
-future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc) {
-    std::vector<sstring> components;
-
+future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) {
+    auto ref_name = make_ref_object_name(desc.generation, node_owner);
     try {
-        auto f = make_readable_file(object_name(_bucket, prefix(), desc.generation, sstable_version_constants::get_component_map(desc.version).at(component_type::TOC)));
-        auto [toc_components, digest] = co_await with_closeable(std::move(f), [] (file& f) {
-            return sstable::read_and_parse_toc(f);
-        });
-        components = std::move(toc_components);
+        co_await delete_object(ref_name);
     } catch (const storage_io_error& e) {
         if (e.code().value() != ENOENT) {
             throw;
         }
     }
 
-    co_await coroutine::parallel_for_each(components, [this, &desc] (sstring comp) -> future<> {
-        if (comp != sstable_version_constants::TOC_SUFFIX) {
-            co_await delete_object(object_name(_bucket, prefix(), desc.generation, comp));
-        }
-    });
-    co_await delete_object(object_name(_bucket, prefix(), desc.generation, sstable_version_constants::TOC_SUFFIX));
+    auto remaining_refs = co_await num_references(desc.generation);
+    if (remaining_refs) {
+        sstlog.debug("Deleted reference {}: remaining_refs={}", ref_name.str(), remaining_refs);
+        co_return;
+    }
+
+    co_await delete_components(desc.version, desc.generation, false);
+    sstlog.debug("Deleted reference {}: remaining_refs={}", ref_name.str(), remaining_refs);
 }
 
 future<> object_storage_base::unlink_component(const sstable& sst, component_type type) noexcept {
@@ -1003,6 +1086,11 @@ future<entry_descriptor> object_storage_base::clone(const sstable& sst, generati
     desc.state = sst.state();
     auto node_owner = sst.manager().get_local_host_id();
     co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
+
+    auto ref_name = make_ref_object_name(gen, node_owner);
+    co_await _client->put_object(ref_name, memory_data_sink_buffers(), abort_source());
+    auto refs = co_await num_references(desc.generation);
+    sstlog.debug("Cloned {} reference {} num_references={}", sst.get_filename(), ref_name, refs);
 
     // Copy all component objects from the source to the destination generation.
     co_await coroutine::parallel_for_each(sst.all_components(), [this, &sst, &gen] (const std::pair<component_type, sstring>& p) -> future<> {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -72,7 +72,8 @@ private:
     future<> move(const sstable& sst, sstring new_dir, generation_type generation, delayed_commit_changes* delay) override;
     future<> rename_new_file(const sstable& sst, sstring from_name, sstring to_name) const;
     future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
-            const std::unordered_set<component_type>& excluded_components) const override;
+            const std::unordered_set<component_type>& excluded_components,
+            optimized_optional<sstable_id> new_sid = {}) const override;
 
     future<> change_dir(sstring new_dir) {
         auto old_dir = std::exchange(_dir, opened_directory(new_dir));
@@ -91,7 +92,7 @@ public:
 
     virtual future<> seal(const sstable& sst) override;
     virtual future<> snapshot(const sstable& sst, sstring name) const override;
-    virtual future<entry_descriptor> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;
+    virtual future<entry_descriptor> clone(sstable& sst, generation_type gen, bool leave_unsealed, bool may_use_reference_sharing = false) const override;
     virtual future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     virtual void open(sstable& sst) override;
@@ -422,7 +423,8 @@ future<> filesystem_storage::create_links(const sstable& sst, const std::filesys
 }
 
 future<> filesystem_storage::link_with_excluded_components(const sstable& sst, generation_type new_gen,
-        const std::unordered_set<component_type>& excluded_components) const {
+        const std::unordered_set<component_type>& excluded_components,
+        optimized_optional<sstable_id>) const {
     sstlog.trace("link_with_excluded_components: {} -> generation={} excluded={}",
             sst.get_filename(), new_gen, excluded_components);
 
@@ -452,7 +454,7 @@ future<> filesystem_storage::snapshot(const sstable& sst, sstring name) const {
     co_await sst.sstable_touch_directory_io_check(snapshot_dir);
     co_await create_links_common(sst, snapshot_dir.native(), sst._generation, link_mode::default_mode);
 }
-future<entry_descriptor> filesystem_storage::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
+future<entry_descriptor> filesystem_storage::clone(sstable& sst, generation_type gen, bool leave_unsealed, bool) const {
     sstlog.debug("Cloning {} dir={} generation={} leave_unsealed={}", sst.get_filename(), _dir.path().native(), gen, leave_unsealed);
     co_await create_links_common(sst, _dir.path().native(), gen, leave_unsealed ? link_mode::leave_unsealed : link_mode::default_mode);
     auto desc = sst.get_descriptor(component_type::TOC);
@@ -657,9 +659,9 @@ protected:
     object_name make_object_name(const sstable& sst, component_type type) const;
     object_name make_object_name(const sstable& sst, sstring comp, generation_type gen) const;
 
-    // Construct the object name for a reference: {prefix}/{gen}/refs/nodes/{host_id}/{gen}
-    object_name make_ref_object_name(generation_type gen, locator::host_id host_id) const {
-        return object_name(_bucket, prefix(), gen, fmt::format("refs/nodes/{}/{}", host_id, gen));
+    // Construct the object name for a reference: {prefix}/{sstable_id}/refs/nodes/{host_id}/{gen}
+    object_name make_ref_object_name(sstable_id sid, generation_type gen, locator::host_id host_id) const {
+        return object_name(_bucket, prefix(), sid, fmt::format("refs/nodes/{}/{}", host_id, gen));
     }
 
     table_id owner() const {
@@ -686,7 +688,7 @@ public:
 
     future<> seal(const sstable& sst) override;
     future<> snapshot(const sstable& sst, sstring name) const override;
-    future<entry_descriptor> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const override;
+    future<entry_descriptor> clone(sstable& sst, generation_type gen, bool leave_unsealed, bool may_use_reference_sharing = false) const override;
     future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     void open(sstable& sst) override;
@@ -705,14 +707,16 @@ public:
         // assumes infinite space on s3/gs (https://aws.amazon.com/s3/faqs/#How_much_data_can_I_store).
         return make_ready_future<uint64_t>(std::numeric_limits<uint64_t>::max());
     }
+    future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
+            const std::unordered_set<component_type>& excluded_components,
+            optimized_optional<sstable_id> new_sid = {}) const override;
     future<> unlink_component(const sstable& sst, component_type) noexcept override;
     future<size_t> num_references(const sstable& sst) const override;
 
     sstable_id get_sstable_identifier(const sstable& sst) const {
         auto sid = sst.sstable_identifier();
         if (!sid) {
-            // We cannot assert that yet since we don't pass the sstable_id yet in the clone_sstable rpc
-            sstlog.warn("SSTable on object storage with generation={} has no sstable_id", sst.generation());
+            on_internal_error(sstlog, fmt::format("SSTable on object storage with generation={} has no sstable_id", sst.generation()));
         }
         return *sid;
     }
@@ -725,15 +729,12 @@ public:
         return _client->object_exists(make_object_name(sst, type), abort_source());
     }
 
-    // FIXME: pass sstable_id when reference sharing is introduced. At this point
-    // only this node's reference can exist, using the same generation as the
-    // object-storage prefix.
-    future<size_t> num_references(generation_type gen) const;
-    future<> delete_components(sstable_version_types version, generation_type gen, bool log_errors) const;
+    future<size_t> num_references(sstable_id sid) const;
+    future<> delete_components(sstable_version_types version, sstable_id sid, bool log_errors) const;
 
     bool is_object_storage() const override { return true; }
 
-    future<> put_object(object_name name, ::memory_data_sink_buffers bufs) {
+    future<> put_object(object_name name, ::memory_data_sink_buffers bufs) const {
         return _client->put_object(std::move(name), std::move(bufs), abort_source());
     }
     future<> copy_object(object_name src, object_name dst) const {
@@ -775,7 +776,7 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
 
     auto ret = _uses_foreign_location
             ? object_name(_bucket, prefix(), sstable::component_basename(sst.get_schema()->ks_name(), sst.get_schema()->cf_name(), sst.get_version(), gen, sst.get_format(), comp))
-            : object_name(_bucket, prefix(), gen, comp);
+            : object_name(_bucket, prefix(), get_sstable_identifier(sst), comp);
     sstlog.trace("make_object_name: sstable_id={} generation={} comp={}: {}", sst.sstable_identifier(), gen, comp, ret.str());
     return ret;
 }
@@ -786,34 +787,34 @@ static future<> collect_lister_entries(abstract_lister& lister, object_storage_r
     }
 }
 
-future<object_storage_reference_names> list_object_storage_references(object_storage_client& client, sstring bucket, std::string_view prefix, generation_type gen) {
+future<object_storage_reference_names> list_object_storage_references(object_storage_client& client, sstring bucket, std::string_view prefix, sstable_id sid) {
     object_storage_reference_names refs;
     try {
-        auto refs_prefix = fmt::format("{}/{}/refs/", prefix, gen);
+        auto refs_prefix = fmt::format("{}/{}/refs/", prefix, sid);
         auto lister = client.make_object_lister(std::move(bucket), refs_prefix, [] (const std::filesystem::path&, const directory_entry&) { return true; });
         co_await with_closeable(std::move(lister), [&refs] (abstract_lister& lister) {
             return collect_lister_entries(lister, refs);
         });
     } catch (...) {
-        throw std::runtime_error(fmt::format("Failed to list references: prefix={} generation={}: {}", prefix, gen, std::current_exception()));
+        throw std::runtime_error(fmt::format("Failed to list references: prefix={} sstable_id={}: {}", prefix, sid, std::current_exception()));
     }
     co_return refs;
 }
 
-future<size_t> object_storage_base::num_references(generation_type gen) const {
-    auto refs = co_await list_object_storage_references(*_client, _bucket, prefix(), gen);
+future<size_t> object_storage_base::num_references(sstable_id sid) const {
+    auto refs = co_await list_object_storage_references(*_client, _bucket, prefix(), sid);
     co_return refs.size();
 }
 
 future<size_t> object_storage_base::num_references(const sstable& sst) const {
-    return num_references(sst.generation());
+    return num_references(get_sstable_identifier(sst));
 }
 
-future<> object_storage_base::delete_components(sstable_version_types version, generation_type gen, bool log_errors) const {
+future<> object_storage_base::delete_components(sstable_version_types version, sstable_id sid, bool log_errors) const {
     auto prefix = this->prefix();
-    auto delete_component = [this, &prefix, &gen, log_errors] (std::string_view component) -> future<> {
+    auto delete_component = [this, &prefix, &sid, log_errors] (std::string_view component) -> future<> {
         try {
-            co_await delete_object(object_name(_bucket, prefix, gen, component));
+            co_await delete_object(object_name(_bucket, prefix, sid, component));
         } catch (const storage_io_error& e) {
             if (e.code().value() != ENOENT) {
                 throw;
@@ -822,7 +823,7 @@ future<> object_storage_base::delete_components(sstable_version_types version, g
             if (!log_errors) {
                 throw;
             }
-            sstlog.warn("Failed to delete {} object {} for generation={}: {}", _type, component, gen, std::current_exception());
+            sstlog.warn("Failed to delete {} object {} for sstable_id={}: {}", _type, component, sid, std::current_exception());
         }
     };
 
@@ -842,7 +843,7 @@ void object_storage_base::open(sstable& sst) {
     auto host_id = sst.manager().get_local_host_id();
     sst.manager().sstables_registry().create_entry(owner(), host_id, status_creating, sst._state, std::move(desc)).get();
 
-    auto ref_name = make_ref_object_name(sst.generation(), host_id);
+    auto ref_name = make_ref_object_name(sid, sst.generation(), host_id);
     put_object(ref_name, memory_data_sink_buffers()).get();
 
     memory_data_sink_buffers bufs;
@@ -991,9 +992,10 @@ future<> object_storage_base::destroy(const sstable& sst) {
     }
 
     auto node_owner = sst.manager().get_local_host_id();
+    auto sid = get_sstable_identifier(sst);
 
     // Remove this node's reference to the sstable
-    auto ref_name = make_ref_object_name(sst.generation(), node_owner);
+    auto ref_name = make_ref_object_name(sid, sst.generation(), node_owner);
     co_await delete_object(ref_name);
 
     // Only delete components if no references remain
@@ -1003,7 +1005,7 @@ future<> object_storage_base::destroy(const sstable& sst) {
         // destroy() is called fire-and-forget from the shared_ptr deleter.
         // Any objects that could not be deleted here will be retried on the
         // next startup via garbage_collect() which handles "removing" entries.
-        co_await delete_components(sst.get_version(), sst.generation(), true);
+        co_await delete_components(sst.get_version(), sid, true);
     }
 
     // Remove the registry entry only after S3 objects are cleaned up.
@@ -1044,7 +1046,12 @@ future<> object_storage_base::atomic_delete_complete(atomic_delete_context ctx) 
 }
 
 future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) {
-    auto ref_name = make_ref_object_name(desc.generation, node_owner);
+    if (!desc.sid) {
+        on_internal_error(sstlog, fmt::format("Cannot remove SSTable on object storage with generation={} from registry: has no sstable_id", desc.generation));
+    }
+    auto sid = *desc.sid;
+
+    auto ref_name = make_ref_object_name(sid, desc.generation, node_owner);
     try {
         co_await delete_object(ref_name);
     } catch (const storage_io_error& e) {
@@ -1053,13 +1060,13 @@ future<> object_storage_base::remove_by_registry_entry(entry_descriptor desc, lo
         }
     }
 
-    auto remaining_refs = co_await num_references(desc.generation);
+    auto remaining_refs = co_await num_references(sid);
     if (remaining_refs) {
         sstlog.debug("Deleted reference {}: remaining_refs={}", ref_name.str(), remaining_refs);
         co_return;
     }
 
-    co_await delete_components(desc.version, desc.generation, false);
+    co_await delete_components(desc.version, sid, false);
     sstlog.debug("Deleted reference {}: remaining_refs={}", ref_name.str(), remaining_refs);
 }
 
@@ -1077,25 +1084,42 @@ future<> object_storage_base::snapshot(const sstable& sst, sstring name) const {
     co_return;
 }
 
-future<entry_descriptor> object_storage_base::clone(const sstable& sst, generation_type gen, bool leave_unsealed) const {
-    sstlog.trace("clone sst: {} generation={} leave_unsealed={}", sst.get_filename(), gen, leave_unsealed);
+future<> object_storage_base::link_with_excluded_components(const sstable& sst, generation_type new_gen,
+        const std::unordered_set<component_type>& excluded_components,
+        optimized_optional<sstable_id> new_sid) const {
+    auto sid = new_sid ? *new_sid : sstable_id(new_gen.as_uuid());
+    auto prefix = this->prefix();
+    co_await coroutine::parallel_for_each(sst.all_components(), [this, &sst, sid, &excluded_components, &prefix] (const std::pair<component_type, sstring>& p) -> future<> {
+        if (excluded_components.contains(p.first)) {
+            co_return;
+        }
+        co_await copy_object(make_object_name(sst, p.second, sst.generation()), object_name(_bucket, prefix, sid, p.second));
+    });
+}
 
-    // Register the cloned sstable as "creating" in the registry
-    auto sid = get_sstable_identifier(sst);
+future<entry_descriptor> object_storage_base::clone(sstable& sst, generation_type gen, bool leave_unsealed, bool may_use_reference_sharing) const {
+    sstlog.debug("Cloning {} sstable_id={} generation={}: new_generation={} leave_unsealed={} may_use_reference_sharing={}",
+            sst.get_filename(), sst.sstable_identifier(), sst.generation(),
+            gen, leave_unsealed, may_use_reference_sharing);
+
+    auto sid = may_use_reference_sharing ? get_sstable_identifier(sst) : sstable_id(gen.as_uuid());
     entry_descriptor desc(gen, sid, sst.get_version(), sst.get_format(), component_type::TOC);
     desc.state = sst.state();
     auto node_owner = sst.manager().get_local_host_id();
     co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
 
-    auto ref_name = make_ref_object_name(gen, node_owner);
+    auto ref_name = make_ref_object_name(sid, gen, node_owner);
     co_await _client->put_object(ref_name, memory_data_sink_buffers(), abort_source());
-    auto refs = co_await num_references(desc.generation);
+    auto refs = co_await num_references(sid);
     sstlog.debug("Cloned {} reference {} num_references={}", sst.get_filename(), ref_name, refs);
 
-    // Copy all component objects from the source to the destination generation.
-    co_await coroutine::parallel_for_each(sst.all_components(), [this, &sst, &gen] (const std::pair<component_type, sstring>& p) -> future<> {
-        co_await copy_object(make_object_name(sst, p.second, sst.generation()), make_object_name(sst, p.second, gen));
-    });
+    if (!may_use_reference_sharing) {
+        co_await link_with_excluded_components(sst, gen, {component_type::Scylla}, sid);
+        auto scylla_metadata = co_await sst.copy_scylla_metadata();
+        scylla_metadata->set_sstable_identifier(sid);
+        auto scylla_metadata_bufs = co_await sst.serialize_scylla_metadata(std::move(*scylla_metadata));
+        co_await put_object(object_name(_bucket, prefix(), sid, sstable_version_constants::get_component_map(sst.get_version()).at(component_type::Scylla)), std::move(*scylla_metadata_bufs));
+    }
 
     if (!leave_unsealed) {
         // Mark the cloned sstable as sealed in the registry

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -690,6 +690,15 @@ public:
     }
     future<> unlink_component(const sstable& sst, component_type) noexcept override;
 
+    sstable_id get_sstable_identifier(const sstable& sst) const {
+        auto sid = sst.sstable_identifier();
+        if (!sid) {
+            // We cannot assert that yet since we don't pass the sstable_id yet in the clone_sstable rpc
+            sstlog.warn("SSTable on object storage with generation={} has no sstable_id", sst.generation());
+        }
+        return *sid;
+    }
+
     sstring prefix() const override { 
         if (_location) {
             return *_location;
@@ -751,7 +760,8 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
 }
 
 void object_storage_base::open(sstable& sst) {
-    entry_descriptor desc(sst._generation, sst._sstable_identifier, sst._version, sst._format, component_type::TOC);
+    auto sid = get_sstable_identifier(sst);
+    entry_descriptor desc(sst._generation, sid, sst._version, sst._format, component_type::TOC);
     sst.manager().sstables_registry().create_entry(owner(), sst.manager().get_local_host_id(), status_creating, sst._state, std::move(desc)).get();
 
     memory_data_sink_buffers bufs;
@@ -984,7 +994,8 @@ future<entry_descriptor> object_storage_base::clone(const sstable& sst, generati
     sstlog.trace("clone sst: {} generation={} leave_unsealed={}", sst.get_filename(), gen, leave_unsealed);
 
     // Register the cloned sstable as "creating" in the registry
-    entry_descriptor desc(gen, sst.sstable_identifier(), sst.get_version(), sst.get_format(), component_type::TOC);
+    auto sid = get_sstable_identifier(sst);
+    entry_descriptor desc(gen, sid, sst.get_version(), sst.get_format(), component_type::TOC);
     desc.state = sst.state();
     auto node_owner = sst.manager().get_local_host_id();
     co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -25,6 +25,7 @@
 #include "sstables/shared_sstable.hh"
 #include "sstables/component_type.hh"
 #include "sstables/generation_type.hh"
+#include "sstables/types.hh"
 #include "locator/host_id.hh"
 #include "utils/disk-error-handler.hh"
 #include "utils/small_vector.hh"
@@ -99,19 +100,19 @@ class storage {
     }
 
 public:
-    // Clone an sstable to a new generation, hard-linking all components except those in excluded_components.
-    // The new sstable is created with a TemporaryTOC, so it will be removed on restart if not sealed.
+    // Clone an sstable to a new generation, linking or copying all components except those in excluded_components.
     virtual future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
-            const std::unordered_set<component_type>& excluded_components) const {
-        SCYLLA_ASSERT(false && "link_with_excluded_components not implemented");
-    }
+            const std::unordered_set<component_type>& excluded_components,
+            optimized_optional<sstable_id> new_sid = {}) const = 0;
     virtual ~storage() {}
 
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage
 
     virtual future<> seal(const sstable& sst) = 0;
     virtual future<> snapshot(const sstable& sst, sstring name) const = 0;
-    virtual future<entry_descriptor> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const = 0;
+    // `may_use_reference_sharing` is a hint: storage backends may ignore it
+    // and use their natural clone method.
+    virtual future<entry_descriptor> clone(sstable& sst, generation_type gen, bool leave_unsealed, bool may_use_reference_sharing = false) const = 0;
     virtual future<> change_state(const sstable& sst, sstable_state to, generation_type generation, delayed_commit_changes* delay) = 0;
     // runs in async context
     virtual void open(sstable& sst) = 0;
@@ -141,7 +142,7 @@ public:
 };
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schema_ptr schema, const data_dictionary::storage_options& s_opts, sstable_state state);
-future<object_storage_reference_names> list_object_storage_references(object_storage_client& client, sstring bucket, sstring prefix, generation_type gen);
+future<object_storage_reference_names> list_object_storage_references(object_storage_client& client, sstring bucket, std::string_view prefix, sstable_id sid);
 future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const sstables_manager&, const schema&, const data_dictionary::storage_options& so);
 future<> destroy_table_storage(const data_dictionary::storage_options& so);
 future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring ks_name);

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -25,7 +25,9 @@
 #include "sstables/shared_sstable.hh"
 #include "sstables/component_type.hh"
 #include "sstables/generation_type.hh"
+#include "locator/host_id.hh"
 #include "utils/disk-error-handler.hh"
+#include "utils/small_vector.hh"
 
 namespace data_dictionary {
 class storage_options;
@@ -37,6 +39,7 @@ namespace sstables {
 
 enum class sstable_state;
 class delayed_commit_changes;
+class object_storage_client;
 class sstable;
 class sstables_manager;
 class entry_descriptor;
@@ -45,6 +48,8 @@ struct atomic_delete_context {
     sstring pending_delete_log;
     std::unordered_set<sstring> prefixes;
 };
+
+using object_storage_reference_names = utils::small_vector<sstring, 3>;
 
 class opened_directory final {
     std::filesystem::path _pathname;
@@ -121,10 +126,11 @@ public:
     virtual future<> destroy(const sstable& sst) = 0;
     virtual future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const = 0;
     virtual future<> atomic_delete_complete(atomic_delete_context ctx) const = 0;
-    virtual future<> remove_by_registry_entry(entry_descriptor desc) = 0;
+    virtual future<> remove_by_registry_entry(entry_descriptor desc, locator::host_id node_owner) = 0;
     // Free space available in the underlying storage.
     virtual future<uint64_t> free_space() const = 0;
     virtual future<> unlink_component(const sstable& sst, component_type) noexcept = 0;
+    virtual future<size_t> num_references(const sstable& sst) const = 0;
 
     virtual std::string_view prefix() const  = 0;
     virtual future<bool> exists(const sstable& sst, component_type type) const = 0;
@@ -135,6 +141,7 @@ public:
 };
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schema_ptr schema, const data_dictionary::storage_options& s_opts, sstable_state state);
+future<object_storage_reference_names> list_object_storage_references(object_storage_client& client, sstring bucket, sstring prefix, generation_type gen);
 future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const sstables_manager&, const schema&, const data_dictionary::storage_options& so);
 future<> destroy_table_storage(const data_dictionary::storage_options& so);
 future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring ks_name);

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -18,13 +18,12 @@
 #include <seastar/core/reactor.hh>
 
 #include "data_dictionary/storage_options.hh"
+#include "schema/schema_fwd.hh"
 #include "seastarx.hh"
 #include "sstables/shared_sstable.hh"
 #include "sstables/component_type.hh"
 #include "sstables/generation_type.hh"
 #include "utils/disk-error-handler.hh"
-
-class schema;
 
 namespace data_dictionary {
 class storage_options;
@@ -133,7 +132,7 @@ public:
     virtual bool is_object_storage() const = 0;
 };
 
-std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state);
+std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, schema_ptr schema, const data_dictionary::storage_options& s_opts, sstable_state state);
 future<lw_shared_ptr<const data_dictionary::storage_options>> init_table_storage(const sstables_manager&, const schema&, const data_dictionary::storage_options& so);
 future<> destroy_table_storage(const data_dictionary::storage_options& so);
 future<> init_keyspace_storage(const sstables_manager&, const data_dictionary::storage_options& so, sstring ks_name);

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -11,11 +11,13 @@
 
 #include "utils/assert.hh"
 #include <filesystem>
+#include <fmt/format.h>
 
 #include <seastar/core/file.hh>
 #include <seastar/core/fstream.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/core/sstring.hh>
 
 #include "data_dictionary/storage_options.hh"
 #include "schema/schema_fwd.hh"
@@ -124,7 +126,7 @@ public:
     virtual future<uint64_t> free_space() const = 0;
     virtual future<> unlink_component(const sstable& sst, component_type) noexcept = 0;
 
-    virtual sstring prefix() const  = 0;
+    virtual std::string_view prefix() const  = 0;
     virtual future<bool> exists(const sstable& sst, component_type type) const = 0;
 
     // Returns true if this storage backend uses object storage (S3/GCS).

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -104,7 +104,7 @@ public:
 
     virtual future<> seal(const sstable& sst) = 0;
     virtual future<> snapshot(const sstable& sst, sstring name) const = 0;
-    virtual future<> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const = 0;
+    virtual future<entry_descriptor> clone(const sstable& sst, generation_type gen, bool leave_unsealed) const = 0;
     virtual future<> change_state(const sstable& sst, sstable_state to, generation_type generation, delayed_commit_changes* delay) = 0;
     // runs in async context
     virtual void open(sstable& sst) = 0;

--- a/sstables/types_fwd.hh
+++ b/sstables/types_fwd.hh
@@ -16,5 +16,6 @@ namespace sstables {
 
 using run_id = utils::tagged_uuid<struct run_id_tag>;
 using integrity_check = bool_class<class integrity_check_tag>;
+using update_sstable_id = bool_class<struct update_sstable_id_tag>;
 
 } // namespace sstables

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -261,6 +261,9 @@ private:
     future<sst_classification_info> download_fully_contained_sstables(std::vector<sstables::shared_sstable> sstables) const {
         sst_classification_info downloaded_sstables(this_smp_shard_count());
         for (const auto& sstable : sstables) {
+            // For now, tablet-aware restore doesn't need to mutate sstable level to 0
+            // since we support only restoring to empty tables and so we can keep the sstable levels on backup.
+            // Once we support restoring onto live tables we may want to mutate the ingested sstables' level to 0.
             auto min_info = co_await download_sstable(_db.local(), _table, sstable, llog);
             downloaded_sstables[min_info.shard].emplace_back(min_info);
         }

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -218,7 +218,7 @@ private:
     using sst_classification_info = std::vector<std::vector<minimal_sst_info>>;
 
     future<> attach_sstable(shard_id from_shard, const sstring& ks, const sstring& cf, const minimal_sst_info& min_info) const {
-        llog.debug("Adding downloaded SSTables to the table {} on shard {}, submitted from shard {}", _table.schema()->cf_name(), this_shard_id(), from_shard);
+        llog.debug("Adding downloaded SSTable gen={} to the table {}.{} on shard {}, submitted from shard {}", min_info.generation, _table.schema()->ks_name(), _table.schema()->cf_name(), this_shard_id(), from_shard);
         auto& db = _db.local();
         auto& table = db.find_column_family(ks, cf);
         auto& sst_manager = table.get_sstables_manager();
@@ -931,7 +931,7 @@ future<tasks::task_id> sstables_loader::download_new_sstables(sstring ks_name, s
 future<sstables::shared_sstable> sstables_loader::attach_sstable(table_id tid, const minimal_sst_info& min_info) const {
     auto& db = _db.local();
     auto& table = db.find_column_family(tid);
-    llog.debug("Adding downloaded SSTables to the table {} on shard {}", table.schema()->cf_name(), this_shard_id());
+    llog.debug("Adding downloaded SSTable gen={} to the table {}.{} on shard {}", min_info.generation, table.schema()->ks_name(), table.schema()->cf_name(), this_shard_id());
     auto& sst_manager = table.get_sstables_manager();
     auto sst = sst_manager.make_sstable(
         table.schema(), table.get_storage_options(), min_info.generation, sstables::sstable_state::normal, min_info.version, min_info.format);

--- a/sstables_loader_helpers.cc
+++ b/sstables_loader_helpers.cc
@@ -58,13 +58,13 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
     for (auto it = components.cbegin(); it != components.cend(); ++it) {
         try {
             auto descriptor = sstable->get_descriptor(it->first);
+            descriptor.generation = gen;
             auto sstable_sink =
                 sstables::create_stream_sink(table.schema(),
                                              table.get_sstables_manager(),
                                              table.get_storage_options(),
                                              sstables::sstable_state::normal,
-                                             sstables::sstable::component_basename(
-                                                 table.schema()->ks_name(), table.schema()->cf_name(), descriptor.version, gen, descriptor.format, it->first),
+                                             descriptor,
                                              sstables::sstable_stream_sink_cfg{.last_component = std::next(it) == components.cend(), .leave_unsealed = true});
             auto out = co_await sstable_sink->output(foptions, stream_options);
 
@@ -100,7 +100,7 @@ future<minimal_sst_info> download_sstable(replica::database& db, replica::table&
                 if (shards.size() != 1) {
                     on_internal_error(logger, "Fully-contained sstable must belong to one shard only");
                 }
-                logger.debug("SSTable shards {}", fmt::join(shards, ", "));
+                logger.debug("SSTable gen={} sid={}: shards {}", gen, sst->sstable_identifier(), fmt::join(shards, ", "));
                 co_return minimal_sst_info{shards.front(), gen, descriptor.version, descriptor.format};
             }
         } catch (...) {

--- a/sstables_loader_helpers.cc
+++ b/sstables_loader_helpers.cc
@@ -14,6 +14,7 @@
 #include "replica/database.hh"
 #include "sstables/shared_sstable.hh"
 #include "sstables/sstables.hh"
+#include "sstables/sstables_manager.hh"
 #include "utils/error_injection.hh"
 
 future<minimal_sst_info> download_sstable(replica::database& db, replica::table& table, sstables::shared_sstable sstable, logging::logger& logger) {

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -54,7 +54,7 @@ static future<> load_sstable_for_tablet(const file_stream_id& ops_id, replica::d
         replica::table& t = db.find_column_family(id);
         auto erm = t.get_effective_replication_map();
         auto& sstm = t.get_sstables_manager();
-        auto sst = sstm.make_sstable(t.schema(), t.get_storage_options(), desc.generation, state, desc.version, desc.format);
+        auto sst = sstm.make_sstable(t.schema(), t.get_storage_options(), desc.generation, desc.sid, state, desc.version, desc.format);
         sstables::sstable_open_config cfg { .unsealed_sstable = true };
         // load() with unsealed_sstable=true opens the SSTable without requiring a "sealed"
         // registry entry — the registry entry is still in "creating" state at this point,

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -45,6 +45,9 @@ constexpr size_t file_stream_write_behind = 10;
 constexpr size_t file_stream_read_ahead = 4;
 
 static sstables::sstable_state sstable_state(const streaming::stream_blob_meta& meta) {
+    if (meta.sstable_meta) {
+        return meta.sstable_meta->state;
+    }
     return meta.sstable_state.value_or(sstables::sstable_state::normal);
 }
 
@@ -566,6 +569,7 @@ tablet_stream_files(netw::messaging_service& ms, std::list<stream_blob_info> sou
             meta.fops = info.fops;
             meta.filename = info.filename;
             meta.sstable_state = info.sstable_state;
+            meta.sstable_meta = info.sstable_meta;
             fstream = co_await info.source(stream_options);
         } catch (...) {
             blogger.warn("fstream[{}] Master failed sources={} targets={} error={}",
@@ -794,6 +798,10 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
             auto& sst = sst_snapshot.sst;
             // stable state (across files) is a must for load to work on destination
             auto sst_state = sst->state();
+            auto sst_id = sst->sstable_identifier();
+            if (!sst_id) {
+                on_internal_error(blogger, format("sstable {} has no identifier", sst->get_filename()));
+            }
 
             if (sst->get_storage().is_object_storage()) {
                 // Clone path for object-storage SSTables: send CLONE_SSTABLE RPC
@@ -810,10 +818,11 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
                     streaming::clone_sstable_request clone_req;
                     clone_req.ops_id = req.ops_id;
                     clone_req.table = req.table;
-                    clone_req.generation = sst->generation().as_uuid();
-                    clone_req.version = static_cast<int32_t>(sst->get_version());
-                    clone_req.format = static_cast<int32_t>(sst->get_format());
-                    clone_req.sstable_state = static_cast<int32_t>(sst_state);
+                    clone_req.sstable_meta.id = *sst->sstable_identifier();
+                    clone_req.sstable_meta.generation = sst->generation().as_uuid();
+                    clone_req.sstable_meta.version = static_cast<int32_t>(sst->get_version());
+                    clone_req.sstable_meta.format = static_cast<int32_t>(sst->get_format());
+                    clone_req.sstable_meta.state = sst_state;
                     clone_req.dst_shard_id = target.shard;
                     clone_req.topo_guard = req.topo_guard;
 
@@ -832,7 +841,7 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
 
                     auto& info = files.emplace_back();
                     info.fops = file_ops::stream_sstables;
-                    info.sstable_state = sst_state;
+                    info.sstable_meta = stream_sstable_meta{*sst_id, sst->generation().as_uuid(), static_cast<int32_t>(sst->get_version()), static_cast<int32_t>(sst->get_format()), sst_state};
                     info.filename = std::move(newname);
                     info.source = [s = std::move(s)](const file_input_stream_options& options) {
                         return s->input(options);
@@ -900,13 +909,11 @@ future<stream_files_response> clone_sstable_handler(replica::database& db, db::v
         blogger.info("stream_mutation_fragments: released (clone)");
     });
 
-    if (req.sstable_state < 0 || req.sstable_state > static_cast<int32_t>(sstables::sstable_state::upload)) {
-        throw std::runtime_error(fmt::format("clone_sstable_handler: invalid sstable_state {}", req.sstable_state));
-    }
-    auto state = static_cast<sstables::sstable_state>(req.sstable_state);
-    auto generation = sstables::generation_type(req.generation);
-    auto version = static_cast<sstables::sstable_version_types>(req.version);
-    auto format = static_cast<sstables::sstable_format_types>(req.format);
+    auto& meta = req.sstable_meta;
+    auto state = meta.state;
+    auto generation = sstables::generation_type(meta.generation);
+    auto version = static_cast<sstables::sstable_version_types>(meta.version);
+    auto format = static_cast<sstables::sstable_format_types>(meta.format);
     // The descriptor carries the ORIGINAL generation from the source node.
     // Server-side copy the S3/GCS objects to a fresh generation owned
     // by this (destination) node.  The source holds shared_sstable
@@ -919,7 +926,7 @@ future<stream_files_response> clone_sstable_handler(replica::database& db, db::v
     // throw away immediately after cloning.
     replica::table& t = db.find_column_family(req.table);
     auto& sstm = t.get_sstables_manager();
-    auto orig_sst = sstm.make_sstable(t.schema(), t.get_storage_options(), generation, state, version, format);
+    auto orig_sst = sstm.make_sstable(t.schema(), t.get_storage_options(), generation, meta.id, state, version, format);
     co_await orig_sst->load_metadata();
     auto new_gen = t.get_sstable_generation_generator()();
     // clone() server-side copies the S3/GCS objects to a fresh generation and

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -441,13 +441,18 @@ future<> stream_blob_handler(replica::database& db, db::view::view_building_work
         stream_options.write_behind = file_stream_write_behind;
 
         auto& table = db.find_column_family(meta.table);
+        auto schema = table.schema();
         if (meta.fops == file_ops::stream_sstables || meta.fops == file_ops::load_sstables) {
             auto& sstm = table.get_sstables_manager();
             // SSTable will be only sealed when added to the sstable set, so we make sure unsplit sstables aren't
             // left sealed on the table directory.
             sstables::sstable_stream_sink_cfg cfg { .last_component = meta.fops == file_ops::load_sstables,
                                                     .leave_unsealed = true };
-            auto sstable_sink = sstables::create_stream_sink(table.schema(), sstm, table.get_storage_options(), sstable_state(meta), meta.filename, cfg);
+            auto desc_result = sstables::parse_path(std::filesystem::path(meta.filename), schema->ks_name(), schema->cf_name());
+            if (!desc_result) {
+                throw std::runtime_error(fmt::format("Cannot stream blob in {}.{}: file={}: {}", schema->ks_name(), schema->cf_name(), meta.filename, desc_result.error()));
+            }
+            auto sstable_sink = sstables::create_stream_sink(table.schema(), sstm, table.get_storage_options(), sstable_state(meta), *desc_result, cfg);
             auto out = co_await sstable_sink->output(foptions, stream_options);
             co_return output_result{
                 [sstable_sink = std::move(sstable_sink), &meta, &db, &vbw](store_result res) -> future<> {

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -24,6 +24,7 @@
 #include "sstables/types.hh"
 #include "idl/streaming.dist.hh"
 #include "service/topology_guard.hh"
+#include "gms/feature_service.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
@@ -805,8 +806,9 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
 
             if (sst->get_storage().is_object_storage()) {
                 // Clone path for object-storage SSTables: send CLONE_SSTABLE RPC
-                // to each target.  The destination performs server-side S3/GCS
-                // CopyObject and loads the clone.
+                // to each target.  The destination may add a reference to the sstable
+                // when the SSTABLE_REFERENCE_SHARING feature is enabled, or
+                // perform server-side S3/GCS CopyObject, and finally it loads the clone.
                 //
                 // Rolling-upgrade safety: object-storage keyspaces can only be
                 // created when the KEYSPACE_STORAGE_OPTIONS cluster feature is
@@ -825,6 +827,10 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
                     clone_req.sstable_meta.state = sst_state;
                     clone_req.dst_shard_id = target.shard;
                     clone_req.topo_guard = req.topo_guard;
+
+                    // FIXME: to pin the sstable while being cloned, create a temporary reference on behalf
+                    // of the target node that would be removed by it once it creates its own reference,
+                    // or be removed by this node on rpc failure.
 
                     co_await ser::streaming_rpc_verbs::send_clone_sstable(&ms, target.node, clone_req);
                 }
@@ -884,7 +890,7 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
     co_return resp;
 }
 
-future<stream_files_response> clone_sstable_handler(replica::database& db, db::view::view_building_worker& vbw, streaming::clone_sstable_request req) {
+future<stream_files_response> clone_sstable_handler(replica::database& db, db::view::view_building_worker& vbw, const gms::feature_service& features, streaming::clone_sstable_request req) {
     stream_files_response resp;
 
     // Reuse the "stream_mutation_fragments" injection point so all existing
@@ -914,27 +920,25 @@ future<stream_files_response> clone_sstable_handler(replica::database& db, db::v
     auto generation = sstables::generation_type(meta.generation);
     auto version = static_cast<sstables::sstable_version_types>(meta.version);
     auto format = static_cast<sstables::sstable_format_types>(meta.format);
-    // The descriptor carries the ORIGINAL generation from the source node.
-    // Server-side copy the S3/GCS objects to a fresh generation owned
-    // by this (destination) node.  The source holds shared_sstable
-    // refs that keep the original objects alive until we confirm.
-    //
-    // We only need the component list (from the TOC) so that clone()
-    // knows which S3 objects to copy.  load_metadata() is the lightest
-    // public API that populates it — a full load() would also validate
-    // metadata, compute shards, and open data files, all of which we
-    // throw away immediately after cloning.
     replica::table& t = db.find_column_family(req.table);
     auto& sstm = t.get_sstables_manager();
     auto orig_sst = sstm.make_sstable(t.schema(), t.get_storage_options(), generation, meta.id, state, version, format);
-    co_await orig_sst->load_metadata();
+    bool use_reference_sharing = features.sstable_reference_sharing;
+    if (!use_reference_sharing) {
+        // The copy path only needs the component list (from the TOC) so that
+        // clone() knows which objects to copy.  load_metadata() is lighter than
+        // load(), which also validates metadata, computes shards, and opens data files.
+        co_await orig_sst->load_metadata();
+    }
     auto new_gen = t.get_sstable_generation_generator()();
-    // clone() server-side copies the S3/GCS objects to a fresh generation and
-    // creates the registry entry in "creating" state (leave_unsealed=true).
+    // With reference sharing, clone() creates a registry entry and a reference
+    // to the source sstable_id instead of copying component objects.
+    // clone() creates the registry entry in "creating" state (leave_unsealed=true).
     // The entry is transitioned to "sealed" later by load_sstable_for_tablet()
     // → add_new_sstable_and_update_cache() → on_add callback → seal_sstable().
-    auto desc = co_await orig_sst->clone(new_gen, /*leave_unsealed=*/true);
-    blogger.debug("stream_sstables[{}] Cloned {} -> {} on destination", req.ops_id, desc.generation, new_gen);
+    auto desc = co_await orig_sst->clone(new_gen, /*leave_unsealed=*/true, /*may_use_reference_sharing=*/use_reference_sharing);
+    blogger.debug("stream_sstables[{}] Cloned {} -> {} on destination using {}", req.ops_id, generation, new_gen,
+        use_reference_sharing ? "reference sharing" : "server-side copy");
     co_await load_sstable_for_tablet(req.ops_id, db, vbw, req.table, state, std::move(desc), req.dst_shard_id);
     co_return resp;
 }

--- a/streaming/stream_blob.hh
+++ b/streaming/stream_blob.hh
@@ -197,7 +197,7 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
 
 // The handler for the CLONE_SSTABLE verb. The destination node performs a
 // server-side S3/GCS CopyObject for a single SSTable and loads the clone.
-future<stream_files_response> clone_sstable_handler(replica::database& db, db::view::view_building_worker& vbw, streaming::clone_sstable_request req);
+future<stream_files_response> clone_sstable_handler(replica::database& db, db::view::view_building_worker& vbw, const gms::feature_service& features, streaming::clone_sstable_request req);
 
 // Ask the src node to stream sstables to dst node for table in the given token range using TABLET_STREAM_FILES verb.
 future<stream_files_response> tablet_stream_files(const file_stream_id& ops_id, replica::table& table, const dht::token_range& range, const locator::host_id& src, const locator::host_id& dst, seastar::shard_id dst_shard_id, netw::messaging_service& ms, abort_source& as, service::frozen_topology_guard topo_guard);

--- a/streaming/stream_blob.hh
+++ b/streaming/stream_blob.hh
@@ -90,6 +90,14 @@ public:
 
 };
 
+struct stream_sstable_meta {
+    sstables::sstable_id id;
+    utils::UUID generation;
+    int32_t version; // serialized sstables::sstable_version_types
+    int32_t format; // serialized sstables::sstable_format_types
+    sstables::sstable_state state;
+};
+
 class stream_blob_meta {
 public:
     file_stream_id ops_id;
@@ -99,6 +107,7 @@ public:
     streaming::file_ops fops;
     service::frozen_topology_guard topo_guard;
     std::optional<sstables::sstable_state> sstable_state;
+    std::optional<stream_sstable_meta> sstable_meta;
     // We can extend this verb to send arbitrary blob of data
 };
 
@@ -115,6 +124,7 @@ struct stream_blob_info {
     sstring filename;
     streaming::file_ops fops;
     std::optional<sstables::sstable_state> sstable_state;
+    std::optional<stream_sstable_meta> sstable_meta;
     stream_blob_source_fn source;
 
     friend inline std::ostream& operator<<(std::ostream& os, const stream_blob_info& x) {
@@ -169,10 +179,7 @@ class clone_sstable_request {
 public:
     file_stream_id ops_id;
     table_id table;
-    utils::UUID generation;      // sstables::generation_type, encoded as its underlying UUID
-    int32_t version;             // serialized sstables::sstable_version_types
-    int32_t format;              // serialized sstables::sstable_format_types
-    int32_t sstable_state;       // serialized sstables::sstable_state
+    streaming::stream_sstable_meta sstable_meta;
     seastar::shard_id dst_shard_id;
     service::frozen_topology_guard topo_guard;
 };

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -13,6 +13,7 @@
 #include "test/lib/log.hh"
 #include "test/lib/sstable_utils.hh"
 #include "sstables/exceptions.hh"
+#include "sstables/open_info.hh"
 #include "sstables/sstables.hh"
 #include "utils/overloaded_functor.hh"
 #include "schema/schema_builder.hh"
@@ -578,21 +579,18 @@ static future<> test_stream_sink_write(sstables::test_env_config cfg) {
             .with_column("v", utf8_type)
             .build();
 
-        auto version = get_highest_sstable_version();
-        auto format = sstable::format_types::big;
         auto generation = env.new_generation();
         auto& mgr = env.manager();
         auto s_opts = env.get_storage_options();
+        auto desc = sstables::entry_descriptor(generation, sstable_id(generation.as_uuid()),
+                get_highest_sstable_version(), sstable::format_types::big, component_type::TOC);
 
         std::visit(overloaded_functor {
             [&env] (data_dictionary::storage_options::local& o) { o.dir = env.tempdir().path().native(); },
             [] (data_dictionary::storage_options::object_storage& o) { o.location = std::nullopt; },
         }, s_opts.value);
 
-        auto toc_basename = sstable::component_basename(
-                s->ks_name(), s->cf_name(), version, generation, format, component_type::TOC);
-
-        auto sink = create_stream_sink(s, mgr, s_opts, sstable_state::normal, toc_basename, {});
+        auto sink = create_stream_sink(s, mgr, s_opts, sstable_state::normal, desc, {});
 
         // output() would succeed before the fix (wrapping the read-only file into a stream),
         // but the write below would throw std::logic_error("unsupported operation on s3 readable file").

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -586,7 +586,7 @@ static future<> test_stream_sink_write(sstables::test_env_config cfg) {
 
         std::visit(overloaded_functor {
             [&env] (data_dictionary::storage_options::local& o) { o.dir = env.tempdir().path().native(); },
-            [&s] (data_dictionary::storage_options::object_storage& o) { o.location = s->id(); },
+            [] (data_dictionary::storage_options::object_storage& o) { o.location = std::nullopt; },
         }, s_opts.value);
 
         auto toc_basename = sstable::component_basename(

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -482,12 +482,8 @@ static future<compact_sstables_result> compact_sstables(test_env& env, std::vect
 
 static future<> check_compacted_sstables(test_env& env, compact_sstables_result res) {
     return seastar::async([&env, res = std::move(res)] {
-        auto s = schema_builder(this_smp_shard_count(), some_keyspace, some_column_family)
-                .with_column("p1", utf8_type, column_kind::partition_key)
-                .with_column("c1", utf8_type, column_kind::clustering_key)
-                .with_column("r1", utf8_type)
-                .build();
         BOOST_REQUIRE_EQUAL(res.output_sstables.size(), 1);
+        auto s = res.output_sstables[0]->get_schema();
         auto sst = env.reusable_sst(s, res.output_sstables[0]).get();
         auto reader = sstable_reader(sst, s, env.make_reader_permit()); // reader holds sst and s alive.
         auto close_reader = deferred_close(reader);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7542,7 +7542,7 @@ SEASTAR_FIXTURE_TEST_CASE(failure_when_adding_new_sstable_test_gcs, gcs_fixture,
                                    test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
-static future<> test_perform_component_rewrite_single_sstable(compaction::compaction_type_options::component_rewrite::update_sstable_id update_id) {
+static future<> test_perform_component_rewrite_single_sstable(sstables::update_sstable_id update_id) {
     return test_env::do_with_async([update_id] (test_env& env) {
         simple_schema ss;
         auto s = ss.schema();
@@ -7603,11 +7603,11 @@ static future<> test_perform_component_rewrite_single_sstable(compaction::compac
 }
 
 SEASTAR_TEST_CASE(test_perform_component_rewrite_single_sstable_with_backup) {
-    return test_perform_component_rewrite_single_sstable(compaction::compaction_type_options::component_rewrite::update_sstable_id::yes);
+    return test_perform_component_rewrite_single_sstable(sstables::update_sstable_id::yes);
 }
 
 SEASTAR_TEST_CASE(test_perform_component_rewrite_single_sstable_without_backup) {
-    return test_perform_component_rewrite_single_sstable(compaction::compaction_type_options::component_rewrite::update_sstable_id::no);
+    return test_perform_component_rewrite_single_sstable(sstables::update_sstable_id::no);
 }
 
 SEASTAR_TEST_CASE(test_perform_component_rewrite_multiple_sstables) {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7361,6 +7361,7 @@ void sstable_clone_leaving_unsealed_dest_sstable_fn(test_env& env) {
     auto mut1 = mutation(s, pk);
     mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
     auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
+    sst->change_state(sstable_state::staging).get();
 
     auto table = env.make_table_for_tests(s);
     auto close_table = deferred_stop(table);
@@ -7369,16 +7370,18 @@ void sstable_clone_leaving_unsealed_dest_sstable_fn(test_env& env) {
 
     bool leave_unsealed = true;
     auto d = sst->clone(gen_generator(), leave_unsealed).get();
+    BOOST_REQUIRE(d.state == sst->state());
 
-    auto sst2 = env.make_sstable(s, d.generation, d.version, d.format);
+    auto sst2 = table->get_sstables_manager().make_sstable(s, table->get_storage_options(), d.generation, d.state.value(), d.version, d.format);
     sst2->load(s->get_sharder(), sstable_open_config{ .unsealed_sstable = leave_unsealed }).get();
     BOOST_REQUIRE(!sst2->get_storage().exists(*sst2, sstables::component_type::TOC).get());
     BOOST_REQUIRE(sst2->get_storage().exists(*sst2, sstables::component_type::TemporaryTOC).get());
 
     leave_unsealed = false;
     d = sst->clone(gen_generator(), leave_unsealed).get();
+    BOOST_REQUIRE(d.state == sst->state());
 
-    auto sst3 = env.make_sstable(s, d.generation, d.version, d.format);
+    auto sst3 = table->get_sstables_manager().make_sstable(s, table->get_storage_options(), d.generation, d.state.value(), d.version, d.format);
     sst3->load(s->get_sharder(), sstable_open_config{ .unsealed_sstable = leave_unsealed }).get();
     BOOST_REQUIRE(sst3->get_storage().exists(*sst3, sstables::component_type::TOC).get());
     BOOST_REQUIRE(!sst3->get_storage().exists(*sst3, sstables::component_type::TemporaryTOC).get());

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -457,11 +457,31 @@ SEASTAR_THREAD_TEST_CASE(sstable_directory_foreign_sstable_should_not_load_local
 
         auto sstables_open_before_process = sstables_opened_for_reading();
         with_sstable_directory(env, [](sharded<sstables::sstable_directory>& sstdir) {
-            distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
+            distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true, .allow_numerical_generations = true }).get();
         });
 
         // verify that all the sstables were loaded only once
         BOOST_REQUIRE_EQUAL(sstables_opened_for_reading(), sstables_open_before_process + this_smp_shard_count());
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(sstable_directory_numerical_generation_can_be_rejected) {
+    sstables::test_env::do_with_sharded_async([] (sharded<test_env>& env) {
+        env.invoke_on(0, [] (sstables::test_env& env) -> future<> {
+            co_return co_await seastar::async([&env] {
+                make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env), generation_type(1)));
+            });
+        }).get();
+
+        sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
+        with_sstable_directory(env, [](sharded<sstables::sstable_directory>& sstdir) {
+            BOOST_REQUIRE_NO_THROW(distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get());
+        });
+
+        with_sstable_directory(env, [](sharded<sstables::sstable_directory>& sstdir) {
+            auto expect_malformed_sstable = distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true, .allow_numerical_generations = false });
+            BOOST_REQUIRE_THROW(expect_malformed_sstable.get(), sstables::malformed_sstable_exception);
+        });
     }).get();
 }
 

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -67,11 +67,13 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_idempotent) {
     auto stop_env = defer([&env] noexcept { env.stop().get(); });
 
     auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), sstables::generation_type(1));
-    sstring old_path = sst->get_storage().prefix();
+    auto old_path = sstring(sst->get_storage().prefix());
     touch_directory(format("{}/{}", old_path, sstables::staging_dir)).get();
     sst->change_state(sstables::sstable_state::staging).get();
     sst->change_state(sstables::sstable_state::normal).get();
-    BOOST_REQUIRE(sstable_directory::compare_sstable_storage_prefix(old_path, sst->get_storage().prefix()));
+    if (!sstable_directory::compare_sstable_storage_prefix(old_path, sst->get_storage().prefix())) {
+        BOOST_FAIL(fmt::format("Expected prefix={}, but got {}", old_path, sst->get_storage().prefix()));
+    }
 
     sst->close_files().get();
 }
@@ -171,7 +173,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_clone_preserves_staging_state) {
     // Load the cloned sstable from the staging directory.  We use the storage
     // prefix of the source (which is the staging sub-directory) so that the
     // loader can find the files, mirroring what distributed_loader does.
-    auto staging_dir = sst->get_storage().prefix();
+    auto staging_dir = sstring(sst->get_storage().prefix());
     auto cloned_sst = env.reusable_sst(schema, staging_dir, clone_gen).get();
 
     // Assert that the cloned sstable preserves the staging state.

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -404,7 +404,7 @@ SEASTAR_TEST_CASE(wrong_range) {
     });
 }
 
-future<sstable_ptr> mutate_sstable_level(test_env& env, sstable_ptr sstp, const std::string& dir_path, uint32_t new_level, bool update_sstable_id = false) {
+future<sstable_ptr> mutate_sstable_level(test_env& env, sstable_ptr sstp, const std::string& dir_path, uint32_t new_level, sstables::update_sstable_id update_id = sstables::update_sstable_id::no) {
     auto modifier = [new_level] (sstables::sstable& sst) {
         sst.mutate_sstable_level(new_level);
     };
@@ -412,7 +412,7 @@ future<sstable_ptr> mutate_sstable_level(test_env& env, sstable_ptr sstp, const 
         return env.make_sstable(sstp->get_schema(), dir_path, sstp->get_version());
     };
 
-    auto new_sst = co_await sstp->link_with_rewritten_component(std::move(creator), component_type::Statistics, modifier, update_sstable_id);
+    auto new_sst = co_await sstp->link_with_rewritten_component(std::move(creator), component_type::Statistics, modifier, update_id);
     co_await sstp->unlink();
     sstp = new_sst;
 
@@ -951,7 +951,7 @@ static future<> test_component_digest_persistence(component_type component, ssta
             original_digest = sst_original->get_component_digest(component);
             BOOST_REQUIRE(original_digest.has_value());
 
-            sst_original = mutate_sstable_level(env, sst_original, dir_path, 10, true).get();
+            sst_original = mutate_sstable_level(env, sst_original, dir_path, 10, sstables::update_sstable_id::yes).get();
             entry_desc.generation = sst_original->generation();
 
             auto new_digest = sst_original->get_component_digest(component);

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -804,6 +804,20 @@ BOOST_AUTO_TEST_CASE(test_empty_key_view_comparison) {
     BOOST_CHECK(lf.begin() == lf.end());
 }
 
+static sstables::entry_descriptor make_entry_descriptor(sstables::generation_type gen, sstables::sstable_version_types version, sstables::sstable_format_types format, sstables::component_type component) {
+    optimized_optional<sstables::sstable_id> sid;
+    if (gen.is_uuid_based()) {
+        sid = sstables::sstable_id(gen.as_uuid());
+    }
+    return entry_descriptor{
+        gen,
+        sid,
+        version,
+        format,
+        component
+    };
+}
+
 // Test that sstables::parse_path is able to parse the paths of sstables
 BOOST_AUTO_TEST_CASE(test_parse_path_good) {
     struct sstable_case {
@@ -817,56 +831,56 @@ BOOST_AUTO_TEST_CASE(test_parse_path_good) {
             "/scylla/system/truncated-38c19fd0fb863310a4b70d0cc66628aa/mc-2-big-Data.db",
             "system",
             "truncated",
-            entry_descriptor{
+            make_entry_descriptor(
                 generation_type{2},
                 sstable_version_types::mc,
                 sstable_format_types::big,
                 component_type::Data
-            }
+            )
         },
         {
             "/scylla/system/scylla_local-2972ec7ffb2038ddaac1d876f2e3fcbd/mc-3-big-Summary.db",
             "system",
             "scylla_local",
-            entry_descriptor{
+            make_entry_descriptor(
                 generation_type{3},
                 sstable_version_types::mc,
                 sstable_format_types::big,
                 component_type::Summary
-            }
+            )
         },
         {
             "/scylla/system_distributed/cdc_generation_timestamps-fdf455c4cfec3e009719d7a45436c89d/me-3g9p_0938_0ecz429c6f019i7yuf-big-Index.db",
             "system_distributed",
             "cdc_generation_timestamps",
-            entry_descriptor{
+            make_entry_descriptor(
                 generation_type::from_string("3g9p_0938_0ecz429c6f019i7yuf"),
                 sstable_version_types::me,
                 sstable_format_types::big,
                 component_type::Index
-            }
+            )
          },
          {
             "/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/md-3g9r_04ux_4be4w2d7t8bg6u7nok-big-Statistics.db",
             "system_schema",
             "columns",
-            entry_descriptor{
+            make_entry_descriptor(
                 generation_type::from_string("3g9r_04ux_4be4w2d7t8bg6u7nok"),
                 sstable_version_types::md,
                 sstable_format_types::big,
                 component_type::Statistics
-            }
+            )
         },
         {
             "/system_schema/columns-24101c25a2ae3af787c1b40ee1aca33f/md-3g9r_04ux_4be4w2d7t8bg6u7nok-big-ReallyBigData.db",
             "system_schema",
             "columns",
-            entry_descriptor{
+            make_entry_descriptor(
                 generation_type::from_string("3g9r_04ux_4be4w2d7t8bg6u7nok"),
                 sstable_version_types::md,
                 sstable_format_types::big,
                 component_type::Unknown
-            }
+            )
         }
     };
     for (auto& [path, expected_ks, expected_cf, expected_desc] : sstables) {

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -509,7 +509,7 @@ async def check_streaming_directions(logger, servers, topology, host_ids, scope,
     for s in servers:
         streamed_to = defaultdict(int)
         log, mark = log_marks[s.server_id]
-        direct_downloads = await log.grep('sstables_loader - Adding downloaded SSTables to the table', from_mark=mark)
+        direct_downloads = await log.grep('sstables_loader - Adding downloaded SSTable.*to the table', from_mark=mark)
         res = await log.grep(r'sstables_loader - load_and_stream:.*target_node=(?P<target_host_id>[0-9a-f-]+)', from_mark=mark)
         for r in res:
             target_host_id = r[1].group('target_host_id')

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -810,6 +810,15 @@ async def test_stream_sink_abort_on_object_storage(manager: ManagerClient, objec
         expected = {i: i for i in range(20)}
         assert result == expected, f"Data mismatch: {result}"
 
+        def get_components():
+            objects = object_storage.get_resource().Bucket(
+                object_storage.bucket_name).objects.all()
+            components = {}
+            for o in objects:
+                generation, _, component = o.key.rpartition("/")
+                components.setdefault(generation, set()).add(component)
+            return components
+
         # The aborted streaming attempt failed while writing the TOC,
         # so on object storage it left behind only
         # a partial TOC.txt.tmp object and never wrote a Data.db.
@@ -821,15 +830,15 @@ async def test_stream_sink_abort_on_object_storage(manager: ManagerClient, objec
         # With the fix the leaked TOC.txt.tmp is gone so the condition converges;
         # without it the orphan persists and wait_for times out.
         async def no_orphaned_objects():
-            objects = object_storage.get_resource().Bucket(
-                object_storage.bucket_name).objects.all()
-            components = {}
-            for o in objects:
-                generation, _, component = o.key.partition("/")
-                components.setdefault(generation, set()).add(component)
+            components = get_components()
             orphans = {gen for gen, comps in components.items()
                        if "Data.db" not in comps}
             return None if orphans else True
 
-        await wait_for(no_orphaned_objects, time.time() + 30,
-                       label="object storage bucket has no orphaned sstable components")
+        try:
+            await wait_for(no_orphaned_objects, time.time() + 30,
+                    label="object storage bucket has no orphaned sstable components")
+        except Exception as e:
+            components = get_components()
+            logger.error(f"Orphaned components: {components=}: {e}")
+            raise

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -810,14 +810,19 @@ async def test_stream_sink_abort_on_object_storage(manager: ManagerClient, objec
         expected = {i: i for i in range(20)}
         assert result == expected, f"Data mismatch: {result}"
 
-        def get_components():
+        def get_components_and_refs():
             objects = object_storage.get_resource().Bucket(
                 object_storage.bucket_name).objects.all()
             components = {}
+            refs = {}
             for o in objects:
-                generation, _, component = o.key.rpartition("/")
-                components.setdefault(generation, set()).add(component)
-            return components
+                generation, has_refs, ref = o.key.rpartition("/refs/")
+                if has_refs:
+                    refs.setdefault(generation, set()).add(ref)
+                else:
+                    generation, _, component = o.key.rpartition("/")
+                    components.setdefault(generation, set()).add(component)
+            return components, refs
 
         # The aborted streaming attempt failed while writing the TOC,
         # so on object storage it left behind only
@@ -830,7 +835,12 @@ async def test_stream_sink_abort_on_object_storage(manager: ManagerClient, objec
         # With the fix the leaked TOC.txt.tmp is gone so the condition converges;
         # without it the orphan persists and wait_for times out.
         async def no_orphaned_objects():
-            components = get_components()
+            components, refs = get_components_and_refs()
+            for gen, refset in refs.items():
+                if not gen in components:
+                    raise RuntimeError(f"Orphaned refs with no components: {gen=} refs={refset}")
+                if len(refset) > 1: 
+                    raise RuntimeError(f"Too many refs: {gen=} refs={refset} comps={components[gen]}")
             orphans = {gen for gen, comps in components.items()
                        if "Data.db" not in comps}
             return None if orphans else True
@@ -839,6 +849,6 @@ async def test_stream_sink_abort_on_object_storage(manager: ManagerClient, objec
             await wait_for(no_orphaned_objects, time.time() + 30,
                     label="object storage bucket has no orphaned sstable components")
         except Exception as e:
-            components = get_components()
-            logger.error(f"Orphaned components: {components=}: {e}")
+            components, refs = get_components_and_refs()
+            logger.error(f"Orphaned components: {components=} {refs=}: {e}")
             raise

--- a/test/cluster/object_store/test_scaling.py
+++ b/test/cluster/object_store/test_scaling.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import time
+import logging
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.object_storage import keyspace_options
+from test.cluster.util import new_test_keyspace, wait_for_no_pending_topology_transition
+from test.pylib.tablets import get_all_tablet_replicas
+from cassandra.query import SimpleStatement, ConsistencyLevel
+
+logger = logging.getLogger(__name__)
+
+async def test_scaling(manager: ManagerClient, object_storage):
+    """Test cluster scaling (add/remove nodes) with tablets on object storage.
+
+    Creates a 3-node cluster (one per rack) with a keyspace on object storage,
+    populates a table, adds a node to each rack, waits for tablet rebalancing,
+    verifies data, then decommissions a node from each rack and verifies again.
+    """
+    num_racks = 3
+    rf = 3
+
+    objconf = object_storage.create_endpoint_conf()
+    cfg = {
+        'enable_user_defined_functions': False,
+        'object_storage_endpoints': objconf,
+        'experimental_features': ['keyspace-storage-options'],
+    }
+
+    # Create initial 3-node cluster, one node per rack
+    logger.info("Creating initial 3-node cluster")
+    servers = []
+    for rack in range(num_racks):
+        server = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": f"r{rack}"})
+        servers.append(server)
+
+    cql = manager.get_cql()
+
+    async def populate_table(cql, ks, num_rows):
+        """Insert test data into the table with CL=ALL to ensure all replicas are consistent."""
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, value) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*[
+            cql.run_async(insert_stmt, [i, i * 10])
+            for i in range(num_rows)
+        ])
+
+    async def verify_data(cql, ks, num_rows):
+        """Verify all test data is readable and correct."""
+        stmt = SimpleStatement(f"SELECT pk, value FROM {ks}.test;", consistency_level=ConsistencyLevel.ONE)
+        res = await cql.run_async(stmt)
+        rows = {r.pk: r.value for r in res}
+        assert len(rows) == num_rows, f"Expected {num_rows} rows, got {len(rows)}"
+        for i in range(num_rows):
+            assert i in rows, f"Missing row with pk={i}"
+            assert rows[i] == i * 10, f"Wrong value for pk={i}: expected {i * 10}, got {rows[i]}"
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage, rf=rf)) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, value int);")
+
+        NUM_ROWS = 100
+
+        # Populate test data
+        logger.info("Populating table with %d rows", NUM_ROWS)
+        await populate_table(cql, ks, NUM_ROWS)
+
+        # Flush to ensure data is on object storage
+        for server in servers:
+            await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        # Verify initial data
+        logger.info("Verifying initial data")
+        await verify_data(cql, ks, NUM_ROWS)
+
+        # Add one node to each rack
+        logger.info("Adding 3 new nodes (one per rack)")
+        new_servers = []
+        for rack in range(num_racks):
+            server = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": f"r{rack}"})
+            new_servers.append(server)
+
+        # Wait for tablet load balancer to finish migrating tablets
+        logger.info("Waiting for tablet rebalancing to complete")
+        deadline = time.time() + 120
+        await wait_for_no_pending_topology_transition(manager, deadline)
+
+        # Verify data after scale-up
+        logger.info("Verifying data after adding nodes")
+        await verify_data(cql, ks, NUM_ROWS)
+
+        # Verify tablets are distributed across all 6 nodes
+        tablet_replicas = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
+        all_servers = servers + new_servers
+        all_host_ids = set()
+        for s in all_servers:
+            host_id = await manager.get_host_id(s.server_id)
+            all_host_ids.add(host_id)
+        replica_hosts = set()
+        for t in tablet_replicas:
+            for host_id, shard in t.replicas:
+                replica_hosts.add(host_id)
+        logger.info("Tablets distributed across %d hosts (total %d)", len(replica_hosts), len(all_host_ids))
+
+        # Decommission one node from each rack (the original nodes)
+        logger.info("Decommissioning 3 original nodes (one per rack)")
+        for server in servers:
+            logger.info("Decommissioning %s", server.server_id)
+            await manager.decommission_node(server.server_id)
+
+        # Wait for topology to stabilize
+        deadline = time.time() + 120
+        await wait_for_no_pending_topology_transition(manager, deadline)
+
+        # Verify data after scale-down
+        logger.info("Verifying data after decommissioning nodes")
+        await verify_data(cql, ks, NUM_ROWS)

--- a/test/cluster/object_store/test_scaling.py
+++ b/test/cluster/object_store/test_scaling.py
@@ -8,11 +8,14 @@
 import asyncio
 import time
 import logging
+import re
+import uuid
 import pytest
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.object_storage import keyspace_options
 from test.cluster.util import new_test_keyspace, wait_for_no_pending_topology_transition
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 from test.pylib.tablets import get_all_tablet_replicas
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
@@ -34,12 +37,13 @@ async def test_scaling(manager: ManagerClient, object_storage):
         'object_storage_endpoints': objconf,
         'experimental_features': ['keyspace-storage-options'],
     }
+    cmdline = ['--logger-log-level', 'sstable=debug']
 
     # Create initial 3-node cluster, one node per rack
     logger.info("Creating initial 3-node cluster")
     servers = []
     for rack in range(num_racks):
-        server = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": f"r{rack}"})
+        server = await manager.server_add(config=cfg, cmdline=cmdline, property_file={"dc": "dc1", "rack": f"r{rack}"})
         servers.append(server)
 
     cql = manager.get_cql()
@@ -63,6 +67,105 @@ async def test_scaling(manager: ManagerClient, object_storage):
             assert i in rows, f"Missing row with pk={i}"
             assert rows[i] == i * 10, f"Wrong value for pk={i}: expected {i * 10}, got {rows[i]}"
 
+    def verify_uuid_sstable_generation(generation):
+        match = re.fullmatch(r"([0-9a-z]{4})_([0-9a-z]{4})_([0-9a-z]{5})([0-9a-z]{13})", generation)
+        assert match is not None
+        assert int(match.group(2), 36) < 24 * 60 * 60
+        assert int(match.group(3), 36) < 10_000_000
+        assert int(match.group(4), 36) < 1 << 64
+
+    def encode_base36(value):
+        digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+        if value == 0:
+            return "0"
+        result = ""
+        while value:
+            value, digit = divmod(value, 36)
+            result = digits[digit] + result
+        return result
+
+    def encode_uuid_sstable_generation(generation_uuid):
+        seconds, decimicroseconds = divmod(generation_uuid.time, 10_000_000)
+        days, seconds = divmod(seconds, 24 * 60 * 60)
+        lsb = generation_uuid.int & ((1 << 64) - 1)
+        generation = f"{encode_base36(days):0>4}_{encode_base36(seconds):0>4}_{encode_base36(decimicroseconds):0>5}{encode_base36(lsb):0>13}"
+        verify_uuid_sstable_generation(generation)
+        return generation
+
+    def parse_node_reference(reference):
+        parts = reference.split("/")
+        assert len(parts) == 3
+        assert parts[0] == "nodes"
+        host_id = str(uuid.UUID(parts[1]))
+        generation = parts[2]
+        verify_uuid_sstable_generation(generation)
+        return host_id, generation
+
+    async def verify_object_storage_namespace(server, live_servers, ks):
+        """Verify object-storage namespace layout and reference counts through REST API."""
+        await manager.disable_tablet_balancing()
+        try:
+            for node in live_servers:
+                await manager.api.disable_autocompaction(node.ip_addr, ks, "test")
+            for node in live_servers:
+                await manager.api.flush_keyspace(node.ip_addr, ks)
+
+            params = {
+                "endpoint": object_storage.address,
+                "bucket": object_storage.bucket_name,
+            }
+            table_id = str(await manager.get_table_id(ks, "test"))
+
+            live_hosts = await wait_for_cql_and_get_hosts(cql, live_servers, time.time() + 30)
+
+            async def get_object_storage_refs():
+                sstables = await manager.api.client.get_json("/storage_service/object_storage/sstables", host=server.ip_addr, params=params)
+                assert sstables
+                refs = {}
+                for sstable in sstables:
+                    sstable_id = str(uuid.UUID(sstable["sstable_id"]))
+                    references = sstable.get("references", [])
+                    assert sstable["num_references"] == len(references)
+                    assert references, f"SSTable {sstable_id} has no object-storage references"
+                    for reference in references:
+                        host_id, generation = parse_node_reference(reference)
+                        key = (sstable_id, host_id, generation)
+                        assert key not in refs
+                        refs[key] = reference
+                return sstables, refs
+
+            async def get_node_registry_refs(host):
+                rows = await cql.run_async("SELECT table_id, node_owner, generation, sstable_id, status FROM system.sstables", host=host)
+                refs = {}
+                for row in rows:
+                    if str(row.table_id) != table_id:
+                        continue
+                    if row.status != "sealed":
+                        continue
+                    sstable_id = str(row.sstable_id if row.sstable_id is not None else row.generation)
+                    generation = encode_uuid_sstable_generation(row.generation)
+                    key = (sstable_id, str(row.node_owner), generation)
+                    assert key not in refs
+                    refs[key] = row.status
+                return refs
+
+            async def get_registry_refs():
+                registry_refs = {}
+                for refs in await asyncio.gather(*(get_node_registry_refs(host) for host in live_hosts)):
+                    for key, status in refs.items():
+                        assert key not in registry_refs
+                        registry_refs[key] = status
+                return registry_refs
+
+            sstables, object_storage_refs = await get_object_storage_refs()
+            registry_refs = await get_registry_refs()
+            assert object_storage_refs.keys() == registry_refs.keys(), f"Only in object_storage: {object_storage_refs.keys() - registry_refs.keys()}\nOnly in registry: {registry_refs.keys() - object_storage_refs.keys()}"
+            logger.info("Verified %d object-storage SSTables and %d references", len(sstables), len(object_storage_refs))
+        finally:
+            for node in live_servers:
+                await manager.api.enable_autocompaction(node.ip_addr, ks, "test")
+            await manager.enable_tablet_balancing()
+
     async with new_test_keyspace(manager, keyspace_options(object_storage, rf=rf)) as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, value int);")
 
@@ -72,19 +175,16 @@ async def test_scaling(manager: ManagerClient, object_storage):
         logger.info("Populating table with %d rows", NUM_ROWS)
         await populate_table(cql, ks, NUM_ROWS)
 
-        # Flush to ensure data is on object storage
-        for server in servers:
-            await manager.api.flush_keyspace(server.ip_addr, ks)
-
         # Verify initial data
         logger.info("Verifying initial data")
         await verify_data(cql, ks, NUM_ROWS)
+        await verify_object_storage_namespace(servers[0], servers, ks)
 
         # Add one node to each rack
         logger.info("Adding 3 new nodes (one per rack)")
         new_servers = []
         for rack in range(num_racks):
-            server = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": f"r{rack}"})
+            server = await manager.server_add(config=cfg, cmdline=cmdline, property_file={"dc": "dc1", "rack": f"r{rack}"})
             new_servers.append(server)
 
         # Wait for tablet load balancer to finish migrating tablets
@@ -95,6 +195,7 @@ async def test_scaling(manager: ManagerClient, object_storage):
         # Verify data after scale-up
         logger.info("Verifying data after adding nodes")
         await verify_data(cql, ks, NUM_ROWS)
+        await verify_object_storage_namespace(servers[0], servers + new_servers, ks)
 
         # Verify tablets are distributed across all 6 nodes
         tablet_replicas = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
@@ -122,3 +223,4 @@ async def test_scaling(manager: ManagerClient, object_storage):
         # Verify data after scale-down
         logger.info("Verifying data after decommissioning nodes")
         await verify_data(cql, ks, NUM_ROWS)
+        await verify_object_storage_namespace(new_servers[0], new_servers, ks)

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -420,7 +420,7 @@ test_env::make_sstable(schema_ptr schema, sstring dir, sstables::generation_type
     auto storage = _impl->storage;
     std::visit(overloaded_functor {
         [&dir] (data_dictionary::storage_options::local& o) { o.dir = dir; },
-        [&schema] (data_dictionary::storage_options::object_storage& o) { o.location = schema->id(); },
+        [] (data_dictionary::storage_options::object_storage& o) { o.location = std::nullopt; },
     }, storage.value);
     return _impl->mgr.make_sstable(std::move(schema), storage, generation, state, v, f, now, default_io_error_handler_gen(), buffer_size);
 }
@@ -557,7 +557,7 @@ test_env::make_table_for_tests(schema_ptr s, sstring dir) {
     auto storage = _impl->storage;
     std::visit(overloaded_functor {
         [&dir] (data_dictionary::storage_options::local& o) { o.dir = dir; },
-        [&s] (data_dictionary::storage_options::object_storage& o) { o.location = s->id(); },
+        [] (data_dictionary::storage_options::object_storage& o) { o.location = std::nullopt; },
     }, storage.value);
     return table_for_tests(manager(), _impl->cmgr->get_compaction_manager(), s, std::move(cfg), std::move(storage));
 }

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -483,7 +483,7 @@ test_env::reusable_sst(schema_ptr schema, sstables::generation_type generation,
 
 future<shared_sstable>
 test_env::reusable_sst(schema_ptr schema, shared_sstable sst) {
-    return reusable_sst(std::move(schema), sst->get_storage().prefix(), sst->generation(), sst->get_version());
+    return reusable_sst(std::move(schema), sstring(sst->get_storage().prefix()), sst->generation(), sst->get_version());
 }
 
 future<shared_sstable>

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -418,11 +418,15 @@ test_env::make_sstable(schema_ptr schema, sstring dir, sstables::generation_type
         dir = std::filesystem::path(dir).parent_path().native();
     }
     auto storage = _impl->storage;
+    optimized_optional<sstable_id> sid_opt;
     std::visit(overloaded_functor {
         [&dir] (data_dictionary::storage_options::local& o) { o.dir = dir; },
-        [] (data_dictionary::storage_options::object_storage& o) { o.location = std::nullopt; },
+        [&] (data_dictionary::storage_options::object_storage& o) {
+            o.location = std::nullopt;
+            sid_opt = sstable_id(generation.as_uuid());
+        },
     }, storage.value);
-    return _impl->mgr.make_sstable(std::move(schema), storage, generation, state, v, f, now, default_io_error_handler_gen(), buffer_size);
+    return _impl->mgr.make_sstable(std::move(schema), storage, generation, sid_opt, state, v, f, now, default_io_error_handler_gen(), buffer_size);
 }
 
 shared_sstable

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -622,7 +622,7 @@ schema_ptr do_load_schema_from_sstable(const db::config& dbcfg, std::filesystem:
     const auto ed = std::move(*ed_result);
     const auto dir_path = sstable_path.parent_path();
     auto local = data_dictionary::make_local_options(dir_path);
-    auto bootstrap_sst = sst_man.make_sstable(bootstrap_schema, local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
+    auto bootstrap_sst = sst_man.make_sstable(bootstrap_schema, local, ed.generation, ed.sid, sstables::sstable_state::normal, ed.version, ed.format);
 
     bootstrap_sst->load_metadata().get();
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -370,7 +370,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
             const auto dir_path = sst_path.parent_path();
             options = data_dictionary::make_local_options(dir_path);
         }
-        auto sst = sst_man.make_sstable(schema, options, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
+        auto sst = sst_man.make_sstable(schema, options, ed.generation, ed.sid, sstables::sstable_state::normal, ed.version, ed.format);
 
         try {
             auto open_cfg = sstables::sstable_open_config{

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -138,7 +138,7 @@ public:
         auto total = std::accumulate(_buffers.begin(), _buffers.end(), size_t{}, [](size_t s, auto& buf) {
             return s + buf.size();
         });
-        if (total == 0) {
+        if (total == 0 && !force) {
             co_return;
         }
 


### PR DESCRIPTION
## Summary

- Restructure the object storage prefix to use `sstables/{sstable_id}/{component}` for automatically managed object-storage tables
- Add `sstable_id` to `system.sstables` and thread SSTable identity through construction, registry, and streaming metadata
- Implement reference objects under each SSTable ID prefix (`.../{sstable_id}/refs/nodes/{host_id}/{generation}`) for object-storage SSTable lifecycle management, including two-phase deletion
- Use reference-based tablet/file streaming for object-storage SSTables when `SSTABLE_REFERENCE_SHARING` is enabled
- Keep the destination-side clone-copy fallback for older peers: copy component objects, assign the destination `sstable_id` from the destination generation, and rewrite `Scylla.db` metadata accordingly
- Fix GCS resumable upload sink handling for zero-length objects used by references
- Add an object-storage tablet scaling test covering scale-out, data verification, scale-down, and final verification

Examples:
* On-disk layout (including leaf-level files' names), on each node:
```
 {data_dir}/{keyspace}/{table}-{table-id}/{format}-{gen}-big-{comp ...}    // for each sstable generation
```

* Keyspace-storage-options old (existing) layout:
```
 {bucket}/{gen}/{comp}
```

* Keyspace-storage-options new (this PR) layout:
```
 {bucket}/sstables/{sstable_id}/{comp ...} +
 {bucket}/sstables/{sstable_id}/refs/nodes/{host_id}/{gen}
```

* Planned snapshot reference format:
```
 {bucket}/sstables/{sstable_id}/{comp ...} +
 {bucket}/sstables/{sstable_id}/refs/nodes/{host_id}/snapshots/{snapshot_id}/{gen}
```

* Existing backup layout (See https://manager.docs.scylladb.com/stable/backup/specification.html):
```
 {bucket}/backup/sst/cluster/{cluster_id}/dc/{datacenter}/node/{host_id}/keyspace/{keyspace}/table/{table}/{table-id}/{format}-{gen}-big-{comp ...}    // for each sstable generation
```

* Planned backup layout (See https://github.com/scylladb/scylladb/pull/29580):
would use the unified prefix layout for all sstable objects, both those uploaded from local storage, and those already existing on object storage, and add a backup reference as follows
```
 {bucket}/sstables/{sstable_id}/{comp ...} + 
 {bucket}/sstables/{sstable_id}/refs/backups/{backup_id}/{gen}
```

Fixes: SCYLLADB-2559

--

This is a new feature/improvement for the unified object storage layout. No backport needed.