### PR TITLE
service_levels: add workload_type metric

### DIFF
--- a/scripts/metrics-config.yml
+++ b/scripts/metrics-config.yml
@@ -72,3 +72,6 @@
 "alternator/stats.cc":
   params:
     group_name: "alternator"
+"service/qos/service_level_controller.cc":
+  groups:
+    "134": "service_level"

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -21,6 +21,7 @@
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/core/timer.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/metrics.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shard_id.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -31,9 +32,12 @@
 #include "service/topology_state_machine.hh"
 #include <seastar/core/reactor.hh>
 #include "utils/managed_string.hh"
+#include "utils/labels.hh"
 
 namespace qos {
 static logging::logger sl_logger("service_level_controller");
+static const seastar::metrics::label service_level_label("service_level");
+static const seastar::metrics::label workload_type_label("workload_type");
 
 sstring service_level_controller::default_service_level_name = "default";
 constexpr const char* scheduling_group_name_pattern = "sl:{}";
@@ -125,6 +129,28 @@ void service_level_controller::reload_distributed_data_accessor(cql3::query_proc
     auto accessor = static_pointer_cast<qos::service_level_controller::service_level_distributed_data_accessor>(
         make_shared<qos::raft_service_level_distributed_data_accessor>(qp, g0));
     set_distributed_data_accessor(std::move(accessor));
+}
+
+void service_level_controller::register_metrics() {
+    if (this_shard_id() != global_controller) {
+        return;
+    }
+    _metrics = {};
+    namespace sm = seastar::metrics;
+    auto new_metrics = sm::metric_groups();
+    std::vector<sm::metric_definition> metrics;
+    metrics.reserve(_service_levels_db.size());
+    for (const auto& [name, sl] : _service_levels_db) {
+        const auto workload_type = service_level_options::to_string(sl.slo.workload);
+        metrics.emplace_back(sm::make_gauge("workload_type", sm::description("Configured workload type for each service level. 0 - unspecified, 1 - batch, 2 - interactive."), {
+            service_level_label(name),
+            workload_type_label(workload_type),
+        }, [&sl] {
+            return static_cast<unsigned>(sl.slo.workload);
+        })(basic_level));
+    }
+    new_metrics.add_group("service_level", std::move(metrics));
+    _metrics = std::exchange(new_metrics, {});
 }
 
 void service_level_controller::do_abort() noexcept {
@@ -508,6 +534,7 @@ future<>  service_level_controller::notify_service_level_added(sstring name, ser
             unsigned sl_idx = internal::scheduling_group_index(sl_data.sg);
             _sl_lookup[sl_idx].first = &(result.first->first);
             _sl_lookup[sl_idx].second = &(result.first->second);
+            register_metrics();
         }
     });
 
@@ -540,6 +567,7 @@ future<> service_level_controller::notify_service_level_updated(sstring name, se
             }
 
             sl_it->second.slo = slo;
+            register_metrics();
         });
     }
     return f;
@@ -560,6 +588,7 @@ future<> service_level_controller::notify_service_level_removed(sstring name) {
             .sg = sl_it->second.sg,
         };
         _service_levels_db.erase(sl_it);
+        register_metrics();
         co_return co_await seastar::async( [this, name, sl_info] {
             _subscribers.thread_for_each([name, sl_info] (qos_configuration_change_subscriber* subscriber) {
                 try {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -14,6 +14,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/metrics_registration.hh>
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/core/lowres_clock.hh>
 
@@ -208,6 +209,7 @@ private:
     std::set<sstring> _effectively_dropped_sls;
     std::pair<const sstring*, service_level*> _sl_lookup[max_scheduling_groups()];
     service_level _default_service_level;
+    seastar::metrics::metric_groups _metrics;
     service_level_distributed_data_accessor_ptr _sl_data_accessor;
     sharded<auth::service>& _auth_service;
     locator::shared_token_metadata& _token_metadata;
@@ -432,6 +434,7 @@ private:
     future<> notify_service_level_updated(sstring name, service_level_options slo);
     future<> notify_service_level_removed(sstring name);
     future<> notify_effective_service_levels_cache_reloaded();
+    void register_metrics();
 
     enum class  set_service_level_op_type {
         add_if_not_exists,

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -708,3 +708,40 @@ async def test_per_service_level_cql_request_latency_histogram(manager: ManagerC
                 logger.warning("Paused CQL request failed while cleaning up", exc_info=True)
         await manager.api.disable_injection(server.ip_addr, "transport_cql_request_pause")
         safe_driver_shutdown(cluster_a)
+
+
+async def test_service_level_metrics(manager: ManagerClient) -> None:
+    """
+    Verify service level workload type metrics
+    """
+    server = await manager.server_add(config=auth_config)
+    cql, hosts = await manager.get_ready_cql([server])
+
+    WORKLOAD_UNSPECIFIED = 0
+    WORKLOAD_BATCH = 1
+    WORKLOAD_INTERACTIVE = 2
+
+    async def verify_initial_metrics():
+        m = await manager.metrics.query(server.ip_addr)
+        default_val = m.get("scylla_service_level_workload_type", {"service_level": "default"})
+        driver_val = m.get("scylla_service_level_workload_type", {"service_level": "driver"})
+        assert default_val == WORKLOAD_UNSPECIFIED
+        assert driver_val == WORKLOAD_BATCH
+        return True
+
+    logger.info("Verifying initial service level metrics")
+    await wait_for(verify_initial_metrics, deadline=time.time() + 30)
+
+    sl_name = "test_interactive_sl"
+    logger.info(f"Creating service level {sl_name}")
+    await cql.run_async(f"CREATE SERVICE LEVEL {sl_name} WITH workload_type='interactive'", host=hosts[0])
+
+    async def verify_new_sl_metric():
+        m = await manager.metrics.query(server.ip_addr)
+        new_sl_val = m.get("scylla_service_level_workload_type", {"service_level": sl_name})
+        assert new_sl_val == WORKLOAD_INTERACTIVE
+        return True
+
+    logger.info(f"Verifying service level metric for {sl_name}")
+    await wait_for(verify_new_sl_metric, deadline=time.time() + 30)
+


### PR DESCRIPTION
Add a metric that exports workload type information.

Fixes: SCYLLADB-2860

Backport: none, a new feature.