### PR TITLE
restrictions: avoid pushing CK bounds into static-column index

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -2634,6 +2634,9 @@ void statement_restrictions::add_clustering_restrictions_to_idx_ck_prefix(const 
         }
         const auto col = on_col->column;
         auto col_in_index = idx_tbl_schema.get_column_definition(col->name());
+        if (!col_in_index) {
+            break;
+        }
         auto replaced = replace_column_def(e.filter, col_in_index);
         auto a = to_predicate_on_column(replaced, col_in_index, &idx_tbl_schema);
         _idx_tbl_ck_prefix->push_back(std::move(a));

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -2200,4 +2200,22 @@ SEASTAR_TEST_CASE(test_large_allocations) {
 }
 #endif
 
+// Reproducer for SCYLLADB-2898.
+//
+// Static-column index views do not contain base clustering-key columns, so CK
+// restrictions must not be pushed into the index-table clustering prefix.
+SEASTAR_TEST_CASE(test_global_index_on_static_column_with_ck_restriction) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE TABLE t (pk int, ck int, s int static, r int, PRIMARY KEY (pk, ck))").get();
+        e.execute_cql("CREATE INDEX ON t(s)").get();
+        e.execute_cql("INSERT INTO t (pk, ck, s, r) VALUES (1, 2, 5, 10)").get();
+        eventually([&] {
+            auto res = e.execute_cql("SELECT * FROM t WHERE pk = 1 AND s = 5 AND ck = 2").get();
+            assert_that(res).is_rows().with_rows({
+                {{int32_type->decompose(1)}, {int32_type->decompose(2)}, {int32_type->decompose(5)}, {int32_type->decompose(10)}},
+            });
+        });
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Static-column index views do not contain base clustering-key columns. When a query used a global index on a static column together with a CK restriction, statement_restrictions tried to translate the base CK restriction into an index-table CK-prefix restriction anyway.

The missing column lookup produced a null column definition, which was later dereferenced while building predicates and crashed Scylla.

Stop extending the index-table CK prefix once a base CK column is not present in the index schema. The CK restriction remains enforced by the base-table read/filtering path.

Fixes SCYLLADB-2898.

Scylla crash fix - should be backported to all supported versions.