### PR TITLE
test/cqlpy: teach run-cassandra to also run "nodetool" via Docker

### DIFF
--- a/test/cqlpy/README.md
+++ b/test/cqlpy/README.md
@@ -273,17 +273,9 @@ test/cqlpy/run-cassandra --docker=4.1.11   # specific patch release
 test/cqlpy/run-cassandra --docker=3.11
 ```
 
-A small number of tests invoke `nodetool` (set via the `NODETOOL` environment
-variable). When using `--docker` there is no local `nodetool` binary, so you
-need to supply one - we haven't yet implemented the ability to use the one in
-Docker. For now, you'll need to point `NODETOOL` at the `nodetool` script from
-a downloaded Cassandra tarball (see _Precompiled Cassandra_ below) - you do
-not need to run that Cassandra, you only need the script:
-
-```
-export NODETOOL=/tmp/apache-cassandra-5.0.3/bin/nodetool
-test/cqlpy/run-cassandra --docker test_file.py
-```
+A small number of tests invoke `nodetool`. When using `--docker`, `nodetool`
+is also taken from the Docker image automatically - no local installation
+or explicit override of `NODETOOL` is needed.
 
 **`--java-docker[=JAVA_VERSION]`**: a lighter alternative for when you have a
 local Cassandra installation but lack a suitable Java version on the host.

--- a/test/cqlpy/run-cassandra
+++ b/test/cqlpy/run-cassandra
@@ -369,6 +369,16 @@ else:
     cmd = run_cassandra_cmd
     check_cql = run.check_cql
 
+# When we run Cassandra using Docker (--docker), nodetool is also available
+# there. Set the NODETOOL environment variable that nodetool.py uses to find
+# the nodetool tool - so the user does not need to supply one. We run nodetool
+# via a short-lived container from the same image, connecting to Cassandra
+# over the host network. This is a slow way to run nodetool, but it is good
+# enough for running tests that only make a handful of nodetool calls, if any.
+if args.docker:
+    docker = shutil.which('docker')
+    os.environ['NODETOOL'] = f'{docker} run --rm --network host cassandra:{args.docker} nodetool'
+
 pid = run.run_with_temporary_dir(cmd)
 ip = run.pid_to_ip(pid)
 


### PR DESCRIPTION
The test/cqlpy/run-cassandra script makes it quite easy to run test/cqlpy tests against Cassandra, which is important for checking compatibility.

Unfortunately, modern Linux distributions no longer have Cassandra or even the specific versions of Java that it needs. In a recent patch we introduced the option "--docker" which allows run-cassandra to automatically download and efficiently run any version of Cassandra (and its requisite Java) from docker.

We forgot that some tests need to run "nodetool", and nodetool is also no longer a part of modern Linux distros, and also requires specific versions of Java :-(

So in this patch we just make "--docker" use nodetool from the same docker image that we get for Cassandra (Cassandra's images include nodetool).

This is NOT fast - every invocation of nodetool in this way takes a few seconds. But it run-cassandra is only used rarely, and only rarely needs nodetool and when it does, it does perhaps a couple of invocations, so I consider this simple implementation good enough.