### PR TITLE
seekable_source: Add a "get_at" method for positioned read

### DIFF
--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -765,3 +765,36 @@ SEASTAR_FIXTURE_TEST_CASE(test_clone_path_stream_uncompressed_gcs, gcs_fixture,
         return do_test_clone_path_stream(env, compress_sstable::no, make_storage_clause(so));
     }, cfg);
 }
+
+// tests that a ranged_source counts any skipped data into
+// remaining "len" (available data)
+SEASTAR_TEST_CASE(test_ranged_data_source_skip) {
+
+    constexpr size_t n_bufs = 30;
+    constexpr size_t buf_len = 4096;
+
+    std::vector<temporary_buffer<char>> src;
+    src.reserve(n_bufs);
+
+    for (size_t i = 0; i < n_bufs; ++i) {
+        auto rnd = tests::random::get_bytes(buf_len);
+        temporary_buffer<char> buf(reinterpret_cast<char*>(rnd.data()), rnd.size());
+        src.emplace_back(std::move(buf));
+    }
+
+    auto size = n_bufs * buf_len;
+    auto off = 1756u;
+    auto len = size - 2*off;
+
+    auto wrapped = create_ranged_source(create_memory_source(std::move(src)), off, len);
+
+    input_stream<char> in(std::move(wrapped));
+    co_await in.skip(off);
+
+    auto buf = co_await in.read_exactly(len); 
+
+    // ensure we did in fact only get (len - off) bytes from the read.
+    // i.e. ranged_source limited the available bytes correctly
+    BOOST_REQUIRE_LT(buf.size(), len);
+    BOOST_REQUIRE_EQUAL(buf.size(), len - off);
+}

--- a/test/boost/gcp_object_storage_test.cc
+++ b/test/boost/gcp_object_storage_test.cc
@@ -23,6 +23,8 @@
 #include <seastar/core/sleep.hh>
 #include <seastar/core/with_timeout.hh>
 
+#include "ent/encryption/symmetric_key.hh"
+#include "ent/encryption/encrypted_file_impl.hh"
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/log.hh"
 #include "test/lib/random_utils.hh"
@@ -67,6 +69,31 @@ static auto check_gcp_storage_test_enabled() {
     return tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true);
 }
 
+static future<> write_object_of_size(data_sink& sink
+                                      , size_t dest_size
+                                      , std::vector<temporary_buffer<char>>* buffer_store = nullptr
+                                      , std::optional<size_t> specific_buffer_size = std::nullopt
+                                      , bool can_share = true
+                                    ) 
+{
+    size_t done = 0;
+    while (done < dest_size) {
+        auto rem = dest_size - done;
+        auto len = std::min(rem, specific_buffer_size.value_or(tests::random::get_int(size_t(1), size_t(4*1024*1024))));
+        auto rnd = tests::random::get_bytes(len);
+        temporary_buffer<char> buf(reinterpret_cast<char*>(rnd.data()), rnd.size());
+        if (buffer_store) {
+            // maybe don't use share. if sink is encrypted, it will do in-place transforms
+            buffer_store->emplace_back(can_share 
+                ? buf.share()
+                : temporary_buffer<char>(buf.get(), len)
+            );
+        }
+        co_await sink.put(std::move(buf));
+        done += len;
+    }
+}
+
 static future<> create_object_of_size(storage::client& c
                                       , std::string_view bucket
                                       , std::string_view name
@@ -76,18 +103,7 @@ static future<> create_object_of_size(storage::client& c
                                     ) 
 {
     auto sink = c.create_upload_sink(bucket, name);
-    size_t done = 0;
-    while (done < dest_size) {
-        auto rem = dest_size - done;
-        auto len = std::min(rem, specific_buffer_size.value_or(tests::random::get_int(size_t(1), size_t(4*1024*1024))));
-        auto rnd = tests::random::get_bytes(len);
-        temporary_buffer<char> buf(reinterpret_cast<char*>(rnd.data()), rnd.size());
-        if (buffer_store) {
-            buffer_store->emplace_back(buf.share());
-        }
-        co_await sink.put(std::move(buf));
-        done += len;
-    }
+    co_await write_object_of_size(sink, dest_size, buffer_store, specific_buffer_size);
     co_await sink.flush();
     co_await sink.close();
 }
@@ -396,6 +412,86 @@ SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_read_in_parallel, local_gcs_wrapper, 
         BOOST_REQUIRE_EQUAL(t2, total);
         co_await compare_stream_data(is2, is_ref, total);
     }
+}
+
+static future<> chunked_read_helper(const local_gcs_wrapper& w, bool do_ranged, bool encrypt, bool do_additional_skip) {
+    auto& c = w.client();
+    auto name = make_name();
+    std::vector<temporary_buffer<char>> written;
+
+    auto dest_size = 56*1024*1024 + 357 + 1022*67;
+
+    // ensure we remove the object
+    w.objects_to_delete.emplace_back(name);
+
+    auto k = make_shared<encryption::symmetric_key>(encryption::key_info{ "AES", 128 });
+
+    {
+        data_sink sink = c.create_upload_sink(w.bucket, name);
+        if (encrypt) {
+            sink = data_sink(encryption::make_encrypted_sink(std::move(sink), k));
+        }
+        co_await write_object_of_size(sink, dest_size, &written, std::nullopt, !encrypt);
+        co_await sink.flush();
+        co_await sink.close();
+    }
+
+    auto [is_ref, total] = stream_from_buffers(std::move(std::move(written)));
+
+    auto chunk_size = 64 * 1024;
+    auto start = do_ranged ? 48*1024*1024 + 6 * chunk_size : 0;
+    auto len = dest_size - start;
+    auto skip = do_additional_skip ? chunk_size : 0;
+
+    co_await is_ref.skip(start + skip);
+
+    data_source source = c.create_download_source(w.bucket, name);
+    if (encrypt) {
+        source = data_source(encryption::make_encrypted_source(std::move(source), k));
+    }
+    if (do_ranged) {
+        source = create_ranged_source(std::move(source), start, len);
+    }
+
+    input_stream<char> is(std::move(source));
+
+    if (skip) {
+        co_await is.skip(chunk_size);
+    }
+
+    for (auto rem = len - skip; rem > 0;) {
+        auto chunk = std::min(rem, chunk_size);
+
+        auto buf1 = co_await is_ref.read_exactly(chunk_size);
+        auto buf2 = co_await is.read_exactly(chunk_size);
+
+        BOOST_REQUIRE_EQUAL(buf1.size(), chunk);
+        BOOST_REQUIRE_EQUAL(buf2.size(), chunk);
+
+        BOOST_REQUIRE_EQUAL(buf1, buf2);
+
+        rem -= chunk;
+    }
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_read_chunked_partial, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {
+    co_await chunked_read_helper(*this, true, false, false);
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_read_chunked_partial_with_skip, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {
+    co_await chunked_read_helper(*this, true, false, true);
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_read_chunked_fully_encrypted, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {
+    co_await chunked_read_helper(*this, false, true, false);
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_read_chunked_partial_encrypted, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {
+    co_await chunked_read_helper(*this, true, true, false);
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_read_chunked_partial_encrypted_with_skip, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {
+    co_await chunked_read_helper(*this, true, true, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/gcp_object_storage_test.cc
+++ b/test/boost/gcp_object_storage_test.cc
@@ -9,12 +9,14 @@
 #include "utils/gcp/object_storage.hh"
 #include "utils/gcp/gcp_credentials.hh"
 
+#include <ranges>
 #include <unordered_set>
 #include <filesystem>
 #include <boost/test/unit_test.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 
+#include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/file.hh>
@@ -31,6 +33,7 @@
 #include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/io-wrappers.hh"
+#include "utils/error_injection.hh"
 
 #include <seastar/testing/test_fixture.hh>
 
@@ -104,10 +107,15 @@ static future<> compare_stream_data(seastar::input_stream<char>& is1, seastar::i
     BOOST_REQUIRE_EQUAL(read, total);
 }
 
-static std::tuple<seastar::input_stream<char>, size_t> stream_from_buffers(std::vector<temporary_buffer<char>>&& bufs) {
+static size_t total_size(const std::vector<temporary_buffer<char>>& bufs) {
     auto total = std::accumulate(bufs.begin(), bufs.end(), size_t{}, [](size_t s, auto& buf) {
         return s + buf.size();
     });
+    return total;
+}
+
+static std::tuple<seastar::input_stream<char>, size_t> stream_from_buffers(std::vector<temporary_buffer<char>>&& bufs) {
+    auto total = total_size(bufs);
     auto is = seastar::input_stream<char>(create_memory_source(std::move(bufs)));
     return std::make_tuple(std::move(is), total);
 }
@@ -331,6 +339,63 @@ SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_read_large_object_iov, local_gcs_wrap
     BOOST_REQUIRE_EQUAL(total, total2);
     co_await compare_stream_data(is1, is2, total);
 
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_read_in_parallel, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {
+    auto& c = client();
+    auto name = make_name();
+    std::vector<temporary_buffer<char>> written;
+
+    // just a random number reasonably large size that is not a
+    // even sector size or anything. 32mb + change
+    auto dest_size = 32*1024*1024 + 357 + 1022*67 + 23324;
+
+    // ensure we remove the object
+    objects_to_delete.emplace_back(name);
+    co_await create_object_of_size(c, bucket, name, dest_size, &written);
+    auto source = c.create_download_source(bucket, name);
+    auto f = create_file_for_seekable_source(std::move(source));
+    auto total = total_size(written);
+
+    utils::get_local_injector().enable("gcp_storage_stall_requests", true);
+    auto def = defer([]() noexcept {
+        utils::get_local_injector().disable("gcp_storage_stall_requests");
+    });
+
+    auto read_file = [&]() -> future<std::tuple<seastar::input_stream<char>, size_t>> {
+        std::vector<temporary_buffer<char>> bufs;
+        for (size_t i = 0; i < total; ) {
+            auto n = std::min(total - i, size_t(64*1024));
+            auto buf = co_await f.dma_read_bulk<char>(i, n);
+            i += buf.size();
+            bufs.emplace_back(std::move(buf));
+        }
+        co_return stream_from_buffers(std::move(std::move(bufs)));
+    };
+
+    auto fut = read_file();
+    BOOST_REQUIRE(!fut.available());
+    auto [is1, t1] = co_await read_file();
+    auto [is2, t2] = co_await std::move(fut);
+
+    co_await f.close();
+
+    auto written2 = written | std::views::transform([](auto& buf) {
+        return buf.share();
+    }) | std::ranges::to<std::vector>();
+
+    {
+        BOOST_TEST_MESSAGE("Check stream 1");
+        auto [is_ref, total] = stream_from_buffers(std::move(written));
+        BOOST_REQUIRE_EQUAL(t1, total);
+        co_await compare_stream_data(is1, is_ref, total);
+    }
+    {
+        BOOST_TEST_MESSAGE("Check stream 2");
+        auto [is_ref, total] = stream_from_buffers(std::move(written2));
+        BOOST_REQUIRE_EQUAL(t2, total);
+        co_await compare_stream_data(is2, is_ref, total);
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -188,15 +188,83 @@ class utils::gcp::storage::client::object_data_source : public seekable_data_sou
     std::string _session_path;
     uint64_t _generation = 0;
     uint64_t _size = 0;
-    uint64_t _position = 0;
     std::chrono::system_clock::time_point _timestamp;
-    seastar::semaphore_units<> _limits;
     seastar::abort_source* _as;
-    std::deque<temporary_buffer<char>> _buffers;
 
-    size_t buffer_size() const {
-        return std::accumulate(_buffers.begin(), _buffers.end(), 0, [](size_t sum, auto& b) { return sum + b.size(); });
-    }
+    struct state {
+        uint64_t position = 0;
+        std::deque<temporary_buffer<char>> buffers;
+        seastar::semaphore_units<> limits;
+
+        size_t buffer_size() const {
+            return std::accumulate(buffers.begin(), buffers.end(), 0, [](size_t sum, auto& b) { return sum + b.size(); });
+        }
+
+        void adjust_lease();
+
+        void adopt(seastar::semaphore_units<> lease) {
+            if (limits) {
+                limits.adopt(std::move(lease));
+            } else {
+                limits = std::move(lease);
+            }
+        }
+
+        void trim() {
+            while (!buffers.empty() && buffers.front().empty()) {
+                buffers.pop_front();
+            }
+        }
+
+        auto get(size_t limit) {
+            temporary_buffer<char> res;
+
+            if (limit == 0) {
+                return res;
+            }
+
+            while (!buffers.empty() && res.empty()) {
+                auto& buf = buffers.front();
+                if (buf.size() > limit) {
+                    res = buf.share(0, limit);
+                    buf.trim_front(limit);
+                } else {
+                    res = std::move(buf);
+                    buffers.pop_front();
+                }
+            }
+            return res;
+        }
+    };
+
+    std::unique_ptr<state> _state;
+
+    class hold_state {
+        object_data_source& _src;
+        std::unique_ptr<state> _state;
+    public:
+        hold_state(object_data_source& s)
+            : _src(s)
+            , _state(std::exchange(s._state, {}))
+        {
+            if (!_state) {
+                _state = std::make_unique<state>();
+            }
+        }
+        ~hold_state() {
+            _state->adjust_lease();
+            if (!std::uncaught_exceptions()) {
+                _src._state = std::move(_state);
+            }
+        }
+        operator state&() const {
+            return *_state;
+        }
+    };
+
+    future<temporary_buffer<char>> get(size_t limit, state&);
+    future<temporary_buffer<char>> skip(uint64_t n, state&);
+    future<> seek(uint64_t pos, state&);
 
 public:
     object_data_source(shared_ptr<impl> i, std::string_view bucket, std::string_view object_name, seastar::abort_source* as)
@@ -208,9 +276,9 @@ public:
     future<temporary_buffer<char>> get() override;
     future<temporary_buffer<char>> skip(uint64_t n) override;
     future<> read_info();
-    void adjust_lease();
 
     future<temporary_buffer<char>> get(size_t limit) override;
+    future<temporary_buffer<char>> get_at(uint64_t pos, size_t limit) override;
     future<> seek(uint64_t pos) override;
     future<uint64_t> size() override;
     future<std::chrono::system_clock::time_point> timestamp() override;
@@ -534,6 +602,9 @@ utils::gcp::storage::client::impl::send_with_retry(const std::string& path, cons
                 co_await coroutine::return_exception_ptr(std::move(eptr));
             }
         };
+
+        co_await utils::get_local_injector().inject("gcp_storage_stall_requests", std::chrono::milliseconds(150));
+
         object_storage_retry_strategy retry_strategy(10,10ms,10000ms, as);
         co_return co_await rest::simple_send(_client, req, wrapped_handler, &retry_strategy, as);
     } catch (...) {
@@ -823,33 +894,31 @@ future<> utils::gcp::storage::client::object_data_sink::remove_upload() {
 }
 
 // Read a single buffer from the source object
-future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::get(size_t limit) {
+future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::get(size_t limit, state& s) {
     // If we don't know the source size yet, get the info from server
     if (_size == 0) {
         co_await read_info();
     }
 
+    s.trim();
+
     // If we don't have buffers to give, try getting one from server
-    if (_buffers.empty()) {
-        auto to_read = std::min(_size - _position, limit);
+    if (s.buffers.empty()) {
+        auto to_read = std::min(_size - s.position, limit);
 
         // to_read == 0 -> eof
         if (to_read != 0) {
-            gcp_storage.debug("Reading object {}:{} ({}-{}/{})", _bucket, _object_name, _position, _position+to_read, _size);
+            gcp_storage.debug("Reading object {}:{} ({}-{}/{})", _bucket, _object_name, s.position, s.position+to_read, _size);
 
             auto lease = _impl->try_get_units(to_read);
             if (lease) {
-                if (_limits) {
-                    _limits.adopt(std::move(*lease));
-                } else {
-                    _limits = std::move(*lease);
-                }
+                s.adopt(std::move(*lease));
             } else {
                 // If we can't get a lease to cover this read, don't wait, as this
                 // could cause deadlock in higher layers, but instead adjust the
                 // size down to decrease memory pressure.
                 to_read = std::min(to_read, min_gcp_storage_chunk_size);
-                gcp_storage.debug("Reading object (adjusted) {}:{} ({}-{}/{})", _bucket, _object_name, _position, _position+to_read, _size);
+                gcp_storage.debug("Reading object (adjusted) {}:{} ({}-{}/{})", _bucket, _object_name, s.position, s.position+to_read, _size);
             }
 
             // Ensure we read from the same generation as we queried in read_info. Note: mock server ignores this.
@@ -858,7 +927,7 @@ future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::
                 , seastar::http::internal::url_encode(_object_name)
                 , _generation
             );
-            auto range = fmt::format("bytes={}-{}", _position, _position+to_read-1); // inclusive range
+            auto range = fmt::format("bytes={}-{}", s.position, s.position+to_read-1); // inclusive range
 
             co_await _impl->send_with_retry(path
                 , GCP_OBJECT_SCOPE_READ_ONLY
@@ -866,16 +935,16 @@ future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::
                 , ""s
                 , [&](const seastar::http::reply& rep, seastar::input_stream<char>& in) -> future<> {
                     if (rep._status != status_type::ok && rep._status != status_type::partial_content) {
-                        throw failed_operation(fmt::format("Could not read object {}: {} ({}/{} - {})", _bucket, _object_name, _position, _size, int(rep._status)));
+                        throw failed_operation(fmt::format("Could not read object {}: {} ({}-{}/{} - {})", _bucket, _object_name, s.position, s.position+to_read, _size, int(rep._status)));
                     }
-                    auto old = _position;
+                    auto old = s.position;
                     // ensure these are on our coroutine frame.
                     auto bufs = co_await util::read_entire_stream(in);
                     for (auto&& buf : bufs) {
-                        _position += buf.size();
-                        _buffers.emplace_back(std::move(buf));
+                        s.position += buf.size();
+                        s.buffers.emplace_back(std::move(buf));
                     }
-                    gcp_storage.debug("Read object {}:{} ({}-{}/{})", _bucket, _object_name, old, _position, _size);
+                    gcp_storage.debug("Read object {}:{} ({}-{}/{})", _bucket, _object_name, old, s.position, _size);
                 }
                 , httpclient::method_type::GET
                 , rest::key_values({ { RANGE, range } })
@@ -884,22 +953,18 @@ future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::
         }
     }
 
-    temporary_buffer<char> res;
+    co_return s.get(limit);
+}
 
-    if (!_buffers.empty()) {
-        auto&& buf = _buffers.front();
-        if (buf.size() >= limit) {
-            res = buf.share(0, limit);
-            buf.trim_front(limit);
-        } else {
-            res = std::move(buf);
-            _buffers.pop_front();
-        }
-    }
+future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::get(size_t limit) {
+    hold_state h(*this);
+    co_return co_await get(limit, h);
+}
 
-    adjust_lease();
-
-    co_return res;
+future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::get_at(uint64_t pos, size_t limit) {
+    hold_state h(*this);
+    co_await seek(pos, h);
+    co_return co_await get(limit, h);
 }
 
 future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::get() {
@@ -907,37 +972,39 @@ future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::
     co_return co_await get(default_gcp_storage_chunk_size);
 }
 
-future<> utils::gcp::storage::client::object_data_source::seek(uint64_t pos) {
+future<> utils::gcp::storage::client::object_data_source::seek(uint64_t pos, state& s) {
     if (_size == 0) {
         co_await read_info();
     }
-    auto buf_size = buffer_size();
-    assert(buf_size <= _position);
-    auto read_pos = _position - buf_size;
-    if (pos < read_pos || pos >= _position) {
-        _buffers.clear();
-        _position = std::min(pos, _size);
+    auto buf_size = s.buffer_size();
+    assert(buf_size <= s.position);
+    auto read_pos = s.position - buf_size;
+    if (pos < read_pos || pos >= s.position) {
+        s.buffers.clear();
+        s.position = std::min(pos, _size);
         co_return;
     }
     auto n = pos - read_pos;
     // Drop superfluous cache
-    while (n > 0 && !_buffers.empty()) {
-        auto m = std::min(n, _buffers.front().size());
-        _buffers.front().trim_front(m);
-        if (_buffers.front().empty()) {
-            _buffers.pop_front();
+    while (n > 0 && !s.buffers.empty()) {
+        auto m = std::min(n, s.buffers.front().size());
+        s.buffers.front().trim_front(m);
+        if (s.buffers.front().empty()) {
+            s.buffers.pop_front();
         }
         n -= m;
     }
-    adjust_lease();
 }
 
-void utils::gcp::storage::client::object_data_source::adjust_lease() {
-    auto total = std::accumulate(_buffers.begin(), _buffers.end(), size_t{}, [](size_t s, auto& buf) {
-        return s + buf.size();
-    });
-    if (total < _limits.count()) {
-        _limits.return_units(_limits.count() - total);
+future<> utils::gcp::storage::client::object_data_source::seek(uint64_t pos) {
+    hold_state h(*this);
+    co_return co_await seek(pos, h);
+}
+
+void utils::gcp::storage::client::object_data_source::state::adjust_lease() {
+    auto total = buffer_size();
+    if (total < limits.count()) {
+        limits.return_units(limits.count() - total);
     }
 }
 
@@ -955,19 +1022,25 @@ future<std::chrono::system_clock::time_point> utils::gcp::storage::client::objec
     co_return _timestamp;
 }
 
-future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::skip(uint64_t n) {
-    auto buf_size = buffer_size();
-    assert(buf_size <= _position);
-    auto read_pos = _position - buf_size;
+future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::skip(uint64_t n, state& s) {
+    auto buf_size = s.buffer_size();
+    assert(buf_size <= s.position);
+    auto read_pos = s.position - buf_size;
     auto new_pos = read_pos + n;
-    co_await seek(new_pos);
+    co_await seek(new_pos, s);
     // seek() clamps position to _size, so if the requested
     // position exceeds _size we are skipping past EOF.
     if (new_pos > _size) {
         throw std::runtime_error("premature end of stream");
     }
+    s.adjust_lease();
     // And get the next buffer
-    co_return co_await get();
+    co_return co_await get(default_gcp_storage_chunk_size, s);
+}
+
+future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::skip(uint64_t n) {
+    hold_state h(*this);
+    co_return co_await skip(n, h);
 }
 
 future<> utils::gcp::storage::client::object_data_source::read_info() {

--- a/utils/io-wrappers.cc
+++ b/utils/io-wrappers.cc
@@ -292,6 +292,7 @@ seastar::data_source create_ranged_source(data_source src, uint64_t offset, std:
                 co_return temporary_buffer<char>{};
             }
             if (auto skip = std::exchange(_offset, 0); (skip + n) > 0) {
+                _read += std::min(_len - _read, n);
                 co_return trim(co_await _src.skip(skip + n));
             }
             co_return trim(co_await _src.get());

--- a/utils/io-wrappers.cc
+++ b/utils/io-wrappers.cc
@@ -192,11 +192,10 @@ seastar::file create_file_for_seekable_source(seekable_data_source src, seekable
             , _src_func(std::move(src_func))
         {}
         future<size_t> read_dma(uint64_t pos, void* buffer, size_t len, io_intent*) override {
-            co_await _source.seek(pos);
             size_t res = 0;
             auto dst = reinterpret_cast<char*>(buffer);
             while (len) {
-                auto buf = co_await _source.get(len);
+                auto buf = co_await _source.get_at(pos + res, len);
                 assert(buf.size() <= len);
                 if (buf.empty()) {
                     break;

--- a/utils/io-wrappers.cc
+++ b/utils/io-wrappers.cc
@@ -293,7 +293,12 @@ seastar::data_source create_ranged_source(data_source src, uint64_t offset, std:
             }
             if (auto skip = std::exchange(_offset, 0); (skip + n) > 0) {
                 _read += std::min(_len - _read, n);
-                co_return trim(co_await _src.skip(skip + n));
+                // SCYLLADB-2962. Need to ensure any empty
+                // result from underlying source is actual eof.
+                auto res = co_await _src.skip(skip + n);
+                if (!res.empty() || _len == _read) {
+                    co_return trim(std::move(res));
+                }
             }
             co_return trim(co_await _src.get());
         }

--- a/utils/seekable_source.hh
+++ b/utils/seekable_source.hh
@@ -14,6 +14,10 @@
 class seekable_data_source_impl : public seastar::data_source_impl {
 public:
     virtual seastar::future<seastar::temporary_buffer<char>> get(size_t limit) = 0;
+    // implementors must guarantee this is atomic-eqsue such that any state
+    // is consistent so that the next get_at call will be equally valid.
+    // Simplest impl is a serialized seek + get.
+    virtual seastar::future<seastar::temporary_buffer<char>> get_at(uint64_t pos, size_t limit) = 0;
     virtual seastar::future<> seek(uint64_t pos) = 0;
     virtual seastar::future<uint64_t> size() {
         return seastar::make_ready_future<uint64_t>(0);
@@ -31,6 +35,13 @@ public:
     seastar::future<seastar::temporary_buffer<char>> get(size_t limit) noexcept {
         try {
             return static_cast<seekable_data_source_impl*>(impl())->get(limit);
+        } catch (...) {
+            return seastar::current_exception_as_future<seastar::temporary_buffer<char>>();
+        }
+    }
+    seastar::future<seastar::temporary_buffer<char>> get_at(uint64_t pos, size_t limit) noexcept {
+        try {
+            return static_cast<seekable_data_source_impl*>(impl())->get_at(pos, limit);
         } catch (...) {
             return seastar::current_exception_as_future<seastar::temporary_buffer<char>>();
         }


### PR DESCRIPTION
Fixes SCYLLADB-2936
Fixes SCYLLADB-2962
Fixes SCYLLADB-2213

Adds a get_at method to the seekable_source interface. The contract is that an implementor must guarantee that this is treated as an "atomic" operation, in that is remains consistent with the input position, and any state after the call is internally consistent such that subsequent pget calls are also ok.

Implements this in gcp::object_storage by moving state into a transitional object which we acquire on seek/skip/get calls, and return afterwards (anyone can win). This state however is now shared internally in call chains such as pget to ensure we do in fact read as directed.
If we race, we can loose cache and similar. But read correctly. If we don't, we more or less retain the same behaviour as before with no performance losses.

This ensures any file object created here can be read by any number of task chains in parallel without state confusion.

Adds a test case to gcp_object_storage_test that reproduces the problem for gcs.

Should backport to 2026.2, just because code exists there, although afaik not really run. 