### PR TITLE
alternator: make TTL scan period live-updatable

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -175,7 +175,16 @@ expiration_service::expiration_service(data_dictionary::database db, service::st
         : _db(db)
         , _proxy(proxy)
         , _gossiper(g)
+        , _ttl_period_observer(_db.get_config().alternator_ttl_period_in_seconds.observe([this] (const double&) {
+            abort_ttl_period_sleep();
+        }))
 {
+}
+
+void expiration_service::abort_ttl_period_sleep() {
+    if (_period_sleep_abort_source && !_period_sleep_abort_source->abort_requested()) {
+        _period_sleep_abort_source->request_abort();
+    }
 }
 
 // Convert the big_decimal used to represent expiration time to an integer.
@@ -885,15 +894,30 @@ future<> expiration_service::run() {
         // in the next iteration by reducing the scanner's scheduling-group
         // share (if using a separate scheduling group), or introduce
         // finer-grain sleeps into the scanning code.
-        std::chrono::milliseconds scan_duration(std::chrono::duration_cast<std::chrono::milliseconds>(lowres_clock::now() - start));
-        std::chrono::milliseconds period(long(_db.get_config().alternator_ttl_period_in_seconds() * 1000));
-        if (scan_duration < period) {
+        bool rescheduling_sleep = false;
+        for (;;) {
+            std::chrono::milliseconds period(long(_db.get_config().alternator_ttl_period_in_seconds() * 1000));
+            auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(lowres_clock::now() - start);
+            if (elapsed >= period) {
+                if (!rescheduling_sleep) {
+                    tlogger.warn("scan took {} seconds, longer than period - not sleeping", elapsed.count()/1000.0);
+                }
+                break;
+            }
             try {
-                tlogger.info("sleeping {} seconds until next period", (period - scan_duration).count()/1000.0);
-                co_await seastar::sleep_abortable(period - scan_duration, _abort_source);
-            } catch(seastar::sleep_aborted&) {}
-        } else {
-                tlogger.warn("scan took {} seconds, longer than period - not sleeping", scan_duration.count()/1000.0);
+                _period_sleep_abort_source.emplace();
+                tlogger.info("sleeping {} seconds until next period", (period - elapsed).count()/1000.0);
+                co_await seastar::sleep_abortable(period - elapsed, *_period_sleep_abort_source);
+                _period_sleep_abort_source.reset();
+                break;
+            } catch(seastar::sleep_aborted&) {
+                _period_sleep_abort_source.reset();
+                if (shutting_down()) {
+                    co_return;
+                }
+                rescheduling_sleep = true;
+                tlogger.info("alternator_ttl_period_in_seconds changed, rescheduling sleep until next period");
+            }
         }
     }
 }
@@ -914,6 +938,7 @@ future<> expiration_service::stop() {
         throw std::logic_error("expiration_service::stop() called a second time");
     }
     _abort_source.request_abort();
+    abort_ttl_period_sleep();
     if (!_end) {
         // if _end is was not set, start() was never called
         return make_ready_future<>();

--- a/alternator/ttl.hh
+++ b/alternator/ttl.hh
@@ -13,6 +13,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/semaphore.hh>
 #include "data_dictionary/data_dictionary.hh"
+#include "utils/observable.hh"
 
 namespace gms {
 class gossiper;
@@ -57,9 +58,12 @@ private:
     // should be triggered. stop() below uses both _abort_source and _end.
     std::optional<future<>> _end;
     abort_source _abort_source;
+    std::optional<abort_source> _period_sleep_abort_source;
+    utils::observer<double> _ttl_period_observer;
     // Ensures that at most 1 page of scan results at a time is processed by the TTL service
     named_semaphore _page_sem{1, named_semaphore_exception_factory{"alternator_ttl"}};
     bool shutting_down() { return _abort_source.abort_requested(); }
+    void abort_ttl_period_sleep();
     stats _expiration_stats;
 public:
     // sharded_service<expiration_service>::start() creates this object on

--- a/db/config.cc
+++ b/db/config.cc
@@ -1610,7 +1610,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "This penalty is incurred only for tables with Alternator Streams enabled.")
     , alternator_timeout_in_ms(this, "alternator_timeout_in_ms", liveness::LiveUpdate, value_status::Used, 10000,
         "The server-side timeout for completing Alternator API requests.")
-    , alternator_ttl_period_in_seconds(this, "alternator_ttl_period_in_seconds", value_status::Used,
+    , alternator_ttl_period_in_seconds(this, "alternator_ttl_period_in_seconds", liveness::LiveUpdate, value_status::Used,
         60*60*24,
         "The default period for Alternator's expiration scan. Alternator attempts to scan every table within that period.")
     , alternator_describe_endpoints(this, "alternator_describe_endpoints", liveness::LiveUpdate, value_status::Used,


### PR DESCRIPTION
- Make `alternator_ttl_period_in_seconds` live-updatable.
- Reschedule the current Alternator TTL inter-scan sleep when the period changes, so the new period is observed without node restart.
- Keep shutdown aborts separate from config-triggered sleep rescheduling.

Fixes: SCYLLADB-2820
Refs: CUSTOMER-466

Cluster restart (a node at a time) is not a big deal, so let's not backport.