### PR TITLE
alternator: add s3 sink / source implementation

### DIFF
--- a/alternator/export.cc
+++ b/alternator/export.cc
@@ -7,8 +7,11 @@
  */
 
 #include "alternator/export.hh"
+#include <exception>
 #include <seastar/core/coroutine.hh>
 #include "utils/rjson.hh"
+#include "utils/s3/client.hh"
+#include <absl/functional/overload.h>
 #include <algorithm>
 #include <string>
 #include <string_view>
@@ -17,9 +20,9 @@ namespace alternator {
 
 // Interfaces for `sink` / `source` pipelines.
 // The `sink` pipeline consists of 3 stages:
-//   - formatter (see `export_pipeline_interface` interface in header) - serializes rjson::value as-is to simple binary format (JSON lines, Ion, CSV are required by Amazon specs),
-//   - compressor - optionally compresses the data - Amazon S3 requires support for gzip compression,
-//   - writer - writes the data to the storage (e.g. S3 or in-memory).
+//   - formatter (implements public interface `export_pipeline_interface`) - serializes rjson::value as-is to simple binary format (JSON lines, Ion, CSV are required by Amazon specs),
+//   - compressor (implements `compression_interface`) - optionally compresses the data - Amazon S3 requires support for gzip compression,
+//   - writer (implements `storage_sink_interface`) - writes the data to the storage (e.g. S3 or in-memory).
 // After construction user is expected to call `export_pipeline_interface::process()` with an item to export,
 // which will call a compressor and a writer for that item. After that the future will complete and user is free to call
 // `export_pipeline_interface::process()` with another item.
@@ -37,41 +40,41 @@ struct compression_interface {
 };
 
 // The `source` pipeline consists of 3 stages:
-//   - reader (see `import_pipeline_interface` interface in header) - reads the data from the storage (e.g. S3 or in-memory).
-//   - decompressor - optionally decompresses the data - Amazon S3 requires support for gzip compression,
-//   - parser - deserializes binary data to rjson::value as-is (JSON lines, Ion, CSV are required by Amazon specs),
+//   - reader (implements public interface `import_pipeline_interface`) - reads the data from the storage (e.g. S3 or in-memory).
+//   - decompressor (implements `decompression_interface`) - optionally decompresses the data - Amazon S3 requires support for gzip compression,
+//   - parser (implements `parsing_interface`) - deserializes binary data to rjson::value as-is (JSON lines, Ion, CSV are required by Amazon specs),
 // After pipeline construction (see `create_**` family of factory functions in header `export.hh`) user is expected to
-// call `import_pipeline_interface::read()`. This will read some data from the source and
+// call `import_pipeline_interface::read_all()`. This will read some data from the source and
 // call `decompression_interface::decompress()` with it, which will - optionally - decompress it,
 // then call `parsing_interface::parse()` with the decompressed data. The parser invokes the `on_item` (passed to the pipeline factory function) callback
-// for each parsed item.
+// for each parsed item. Once all data is read, `read_all()` future will complete. After that user is expected to call `import_pipeline_interface::close()` to finalize the pipeline.
 struct parsing_interface {
     virtual seastar::future<> parse(std::span<const std::byte>) = 0;
-    virtual seastar::future<> flush_and_close() = 0;
+    virtual seastar::future<> close() = 0;
     virtual ~parsing_interface() = default;
 };
 
 struct decompression_interface {
     virtual seastar::future<> decompress(std::span<const std::byte>) = 0;
-    virtual seastar::future<> flush_and_close() = 0;
+    virtual seastar::future<> close() = 0;
     virtual ~decompression_interface() = default;
 };
 
 // In memory sink - stores data to a caller owned in_memory_test_storage buffer object.
 // Single threaded, single "file" use only. Caller must ensure in_memory_test_storage object lives long enough.
 class in_memory_storage_sink : public storage_sink_interface {
-    in_memory_test_storage& _storage;
+    std::shared_ptr<in_memory_test_storage> _storage;
 public:
-    explicit in_memory_storage_sink(in_memory_test_storage& storage)
-        : _storage(storage) {}
+    explicit in_memory_storage_sink(std::shared_ptr<in_memory_test_storage> storage)
+        : _storage(std::move(storage)) {}
 
     seastar::future<> write(std::span<const std::byte> data) override {
-        _storage.append(data);
+        _storage->append(data);
         co_return;
     }
 
     seastar::future<> flush_and_close() override {
-        _storage.flush_write();
+        _storage->flush_write();
         co_return;
     }
 };
@@ -116,30 +119,33 @@ public:
 // Single threaded, single "file" use only. Caller must ensure in_memory_test_storage object lives long enough, and that on_item callback remains valid until flush_and_close() is called.
 // Due to a low chunk size this is test only class.
 class in_memory_source : public import_pipeline_interface {
-    in_memory_test_storage& _storage;
+    std::shared_ptr<in_memory_test_storage> _storage;
     std::unique_ptr<decompression_interface> _decompressor;
 public:
-    in_memory_source(in_memory_test_storage& storage,
+    in_memory_source(std::shared_ptr<in_memory_test_storage> storage,
                      std::unique_ptr<decompression_interface> decompressor)
-        : _storage(storage)
+        : _storage(std::move(storage))
         , _decompressor(std::move(decompressor)) {}
 
-    seastar::future<> read() override {
-        auto data = _storage.data();
+    seastar::future<> read_all(seastar::abort_source *abort_source) override {
+        auto data = _storage->data();
         auto* ptr = reinterpret_cast<const char*>(data.data());
         constexpr size_t chunk_size = 16;
         // We feed the data in small chunks here to test the pipeline.
         size_t position = 0;
         while(position < data.size()) {
+            if (abort_source && abort_source->abort_requested()) {
+                break;
+            }
             auto n = std::min(chunk_size, data.size() - position);
             co_await _decompressor->decompress(std::as_bytes(std::span<const char>(ptr + position, n)));
             position += n;
         }
     }
 
-    seastar::future<> flush_and_close() override {
-        _storage.flush_read();
-        return _decompressor->flush_and_close();
+    seastar::future<> close() override {
+        _storage->flush_read();
+        return _decompressor->close();
     }
 };
 
@@ -153,8 +159,8 @@ public:
         co_await _parser->parse(data);
     }
 
-    seastar::future<> flush_and_close() override {
-        co_await _parser->flush_and_close();
+    seastar::future<> close() override {
+        co_await _parser->close();
     }
 };
 
@@ -184,7 +190,7 @@ public:
         }
     }
 
-    seastar::future<> flush_and_close() override {
+    seastar::future<> close() override {
         if (!_buffer.empty()) {
             // Process any remaining data as a final line (even if it doesn't end with a newline).
             co_await _on_item(rjson::parse(_buffer));
@@ -194,18 +200,112 @@ public:
     }
 };
 
-// Factory function to create in-memory sink pipeline for testing (no compression, JSON formatter).
-std::unique_ptr<export_pipeline_interface> create_in_memory_sink_pipeline(in_memory_test_storage& storage) {
-    auto sink = std::make_unique<in_memory_storage_sink>(storage);
+/// Writes data to an S3 object. The data is passed to `s3::client` object, which will upload it to S3 asynchronously.
+/// The upload is completed when `flush_and_close()` is called.
+class s3_storage_sink : public storage_sink_interface {
+    seastar::shared_ptr<s3::client> _client;
+    seastar::sstring _object_name;
+    seastar::output_stream<char> _upload_stream;
+
+public:
+    s3_storage_sink(seastar::shared_ptr<s3::client> client, seastar::sstring object_name)
+        : _client(std::move(client))
+        , _object_name(std::move(object_name))
+        , _upload_stream(seastar::output_stream<char>(_client->make_upload_sink(_object_name)))
+    {
+    }
+
+    seastar::future<> write(std::span<const std::byte> data) override {
+        // we will return the future from write() directly, no need to add `co_await` here.
+        return _upload_stream.write(reinterpret_cast<const char*>(data.data()), data.size());
+    }
+
+    seastar::future<> flush_and_close() override {
+        return _upload_stream.close();
+    }
+};
+
+/// Reads data from an S3 object and feeds it through a decompression_interface.
+/// read_all() streams the entire object, calling decompress() for each chunk.
+class s3_storage_source : public import_pipeline_interface {
+    seastar::shared_ptr<s3::client> _client;
+    seastar::sstring _object_name;
+    std::unique_ptr<decompression_interface> _decompressor;
+
+public:
+    s3_storage_source(seastar::shared_ptr<s3::client> client, seastar::sstring object_name,
+                      std::unique_ptr<decompression_interface> decompressor)
+        : _client(std::move(client))
+        , _object_name(std::move(object_name))
+        , _decompressor(std::move(decompressor))
+    {
+    }
+
+    seastar::future<> read_all(seastar::abort_source *abort_source) override {
+        auto src = seastar::input_stream<char>{ _client->make_chunked_download_source(_object_name, s3::full_range, abort_source) };
+        std::exception_ptr exception;
+
+        try {
+            while (!abort_source || !abort_source->abort_requested()) {
+                auto buf = co_await src.read();
+                if (buf.empty()) {
+                    break;
+                }
+                co_await _decompressor->decompress(
+                    std::span<const std::byte>(reinterpret_cast<const std::byte*>(buf.get()), buf.size()));
+            }
+        }
+        catch(...) {
+            exception = std::current_exception();
+        }
+        co_await src.close();
+        if (exception) {
+            std::rethrow_exception(std::move(exception));
+        }
+    }
+    seastar::future<> close() override {
+        co_await _decompressor->close();
+    }
+};
+
+static std::unique_ptr<export_pipeline_interface> create_export_pipeline(std::unique_ptr<storage_sink_interface> sink) {
     auto compressor = std::make_unique<noop_compressor>(std::move(sink));
     return std::make_unique<json_formatter>(std::move(compressor));
 }
 
-// Factory function to create in-memory source pipeline for testing (no compression, JSON parser).
-std::unique_ptr<import_pipeline_interface> create_in_memory_source_pipeline(in_memory_test_storage& storage, std::function<seastar::future<>(rjson::value)> on_item) {
+static std::unique_ptr<decompression_interface> create_decompression_pipeline(std::function<seastar::future<>(rjson::value)> on_item) {
     auto parser = std::make_unique<json_parser>(std::move(on_item));
-    auto decompressor = std::make_unique<noop_decompressor>(std::move(parser));
-    return std::make_unique<in_memory_source>(storage, std::move(decompressor));
+    return std::make_unique<noop_decompressor>(std::move(parser));
+}
+
+// Factory function to create sink pipeline. Depending on target_config it will be either
+// - in_memory_target_config - in-memory sink pipeline for testing.
+// - s3_target_config - pipeline that will write to S3 object.
+std::unique_ptr<export_pipeline_interface> create_sink_pipeline(std::variant<in_memory_target_config, s3_target_config> target_config) {
+    return std::visit(absl::Overload{
+        [](in_memory_target_config &cfg) -> std::unique_ptr<export_pipeline_interface> {
+            return create_export_pipeline(std::make_unique<in_memory_storage_sink>(std::move(cfg.storage)));
+        },
+        [](s3_target_config &cfg) -> std::unique_ptr<export_pipeline_interface> {
+            return create_export_pipeline(std::make_unique<s3_storage_sink>(std::move(cfg.client), std::move(cfg.object_name)));
+        }
+    }, target_config);
+}
+
+// Factory function to create source pipeline. Depending on target_config it will be either
+// - in_memory_target_config - in-memory source pipeline for testing.
+// - s3_target_config - pipeline that will read from S3 object.
+std::unique_ptr<import_pipeline_interface> create_source_pipeline(std::variant<in_memory_target_config, s3_target_config> target_config, std::function<seastar::future<>(rjson::value)> on_item) {
+    return std::visit(absl::Overload{
+        [&](in_memory_target_config &cfg) -> std::unique_ptr<import_pipeline_interface> {
+            auto decompressor = create_decompression_pipeline(std::move(on_item));
+            return std::make_unique<in_memory_source>(cfg.storage, std::move(decompressor));
+        },
+        [&](s3_target_config &cfg) -> std::unique_ptr<import_pipeline_interface> {
+            auto decompressor = create_decompression_pipeline(std::move(on_item));
+            return std::make_unique<s3_storage_source>(std::move(cfg.client), std::move(cfg.object_name), std::move(decompressor));
+        }
+    }, target_config);
 }
 
 } // namespace alternator

--- a/alternator/export.hh
+++ b/alternator/export.hh
@@ -13,15 +13,22 @@
 #include <memory>
 #include <span>
 #include <vector>
+#include <variant>
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/core/temporary_buffer.hh>
 #include "utils/rjson.hh"
+
+namespace s3 { class client; }
 
 namespace alternator {
 
 // An interface encapsulating write (sink) pipeline for exporting data. Is used to implement DynamoDB export api (ExportTableToPointInTime call).
 // The pipeline is a multistage processing unit, which takes `rjson::value` item (of any content), serializes it as-is and writes it depending on the configuration.
-// Currently supporting only test-only in-memory pipeline, serializing to raw text JSON lines. In the future we will add support for S3, compression and different formats (e.g. Ion, CSV).
-// Call respective factory method below (`create_in_memory_sink_pipeline`) to construct.
+// Currently supporting only test-only in-memory pipeline, serializing to raw text JSON lines. In the future we will add support for compression and different formats (e.g. Ion, CSV).
+// Call respective factory method below (`create_sink_pipeline`) to construct.
 // Call `process()` method for each item (they might come in random order) - they will be serialized and written to the appropriate sink.
 // After all items are processed, call `flush_and_close()` to flush and finalize the pipeline - the call is mandatory, otherwise part of the data might not be written.
 // Calling `flush_and_close()` is required and needs to be done manually.
@@ -43,23 +50,23 @@ struct export_pipeline_interface {
 // An interface encapsulating read (source) pipeline. This mirrors write (sink) pipeline - what sink pipeline can produce, source pipeline will consume.
 // This will be used in future for DynamoDB import api (ImportTable call).
 // Added currently for testing purposes - so we have a consistent way to read exported data without relying on connection to S3 / DynamoDB.
-// Call respective factory method below (`create_in_memory_source_pipeline`) to construct.
+// Call respective factory method below (`create_source_pipeline`) to construct.
 // Call `read()` (only once!) method to start reading the data - it will read all data, pass it through the decompressor and parser
 // and call the callback provided to the factory function for each parsed item. The pipeline will wait
 // for each callback's future to complete before processing the next item.
-// After all data is read (the future from `read()` call completes), call `flush_and_close()` to flush and finalize the pipeline.
-// Calling `flush_and_close()` is required and needs to be done manually.
+// After all data is read (the future from `read()` call completes), call `close()` to flush and finalize the pipeline.
+// Calling `close()` is required and needs to be done manually. `close()` can be called more than once.
 struct import_pipeline_interface {
     // Reads all available data from the source, feeds it through the decompression and parsing pipeline,
     // and invokes the on_item callback (passed to the pipeline constructor function) for each parsed item.
     // The future completes after source is exhausted.
-    // Note: you still need to call `flush_and_close()` to finalize the pipeline - there might be some remaining data to process.
-    virtual seastar::future<> read() = 0;
+    // `abort_source` if passed, can be used to abort the read operation early.
+    // Note: you still need to call `close()` to finalize the pipeline - there might be some remaining data to process.
+    virtual seastar::future<> read_all(seastar::abort_source *abort_source = nullptr) = 0;
 
-    // Flushes and closes the pipeline. The future will complete once all remaining, already read data is processed, flushed and pipeline is finalized.
-    // The call doesn't read additional data.
-    // Do not call read() after calling flush_and_close().
-    virtual seastar::future<> flush_and_close() = 0;
+    // Closes the pipeline, releasing all resources. The call doesn't read additional data.
+    // Do not call read() after calling close().
+    virtual seastar::future<> close() = 0;
 
     virtual ~import_pipeline_interface() = default;
 };
@@ -83,14 +90,30 @@ public:
     bool is_write_flushed() const { return _write_flushed; }
 };
 
-// Create in-memory sink pipeline for a single file
-// You should not use the same in_memory_test_storage object for sink and source pipeline simultaneously -
-// you need to complete sink pipeline first, then create and run source pipeline.
-std::unique_ptr<export_pipeline_interface> create_in_memory_sink_pipeline(in_memory_test_storage&);
+struct in_memory_target_config {
+    std::shared_ptr<in_memory_test_storage> storage;
+};
 
-// Create in-memory source pipeline for a single file
-// You should not use the same in_memory_test_storage object for sink and source pipeline simultaneously -
-// you need to complete sink pipeline first, then create and run source pipeline.
-std::unique_ptr<import_pipeline_interface> create_in_memory_source_pipeline(in_memory_test_storage &, std::function<seastar::future<>(rjson::value)> on_item);
+// Configuration for S3 target pipeline.
+// There's an implicit size limit for S3 object - 50 GiB - from `S3::client::make_upload_sink` used internally.
+struct s3_target_config {
+    seastar::shared_ptr<s3::client> client;
+    seastar::sstring object_name;
+};
+
+// Create sink pipeline for a single file. Depending on the configuration:
+// - in_memory_target_config - creates in-memory sink pipeline for testing.
+//   You should not use the same in_memory_test_storage object for sink and source pipeline simultaneously -
+//   you need to complete sink pipeline first, then create and run source pipeline.
+// - s3_target_config - creates sink pipeline that will write to S3 object. The object will be created if it doesn't exist, or overwritten if it does.
+std::unique_ptr<export_pipeline_interface> create_sink_pipeline(std::variant<in_memory_target_config, s3_target_config> target_config);
+
+// Create source pipeline for a single file. Depending on the configuration:
+// - in_memory_target_config - creates in-memory source pipeline for testing.
+//   You should not use the same in_memory_test_storage object for sink and source pipeline simultaneously -
+//   you need to complete sink pipeline first, then create and run source pipeline.
+// - s3_target_config - creates source pipeline that will read from S3 object.
+std::unique_ptr<import_pipeline_interface> create_source_pipeline(std::variant<in_memory_target_config, s3_target_config> target_config, std::function<seastar::future<>(rjson::value)> on_item);
+
 
 } // namespace alternator

--- a/configure.py
+++ b/configure.py
@@ -686,6 +686,7 @@ scylla_tests = set([
     'test/manual/streaming_histogram_test',
     'test/manual/bti_cassandra_compatibility_test',
     'test/manual/sstable_scan_footprint_test',
+    'test/manual/s3_storage_roundtrip_test',
     'test/perf/memory_footprint_test',
     'test/perf/perf_cache_eviction',
     'test/perf/perf_commitlog',

--- a/test/boost/alternator_export_test.cc
+++ b/test/boost/alternator_export_test.cc
@@ -15,49 +15,49 @@
 #include <span>
 
 SEASTAR_TEST_CASE(test_in_memory_roundtrip_single_item) {
-    auto storage = alternator::in_memory_test_storage();
-    auto sink = alternator::create_in_memory_sink_pipeline(storage);
+    auto storage = std::make_shared<alternator::in_memory_test_storage>();
+    auto sink = alternator::create_sink_pipeline(alternator::in_memory_target_config{ storage });
 
     auto item = rjson::parse("{\"key\": \"value\"}");
     co_await sink->process(item);
     co_await sink->flush_and_close();
 
-    BOOST_CHECK(storage.is_write_flushed());
+    BOOST_CHECK(storage->is_write_flushed());
 
     std::vector<rjson::value> received;
-    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+    auto source = alternator::create_source_pipeline(alternator::in_memory_target_config{ storage }, [&](rjson::value v) -> seastar::future<> {
         received.push_back(std::move(v));
         co_return;
     });
-    co_await source->read();
-    co_await source->flush_and_close();
+    co_await source->read_all();
+    co_await source->close();
 
-    BOOST_CHECK(storage.is_read_flushed());
+    BOOST_CHECK(storage->is_read_flushed());
     BOOST_REQUIRE_EQUAL(received.size(), 1u);
     BOOST_CHECK_EQUAL(rjson::print(received[0]), rjson::print(item));
 }
 
 SEASTAR_TEST_CASE(test_in_memory_line_without_newline) {
-    auto storage = alternator::in_memory_test_storage();
+    auto storage = std::make_shared<alternator::in_memory_test_storage>();
     std::string line = "{\"key\": \"value\"}"; // Note: no newline at the end
-    storage.append(std::as_bytes(std::span<const char>(line)));
+    storage->append(std::as_bytes(std::span<const char>(line)));
 
     std::vector<rjson::value> received;
-    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+    auto source = alternator::create_source_pipeline(alternator::in_memory_target_config{ storage }, [&](rjson::value v) -> seastar::future<> {
         received.push_back(std::move(v));
         co_return;
     });
-    co_await source->read();
-    co_await source->flush_and_close();
+    co_await source->read_all();
+    co_await source->close();
 
-    BOOST_CHECK(storage.is_read_flushed());
+    BOOST_CHECK(storage->is_read_flushed());
     BOOST_REQUIRE_EQUAL(received.size(), 1u);
     BOOST_CHECK_EQUAL(rjson::print(received[0]), rjson::print(rjson::parse(line)));
 }
 
 SEASTAR_TEST_CASE(test_in_memory_roundtrip_multiple_items) {
-    auto storage = alternator::in_memory_test_storage();
-    auto sink = alternator::create_in_memory_sink_pipeline(storage);
+    auto storage = std::make_shared<alternator::in_memory_test_storage>();
+    auto sink = alternator::create_sink_pipeline(alternator::in_memory_target_config{ storage });
 
     auto item1 = rjson::parse("{\"id\": 1, \"name\": \"alice\"}");
     auto item2 = rjson::parse("{\"id\": 2, \"name\": \"bob\"}");
@@ -68,12 +68,12 @@ SEASTAR_TEST_CASE(test_in_memory_roundtrip_multiple_items) {
     co_await sink->flush_and_close();
 
     std::vector<rjson::value> received;
-    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+    auto source = alternator::create_source_pipeline(alternator::in_memory_target_config{ storage }, [&](rjson::value v) -> seastar::future<> {
         received.push_back(std::move(v));
         co_return;
     });
-    co_await source->read();
-    co_await source->flush_and_close();
+    co_await source->read_all();
+    co_await source->close();
 
     BOOST_REQUIRE_EQUAL(received.size(), 3u);
     BOOST_CHECK_EQUAL(rjson::print(received[0]), rjson::print(item1));
@@ -82,45 +82,45 @@ SEASTAR_TEST_CASE(test_in_memory_roundtrip_multiple_items) {
 }
 
 SEASTAR_TEST_CASE(test_in_memory_roundtrip_nested_json) {
-    auto storage = alternator::in_memory_test_storage();
-    auto sink = alternator::create_in_memory_sink_pipeline(storage);
+    auto storage = std::make_shared<alternator::in_memory_test_storage>();
+    auto sink = alternator::create_sink_pipeline(alternator::in_memory_target_config{ storage });
 
     auto item = rjson::parse("{\"nested\": {\"array\": [1, 2, 3], \"obj\": {\"a\": true}}}");
     co_await sink->process(item);
     co_await sink->flush_and_close();
 
     std::vector<rjson::value> received;
-    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+    auto source = alternator::create_source_pipeline(alternator::in_memory_target_config{ storage }, [&](rjson::value v) -> seastar::future<> {
         received.push_back(std::move(v));
         co_return;
     });
-    co_await source->read();
-    co_await source->flush_and_close();
+    co_await source->read_all();
+    co_await source->close();
 
     BOOST_REQUIRE_EQUAL(received.size(), 1u);
     BOOST_CHECK_EQUAL(rjson::print(received[0]), rjson::print(item));
 }
 
 SEASTAR_TEST_CASE(test_in_memory_roundtrip_empty_storage) {
-    auto storage = alternator::in_memory_test_storage();
+    auto storage = std::make_shared<alternator::in_memory_test_storage>();
 
     std::vector<rjson::value> received;
-    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+    auto source = alternator::create_source_pipeline(alternator::in_memory_target_config{ storage }, [&](rjson::value v) -> seastar::future<> {
         received.push_back(std::move(v));
         co_return;
     });
-    co_await source->read();
-    co_await source->flush_and_close();
+    co_await source->read_all();
+    co_await source->close();
 
-    BOOST_CHECK(storage.is_read_flushed());
+    BOOST_CHECK(storage->is_read_flushed());
     BOOST_CHECK(received.empty());
 }
 
 // Test that special characters in JSON strings are properly escaped and unescaped during export/import roundtrip,
 // especially end of line character, which has additional meaning as item separator.
 SEASTAR_TEST_CASE(test_in_memory_roundtrip_special_characters) {
-    auto storage = alternator::in_memory_test_storage();
-    auto sink = alternator::create_in_memory_sink_pipeline(storage);
+    auto storage = std::make_shared<alternator::in_memory_test_storage>();
+    auto sink = alternator::create_sink_pipeline(alternator::in_memory_target_config{ storage });
 
     auto item1 = rjson::parse("{\"msg\": \"hello\\nworld\\t\\\"quoted1\\\"\"}");
     auto item2 = rjson::parse("{\"msg\": \"hello\\nworld\\t\\\"quoted2\\\"\"}");
@@ -130,12 +130,12 @@ SEASTAR_TEST_CASE(test_in_memory_roundtrip_special_characters) {
     co_await sink->flush_and_close();
 
     std::vector<rjson::value> received;
-    auto source = alternator::create_in_memory_source_pipeline(storage, [&](rjson::value v) -> seastar::future<> {
+    auto source = alternator::create_source_pipeline(alternator::in_memory_target_config{ storage }, [&](rjson::value v) -> seastar::future<> {
         received.push_back(std::move(v));
         co_return;
     });
-    co_await source->read();
-    co_await source->flush_and_close();
+    co_await source->read_all();
+    co_await source->close();
 
     BOOST_REQUIRE_EQUAL(received.size(), 2u);
     BOOST_CHECK_EQUAL(rjson::print(received[0]), rjson::print(item1));

--- a/test/manual/CMakeLists.txt
+++ b/test/manual/CMakeLists.txt
@@ -20,5 +20,8 @@ add_scylla_test(sstable_scan_footprint_test
   KIND SEASTAR)
 add_scylla_test(streaming_histogram_test
   KIND BOOST)
+add_scylla_test(s3_storage_roundtrip_test
+  KIND SEASTAR
+  LIBRARIES alternator)
 add_scylla_test(bti_cassandra_compatibility_test
   KIND SEASTAR)

--- a/test/manual/s3_storage_roundtrip_test.cc
+++ b/test/manual/s3_storage_roundtrip_test.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include "test/lib/scylla_test_case.hh"
+
+#include <exception>
+#include <seastar/core/coroutine.hh>
+#include <seastar/util/defer.hh>
+#include "alternator/export.hh"
+#include "utils/rjson.hh"
+#include "utils/s3/client.hh"
+#include "utils/s3/creds.hh"
+#include "test/lib/test_utils.hh"
+
+// Manual test for s3_storage_sink and s3_storage_source against a real S3 instance.
+// To run with MinIO (S3-compatible local storage):
+/*
+docker run -d --name minio -p 9000:9000 -p 9001:9001 -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin minio/minio server /data --console-address ":9001" && \
+sleep 5 && \
+docker exec minio mc alias set local http://localhost:9000 minioadmin minioadmin && \
+docker exec minio mc mb local/test-bucket && \
+export S3_SERVER_ADDRESS_FOR_TEST=localhost && \
+export S3_SERVER_PORT_FOR_TEST=9000 && \
+export S3_BUCKET_FOR_TEST=test-bucket && \
+export AWS_ACCESS_KEY_ID=minioadmin && \
+export AWS_SECRET_ACCESS_KEY=minioadmin && \
+build/debug/test/manual/s3_storage_roundtrip_test
+*/
+// You can run against real AWS S3 by setting appropriate environment variables -
+// S3_SERVER_ADDRESS_FOR_TEST, S3_SERVER_PORT_FOR_TEST, S3_BUCKET_FOR_TEST, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and optionally AWS_DEFAULT_REGION.
+// You will need to manually create S3 bucket before running the test, and the test will delete the object it created but not the bucket.
+SEASTAR_TEST_CASE(test_s3_storage_sink_source_roundtrip) {
+    auto port = std::stoul(tests::getenv_or_default("S3_SERVER_PORT_FOR_TEST", "9000"));
+    auto bucket = tests::getenv_or_default("S3_BUCKET_FOR_TEST", "test-bucket");
+    auto server = tests::getenv_or_default("S3_SERVER_ADDRESS_FOR_TEST", "127.0.0.1");
+    auto region = tests::getenv_or_default("AWS_DEFAULT_REGION", "local");
+
+    if (tests::getenv_or_default("AWS_ACCESS_KEY_ID", "").empty()) {
+        setenv("AWS_ACCESS_KEY_ID", "minioadmin", 1);
+    }
+    if (tests::getenv_or_default("AWS_SECRET_ACCESS_KEY", "").empty()) {
+        setenv("AWS_SECRET_ACCESS_KEY", "minioadmin", 1);
+    }
+    s3::endpoint_config cfg = {
+        .port = port,
+        .use_https = false,
+        .region = region,
+    };
+    auto client = s3::client::make(server, make_lw_shared<s3::endpoint_config>(std::move(cfg)));
+    const sstring object_name = fmt::format("/{}/alternator-export-test-{}", bucket, ::getpid());
+
+    std::exception_ptr ex;
+    std::string large_value;
+    for(auto j = 0; j < 1000; ++j) {
+        large_value += "Lorem ipsum dolor sit amet, consectetur adipiscing elit. ";
+    }
+    const auto large_value_size = large_value.size();
+
+    // single item should be ~57kb
+    auto make_large_item = [&](unsigned int index) {
+        auto ret = rjson::empty_object();
+        rjson::add(ret, "id", index);
+        large_value.resize(large_value_size);
+        large_value += std::to_string(index);
+        rjson::add(ret, "value", large_value);
+        return ret;
+    };
+    try {
+        std::vector<rjson::value> items;
+        // This should produce ~57 mb of data.
+        for(auto i = 0; i < 1000; ++i) {
+            items.push_back(make_large_item(i));
+        }
+
+        // Write via s3_storage_sink.
+        {
+            auto sink = alternator::create_sink_pipeline(alternator::s3_target_config{ client, object_name });
+            for(auto &item : items) {
+                co_await sink->process(item);
+            }
+            co_await sink->flush_and_close();
+        }
+
+        // Read back via s3_storage_source and verify data integrity.
+        {
+            std::vector<rjson::value> received;
+            auto source = alternator::create_source_pipeline(alternator::s3_target_config{ client, object_name }, [&](rjson::value v) -> seastar::future<> {
+                received.push_back(std::move(v));
+                co_return;
+            });
+            co_await source->read_all();
+            co_await source->close();
+
+            BOOST_CHECK_EQUAL(received.size(), items.size());
+            for (size_t i = 0; i < items.size(); ++i) {
+                BOOST_CHECK_EQUAL(rjson::print(received[i]), rjson::print(items[i]));
+            }
+        }
+    } catch (...) {
+        ex = std::current_exception();
+    }
+
+    try {
+        co_await client->delete_object(object_name);
+    } catch (const std::exception& e) {
+        std::cout << "Failed to delete object " << object_name << ": " << e.what() << std::endl;
+    }
+
+    co_await client->close();
+
+    if (ex) {
+        std::rethrow_exception(ex);
+    }
+}


### PR DESCRIPTION
Part of S3 export implementation for Alternator.
S3 export feature is splited into three parts:
- `sink` - takes `rjson::value` representing a single row and serializes / compresses / writes to final storage,
- `scan` - somehow produce `rjson::value` representation for every row in a table,
- `orchestration` - management and configuration of `sink` and `scan`, deals with node going down / up and so on as well.

This patch is part of `sink` part. The `sink` part is done by three element chain of implementations, each inheriting from a single interface and calling next one:
- `format` - takes `rjson::value` and serializes it to binary format (or text),
- `compress` - optionally compresses payload (Amazon requires gzip),
- `write` - writes compressed data where it needs to be.

We started with a patch adding in-memory storage (which will be basis of most tests), this patch adds support for writing to S3. The `orchestration` will create and configure S3 `client` class - here we just use it.

The patch's content:
- add `s3_storage_sink` / `s3_storage_source` implementation classes, respectively writing and reading from a S3 bucket (we add reading for testing, although in future it will be used by S3 Import feature),
- rename `create_in_memory_sink_pipeline` / `create_in_memory_source_pipeline` to `create_sink_pipeline` / `create_source_pipeline` respectively,
- add additional parameter to `create_sink_pipeline` / `create_source_pipeline` - functions will be now responsible for creating both in-memory test variants (first argument `in_memory_target_config`) and for outputing to S3 variants (first argument `s3_target_config`),
- add `test/manual/s3_storage_roundtrip_test.cc` file and `test_s3_storage_sink_source_roundtrip` manual test. The test requires either setting up a MinIO instance (or any other server that can pretend to be S3) or existing AWS access. Once run, it will do full write -> read to S3.

Refs: SCYLLADB-1370
Fixes: SCYLLADB-1878

Backport: none, new feature.