### PR TITLE
Make tablet restore re-entrant for API node failover

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5926,6 +5926,28 @@ future<> storage_service::restore_tablets(table_id table, sstring snap_name) {
     utils::UUID request_id;
     while (true) {
         auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
+
+        // If a restore for the same table is already in flight (e.g. started
+        // by a node that has since died), join it instead of starting a new
+        // one. Reject a mismatched snapshot for the same table.
+        std::optional<utils::UUID> ongoing;
+        for (auto req : _topology_state_machine._topology.ongoing_restore_requests) {
+            auto entry = co_await _sys_ks.local().get_topology_request_entry(req);
+            if (entry.restore_table_id == table) {
+                if (entry.restore_snapshot_name != snap_name) {
+                    throw std::runtime_error(fmt::format("Table {} is already being restored from a different snapshot {}", table, *entry.restore_snapshot_name));
+                }
+                ongoing = req;
+                break;
+            }
+        }
+        if (ongoing) {
+            release_guard(std::move(guard));
+            request_id = *ongoing;
+            slogger.info("Restore for {} already in flight, waiting for it", table);
+            break;
+        }
+
         request_id = guard.new_group0_state_id();
 
         topology_mutation_builder builder(guard.write_timestamp());

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -986,7 +986,10 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
         co_return;
     }
 
-    auto [ fully, partially ] = co_await get_sstables_for_tablet(sst_infos, tablet_range, [] (const auto& si) { return si.first_token; }, [] (const auto& si) { return si.last_token; });
+    // Skip sstables a previous restore attempt already fetched so a re-entered
+    // or retried restore doesn't re-download what's already in place.
+    auto pending = sst_infos | std::views::filter([] (const auto& si) { return si.downloaded == db::is_downloaded::no; });
+    auto [ fully, partially ] = co_await get_sstables_for_tablet(pending, tablet_range, [] (const auto& si) { return si.first_token; }, [] (const auto& si) { return si.last_token; });
     if (!partially.empty()) {
         llog.debug("Sstable {} is partially contained", partially.front().sstable_id);
         throw std::logic_error("sstables_partially_contained");

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -891,6 +891,12 @@ async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: Ma
             await manager.server_stop(servers[1].server_id, convict=True)
             with pytest.raises(aiohttp.client_exceptions.ClientConnectorError):
                 await manager.api.wait_task(servers[1].ip_addr, tid)
+            # The restore is still in flight on the coordinator. Re-issue it from
+            # another node, which should join the in-flight restore rather than
+            # fail or duplicate it. Release the pause and just make sure it finishes.
+            tid = await manager.api.restore_tablets(servers[3].ip_addr, ks, 'test', snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
+            await manager.api.message_injection(servers[2].ip_addr, "pause_tablet_restore")
+            await asyncio.wait_for(manager.api.wait_task(servers[3].ip_addr, tid), timeout=60)
         else:
             if target == 'coordinator':
                 await manager.server_stop(servers[0].server_id, convict=True)


### PR DESCRIPTION
The tablet-aware restore is driven by a global topology request: the API node queues the request, the topology coordinator populates the tablet transitions and tracks them, and the caller waits for the request to complete. If the node that issued the request dies mid-restore, there is currently no clean way to resume — re-issuing the restore on another node starts a duplicate that re-stamps every tablet and re-downloads all sstables.

This series makes restore re-entrant so a second node can pick up an in-flight restore by checking the ongoing restores to contain the matching one and waiting for the relevant request if found.

There's a race -- if two nodes submit the same restore at roughly the same time, both may see nothing in flight and queue their own topology request. It's not expected to happen deliberately, the re-entrability is for the cases when API node dies and the caller wants to wait for the ongoing restore to complete somehow. However, if it does happens the coordinator serializes them — it runs the first to completion, then pops the second. By then no tablet is in transition, so it re-stamps and runs a second restore pass. However, that second pass is cheap: every sstable was marked downloaded by the first pass, so the skip-already-downloaded filter leaves nothing to fetch, and both callers complete successfully.

Fixes SCYLLADB-1828
New feature, not backporting