### PR TITLE
test/pylib: add retry/timeout to S3 release listing

### DIFF
--- a/test/pylib/version_fetch_utils.py
+++ b/test/pylib/version_fetch_utils.py
@@ -35,7 +35,12 @@ def _list_scylla_release_entries(bucket: str, prefix: str, pack: str = "") -> li
     pack_part = rf"{re.escape(pack)}-" if pack else ""    
     pattern = re.compile(rf"^scylla(?:db)?-{pack_part}\d{{4}}\.\d+(?:\.\d+)?(?:/|$|[~.-])")
 
-    s3 = boto3.client("s3", region_name="us-east-1", config=Config(signature_version=UNSIGNED))
+    s3 = boto3.client("s3", region_name="us-east-1", config=Config(
+        signature_version=UNSIGNED,
+        connect_timeout=60,
+        read_timeout=60,
+        retries={"max_attempts": 10, "mode": "adaptive"},
+    ))
 
     files = []
     folders = []


### PR DESCRIPTION
The S3 listing call in `_list_scylla_release_entries()` that resolves relocatable release versions used the default boto3 client config. During transient CI network blips the `list_objects_v2()` request to **s3.amazonaws.com/downloads.scylladb.com** exhausted botocore's default 5 retry attempts and surfaced an unhandled `ConnectTimeoutError / EndpointConnectionError` straight into test setup, failing the version fetch during fixture setup.

Configure an explicit retry/timeout strategy on the S3 client `(connect_timeout=60, read_timeout=60, adaptive retries with max_attempts=10)` so the listing survives short connectivity hiccups, the same way the download path is already resilient (retry=40).

Seen in:
- scylla-ci https://jenkins.scylladb.com/job/scylla-master/job/scylla-ci/30147/ - test.py - release: test/cluster/test_audit.py::test_upgrade_preserves_ddl_audit_for_tables test/cluster/test_sstable_compression_config.py::test_default_compression_on_upgrade 
- master-nightly https://jenkins.scylladb.com/job/scylla-master/job/master-nightly/367/ - test_upgrade_preserves_ddl_audit_for_tables, test_upgrade_and_rollback 

Both failed at the same frame:
`E           botocore.exceptions.EndpointConnectionError: Could not connect to the endpoint URL: "https://s3.amazonaws.com/downloads.scylladb.com?list-type=2&prefix=downloads%2Fscylla%2Frelocatable%2Fscylladb-2025.1%2F&delimiter=%2F&encoding-type=url"`

Fixes: https://scylladb.atlassian.net/browse/RELENG-632

No backport: the affected code is only in master.
