### PR TITLE
vector-store: fix vector_store_client shutdown

### DIFF
--- a/vector_search/clients.cc
+++ b/vector_search/clients.cc
@@ -147,7 +147,9 @@ future<> clients::close_clients() {
         co_await client->close();
     }
     for (auto& client : _old_clients) {
-        co_await client->close();
+        if (client) {
+            co_await client->close();
+        }
     }
     _clients.clear();
     _old_clients.clear();

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -476,9 +476,9 @@ void vector_store_client::start_background_tasks() {
 }
 
 auto vector_store_client::stop() -> future<> {
+    co_await _impl->_dns.stop();
     co_await _impl->_primary_clients.stop();
     co_await _impl->_secondary_clients.stop();
-    co_await _impl->_dns.stop();
     co_await _impl->_truststore.stop();
 }
 


### PR DESCRIPTION
When stopping the vector store client, the DNS module was still running while clients were stopping, causing a race condition. DNS refresh could be triggered while clients were shutting down, leading to access of a null client.

This fix ensures the DNS refresh task stops before closing clients. Additionally, the old client is checked for null pointer access as it can be nullified in close_old_clients.

Closes SCYLLADB-2903

Backport to 2026.1 and 2026.2 as these branches are also affected.