### PR TITLE
docs: add large data guardrails documentation

### DIFF
--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -21,6 +21,30 @@ clause:
     ALLOW FILTERING          -- optional
     BYPASS CACHE
 
+## BYPASS LARGE_DATA_GUARDRAILS clause
+
+The `BYPASS LARGE_DATA_GUARDRAILS` clause on standalone `DELETE` statements
+skips large data guardrail checks for that delete. This is useful when a table
+has large data guardrails enabled and an oversized partition, row, or collection
+must be deleted, but ordinary writes to the same data are rejected by the hard
+limit.
+
+The clause is placed after the optional `IF` condition:
+
+```cql
+DELETE FROM ks.tbl
+WHERE pk = 1 AND ck = 10
+BYPASS LARGE_DATA_GUARDRAILS;
+
+DELETE FROM ks.tbl
+WHERE pk = 1 AND ck = 10
+IF EXISTS
+BYPASS LARGE_DATA_GUARDRAILS;
+```
+
+The clause is supported only for standalone `DELETE` statements. It is not
+supported for `INSERT`, `UPDATE`, or `BATCH` statements.
+
 ## "Paxos grace seconds" per-table option
 
 The `paxos_grace_seconds` option is used to set the amount of seconds which

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -906,6 +906,10 @@ A table supports the following options:
      - map
      - see below
      - :ref:`Per-table tablet options <cql-per-table-tablet-options>`
+   * - ``large_data_guardrails_enabled``
+     - simple
+     - ``false``
+     - Enables :ref:`large data guardrails <guardrails-large-data>` for this table.
 
 
 .. _speculative-retry-options:

--- a/docs/cql/dml/delete.rst
+++ b/docs/cql/dml/delete.rst
@@ -14,6 +14,7 @@ Deleting rows or parts of rows uses the ``DELETE`` statement:
                    : [ USING `update_parameter` ( AND `update_parameter` )* ]
                    : WHERE `where_clause`
                    : [ IF ( EXISTS | `condition` ( AND `condition` )* ) ]
+                   : [ BYPASS LARGE_DATA_GUARDRAILS ]
 
 For instance:
 
@@ -45,6 +46,12 @@ A ``DELETE`` operation can be conditional through the use of an ``IF`` clause, s
 statements. Each such ``DELETE`` gets a globally unique timestamp.
 However, as with ``INSERT`` and ``UPDATE`` statements, this will incur a non-negligible performance cost
 (internally, Paxos will be used) and so should be used sparingly.
+
+The ``BYPASS LARGE_DATA_GUARDRAILS`` clause is a ScyllaDB CQL extension for
+deleting data from tables with :ref:`large data guardrails <guardrails-large-data>`
+enabled. It skips large data guardrail checks for this standalone ``DELETE`` so
+that oversized data can be removed even when writes to the same partition, row,
+or collection would otherwise be rejected.
 
 Please refer to the :ref:`update parameters <update-parameters>` section for more information on the :token:`update_parameter`.
 

--- a/docs/cql/guardrails.rst
+++ b/docs/cql/guardrails.rst
@@ -207,6 +207,194 @@ useful for understanding the current write-CL distribution across the cluster
 this metric can reveal whether any application is inadvertently using ``ANY``
 or ``ALL`` for writes.
 
+.. _guardrails-large-data:
+
+Large Data Guardrails
+---------------------
+
+Large data guardrails help detect and block writes that create or continue to
+write into data shapes that are known to hurt performance: oversized
+partitions, rows, cells, and collections with too many elements.
+
+Unlike schema-only guardrails, large data guardrails are enabled per table:
+
+.. code-block:: cql
+
+   CREATE TABLE ks.events (
+       pk int,
+       ck int,
+       payload blob,
+       PRIMARY KEY (pk, ck)
+   ) WITH large_data_guardrails_enabled = true;
+
+   ALTER TABLE ks.events WITH large_data_guardrails_enabled = false;
+
+If ``large_data_guardrails_enabled`` is ``false`` or omitted, writes to that
+table are not checked by the large data guardrails. The option can be used only
+after all nodes in the cluster support the ``LARGE_DATA_GUARDRAILS`` feature.
+
+The global thresholds are live-updateable configuration parameters. A value of
+``0`` disables a hard-limit threshold. Soft-limit thresholds use the existing
+``compaction_*_warning_threshold`` parameters and are also used to decide which
+large-data records are stored in SSTable metadata. The table below lists both
+the defaults generated in ``scylla.yaml`` for new clusters and the built-in
+defaults used when a parameter is absent, for example on upgraded clusters.
+
+Large data guardrails use two kinds of checks:
+
+* **Coordinator-side checks** inspect the mutation being written before it is
+  sent to replicas. These checks catch an individual write that is already too
+  large, such as a single oversized cell, row, or collection update.
+* **Replica-side checks** inspect large-data metadata recorded for existing
+  SSTables and, for rows and collections, recently merged memtable data. These
+  checks catch writes to a partition, row, or collection that became too large
+  cumulatively across previous writes.
+
+Enabling large data guardrails adds work to the write path. ScyllaDB examines
+mutations on the coordinator and performs replica-side metadata and cache lookups
+for affected writes. Enable this guardrail selectively on tables where the
+protection from large data shapes is worth the additional write-path overhead.
+
+Hard-limit violations reject the write. Hard-limit failures are
+returned to the client as an ``InvalidRequestException``.
+
+Soft-limit violations are logged by the ``large_data`` logger. If
+``large_data_cql_warnings`` is enabled, ScyllaDB also returns a CQL protocol
+warning to the client. The warning identifies the violated category, for
+example:
+
+.. code-block:: none
+
+   Large data guardrail: Soft limit violation for partition, row
+
+Be aware that CQL warnings are attached to write responses and can increase
+network traffic for workloads that frequently hit soft limits.
+
+.. list-table:: Large data guardrail configuration parameters
+   :widths: 28 11 13 13 35
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - New-cluster default
+     - Built-in default
+     - Description
+   * - ``compaction_large_partition_warning_threshold_mb``
+     - Soft limit
+     - ``1000`` MB
+     - ``1000`` MB
+     - If a partition's on-disk size exceeds this threshold, a write to that
+       partition triggers a soft-limit violation. This is replica-side because
+       it depends on accumulated on-disk partition size. SSTable large-data
+       metadata is recorded during flush and compaction.
+   * - ``large_partition_fail_threshold_mb``
+     - Hard limit
+     - ``2000`` MB
+     - ``0``
+     - If a partition's on-disk size already exceeds this threshold, writes
+       targeting that partition are rejected. Set to ``0`` to disable.
+   * - ``compaction_rows_count_warning_threshold``
+     - Soft limit
+     - ``100000`` rows
+     - ``100000`` rows
+     - If a partition's on-disk row count exceeds this threshold, a write to
+       that partition triggers a soft-limit violation.
+   * - ``rows_count_fail_threshold``
+     - Hard limit
+     - ``200000`` rows
+     - ``0``
+     - If a partition's on-disk row count already exceeds this threshold,
+       writes targeting that partition are rejected. Set to ``0`` to disable.
+   * - ``compaction_large_row_warning_threshold_mb``
+     - Soft limit
+     - ``10`` MB
+     - ``10`` MB
+     - If a row exceeds this threshold, a write to that row triggers a
+       soft-limit violation. Coordinator-side checks can detect an oversized
+       row in the current mutation. Replica-side checks can detect a row that
+       became oversized across previous writes.
+   * - ``large_row_fail_threshold_mb``
+     - Hard limit
+     - ``20`` MB
+     - ``0``
+     - If a row exceeds this threshold, writes targeting that row are rejected.
+       Set to ``0`` to disable.
+   * - ``compaction_large_cell_warning_threshold_mb``
+     - Soft limit
+     - ``1`` MB
+     - ``1`` MB
+     - If a cell value exceeds this threshold, the write triggers a soft-limit
+       violation. This check is coordinator-side and applies to individual
+       atomic cell values in the mutation being written.
+   * - ``large_cell_fail_threshold_mb``
+     - Hard limit
+     - ``2`` MB
+     - ``0``
+     - If a cell value exceeds this threshold, the write is rejected. Set to
+       ``0`` to disable.
+   * - ``compaction_collection_elements_count_warning_threshold``
+     - Soft limit
+     - ``10000`` elements
+     - ``10000`` elements
+     - If a collection contains more elements than this threshold, a write to
+       that collection triggers a soft-limit violation. Coordinator-side checks
+       can detect an oversized collection mutation. Replica-side checks can
+       detect a collection that became oversized across previous writes.
+   * - ``large_collection_elements_fail_threshold``
+     - Hard limit
+     - ``20000`` elements
+     - ``0``
+     - If a collection contains more elements than this threshold, writes
+       targeting that collection are rejected. Set to ``0`` to disable.
+   * - ``large_data_cql_warnings``
+     - Warning output
+     - ``true``
+     - ``false``
+     - When set to ``true``, soft-limit violations are returned to CQL clients
+       as protocol warnings in addition to being logged. When set to ``false``,
+       soft-limit violations are logged only. This setting does not affect
+       hard-limit enforcement.
+   * - ``compaction_large_data_records_per_sstable``
+     - Metadata
+     - ``10``
+     - ``10``
+     - Controls how many large-data metadata records of each type ScyllaDB
+       stores in each SSTable. Replica-side checks use these records to detect
+       writes to already large partitions, rows, and collections.
+
+Bypassing Guardrails for Deletes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Deletes are sometimes needed to remove data from a partition, row, or collection
+that already exceeds a hard limit. A standalone ``DELETE`` statement can bypass
+large data guardrail checks by adding ``BYPASS LARGE_DATA_GUARDRAILS`` after the
+optional ``IF`` clause:
+
+.. code-block:: cql
+
+   DELETE FROM ks.events
+   WHERE pk = 1 AND ck = 10
+   BYPASS LARGE_DATA_GUARDRAILS;
+
+   DELETE FROM ks.events
+   WHERE pk = 1 AND ck = 10
+   IF EXISTS
+   BYPASS LARGE_DATA_GUARDRAILS;
+
+The bypass clause is supported only for standalone ``DELETE`` statements. It is
+not supported for ``INSERT``, ``UPDATE``, or ``BATCH`` statements.
+
+**Metrics.** ScyllaDB exposes per-shard metrics for large-data soft-threshold
+detection:
+
+* ``scylla_database_large_partition_exceeding_threshold``
+* ``scylla_database_large_rows_exceeding_threshold``
+* ``scylla_database_large_cell_exceeding_threshold``
+* ``scylla_database_large_collection_exceeding_threshold``
+
+These metrics count data items that exceed the corresponding warning threshold
+while large-data metadata is recorded.
+
 .. _guardrails-compact-storage:
 
 Compact Storage Guardrail


### PR DESCRIPTION
- guardrails.rst: new 'Large Data Guardrails' section covering per-table opt-in, coordinator vs replica checks, write-path performance cost, config parameters table (new-cluster and built-in defaults), BYPASS LARGE_DATA_GUARDRAILS, and metrics
- ddl.rst: add large_data_guardrails_enabled to table options list
- dml/delete.rst: document BYPASS LARGE_DATA_GUARDRAILS syntax
- cql-extensions.md: add BYPASS LARGE_DATA_GUARDRAILS extension entry

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1092

Backport is not required