### PR TITLE
test/scylla_gdb: advance all shards to reactor::poll_once before a test

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -20,6 +20,8 @@ import time
 import socket
 import string
 import math
+import contextlib
+import tempfile
 
 
 def align_up(ptr, alignment):
@@ -6564,6 +6566,57 @@ class scylla_prepared_statements(gdb.Command):
                 else:
                     gdb.write("{}\n".format(val))
 
+@contextlib.contextmanager
+def with_saved_breakpoints():
+    """Saves the current breakpoints, deletes them, and restores them on exit."""
+    had_breakpoints = bool(gdb.breakpoints())
+    if had_breakpoints:
+        with tempfile.NamedTemporaryFile() as breakpoint_file:
+            gdb.execute(f'save breakpoints {breakpoint_file.name}')
+            gdb.execute('delete breakpoints')
+            try:
+                yield
+            finally:
+                gdb.execute(f'source {breakpoint_file.name}')
+    else:
+        try:
+            yield
+        finally:
+            if gdb.breakpoints():
+                gdb.execute('delete breakpoints')
+
+@contextlib.contextmanager
+def with_saved_thread():
+    """Saves the current thread and restores it on exit."""
+    orig = gdb.selected_thread()
+    try:
+        yield
+    finally:
+        orig.switch()
+
+class scylla_run_all_shards_until_poll(gdb.Command):
+    """Advances all reactor threads until a poll point.
+
+    Used for ensuring that gdb tests run in a consistent database state.
+    """
+
+    def __init__(self):
+        gdb.Command.__init__(self, 'scylla run-all-shards-until-poll', gdb.COMMAND_USER, gdb.COMPLETE_NONE, True)
+
+    def invoke(self, arg, for_tty):
+        with with_saved_breakpoints():
+            with gdb.with_parameter("scheduler-locking", "on"):
+                with with_saved_thread():
+                    for t in gdb.selected_inferior().threads():
+                        t.switch()
+                        reactor = gdb.parse_and_eval('::seastar::local_engine')
+                        if not reactor:
+                            continue
+                        gdb.execute("tbreak ::seastar::reactor::poll_once")
+                        # If setting the breakpoint fails, gdb only warns...
+                        assert gdb.breakpoints()
+                        gdb.execute("continue")
+
 class scylla_gdb_func_collection_element(gdb.Function):
     """Return the element at the specified index/key from the container.
 
@@ -6770,6 +6823,7 @@ scylla_sstable_promoted_index()
 scylla_sstable_dump_cached_index()
 scylla_tablet_metadata()
 scylla_prepared_statements()
+scylla_run_all_shards_until_poll()
 
 
 # Convenience functions

--- a/test/scylla_gdb/conftest.py
+++ b/test/scylla_gdb/conftest.py
@@ -41,6 +41,8 @@ def gdb_cmd(scylla_server, request):
         scylla_gdb_py,
         "-x",
         script_py,
+        "-ex",
+        "python gdb.execute('scylla run-all-shards-until-poll')",
     ]
     return cmd
 

--- a/test/scylla_gdb/gdb_utils.py
+++ b/test/scylla_gdb/gdb_utils.py
@@ -11,6 +11,8 @@ Depends on helper functions injected to GDB by `scylla-gdb.py` script.
 get_seastar_memory_start_and_size).
 """
 
+import contextlib
+import tempfile
 import gdb
 import uuid
 
@@ -90,8 +92,61 @@ class get_coroutine(gdb.Function):
         print("COROUTINE_NOT_FOUND")
 
 
+@contextlib.contextmanager
+def with_saved_breakpoints():
+    """Save the current breakpoints, delete them, and restore them on exit."""
+    had_breakpoints = bool(gdb.breakpoints())
+    if had_breakpoints:
+        with tempfile.NamedTemporaryFile() as breakpoint_file:
+            gdb.execute(f"save breakpoints {breakpoint_file.name}")
+            gdb.execute("delete breakpoints")
+            try:
+                yield
+            finally:
+                gdb.execute(f"source {breakpoint_file.name}")
+    else:
+        try:
+            yield
+        finally:
+            if gdb.breakpoints():
+                gdb.execute("delete breakpoints")
+
+
+@contextlib.contextmanager
+def with_saved_thread():
+    """Save the current thread and restore it on exit."""
+    orig = gdb.selected_thread()
+    try:
+        yield
+    finally:
+        orig.switch()
+
+
+class scylla_run_all_shards_until_poll(gdb.Command):
+    """Advance all reactor threads until a poll point."""
+
+    def __init__(self):
+        gdb.Command.__init__(self, "scylla run-all-shards-until-poll", gdb.COMMAND_USER, gdb.COMPLETE_NONE, True)
+
+    def invoke(self, arg, for_tty):
+        with with_saved_breakpoints():
+            with gdb.with_parameter("scheduler-locking", "on"):
+                with with_saved_thread():
+                    for t in gdb.selected_inferior().threads():
+                        t.switch()
+                        reactor = gdb.parse_and_eval("::seastar::local_engine")
+                        if not reactor:
+                            continue
+                        gdb.execute("tbreak ::seastar::reactor::poll_once")
+                        # If setting the breakpoint fails, gdb only warns.
+                        # If we want that to turn into a test failure, we have to do that ourselves.
+                        assert gdb.breakpoints()
+                        gdb.execute("continue")
+
+
 # Register the functions in GDB
 get_schema()
 get_sstable()
 get_task()
 get_coroutine()
+scylla_run_all_shards_until_poll()

--- a/test/scylla_gdb/test_basic_commands.py
+++ b/test/scylla_gdb/test_basic_commands.py
@@ -46,6 +46,7 @@ pytestmark = [
         "mem-range",
         "mem-ranges",
         "memory",
+        "run-all-shards-until-poll",
         "segment-descs",
         "small-object -o 32 --random-page",
         "small-object -o 64 --summarize",


### PR DESCRIPTION
This is an attempt to prevent spurious gdb test failures due to tests running while Scylla is suspended while modifying one of the tested data structures.

We can prevent this by ensuring that tests run in a state when all shards are suspended at a point in which all data structures are consistent. We can do this by advancing every shards to such a point before the test.

We need to choose a point which all shards are guaranteed to visit soon. reactor::poll_once is an arbitrary choice of such a point.

Fixes: SCYLLADB-2675

Minor CI stability improvement, doesn't need backporting.