### PR TITLE
Make tablet-aware restore abortable

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5913,6 +5913,48 @@ future<> storage_service::del_tablet_replica(table_id table, dht::token token, l
     });
 }
 
+future<> storage_service::abort_restore_tablets(table_id table) {
+    auto holder = _async_gate.hold();
+
+    if (this_shard_id() != 0) {
+        // group0 is only set on shard 0.
+        co_return co_await container().invoke_on(0, [&] (auto& ss) {
+            return ss.abort_restore_tablets(table);
+        });
+    }
+
+    slogger.info("Aborting tablet restore for table_id={}", table);
+    while (true) {
+        auto guard = co_await get_guard_for_tablet_update();
+
+        auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
+        utils::chunked_vector<canonical_mutation> updates;
+
+        co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) -> future<> {
+            auto* trinfo = tmap.get_tablet_transition_info(tid);
+            if (!trinfo || trinfo->transition != locator::tablet_transition_kind::restore || !trinfo->session_id) {
+                co_return;
+            }
+            auto last_token = tmap.get_last_token(tid);
+            // Deleting the session aborts the restore: see the restore handling in the
+            // topology coordinator.
+            updates.emplace_back(tablet_mutation_builder_for_base_table(guard.write_timestamp(), table)
+                .del_session(last_token)
+                .build());
+        });
+
+        if (updates.empty()) {
+            break;
+        }
+
+        sstring reason = format("Aborting tablet restore for table_id={}", table);
+        if (co_await exec_tablet_update(std::move(guard), std::move(updates), std::move(reason))) {
+            break;
+        }
+    }
+    slogger.info("Aborted tablet restore for table_id={}", table);
+}
+
 future<> storage_service::restore_tablets(table_id table, sstring snap_name) {
     auto holder = _async_gate.hold();
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -990,6 +990,7 @@ public:
     future<> add_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> del_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> restore_tablets(table_id, sstring snap_name);
+    future<> abort_restore_tablets(table_id);
     future<> set_tablet_balancing_enabled(bool);
 
     future<utils::UUID> submit_quiesce_topology_request();

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1482,7 +1482,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         .set_stage(last_token, locator::tablet_transition_stage::restore)
                         .set_new_replicas(last_token, info.replicas)
                         .set_snapshot_name(last_token, snap_name)
-                        .set_transition(last_token, locator::tablet_transition_kind::restore);
+                        .set_transition(last_token, locator::tablet_transition_kind::restore)
+                        .set_session(last_token, service::session_id(req_id));
                     return make_ready_future<>();
                 });
                 updates.emplace_back(tablet_builder.build());
@@ -2450,7 +2451,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     if (action_failed(tablet_state.restore)) {
                         auto ep = tablet_state.restore->get_exception();
                         rtlogger.debug("Clearing restore transition for {} due to error", gid);
-                        updates.emplace_back(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).build());
+                        updates.emplace_back(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).del_session(last_token).build());
                         // Record error on the ongoing restore request so it's propagated to the caller.
                         if (auto it = restore_request_for_table.find(gid.table); it != restore_request_for_table.end()) {
                             updates.emplace_back(
@@ -2474,7 +2475,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         });
                     })) {
                         rtlogger.debug("Clearing restore transition for {}", gid);
-                        updates.emplace_back(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).build());
+                        updates.emplace_back(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).del_session(last_token).build());
                     }
                 }
                     break;

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1052,58 +1052,58 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
     named_gate g("sstables_loader::download_tablet_sstables");
     std::exception_ptr ex;
     try {
-    auto& session_as = session_guard.abort_source();
-    session_as.check();
-    auto sub = session_as.subscribe([&shard_aborts, &g, &session_as] () noexcept {
-        try {
-            auto h = g.hold();
-            (void)smp::invoke_on_all([&shard_aborts, ex = session_as.abort_requested_exception_ptr()] {
-                shard_aborts[this_shard_id()].request_abort_ex(ex);
-            }).finally([h = std::move(h)] {});
-        } catch (...) {
-        }
-    });
+        auto& session_as = session_guard.abort_source();
+        session_as.check();
+        auto sub = session_as.subscribe([&shard_aborts, &g, &session_as] () noexcept {
+            try {
+                auto h = g.hold();
+                (void)smp::invoke_on_all([&shard_aborts, ex = session_as.abort_requested_exception_ptr()] {
+                    shard_aborts[this_shard_id()].request_abort_ex(ex);
+                }).finally([h = std::move(h)] {});
+            } catch (...) {
+            }
+        });
 
-    auto downloaded_ssts = co_await container().map_reduce0(
-        [tid, &sstables_on_shards](auto& loader) -> future<std::vector<std::vector<minimal_sst_info>>> {
-            sstables_col sst_chunk;
-            for (auto& psst : sstables_on_shards[this_shard_id()]) {
-                for (auto&& sst : psst) {
-                    sst_chunk.push_back(std::move(sst));
+        auto downloaded_ssts = co_await container().map_reduce0(
+            [tid, &sstables_on_shards](auto& loader) -> future<std::vector<std::vector<minimal_sst_info>>> {
+                sstables_col sst_chunk;
+                for (auto& psst : sstables_on_shards[this_shard_id()]) {
+                    for (auto&& sst : psst) {
+                        sst_chunk.push_back(std::move(sst));
+                    }
                 }
-            }
-            std::vector<std::vector<minimal_sst_info>> local_min_infos(this_smp_shard_count());
-            co_await max_concurrent_for_each(sst_chunk, 16, [&loader, tid, &local_min_infos](const auto& sst) -> future<> {
-                auto& table = loader._db.local().find_column_family(tid.table);
-                auto stream_guard = table.stream_in_progress();
-                auto min_info = co_await download_sstable(loader._db.local(), table, sst, llog);
-                local_min_infos[min_info.shard].emplace_back(std::move(min_info));
+                std::vector<std::vector<minimal_sst_info>> local_min_infos(this_smp_shard_count());
+                co_await max_concurrent_for_each(sst_chunk, 16, [&loader, tid, &local_min_infos](const auto& sst) -> future<> {
+                    auto& table = loader._db.local().find_column_family(tid.table);
+                    auto stream_guard = table.stream_in_progress();
+                    auto min_info = co_await download_sstable(loader._db.local(), table, sst, llog);
+                    local_min_infos[min_info.shard].emplace_back(std::move(min_info));
+                });
+                co_return local_min_infos;
+            },
+            std::vector<std::vector<minimal_sst_info>>(this_smp_shard_count()),
+            [](auto init, auto&& item) -> std::vector<std::vector<minimal_sst_info>> {
+                for (std::size_t i = 0; i < item.size(); ++i) {
+                    init[i].append_range(std::move(item[i]));
+                }
+                return init;
             });
-            co_return local_min_infos;
-        },
-        std::vector<std::vector<minimal_sst_info>>(this_smp_shard_count()),
-        [](auto init, auto&& item) -> std::vector<std::vector<minimal_sst_info>> {
-            for (std::size_t i = 0; i < item.size(); ++i) {
-                init[i].append_range(std::move(item[i]));
-            }
-            return init;
-        });
 
-    co_await container().invoke_on_all([tid, &downloaded_ssts, snap_name = snapshot_name, keyspace_name, table_name, datacenter, rack] (auto& loader) -> future<> {
-        auto shard_ssts = std::move(downloaded_ssts[this_shard_id()]);
-        db::snapshot_table_helper sth(loader._sys_dist_ks.qp());
-        co_await max_concurrent_for_each(shard_ssts, 16, [&sth, &loader, tid, snap_name, keyspace_name, table_name, datacenter, rack](const auto& min_info) -> future<> {
-            sstables::shared_sstable attached_sst = co_await loader.attach_sstable(tid.table, min_info);
-            co_await sth.update_sstable_download_status(snap_name,
-                                                        keyspace_name,
-                                                        table_name,
-                                                        datacenter,
-                                                        rack,
-                                                        *attached_sst->sstable_identifier(),
-                                                        attached_sst->get_first_decorated_key().token(),
-                                                        db::is_downloaded::yes);
+        co_await container().invoke_on_all([tid, &downloaded_ssts, snap_name = snapshot_name, keyspace_name, table_name, datacenter, rack] (auto& loader) -> future<> {
+            auto shard_ssts = std::move(downloaded_ssts[this_shard_id()]);
+            db::snapshot_table_helper sth(loader._sys_dist_ks.qp());
+            co_await max_concurrent_for_each(shard_ssts, 16, [&sth, &loader, tid, snap_name, keyspace_name, table_name, datacenter, rack](const auto& min_info) -> future<> {
+                sstables::shared_sstable attached_sst = co_await loader.attach_sstable(tid.table, min_info);
+                co_await sth.update_sstable_download_status(snap_name,
+                                                            keyspace_name,
+                                                            table_name,
+                                                            datacenter,
+                                                            rack,
+                                                            *attached_sst->sstable_identifier(),
+                                                            attached_sst->get_first_decorated_key().token(),
+                                                            db::is_downloaded::yes);
+            });
         });
-    });
     } catch (...) {
         ex = std::current_exception();
     }

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -959,9 +959,16 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
     if (!trinfo) {
         throw std::runtime_error(fmt::format("No transition info for tablet {}", tid));
     }
+    if (!trinfo->session_id) {
+        throw std::runtime_error(fmt::format("Restore of tablet {} was cancelled", tid));
+    }
     if (trinfo->snapshot_name.empty()) {
         throw std::runtime_error(format("No snapshot name for tablet {} restore transition", tid));
     }
+
+    // Aborting the restore closes the session, which fires this guard's abort source and
+    // interrupts the downloads below.
+    service::session_topology_guard session_guard(trinfo->session_id);
 
     sstring snapshot_name = trinfo->snapshot_name;
 
@@ -1016,9 +1023,15 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
     using sstables_col = std::vector<sstables::shared_sstable>;
     using prefix_sstables = std::vector<sstables_col>;
 
+    // Per-shard abort sources for the object-store download pipeline (cf. download_task_impl::run).
+    // They are wired to the session abort only after the sstables are opened (see below).
+    std::vector<seastar::abort_source> shard_aborts(this_smp_shard_count());
+
     auto sstables_on_shards = co_await map_reduce(toc_names_by_prefix, [&] (auto ent) {
         return replica::distributed_loader::get_sstables_from_object_store(_db, s->ks_name(), s->cf_name(),
-                std::move(ent.second), snapshot_info.endpoint, ep_type, snapshot_info.bucket, std::move(ent.first), cfg, [&] { return nullptr; }).then_unpack([] (table_id, auto sstables) {
+                std::move(ent.second), snapshot_info.endpoint, ep_type, snapshot_info.bucket, std::move(ent.first), cfg, [&] {
+                    return &shard_aborts[this_shard_id()];
+                }).then_unpack([] (table_id, auto sstables) {
                     return make_ready_future<std::vector<sstables_col>>(std::move(sstables));
                 });
     }, std::vector<prefix_sstables>(this_smp_shard_count()), [&] (std::vector<prefix_sstables> a, std::vector<sstables_col> b) {
@@ -1031,6 +1044,24 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
             a[i].push_back(std::move(b[i]));
         }
         return a;
+    });
+
+    // Wire the session abort into the download sources only now, after opening: an aborted
+    // metadata read would be misreported as sstable corruption, so opening above must stay
+    // non-abortable.
+    named_gate g("sstables_loader::download_tablet_sstables");
+    std::exception_ptr ex;
+    try {
+    auto& session_as = session_guard.abort_source();
+    session_as.check();
+    auto sub = session_as.subscribe([&shard_aborts, &g, &session_as] () noexcept {
+        try {
+            auto h = g.hold();
+            (void)smp::invoke_on_all([&shard_aborts, ex = session_as.abort_requested_exception_ptr()] {
+                shard_aborts[this_shard_id()].request_abort_ex(ex);
+            }).finally([h = std::move(h)] {});
+        } catch (...) {
+        }
     });
 
     auto downloaded_ssts = co_await container().map_reduce0(
@@ -1073,6 +1104,22 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
                                                         db::is_downloaded::yes);
         });
     });
+    } catch (...) {
+        ex = std::current_exception();
+    }
+
+    // Drain any in-flight abort dispatch before shard_aborts/session_as go out of scope.
+    co_await g.close();
+
+    if (ex) {
+        // An aborted download leaves unconsumed sstables in sstables_on_shards. These are
+        // lw_shared_ptr-s owned by their respective shards, so they must be released there
+        // rather than while this coroutine frame unwinds on the home shard.
+        co_await container().invoke_on_all([&sstables_on_shards] (sstables_loader&) {
+            sstables_on_shards[this_shard_id()] = {}; // clear on correct shard
+        });
+        std::rethrow_exception(ex);
+    }
 }
 
 future<std::vector<tablet_sstable_collection>> get_sstables_for_tablets_for_tests(const std::vector<sstables::shared_sstable>& sstables,
@@ -1210,7 +1257,18 @@ public:
     }
 
     tasks::is_abortable is_abortable() const noexcept override {
-        return tasks::is_abortable::no;
+        return tasks::is_abortable::yes;
+    }
+
+    void abort() noexcept override {
+        tasks::task_manager::task::impl::abort();
+        // Closing the restore sessions makes the in-flight download RPCs fail and the
+        // topology coordinator clear the restore transitions, which lets run() (waiting
+        // on the topology request) return. Fire-and-forget: the task's own abort source,
+        // already triggered above, surfaces the abort_requested error to the caller.
+        (void)_loader.local()._ss.local().abort_restore_tablets(_tid).handle_exception([tid = _tid] (std::exception_ptr ex) {
+            llog.warn("Failed to abort restore for table {}: {}", tid, ex);
+        });
     }
 
 protected:

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -18,6 +18,7 @@
 #include "tasks/task_manager.hh"
 #include "db/consistency_level_type.hh"
 #include "locator/tablets.hh"
+#include "service/topology_guard.hh"
 
 using namespace seastar;
 

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -854,6 +854,88 @@ async def test_restore_tablets_download_failure(build_mode: str, manager: Manage
         assert 'error' in status and 'Failing sstable download' in status['error']
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_restore_tablets_abort(build_mode: str, manager: ManagerClient, object_storage):
+    '''Verify that aborting a tablet restore task interrupts in-flight downloads
+    without crashing the node.
+
+    Pause the restore inside download_sstable (after the sstables are opened, so
+    the abort exercises the per-shard download abort sources), abort the restore
+    task and wait (via a read barrier) for the session removal to reach every node,
+    then release the pause. The task must fail with an abort error and no download
+    must have completed.'''
+
+    topology = topo(rf = 1, nodes = 2, racks = 1, dcs = 1)
+    servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
+
+    await manager.disable_tablet_balancing()
+    cql = manager.get_cql()
+
+    num_keys = 12
+    tablet_count = 4
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count}}};")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, value) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, (str(i), i)) for i in range(num_keys)))
+        snap_name, sstables = await take_snapshot(ks, servers, manager, logger)
+        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}', ks, 'test', object_storage, manager, logger) for s in servers))
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {topology.rf}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test ( pk text primary key, value int ) WITH tablets = {{'min_tablet_count': {tablet_count}, 'max_tablet_count': {tablet_count}}};")
+
+        # Park every download inside download_sstable (after the sstables are opened),
+        # so the abort below has to interrupt the object store reads themselves.
+        await asyncio.gather(*(manager.api.enable_injection(s.ip_addr, "pause_download_sstable", one_shot=False) for s in servers))
+
+        logger.info(f'Restore cluster via {servers[0].ip_addr}')
+        manifests = [ f'{s.server_id}/{snap_name}/manifest.json' for s in servers ]
+        tid = await manager.api.restore_tablets(servers[0].ip_addr, ks, 'test', snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
+
+        # Wait until a download is parked on at least one node.
+        enter_waiters = [asyncio.create_task(manager.api.wait_for_injection_enter(s.ip_addr, "pause_download_sstable")) for s in servers]
+        done, pending = await asyncio.wait(enter_waiters, timeout=30, return_when=asyncio.FIRST_COMPLETED)
+        for t in pending:
+            t.cancel()
+        assert done, "Restore did not reach the download pause on any node"
+
+        coordinator_log = await manager.server_open_log(servers[0].server_id)
+        log_mark = await coordinator_log.mark()
+
+        logger.info('Aborting restore task')
+        await manager.api.abort_task(servers[0].ip_addr, tid)
+
+        # Wait for the abort to delete the restore session before releasing the pause, so
+        # the resumed downloads observe the closed session and abort their object store reads.
+        await coordinator_log.wait_for("Aborted tablet restore for table_id", from_mark=log_mark)
+
+        # The coordinator commits the session removal to group0, but the other nodes apply it
+        # asynchronously. Issue a read barrier on the non-coordinator nodes so that, by the time
+        # we release the pause, every node has applied the removal and armed its download abort.
+        await asyncio.gather(*(read_barrier(manager.api, s.ip_addr) for s in servers[1:]))
+
+        # Release the parked downloads; disabling also prevents any retry from re-parking.
+        await asyncio.gather(*(manager.api.disable_injection(s.ip_addr, "pause_download_sstable") for s in servers))
+
+        status = await asyncio.wait_for(manager.api.wait_task(servers[0].ip_addr, tid), timeout=60)
+        assert status is not None and status['state'] == 'failed', f"Expected task to fail after abort, got: {status}"
+        assert 'abort' in status['error'].lower(), f"Expected abort error, got: {status['error']}"
+        logger.info(f'Restore task aborted as expected: {status["error"]}')
+
+        # Every node had its session closed before the pause was released, so no download could
+        # complete: none of the sstables must be marked as downloaded.
+        dc = servers[0].datacenter
+        rack = 'rack0'
+        rows = list(await cql.run_async(f"SELECT downloaded FROM system_distributed.snapshot_sstables "
+                                        f"WHERE snapshot_name = '{snap_name}' AND \"keyspace\" = '{ks}' AND \"table\" = 'test' "
+                                        f"AND datacenter = '{dc}' AND rack = '{rack}'"))
+        total = len(rows)
+        downloaded = sum(1 for row in rows if row.downloaded)
+        assert total > 0, "No sstables were recorded for the snapshot"
+        assert downloaded == 0, f"Expected no downloads to complete after abort, but {downloaded} of {total} sstables were downloaded"
+
+
 @pytest.mark.parametrize("target", ['coordinator', 'replica', 'api'])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: ManagerClient, object_storage, target):


### PR DESCRIPTION
First, tablet restore transitions are equipped with a session_id, and the single tablet restoring RPC handler is subscribed on the respective session_guard's abort_source. Whenever the restore should be aborted, the transitions are updated with the session_id removed. This triggers the cascade of abort-s on the linked abort_sources and eventually all tablet-restoring RPCs resolve with exception, which is picked up by topology_coordinator normally and the restore request finishes.

The entry point is regular tablet_restore_task_impl::abort() method.

Fixes SCYLLADB-1076

New feature, not backporting