### PR TITLE
ci: scylla-ci-route: accept HTTP 3xx redirects from Jenkins

### DIFF
--- a/.github/workflows/scylla-ci-route.yaml
+++ b/.github/workflows/scylla-ci-route.yaml
@@ -365,7 +365,7 @@ jobs:
             -w "\n%{http_code}")
 
           HTTP_CODE=$(echo "$RESPONSE" | tail -1)
-          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 400 ]; then
             echo "::error::Failed to trigger Jenkins job (HTTP $HTTP_CODE)"
             echo "$RESPONSE"
             exit 1


### PR DESCRIPTION
The `Trigger scylla-ci` step in `.github/workflows/scylla-ci-route.yaml` treats HTTP 303 (See Other) responses from Jenkins as a failure. Jenkins returns 303 as a normal redirect after successfully queuing a build, but the HTTP status check rejects any code >= 300:

```bash
if [ "\$HTTP_CODE" -lt 200 ] || [ "\$HTTP_CODE" -ge 300 ]; then
```

This causes the route-ci job to fail with `Failed to trigger Jenkins job (HTTP 303)`, blocking CI for all PRs.

The workflow already extracts the queue URL from the `Location` header in the 303 redirect response (line 375), so accepting 3xx is correct behavior.

**Fix:** Change the upper bound from 300 to 400.

Observed on PR #26877: https://github.com/scylladb/scylladb/actions/runs/27977745184/job/82799729422

Fixes: SCYLLADB-2823