### PR TITLE
test: remove tests skipped due to VECTOR-374

### DIFF
--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -1271,45 +1271,6 @@ def test_wait_for_vector_index_active(vs, needs_vector_store):
         )
         assert result.get('Items') and result['Items'][0]['p'] == p
 
-# The tests test_query_vector_prefill and test_query_vector_with_ck_prefill
-# used string keys in the indexed table. In theory, there shouldn't be any
-# difference in the vector store's behavior if the keys are of a different
-# type (in addition to string, they can be numeric or binary). But in
-# practice, the factor store does handle different key types differently,
-# and this test used to fail before this was fixed.
-# To save a bit of time, we don't test all combinations of hash and range
-# key types but test each type at least once as a hash key and a range key.
-@pytest.mark.skip_bug(
-    link="https://scylladb.atlassian.net/browse/VECTOR-374",
-    reason="Bug in vector store for non-string keys, fails very slowly",
-)
-@pytest.mark.parametrize('hash_type,range_type', [
-    ('N', None), ('B', None), ('S', 'N'),  ('S', 'B'),
-], ids=[
-    'N', 'B', 'SN', 'SB'])
-def test_query_vector_prefill_key_types(vs, needs_vector_store, hash_type, range_type):
-    key_schema = [{'AttributeName': 'p', 'KeyType': 'HASH'}]
-    attr_defs = [{'AttributeName': 'p', 'AttributeType': hash_type}]
-    if range_type is not None:
-        key_schema.append({'AttributeName': 'c', 'KeyType': 'RANGE'})
-        attr_defs.append({'AttributeName': 'c', 'AttributeType': range_type})
-    key = {'S': 'hello', 'N': Decimal('42'), 'B': b'hello'}
-    with new_test_table(vs, KeySchema=key_schema,
-                            AttributeDefinitions=attr_defs) as table:
-        p = key[hash_type]
-        item = {'p': p, 'v': [1, 0, 0]}
-        if range_type is not None:
-            c = key[range_type]
-            item['c'] = c
-        table.put_item(Item=item)
-        table.update(VectorIndexUpdates=[{'Create':
-            {'IndexName': 'vind',
-             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
-        wait_for_vector_index_active(table, 'vind')
-        result = table.query(IndexName='vind',
-            VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1)
-        assert len(result['Items']) == 1 and result['Items'] == [item]
-
 # Same as test_query_vector_prefill but whereas in test_query_vector_prefill
 # the vector store reads the indexed data by scanning the table, here the
 # vector index is created first and only later the data is written, so the

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -233,56 +233,6 @@ def test_ann_ordering_not_allowed_without_index_where_indexed_column_exists_in_q
             "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
         )
 
-@pytest.mark.skip_bug(
-    link="https://scylladb.atlassian.net/browse/VECTOR-374",
-    reason="Restricted queries are passed to vector store and pytest does not support vector store",
-)
-def test_cannot_post_filter_on_non_indexed_column_with_ann_ordering(cql, test_keyspace):
-    ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = (
-        SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else CASSANDRA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE
-    )
-    with create_table(
-        cql,
-        test_keyspace,
-        "(pk1 int, pk2 int, ck1 int, ck2 int, v vector<float, 1>, c int, primary key ((pk1, pk2), ck1, ck2))"
-    ) as table:
-        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
-        execute(cql, table, f"CREATE CUSTOM INDEX ON %s(v) USING '{custom_index}' WITH OPTIONS = {{'similarity_function': 'euclidean'}}")
-
-        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (1, 1, 1, 1, [4], 1)")
-        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (2, 2, 1, 1, [3], 10)")
-        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (3, 3, 1, 1, [2], 100)")
-        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (4, 4, 1, 1, [1], 1000)")
-
-        assert_invalid_message(
-            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-            "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
-        )
-        assert_invalid_message(
-            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-            "SELECT * FROM %s WHERE ck1 >= 0 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
-        )
-        assert_invalid_message(
-            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-            "SELECT * FROM %s WHERE ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
-        )
-        assert_invalid_message(
-            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-            "SELECT * FROM %s WHERE pk1 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
-        )
-        assert_invalid_message(
-            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-            "SELECT * FROM %s WHERE pk2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
-        )
-        assert_invalid_message(
-            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-            "SELECT * FROM %s WHERE pk1 = 1 AND pk2 = 1 AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
-        )
-        assert_invalid_message(
-            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-            "SELECT * FROM %s WHERE token(pk1, pk2) = token(1, 1) AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
-        )
-
 def test_cannot_have_per_partition_limit_with_ann_ordering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, v vector<float, 1>, PRIMARY KEY(k, c))") as table:
         custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"


### PR DESCRIPTION
VECTOR-374 is closed. Remove the tests that were skipped due to this bug as they cannot work as test.py tests now:
- test_cannot_post_filter_on_non_indexed_column_with_ann_ordering in test/cqlpy/cassandra_tests/vector_invalid_query_test.py
- test_query_vector_prefill_key_types in test/alternator/test_vector.py

Fixes: SCYLLADB-2724

