### PR TITLE
utils: introduce wrapped_function for type-safe void callbacks

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -97,7 +97,7 @@ future<> unset_server_config(http_context& ctx) {
 
 static future<> register_api(http_context& ctx, const sstring& api_name,
         const sstring api_desc,
-        std::function<void(http_context& ctx, routes& r)> f) {
+        utils::wrapped_function<void(http_context& ctx, routes& r)> f) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 
     return ctx.http_server.set_routes([rb, &ctx, api_name, api_desc, f](routes& r) {

--- a/auth/cache.cc
+++ b/auth/cache.cc
@@ -55,7 +55,7 @@ lw_shared_ptr<const cache::role_record> cache::get(std::string_view role) const 
     return it->second;
 }
 
-void cache::for_each_role(const std::function<void(const role_name_t&, const role_record&)>& func) const {
+void cache::for_each_role(const utils::wrapped_function<void(const role_name_t&, const role_record&)>& func) const {
     for (const auto& [name, record] : _roles) {
         func(name, *record);
     }

--- a/auth/cache.hh
+++ b/auth/cache.hh
@@ -16,6 +16,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
+#include "utils/wrapped_function.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/metrics_registration.hh>
@@ -66,7 +67,7 @@ public:
 
     // The callback doesn't suspend (no co_await) so it observes the state
     // of the cache atomically.
-    void for_each_role(const std::function<void(const role_name_t&, const role_record&)>& func) const;
+    void for_each_role(const utils::wrapped_function<void(const role_name_t&, const role_record&)>& func) const;
 
 private:
     using roles_map = absl::flat_hash_map<role_name_t, lw_shared_ptr<role_record>, sstring_hash, sstring_eq>;

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -383,7 +383,7 @@ class compacted_fragments_writer {
     compaction& _c;
     std::optional<compaction_writer> _compaction_writer = {};
     using creator_func_t = std::function<compaction_writer(const dht::decorated_key&)>;
-    using stop_func_t = std::function<void(compaction_writer*)>;
+    using stop_func_t = utils::wrapped_function<void(compaction_writer*)>;
     creator_func_t _create_compaction_writer;
     stop_func_t _stop_compaction_writer;
     std::optional<utils::observer<>> _stop_request_observer;
@@ -1577,7 +1577,7 @@ private:
         compaction_type_options::scrub::drop_unfixable_sstables _drop_unfixable_sstables;
 
     private:
-        void maybe_abort_scrub(std::function<void()> report_error) {
+        void maybe_abort_scrub(utils::wrapped_function<void()> report_error) {
             if (_scrub_mode == compaction_type_options::scrub::mode::abort) {
                 report_error();
                 throw compaction_aborted_exception(_schema->ks_name(), _schema->cf_name(), "scrub compaction found invalid data");

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -17,6 +17,7 @@
 #include "sstables/sstable_set.hh"
 #include "compaction_fwd.hh"
 #include "mutation_writer/token_group_based_splitting_writer.hh"
+#include "utils/wrapped_function.hh"
 #include "utils/chunked_vector.hh"
 
 namespace compaction {
@@ -47,7 +48,7 @@ struct compaction_completion_desc {
 // creates a new SSTable for a given shard
 using compaction_sstable_creator_fn = std::function<sstables::shared_sstable(shard_id shard)>;
 // Replaces old sstable(s) by new one(s) which contain all non-expired data.
-using compaction_sstable_replacer_fn = std::function<void(compaction_completion_desc)>;
+using compaction_sstable_replacer_fn = utils::wrapped_function<void(compaction_completion_desc)>;
 
 class compaction_type_options {
 public:
@@ -97,7 +98,7 @@ public:
     };
     struct component_rewrite {
         sstables::component_type component_to_rewrite;
-        std::function<void(sstables::sstable&)> modifier;
+        utils::wrapped_function<void(sstables::sstable&)> modifier;
 
         using update_sstable_id = bool_class<class update_sstable_id_tag>;
         update_sstable_id update_id = update_sstable_id::yes;
@@ -141,7 +142,7 @@ public:
         return compaction_type_options(scrub{.operation_mode = mode, .quarantine_sstables = quarantine_sstables, .drop_unfixable = drop_unfixable_sstables});
     }
 
-    static compaction_type_options make_component_rewrite(component_type component, std::function<void(sstables::sstable&)> modifier, component_rewrite::update_sstable_id update_id = component_rewrite::update_sstable_id::yes) {
+    static compaction_type_options make_component_rewrite(component_type component, utils::wrapped_function<void(sstables::sstable&)> modifier, component_rewrite::update_sstable_id update_id = component_rewrite::update_sstable_id::yes) {
         return compaction_type_options(component_rewrite{.component_to_rewrite = component, .modifier = std::move(modifier), .update_id = update_id});
     }
 

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1114,7 +1114,7 @@ void compaction_manager::enable() {
     cmlog.info("Enabled");
 }
 
-std::function<void()> compaction_manager::compaction_submission_callback() {
+utils::wrapped_function<void()> compaction_manager::compaction_submission_callback() {
     return [this] () mutable {
         auto now = gc_clock::now();
         for (auto& [table, state] : _compaction_state) {
@@ -2397,7 +2397,7 @@ future<std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>> c
             tasks::task_info info,
             std::vector<sstables::shared_sstable> sstables,
             sstables::component_type component,
-            std::function<void(sstables::sstable&)> modifier,
+            utils::wrapped_function<void(sstables::sstable&)> modifier,
             compaction_type_options::component_rewrite::update_sstable_id update_id) {
     std::unordered_map<sstables::shared_sstable, sstables::shared_sstable> rewritten_sstables;
     rewritten_sstables.reserve(sstables.size());

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -17,6 +17,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/rwlock.hh>
+#include "utils/wrapped_function.hh"
 #include "sstables/shared_sstable.hh"
 #include "utils/exponential_backoff_retry.hh"
 #include "utils/updateable_value.hh"
@@ -149,7 +150,7 @@ private:
 
     utils::pluggable<db::system_keyspace> _sys_ks;
 
-    std::function<void()> compaction_submission_callback();
+    utils::wrapped_function<void()> compaction_submission_callback();
     // all registered tables are reevaluated at a constant interval.
     // Submission is a NO-OP when there's nothing to do, so it's fine to call it regularly.
     static constexpr std::chrono::seconds periodic_compaction_submission_interval() { return std::chrono::seconds(3600); }
@@ -372,7 +373,7 @@ public:
             tasks::task_info info,
             std::vector<sstables::shared_sstable> sstables,
             sstables::component_type component,
-            std::function<void(sstables::sstable&)> modifier,
+            utils::wrapped_function<void(sstables::sstable&)> modifier,
             compaction_type_options::component_rewrite::update_sstable_id update_id = compaction_type_options::component_rewrite::update_sstable_id::yes);
 
     // Submit a table for major compaction.

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -20,6 +20,7 @@
 #include "seastarx.hh"
 #include "cql3/values.hh"
 #include "utils/chunked_string.hh"
+#include "utils/wrapped_function.hh"
 
 class row;
 
@@ -448,7 +449,7 @@ struct collection_constructor {
 };
 
 // Called with error message string.
-using error_sink_fn = std::function<void(const std::string&)>;
+using error_sink_fn = utils::wrapped_function<void(const std::string&)>;
 
 std::map<sstring, sstring> convert_property_map(const collection_constructor&, error_sink_fn);
 

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -127,7 +127,7 @@ void functions::add_function(shared_ptr<function> func) {
     _declared.emplace(func->name(), func);
 }
 
-void functions::with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, std::function<void(declared_t::iterator)> f) {
+void functions::with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, utils::wrapped_function<void(declared_t::iterator)> f) {
     auto cit = find_iter(name, arg_types);
     if (cit == _declared.end() || cit->second->is_native()) {
         log.error("attempted to remove or alter non existent user defined function {}({})", name, arg_types);

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -15,6 +15,7 @@
 #include "cql3/cql3_type.hh"
 #include "cql3/functions/function_name.hh"
 #include "schema/schema.hh"
+#include "utils/wrapped_function.hh"
 #include <unordered_map>
 #include "data_dictionary/user_types_metadata.hh"
 
@@ -74,7 +75,7 @@ public:
     std::optional<function_name> used_by_user_aggregate(shared_ptr<user_function>) const;
     std::optional<function_name> used_by_user_function(const ut_name& user_type) const;
 private:
-    void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, std::function<void(declared_t::iterator)> f);
+    void with_udf_iter(const function_name& name, const std::vector<data_type>& arg_types, utils::wrapped_function<void(declared_t::iterator)> f);
 
     template <typename F>
     std::vector<shared_ptr<F>> get_filtered_transformed(const sstring& keyspace) const;

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -141,7 +141,7 @@ private:
     // Tracks the rolling maximum of gross bytes allocated during CQL parsing
     utils::rolling_max_tracker _parsing_cost_tracker{1000};
 
-    std::function<void(uint32_t)> _auth_prepared_cache_cfg_cb;
+    utils::wrapped_function<void(uint32_t)> _auth_prepared_cache_cfg_cb;
     serialized_action _authorized_prepared_cache_config_action;
     utils::observer<uint32_t> _authorized_prepared_cache_update_interval_in_ms_observer;
     utils::observer<uint32_t> _authorized_prepared_cache_validity_in_ms_observer;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1974,7 +1974,7 @@ build_get_multi_column_clustering_bounds_fn(
         const std::vector<predicate>& multi_column_restrictions,
         bool all_natural, bool all_reverse) {
     const auto prefix3cmp = get_unreversed_tri_compare(*schema);
-    std::vector<std::function<void (multi_column_range_accumulator&, const query_options&)>> range_builders;
+    std::vector<utils::wrapped_function<void (multi_column_range_accumulator&, const query_options&)>> range_builders;
     for (const auto& pred : multi_column_restrictions) {
         const auto& binop = expr::as<binary_operator>(pred.filter);
         range_builders.emplace_back([binop, schema, prefix3cmp] (multi_column_range_accumulator& acc, const query_options& options) {

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -356,7 +356,7 @@ std::pair<schema_ptr, std::vector<view_ptr>> alter_table_statement::prepare_sche
     auto cf = db.find_column_family(s);
     std::vector<view_ptr> view_updates;
 
-    using column_change_fn = std::function<void (const alter_table_statement*, const query_options&, const schema&, data_dictionary::table, schema_builder&, std::vector<view_ptr>&, const column_identifier&, const data_type, const column_definition*, bool)>;
+    using column_change_fn = utils::wrapped_function<void (const alter_table_statement*, const query_options&, const schema&, data_dictionary::table, schema_builder&, std::vector<view_ptr>&, const column_identifier&, const data_type, const column_definition*, bool)>;
 
     auto invoke_column_change_fn = [&] (column_change_fn fn) {
          for (auto& [raw_name, raw_validator, is_static] : _column_changes) {

--- a/db/chained_delegating_reader.hh
+++ b/db/chained_delegating_reader.hh
@@ -9,16 +9,17 @@
 #pragma once
 
 #include "readers/mutation_reader.hh"
+#include "utils/wrapped_function.hh"
 
 // A reader which allows to insert a deferring operation before reading.
 // All calls will first wait for a future to resolve, then forward to a given underlying reader.
 class chained_delegating_reader : public mutation_reader::impl {
     std::unique_ptr<mutation_reader> _underlying;
     std::function<future<mutation_reader>()> _populate_reader;
-    std::function<void()> _on_destroyed;
+    utils::wrapped_function<void()> _on_destroyed;
     
 public:
-    chained_delegating_reader(schema_ptr s, std::function<future<mutation_reader>()>&& populate, reader_permit permit, std::function<void()> on_destroyed = []{})
+    chained_delegating_reader(schema_ptr s, std::function<future<mutation_reader>()>&& populate, reader_permit permit, utils::wrapped_function<void()> on_destroyed = []{})
         : impl(s, std::move(permit))
         , _populate_reader(std::move(populate))
         , _on_destroyed(std::move(on_destroyed))

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -14,6 +14,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/simple-stream.hh>
 #include "replay_position.hh"
+#include "utils/wrapped_function.hh"
 #include "commitlog_entry.hh"
 #include "db/timeout_clock.hh"
 #include "gc_clock.hh"
@@ -189,7 +190,7 @@ public:
      * Don't write less, absolutely don't write more...
      */
     using output = typename seastar::memory_output_stream<detail::sector_split_iterator>;
-    using serializer_func = std::function<void(output&)>;
+    using serializer_func = utils::wrapped_function<void(output&)>;
 
     /**
      * Add a "Mutation" to the commit log.
@@ -280,7 +281,7 @@ public:
      * in the background.
      *
      */
-    typedef std::function<void(cf_id_type, replay_position)> flush_handler;
+    typedef utils::wrapped_function<void(cf_id_type, replay_position)> flush_handler;
     typedef uint64_t flush_handler_id;
 
     class flush_handler_anchor {

--- a/db/tags/utils.cc
+++ b/db/tags/utils.cc
@@ -38,7 +38,7 @@ std::optional<std::string> find_tag(const schema& s, const sstring& tag) {
 }
 
 future<> modify_tags(service::migration_manager& mm, sstring ks, sstring cf,
-                     std::function<void(std::map<sstring, sstring>&)> modify) {
+                     utils::wrapped_function<void(std::map<sstring, sstring>&)> modify) {
     co_await mm.container().invoke_on(0, [ks = std::move(ks), cf = std::move(cf), modify = std::move(modify)] (service::migration_manager& mm) -> future<> {
         size_t retries = mm.get_concurrent_ddl_retries();
         for (;;) {

--- a/db/tags/utils.hh
+++ b/db/tags/utils.hh
@@ -14,6 +14,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 #include "seastarx.hh"
+#include "utils/wrapped_function.hh"
 
 #include "schema/schema.hh"
 #include "service/migration_manager.hh"
@@ -45,5 +46,5 @@ std::optional<std::string> find_tag(const schema& s, const sstring& tag);
 // If the table didn't have the tags schema extension, it's fine: The function
 // is passed an empty map, and the tags it adds will be added to the table.
 future<> modify_tags(service::migration_manager& mm, sstring ks, sstring cf,
-                     std::function<void(std::map<sstring, sstring>&)> modify_func);
+                     utils::wrapped_function<void(std::map<sstring, sstring>&)> modify_func);
 }

--- a/db/virtual_table.hh
+++ b/db/virtual_table.hh
@@ -10,6 +10,7 @@
 
 #include "replica/memtable.hh"
 #include "replica/database_fwd.hh"
+#include "utils/wrapped_function.hh"
 
 namespace db {
 
@@ -54,13 +55,13 @@ public:
 
     // Override one of these execute() overloads.
     // The handler is always allowed to produce more data than implied by the query_restrictions.
-    virtual future<> execute(std::function<void(mutation)> mutation_sink) { return make_ready_future<>(); }
+    virtual future<> execute(utils::wrapped_function<void(mutation)> mutation_sink) { return make_ready_future<>(); }
 
-    virtual future<> execute(std::function<void(mutation)> mutation_sink, reader_permit) {
+    virtual future<> execute(utils::wrapped_function<void(mutation)> mutation_sink, reader_permit) {
         return execute(mutation_sink);
     }
 
-    virtual future<> execute(std::function<void(mutation)> mutation_sink, const query_restrictions&, reader_permit permit) {
+    virtual future<> execute(utils::wrapped_function<void(mutation)> mutation_sink, const query_restrictions&, reader_permit permit) {
         return execute(mutation_sink, permit);
     }
 

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -83,7 +83,7 @@ public:
             .build();
     }
 
-    future<> execute(std::function<void(mutation)> mutation_sink) override {
+    future<> execute(utils::wrapped_function<void(mutation)> mutation_sink) override {
         auto muts = co_await _dist_ss.invoke_on(0, [this] (service::storage_service& ss) -> future<utils::chunked_vector<frozen_mutation>> {
             auto& gossiper = _dist_gossiper.local();
             auto ownership = co_await ss.get_ownership();
@@ -358,7 +358,7 @@ public:
             .build();
     }
 
-    future<> execute(std::function<void(mutation)> mutation_sink) override {
+    future<> execute(utils::wrapped_function<void(mutation)> mutation_sink) override {
         // Servers are registered on shard 0 only
         const auto server_infos = co_await smp::submit_to(0ul, [&ss = _ss.container()] {
             return ss.local().protocol_servers()
@@ -396,7 +396,7 @@ private:
         return std::nullopt;
     }
 
-    void do_add_partition(std::function<void(mutation)>& mutation_sink, dht::decorated_key key, std::vector<std::pair<sstring, sstring>> rows) {
+    void do_add_partition(utils::wrapped_function<void(mutation)>& mutation_sink, dht::decorated_key key, std::vector<std::pair<sstring, sstring>> rows) {
         mutation m(schema(), std::move(key));
         for (auto&& [ckey, cvalue] : rows) {
             row& cr = m.partition().clustered_row(*schema(), clustering_key::from_single_value(*schema(), data_value(std::move(ckey)).serialize_nonnull())).cells();
@@ -405,26 +405,26 @@ private:
         mutation_sink(std::move(m));
     }
 
-    void add_partition(std::function<void(mutation)>& mutation_sink, sstring key, sstring value) {
+    void add_partition(utils::wrapped_function<void(mutation)>& mutation_sink, sstring key, sstring value) {
         if (_generic_key) {
             do_add_partition(mutation_sink, *_generic_key, {{key, std::move(value)}});
         }
     }
 
-    void add_partition(std::function<void(mutation)>& mutation_sink, sstring key, std::initializer_list<std::pair<sstring, sstring>> rows) {
+    void add_partition(utils::wrapped_function<void(mutation)>& mutation_sink, sstring key, std::initializer_list<std::pair<sstring, sstring>> rows) {
         auto dk = maybe_make_key(std::move(key));
         if (dk) {
             do_add_partition(mutation_sink, std::move(*dk), std::move(rows));
         }
     }
 
-    future<> add_partition(std::function<void(mutation)>& mutation_sink, sstring key, std::function<future<sstring>()> value_producer) {
+    future<> add_partition(utils::wrapped_function<void(mutation)>& mutation_sink, sstring key, std::function<future<sstring>()> value_producer) {
         if (_generic_key) {
             do_add_partition(mutation_sink, *_generic_key, {{key, co_await value_producer()}});
         }
     }
 
-    future<> add_partition(std::function<void(mutation)>& mutation_sink, sstring key, std::function<future<std::vector<std::pair<sstring, sstring>>>()> value_producer) {
+    future<> add_partition(utils::wrapped_function<void(mutation)>& mutation_sink, sstring key, std::function<future<std::vector<std::pair<sstring, sstring>>>()> value_producer) {
         auto dk = maybe_make_key(std::move(key));
         if (dk) {
             do_add_partition(mutation_sink, std::move(*dk), co_await value_producer());
@@ -485,7 +485,7 @@ public:
             .build();
     }
 
-    future<> execute(std::function<void(mutation)> mutation_sink) override {
+    future<> execute(utils::wrapped_function<void(mutation)> mutation_sink) override {
         co_await add_partition(mutation_sink, "gossip_active", [this] () -> future<sstring> {
             return _ss.is_gossip_running().then([] (bool running){
                 return format("{}", running);
@@ -626,7 +626,7 @@ public:
             .build();
     }
 
-    future<> execute(std::function<void(mutation)> mutation_sink) override {
+    future<> execute(utils::wrapped_function<void(mutation)> mutation_sink) override {
         mutation m(schema(), partition_key::from_single_value(*schema(), data_value("local").serialize_nonnull()));
         row& cr = m.partition().clustered_row(*schema(), clustering_key::make_empty()).cells();
         set_cell(cr, "version", scylla_version());
@@ -1054,7 +1054,7 @@ public:
         co_return leader == _raft_gr.local().get_my_raft_id();
     }
 
-    future<> redirect_to_leader(std::function<void(mutation)> mutation_sink, reader_permit permit) {
+    future<> redirect_to_leader(utils::wrapped_function<void(mutation)> mutation_sink, reader_permit permit) {
         auto leader = co_await get_leader(permit);
         auto cmd = query::read_command(_s->id(),
                                        _s->version(),
@@ -1083,9 +1083,9 @@ public:
     // This function is executed on the node which was a group0 leader at some point since the query started.
     // The node may not be the leader anymore by the time it is executed.
     // Only executed on shard 0.
-    virtual future<> execute_on_leader(std::function<void(mutation)> mutation_sink, reader_permit) = 0;
+    virtual future<> execute_on_leader(utils::wrapped_function<void(mutation)> mutation_sink, reader_permit) = 0;
 
-    future<> execute(std::function<void(mutation)> mutation_sink, reader_permit permit) override {
+    future<> execute(utils::wrapped_function<void(mutation)> mutation_sink, reader_permit permit) override {
         if (this_shard_id() != 0) {
             co_return;
         }
@@ -1116,7 +1116,7 @@ public:
         , _gossiper(gossiper)
     { }
 
-    future<> execute_on_leader(std::function<void(mutation)> mutation_sink, reader_permit permit) override {
+    future<> execute_on_leader(utils::wrapped_function<void(mutation)> mutation_sink, reader_permit permit) override {
         auto stats = _talloc.local().get_load_stats();
         while (!stats) {
             // Wait for stats to be refreshed by topology coordinator
@@ -1221,7 +1221,7 @@ public:
         , _db(db)
     { }
 
-    future<> execute_on_leader(std::function<void(mutation)> mutation_sink, reader_permit permit) override {
+    future<> execute_on_leader(utils::wrapped_function<void(mutation)> mutation_sink, reader_permit permit) override {
         auto stats = _talloc.local().get_load_stats();
         while (!stats) {
             // Wait for stats to be refreshed by topology coordinator

--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -743,7 +743,7 @@ public:
         co_return file{};
     }
 
-    future<bool> wrap_writeonly(const sstables::sstable& sst, sstables::component_type type, std::function<void(shared_ptr<symmetric_key>)> apply) {
+    future<bool> wrap_writeonly(const sstables::sstable& sst, sstables::component_type type, utils::wrapped_function<void(shared_ptr<symmetric_key>)> apply) {
         auto s = sst.get_schema();
         shared_ptr<encryption_schema_extension> esx;
         auto e = s->extensions().find(encryption_attribute);

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -894,7 +894,7 @@ future<semaphore_units<>> gossiper::lock_endpoint_update_semaphore() {
     return get_units(_endpoint_update_semaphore, 1, _abort_source);
 }
 
-future<> gossiper::mutate_live_and_unreachable_endpoints(std::function<void(live_and_unreachable_endpoints&)> func) {
+future<> gossiper::mutate_live_and_unreachable_endpoints(utils::wrapped_function<void(live_and_unreachable_endpoints&)> func) {
     auto lock = co_await lock_endpoint_update_semaphore();
     auto cloned = std::make_unique<live_and_unreachable_endpoints>(_live_endpoints, _unreachable_endpoints);
     func(*cloned);

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -13,6 +13,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/rpc/rpc_types.hh>
+#include "utils/wrapped_function.hh"
 #include "locator/host_id.hh"
 #include "utils/atomic_vector.hh"
 #include "utils/UUID.hh"
@@ -250,7 +251,7 @@ private:
     // which is then copied to temporary copies for all shards
     // and then applied atomcically on all shards.
     //
-    future<> mutate_live_and_unreachable_endpoints(std::function<void(live_and_unreachable_endpoints&)> func);
+    future<> mutate_live_and_unreachable_endpoints(utils::wrapped_function<void(live_and_unreachable_endpoints&)> func);
 
     // replicate shard 0 live and unreachable endpoints sets across all other shards.
     // _endpoint_update_semaphore must be held for the whole duration
@@ -387,7 +388,7 @@ public:
 
     // Calls func for each endpoint_state.
     // Called function must not yield
-    void for_each_endpoint_state(std::function<void(const endpoint_state&)> func) const {
+    void for_each_endpoint_state(utils::wrapped_function<void(const endpoint_state&)> func) const {
         for_each_endpoint_state_until([func = std::move(func)] (const endpoint_state& eps) {
             func(eps);
             return stop_iteration::no;

--- a/index/fulltext_index.cc
+++ b/index/fulltext_index.cc
@@ -24,7 +24,7 @@ namespace secondary_index {
 static const std::vector<sstring> analyzer_values = {
         "standard", "english", "german", "french", "spanish", "italian", "portuguese", "russian", "simple", "whitespace"};
 
-const static std::unordered_map<sstring, std::function<void(std::string_view, const sstring&, const sstring&)>> fulltext_index_options = {
+const static std::unordered_map<sstring, utils::wrapped_function<void(std::string_view, const sstring&, const sstring&)>> fulltext_index_options = {
         // 'analyzer' specifies the built-in text analyzer to use for tokenization.
         {"analyzer", std::bind_front(util::validate_enumerated_option, analyzer_values)},
         // 'positions' controls whether token positions are stored in the index.

--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -34,7 +34,7 @@ static const std::vector<sstring> quantization_values = {
     "f32", "f16", "bf16", "i8", "b1"
 };
 
-const static std::unordered_map<sstring, std::function<void(std::string_view, const sstring&, const sstring&)>> vector_index_options = {
+const static std::unordered_map<sstring, utils::wrapped_function<void(std::string_view, const sstring&, const sstring&)>> vector_index_options = {
         // `similarity_function` defines method of calculating similarity between vectors
         // Used internally by vector store during both indexing and querying
         // CQL implements corresponding functions in cql3/functions/similarity_functions.hh

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -234,7 +234,7 @@ public:
         return _normal_token_owners;
     }
 
-    void for_each_token_owner(std::function<void(const node&)> func) const;
+    void for_each_token_owner(utils::wrapped_function<void(const node&)> func) const;
 
     /* Returns the number of different endpoints that own tokens in the ring.
      * Bootstrapping tokens are not taken into account. */
@@ -729,7 +729,7 @@ size_t token_metadata_impl::count_normal_token_owners() const {
     return _normal_token_owners.size();
 }
 
-void token_metadata_impl::for_each_token_owner(std::function<void(const node&)> func) const {
+void token_metadata_impl::for_each_token_owner(utils::wrapped_function<void(const node&)> func) const {
     _topology.for_each_node([this, func = std::move(func)] (const node& node) {
         if (is_normal_token_owner(node.host_id())) {
             func(node);
@@ -1117,7 +1117,7 @@ token_metadata::get_normal_token_owners() const {
     return _impl->get_normal_token_owners();
 }
 
-void token_metadata::for_each_token_owner(std::function<void(const node&)> func) const {
+void token_metadata::for_each_token_owner(utils::wrapped_function<void(const node&)> func) const {
     return _impl->for_each_token_owner(func);
 }
 

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -13,6 +13,7 @@
 #include <functional>
 #include <unordered_set>
 #include <unordered_map>
+#include "utils/wrapped_function.hh"
 #include "gms/inet_address.hh"
 #include "dht/ring_position.hh"
 #include <optional>
@@ -320,7 +321,7 @@ public:
 
     const std::unordered_set<host_id>& get_normal_token_owners() const;
 
-    void for_each_token_owner(std::function<void(const node&)> func) const;
+    void for_each_token_owner(utils::wrapped_function<void(const node&)> func) const;
 
     /* Returns the number of different endpoints that own tokens in the ring.
      * Bootstrapping tokens are not taken into account. */

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -540,7 +540,7 @@ int topology::distance(const locator::host_id& address, const endpoint_dc_rack& 
     return d1;
 }
 
-void topology::for_each_node(std::function<void(const node&)> func) const {
+void topology::for_each_node(utils::wrapped_function<void(const node&)> func) const {
     for (const auto& np : _nodes) {
         if (np && !np->left() && !np->is_none()) {
             func(*np);

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -22,6 +22,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
 
+#include "utils/wrapped_function.hh"
 #include "locator/types.hh"
 #include "inet_address_vectors.hh"
 
@@ -384,7 +385,7 @@ public:
     static int distance(const locator::host_id& address, const endpoint_dc_rack& loc, const locator::host_id& address1, const endpoint_dc_rack& loc1) noexcept;
 
     // Executes a function for each node in a state other than "none" and "left".
-    void for_each_node(std::function<void(const node&)> func) const;
+    void for_each_node(utils::wrapped_function<void(const node&)> func) const;
 
     // Returns pointers to all nodes in a state other than "none" and "left".
     std::unordered_set<std::reference_wrapper<const node>> get_nodes() const;

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -243,7 +243,7 @@ rpc::stats messaging_service::shard_info::get_stats() const {
     return rpc_client->get_stats();
 }
 
-void messaging_service::foreach_client(std::function<void(const msg_addr& id, const shard_info& info)> f) const {
+void messaging_service::foreach_client(utils::wrapped_function<void(const msg_addr& id, const shard_info& info)> f) const {
     for (unsigned idx = 0; idx < _clients.size(); idx ++) {
         for (auto i = _clients[idx].cbegin(); i != _clients[idx].cend(); i++) {
             f(i->first, i->second);
@@ -251,7 +251,7 @@ void messaging_service::foreach_client(std::function<void(const msg_addr& id, co
     }
 }
 
-void messaging_service::foreach_server_connection_stats(std::function<void(const rpc::client_info&, const rpc::stats&)>&& f) const {
+void messaging_service::foreach_server_connection_stats(utils::wrapped_function<void(const rpc::client_info&, const rpc::stats&)>&& f) const {
     for (auto&& s : _server) {
         if (s) {
             s->foreach_connection([f](const rpc_protocol::server::connection& c) {

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -271,7 +271,7 @@ public:
         rpc::stats get_stats() const;
     };
 
-    void foreach_client(std::function<void(const msg_addr& id, const shard_info& info)> f) const;
+    void foreach_client(utils::wrapped_function<void(const msg_addr& id, const shard_info& info)> f) const;
 
     void increment_dropped_messages(messaging_verb verb);
 
@@ -445,7 +445,7 @@ public:
     void register_repair_get_full_row_hashes_with_rpc_stream(std::function<future<rpc::sink<repair_hash_with_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_stream_cmd> source, rpc::optional<shard_id> dst_cpu_id_opt)>&& func);
     future<> unregister_repair_get_full_row_hashes_with_rpc_stream();
 
-    void foreach_server_connection_stats(std::function<void(const rpc::client_info&, const rpc::stats&)>&& f) const;
+    void foreach_server_connection_stats(utils::wrapped_function<void(const rpc::client_info&, const rpc::stats&)>&& f) const;
 
     // Drops all connections from the given hosts and prevents further communication from it to happen.
     //

--- a/message/messaging_service_fwd.hh
+++ b/message/messaging_service_fwd.hh
@@ -11,6 +11,7 @@
 #include <boost/signals2/connection.hpp>
 #include <boost/signals2/dummy_mutex.hpp>
 #include <boost/signals2/signal_type.hpp>
+#include "utils/wrapped_function.hh"
 #include "locator/host_id.hh"
 
 namespace gms { class inet_address; }
@@ -22,7 +23,7 @@ enum class messaging_verb;
 class messaging_service;
 
 using connection_drop_signal_t = boost::signals2::signal_type<void (locator::host_id), boost::signals2::keywords::mutex_type<boost::signals2::dummy_mutex>>::type;
-using connection_drop_slot_t = std::function<void(locator::host_id)>;
+using connection_drop_slot_t = utils::wrapped_function<void(locator::host_id)>;
 using connection_drop_registration_t = boost::signals2::scoped_connection;
 
 }

--- a/mutation/json.hh
+++ b/mutation/json.hh
@@ -12,6 +12,7 @@
 #include "dht/token.hh"
 #include "schema/schema.hh"
 #include "utils/rjson.hh"
+#include "utils/wrapped_function.hh"
 
 /*
  * Utilities for converting mutations, mutation-fragments and their parts into json.
@@ -69,7 +70,7 @@ class mutation_partition_json_writer {
     json_writer _writer;
 
 private:
-    void write_each_collection_cell(collection_mutation_view cmv, data_type type, std::function<void(atomic_cell_view, data_type)> func);
+    void write_each_collection_cell(collection_mutation_view cmv, data_type type, utils::wrapped_function<void(atomic_cell_view, data_type)> func);
 
 public:
     explicit mutation_partition_json_writer(const schema& s, std::ostream& os = std::cout)

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -318,7 +318,7 @@ auto fmt::formatter<mutation>::format(const mutation& m, fmt::format_context& ct
 namespace mutation_json {
 
 void mutation_partition_json_writer::write_each_collection_cell(collection_mutation_view cmv, data_type type,
-        std::function<void(atomic_cell_view, data_type)> func) {
+        utils::wrapped_function<void(atomic_cell_view, data_type)> func) {
     std::function<void(size_t, managed_bytes_view)> write_key;
     std::function<void(size_t, atomic_cell_view)> write_value;
     if (auto t = dynamic_cast<const collection_type_impl*>(type.get())) {

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -213,7 +213,7 @@ class mutation_by_size_splitter {
     };
     const schema_ptr _schema;
     const size_t _max_size;
-    std::function<void(mutation)> _process_mutation;
+    utils::wrapped_function<void(mutation)> _process_mutation;
     std::optional<partition_state> _state;
     template <typename T>
     stop_iteration consume_fragment(T&& fragment) {
@@ -234,7 +234,7 @@ class mutation_by_size_splitter {
         return stop_iteration::no;
     }
 public:
-    mutation_by_size_splitter(schema_ptr schema, size_t max_size, std::function<void(mutation)> process_mutation)
+    mutation_by_size_splitter(schema_ptr schema, size_t max_size, utils::wrapped_function<void(mutation)> process_mutation)
         : _schema(std::move(schema))
         , _max_size(max_size)
         , _process_mutation(process_mutation)
@@ -319,8 +319,8 @@ namespace mutation_json {
 
 void mutation_partition_json_writer::write_each_collection_cell(collection_mutation_view cmv, data_type type,
         utils::wrapped_function<void(atomic_cell_view, data_type)> func) {
-    std::function<void(size_t, managed_bytes_view)> write_key;
-    std::function<void(size_t, atomic_cell_view)> write_value;
+    utils::wrapped_function<void(size_t, managed_bytes_view)> write_key;
+    utils::wrapped_function<void(size_t, atomic_cell_view)> write_value;
     if (auto t = dynamic_cast<const collection_type_impl*>(type.get())) {
         write_key = [this, t = t->name_comparator()] (size_t, managed_bytes_view k) {
             k.with_linearized([&](bytes_view bv) { _writer.String(t->to_string(bv)); });

--- a/mutation/mutation_cleaner.hh
+++ b/mutation/mutation_cleaner.hh
@@ -12,6 +12,7 @@
 
 #include "partition_version.hh"
 #include "partition_version_list.hh"
+#include "utils/wrapped_function.hh"
 
 #include "utils/logalloc.hh"
 
@@ -36,7 +37,7 @@ private:
     lw_shared_ptr<worker> _worker_state;
     mutation_application_stats& _app_stats;
     seastar::scheduling_group _scheduling_group;
-    std::function<void(size_t)> _on_space_freed;
+    utils::wrapped_function<void(size_t)> _on_space_freed;
 private:
     stop_iteration merge_some(partition_snapshot& snp) noexcept;
     stop_iteration merge_some() noexcept;
@@ -45,7 +46,7 @@ public:
     mutation_cleaner_impl(logalloc::region& r, cache_tracker* t, mutation_cleaner* cleaner,
             mutation_application_stats& app_stats,
             seastar::scheduling_group sg = seastar::current_scheduling_group(),
-            std::function<void(size_t)> on_space_freed = nullptr)
+            utils::wrapped_function<void(size_t)> on_space_freed = {})
         : _region(r)
         , _tracker(t)
         , _cleaner(cleaner)
@@ -128,7 +129,7 @@ class mutation_cleaner final {
 public:
     mutation_cleaner(logalloc::region& r, cache_tracker* t, mutation_application_stats& app_stats,
             seastar::scheduling_group sg = seastar::current_scheduling_group(),
-            std::function<void(size_t)> on_space_freed = nullptr)
+            utils::wrapped_function<void(size_t)> on_space_freed = {})
         : _impl(make_lw_shared<mutation_cleaner_impl>(r, t, this, app_stats, sg, std::move(on_space_freed))) {
     }
 

--- a/partition_slice_builder.cc
+++ b/partition_slice_builder.cc
@@ -84,7 +84,7 @@ partition_slice_builder::with_ranges(std::vector<query::clustering_range> ranges
 }
 
 partition_slice_builder&
-partition_slice_builder::mutate_ranges(std::function<void(std::vector<query::clustering_range>&)> func) {
+partition_slice_builder::mutate_ranges(utils::wrapped_function<void(std::vector<query::clustering_range>&)> func) {
     if (_row_ranges) {
         func(*_row_ranges);
     }
@@ -92,7 +92,7 @@ partition_slice_builder::mutate_ranges(std::function<void(std::vector<query::clu
 }
 
 partition_slice_builder&
-partition_slice_builder::mutate_specific_ranges(std::function<void(query::specific_ranges&)> func) {
+partition_slice_builder::mutate_specific_ranges(utils::wrapped_function<void(query::specific_ranges&)> func) {
     if (_specific_ranges) {
         func(*_specific_ranges);
     }

--- a/partition_slice_builder.hh
+++ b/partition_slice_builder.hh
@@ -13,6 +13,7 @@
 
 #include "query/query-request.hh"
 #include "schema/schema_fwd.hh"
+#include "utils/wrapped_function.hh"
 
 //
 // Fluent builder for query::partition_slice.
@@ -42,9 +43,9 @@ public:
     partition_slice_builder& with_range(query::clustering_range range);
     partition_slice_builder& with_ranges(std::vector<query::clustering_range>);
     // noop if no ranges have been set yet
-    partition_slice_builder& mutate_ranges(std::function<void(std::vector<query::clustering_range>&)>);
+    partition_slice_builder& mutate_ranges(utils::wrapped_function<void(std::vector<query::clustering_range>&)>);
     // noop if no specific ranges have been set yet
-    partition_slice_builder& mutate_specific_ranges(std::function<void(query::specific_ranges&)>);
+    partition_slice_builder& mutate_specific_ranges(utils::wrapped_function<void(query::specific_ranges&)>);
     partition_slice_builder& set_specific_ranges(query::specific_ranges);
     partition_slice_builder& without_partition_key_columns();
     partition_slice_builder& without_clustering_key_columns();

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -8,6 +8,7 @@
 #pragma once
 #include <seastar/core/abort_source.hh>
 #include "raft.hh"
+#include "utils/wrapped_function.hh"
 
 namespace raft {
 
@@ -62,7 +63,7 @@ public:
         size_t max_command_size = 100 * 1024;
         // A callback to invoke if one of internal server
         // background activities has stopped because of an error.
-        std::function<void(std::exception_ptr e)> on_background_error;
+        utils::wrapped_function<void(std::exception_ptr e)> on_background_error;
     };
 
     virtual ~server() {}

--- a/reader_concurrency_semaphore_group.cc
+++ b/reader_concurrency_semaphore_group.cc
@@ -98,7 +98,7 @@ size_t reader_concurrency_semaphore_group::size() {
     return _semaphores.size();
 }
 
-void reader_concurrency_semaphore_group::foreach_semaphore(std::function<void(scheduling_group, reader_concurrency_semaphore&)> func) {
+void reader_concurrency_semaphore_group::foreach_semaphore(utils::wrapped_function<void(scheduling_group, reader_concurrency_semaphore&)> func) {
     for (auto& [sg, wsem] : _semaphores) {
         func(sg, wsem.sem);
     }

--- a/reader_concurrency_semaphore_group.hh
+++ b/reader_concurrency_semaphore_group.hh
@@ -10,6 +10,7 @@
 
 #include <unordered_map>
 #include <optional>
+#include "utils/wrapped_function.hh"
 #include "reader_concurrency_semaphore.hh"
 
 // The reader_concurrency_semaphore_group is a group of semaphores that shares a common pool of memory,
@@ -81,7 +82,7 @@ public:
     reader_concurrency_semaphore& add_or_update(scheduling_group sg, size_t shares);
     future<> remove(scheduling_group sg);
     size_t size();
-    void foreach_semaphore(std::function<void(scheduling_group, reader_concurrency_semaphore&)> func);
+    void foreach_semaphore(utils::wrapped_function<void(scheduling_group, reader_concurrency_semaphore&)> func);
 
     future<> foreach_semaphore_async(std::function<future<> (scheduling_group, reader_concurrency_semaphore&)> func);
 

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -42,7 +42,7 @@ mutation_reader make_delegating_reader(mutation_reader& r) {
 namespace {
 class partition_slicer {
 public:
-    using fragment_consumer = std::function<void(mutation_fragment_v2)>;
+    using fragment_consumer = utils::wrapped_function<void(mutation_fragment_v2)>;
 private:
     schema_ptr _schema;
     reader_permit _permit;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -605,7 +605,7 @@ named_semaphore& repair::task_manager_module::range_parallelism_semaphore() {
     return _range_parallelism_semaphore;
 }
 
-future<> repair::task_manager_module::run(repair_uniq_id id, std::function<void ()> func) {
+future<> repair::task_manager_module::run(repair_uniq_id id, utils::wrapped_function<void()> func) {
     return seastar::with_gate(async_gate(), [this, id, func = std::move(func)] () mutable {
         start(id);
         return seastar::async([func = std::move(func)] { func(); }).then([this, id] {

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -10,6 +10,7 @@
 
 #include "node_ops/node_ops_ctl.hh"
 #include "repair/repair.hh"
+#include "utils/wrapped_function.hh"
 #include "service/topology_guard.hh"
 #include "streaming/stream_reason.hh"
 #include "tasks/task_manager.hh"
@@ -296,7 +297,7 @@ public:
     size_t nr_running_repair_jobs();
     void abort_all_repairs();
     named_semaphore& range_parallelism_semaphore();
-    future<> run(repair_uniq_id id, std::function<void ()> func);
+    future<> run(repair_uniq_id id, utils::wrapped_function<void()> func);
     future<repair_status> repair_await_completion(int id, std::chrono::steady_clock::time_point timeout);
     float report_progress();
     future<bool> is_aborted(const tasks::task_id& uuid, shard_id shard);

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -385,7 +385,7 @@ public:
 
     uint64_t live_disk_space_used() const;
 
-    void for_each_compaction_group(std::function<void(const compaction_group_ptr&)> action) const;
+    void for_each_compaction_group(utils::wrapped_function<void(const compaction_group_ptr&)> action) const;
     utils::small_vector<compaction_group_ptr, 3> compaction_groups_immediate();
     utils::small_vector<const_compaction_group_ptr, 3> compaction_groups_immediate() const;
 
@@ -491,7 +491,7 @@ public:
     // invalidated when storage group count changes (e.g. split or merge).
     future<> parallel_foreach_storage_group(std::function<future<>(storage_group&)> f);
     future<> for_each_storage_group_gently(std::function<future<>(storage_group&)> f);
-    void for_each_storage_group(std::function<void(size_t, storage_group&)> f) const;
+    void for_each_storage_group(utils::wrapped_function<void(size_t, storage_group&)> f) const;
     const storage_group_map& storage_groups() const;
 
     future<> stop_storage_groups() noexcept;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3590,13 +3590,13 @@ bool database::tables_metadata::contains(std::pair<std::string_view, std::string
     return _ks_cf_to_uuid.contains(kscf);
 }
 
-void database::tables_metadata::for_each_table(std::function<void(table_id, lw_shared_ptr<table>)> f) const {
+void database::tables_metadata::for_each_table(utils::wrapped_function<void(table_id, lw_shared_ptr<table>)> f) const {
     for (auto& [id, table]: _column_families) {
         f(id, table);
     }
 }
 
-void database::tables_metadata::for_each_table_id(std::function<void(const ks_cf_t&, table_id)> f) const {
+void database::tables_metadata::for_each_table_id(utils::wrapped_function<void(const ks_cf_t&, table_id)> f) const {
     for (auto& [kscf, id]: _ks_cf_to_uuid) {
         f(kscf, id);
     }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -21,6 +21,7 @@
 #include "types/user.hh"
 #include "utils/assert.hh"
 #include "utils/hash.hh"
+#include "utils/wrapped_function.hh"
 #include "cell_locking.hh"
 #include "db_clock.hh"
 #include "gc_clock.hh"
@@ -751,8 +752,8 @@ private:
     compaction_group& compaction_group_for_logstor_segment(logstor::log_segment_id, dht::token first_token, dht::token last_token) const;
     // Safely iterate through compaction groups, while performing async operations on them.
     future<> parallel_foreach_compaction_group(std::function<future<>(compaction_group&)> action);
-    void for_each_compaction_group(std::function<void(compaction_group&)> action);
-    void for_each_compaction_group(std::function<void(const compaction_group&)> action) const;
+    void for_each_compaction_group(utils::wrapped_function<void(compaction_group&)> action);
+    void for_each_compaction_group(utils::wrapped_function<void(const compaction_group&)> action) const;
     // Unsafe reference to all storage groups. Don't use it across preemption points.
     const storage_group_map& storage_groups() const;
 
@@ -829,7 +830,7 @@ private:
              const tracing::trace_state_ptr& trace_state,
              streamed_mutation::forwarding fwd,
              mutation_reader::forwarding fwd_mr,
-             std::function<void(size_t)> reserve_fn) const;
+             utils::wrapped_function<void(size_t)> reserve_fn) const;
 public:
     const storage_options& get_storage_options() const noexcept { return *_storage_opts; }
     lw_shared_ptr<const storage_options> get_storage_options_ptr() const noexcept { return _storage_opts; }
@@ -1633,8 +1634,8 @@ public:
         table_id get_table_id_if_exists(const std::pair<std::string_view, std::string_view>& kscf) const;
         bool contains(table_id id) const;
         bool contains(std::pair<std::string_view, std::string_view> kscf) const;
-        void for_each_table(std::function<void(table_id, lw_shared_ptr<table>)> f) const;
-        void for_each_table_id(std::function<void(const ks_cf_t&, table_id)> f) const;
+        void for_each_table(utils::wrapped_function<void(table_id, lw_shared_ptr<table>)> f) const;
+        void for_each_table_id(utils::wrapped_function<void(const ks_cf_t&, table_id)> f) const;
         future<> for_each_table_gently(std::function<future<>(table_id, lw_shared_ptr<table>)> f);
         future<> parallel_for_each_table(std::function<future<>(table_id, lw_shared_ptr<table>)> f);
         const std::unordered_map<table_id, lw_shared_ptr<table>> get_column_families_copy() const;

--- a/replica/logstor/compaction.hh
+++ b/replica/logstor/compaction.hh
@@ -9,6 +9,7 @@
 
 #include "types.hh"
 #include "utils/chunked_vector.hh"
+#include "utils/wrapped_function.hh"
 #include "write_buffer.hh"
 #include "utils/log_heap.hh"
 #include <seastar/coroutine/maybe_yield.hh>
@@ -118,8 +119,8 @@ struct segment_set {
 class segment_ref {
     struct state {
         log_segment_id id;
-        std::function<void()> on_last_release;
-        std::function<void()> on_failure;
+        utils::wrapped_function<void()> on_last_release;
+        utils::wrapped_function<void()> on_failure;
         bool flush_failure{false};
         ~state() {
             if (!flush_failure) {
@@ -146,7 +147,7 @@ public:
 
 private:
     friend class segment_manager_impl;
-    explicit segment_ref(log_segment_id id, std::function<void()> on_last_release, std::function<void()> on_failure)
+    explicit segment_ref(log_segment_id id, utils::wrapped_function<void()> on_last_release, utils::wrapped_function<void()> on_failure)
         : _state(make_lw_shared<state>(id, std::move(on_last_release), std::move(on_failure)))
     {}
 };
@@ -194,10 +195,10 @@ struct separator_buffer {
 };
 
 class compaction_reenabler {
-    std::function<void()> _release;
+    utils::wrapped_function<void()> _release;
 public:
     compaction_reenabler() = default;
-    explicit compaction_reenabler(std::function<void()> release)
+    explicit compaction_reenabler(utils::wrapped_function<void()> release)
         : _release(std::move(release)) {}
     ~compaction_reenabler() { if (_release) _release(); }
 

--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -306,11 +306,11 @@ mutation_reader logstor::make_reader(schema_ptr schema,
     );
 }
 
-void logstor::set_trigger_compaction_hook(std::function<void()> fn) {
+void logstor::set_trigger_compaction_hook(utils::wrapped_function<void()> fn) {
     _segment_manager.set_trigger_compaction_hook(std::move(fn));
 }
 
-void logstor::set_trigger_separator_flush_hook(std::function<void(segment_sequence)> fn) {
+void logstor::set_trigger_separator_flush_hook(utils::wrapped_function<void(segment_sequence)> fn) {
     _segment_manager.set_trigger_separator_flush_hook(std::move(fn));
 }
 

--- a/replica/logstor/logstor.hh
+++ b/replica/logstor/logstor.hh
@@ -73,8 +73,8 @@ public:
                                        const query::partition_slice& slice,
                                        tracing::trace_state_ptr trace_state = nullptr);
 
-    void set_trigger_compaction_hook(std::function<void()> fn);
-    void set_trigger_separator_flush_hook(std::function<void(segment_sequence)> fn);
+    void set_trigger_compaction_hook(utils::wrapped_function<void()> fn);
+    void set_trigger_separator_flush_hook(utils::wrapped_function<void(segment_sequence)> fn);
 };
 
 } // namespace logstor

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -603,8 +603,8 @@ class segment_manager_impl {
     std::vector<write_buffer> _separator_buffer_pool;
     std::vector<write_buffer*> _available_separator_buffers;
 
-    std::function<void()> _trigger_compaction_fn;
-    std::function<void(segment_sequence)> _trigger_separator_flush_fn;
+    utils::wrapped_function<void()> _trigger_compaction_fn;
+    utils::wrapped_function<void(segment_sequence)> _trigger_separator_flush_fn;
 
     utils::phased_barrier _writes_phaser{"logstor_sm_writes"};
 
@@ -670,11 +670,11 @@ public:
         return _compaction_mgr;
     }
 
-    void set_trigger_compaction_hook(std::function<void()> fn) {
+    void set_trigger_compaction_hook(utils::wrapped_function<void()> fn) {
         _trigger_compaction_fn = std::move(fn);
     }
 
-    void set_trigger_separator_flush_hook(std::function<void(segment_sequence)> fn) {
+    void set_trigger_separator_flush_hook(utils::wrapped_function<void(segment_sequence)> fn) {
         _trigger_separator_flush_fn = std::move(fn);
     }
 
@@ -1985,11 +1985,11 @@ void segment_manager::free_record(log_location location) {
     _impl->free_record(location);
 }
 
-void segment_manager::set_trigger_compaction_hook(std::function<void()> fn) {
+void segment_manager::set_trigger_compaction_hook(utils::wrapped_function<void()> fn) {
     _impl->set_trigger_compaction_hook(std::move(fn));
 }
 
-void segment_manager::set_trigger_separator_flush_hook(std::function<void(segment_sequence)> fn) {
+void segment_manager::set_trigger_separator_flush_hook(utils::wrapped_function<void(segment_sequence)> fn) {
     _impl->set_trigger_separator_flush_hook(std::move(fn));
 }
 

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -647,7 +647,7 @@ public:
     }
 
     future<> load_segment(replica::database&, log_segment_id);
-    future<> recover_segment(replica::database&, log_segment_id, primary_index::entry_cmp_fn cmp, std::function<void(const segment_header&)> on_header);
+    future<> recover_segment(replica::database&, log_segment_id, primary_index::entry_cmp_fn cmp, utils::wrapped_function<void(const segment_header&)> on_header);
     future<> add_segment_to_compaction_group(replica::database&, segment_descriptor&);
 
     void trigger_compaction() {
@@ -1825,7 +1825,7 @@ future<> segment_manager_impl::do_recovery(replica::database& db) {
 }
 
 future<> segment_manager_impl::recover_segment(replica::database& db, log_segment_id segment_id,
-        primary_index::entry_cmp_fn cmp, std::function<void(const segment_header&)> on_header) {
+        primary_index::entry_cmp_fn cmp, utils::wrapped_function<void(const segment_header&)> on_header) {
     auto& desc = get_segment_descriptor(segment_id);
     desc.reset(_cfg.segment_size);
 

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -126,8 +126,8 @@ public:
     compaction_manager& get_compaction_manager() noexcept;
     const compaction_manager& get_compaction_manager() const noexcept;
 
-    void set_trigger_compaction_hook(std::function<void()> fn);
-    void set_trigger_separator_flush_hook(std::function<void(segment_sequence)> fn);
+    void set_trigger_compaction_hook(utils::wrapped_function<void()> fn);
+    void set_trigger_separator_flush_hook(utils::wrapped_function<void(segment_sequence)> fn);
 
     size_t get_segment_size() const noexcept;
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -193,7 +193,7 @@ table::add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
         const tracing::trace_state_ptr& trace_state,
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,
-        std::function<void(size_t)> reserve_fn) const {
+        utils::wrapped_function<void(size_t)> reserve_fn) const {
     auto add_memtables_from_cg = [&] (compaction_group& cg) mutable {
         for (auto&& mt: *cg.memtables()) {
             if (auto reader_opt = mt->make_mutation_reader_opt(s, permit, range, slice, trace_state, fwd, fwd_mr)) {
@@ -650,7 +650,7 @@ future<> storage_group_manager::for_each_storage_group_gently(std::function<futu
     }
 }
 
-void storage_group_manager::for_each_storage_group(std::function<void(size_t, storage_group&)> f) const {
+void storage_group_manager::for_each_storage_group(utils::wrapped_function<void(size_t, storage_group&)> f) const {
     for (auto& [id, sg]: _storage_groups) {
         if (auto holder = try_hold_gate(sg->async_gate())) {
             f(id, *sg);
@@ -1014,7 +1014,7 @@ compaction_group_ptr& storage_group::select_compaction_group(dht::token first, d
     return _main_cg;
 }
 
-void storage_group::for_each_compaction_group(std::function<void(const compaction_group_ptr&)> action) const {
+void storage_group::for_each_compaction_group(utils::wrapped_function<void(const compaction_group_ptr&)> action) const {
     action(_main_cg);
     for (auto& cg : _merging_groups) {
         action(cg);
@@ -1490,7 +1490,7 @@ future<> table::parallel_foreach_compaction_group(std::function<future<>(compact
     });
 }
 
-void table::for_each_compaction_group(std::function<void(compaction_group&)> action) {
+void table::for_each_compaction_group(utils::wrapped_function<void(compaction_group&)> action) {
     _sg_manager->for_each_storage_group([&] (size_t, storage_group& sg) {
         sg.for_each_compaction_group([&] (const compaction_group_ptr& cg) {
             if (auto holder = try_hold_gate(cg->async_gate())) {
@@ -1500,7 +1500,7 @@ void table::for_each_compaction_group(std::function<void(compaction_group&)> act
     });
 }
 
-void table::for_each_compaction_group(std::function<void(const compaction_group&)> action) const {
+void table::for_each_compaction_group(utils::wrapped_function<void(const compaction_group&)> action) const {
     _sg_manager->for_each_storage_group([&] (size_t, storage_group& sg) {
         sg.for_each_compaction_group([&] (const compaction_group_ptr& cg) {
             if (auto holder = try_hold_gate(cg->async_gate())) {

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -1080,7 +1080,7 @@ future<> update_tablet_metadata(replica::database& db, cql3::query_processor& qp
     tablet_logger.trace("Updated tablet metadata: {}", tm);
 }
 
-future<> read_tablet_mutations(seastar::sharded<replica::database>& db, std::function<void(canonical_mutation)> process_mutation) {
+future<> read_tablet_mutations(seastar::sharded<replica::database>& db, utils::wrapped_function<void(canonical_mutation)> process_mutation) {
     auto s = db::system_keyspace::tablets();
     auto rs = co_await db::system_keyspace::query_mutations(db, db::system_keyspace::NAME, db::system_keyspace::TABLETS);
     utils::chunked_vector<canonical_mutation> result;

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -15,6 +15,7 @@
 #include "mutation/mutation.hh"
 #include "mutation/canonical_mutation.hh"
 #include "replica/database_fwd.hh"
+#include "utils/wrapped_function.hh"
 
 #include <seastar/core/future.hh>
 
@@ -107,7 +108,7 @@ future<std::unordered_set<locator::host_id>> read_required_hosts(cql3::query_pro
 future<> update_tablet_metadata(replica::database& db, cql3::query_processor&, locator::tablet_metadata&, const locator::tablet_metadata_change_hint&);
 
 /// Reads tablet metadata from system.tablets in the form of mutations.
-future<> read_tablet_mutations(seastar::sharded<database>&, std::function<void(canonical_mutation)> process_mutation);
+future<> read_tablet_mutations(seastar::sharded<database>&, utils::wrapped_function<void(canonical_mutation)> process_mutation);
 
 /// Reads tablet transition stage (if any)
 future<std::optional<locator::tablet_transition_stage>> read_tablet_transition_stage(cql3::query_processor& qp, table_id tid, dht::token last_token);

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -522,7 +522,7 @@ schema::schema(private_tag, const raw_schema& raw, const schema_static_props& pr
     }
 }
 
-schema::schema(const schema& o, const std::function<void(schema&)>& transform)
+schema::schema(const schema& o, const utils::wrapped_function<void(schema&)>& transform)
     : _raw(o._raw)
     , _static_props(o._static_props)
     , _cdc_schema(o._cdc_schema)

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -10,6 +10,7 @@
 
 #include "cql3/description.hh"
 #include "utils/assert.hh"
+#include "utils/wrapped_function.hh"
 #include <functional>
 #include <optional>
 #include <unordered_map>
@@ -684,7 +685,7 @@ private:
     lw_shared_ptr<cql3::column_specification> make_column_specification(const column_definition& def) const;
     void rebuild();
     void compute_all_columns_in_select_order();
-    schema(const schema&, const std::function<void(schema&)>&);
+    schema(const schema&, const utils::wrapped_function<void(schema&)>&);
     class private_tag{};
 public:
     schema(private_tag, const raw_schema&, const schema_static_props& props, schema_ptr cdc_schema, std::optional<std::variant<schema_ptr, db::view::base_dependent_view_info>> base = std::nullopt);

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -13,6 +13,7 @@
 #include <vector>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
+#include "utils/wrapped_function.hh"
 #include "utils/atomic_vector.hh"
 #include "utils/chunked_vector.hh"
 
@@ -126,7 +127,7 @@ class migration_notifier {
 private:
     atomic_vector<migration_listener*> _listeners;
 
-    future<> on_schema_change(std::function<void(migration_listener*)> notify, std::function<std::string(std::exception_ptr)> describe_error);
+    future<> on_schema_change(utils::wrapped_function<void(migration_listener*)> notify, std::function<std::string(std::exception_ptr)> describe_error);
 public:
     /// Register a migration listener on current shard.
     void register_listener(migration_listener* listener);

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -255,7 +255,7 @@ future<> migration_manager::merge_schema_from(locator::host_id src, const utils:
     co_await db::schema_tables::merge_schema(_sys_ks, proxy.container(), ss.get()->container(), std::move(mutations));
 }
 
-future<> migration_notifier::on_schema_change(std::function<void(migration_listener*)> notify, std::function<std::string(std::exception_ptr)> describe_error) {
+future<> migration_notifier::on_schema_change(utils::wrapped_function<void(migration_listener*)> notify, std::function<std::string(std::exception_ptr)> describe_error) {
     return seastar::async([this, notify = std::move(notify), describe_error = std::move(describe_error)] {
         std::exception_ptr ex;
         _listeners.thread_for_each([&] (migration_listener* listener) {

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -506,7 +506,7 @@ future<> raft_group0::leadership_monitor_fiber() {
     }
 }
 
-utils::observer<bool> raft_group0::observe_leadership(std::function<void(bool)> cb) {
+utils::observer<bool> raft_group0::observe_leadership(utils::wrapped_function<void(bool)> cb) {
     if (_leadership_observable.get()) {
         cb(true);
     }

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -9,6 +9,7 @@
 
 #include "service/raft/join_node.hh"
 #include "service/raft/raft_group_registry.hh"
+#include "utils/wrapped_function.hh"
 #include "service/raft/discovery.hh"
 #include "service/raft/group0_fwd.hh"
 #include "gms/feature.hh"
@@ -268,7 +269,7 @@ public:
     // Returns true after the group 0 server has been started.
     bool joined_group0() const;
 
-    utils::observer<bool> observe_leadership(std::function<void(bool)>);
+    utils::observer<bool> observe_leadership(utils::wrapped_function<void(bool)>);
 
     // Returns scheduling group group0 is configured to run with
     seastar::scheduling_group get_scheduling_group() {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1608,7 +1608,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         return true;
     }
 
-    future<> for_each_tablet_group_transition(std::function<void(const locator::tablet_map&,
+    future<> for_each_tablet_group_transition(utils::wrapped_function<void(const locator::tablet_map&,
                                                            table_id,
                                                            const locator::table_group_set&,
                                                            locator::tablet_id,

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -15,6 +15,7 @@
 #include <unordered_map>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/sstring.hh>
+#include "utils/wrapped_function.hh"
 #include "cdc/generation_id.hh"
 #include "dht/token.hh"
 #include "raft/raft.hh"
@@ -277,7 +278,7 @@ struct topology_state_machine {
     // Called by the tablet split monitor when all local storage groups
     // for a table are split-ready, to trigger an early load stats
     // refresh so the coordinator can finalize the resize promptly.
-    std::function<void()> on_tablet_split_ready;
+    utils::wrapped_function<void()> on_tablet_split_ready;
 
     future<> await_not_busy();
     future<sstring> wait_for_request_completion(db::system_keyspace& sys_ks, utils::UUID id, bool require_entry);

--- a/sstables/checksummed_data_source.hh
+++ b/sstables/checksummed_data_source.hh
@@ -12,12 +12,13 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/iostream.hh>
 
+#include "utils/wrapped_function.hh"
 #include "sstables/types.hh"
 
 namespace sstables {
 
 using stream_creator_fn = std::function<future<input_stream<char>>(uint64_t, uint64_t, file_input_stream_options)>;
-using integrity_error_handler = std::function<void(sstring)>;
+using integrity_error_handler = utils::wrapped_function<void(sstring)>;
 
 void throwing_integrity_error_handler(sstring msg);
 

--- a/sstables/compressor.cc
+++ b/sstables/compressor.cc
@@ -56,7 +56,7 @@ public:
 
 // A custom allocator for zstd, so that we can track its memory usage.
 struct zstd_callback_allocator {
-    using callback_type = std::function<void(ssize_t)>;
+    using callback_type = utils::wrapped_function<void(ssize_t)>;
     callback_type _callback;
     using self = zstd_callback_allocator;
     zstd_callback_allocator(callback_type cb) : _callback(std::move(cb)) {}

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -2045,7 +2045,7 @@ public:
 private:
     schema_ptr _schema;
     reader_permit _permit;
-    std::function<void(sstring)> _error_handler;
+    utils::wrapped_function<void(sstring)> _error_handler;
     // For static-compact tables C* stores the only row in the static row but in our representation they're regular rows.
     const bool _treat_static_row_as_regular;
     mutation_fragment_stream_validator _validator;
@@ -2093,7 +2093,7 @@ private:
     }
 
 public:
-    validating_consumer(const schema_ptr schema, reader_permit permit, const shared_sstable& sst, std::function<void(sstring)> error_handler)
+    validating_consumer(const schema_ptr schema, reader_permit permit, const shared_sstable& sst, utils::wrapped_function<void(sstring)> error_handler)
         : _schema(schema)
         , _permit(std::move(permit))
         , _error_handler(std::move(error_handler))
@@ -2250,7 +2250,7 @@ future<uint64_t> validate(
         shared_sstable sstable,
         reader_permit permit,
         abort_source& abort,
-        std::function<void(sstring)> error_handler,
+        utils::wrapped_function<void(sstring)> error_handler,
         sstables::read_monitor& monitor) {
     auto schema = sstable->get_schema();
     validating_consumer consumer(schema, permit, sstable, std::move(error_handler));

--- a/sstables/mx/reader.hh
+++ b/sstables/mx/reader.hh
@@ -10,6 +10,7 @@
 
 #include "readers/mutation_reader_fwd.hh"
 #include "readers/mutation_reader.hh"
+#include "utils/wrapped_function.hh"
 #include "sstables/progress_monitor.hh"
 #include "sstables/types_fwd.hh"
 #include "sstables/index_reader.hh"
@@ -68,7 +69,7 @@ future<uint64_t> validate(
         shared_sstable sstable,
         reader_permit permit,
         abort_source& abort,
-        std::function<void(sstring)> error_handler,
+        utils::wrapped_function<void(sstring)> error_handler,
         sstables::read_monitor& monitor);
 
 } // namespace mx

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -161,7 +161,7 @@ sstable_set::all() const {
     return _impl->all();
 }
 
-void sstable_set::for_each_sstable(std::function<void(const shared_sstable&)> func) const {
+void sstable_set::for_each_sstable(utils::wrapped_function<void(const shared_sstable&)> func) const {
     _impl->for_each_sstable_until([func = std::move(func)] (const shared_sstable& sst) {
         func(sst);
         return stop_iteration::no;

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -10,6 +10,7 @@
 
 #include "readers/mutation_reader_fwd.hh"
 #include "readers/mutation_reader.hh"
+#include "utils/wrapped_function.hh"
 #include "sstables/progress_monitor.hh"
 #include "sstables/types_fwd.hh"
 #include "sstables/file_size_stats.hh"
@@ -141,7 +142,7 @@ public:
     // Return all sstables. It's not guaranteed that sstable_set will keep a reference to the returned list, so user should keep it.
     lw_shared_ptr<const sstable_list> all() const;
     // Prefer for_each_sstable() over all() for iteration purposes, as the latter may have to copy all sstables into a temporary
-    void for_each_sstable(std::function<void(const shared_sstable&)> func) const;
+    void for_each_sstable(utils::wrapped_function<void(const shared_sstable&)> func) const;
     template <typename Func>
     requires std::same_as<typename futurize<std::invoke_result_t<Func, shared_sstable>>::type, future<>>
     future<> for_each_sstable_gently(Func&& func) const {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1593,7 +1593,7 @@ bool sstable::should_update_repaired_at(int64_t repaired_at) const {
 //    - Copy sharding information, seal the SSTable, and open data files
 future<shared_sstable> sstable::link_with_rewritten_component(std::function<shared_sstable(shared_sstable)> sstable_creator,
         component_type component,
-        std::function<void(sstable&)> modifier,
+        utils::wrapped_function<void(sstable&)> modifier,
         bool update_sstable_id) {
     if (!is_component_rewrite_supported(component)) {
         on_internal_error(sstlog, "Only Statistics component can be rewritten.");
@@ -2480,7 +2480,7 @@ sstable_writer sstable::get_writer(const schema& s, uint64_t estimated_partition
 }
 
 future<uint64_t> sstable::validate(reader_permit permit, abort_source& abort,
-        std::function<void(sstring)> error_handler, sstables::read_monitor& monitor, bool validate_index) {
+        utils::wrapped_function<void(sstring)> error_handler, sstables::read_monitor& monitor, bool validate_index) {
     auto handle_sstable_exception = [&error_handler](const malformed_sstable_exception& e, uint64_t& errors) -> std::exception_ptr {
         std::exception_ptr ex;
         try {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -11,6 +11,7 @@
 
 #include "version.hh"
 #include "shared_sstable.hh"
+#include "utils/wrapped_function.hh"
 #include "open_info.hh"
 #include "sstables_registry.hh"
 #include <seastar/core/file.hh>
@@ -336,7 +337,7 @@ public:
     // (e.g. parse error), it will return with validation error count seen up to
     // the abort. In the latter case it will call the error-handler before doing so.
     future<uint64_t> validate(reader_permit permit, abort_source& abort,
-            std::function<void(sstring)> error_handler, sstables::read_monitor& monitor = default_read_monitor(), bool validate_index = false);
+            utils::wrapped_function<void(sstring)> error_handler, sstables::read_monitor& monitor = default_read_monitor(), bool validate_index = false);
 
     encoding_stats get_encoding_stats_for_compaction() const;
 
@@ -478,11 +479,11 @@ public:
         return _now;
     }
 
-    utils::observer<sstable&> add_on_closed_handler(std::function<void (sstable&)> on_closed_handler) noexcept {
+    utils::observer<sstable&> add_on_closed_handler(utils::wrapped_function<void (sstable&)> on_closed_handler) noexcept {
         return _on_closed.observe(on_closed_handler);
     }
 
-    utils::observer<sstable&> add_on_delete_handler(std::function<void (sstable&)> on_delete_handler) noexcept {
+    utils::observer<sstable&> add_on_delete_handler(utils::wrapped_function<void (sstable&)> on_delete_handler) noexcept {
         return _on_delete.observe(on_delete_handler);
     }
 
@@ -1188,7 +1189,7 @@ public:
     // Returns the newly created and sealed sstable.
     future<shared_sstable> link_with_rewritten_component(std::function<shared_sstable(shared_sstable)> sstable_creator,
             component_type component,
-            std::function<void(sstable&)> modifier,
+            utils::wrapped_function<void(sstable&)> modifier,
             bool update_sstable_id);
     // Must be called in a seastar thread
     void write_component_with_metadata(component_type type, scylla_metadata metadata);

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -30,7 +30,7 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
         stream_reason reason,
         sstables::offstrategy offstrategy,
         service::frozen_topology_guard frozen_guard,
-        std::function<void (sstables::shared_sstable sst)> on_sstable_written) {
+        utils::wrapped_function<void (sstables::shared_sstable sst)> on_sstable_written) {
     return [&db, &vb = vb.container(), &vbw, estimated_partitions, reason, offstrategy, origin = std::move(origin), frozen_guard, on_sstable_written] (mutation_reader reader) -> future<> {
         std::exception_ptr ex;
         try {

--- a/streaming/consumer.hh
+++ b/streaming/consumer.hh
@@ -10,6 +10,7 @@
 
 #include "sstables/sstable_set.hh"
 #include "streaming/stream_reason.hh"
+#include "utils/wrapped_function.hh"
 #include "service/topology_guard.hh"
 #include <optional>
 
@@ -34,6 +35,6 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
     stream_reason reason,
     sstables::offstrategy offstrategy,
     service::frozen_topology_guard,
-    std::function<void (sstables::shared_sstable sst)> on_sstable_written = {});
+    utils::wrapped_function<void (sstables::shared_sstable sst)> on_sstable_written = {});
 
 }

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -325,7 +325,7 @@ SEASTAR_TEST_CASE(test_commitlog_delete_when_over_disk_limit) {
                 }
 
                 // Verify #5899 - file size should not exceed the config max.
-                return parallel_for_each(active_segments, [](sstring filename) {
+                (void)parallel_for_each(active_segments, [](sstring filename) {
                     return file_size(filename).then([](uint64_t size) {
                         BOOST_REQUIRE_LE(size, max_size_mb * 1024 * 1024);
                     });

--- a/test/boost/cql_query_group_test.cc
+++ b/test/boost/cql_query_group_test.cc
@@ -93,8 +93,6 @@ SEASTAR_TEST_CASE(test_group_by_syntax) {
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("select * from t2 group by p1, p2").get(), ire, partition);
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("select * from t2 group by p1").get(), ire, partition);
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("select * from t1 group by p1").get(), ire, partition);
-
-        return make_ready_future<>();
     });
 }
 
@@ -130,7 +128,6 @@ SEASTAR_TEST_CASE(test_group_by_aggregate_single_key) {
         require_rows(e, "select sum(n) from t group by p", {{I(10), I(1)}, {I(20), I(2)}});
         require_rows(e, "select avg(n) from t group by p", {{I(20), I(2)}, {I(10), I(1)}});
         require_rows(e, "select count(n) from t group by p", {{L(1), I(2)}, {L(1), I(1)}});
-        return make_ready_future<>();
     });
 }
 
@@ -151,7 +148,6 @@ SEASTAR_TEST_CASE(test_group_by_aggregate_partition_only) {
         cquery_nofail(e, "delete from t where p1=1 and p2=1 and p3=1");
         require_rows(e, "select sum(v) from t group by p1, p2, p3",
                      {{I(100), I(1), I(2), I(1)}, {I(100), I(1), I(2), I(2)}});
-        return make_ready_future<>();
     });
 }
 
@@ -172,7 +168,6 @@ SEASTAR_TEST_CASE(test_group_by_aggregate_clustering) {
         require_rows(e, "select sum(v) from t group by p1, c1, c2",
                      {{I(100), I(1), I(1), I(1)}, {I(100), I(1), I(1), I(2)},
                       {I(100), I(2), I(1), I(1)}, {I(100), I(2), I(2), I(2)}});
-        return make_ready_future<>();
     });
 }
 
@@ -204,7 +199,6 @@ SEASTAR_TEST_CASE(test_group_by_text_key) {
         require_rows(e, "select avg(v) from t2 group by p, c1", {{I(15), T(" "), T("")}, {I(35), T(" "), T("a")}});
         require_rows(e, "select sum(v) from t2 where c1='' group by p, c2 allow filtering",
                      {{I(10), T(" "), T("")}, {I(20), T(" "), T("b")}});
-        return make_ready_future<>();
     });
 }
 
@@ -221,7 +215,6 @@ SEASTAR_TEST_CASE(test_group_by_non_aggregate) {
         cquery_nofail(e, "insert into t (p, c, n) values (1, 2, 12)");
         cquery_nofail(e, "insert into t (p, c, n) values (1, 3, 13)");
         require_rows(e, "select n from t group by p", {{I(11), I(1)}, {I(21), I(2)}});
-        return make_ready_future<>();
     });
 }
 
@@ -230,7 +223,6 @@ SEASTAR_TEST_CASE(test_group_by_null_clustering) {
         cquery_nofail(e, "create table t (p int, c int, sv int static, primary key(p, c))");
         cquery_nofail(e, "insert into t (p, sv) values (1, 100)"); // c will be NULL.
         require_rows(e, "select sv from t where p=1 group by c", {{I(100), std::nullopt}});
-        return make_ready_future<>();
     });
 }
 

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -66,8 +66,6 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection) {
             .is_rows()
             .with_size(1)
             .with_row({"42", "b", "tbl"});
-
-        return make_ready_future<>();
     }, cfg).get();
 }
 
@@ -142,8 +140,6 @@ SEASTAR_THREAD_TEST_CASE(test_large_data) {
         assert_that(e.execute_cql("select partition_key from system.large_partitions where table_name = 'tbl' allow filtering;").get())
             .is_rows()
             .is_empty();
-
-        return make_ready_future<>();
     }, cfg).get();
 }
 
@@ -164,8 +160,6 @@ SEASTAR_THREAD_TEST_CASE(test_large_row_count_warning) {
             .with_row({ { utf8_type->decompose("42") },
                         { long_type->decompose(11L) },
                         { utf8_type->decompose("tbl") } });
-
-        return make_ready_future<>();
     }, cfg).get();
 }
 
@@ -197,8 +191,6 @@ SEASTAR_THREAD_TEST_CASE(test_large_partitions_dual_threshold) {
                 "where table_name = 'tbl' allow filtering;").get())
             .is_rows()
             .with_size(1);
-
-        return make_ready_future<>();
     }, cfg).get();
 }
 
@@ -229,8 +221,6 @@ SEASTAR_THREAD_TEST_CASE(test_large_cells_dual_threshold) {
                 "where table_name = 'tbl' allow filtering;").get())
             .is_rows()
             .with_size(1);
-
-        return make_ready_future<>();
     }, cfg).get();
 }
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -3828,7 +3828,7 @@ SEASTAR_TEST_CASE(test_select_with_mixed_order_table) {
 }
 
 uint64_t
-run_and_examine_cache_read_stats_change(cql_test_env& e, std::string_view cf_name, std::function<void (cql_test_env& e)> func) {
+run_and_examine_cache_read_stats_change(cql_test_env& e, std::string_view cf_name, utils::wrapped_function<void (cql_test_env& e)> func) {
     auto read_stat = [&] {
         return e.db().map_reduce0([&cf_name] (const replica::database& db) {
             auto& t = db.find_column_family("ks", cf_name);
@@ -3904,7 +3904,6 @@ SEASTAR_TEST_CASE(test_aggregate_and_simple_selection_together) {
         require_rows(e, "select c, avg(c) from t", {{I(1), I(2)}});
         require_rows(e, "select p, sum(v) from t", {{I(1), I(58)}});
         require_rows(e, "select p, count(c) from t group by p", {{I(1), L(3)}, {I(2), L(1)}});
-        return make_ready_future<>();
     });
 }
 
@@ -5421,11 +5420,11 @@ SEASTAR_TEST_CASE(timeuuid_fcts_prepared_re_evaluation) {
     });
 }
 
-static future<> with_parallelized_aggregation_enabled_thread(std::function<void(cql_test_env&)>&& func) {
+static future<> with_parallelized_aggregation_enabled_thread(utils::wrapped_function<void(cql_test_env&)>&& func) {
     auto db_cfg_ptr = make_shared<db::config>();
     auto& db_cfg = *db_cfg_ptr;
     db_cfg.enable_parallelized_aggregation({true}, db::config::config_source::CommandLine);
-    return do_with_cql_env_thread(std::forward<std::function<void(cql_test_env&)>>(func), db_cfg_ptr);
+    return do_with_cql_env_thread(std::forward<utils::wrapped_function<void(cql_test_env&)>>(func), db_cfg_ptr);
 }
 
 SEASTAR_TEST_CASE(test_parallelized_select_count) {
@@ -5641,14 +5640,14 @@ SEASTAR_TEST_CASE(test_single_partition_aggregation_is_not_parallelized) {
     });
 }
 
-static future<> with_udf_and_parallel_aggregation_enabled_thread(std::function<void(cql_test_env&)>&& func) {
+static future<> with_udf_and_parallel_aggregation_enabled_thread(utils::wrapped_function<void(cql_test_env&)>&& func) {
     auto db_cfg_ptr = make_shared<db::config>();
     auto& db_cfg = *db_cfg_ptr;
     db_cfg.enable_user_defined_functions({true}, db::config::config_source::CommandLine);
     db_cfg.user_defined_function_time_limit_ms(1000);
     db_cfg.experimental_features({db::experimental_features_t::feature::UDF}, db::config::config_source::CommandLine);
     db_cfg.enable_parallelized_aggregation({true}, db::config::config_source::CommandLine);
-    return do_with_cql_env_thread(std::forward<std::function<void(cql_test_env&)>>(func), db_cfg_ptr);
+    return do_with_cql_env_thread(std::forward<utils::wrapped_function<void(cql_test_env&)>>(func), db_cfg_ptr);
 }
 
 SEASTAR_TEST_CASE(test_parallelized_select_uda) {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -156,7 +156,6 @@ SEASTAR_TEST_CASE(test_safety_after_truncate) {
         }).get();
 
         assert_query_result(keys_per_shard);
-        return make_ready_future<>();
     }, cfg);
 }
 
@@ -2107,8 +2106,6 @@ SEASTAR_TEST_CASE(test_query_tombstone_gc) {
             const auto res = replica::query_mutations_on_all_shards(env.db(), schema, cmd, {pr}, {}, db::no_timeout).get();
             BOOST_CHECK_EQUAL(std::get<0>(res)->partitions().size(), 0);
         }
-
-        return make_ready_future<>();
     });
 }
 

--- a/test/boost/database_test.hh
+++ b/test/boost/database_test.hh
@@ -20,7 +20,7 @@
 
 // Snapshot tests and their helpers
 // \param func: function to be called back, in a seastar thread.
-future<> do_with_some_data_in_thread(std::vector<sstring> cf_names, std::function<void (cql_test_env&)> func, bool create_mvs = false, shared_ptr<db::config> db_cfg_ptr = {}, size_t num_keys = 2) {
+future<> do_with_some_data_in_thread(std::vector<sstring> cf_names, utils::wrapped_function<void (cql_test_env&)> func, bool create_mvs = false, shared_ptr<db::config> db_cfg_ptr = {}, size_t num_keys = 2) {
     return seastar::async([cf_names = std::move(cf_names), func = std::move(func), create_mvs,  db_cfg_ptr = std::move(db_cfg_ptr), num_keys] () mutable {
         lw_shared_ptr<tmpdir> tmpdir_for_data;
         if (!db_cfg_ptr) {

--- a/test/boost/multishard_combining_reader_as_mutation_source_test.cc
+++ b/test/boost/multishard_combining_reader_as_mutation_source_test.cc
@@ -116,9 +116,8 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader) {
         return;
     }
 
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         run_mutation_source_tests(make_populate(false, false));
-        return make_ready_future<>();
     }).get();
 }
 
@@ -128,9 +127,8 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_evict_paused) {
         return;
     }
 
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         run_mutation_source_tests(make_populate(true, false));
-        return make_ready_future<>();
     }).get();
 }
 
@@ -143,9 +141,8 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_with_tiny_buffer) {
         return;
     }
 
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         run_mutation_source_tests_plain(make_populate(true, true), true);
-        return make_ready_future<>();
     }).get();
 }
 
@@ -155,9 +152,8 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_with_tiny_buffer_rever
         return;
     }
 
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         run_mutation_source_tests_reverse(make_populate(true, true), true);
-        return make_ready_future<>();
     }).get();
 }
 

--- a/test/boost/multishard_query_test.cc
+++ b/test/boost/multishard_query_test.cc
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_SUITE(multishard_query_test)
 
 // Best run with SMP>=2
 SEASTAR_THREAD_TEST_CASE(test_abandoned_read) {
-    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) {
         using namespace std::chrono_literals;
 
         env.db().invoke_on_all([] (replica::database& db) {
@@ -228,8 +228,6 @@ SEASTAR_THREAD_TEST_CASE(test_abandoned_read) {
         query_mutations_on_all_shards(env.db(), s, cmd, {query::full_partition_range}, nullptr, db::no_timeout).get();
 
         require_eventually_empty_caches(env.db());
-
-        return make_ready_future<>();
     }, cql_config_with_extensions()).get();
 }
 
@@ -544,7 +542,7 @@ namespace multishard_query_test {
 
 // Best run with SMP>=2
 SEASTAR_THREAD_TEST_CASE(test_read_all) {
-    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) {
         using namespace std::chrono_literals;
 
         env.db().invoke_on_all([] (replica::database& db) {
@@ -594,14 +592,12 @@ SEASTAR_THREAD_TEST_CASE(test_read_all) {
         }).first;
 
         check_results_are_equal(results1, results3);
-
-        return make_ready_future<>();
     }, cql_config_with_extensions()).get();
 }
 
 // Best run with SMP>=2
 SEASTAR_THREAD_TEST_CASE(test_read_all_multi_range) {
-    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) {
         using namespace std::chrono_literals;
 
         env.db().invoke_on_all([] (replica::database& db) {
@@ -656,14 +652,12 @@ SEASTAR_THREAD_TEST_CASE(test_read_all_multi_range) {
         }
 
         require_eventually_empty_caches(env.db());
-
-        return make_ready_future<>();
     }, cql_config_with_extensions()).get();
 }
 
 // Best run with SMP>=2
 SEASTAR_THREAD_TEST_CASE(test_read_with_partition_row_limits) {
-    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) {
         using namespace std::chrono_literals;
 
         env.db().invoke_on_all([] (replica::database& db) {
@@ -722,14 +716,12 @@ SEASTAR_THREAD_TEST_CASE(test_read_with_partition_row_limits) {
             tests::require_equal(aggregate_querier_cache_stat(env.db(), &replica::querier_cache::stats::time_based_evictions), 0u);
             tests::require_equal(aggregate_querier_cache_stat(env.db(), &replica::querier_cache::stats::resource_based_evictions), 0u);
         } } }
-
-        return make_ready_future<>();
     }, cql_config_with_extensions()).get();
 }
 
 // Best run with SMP>=2
 SEASTAR_THREAD_TEST_CASE(test_evict_a_shard_reader_on_each_page) {
-    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) {
         using namespace std::chrono_literals;
 
         env.db().invoke_on_all([] (replica::database& db) {
@@ -775,14 +767,12 @@ SEASTAR_THREAD_TEST_CASE(test_evict_a_shard_reader_on_each_page) {
         tests::require_equal(aggregate_querier_cache_stat(env.db(), &replica::querier_cache::stats::resource_based_evictions), evictions);
 
         require_eventually_empty_caches(env.db());
-
-        return make_ready_future<>();
     }, cql_config_with_extensions()).get();
 }
 
 // Best run with SMP>=2
 SEASTAR_THREAD_TEST_CASE(test_read_reversed) {
-    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) {
         using namespace std::chrono_literals;
 
         auto& db = env.db();
@@ -832,8 +822,6 @@ SEASTAR_THREAD_TEST_CASE(test_read_reversed) {
         } } }
 
         require_eventually_empty_caches(env.db());
-
-        return make_ready_future<>();
     }, cql_config_with_extensions()).get();
 }
 
@@ -1145,7 +1133,7 @@ SEASTAR_THREAD_TEST_CASE(fuzzy_test) {
     auto cql_cfg = cql_config_with_extensions();
     cql_cfg.db_config->enable_commitlog(false);
 
-    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) {
         // REPLACE RANDOM SEED HERE.
         const auto seed = tests::random::get_int<uint32_t>();
         testlog.info("fuzzy test seed: {}", seed);
@@ -1196,8 +1184,6 @@ SEASTAR_THREAD_TEST_CASE(fuzzy_test) {
             // Fail the test on any exception.
             BOOST_FAIL("Test run finished with exception");
         }).get();
-
-        return make_ready_future<>();
     }, cql_cfg).get();
 }
 

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1248,7 +1248,7 @@ SEASTAR_THREAD_TEST_CASE(test_foreign_reader_as_mutation_source, *test_label::la
         return;
     }
 
-    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) {
         auto populate = [&env] (schema_ptr s, const utils::chunked_vector<mutation>& mutations) {
             const auto remote_shard = (this_shard_id() + 1) % this_smp_shard_count();
             auto frozen_mutations =
@@ -1299,7 +1299,6 @@ SEASTAR_THREAD_TEST_CASE(test_foreign_reader_as_mutation_source, *test_label::la
         };
 
         run_mutation_source_tests(populate);
-        return make_ready_future<>();
     }).get();
 }
 
@@ -1651,7 +1650,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_reading_empty_table) {
         return;
     }
 
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         std::vector<std::atomic<bool>> shards_touched(this_smp_shard_count());
         simple_schema s;
 
@@ -1682,8 +1681,6 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_reading_empty_table) {
         for (unsigned i = 0; i < this_smp_shard_count(); ++i) {
             BOOST_REQUIRE(shards_touched.at(i));
         }
-
-        return make_ready_future<>();
     }).get();
 }
 
@@ -1821,7 +1818,7 @@ SEASTAR_THREAD_TEST_CASE(test_stopping_reader_with_pending_read_ahead) {
         return;
     }
 
-    do_with_cql_env_thread([] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& env) {
         const auto shard_of_interest = (this_shard_id() + 1) % this_smp_shard_count();
         auto s = simple_schema();
         auto remote_control_remote_reader = smp::submit_to(shard_of_interest, [&env, gs = global_simple_schema(s)] {
@@ -1871,8 +1868,6 @@ SEASTAR_THREAD_TEST_CASE(test_stopping_reader_with_pending_read_ahead) {
         }).get();
 
         BOOST_REQUIRE(destroyed_after_close.get());
-
-        return make_ready_future<>();
     }).get();
 }
 
@@ -1958,7 +1953,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_custom_shard_number) {
 
     auto no_shards = this_smp_shard_count() - 1;
 
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         std::vector<std::atomic<bool>> shards_touched(this_smp_shard_count());
         simple_schema s;
         auto sharder = std::make_unique<dht::static_sharder>(no_shards, 0);
@@ -1986,8 +1981,6 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_custom_shard_number) {
             BOOST_REQUIRE(shards_touched[i]);
         }
         BOOST_REQUIRE(!shards_touched[no_shards]);
-
-        return make_ready_future<>();
     }).get();
 }
 
@@ -1998,7 +1991,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_only_reads_from_needed
         return;
     }
 
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         std::vector<std::atomic<bool>> shards_touched(this_smp_shard_count());
         simple_schema s;
         auto factory = [&shards_touched] (
@@ -2056,8 +2049,6 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_only_reads_from_needed
             testlog.info("[{}]: {} == {}", i, shards_touched[i], expected_shards_touched[i]);
             BOOST_CHECK(shards_touched[i] == expected_shards_touched[i]);
         }
-
-        return make_ready_future<>();
     }).get();
 }
 
@@ -2091,7 +2082,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_destroyed_with_pending
         return;
     }
 
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         auto s = simple_schema();
 
         auto reader_sharder_remote_controls__ = prepare_multishard_reader_for_read_ahead_test(s, make_reader_permit(env));
@@ -2137,8 +2128,6 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_destroyed_with_pending
                 true,
                 std::logical_and<bool>()).get();
         }));
-
-        return make_ready_future<>();
     }).get();
 }
 
@@ -2148,7 +2137,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_fast_forwarded_with_pe
         return;
     }
 
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         auto s = simple_schema();
 
         auto reader_sharder_remote_controls_pr = prepare_multishard_reader_for_read_ahead_test(s, make_reader_permit(env));
@@ -2212,13 +2201,11 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_fast_forwarded_with_pe
                 true,
                 std::logical_and<bool>()).get();
         }));
-
-        return make_ready_future<>();
     }).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_next_partition) {
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         env.execute_cql("CREATE KEYSPACE multishard_combining_reader_next_partition_ks"
                 " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1};").get();
         env.execute_cql("CREATE TABLE multishard_combining_reader_next_partition_ks.test (pk int, v int, PRIMARY KEY(pk));").get();
@@ -2290,8 +2277,6 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_next_partition) {
             assertions.produces(pkeys[i]);
         }
         assertions.produces_end_of_stream();
-
-        return make_ready_future<>();
     }).get();
 }
 
@@ -2305,7 +2290,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_streaming_reader) {
         return;
     }
 
-    do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
+    do_with_cql_env_thread([&] (cql_test_env& env) {
         env.execute_cql("CREATE KEYSPACE multishard_streaming_reader_ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1};").get();
         env.execute_cql("CREATE TABLE multishard_streaming_reader_ks.test (pk int, v int, PRIMARY KEY(pk));").get();
 
@@ -2374,8 +2359,6 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_streaming_reader) {
             testlog.trace("Comparing mutation {:d}/{:d}", i, min_size - 1);
             assert_that(tested_muts[i]).is_equal_to(reference_muts[i]);
         }
-
-        return make_ready_future<>();
     }).get();
 }
 

--- a/test/boost/per_partition_rate_limit_test.cc
+++ b/test/boost/per_partition_rate_limit_test.cc
@@ -13,7 +13,7 @@
 BOOST_AUTO_TEST_SUITE(per_partition_rate_limit_test)
 
 SEASTAR_TEST_CASE(test_internal_operation_filtering) {
-    return do_with_cql_env_thread([] (cql_test_env& e) -> future<> {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
         // The test requires at least two shards
         // so that it can test the shard!=coordinator case
         BOOST_REQUIRE_GT(this_smp_shard_count(), 1);
@@ -106,8 +106,6 @@ SEASTAR_TEST_CASE(test_internal_operation_filtering) {
                 }
             }
         }
-
-        return make_ready_future<>();
     });
 }
 

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -741,7 +741,6 @@ SEASTAR_THREAD_TEST_CASE(test_resources_based_cache_eviction) {
                 query::full_partition_range,
                 nullptr,
                 db::no_timeout).get();
-        return make_ready_future<>();
     }, std::move(db_cfg_ptr)).get();
 }
 

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1679,7 +1679,6 @@ SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_no_oom) {
                 assert_that(fut.get()).is_rows().with_rows_ignore_order({ {serialized(tbl.value)} });
             });
         }).get();
-        return make_ready_future<>();
     }, std::move(db_cfg_ptr));
 }
 
@@ -1762,8 +1761,6 @@ SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_engages) {
 
         // All failures must be caused by the kill limit triggering.
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().total_reads_killed_due_to_kill_limit, failed_reads);
-
-        return make_ready_future<>();
     }, std::move(db_cfg_ptr));
 }
 

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "utils/assert.hh"
+#include "utils/wrapped_function.hh"
 #include "types/map.hh"
 #include "sstables/sstables.hh"
 #include "replica/database.hh"
@@ -339,11 +340,11 @@ inline dht::decorated_key make_dkey(schema_ptr s, bytes b)
 }
 
 // Must be called from a seastar thread.
-future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify);
-inline future<sstables::shared_sstable> verify_mutation(test_env& env, std::function<shared_sstable()> sst_gen, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify) {
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, bytes key, utils::wrapped_function<void(mutation_opt&)> verify);
+inline future<sstables::shared_sstable> verify_mutation(test_env& env, std::function<shared_sstable()> sst_gen, lw_shared_ptr<replica::memtable> mt, bytes key, utils::wrapped_function<void(mutation_opt&)> verify) {
     return verify_mutation(env, sst_gen(), std::move(mt), std::move(key), std::move(verify));
 }
-future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sstp, bytes key, std::function<void(mutation_opt&)> verify);
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sstp, bytes key, utils::wrapped_function<void(mutation_opt&)> verify);
 
 future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify);
 inline future<sstables::shared_sstable> verify_mutation(test_env& env, std::function<shared_sstable()> sst_gen, lw_shared_ptr<replica::memtable> mt, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify) {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2778,7 +2778,6 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_map_layout) {
         // so the layout should remain arbitrary.
         BOOST_REQUIRE(stm.get()->tablets().get_tablet_map(table1).tablet_count() == 2);
         BOOST_REQUIRE(tablet_layout::arbitrary == stm.get()->tablets().get_tablet_map(table1).get_layout());
-        return make_ready_future<>();
     }, std::move(cfg)).get();
 }
 

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -510,7 +510,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_deadlock) {
     db_cfg.enable_cache(false);
     db_cfg.enable_commitlog(false);
 
-    do_with_cql_env_thread([] (cql_test_env& e) -> future<> {
+    do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table t (p text, c text, v text, primary key (p, c))").get();
         e.execute_cql("create materialized view tv as select * from t "
                       "where p is not null and c is not null and v is not null "
@@ -568,8 +568,6 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_deadlock) {
         eventually_true([&] {
             return sem.get_stats().permit_based_evictions > 0;
         });
-
-        return make_ready_future<>();
     }, std::move(test_cfg)).get();
 }
 

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -22,7 +22,7 @@ public:
             : memtable_filling_virtual_table(s)
             , _mutations(std::move(mutations)) {}
 
-    future<> execute(std::function<void(mutation)> mutation_sink, reader_permit permit) override {
+    future<> execute(utils::wrapped_function<void(mutation)> mutation_sink, reader_permit permit) override {
         return with_timeout(permit.timeout(), do_for_each(_mutations, [mutation_sink = std::move(mutation_sink)] (const mutation& m) { mutation_sink(m); }));
     }
 };

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -27,7 +27,7 @@ void columns_assertions::fail(const sstring& msg) {
     ::fail(msg, _loc);
 }
 
-columns_assertions& columns_assertions::do_with_raw_column(const char* name, std::function<void(data_type, managed_bytes_view)> func) {
+columns_assertions& columns_assertions::do_with_raw_column(const char* name, utils::wrapped_function<void(data_type, managed_bytes_view)> func) {
     const auto& names = _metadata.get_names();
 
     auto it = std::ranges::find_if(names, [name] (const auto& col) {
@@ -233,7 +233,7 @@ columns_assertions rows_assertions::with_columns_of_row(size_t row_index) {
     return columns_assertions(rs.get_metadata(), rs.rows().at(row_index), _loc);
 }
 
-rows_assertions& rows_assertions::assert_for_columns_of_each_row(std::function<void(columns_assertions&)> func) {
+rows_assertions& rows_assertions::assert_for_columns_of_each_row(utils::wrapped_function<void(columns_assertions&)> func) {
     const auto& rs = _rows->rs().result_set();
     for (size_t i = 0; i < rs.size(); ++i) {
         auto columns = with_columns_of_row(i);

--- a/test/lib/cql_assertions.hh
+++ b/test/lib/cql_assertions.hh
@@ -23,7 +23,7 @@ class columns_assertions {
     const std::vector<managed_bytes_opt>& _columns;
     std::source_location _loc;
 
-    columns_assertions& do_with_raw_column(const char* name, std::function<void(data_type, managed_bytes_view)> func);
+    columns_assertions& do_with_raw_column(const char* name, utils::wrapped_function<void(data_type, managed_bytes_view)> func);
 
     void fail(const sstring& msg);
 
@@ -98,7 +98,7 @@ public:
 
     columns_assertions with_columns_of_row(size_t row_index);
 
-    rows_assertions& assert_for_columns_of_each_row(std::function<void(columns_assertions&)> func);
+    rows_assertions& assert_for_columns_of_each_row(utils::wrapped_function<void(columns_assertions&)> func);
 
     rows_assertions is_null();
     rows_assertions is_not_null();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -507,7 +507,7 @@ public:
     }
 
 private:
-    static auto defer_verbose_shutdown(const char* what, std::function<void()> func) {
+    static auto defer_verbose_shutdown(const char* what, utils::wrapped_function<void()> func) {
         return defer([what, func = std::move(func)] {
             testlog.info("Shutting down {}", what);
             try {
@@ -1333,7 +1333,7 @@ future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_c
     return single_node_cql_env::do_with(func, std::move(cfg_in), std::move(init_configurables));
 }
 
-future<> do_with_cql_env_thread(std::function<void(cql_test_env&)> func, cql_test_config cfg_in, thread_attributes thread_attr, std::optional<cql_test_init_configurables> init_configurables) {
+future<> do_with_cql_env_thread(utils::wrapped_function<void(cql_test_env&)> func, cql_test_config cfg_in, thread_attributes thread_attr, std::optional<cql_test_init_configurables> init_configurables) {
     return single_node_cql_env::do_with([func = std::move(func), thread_attr] (auto& e) {
         return seastar::async(thread_attr, [func = std::move(func), &e] {
             return func(e);
@@ -1346,7 +1346,7 @@ void do_with_cql_env_noreentrant_in_thread(std::function<future<>(cql_test_env&)
 }
 
 // this function should be called in seastar thread
-void do_with_mc(cql_test_env& env, std::function<void(service::group0_batch&)> func) {
+void do_with_mc(cql_test_env& env, utils::wrapped_function<void(service::group0_batch&)> func) {
     seastar::abort_source as;
     auto& g0 = env.get_raft_group0_client();
     auto guard = g0.start_operation(as).get();

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -29,6 +29,7 @@
 #include "bytes.hh"
 #include "schema/schema.hh"
 #include "service/tablet_allocator.hh"
+#include "utils/wrapped_function.hh"
 #include "vector_search/vector_store_client.hh"
 #include "db/commitlog/raft_commitlog_replay_buffer.hh"
 
@@ -227,11 +228,11 @@ public:
 };
 
 future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, std::optional<cql_test_init_configurables> = {});
-future<> do_with_cql_env_thread(std::function<void(cql_test_env&)> func, cql_test_config = {}, thread_attributes thread_attr = {}, std::optional<cql_test_init_configurables> = {});
+future<> do_with_cql_env_thread(utils::wrapped_function<void(cql_test_env&)> func, cql_test_config = {}, thread_attributes thread_attr = {}, std::optional<cql_test_init_configurables> = {});
 
 void do_with_cql_env_noreentrant_in_thread(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, std::optional<cql_test_init_configurables> = {});
 
 // this function should be called in seastar thread
-void do_with_mc(cql_test_env& env, std::function<void(service::group0_batch&)> func);
+void do_with_mc(cql_test_env& env, utils::wrapped_function<void(service::group0_batch&)> func);
 
 reader_permit make_reader_permit(cql_test_env&);

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1956,7 +1956,7 @@ static const mutation_sets& get_mutation_sets() {
     return ms;
 }
 
-void for_each_mutation_pair(std::function<void(const mutation&, const mutation&, are_equal)> callback) {
+void for_each_mutation_pair(utils::wrapped_function<void(const mutation&, const mutation&, are_equal)> callback) {
     auto&& ms = get_mutation_sets();
     for (auto&& mutations : ms.equal) {
         auto i = mutations.begin();
@@ -1978,7 +1978,7 @@ void for_each_mutation_pair(std::function<void(const mutation&, const mutation&,
     }
 }
 
-void for_each_mutation(std::function<void(const mutation&)> callback) {
+void for_each_mutation(utils::wrapped_function<void(const mutation&)> callback) {
     auto&& ms = get_mutation_sets();
     for (auto&& mutations : ms.equal) {
         for (auto&& m : mutations) {
@@ -2444,8 +2444,8 @@ void random_mutation_generator::set_key_cardinality(size_t n_keys) {
     _impl->set_key_cardinality(n_keys);
 }
 
-void for_each_schema_change(std::function<void(schema_ptr, const utils::chunked_vector<mutation>&,
-                                               schema_ptr, const utils::chunked_vector<mutation>&)> fn) {
+void for_each_schema_change(utils::wrapped_function<void(schema_ptr, const utils::chunked_vector<mutation>&,
+                                                schema_ptr, const utils::chunked_vector<mutation>&)> fn) {
     auto map_of_int_to_int = map_type_impl::get_instance(int32_type, int32_type, true);
     auto map_of_int_to_bytes = map_type_impl::get_instance(int32_type, bytes_type, true);
     auto frozen_map_of_int_to_int = map_type_impl::get_instance(int32_type, int32_type, false);

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -10,6 +10,7 @@
 
 #include "readers/mutation_reader_fwd.hh"
 #include "test/lib/simple_schema.hh"
+#include "utils/wrapped_function.hh"
 
 using populate_fn = std::function<mutation_source(schema_ptr s, const utils::chunked_vector<mutation>&)>;
 using populate_fn_ex = std::function<mutation_source(schema_ptr s, const utils::chunked_vector<mutation>&, gc_clock::time_point)>;
@@ -32,10 +33,10 @@ enum are_equal { no, yes };
 
 // Calls the provided function on mutation pairs, equal and not equal. Is supposed
 // to exercise all potential ways two mutations may differ.
-void for_each_mutation_pair(std::function<void(const mutation&, const mutation&, are_equal)>);
+void for_each_mutation_pair(utils::wrapped_function<void(const mutation&, const mutation&, are_equal)>);
 
 // Calls the provided function on mutations. Is supposed to exercise as many differences as possible.
-void for_each_mutation(std::function<void(const mutation&)>);
+void for_each_mutation(utils::wrapped_function<void(const mutation&)>);
 
 // Returns true if mutations in schema s1 can be upgraded to s2.
 inline bool can_upgrade_schema(schema_ptr from, schema_ptr to) {
@@ -80,8 +81,8 @@ public:
 
 bytes make_blob(size_t blob_size);
 
-void for_each_schema_change(std::function<void(schema_ptr, const utils::chunked_vector<mutation>&,
-                                               schema_ptr, const utils::chunked_vector<mutation>&)>);
+void for_each_schema_change(utils::wrapped_function<void(schema_ptr, const utils::chunked_vector<mutation>&,
+                                                schema_ptr, const utils::chunked_vector<mutation>&)>);
 
 void compare_readers(const schema&, mutation_reader authority, mutation_reader tested, bool exact = false);
 void compare_readers(const schema&, mutation_reader authority, mutation_reader tested, const std::vector<position_range>& fwd_ranges);

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -156,12 +156,12 @@ future<> run_compaction_task(test_env& env, sstables::run_id output_run_id, comp
     co_await tcm.perform_compaction(std::move(task));
 }
 
-future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify) {
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, bytes key, utils::wrapped_function<void(mutation_opt&)> verify) {
     auto sstp = co_await make_sstable_containing(std::move(sst), mt);
     co_return co_await verify_mutation(env, std::move(sstp), std::move(key), std::move(verify));
 }
 
-future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sstp, bytes key, std::function<void(mutation_opt&)> verify) {
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sstp, bytes key, utils::wrapped_function<void(mutation_opt&)> verify) {
     auto s = sstp->get_schema();
     auto pr = dht::partition_range::make_singular(make_dkey(s, key));
     auto rd = sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice());

--- a/test/lib/topology_builder.hh
+++ b/test/lib/topology_builder.hh
@@ -290,7 +290,7 @@ public:
         return h;
     }
 
-    void modify_group0(std::function<void(service::group0_guard&, utils::chunked_vector<canonical_mutation>&)> func) {
+    void modify_group0(utils::wrapped_function<void(service::group0_guard&, utils::chunked_vector<canonical_mutation>&)> func) {
         abort_source as;
         auto& client = _env.get_raft_group0_client();
         while (true) {
@@ -308,7 +308,7 @@ public:
         }
     }
 
-    void modify_topology(std::function<void(service::topology_mutation_builder&)> func) {
+    void modify_topology(utils::wrapped_function<void(service::topology_mutation_builder&)> func) {
         modify_group0([&] (service::group0_guard& guard, utils::chunked_vector<canonical_mutation>& muts) {
             service::topology_mutation_builder builder(guard.write_timestamp());
             func(builder);

--- a/test/vector_search/utils.hh
+++ b/test/vector_search/utils.hh
@@ -90,7 +90,7 @@ inline auto listen_on_port(std::unique_ptr<seastar::httpd::http_server> server, 
     co_return std::make_tuple(std::move(server), listeners.at(0).local_address().port());
 }
 
-inline auto make_http_server(std::function<void(seastar::httpd::routes& r)> set_routes) {
+inline auto make_http_server(utils::wrapped_function<void(seastar::httpd::routes& r)> set_routes) {
     static unsigned id = 0;
     auto server = std::make_unique<seastar::httpd::http_server>(fmt::format("test_vector_store_client_{}", id++));
     set_routes(server->_routes);
@@ -98,13 +98,13 @@ inline auto make_http_server(std::function<void(seastar::httpd::routes& r)> set_
     return server;
 }
 
-inline auto new_http_server(std::function<void(seastar::httpd::routes& r)> set_routes, seastar::sstring host = LOCALHOST, uint16_t port = 0,
+inline auto new_http_server(utils::wrapped_function<void(seastar::httpd::routes& r)> set_routes, seastar::sstring host = LOCALHOST, uint16_t port = 0,
         seastar::httpd::http_server::server_credentials_ptr credentials = nullptr)
         -> seastar::future<std::tuple<std::unique_ptr<seastar::httpd::http_server>, seastar::socket_address>> {
     co_return co_await listen_on_port(make_http_server(set_routes), std::move(host), port, credentials);
 }
 
-inline auto new_http_server(std::function<void(seastar::httpd::routes& r)> set_routes, seastar::server_socket socket)
+inline auto new_http_server(utils::wrapped_function<void(seastar::httpd::routes& r)> set_routes, seastar::server_socket socket)
         -> seastar::future<std::tuple<std::unique_ptr<seastar::httpd::http_server>, seastar::socket_address>> {
     auto server = make_http_server(set_routes);
     auto& listeners = seastar::httpd::http_server_tester::listeners(*server);

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -205,7 +205,7 @@ gc_clock::time_point tombstone_gc_state::get_gc_before_for_key(schema_ptr s, con
     std::abort();
 }
 
-void shared_tombstone_gc_state::mutate_repair_history(std::function<void(per_table_history_maps&)> mutator) {
+void shared_tombstone_gc_state::mutate_repair_history(utils::wrapped_function<void(per_table_history_maps&)> mutator) {
     auto new_maps = make_lw_shared<per_table_history_maps>(*_reconcile_history_maps);
     mutator(*new_maps);
     _reconcile_history_maps = std::move(new_maps);

--- a/tombstone_gc.hh
+++ b/tombstone_gc.hh
@@ -11,6 +11,7 @@
 #include <span>
 #include <tuple>
 #include <seastar/core/shared_ptr.hh>
+#include "utils/wrapped_function.hh"
 #include "gc_clock.hh"
 #include "db/commitlog/replay_position.hh"
 #include "dht/token.hh"
@@ -74,7 +75,7 @@ class shared_tombstone_gc_state {
     std::unordered_map<table_id, utils::chunked_vector<range_repair_time>> _pending_updates;
 
 private:
-    void mutate_repair_history(std::function<void(per_table_history_maps&)>);
+    void mutate_repair_history(utils::wrapped_function<void(per_table_history_maps&)>);
 
 public:
     shared_tombstone_gc_state();

--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -763,8 +763,8 @@ int collection_index_l(lua_State* l) {
         return 1;
     } else if (strcmp(field, "values") == 0) {
         const auto size = cmv.size();
-        std::function<void(size_t, managed_bytes_view)> push_key;
-        std::function<void(size_t, atomic_cell_view)> push_value;
+        utils::wrapped_function<void(size_t, managed_bytes_view)> push_key;
+        utils::wrapped_function<void(size_t, atomic_cell_view)> push_value;
         if (auto t = dynamic_cast<const collection_type_impl*>(type.get())) {
             push_key = [l, t = t->name_comparator()] (size_t, managed_bytes_view k) {
                 k.with_linearized([&](bytes_view bv) {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1649,7 +1649,7 @@ void decompress_operation(schema_ptr schema, reader_permit permit, const std::ve
     }
 }
 
-void invoke_on_user_type(const data_type& t, const std::function<void(const user_type_impl&)>& f) {
+void invoke_on_user_type(const data_type& t, const utils::wrapped_function<void(const user_type_impl&)>& f) {
     if (t->is_user_type()) {
         const auto udt = dynamic_pointer_cast<const user_type_impl>(t);
 

--- a/utils/abstract_formatter.hh
+++ b/utils/abstract_formatter.hh
@@ -10,11 +10,12 @@
 
 #include <fmt/format.h>
 #include <functional>
+#include "utils/wrapped_function.hh"
 
 /// Type-erased formatter.
 /// Allows passing formattable objects without exposing their types.
 class abstract_formatter {
-    std::function<void(fmt::format_context&)> _formatter;
+    utils::wrapped_function<void(fmt::format_context&)> _formatter;
 public:
     abstract_formatter() = default;
 

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -201,7 +201,7 @@ public:
 
         operator updateable_value<T>() const &;
 
-        observer<T> observe(std::function<void (const T&)> callback) const;
+        observer<T> observe(utils::wrapped_function<void (const T&)> callback) const;
 
         void add_command_line_option(bpo::options_description_easy_init&) override;
         void set_value(const YAML::Node&, config_source) override;
@@ -245,7 +245,7 @@ public:
      * If invalid, it is invalid. Otherwise, a parse error.
      *
      */
-    using error_handler = std::function<void(const sstring&, const sstring&, std::optional<value_status>)>;
+    using error_handler = utils::wrapped_function<void(const sstring&, const sstring&, std::optional<value_status>)>;
 
     void read_from_yaml(const sstring&, error_handler = {});
     void read_from_yaml(const char *, error_handler = {});

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -301,7 +301,7 @@ utils::config_file::named_value<T>::operator utils::updateable_value<T>() const 
 }
 
 template<typename T>
-utils::observer<T> utils::config_file::named_value<T>::observe(std::function<void (const T&)> callback) const {
+utils::observer<T> utils::config_file::named_value<T>::observe(utils::wrapped_function<void (const T&)> callback) const {
     return the_value().observe(std::move(callback));
 }
 

--- a/utils/disk-error-handler.hh
+++ b/utils/disk-error-handler.hh
@@ -15,6 +15,7 @@
 #include <seastar/core/future.hh>
 
 #include "seastarx.hh"
+#include "utils/wrapped_function.hh"
 
 namespace bs2 = boost::signals2;
 
@@ -27,7 +28,7 @@ extern thread_local disk_error_signal_type general_disk_error;
 
 bool should_stop_on_system_error(const std::system_error& e);
 
-using io_error_handler = std::function<void (std::exception_ptr)>;
+using io_error_handler = utils::wrapped_function<void (std::exception_ptr)>;
 // stores a function that generates a io handler for a given signal.
 using io_error_handler_gen = std::function<io_error_handler (disk_error_signal_type&)>;
 

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -10,6 +10,7 @@
 
 #include "utils/assert.hh"
 #include "utils/from_chars_exactly.hh"
+#include "utils/wrapped_function.hh"
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sleep.hh>
@@ -135,7 +136,7 @@ struct wait_for_message {
 template <bool injection_enabled>
 class error_injection {
     inline static thread_local error_injection _local;
-    using handler_fun = std::function<void()>;
+    using handler_fun = utils::wrapped_function<void()>;
 
     /**
      * It is shared between the injection_data. It is created once when enabling an injection
@@ -340,7 +341,7 @@ private:
     // Callbacks invoked when a specific injection is disabled.
     // Registered independently of the injection being enabled, so
     // the callback can be set up before the injection is ever activated.
-    std::unordered_map<sstring, std::function<void()>> _on_disable_callbacks;
+    std::unordered_map<sstring, utils::wrapped_function<void()>> _on_disable_callbacks;
 
     bool is_one_shot(const std::string_view& injection_name) const {
         const auto it = _enabled.find(injection_name);
@@ -467,7 +468,7 @@ public:
     // before the injection is ever activated and survives enable/disable
     // cycles.  Only one callback per injection name is supported; a second
     // registration for the same name replaces the previous one.
-    void register_on_disable(const sstring& injection_name, std::function<void()> callback) {
+    void register_on_disable(const sstring& injection_name, utils::wrapped_function<void()> callback) {
         _on_disable_callbacks[injection_name] = std::move(callback);
     }
 
@@ -670,7 +671,7 @@ public:
 template <>
 class error_injection<false> {
     static thread_local error_injection _local;
-    using handler_fun = std::function<void()>;
+    using handler_fun = utils::wrapped_function<void()>;
     using waiting_handler_fun = std::function<future<>(error_injection<true>::injection_handler&)>;
 public:
     bool is_enabled(const std::string_view& name) const {
@@ -706,7 +707,7 @@ public:
     std::vector<sstring> enabled_injections() const { return {}; };
 
     [[gnu::always_inline]]
-    void register_on_disable(const sstring&, std::function<void()>) {}
+    void register_on_disable(const sstring&, utils::wrapped_function<void()>) {}
 
     [[gnu::always_inline]]
     void unregister_on_disable(const sstring&) {}

--- a/utils/observable.hh
+++ b/utils/observable.hh
@@ -11,6 +11,7 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <vector>
 #include <algorithm>
+#include "utils/wrapped_function.hh"
 
 namespace utils {
 
@@ -128,7 +129,7 @@ public:
         }
     }
     // Adds an observer to an observable
-    observer observe(std::function<void (Args...)> callback) {
+    observer observe(utils::wrapped_function<void (Args...)> callback) {
         observer ob(this, std::move(callback));
         _observers.push_back(&ob);
         return ob;

--- a/utils/rest/client.cc
+++ b/utils/rest/client.cc
@@ -198,7 +198,7 @@ future<> rest::send_request(std::string_view uri
     , seastar::shared_ptr<seastar::tls::certificate_credentials> creds
     , std::string body
     , std::string_view content_type
-    , const std::function<void(const http::reply&, std::string_view)>& handler
+    , const utils::wrapped_function<void(const http::reply&, std::string_view)>& handler
     , httpd::operation_type op
     , key_values headers
     , seastar::abort_source* as)

--- a/utils/rest/client.hh
+++ b/utils/rest/client.hh
@@ -13,6 +13,7 @@
 #include <seastar/http/client.hh>
 #include <seastar/http/request.hh>
 #include <seastar/http/reply.hh>
+#include "utils/wrapped_function.hh"
 #include <seastar/http/exception.hh>
 
 #include "utils/rjson.hh"
@@ -90,7 +91,7 @@ public:
         }
     };
 
-    using handler_func = std::function<void(const seastar::http::reply&, std::string_view)>;
+    using handler_func = utils::wrapped_function<void(const seastar::http::reply&, std::string_view)>;
 
     seastar::future<result_type> send(seastar::abort_source* = nullptr);
     seastar::future<> send(const handler_func&, seastar::abort_source* = nullptr);
@@ -189,7 +190,7 @@ future<> send_request(std::string_view uri
     , seastar::shared_ptr<seastar::tls::certificate_credentials>
     , std::string body
     , std::string_view content_type
-    , const std::function<void(const httpclient::reply_type&, std::string_view)>& handler
+    , const utils::wrapped_function<void(const httpclient::reply_type&, std::string_view)>& handler
     , httpclient::method_type op
     , key_values headers = {}
     , seastar::abort_source* = nullptr

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -11,6 +11,7 @@
 #include <seastar/core/file.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
+#include "utils/wrapped_function.hh"
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/queue.hh>
@@ -157,7 +158,7 @@ class client : public enable_shared_from_this<client> {
     future<group_client&> find_or_create_client_slow();
     future<> rebalance_connections();
 
-    using error_handler = std::function<void(std::exception_ptr)>;
+    using error_handler = utils::wrapped_function<void(std::exception_ptr)>;
     using reply_handler_ext = noncopyable_function<future<>(group_client&, const http::reply&, input_stream<char>&& body)>;
 
     http::client::reply_handler wrap_handler(http::request& request,

--- a/utils/updateable_value.cc
+++ b/utils/updateable_value.cc
@@ -79,7 +79,7 @@ updateable_value_base::updateable_value_base::operator=(std::nullptr_t) {
 }
 
 void
-updateable_value_source_base::for_each_ref(std::function<void (updateable_value_base* ref)> func) {
+updateable_value_source_base::for_each_ref(utils::wrapped_function<void (updateable_value_base* ref)> func) {
     for (auto ref : _refs) {
         func(ref);
     }

--- a/utils/updateable_value.hh
+++ b/utils/updateable_value.hh
@@ -75,7 +75,7 @@ public:
     const T& operator()() const { return _value; }
     operator const T& () const { return _value; }
     const T& get() const { return _value; }
-    observer<T> observe(std::function<void (const T&)> callback) const;
+    observer<T> observe(utils::wrapped_function<void (const T&)> callback) const;
 
     friend class updateable_value_source_base;
     template <typename U>
@@ -91,7 +91,7 @@ protected:
     // such references const operations since they don't change the logical
     // state of the object (they don't allow changing the carried value).
     mutable std::vector<updateable_value_base*> _refs; // all connected updateable_values on this shard
-    void for_each_ref(std::function<void (updateable_value_base* ref)> func);
+    void for_each_ref(utils::wrapped_function<void (updateable_value_base* ref)> func);
 protected:
     ~updateable_value_source_base();
     void add_ref(updateable_value_base* ref) const;
@@ -105,7 +105,7 @@ template <typename T>
 class updateable_value_source : public updateable_value_source_base {
     T _value;
     mutable observable<T> _updater;
-    void for_each_ref(std::function<void (updateable_value<T>*)> func) {
+    void for_each_ref(utils::wrapped_function<void (updateable_value<T>*)> func) {
         updateable_value_source_base::for_each_ref([func = std::move(func)] (updateable_value_base* ref) {
             func(static_cast<updateable_value<T>*>(ref));
         });
@@ -147,7 +147,7 @@ public:
     observable<T>& as_observable() const {
         return _updater;
     }
-    observer<T> observe(std::function<void (const T&)> callback) const {
+    observer<T> observe(utils::wrapped_function<void (const T&)> callback) const {
         return _updater.observe(std::move(callback));
     }
 
@@ -206,7 +206,7 @@ updateable_value<T>::source() const {
 
 template <typename T>
 [[nodiscard]] observer<T>
-updateable_value<T>::observe(std::function<void (const T&)> callback) const {
+updateable_value<T>::observe(utils::wrapped_function<void (const T&)> callback) const {
     auto* src = source();
     return src ? src->observe(std::move(callback)) : dummy_observer<T>();
 }

--- a/utils/wrapped_function.hh
+++ b/utils/wrapped_function.hh
@@ -1,0 +1,42 @@
+#pragma once
+
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include <concepts>
+#include <functional>
+
+namespace utils {
+
+template <typename Signature>
+class wrapped_function;
+
+/// type-safe wrapper around \c std::function that uses concepts to enforce
+/// strict type checking on lambdas passed to it.
+/// Works around https://github.com/llvm/llvm-project/issues/141791
+template <typename Ret, typename... Args, bool Noexcept>
+class wrapped_function<Ret (Args...) noexcept(Noexcept)> {
+    std::function<Ret (Args...) noexcept(Noexcept)> _func;
+
+public:
+    wrapped_function() noexcept = default;
+    wrapped_function(std::nullptr_t) noexcept {}
+
+    template <std::invocable<Args...> Func>
+    requires ((std::is_void_v<Ret> && std::is_void_v<std::invoke_result_t<Func, Args...>>)
+        || (!std::is_void_v<Ret> && std::convertible_to<std::invoke_result_t<Func, Args...>, Ret>))
+    wrapped_function(Func&& func) : _func(std::forward<Func>(func)) {}
+
+    explicit operator bool() const noexcept { return static_cast<bool>(_func); }
+
+    Ret operator()(Args...args) const noexcept(Noexcept) {
+        return _func(std::forward<Args>(args)...);
+    }
+};
+
+} // namespace utils

--- a/vector_search/clients.hh
+++ b/vector_search/clients.hh
@@ -10,6 +10,7 @@
 
 #include "client.hh"
 #include "dns.hh"
+#include "utils/wrapped_function.hh"
 #include "truststore.hh"
 #include <seastar/core/future.hh>
 #include "uri.hh"
@@ -27,7 +28,7 @@ namespace vector_search {
 
 class clients {
 public:
-    using refresh_trigger_callback = std::function<void()>;
+    using refresh_trigger_callback = utils::wrapped_function<void()>;
 
     using request_error = std::variant<aborted_error, addr_unavailable_error, service_unavailable_error>;
     using request_result = std::expected<client::response, request_error>;


### PR DESCRIPTION
## Summary

- Introduce `utils::wrapped_function<Ret(Args...)>` as a type-safe wrapper around `std::function` that uses C++20 concepts (`std::invocable` and `std::is_void_v` / `std::convertible_to`) to enforce strict type checking when constructing from a lambda or callable.

- This works around https://github.com/llvm/llvm-project/issues/141791 where `std::function<void(...)>` silently accepts lambdas with `[[nodiscard]]` return values, discarding them without warning. For example, a lambda returning `future<>` passed to `std::function<void(...)>` would silently discard the future — a real bug pattern found and fixed in this series.

- Convert all `std::function<void(...)>` uses across the codebase (public interfaces and internal) to `utils::wrapped_function<void(...)>`, organized by directory. Each patch is self-contained and builds independently.

### Bugs found and fixed by this conversion

- `test/boost/cql_query_*_test.cc`: lambdas passed to `do_with_cql_env_thread(std::function<void(cql_test_env&)>)` were returning `make_ready_future<>()`, silently discarding futures.
- `test/boost/commitlog_test.cc`: flush handler lambda returning `future<>` from `parallel_for_each()` — the future was silently discarded.

### Scope

- Only void-returning `std::function` conversions (the bug-triggering case).
- `test/perf/` excluded to avoid risking performance benchmark regressions.
- Seastar `file_impl` virtual overrides excluded (`cached_file.hh`, `checked-file-impl.hh`).

--
This is a cleanup series. No backport is required.