### PR TITLE
readers/multishard: evictable_reader: prevent buffer overfill

### DIFF
--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -599,11 +599,13 @@ future<> evictable_reader::fill_buffer() {
     _reader->move_buffer_content_to(*this);
 
     // Ensure that each buffer represents forward progress. Only a concern when
-    // the last fragment in the buffer is range tombstone change. In this case
-    // ensure that:
+    // the last fragment in the buffer is range tombstone change and the entire
+    // buffer comes from the same partition from which the last fragment of the
+    // previous buffer came from. In this case ensure that:
     // * buffer().back().position() > _next_position_in_partition;
     // * _reader.peek()->position() > buffer().back().position();
-    if (!is_buffer_empty() && buffer().back().is_range_tombstone_change()) {
+    if (!is_buffer_empty() && buffer().back().is_range_tombstone_change()
+            && std::ranges::none_of(buffer(), std::mem_fn(&mutation_fragment_v2::is_partition_start))) {
         auto* next_mf = co_await _reader->peek();
 
         // First make sure we've made progress w.r.t. _next_position_in_partition.

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -3716,6 +3716,98 @@ SEASTAR_THREAD_TEST_CASE(test_evictable_reader_next_pos_is_partition_start) {
     BOOST_REQUIRE_LE(buf1.size(), 10);
 }
 
+SEASTAR_THREAD_TEST_CASE(test_evictable_reader_buffer_overfill) {
+    reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, get_name(), 1, 0);
+    auto stop_sem = deferred_stop(semaphore);
+    simple_schema s;
+    auto schema = s.schema();
+    auto permit = semaphore.make_tracking_only_permit(s.schema(), get_name(), db::no_timeout, {});
+
+    auto pks = s.make_pkeys(2);
+    const auto prange = dht::partition_range::make_open_ended_both_sides();
+
+    sstring value(1024, 'v');
+
+    std::deque<mutation_fragment_v2> frags;
+    uint32_t ck = 1000;
+
+    // first buffer
+    size_t first_buffer_size{0};
+
+    frags.emplace_back(*schema, permit, partition_start(pks[0], {}));
+    first_buffer_size += frags.back().memory_usage();
+    for (; ck < 1100; ++ck) {
+        frags.emplace_back(s.make_row_v2(permit, s.make_ckey(ck), value));
+        first_buffer_size += frags.back().memory_usage();
+    }
+
+    const uint32_t first_buffer_last_ck = ck - 1;
+
+    // second buffer
+    size_t second_buffer_size{0};
+
+    for (; ck < 1110; ++ck) {
+        frags.emplace_back(s.make_row_v2(permit, s.make_ckey(ck), value));
+        second_buffer_size += frags.back().memory_usage();
+    }
+
+    frags.emplace_back(*schema, permit, partition_end{});
+    second_buffer_size += frags.back().memory_usage();
+
+    frags.emplace_back(*schema, permit, partition_start(pks[1], {}));
+    second_buffer_size += frags.back().memory_usage();
+
+    ck = 0; // reset ck in new partition
+    BOOST_REQUIRE_LT(second_buffer_size, first_buffer_size); // sanity check
+
+    for  (; second_buffer_size < first_buffer_size; second_buffer_size += frags.back().memory_usage(), ++ck) {
+        frags.emplace_back(s.make_row_v2(permit, s.make_ckey(ck), value));
+    }
+
+    // pop enough rows to go back below first buffer size
+    second_buffer_size -= frags.back().memory_usage();
+    frags.pop_back();
+    // fill remaining room with range tombstone changes, so last fragment is a range tombstone change
+    for  (; second_buffer_size < first_buffer_size; second_buffer_size += frags.back().memory_usage(), ++ck) {
+        frags.emplace_back(*schema, permit, range_tombstone_change(position_in_partition::before_key(s.make_ckey(ck)), tombstone(s.new_timestamp(), {})));
+    }
+
+    // the below fragments should not make it into buffer 2, we add enough data here so the test can reliably detect overfill
+    frags.emplace_back(*schema, permit, range_tombstone_change(position_in_partition::before_key(s.make_ckey(ck)), tombstone()));
+    for (ck = 0; ck < 1000; ++ck) {
+        frags.emplace_back(s.make_row_v2(permit, s.make_ckey(ck), value));
+    }
+    frags.emplace_back(*schema, permit, partition_end{});
+
+    auto ms = mutation_source([&frags, first_buffer_size] (
+            schema_ptr schema,
+            reader_permit permit,
+            const dht::partition_range& pr,
+            const query::partition_slice& ps) {
+        auto rd = make_mutation_reader_from_fragments(std::move(schema), std::move(permit), std::move(frags), pr, ps);
+        rd.set_max_buffer_size(first_buffer_size);
+        return rd;
+    });
+
+    auto tri_cmp = position_in_partition::tri_compare(*s.schema());
+
+    auto [rd, handle] = make_manually_paused_evictable_reader(ms, schema, permit, prange, schema->full_slice(), {},
+            mutation_reader::forwarding::no);
+    auto stop_rd = deferred_close(rd);
+    rd.set_max_buffer_size(first_buffer_size);
+
+    testlog.info("first buffer fill");
+    rd.fill_buffer().get();
+
+    BOOST_REQUIRE_EQUAL(rd.buffer_size(), first_buffer_size);
+    auto first_buffer = rd.detach_buffer();
+    BOOST_REQUIRE_EQUAL(tri_cmp(first_buffer.back().position(), position_in_partition::for_key(s.make_ckey(first_buffer_last_ck))), std::strong_ordering::equal);
+
+    testlog.info("second buffer fill");
+    rd.fill_buffer().get();
+    BOOST_REQUIRE_LT(rd.buffer_size(), first_buffer_size + 2048);
+}
+
 struct mutation_bounds {
     std::optional<mutation> m;
     position_in_partition lower;


### PR DESCRIPTION
The evictable reader has some special logic to make sure the reader doesn't re-emit data it already emited. Doing so would not only break all reader consumers which assume monotonic positions, but in the extreme case, could also lead to infinite loop.
To ensure this, the evictable reader ensures that:
* The position of the first fragment of a new buffer is > than that of the last fragment in the last buffer.
* If the last fragment in the buffer is a range tombstone, its position is > than the next fragment in the buffer.

This logic has a bug: if the new buffer contains a new partition, the logic would end up comparing clustering positions between two different partitions, which is meaningless and also undefined behaviour. This would manifest in the evictable reader wastly over-filling its buffer, to the extent that it was observed to cause OOM by reading 5.9G worth of fragments into memory.

Fix by not executing the progress enforcement logic if the buffer has a partition-start fragment. If the new buffer contains a new partition, forward progress is guaranteed.

Add a test which reproduces the buffer overfill.

Fixes: SCYLLADB-2759

Backport: bug is present in all releases, need backport to all active releases