### PR TITLE
build: switch from slirp4netns to pasta

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -153,7 +153,7 @@ fedora_packages=(
 
     podman
     buildah
-    slirp4netns
+    passt
 
     # for cassandra-stress
     java-openjdk-headless

--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -179,7 +179,7 @@ volume_path = "$HOME/.local/share/containers/storage/libpod"
 [containers]
 # netns = private, the default, doesn't work in nested containers,
 # but we need to use port forwarded networking for our mocks etc.
-netns = "slirp4netns"
+netns = "pasta"
 
 EOF
 

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-44-20260613
+docker.io/scylladb/scylla-toolchain:fedora-44-20260622


### PR DESCRIPTION
podman 6.0 removed support for slirp4netns networking in favor of pasta [1]. Prepare for that by changing the dbuild configuration.

We also update install-dependencies. passt (the package providing pasta) is a dependency of podman, so it's here more of as documentation.

The frozen toolchain is regenerated, to bring in a fix for passt.

Using optimized clang from
  https://devpkg.scylladb.com/clang/clang-22.1.7-Fedora-44-aarch64.tar.gz
  https://devpkg.scylladb.com/clang/clang-22.1.7-Fedora-44-x86_64.tar.gz

[1] https://github.com/podman-container-tools/podman/commit/e81328e2a291c264eeae6382b54f0fa6eb2ecf50

Preparing for podman 6, so not backporting.