### PR TITLE
external_search: throw on unsupported subscript restriction

### DIFF
--- a/cql3/statements/external_search/filter.cc
+++ b/cql3/statements/external_search/filter.cc
@@ -93,6 +93,8 @@ rjson::value lhs_to_json(const expr::tuple_constructor& lhs_tuple) {
     for (const auto& elem : lhs_tuple.elements) {
         if (auto* cv = expr::as_if<expr::column_value>(&elem)) {
             rjson::push_back(arr, rjson::from_string(cv->col->name_as_text()));
+        } else {
+            throw exceptions::invalid_request_exception(sstring("Unsupported restriction: non-column element in tuple: ") + to_string(elem));
         }
     }
     return arr;
@@ -139,6 +141,8 @@ void binary_operator_to_prepared(const expr::binary_operator& binop, std::vector
         multi_column_restriction_to_prepared(binop, *tuple, restrictions);
         return;
     }
+
+    throw exceptions::invalid_request_exception(sstring("Unsupported restriction: ") + to_string(binop));
 }
 
 void expression_to_prepared(const expr::expression& expr, std::vector<prepared_restriction>& restrictions) {

--- a/cql3/statements/external_search/filter.cc
+++ b/cql3/statements/external_search/filter.cc
@@ -115,7 +115,7 @@ void single_column_restriction_to_prepared(
         const expr::binary_operator& binop, const expr::column_value& col, std::vector<prepared_restriction>& restrictions) {
     auto op_str = to_single_column_op_string(binop.op);
     if (!op_str) {
-        throw exceptions::unsupported_operation_exception(sstring("Unsupported operator in restriction on column ") + col.col->name_as_text());
+        throw exceptions::invalid_request_exception(sstring("Unsupported operator in restriction on column ") + col.col->name_as_text());
     }
 
     restrictions.push_back(make_prepared_restriction(*op_str, lhs_to_json(col), binop.rhs));
@@ -125,7 +125,7 @@ void multi_column_restriction_to_prepared(
         const expr::binary_operator& binop, const expr::tuple_constructor& lhs_tuple, std::vector<prepared_restriction>& restrictions) {
     auto op_str = to_multi_column_op_string(binop.op);
     if (!op_str) {
-        throw exceptions::unsupported_operation_exception(sstring("Unsupported operator in restriction on columns ") + to_string(lhs_tuple));
+        throw exceptions::invalid_request_exception(sstring("Unsupported operator in restriction on columns ") + to_string(lhs_tuple));
     }
 
     restrictions.push_back(make_prepared_restriction(*op_str, lhs_to_json(lhs_tuple), binop.rhs));

--- a/test/cqlpy/test_vector_search_with_vector_store_mock.py
+++ b/test/cqlpy/test_vector_search_with_vector_store_mock.py
@@ -300,3 +300,23 @@ def test_vector_search_ann_with_restricted_key_column_not_selected(cql, test_key
                     f"SELECT category FROM {table} WHERE {where_clause} ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 2")
 
                 assert list(result) == [(8,), (7,)]
+
+
+# Regression test: a map subscript restriction in a vector ANN query
+# (e.g. WHERE metadata_s['source'] = 'docs') was silently dropped by
+# binary_operator_to_prepared instead of raising an error, causing the
+# vector store to receive a request with no filter and return results
+# that violated the predicate.
+def test_vector_search_map_subscript_restriction_raises_error(cql, test_keyspace, vector_store_mock, skip_without_tablets):
+    schema = "pk text, metadata_s map<text, text>, embedding vector<float, 3>, PRIMARY KEY (pk)"
+
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(embedding) USING 'vector_index'")
+
+        with pytest.raises(InvalidRequest, match="Unsupported restriction"):
+            cql.execute(
+                f"SELECT pk FROM {table}"
+                " WHERE metadata_s['source'] = 'docs'"
+                " ORDER BY embedding ANN OF [1.0, 0.0, 0.0]"
+                " LIMIT 10 ALLOW FILTERING"
+            )

--- a/test/vector_search/filter_test.cc
+++ b/test/vector_search/filter_test.cc
@@ -9,6 +9,8 @@
 #include <seastar/testing/test_case.hh>
 
 #include "cql3/restrictions/statement_restrictions.hh"
+#include "exceptions/exceptions.hh"
+#include "test/lib/exception_utils.hh"
 #include "cql3/expr/expr-utils.hh"
 #include "cql3/util.hh"
 #include "test/lib/cql_assertions.hh"
@@ -514,6 +516,22 @@ SEASTAR_TEST_CASE(to_json_varint) {
         auto options = make_query_options(std::move(bind_values));
         json = rjson::print(filter.to_json(options));
         BOOST_CHECK_EQUAL(json, expected);
+    });
+}
+
+// Regression test: `binary_operator_to_prepared` used to silently drop
+// restrictions whose LHS was a subscript expression (e.g. map_col['key']),
+// causing the filter to be omitted from vector ANN queries instead of
+// reporting an error.
+SEASTAR_TEST_CASE(prepare_filter_throws_on_map_subscript_restriction) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        cquery_nofail(e, "create table ks.t(pk text, metadata_s map<text, text>, v vector<float, 3>, primary key(pk))");
+
+        auto restr = make_restrictions("metadata_s['source']='docs'", e);
+        BOOST_CHECK_EXCEPTION(
+            statements::external_search::prepare_filter(*restr, true),
+            exceptions::invalid_request_exception,
+            exception_predicate::message_contains("Unsupported restriction"));
     });
 }
 

--- a/test/vector_search/filter_test.cc
+++ b/test/vector_search/filter_test.cc
@@ -519,6 +519,21 @@ SEASTAR_TEST_CASE(to_json_varint) {
     });
 }
 
+// `single_column_restriction_to_prepared` throws when the operator is not
+// supported for serialization (e.g. LIKE is valid CQL but has no JSON filter
+// representation).
+SEASTAR_TEST_CASE(prepare_filter_throws_on_unsupported_single_column_operator) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        cquery_nofail(e, "create table ks.t(pk int, ck int, s text, v vector<float, 3>, primary key(pk, ck))");
+
+        auto restr = make_restrictions("pk=1 AND s LIKE 'abc%'", e);
+        BOOST_CHECK_EXCEPTION(
+            statements::external_search::prepare_filter(*restr, true),
+            exceptions::invalid_request_exception,
+            exception_predicate::message_contains("Unsupported operator in restriction on column s"));
+    });
+}
+
 // Regression test: `binary_operator_to_prepared` used to silently drop
 // restrictions whose LHS was a subscript expression (e.g. map_col['key']),
 // causing the filter to be omitted from vector ANN queries instead of


### PR DESCRIPTION
Restrictions that does not consist of column reference or tuple of column references on the LHS were just silently skipped when building ANN query filter. This caused a silent non-filter behavior Vector Store (in which the filtering is validated) could not return an "unsupported operation" exception, since it had no information about any filters produced on Scylla side.

This patch adds an exception of unsupported restriction when found non column reference filter, f. e. map subscript as in the reproducer.

Fixes: SCYLLADB-2889

Backport to 2026.2 needed as the bug was introduced in https://github.com/scylladb/scylladb/commit/a84d1361db393ab9c8c77572ba43faa0e4fc9b1d