### PR TITLE
raft topology: allow left nodes as ignored nodes for replace

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2823,6 +2823,21 @@ future<> storage_service::raft_removenode(locator::host_id host_id, locator::hos
             }
         }
 
+        for (auto& [node_id, _] : _topology_state_machine._topology.normal_nodes) {
+            bool is_excluded = node_id == id
+                    || ignored_ids.contains(node_id)
+                    || _topology_state_machine._topology.excluded_tablet_nodes.contains(node_id);
+            if (!is_excluded && !_gossiper.is_alive(locator::host_id(node_id.uuid()))) {
+                const std::string message = ::format(
+                        "removenode: Rejected removenode operation for node {} because node {} is down and not ignored; "
+                        "if the node is down, restart it before retrying removenode; "
+                        "if the node is unrecoverable, retry removenode with the node added to the ignore list",
+                        id, node_id);
+                rtlogger.warn("{}", message);
+                throw std::runtime_error(message);
+            }
+        }
+
         // insert node that should be removed to ignore list so that other topology operations
         // can ignore it
         ignored_ids.insert(id);
@@ -6135,6 +6150,22 @@ future<join_node_request_result> storage_service::join_node_request_handler(join
                 if (_gossiper.is_alive(locator::host_id(ignored_id.uuid()))) {
                     result.result = join_node_request_result::rejected{
                         .reason = fmt::format("Cannot replace node {} because ignored node {} is alive", *params.replaced_id, ignored_id),
+                    };
+                    co_return result;
+                }
+            }
+
+            for (auto& [node_id, _] : _topology_state_machine._topology.normal_nodes) {
+                bool is_excluded = node_id == *params.replaced_id
+                        || ignored_nodes.contains(node_id)
+                        || _topology_state_machine._topology.excluded_tablet_nodes.contains(node_id);
+                if (!is_excluded && !_gossiper.is_alive(locator::host_id(node_id.uuid()))) {
+                    result.result = join_node_request_result::rejected{
+                        .reason = fmt::format(
+                            "Cannot replace node {} because node {} is down and not ignored; "
+                            "if the node is down, restart it before retrying replacement; "
+                            "if the node is unrecoverable, retry replacement with the node added to the ignore list",
+                            *params.replaced_id, node_id),
                     };
                     co_return result;
                 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2812,6 +2812,17 @@ future<> storage_service::raft_removenode(locator::host_id host_id, locator::hos
         }
 
         auto ignored_ids = find_raft_nodes_from_hoeps(ignore_nodes_params);
+
+        for (auto ignored_id : ignored_ids) {
+            if (_gossiper.is_alive(locator::host_id(ignored_id.uuid()))) {
+                const std::string message = fmt::format(
+                    "removenode: Rejected removenode operation for node {}; ignored node {} is alive",
+                    id, ignored_id);
+                rtlogger.warn("{}", message);
+                throw std::runtime_error(message);
+            }
+        }
+
         // insert node that should be removed to ignore list so that other topology operations
         // can ignore it
         ignored_ids.insert(id);
@@ -6117,6 +6128,16 @@ future<join_node_request_result> storage_service::join_node_request_handler(join
                     .reason = fmt::format("Cannot replace the token-owning node {} with a zero-token node", *params.replaced_id),
                 };
                 co_return result;
+            }
+
+            auto ignored_nodes = ignored_nodes_from_join_params(params);
+            for (auto ignored_id : ignored_nodes) {
+                if (_gossiper.is_alive(locator::host_id(ignored_id.uuid()))) {
+                    result.result = join_node_request_result::rejected{
+                        .reason = fmt::format("Cannot replace node {} because ignored node {} is alive", *params.replaced_id, ignored_id),
+                    };
+                    co_return result;
+                }
             }
 
             if (_topology_state_machine._topology.requests.find(*params.replaced_id) != _topology_state_machine._topology.requests.end()) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1212,7 +1212,8 @@ utils::chunked_vector<canonical_mutation> storage_service::build_mutation_from_j
 
     if (!ignored_nodes.empty()) {
         auto bad_id = std::find_if_not(ignored_nodes.begin(), ignored_nodes.end(), [&] (auto n) {
-            return _topology_state_machine._topology.normal_nodes.contains(n);
+            return _topology_state_machine._topology.normal_nodes.contains(n)
+                    || _topology_state_machine._topology.left_nodes.contains(n);
         });
         if (bad_id != ignored_nodes.end()) {
             throw std::runtime_error(::format("replace: there is no node with id {} in normal state. Cannot ignore it.", *bad_id));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2798,7 +2798,7 @@ future<> storage_service::raft_removenode(locator::host_id host_id, locator::hos
 
         if (_gossiper.is_alive(host_id)) {
             const std::string message = ::format(
-                "removenode: Rejected removenode operation for node {}"
+                "removenode: Rejected removenode operation for node {}; "
                 "the node being removed is alive, maybe you should use decommission instead?",
                 id);
             rtlogger.warn("{}", message);

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -12,8 +12,7 @@ from test.pylib.util import unique_name, wait_for_cql_and_get_hosts, wait_for
 from test.pylib.manager_client import ManagerClient
 from test.pylib.driver_utils import safe_driver_shutdown
 from test.cluster.util import trigger_snapshot, reconnect_driver, \
-        wait_for_token_ring_and_group0_consistency, get_topology_coordinator, \
-        find_server_by_host_id
+        wait_for_token_ring_and_group0_consistency, get_topology_coordinator
 from test.cqlpy.test_service_levels import MAX_USER_SERVICE_LEVELS
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
@@ -370,7 +369,7 @@ async def test_driver_service_level(manager: ManagerClient) -> None:
 
     logger.info("Verify that sl:driver is not re-created even after topology coordinator reload")
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
     await manager.api.reload_raft_topology_state(coord_serv.ip_addr)
 
     hosts = await wait_for_cql_and_get_hosts(cql, servers + new_servers, time.time() + 60)
@@ -400,7 +399,7 @@ async def test_driver_service_creation_failure(manager: ManagerClient) -> None:
 
     logger.info("Check the logs to see that sl:driver creation failed")
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
     log_file = await manager.server_open_log(coord_serv.server_id)
     mark = await log_file.mark()
 

--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -17,7 +17,7 @@ import logging
 import time
 from typing import Callable
 
-from test.cluster.util import get_topology_coordinator, find_server_by_host_id
+from test.cluster.util import get_topology_coordinator
 from test.cluster.mv.tablets.test_mv_tablets import get_tablet_replicas
 from test.cluster.util import new_test_keyspace, wait_for
 
@@ -40,8 +40,8 @@ async def get_disjoint_paired_replicas(manager, servers, ks):
     if base_ids & view_ids:
         logger.info("Waiting for disjoint base/view replicas: base=%s view=%s", base_replicas, view_replicas)
         return None
-    base_servers = [ await find_server_by_host_id(manager, servers, host) for host, _ in base_replicas ]
-    view_servers = [ await find_server_by_host_id(manager, servers, host) for host, _ in view_replicas ]
+    base_servers = [ await manager.find_server_by_host_id(servers, host) for host, _ in base_replicas ]
+    view_servers = [ await manager.find_server_by_host_id(servers, host) for host, _ in view_replicas ]
     base_by_rack = {(s.datacenter, s.rack): s for s in base_servers}
     view_by_rack = {(s.datacenter, s.rack): s for s in view_servers}
     if len(base_by_rack) != len(base_servers) or len(view_by_rack) != len(view_servers):
@@ -99,7 +99,7 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient, 
 
         # get topology coordinator so we wont stop it
         coord = await get_topology_coordinator(manager)
-        coord_serv = await find_server_by_host_id(manager, servers, coord)
+        coord_serv = await manager.find_server_by_host_id(servers, coord)
 
         # make sure that our replicas are still in a good shape and paired correctly
         base_replicas, view_replicas, base_by_rack, view_by_rack = await wait_for(read_disjoint_paired_replicas, time.time() + scale_timeout(60))

--- a/test/cluster/random_failures/cluster_events.py
+++ b/test/cluster/random_failures/cluster_events.py
@@ -615,7 +615,7 @@ async def remove_node(manager: ManagerClient,
     await manager.remove_node(
         initiator_id=coordinator.server_id,
         server_id=target.server_id,
-        wait_removed_dead=False,
+        wait_dead=False,
         timeout=TOPOLOGY_TIMEOUT,
     )
 

--- a/test/cluster/random_failures/test_random_failures.py
+++ b/test/cluster/random_failures/test_random_failures.py
@@ -225,7 +225,7 @@ async def test_random_failures(manager: ManagerClient,
             await manager.remove_node(
                 initiator_id=(await manager.running_servers())[0].server_id,
                 server_id=s_info.server_id,
-                wait_removed_dead=False,
+                wait_dead=False,
                 timeout=TOPOLOGY_TIMEOUT,
             )
 

--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -16,7 +16,7 @@ from cassandra.cluster import ConsistencyLevel
 from cassandra.query import SimpleStatement
 from typing import Callable
 
-from test.cluster.util import get_topology_coordinator, find_server_by_host_id, new_test_keyspace, new_test_table, reconnect_driver
+from test.cluster.util import get_topology_coordinator, new_test_keyspace, new_test_table, reconnect_driver
 from test.pylib.manager_client import ManagerClient, wait_for_cql_and_get_hosts
 from test.pylib.tablets import get_tablet_count
 from test.pylib.util import Host
@@ -311,7 +311,7 @@ async def test_tablet_repair(manager: ManagerClient, volumes_factory: Callable) 
                         mark, _ = await log.wait_for("repair - Drained", from_mark=mark)
 
                     coord = await get_topology_coordinator(manager)
-                    coord_serv = await find_server_by_host_id(manager, servers, coord)
+                    coord_serv = await manager.find_server_by_host_id(servers, coord)
                     coord_log = await manager.server_open_log(coord_serv.server_id)
                     coord_mark = await coord_log.mark()
 
@@ -447,7 +447,7 @@ async def test_node_restart_while_tablet_split(manager: ManagerClient, volumes_f
                     logger.info("Trigger split in table and restart the node")
                     coord = await get_topology_coordinator(manager)
                     logger.info(f"Topology coordinator is {coord}")
-                    coord_serv = await find_server_by_host_id(manager, servers, coord)
+                    coord_serv = await manager.find_server_by_host_id(servers, coord)
                     coord_log = await manager.server_open_log(coord_serv.server_id)
 
                     await cql.run_async(f"ALTER TABLE {cf} WITH tablets = {{'min_tablet_count': 2}};")
@@ -493,7 +493,7 @@ async def test_repair_failure_on_split_rejection(manager: ManagerClient, volumes
                 await manager.api.flush_keyspace(servers[0].ip_addr, ks)
 
                 coord = await get_topology_coordinator(manager)
-                coord_serv = await find_server_by_host_id(manager, servers, coord)
+                coord_serv = await manager.find_server_by_host_id(servers, coord)
                 coord_log = await manager.server_open_log(coord_serv.server_id)
 
                 async def run_split():

--- a/test/cluster/tasks/test_tablet_tasks.py
+++ b/test/cluster/tasks/test_tablet_tasks.py
@@ -14,7 +14,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.repair import create_table_insert_data_for_repair, get_tablet_task_id
 from test.pylib.rest_client import read_barrier
 from test.pylib.tablets import get_all_tablet_replicas
-from test.cluster.util import create_new_test_keyspace, new_test_keyspace, get_topology_coordinator, find_server_by_host_id
+from test.cluster.util import create_new_test_keyspace, new_test_keyspace, get_topology_coordinator
 from test.cluster.test_incremental_repair import trigger_tablet_merge
 from test.cluster.test_tablets2 import inject_error_on
 from test.cluster.tasks.task_manager_client import TaskManagerClient
@@ -222,7 +222,7 @@ async def test_tablet_repair_wait(manager: ManagerClient):
         await message_injection(manager, servers, stop_repair_injection)
 
         # Merge tablets.
-        coord = await find_server_by_host_id(manager, servers, await get_topology_coordinator(manager))
+        coord = await manager.find_server_by_host_id(servers, await get_topology_coordinator(manager))
         log2 = await manager.server_open_log(coord.server_id)
         await trigger_tablet_merge(manager, servers, [log2])
 

--- a/test/cluster/test_coordinator_queue_management.py
+++ b/test/cluster/test_coordinator_queue_management.py
@@ -27,24 +27,31 @@ async def test_coordinator_queue_management(manager: ManagerClient):
     servers = await manager.running_servers()
     logs = [await manager.server_open_log(srv.server_id) for srv in servers]
     marks = [await log.mark() for log in logs]
+    # Submit the removenode for servers[3] while servers[4] is still alive
+    # to avoid the initiator-side liveness check. Stop servers[4] after
+    # the removenode is confirmed as queued.
     await manager.server_stop_gracefully(servers[3].server_id)
-    await manager.server_stop_gracefully(servers[4].server_id)
     await manager.server_not_sees_other_server(servers[0].ip_addr, servers[3].ip_addr)
-    await manager.server_not_sees_other_server(servers[0].ip_addr, servers[4].ip_addr)
 
     inj = 'topology_coordinator_pause_before_processing_backlog'
     [await manager.api.enable_injection(s.ip_addr, inj, one_shot=True) for s in servers[:3]]
 
     s3_id = await manager.get_host_id(servers[3].server_id)
     tasks = [asyncio.create_task(manager.server_add()),
-             asyncio.create_task(manager.remove_node(servers[0].server_id, servers[3].server_id)),
-             asyncio.create_task(manager.remove_node(servers[0].server_id, servers[4].server_id, [s3_id]))]
+             asyncio.create_task(manager.remove_node(servers[0].server_id, servers[3].server_id))]
+
+    # Ensure the removenode is queued before stopping servers[4].
+    marks[0], _ = await logs[0].wait_for("raft_topology - removenode: waiting for completion", from_mark=marks[0])
+
+    await manager.server_stop_gracefully(servers[4].server_id)
+    await manager.server_not_sees_other_server(servers[0].ip_addr, servers[4].ip_addr)
+
+    tasks += [asyncio.create_task(manager.remove_node(servers[0].server_id, servers[4].server_id, [s3_id]))]
 
     await wait_for_first_completed([
         l.wait_for("received request to join from host_id", from_mark=m) for l, m in zip(logs[:3], marks[:3])
     ])
 
-    marks[0], _ = await logs[0].wait_for("raft_topology - removenode: waiting for completion", from_mark=marks[0])
     marks[0], _ = await logs[0].wait_for("raft_topology - removenode: waiting for completion", from_mark=marks[0])
 
     [await manager.api.message_injection(s.ip_addr, inj) for s in servers[:3]]

--- a/test/cluster/test_decommission_kill_then_replace.py
+++ b/test/cluster/test_decommission_kill_then_replace.py
@@ -13,7 +13,6 @@ import pytest
 
 from test.cluster.util import (
     get_topology_coordinator,
-    find_server_by_host_id,
     wait_for_token_ring_and_group0_consistency,
 )
 from test.pylib.manager_client import ManagerClient
@@ -35,7 +34,7 @@ async def test_decommission_kill_then_replace(manager: ManagerClient) -> None:
 
     # Identify the topology coordinator and enable the pause injection there
     coord_host_id = await get_topology_coordinator(manager)
-    coord_srv = await find_server_by_host_id(manager, servers, coord_host_id)
+    coord_srv = await manager.find_server_by_host_id(servers, coord_host_id)
     inj = 'topology_coordinator_pause_before_processing_backlog'
     await manager.api.enable_injection(coord_srv.ip_addr, inj, one_shot=True)
 

--- a/test/cluster/test_global_ignore_nodes.py
+++ b/test/cluster/test_global_ignore_nodes.py
@@ -27,7 +27,7 @@ async def test_global_ignored_nodes_list(manager: ManagerClient, random_tables) 
     # test that non existing uuid is rejected
     rnd_id = str(uuid.uuid4())
     await manager.remove_node(servers[1].server_id, servers[4].server_id, [rnd_id],
-                        expected_error=f"Node {rnd_id} is not found in the cluster")
+                        expected_error=f"Node {rnd_id} is not found in the cluster", wait_dead=False)
     # now remove one dead node while ignoring another one
     s3_id = await manager.get_host_id(servers[3].server_id)
     await manager.remove_node(servers[1].server_id, servers[4].server_id, [s3_id])

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -20,7 +20,7 @@ from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import gather_safely, wait_for
 
 from test.pylib import nodetool
-from test.cluster.util import get_topology_coordinator, find_server_by_host_id, keyspace_has_tablets, new_test_keyspace, new_test_table
+from test.cluster.util import get_topology_coordinator, keyspace_has_tablets, new_test_keyspace, new_test_table
 
 
 logger = logging.getLogger(__name__)
@@ -218,7 +218,7 @@ async def test_hints_consistency_during_decommission(manager: ManagerClient):
 
         async with asyncio.TaskGroup() as tg:
             coord = await get_topology_coordinator(manager)
-            coord_srv = await find_server_by_host_id(manager, [server1, server2, server3], coord)
+            coord_srv = await manager.find_server_by_host_id([server1, server2, server3], coord)
 
             # Make sure topology coordinator will pause right after streaming
             logger.info("Enabling injection on the topology coordinator that will tell it to pause streaming")
@@ -478,7 +478,7 @@ async def test_hint_to_leaving_when_reducing_rf(manager: ManagerClient):
         await manager.server_start(servers[2].server_id)
 
         coord = await get_topology_coordinator(manager)
-        coord_serv = await find_server_by_host_id(manager, servers, coord)
+        coord_serv = await manager.find_server_by_host_id(servers, coord)
         await manager.api.enable_injection(coord_serv.ip_addr, "stream_tablet_wait", one_shot=False)
 
         alter_rf_fut = cql.run_async(f"ALTER KEYSPACE {ks} WITH REPLICATION = {{'class' : 'NetworkTopologyStrategy', 'dc1': ['r2']}}")

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -8,7 +8,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.repair import load_tablet_sstables_repaired_at, load_tablet_repair_time, create_table_insert_data_for_repair
 from test.pylib.tablets import get_all_tablet_replicas
 from test.cluster.tasks.task_manager_client import TaskManagerClient
-from test.cluster.util import reconnect_driver, find_server_by_host_id, get_topology_coordinator, ensure_group0_leader_on, new_test_keyspace, new_test_table, trigger_stepdown, create_new_test_keyspace
+from test.cluster.util import reconnect_driver, get_topology_coordinator, ensure_group0_leader_on, new_test_keyspace, new_test_table, trigger_stepdown, create_new_test_keyspace
 from test.pylib.util import wait_for_cql_and_get_hosts
 
 from cassandra.query import ConsistencyLevel, SimpleStatement
@@ -666,7 +666,7 @@ async def do_test_tablet_incremental_repair_merge_error(manager, error):
     scylla_path = await manager.server_get_exe(server.server_id)
 
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
     coord_log = await manager.server_open_log(coord_serv.server_id)
 
     # Trigger merge and error in merge
@@ -760,7 +760,7 @@ async def test_incremental_repair_finishes_when_tablet_skips_end_repair_stage(ma
             table = cf.split('.')[-1]
 
             coord = await get_topology_coordinator(manager)
-            coord_serv = await find_server_by_host_id(manager, servers, coord)
+            coord_serv = await manager.find_server_by_host_id(servers, coord)
             coord_log = await manager.server_open_log(coord_serv.server_id)
             coord_mark = await coord_log.mark()
 
@@ -786,7 +786,7 @@ async def test_incremental_repair_rejoin_do_tablet_operation(manager):
 
             async def get_coord():
                 coord = await get_topology_coordinator(manager)
-                coord_serv = await find_server_by_host_id(manager, servers, coord)
+                coord_serv = await manager.find_server_by_host_id(servers, coord)
                 coord_log = await manager.server_open_log(coord_serv.server_id)
                 return coord, coord_serv, coord_log
 
@@ -833,7 +833,7 @@ async def test_incremental_retry_end_repair_stage(manager):
 
             async def get_coord():
                 coord = await get_topology_coordinator(manager)
-                coord_serv = await find_server_by_host_id(manager, servers, coord)
+                coord_serv = await manager.find_server_by_host_id(servers, coord)
                 coord_log = await manager.server_open_log(coord_serv.server_id)
                 return coord, coord_serv, coord_log
 
@@ -923,7 +923,7 @@ async def test_tablet_incremental_repair_table_drop_compaction_group_gone(manage
     servers, cql, hosts, ks, table_id, logs, _, _, _, _ = await prepare_cluster_for_incremental_repair(manager, cmdline=cmdline)
 
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
     coord_log = await manager.server_open_log(coord_serv.server_id)
 
     # Trigger merge and wait until the merge fiber starts
@@ -1025,12 +1025,12 @@ async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, to
     # and marking post-repair data as repaired.  That legitimate re-repair masks
     # the compaction-merge bug this test detects.
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
     if coord_serv == servers[1]:
         other = next(s for s in servers if s != servers[1])
         await ensure_group0_leader_on(manager, other)
         coord = await get_topology_coordinator(manager)
-        coord_serv = await find_server_by_host_id(manager, servers, coord)
+        coord_serv = await manager.find_server_by_host_id(servers, coord)
     coord_log = await manager.server_open_log(coord_serv.server_id)
     coord_mark = await coord_log.mark()
 

--- a/test/cluster/test_raft_ignore_nodes.py
+++ b/test/cluster/test_raft_ignore_nodes.py
@@ -73,9 +73,7 @@ async def test_raft_replace_ignore_nodes(manager: ManagerClient) -> None:
     s2_id = await manager.get_host_id(servers[2].server_id)
     s3_id = await manager.get_host_id(servers[3].server_id)
     logger.info(f"Stopping servers {servers[:3]}")
-    await manager.server_stop(servers[0].server_id, convict=True)
-    await manager.server_stop(servers[1].server_id, convict=True)
-    await manager.server_stop_gracefully(servers[2].server_id)
+    await gather_safely(*(manager.server_stop(srv.server_id, convict=True) for srv in servers[:3]))
     await gather_safely(*(manager.others_not_see_server(srv.ip_addr) for srv in servers[:3]))
 
     ignore_dead = [s1_id, s2_id, s3_id]
@@ -123,9 +121,7 @@ async def test_raft_remove_ignore_nodes(manager: ManagerClient) -> None:
     s2_id = await manager.get_host_id(servers[2].server_id)
     s3_id = await manager.get_host_id(servers[3].server_id)
     logger.info(f"Stopping servers {servers[:3]}")
-    await manager.server_stop_gracefully(servers[0].server_id)
-    await manager.server_stop_gracefully(servers[1].server_id)
-    await manager.server_stop_gracefully(servers[2].server_id)
+    await gather_safely(*(manager.server_stop(srv.server_id, convict=True) for srv in servers[:3]))
     await gather_safely(*(manager.others_not_see_server(srv.ip_addr) for srv in servers[:3]))
 
     ignore_dead = [s1_id, s2_id, s3_id]

--- a/test/cluster/test_raft_ignore_nodes.py
+++ b/test/cluster/test_raft_ignore_nodes.py
@@ -11,6 +11,7 @@ import logging
 from test.pylib.internal_types import IPAddress, HostID
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.manager_client import ManagerClient, ServerInfo
+from test.pylib.util import gather_safely
 from test.cluster.util import get_current_group0_config, wait_for_token_ring_and_group0_consistency
 
 
@@ -70,10 +71,18 @@ async def test_raft_replace_ignore_nodes(manager: ManagerClient) -> None:
 
     s1_id = await manager.get_host_id(servers[1].server_id)
     s2_id = await manager.get_host_id(servers[2].server_id)
+    s3_id = await manager.get_host_id(servers[3].server_id)
     logger.info(f"Stopping servers {servers[:3]}")
     await manager.server_stop(servers[0].server_id, convict=True)
     await manager.server_stop(servers[1].server_id, convict=True)
     await manager.server_stop_gracefully(servers[2].server_id)
+    await gather_safely(*(manager.others_not_see_server(srv.ip_addr) for srv in servers[:3]))
+
+    ignore_dead = [s1_id, s2_id, s3_id]
+    logger.info(f"Replacing {servers[0]}, ignore_dead_nodes = {ignore_dead}, expecting error")
+    replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True,
+                                ignore_dead_nodes = ignore_dead, wait_dead=False)
+    await manager.server_add(replace_cfg=replace_cfg, expected_error=f"ignored node {s3_id} is alive")
 
     ignore_dead: list[IPAddress | HostID] = [s1_id, servers[2].ip_addr]
     logger.info(f"Replacing {servers[0]}, ignore_dead_nodes = {ignore_dead}")
@@ -106,10 +115,17 @@ async def test_raft_remove_ignore_nodes(manager: ManagerClient) -> None:
 
     s1_id = await manager.get_host_id(servers[1].server_id)
     s2_id = await manager.get_host_id(servers[2].server_id)
+    s3_id = await manager.get_host_id(servers[3].server_id)
     logger.info(f"Stopping servers {servers[:3]}")
     await manager.server_stop_gracefully(servers[0].server_id)
     await manager.server_stop_gracefully(servers[1].server_id)
     await manager.server_stop_gracefully(servers[2].server_id)
+    await gather_safely(*(manager.others_not_see_server(srv.ip_addr) for srv in servers[:3]))
+
+    ignore_dead = [s1_id, s2_id, s3_id]
+    logger.info(f"Removing {servers[0]} initiated by {servers[4]}, ignore_dead_nodes = {ignore_dead}, expecting error")
+    await manager.remove_node(servers[4].server_id, servers[0].server_id, ignore_dead,
+                              f"ignored node {s3_id} is alive", False)
 
     ignore_dead: list[IPAddress] | list[HostID] = [s1_id, s2_id]
     logger.info(f"Removing {servers[0]} initiated by {servers[3]}, ignore_dead_nodes = {ignore_dead}")

--- a/test/cluster/test_raft_ignore_nodes.py
+++ b/test/cluster/test_raft_ignore_nodes.py
@@ -84,6 +84,12 @@ async def test_raft_replace_ignore_nodes(manager: ManagerClient) -> None:
                                 ignore_dead_nodes = ignore_dead, wait_dead=False)
     await manager.server_add(replace_cfg=replace_cfg, expected_error=f"ignored node {s3_id} is alive")
 
+    ignore_dead = [s1_id]
+    logger.info(f"Replacing {servers[0]}, ignore_dead_nodes = {ignore_dead}, expecting error")
+    replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True,
+                                ignore_dead_nodes = ignore_dead, wait_dead=False)
+    await manager.server_add(replace_cfg=replace_cfg, expected_error=f"node {s2_id} is down and not ignored")
+
     ignore_dead: list[IPAddress | HostID] = [s1_id, servers[2].ip_addr]
     logger.info(f"Replacing {servers[0]}, ignore_dead_nodes = {ignore_dead}")
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True,
@@ -126,6 +132,11 @@ async def test_raft_remove_ignore_nodes(manager: ManagerClient) -> None:
     logger.info(f"Removing {servers[0]} initiated by {servers[4]}, ignore_dead_nodes = {ignore_dead}, expecting error")
     await manager.remove_node(servers[4].server_id, servers[0].server_id, ignore_dead,
                               f"ignored node {s3_id} is alive", False)
+
+    ignore_dead = [s1_id]
+    logger.info(f"Removing {servers[0]} initiated by {servers[4]}, ignore_dead_nodes = {ignore_dead}, expecting error")
+    await manager.remove_node(servers[4].server_id, servers[0].server_id, ignore_dead,
+                              f"node {s2_id} is down and not ignored")
 
     ignore_dead: list[IPAddress] | list[HostID] = [s1_id, s2_id]
     logger.info(f"Removing {servers[0]} initiated by {servers[3]}, ignore_dead_nodes = {ignore_dead}")

--- a/test/cluster/test_raft_recovery_during_join.py
+++ b/test/cluster/test_raft_recovery_during_join.py
@@ -116,10 +116,9 @@ async def test_raft_recovery_during_join(manager: ManagerClient):
     await manager.rolling_restart(live_servers, with_down=set_recovery_leader)
 
     logging.info(f'Removing {dead_servers}')
-    for i, being_removed in enumerate(dead_servers):
-        ignored = [dead_srv.ip_addr for dead_srv in dead_servers[i + 1:]]
-        initiator = live_servers[i % 2]
-        await manager.remove_node(initiator.server_id, being_removed.server_id, ignored)
+    dead_host_ids = await gather_safely(*(manager.get_host_id(srv.server_id) for srv in dead_servers))
+    await gather_safely(*(manager.remove_node(live_servers[i % 2].server_id, dead_servers[i].server_id,
+                                              dead_host_ids) for i in range(len(dead_servers))))
 
     logging.info(f'Unsetting the recovery_leader config option on {live_servers}')
     await gather_safely(*(manager.server_remove_config_option(srv.server_id, 'recovery_leader') for srv in live_servers))

--- a/test/cluster/test_raft_recovery_entry_loss.py
+++ b/test/cluster/test_raft_recovery_entry_loss.py
@@ -146,10 +146,9 @@ async def test_raft_recovery_entry_loss(manager: ManagerClient):
     assert v_group0 != new_v_group0 and new_v_group0 == new_v_node1 and new_v_node1 == new_v_node2
 
     logging.info(f'Removing {dead_servers}')
-    for i, being_removed in enumerate(dead_servers):
-        ignored = [dead_srv.ip_addr for dead_srv in dead_servers[i + 1:]]
-        initiator = live_servers[i % 2]
-        await manager.remove_node(initiator.server_id, being_removed.server_id, ignored)
+    dead_host_ids = await gather_safely(*(manager.get_host_id(srv.server_id) for srv in dead_servers))
+    await gather_safely(*(manager.remove_node(live_servers[i % 2].server_id, dead_servers[i].server_id,
+                                              dead_host_ids) for i in range(len(dead_servers))))
 
     logging.info(f'Unsetting the recovery_leader config option on {live_servers}')
     await gather_safely(*(manager.server_remove_config_option(srv.server_id, 'recovery_leader') for srv in live_servers))

--- a/test/cluster/test_raft_recovery_user_data.py
+++ b/test/cluster/test_raft_recovery_user_data.py
@@ -23,7 +23,6 @@ from test.cluster.util import check_system_topology_and_cdc_generations_v3_consi
         reconnect_driver, start_writes, wait_for_cdc_generations_publishing
 
 
-@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("remove_dead_nodes_with", ["remove", "replace"])
 async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes_with: str):
     """
@@ -144,39 +143,20 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
                             {{'class': 'NetworkTopologyStrategy', 'dc1': {rf}, 'dc2': 0}}""")
 
         logging.info(f'Removing {dead_servers}')
-        for i, being_removed in enumerate(dead_servers):
-            ignored = [dead_srv.ip_addr for dead_srv in dead_servers[i + 1:]]
-            initiator = live_servers[i]
-            await manager.remove_node(initiator.server_id, being_removed.server_id, ignored)
+        await gather_safely(*(manager.remove_node(live_servers[i].server_id, dead_servers[i].server_id,
+                                                  dead_host_ids) for i in range(len(dead_servers))))
     else:
         # Replace dead nodes concurrently. Not recommended for users, but it should work, and it significantly speeds up
         # the test in debug mode.
-        # Enable topology_coordinator_pause_before_processing_backlog and wait for all join requests to be placed before
-        # unblocking the topology coordinator to prevent the request rejection due to a non-ignored node being down.
-        # Ignoring all dead nodes in all replace requests would also result in rejection due to ignoring a left node.
-        recovery_leader = live_servers[0]
-        inj = 'topology_coordinator_pause_before_processing_backlog'
-        await manager.api.enable_injection(recovery_leader.ip_addr, inj, one_shot=True)
-        log = await manager.server_open_log(recovery_leader.server_id)
-        mark = await log.mark()
+        logging.info(f'Replacing {dead_servers}')
 
-        async def replace_server(i, being_replaced):
+        async def replace_server(being_replaced, rack_idx):
             replace_cfg = ReplaceConfig(replaced_id=being_replaced.server_id, reuse_ip_addr=False, use_host_id=True,
-                                        ignore_dead_nodes=[dead_srv.ip_addr for dead_srv in dead_servers[i + 1:]])
-            # Specify the leader as the only seed to make sure it receives all join requests (for simplicity).
+                                        ignore_dead_nodes=dead_host_ids)
             return await manager.server_add(replace_cfg=replace_cfg, config=cfg,
-                                            property_file={'dc': 'dc2', 'rack': f'rack{i + 1}'},
-                                            seeds=[recovery_leader.ip_addr])
-        replace_tasks = []
-        for i, srv in enumerate(dead_servers):
-            logging.info(f'Starting replacement of {srv}')
-            replace_tasks.append(asyncio.create_task(replace_server(i, srv)))
-            mark, _ = await log.wait_for("placed join request for", from_mark=mark)
+                                            property_file={'dc': 'dc2', 'rack': f'rack{rack_idx + 1}'})
 
-        await manager.api.message_injection(recovery_leader.ip_addr, inj)
-
-        logging.info('Waiting for replace operations to complete')
-        replace_results = await gather_safely(*replace_tasks)
+        replace_results = await gather_safely(*(replace_server(srv, i) for i, srv in enumerate(dead_servers)))
         new_servers.extend(replace_results)
 
     logging.info(f'Unsetting the recovery_leader config option on {live_servers}')

--- a/test/cluster/test_raft_recovery_user_data.py
+++ b/test/cluster/test_raft_recovery_user_data.py
@@ -160,7 +160,6 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
         log = await manager.server_open_log(recovery_leader.server_id)
         mark = await log.mark()
 
-        logging.info(f'Starting replacement of {dead_servers}')
         async def replace_server(i, being_replaced):
             replace_cfg = ReplaceConfig(replaced_id=being_replaced.server_id, reuse_ip_addr=False, use_host_id=True,
                                         ignore_dead_nodes=[dead_srv.ip_addr for dead_srv in dead_servers[i + 1:]])
@@ -168,10 +167,10 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
             return await manager.server_add(replace_cfg=replace_cfg, config=cfg,
                                             property_file={'dc': 'dc2', 'rack': f'rack{i + 1}'},
                                             seeds=[recovery_leader.ip_addr])
-        replace_tasks = [asyncio.create_task(replace_server(i, srv)) for i, srv in enumerate(dead_servers)]
-
-        logging.info(f'Waiting for join requests to be placed')
-        for _ in dead_servers:
+        replace_tasks = []
+        for i, srv in enumerate(dead_servers):
+            logging.info(f'Starting replacement of {srv}')
+            replace_tasks.append(asyncio.create_task(replace_server(i, srv)))
             mark, _ = await log.wait_for("placed join request for", from_mark=mark)
 
         await manager.api.message_injection(recovery_leader.ip_addr, inj)

--- a/test/cluster/test_replace_alive_node.py
+++ b/test/cluster/test_replace_alive_node.py
@@ -21,7 +21,7 @@ async def test_replacing_alive_node_fails(manager: ManagerClient) -> None:
     # Both errors contain the expected string below.
     for srv in servers:
         replace_cfg = ReplaceConfig(replaced_id = srv.server_id, reuse_ip_addr = False,
-                                    use_host_id = False, wait_replaced_dead = False)
+                                    use_host_id = False, wait_dead = False)
         await manager.server_add(replace_cfg=replace_cfg,
                                  property_file=srv.property_file(),
                                  expected_error="the topology coordinator rejected request to join the cluster")

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -15,7 +15,7 @@ from test.pylib.repair import create_table_insert_data_for_repair
 from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
-from test.pylib.util import unique_name, wait_for, wait_for_first_completed
+from test.pylib.util import unique_name, wait_for, wait_for_first_completed, gather_safely
 from test.cluster.util import wait_for_cql_and_get_hosts, create_new_test_keyspace, new_test_keyspace, reconnect_driver, \
     get_topology_coordinator, parse_replication_options, get_replication, get_replica_count
 from contextlib import nullcontext as does_not_raise
@@ -1824,20 +1824,19 @@ async def test_replace_with_no_normal_token_owners_in_dc(manager: ManagerClient,
         await asyncio.gather(*[cql.run_async(stmt, [k, k]) for k in keys])
 
         nodes_to_replace = servers['dc1'][0:2]
-        replaced_host_id = await manager.get_host_id(nodes_to_replace[1].server_id)
+        host_ids_to_replace = await gather_safely(*(manager.get_host_id(node.server_id) for node in nodes_to_replace))
 
         # Stop both token owners in dc1 to leave no token owners in the datacenter
         for node in nodes_to_replace:
             await manager.server_stop_gracefully(node.server_id)
 
-        logger.info(f"Replacing {nodes_to_replace[0]} with a new node")
-        replace_cfg = ReplaceConfig(replaced_id=nodes_to_replace[0].server_id, reuse_ip_addr = False, use_host_id=True, wait_dead=True,
-                                    ignore_dead_nodes=[replaced_host_id])
-        await manager.server_add(replace_cfg=replace_cfg, property_file=nodes_to_replace[0].property_file())
+        async def replace_node(node):
+            replace_cfg = ReplaceConfig(replaced_id=node.server_id, reuse_ip_addr=False, use_host_id=True, wait_dead=True,
+                                        ignore_dead_nodes=host_ids_to_replace)
+            await manager.server_add(replace_cfg=replace_cfg, property_file=node.property_file())
 
-        logger.info(f"Replacing {nodes_to_replace[1]} with a new node")
-        replace_cfg = ReplaceConfig(replaced_id=nodes_to_replace[1].server_id, reuse_ip_addr = False, use_host_id=True, wait_dead=True)
-        await manager.server_add(replace_cfg=replace_cfg, property_file=nodes_to_replace[1].property_file())
+        logger.info(f"Replacing {nodes_to_replace}")
+        await gather_safely(*(replace_node(node) for node in nodes_to_replace))
 
         logger.info("Verifying data")
         for node in servers['dc2']:

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -17,7 +17,7 @@ from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from test.pylib.util import unique_name, wait_for, wait_for_first_completed
 from test.cluster.util import wait_for_cql_and_get_hosts, create_new_test_keyspace, new_test_keyspace, reconnect_driver, \
-    get_topology_coordinator, parse_replication_options, get_replication, get_replica_count, find_server_by_host_id
+    get_topology_coordinator, parse_replication_options, get_replication, get_replica_count
 from contextlib import nullcontext as does_not_raise
 import time
 import pytest
@@ -797,7 +797,7 @@ async def test_multi_rf_increase_abort_0_N(request: pytest.FixtureRequest, manag
     await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
 
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
 
     for s in servers:
         await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
@@ -870,7 +870,7 @@ async def test_multi_rf_decrease_abort_0_N(request: pytest.FixtureRequest, manag
     await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk, v) VALUES ({k}, {k});") for k in range(10)])
 
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
 
     for s in servers:
         await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
@@ -951,7 +951,7 @@ async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, ma
     await asyncio.gather(*[cql.run_async(f"INSERT INTO ks3.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
 
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
 
     for s in servers:
         await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
@@ -1025,7 +1025,7 @@ async def test_multi_rf_increase_before_decrease_0_N(request: pytest.FixtureRequ
     await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
 
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
 
     for s in servers:
         await manager.api.enable_injection(s.ip_addr, injection, one_shot=False)
@@ -1115,7 +1115,7 @@ async def test_numeric_rf_to_rack_list_conversion_abort(request: pytest.FixtureR
     [await manager.api.disable_injection(s.ip_addr, numeric_injection) for s in servers]
 
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
     s1_log = await manager.server_open_log(coord_serv.server_id)
     s1_mark = await s1_log.mark()
 
@@ -1169,7 +1169,7 @@ async def test_failed_tablet_rebuild_is_retried(request: pytest.FixtureRequest, 
     await asyncio.gather(*[cql.run_async(f"INSERT INTO ks1.t (pk) VALUES ({pk});") for pk in range(16)])
 
     coord = await get_topology_coordinator(manager)
-    coord_serv = await find_server_by_host_id(manager, servers, coord)
+    coord_serv = await manager.find_server_by_host_id(servers, coord)
     log = await manager.server_open_log(coord_serv.server_id)
     mark = await log.mark()
 

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1670,7 +1670,7 @@ async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: Manager
             await manager.remove_node(initiator_node.server_id, server_id=node_to_remove.server_id, ignore_dead=[replaced_host_id])
 
         logger.info(f"Replacing {node_to_replace} with a new node")
-        replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True,
+        replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_dead=True,
                                     ignore_dead_nodes=[replaced_host_id])
         await manager.server_add(replace_cfg=replace_cfg, property_file=node_to_remove.property_file())
 
@@ -1790,7 +1790,7 @@ async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_tok
                                 expected_error="Removenode failed")
 
         logger.info(f"Replacing {node_to_remove} with a new node")
-        replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True)
+        replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_dead=True)
         await manager.server_add(replace_cfg=replace_cfg, property_file=node_to_remove.property_file())
 
 @pytest.mark.nightly
@@ -1831,12 +1831,12 @@ async def test_replace_with_no_normal_token_owners_in_dc(manager: ManagerClient,
             await manager.server_stop_gracefully(node.server_id)
 
         logger.info(f"Replacing {nodes_to_replace[0]} with a new node")
-        replace_cfg = ReplaceConfig(replaced_id=nodes_to_replace[0].server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True,
+        replace_cfg = ReplaceConfig(replaced_id=nodes_to_replace[0].server_id, reuse_ip_addr = False, use_host_id=True, wait_dead=True,
                                     ignore_dead_nodes=[replaced_host_id])
         await manager.server_add(replace_cfg=replace_cfg, property_file=nodes_to_replace[0].property_file())
 
         logger.info(f"Replacing {nodes_to_replace[1]} with a new node")
-        replace_cfg = ReplaceConfig(replaced_id=nodes_to_replace[1].server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True)
+        replace_cfg = ReplaceConfig(replaced_id=nodes_to_replace[1].server_id, reuse_ip_addr = False, use_host_id=True, wait_dead=True)
         await manager.server_add(replace_cfg=replace_cfg, property_file=nodes_to_replace[1].property_file())
 
         logger.info("Verifying data")

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -385,7 +385,7 @@ async def test_lwt_state_is_preserved_on_tablet_rebuild(manager: ManagerClient):
             replaced_id=servers[0].server_id,
             reuse_ip_addr=False,
             use_host_id=True,
-            wait_replaced_dead=True
+            wait_dead=True
         )
         servers += [await manager.server_add(replace_cfg=replace_cfg,
                                              cmdline=cmdline,

--- a/test/cluster/test_tablets_parallel_decommission.py
+++ b/test/cluster/test_tablets_parallel_decommission.py
@@ -308,11 +308,27 @@ async def test_remove_is_canceled_if_there_is_node_down(manager: ManagerClient):
                         " 'dc1': ['rack1', 'rack2']} AND tablets = {'initial': 32};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
 
-        await manager.server_stop_gracefully(servers[3].server_id)
+        # Submit the removenode while servers[3] is still alive to avoid
+        # the initiator-side liveness check. Pause the coordinator so that
+        # it doesn't process the removenode before we stop servers[3].
         await manager.server_stop_gracefully(servers[2].server_id)
 
+        coord_log = await manager.server_open_log(coord_serv.server_id)
+        inj = 'topology_coordinator_pause_before_processing_backlog'
+        await manager.api.enable_injection(coord_serv.ip_addr, inj, one_shot=True)
+        await coord_log.wait_for(f"{inj}: waiting")
+
+        remove_task = asyncio.create_task(
+            manager.remove_node(coord_serv.server_id, servers[2].server_id))
+
+        # Ensure the removenode is queued before stopping servers[3].
+        await coord_log.wait_for("raft_topology - removenode: waiting for completion")
+
+        await manager.server_stop_gracefully(servers[3].server_id)
+        await manager.api.message_injection(coord_serv.ip_addr, inj)
+
         with pytest.raises(Exception, match="Canceled. Dead nodes: "):
-            await manager.remove_node(coord_serv.server_id, servers[2].server_id)
+            await remove_task
 
 
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -97,12 +97,6 @@ async def get_topology_version(cql: Session, host: Host) -> int:
     return rows[0].version
 
 
-async def find_server_by_host_id(manager: ManagerClient, servers: List[ServerInfo], host_id: HostID) -> ServerInfo:
-    for s in servers:
-        if await manager.get_host_id(s.server_id) == host_id:
-            return s
-    raise Exception(f"Host ID {host_id} not found in {servers}")
-
 
 async def check_token_ring_and_group0_consistency(manager: ManagerClient) -> None:
     """Ensure that the normal token owners and group 0 members match

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -326,8 +326,11 @@ class ManagerClient:
 
     async def find_server_by_host_id(self, servers: List[ServerInfo], host_id: HostID) -> ServerInfo:
         for s in servers:
-            if await self.get_host_id(s.server_id) == host_id:
-                return s
+            try:
+                if await self.get_host_id(s.server_id) == host_id:
+                    return s
+            except Exception:
+                logger.warning(f"Failed to get host ID of server {s} while looking for a server with host ID {host_id}")
         raise Exception(f"Host ID {host_id} not found in {servers}")
 
     async def starting_servers(self) -> list[ServerInfo]:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -324,6 +324,12 @@ class ManagerClient:
             result[await self.get_host_id(s.server_id)] = s
         return result
 
+    async def find_server_by_host_id(self, servers: List[ServerInfo], host_id: HostID) -> ServerInfo:
+        for s in servers:
+            if await self.get_host_id(s.server_id) == host_id:
+                return s
+        raise Exception(f"Host ID {host_id} not found in {servers}")
+
     async def starting_servers(self) -> list[ServerInfo]:
         """Get List of server info (id and IP address) of servers currently
            starting. Can be useful for killing (with server_stop()) a server

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -908,7 +908,7 @@ class ManagerClient:
     async def servers_see_each_other(self, servers: List[ServerInfo], interval: float = 45.):
         """Wait till all servers see all other servers in the list"""
         others = [self.server_sees_others(srv.server_id, len(servers) - 1, interval) for srv in servers]
-        await asyncio.gather(*others)
+        await gather_safely(*others)
 
     async def server_not_sees_other_server(self, server_ip: IPAddress, other_ip: IPAddress,
                                            interval: float = 45.):
@@ -922,8 +922,7 @@ class ManagerClient:
     async def others_not_see_server(self, server_ip: IPAddress, interval: float = 45.):
         """Wait till a server is seen as dead by all other running servers in the cluster"""
         others_ips = [srv.ip_addr for srv in await self.running_servers() if srv.ip_addr != server_ip]
-        await asyncio.gather(*(self.server_not_sees_other_server(ip, server_ip, interval)
-                               for ip in others_ips))
+        await gather_safely(*(self.server_not_sees_other_server(ip, server_ip, interval) for ip in others_ips))
 
     async def server_open_log(self, server_id: ServerNum) -> ScyllaLogFile:
         logger.debug("ManagerClient getting log filename for %s", server_id)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -19,7 +19,7 @@ from time import time
 import logging
 from test.pylib.log_browsing import ScyllaLogFile
 from test.pylib.rest_client import UnixRESTClient, ScyllaRESTAPIClient, ScyllaMetricsClient
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, universalasync_typed_wrap, Host, gather_safely
+from test.pylib.util import gather_safely, wait_for, wait_for_cql_and_get_hosts, universalasync_typed_wrap, Host
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from test.pylib.scylla_cluster import ReplaceConfig, ScyllaServer, ScyllaVersionDescription
 from test.pylib.driver_utils import safe_driver_shutdown
@@ -551,6 +551,23 @@ class ManagerClient:
         """Get the total size of all sstable files for the given table"""
         return await self.client.get_json(f"/cluster/server/{server_id}/sstables_disk_usage", params={"keyspace": keyspace, "table": table})
 
+    async def _get_ignored_ip_addresses(self, ignore_dead: List[IPAddress | HostID]) -> List[IPAddress]:
+        """
+        Get IP addresses of nodes ignored in the replace and removenode operations.
+
+        FIXME: Simplify the code once we disallow specifying ignored nodes through IP addresses in Scylla.
+        """
+        servers = await self.all_servers()
+        ignored_ips = []
+        for ignored in ignore_dead:
+            # IPAddress and HostID are both NewType over str, so isinstance() cannot distinguish them at runtime.
+            if '.' in ignored:
+                ignored_ips.append(ignored)
+            else:
+                ignored_server = await self.find_server_by_host_id(servers, ignored)
+                ignored_ips.append(ignored_server.ip_addr)
+        return ignored_ips
+
     def _create_server_add_data(self,
                                 replace_cfg: Optional[ReplaceConfig],
                                 cmdline: Optional[List[str]],
@@ -624,14 +641,15 @@ class ManagerClient:
                 expected_server_up_state,
             )
 
-            # If we replace, we should wait until other nodes see the node being
-            # replaced as dead because the replace operation can be rejected if
-            # the node being replaced is considered alive. However, we sometimes
-            # do not want to wait, for example, when we test that replace fails
-            # as expected. Therefore, we make waiting optional and default.
-            if replace_cfg and replace_cfg.wait_replaced_dead:
+            # We should wait until all running nodes see the node being replaced
+            # and all ignored nodes as dead. Replace could be rejected otherwise.
+            # We make this waiting default and optional to allow testing expected
+            # replace failures.
+            if replace_cfg and replace_cfg.wait_dead:
                 replaced_ip = await self.get_host_ip(replace_cfg.replaced_id)
-                await self.others_not_see_server(replaced_ip)
+                ignored_ips = await self._get_ignored_ip_addresses(replace_cfg.ignore_dead_nodes)
+                dead_ips = [replaced_ip] + ignored_ips
+                await gather_safely(*(self.others_not_see_server(ip) for ip in dead_ips))
 
             server_info = await self.client.put_json("/cluster/addserver", data, response_type="json",
                                                      timeout=timeout)
@@ -708,7 +726,7 @@ class ManagerClient:
     async def remove_node(self, initiator_id: ServerNum, server_id: ServerNum,
                           ignore_dead: List[IPAddress] | List[HostID] = list[IPAddress](),
                           expected_error: str | None = None,
-                          wait_removed_dead: bool = True,
+                          wait_dead: bool = True,
                           timeout: Optional[float] = ScyllaServer.TOPOLOGY_TIMEOUT) -> None:
         """Invoke remove node Scylla REST API for a specified server"""
         if expected_error is not None:
@@ -716,14 +734,15 @@ class ManagerClient:
 
         logger.debug("ManagerClient remove node %s on initiator %s", server_id, initiator_id)
 
-        # If we remove a node, we should wait until other nodes see it as dead
-        # because the removenode operation can be rejected if the node being
-        # removed is considered alive. However, we sometimes do not want to
-        # wait, for example, when we test that removenode fails as expected.
-        # Therefore, we make waiting optional and default.
-        if wait_removed_dead:
+        # We should wait until all running nodes see the node being removed
+        # and all ignored nodes as dead. Removenode could be rejected
+        # otherwise. We make this waiting default and optional to allow testing
+        # expected removenode failures.
+        if wait_dead:
             removed_ip = await self.get_host_ip(server_id)
-            await self.others_not_see_server(removed_ip)
+            ignored_ips = await self._get_ignored_ip_addresses(ignore_dead)
+            dead_ips = [removed_ip] + ignored_ips
+            await gather_safely(*(self.others_not_see_server(ip) for ip in dead_ips))
 
         data = {"server_id": server_id, "ignore_dead": ignore_dead, "expected_error": expected_error}
         await self.client.put_json(f"/cluster/remove-node/{initiator_id}", data,

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -75,7 +75,7 @@ class ReplaceConfig(NamedTuple):
     reuse_ip_addr: bool
     use_host_id: bool
     ignore_dead_nodes: list[IPAddress | HostID] = []
-    wait_replaced_dead: bool = True
+    wait_dead: bool = True
 
 
 def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addrs: List[str], cluster_name: str,


### PR DESCRIPTION
The goal is to make concurrent replace of multiple nodes simpler by
allowing all replacing nodes to specify all dead nodes as ignored
nodes. I'm not sure if this will ever be used in production, but
we will be able to make some tests faster and simpler.

Note that we don't make providing a left node instead of a normal dead
node by mistake dangerous because the operation will fail as before.

We don't need a similar change for concurrent removenode. It already
works.

We use this change to simplify and speed up some tests. We do the
same for removenode.

No backport: minor improvements.