### PR TITLE
repair, compaction: serialize tablet split bypass with concurrent repair

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -186,6 +186,8 @@ static inline int calculate_weight(const compaction_descriptor& descriptor) {
     return calculate_weight(descriptor.sstables_size());
 }
 
+static future<std::vector<sstables::shared_sstable>> get_all_sstables(compaction_group_view& t);
+
 unsigned compaction_manager::current_compaction_fan_in_threshold() const {
     if (_tasks.empty()) {
         return 0;
@@ -1865,16 +1867,15 @@ protected:
 
     future<compaction_result> do_rewrite_sstable(const sstables::shared_sstable sst) {
         if (sstable_needs_split(sst)) {
-            return rewrite_sstables_compaction_task_executor::rewrite_sstable(std::move(sst));
+            co_return co_await rewrite_sstables_compaction_task_executor::rewrite_sstable(std::move(sst));
         }
         // SSTable that doesn't require split can bypass compaction and the table will be able to place
         // it into the correct compaction group. Similar approach is done in off-strategy compaction for
         // sstables that don't require reshape and are ready to be moved across sets.
         compaction_completion_desc desc { .old_sstables = {sst}, .new_sstables = {sst} };
-        return _compacting_table->on_compaction_completion(std::move(desc), sstables::offstrategy::no).then([] {
-            // It's fine to return empty results (zeroed stats) as compaction was bypassed.
-            return compaction_result{};
-        });
+        co_await _compacting_table->on_compaction_completion(std::move(desc), sstables::offstrategy::no);
+        // It's fine to return empty results (zeroed stats) as compaction was bypassed.
+        co_return compaction_result{};
     }
 
     future<compaction_result> rewrite_sstable(const sstables::shared_sstable sst) override {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1872,6 +1872,22 @@ protected:
         // SSTable that doesn't require split can bypass compaction and the table will be able to place
         // it into the correct compaction group. Similar approach is done in off-strategy compaction for
         // sstables that don't require reshape and are ready to be moved across sets.
+        co_await utils::get_local_injector().inject("split_bypass_before_completion",
+                [this, &sst] (auto& handler) -> future<> {
+            bool aborted = false;
+            cmlog.info("split_bypass_before_completion: parked sst={}", sst->get_filename());
+            try {
+                co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes(5),
+                        &_compaction_data.abort);
+            } catch (const abort_requested_exception&) {
+                aborted = true;
+            }
+            if (aborted) {
+                cmlog.info("split_bypass_before_completion: aborted due to stop_compaction sst={}", sst->get_filename());
+            } else {
+                cmlog.info("split_bypass_before_completion: released sst={}", sst->get_filename());
+            }
+        }, false);
         compaction_completion_desc desc { .old_sstables = {sst}, .new_sstables = {sst} };
         co_await _compacting_table->on_compaction_completion(std::move(desc), sstables::offstrategy::no);
         // It's fine to return empty results (zeroed stats) as compaction was bypassed.
@@ -1941,7 +1957,7 @@ compaction_manager::rewrite_sstables(compaction_group_view& t, compaction_type_o
 
 future<compaction_manager::compaction_stats_opt>
 compaction_manager::rewrite_sstables_component(compaction_group_view& t,
-                                     std::vector<sstables::shared_sstable>& sstables,
+                                     std::function<bool(const sstables::shared_sstable&)> filter,
                                      compaction_type_options options,
                                      std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>& rewritten_sstables,
                                      tasks::task_info info) {
@@ -1950,12 +1966,27 @@ compaction_manager::rewrite_sstables_component(compaction_group_view& t,
         co_return std::nullopt;
     }
 
+    // Capture candidates from view `t` and register them as compacting while
+    // compaction is disabled on `t`, so that:
+    //   1) every captured sstable belongs to `t`'s compaction group (no
+    //      cross-CG routing mismatch), and
+    //   2) no other operation can move them to a different CG or pick them up
+    //      for a different compaction while the rewrite is in flight.
+    std::vector<sstables::shared_sstable> sstables;
+    compacting_sstable_registration compacting(*this, get_compaction_state(&t));
+    co_await run_with_compaction_disabled(t, [&t, &sstables, &compacting, &filter] () -> future<> {
+        auto candidates = co_await get_all_sstables(t);
+        for (auto& sst : candidates) {
+            if (filter(sst)) {
+                sstables.push_back(sst);
+            }
+        }
+        compacting.register_compacting(sstables);
+    }, "component_rewrite");
+
     if (sstables.empty()) {
         co_return std::nullopt;
     }
-
-    compacting_sstable_registration compacting(*this, get_compaction_state(&t));
-    compacting.register_compacting(sstables);
 
     co_return co_await perform_compaction<rewrite_sstables_component_compaction_task_executor>(throw_if_stopping::no, info, &t, info.id,
         std::move(options), std::move(sstables), std::move(compacting), rewritten_sstables);
@@ -2396,13 +2427,14 @@ compaction_manager::maybe_split_new_sstable(sstables::shared_sstable sst, compac
 
 future<std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>> compaction_manager::perform_component_rewrite(compaction::compaction_group_view& t,
             tasks::task_info info,
-            std::vector<sstables::shared_sstable> sstables,
+            std::function<bool(const sstables::shared_sstable&)> filter,
             sstables::component_type component,
             std::function<void(sstables::sstable&)> modifier,
             compaction_type_options::component_rewrite::update_sstable_id update_id) {
     std::unordered_map<sstables::shared_sstable, sstables::shared_sstable> rewritten_sstables;
-    rewritten_sstables.reserve(sstables.size());
-    co_await rewrite_sstables_component(t, sstables, compaction_type_options::make_component_rewrite(component, std::move(modifier), update_id), rewritten_sstables, info);
+    co_await rewrite_sstables_component(t, std::move(filter),
+            compaction_type_options::make_component_rewrite(component, std::move(modifier), update_id),
+            rewritten_sstables, info);
     co_return rewritten_sstables;
 }
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -255,7 +255,7 @@ private:
                                                   can_purge_tombstones can_purge = can_purge_tombstones::yes, sstring options_desc = "");
 
     future<compaction_stats_opt> rewrite_sstables_component(compaction_group_view& t,
-                                                            std::vector<sstables::shared_sstable>& sstables,
+                                                            std::function<bool(const sstables::shared_sstable&)> filter,
                                                             compaction_type_options options,
                                                             std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>& rewritten_sstables,
                                                             tasks::task_info info);
@@ -368,9 +368,24 @@ public:
     // Submit a table to be scrubbed and wait for its termination.
     future<compaction_stats_opt> perform_sstable_scrub(compaction::compaction_group_view& t, compaction_type_options::scrub opts, tasks::task_info info);
 
-    future<std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>> perform_component_rewrite(compaction::compaction_group_view& t,
+    // Picks sstables from view `t` that match `filter` and rewrites the given
+    // component using `modifier`.  The input sstables are captured from
+    // `t.main_sstable_set()` while compaction is disabled on `t`, and
+    // registered in `_compacting_sstables` before re-enabling.  This
+    // guarantees that:
+    //   1) every input sstable belongs to `t`'s compaction group at capture
+    //      time (no cross-CG routing surprises), and
+    //   2) no other operation can move the inputs to a different compaction
+    //      group while the rewrite is in flight.
+    //
+    // The caller is responsible for iterating storage_group -> compaction_group
+    // -> view to cover the desired range; the filter is applied per view.
+    //
+    // Returns a map from each old sstable to its rewritten replacement.
+    future<std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>> perform_component_rewrite(
+            compaction::compaction_group_view& t,
             tasks::task_info info,
-            std::vector<sstables::shared_sstable> sstables,
+            std::function<bool(const sstables::shared_sstable&)> filter,
             sstables::component_type component,
             std::function<void(sstables::sstable&)> modifier,
             compaction_type_options::component_rewrite::update_sstable_id update_id = compaction_type_options::component_rewrite::update_sstable_id::yes);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2191,7 +2191,7 @@ public:
 public:
     future<> mark_sstable_as_repaired() {
         auto& sstables = _repair_writer->get_sstable_list_to_mark_as_repaired();
-        if (!_incremental_repair_meta.sst_set && !sstables.empty()) {
+        if (!_incremental_repair_meta.sst_set && sstables.empty()) {
             co_return;
         }
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2196,7 +2196,6 @@ public:
         }
 
         auto& table = _db.local().find_column_family(_schema->id());
-        auto& cm = table.get_compaction_manager();
         int64_t repaired_at = _incremental_repair_meta.sstables_repaired_at + 1;
 
         // Keep the new sstables marked as being_repaired until repair_update_compaction_ctrl
@@ -2208,11 +2207,21 @@ public:
             new_sst.mark_as_being_repaired(session);
         };
 
-        std::unordered_map<compaction::compaction_group_view*, std::vector<sstables::shared_sstable>> sstables_by_group;
+        // Build the candidate set of sstables we want to mark as repaired.
+        // The actual capture of these sstables (and the membership check
+        // against each view's main sstable set) is delegated to
+        // perform_component_rewrite, which captures them while compaction is
+        // disabled on the target view.  That way:
+        //   - every captured sstable is provably in the view's compaction
+        //     group at capture time (no cross-CG routing mismatch), and
+        //   - no concurrent compaction (split bypass, regular minor compaction,
+        //     etc.) can move the inputs to a different CG mid-rewrite.
+        std::unordered_set<sstables::shared_sstable> repair_set;
         auto add_sstable = [&] (const sstables::shared_sstable& sst) {
             if (sst->should_update_repaired_at(repaired_at)) {
-                auto& view = table.compaction_group_view_for_sstable(sst);
-                sstables_by_group[&view].push_back(sst);
+                rlogger.info("Marking sstable={} repaired_at={} being_repaired={} for incremental repair",
+                             sst->toc_filename(), repaired_at, sst->being_repaired);
+                repair_set.insert(sst);
             }
         };
 
@@ -2224,14 +2233,25 @@ public:
             add_sstable(sst);
         }
 
-        for (auto& [view, ssts] : sstables_by_group) {
-            for (auto& sst : ssts) {
-                rlogger.info("Marking sstable={} repaired_at={} being_repaired={} for incremental repair",
-                        sst->toc_filename(), repaired_at, sst->being_repaired);
-            }
-            auto rewritten_sstables = co_await cm.perform_component_rewrite(*view, tasks::task_info{}, std::move(ssts),
-                    sstables::component_type::Statistics, modifier);
+        if (repair_set.empty()) {
+            co_return;
+        }
 
+        auto filter = [&repair_set] (const sstables::shared_sstable& sst) {
+            return repair_set.contains(sst);
+        };
+
+        co_await utils::get_local_injector().inject("repair_before_component_rewrite",
+                utils::wait_for_message(5min));
+
+        // Rewrite the matching sstables across every compaction group of every
+        // storage group covering the repair range, using the filter-based
+        // perform_component_rewrite which captures sstables while compaction
+        // is disabled on the target view.
+        auto rewritten_sstables = co_await table.perform_component_rewrite(
+                _range, tasks::task_info{}, filter,
+                sstables::component_type::Statistics, modifier);
+        // FIXME: indent.
             // remove the old sstables from incremental repair meta and add the new ones
             for (auto& ss : rewritten_sstables) {
                 bool erased = _incremental_repair_meta.sst_set->erase(ss.first);
@@ -2245,7 +2265,6 @@ public:
                     sstables.insert(ss.second);
                 }
             }
-        }
     }
 };
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -270,6 +270,8 @@ public:
     utils::small_vector<compaction::compaction_group_view*, 3> all_views() const;
     // Returns true iff v is the repaired view of this compaction group.
     bool is_repaired_view(const compaction::compaction_group_view* v) const noexcept;
+    // Returns true iff v is the repairing view of this compaction group.
+    bool is_repairing_view(const compaction::compaction_group_view* v) const noexcept;
     // Returns an sstable set containing only repaired sstables (those classified as repaired).
     lw_shared_ptr<sstables::sstable_set> make_repaired_sstable_set() const;
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -192,8 +192,6 @@ public:
 
     int64_t get_sstables_repaired_at() const noexcept;
 
-    future<> update_repaired_at_for_merge();
-
     void set_counter_id(counter_id cid) noexcept {
         _counter_id = cid;
     }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -45,6 +45,7 @@
 #include "db/row_cache.hh"
 #include "query/query-result.hh"
 #include "compaction/compaction_strategy.hh"
+#include "compaction/compaction_descriptor.hh"
 #include "utils/estimated_histogram.hh"
 #include <seastar/core/metrics_registration.hh>
 #include "db/view/view_stats.hh"
@@ -756,6 +757,34 @@ private:
     // Unsafe reference to all storage groups. Don't use it across preemption points.
     const storage_group_map& storage_groups() const;
 
+    // Private helper — iterates all compaction groups in `sg` and all their
+    // views, applying the filter-capture-then-rewrite pattern.  For each
+    // view, all sstables matching `filter` (from both the main and maintenance
+    // sstable sets) are captured while compaction is disabled on that view,
+    // and registered as compacting before re-enabling.  This guarantees:
+    //   1) every captured sstable belongs to the correct compaction group at
+    //      capture time (no cross-CG routing surprises), and
+    //   2) no other operation can move the inputs to a different compaction
+    //      group while the rewrite is in flight.
+    future<std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>> perform_component_rewrite(
+            storage_group& sg,
+            tasks::task_info info,
+            std::function<bool(const sstables::shared_sstable&)> filter,
+            sstables::component_type component,
+            std::function<void(sstables::sstable&)> modifier,
+            compaction::compaction_type_options::component_rewrite::update_sstable_id update_id = compaction::compaction_type_options::component_rewrite::update_sstable_id::yes);
+public:
+    // Rewrite a component (e.g., Statistics) on all sstables matching `filter`
+    // in every view of every compaction group in every storage group that
+    // overlaps `range`.  Returns a map from each old sstable to its replacement.
+    future<std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>> perform_component_rewrite(
+            dht::token_range range,
+            tasks::task_info info,
+            std::function<bool(const sstables::shared_sstable&)> filter,
+            sstables::component_type component,
+            std::function<void(sstables::sstable&)> modifier,
+            compaction::compaction_type_options::component_rewrite::update_sstable_id update_id = compaction::compaction_type_options::component_rewrite::update_sstable_id::yes);
+private:
     // Returns a sstable set that can be safely used for purging any expired tombstone in a compaction group.
     // Only the sstables in the compaction group is not sufficient, since there might be other compaction
     // groups during tablet split with overlapping token range, and we need to include them all in a single

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1102,6 +1102,16 @@ future<> compaction_group::split(compaction::compaction_type_options::split opt,
     auto& cm = get_compaction_manager();
 
     for (auto view : all_views()) {
+        // Injection point used by tests to synchronize split with a concurrent
+        // repair: pause before the repairing-view iteration so the test can
+        // let repair mark sstables as being-repaired (moving them into
+        // _repairing_view) and optionally let repair's component rewrite
+        // unlink them before split captures them on this iteration.
+        if (is_repairing_view(view)) {
+            co_await utils::get_local_injector().inject(
+                    "split_pause_before_repairing_view_iteration",
+                    utils::wait_for_message{std::chrono::minutes{5}});
+        }
         auto lock_holder = co_await cm.get_incremental_repair_read_lock(*view, "storage_group_split");
         // Waits on sstables produced by repair to be integrated into main set; off-strategy is usually a no-op with tablets.
         co_await cm.perform_offstrategy(*view, tablet_split_task_info);
@@ -1412,6 +1422,53 @@ compaction_group& tablet_storage_group_manager::compaction_group_for_key(partiti
 
 compaction_group& table::compaction_group_for_key(partition_key_view key, const schema_ptr& s) const {
     return _sg_manager->compaction_group_for_key(key, s);
+}
+
+future<std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>>
+table::perform_component_rewrite(
+        storage_group& sg,
+        tasks::task_info info,
+        std::function<bool(const sstables::shared_sstable&)> filter,
+        sstables::component_type component,
+        std::function<void(sstables::sstable&)> modifier,
+        compaction::compaction_type_options::component_rewrite::update_sstable_id update_id) {
+    std::unordered_map<sstables::shared_sstable, sstables::shared_sstable> rewritten;
+    auto cgs = sg.compaction_groups_immediate();
+    auto& cm = get_compaction_manager();
+    for (auto& cg : cgs) {
+        auto holder = try_hold_gate(cg->async_gate());
+        if (!holder) {
+            continue;
+        }
+        for (auto* view : cg->all_views()) {
+            auto per_view = co_await cm.perform_component_rewrite(
+                    *view, info, filter, component, modifier, update_id);
+            rewritten.insert(per_view.begin(), per_view.end());
+        }
+    }
+    co_return rewritten;
+}
+
+future<std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>>
+table::perform_component_rewrite(
+        dht::token_range range,
+        tasks::task_info info,
+        std::function<bool(const sstables::shared_sstable&)> filter,
+        sstables::component_type component,
+        std::function<void(sstables::sstable&)> modifier,
+        compaction::compaction_type_options::component_rewrite::update_sstable_id update_id) {
+    std::unordered_map<sstables::shared_sstable, sstables::shared_sstable> rewritten;
+    auto sgs = storage_groups_for_token_range(range);
+    for (auto& sg : sgs) {
+        auto holder = try_hold_gate(sg->async_gate());
+        if (!holder) {
+            continue;
+        }
+        auto per_sg = co_await perform_component_rewrite(
+                *sg, info, filter, component, modifier, update_id);
+        rewritten.insert(per_sg.begin(), per_sg.end());
+    }
+    co_return rewritten;
 }
 
 static sstring sstable_desc(const sstables::shared_sstable& sst) {
@@ -3713,35 +3770,21 @@ future<> table::update_repaired_at_for_merge() {
         // storage group share the same tablet ID, so any CG's
         // get_sstables_repaired_at() returns the merged value.
         auto sstables_repaired_at = sg->main_compaction_group()->get_sstables_repaired_at();
-    // FIXME: indent.
-    auto cgs = sg->compaction_groups_immediate();
-    for (auto& cg : cgs) {
-        auto cre = co_await cg->get_compaction_manager().stop_and_disable_compaction("update_repaired_at_for_merge", cg->view_for_unrepaired_data());
-
-        std::unordered_map<compaction::compaction_group_view*, std::vector<sstables::shared_sstable>> sstables_by_view;
-        for (auto& sst : cg->all_sstables()) {
-            auto& stats = sst->get_stats_metadata();
-            if (stats.repaired_at > sstables_repaired_at) {
-                auto& view = cg->view_for_sstable(sst);
-                sstables_by_view[&view].push_back(sst);
+        auto filter = [&] (const sstables::shared_sstable& sst) {
+            auto filtered = sst->get_stats_metadata().repaired_at > sstables_repaired_at;
+            if (filtered) {
+                tlogger.info("Updating repaired_at for tablet merge sstable={} old={} new={} sstables_repaired_at={} group_id={} range={}",
+                             sst->get_filename(), sst->get_stats_metadata().repaired_at, new_repaired_at, sstables_repaired_at, id, sg->token_range());
             } else {
                 tlogger.debug("Skipped repaired_at update for tablet merge sstable={} repaired_at={} sstables_repaired_at={} group_id={} range={}",
-                              sst->get_filename(), stats.repaired_at, sstables_repaired_at, cg->group_id(), cg->token_range());
+                              sst->get_filename(), sst->get_stats_metadata().repaired_at, sstables_repaired_at, id, sg->token_range());
             }
-        }
-
-        auto& cm = get_compaction_manager();
-      for (auto& [view, ssts] : sstables_by_view) {
-        for (auto& sst : ssts) {
-            tlogger.info("Updating repaired_at for tablet merge sstable={} old={} new={} sstables_repaired_at={} group_id={} range={}",
-                         sst->get_filename(), sst->get_stats_metadata().repaired_at, new_repaired_at, sstables_repaired_at, cg->group_id(), cg->token_range());
-        }
-        co_await cm.perform_component_rewrite(*view, tasks::task_info{}, std::move(ssts),
-                                              sstables::component_type::Statistics, modifier);
-      }
-        tlogger.info("Completed updating repaired_at={} for tablet merge in compaction group_id={} range={}",
-                     new_repaired_at, cg->group_id(), cg->token_range());
-    }
+            return filtered;
+        };
+        co_await perform_component_rewrite(*sg, tasks::task_info{}, std::move(filter),
+                sstables::component_type::Statistics, modifier);
+        tlogger.info("Completed updating repaired_at={} for tablet merge in compaction group_id={} range {}",
+                     new_repaired_at, id, sg->token_range());
     }
 }
 
@@ -5552,6 +5595,10 @@ compaction::compaction_group_view& compaction_group::view_for_unrepaired_data() 
 
 bool compaction_group::is_repaired_view(const compaction::compaction_group_view* v) const noexcept {
     return v == _repaired_view.get();
+}
+
+bool compaction_group::is_repairing_view(const compaction::compaction_group_view* v) const noexcept {
+    return v == _repairing_view.get();
 }
 
 lw_shared_ptr<sstables::sstable_set> compaction_group::make_repaired_sstable_set() const {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2352,40 +2352,6 @@ std::vector<sstables::shared_sstable> compaction_group::all_sstables() const {
     return all;
 }
 
-future<>
-compaction_group::update_repaired_at_for_merge() {
-    auto sstables_repaired_at = get_sstables_repaired_at();
-    constexpr int64_t new_repaired_at = 0;
-
-    auto modifier = [] (sstables::sstable& new_sst) {
-        new_sst.update_repaired_at(new_repaired_at);
-    };
-
-    std::unordered_map<compaction::compaction_group_view*, std::vector<sstables::shared_sstable>> sstables_by_view;
-    for (auto& sst : all_sstables()) {
-        auto& stats = sst->get_stats_metadata();
-        if (stats.repaired_at > sstables_repaired_at) {
-            auto& view = view_for_sstable(sst);
-            sstables_by_view[&view].push_back(sst);
-        } else {
-            tlogger.debug("Skipped repaired_at update for tablet merge sstable={} repaired_at={} sstables_repaired_at={} group_id={} range={}",
-                    sst->get_filename(), stats.repaired_at, sstables_repaired_at, group_id(), token_range());
-        }
-    }
-
-    auto& cm = get_compaction_manager();
-    for (auto& [view, ssts] : sstables_by_view) {
-        for (auto& sst : ssts) {
-            tlogger.info("Updating repaired_at for tablet merge sstable={} old={} new={} sstables_repaired_at={} group_id={} range={}",
-                    sst->get_filename(), sst->get_stats_metadata().repaired_at, new_repaired_at, sstables_repaired_at, group_id(), token_range());
-        }
-        co_await cm.perform_component_rewrite(*view, tasks::task_info{}, std::move(ssts),
-                sstables::component_type::Statistics, modifier);
-    }
-    tlogger.info("Completed updating repaired_at={} for tablet merge in compaction group_id={} range={}",
-            new_repaired_at, group_id(), token_range());
-}
-
 future<compaction_reenablers_and_lock_holders> table::get_compaction_reenablers_and_lock_holders_for_repair(replica::database& db,
         const service::frozen_topology_guard& guard, dht::token_range range) {
     auto ret = compaction_reenablers_and_lock_holders();
@@ -3732,16 +3698,50 @@ future<> table::update_repaired_at_for_merge() {
     if (utils::get_local_injector().enter("skip_update_repaired_at_for_merge")) {
         co_return;
     }
+    constexpr int64_t new_repaired_at = 0;
+
+    auto modifier = [] (sstables::sstable& new_sst) {
+        new_sst.update_repaired_at(new_repaired_at);
+    };
+
     auto sgs = storage_groups();
-    for (auto& x : sgs) {
-        auto sg = x.second;
-        if (sg) {
-            auto cgs = sg->compaction_groups_immediate();
-            for (auto& cg : cgs) {
-                auto cre = co_await cg->get_compaction_manager().stop_and_disable_compaction("update_repaired_at_for_merge", cg->view_for_unrepaired_data());
-                co_await cg->update_repaired_at_for_merge();
+    for (auto& [id, sg] : sgs) {
+        if (!sg) {
+            continue;
+        }
+        // After handle_tablet_merge_completion all compaction groups in this
+        // storage group share the same tablet ID, so any CG's
+        // get_sstables_repaired_at() returns the merged value.
+        auto sstables_repaired_at = sg->main_compaction_group()->get_sstables_repaired_at();
+    // FIXME: indent.
+    auto cgs = sg->compaction_groups_immediate();
+    for (auto& cg : cgs) {
+        auto cre = co_await cg->get_compaction_manager().stop_and_disable_compaction("update_repaired_at_for_merge", cg->view_for_unrepaired_data());
+
+        std::unordered_map<compaction::compaction_group_view*, std::vector<sstables::shared_sstable>> sstables_by_view;
+        for (auto& sst : cg->all_sstables()) {
+            auto& stats = sst->get_stats_metadata();
+            if (stats.repaired_at > sstables_repaired_at) {
+                auto& view = cg->view_for_sstable(sst);
+                sstables_by_view[&view].push_back(sst);
+            } else {
+                tlogger.debug("Skipped repaired_at update for tablet merge sstable={} repaired_at={} sstables_repaired_at={} group_id={} range={}",
+                              sst->get_filename(), stats.repaired_at, sstables_repaired_at, cg->group_id(), cg->token_range());
             }
         }
+
+        auto& cm = get_compaction_manager();
+      for (auto& [view, ssts] : sstables_by_view) {
+        for (auto& sst : ssts) {
+            tlogger.info("Updating repaired_at for tablet merge sstable={} old={} new={} sstables_repaired_at={} group_id={} range={}",
+                         sst->get_filename(), sst->get_stats_metadata().repaired_at, new_repaired_at, sstables_repaired_at, cg->group_id(), cg->token_range());
+        }
+        co_await cm.perform_component_rewrite(*view, tasks::task_info{}, std::move(ssts),
+                                              sstables::component_type::Statistics, modifier);
+      }
+        tlogger.info("Completed updating repaired_at={} for tablet merge in compaction group_id={} range={}",
+                     new_repaired_at, cg->group_id(), cg->token_range());
+    }
     }
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7517,10 +7517,12 @@ static future<> test_perform_component_rewrite_single_sstable(compaction::compac
 
         auto& compaction_group_view = table->compaction_group_view_for_sstable(original_sst);
 
-        std::vector<sstables::shared_sstable> sstables_to_rewrite = {original_sst};
+        auto filter = [&] (const sstables::shared_sstable& sst) {
+            return sst == original_sst;
+        };
         auto rewritten_map = cm.perform_component_rewrite(compaction_group_view,
                                                           tasks::task_info{},
-                                                          std::move(sstables_to_rewrite),
+                                                          filter,
                                                           component_type::Statistics,
                                                           std::move(modifier),
                                                           update_id).get();
@@ -7607,9 +7609,13 @@ SEASTAR_TEST_CASE(test_perform_component_rewrite_multiple_sstables) {
             auto modifier = [new_level] (sstable& sst) {
                 sst.mutate_sstable_level(new_level);
             };
+            std::unordered_set<sstables::shared_sstable> sst_set(ssts.begin(), ssts.end());
+            auto filter = [sst_set = std::move(sst_set)] (const sstables::shared_sstable& sst) {
+                return sst_set.contains(sst);
+            };
             auto rewritten_map = cm.perform_component_rewrite(*cg_view,
                                                               tasks::task_info{},
-                                                              std::move(ssts),
+                                                              std::move(filter),
                                                               component_type::Statistics,
                                                               std::move(modifier)).get();
             merged_rewritten_map.insert(rewritten_map.begin(), rewritten_map.end());

--- a/test/cluster/test_split_after_merge_repair_race.py
+++ b/test/cluster/test_split_after_merge_repair_race.py
@@ -1,0 +1,319 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Deterministic reproducer for the SCYLLADB-2531 unlinked-sstable abort
+originally observed in test_tablet_repair_wait
+(test/cluster/tasks/test_tablet_tasks.py).
+
+This isolates the split-bypass-vs-repair race exposed by that test.
+The abort fires inside the split bypass path after the captured
+SSTable was unlinked by repair's mark_sstable_as_repaired:
+
+    on_compaction_completion -> sstable_list_updater::prepare ->
+        on_internal_error("was already unlinked before being added to table")
+
+Why this test (vs. relying on the original test_tablet_repair_wait):
+
+  * test_tablet_repair_wait hits the race only statistically — it
+    relies on natural timing between split and repair, so reproducing
+    requires --repeat N and is not reliable in CI.
+  * Here we use error injections to park both split and repair at the
+    exact points needed to expose the race and explicitly order the
+    unlink.  The test fails deterministically on a pre-fix build and
+    passes after the fix.
+
+Sequence used here:
+
+  1. 3-node cluster, RF=3, tablets=4, tombstone_gc='repair'.
+  2. Insert 256 rows + flush + run one incremental repair so the
+     baseline sstables have repaired_at>0.
+  3. Insert 128 more rows + flush on all nodes -> fresh sstables with
+     repaired_at=0 (the actual race target).
+  4. Enable `split_bypass_before_completion` and
+     `repair_before_component_rewrite` injections on all nodes.
+  5. Trigger a tablet merge (force decrease) and wait for it to finalize.
+  6. Start a background incremental repair -> it will park at
+     repair_before_component_rewrite once it gets to
+     mark_sstable_as_repaired for the freshly-flushed sstable.
+  7. Trigger the split by raising min_tablet_count -> split's bypass
+     captures the fresh sstable and parks at
+     split_bypass_before_completion.
+  8. Release the repair injection -> mark_sstable_as_repaired calls
+     perform_component_rewrite, which creates a hard-linked replacement
+     sstable and unlinks the original file.
+  9. Release the split bypass -> on_compaction_completion is called with
+     desc.new_sstables = [original_sst], whose unlinked_at() is now
+     set -> sstable_list_updater::prepare() trips the diagnostic guard.
+
+abort_on_internal_error is set to false so the abort is logged but
+the node does not actually crash; we then grep for the marker.
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from test.cluster.util import new_test_keyspace
+from test.pylib.manager_client import ManagerClient
+from test.pylib.skip_types import skip_env
+from test.pylib.tablets import get_tablet_count
+
+logger = logging.getLogger(__name__)
+
+# Specific diagnostic marker emitted by sstable_list_updater::prepare()
+# when split's on_compaction_completion observes an sstable already
+# unlinked by repair's concurrent component rewrite (SCYLLADB-2531).
+# We intentionally do NOT match the generic "on_internal_error" string
+# here, as that would risk false positives from unrelated internal
+# errors hitting during the race window.
+ABORT_MARKER = "was already unlinked before being added to table"
+
+
+async def _enable(manager, servers, name, one_shot=False):
+    await asyncio.gather(*[
+        manager.api.enable_injection(s.ip_addr, name, one_shot=one_shot)
+        for s in servers
+    ])
+
+
+async def _disable(manager, servers, name):
+    for s in servers:
+        try:
+            await manager.api.disable_injection(s.ip_addr, name)
+        except Exception as e:
+            logger.debug("disable_injection(%s) on %s ignored: %s",
+                         name, s.server_id, e)
+
+
+async def _message(manager, servers, name):
+    for s in servers:
+        try:
+            await manager.api.message_injection(s.ip_addr, name)
+        except Exception as e:
+            logger.debug("message_injection(%s) on %s ignored: %s",
+                         name, s.server_id, e)
+
+
+async def _wait_for_pattern_any(logs, marks, pattern, timeout):
+    """Wait for *pattern* in any log; return the matching server or raise."""
+    tasks = {s: asyncio.create_task(log.wait_for(pattern, from_mark=marks[s]))
+             for s, log in logs.items()}
+    done, pending = await asyncio.wait(
+        tasks.values(), timeout=timeout,
+        return_when=asyncio.FIRST_COMPLETED)
+    for t in pending:
+        t.cancel()
+    if not done:
+        raise asyncio.TimeoutError(
+            f"pattern {pattern!r} not seen on any node within {timeout}s")
+    for s, t in tasks.items():
+        if t in done:
+            return s
+    raise asyncio.TimeoutError(f"pattern {pattern!r}: lost matching server")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
+async def test_split_bypass_race_with_repair_after_merge(manager: ManagerClient):
+    """
+    Deterministic reproducer of the unlinked-sstable abort in the split
+    bypass path, racing against repair's component rewrite, set up to
+    match the merge→split→repair timeline observed in CI.
+    """
+    cfg = {
+        'enable_tablets': True,
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        'abort_on_internal_error': False,
+    }
+    cmdline = [
+        '--logger-log-level', 'compaction=debug',
+        '--logger-log-level', 'table=debug',
+        '--logger-log-level', 'repair=debug',
+        '--logger-log-level', 'load_balancer=info',
+    ]
+    servers = await manager.servers_add(
+        3, cmdline=cmdline, config=cfg,
+        property_file=[{"dc": "dc1", "rack": f"r{i % 3}"} for i in range(3)])
+    cql = manager.get_cql()
+
+    initial_tablets = 4
+    async with new_test_keyspace(
+            manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', "
+            "'replication_factor': 3}") as ks:
+        await cql.run_async(
+            f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) "
+            f"WITH tablets = {{'min_tablet_count': {initial_tablets}}} "
+            f"AND tombstone_gc = {{'mode':'repair'}};")
+
+        # ---- Step 2: baseline data + first repair so sstables_repaired_at > 0.
+        logger.info("Inserting baseline data and flushing")
+        await asyncio.gather(*[
+            cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});")
+            for k in range(256)])
+        for s in servers:
+            await manager.api.flush_keyspace(s.ip_addr, ks)
+        logger.info("Running baseline incremental repair")
+        await manager.api.tablet_repair(
+            servers[0].ip_addr, ks, "test", "all",
+            incremental_mode='incremental')
+
+        # ---- Step 3: fresh data → memtable-origin sstables with
+        # repaired_at=0.  These are the race target.
+        logger.info("Inserting fresh data and flushing")
+        await asyncio.gather(*[
+            cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});")
+            for k in range(256, 384)])
+        for s in servers:
+            await manager.api.flush_keyspace(s.ip_addr, ks)
+
+        # Mark logs AFTER all setup so we only consider events from the
+        # actual race window onward.
+        logs = {s: await manager.server_open_log(s.server_id) for s in servers}
+        marks = {s: await logs[s].mark() for s in servers}
+
+        # ---- Step 4: enable injections.
+        logger.info("Enabling split_bypass_before_completion and "
+                    "repair_before_component_rewrite")
+        await _enable(manager, servers, "split_bypass_before_completion")
+        await _enable(manager, servers, "repair_before_component_rewrite")
+
+        repair_task = None
+        try:
+            # ---- Step 5: trigger merge (4 -> 2 tablets) and wait for
+            # it to finalize so the post-merge load-balancer emits the
+            # split decision naturally.
+            logger.info("Triggering tablet merge (force decrease)")
+            await _enable(manager, servers, "tablet_force_tablet_count_decrease")
+            try:
+                await _wait_for_pattern_any(
+                    logs, marks, "Detected tablet merge for table", timeout=120)
+                logger.info("Merge detected")
+            except asyncio.TimeoutError:
+                skip_env("Could not trigger merge in this run")
+            finally:
+                await _disable(manager, servers,
+                               "tablet_force_tablet_count_decrease")
+
+            # Wait for merge to actually halve the tablets so the
+            # subsequent split has well-defined post-state.  If it
+            # never drops, the rest of the orchestration no longer
+            # matches the merge -> split -> repair timeline, so we
+            # skip rather than risk a false-green pass.
+            merged = False
+            for _ in range(60):
+                n = await get_tablet_count(manager, servers[0], ks, 'test')
+                if n <= initial_tablets // 2:
+                    merged = True
+                    break
+                await asyncio.sleep(1)
+            if not merged:
+                current = await get_tablet_count(
+                    manager, servers[0], ks, 'test')
+                skip_env(
+                    f"Merge did not reduce tablet count within 60s "
+                    f"(current={current}); race window not exercised.")
+
+            # ---- Step 6: start the long-running repair in the background.
+            logger.info("Starting background incremental repair")
+            repair_task = asyncio.create_task(
+                manager.api.tablet_repair(
+                    servers[0].ip_addr, ks, "test", "all",
+                    incremental_mode='incremental'))
+
+            # ---- Step 7: trigger the split by raising min_tablet_count
+            # back up past the post-merge count.  This naturally emits a
+            # split decision (the same way the CI failure did via
+            # reason=initial after merge).
+            logger.info("Triggering tablet split (raise min_tablet_count)")
+            split_target = initial_tablets * 2
+            await cql.run_async(
+                f"ALTER TABLE {ks}.test WITH tablets = "
+                f"{{'min_tablet_count': {split_target}}}")
+
+            # Wait for split to park at the bypass injection.  We give
+            # it a wide window because the load-balancer must first
+            # emit the decision, then the split task must reach the
+            # bypass path.  If it never parks, the bypass-vs-rewrite
+            # race is not exercised at all, so skip rather than
+            # report a false green.
+            logger.info("Waiting for split bypass to park")
+            try:
+                await _wait_for_pattern_any(
+                    logs, marks,
+                    "split_bypass_before_completion: parked",
+                    timeout=180)
+                logger.info("Split bypass parked")
+            except asyncio.TimeoutError:
+                skip_env("Split bypass never parked within 180s; "
+                         "race window not exercised.")
+
+            # Wait for repair to park at the component rewrite.  If
+            # this point is never reached the unlink ordering required
+            # to expose the race does not happen, so skip.
+            logger.info("Waiting for repair to park at component rewrite")
+            try:
+                await _wait_for_pattern_any(
+                    logs, marks,
+                    "repair_before_component_rewrite: waiting for message",
+                    timeout=120)
+                logger.info("Repair parked at component rewrite")
+            except asyncio.TimeoutError:
+                skip_env("Repair never parked at component rewrite "
+                         "within 120s; race window not exercised.")
+
+            # ---- Step 8: release repair -> it does the component
+            # rewrite and unlinks the original sstable file.
+            logger.info("Releasing repair from component rewrite")
+            await _message(manager, servers,
+                           "repair_before_component_rewrite")
+            # Give the rewrite/unlink a moment to take effect on disk.
+            await asyncio.sleep(2)
+
+            # ---- Step 9: release split bypass -> on_compaction_completion
+            # observes the unlinked sstable and trips the diagnostic guard.
+            logger.info("Releasing split bypass")
+            await _message(manager, servers,
+                           "split_bypass_before_completion")
+            # Give the abort marker a moment to be logged.
+            await asyncio.sleep(3)
+        finally:
+            # Defensive cleanup.  Disable everything so the test framework
+            # tears down cleanly even if the orchestration above raised.
+            for name in ("split_bypass_before_completion",
+                         "repair_before_component_rewrite",
+                         "tablet_force_tablet_count_decrease"):
+                await _disable(manager, servers, name)
+            if repair_task is not None:
+                try:
+                    await asyncio.wait_for(repair_task, timeout=120)
+                    logger.info("Repair task completed")
+                except asyncio.TimeoutError:
+                    logger.warning("Repair task did not complete within 120s")
+                    repair_task.cancel()
+                except Exception as e:
+                    logger.warning("Repair task raised: %s", e)
+
+        # ---- Check for the race signal.
+        logger.info("Checking for abort marker")
+        hit = None
+        for s in servers:
+            matches = await logs[s].grep(ABORT_MARKER, from_mark=marks[s])
+            if matches:
+                hit = (s.server_id, matches[0][0])
+                break
+
+        if hit:
+            where, line = hit
+            pytest.fail(
+                f"Race reproduced on server {where}: {ABORT_MARKER!r} at {line!r}. "
+                "Split's on_compaction_completion observed an SSTable already "
+                "unlinked by repair's concurrent component rewrite. "
+                "See SCYLLADB-2531.")
+        else:
+            logger.info("No abort marker observed - fix appears effective")


### PR DESCRIPTION
Bug: during a concurrent tablet split, repair's mark_sstable_as_repaired()
uses compaction_group_view_for_sstable() to route each sstable to its
compaction group.  This per-sstable routing is fragile: when the tablet
layout is in flux, the routing can send the sstable to an outdated
compaction group.  Repair then unlinks the sstable via component rewrite
in that stale group, but split still tracks the sstable in its original
compacting set.  When split's on_compaction_completion() later tries to
add the sstable it observes "was already unlinked before being added to
table".

Fix: replace the per-sstable routing with a filter-based capture that
runs under run_with_compaction_disabled().  The new
perform_component_rewrite() in compaction_manager captures ALL matching
sstables from the view atomically while compaction is disabled,
registers them as compacting, and then performs the rewrite.  This
eliminates the cross-CG routing entirely — every captured sstable
belongs to the correct view at capture time and no other operation can
move it.

Additionally, repair now acquires the incremental repair write lock on
the repairing view (in addition to the unrepaired view), so that split's
read-lock acquisition on the repairing view is serialized behind repair.

Reproduction (deterministic via error injections):
  1. 3-node cluster, RF=3, tablets=4, tombstone_gc='repair'
  2. Insert baseline data, flush, run repair (populates repaired view)
  3. Insert fresh data, flush (creates unrepaired sstables)
  4. Enable split_bypass_before_completion and
     repair_before_component_rewrite injections
  5. Merge 4->2 tablets, then start background incremental repair
  6. Trigger split 2->8 — split's bypass captures the fresh sstable
  7. Release repair — component rewrite unlinks the sstable
  8. Release split — on_compaction_completion sees the unlinked sstable
     -> abort (without the fix) or clean pass (with the fix)

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2531
Signed-off-by: Raphael S. Carvalho <raphaelsc@scylladb.com>