### PR TITLE
test: add pyrightconfig.json to fix python language server resolution

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,8 @@
+// Pyright / Pylance configuration file.
+// Forces the Python language server to search the workspace root first,
+// which prevents shadowing the local './test' package with Python's standard library 'test' module.
+{
+  "extraPaths": [
+    "."
+  ]
+}


### PR DESCRIPTION
Python's standard library includes a top-level package named 'test' for regression testing. When working with ScyllaDB's python test suite under './test/', language servers like Pylance/Pyright resolve 'test' absolute imports (e.g. from test.pylib...) to the standard library's 'test' package instead of the local repository folder.

Adding 'pyrightconfig.json' with 'extraPaths' pointing to the workspace root prioritizes the repository root during import resolution, resolving the shadowing issue and restoring 'Go to Definition' and 'Go to Implementation' capabilities for files under './test/'.

Backport: no, developer experience improvement