### PR TITLE
s3: throttle uploads by connection budget to fix flush/compaction deadlock

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -249,7 +249,24 @@ future<semaphore_units<>> client::claim_memory(size_t size, abort_source* as) {
     return get_units(_memory, size);
 }
 
-client::group_client::group_client(std::unique_ptr<http::connection_factory> f, unsigned max_conn) : http(std::move(f), max_conn) {
+client::group_client::group_client(std::unique_ptr<http::connection_factory> f, unsigned max_conn)
+        : http(std::move(f), max_conn)
+        , write_slots(max_conn)
+        , max_connections(max_conn) {
+}
+
+future<> client::group_client::set_max_connections(unsigned nr) {
+    // Keep the write-slots semaphore in sync with the connection limit. Growing
+    // the pool releases the extra slots; shrinking consumes them. consume() may
+    // drive the count negative when slots are currently held -- new acquirers
+    // then simply wait until enough in-flight uploads complete.
+    if (nr > max_connections) {
+        write_slots.signal(nr - max_connections);
+    } else if (nr < max_connections) {
+        write_slots.consume(max_connections - nr);
+    }
+    max_connections = nr;
+    return http.set_maximum_connections(nr);
 }
 
 void client::group_client::register_metrics(std::string class_name, std::string host) {
@@ -337,14 +354,14 @@ future<> client::rebalance_connections() {
                   total_shares,
                   _cfg->connections_per_shard,
                   max_connections);
-        co_await gc.http.set_maximum_connections(max_connections);
+        co_await gc.set_max_connections(max_connections);
     }
 
     // Assign remainder to the group with the most shares
     unsigned remainder;
     if (!__builtin_sub_overflow(_cfg->connections_per_shard, total_assigned, &remainder) && remainder > 0) {
         s3l.debug("Assigning {} remainder connections to scheduling group '{}'", remainder, max_shares_sg.name());
-        co_await _https.at(max_shares_sg).http.set_maximum_connections(max_shares_connections + remainder);
+        co_await _https.at(max_shares_sg).set_max_connections(max_shares_connections + remainder);
     }
 }
 
@@ -675,6 +692,13 @@ future<temporary_buffer<char>> client::get_object_contiguous(sstring object_name
 
 future<> client::put_object(sstring object_name, temporary_buffer<char> buf, seastar::abort_source* as) {
     s3l.trace("PUT {}", object_name);
+    // Single-shot PUTs (e.g. small sstable components like TOC) occupy a
+    // connection too, so account them against the group's write budget. The
+    // slot is held for the whole request, throttling the caller when the group
+    // has no spare connections.
+    auto& gc = co_await find_or_create_client();
+    auto slot = as ? co_await get_units(gc.write_slots, 1, *as)
+                   : co_await get_units(gc.write_slots, 1);
     auto req = http::request::make("PUT", _host, object_name);
     auto len = buf.size();
     req.write_body("bin", len, [buf = std::move(buf)] (output_stream<char>&& out_) -> future<> {
@@ -699,6 +723,11 @@ future<> client::put_object(sstring object_name, temporary_buffer<char> buf, sea
 
 future<> client::put_object(sstring object_name, ::memory_data_sink_buffers bufs, seastar::abort_source* as) {
     s3l.trace("PUT {} (buffers)", object_name);
+    // See the temporary_buffer overload above: account single-shot PUTs against
+    // the group's write budget, holding the slot for the whole request.
+    auto& gc = co_await find_or_create_client();
+    auto slot = as ? co_await get_units(gc.write_slots, 1, *as)
+                   : co_await get_units(gc.write_slots, 1);
     auto req = http::request::make("PUT", _host, object_name);
     auto len = bufs.size();
     req.write_body("bin", len, [bufs = std::move(bufs)] (output_stream<char>&& out_) -> future<> {
@@ -1046,7 +1075,21 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
         co_await start_upload();
     }
 
-    auto claim = co_await _client->claim_memory(bufs.size(), _as);
+    // Reserve a slot in the group's write budget *before* launching the
+    // background request, held until the whole request completes (a connection
+    // is busy until the response arrives -- see the finally() at the end). The
+    // budget's count equals the number of HTTP connections configured for the
+    // scheduling group, so the total upload parts in flight across all sinks --
+    // and therefore the aggregate producer-owned buffers we hold -- is bounded
+    // by the connection budget. Because this coroutine is co_await-ed by the
+    // sink's put()/maybe_flush(), the producer (memtable flush or compaction)
+    // blocks here once all connections are busy, applying backpressure instead
+    // of accumulating buffers. Note this no longer draws from the shared client
+    // memory pool, so uploads can't deadlock against concurrent downloads that
+    // hold it.
+    auto& gc = co_await _client->find_or_create_client();
+    auto slot = _as ? co_await get_units(gc.write_slots, 1, *_as)
+                    : co_await get_units(gc.write_slots, 1);
 
     unsigned part_number = _part_etags.size();
     _part_etags.emplace_back();
@@ -1056,7 +1099,7 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
     req._headers["Content-Length"] = seastar::format("{}", size);
     req.set_query_param("partNumber", seastar::format("{}", part_number + 1));
     req.set_query_param("uploadId", _upload_id);
-    req.write_body("bin", size, [this, part_number, bufs = std::move(bufs), p = std::move(claim)] (output_stream<char>&& out_) mutable -> future<> {
+    req.write_body("bin", size, [this, part_number, bufs = std::move(bufs)] (output_stream<char>&& out_) mutable -> future<> {
         auto out = std::move(out_);
         std::exception_ptr ex;
         s3l.trace("upload {} part data (upload id {})", part_number, _upload_id);
@@ -1072,8 +1115,6 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
         if (ex) {
             co_await coroutine::return_exception_ptr(std::move(ex));
         }
-        // note: At this point the buffers are sent, but the response is not yet
-        // received. However, claim is released and next part may start uploading
     });
 
     // Do upload in the background so that several parts could go in parallel.
@@ -1081,9 +1122,10 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
     // before checking the progress.
     //
     // Upload parallelizm is managed per-sched-group -- client maintains a set
-    // of http clients each with its own max-connections. When upload happens it
-    // will naturally be limited with the relevant http client's connections
-    // limit not affecting other groups' requests concurrency
+    // of http clients each with its own max-connections, mirrored by the
+    // write_slots semaphore reserved above. When upload happens it will
+    // naturally be limited with the relevant http client's connections limit
+    // not affecting other groups' requests concurrency.
     //
     // In case part upload goes wrong and doesn't happen, the _part_etags[part]
     // is not set, so the finalize_upload() sees it and aborts the whole thing.
@@ -1097,7 +1139,7 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
     }, http::reply::status_type::ok, _as).handle_exception([this, part_number] (auto ex) {
         // ... the exact exception only remains in logs
         s3l.warn("couldn't upload part {}: {} (upload id {})", part_number, ex, _upload_id);
-    }).finally([gh = std::move(gh)] {});
+    }).finally([gh = std::move(gh), slot = std::move(slot)] {});
 }
 
 future<> client::multipart_upload::abort_upload() {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -839,6 +839,12 @@ protected:
     named_gate _bg_flushes;
     std::optional<tag> _tag;
     seastar::abort_source* _as;
+    // Per-sink cap on the number of parts uploaded concurrently. Layered on top
+    // of the group's shared write_slots so that a single sink can't grab the
+    // whole per-scheduling-group connection budget and starve other sinks
+    // (flushes / compactions) in the same group. Also bounds this sink's
+    // in-flight producer buffers to _max_multipart_concurrency * part_size.
+    seastar::semaphore _inflight_parts{_max_multipart_concurrency};
 
     future<> start_upload();
     future<> finalize_upload();
@@ -1075,18 +1081,25 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
         co_await start_upload();
     }
 
-    // Reserve a slot in the group's write budget *before* launching the
-    // background request, held until the whole request completes (a connection
-    // is busy until the response arrives -- see the finally() at the end). The
-    // budget's count equals the number of HTTP connections configured for the
-    // scheduling group, so the total upload parts in flight across all sinks --
-    // and therefore the aggregate producer-owned buffers we hold -- is bounded
-    // by the connection budget. Because this coroutine is co_await-ed by the
-    // sink's put()/maybe_flush(), the producer (memtable flush or compaction)
-    // blocks here once all connections are busy, applying backpressure instead
-    // of accumulating buffers. Note this no longer draws from the shared client
-    // memory pool, so uploads can't deadlock against concurrent downloads that
-    // hold it.
+    // Reserve two slots *before* launching the background request, both held
+    // until the whole request completes (a connection is busy until the
+    // response arrives -- see the finally() at the end):
+    //
+    //  - _inflight_parts: a per-sink cap, so this single sink can never hold
+    //    more than _max_multipart_concurrency parts in flight and thus can't
+    //    monopolize the group's connection budget and starve other sinks
+    //    (flushes / compactions) sharing the same scheduling group.
+    //  - gc.write_slots: the shared per-scheduling-group budget (see the group
+    //    write-budget commit) whose count equals the configured connection
+    //    count, bounding the aggregate in-flight parts across all sinks.
+    //
+    // The per-sink slot is taken first (cheap, low-contention) so we don't hold
+    // a scarce group slot while waiting on it. Because this coroutine is
+    // co_await-ed by the sink's put()/maybe_flush(), the producer blocks here
+    // once either limit is hit, applying backpressure instead of accumulating
+    // buffers.
+    auto sink_slot = _as ? co_await get_units(_inflight_parts, 1, *_as)
+                         : co_await get_units(_inflight_parts, 1);
     auto& gc = co_await _client->find_or_create_client();
     auto slot = _as ? co_await get_units(gc.write_slots, 1, *_as)
                     : co_await get_units(gc.write_slots, 1);
@@ -1139,7 +1152,7 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
     }, http::reply::status_type::ok, _as).handle_exception([this, part_number] (auto ex) {
         // ... the exact exception only remains in logs
         s3l.warn("couldn't upload part {}: {} (upload id {})", part_number, ex, _upload_id);
-    }).finally([gh = std::move(gh), slot = std::move(slot)] {});
+    }).finally([gh = std::move(gh), slot = std::move(slot), sink_slot = std::move(sink_slot)] {});
 }
 
 future<> client::multipart_upload::abort_upload() {

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -132,6 +132,17 @@ class client : public enable_shared_from_this<client> {
     };
     struct group_client {
         seastar::http::client http;
+        // Bounds the number of background upload requests in flight for this
+        // scheduling group to the number of HTTP connections configured for it.
+        // Buffer-bearing uploads (memtable flush / compaction via upload_sink)
+        // acquire a slot before launching the background PUT, so the producer is
+        // throttled -- and the buffers it owns are kept bounded -- instead of
+        // piling up requests once all connections are busy. The connection pool
+        // is the shared arbiter across all sinks in the group, analogous to the
+        // per-class IO scheduler used for local (NVMe) flushes. Kept in sync with
+        // the http client's connection limit via set_max_connections().
+        seastar::semaphore write_slots;
+        unsigned max_connections;
         io_stats read_stats;
         io_stats write_stats;
         uint64_t prefetch_bytes = 0;
@@ -139,6 +150,8 @@ class client : public enable_shared_from_this<client> {
         seastar::metrics::metric_groups metrics;
         group_client(std::unique_ptr<http::connection_factory> f, unsigned max_conn);
         void register_metrics(std::string class_name, std::string host);
+        // Set the connection limit, keeping write_slots in sync with it.
+        seastar::future<> set_max_connections(unsigned nr);
     };
     std::unordered_map<seastar::scheduling_group, group_client> _https;
     semaphore _rebalance_sem{1};


### PR DESCRIPTION
S3 memtable flush and compaction stream sstable data through upload_sink, whose multipart upload_part() launches each PUT in the background and reserved buffer space from the shared per-shard client memory pool (object_storage_clients_memory). That same pool also feeds chunked_download_source. When concurrent downloads held the pool (as part of compaction), an upload's claim_memory() blocked, so memtables could no longer be flushed and the shard  end it up in deadlock. 

Move upload backpressure out of the shared memory pool and onto the per-scheduling-group HTTP connection budget instead, managed entirely in the application layer:

- Per-group shared budget: group_client gains a write_slots semaphore sized to the group's configured connection count, kept in sync with the http client's limit via set_max_connections() (wired through rebalance_connections()). A buffer-bearing upload reserves a slot before launching its background PUT, so the producer (flush / compaction) blocks once all connections are busy rather than accumulating buffers, and total in-flight uploads stay bounded by the connection budget.

- Per-sink fairness cap: multipart_upload gains an _inflight_parts semaphore (_max_multipart_concurrency = 16) so a single sink cannot grab the whole group budget and starve other sinks (other flushes / compactions) sharing the same scheduling group. It is taken before the group slot and also bounds a single sink's in-flight buffers.

- Decoupled from the memory pool: the streaming upload_sink path no longer calls claim_memory(), so uploads can no longer deadlock against downloads holding the pool. Downloads and the backup path (do_upload_file, still capped by max_concurrent_for_each(16)) keep using the memory pool unchanged.

No backport required, S3 is experimental feature

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1917