### PR TITLE
encryption::kms_host: extend retry to all retryable errors

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -570,6 +570,7 @@ scylla_tests = set([
     'test/boost/dynamic_bitset_test',
     'test/boost/encrypted_file_test',
     'test/boost/encryption_at_rest_test',
+    'test/boost/http_error_classification_test',
     'test/boost/enum_option_test',
     'test/boost/enum_set_test',
     'test/boost/estimated_histogram_test',

--- a/ent/encryption/kms_host.cc
+++ b/ent/encryption/kms_host.cc
@@ -34,6 +34,7 @@
 #include "utils.hh"
 #include "utils/exponential_backoff_retry.hh"
 #include "utils/hash.hh"
+#include "utils/http_client_error_processing.hh"
 #include "utils/loading_cache.hh"
 #include "utils/http.hh"
 #include "utils/UUID.hh"
@@ -375,12 +376,20 @@ future<rjson::value> encryption::kms_host::impl::post(std::string_view target, s
         try {
             co_return co_await do_post(target, aws_assume_role_arn, query);
         } catch (kms_error& e) {
-            // Special case 503. This can be both actual service or ec2 metadata.
-            // In either case, do local backoff-retry here.
-            // https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-returns
-            if (e.result() != httpclient::reply_status::service_unavailable || retry >= max_retries) {
+            if (retry >= max_retries || !utils::http::from_http_code(e.result())) {
                 throw;
             }
+            kms_log.debug("Retryable KMS error ({}), retry {}/{}: {}", e.result(), retry + 1, max_retries, e.what());
+        } catch (std::system_error& e) {
+            if (retry >= max_retries || !utils::http::from_system_error(e)) {
+                throw;
+            }
+            kms_log.debug("Retryable system error ({}), retry {}/{}: {}", e.code().message(), retry + 1, max_retries, e.what());
+        } catch (service_error& e) {
+            if (retry >= max_retries) {
+                throw;
+            }
+            kms_log.debug("Retryable service error, retry {}/{}: {}", retry + 1, max_retries, e.what());
         }
 
         co_await exr.retry();

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -97,6 +97,10 @@ add_scylla_test(encryption_at_rest_test
   KIND SEASTAR
   LIBRARIES
     encryption)
+add_scylla_test(http_error_classification_test
+  KIND SEASTAR
+  LIBRARIES
+    encryption)
 add_scylla_test(enum_option_test
   KIND BOOST)
 add_scylla_test(enum_set_test

--- a/test/boost/http_error_classification_test.cc
+++ b/test/boost/http_error_classification_test.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include <boost/test/unit_test.hpp>
+#include <seastar/testing/test_case.hh>
+#include <seastar/http/reply.hh>
+#include <seastar/core/sleep.hh>
+#include <system_error>
+
+#include "utils/http_client_error_processing.hh"
+#include "utils/exponential_backoff_retry.hh"
+
+using namespace std::chrono_literals;
+
+SEASTAR_TEST_CASE(test_http_error_classification_http_status_codes) {
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::service_unavailable), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::internal_server_error), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::too_many_requests), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::request_timeout), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::gateway_timeout), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::bandwidth_limit_exceeded), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::network_connect_timeout), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::network_read_timeout), utils::http::retryable::yes);
+
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::unauthorized), utils::http::retryable::no);
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::forbidden), utils::http::retryable::no);
+    BOOST_REQUIRE_EQUAL(utils::http::from_http_code(seastar::http::reply::status_type::not_found), utils::http::retryable::no);
+
+    co_return;
+}
+
+SEASTAR_TEST_CASE(test_http_error_classification_system_errors) {
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(ECONNRESET, std::system_category())), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(ECONNREFUSED, std::system_category())), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(ENETUNREACH, std::system_category())), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(EHOSTUNREACH, std::system_category())), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(ETIMEDOUT, std::system_category())), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(EAGAIN, std::system_category())), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(ECONNABORTED, std::system_category())), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(static_cast<int>(std::errc::broken_pipe), std::system_category())), utils::http::retryable::yes);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(ENETDOWN, std::system_category())), utils::http::retryable::yes);
+
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(EACCES, std::system_category())), utils::http::retryable::no);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(EPERM, std::system_category())), utils::http::retryable::no);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(ENOENT, std::system_category())), utils::http::retryable::no);
+    BOOST_REQUIRE_EQUAL(utils::http::from_system_error(std::system_error(EADDRINUSE, std::system_category())), utils::http::retryable::no);
+
+    co_return;
+}
+
+SEASTAR_TEST_CASE(test_exponential_backoff_retry) {
+    exponential_backoff_retry exr(10ms, 1000ms);
+
+    BOOST_REQUIRE_EQUAL(exr.sleep_time().count(), 10);
+
+    co_await exr.retry();
+    BOOST_REQUIRE_EQUAL(exr.sleep_time().count(), 20);
+
+    co_await exr.retry();
+    BOOST_REQUIRE_EQUAL(exr.sleep_time().count(), 40);
+
+    co_await exr.retry();
+    BOOST_REQUIRE_EQUAL(exr.sleep_time().count(), 80);
+
+    co_await exr.retry();
+    BOOST_REQUIRE_EQUAL(exr.sleep_time().count(), 160);
+
+    exr.reset();
+    BOOST_REQUIRE_EQUAL(exr.sleep_time().count(), 10);
+}


### PR DESCRIPTION
Follow-up to #26934.

Previously the exponential backoff-retry in kms_host::post() only
retried on HTTP 503 (Service Unavailable). Other transient errors
such as ENETUNREACH, ECONNREFUSED, ETIMEDOUT, 5xx, 429, 408, 504,
etc. were immediately propagated without retry.

Uses the shared error-classification utilities (from_http_code and
from_system_error) to retry on any retryable error, matching the
pattern already used by S3 and GCP retry strategies.

Also adds debug logging on each retry attempt and unit tests for the
retry condition logic.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2477

Could be backported, but it's a benign issue, I suspect.