### PR TITLE
db: bound schema boot fanout and startup backlog

### DIFF
--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -661,6 +661,10 @@ void audit::on_role_dropped(const sstring& role) {
     logger.debug("Audit: known role removed: {}", role);
 }
 
+bool audit::wants_eager_known_tables(size_t table_count) const noexcept {
+    return _preprocessed_rules.wants_eager_known_tables(table_count);
+}
+
 future<> audit::set_known_entities(std::unordered_set<sstring> roles,
                                     preprocessed_audit_rules::known_table_set tables) {
     logger.info("Audit: loading {} known roles and {} known tables into preprocessed rules cache",

--- a/audit/audit.hh
+++ b/audit/audit.hh
@@ -223,6 +223,7 @@ public:
     void on_role_created(const sstring& role);
     void on_role_dropped(const sstring& role);
 
+    bool wants_eager_known_tables(size_t table_count) const noexcept;
     future<> set_known_entities(std::unordered_set<sstring> roles,
                                 preprocessed_audit_rules::known_table_set tables);
 };

--- a/audit/preprocessed_audit_rules.cc
+++ b/audit/preprocessed_audit_rules.cc
@@ -19,6 +19,12 @@ preprocessed_audit_rules::preprocessed_audit_rules(std::vector<audit_rule> rules
 
 future<> preprocessed_audit_rules::refresh_rules(std::vector<audit_rule> rules) {
     _rules = std::move(rules);
+    if (!wants_eager_known_tables(_known_tables.size())) {
+        _known_tables.clear();
+        _known_table_cache_enabled = false;
+    } else {
+        _known_table_cache_enabled = true;
+    }
     _role_to_matching_rules.clear();
     _table_to_matching_rules.clear();
     ++_cache_generation;
@@ -41,6 +47,16 @@ void preprocessed_audit_rules::remove_known_role(const sstring& role) {
 }
 
 void preprocessed_audit_rules::add_known_table(const sstring& keyspace, const sstring& table) {
+    if (!_known_table_cache_enabled || _rules.empty()) {
+        return;
+    }
+    if (_known_tables.size() >= max_preprocessed_known_tables) {
+        _known_tables.clear();
+        _table_to_matching_rules.clear();
+        _known_table_cache_enabled = false;
+        ++_cache_generation;
+        return;
+    }
     auto [it, inserted] = _known_tables.emplace(keyspace, table);
     if (inserted) {
         ++_cache_generation;
@@ -49,6 +65,9 @@ void preprocessed_audit_rules::add_known_table(const sstring& keyspace, const ss
 }
 
 void preprocessed_audit_rules::remove_known_table(const sstring& keyspace, const sstring& table) {
+    if (!_known_table_cache_enabled) {
+        return;
+    }
     if (_known_tables.erase(known_table{keyspace, table})) {
         ++_cache_generation;
         _table_to_matching_rules.erase(known_table{keyspace, table});
@@ -100,7 +119,8 @@ future<> preprocessed_audit_rules::rebuild_cache() {
         // by the number of audit rules, roles, and tables — expected to be modest.
         auto rules = _rules;
         auto known_roles = _known_roles;
-        auto known_tables = _known_tables;
+        auto known_table_cache_enabled = _known_table_cache_enabled;
+        auto known_tables = known_table_cache_enabled ? _known_tables : known_table_set{};
         auto generation = _cache_generation;
 
         std::unordered_map<sstring, rule_bitset, sstring_hash, sstring_eq>
@@ -115,9 +135,11 @@ future<> preprocessed_audit_rules::rebuild_cache() {
                 role_to_matching_rules[role] = compute_role_bits(rules, role);
                 co_await coroutine::maybe_yield();
             }
-            for (const auto& [ks, tbl] : known_tables) {
-                table_to_matching_rules[known_table{ks, tbl}] = compute_table_bits(rules, ks, tbl);
-                co_await coroutine::maybe_yield();
+            if (known_table_cache_enabled) {
+                for (const auto& [ks, tbl] : known_tables) {
+                    table_to_matching_rules[known_table{ks, tbl}] = compute_table_bits(rules, ks, tbl);
+                    co_await coroutine::maybe_yield();
+                }
             }
         }
 
@@ -131,11 +153,20 @@ future<> preprocessed_audit_rules::rebuild_cache() {
 
 future<> preprocessed_audit_rules::replace_known_entities(std::unordered_set<sstring> roles, known_table_set tables) {
     _known_roles = std::move(roles);
-    _known_tables = std::move(tables);
+    _known_table_cache_enabled = wants_eager_known_tables(tables.size());
+    if (_known_table_cache_enabled) {
+        _known_tables = std::move(tables);
+    } else {
+        _known_tables.clear();
+    }
     _role_to_matching_rules.clear();
     _table_to_matching_rules.clear();
     ++_cache_generation;
     co_await rebuild_cache();
+}
+
+bool preprocessed_audit_rules::wants_eager_known_tables(size_t table_count) const noexcept {
+    return !_rules.empty() && table_count <= max_preprocessed_known_tables;
 }
 
 audit_sink_set preprocessed_audit_rules::matching_sinks(statement_category category,

--- a/audit/preprocessed_audit_rules.hh
+++ b/audit/preprocessed_audit_rules.hh
@@ -28,6 +28,8 @@ public:
     using known_table_set = std::unordered_set<known_table, utils::tuple_hash>;
     using rule_bitset = boost::dynamic_bitset<uint64_t>;
 
+    static constexpr size_t max_preprocessed_known_tables = 4096;
+
     preprocessed_audit_rules() noexcept = default;
     explicit preprocessed_audit_rules(std::vector<audit_rule> rules) noexcept;
 
@@ -46,8 +48,14 @@ public:
     audit_sink_set matching_sinks(statement_category category, std::string_view keyspace,
                                   std::string_view table, std::string_view role) const;
 
+    bool wants_eager_known_tables(size_t table_count) const noexcept;
+
     const std::vector<audit_rule>& rules() const noexcept { return _rules; }
     const std::unordered_set<sstring>& known_roles() const noexcept { return _known_roles; }
+    static constexpr size_t max_preprocessed_known_tables_for_tests() noexcept { return max_preprocessed_known_tables; }
+    bool table_cache_enabled_for_tests() const noexcept { return _known_table_cache_enabled; }
+    size_t known_tables_size_for_tests() const noexcept { return _known_tables.size(); }
+    size_t cached_tables_size_for_tests() const noexcept { return _table_to_matching_rules.size(); }
 
 private:
     rule_bitset compute_role_bits(const std::vector<audit_rule>& rules, const sstring& role) const;
@@ -62,6 +70,7 @@ private:
     std::vector<audit_rule> _rules;
     std::unordered_set<sstring> _known_roles;
     known_table_set _known_tables;
+    bool _known_table_cache_enabled = true;
     size_t _cache_generation = 0;
 
     /// For each known role, a bitset indicating which rules match that role.

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1086,6 +1086,10 @@ void compaction_manager::register_metrics() {
                        sm::description("Holds the number of failed compaction tasks.")),
         sm::make_gauge("postponed_compactions", [this] { return _postponed.size(); },
                        sm::description("Holds the number of tables with postponed compaction.")),
+        sm::make_gauge("regular_compaction_task_backlog", [this] { return _tasks.size(); },
+                       sm::description("Holds the number of regular compaction task objects currently retained by the compaction manager.")),
+        sm::make_gauge("regular_compaction_task_backlog_limit", [this] { return _startup_regular_compaction_backlog_limit_enabled ? regular_compaction_task_backlog_limit() : 0; },
+                       sm::description("Startup-only maximum number of regular compaction task objects retained before additional submissions are postponed. Reports 0 after the startup limiter is disabled.")),
         sm::make_gauge("backlog", [this] { return _last_backlog; },
                        sm::description("Holds the sum of compaction backlog for all tables in the system.")),
         sm::make_gauge("normalized_backlog", [this] { return _last_backlog / available_memory(); },
@@ -1133,29 +1137,40 @@ future<> compaction_manager::postponed_compactions_reevaluation() {
             _postponed.clear();
             co_return;
         }
-        // A task_state being reevaluated can re-insert itself into postponed list, which is the reason
-        // for moving the list to be processed into a local.
-        auto postponed = std::exchange(_postponed, {});
         try {
-            for (auto it = postponed.begin(); it != postponed.end();) {
+            while (!_postponed.empty() && !regular_compaction_task_backlog_full()) {
+                auto it = _postponed.begin();
                 compaction_group_view* t = *it;
-                it = postponed.erase(it);
+                _postponed.erase(it);
                 // skip reevaluation of a compaction_group_view that became invalid post its removal
                 if (!_compaction_state.contains(t)) {
                     continue;
                 }
                 cmlog.debug("resubmitting postponed compaction for table {} [{}]", *t, fmt::ptr(t));
-                submit(*t);
+                try {
+                    submit(*t);
+                } catch (...) {
+                    _postponed.insert(t);
+                    throw;
+                }
                 co_await coroutine::maybe_yield();
             }
         } catch (...) {
-            _postponed.insert(postponed.begin(), postponed.end());
+            cmlog.warn("Failed to reevaluate postponed compactions: {}", std::current_exception());
         }
     }
 }
 
 void compaction_manager::reevaluate_postponed_compactions() noexcept {
     _postponed_reevaluation.signal();
+}
+
+void compaction_manager::disable_startup_regular_compaction_backlog_limit() noexcept {
+    if (!_startup_regular_compaction_backlog_limit_enabled) {
+        return;
+    }
+    _startup_regular_compaction_backlog_limit_enabled = false;
+    reevaluate_postponed_compactions();
 }
 
 future<> compaction_manager::stop_postponed_compactions() noexcept {
@@ -1496,6 +1511,13 @@ void compaction_manager::submit(compaction_group_view& t) {
         return;
     }
 
+    if (regular_compaction_task_backlog_full()) {
+        if (!is_disabled() && _compaction_state.contains(&t)) {
+            postpone_compaction_for_table(&t);
+        }
+        return;
+    }
+
     auto gh = start_compaction(t);
     if (!gh) {
         return;
@@ -1503,7 +1525,10 @@ void compaction_manager::submit(compaction_group_view& t) {
 
     // OK to drop future.
     // waited via compaction_task_executor::compaction_done()
-    (void)perform_compaction<regular_compaction_task_executor>(throw_if_stopping::no, tasks::task_info{}, t).then_wrapped([gh = std::move(gh)] (auto f) { f.ignore_ready_future(); });
+    (void)perform_compaction<regular_compaction_task_executor>(throw_if_stopping::no, tasks::task_info{}, t).then_wrapped([this, gh = std::move(gh)] (auto f) {
+        f.ignore_ready_future();
+        reevaluate_postponed_compactions();
+    });
 }
 
 bool compaction_manager::can_perform_regular_compaction(compaction_group_view& t) {

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -153,6 +153,11 @@ private:
     // all registered tables are reevaluated at a constant interval.
     // Submission is a NO-OP when there's nothing to do, so it's fine to call it regularly.
     static constexpr std::chrono::seconds periodic_compaction_submission_interval() { return std::chrono::seconds(3600); }
+    static constexpr size_t regular_compaction_task_backlog_limit() { return 256; }
+    bool _startup_regular_compaction_backlog_limit_enabled = true;
+    bool regular_compaction_task_backlog_full() const {
+        return _startup_regular_compaction_backlog_limit_enabled && _tasks.size() >= regular_compaction_task_backlog_limit();
+    }
 
     config _cfg;
     timer<lowres_clock> _compaction_submission_timer;
@@ -428,6 +433,20 @@ public:
 
     const stats& get_stats() const {
         return _stats;
+    }
+
+    void disable_startup_regular_compaction_backlog_limit() noexcept;
+    static constexpr size_t max_regular_compaction_task_backlog_for_tests() {
+        return regular_compaction_task_backlog_limit();
+    }
+    bool startup_regular_compaction_backlog_limit_enabled_for_tests() const {
+        return _startup_regular_compaction_backlog_limit_enabled;
+    }
+    size_t live_compaction_tasks_for_tests() const {
+        return _tasks.size();
+    }
+    size_t postponed_compactions_for_tests() const {
+        return _postponed.size();
     }
 
     const std::vector<compaction_info> get_compactions(std::function<bool(const compaction_group_view*)> filter = [] (auto) { return true; }) const;

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2785,13 +2785,15 @@ void check_no_legacy_secondary_index_mv_schema(replica::database& db, const view
 
 static auto GET_COLUMN_MAPPING_QUERY = format("SELECT column_name, clustering_order, column_name_bytes, kind, position, type FROM system.{} WHERE cf_id = ? AND schema_version = ?",
     db::schema_tables::SCYLLA_TABLE_SCHEMA_HISTORY);
+static auto COLUMN_MAPPING_EXISTS_QUERY = format("SELECT column_name FROM system.{} WHERE cf_id = ? AND schema_version = ? LIMIT 1",
+    db::schema_tables::SCYLLA_TABLE_SCHEMA_HISTORY);
 
 future<std::optional<column_mapping>> get_column_mapping_if_exists(db::system_keyspace& sys_ks, table_id table_id, table_schema_version version) {
     shared_ptr<cql3::untyped_result_set> results = co_await sys_ks.query_processor().execute_internal(
         GET_COLUMN_MAPPING_QUERY,
         db::consistency_level::LOCAL_ONE,
         {table_id.uuid(), version.uuid()},
-        cql3::query_processor::cache_internal::no
+        cql3::query_processor::cache_internal::yes
     );
     if (results->empty()) {
         co_return std::nullopt;
@@ -2836,7 +2838,7 @@ future<column_mapping> get_column_mapping(db::system_keyspace& sys_ks, ::table_i
 
 future<bool> column_mapping_exists(db::system_keyspace& sys_ks, table_id table_id, table_schema_version version) {
     shared_ptr<cql3::untyped_result_set> results = co_await sys_ks._qp.execute_internal(
-        GET_COLUMN_MAPPING_QUERY,
+        COLUMN_MAPPING_EXISTS_QUERY,
         db::consistency_level::LOCAL_ONE,
         {table_id.uuid(), version.uuid()},
         cql3::query_processor::cache_internal::yes

--- a/main.cc
+++ b/main.cc
@@ -2721,6 +2721,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             db.invoke_on_all(&replica::database::revert_initial_system_read_concurrency_boost).get();
+            cm.invoke_on_all(&compaction::compaction_manager::disable_startup_regular_compaction_backlog_limit).get();
             notify_set.notify_all(configurable::system_state::started).get();
             seastar::set_abort_on_ebadf(cfg->abort_on_ebadf());
             api::set_server_done(ctx).get();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -9,6 +9,7 @@
 #include <algorithm>
 
 #include <exception>
+#include <vector>
 #include <fmt/ranges.h>
 #include <fmt/std.h>
 #include <seastar/core/rwlock.hh>
@@ -24,6 +25,7 @@
 #include "utils/assert.hh"
 #include "utils/lister.hh"
 #include "replica/database.hh"
+#include "replica/schema_boot.hh"
 #include <memory>
 #include <seastar/core/future-util.hh>
 #include <seastar/coroutine/try_future.hh>
@@ -798,16 +800,18 @@ do_parse_schema_tables(sharded<service::storage_proxy>& proxy, const sstring cf_
     using namespace db::schema_tables;
 
     auto rs = co_await db::system_keyspace::query(proxy.local().get_db(), db::schema_tables::NAME, cf_name);
-    auto names = std::set<sstring>();
+    std::vector<sstring> names;
     for (auto& r : rs->rows()) {
         auto keyspace_name = r.template get_nonnull<sstring>("keyspace_name");
-        names.emplace(keyspace_name);
-    }
-    co_await coroutine::parallel_for_each(names, [&] (sstring name) mutable -> future<> {
-        if (is_system_keyspace(name)) {
-            co_return;
+        if (!is_system_keyspace(keyspace_name)) {
+            names.emplace_back(std::move(keyspace_name));
         }
+    }
+    std::sort(names.begin(), names.end());
+    names.erase(std::unique(names.begin(), names.end()), names.end());
 
+    dblog.info("Loading schema table {} for {} keyspaces with concurrency {}", cf_name, names.size(), schema_boot::max_concurrent_keyspace_schema_partitions);
+    co_await schema_boot::for_each_keyspace_schema_partition(names, [&] (const sstring& name) mutable -> future<> {
         auto v = co_await read_schema_partition_for_keyspace(proxy, cf_name, name);
         try {
             co_await func(v);
@@ -874,7 +878,8 @@ future<> database::parse_system_tables(sharded<service::storage_proxy>& proxy, s
     batch.commit();
     co_await do_parse_schema_tables(proxy, db::schema_tables::TABLES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         std::map<sstring, schema_ptr> tables = co_await create_tables_from_tables_partition(proxy, v.second);
-        co_await coroutine::parallel_for_each(tables, [&] (auto& t) -> future<> {
+        dblog.debug("Loading {} tables for keyspace {} with concurrency {}", tables.size(), v.first, schema_boot::max_concurrent_tables_per_keyspace);
+        co_await schema_boot::for_each_table_in_keyspace(tables, [&] (auto& t) -> future<> {
             co_await this->add_column_family_and_make_directory(t.second, replica::database::is_new_cf::no, storage_mode);
             auto s = t.second;
             // Recreate missing column mapping entries in case
@@ -888,7 +893,8 @@ future<> database::parse_system_tables(sharded<service::storage_proxy>& proxy, s
     }));
     co_await do_parse_schema_tables(proxy, db::schema_tables::VIEWS, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         std::vector<view_ptr> views = co_await create_views_from_schema_partition(proxy, v.second);
-        co_await coroutine::parallel_for_each(views, [&] (auto&& v) -> future<> {
+        dblog.debug("Loading {} views for keyspace {} with concurrency {}", views.size(), v.first, schema_boot::max_concurrent_views_per_keyspace);
+        co_await schema_boot::for_each_view_in_keyspace(views, [&] (auto&& v) -> future<> {
             check_no_legacy_secondary_index_mv_schema(*this, v, nullptr);
             co_await this->add_column_family_and_make_directory(v, replica::database::is_new_cf::no, storage_mode);
         });

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -18,6 +18,7 @@
 #include "distributed_loader.hh"
 #include "replica/database.hh"
 #include "replica/global_table_ptr.hh"
+#include "replica/schema_boot.hh"
 #include "db/config.hh"
 #include "db/extensions.hh"
 #include "db/system_keyspace.hh"
@@ -588,7 +589,7 @@ future<> distributed_loader::init_non_system_keyspaces(sharded<replica::database
         const auto& cfg = db.local().get_config();
 
         for (bool prio_only : { true, false}) {
-            std::vector<future<>> futures;
+            std::vector<sstring> keyspaces;
 
             for (auto& ks : db.local().get_keyspaces()) {
                 auto& ks_name = ks.first;
@@ -607,10 +608,17 @@ future<> distributed_loader::init_non_system_keyspaces(sharded<replica::database
                     continue;
                 }
 
-                futures.emplace_back(distributed_loader::populate_keyspace(db, sys_ks, ks.second, ks_name, storage_mode));
+                keyspaces.push_back(ks_name);
             }
 
-            when_all_succeed(futures.begin(), futures.end()).discard_result().get();
+            dblog.info("Populating {} {}non-system keyspaces with concurrency {}",
+                    keyspaces.size(),
+                    prio_only ? "priority " : "",
+                    schema_boot::max_concurrent_keyspace_population);
+            schema_boot::for_each_keyspace_population(keyspaces, [&] (const sstring& ks_name) -> future<> {
+                auto& ks = db.local().get_keyspaces().at(ks_name);
+                co_await distributed_loader::populate_keyspace(db, sys_ks, ks, ks_name, storage_mode);
+            }).get();
         }
     });
 }

--- a/replica/schema_boot.hh
+++ b/replica/schema_boot.hh
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include <seastar/core/future-util.hh>
+
+namespace replica::schema_boot {
+
+inline constexpr size_t max_concurrent_keyspace_schema_partitions = 1;
+inline constexpr size_t max_concurrent_keyspace_population = 2;
+inline constexpr size_t max_concurrent_tables_per_keyspace = 8;
+inline constexpr size_t max_concurrent_views_per_keyspace = 8;
+
+template <typename Range, typename Func>
+seastar::future<> for_each_keyspace_schema_partition(Range&& range, Func&& func) {
+    return seastar::max_concurrent_for_each(
+            std::forward<Range>(range),
+            max_concurrent_keyspace_schema_partitions,
+            std::forward<Func>(func));
+}
+
+template <typename Range, typename Func>
+seastar::future<> for_each_keyspace_population(Range&& range, Func&& func) {
+    return seastar::max_concurrent_for_each(
+            std::forward<Range>(range),
+            max_concurrent_keyspace_population,
+            std::forward<Func>(func));
+}
+
+template <typename Range, typename Func>
+seastar::future<> for_each_table_in_keyspace(Range&& range, Func&& func) {
+    return seastar::max_concurrent_for_each(
+            std::forward<Range>(range),
+            max_concurrent_tables_per_keyspace,
+            std::forward<Func>(func));
+}
+
+template <typename Range, typename Func>
+seastar::future<> for_each_view_in_keyspace(Range&& range, Func&& func) {
+    return seastar::max_concurrent_for_each(
+            std::forward<Range>(range),
+            max_concurrent_views_per_keyspace,
+            std::forward<Func>(func));
+}
+
+} // namespace replica::schema_boot

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -492,9 +492,17 @@ future<> group0_state_machine::sync_audit_known_entities() {
         });
 
         audit::preprocessed_audit_rules::known_table_set known_tables;
-        _ss.get_database().get_tables_metadata().for_each_table_id([&known_tables](const std::pair<sstring, sstring>& ks_cf, table_id) {
-            known_tables.emplace(ks_cf.first, ks_cf.second);
-        });
+        const auto table_count = _ss.get_database().get_tables_metadata().size();
+        if (audit::audit::local_audit_instance().wants_eager_known_tables(table_count)) {
+            known_tables.reserve(table_count);
+            _ss.get_database().get_tables_metadata().for_each_table_id([&known_tables](const std::pair<sstring, sstring>& ks_cf, table_id) {
+                known_tables.emplace(ks_cf.first, ks_cf.second);
+            });
+        } else {
+            slogger.info("Skipping eager audit known-table cache for {} tables; cap is {}; matching remains exact via per-request rule evaluation",
+                    table_count,
+                    audit::preprocessed_audit_rules::max_preprocessed_known_tables);
+        }
 
         co_await audit::audit::audit_instance().invoke_on_all(
             [&known_roles, &known_tables] (auto& a) -> future<> {

--- a/test/boost/audit_rule_test.cc
+++ b/test/boost/audit_rule_test.cc
@@ -306,6 +306,10 @@ SEASTAR_THREAD_TEST_CASE(test_preprocessed_rules_match_fast_and_slow_paths) {
     });
     rules.replace_known_entities({"admin_read", "viewer"}, {{"ks", "t1"}, {"ks", "t2"}}).get();
 
+    BOOST_CHECK(rules.table_cache_enabled_for_tests());
+    BOOST_CHECK_EQUAL(rules.known_tables_size_for_tests(), 2u);
+    BOOST_CHECK_EQUAL(rules.cached_tables_size_for_tests(), 2u);
+
     BOOST_CHECK(rules.matching_sinks(audit::statement_category::DML, "ks", "t1", "admin_read").contains(audit::audit_sink::table));
     BOOST_CHECK(!rules.matching_sinks(audit::statement_category::DML, "ks", "t1", "viewer"));
     BOOST_CHECK(rules.matching_sinks(audit::statement_category::DML, "ks", "unknown", "admin_new").contains(audit::audit_sink::table));
@@ -351,15 +355,44 @@ SEASTAR_THREAD_TEST_CASE(test_preprocessed_rules_update_known_entities) {
 SEASTAR_THREAD_TEST_CASE(test_preprocessed_empty_rules_skip_cache) {
     audit::preprocessed_audit_rules rules;
     rules.replace_known_entities({"alice", "bob"}, {{"ks", "t1"}, {"ks", "t2"}}).get();
+    BOOST_CHECK(!rules.table_cache_enabled_for_tests());
+    BOOST_CHECK_EQUAL(rules.known_tables_size_for_tests(), 0u);
+    BOOST_CHECK_EQUAL(rules.cached_tables_size_for_tests(), 0u);
     BOOST_CHECK(!rules.matching_sinks(audit::statement_category::DML, "ks", "t1", "alice"));
 
     rules.add_known_role("charlie");
     rules.add_known_table("ks", "t3");
+    BOOST_CHECK_EQUAL(rules.known_tables_size_for_tests(), 0u);
+    BOOST_CHECK_EQUAL(rules.cached_tables_size_for_tests(), 0u);
     BOOST_CHECK(!rules.matching_sinks(audit::statement_category::DML, "ks", "t3", "charlie"));
 
     rules.refresh_rules({make_rule({"table"}, {"DML"}, {"ks.*"}, {"*"})}).get();
     BOOST_CHECK(rules.matching_sinks(audit::statement_category::DML, "ks", "t1", "alice"));
     BOOST_CHECK(rules.matching_sinks(audit::statement_category::DML, "ks", "t3", "charlie"));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_preprocessed_large_known_table_set_uses_bounded_lazy_path) {
+    audit::preprocessed_audit_rules rules({make_rule({"table"}, {"DML"}, {"ks.*"}, {"*"})});
+
+    audit::preprocessed_audit_rules::known_table_set known_tables;
+    const auto table_count = audit::preprocessed_audit_rules::max_preprocessed_known_tables_for_tests() + 1;
+    known_tables.reserve(table_count);
+    for (size_t i = 0; i < table_count; ++i) {
+        known_tables.emplace("ks", sstring("t") + to_sstring(i));
+    }
+
+    BOOST_CHECK(!rules.wants_eager_known_tables(table_count));
+    rules.replace_known_entities({"alice"}, std::move(known_tables)).get();
+
+    BOOST_CHECK(!rules.table_cache_enabled_for_tests());
+    BOOST_CHECK_EQUAL(rules.known_tables_size_for_tests(), 0u);
+    BOOST_CHECK_EQUAL(rules.cached_tables_size_for_tests(), 0u);
+    BOOST_CHECK(rules.matching_sinks(audit::statement_category::DML, "ks", "t42", "alice").contains(audit::audit_sink::table));
+
+    rules.add_known_table("ks", "new_table");
+    BOOST_CHECK_EQUAL(rules.known_tables_size_for_tests(), 0u);
+    BOOST_CHECK_EQUAL(rules.cached_tables_size_for_tests(), 0u);
+    BOOST_CHECK(rules.matching_sinks(audit::statement_category::DML, "ks", "new_table", "alice").contains(audit::audit_sink::table));
 }
 
 BOOST_AUTO_TEST_CASE(test_alternator_batch_sink_tables_aggregate_per_sink) {

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -9,6 +9,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/aligned_buffer.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/util/closeable.hh>
 
 #include "test/lib/scylla_test_case.hh"
@@ -26,8 +27,10 @@
 #include "compaction/compaction.hh"
 #include "compaction/compaction_manager.hh"
 #include "replica/compaction_group.hh"
+#include "utils/error_injection.hh"
 
 using namespace sstables;
+using namespace std::chrono_literals;
 
 static sstables::shared_sstable generate_sstable(schema_ptr s, std::function<shared_sstable()> sst_gen, noncopyable_function<bool(dht::token)> token_filter) {
     auto make_insert = [&] (const dht::decorated_key& key) {
@@ -202,6 +205,63 @@ SEASTAR_TEST_CASE(basic_compaction_group_splitting_test) {
                 found_input2 |= sst->generation() == input2->generation();
             });
             BOOST_REQUIRE(found_input2);
+        }
+    });
+}
+
+SEASTAR_TEST_CASE(regular_compaction_submission_backlog_is_bounded_test) {
+    return test_env::do_with_async([] (test_env& env) {
+        static constexpr std::string_view pause_injection = "compaction_regular_compaction_task_executor_do_run";
+
+        auto builder = schema_builder(this_smp_shard_count(), "tests", "regular_compaction_submission_backlog")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("cl", int32_type, column_kind::clustering_key)
+                .with_column("value", int32_type);
+        auto s = builder.build();
+
+        auto t = env.make_table_for_tests(s);
+        auto close_table = deferred_stop(t);
+        t->start();
+
+        auto& cm = t->get_compaction_manager();
+        auto sst_factory = env.make_sst_factory(s);
+        std::vector<std::unique_ptr<single_compaction_group>> groups;
+        const auto limit = compaction::compaction_manager::max_regular_compaction_task_backlog_for_tests();
+        groups.reserve(limit + 64);
+
+        utils::get_local_injector().enable(pause_injection);
+        auto disable_injection = defer([] {
+            utils::get_local_injector().disable(pause_injection);
+        });
+
+        for (size_t i = 0; i < limit + 64; ++i) {
+            groups.push_back(std::make_unique<single_compaction_group>(t, env.manager(), sst_factory));
+            cm.submit(*groups.back());
+        }
+
+        auto deadline = lowres_clock::now() + 5s;
+        while (cm.live_compaction_tasks_for_tests() < limit && lowres_clock::now() < deadline) {
+            sleep(10ms).get();
+        }
+
+        BOOST_REQUIRE_EQUAL(cm.live_compaction_tasks_for_tests(), limit);
+        BOOST_REQUIRE_GE(cm.postponed_compactions_for_tests(), 64);
+
+        BOOST_REQUIRE(cm.startup_regular_compaction_backlog_limit_enabled_for_tests());
+        cm.disable_startup_regular_compaction_backlog_limit();
+        deadline = lowres_clock::now() + 5s;
+        while (cm.live_compaction_tasks_for_tests() <= limit && lowres_clock::now() < deadline) {
+            sleep(10ms).get();
+        }
+
+        BOOST_REQUIRE(!cm.startup_regular_compaction_backlog_limit_enabled_for_tests());
+        BOOST_REQUIRE_GT(cm.live_compaction_tasks_for_tests(), limit);
+
+        disable_injection.cancel();
+        utils::get_local_injector().disable(pause_injection);
+
+        for (auto& group : groups) {
+            group->stop(t).get();
         }
     });
 }

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -7,8 +7,10 @@
  */
 
 #include "utils/assert.hh"
+#include "replica/schema_boot.hh"
 #include <seastar/util/closeable.hh>
 #include <seastar/core/file.hh>
+#include <seastar/core/semaphore.hh>
 #include "reader_concurrency_semaphore.hh"
 #include "sstables/sstables_manager.hh"
 #include "reader_concurrency_semaphore_group.hh"
@@ -35,6 +37,10 @@
 #include "readers/from_mutations.hh"
 #include "replica/database.hh" // new_reader_base_cost is there :(
 #include "db/config.hh"
+
+#include <algorithm>
+#include <numeric>
+#include <utility>
 
 // Provides access to private members of reader_concurrency_semaphore for testing.
 struct reader_concurrency_semaphore_tester {
@@ -587,6 +593,53 @@ SEASTAR_TEST_CASE(reader_concurrency_semaphore_max_queue_length) {
 
         REQUIRE_EVENTUALLY_EQUAL<ssize_t>([&] { return semaphore.available_resources().memory; }, replica::new_reader_base_cost);
     });
+}
+
+SEASTAR_THREAD_TEST_CASE(test_boot_schema_fanout_helpers_throttle_work_without_dropping_items) {
+    auto check_limit = [] (const char* name, auto&& run, size_t limit) {
+        BOOST_TEST_CONTEXT(name) {
+            std::vector<size_t> items(limit * 4);
+            std::iota(items.begin(), items.end(), 0);
+
+            seastar::semaphore release(0);
+            size_t in_flight = 0;
+            size_t max_in_flight = 0;
+            size_t completed = 0;
+
+            auto done = run(items, [&] (size_t) -> future<> {
+                ++in_flight;
+                max_in_flight = std::max(max_in_flight, in_flight);
+                co_await release.wait(1);
+                --in_flight;
+                ++completed;
+            });
+
+            BOOST_REQUIRE(eventually_true([&] { return in_flight == limit; }));
+            BOOST_REQUIRE_EQUAL(in_flight, limit);
+            BOOST_REQUIRE_EQUAL(completed, 0);
+            BOOST_REQUIRE_LE(max_in_flight, limit);
+
+            release.signal(items.size());
+            done.get();
+
+            BOOST_REQUIRE_EQUAL(completed, items.size());
+            BOOST_REQUIRE_EQUAL(in_flight, 0);
+            BOOST_REQUIRE_LE(max_in_flight, limit);
+        }
+    };
+
+    check_limit("keyspace schema partitions", [] (auto& items, auto&& func) {
+        return replica::schema_boot::for_each_keyspace_schema_partition(items, std::forward<decltype(func)>(func));
+    }, replica::schema_boot::max_concurrent_keyspace_schema_partitions);
+    check_limit("keyspace population", [] (auto& items, auto&& func) {
+        return replica::schema_boot::for_each_keyspace_population(items, std::forward<decltype(func)>(func));
+    }, replica::schema_boot::max_concurrent_keyspace_population);
+    check_limit("tables per keyspace", [] (auto& items, auto&& func) {
+        return replica::schema_boot::for_each_table_in_keyspace(items, std::forward<decltype(func)>(func));
+    }, replica::schema_boot::max_concurrent_tables_per_keyspace);
+    check_limit("views per keyspace", [] (auto& items, auto&& func) {
+        return replica::schema_boot::for_each_view_in_keyspace(items, std::forward<decltype(func)>(func));
+    }, replica::schema_boot::max_concurrent_views_per_keyspace);
 }
 
 SEASTAR_THREAD_TEST_CASE(reader_concurrency_semaphore_dump_reader_diganostics) {


### PR DESCRIPTION
## Summary

This PR fixes a startup scalability failure where a node with many keyspaces or tables can create unbounded boot work before CQL is available.

The fix keeps cache enabled. It does not skip schema, table, view, or compaction work. It bounds how much startup work is retained or in flight at once.

Main changes:

- Bound schema boot fanout with explicit helpers in `replica/schema_boot.hh`.
- Bound non-system keyspace population fanout in `replica/distributed_loader.cc`.
- Keep internal query caching enabled, but make the column-mapping existence check use `LIMIT 1`.
- Add a startup-only retained-task cap for regular compaction submissions.
- Disable that compaction startup cap before Scylla announces serving, so steady-state compaction scheduling is not globally throttled.
- Postpone regular compaction submissions only while the startup cap is active and full.
- Drain postponed compactions when retained tasks complete and when the startup cap is disabled.
- Add metrics for the regular compaction task backlog and startup cap state.
- Make audit known-table preprocessing bounded.
- Skip building the eager audit known-table hash set above the cap while keeping exact rule matching through the existing per-request rule evaluation path.
- Add regression tests for schema fanout, compaction startup backlog retention, post-startup compaction behavior, and bounded audit preprocessing.

## Problem

A Scylla node can have many stale or high-cardinality keyspaces and tables. During boot, several paths scaled directly with that table count before the node reached CQL serving state.

Observed symptoms on a single-shard developer node included:

- systemd stuck in startup
- status stuck around loading non-system sstables
- CQL not ready while metrics and API were already up
- system read admission showed tens of thousands of queued reads
- disk reads were idle
- SIGQUIT diagnostics showed schema reads waiting behind system read admission
- startup task queues grew into the tens of thousands

This was not caused by row cache. The live process showed row cache, memtables, bloom filters, index summaries, and active read buffers were small. The problem was startup work and metadata fanout.

## Failure evidence

Representative journal snippets from the failing node:

```text
Jun 21 02:04:33 node scylla[157948]: INFO  2026-06-21 02:04:33,062 [shard 0:main] init - loading non-system sstables
Jun 21 02:28:48 node scylla[157948]: 1        1        16K        system_schema.tables/data-query/active/need_cpu
Jun 21 02:28:48 node scylla[157948]: reads_queued_because_need_cpu_permits: 27267
Jun 21 04:58:04 node scylla[380858]: WARN  2026-06-21 04:58:04,700 [shard 0:main] seastar - Too long queue accumulated for main (8777 tasks)
Jun 21 04:58:20 node scylla[380858]: WARN  2026-06-21 04:58:20,734 [shard 0:main] seastar - (rate limiting dropped 21609 similar messages) Too long queue accumulated for main (26501 tasks)
Jun 21 04:58:30 node scylla[380858]: WARN  2026-06-21 04:58:30,735 [shard 0:comp] seastar - (rate limiting dropped 14523 similar messages) Too long queue accumulated for compaction (18728 tasks)
```

The important part is that one `system_schema.tables` read was active in `need_cpu` while tens of thousands of schema/system reads were queued behind the system read semaphore.

## Root causes

### 1. Schema boot fanout was unbounded across keyspaces

`parse_system_tables()` read keyspace names and launched schema work for all keyspaces with `coroutine::parallel_for_each()`.

That was then multiplied by later table-level work.

The result was too many schema reads and schema jobs retained at once.

### 2. Non-system keyspace population retained one future per keyspace

`init_non_system_keyspaces()` collected a vector of futures for all keyspaces and waited on all of them.

With many keyspaces, this retained startup work proportional to keyspace count.

### 3. Column-mapping existence checks read more than needed

The boot path only needs to know whether a mapping exists.

The old query used the full column mapping query for existence checks. That can read all mapping rows for a table version when one row is enough.

This PR keeps internal caching enabled and changes only the existence query to use `LIMIT 1`.

### 4. Regular compaction submission could retain too many task objects during boot

During table load, regular compaction submission could retain a large number of compaction task objects.

On a high-cardinality boot this can create very large task queues and memory pressure.

This is a startup problem. The fix is startup-only and is disabled before serving.

### 5. Audit rule preprocessing eagerly copied all known tables

Group0 audit synchronization built a full known-table hash set and passed it into the audit preprocessor.

The audit preprocessor then retained known table names and per-table rule bitsets.

This was only an optimization. The matcher already has an exact slow path for unknown tables.

With thousands of tables, this optimization becomes a startup memory and CPU cost.

## Fix details

### Schema boot helpers

Added `replica/schema_boot.hh` with named limits:

- `max_concurrent_keyspace_schema_partitions`
- `max_concurrent_keyspace_population`
- `max_concurrent_tables_per_keyspace`
- `max_concurrent_views_per_keyspace`

The helpers use `seastar::max_concurrent_for_each()`.

### Schema table parsing

`replica/database.cc` now uses the schema boot helpers for:

- keyspace schema partition reads
- table add and column-mapping checks
- view add operations

The loader still processes every keyspace, table, and view. It only bounds concurrency and retained work.

### Non-system keyspace population

`replica/distributed_loader.cc` now collects keyspace names, logs the count, and uses the bounded keyspace population helper.

This avoids retaining one future per keyspace for the whole phase.

### Column-mapping existence probe

`db/schema_tables.cc` now uses:

```sql
SELECT column_name
FROM system.scylla_table_schema_history
WHERE cf_id = ? AND schema_version = ?
LIMIT 1
```

This is used only by `column_mapping_exists()`.

The full mapping query is unchanged for callers that need the full mapping.

Internal query caching stays enabled.

### Startup-only regular compaction backlog cap

`compaction_manager` now has:

- `regular_compaction_task_backlog_limit()`
- `regular_compaction_task_backlog_full()`
- `disable_startup_regular_compaction_backlog_limit()`

When the startup cap is full, regular compaction submission is postponed instead of retaining another task object.

When a retained regular task completes, postponed compactions are reevaluated.

Before Scylla announces serving, `main.cc` calls `disable_startup_regular_compaction_backlog_limit()` on all shards. That disables the guard and wakes postponed compaction reevaluation.

This means normal runtime compaction scheduling is not capped by this startup guard.

New metrics:

- `scylla_compaction_manager_regular_compaction_task_backlog`
- `scylla_compaction_manager_regular_compaction_task_backlog_limit`
- existing `scylla_compaction_manager_postponed_compactions`

The backlog limit metric reports `0` after startup to show that the startup guard is inactive.

### Bounded audit known-table preprocessing

`preprocessed_audit_rules` now has `max_preprocessed_known_tables`.

It keeps the eager known-table cache only when:

- audit rules are non-empty
- known table count is at or below the cap

Above the cap:

- group0 skips building the known-table hash set
- the audit preprocessor keeps no eager known-table cache
- matching remains exact through the existing per-request rule evaluation path

This changes startup memory behavior only. It does not make audit rule matching approximate.

## Correctness notes

This PR does not disable cache.

This PR does not skip schema work.

This PR does not drop compaction work.

This PR does not weaken audit rule matching.

This PR does not globally throttle steady-state compaction.

When startup work is over the new bounds, work is parked or evaluated lazily instead of being allocated eagerly.

## Tests

Built:

```console
./tools/toolchain/dbuild ninja build/dev/scylla build/dev/test/boost/combined_tests build/dev/test/boost/compaction_group_test build/dev/test/boost/audit_rule_test
```

Ran:

```console
./tools/toolchain/dbuild ./build/dev/test/boost/combined_tests -t reader_concurrency_semaphore_test/test_boot_schema_fanout_helpers_throttle_work_without_dropping_items -- -c1 -m1G
./tools/toolchain/dbuild ./build/dev/test/boost/compaction_group_test -t regular_compaction_submission_backlog_is_bounded_test -- -c1 -m1G
./tools/toolchain/dbuild ./build/dev/test/boost/audit_rule_test --run_test=test_preprocessed_rules_match_fast_and_slow_paths,test_preprocessed_empty_rules_skip_cache,test_preprocessed_large_known_table_set_uses_bounded_lazy_path -- -c1 -m1G
```

All targeted tests passed with `No errors detected`.

After making the compaction cap startup-only, rebuilt and reran:

```console
./tools/toolchain/dbuild ninja build/dev/scylla build/dev/test/boost/compaction_group_test
./tools/toolchain/dbuild ./build/dev/test/boost/compaction_group_test -t regular_compaction_submission_backlog_is_bounded_test -- -c1 -m1G
```

The updated compaction test verifies both conditions:

- startup submissions are capped while the startup guard is enabled
- submissions can exceed the cap after the startup guard is disabled

## Runtime validation

### First filesystem-copy run

An isolated 2 GiB run against a filesystem copy of `/var/lib/scylla` reached `init - serving`, with no read queue and no malloc failures.

That copied workdir still had thousands of stale keyspace and table directories on disk, but its system schema loaded zero non-system keyspaces in the dev run. So that run validated the orphaned-directory case but not the full logical-schema case.

### Full logical-schema run

For the real proof, I used a repo-mounted workdir so the data persisted across `dbuild` container invocations:

```text
/tmp/dacely-scylladb/build/highcard-proof-20260621
```

I created 4,200 real keyspaces with one table each:

```console
time cqlsh 127.0.0.1 19142 --connect-timeout=30 --request-timeout=120 -f /tmp/scylla-highcard-schema.cql
```

The create workload completed in 5m31s.

CQL confirmed the created schema before restart:

```text
 count
-------
  4200

 count
-------
  4200

 keyspace_name
---------------
       hc_4199

 table_name
------------
          t
```

The data directory had 4,208 top-level entries, confirming the schema was in the mounted workdir.

### Restart proof

The final patched binary was restarted from the same mounted workdir with 4 GiB and 1 shard.

Startup log:

```text
INFO  2026-06-21 06:40:32,536 [shard 0:main] database - Loading schema table keyspaces for 4205 keyspaces with concurrency 1
INFO  2026-06-21 06:40:32,817 [shard 0:main] database - Loading schema table tables for 4204 keyspaces with concurrency 1
INFO  2026-06-21 06:40:40,868 [shard 0:main] database - Loading schema table views for 0 keyspaces with concurrency 1
INFO  2026-06-21 06:40:40,868 [shard 0:main] database - Populating 1 priority non-system keyspaces with concurrency 2
INFO  2026-06-21 06:40:40,870 [shard 0:main] database - Populating 4204 non-system keyspaces with concurrency 2
INFO  2026-06-21 06:40:43,288 [shard 0:main] group0_raft_sm - Skipping eager audit known-table cache for 4286 tables; cap is 4096; matching remains exact via per-request rule evaluation
INFO  2026-06-21 06:40:43,472 [shard 0:main] init - serving
INFO  2026-06-21 06:40:43,472 [shard 0:main] init - Scylla version 2026.3.0~dev-0.20260621.048d9b50079c initialization completed.
```

Post-boot CQL confirmed the schema survived restart:

```text
 count
-------
  4200

 count
-------
  4200

 keyspace_name
---------------
       hc_4199

 table_name
------------
          t
```

Post-boot metrics:

```text
scylla_compaction_manager_postponed_compactions{shard="0"} 0.000000
scylla_compaction_manager_regular_compaction_task_backlog{shard="0"} 0.000000
scylla_compaction_manager_regular_compaction_task_backlog_limit{shard="0"} 0.000000
scylla_database_queued_reads{class="system",shard="0"} 0.000000
scylla_database_reads_memory_consumption{class="system",shard="0"} 0.000000
scylla_memory_malloc_failed{shard="0"} 0
```

Restart log error scan:

```text
No ERROR, FATAL, bad_alloc, std::bad_alloc, Aborting, or malloc_failed lines.
```

Observed non-fatal dev-environment warnings:

- sysctl `net.ipv4.tcp_timestamps` set to 0
- I/O scheduler not configured for production
- default cluster name warning
- single-node gossip warnings
- two nonfatal oversized allocation warnings of 135,168 and 270,336 bytes

## Validation status

The high-cardinality logical-schema restart case is reproduced and closed for a single-shard 4 GiB dev node with 4,200 real one-table keyspaces.

Broader multi-shard and production-hardware validation is still useful, but the original startup fanout failure mode is covered by tests and by the full local restart run above.
