### PR TITLE
storage_proxy: drop unused argument from storage_proxy_stats::split_stats::register_metrics_for

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3264,7 +3264,7 @@ inline uint64_t& storage_proxy_stats::split_stats::get_ep_stat(const locator::to
     try {
         sstring dc = topo.get_datacenter(ep);
         if (_auto_register_metrics) {
-            register_metrics_for(dc, ep);
+            register_metrics_for(dc);
         }
         return _dc_stats[dc].val;
     } catch (...) {
@@ -3284,7 +3284,7 @@ void storage_proxy_stats::split_stats::register_metrics_local() {
     _metrics = std::exchange(new_metrics, {});
 }
 
-void storage_proxy_stats::split_stats::register_metrics_for(sstring dc, locator::host_id ep) {
+void storage_proxy_stats::split_stats::register_metrics_for(sstring dc) {
     namespace sm = seastar::metrics;
 
     // if this is the first time we see an endpoint from this DC - add a

--- a/service/storage_proxy_stats.hh
+++ b/service/storage_proxy_stats.hh
@@ -54,7 +54,7 @@ public:
     split_stats(const sstring& category, const sstring& short_description_prefix, const sstring& long_description_prefix, const sstring& op_type, bool auto_register_metrics = true);
 
     void register_metrics_local();
-    void register_metrics_for(sstring dc, locator::host_id ep);
+    void register_metrics_for(sstring dc);
 
     /**
      * Get a reference to the statistics counter corresponding to the given

--- a/test/boost/storage_proxy_test.cc
+++ b/test/boost/storage_proxy_test.cc
@@ -114,7 +114,6 @@ SEASTAR_TEST_CASE(test_get_restricted_ranges) {
 }
 
 SEASTAR_THREAD_TEST_CASE(test_split_stats) {
-    auto ep1 = locator::host_id{};
     auto sg1 = create_scheduling_group("apa1", 100).get();
     auto sg2 = create_scheduling_group("apa2", 100).get();
 
@@ -139,8 +138,8 @@ SEASTAR_THREAD_TEST_CASE(test_split_stats) {
     // Point being is that either the above should not happen, or 
     // split_stats should be resilient to being called from different
     // scheduling group.
-    stats1->register_metrics_for("DC1", ep1);
-    stats2->register_metrics_for("DC1", ep1);
+    stats1->register_metrics_for("DC1");
+    stats2->register_metrics_for("DC1");
 }
 
 SEASTAR_TEST_CASE(test_drop_table_during_range_scan) {


### PR DESCRIPTION
Cleanup, no backport needed.