### PR TITLE
sstables_loader: pin ERM before co_await sst->load()

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -229,7 +229,7 @@ private:
         sstables::sstable_open_config cfg {
             .unsealed_sstable = true,
         };
-        co_await sst->load(table.get_effective_replication_map()->get_sharder(*table.schema()), cfg);
+        co_await sst->load(_erm->get_sharder(*table.schema()), cfg);
         co_await table.add_new_sstable_and_update_cache(sst, [&sst_manager, sst] (sstables::shared_sstable loading_sst) -> future<> {
             if (loading_sst == sst) {
                 auto writer_cfg = sst_manager.configure_writer(loading_sst->get_origin());


### PR DESCRIPTION
The sharder reference obtained from get_effective_replication_map() was passed directly into co_await sst->load() without a local shared_ptr copy to pin the ERM. If the table's internal _erm is swapped during the co_await (due to a topology change), the old ERM is freed and the sharder reference dangles.

Fix by pinning the ERM with a local shared_ptr copy, matching the pattern already used at line 938 in the same file.

Refs: https://scylladb.atlassian.net/browse/SCYLLADB-2867

Backport: no, probably benign, rare edge case.