### PR TITLE
[2026.2] build: bump node_exporter to 1.12.0 and follow minio checksum redirects

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -308,10 +308,10 @@ go_arch() {
     echo ${GO_ARCH["$(arch)"]}
 }
 
-NODE_EXPORTER_VERSION=1.10.2
+NODE_EXPORTER_VERSION=1.12.0
 declare -A NODE_EXPORTER_CHECKSUM=(
-    ["x86_64"]=c46e5b6f53948477ff3a19d97c58307394a29fe64a01905646f026ddc32cb65b
-    ["aarch64"]=de69ec8341c8068b7c8e4cfe3eb85065d24d984a3b33007f575d307d13eb89a6
+    ["x86_64"]=b206d98e98a431f2687d4c217abb4b15c46a6b272896113ce9a1585cf1a75d1f
+    ["aarch64"]=4ea211ce95224acb7f7c932693cb25f91f7fbe202c86bf6dc943c8569b3f6bac
 )
 NODE_EXPORTER_DIR=/opt/scylladb/dependencies
 
@@ -343,8 +343,8 @@ minio_client_url() {
 
 minio_download_jobs() {
     cfile=$(mktemp)
-    echo $(curl -s "$(minio_server_url).sha256sum" | cut -f1 -d' ') "${MINIO_BINARIES_DIR}/minio" > $cfile
-    echo $(curl -s "$(minio_client_url).sha256sum" | cut -f1 -d' ') "${MINIO_BINARIES_DIR}/mc" >> $cfile
+    echo $(curl -sL "$(minio_server_url).sha256sum" | cut -f1 -d' ') "${MINIO_BINARIES_DIR}/minio" > $cfile
+    echo $(curl -sL "$(minio_client_url).sha256sum" | cut -f1 -d' ') "${MINIO_BINARIES_DIR}/mc" >> $cfile
     sha256sum -c $cfile | grep -F FAILED | sed \
         -e 's/:.*$//g' \
         -e "s#${MINIO_BINARIES_DIR}/minio#$(minio_server_url) -o ${MINIO_BINARIES_DIR}/minio#" \

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-43-20260304
+docker.io/scylladb/scylla-toolchain:branch-2026.2-fedora-43-20260712


### PR DESCRIPTION
Simplify the previous approach of switching to a ScyllaDB-built
relocatable node_exporter tarball: keep fetching the upstream
Prometheus release, just bump it to 1.12.0 and update checksums.

Also fix minio_download_jobs() fetching checksums with 'curl -s'
(no -L): the minio CDN 302-redirects the .sha256sum URLs to GitHub
releases, so without -L curl captured the HTML redirect body instead
of the actual checksum.

- regenerate frozen toolchain with optimized clang from
        https://devpkg.scylladb.com/clang/clang-21.1.8-Fedora-43-aarch64.tar.gz
        https://devpkg.scylladb.com/clang/clang-21.1.8-Fedora-43-x86_64.tar.gz

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2909
