### PR TITLE
 raft_group0_client: start_operation: handle use_pre_raft_procedures after starting group0

### DIFF
--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -256,9 +256,28 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source& 
 
     std::pair<rwlock::holder, group0_upgrade_state> upgrade_lock_and_state = co_await get_group0_upgrade_state();
     auto [upgrade_lock_holder, upgrade_state] = std::move(upgrade_lock_and_state);
+    auto make_legacy_guard = [&] {
+        return group0_guard {
+            std::make_unique<group0_guard::impl>(
+                semaphore_units<>{},
+                semaphore_units<>{},
+                utils::UUID{},
+                generate_group0_state_id(utils::UUID{}),
+                std::move(upgrade_lock_holder),
+                false
+            )
+        };
+    };
     switch (upgrade_state) {
+        case group0_upgrade_state::use_pre_raft_procedures:
+            if (!_raft_gr.started_group0()) {
+                co_return make_legacy_guard();
+            }
+            [[fallthrough]];
         case group0_upgrade_state::synchronize:
-            logger.info("start_operation: waiting until local node leaves synchronize state to start a group 0 operation");
+            logger.info("start_operation: waiting until local node in state {} completes upgrade to group 0",
+                    upgrade_state == group0_upgrade_state::use_pre_raft_procedures
+                    ? "use_pre_raft_procedures" : "synchronize");
             upgrade_lock_holder.return_all();
             co_await when_any(wait_until_group0_upgraded(as), sleep_abortable(std::chrono::seconds{10}, as));
             // Checks whether above wait returned due to sleep timeout, which confirms the upgrade procedure stuck case.
@@ -300,18 +319,7 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source& 
 
         case group0_upgrade_state::recovery:
             logger.warn("starting operation in RECOVERY mode (using old procedures)");
-            [[fallthrough]];
-        case group0_upgrade_state::use_pre_raft_procedures:
-            co_return group0_guard {
-                std::make_unique<group0_guard::impl>(
-                    semaphore_units<>{},
-                    semaphore_units<>{},
-                    utils::UUID{},
-                    generate_group0_state_id(utils::UUID{}),
-                    std::move(upgrade_lock_holder),
-                    false
-                )
-            };
+            co_return make_legacy_guard();
     }
 }
 

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -259,14 +259,14 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source& 
     switch (upgrade_state) {
         case group0_upgrade_state::synchronize:
             logger.info("start_operation: waiting until local node leaves synchronize state to start a group 0 operation");
-            upgrade_lock_holder.release();
+            upgrade_lock_holder.return_all();
             co_await when_any(wait_until_group0_upgraded(as), sleep_abortable(std::chrono::seconds{10}, as));
             // Checks whether above wait returned due to sleep timeout, which confirms the upgrade procedure stuck case.
             // Returns the corresponding runtime error in such cases.
             upgrade_lock_and_state = co_await get_group0_upgrade_state();
             upgrade_lock_holder = std::move(upgrade_lock_and_state.first);
             upgrade_state = std::move(upgrade_lock_and_state.second);
-            upgrade_lock_holder.release();
+            upgrade_lock_holder.return_all();
             if (upgrade_state != group0_upgrade_state::use_post_raft_procedures) {
                 throw std::runtime_error{
                     "Cannot perform schema or topology changes during this time; the cluster is currently upgrading to use Raft for schema operations."

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -187,6 +187,9 @@ public:
     bool is_group0_alive() const {
         return _group0_is_alive;
     }
+    bool started_group0() const {
+        return _group0_id.has_value();
+    }
 };
 
 // Implementation of `direct_failure_detector::pinger` which uses DIRECT_FD_PING verb for pinging.

--- a/test/cluster/test_joining_node_as_seed.py
+++ b/test/cluster/test_joining_node_as_seed.py
@@ -1,0 +1,58 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import asyncio
+import logging
+
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_joining_node_as_seed(manager: ManagerClient) -> None:
+    """
+    1. Add node A.
+    2. Add node B with seeds={A}, but block it via an error injection after it joins group0, and before it sets its
+    local group0 upgrade state to synchronize and later to use_post_raft_procedures.
+    3. Add node C with seeds={B}, so that B starts handling C's join request while still using use_pre_raft_procedures.
+    4. Unblock B after it starts handling C's join request (and calls raft_group0_client::start_operation()).
+    5. Make sure B and C successfully start.
+
+    Reproducer for https://scylladb.atlassian.net/browse/SCYLLADB-2843.
+    """
+    logger.info("Starting node A")
+    node_a = await manager.server_add()
+
+    injection = 'join_group0_pause_before_config_check'
+    logger.info(f"Adding stopped node B with {injection} enabled")
+    node_b = await manager.server_add(start=False, config={
+        'error_injections_at_startup': [injection],
+    })
+
+    logger.info("Starting node B")
+    node_b_start = asyncio.create_task(manager.server_start(node_b.server_id, seeds=[node_a.ip_addr]))
+
+    node_b_log = await manager.server_open_log(node_b.server_id)
+    await node_b_log.wait_for(f"{injection}: waiting for message", timeout=60)
+
+    logger.info("Adding node C")
+    node_c_add = asyncio.create_task(manager.server_add(seeds=[node_b.ip_addr]))
+
+    # Lower timeout to fail the test faster without the fix.
+    await node_b_log.wait_for("waiting until local node in state use_pre_raft_procedures completes upgrade to group 0",
+                              timeout=15)
+
+    logger.info("Unblocking node B")
+    await manager.api.message_injection(node_b.ip_addr, injection)
+
+    logger.info("Waiting for nodes B and C to start")
+    await node_b_start
+    await node_c_add

--- a/test/cluster/test_view_build_status.py
+++ b/test/cluster/test_view_build_status.py
@@ -579,7 +579,7 @@ async def test_view_build_status_with_synchronize_wait(manager: ManagerClient):
     })
     task = asyncio.create_task(manager.server_start(new_server.server_id))
     log = await manager.server_open_log(new_server.server_id)
-    await log.wait_for("start_operation: waiting until local node leaves synchronize state to start a group 0 operation")
+    await log.wait_for("start_operation: waiting until local node in state synchronize completes upgrade to group 0")
     await manager.api.message_injection(new_server.ip_addr, 'sleep_in_synchronize')
 
     await task


### PR DESCRIPTION
https://scylladb.atlassian.net/browse/SCYLLADB-2843 uncovered a scenario
(visible in the new test) where a node can initiate a group0 operation (and
thus call `raft_group0_client::start_operation()`) just after it starts the group0
server, but before it updates its group0 upgrade state to
`synchronize` and later to `use_post_raft_procedures`.
`raft_group0_client::start_operation()` currently doesn't work properly in this
case. It returns a legacy guard with `_read_apply_mutex_holder` owning 0
semaphore units, which makes `add_entry()` fail
`SCYLLA_ASSERT(_read_apply_mutex_holder.count() == 1);` in
`group0_guard::impl::release_read_apply_mutex()`.

The fix extends 5ff693eff672630677a9ba8bf9438385f838717e to cover the
discovered scenario.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2843

This PR is submitted directly to 2026.1, as 2026.2 and newer branches don't
have the issue being fixed. The buggy code has been removed from those
branches.

Backport to the supported branches older than 2026.1. The bug being fixed
could be problematic and the fix is safe.