### PR TITLE
Remove replica::database usage from range_streamer and boot_strapper

### DIFF
--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -41,7 +41,8 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
         throw std::runtime_error("Wrong stream_reason provided: it can only be replace or bootstrap");
     }
     try {
-        auto streamer = make_lw_shared<range_streamer>(_db, _stream_manager, _token_metadata_ptr, _abort_source, _tokens, _address, _dr, description, reason, topo_guard);
+        auto streamer = make_lw_shared<range_streamer>(_db, _stream_manager, _token_metadata_ptr, _abort_source, _tokens, _address, _dr, description, reason, topo_guard,
+                _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
         auto nodes_to_filter = gossiper.get_unreachable_members();
         if (reason == streaming::stream_reason::replace) {
             nodes_to_filter.insert(std::move(replace_address));

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -21,7 +21,6 @@
 #include "gms/gossiper.hh"
 #include "utils/log.hh"
 #include "db/config.hh"
-#include "replica/database.hh"
 #include "streaming/stream_reason.hh"
 #include "locator/abstract_replication_strategy.hh"
 
@@ -30,6 +29,7 @@ static logging::logger blogger("boot_strapper");
 namespace dht {
 
 future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper& gossiper, service::frozen_topology_guard topo_guard,
+                                  std::unordered_map<sstring, locator::static_effective_replication_map_ptr> ks_erms,
                                   locator::host_id replace_address) {
     blogger.debug("Beginning bootstrap process: sorted_tokens={}", get_token_metadata().sorted_tokens());
     sstring description;
@@ -49,7 +49,6 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
         }
         blogger.debug("nodes_to_filter={}", nodes_to_filter);
         streamer->add_source_filter(std::make_unique<range_streamer::failure_detector_source_filter>(nodes_to_filter));
-        auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
         for (const auto& [keyspace_name, erm] : ks_erms) {
             auto& strategy = erm->get_replication_strategy();
             // We took a strategy ptr to keep it alive during the `co_await`.

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -41,7 +41,7 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
         throw std::runtime_error("Wrong stream_reason provided: it can only be replace or bootstrap");
     }
     try {
-        auto streamer = make_lw_shared<range_streamer>(_db, _stream_manager, _token_metadata_ptr, _abort_source, _tokens, _address, _dr, description, reason, topo_guard,
+        auto streamer = make_lw_shared<range_streamer>(_stream_manager, _token_metadata_ptr, _abort_source, _tokens, _address, _dr, description, reason, topo_guard,
                 _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
         auto nodes_to_filter = gossiper.get_unreachable_members();
         if (reason == streaming::stream_reason::replace) {

--- a/dht/boot_strapper.cc
+++ b/dht/boot_strapper.cc
@@ -42,7 +42,7 @@ future<> boot_strapper::bootstrap(streaming::stream_reason reason, gms::gossiper
     }
     try {
         auto streamer = make_lw_shared<range_streamer>(_stream_manager, _token_metadata_ptr, _abort_source, _tokens, _address, _dr, description, reason, topo_guard,
-                _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
+                _consistent_rangemovement, _stream_plan_ranges_fraction);
         auto nodes_to_filter = gossiper.get_unreachable_members();
         if (reason == streaming::stream_reason::replace) {
             nodes_to_filter.insert(std::move(replace_address));

--- a/dht/boot_strapper.hh
+++ b/dht/boot_strapper.hh
@@ -10,9 +10,10 @@
 #pragma once
 #include "gms/inet_address.hh"
 #include "locator/token_metadata.hh"
+#include "locator/abstract_replication_strategy.hh"
 #include "dht/token.hh"
 #include <unordered_set>
-#include "replica/database_fwd.hh"
+#include <unordered_map>
 #include "streaming/stream_reason.hh"
 #include "service/topology_guard.hh"
 #include <seastar/core/sharded.hh>
@@ -31,7 +32,6 @@ class boot_strapper {
     using token_metadata = locator::token_metadata;
     using token_metadata_ptr = locator::token_metadata_ptr;
     using token = dht::token;
-    sharded<replica::database>& _db;
     sharded<streaming::stream_manager>& _stream_manager;
     abort_source& _abort_source;
     /* endpoint that needs to be bootstrapped */
@@ -44,11 +44,10 @@ class boot_strapper {
     bool _consistent_rangemovement;
     double _stream_plan_ranges_fraction;
 public:
-    boot_strapper(sharded<replica::database>& db, sharded<streaming::stream_manager>& sm, abort_source& abort_source,
+    boot_strapper(sharded<streaming::stream_manager>& sm, abort_source& abort_source,
             locator::host_id addr, locator::endpoint_dc_rack dr, std::unordered_set<token> tokens, const token_metadata_ptr tmptr,
             bool consistent_rangemovement, double stream_plan_ranges_fraction)
-        : _db(db)
-        , _stream_manager(sm)
+        : _stream_manager(sm)
         , _abort_source(abort_source)
         , _address(addr)
         , _dr(std::move(dr))
@@ -58,7 +57,9 @@ public:
         , _stream_plan_ranges_fraction(stream_plan_ranges_fraction) {
     }
 
-    future<> bootstrap(streaming::stream_reason reason, gms::gossiper& gossiper, service::frozen_topology_guard, locator::host_id replace_address = {});
+    future<> bootstrap(streaming::stream_reason reason, gms::gossiper& gossiper, service::frozen_topology_guard,
+                       std::unordered_map<sstring, locator::static_effective_replication_map_ptr> ks_erms,
+                       locator::host_id replace_address = {});
 
     /**
      * if initialtoken was specified, use that (split on comma).

--- a/dht/boot_strapper.hh
+++ b/dht/boot_strapper.hh
@@ -41,16 +41,21 @@ class boot_strapper {
     /* token of the node being bootstrapped. */
     std::unordered_set<token> _tokens;
     const locator::token_metadata_ptr _token_metadata_ptr;
+    bool _consistent_rangemovement;
+    double _stream_plan_ranges_fraction;
 public:
     boot_strapper(sharded<replica::database>& db, sharded<streaming::stream_manager>& sm, abort_source& abort_source,
-            locator::host_id addr, locator::endpoint_dc_rack dr, std::unordered_set<token> tokens, const token_metadata_ptr tmptr)
+            locator::host_id addr, locator::endpoint_dc_rack dr, std::unordered_set<token> tokens, const token_metadata_ptr tmptr,
+            bool consistent_rangemovement, double stream_plan_ranges_fraction)
         : _db(db)
         , _stream_manager(sm)
         , _abort_source(abort_source)
         , _address(addr)
         , _dr(std::move(dr))
         , _tokens(tokens)
-        , _token_metadata_ptr(std::move(tmptr)) {
+        , _token_metadata_ptr(std::move(tmptr))
+        , _consistent_rangemovement(consistent_rangemovement)
+        , _stream_plan_ranges_fraction(stream_plan_ranges_fraction) {
     }
 
     future<> bootstrap(streaming::stream_reason reason, gms::gossiper& gossiper, service::frozen_topology_guard, locator::host_id replace_address = {});

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -29,7 +29,8 @@ using inet_address = gms::inet_address;
 std::unordered_map<locator::host_id, dht::token_range_vector>
 range_streamer::get_range_fetch_map(const std::unordered_map<dht::token_range, std::vector<locator::host_id>>& ranges_with_sources,
                                     const std::unordered_set<std::unique_ptr<i_source_filter>>& source_filters,
-                                    const sstring& keyspace) {
+                                    const sstring& keyspace,
+                                    const locator::vnode_effective_replication_map* erm) {
     std::unordered_map<locator::host_id, dht::token_range_vector> range_fetch_map_map;
     const auto& topo = _token_metadata_ptr->get_topology();
     for (const auto& x : ranges_with_sources) {
@@ -62,8 +63,7 @@ range_streamer::get_range_fetch_map(const std::unordered_map<dht::token_range, s
         }
 
         if (!found_source) {
-            auto& ks = _db.local().find_keyspace(keyspace);
-            auto rf = ks.get_static_effective_replication_map()->get_replication_factor();
+            auto rf = erm->get_replication_factor();
             // When a replacing node replaces a dead node with keyspace of RF
             // 1, it is expected that replacing node could not find a peer node
             // that contains data to stream from.
@@ -232,7 +232,7 @@ future<> range_streamer::add_ranges(const sstring& keyspace_name, locator::stati
         }
     }
 
-    std::unordered_map<locator::host_id, dht::token_range_vector> range_fetch_map = get_range_fetch_map(ranges_for_keyspace, _source_filters, keyspace_name);
+    std::unordered_map<locator::host_id, dht::token_range_vector> range_fetch_map = get_range_fetch_map(ranges_for_keyspace, _source_filters, keyspace_name, erm);
     utils::clear_gently(ranges_for_keyspace).get();
 
     if (logger.is_enabled(logging::log_level::debug)) {

--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -188,7 +188,7 @@ bool range_streamer::use_strict_sources_for_ranges(const sstring& keyspace_name,
     auto nr_nodes_in_ring = get_token_metadata().get_normal_token_owners().size();
     bool everywhere_topology = erm.get_replication_strategy().get_type() == locator::replication_strategy_type::everywhere_topology;
     // Use strict when number of nodes in the ring is equal or more than RF
-    auto strict = _db.local().get_config().consistent_rangemovement()
+    auto strict = _consistent_rangemovement
            && !_tokens.empty()
            && !everywhere_topology
            && nr_nodes_in_ring >= rf;
@@ -295,7 +295,7 @@ future<> range_streamer::stream_async() {
                     for (auto it = range_vec.begin(); it < range_vec.end();) {
                         ranges_to_stream.push_back(*it);
                         ++it;
-                        auto fraction = _db.local().get_config().stream_plan_ranges_fraction();
+                        auto fraction = _stream_plan_ranges_fraction;
                         size_t nr_ranges_per_stream_plan = nr_ranges_total * fraction;
                         if (ranges_to_stream.size() < nr_ranges_per_stream_plan) {
                             continue;

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -21,10 +21,6 @@
 #include <unordered_map>
 #include <memory>
 
-namespace replica {
-class database;
-}
-
 namespace gms { class gossiper; }
 namespace locator { class topology; }
 
@@ -76,13 +72,12 @@ public:
         }
     };
 
-    range_streamer(sharded<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source, std::unordered_set<token> tokens,
+    range_streamer(sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source, std::unordered_set<token> tokens,
             locator::host_id address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason,
             service::frozen_topology_guard topo_guard,
             bool consistent_rangemovement, double stream_plan_ranges_fraction,
             std::vector<sstring> tables = {})
-        : _db(db)
-        , _stream_manager(sm)
+        : _stream_manager(sm)
         , _token_metadata_ptr(std::move(tmptr))
         , _abort_source(abort_source)
         , _tokens(std::move(tokens))
@@ -96,15 +91,14 @@ public:
         , _stream_plan_ranges_fraction(stream_plan_ranges_fraction)
     {
         _abort_source.check();
-        (void)_db;
     }
 
-    range_streamer(sharded<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source,
+    range_streamer(sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source,
             locator::host_id address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason,
             service::frozen_topology_guard topo_guard,
             bool consistent_rangemovement, double stream_plan_ranges_fraction,
             std::vector<sstring> tables = {})
-        : range_streamer(db, sm, std::move(tmptr), abort_source, std::unordered_set<token>(), address, std::move(dr), description, reason, std::move(topo_guard), consistent_rangemovement, stream_plan_ranges_fraction, std::move(tables)) {
+        : range_streamer(sm, std::move(tmptr), abort_source, std::unordered_set<token>(), address, std::move(dr), description, reason, std::move(topo_guard), consistent_rangemovement, stream_plan_ranges_fraction, std::move(tables)) {
     }
 
     void add_source_filter(std::unique_ptr<i_source_filter> filter) {
@@ -159,7 +153,6 @@ public:
     future<> stream_async();
     size_t nr_ranges_to_stream();
 private:
-    sharded<replica::database>& _db;
     sharded<streaming::stream_manager>& _stream_manager;
     token_metadata_ptr _token_metadata_ptr;
     abort_source& _abort_source;

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -79,6 +79,7 @@ public:
     range_streamer(sharded<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source, std::unordered_set<token> tokens,
             locator::host_id address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason,
             service::frozen_topology_guard topo_guard,
+            bool consistent_rangemovement, double stream_plan_ranges_fraction,
             std::vector<sstring> tables = {})
         : _db(db)
         , _stream_manager(sm)
@@ -91,13 +92,19 @@ public:
         , _reason(reason)
         , _tables(std::move(tables))
         , _topo_guard(topo_guard)
+        , _consistent_rangemovement(consistent_rangemovement)
+        , _stream_plan_ranges_fraction(stream_plan_ranges_fraction)
     {
         _abort_source.check();
+        (void)_db;
     }
 
     range_streamer(sharded<replica::database>& db, sharded<streaming::stream_manager>& sm, const token_metadata_ptr tmptr, abort_source& abort_source,
-            locator::host_id address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason, service::frozen_topology_guard topo_guard, std::vector<sstring> tables = {})
-        : range_streamer(db, sm, std::move(tmptr), abort_source, std::unordered_set<token>(), address, std::move(dr), description, reason, std::move(topo_guard), std::move(tables)) {
+            locator::host_id address, locator::endpoint_dc_rack dr, sstring description, streaming::stream_reason reason,
+            service::frozen_topology_guard topo_guard,
+            bool consistent_rangemovement, double stream_plan_ranges_fraction,
+            std::vector<sstring> tables = {})
+        : range_streamer(db, sm, std::move(tmptr), abort_source, std::unordered_set<token>(), address, std::move(dr), description, reason, std::move(topo_guard), consistent_rangemovement, stream_plan_ranges_fraction, std::move(tables)) {
     }
 
     void add_source_filter(std::unique_ptr<i_source_filter> filter) {
@@ -163,6 +170,8 @@ private:
     streaming::stream_reason _reason;
     std::vector<sstring> _tables;
     service::frozen_topology_guard _topo_guard;
+    bool _consistent_rangemovement;
+    double _stream_plan_ranges_fraction;
     std::unordered_multimap<sstring, std::unordered_map<locator::host_id, dht::token_range_vector>> _to_stream;
     std::unordered_set<std::unique_ptr<i_source_filter>> _source_filters;
     // Number of tx and rx ranges added

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -132,7 +132,8 @@ private:
     std::unordered_map<locator::host_id, dht::token_range_vector>
     get_range_fetch_map(const std::unordered_map<dht::token_range, std::vector<locator::host_id>>& ranges_with_sources,
                         const std::unordered_set<std::unique_ptr<i_source_filter>>& source_filters,
-                        const sstring& keyspace);
+                        const sstring& keyspace,
+                        const locator::vnode_effective_replication_map* erm);
 
 #if 0
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4750,10 +4750,11 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
 
                                         co_await _repair.local().bootstrap_with_repair(get_token_metadata_ptr(), rs.ring.value().tokens, session);
                                     } else {
-                                        dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
+                                        dht::boot_strapper bs(_stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
                                             locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr(),
                                             _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
-                                        co_await bs.bootstrap(streaming::stream_reason::bootstrap, _gossiper, session);
+                                        co_await bs.bootstrap(streaming::stream_reason::bootstrap, _gossiper, session,
+                                            _db.local().get_non_local_strategy_keyspaces_erms());
                                     }
                                 });
                                 co_await task->done();
@@ -4777,10 +4778,11 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     auto replaced_node = locator::host_id(replaced_id.uuid());
                                     co_await _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_nodes), replaced_node, session);
                                 } else {
-                                    dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
+                                    dht::boot_strapper bs(_stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
                                                           locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr(),
                                                           _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
-                                    co_await bs.bootstrap(streaming::stream_reason::replace, _gossiper, session, locator::host_id{replaced_id.uuid()});
+                                    co_await bs.bootstrap(streaming::stream_reason::replace, _gossiper, session,
+                                        _db.local().get_non_local_strategy_keyspaces_erms(), locator::host_id{replaced_id.uuid()});
                                 }
                             });
                             co_await task->done();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3783,7 +3783,8 @@ future<> storage_service::removenode_with_stream(locator::host_id leaving_node,
                 as.request_abort();
             }
         });
-        auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, tmptr, as, tmptr->get_my_id(), _snitch.local()->get_location(), "Removenode", streaming::stream_reason::removenode, topo_guard);
+        auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, tmptr, as, tmptr->get_my_id(), _snitch.local()->get_location(), "Removenode", streaming::stream_reason::removenode, topo_guard,
+                _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
         removenode_add_ranges(streamer, leaving_node).get();
         try {
             streamer->stream_async().get();
@@ -3796,7 +3797,8 @@ future<> storage_service::removenode_with_stream(locator::host_id leaving_node,
 
 future<>
 storage_service::stream_ranges(std::unordered_map<sstring, std::unordered_multimap<dht::token_range, locator::host_id>> ranges_to_stream_by_keyspace) {
-    auto streamer = dht::range_streamer(_db, _stream_manager, get_token_metadata_ptr(), _abort_source, get_token_metadata_ptr()->get_my_id(), _snitch.local()->get_location(), "Unbootstrap", streaming::stream_reason::decommission, null_topology_guard);
+    auto streamer = dht::range_streamer(_db, _stream_manager, get_token_metadata_ptr(), _abort_source, get_token_metadata_ptr()->get_my_id(), _snitch.local()->get_location(), "Unbootstrap", streaming::stream_reason::decommission, null_topology_guard,
+            _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
     for (auto& entry : ranges_to_stream_by_keyspace) {
         const auto& keyspace = entry.first;
         auto& ranges_with_endpoints = entry.second;
@@ -4853,7 +4855,8 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                 co_await _repair.local().rebuild_with_repair(std::move(ks_erms), tmptr, std::move(sdc_param), session);
                             } else {
                                 auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, tmptr, _abort_source,
-                                        tmptr->get_my_id(), _snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, session);
+                                        tmptr->get_my_id(), _snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, session,
+                                        _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
                                 streamer->add_source_filter(std::make_unique<dht::range_streamer::failure_detector_source_filter>(_gossiper.get_unreachable_members()));
                                 if (source_dc != "") {
                                     streamer->add_source_filter(std::make_unique<dht::range_streamer::single_datacenter_filter>(source_dc));
@@ -5269,6 +5272,8 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
                                                                 format("Tablet {}", trinfo->transition),
                                                                 reason,
                                                                 topo_guard,
+                                                                _db.local().get_config().consistent_rangemovement(),
+                                                                _db.local().get_config().stream_plan_ranges_fraction(),
                                                                 std::move(tables));
             tm = nullptr;
             streamer->add_source_filter(std::make_unique<dht::range_streamer::failure_detector_source_filter>(

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4751,7 +4751,8 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                         co_await _repair.local().bootstrap_with_repair(get_token_metadata_ptr(), rs.ring.value().tokens, session);
                                     } else {
                                         dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
-                                            locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr());
+                                            locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr(),
+                                            _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
                                         co_await bs.bootstrap(streaming::stream_reason::bootstrap, _gossiper, session);
                                     }
                                 });
@@ -4777,7 +4778,8 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     co_await _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_nodes), replaced_node, session);
                                 } else {
                                     dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
-                                                          locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr());
+                                                          locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr(),
+                                                          _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
                                     co_await bs.bootstrap(streaming::stream_reason::replace, _gossiper, session, locator::host_id{replaced_id.uuid()});
                                 }
                             });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3783,7 +3783,7 @@ future<> storage_service::removenode_with_stream(locator::host_id leaving_node,
                 as.request_abort();
             }
         });
-        auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, tmptr, as, tmptr->get_my_id(), _snitch.local()->get_location(), "Removenode", streaming::stream_reason::removenode, topo_guard,
+        auto streamer = make_lw_shared<dht::range_streamer>(_stream_manager, tmptr, as, tmptr->get_my_id(), _snitch.local()->get_location(), "Removenode", streaming::stream_reason::removenode, topo_guard,
                 _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
         removenode_add_ranges(streamer, leaving_node).get();
         try {
@@ -3797,7 +3797,7 @@ future<> storage_service::removenode_with_stream(locator::host_id leaving_node,
 
 future<>
 storage_service::stream_ranges(std::unordered_map<sstring, std::unordered_multimap<dht::token_range, locator::host_id>> ranges_to_stream_by_keyspace) {
-    auto streamer = dht::range_streamer(_db, _stream_manager, get_token_metadata_ptr(), _abort_source, get_token_metadata_ptr()->get_my_id(), _snitch.local()->get_location(), "Unbootstrap", streaming::stream_reason::decommission, null_topology_guard,
+    auto streamer = dht::range_streamer(_stream_manager, get_token_metadata_ptr(), _abort_source, get_token_metadata_ptr()->get_my_id(), _snitch.local()->get_location(), "Unbootstrap", streaming::stream_reason::decommission, null_topology_guard,
             _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
     for (auto& entry : ranges_to_stream_by_keyspace) {
         const auto& keyspace = entry.first;
@@ -4854,7 +4854,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                 }
                                 co_await _repair.local().rebuild_with_repair(std::move(ks_erms), tmptr, std::move(sdc_param), session);
                             } else {
-                                auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, tmptr, _abort_source,
+                                auto streamer = make_lw_shared<dht::range_streamer>(_stream_manager, tmptr, _abort_source,
                                         tmptr->get_my_id(), _snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, session,
                                         _db.local().get_config().consistent_rangemovement(), _db.local().get_config().stream_plan_ranges_fraction());
                                 streamer->add_source_filter(std::make_unique<dht::range_streamer::failure_detector_source_filter>(_gossiper.get_unreachable_members()));
@@ -5266,7 +5266,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
             auto& table = _db.local().find_column_family(tablet.table);
             std::vector<sstring> tables = {table.schema()->cf_name()};
             auto my_id = tm->get_my_id();
-            auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, std::move(tm),
+            auto streamer = make_lw_shared<dht::range_streamer>(_stream_manager, std::move(tm),
                                                                 guard.get_abort_source(),
                                                                 my_id, _snitch.local()->get_location(),
                                                                 format("Tablet {}", trinfo->transition),


### PR DESCRIPTION
Both `range_streamer` and `boot_strapper` held a reference to `replica::database` mainly to reach into `db::config`. This creates an unnecessary coupling between the dht bootstrap/streaming layer and the top-level database object. This PR cuts this dependency and moves is up the layers stack -- to the storage_service. The storage_service gains few more calls to `replica::database::get_config()` but it's OK for now, the s.s. already calls it in many places, it will be addressed later.

Cleaning components inter-dependencies, not backporting