### PR TITLE
test/cqlpy/test_select_from_mutation_fragments.py: un-flake test_ck_in_query

### DIFF
--- a/test/cqlpy/test_select_from_mutation_fragments.py
+++ b/test/cqlpy/test_select_from_mutation_fragments.py
@@ -454,12 +454,10 @@ def test_ck_in_query(cql, test_table, scylla_only):
     sources_res = list(cql.execute(f"SELECT * FROM MUTATION_FRAGMENTS({test_table}) WHERE pk1 = {pk1} AND pk2 = {pk2}"))
 
     sources = {r.mutation_source.split(":")[0]: r.mutation_source for r in sources_res}
-    assert len(sources) == 3
-    assert "memtable" in sources
-    assert "row-cache" in sources
-    assert "sstable" in sources
+    assert "sstable" in sources # the only source we are guaranteed to have
+    assert set(sources.keys()).issubset({"memtable", "row-cache", "sstable"})
 
-    res = list(cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
+    res = list(reversed(list(cql.execute(f"""SELECT * FROM MUTATION_FRAGMENTS({test_table})
         WHERE
             pk1 = {pk1} AND
             pk2 = {pk2} AND
@@ -468,17 +466,18 @@ def test_ck_in_query(cql, test_table, scylla_only):
                 ('{sources["row-cache"]}', 2, 0, 0, 0),
                 ('{sources["sstable"]}', 2, 0, 0, 0),
                 ('{sources["sstable"]}', 2, 1, 1, 0))
-        """))
+        """))))
 
     columns = ("mutation_source", "partition_region", "ck1", "ck2", "position_weight")
-    expected_results = [
-            (sources["memtable"], 2, 0, 0, 0),
-            (sources["row-cache"], 2, 0, 0, 0),
-            (sources["sstable"], 2, 0, 0, 0),
+    expected_results = [ # reversed order
             (sources["sstable"], 2, 1, 1, 0),
+            (sources["sstable"], 2, 0, 0, 0),
+            (sources["row-cache"], 2, 0, 0, 0),
+            (sources["memtable"], 2, 0, 0, 0),
     ]
 
-    assert len(res) == len(expected_results)
+    assert len(res) >= 2
+    assert len(res) <= len(expected_results)
     for row, expected_row in zip(res, expected_results):
         for col_name, expected_value in zip(columns, expected_row):
             assert hasattr(row, col_name)


### PR DESCRIPTION
The test in question assumed that the data written to the table will be found both in the memtable and the row-cache. However, neither the memtable nor the cache are stable: both are subject to flush/eviction based on external factors, outside of the tests's control. Relax the test to not assume that the memtable or tha cache content exists. However, if it does exists, check that it is the expected value. The only mutation source that is stable is the sstable. This is still assumed to be such and checked by the test.

Fixes: SCYLLADB-1634

Backport: failure only seen on master, no backport for now