### PR TITLE
configure: fix Ctrl-C leaving sccache compilations running

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2464,8 +2464,43 @@ def write_build_file(f,
     rustc_target = pick_rustc_target('wasm32-wasi', 'wasm32-wasip1')
     # If compiler cache is available, prefix the compiler with it
     cxx_with_cache = f'{compiler_cache} {args.cxx}' if compiler_cache else args.cxx
-    # For Rust, sccache is used via RUSTC_WRAPPER environment variable
-    rustc_wrapper = f'RUSTC_WRAPPER={compiler_cache} ' if compiler_cache and 'sccache' in compiler_cache and args.sccache_rust else ''
+    if compiler_cache and 'sccache' in compiler_cache:
+        # With sccache, its default is to run compilations via a background
+        # daemon shared with (and possibly already running for) other,
+        # unrelated builds. This is inconvenient for interactive builds
+        # because of SCYLLADB-2913: The compilation processes run in a
+        # different process group, so interrupting the build with control-C
+        # leaves all the compilation processes running until completion.
+        # There is no way to tell sccache not to use a build server at all -
+        # its developers consider a build server to be necessary for multiple
+        # concurrent compilations to efficiently connect to a remote cache.
+        # We work around the problem with two environment variables:
+        # * SCCACHE_NO_DAEMON=1 tells sccache to not daemonize (double-fork
+        #   and detach) the server it starts, so the server (and the
+        #   compilations it runs) stays in ninja's process group and dies
+        #   with it on Ctrl-C.
+        # * SCCACHE_SERVER_UDS gives sccache a per-build Unix-domain socket
+        #   instead of the default TCP port shared by every sccache
+        #   invocation on the machine. We embed $$PPID in the path: ninja
+        #   writes $$ to get a literal $ in the variable value, which the
+        #   shell expands as $PPID (ninja's own PID, since each rule command
+        #   runs in a shell spawned directly by ninja). All compilations
+        #   within one ninja run share the same PID, so they all use the
+        #   same server. Different ninja runs have different PIDs, so they
+        #   get distinct socket paths, eliminating any "address already in
+        #   use" conflicts and guaranteeing each build starts a fresh server
+        #   in the right process group.
+        sccache_env = f'SCCACHE_NO_DAEMON=1 SCCACHE_SERVER_UDS={os.path.abspath(outdir)}/sccache-$$PPID.sock '
+        cxx_with_cache = f'{sccache_env}{cxx_with_cache}'
+    else:
+        sccache_env = ''
+    # For Rust, sccache is used via RUSTC_WRAPPER environment variable.
+    # The same environment variables as in cxx_with_cache above are needed,
+    # and for the same reasons.
+    if compiler_cache and 'sccache' in compiler_cache and args.sccache_rust:
+        rustc_wrapper = f'{sccache_env}RUSTC_WRAPPER={compiler_cache} '
+    else:
+        rustc_wrapper = ''
     f.write(textwrap.dedent('''\
         configure_args = {configure_args}
         builddir = {outdir}


### PR DESCRIPTION
    When ninja is interrupted with Ctrl-C, all clang++ compilation processes
    keep running until completion instead of stopping immediately. The root
    cause is sccache's build-server architecture: sccache clients send work
    to a background server, and that server spawns clang++ as its own children
    in a separate process group. Ctrl-C sends SIGINT only to ninja's foreground
    process group, killing the sccache clients but not the clang++ processes
    owned by the daemon.
    
    This is very frustrating for developers doing interactive builds,
    because these compilation processes often continue to run for minutes (!)
    after interrupting the build.
    
    Unfortunately there is no way to directly tell sccache to *not* use a
    build server. It appears that the sscache developers believe that a
    long-running server that many concurrent compilations use is important
    for performance - especially when this server maintains connections to
    some remote cache storage. So in our solution, we still have a build
    server, but use three environment variables to tweak how it works:
    
    1. The option SCCACHE_NO_DAEMON=1 means that when our first sscache
       invocation needs to start a build server, it starts it without
       "daemonizing". The new build server will remain in ninja's process
       group, and will get killed by control-C.
    
    2. The option SCCACHE_SERVER_UDS is set to a unique (for each ninja
       invocation) path. It ensures that we cannot connect to a build
       server started by an unrelated build on the same machine, and not
       even to an earlier build here. The build server we will connect
       to must be one we started now, in ninja's process group, and will
       get killed by control-C as expected.
    
    There are two ugly, but harmless, downsides to this approach:
    
    1. The build server for each ninja run will linger a bit after each
       succcessful build (one not inerrupted by control-C). This delay
       can be lowered by setting SCCACHE_IDLE_TIMEOUT.
    
    2. We can see warnings "sccache: error: Address already in use (os error 98)"
       when the build begins. This is harmless. Many sccache instances start
       in parallel very quickly, and race to create the unix-domain socket.
       The "losers" will use the winner's socket, and work correctly, but
       will still output that error message.

Fixes SCYLLADB-2913