### PR TITLE
test: migrate skip_not_implemented to skip_bug

### DIFF
--- a/test/cluster/dtest/schema_management_test.py
+++ b/test/cluster/dtest/schema_management_test.py
@@ -239,7 +239,7 @@ class TestSchemaManagement(Tester):
         expected_cols = 1 + col_number - columns_to_drop  # pk + remaining columns
         assert len(rows_to_list(rows)[0]) == expected_cols, f"Expected {expected_cols} columns but got {len(rows_to_list(rows)[0])}"
 
-    @pytest.mark.skip_not_implemented(reason="unimplemented")
+    @pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-2785", reason="unimplemented")
     def commitlog_replays_after_schema_change(self):
         """
         Commitlog can be replayed even though schema has been changed

--- a/test/cluster/test_blocked_bootstrap.py
+++ b/test/cluster/test_blocked_bootstrap.py
@@ -11,7 +11,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skip_not_implemented(reason="can't make it work with the new join procedure, without error recovery")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-2784", reason="can't make it work with the new join procedure, without error recovery")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_blocked_bootstrap(manager: ManagerClient):
     """

--- a/test/cluster/test_mv.py
+++ b/test/cluster/test_mv.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
-@pytest.mark.skip_not_implemented(reason="tombstone_gc repair mode is not supported yet for MVs due to #24816")
+@pytest.mark.skip_bug(link="https://github.com/scylladb/scylladb/issues/24816", reason="tombstone_gc repair mode is not supported yet for MVs due to #24816")
 async def test_mv_tombstone_gc_setting(manager):
     """
     Test that the tombstone_gc parameter can be set on a materialized view,

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -383,7 +383,7 @@ async def test_create_colocated_table_while_base_is_migrating(manager: ManagerCl
 # 3. bring the node back up - it is now missing some data
 # 4. run tablet repair on the base table
 # 5. verify both the base table and the view contain the missing data on the node that was down
-@pytest.mark.skip_not_implemented(reason="tablet repair of colocated tables is not supported currently")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-362", reason="tablet repair of colocated tables is not supported currently")
 async def test_repair_colocated_base_and_view(manager: ManagerClient):
     cfg = {'enable_tablets': True}
     cmdline = [

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -21,7 +21,7 @@ def all_tests_in_this_file_use_compact_storage(compact_storage):
 # flag is used) by Cassandra, and it was never implemented in Scylla, so
 # let's skip its test.
 # See issue #3882
-@pytest.mark.skip_not_implemented(reason="issue #3882 - COMPACT STORAGE not implemented")
+@pytest.mark.skip_bug(link="https://github.com/scylladb/scylladb/issues/3882", reason="issue #3882 - COMPACT STORAGE not implemented")
 def testSparseCompactTableIndex(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(key ascii PRIMARY KEY, val ascii) WITH COMPACT STORAGE") as table:
 

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_table_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_table_test.py
@@ -32,7 +32,7 @@ def all_tests_in_this_file_use_compact_storage(compact_storage):
 # flag is used) by Cassandra, and it was never implemented in Scylla, so
 # let's skip its test.
 # See issue #3882
-@pytest.mark.skip_not_implemented(reason="issue #3882 - DROP COMPACT STORAGE not implemented")
+@pytest.mark.skip_bug(link="https://github.com/scylladb/scylladb/issues/3882", reason="issue #3882 - DROP COMPACT STORAGE not implemented")
 def testDropCompactStorage(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, ck int, PRIMARY KEY(pk)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (pk, ck) VALUES (1, 1)")

--- a/test/cqlpy/test_permissions.py
+++ b/test/cqlpy/test_permissions.py
@@ -1241,28 +1241,28 @@ def test_drop_keyspace_cleans_up_function_level_permissions(cql, scylla_only):
 
 # Test EXECUTE permission is required to use UDF in WHERE clause
 # Scylla does not support UDF calls in WHERE clauses
-@pytest.mark.skip_not_implemented(reason="Scylla does not support UDF calls in WHERE clauses")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-440", reason="Scylla does not support UDF calls in WHERE clauses")
 def test_udf_permissions_in_select_where_clause(cql, test_keyspace, scylla_only):
     _verify_udf_execute_permission(cql, test_keyspace,
         lambda table, func: f"SELECT k, v FROM {table} WHERE k = {test_keyspace}.{func}(0)")
 
 # Test EXECUTE permission is required to use UDF in INSERT
 # Scylla does not support UDF calls in INSERT values
-@pytest.mark.skip_not_implemented(reason="Scylla does not support UDF calls in INSERT/UPDATE/DELETE contexts")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-440", reason="Scylla does not support UDF calls in INSERT/UPDATE/DELETE contexts")
 def test_udf_permissions_in_insert(cql, test_keyspace, scylla_only):
     _verify_udf_execute_permission(cql, test_keyspace,
         lambda table, func: f"INSERT INTO {table} (k, v) VALUES (1, {test_keyspace}.{func}(1))")
 
 # Test EXECUTE permission is required to use UDF in UPDATE
 # Scylla does not support UDF calls in UPDATE/DELETE contexts
-@pytest.mark.skip_not_implemented(reason="Scylla does not support UDF calls in INSERT/UPDATE/DELETE contexts")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-440", reason="Scylla does not support UDF calls in INSERT/UPDATE/DELETE contexts")
 def test_udf_permissions_in_update(cql, test_keyspace, scylla_only):
     _verify_udf_execute_permission(cql, test_keyspace,
         lambda table, func: f"UPDATE {table} SET v = {test_keyspace}.{func}(2) WHERE k = {test_keyspace}.{func}(0)")
 
 # Test EXECUTE permission is required to use UDF in DELETE
 # Scylla does not support UDF calls in DELETE WHERE
-@pytest.mark.skip_not_implemented(reason="Scylla does not support UDF calls in INSERT/UPDATE/DELETE contexts")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-440", reason="Scylla does not support UDF calls in INSERT/UPDATE/DELETE contexts")
 def test_udf_permissions_in_delete(cql, test_keyspace, scylla_only):
     _verify_udf_execute_permission(cql, test_keyspace,
         lambda table, func: f"DELETE FROM {table} WHERE k = {test_keyspace}.{func}(0)")


### PR DESCRIPTION
All skip_not_implemented should be  skip_bug marker with proper issues link(create if not exists) One unifi bug is better than two, but I expect a hard discussion at PR, while the code change will be quite simple

NOTE: there is still one unclear skip_not_implemented marker left, will be eliminated after clarification.

related to https://scylladb.atlassian.net/browse/SCYLLADB-2720

- [x] @DarioMirovic please approve https://scylladb.atlassian.net/browse/SCYLLADB-2785 linkage correctness
- [x] @piodul please approve https://scylladb.atlassian.net/browse/SCYLLADB-2784 and
https://scylladb.atlassian.net/browse/SCYLLADB-362 linkage correctness
- [x] @nyh  approved  https://scylladb.atlassian.net/browse/SCYLLADB-440 linkage correctness
