### PR TITLE
repair: batch tablet mutations per table in add_repair_tablet_request

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2513,15 +2513,17 @@ future<> system_keyspace::get_repair_history(::table_id table_id, repair_history
     });
 }
 
-future<utils::chunked_vector<canonical_mutation>> system_keyspace::get_update_repair_task_mutations(const repair_task_entry& entry, api::timestamp_type ts) {
+future<mutation> system_keyspace::get_update_repair_task_mutation(const repair_task_entry& entry, api::timestamp_type ts) {
     // Default to timeout the repair task entries in 10 days, this should be enough time for the management tools to query
     constexpr int ttl = 10 * 24 * 3600;
     sstring req = format("INSERT INTO system.{} (task_uuid, operation, first_token, last_token, timestamp, table_uuid) VALUES (?, ?, ?, ?, ?, ?) USING TTL {}", REPAIR_TASKS, ttl);
     auto muts = co_await _qp.get_mutations_internal(req, internal_system_query_state(), ts,
             {entry.task_uuid.uuid(), repair_task_operation_to_string(entry.operation),
             entry.first_token, entry.last_token, entry.timestamp, entry.table_uuid.uuid()});
-    utils::chunked_vector<canonical_mutation> cmuts(muts.begin(), muts.end());
-    co_return cmuts;
+    if (muts.size() != 1) {
+        on_internal_error(slogger, fmt::format("expected 1 mutation got {}", muts.size()));
+    }
+    co_return std::move(muts[0]);
 }
 
 future<> system_keyspace::get_repair_task(tasks::task_id task_uuid, repair_task_consumer f) {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -435,7 +435,7 @@ public:
     using repair_history_consumer = noncopyable_function<future<>(const repair_history_entry&)>;
     future<> get_repair_history(table_id, repair_history_consumer f);
 
-    future<utils::chunked_vector<canonical_mutation>> get_update_repair_task_mutations(const repair_task_entry& entry, api::timestamp_type ts);
+    future<mutation> get_update_repair_task_mutation(const repair_task_entry& entry, api::timestamp_type ts);
     using repair_task_consumer = noncopyable_function<future<>(const repair_task_entry&)>;
     future<> get_repair_task(tasks::task_id task_uuid, repair_task_consumer f);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5632,6 +5632,8 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
         }
 
         auto ts = db_clock::now();
+        auto builder = tablet_mutation_builder_for_base_table(guard.write_timestamp(), table);
+        std::optional<mutation> repair_task_update;
         for (const auto& token : tokens) {
             auto tid = tmap.get_tablet_id(token);
             auto& tinfo = tmap.get_tablet_info(tid);
@@ -5641,10 +5643,7 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
                         locator::global_tablet_id{table, tid}, req_id));
             }
             auto last_token = tmap.get_last_token(tid);
-            updates.emplace_back(
-                tablet_mutation_builder_for_base_table(guard.write_timestamp(), table)
-                    .set_repair_task_info(last_token, repair_task_info, _feature_service)
-                    .build());
+            builder.set_repair_task_info(last_token, repair_task_info, _feature_service);
             db::system_keyspace::repair_task_entry entry{
                 .task_uuid   = tasks::task_id(repair_task_info.tablet_task_id.uuid()),
                 .operation   = db::system_keyspace::repair_task_operation::requested,
@@ -5655,8 +5654,21 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
             };
             if (_feature_service.tablet_repair_tasks_table) {
                 auto m = co_await _sys_ks.local().get_update_repair_task_mutation(entry, guard.write_timestamp());
-                updates.emplace_back(std::move(m));
+                if (repair_task_update) {
+                    if (!m.decorated_key().equal(*m.schema(), repair_task_update->decorated_key())) {
+                        on_internal_error(rtlogger, "add_repair_tablet_request(): repair task mutations have different partition keys");
+                    }
+                    repair_task_update->apply(std::move(m));
+                } else {
+                    repair_task_update = std::move(m);
+                }
             }
+        }
+        if (repair_task_update) {
+            updates.emplace_back(std::move(*repair_task_update));
+        }
+        if (!tokens.empty()) {
+            updates.emplace_back(builder.build());
         }
 
         sstring reason = format("Repair tablet by API request tokens={} tablet_task_id={}", tokens, repair_task_info.tablet_task_id);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5654,10 +5654,8 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
                 .table_uuid  = table,
             };
             if (_feature_service.tablet_repair_tasks_table) {
-                auto cmuts = co_await _sys_ks.local().get_update_repair_task_mutations(entry, guard.write_timestamp());
-                for (auto& m : cmuts) {
-                    updates.push_back(std::move(m));
-                }
+                auto m = co_await _sys_ks.local().get_update_repair_task_mutation(entry, guard.write_timestamp());
+                updates.emplace_back(std::move(m));
             }
         }
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1603,8 +1603,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         std::unordered_map<locator::tablet_transition_stage, background_action_holder> barriers;
         // Record the repair_time returned by the repair_tablet rpc call
         db_clock::time_point repair_time;
-        // Record the repair task update muations
-        utils::chunked_vector<canonical_mutation> repair_task_updates;
+        // Record the repair task update mutation
+        std::optional<mutation> repair_task_updates;
         service::session_id session_id;
         uint32_t repair_update_compaction_ctrl_retried = 0;
     };
@@ -2322,7 +2322,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         tablet_state.repair_time = db_clock::from_time_t(gc_clock::to_time_t(res.repair_time));
                         if (_feature_service.tablet_repair_tasks_table) {
                             entry.timestamp = db_clock::now();
-                            tablet_state.repair_task_updates = co_await _sys_ks.get_update_repair_task_mutations(entry, api::new_timestamp());
+                            tablet_state.repair_task_updates = co_await _sys_ks.get_update_repair_task_mutation(entry, api::new_timestamp());
                         }
                         rtlogger.info("Finished tablet repair host={} tablet={} duration={} repair_time={} request_type={}",
                                 dst, tablet, duration, res.repair_time, request_type);
@@ -2342,8 +2342,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                         .set_stage(last_token, locator::tablet_transition_stage::end_repair)
                                         .del_repair_task_info(last_token, _feature_service)
                                         .del_session(last_token);
-                        for (auto& m : tablet_state.repair_task_updates) {
-                            updates.push_back(m);
+                        if (tablet_state.repair_task_updates) {
+                            updates.push_back(canonical_mutation(*tablet_state.repair_task_updates));
                         }
                         // Skip update repair time in case hosts filter or dcs filter is set.
                         if (valid && is_filter_off) {


### PR DESCRIPTION
add_repair_tablet_request() was emitting one canonical_mutation per tablet into the group0 command, making command size O(tablets). That bloats the group0 command, due to per-canonical_mutation overheads, which dominate the size.

Build one mutation per table to amortize the costs.

Fixes SCYLLADB-2856

Backport: all supported branches are vulnerable, and it blocks repair from starting.