### PR TITLE
test: fix flaky test_tablet_resize_list split/migration race

### DIFF
--- a/test/cluster/tasks/test_tablet_tasks.py
+++ b/test/cluster/tasks/test_tablet_tasks.py
@@ -525,16 +525,25 @@ async def test_tablet_resize_list(manager: ManagerClient):
         keys = range(total_keys)
         await prepare_split(manager, servers[0], keyspace, table1, keys)
 
+        injection = "tablet_split_finalization_postpone"
+        compaction_injection = "split_sstable_rewrite"
+        await manager.api.enable_injection(servers[0].ip_addr, injection, False)
+        await manager.api.enable_injection(servers[0].ip_addr, compaction_injection, one_shot=True)
+
+        # Trigger split with only 1 server so the load balancer cannot schedule
+        # a concurrent tablet migration (which would stop the split compaction
+        # and consume the one_shot injection).
+        await manager.enable_tablet_balancing()
+        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "split_sstable_rewrite")
+
+        # Now add the second server while the split compaction is held by the
+        # injection. The split is already in progress so the coordinator won't
+        # schedule a migration for this tablet.
         servers.append(await manager.server_add(cmdline=cmdline, config={
             'tablet_load_stats_refresh_interval_in_seconds': 1
         }))
+        await manager.api.enable_injection(servers[1].ip_addr, injection, False)
 
-        injection = "tablet_split_finalization_postpone"
-        compaction_injection = "split_sstable_rewrite"
-        await enable_injection(manager, servers, injection)
-        await manager.api.enable_injection(servers[0].ip_addr, compaction_injection, one_shot=True)
-
-        await manager.enable_tablet_balancing()
         task0 = (await wait_tasks_created(tm, servers[0], module_name, 1, "split", keyspace, table1))[0]
         task1 = (await wait_tasks_created(tm, servers[1], module_name, 1, "split", keyspace, table1))[0]
 
@@ -548,7 +557,6 @@ async def test_tablet_resize_list(manager: ManagerClient):
             assert task.table == table1
             assert task.keyspace == keyspace
 
-        await manager.api.wait_for_injection_enter(servers[0].ip_addr, "split_sstable_rewrite")
         await manager.api.message_injection(servers[0].ip_addr, "split_sstable_rewrite")
 
         status1 = await tm.get_task_status(servers[1].ip_addr, task0.task_id)


### PR DESCRIPTION
The test intermittently timed out waiting for the split_sstable_rewrite injection to fire during tablet split compaction.

Root cause: With RF=1, 1 tablet, and 2 servers, enabling tablet balancing triggers BOTH a split (tablet exceeds size threshold) AND a migration (load imbalance between nodes). The migration progresses through its cleanup stage which stops all compactions for the tablet, forcibly releasing the split compaction that was held by the one_shot injection. Once the one_shot injection is consumed (disabled/erased from the _enabled map), enter_count() returns 0 and wait_for_injection_enter() times out.

Timeline from the failure:
  23:15:11.389 - split_sstable_rewrite injection enters (compaction held)
  23:15:11.396 - topology coordinator starts tablet migration (402->403)
  23:15:13.839 - migration cleanup stops split compaction on server 402
  23:15:13.844 - one_shot injection consumed (disabled, enter_count lost)
  ~23:15:14+   - test calls wait_for_injection_enter -> always sees 0
  23:16:14     - timeout after 60s

Fix: Reorder operations so the split is triggered with only 1 server, eliminating any possibility of a concurrent migration. The second server is added afterward while the injection holds the split compaction, allowing the test to still verify cross-cluster task visibility.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2755