### PR TITLE
[Backport 2025.4] raft/server: don't report shutdown fiber errors as background failures

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -9,6 +9,7 @@
 
 #include "utils/assert.hh"
 #include "utils/error_injection.hh"
+#include "utils/exceptions.hh"
 #include <boost/range/adaptor/transformed.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
@@ -1607,7 +1608,11 @@ void server_impl::check_not_aborted() {
 
 void server_impl::handle_background_error(const char* fiber_name) {
     _is_alive = false;
-    const auto e = std::current_exception();
+    auto e = std::current_exception();
+    if (_aborted && try_catch<const seastar::gate_closed_exception>(e)) {
+        logger.debug("[{}] {} fiber stopped while aborting raft server: {}", _id, fiber_name, e);
+        return;
+    }
     logger.error("[{}] {} fiber stopped because of the error: {}", _id, fiber_name, e);
     if (_config.on_background_error) {
         _config.on_background_error(e);


### PR DESCRIPTION
During shutdown, raft background fibers can hit exceptions from services that are already stopping, such as gate_closed_exception or write timeouts while persisting system.raft updates. These errors are expected after raft::server::abort() has started, but the generic background error handler currently logs them as ERROR and reports them through on_background_error, which can fail dtests on benign teardown races. Handle this as part of the stop path: once _aborted is set, keep marking the server as not alive, but log the fiber failure at debug and return. Errors before abort() keep the existing ERROR log and on_background_error behavior, so real raft failures are still reported.

Fixes: [SCYLLADB-2847](https://scylladb.atlassian.net/browse/SCYLLADB-2849)

backport: This seems as a good backport candidate for all active branches because this can happen in other versions as well.

    (cherry picked from commit https://github.com/scylladb/scylladb/commit/cf142457a67bf60d649d5ef293e66ae98c9f976a)

Parent PR: https://github.com/scylladb/scylladb/pull/30376

[SCYLLADB-2847]: https://scylladb.atlassian.net/browse/SCYLLADB-2847?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ