### PR TITLE
s3_client: replace memory semaphore with operation-counting semaphores

### DIFF
--- a/scripts/metrics-config.yml
+++ b/scripts/metrics-config.yml
@@ -65,7 +65,7 @@
         "_queue_name + \"_rx_frags\"": ["queue"]
 "utils/s3/client.cc":
   groups:
-    "262": "s3"
+    "254": "s3"
   params:
     lower_method_name: ["get", "post", "put", "delete", "head", "options", "trace", "connect", "patch"]
     method_name: ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE", "CONNECT", "PATCH"]

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -65,17 +65,17 @@ fmt::formatter<sstables::object_name>::format(const sstables::object_name& n, fm
     return fmt::format_to(ctx.out(), "{}", n.str());
 }
 
-static shared_ptr<s3::client> make_s3_client(const db::object_storage_endpoint_param& ep, semaphore& memory, std::function<shared_ptr<s3::client>(std::string)> factory, unsigned connections_per_shard) {
+static shared_ptr<s3::client> make_s3_client(const db::object_storage_endpoint_param& ep, std::function<shared_ptr<s3::client>(std::string)> factory, unsigned connections_per_shard) {
     auto& epc = ep.get_s3_storage();
-    return s3::client::make(epc.endpoint, epc.region, epc.iam_role_arn, memory, std::move(factory), connections_per_shard);
+    return s3::client::make(epc.endpoint, epc.region, epc.iam_role_arn, std::move(factory), connections_per_shard);
 }
 
 class s3_client_wrapper : public sstables::object_storage_client {
     shared_ptr<s3::client> _client;
     shard_client_factory _cf;
 public:
-    s3_client_wrapper(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf, unsigned connections_per_shard)
-        : _client(make_s3_client(ep, memory, std::bind_front(&s3_client_wrapper::shard_client, this), connections_per_shard))
+    s3_client_wrapper(const db::object_storage_endpoint_param& ep, shard_client_factory cf, unsigned connections_per_shard)
+        : _client(make_s3_client(ep, std::bind_front(&s3_client_wrapper::shard_client, this), connections_per_shard))
         , _cf(std::move(cf))
     {}
     shared_ptr<s3::client> shard_client(std::string host) const {
@@ -341,7 +341,7 @@ public:
 
 shared_ptr<object_storage_client> sstables::make_object_storage_client(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf, unsigned connections_per_shard) {
     if (ep.is_s3_storage()) {
-        return seastar::make_shared<s3_client_wrapper>(ep, memory, std::move(cf), connections_per_shard);
+        return seastar::make_shared<s3_client_wrapper>(ep, std::move(cf), connections_per_shard);
     }
     if (ep.is_gs_storage()) {
         return seastar::make_shared<gs_client_wrapper>(ep, memory, std::move(cf));

--- a/test/boost/aws_error_injection_test.cc
+++ b/test/boost/aws_error_injection_test.cc
@@ -56,7 +56,7 @@ static void register_policy(const std::string& key, failure_policy policy) {
     cln.make_request(std::move(req), [](const http::reply&, input_stream<char>&&) -> future<> { return seastar::make_ready_future(); }).get();
 }
 
-void test_client_upload_file(std::string_view test_name, failure_policy policy, size_t total_size, size_t memory_size) {
+void test_client_upload_file(std::string_view test_name, failure_policy policy, size_t total_size) {
     tmpdir tmp;
     const auto file_path = tmp.path() / fmt::format("test-{}", ::getpid());
     {
@@ -75,8 +75,7 @@ void test_client_upload_file(std::string_view test_name, failure_policy policy, 
     const auto object_name = fmt::format("/{}/{}-{}", "test", test_name, ::getpid());
     register_policy(object_name, policy);
 
-    semaphore mem{memory_size};
-    auto client = s3::client::make(get_address(), make_minio_config(), mem);
+    auto client = s3::client::make(get_address(), make_minio_config());
     auto client_shutdown = deferred_close(*client);
     client->upload_file(file_path, object_name).get();
 }
@@ -85,24 +84,21 @@ SEASTAR_THREAD_TEST_CASE(test_multipart_upload_file_success) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    BOOST_REQUIRE_NO_THROW(test_client_upload_file(seastar_test::get_name(), failure_policy::SUCCESS, total_size, memory_size));
+    BOOST_REQUIRE_NO_THROW(test_client_upload_file(seastar_test::get_name(), failure_policy::SUCCESS, total_size));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_multipart_upload_file_retryable_success) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    BOOST_REQUIRE_NO_THROW(test_client_upload_file(seastar_test::get_name(), failure_policy::RETRYABLE_FAILURE, total_size, memory_size));
+    BOOST_REQUIRE_NO_THROW(test_client_upload_file(seastar_test::get_name(), failure_policy::RETRYABLE_FAILURE, total_size));
 }
 
 SEASTAR_THREAD_TEST_CASE(test_multipart_upload_file_failure_1) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    BOOST_REQUIRE_EXCEPTION(test_client_upload_file(seastar_test::get_name(), failure_policy::NEVERENDING_RETRYABLE_FAILURE, total_size, memory_size),
+    BOOST_REQUIRE_EXCEPTION(test_client_upload_file(seastar_test::get_name(), failure_policy::NEVERENDING_RETRYABLE_FAILURE, total_size),
             storage_io_error, [](const storage_io_error& e) {
                 return e.code().value() == EIO && e.what() == "S3 request failed. Code: 1. Reason: We encountered an internal error. Please try again."sv;
             });
@@ -112,8 +108,7 @@ SEASTAR_THREAD_TEST_CASE(test_multipart_upload_file_failure_2) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    BOOST_REQUIRE_EXCEPTION(test_client_upload_file(seastar_test::get_name(), failure_policy::NONRETRYABLE_FAILURE, total_size, memory_size), storage_io_error,
+    BOOST_REQUIRE_EXCEPTION(test_client_upload_file(seastar_test::get_name(), failure_policy::NONRETRYABLE_FAILURE, total_size), storage_io_error,
             [](const storage_io_error& e) {
                 return e.code().value() == EIO && e.what() == "S3 request failed. Code: 2. Reason: Something went terribly wrong"sv;
             });
@@ -124,8 +119,7 @@ void do_test_client_multipart_upload(failure_policy policy, bool is_jumbo = fals
 
     register_policy(name, policy);
     testlog.info("Make client");
-    semaphore mem(16 << 20);
-    auto cln = s3::client::make(get_address(), make_minio_config(), mem);
+    auto cln = s3::client::make(get_address(), make_minio_config());
     auto close_client = deferred_close(*cln);
 
     testlog.info("Upload object");

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -746,52 +746,6 @@ SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_with_delays_proxy) {
     test_chunked_download_data_source(make_proxy_client, 20_MiB);
 }
 
-void do_test_chunked_download_data_source_memory(const client_maker_function& client_maker, size_t object_size) {
-    tmpdir tmp;
-    const auto file_path = tmp.path() / "test_object";
-    create_file(file_path, object_size).get();
-
-    s3_test_fixture guard(client_maker);
-    auto cln = guard.client();
-    const auto object_name = guard.object_path("test_object");
-    cln->upload_file(file_path, object_name).get();
-
-    testlog.info("Test client memory exhaust");
-    std::vector<input_stream<char>> clients;
-    for (auto _ : {1, 2, 3}) {
-        clients.emplace_back(cln->make_chunked_download_source(object_name, s3::full_range));
-    }
-    testlog.info("Wait to exhaust client memory.");
-    // Allow the background fiber time to fill the buffer queue.
-    // This may introduce some unpredictability in the queue's contents,
-    // but that's intentional—we want to verify the client's ability to handle such conditions.
-    seastar::sleep(100ms).get();
-    std::mt19937_64 rand_gen(std::random_device{}());
-    std::uniform_int_distribution<std::size_t> dist(0, clients.size() - 1);
-    while (true) {
-        auto idx = dist(rand_gen);
-        // Introduce additional randomness: read from input streams in a non-deterministic order,
-        // and sleep briefly between reads to give the background fiber time to potentially stall while filling the queue.
-        seastar::sleep(std::chrono::microseconds(50 * (idx + 1))).get();
-        auto buf = clients[idx].read().get();
-        testlog.info("Got {} bytes from client {}", buf.size(), idx);
-        if (buf.empty()) {
-            clients[idx].close().get();
-            clients.erase(clients.begin() + idx);
-
-            // Recalculate distribution range. May overflow if last client was removed - this is acceptable for the test.
-            dist = std::uniform_int_distribution<std::size_t>(0, clients.size() - 1);
-        }
-        if (clients.empty()) {
-            break;
-        }
-    }
-}
-
-SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_memory) {
-    do_test_chunked_download_data_source_memory(make_minio_client, 20_MiB);
-}
-
 void test_object_copy(const client_maker_function& client_maker, size_t chunk_size, size_t chunks) {
     s3_test_fixture guard(client_maker);
     auto cln = guard.client();

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -82,25 +82,25 @@ static std::unique_ptr<seastar::http::retry_strategy> make_test_retry_strategy()
 //   export AWS_SESSION_TOKEN=${aws_session_token}
 //   export AWS_DEFAULT_REGION="us-east-2"
 
-static shared_ptr<s3::client> make_proxy_client(semaphore& mem) {
+static shared_ptr<s3::client> make_proxy_client() {
     s3::endpoint_config cfg = {
         .port = std::stoul(tests::getenv_safe("PROXY_S3_SERVER_PORT")),
         .use_https = false,
         .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
     };
-    return s3::client::make(tests::getenv_safe("PROXY_S3_SERVER_HOST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), mem, make_test_retry_strategy());
+    return s3::client::make(tests::getenv_safe("PROXY_S3_SERVER_HOST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), make_test_retry_strategy());
 }
 
-static shared_ptr<s3::client> make_minio_client(semaphore& mem) {
+static shared_ptr<s3::client> make_minio_client() {
     s3::endpoint_config cfg = {
         .port = std::stoul(tests::getenv_safe("S3_SERVER_PORT_FOR_TEST")),
         .use_https = ::getenv("AWS_DEFAULT_REGION") != nullptr,
         .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
     };
-    return s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), mem, make_test_retry_strategy());
+    return s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), make_test_retry_strategy());
 }
 
-using client_maker_function = std::function<shared_ptr<s3::client>(semaphore&)>;
+using client_maker_function = std::function<shared_ptr<s3::client>()>;
 
 // Per-test S3 fixture: creates an S3 client and a unique bucket on
 // construction, closes the client and deletes the bucket (with all
@@ -128,8 +128,8 @@ class s3_test_fixture {
     }
 
 public:
-    s3_test_fixture(const client_maker_function& maker, semaphore& mem)
-        : _client(maker(mem))
+    explicit s3_test_fixture(const client_maker_function& maker)
+        : _client(maker())
         , _bucket(get_sanitized_bucket_name())
     {
         testlog.info("Creating test bucket {}", _bucket);
@@ -181,8 +181,7 @@ static future<uint32_t> create_file(const std::string& path, size_t file_size) {
  */
 
 void client_put_get_object(const client_maker_function& client_maker) {
-    semaphore mem(16 << 20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto cln = guard.client();
     const auto name = guard.object_path("testobject");
 
@@ -226,8 +225,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_put_get_object_proxy) {
 }
 
 void do_test_client_multipart_upload(const client_maker_function& client_maker, bool with_copy_upload) {
-    semaphore mem(16<<20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto cln = guard.client();
     const auto name = guard.object_path(fmt::format("test{}object", with_copy_upload ? "jumbo" : "large"));
 
@@ -290,49 +288,15 @@ SEASTAR_THREAD_TEST_CASE(test_client_multipart_copy_upload_proxy) {
     do_test_client_multipart_upload(make_proxy_client, true);
 }
 
-void client_multipart_upload_fallback(const client_maker_function& client_maker) {
-    semaphore mem(0);
-    mem.broken(); // so that any attempt to use it throws
-    s3_test_fixture guard(client_maker, mem);
-    auto cln = guard.client();
-    const auto name = guard.object_path("testfbobject");
-
-    testlog.info("Upload object");
-    auto out = output_stream<char>(cln->make_upload_sink(name));
-    auto close = seastar::deferred_close(out);
-
-    temporary_buffer<char> data = sstring("1A3B5C7890").release();
-    out.write(reinterpret_cast<const char*>(data.begin()), data.size()).get();
-
-    testlog.info("Flush upload");
-    out.flush().get(); // if it tries to do regular flush, memory claim would throw
-
-    testlog.info("Closing");
-    close.close_now();
-
-    testlog.info("Get object content");
-    temporary_buffer<char> res = cln->get_object_contiguous(name).get();
-    BOOST_REQUIRE_EQUAL(to_sstring(std::move(res)), to_sstring(std::move(data)));
-}
-
-SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload_fallback_minio) {
-    client_multipart_upload_fallback(make_minio_client);
-}
-
-SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload_fallback_proxy) {
-    client_multipart_upload_fallback(make_proxy_client);
-}
-
 using with_remainder_t = bool_class<class with_remainder_tag>;
 
-void test_client_upload_file(const client_maker_function& client_maker, size_t total_size, size_t memory_size) {
+void test_client_upload_file(const client_maker_function& client_maker, size_t total_size) {
     tmpdir tmp;
     const auto file_path = tmp.path() / "test";
 
     auto expected_checksum = create_file(file_path, total_size).get();
 
-    semaphore guard_mem(memory_size);
-    s3_test_fixture guard(client_maker, guard_mem);
+    s3_test_fixture guard(client_maker);
     auto client = guard.client();
     const auto object_name = guard.object_path("upload-test");
 
@@ -367,50 +331,43 @@ void test_client_upload_file(const client_maker_function& client_maker, size_t t
 SEASTAR_THREAD_TEST_CASE(test_client_upload_file_multi_part_without_remainder_minio) {
     const size_t part_size = 5_MiB;
     const size_t total_size = 4 * part_size;
-    const size_t memory_size = part_size;
-    test_client_upload_file(make_minio_client, total_size, memory_size);
+    test_client_upload_file(make_minio_client, total_size);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_client_upload_file_multi_part_without_remainder_proxy) {
     const size_t part_size = 5_MiB;
     const size_t total_size = 4 * part_size;
-    const size_t memory_size = part_size;
-    test_client_upload_file(make_proxy_client, total_size, memory_size);
+    test_client_upload_file(make_proxy_client, total_size);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_client_upload_file_multi_part_with_remainder_minio) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    test_client_upload_file(make_minio_client, total_size, memory_size);
+    test_client_upload_file(make_minio_client, total_size);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_client_upload_file_multi_part_with_remainder_proxy) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
-    const size_t memory_size = part_size;
-    test_client_upload_file(make_proxy_client, total_size, memory_size);
+    test_client_upload_file(make_proxy_client, total_size);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_client_upload_file_single_part_minio) {
     const size_t part_size = 5_MiB;
     const size_t total_size = part_size / 2;
-    const size_t memory_size = part_size;
-    test_client_upload_file(make_minio_client, total_size, memory_size);
+    test_client_upload_file(make_minio_client, total_size);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_client_upload_file_single_part_proxy) {
     const size_t part_size = 5_MiB;
     const size_t total_size = part_size / 2;
-    const size_t memory_size = part_size;
-    test_client_upload_file(make_proxy_client, total_size, memory_size);
+    test_client_upload_file(make_proxy_client, total_size);
 }
 
 void client_readable_file(const client_maker_function& client_maker) {
-    semaphore mem(16<<20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto cln = guard.client();
     const auto name = guard.object_path("testroobject");
 
@@ -456,8 +413,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_readable_file_proxy) {
 }
 
 void client_readable_file_stream(const client_maker_function& client_maker) {
-    semaphore mem(16<<20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto cln = guard.client();
     const auto name = guard.object_path("teststreamobject");
 
@@ -485,8 +441,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_readable_file_stream_proxy) {
 }
 
 void client_put_get_tagging(const client_maker_function& client_maker) {
-    semaphore mem(16<<20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto client = guard.client();
     const auto name = guard.object_path("testobject");
 
@@ -534,8 +489,7 @@ static std::unordered_set<sstring> populate_bucket(shared_ptr<s3::client> client
 }
 
 void client_list_objects(const client_maker_function& client_maker) {
-    semaphore mem(16<<20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto client = guard.client();
     const sstring& bucket = guard.bucket();
     const sstring prefix("testprefix/");
@@ -566,8 +520,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_list_objects_proxy) {
 }
 
 void client_list_objects_incomplete(const client_maker_function& client_maker) {
-    semaphore mem(16<<20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto client = guard.client();
     const sstring& bucket = guard.bucket();
     const sstring prefix("testprefix/");
@@ -594,8 +547,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_list_objects_incomplete_proxy) {
 // non-existent bucket, so there is no bucket to create or clean up.
 void client_broken_bucket(const client_maker_function& client_maker) {
     const sstring name("/NO_BUCKET/testobject");
-    semaphore mem(16 << 20);
-    auto client = client_maker(mem);
+    auto client = client_maker();
 
     auto close_client = deferred_close(*client);
     auto data = sstring("1234567890ABCDEF").release();
@@ -609,8 +561,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_broken_bucket_minio) {
 }
 
 void client_missing_prefix(const client_maker_function& client_maker) {
-    semaphore mem(16 << 20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto client = guard.client();
     const auto name = guard.object_path("testobject");
 
@@ -624,8 +575,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_missing_prefix_minio) {
 }
 
 void client_access_missing_object(const client_maker_function& client_maker) {
-    semaphore mem(16 << 20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto client = guard.client();
     const auto name = guard.object_path("testobject");
 
@@ -640,8 +590,7 @@ SEASTAR_THREAD_TEST_CASE(test_client_access_missing_object_minio) {
 
 SEASTAR_THREAD_TEST_CASE(test_object_reupload) {
     // Pay attention, we are reuploading the same file during the test
-    semaphore mem(16 << 20);
-    s3_test_fixture guard(make_minio_client, mem);
+    s3_test_fixture guard(make_minio_client);
     auto cln = guard.client();
     const auto name = guard.object_path("testobject");
     constexpr std::string_view content{"1234567890"};
@@ -687,8 +636,7 @@ SEASTAR_THREAD_TEST_CASE(test_object_reupload) {
 }
 
 void test_download_data_source(const client_maker_function& client_maker, bool is_chunked, unsigned chunks) {
-    semaphore mem(16<<20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto cln = guard.client();
     const auto name = guard.object_path("testdatasourceobject");
 
@@ -735,8 +683,7 @@ void test_chunked_download_data_source(const client_maker_function& client_maker
     const auto file_path = tmp.path() / "test_object";
     create_file(file_path, object_size).get();
 
-    semaphore mem(16 << 20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto cln = guard.client();
     const auto object_name = guard.object_path("test_object");
     cln->upload_file(file_path, object_name).get();
@@ -804,8 +751,7 @@ void do_test_chunked_download_data_source_memory(const client_maker_function& cl
     const auto file_path = tmp.path() / "test_object";
     create_file(file_path, object_size).get();
 
-    semaphore guard_mem(1_MiB);
-    s3_test_fixture guard(client_maker, guard_mem);
+    s3_test_fixture guard(client_maker);
     auto cln = guard.client();
     const auto object_name = guard.object_path("test_object");
     cln->upload_file(file_path, object_name).get();
@@ -847,8 +793,7 @@ SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_memory) {
 }
 
 void test_object_copy(const client_maker_function& client_maker, size_t chunk_size, size_t chunks) {
-    semaphore mem(16 << 20);
-    s3_test_fixture guard(client_maker, mem);
+    s3_test_fixture guard(client_maker);
     auto cln = guard.client();
     const auto name = guard.object_path("testobject");
     const auto name_copy = guard.object_path("testobject-copy");

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -408,30 +408,6 @@ SEASTAR_THREAD_TEST_CASE(test_client_upload_file_single_part_proxy) {
     test_client_upload_file(make_proxy_client, total_size, memory_size);
 }
 
-
-SEASTAR_THREAD_TEST_CASE(test_client_abort_stuck_semaphore) {
-    constexpr size_t object_size = 128_KiB;
-
-    tmpdir tmp;
-    const auto file_path = tmp.path() / "test_object";
-
-    create_file(file_path, object_size).get();
-
-    semaphore mem(32_KiB);
-    s3_test_fixture guard(make_minio_client, mem);
-    auto cln = guard.client();
-    const auto object_name = guard.object_path("test_object");
-    abort_source as;
-    auto upload = cln->upload_file(file_path, object_name, {}, {}, &as);
-    auto ex = std::make_exception_ptr(std::runtime_error("Cancelling!"));
-    as.request_abort_ex(ex);
-    upload.wait();
-    BOOST_REQUIRE(upload.failed());
-    BOOST_REQUIRE_EXCEPTION(std::rethrow_exception(upload.get_exception()), semaphore_aborted, [](const semaphore_aborted& e) {
-        return e.what() == "Semaphore aborted"sv;
-    });
-}
-
 void client_readable_file(const client_maker_function& client_maker) {
     semaphore mem(16<<20);
     s3_test_fixture guard(client_maker, mem);

--- a/test/perf/perf_s3_client.cc
+++ b/test/perf/perf_s3_client.cc
@@ -24,7 +24,6 @@ class tester {
     std::chrono::seconds _duration;
     std::string _object_name;
     size_t _object_size;
-    semaphore _mem;
     shared_ptr<s3::client> _client;
     utils::estimated_histogram _latencies;
     unsigned _errors = 0;
@@ -51,8 +50,7 @@ public:
             , _duration(dur)
             , _object_name(std::move(object_name))
             , _object_size(obj_size)
-            , _mem(memory::stats().total_memory())
-            , _client(s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_config(sockets), _mem))
+            , _client(s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_config(sockets)))
             , _part_size_mb(part_size)
             , _remove_file(false)
     {}

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1758,7 +1758,6 @@ class client::do_upload_file : private multipart_upload {
     future<> put_object(file&& f, uint64_t len) {
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html
         s3l.trace("PUT {} ({})", _object_name, _path.native());
-        auto mem_units = co_await _client->claim_memory(_transmit_size, _as);
 
         auto req = http::request::make("PUT", _client->_host, _object_name);
         if (_tag) {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -287,9 +287,9 @@ void client::group_client::register_metrics(std::string class_name, std::string 
             sm::description("Total time spend writing data to objects"), {ep_label, sg_label}));
     defs.emplace_back(sm::make_counter("total_read_prefetch_bytes", [this] { return prefetch_bytes; },
             sm::description("Total number of bytes requested from object"), {ep_label, sg_label}));
-    defs.emplace_back(sm::make_counter("downloads_blocked_on_memory",
-                      [this] { return downloads_blocked_on_memory; },
-                      sm::description("Counts the number of times S3 client downloads were delayed due to insufficient memory availability"),
+    defs.emplace_back(sm::make_counter("downloads_starving_on_max_concurrency",
+                      [this] { return downloads_starving_on_max_concurrency; },
+                      sm::description("Counts the number of times S3 client downloads were starving on max concurrency limit"),
                       {ep_label, sg_label}));
     defs.emplace_back(sm::make_counter("integrated_request_queue_length",
                           [this] { return http.integrated_requests_queued().integral(); },
@@ -1362,12 +1362,6 @@ data_sink client::make_upload_jumbo_sink(sstring object_name, std::optional<unsi
 }
 
 class client::chunked_download_source final : public seastar::data_source_impl {
-    struct claimed_buffer {
-        temporary_buffer<char> _buffer;
-        std::optional<semaphore_units<>> _claimed_memory;
-        claimed_buffer(temporary_buffer<char>&& buf, std::optional<semaphore_units<>>&& claimed_memory) noexcept
-            : _buffer(std::move(buf)), _claimed_memory(std::move(claimed_memory)) {}
-    };
     struct content_range {
         uint64_t start;
         uint64_t end;
@@ -1381,7 +1375,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
     static constexpr size_t _max_buffers_size = 5_MiB;
     static constexpr double _buffers_low_watermark = 0.5;
     static constexpr double _buffers_high_watermark = 0.9;
-    std::deque<claimed_buffer> _buffers;
+    std::deque<temporary_buffer<char>> _buffers;
     size_t _buffers_size = 0;
     bool _is_finished = false;
     bool _is_contiguous_mode = false;
@@ -1402,17 +1396,21 @@ class client::chunked_download_source final : public seastar::data_source_impl {
     future<> make_filling_fiber() {
         seastar::http::no_retry_strategy no_retry;
         s3l.trace("Fiber starts cycle for object '{}'", _object_name);
+        auto units = try_get_units(_client->_buffered_dl_sem, 1);
         while (!_is_finished) {
             try {
                 if (!_is_finished && _buffers_size >= _max_buffers_size * _buffers_low_watermark) {
                     co_await _bg_fiber_cv.when([this] { return _is_finished || (_buffers_size < _max_buffers_size * _buffers_low_watermark); });
                 }
 
-                if (auto units = try_get_units(_client->_memory, _socket_buff_size); !_is_finished && !_buffers.empty() && !units) {
+                if (!_is_finished && !_buffers.empty() && !units) {
                     auto& gc = co_await _client->find_or_create_client();
-                    ++gc.downloads_blocked_on_memory;
-                    co_await _bg_fiber_cv.when([this] {
-                        return _is_finished || _buffers.empty() || try_get_units(_client->_memory, _socket_buff_size);
+                    ++gc.downloads_starving_on_max_concurrency;
+                    co_await _bg_fiber_cv.when([this, &units] {
+                        if (_is_finished || _buffers.empty())
+                            return true;
+                        units = try_get_units(_client->_buffered_dl_sem, 1);
+                        return units.has_value();
                     });
                 }
 
@@ -1436,7 +1434,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                 }
                 if (current_range.length() == 0) {
                     s3l.trace("Fiber for object '{}' completed downloading, signals EOS and leaving fiber", _object_name);
-                    _buffers.emplace_back(temporary_buffer<char>(), co_await _client->claim_memory(0, _as));
+                    _buffers.emplace_back(temporary_buffer<char>());
                     _get_cv.signal();
                     _is_finished = true;
                     co_return;
@@ -1448,7 +1446,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                 s3l.trace("Fiber for object '{}' will make HTTP request within range {}", _object_name, current_range);
                 co_await _client->make_request(
                     std::move(req),
-                    [this, pf_length = current_range.length()](group_client& gc, const http::reply& reply, input_stream<char>&& in_) mutable -> future<> {
+                    [this, &units, pf_length = current_range.length()](group_client& gc, const http::reply& reply, input_stream<char>&& in_) mutable -> future<> {
                         if (reply._status != http::reply::status_type::ok && reply._status != http::reply::status_type::partial_content) {
                             s3l.warn("Fiber for object '{}' failed: {}. Exiting", _object_name, reply._status);
                             throw httpd::unexpected_status_error(reply._status);
@@ -1468,13 +1466,12 @@ class client::chunked_download_source final : public seastar::data_source_impl {
 
                             s3l.trace("Fiber for object '{}' will try to read within range {}", _object_name, _range);
                             temporary_buffer<char> buf;
-                            auto units = try_get_units(_client->_memory, _socket_buff_size);
+                            if (!units) {
+                                units = try_get_units(_client->_buffered_dl_sem, 1);
+                            }
                             if (_buffers.empty() || units) {
                                 buf = co_await in.read();
                                 assert(buf.size() <= _socket_buff_size);
-                                if (units) {
-                                    units->return_units(_socket_buff_size - buf.size());
-                                }
                             } else {
                                 break;
                             }
@@ -1484,7 +1481,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                             _buffers_size += buff_size;
                             if (buff_size == 0 && _range.length() == 0) {
                                 s3l.trace("Fiber for object '{}' signals EOS", _object_name);
-                                _buffers.emplace_back(std::move(buf), std::move(units));
+                                _buffers.emplace_back(std::move(buf));
                                 _get_cv.signal();
                                 _is_finished = true;
                                 break;
@@ -1494,7 +1491,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                                 break;
                             }
                             s3l.trace("Fiber for object '{}' pushes {} bytes buffer", _object_name, buff_size);
-                            _buffers.emplace_back(std::move(buf), std::move(units));
+                            _buffers.emplace_back(std::move(buf));
                             _get_cv.signal();
                             utils::get_local_injector().inject("break_s3_inflight_req", [] {
                                 // Inject a non-`aws_error` after partial data download to verify proper
@@ -1534,12 +1531,12 @@ public:
             if (!_buffers.empty()) {
                 auto claimed_buff = std::move(_buffers.front());
                 _buffers.pop_front();
-                _buffers_size -= claimed_buff._buffer.size();
+                _buffers_size -= claimed_buff.size();
                 if (_buffers_size < _max_buffers_size * _buffers_low_watermark) {
                     _bg_fiber_cv.signal();
                 }
-                s3l.trace("get() for object '{}' popped buffer of {} bytes", _object_name, claimed_buff._buffer.size());
-                co_return std::move(claimed_buff._buffer);
+                s3l.trace("get() for object '{}' popped buffer of {} bytes", _object_name, claimed_buff.size());
+                co_return std::move(claimed_buff);
             }
             _bg_fiber_cv.signal();
             s3l.trace("get() for object '{}' waiting for buffer", _object_name);

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -249,6 +249,10 @@ future<semaphore_units<>> client::claim_memory(size_t size, abort_source* as) {
     return get_units(_memory, size);
 }
 
+static future<semaphore_units<>> claim_unit(semaphore& sem, seastar::abort_source* as) {
+    return as ? get_units(sem, 1, *as) : get_units(sem, 1);
+}
+
 client::group_client::group_client(std::unique_ptr<http::connection_factory> f, unsigned max_conn) : http(std::move(f), max_conn) {
 }
 
@@ -1080,7 +1084,7 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
         co_await start_upload();
     }
 
-    auto claim = co_await _client->claim_memory(bufs.size(), _as);
+    auto mpu = co_await claim_unit(_client->_mpus_sem, _as);
 
     unsigned part_number = _part_etags.size();
     _part_etags.emplace_back();
@@ -1090,7 +1094,7 @@ future<> client::multipart_upload::upload_part(memory_data_sink_buffers bufs) {
     req._headers["Content-Length"] = seastar::format("{}", size);
     req.set_query_param("partNumber", seastar::format("{}", part_number + 1));
     req.set_query_param("uploadId", _upload_id);
-    req.write_body("bin", size, [this, part_number, bufs = std::move(bufs), p = std::move(claim)] (output_stream<char>&& out_) mutable -> future<> {
+    req.write_body("bin", size, [this, part_number, bufs = std::move(bufs), p = std::move(mpu)] (output_stream<char>&& out_) mutable -> future<> {
         auto out = std::move(out_);
         std::exception_ptr ex;
         s3l.trace("upload {} part data (upload id {})", part_number, _upload_id);
@@ -1706,14 +1710,14 @@ class client::do_upload_file : private multipart_upload {
     future<> upload_part(file f, uint64_t offset, uint64_t part_size, uint64_t part_number) {
         // upload a part in a multipart upload, see
         // https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
-        auto mem_units = co_await _client->claim_memory(_transmit_size, _as);
+        auto mpu = co_await claim_unit(_client->_mpus_sem, _as);
 
         auto req = http::request::make("PUT", _client->_host, _object_name);
         req._headers["Content-Length"] = to_sstring(part_size);
         req.set_query_param("partNumber", to_sstring(part_number + 1));
         req.set_query_param("uploadId", _upload_id);
         s3l.trace("PUT part {}, {} bytes (upload id {})", part_number, part_size, _upload_id);
-        req.write_body("bin", part_size, [f=std::move(f), mem_units=std::move(mem_units), offset, part_size, &progress = _progress] (output_stream<char>&& out_) {
+        req.write_body("bin", part_size, [f=std::move(f), mpu=std::move(mpu), offset, part_size, &progress = _progress] (output_stream<char>&& out_) {
             auto input = make_file_input_stream(f, offset, part_size, input_stream_options());
             auto output = std::move(out_);
             return copy_to(std::move(input), std::move(output), _transmit_size, progress);

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -84,7 +84,7 @@ future<> ignore_reply(const http::reply& rep, input_stream<char>&& in_) {
     co_await util::skip_entire_stream(in);
 }
 
-client::client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<http::retry_strategy> rs)
+client::client(std::string host, endpoint_config_ptr cfg, global_factory gf, private_tag, std::unique_ptr<http::retry_strategy> rs)
         : _host(std::move(host))
         , _cfg(std::move(cfg))
         , _creds_sem(1)
@@ -108,7 +108,6 @@ client::client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global
             }();
         })
         , _gf(std::move(gf))
-        , _memory(mem)
         , _retry_strategy(std::move(rs)) {
     _creds_provider_chain
         .add_credentials_provider(std::make_unique<aws::environment_aws_credentials_provider>())
@@ -164,15 +163,15 @@ void client::update_connections_per_shard(unsigned connections_per_shard) {
     });
 }
 
-shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, semaphore& mem, global_factory gf) {
-    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{});
+shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, global_factory gf) {
+    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), std::move(gf), private_tag{});
 }
 
-shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, semaphore& mem, std::unique_ptr<http::retry_strategy> rs, global_factory gf) {
-    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{}, std::move(rs));
+shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, std::unique_ptr<http::retry_strategy> rs, global_factory gf) {
+    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), std::move(gf), private_tag{}, std::move(rs));
 }
 
-shared_ptr<client> client::make(std::string ep, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf, unsigned connections_per_shard) {
+shared_ptr<client> client::make(std::string ep, std::string region, std::string iam_role_arn, global_factory gf, unsigned connections_per_shard) {
     auto url = utils::http::parse_simple_url(ep);
     endpoint_config cfg = {
         .port = url.port,
@@ -181,7 +180,7 @@ shared_ptr<client> client::make(std::string ep, std::string region, std::string 
         .role_arn = std::move(iam_role_arn),
         .connections_per_shard = connections_per_shard,
     };
-    return make(url.host, make_lw_shared<endpoint_config>(std::move(cfg)), memory, gf);
+    return make(url.host, make_lw_shared<endpoint_config>(std::move(cfg)), gf);
 }
 
 future<> client::update_credentials_and_rearm() {
@@ -240,13 +239,6 @@ future<> client::authorize(http::request& req) {
         utils::aws::unsigned_content,
         _cfg->region, "s3", query_string);
     req._headers["Authorization"] = seastar::format("AWS4-HMAC-SHA256 Credential={}/{}/{}/s3/aws4_request,SignedHeaders={},Signature={}", _credentials.access_key_id, time_point_st, _cfg->region, signed_headers_list, sig);
-}
-
-future<semaphore_units<>> client::claim_memory(size_t size, abort_source* as) {
-    if (as) {
-        return get_units(_memory, size, *as);
-    }
-    return get_units(_memory, size);
 }
 
 static future<semaphore_units<>> claim_unit(semaphore& sem, seastar::abort_source* as) {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -839,8 +839,6 @@ sstring parse_multipart_copy_upload_etag(sstring& body) {
 
 class client::multipart_upload {
 protected:
-    static constexpr size_t _max_multipart_concurrency = 16;
-
     shared_ptr<client> _client;
     sstring _object_name;
     sstring _upload_id;
@@ -913,7 +911,7 @@ private:
             auto parts = std::views::iota(size_t{0}, (source_size + part_size - 1) / part_size);
             _part_etags.resize(parts.size());
             co_await max_concurrent_for_each(parts,
-                                             _max_multipart_concurrency,
+                                             max_client_mpu_in_flight,
                                              [part_size, source_size, this](auto part_num) -> future<> {
                                                  auto part_offset = part_num * part_size;
                                                  auto actual_part_size = std::min(source_size - part_offset, part_size);
@@ -1728,7 +1726,7 @@ class client::do_upload_file : private multipart_upload {
         std::exception_ptr ex;
         try {
             co_await max_concurrent_for_each(std::views::iota(size_t{0}, (total_size + part_size - 1) / part_size),
-                                             _max_multipart_concurrency,
+                                             max_client_mpu_in_flight,
                                              [part_size, total_size, this, f = file{f}](auto part_num) -> future<> {
                                                  auto part_offset = part_num * part_size;
                                                  auto actual_part_size = std::min(total_size - part_offset, part_size);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -136,12 +136,9 @@ class client : public enable_shared_from_this<client> {
     semaphore _rebalance_sem{1};
     using global_factory = std::function<shared_ptr<client>(std::string)>;
     global_factory _gf;
-    semaphore& _memory;
     std::unique_ptr<seastar::http::retry_strategy> _retry_strategy;
 
     struct private_tag {};
-
-    future<semaphore_units<>> claim_memory(size_t mem, seastar::abort_source* as);
 
     future<> update_credentials_and_rearm();
     future<> authorize(http::request&);
@@ -180,10 +177,10 @@ class client : public enable_shared_from_this<client> {
     future<> get_object_header(sstring object_name, http::client::reply_handler handler, seastar::abort_source* = nullptr);
 public:
 
-    client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<seastar::http::retry_strategy> rs = nullptr);
-    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, global_factory gf = {});
-    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, std::unique_ptr<seastar::http::retry_strategy> rs, global_factory gf = {});
-    static shared_ptr<client> make(std::string url, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf = {}, unsigned connections_per_shard = endpoint_config::default_connections_per_shard);
+    client(std::string host, endpoint_config_ptr cfg, global_factory gf, private_tag, std::unique_ptr<seastar::http::retry_strategy> rs = nullptr);
+    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, global_factory gf = {});
+    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, std::unique_ptr<seastar::http::retry_strategy> rs, global_factory gf = {});
+    static shared_ptr<client> make(std::string url, std::string region, std::string iam_role_arn, global_factory gf = {}, unsigned connections_per_shard = endpoint_config::default_connections_per_shard);
 
     future<uint64_t> get_object_size(sstring object_name, seastar::abort_source* = nullptr);
     future<stats> get_object_stats(sstring object_name, seastar::abort_source* = nullptr);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -38,6 +38,7 @@ static constexpr unsigned maximum_parts_in_piece = 10'000;
 static constexpr size_t maximum_object_size = maximum_parts_in_piece * maximum_part_size;
 
 static constexpr size_t max_client_mpu_in_flight = 32;
+static constexpr size_t max_client_buffered_downloads_in_flight = 32;
 
 class range {
     friend struct fmt::formatter<range>;
@@ -114,6 +115,7 @@ class client : public enable_shared_from_this<client> {
     endpoint_config_ptr _cfg;
     semaphore _creds_sem;
     semaphore _mpus_sem{max_client_mpu_in_flight};
+    semaphore _buffered_dl_sem{max_client_buffered_downloads_in_flight};
     timer<seastar::lowres_clock> _creds_invalidation_timer;
     timer<seastar::lowres_clock> _creds_update_timer;
     aws_credentials _credentials;
@@ -125,7 +127,7 @@ class client : public enable_shared_from_this<client> {
         uint64_t read_bytes = 0;
         uint64_t write_bytes = 0;
         uint64_t prefetch_bytes = 0;
-        uint64_t downloads_blocked_on_memory = 0;
+        uint64_t downloads_starving_on_max_concurrency = 0;
         seastar::metrics::metric_groups metrics;
         group_client(std::unique_ptr<http::connection_factory> f, unsigned max_conn);
         void register_metrics(std::string class_name, std::string host);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -37,6 +37,8 @@ static constexpr unsigned maximum_parts_in_piece = 10'000;
 // https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingObjects.html
 static constexpr size_t maximum_object_size = maximum_parts_in_piece * maximum_part_size;
 
+static constexpr size_t max_client_mpu_in_flight = 32;
+
 class range {
     friend struct fmt::formatter<range>;
 
@@ -111,6 +113,7 @@ class client : public enable_shared_from_this<client> {
     std::string _host;
     endpoint_config_ptr _cfg;
     semaphore _creds_sem;
+    semaphore _mpus_sem{max_client_mpu_in_flight};
     timer<seastar::lowres_clock> _creds_invalidation_timer;
     timer<seastar::lowres_clock> _creds_update_timer;
     aws_credentials _credentials;


### PR DESCRIPTION
### Problem

The S3 client used a shared byte-based memory semaphore to throttle concurrent operations: every multipart upload part and every buffered download had to claim bytes from a single per-shard pool before it could proceed. This coupled the client's concurrency limit to the size of the memory budget handed to it, which is fragile — the right number of *operations* to run in parallel does not naturally derive from the number of *bytes* available, and the two concerns drift apart easily (e.g. an operator tuning the memory budget unintentionally changes how many uploads can run at once, and vice versa). The same byte pool was also used to bound downloads, mixing two unrelated workloads behind one knob.

### Changes

This series is a tactical move to decouple the S3 client's bounding mechanism from its memory allocation. The byte semaphore is replaced with two dedicated counting semaphores that limit operations directly:

- `put_object` no longer claims memory — it streams data through `copy_to` with a fixed 64 KiB `_transmit_size`, so it is bounded already (consistent with how we don't gate file-to-file or stream-to-stream copies on a memory semaphore).
- Multipart upload concurrency is now bounded by a dedicated per-client MPU counting semaphore (`_mpus_sem`, `max_client_mpu_in_flight = 32` units). Concurrency was `_max_multipart_concurrency = 16` before; `max_client_mpu_in_flight = 32` is the new, single source of truth (it is also passed to `max_concurrent_for_each` in `multipart_upload` and `copy_s3_object`, so the local constant is dropped).
- Buffered download concurrency (today only `chunked_download_source`) is bounded by a dedicated per-client counting semaphore (`_buffered_dl_sem`, `max_client_buffered_downloads_in_flight = 32` units). Back-pressure semantics shift from per-buffer (claim bytes for every buffer) to per-fiber: a unit is opportunistically held by the filling fiber; when it cannot be acquired and buffers are still queued, the fiber parks on `_bg_fiber_cv` until either the queue drains or a unit becomes available. The number of such waits is exposed via a new per-group counter `downloads_starving_on_max_concurrency`. Per-fiber memory remains bounded by the existing `_max_buffers_size` (5 MiB) watermark inside the fiber loop.
- All remnants of the old memory semaphore are removed: the `_memory` field, `claim_memory()`, and the `semaphore& memory` parameter on `client::client` / `client::make`. `make_object_storage_client` keeps its `semaphore& memory` parameter because the GCS wrapper still needs it.
- The obsolete `do_test_chunked_download_data_source_memory` unit test is removed — it exercised the per-buffer `guard_mem(1_MiB)` path that no longer exists.

### Memory footprint estimate

With the byte semaphore gone, the buffered memory a client may hold is now bounded by the product of the two counting semaphores and the per-operation watermark:

- **Buffered downloads**: at most `max_client_buffered_downloads_in_flight × _max_buffers_size = 32 × 5 MiB = 160 MiB` per client per shard. Each `chunked_download_source` holds at most `_max_buffers_size` worth of queued buffers; a 33rd source will not start filling until one of the running ones releases its slot.
- **Multipart uploads**: at most `max_client_mpu_in_flight × part_size = 32 × part_size` per client per shard. `part_size` is the caller-chosen upload part size, bounded by `[minimum_part_size = 5 MiB, maximum_part_size = 5 GiB]`. In practice callers pick sizes close to `minimum_part_size` (giving ~160 MiB in flight), so realistic worst case is comparable to downloads; the theoretical worst case is only reached for objects large enough to need multi-GiB parts.

Roughly speaking, a fully saturated client holds on the order of **~320 MiB** of transfer buffers per shard under normal part sizes.

### Issue

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1917
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2563
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2052

### Backport

No backport needed; this addresses possible problems with KS on object_store.
