### PR TITLE
docs: remove stale ABRT comment from install-on-linux

### DIFF
--- a/docs/getting-started/install-scylla/install-on-linux.rst
+++ b/docs/getting-started/install-scylla/install-on-linux.rst
@@ -28,8 +28,6 @@ Prerequisites
 
      sudo yum remove -y abrt
 
-.. The last requirement may need to be removed. See https://github.com/scylladb/scylladb/issues/14488.
-
 Install ScyllaDB
 --------------------
 


### PR DESCRIPTION
A RST developer comment in \install-on-linux.rst\ noted that the ABRT removal prerequisite 'may need to be removed', referencing issue #14488.

Issue #14488 has been resolved (COMPLETED): the ABRT requirement was confirmed as still valid. The now-outdated comment asking about its potential removal is removed.