### PR TITLE
view_building_worker: don't hold staging tasks mutex across group0 add_entry

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -330,6 +330,12 @@ future<> view_building_worker::create_staging_sstable_tasks() {
         }
     }
 
+    // Release `_started_staging_tasks_mutex` before `add_entry()` below: it is only needed to read
+    // `_started_staging_tasks` in the loop above. Holding it across `add_entry()` deadlocks, since
+    // `add_entry()` waits for the command to be applied (which takes the group0 read-apply mutex)
+    // while the view building state observer holds the read-apply mutex and waits for this mutex.
+    started_tasks_lock.return_all();
+
     utils::chunked_vector<canonical_mutation> cmuts;
     cmuts.emplace_back(builder.build());
     auto cmd = _group0.client().prepare_command(service::write_mutations{std::move(cmuts)}, guard, "create view building tasks");


### PR DESCRIPTION
create_staging_sstable_tasks() acquired _started_staging_tasks_mutex to read _started_staging_tasks while building the command, but kept holding it across the group0 add_entry() call that commits the command.

This can deadlock group0 apply. add_entry() waits for the command to be applied, and group0_state_machine::apply() takes the read-apply mutex. Meanwhile the view building state observer takes the read-apply mutex and then waits for _started_staging_tasks_mutex in clear_started_staging_tasks(). If the observer grabs read-apply right after add_entry() releases it, the two form a circular wait: the observer holds read-apply and wants the staging tasks mutex, while create_staging_sstable_tasks() holds that mutex and needs apply (hence read-apply) to make progress.

When this happens during a tablet migration, group0 apply on the destination stalls, so the topology coordinator's barrier_and_drain read_barrier never completes and the migration hangs (move_tablet times out), e.g. in test_staging_backlog_is_preserved_with_file_based_streaming.

The deadlock is rarely hit in practice: it requires the observer to grab the read-apply mutex in the tiny window between add_entry() releasing it and the apply fiber re-acquiring it to apply the command. The observer must already be queued on that mutex at that exact moment, so only an unlucky interleaving triggers it, which is why the test was only flaky.

Fix by releasing the mutex right after the loop, before add_entry(): it is not needed once the command has been built.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2879

Backport is  required, since problematic PR(https://github.com/scylladb/scylladb/pull/30303) was backported