### PR TITLE
storage_proxy: preserve local writes while stopping RPC

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -7303,8 +7303,18 @@ void storage_proxy::start_remote(netw::messaging_service& ms, gms::gossiper& g, 
 }
 
 future<> storage_proxy::stop_remote() {
-    co_await drain_on_shutdown();
+    co_await cancel_nonlocal_write_response_handlers();
+    co_await _hints_resource_manager.stop();
+
+    // Local write handlers must remain alive while storage-proxy RPC
+    // handlers can still run. Some local-looking operations, such as
+    // raft log persistence through internal CQL, need their local write
+    // handler to complete normally during shutdown; canceling all write
+    // handlers before unregistering RPC verbs can turn those local writes
+    // into spurious timeouts. After _remote->stop() finishes, no RPC
+    // handler can start or continue storage-proxy work through _remote.
     co_await _remote->stop();
+    co_await cancel_all_write_response_handlers();
     _remote = nullptr;
 }
 
@@ -7541,11 +7551,6 @@ void storage_proxy::on_down(const gms::inet_address& endpoint, locator::host_id 
         return std::ranges::find(targets, id) != targets.end();
     }).get();
 };
-
-future<> storage_proxy::drain_on_shutdown() {
-    co_await cancel_all_write_response_handlers();
-    co_await _hints_resource_manager.stop();
-}
 
 future<> storage_proxy::abort_view_writes() {
     return cancel_write_handlers([] (const abstract_write_response_handler& handler) { 

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -704,7 +704,6 @@ private:
         fencing_token caller_token, locator::host_id caller_id,
         Func&& write_func);
 
-    future<> drain_on_shutdown();
 public:
     void update_fence_version(locator::token_metadata::version_t fence_version);
 


### PR DESCRIPTION
During startup-failure unwind, stop_remote() canceled all write response handlers before unregistering storage-proxy RPC verbs. A still-running RPC path could then rely on a local write handler, for example group0 raft log persistence through internal CQL, and hit a spurious mutation_write_timeout_exception.

Cancel only handlers waiting for nonlocal responses before stopping hints and RPC verbs. Once RPC handlers are unregistered and drained, cancel the remaining handlers before dropping remote state.

Fixes SCYLLADB-2676

backport: no backport -- minor issue during shutdown