### PR TITLE
utils/managed_vector: fall back to standard_allocator for large allocations

### DIFF
--- a/test/boost/managed_bytes_test.cc
+++ b/test/boost/managed_bytes_test.cc
@@ -21,11 +21,10 @@ struct fragmenting_allocation_strategy : standard_allocation_strategy {
     size_t allocated_bytes = 0;
     std::unordered_set<void*> allocations;
 
-    fragmenting_allocation_strategy(size_t n) {
-        _preferred_max_contiguous_allocation = n;
+    fragmenting_allocation_strategy(size_t n) : standard_allocation_strategy(n) {
     }
     virtual void* alloc(migrate_fn mf, size_t size, size_t alignment) override {
-        BOOST_CHECK_LE(size, _preferred_max_contiguous_allocation);
+        BOOST_CHECK_LE(size, preferred_max_contiguous_allocation());
         void* addr = standard_allocation_strategy::alloc(mf, size, alignment);
         allocated_bytes += size;
         allocations.insert(addr);

--- a/test/boost/managed_vector_test.cc
+++ b/test/boost/managed_vector_test.cc
@@ -142,3 +142,11 @@ SEASTAR_THREAD_TEST_CASE(test_compaction) {
         verify_filled(vec);
     });
 }
+
+SEASTAR_THREAD_TEST_CASE(test_large_allocation) {
+    logalloc::region reg;
+    with_allocator(reg.allocator(), [&] {
+        managed_vector<unsigned> vec;
+        vec.resize(logalloc::max_managed_object_size * 2);
+    });
+}

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2574,8 +2574,7 @@ SEASTAR_TEST_CASE(test_continuity_merging_past_last_entry_in_evictable) {
 class measuring_allocator final : public allocation_strategy {
     size_t _allocated_bytes = 0;
 public:
-    measuring_allocator() {
-        _preferred_max_contiguous_allocation = standard_allocator().preferred_max_contiguous_allocation();
+    measuring_allocator() : allocation_strategy(standard_allocator().preferred_max_contiguous_allocation()) {
     }
     virtual void* alloc(migrate_fn mf, size_t size, size_t alignment) override {
         _allocated_bytes += size;

--- a/test/boost/types_test.cc
+++ b/test/boost/types_test.cc
@@ -604,8 +604,7 @@ static managed_bytes make_fragmented_managed_bytes(bytes_view data, size_t frag_
         + std::max(sizeof(multi_chunk_blob_storage), sizeof(single_chunk_blob_storage));
     class limited_alloc : public standard_allocation_strategy {
     public:
-        explicit limited_alloc(size_t limit) {
-            _preferred_max_contiguous_allocation = limit;
+        explicit limited_alloc(size_t limit) : standard_allocation_strategy(limit) {
         }
     };
     limited_alloc alloc(alloc_limit);

--- a/test/lib/failure_injecting_allocation_strategy.hh
+++ b/test/lib/failure_injecting_allocation_strategy.hh
@@ -15,7 +15,10 @@ class failure_injecting_allocation_strategy : public allocation_strategy {
     uint64_t _alloc_count = 0;
     uint64_t _fail_at = std::numeric_limits<uint64_t>::max();
 public:
-    failure_injecting_allocation_strategy(allocation_strategy& delegate) : _delegate(delegate) {}
+    failure_injecting_allocation_strategy(allocation_strategy& delegate)
+        : allocation_strategy(delegate.preferred_max_contiguous_allocation()),
+        _delegate(delegate)
+    {}
 
     virtual void* alloc(migrate_fn mf, size_t size, size_t alignment) override {
         if (_alloc_count >= _fail_at) {

--- a/utils/allocation_strategy.hh
+++ b/utils/allocation_strategy.hh
@@ -114,12 +114,18 @@ class allocation_strategy {
         return instance;
     }
 
+private:
+    // const: there are some users of allocation_strategy which rely on this being stable
+    // over the allocator's lifetime.
+    const size_t _preferred_max_contiguous_allocation = std::numeric_limits<size_t>::max();
 protected:
-    size_t _preferred_max_contiguous_allocation = std::numeric_limits<size_t>::max();
     uint64_t _invalidate_counter = 1;
 public:
     using migrate_fn = const migrate_fn_type*;
 
+    allocation_strategy(size_t preferred_max_contiguous_allocation)
+        : _preferred_max_contiguous_allocation(preferred_max_contiguous_allocation)
+    {}
     virtual ~allocation_strategy() {}
 
     // Allocates space.
@@ -233,8 +239,7 @@ public:
 
 class standard_allocation_strategy : public allocation_strategy {
 public:
-    constexpr standard_allocation_strategy() {
-        _preferred_max_contiguous_allocation = 128 * 1024;
+    constexpr standard_allocation_strategy(size_t preferred_max_contiguous_allocation=128*1024) : allocation_strategy(preferred_max_contiguous_allocation) {
     }
     virtual void* alloc(migrate_fn, size_t size, size_t alignment) override {
         seastar::memory::on_alloc_point();

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2000,7 +2000,6 @@ public:
         : basic_region_impl(tracker), _region(region), _sanitizer(tracker.get_impl().sanitizer_report_backtrace()), _id(next_id())
     {
         _buf_ptrs_for_compact_segment.reserve(segment::size / buf_align);
-        _preferred_max_contiguous_allocation = max_managed_object_size;
         tracker_instance._impl->register_region(this);
     }
 

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -299,7 +299,7 @@ protected:
     bool _reclaiming_enabled = true;
     seastar::shard_id _cpu = this_shard_id();
 public:
-    basic_region_impl(tracker& tracker) : _tracker(tracker)
+    basic_region_impl(tracker& tracker) : allocation_strategy(max_managed_object_size), _tracker(tracker)
     { }
 
     tracker& get_tracker() { return _tracker; }

--- a/utils/managed_vector.hh
+++ b/utils/managed_vector.hh
@@ -62,13 +62,25 @@ private:
         auto new_capacity = std::max({ _capacity + std::min(_capacity, size_type(1024)), new_size, size_type(InternalSize + 8) });
         reserve(new_capacity);
     }
+    static allocation_strategy& choose_allocator(size_t n_bytes) {
+        if (n_bytes <= current_allocator().preferred_max_contiguous_allocation()) {
+            return current_allocator();
+        }
+        return standard_allocator();
+    }
+    static void* alloc_external(size_t n_bytes) {
+        return choose_allocator(n_bytes).alloc<external>(n_bytes);
+    }
+    static void free_external(void* ptr, size_t n_bytes) {
+        choose_allocator(n_bytes).free(ptr, n_bytes);
+    }
 public:
     // Clears the vector and ensures that the destructor will not have to free any memory so
     // that the object can be destroyed under any allocator.
     void clear_and_release() noexcept {
         clear();
         if (is_external()) {
-            current_allocator().free(get_external(), get_external()->storage_size());
+            free_external(get_external(), get_external()->storage_size());
             _data = reinterpret_cast<T*>(_internal.data());
         }
     }
@@ -172,7 +184,7 @@ public:
         if (new_capacity <= _capacity) {
             return;
         }
-        auto ptr = current_allocator().alloc<external>(sizeof(external) + sizeof(T) * new_capacity);
+        auto ptr = alloc_external(sizeof(external) + sizeof(T) * new_capacity);
         auto ext = static_cast<external*>(ptr);
         ext->_backref = this;
         T* data_ptr = ext->_data;
@@ -181,7 +193,7 @@ public:
             _data[i].~T();
         }
         if (is_external()) {
-            current_allocator().free(get_external(), get_external()->storage_size());
+            free_external(get_external(), get_external()->storage_size());
         }
         _data = data_ptr;
         _capacity = new_capacity;


### PR DESCRIPTION
Partition index entries are stored in a chunked_managed_vector, which is
a two-level tree, with nodes implemented as managed_vector.

The top level of the tree has unbounded size.
Usually it's small enough to fit inside LSA's allocation limit,
but we have seen some pathological cases in practice which exceed the limit.
Currently, when this happens, this trips an on_internal_error in LSA.

There are two ways to solve this: replace chunked_managed_vector
with a tree of arbitrary heights, or fall back to the standard allocator
when the top level doesn't fit into LSA's limit.

This patch implements the latter. We choose which allocator to use for
a given alloc/free based on its size. If it fits inside current_allocator's
limit, we use current_allocator. If it doesn't, we fall back to
standard_allocator which can handle allocations of any size.

Fixes: SCYLLADB-2679

Should be backported to all supported releases.