### PR TITLE
ci: scylla-ci-route: fix BASH_ENV not set on Blacksmith runners

### DIFF
--- a/.github/workflows/scylla-ci-route.yaml
+++ b/.github/workflows/scylla-ci-route.yaml
@@ -28,9 +28,11 @@ jobs:
     steps:
       - name: Set up gh api retry helper
         run: |
-          # Write a reusable retry wrapper for gh api calls into BASH_ENV
-          # so it is automatically available in every subsequent step.
-          cat >> "$BASH_ENV" << 'RETRY_EOF'
+          # Write a reusable retry wrapper for gh api calls into a helper
+          # script that subsequent steps source explicitly.
+          # NOTE: Do NOT use $BASH_ENV here — Blacksmith runners do not set it.
+          mkdir -p "$HOME/.ci-helpers"
+          cat > "$HOME/.ci-helpers/gh_api_retry.sh" << 'RETRY_EOF'
           gh_api_retry() {
             local max_attempts=4 attempt=1 delay=1 output rc
             while [ $attempt -le $max_attempts ]; do
@@ -96,6 +98,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         shell: bash
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           PR_REPO="$PR_REPO_FROM_EVENT"
 
           if [ "$EVENT_NAME" = "issue_comment" ]; then
@@ -152,6 +155,7 @@ jobs:
           PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
           PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           echo "Fetching PR #$PR_NUMBER files from $PR_REPO..."
           ALL_DOCS=true
           TRIGGER_DOCS_CI=false
@@ -222,6 +226,7 @@ jobs:
           PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
           PR_URL: ${{ steps.resolve-pr.outputs.pr_url }}
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           echo "Fetching PR #$PR_NUMBER details..."
           PR_JSON=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER")
 
@@ -303,6 +308,7 @@ jobs:
           PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
           PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           # Fetch all PR files for pattern matching
           ALL_FILES=""
           PAGE=1
@@ -409,6 +415,7 @@ jobs:
           PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
           PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           TRUSTED=false
 
           # Check if user is a ScyllaDB org member
@@ -449,6 +456,7 @@ jobs:
           PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
           PR_SHA: ${{ steps.resolve-pr.outputs.pr_sha }}
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           TARGET_FOLDER="${{ steps.target-folder.outputs.folder }}"
           RUN_DTEST="${{ steps.required-checks.outputs.dtest_required }}"
           RUN_UNITTEST="${{ steps.required-checks.outputs.unittest_required }}"


### PR DESCRIPTION
Blacksmith runners (`blacksmith-2vcpu-ubuntu-2404`) do not pre-set the `BASH_ENV` variable, unlike GitHub-hosted runners. This causes the 'Set up gh api retry helper' step to fail with:

```
line 3: : No such file or directory
```

since `cat >> "$BASH_ENV"` expands to `cat >> ""`.

**Fix:** Replace the `BASH_ENV` approach with an explicit source-file pattern — write the `gh_api_retry()` function to `$HOME/.ci-helpers/gh_api_retry.sh` and source it at the top of each step that needs it.

This has been broken since 877d550ce9 landed (~June 23 19:59 UTC), causing **100% failure rate** on all non-skipped CI route runs for PRs targeting master/next.

Fixes: SCYLLADB-2858