### PR TITLE
main: start batchlog_manager before join_cluster()

### DIFF
--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -468,7 +468,7 @@ future<db::all_batches_replayed> db::batchlog_manager::replay_all_failed_batches
     db::all_batches_replayed all_replayed = all_batches_replayed::yes;
     // rate limit is in bytes per second. Uses Double.MAX_VALUE if disabled (set to 0 in cassandra.yaml).
     // max rate is scaled by the number of nodes in the cluster (same as for HHOM - see CASSANDRA-5272).
-    auto throttle = _replay_rate / _qp.proxy().get_token_metadata_ptr()->count_normal_token_owners();
+    auto throttle = _replay_rate / std::max<uint64_t>(1, _qp.proxy().get_token_metadata_ptr()->count_normal_token_owners());
     utils::rate_limiter limiter(throttle);
 
     auto schema = _qp.db().find_schema(system_keyspace::NAME, system_keyspace::BATCHLOG);
@@ -509,7 +509,7 @@ future<db::all_batches_replayed> db::batchlog_manager::replay_all_failed_batches
     db::all_batches_replayed all_replayed = all_batches_replayed::yes;
     // rate limit is in bytes per second. Uses Double.MAX_VALUE if disabled (set to 0 in cassandra.yaml).
     // max rate is scaled by the number of nodes in the cluster (same as for HHOM - see CASSANDRA-5272).
-    auto throttle = _replay_rate / _qp.proxy().get_token_metadata_ptr()->count_normal_token_owners();
+    auto throttle = _replay_rate / std::max<uint64_t>(1, _qp.proxy().get_token_metadata_ptr()->count_normal_token_owners());
     utils::rate_limiter limiter(throttle);
 
     auto schema = _qp.db().find_schema(system_keyspace::NAME, system_keyspace::BATCHLOG_V2);

--- a/main.cc
+++ b/main.cc
@@ -2451,6 +2451,18 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_server_client_routes(ctx).get();
             });
 
+            checkpoint(stop_signal, "starting batchlog manager");
+            db::batchlog_manager_config bm_cfg;
+            bm_cfg.replay_timeout = cfg->write_request_timeout_in_ms() * 1ms * 2;
+            bm_cfg.replay_rate = cfg->batchlog_replay_throttle_in_kb() * 1000;
+            bm_cfg.delay = std::chrono::milliseconds(cfg->ring_delay_ms());
+            bm_cfg.replay_cleanup_after_replays = cfg->batchlog_replay_cleanup_after_replays();
+
+            bm.start(std::ref(qp), std::ref(sys_ks), std::ref(feature_service), bm_cfg).get();
+            auto stop_batchlog_manager = defer_verbose_shutdown("batchlog manager", [&bm] {
+                bm.stop().get();
+            });
+
             checkpoint(stop_signal, "join cluster");
             // Allow abort during join_cluster since bootstrap or replace
             // can take a long time.
@@ -2606,18 +2618,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 sl_controller.invoke_on_all([&lifecycle_notifier] (qos::service_level_controller& controller) {
                     return lifecycle_notifier.local().unregister_subscriber(&controller);
                 }).get();
-            });
-
-            checkpoint(stop_signal, "starting batchlog manager");
-            db::batchlog_manager_config bm_cfg;
-            bm_cfg.replay_timeout = cfg->write_request_timeout_in_ms() * 1ms * 2;
-            bm_cfg.replay_rate = cfg->batchlog_replay_throttle_in_kb() * 1000;
-            bm_cfg.delay = std::chrono::milliseconds(cfg->ring_delay_ms());
-            bm_cfg.replay_cleanup_after_replays = cfg->batchlog_replay_cleanup_after_replays();
-
-            bm.start(std::ref(qp), std::ref(sys_ks), std::ref(feature_service), bm_cfg).get();
-            auto stop_batchlog_manager = defer_verbose_shutdown("batchlog manager", [&bm] {
-                bm.stop().get();
             });
 
             checkpoint(stop_signal, "starting load meter");


### PR DESCRIPTION
Fixes a startup-ordering race where the streaming topology command during decommission of another node arrived while sharded<batchlog_manager> was still uninitialized, causing an assertion failure in unbootstrap():

```
sharded<db::batchlog_manager>::local(): Assertion `local_is_initialized()` failed.
Aborting on shard 0, in scheduling group streaming.
```

The race window opened between STATUS=NORMAL gossip broadcast (inside join_topology()) and the original bm.start() call ~158 lines later in main.cc. During this window, the Raft coordinator could drive barrier_and_drain -> stream_ranges -> unbootstrap() on the decommissioning node, hitting the uninitialized bm.

Fix: move bm.start() to before join_cluster(). All dependencies (qp, sys_ks, feature_service) are already initialized at that point.

Also, clamping the divisor to at least 1 in both replay_all_failed_batches_v1 and replay_all_failed_batches_v2 to avoid division by zero in case of no token owners assigned yet (which can happen now after the startup order changed). With the divisor clamped, a replay attempted with zero normal token owners degenerates to an effectively unthrottled pass over the  batchlog rather than aborting or hanging. Verified empirically that storage_proxy handles this window gracefully: nodes survive it, there is no secondary crash or stall, and the cluster reaches healthy recovery once token metadata is populated.

Fixes: SCYLLADB-2822

No backport: This is a problem in scylla, but it's rare occurrence currently only known in tests (with a very tight timing), and there is some risk (changing the startup and shutdown order). Therefore not backporting now.