### PR TITLE
docs: update CDC preimage caution for large collections

### DIFF
--- a/docs/features/cdc/cdc-preimages.rst
+++ b/docs/features/cdc/cdc-preimages.rst
@@ -196,7 +196,7 @@ returns:
 
 The preimage of ``v`` for the second update is ``{a252bb60-3f95-11eb-9a61-000000000001: 1, a252bb61-3f95-11eb-9a61-000000000001: 2}``. Performing a standard read before the second update would return the list ``[1, 2]``. Observe that this list can also be obtained from the preimage by listing the (key, value) pairs in the order shown in the preimage map and removing the keys.
 
-.. caution:: When using CDC with large collections, note that generating a preimage requires reading (and storing) the entire value, which may be costly.
+.. note:: When using CDC with large collections, note that generating a preimage requires reading (and storing) the entire value, which may be costly.
 
 Preimages vs concurrent writes
 ******************************

--- a/docs/features/cdc/cdc-preimages.rst
+++ b/docs/features/cdc/cdc-preimages.rst
@@ -196,7 +196,7 @@ returns:
 
 The preimage of ``v`` for the second update is ``{a252bb60-3f95-11eb-9a61-000000000001: 1, a252bb61-3f95-11eb-9a61-000000000001: 2}``. Performing a standard read before the second update would return the list ``[1, 2]``. Observe that this list can also be obtained from the preimage by listing the (key, value) pairs in the order shown in the preimage map and removing the keys.
 
-.. caution:: Unfortunately, CDC is currently not suited for working with large collections. The reason is that freezing a collection may cause a large allocation - while non-frozen collections are stored as sequences of (small) cells, freezing a collection requires all cells to be fitted in a continuous memory buffer. This issue is currently being worked on; you can track it here: https://github.com/scylladb/scylla/issues/7506. But even after this issue is resolved, remember that generating a preimage requires reading (and storing) the entire value, which may be costly with large collections.
+.. caution:: When using CDC with large collections, note that generating a preimage requires reading (and storing) the entire value, which may be costly.
 
 Preimages vs concurrent writes
 ******************************


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/30468

The caution note in \cdc-preimages.rst\ warned that CDC is 'currently not suited for working with large collections' due to a linearization issue that caused large allocations, referencing issue scylladb/scylla#7506.

Issue #7506 has been fixed. The outdated explanation and issue link have been removed. The still-valid part of the note (that preimage generation may be costly with large collections) is retained.

### Backport reason
The corresponding issue was fixed five years ago. This PR is relevant in all currently supported version, so it should be backported.