### PR TITLE
docs: remove outdated OSS version references from documentation

### DIFF
--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -388,7 +388,7 @@ Limiting results
 ~~~~~~~~~~~~~~~~
 
 The ``LIMIT`` option to a ``SELECT`` statement limits the number of rows returned by a query, while the ``PER PARTITION
-LIMIT``  option (introduced in ScyllaDB 3.1) limits the number of rows returned for a given **partition** by the query. Note that both types of limit can be
+LIMIT`` option limits the number of rows returned for a given **partition** by the query. Note that both types of limit can be
 used in the same statement.
 
 .. note::

--- a/docs/cql/wasm.rst
+++ b/docs/cql/wasm.rst
@@ -5,8 +5,6 @@ Wasm support for user-defined functions
 This document describes the details of Wasm language support in user-defined functions (UDF). The language ``wasm`` is one of the possible languages to use, besides Lua, to implement these functions. To learn more about User-defined functions in ScyllaDB, click :ref:`here <udfs>`.
 
 
-.. note:: Until ScyllaDB 5.2, the Wasm language was called ``xwasm``. This name is replaced with ``wasm`` in ScyllaDB 5.4.
-
 How to generate a correct Wasm UDF source code
 ----------------------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -142,7 +142,7 @@ To configure using :code:`scylla.yaml` file:
    
    :code:`$ docker stop <your_node> && docker start <your_node>`
 
-Alternately, starting from ScyllaDB 3.3, you can enable features directly via command line flags the :code:`--experimental-features` flag as follows. This command line options can be repeated multiple times. For example, to enable UDF and Strongly Consistent Tables:
+Alternately, you can enable features directly via command line flags the :code:`--experimental-features` flag as follows. This command line options can be repeated multiple times. For example, to enable UDF and Strongly Consistent Tables:
 
 .. code-block:: console
 
@@ -160,12 +160,6 @@ Check the `Operating System Support Guide <https://docs.scylladb.com/stable/vers
 
 * On a docker node: :code:`$ docker exec -it Node_Z scylla --version`
 
-I am upgrading my nodes to a version that uses a newer SSTable format, when will the nodes start using the new SSTable format?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-The :doc:`new "mc" SSTable format</architecture/sstable/sstable3/index>` is supported in ScyllaDB 3.0 and later.
-ScyllaDB only starts using the newer format when every node in the cluster is capable to generate it.
-Therefore, only when all nodes in the cluster are upgraded the new format is used.
 
 Docker
 -------

--- a/docs/kb/count-all-rows.rst
+++ b/docs/kb/count-all-rows.rst
@@ -13,7 +13,7 @@ Trying to count all rows in a table using
 may fail with the **ReadTimeout** error.
 
 COUNT() runs a full-scan query on all nodes, which might take a long time to finish. As a result, the count time may be greater than the ScyllaDB query timeout. 
-One way to prevent that issue in ScyllaDB 4.4 or later is to increase the timeout for the query using the :ref:`USING TIMEOUT <using-timeout>` directive, for example:
+One way to prevent that issue is to increase the timeout for the query using the :ref:`USING TIMEOUT <using-timeout>` directive, for example:
 
 
 .. code-block:: cql
@@ -21,10 +21,3 @@ One way to prevent that issue in ScyllaDB 4.4 or later is to increase the timeou
    SELECT COUNT(1) FROM ks.table USING TIMEOUT 120s;
 
 You can also get an *estimation* of the number **of partitions** (not rows) with :doc:`nodetool tablestats </operating-scylla/nodetool-commands/tablestats>`.
-
-.. note::
-    ScyllaDB 5.1 includes improvements to speed up the execution of SELECT COUNT(*) queries. 
-    To increase the count speed, we recommend upgrading to ScyllaDB 5.1 or later. 
- 
-
- .. REMOVE IN FUTURE VERSIONS - Remove the note above in version 5.1.

--- a/docs/operating-scylla/nodetool-commands/toppartitions.rst
+++ b/docs/operating-scylla/nodetool-commands/toppartitions.rst
@@ -9,26 +9,18 @@ Nodetool toppartitions
 
    The command needs to be run while there are writes and reads operations.
 
-=========  ============================
-Parameter  Description
-=========  ============================
-keyspace   The keyspace name
----------  ----------------------------
-table      The table name
----------  ----------------------------
-duration   The duration in milliseconds
-=========  ============================
-
-Additional parameters from ScyllaDB 4.6
-
 ==========  ===================================
 Parameter   Description
 ==========  ===================================
+keyspace    The keyspace name
+----------  -----------------------------------
+table       The table name
+----------  -----------------------------------
+duration    The duration in milliseconds (requires a ``-d`` prefix)
+----------  -----------------------------------
 ks-filters  List of keyspaces
 ----------  -----------------------------------
 cf-filters  List of Tables (Column Families)
-----------  -----------------------------------
-duration    The duration in milliseconds
 ----------  -----------------------------------
 capacity    The capacity of the sampler; higher values increase accuracy at the cost of memory (default 256 keys).
 ----------  -----------------------------------
@@ -41,18 +33,13 @@ For example:
 
    nodetool toppartitions nba team_roster 5000
 
-For Example (Starting from ScyllaDB 4.6):
+Additional examples:
 
 * listing the top partitions from *all* tables in *all* keyspaces ``nodetool toppartitions``
 * listing the top partitions for the last 1000 ms ``nodetool toppartitions -d 1000``
 * listing the top partitions from a list of tables ``nodetool toppartitions --cf-filters ks:t,system:status``
 * listing the top partitions from all tables from a list of keyspaces ``nodetool toppartitions --ks-filters ks,system``
 * combining lists of keyspaces and tables ``nodetool toppartitions --ks-filters ks --cf-filters system:local``
-
-.. note::
-
-   In ScyllaDB 4.6, **duration** parameter requires a *-d* prefix
-  
 
 Example output:
 
@@ -92,7 +79,7 @@ Output
 =============  =============================================================================================
 Parameter      Description
 =============  =============================================================================================
-Partition      The Partition Key, prefixed by the Keyspace and table (ks:cf) for ScyllaDB 4.6 and later
+Partition      The Partition Key, prefixed by the Keyspace and table (ks:cf)
 -------------  ---------------------------------------------------------------------------------------------
 Count          The number of operations of the specified type that occurred during the specified time period
 -------------  ---------------------------------------------------------------------------------------------

--- a/docs/using-scylla/tracing.rst
+++ b/docs/using-scylla/tracing.rst
@@ -149,8 +149,8 @@ Traces are created in the context of a **tracing session**. For instance, if we 
 * ``duration``:  the total duration of this tracing session in microseconds
 * ``parameters``: this map contains string pairs that describe the query. This may include *query string* or *consistency level*.
 * ``request``: a short string describing the current query, like "Execute CQL3 query".
-* ``request_size``: size of the request (available from ScyllaDB 3.0).
-* ``response_size``: size of the response (available from ScyllaDB 3.0).
+* ``request_size``: size of the request.
+* ``response_size``: size of the response.
 * ``started_at``: a timestamp taken when the tracing session has begun.
 
 ``events`` table column descriptions
@@ -323,7 +323,7 @@ Therefore all of them are likely going to hit the Slow Query threshold and get l
 If queueing is caused by some particularly heavy request, we would like to be able to filter this request from those that got logged due to a long queueing. 
 We have recently added tools that would help us do that:
 
-New columns were added to `system_traces.sessions`_ (available from ScyllaDB 3.0)
+New columns were added to `system_traces.sessions`_
 
 * ``request_size``
 * ``response_size``


### PR DESCRIPTION
Fixes SCYLLADB-2828

ScyllaDB no longer has an Open Source version with x.y versioning (e.g. 4.6, 5.1, 3.0). References to these old versions in the documentation are now redundant and confusing since all supported versions already include those features.

## Changes

- **toppartitions.rst**: Merged the two parameter tables into one (removing the separate 'Additional parameters from ScyllaDB 4.6' table). Removed version-gated example section heading and the note about \-d\ prefix being required in 4.6. Cleaned up the Output table description.
- **tracing.rst**: Removed 'available from ScyllaDB 3.0' qualifiers from \equest_size\ and \esponse_size\ column descriptions and from the \system_traces.sessions\ new columns note.
- **cql/dml/select.rst**: Removed 'introduced in ScyllaDB 3.1' parenthetical from the PER PARTITION LIMIT description.
- **kb/count-all-rows.rst**: Removed 'in ScyllaDB 4.4 or later' qualifier and the outdated note recommending upgrade to ScyllaDB 5.1 (including its internal REMOVE IN FUTURE VERSIONS comment).
- **cql/wasm.rst**: Removed the note about the old \xwasm\ name from versions 5.2/5.4.
- **faq.rst**: Removed 'starting from ScyllaDB 3.3' from the \--experimental-features\ flag description. Updated SSTable format description to remove 'supported in ScyllaDB 3.0 and later'.