### PR TITLE
test: migrate skip_slow to nightly

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/timestamp_test.py
@@ -129,7 +129,7 @@ def testTimestampsOnUnsetColumnsWide(cql, test_keyspace):
                    [2, 2, None, None],
                    [3, 3, 3, 1])
 
-@pytest.mark.skip_slow(reason="a very slow test (6 seconds), skipping it")
+@pytest.mark.nightly
 def testTimestampAndTTLPrepared(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, i int, PRIMARY KEY (k, c))") as table:
         execute(cql, table, "INSERT INTO %s (k, c, i) VALUES (1, 1, 1) USING TIMESTAMP ? AND TTL ?;", 1, 5)
@@ -146,7 +146,7 @@ def testTimestampAndTTLPrepared(cql, test_keyspace):
         time.sleep(6)
         assert_empty(execute(cql, table, "SELECT k, c, i, writetime(i) FROM %s "))
 
-@pytest.mark.skip_slow(reason="a very slow test (6 seconds), skipping it")
+@pytest.mark.nightly
 def testTimestampAndTTLUpdatePrepared(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, i int, PRIMARY KEY (k, c))") as table:
         execute(cql, table, "UPDATE %s USING TIMESTAMP ? AND TTL ? SET i=1 WHERE k=1 AND c = 1 ;", 1, 5)

--- a/test/cqlpy/cassandra_tests/validation/operations/batch_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/batch_test.py
@@ -189,7 +189,7 @@ def testBatchWithInRestriction(cql, test_keyspace):
 # TTLs. These sleeps also make it dependent on timing - in the very unlikely
 # case that the test code is delayed by a large fraction of a second, we can
 # end up with the wrong TTL.
-@pytest.mark.skip_slow(reason="slow test, remove skip to try it anyway")
+@pytest.mark.nightly
 def testBatchTTLConditionalInteraction(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int, clustering1 int, clustering2 int, clustering3 int, val int, PRIMARY KEY (id, clustering1, clustering2, clustering3))") as clustering:
         execute(cql, clustering, "DELETE FROM %s WHERE id=1")
@@ -338,7 +338,7 @@ def testBatchTTLConditionalInteraction(cql, test_keyspace):
 # TTLs. These sleeps also make it dependent on timing - in the very unlikely
 # case that the test code is delayed by a large fraction of a second, we can
 # end up with the wrong TTL.
-@pytest.mark.skip_slow(reason="slow test, remove skip to try it anyway")
+@pytest.mark.nightly
 def testBatchStaticTTLConditionalInteraction(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(id int, clustering1 int, clustering2 int, clustering3 int, sval int static, val int, PRIMARY KEY (id, clustering1, clustering2, clustering3))") as clustering_static:
         execute(cql, clustering_static, f"DELETE FROM {clustering_static} WHERE id=1")

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -506,11 +506,38 @@ def wait_for_services(pid, checkers):
 def wait_for_cql(pid, ip):
     wait_for_services(pid, [lambda: check_cql(ip)])
 
+
+def _has_marker_expression(pytest_args: list[str]) -> bool:
+    """Return True when *pytest_args* already defines a pytest marker expression."""
+    for i, arg in enumerate(pytest_args):
+        if arg == "-m":
+            return i + 1 < len(pytest_args)
+        if arg.startswith("-m="):
+            return True
+    return False
+
+
+def _prepare_pytest_args(pytest_args: list[str]) -> list[str]:
+    """Prepare pytest arguments for runpy wrappers.
+
+    By default, runpy wrappers skip tests marked ``nightly`` to keep
+    local and per-PR runs focused and fast.
+
+    Marker policy:
+    * if no marker expression is provided, add ``-m 'not nightly'``;
+    * if marker expression is provided, keep it unchanged.
+    """
+    prepared_args = list(pytest_args)
+    if _has_marker_expression(prepared_args):
+        return prepared_args
+    return ["-m", "not nightly"] + prepared_args
+
 def run_pytest(pytest_dir, additional_parameters):
     global run_with_temporary_dir_pids
     global run_pytest_pids
     sys.stdout.flush()
     sys.stderr.flush()
+    additional_parameters = _prepare_pytest_args(additional_parameters)
     pid = os.fork()
     if pid == 0:
         # child:

--- a/test/cqlpy/test_system_tables.py
+++ b/test/cqlpy/test_system_tables.py
@@ -75,7 +75,7 @@ def test_partitions_estimate_simple_small(cql, test_keyspace):
 # This is a relatively long test (takes around 2 seconds), and isn't
 # needed to reproduce #9083 (the previous shorter test does it too),
 # so we skip this test.
-@pytest.mark.skip_slow(reason="slow test, remove skip to try it anyway")
+@pytest.mark.nightly
 def test_partitions_estimate_simple_large(cql, test_keyspace):
     N = 10000
     count = write_table_and_estimate_partitions(cql, test_keyspace, N)

--- a/test/cqlpy/test_wasm.py
+++ b/test/cqlpy/test_wasm.py
@@ -578,7 +578,8 @@ def test_UDA(cql, test_keyspace, table1, scylla_with_wasm_only, metrics):
 # FIXME: shorten the wait time when such configuration becomes possible
 
 # The function grows the memory by n pages and returns n.
-@pytest.mark.skip_slow(reason="slow test, remove skip to try it anyway")
+@pytest.mark.skip_bug(link="https://scylladb.atlassian.net/browse/SCYLLADB-2800", reason="bug in WASM memory limit enforcement")
+@pytest.mark.nightly
 def test_mem_grow(cql, test_keyspace, table1, scylla_with_wasm_only, metrics):
     table = table1
     mem_grow_name = "mem_grow_" + unique_name()

--- a/test/pylib/skip_types.py
+++ b/test/pylib/skip_types.py
@@ -46,7 +46,6 @@ def _is_valid_skip_bug_link(link: str) -> bool:
 class SkipType(StrEnum):
     SKIP_BUG = "bug"
     SKIP_NOT_IMPLEMENTED = "not_implemented"
-    SKIP_SLOW = "slow"
     SKIP_ENV = "env"
 
     @staticmethod
@@ -99,11 +98,6 @@ def skip_bug(*, link: str, reason: str) -> None:
 def skip_not_implemented(reason: str) -> None:
     """Runtime skip for a feature that is not yet implemented."""
     skip(reason, skip_type=SkipType.SKIP_NOT_IMPLEMENTED)
-
-
-def skip_slow(reason: str) -> None:
-    """Runtime skip for a test that is too slow for regular CI."""
-    skip(reason, skip_type=SkipType.SKIP_SLOW)
 
 
 def skip_env(reason: str) -> None:

--- a/test/pylib_test/test_skip_reason_plugin.py
+++ b/test/pylib_test/test_skip_reason_plugin.py
@@ -77,7 +77,6 @@ def test_skip_bug_marker_skips_with_prefix(skippytest):
 
 @pytest.mark.parametrize("marker, skip_type, reason", [
     ("skip_not_implemented", "not_implemented", "feature X not built yet"),
-    ("skip_slow", "slow", "takes 10 minutes"),
     ("skip_env", "env", "need --special-flag"),
 ])
 def test_non_bug_typed_marker_skips_with_prefix(skippytest, marker, skip_type, reason):
@@ -109,7 +108,6 @@ def test_skip_bug_positional_reason_rejected(skippytest):
 
 @pytest.mark.parametrize("marker, skip_type", [
     ("skip_not_implemented", "not_implemented"),
-    ("skip_slow", "slow"),
     ("skip_env", "env"),
 ])
 def test_typed_marker_positional_reason_accepted(skippytest, marker, skip_type):
@@ -129,7 +127,7 @@ def test_typed_marker_positional_reason_accepted(skippytest, marker, skip_type):
 
 # -- Missing reason ---------------------------------------------------------
 
-@pytest.mark.parametrize("marker", ["skip_not_implemented", "skip_slow", "skip_env"])
+@pytest.mark.parametrize("marker", ["skip_not_implemented", "skip_env"])
 def test_missing_reason_is_rejected(skippytest, marker):
     skippytest.makepyfile(f"""
         import pytest
@@ -180,7 +178,7 @@ def test_bare_skip_rejected_and_lists_alternatives(skippytest):
     result.stderr.fnmatch_lines(["*Untyped skip*some bare reason*"])
     assert result.ret != 0
     out = result.stderr.str()
-    for m in ("skip_bug", "skip_not_implemented", "skip_slow",
+    for m in ("skip_bug", "skip_not_implemented",
               "skip_env"):
         assert m in out, f"expected '{m}' in error output"
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -40,7 +40,6 @@ markers =
     skip_mode(mode, reason, platform_key=None): Skip test in a specific build mode (e.g. dev, debug, release).
     skip_bug(link=..., reason=...): Skip due to a known bug (link = issue URL, reason = human-readable explanation).
     skip_not_implemented(reason): Skip because the feature is not yet implemented.
-    skip_slow(reason): Skip because the test is too slow for regular CI.
     skip_env(reason): Skip due to a missing environment requirement.
 
 norecursedirs = manual perf lib pylib_test


### PR DESCRIPTION
All skip_slow should be a nightly marker.
Main motivation is:  the nightly marker already exists for "tests that are stable but too long to run on every PR." The difference: skip_slow = never runs in CI, nightly = runs in nightly and next builds.

Add auto-adding '-m= mot nightly' to runpy mode to keep the default behaviour
unchanged

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2721

