### PR TITLE
streaming: add clone-based streaming for object-storage tablet migrations

### DIFF
--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -409,6 +409,61 @@ Invariants:
    on behalf of previous transitions can still run in the cluster, but they can have no side effects. This is ensured
    by the proper use of the topology guard mechanism (see the "Topology guards" section).
 
+## File-based streaming
+
+The `streaming` stage of a tablet migration (and of `rebuild` / `rebuild_v2`)
+transfers SSTables from the source replica to the destination. The mechanism
+used depends on where the table's data is stored.
+
+### Local-filesystem tables
+
+For tables stored on local disks, the source node reads each SSTable component
+file and transfers its raw bytes to the destination over the internal streaming
+protocol (`TABLET_STREAM_FILES` RPC verb). The destination writes the received
+bytes directly to disk and then loads the reconstructed SSTables into the table.
+
+### Object-storage tables (S3 / GCS)
+
+For tables backed by object storage, the SSTable data already resides in the
+cloud — transferring the bytes over the network would be redundant and
+expensive. Instead, ScyllaDB uses a server-side copy (clone) approach:
+
+1. The source node takes a storage snapshot of the tablet's SSTables, holding
+   `shared_sstable` references that keep the original cloud objects alive even
+   if concurrent compaction would otherwise delete them.
+
+2. For each SSTable, the source sends a `CLONE_SSTABLE` RPC to the destination
+   node. The request carries the SSTable identity (generation, version, format)
+   rather than raw bytes.
+
+3. The destination node issues a server-side copy of every SSTable component
+   object (e.g. S3 `CopyObject`), writing the copies to a fresh generation
+   owned by the destination, and then loads the cloned SSTables.
+
+No SSTable bytes traverse the network between source and destination. Only the
+small `CLONE_SSTABLE` control messages are exchanged.
+
+#### Crash safety
+
+The migration protocol never marks source SSTables for deletion until the
+destination has confirmed that its clones are loaded and sealed. Source SSTable
+cleanup (`wipe()` → `"removing"` → `destroy()`) only runs during
+`cleanup_tablet()`, which is triggered exclusively after the topology
+coordinator advances to the `cleanup` stage — and that only happens after the
+destination node has successfully added the cloned SSTables to its table. If a
+clone RPC fails, the coordinator retries the whole migration without touching
+the source SSTable registry; the source data is never at risk.
+
+The `"removing"` registry state also arises when compaction runs concurrently
+on the source *during* migration: `wipe()` marks the compacted-away SSTables as
+`"removing"` while the migration snapshot holds `shared_sstable` references
+that keep their cloud objects alive. If the node crashes before `destroy()`
+completes the cloud cleanup, the `"removing"` entry survives and
+`garbage_collect()` on the next startup retries the deletion before removing
+the entry. The compacted data is not lost because compaction has already
+incorporated it into new SSTables; any in-progress migration retries against
+the current (post-compaction) SSTable set.
+
 # Tablet resize
 
 Each table has its resize metadata stored in group0.

--- a/idl/streaming.idl.hh
+++ b/idl/streaming.idl.hh
@@ -120,6 +120,17 @@ class stream_files_request {
     service::frozen_topology_guard topo_guard;
 };
 
+class clone_sstable_request {
+    streaming::file_stream_id ops_id;
+    table_id table;
+    utils::UUID generation;      // sstables::generation_type, encoded as its underlying UUID
+    int32_t version;             // cast from sstables::sstable_version_types
+    int32_t format;              // cast from sstables::sstable_format_types
+    int32_t sstable_state;
+    seastar::shard_id dst_shard_id;
+    service::frozen_topology_guard topo_guard;
+};
+
 class stream_files_response {
     size_t stream_bytes;
 };
@@ -130,5 +141,10 @@ verb [[with_client_info]] stream_mutation_done (streaming::plan_id plan_id, dht:
 verb [[with_client_info]] complete_message (streaming::plan_id plan_id, unsigned dst_cpu_id, bool failed [[version 2.1.0]]);
 
 verb [[with_client_info, cancellable]] tablet_stream_files (streaming::stream_files_request req) -> streaming::stream_files_response;
+// Not marked cancellable: clone_sstable performs a single server-side
+// CopyObject which is typically fast and cannot be interrupted mid-flight.
+// The topology_guard check inside the handler provides correctness if
+// the topology changes before the copy starts.
+verb [[with_client_info]] clone_sstable (streaming::clone_sstable_request req) -> streaming::stream_files_response;
 
 }

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -759,6 +759,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::NODE_OPS_CMD:
     case messaging_verb::HINT_MUTATION:
     case messaging_verb::TABLET_STREAM_FILES:
+    case messaging_verb::CLONE_SSTABLE:
     case messaging_verb::TABLET_STREAM_DATA:
     case messaging_verb::TABLET_CLEANUP:
     case messaging_verb::TABLET_REPAIR:

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -216,7 +216,8 @@ enum class messaging_verb : int32_t {
     FORWARD_CQL_PREPARE = 87,
     RESTORE_TABLET = 88,
     WAIT_FOR_RAFT_GROUPS_TO_START = 89,
-    LAST = 90,
+    CLONE_SSTABLE = 90,
+    LAST = 91,
 };
 
 } // namespace netw

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1576,7 +1576,15 @@ table::clone_tablet_storage(locator::tablet_id tid, bool leave_unsealed) {
     utils::chunked_vector<sstables::entry_descriptor> ret;
     auto holder = async_gate().hold();
 
-    auto& sg = storage_group_for_id(tid.value());
+    // In the internode migration path the handler runs on all shards via
+    // map_reduce0.  Only the shard that owns the tablet will have a storage
+    // group for it; other shards should return an empty result, just like
+    // take_storage_snapshot / storage_groups_for_token_range do.
+    auto* sgp = _sg_manager->maybe_storage_group_for_id(_schema, tid.value());
+    if (!sgp) {
+        co_return ret;
+    }
+    auto& sg = *sgp;
     auto sg_holder = sg.async_gate().hold();
     co_await sg.flush();
     // The sstable set must be obtained *after* the deletion lock is taken,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6608,12 +6608,16 @@ void storage_service::init_messaging_service() {
             [this] (const rpc::client_info& cinfo, streaming::stream_files_request req) -> future<streaming::stream_files_response> {
         streaming::stream_files_response resp;
         resp.stream_bytes = co_await container().map_reduce0([req] (storage_service& ss) -> future<size_t> {
-            auto res = co_await streaming::tablet_stream_files_handler(ss._db.local(), ss._messaging.local(), req);
+            auto res = co_await streaming::tablet_stream_files_handler(ss._db.local(), ss._view_building_worker.local(), ss._messaging.local(), req);
             co_return res.stream_bytes;
         },
         size_t(0),
         std::plus<size_t>());
         co_return resp;
+    });
+    ser::streaming_rpc_verbs::register_clone_sstable(&_messaging.local(),
+            [this] (const rpc::client_info& cinfo, streaming::clone_sstable_request req) -> future<streaming::stream_files_response> {
+        co_return co_await streaming::clone_sstable_handler(_db.local(), _view_building_worker.local(), req);
     });
     ser::storage_service_rpc_verbs::register_raft_topology_cmd(&_messaging.local(), [this] (raft::server_id dst_id, raft::term_t term, uint64_t cmd_index, raft_topology_cmd cmd) {
         return handle_raft_rpc(dst_id, [cmd = std::move(cmd), term, cmd_index] (auto& ss) {
@@ -6805,7 +6809,8 @@ future<> storage_service::uninit_messaging_service() {
         ser::node_ops_rpc_verbs::unregister(&_messaging.local()),
         ser::storage_service_rpc_verbs::unregister(&_messaging.local()),
         ser::join_node_rpc_verbs::unregister(&_messaging.local()),
-        ser::streaming_rpc_verbs::unregister_tablet_stream_files(&_messaging.local())
+        ser::streaming_rpc_verbs::unregister_tablet_stream_files(&_messaging.local()),
+        ser::streaming_rpc_verbs::unregister_clone_sstable(&_messaging.local())
     ).discard_result();
 }
 

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -28,7 +28,6 @@
 #include "utils/s3/creds.hh"
 #include "utils/memory_data_sink.hh"
 #include "utils/lister.hh"
-#include "utils/io-wrappers.hh"
 
 using namespace seastar;
 using namespace sstables;
@@ -175,10 +174,10 @@ public:
         return _client->delete_object(name.bucket(), name.object(), as);
     }
     file make_readable_file(object_name name, abort_source* as) override {
-        auto src = _client->create_download_source(name.bucket(), name.object(), as);
-        return create_file_for_seekable_source(std::move(src), [scf = _shard_client, name] {
-            return scf()->create_download_source(name.bucket(), name.object());
-        });
+        return _client->make_readable_file(name.bucket(), name.object(),
+                [scf = _shard_client, name] {
+                    return scf();
+                }, as);
     }
     data_sink make_data_upload_sink(object_name name, std::optional<unsigned> max_parts_per_piece, abort_source* as) override {
         return make_upload_sink(std::move(name), as);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -259,6 +259,13 @@ public:
     void plug_sstables_registry(std::unique_ptr<sstables_registry>) noexcept;
     void unplug_sstables_registry() noexcept;
 
+    // Whether a sstables_registry is currently plugged. Background work that may
+    // race with shutdown (e.g. fire-and-forget object-storage sstable deletion)
+    // can use this to avoid touching the registry after it has been unplugged.
+    bool has_sstables_registry() const noexcept {
+        return bool(_sstables_registry);
+    }
+
     // Only for sstable::storage usage
     sstables::sstables_registry& sstables_registry() const noexcept {
         SCYLLA_ASSERT(_sstables_registry && "sstables_registry is not plugged");

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -93,7 +93,7 @@ public:
     virtual future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     virtual void open(sstable& sst) override;
-    virtual future<> wipe(const sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept override;
+    virtual future<> wipe(sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept override;
     virtual future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) override;
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) override;
     future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
@@ -508,7 +508,7 @@ static inline fs::path parent_path(const sstring& fname) {
     return fs::canonical(fs::path(fname)).parent_path();
 }
 
-future<> filesystem_storage::wipe(const sstable& sst, const atomic_delete_context* ctx) noexcept {
+future<> filesystem_storage::wipe(sstable& sst, const atomic_delete_context* ctx) noexcept {
     auto sync = ctx ? sync_dir::no : sync_dir::yes;
     // We must be able to generate toc_filename()
     // in order to delete the sstable.
@@ -666,16 +666,14 @@ public:
     future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     void open(sstable& sst) override;
-    future<> wipe(const sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept override;
+    future<> wipe(sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept override;
     future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) override;
     future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) override;
     future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const override;
     future<data_source> make_source(sstable& sst, component_type type, file, uint64_t offset, uint64_t len, file_input_stream_options) const override;
 
     future<data_sink> make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) override;
-    future<> destroy(const sstable& sst) override {
-        return make_ready_future<>();
-    }
+    future<> destroy(const sstable& sst) override;
     future<atomic_delete_context> atomic_delete_prepare(const std::vector<shared_sstable>&) const override;
     future<> atomic_delete_complete(atomic_delete_context ctx) const override;
     future<> remove_by_registry_entry(entry_descriptor desc) override;
@@ -856,23 +854,60 @@ future<> object_storage_base::change_state(const sstable& sst, sstable_state sta
     co_await sst.manager().sstables_registry().update_entry_state(owner(), sst.manager().get_local_host_id(), sst.generation(), state);
 }
 
-future<> object_storage_base::wipe(const sstable& sst, const atomic_delete_context* ctx) noexcept {
+future<> object_storage_base::wipe(sstable& sst, const atomic_delete_context* ctx) noexcept {
+    // Mark the sstable for deletion so that destroy() — called when the
+    // last shared_sstable reference is dropped — will delete the cloud
+    // objects.
+    sst.mark_for_deletion();
+    // Transition the registry entry to "removing" state to signal intent to
+    // delete.  The entry must survive the crash window so that
+    // garbage_collect() on restart can retry the S3 object deletion.
+    //
+    // Durability argument: if a crash loses the unfsynced commitlog, BOTH
+    // the status update and the S3 objects survive — the state is consistent
+    // and the sstable is loadable on restart.  If the update is committed,
+    // the entry is in "removing" and destroy() will clean up the S3 objects
+    // and delete the registry entry.  Either way, the registry is never left
+    // pointing at deleted objects, and orphaned S3 objects are always covered
+    // by a "removing" registry entry that garbage_collect() can act on.
+    //
     // FIXME: unlike filesystem_storage::wipe, this implementation does not
-    // catch exceptions from delete_object / sstables_registry calls and may
-    // return an exceptional future, breaking the contract documented on
-    // storage::wipe.
-    auto& sstables_registry = sst.manager().sstables_registry();
-    auto node_owner = sst.manager().get_local_host_id();
-
+    // catch exceptions from sstables_registry calls and may return an
+    // exceptional future, breaking the contract documented on storage::wipe.
     if (!ctx) {
-        co_await sstables_registry.update_entry_status(owner(), node_owner, sst.generation(), status_removing);
+        co_await sst.manager().sstables_registry().update_entry_status(owner(), sst.manager().get_local_host_id(), sst.generation(), status_removing);
     }
+}
 
+future<> object_storage_base::destroy(const sstable& sst) {
+    // Only delete cloud objects if the SSTable was explicitly marked
+    // for deletion (by compaction or unlink).  Two cases are skipped:
+    //  - Normal shutdown: the last shared_sstable ref is dropped but
+    //    the SSTable is NOT marked for deletion — it must survive on
+    //    S3 so the node can reload it on restart.
+    //  - SSTables never sealed: not marked for deletion, also skipped.
+    if (!sst.marked_for_deletion()) {
+        co_return;
+    }
+    // Delete the S3 objects. Errors are logged but not propagated because
+    // destroy() is called fire-and-forget from the shared_ptr deleter.
+    // Any objects that could not be deleted here will be retried on the
+    // next startup via garbage_collect() which handles "removing" entries.
     co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
-        co_await delete_object(make_object_name(sst, type));
+        try {
+            co_await delete_object(make_object_name(sst, type));
+        } catch (...) {
+            sstlog.warn("Failed to delete {} object for {}: {}", _type, sst.toc_filename(), std::current_exception());
+        }
     });
-
-    co_await sstables_registry.delete_entry(owner(), node_owner, sst.generation());
+    // Remove the registry entry only after S3 objects are cleaned up.
+    // If this fails, the "removing" entry survives and garbage_collect()
+    // will delete the (already gone) objects tolerantly and retry deletion.
+    try {
+        co_await sst.manager().sstables_registry().delete_entry(owner(), sst.manager().get_local_host_id(), sst.generation());
+    } catch (...) {
+        sstlog.warn("Failed to delete registry entry for {}: {}", sst.toc_filename(), std::current_exception());
+    }
 }
 
 future<atomic_delete_context> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -757,6 +757,13 @@ void object_storage_base::open(sstable& sst) {
 }
 
 future<file> object_storage_base::open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) {
+    // Object-storage SSTables never have a TemporaryTOC object — the
+    // sealed/unsealed distinction is tracked via the SSTable registry
+    // (creating vs sealed), not via a separate TOC file.  Transparently
+    // redirect TemporaryTOC requests to the regular TOC.
+    if (type == component_type::TemporaryTOC) {
+        type = component_type::TOC;
+    }
     return maybe_wrap_file(sst, type, flags, make_readable_file(make_object_name(sst, type)));
 }
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -906,7 +906,19 @@ future<> object_storage_base::destroy(const sstable& sst) {
     // Remove the registry entry only after S3 objects are cleaned up.
     // If this fails, the "removing" entry survives and garbage_collect()
     // will delete the (already gone) objects tolerantly and retry deletion.
+    //
+    // This destroy() is fire-and-forget from the shared_sstable deleter and can
+    // race with shutdown: unplug_system_keyspace() may have already unplugged the
+    // sstables_registry by the time we get here. Accessing it then would trip the
+    // SCYLLA_ASSERT in sstables_manager::sstables_registry(). Skip the entry
+    // deletion in that case — the "removing" entry survives and garbage_collect()
+    // on the next startup deletes the (already gone) objects tolerantly and
+    // removes the entry.
     try {
+        if (!sst.manager().has_sstables_registry()) {
+            sstlog.warn("Skipping registry entry deletion for {}: sstables registry already unplugged (shutdown in progress)", sst.toc_filename());
+            co_return;
+        }
         co_await sst.manager().sstables_registry().delete_entry(owner(), sst.manager().get_local_host_id(), sst.generation());
     } catch (...) {
         sstlog.warn("Failed to delete registry entry for {}: {}", sst.toc_filename(), std::current_exception());

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -109,6 +109,7 @@ public:
     virtual future<> unlink_component(const sstable& sst, component_type) noexcept override;
 
     virtual sstring prefix() const override { return _dir.native(); }
+    bool is_object_storage() const override { return false; }
     future<bool> exists(const sstable& sst, component_type type) const override {
         return file_exists(sst.get_filename(type).format());
     }
@@ -690,6 +691,8 @@ public:
     future<bool> exists(const sstable& sst, component_type type) const override {
         return _client->object_exists(make_object_name(sst, type), abort_source());
     }
+
+    bool is_object_storage() const override { return true; }
 
     future<> put_object(object_name name, ::memory_data_sink_buffers bufs) {
         return _client->put_object(std::move(name), std::move(bufs), abort_source());

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -127,6 +127,10 @@ public:
 
     virtual sstring prefix() const  = 0;
     virtual future<bool> exists(const sstable& sst, component_type type) const = 0;
+
+    // Returns true if this storage backend uses object storage (S3/GCS).
+    // Used to decide per-SSTable whether to clone or byte-stream during tablet migration.
+    virtual bool is_object_storage() const = 0;
 };
 
 std::unique_ptr<sstables::storage> make_storage(sstables_manager& manager, const data_dictionary::storage_options& s_opts, sstable_state state);

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -111,7 +111,7 @@ public:
     virtual void open(sstable& sst) = 0;
     // Must never return an exceptional future: implementations are expected
     // to catch and log any errors internally.
-    virtual future<> wipe(const sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept = 0;
+    virtual future<> wipe(sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept = 0;
     virtual future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) = 0;
     virtual future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) = 0;
     virtual future<data_source> make_data_or_index_source(sstable& sst, component_type type, file f, uint64_t offset, uint64_t len, file_input_stream_options opt) const = 0;

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -814,28 +814,28 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
                     co_await ser::streaming_rpc_verbs::send_clone_sstable(&ms, target.node, clone_req);
                 }
             } else {
-            // Byte-streaming path for local-filesystem SSTables.
-            auto sources = co_await create_stream_sources(sst_snapshot, reader);
-            auto newgen = fmt::to_string(sst_gen());
+                // Byte-streaming path for local-filesystem SSTables.
+                auto sources = co_await create_stream_sources(sst_snapshot, reader);
+                auto newgen = fmt::to_string(sst_gen());
 
-            for (auto&& s : sources) {
-                auto oldname = s->component_basename();
-                auto newname = get_sstable_name_with_generation(req.ops_id, oldname, newgen);
+                for (auto&& s : sources) {
+                    auto oldname = s->component_basename();
+                    auto newname = get_sstable_name_with_generation(req.ops_id, oldname, newgen);
 
-                blogger.debug("fstream[{}] Get name oldname={}, newname={}", req.ops_id, oldname, newname);
+                    blogger.debug("fstream[{}] Get name oldname={}, newname={}", req.ops_id, oldname, newname);
 
-                auto& info = files.emplace_back();
-                info.fops = file_ops::stream_sstables;
-                info.sstable_state = sst_state;
-                info.filename = std::move(newname);
-                info.source = [s = std::move(s)](const file_input_stream_options& options) {
-                    return s->input(options);
-                };
-            }
-            // ensure we mark the end of each component sequence.
-            if (!files.empty()) {
-                files.back().fops = file_ops::load_sstables;
-            }
+                    auto& info = files.emplace_back();
+                    info.fops = file_ops::stream_sstables;
+                    info.sstable_state = sst_state;
+                    info.filename = std::move(newname);
+                    info.source = [s = std::move(s)](const file_input_stream_options& options) {
+                        return s->input(options);
+                    };
+                }
+                // ensure we mark the end of each component sequence.
+                if (!files.empty()) {
+                    files.back().fops = file_ops::load_sstables;
+                }
             }
         }
         sstable_nr = sstables.size();

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -847,7 +847,7 @@ future<stream_files_response> tablet_stream_files(const file_stream_id& ops_id,
         try {
             streaming::stream_files_request req;
             req.ops_id = ops_id;
-            req.keyspace_name = table.schema()->ks_name(),
+            req.keyspace_name = table.schema()->ks_name();
             req.table_name = table.schema()->cf_name();
             req.table = table.schema()->id();
             req.range = range;

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -851,6 +851,10 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
                 req.ops_id, sstable_nr, files.size(), files, req.range);
     }
     if (files.empty()) {
+        if (sstable_nr > 0) {
+            blogger.info("stream_sstables[{}] Finished cloning sstable_nr={} range={} (object-storage clone path, zero wire bytes)",
+                    req.ops_id, sstable_nr, req.range);
+        }
         co_return resp;
     }
     auto ops_start_time = std::chrono::steady_clock::now();

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -17,6 +17,8 @@
 #include "replica/database.hh"
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
+#include "sstables/storage.hh"
+#include "sstables/open_info.hh"
 #include "sstables/sstable_version.hh"
 #include "sstables/generation_type.hh"
 #include "sstables/types.hh"
@@ -54,10 +56,16 @@ static future<> load_sstable_for_tablet(const file_stream_id& ops_id, replica::d
         auto& sstm = t.get_sstables_manager();
         auto sst = sstm.make_sstable(t.schema(), t.get_storage_options(), desc.generation, state, desc.version, desc.format);
         sstables::sstable_open_config cfg { .unsealed_sstable = true };
+        // load() with unsealed_sstable=true opens the SSTable without requiring a "sealed"
+        // registry entry — the registry entry is still in "creating" state at this point,
+        // as left by clone() on the caller side.
         co_await sst->load(erm->get_sharder(*t.schema()), cfg);
         auto on_add = [sst, &sstm] (sstables::shared_sstable loading_sst) -> future<> {
             if (loading_sst == sst) {
                 auto cfg = sstm.configure_writer(sst->get_origin());
+                // seal_sstable() transitions the registry entry from "creating" to "sealed",
+                // completing the lifecycle started by clone(..., leave_unsealed=true) in
+                // clone_sstable_handler.
                 co_await loading_sst->seal_sstable(cfg.backup);
             }
             co_return;
@@ -738,11 +746,13 @@ tablet_stream_files(netw::messaging_service& ms, std::list<stream_blob_info> sou
 }
 
 
-future<stream_files_response> tablet_stream_files_handler(replica::database& db, netw::messaging_service& ms, streaming::stream_files_request req) {
+future<stream_files_response> tablet_stream_files_handler(replica::database& db, db::view::view_building_worker& vbw, netw::messaging_service& ms, streaming::stream_files_request req) {
     stream_files_response resp;
     auto& table = db.find_column_family(req.table);
     auto table_stream_op = table.stream_in_progress();
     auto files = std::list<stream_blob_info>();
+    size_t sstable_nr = 0;
+
     auto reader = co_await db.obtain_reader_permit(table, "tablet_file_streaming", db::no_timeout, {});
     bool is_logstor_table = table.uses_logstor();
 
@@ -779,6 +789,32 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
             // stable state (across files) is a must for load to work on destination
             auto sst_state = sst->state();
 
+            if (sst->get_storage().is_object_storage()) {
+                // Clone path for object-storage SSTables: send CLONE_SSTABLE RPC
+                // to each target.  The destination performs server-side S3/GCS
+                // CopyObject and loads the clone.
+                //
+                // Rolling-upgrade safety: object-storage keyspaces can only be
+                // created when the KEYSPACE_STORAGE_OPTIONS cluster feature is
+                // active, which requires all nodes to run the version that also
+                // introduces the CLONE_SSTABLE verb.  Therefore, every node that
+                // can own a tablet for an object-storage table necessarily
+                // supports this RPC.
+                for (auto& target : req.targets) {
+                    streaming::clone_sstable_request clone_req;
+                    clone_req.ops_id = req.ops_id;
+                    clone_req.table = req.table;
+                    clone_req.generation = sst->generation().as_uuid();
+                    clone_req.version = static_cast<int32_t>(sst->get_version());
+                    clone_req.format = static_cast<int32_t>(sst->get_format());
+                    clone_req.sstable_state = static_cast<int32_t>(sst_state);
+                    clone_req.dst_shard_id = target.shard;
+                    clone_req.topo_guard = req.topo_guard;
+
+                    co_await ser::streaming_rpc_verbs::send_clone_sstable(&ms, target.node, clone_req);
+                }
+            } else {
+            // Byte-streaming path for local-filesystem SSTables.
             auto sources = co_await create_stream_sources(sst_snapshot, reader);
             auto newgen = fmt::to_string(sst_gen());
 
@@ -800,8 +836,9 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
             if (!files.empty()) {
                 files.back().fops = file_ops::load_sstables;
             }
+            }
         }
-        auto sstable_nr = sstables.size();
+        sstable_nr = sstables.size();
         // Release reference to sstables to be streamed here. Since one sstable is streamed at a time,
         // a sstable - that has been compacted - can have its space released from disk right after
         // that sstable's content has been fully streamed.
@@ -824,6 +861,64 @@ future<stream_files_response> tablet_stream_files_handler(replica::database& db,
     blogger.info("stream_{}[{}] Finished sending files_nr={} range={} stream_bytes={} stream_time={} stream_bw={}",
             is_logstor_table ? "logstor_segments" : "sstables",
             req.ops_id, files_nr, req.range, stream_bytes, duration, get_bw(stream_bytes, ops_start_time));
+
+    co_return resp;
+}
+
+future<stream_files_response> clone_sstable_handler(replica::database& db, db::view::view_building_worker& vbw, streaming::clone_sstable_request req) {
+    stream_files_response resp;
+
+    // Reuse the "stream_mutation_fragments" injection point so all existing
+    // tablet-migration tests work for object-storage tables without
+    // modification.  The "(clone)" suffix (vs "(tablets)" in the byte-streaming
+    // path) distinguishes the two paths in logs while keeping the common
+    // "stream_mutation_fragments: waiting" prefix that tests wait_for().
+    lw_shared_ptr<std::any> log_done;
+    if (utils::get_local_injector().is_enabled("stream_mutation_fragments")) {
+        log_done = make_lw_shared<std::any>(seastar::make_shared(seastar::defer([] {
+            blogger.info("stream_mutation_fragments: done (clone)");
+        })));
+    }
+
+    auto guard = service::topology_guard(req.topo_guard);
+    co_await utils::get_local_injector().inject("stream_mutation_fragments", [&guard] (auto& handler) -> future<> {
+        blogger.info("stream_mutation_fragments: waiting (clone)");
+        while (!handler.poll_for_message()) {
+            guard.check();
+            co_await sleep(std::chrono::milliseconds(5));
+        }
+        blogger.info("stream_mutation_fragments: released (clone)");
+    });
+
+    if (req.sstable_state < 0 || req.sstable_state > static_cast<int32_t>(sstables::sstable_state::upload)) {
+        throw std::runtime_error(fmt::format("clone_sstable_handler: invalid sstable_state {}", req.sstable_state));
+    }
+    auto state = static_cast<sstables::sstable_state>(req.sstable_state);
+    auto generation = sstables::generation_type(req.generation);
+    auto version = static_cast<sstables::sstable_version_types>(req.version);
+    auto format = static_cast<sstables::sstable_format_types>(req.format);
+    // The descriptor carries the ORIGINAL generation from the source node.
+    // Server-side copy the S3/GCS objects to a fresh generation owned
+    // by this (destination) node.  The source holds shared_sstable
+    // refs that keep the original objects alive until we confirm.
+    //
+    // We only need the component list (from the TOC) so that clone()
+    // knows which S3 objects to copy.  load_metadata() is the lightest
+    // public API that populates it — a full load() would also validate
+    // metadata, compute shards, and open data files, all of which we
+    // throw away immediately after cloning.
+    replica::table& t = db.find_column_family(req.table);
+    auto& sstm = t.get_sstables_manager();
+    auto orig_sst = sstm.make_sstable(t.schema(), t.get_storage_options(), generation, state, version, format);
+    co_await orig_sst->load_metadata();
+    auto new_gen = t.get_sstable_generation_generator()();
+    // clone() server-side copies the S3/GCS objects to a fresh generation and
+    // creates the registry entry in "creating" state (leave_unsealed=true).
+    // The entry is transitioned to "sealed" later by load_sstable_for_tablet()
+    // → add_new_sstable_and_update_cache() → on_add callback → seal_sstable().
+    auto desc = co_await orig_sst->clone(new_gen, /*leave_unsealed=*/true);
+    blogger.debug("stream_sstables[{}] Cloned {} -> {} on destination", req.ops_id, desc.generation, new_gen);
+    co_await load_sstable_for_tablet(req.ops_id, db, vbw, req.table, state, std::move(desc), req.dst_shard_id);
     co_return resp;
 }
 

--- a/streaming/stream_blob.hh
+++ b/streaming/stream_blob.hh
@@ -165,6 +165,18 @@ public:
     service::frozen_topology_guard topo_guard;
 };
 
+class clone_sstable_request {
+public:
+    file_stream_id ops_id;
+    table_id table;
+    utils::UUID generation;      // sstables::generation_type, encoded as its underlying UUID
+    int32_t version;             // serialized sstables::sstable_version_types
+    int32_t format;              // serialized sstables::sstable_format_types
+    int32_t sstable_state;       // serialized sstables::sstable_state
+    seastar::shard_id dst_shard_id;
+    service::frozen_topology_guard topo_guard;
+};
+
 class stream_files_response {
 public:
     size_t stream_bytes = 0;
@@ -172,7 +184,13 @@ public:
 
 // The handler for the TABLET_STREAM_FILES verb. The receiver of this verb will
 // stream sstables files specified by the stream_files_request req.
-future<stream_files_response> tablet_stream_files_handler(replica::database& db, netw::messaging_service& ms, streaming::stream_files_request req);
+// For object-storage tables, it takes a snapshot and sends per-SSTable
+// CLONE_SSTABLE RPCs instead of byte-streaming via STREAM_BLOB.
+future<stream_files_response> tablet_stream_files_handler(replica::database& db, db::view::view_building_worker& vbw, netw::messaging_service& ms, streaming::stream_files_request req);
+
+// The handler for the CLONE_SSTABLE verb. The destination node performs a
+// server-side S3/GCS CopyObject for a single SSTable and loads the clone.
+future<stream_files_response> clone_sstable_handler(replica::database& db, db::view::view_building_worker& vbw, streaming::clone_sstable_request req);
 
 // Ask the src node to stream sstables to dst node for table in the given token range using TABLET_STREAM_FILES verb.
 future<stream_files_response> tablet_stream_files(const file_stream_id& ops_id, replica::table& table, const dht::token_range& range, const locator::host_id& src, const locator::host_id& dst, seastar::shard_id dst_shard_id, netw::messaging_service& ms, abort_source& as, service::frozen_topology_guard topo_guard);

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -7,6 +7,7 @@
  */
 
 #include "test/lib/cql_test_env.hh"
+#include "test/lib/cql_assertions.hh"
 #include "streaming/stream_blob.hh"
 #include "message/messaging_service.hh"
 #include "test/lib/log.hh"
@@ -74,6 +75,23 @@ future<> write_random_content_to_file(const sstring& filename, size_t content_si
 }
 
 using namespace streaming;
+
+// Build a cql_test_config whose db::config is set up for the given object-storage
+// backend (S3 or GCS).  The caller is responsible for setting ms_listen when needed.
+static cql_test_config make_object_storage_test_config(const data_dictionary::storage_options& so) {
+    cql_test_config cfg;
+    cfg.db_config = make_shared<db::config>();
+    cfg.db_config->experimental_features({db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS});
+    cfg.db_config->object_storage_endpoints(sstables::make_storage_options_config(so));
+    return cfg;
+}
+
+// Build the CQL STORAGE = {...} map literal for a CREATE KEYSPACE statement.
+static sstring make_storage_clause(const data_dictionary::storage_options& so) {
+    auto m = so.to_map();
+    return fmt::format("STORAGE = {{'type': '{}', 'endpoint': '{}', 'bucket': '{}'}}",
+            so.type_string(), m.at("endpoint"), m.at("bucket"));
+}
 
 static future<bool>
 do_test_file_stream(replica::database& db, netw::messaging_service& ms, std::vector<sstring> filelist, const std::string& suffix, bool inject_error, bool unsupported_file_ops = false) {
@@ -173,7 +191,7 @@ static future<> corrupt_data_component(sstables::shared_sstable sst) {
 
 using compress_sstable = bool_class<struct compress_sstable_tag>;
 static future<>
-do_test_sstable_stream(cql_test_env& env, compress_sstable compress, std::function<future<>(shared_sstable)> corruption_fn = nullptr, const sstring& expected_error_msg = "") {
+do_test_sstable_stream(cql_test_env& env, compress_sstable compress, std::function<future<>(shared_sstable)> corruption_fn = nullptr, const sstring& expected_error_msg = "", sstring storage_clause = "") {
     sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
     bool verb_register = false;
     auto ops_id = file_stream_id::create_random_id();
@@ -209,7 +227,11 @@ do_test_sstable_stream(cql_test_env& env, compress_sstable compress, std::functi
             }
             verb_register = true;
 
-            co_await env.execute_cql("CREATE KEYSPACE ks_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};");
+            sstring ks_stmt = "CREATE KEYSPACE ks_test WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}";
+            if (!storage_clause.empty()) {
+                ks_stmt += " AND " + storage_clause;
+            }
+            co_await env.execute_cql(ks_stmt + ";");
             if (compress) {
                 co_await env.execute_cql("CREATE TABLE ks_test.cf (pk text PRIMARY KEY, v int);");
             } else {
@@ -511,11 +533,11 @@ SEASTAR_THREAD_TEST_CASE(test_sink_wrapper_iovec) {
     BOOST_REQUIRE(std::equal(lin.begin(), lin.begin() + final_len, src.begin()));
 }
 
-static void test_sstable_stream(compress_sstable compress, std::function<future<>(shared_sstable)> corruption_fn = nullptr, const sstring& expected_error_msg = "") {
-    cql_test_config cfg;
+static void test_sstable_stream(compress_sstable compress, std::function<future<>(shared_sstable)> corruption_fn = nullptr, const sstring& expected_error_msg = "",
+    cql_test_config cfg = {}, sstring storage_clause = "") {
     cfg.ms_listen = true;
     do_with_cql_env_thread([&](cql_test_env& env) {
-        do_test_sstable_stream(env, compress, corruption_fn, expected_error_msg).get();
+        do_test_sstable_stream(env, compress, corruption_fn, expected_error_msg, storage_clause).get();
     }, cfg).get();
 }
 
@@ -593,4 +615,153 @@ SEASTAR_TEST_CASE(test_stream_sink_write_s3, *boost::unit_test::precondition(tes
 
 SEASTAR_FIXTURE_TEST_CASE(test_stream_sink_write_gs, gcs_fixture, *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
     return test_stream_sink_write(sstables::test_env_config{ .storage = make_test_object_storage_options("GS") });
+}
+
+// S3 variants: exercise reading SSTables from object storage.  Corruption
+// tests are omitted because the corruption helpers use local-filesystem I/O.
+SEASTAR_THREAD_TEST_CASE(test_sstable_stream_compressed_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    auto so = make_test_object_storage_options("S3");
+    test_sstable_stream(compress_sstable::yes, nullptr, "", make_object_storage_test_config(so), make_storage_clause(so));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_sstable_stream_uncompressed_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    auto so = make_test_object_storage_options("S3");
+    test_sstable_stream(compress_sstable::no, nullptr, "", make_object_storage_test_config(so), make_storage_clause(so));
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_sstable_stream_compressed_gcs, gcs_fixture,
+        *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
+    auto so = make_test_object_storage_options("GS");
+    auto cfg = make_object_storage_test_config(so);
+    cfg.ms_listen = true;
+    return do_with_cql_env([so = std::move(so)](cql_test_env& env) {
+        return do_test_sstable_stream(env, compress_sstable::yes, nullptr, "", make_storage_clause(so));
+    }, cfg);
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_sstable_stream_uncompressed_gcs, gcs_fixture,
+        *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
+    auto so = make_test_object_storage_options("GS");
+    auto cfg = make_object_storage_test_config(so);
+    cfg.ms_listen = true;
+    return do_with_cql_env([so = std::move(so)](cql_test_env& env) {
+        return do_test_sstable_stream(env, compress_sstable::no, nullptr, "", make_storage_clause(so));
+    }, cfg);
+}
+
+// Exercise the clone-based object-storage streaming path.
+// This verifies that tablet_stream_files_handler correctly detects the
+// object-storage table and sends per-SSTable CLONE_SSTABLE RPCs (via
+// the clone_sstable_handler) instead of byte-streaming via STREAM_BLOB.
+static future<>
+do_test_clone_path_stream(cql_test_env& env, compress_sstable compress, sstring storage_clause) {
+    auto& db = env.local_db();
+    auto& ms = env.get_messaging_service().local();
+    auto& sharded_vbw = env.view_building_worker();
+
+    // Create keyspace with tablets + object storage.
+    sstring ks_stmt = format(
+            "CREATE KEYSPACE ks_clone WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} "
+            "AND tablets = {{'initial': 1}} AND {}", storage_clause);
+    co_await env.execute_cql(ks_stmt + ";");
+    if (compress) {
+        co_await env.execute_cql("CREATE TABLE ks_clone.cf (pk text PRIMARY KEY, v int);");
+    } else {
+        co_await env.execute_cql("CREATE TABLE ks_clone.cf (pk text PRIMARY KEY, v int) WITH compression = { 'sstable_compression' : '' };");
+    }
+
+    for (int i = 0; i < 10; i++) {
+        co_await env.execute_cql(format("INSERT INTO ks_clone.cf (pk, v) VALUES ('key_{}', {});", i, i * 10));
+    }
+
+    auto& table = db.find_column_family("ks_clone", "cf");
+    co_await table.flush();
+    auto schema = table.schema();
+
+    // Verify the table uses object storage and tablets.
+    BOOST_REQUIRE(table.get_storage_options().is_object_storage_type());
+    BOOST_REQUIRE(table.uses_tablets());
+
+    // Get the tablet map and derive a token range for the first tablet.
+    auto& tmap = table.get_effective_replication_map()->get_token_metadata().tablets().get_tablet_map(schema->id());
+    BOOST_REQUIRE_GT(tmap.tablet_count(), 0);
+    auto tid = tmap.first_tablet();
+    auto range = tmap.get_token_range(tid);
+
+    // Build a stream_files_request — tablet_stream_files_handler will
+    // detect the object-storage table and use the clone path.
+    auto hostid = db.get_token_metadata().get_my_id();
+    auto ops_id = streaming::file_stream_id::create_random_id();
+
+    streaming::stream_files_request req;
+    req.ops_id = ops_id;
+    req.keyspace_name = schema->ks_name();
+    req.table_name = schema->cf_name();
+    req.table = schema->id();
+    req.range = range;
+    req.targets = {streaming::node_and_shard{hostid, 0}};
+    req.topo_guard = service::null_topology_guard;
+
+    co_await streaming::mark_tablet_stream_start(ops_id);
+    auto resp = co_await streaming::tablet_stream_files_handler(db, sharded_vbw.local(), ms, std::move(req));
+    co_await streaming::mark_tablet_stream_done(ops_id);
+
+    // In clone mode zero payload bytes are transferred over the wire;
+    // only server-side copies are performed on the destination.
+    testlog.info("do_test_clone_path_stream[{}] stream_bytes={}", ops_id, resp.stream_bytes);
+    BOOST_REQUIRE_EQUAL(resp.stream_bytes, 0);
+
+    // Verify the cloned data is actually readable on the destination.
+    auto result = co_await env.execute_cql("SELECT COUNT(*) FROM ks_clone.cf;");
+    assert_that(result).is_rows().with_size(1).with_row({{long_type->decompose(int64_t(10))}});
+}
+
+// S3 clone-path test (compressed)
+SEASTAR_THREAD_TEST_CASE(test_clone_path_stream_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    auto so = make_test_object_storage_options("S3");
+    auto cfg = make_object_storage_test_config(so);
+    cfg.ms_listen = true;
+    cfg.initial_tablets = 1;
+    do_with_cql_env_thread([so = std::move(so)](cql_test_env& env) {
+        do_test_clone_path_stream(env, compress_sstable::yes, make_storage_clause(so)).get();
+    }, cfg).get();
+}
+
+// S3 clone-path test (uncompressed)
+SEASTAR_THREAD_TEST_CASE(test_clone_path_stream_uncompressed_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    auto so = make_test_object_storage_options("S3");
+    auto cfg = make_object_storage_test_config(so);
+    cfg.ms_listen = true;
+    cfg.initial_tablets = 1;
+    do_with_cql_env_thread([so = std::move(so)](cql_test_env& env) {
+        do_test_clone_path_stream(env, compress_sstable::no, make_storage_clause(so)).get();
+    }, cfg).get();
+}
+
+// GCS clone-path test (compressed)
+// Note: GCS tests use SEASTAR_FIXTURE_TEST_CASE (async coroutine) because
+// gcs_fixture requires it, while S3 tests use SEASTAR_THREAD_TEST_CASE
+// (threaded).  This is a consequence of the fixture, not a deliberate
+// semantic distinction — both exercise the same streaming code paths.
+SEASTAR_FIXTURE_TEST_CASE(test_clone_path_stream_gcs, gcs_fixture,
+        *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
+    auto so = make_test_object_storage_options("GS");
+    auto cfg = make_object_storage_test_config(so);
+    cfg.ms_listen = true;
+    cfg.initial_tablets = 1;
+    return do_with_cql_env([so = std::move(so)](cql_test_env& env) {
+        return do_test_clone_path_stream(env, compress_sstable::yes, make_storage_clause(so));
+    }, cfg);
+}
+
+// GCS clone-path test (uncompressed)
+SEASTAR_FIXTURE_TEST_CASE(test_clone_path_stream_uncompressed_gcs, gcs_fixture,
+        *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
+    auto so = make_test_object_storage_options("GS");
+    auto cfg = make_object_storage_test_config(so);
+    cfg.ms_listen = true;
+    cfg.initial_tablets = 1;
+    return do_with_cql_env([so = std::move(so)](cql_test_env& env) {
+        return do_test_clone_path_stream(env, compress_sstable::no, make_storage_clause(so));
+    }, cfg);
 }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7461,16 +7461,57 @@ void failure_when_adding_new_sstable_fn(test_env& env) {
     auto on_add = [] (sstables::shared_sstable) { throw std::runtime_error("fail to seal"); return make_ready_future<>(); };
     BOOST_REQUIRE_THROW(table->add_new_sstable_and_update_cache(sst, on_add).get(), std::runtime_error);
 
-    // Verify new sstable was unlinked on failure.
-    BOOST_REQUIRE(!sst->get_storage().exists(*sst, sstables::component_type::Data).get());
+    if (env.get_storage_options().is_local_type()) {
+        // Verify new sstable was unlinked on failure.
+        BOOST_REQUIRE(!sst->get_storage().exists(*sst, sstables::component_type::Data).get());
+    } else {
+        // wipe() transitions the registry entry to "removing"; verify it is
+        // present with that status (not "sealed").  The entry will be cleaned
+        // by garbage_collect() on next startup.
+        sstring sst_status;
+        env.manager()
+            .sstables_registry()
+            .sstables_registry_list(table.schema()->id(), env.manager().get_local_host_id(),
+                                    [&sst_status, sst_desc = sst->get_descriptor(component_type::Data)](sstring status, sstable_state, entry_descriptor desc) {
+                                        if (desc.generation == sst_desc.generation) {
+                                            sst_status = std::move(status);
+                                        }
+                                        return make_ready_future();
+                                    })
+            .get();
+        BOOST_REQUIRE_EQUAL(sst_status, "removing");
+    }
 
     auto sst2 = make_sstable_containing(env.make_sstable(s), {mut1}).get();
     auto sst3 = make_sstable_containing(env.make_sstable(s), {mut1}).get();
     BOOST_REQUIRE_THROW(table->add_new_sstables_and_update_cache({sst2, sst3}, on_add).get(), std::runtime_error);
 
-    // Verify both sstables are unlinked on failure.
-    BOOST_REQUIRE(!sst2->get_storage().exists(*sst2, sstables::component_type::Data).get());
-    BOOST_REQUIRE(!sst3->get_storage().exists(*sst3, sstables::component_type::Data).get());
+    if (env.get_storage_options().is_local_type()) {
+        // Verify both sstables are unlinked on failure.
+        BOOST_REQUIRE(!sst2->get_storage().exists(*sst2, sstables::component_type::Data).get());
+        BOOST_REQUIRE(!sst3->get_storage().exists(*sst3, sstables::component_type::Data).get());
+    } else {
+        // wipe() transitions registry entries to "removing"; verify both are
+        // present with that status (not "sealed").
+        sstring sst2_status, sst3_status;
+        env.manager()
+            .sstables_registry()
+            .sstables_registry_list(table.schema()->id(), env.manager().get_local_host_id(),
+                                    [&sst2_status, &sst3_status,
+                                     sst2_desc = sst2->get_descriptor(component_type::Data),
+                                     sst3_desc = sst3->get_descriptor(component_type::Data)](sstring status, sstable_state, entry_descriptor desc) {
+                                        if (desc.generation == sst2_desc.generation) {
+                                            sst2_status = status;
+                                        }
+                                        if (desc.generation == sst3_desc.generation) {
+                                            sst3_status = status;
+                                        }
+                                        return make_ready_future();
+                                    })
+            .get();
+        BOOST_REQUIRE_EQUAL(sst2_status, "removing");
+        BOOST_REQUIRE_EQUAL(sst3_status, "removing");
+    }
 }
 
 SEASTAR_TEST_CASE(failure_when_adding_new_sstable_test) {

--- a/test/cluster/object_store/test_atomic_delete.py
+++ b/test/cluster/object_store/test_atomic_delete.py
@@ -196,15 +196,14 @@ async def test_crash_before_batch_mutation_commits(manager: ManagerClient, objec
         # The injection throws before apply_mutation, so the batch mutation
         # marking entries as 'removing' is never committed. Compaction handles
         # the error internally — the REST API does not propagate it.
-        await inject_error_one_shot(manager.api, server.ip_addr, "batch_update_entry_status_before_apply")
-        await manager.api.keyspace_compaction(server.ip_addr, ks)
-
-        # Verify: no entries should be in 'removing' state since the mutation
-        # was never committed.
-        entries = await get_registry_entries(cql, table_id)
-        removing = {gen for status, gen in entries if status == 'removing'}
-        assert len(removing) == 0, f"Mutation should not have been committed, but found 'removing' entries: {removing}"
-        logger.info("After failed compaction: %d entries, none in 'removing' state", len(entries))
+        async with inject_error(manager.api, server.ip_addr, "batch_update_entry_status_before_apply"):
+            await manager.api.keyspace_compaction(server.ip_addr, ks)
+            # Verify: no entries should be in 'removing' state since the mutation
+            # was never committed.
+            entries = await get_registry_entries(cql, table_id)
+            removing = {gen for status, gen in entries if status == 'removing'}
+            assert len(removing) == 0, f"Mutation should not have been committed, but found 'removing' entries: {removing}"
+            logger.info("After failed compaction: %d entries, none in 'removing' state", len(entries))
 
         # All data should be readable.
         res = cql.execute(f"SELECT count(*) FROM {ks}.test;")

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -102,10 +102,22 @@ async def test_basic(manager: ManagerClient, object_storage, tmp_path, mode, rep
 
         print('Drop table')
         cql.execute(f"DROP TABLE {ks}.test;")
-        # Check that the ownership table is de-populated
+        # Check that the ownership table is de-populated.
+        # With two-phase deletion for object-storage SSTables, wipe() transitions
+        # registry entries to "removing" state and defers the actual registry
+        # entry deletion to destroy() (runs when the last shared_sstable ref is
+        # dropped).  So entries still in "removing" state are expected — they
+        # confirm that wipe() ran correctly.
         res = cql.execute("SELECT * FROM system.sstables;")
-        rows = "\n".join(f"{row.table_id} {row.status}" for row in res)
-        assert not rows, 'Unexpected entries in registry'
+        unexpected = [row for row in res if row.status != 'removing']
+        assert not unexpected, \
+            f'Unexpected entries in registry: {[(row.table_id, row.status) for row in unexpected]}'
+        # Make sure objects also disappeared
+        await asyncio.gather(*(manager.server_restart(s.server_id) for s in servers))
+        cql = await reconnect_driver(manager)
+        objects = object_storage.get_resource().Bucket(object_storage.bucket_name).objects.all()
+        print(f'Found objects: {[ objects ]}')
+        assert not list(objects), 'Expected no objects in object storage after table drop'
 
 async def test_garbage_collect(manager: ManagerClient, object_storage):
     '''verify ownership table is garbage-collected on boot'''

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -15,6 +15,7 @@
 
 #include "data_dictionary/storage_options.hh"
 #include "db/large_data_handler.hh"
+#include "db/object_storage_endpoint_param.hh"
 #include "db/corrupt_data_handler.hh"
 #include "sstables/version.hh"
 #include "sstables/sstable_directory.hh"
@@ -102,6 +103,7 @@ struct test_env_config {
 };
 
 data_dictionary::storage_options make_test_object_storage_options(std::string_view type);
+std::vector<db::object_storage_endpoint_param> make_storage_options_config(const data_dictionary::storage_options& so);
 
 class test_env {
     struct impl;

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -249,6 +249,171 @@ public:
     future<> close();
 };
 
+// A file implementation that does stateless HTTP range requests per read_dma
+// call, safe for concurrent reads (unlike seekable_data_source_file_impl which
+// has non-atomic seek+get).
+class utils::gcp::storage::client::readable_file : public file_impl {
+    shared_ptr<impl> _impl;
+    std::string _bucket;
+    std::string _object_name;
+    uint64_t _generation = 0;
+    uint64_t _size = 0;
+    std::chrono::system_clock::time_point _timestamp;
+    shard_client_factory _shard_factory;
+    seastar::abort_source* _as;
+
+    [[noreturn]] void unsupported() {
+        throw std::logic_error("unsupported operation on gcs readable file");
+    }
+
+    // Multiple concurrent read_dma coroutines can both see _size == 0 and
+    // issue parallel GET-metadata requests.  This is benign: every fetch
+    // returns the same immutable object metadata, so whichever write wins
+    // leaves the same values.  Same pattern as S3's maybe_update_stats().
+    future<> ensure_metadata() {
+        if (_size != 0) {
+            co_return;
+        }
+        auto path = fmt::format("/storage/v1/b/{}/o/{}", _bucket, seastar::http::internal::url_encode(_object_name));
+        auto res = co_await _impl->send_with_retry(path, GCP_OBJECT_SCOPE_READ_ONLY, ""s, ""s,
+                httpclient::method_type::GET, {}, _as);
+        if (res.result() != seastar::http::reply::status_type::ok) {
+            throw failed_operation(fmt::format("Could not query object {}:{} {}", _bucket, _object_name, res.result()));
+        }
+        auto item = rjson::parse(std::move(res.body()));
+        if (rjson::get<std::string>(item, "kind") != "storage#object"s) {
+            throw failed_operation("Malformed query object reply");
+        }
+        _size = std::stoull(rjson::get<std::string>(item, "size"));
+        _generation = std::stoull(rjson::get<std::string>(item, "generation"));
+        _timestamp = parse_rfc3339(rjson::get<std::string>(item, "updated"));
+    }
+
+public:
+    readable_file(shared_ptr<impl> i, std::string_view bucket, std::string_view object_name,
+                  shard_client_factory shard_factory, seastar::abort_source* as)
+        : _impl(std::move(i))
+        , _bucket(bucket)
+        , _object_name(object_name)
+        , _shard_factory(std::move(shard_factory))
+        , _as(as)
+    {}
+
+    future<size_t> write_dma(uint64_t, const void*, size_t, io_intent*) override { unsupported(); }
+    future<size_t> write_dma(uint64_t, std::vector<iovec>, io_intent*) override { unsupported(); }
+    future<> truncate(uint64_t) override { unsupported(); }
+    subscription<directory_entry> list_directory(std::function<future<>(directory_entry)>) override { unsupported(); }
+    future<> flush() override { return make_ready_future<>(); }
+    future<> allocate(uint64_t, uint64_t) override { return make_ready_future<>(); }
+    future<> discard(uint64_t, uint64_t) override { return make_ready_future<>(); }
+
+    future<size_t> read_dma(uint64_t pos, void* buffer, size_t len, io_intent*) override {
+        co_await ensure_metadata();
+        if (pos >= _size) {
+            co_return 0;
+        }
+        auto to_read = std::min<uint64_t>(len, _size - pos);
+        auto path = fmt::format("/storage/v1/b/{}/o/{}?ifGenerationMatch={}&alt=media",
+                _bucket, seastar::http::internal::url_encode(_object_name), _generation);
+        auto range = fmt::format("bytes={}-{}", pos, pos + to_read - 1);
+        size_t result = 0;
+        co_await _impl->send_with_retry(path, GCP_OBJECT_SCOPE_READ_ONLY, ""s, ""s,
+                [&](const seastar::http::reply& rep, seastar::input_stream<char>& in) -> future<> {
+                    if (rep._status != seastar::http::reply::status_type::ok
+                            && rep._status != seastar::http::reply::status_type::partial_content) {
+                        throw failed_operation(fmt::format("Could not read object {}:{} ({}/{} - {})",
+                                _bucket, _object_name, pos, _size, int(rep._status)));
+                    }
+                    auto bufs = co_await util::read_entire_stream(in);
+                    auto dst = reinterpret_cast<char*>(buffer);
+                    for (auto& buf : bufs) {
+                        auto n = std::min(buf.size(), len - result);
+                        std::copy_n(buf.get(), n, dst + result);
+                        result += n;
+                    }
+                },
+                httpclient::method_type::GET,
+                rest::key_values({{ RANGE, range }}),
+                _as);
+        co_return result;
+    }
+
+    future<size_t> read_dma(uint64_t pos, std::vector<iovec> iov, io_intent*) override {
+        size_t total_len = 0;
+        for (auto& v : iov) {
+            total_len += v.iov_len;
+        }
+        temporary_buffer<char> buf(total_len);
+        auto n = co_await read_dma(pos, buf.get_write(), total_len, nullptr);
+        size_t off = 0;
+        for (auto& v : iov) {
+            auto sz = std::min(v.iov_len, n - off);
+            if (sz == 0) {
+                break;
+            }
+            std::copy_n(buf.get() + off, sz, reinterpret_cast<char*>(v.iov_base));
+            off += sz;
+        }
+        co_return off;
+    }
+
+    future<temporary_buffer<uint8_t>> dma_read_bulk(uint64_t offset, size_t range_size, io_intent* intent) override {
+        temporary_buffer<uint8_t> buf(range_size);
+        auto n = co_await read_dma(offset, buf.get_write(), range_size, intent);
+        buf.trim(n);
+        co_return buf;
+    }
+
+    future<uint64_t> size() override {
+        co_await ensure_metadata();
+        co_return _size;
+    }
+
+    future<struct stat> stat() override {
+        co_await ensure_metadata();
+        struct stat ret = {};
+        ret.st_nlink = 1;
+        ret.st_mode = S_IFREG | S_IRUSR | S_IRGRP | S_IROTH;
+        ret.st_size = _size;
+        ret.st_blksize = 1 << 10;
+        ret.st_blocks = _size >> 9;
+        ret.st_mtime = std::chrono::system_clock::to_time_t(_timestamp);
+        ret.st_ctime = ret.st_mtime;
+        co_return ret;
+    }
+
+    std::unique_ptr<file_handle_impl> dup() override {
+        if (!_shard_factory) {
+            throw std::logic_error("dup() not supported: no shard factory provided");
+        }
+        class gcs_file_handle_impl : public file_handle_impl {
+            shard_client_factory _factory;
+            std::string _bucket;
+            std::string _object_name;
+        public:
+            gcs_file_handle_impl(shard_client_factory f, std::string bucket, std::string object_name)
+                : _factory(std::move(f))
+                , _bucket(std::move(bucket))
+                , _object_name(std::move(object_name))
+            {}
+            std::unique_ptr<file_handle_impl> clone() const override {
+                return std::make_unique<gcs_file_handle_impl>(_factory, _bucket, _object_name);
+            }
+            shared_ptr<file_impl> to_file() && override {
+                auto cl = _factory();
+                // _as is nullptr because abort_source is shard-local; the
+                // dup'd file will live on a different shard.  Same as S3.
+                return seastar::make_shared<readable_file>(cl->_impl, _bucket, _object_name, _factory, nullptr);
+            }
+        };
+        return std::make_unique<gcs_file_handle_impl>(_shard_factory, _bucket, _object_name);
+    }
+
+    future<> close() override {
+        return make_ready_future<>();
+    }
+};
+
 future<> storage::client::impl::authorize(request_wrapper& req, const std::string& scope) {
     if (_credentials) {
         co_await _credentials->refresh(scope, &storage_scope_implies, _certs);
@@ -1170,6 +1335,11 @@ seastar::data_sink utils::gcp::storage::client::create_upload_sink(std::string_v
 
 seekable_data_source utils::gcp::storage::client::create_download_source(std::string_view bucket, std::string_view object_name, seastar::abort_source* as) const {
     return seekable_data_source(std::make_unique<object_data_source>(_impl, bucket, object_name, as));
+}
+
+seastar::file utils::gcp::storage::client::make_readable_file(std::string_view bucket, std::string_view object_name,
+                                                               shard_client_factory shard_factory, seastar::abort_source* as) const {
+    return seastar::file(seastar::make_shared<readable_file>(_impl, bucket, object_name, std::move(shard_factory), as));
 }
 
 future<bool> storage::client::object_exists(std::string_view bucket, std::string_view object_name, seastar::abort_source* as) const {

--- a/utils/gcp/object_storage.hh
+++ b/utils/gcp/object_storage.hh
@@ -11,7 +11,9 @@
 #include <variant>
 #include <string>
 #include <chrono>
+#include <functional>
 
+#include <seastar/core/file.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/iostream.hh>
 #include <seastar/core/semaphore.hh>
@@ -67,9 +69,12 @@ namespace utils::gcp::storage {
         class impl;
         class object_data_sink;
         class object_data_source;
+        class readable_file;
         shared_ptr<impl> _impl;
     public:
         static const std::string DEFAULT_ENDPOINT;
+        /// Factory for obtaining a shard-local client (used for cross-shard dup)
+        using shard_client_factory = std::function<shared_ptr<client>()>;
 
         client(client&&);
 
@@ -154,6 +159,15 @@ namespace utils::gcp::storage {
          * Creates a data_source for reading from a named object.
          */
         seekable_data_source create_download_source(std::string_view bucket, std::string_view object_name, seastar::abort_source* = nullptr) const;
+        /**
+         * Creates a readable file for a named object.
+         * Unlike create_download_source, the returned file supports concurrent
+         * read_dma calls because each read is a stateless HTTP range request.
+         * @shard_factory is used for cross-shard dup() support.
+         */
+        seastar::file make_readable_file(std::string_view bucket, std::string_view object_name,
+                                         shard_client_factory shard_factory = {},
+                                         seastar::abort_source* as = nullptr) const;
         /**
          * Checks if an object exists.
          */


### PR DESCRIPTION
Previously, tablet migrations for object-storage-backed tables transferred the full SSTable bytes over the wire — the same as local-filesystem tables. This is wasteful because the data already resides in S3/GCS: we can server-side-copy the objects and send only a zero-byte descriptor to the target, which loads the cloned SSTables directly from object storage.

This series adds the clone-based streaming path and the prerequisite fixes that make it work end-to-end.

Changes
GCS stateless readable_file — the existing GCS file implementation used create_file_for_seekable_source(), whose seek()+get() two-step corrupts the read position under concurrent read_dma calls (e.g. index cache misses). A new readable_file class (matching S3's design) issues a single stateless HTTP range request per read, eliminating the race.

Comma operator fix — a stray comma operator in tablet_stream_files was harmless but clearly a typo; replaced with a semicolon.

TemporaryTOC redirect for object storage — object-storage SSTables track sealed/unsealed state in the SSTable registry, not via a TemporaryTOC file. When loading a cloned SSTable with unsealed_sstable=true, read_toc() requests TemporaryTOC which does not exist on S3/GCS, resulting in a 404. Fixed by transparently redirecting TemporaryTOC requests to the regular TOC in object_storage_base::open_component().

Missing storage group handling — clone_tablet_storage now uses maybe_storage_group_for_id instead of throwing when a shard does not own the tablet, matching take_storage_snapshot.

Two-phase object-storage deletion — inverts wipe()/destroy() semantics for object-storage SSTables: wipe() now marks the SSTable for deletion and transitions the registry entry to "removing" state (the entry stays alive), deferring both cloud-object deletion and delete_entry() to destroy() (called when the last shared_sstable reference is dropped). This gives object-storage SSTables POSIX-like semantics — analogous to local files surviving after unlink() while a file descriptor is open. It adds crash-safety for the source-cleanup window: if the node dies between wipe() and destroy(), the "removing" registry entry survives and garbage_collect() on the next startup retries the S3/GCS cleanup via remove_by_registry_entry() (ENOENT-tolerant) before removing the entry. This is also a prerequisite for snapshot-based streaming: the source can hold shared_sstable refs during migration, keeping the original cloud objects alive while the destination clones them.

Clone-based streaming — when the source table uses object storage, tablet_stream_files_handler takes a storage snapshot of the tablet's SSTables (holding shared_sstable references to keep cloud objects alive) and, for each SSTable, sends a standalone clone_sstable RPC to each target node. The decision is made per-SSTable via sst->get_storage().is_object_storage(), so mixed tables (if they ever exist) would stream each SSTable by the appropriate method. On the destination, clone_sstable_handler server-side-copies the S3/GCS objects to a fresh generation and loads the cloned SSTable via the existing load_sstable_for_tablet() path. The handler includes the stream_mutation_fragments error injection point for test parity with the byte-streaming path. The clone_sstable_request IDL carries (generation, version, format) directly, eliminating the parse_path() round-trip on the destination. Source SSTable cleanup (wipe() → "removing" → destroy()) only runs during cleanup_tablet(), which the topology coordinator triggers exclusively after the destination has confirmed success — so a failed clone RPC leaves the source untouched and the coordinator simply retries.

Test coverage — unit tests in file_stream_test.cc exercise both the regular object-storage streaming path (S3 + GCS, compressed + uncompressed) and the clone path. 

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1006
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2108

No backport needed — new feature targeting object-storage tablet migrations.