### PR TITLE
ci: enable AI conflict resolution in backport workflow

### DIFF
--- a/.github/workflows/call_backport_with_jira.yaml
+++ b/.github/workflows/call_backport_with_jira.yaml
@@ -30,6 +30,9 @@ jobs:
     secrets:
       gh_token: ${{ secrets.AUTO_BACKPORT_TOKEN }}
       jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+      copilot_token: ${{ secrets.COPILOT_TOKEN }}
+      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   backport-on-label:
     if: github.event_name == 'pull_request_target' && github.event.action == 'labeled'
@@ -44,6 +47,9 @@ jobs:
     secrets:
       gh_token: ${{ secrets.AUTO_BACKPORT_TOKEN }}
       jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+      copilot_token: ${{ secrets.COPILOT_TOKEN }}
+      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   backport-chain:
     if: github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true
@@ -56,3 +62,6 @@ jobs:
     secrets:
       gh_token: ${{ secrets.AUTO_BACKPORT_TOKEN }}
       jira_auth: ${{ secrets.USER_AND_KEY_FOR_JIRA_AUTOMATION }}
+      copilot_token: ${{ secrets.COPILOT_TOKEN }}
+      dockerhub_username: ${{ secrets.DOCKERHUB_USERNAME }}
+      dockerhub_token: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Pass copilot_token, dockerhub_username, and dockerhub_token secrets to the reusable backport-with-jira workflow to enable automatic AI-based merge conflict resolution for backport PRs.

Fixes: SCYLLADB-2806

**Since this patch will do automatic conflict resolve we should backport to all active releases**