### PR TITLE
error_injection: Use smp::shard_count() instead of deprecated smp::count

### DIFF
--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -395,7 +395,7 @@ public:
 
     // \brief Returns the sum of enter_count across all shards.
     static future<size_t> enter_count_on_all(const std::string_view& injection_name) {
-        auto counts = std::vector<size_t>(smp::count, 0);
+        auto counts = std::vector<size_t>(this_smp_shard_count(), 0);
         co_await smp::invoke_on_all([&counts, name = sstring(injection_name)] {
             counts[this_shard_id()] = _local.enter_count(name);
         });


### PR DESCRIPTION
Two commits clashed together and introduced the problem:

1. 11f092b74a "error_injection: Add enter_count API for test synchronization": added the enter_count_on_all() function to utils/error_injection.hh, which uses the deprecated smp::count

2. 224ac13166 "seastar: update the submodule to the latest": updated the Seastar submodule which deprecated the smp::count API

Fixing compilation on master branch, not backporting