### PR TITLE
test/cqlpy: deflake test_row_ttl_expiration

### DIFF
--- a/test/cqlpy/test_ttl_row.py
+++ b/test/cqlpy/test_ttl_row.py
@@ -369,22 +369,31 @@ def test_row_ttl_expiration(cql, test_keyspace, ttl_period, typ):
         # my birth date...), it should be ignored and this row will never be
         # expired.
         cql.execute(f'INSERT INTO {table} (p, e) values (4, {to_ttl(typ, 162777600)})')
-        # Row 5 has an expiration one second into the future, so should
+        # Row 5 has an expiration two seconds into the future, so should
         # expire by the time the test ends.
-        cql.execute(f'INSERT INTO {table} (p, e) values (5, {to_ttl(typ, time.time()+1)})')
-        # Row 6 is created with an expiration one second into the future,
+        cql.execute(f'INSERT INTO {table} (p, e) values (5, {to_ttl(typ, time.time()+2)})')
+        # Row 6 is created with an expiration two seconds into the future,
         # but immediately, presumably before it can expire, we change its
         # expiration time to never expire.
-        cql.execute(f'INSERT INTO {table} (p, e) values (6, {to_ttl(typ, time.time()+1)})')
+        # The "+2" here, matching row 5, must not be lowered: the expiration is
+        # truncated to whole seconds, so "+1" can leave almost no slack before
+        # the row counts as expired, letting the expiration scanner delete row 6
+        # in the window between this INSERT and the cancelling UPDATE - the row
+        # deletion is unconditional and clobbers the e=NULL (SCYLLADB-2782).
+        # "+2" leaves a full second for the UPDATE to land first, and keeping it
+        # equal to row 5 ensures row 6 is past its original expiration time by
+        # the time we check below, so its survival still proves the cancellation.
+        cql.execute(f'INSERT INTO {table} (p, e) values (6, {to_ttl(typ, time.time()+2)})')
         cql.execute(f'UPDATE {table} SET e=NULL WHERE p=6')
         # Row 7 is created with an expiration one hour into the future, so
         # it will remain alive until the test ends.
         cql.execute(f'INSERT INTO {table} (p, e) values (7, {to_ttl(typ, time.time()+3600)})')
-        # Row 1, 3, and 5 are expected to expire soon: row 5 will take one
-        # second, plus maybe an extra two ttl_periods until really expired.
+        # Row 1, 3, and 5 are expected to expire soon: row 5 will take two
+        # seconds, plus maybe an extra two ttl_periods until really expired.
         # Let's use a little higher timeout, just in case. But in the
-        # successful case, we won't need to wait so long.
-        deadline = time.time() + 3*ttl_period + 2
+        # successful case, we won't need to wait so long. The "+3" tracks row
+        # 5's two-second expiration plus one second of slack.
+        deadline = time.time() + 3*ttl_period + 3
         while time.time() < deadline:
             p_vals = {row.p for row in cql.execute(f'SELECT p from {table}')}
             if {1, 3, 5}.isdisjoint(p_vals):


### PR DESCRIPTION
Row 6 is inserted with an expiration one second out, then immediately cancelled with UPDATE ... SET e=NULL. The test expects it to survive.

The expiration is truncated to whole seconds. to_ttl() does int(time.time()+1), and the scanner compares against gc_clock's one-second resolution. So the real grace is 1 - frac(time.time()). That is up to a second, but only milliseconds when the insert lands near a second boundary.

If the INSERT and the cancelling UPDATE land in different whole seconds, the scanner can read row 6's old expiration in the gap between them. It finds it past and deletes the whole row. The delete is unconditional. It clobbers the e=NULL, and row 6 vanishes. The window is narrow and timing-dependent, hence the intermittent debug failures.

Bump rows 5 and 6 from "+1" to "+2". The grace becomes one to two seconds. The UPDATE always has a full second to land first. The window now opens only under a multi-second stall.

Keep the two rows equal. Row 6 still passes its original expiration before the assertion runs, so its survival still proves the cancel worked.

Bump the deadline slack from +2 to +3. Row 5 now takes two seconds, not one, so this restores the original margin.

Fixes SCYLLADB-2782

The code is present on 2026.2, backport to that version.