### PR TITLE
ci: scylla-ci-route: fix BASH_ENV not set on Blacksmith runners

### DIFF
--- a/.github/workflows/scylla-ci-route.yaml
+++ b/.github/workflows/scylla-ci-route.yaml
@@ -5,6 +5,12 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, unlabeled]
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to trigger CI for'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,7 +22,9 @@ jobs:
     # 1. PR events (opened/reopened/synchronize/ready_for_review) for non-draft PRs
     # 2. PR unlabeled event when 'conflicts' label is removed
     # 3. issue_comment event when a non-bot org member comments '@scylladbbot trigger-ci'
+    # 4. workflow_dispatch (manual trigger from any branch for testing)
     if: |
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' && github.event.action != 'unlabeled' && !github.event.pull_request.draft) ||
       (github.event_name == 'pull_request_target' && github.event.action == 'unlabeled' && github.event.label.name == 'conflicts') ||
       (github.event_name == 'issue_comment' && github.event.comment.user.login != 'scylladbbot')
@@ -96,12 +104,23 @@ jobs:
           AFTER_SHA: ${{ github.event.after }}
           # Comment event context
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          # Manual dispatch context
+          DISPATCH_PR_NUMBER: ${{ github.event.inputs.pr_number }}
         shell: bash
         run: |
           source "$HOME/.ci-helpers/gh_api_retry.sh"
           PR_REPO="$PR_REPO_FROM_EVENT"
 
-          if [ "$EVENT_NAME" = "issue_comment" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # For manual dispatch, fetch PR details from the input PR number
+            PR_NUMBER="$DISPATCH_PR_NUMBER"
+            PR_JSON=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER")
+            PR_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+            PR_USER=$(echo "$PR_JSON" | jq -r '.user.login')
+            PR_DRAFT=$(echo "$PR_JSON" | jq -r '.draft')
+            BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.base.ref')
+            PR_URL=$(echo "$PR_JSON" | jq -r '.html_url')
+          elif [ "$EVENT_NAME" = "issue_comment" ]; then
             # For comment events, fetch PR details from the API
             PR_NUMBER="$ISSUE_NUMBER"
             PR_JSON=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER")
@@ -407,7 +426,7 @@ jobs:
           echo "Required checks: build=$BUILD_REQUIRED dtest=$DTEST_REQUIRED unittest=$UNITTEST_REQUIRED artifacts=$ARTIFACTS_REQUIRED gdb=$GDB_REQUIRED"
 
       - name: Check trusted contributor
-        if: steps.resolve-pr.outputs.should_continue == 'true' && steps.docs-check.outputs.is_docs_only != 'true' && github.event_name != 'issue_comment'
+        if: steps.resolve-pr.outputs.should_continue == 'true' && steps.docs-check.outputs.is_docs_only != 'true' && github.event_name != 'issue_comment' && github.event_name != 'workflow_dispatch'
         id: trust-check
         env:
           GH_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
@@ -444,7 +463,7 @@ jobs:
         if: |
           steps.resolve-pr.outputs.should_continue == 'true' &&
           steps.docs-check.outputs.is_docs_only != 'true' &&
-          (steps.trust-check.outputs.trusted == 'true' || github.event_name == 'issue_comment') &&
+          (steps.trust-check.outputs.trusted == 'true' || github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch') &&
           steps.pr-details.outputs.has_conflicts != 'true' &&
           steps.required-checks.outputs.build_required == 'true' &&
           steps.target-folder.outputs.folder != ''

--- a/.github/workflows/scylla-ci-route.yaml
+++ b/.github/workflows/scylla-ci-route.yaml
@@ -28,9 +28,11 @@ jobs:
     steps:
       - name: Set up gh api retry helper
         run: |
-          # Write a reusable retry wrapper for gh api calls into BASH_ENV
-          # so it is automatically available in every subsequent step.
-          cat >> "$BASH_ENV" << 'RETRY_EOF'
+          # Write a reusable retry wrapper for gh api calls into a helper
+          # script that subsequent steps source explicitly.
+          # NOTE: Do NOT use $BASH_ENV here — Blacksmith runners do not set it.
+          mkdir -p "$HOME/.ci-helpers"
+          cat > "$HOME/.ci-helpers/gh_api_retry.sh" << 'RETRY_EOF'
           gh_api_retry() {
             local max_attempts=4 attempt=1 delay=1 output rc
             while [ $attempt -le $max_attempts ]; do
@@ -96,6 +98,7 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
         shell: bash
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           PR_REPO="$PR_REPO_FROM_EVENT"
 
           if [ "$EVENT_NAME" = "issue_comment" ]; then
@@ -152,6 +155,7 @@ jobs:
           PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
           PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           echo "Fetching PR #$PR_NUMBER files from $PR_REPO..."
           ALL_DOCS=true
           TRIGGER_DOCS_CI=false
@@ -222,6 +226,7 @@ jobs:
           PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
           PR_URL: ${{ steps.resolve-pr.outputs.pr_url }}
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           echo "Fetching PR #$PR_NUMBER details..."
           PR_JSON=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER")
 
@@ -303,6 +308,7 @@ jobs:
           PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
           PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           # Fetch all PR files for pattern matching
           ALL_FILES=""
           PAGE=1
@@ -409,6 +415,7 @@ jobs:
           PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
           PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           TRUSTED=false
 
           # Check if user is a ScyllaDB org member
@@ -449,6 +456,7 @@ jobs:
           PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
           PR_SHA: ${{ steps.resolve-pr.outputs.pr_sha }}
         run: |
+          source "$HOME/.ci-helpers/gh_api_retry.sh"
           TARGET_FOLDER="${{ steps.target-folder.outputs.folder }}"
           RUN_DTEST="${{ steps.required-checks.outputs.dtest_required }}"
           RUN_UNITTEST="${{ steps.required-checks.outputs.unittest_required }}"


### PR DESCRIPTION
Blacksmith runners (blacksmith-2vcpu-ubuntu-2404) do not pre-set the
BASH_ENV variable, unlike GitHub-hosted runners. This causes the
'Set up gh api retry helper' step to fail with:

  line 3: : No such file or directory

since `cat >> "$BASH_ENV"` expands to `cat >> ""`.

Replace the BASH_ENV approach with an explicit source-file pattern:
write the gh_api_retry() function to $HOME/.ci-helpers/gh_api_retry.sh
and source it at the top of each step that needs it.

This has been broken since https://github.com/scylladb/scylladb/commit/877d550ce9ce4e6b3b8ac379e057e985880fb2bd landed (~June 23 19:59 UTC),
causing 100% failure rate on all non-skipped CI route runs for PRs targeting master/next.

Fixes: [SCYLLADB-2858](https://scylladb.atlassian.net/browse/SCYLLADB-2858)

[SCYLLADB-2858]: https://scylladb.atlassian.net/browse/SCYLLADB-2858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ