### PR TITLE
test/lib: fix gcs fixture startup

### DIFF
--- a/test/lib/gcs_fixture.cc
+++ b/test/lib/gcs_fixture.cc
@@ -51,7 +51,8 @@ static future<std::tuple<tp::process_fixture, int>> start_fake_gcs_server(const 
             if (line.find("server started at") != std::string::npos) {
                 return tp::service_parse_state::success;
             }
-            if (line.find("address already in use") != std::string::npos) {
+            if (line.find("address already in use") != std::string::npos || line.find("Address already in use") != std::string::npos ||
+                line.find("port is already allocated") != std::string::npos) {
                 return tp::service_parse_state::failed;
             }
             return tp::service_parse_state::cont;


### PR DESCRIPTION
### Problem

`start_fake_gcs_server` in `test/lib/gcs_fixture.cc` fails to detect "port in use" errors from docker and podman, causing GCS fixture startup to hang or fail with an opaque error instead of triggering a retry.

### Changes

Commit `bc544eb08e` ("gcs_fixture: Change to use docker helper") refactored `start_fake_gcs_server` to use `tp::start_docker_service`, but silently dropped two of the three "port in use" error-string checks that existed in the original code:

- `"address already in use"` (fake-gcs-server / generic Linux) — was kept
- `"Address already in use"` (podman) — **dropped**
- `"port is already allocated"` (docker) — **dropped**

This fix restores the two missing checks so `service_parse_state::failed` is returned correctly on all runtimes, allowing the docker helper to retry with a different port.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2899

Needs to be ported back to 2026.2 to avoid future CI failures