### PR TITLE
docs: remove outdated warning from workload-prioritization page

### DIFF
--- a/docs/features/workload-prioritization.rst
+++ b/docs/features/workload-prioritization.rst
@@ -148,13 +148,6 @@ Where:
 * ``shares_number`` - The number of shares in the CPU that you're granting to the service level name.   You can use any number within the range from 1 to 1000. **Default : 1000**
 
 
-.. warning::
-
-   Altering the SERVICE LEVEL does not affect active sessions (see `#12923 <https://github.com/scylladb/scylladb/issues/12923>`_).
-   
-   To apply a new timeout to existing clients, execute a :doc:`rolling restart </operating-scylla/procedures/config-change/rolling-restart>` after the ALTER command.
-
-
 Example
 ........
 


### PR DESCRIPTION
Fixes #30408

The warning about ALTER SERVICE LEVEL not affecting active sessions referenced issue #12923, which has been fixed. The warning is no longer accurate and has been removed.

### Backport reason

This fix always works in the latest version (2026.1) and the upcoming version (2026.2), so it should be backported to both. We must remove and avoid adding warnings, especially if they are redundant.