### PR TITLE
test: stop using Python ssl.PROTOCOL_TLSv1_2

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -124,9 +124,7 @@ def cluster_con(hosts: list[IPAddress | EndPoint], port: int = 9042, use_ssl: bo
         serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL,
         request_timeout=200)
     if use_ssl:
-        # Scylla does not support any earlier TLS protocol. If you try,
-        # you will get mysterious EOF errors (see issue #6971) :-(
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     else:
         ssl_context = None
 

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -439,9 +439,7 @@ def check_cql(ip, ssl_context=None):
         raise NotYetUp
     # Any other exception may indicate a problem, and is passed to the caller.
 def check_ssl_cql(ip):
-    # Note that Scylla does not support any earlier TLS protocol. If you
-    # try, you get mysterious EOF errors (see issue #6971) :-(
-    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+    ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     check_cql(ip, ssl_context)
 
 # Test that the Scylla REST API is serving.

--- a/test/cqlpy/util.py
+++ b/test/cqlpy/util.py
@@ -215,9 +215,7 @@ def cql_session(host, port, is_ssl, username, password, request_timeout=120, pro
         # 10 seconds may not be enough, so let's increase it. See issue #7838.
         request_timeout=request_timeout)
     if is_ssl:
-        # Scylla does not support any earlier TLS protocol. If you try,
-        # you will get mysterious EOF errors (see issue #6971) :-(
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     else:
         ssl_context = None
     cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},

--- a/test/pylib/kmip_wrapper.py
+++ b/test/pylib/kmip_wrapper.py
@@ -12,6 +12,12 @@ import signal
 import sqlalchemy
 from sqlalchemy.pool import StaticPool
 
+# Python 3.15 removed ssl.PROTOCOL_TLSv1_2. The kmip library references it
+# in TLS12AuthenticationSuite.__init__. Provide a shim so the import (and
+# super().__init__) doesn't crash. We override _protocol immediately after.
+if not hasattr(ssl, 'PROTOCOL_TLSv1_2'):
+    ssl.PROTOCOL_TLSv1_2 = ssl.PROTOCOL_TLS_SERVER
+
 from kmip.services import auth
 from kmip.services.server.server import KmipServer, build_argument_parser, exceptions
 


### PR DESCRIPTION
Python with openssl 4 does not provide support for TLS 1.2 [1]. Fedora 45 started building Python with openssl 4 [2]. As a result, our test suite won't run on Fedora 45.

Fix that by changing use of ssl.PROTOCOL_TLSv1_2 to ssl.PROTOCOL_TLS. The PyKMIP package hard-codes ssl.PROTOCOL_TLSv1_2, so we hot-patch the ssl package to provide that symbol.

[1] https://github.com/python/cpython/blob/13c1225443ad1459bc859392ea11a7053cbad190/Modules/_ssl.c#L171
[2] https://src.fedoraproject.org/rpms/python3.15/c/e70867cda8389990d6224cb922823392f5b51759?branch=rawhide

Preparing for a future toolchain, so not backporting.