### PR TITLE
topology: let bootstrap bypass unrelated tablet migrations

### DIFF
--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -226,17 +226,22 @@ the load balancer will not be invoked to allow for current migrations to drain,
 after which the state machine will exit the tablet migration track and allow pending topology
 operation to start.
 
-The tablet migration track excludes with other topology changes, so node operations
-will have to wait for tablet migration track to finish before they can take over
-the state machine.
+The exception is a pending join request. Bootstrap can preempt the tablet migration
+track and take over the state machine before all active tablet transitions finish.
+The tablet transitions remain recorded in tablet metadata and the state machine
+returns to the tablet migration track after bootstrap if any tablet transitions are still pending.
+Other node operations still wait for the tablet migration track to finish before they
+can take over the state machine.
 
 The reason why the load balancer is part of the main state machine and excludes with other topology
 changes is that we want to share the infrastructure for fencing between vnode-based topology
 changes and tablet migration. This calls for some way to mutually exclude the two so that they
 don't interfere with each other. The simplest is to make them part of the same state machine.
 
-When the topology state machine is not in the tablet_migration track, it is guaranteed
-that there are no tablet transitions in the system.
+When the topology state machine is not in the tablet_migration track and no bootstrap
+preemption is in progress, it is guaranteed that there are no tablet transitions in the system.
+During bootstrap preemption, tablet transitions may exist outside the tablet_migration track,
+but they are not removed or rolled back and will be resumed by returning to tablet_migration.
 
 Tablets are migrated in parallel and independently.
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1955,6 +1955,62 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         }
     }
 
+    bool has_tablet_transitions() const {
+        auto tm = get_token_metadata_ptr();
+        for (auto&& e : tm->tablets().all_table_groups()) {
+            auto& base_table = e.first;
+            if (!tm->tablets().get_tablet_map(base_table).transitions().empty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // This function must not release and reacquire the guard, callers rely
+    // on the fact that the block which calls this is atomic.
+    std::variant<group0_guard, node_to_work_on> get_bootstrap_to_preempt_tablet_migration(group0_guard guard) {
+        auto work = get_next_task(std::move(guard));
+        return std::visit(overloaded_functor{
+            [] (group0_guard&& guard) -> std::variant<group0_guard, node_to_work_on> {
+                return std::move(guard);
+            },
+            [] (cancel_requests&& cancel) -> std::variant<group0_guard, node_to_work_on> {
+                return std::move(cancel.guard);
+            },
+            [] (start_vnodes_cleanup&& cleanup) -> std::variant<group0_guard, node_to_work_on> {
+                return std::move(cleanup.guard);
+            },
+            [] (node_to_work_on&& node) -> std::variant<group0_guard, node_to_work_on> {
+                if (node.request && *node.request == topology_request::join) {
+                    return std::move(node);
+                }
+                return std::move(node.guard);
+            },
+        }, std::move(work));
+    }
+
+    // Returns std::nullopt if preemption consumed the guard and started a node transition.
+    future<std::optional<group0_guard>> maybe_preempt_now(group0_guard guard) {
+        auto ts = guard.write_timestamp();
+        auto work = get_bootstrap_to_preempt_tablet_migration(std::move(guard));
+        if (auto* node = std::get_if<node_to_work_on>(&work)) {
+            if (ts != node->guard.write_timestamp()) {
+                // We rely on the fact that get_bootstrap_to_preempt_tablet_migration() does not release the guard
+                // so that tablet metadata reading and updates are atomic.
+                on_internal_error(rtlogger, "get_bootstrap_to_preempt_tablet_migration() retook the guard");
+            }
+            co_await handle_node_transition(std::move(*node));
+            co_return std::nullopt;
+        }
+        guard = std::get<group0_guard>(std::move(work));
+        if (ts != guard.write_timestamp()) {
+            // We rely on the fact that get_bootstrap_to_preempt_tablet_migration() does not release the guard
+            // so that tablet metadata reading and updates are atomic.
+            on_internal_error(rtlogger, "get_bootstrap_to_preempt_tablet_migration() retook the guard");
+        }
+        co_return std::move(guard);
+    }
+
     // When "drain" is true, we migrate tablets only as long as there are nodes to drain
     // and then change the transition state to write_both_read_old. Also, while draining,
     // we ignore pending topology requests which normally interrupt load balancing.
@@ -1978,6 +2034,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         });
 
         _tablets_ready = false;
+
+        if (!drain) {
+            if (auto new_guard = co_await maybe_preempt_now(std::move(guard))) {
+                guard = std::move(*new_guard);
+            } else {
+                co_return;
+            }
+        }
 
         // Build table_id -> request_id mapping for ongoing restore requests
         // so that we can find the owning request when a restore transition fails.
@@ -3548,8 +3612,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     // Since after bootstrapping a new node some nodes lost some ranges they need to cleanup
                     muts = mark_nodes_as_cleanup_needed(node, false);
                     topology_mutation_builder builder(node.guard.write_timestamp());
-                    builder.del_transition_state()
-                           .set_version(_topo_sm._topology.version + 1)
+                    if (has_tablet_transitions()) {
+                        builder.set_transition_state(topology::transition_state::tablet_migration);
+                    } else {
+                        builder.del_transition_state();
+                    }
+                    builder.set_version(_topo_sm._topology.version + 1)
                            .with_node(node.id)
                            .set("node_state", node_state::normal);
                     muts.emplace_back(builder.build());
@@ -3674,8 +3742,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
                     topology_mutation_builder builder(node.guard.write_timestamp());
                     cleanup_ignored_nodes_on_left(builder, node.id);
-                    builder.del_transition_state()
-                            .with_node(node.id)
+                    if (has_tablet_transitions()) {
+                        builder.set_transition_state(topology::transition_state::tablet_migration);
+                    } else {
+                        builder.del_transition_state();
+                    }
+                    builder.with_node(node.id)
                             .set("node_state", node_state::left);
                     muts.push_back(builder.build());
                     co_await remove_view_build_statuses_on_left_node(muts, node.guard, node.id);
@@ -3847,9 +3919,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         co_return true;
     };
 
-    // Called when there is no ongoing topology transition.
-    // Used to start new topology transitions using node requests or perform node operations
-    // that don't change the topology (like rebuild).
+    // Used to start node topology transitions from the idle state machine path, or from
+    // tablet_migration when a join request preempts tablet migration scheduling.
+    // Also performs node operations that don't change the topology (like rebuild).
     future<> handle_node_transition(node_to_work_on&& node) {
         rtlogger.info("coordinator fiber found a node to work on id={} state={}", node.id, node.rs->state);
 
@@ -4474,6 +4546,17 @@ future<std::optional<group0_guard>> topology_coordinator::maybe_start_tablet_mig
     rtlogger.debug("Evaluating tablet balance");
 
     auto tm = get_token_metadata_ptr();
+    if (has_tablet_transitions()) {
+        utils::chunked_vector<canonical_mutation> updates;
+        updates.emplace_back(
+            topology_mutation_builder(guard.write_timestamp())
+                .set_transition_state(topology::transition_state::tablet_migration)
+                .set_version(_topo_sm._topology.version + 1)
+                .build());
+        co_await update_topology_state(std::move(guard), std::move(updates), "Resuming tablet migration");
+        co_return std::nullopt;
+    }
+
     auto plan = co_await _tablet_allocator.balance_tablets(tm, &_topo_sm._topology, &_sys_ks, {}, get_dead_nodes());
     if (plan.empty()) {
         rtlogger.debug("Tablet load balancer did not make any plan");

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -12,7 +12,10 @@ from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.skip_types import skip_env
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_info
 from test.pylib.util import start_writes, scale_timeout_by_mode
-from test.cluster.util import wait_for_cql_and_get_hosts, new_test_keyspace, reconnect_driver, wait_for
+from test.cluster.util import (
+    wait_for_cql_and_get_hosts, new_test_keyspace, reconnect_driver, wait_for,
+    wait_for_no_pending_topology_transition, get_topology_coordinator,
+)
 import time
 import pytest
 import logging
@@ -112,6 +115,66 @@ async def test_tablet_transition_sanity(manager: ManagerClient, action):
                 assert res[0].count != 0
             else:
                 assert res[0].count == 0
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_bootstrap_starts_while_tablet_migration_is_blocked(manager: ManagerClient, scale_timeout):
+    cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
+    servers = []
+    hosts_by_rack = defaultdict(list)
+
+    async def make_server(rack: str, start: bool = True):
+        server = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": rack}, start=start)
+        if start:
+            servers.append(server)
+            hosts_by_rack[rack].append(await manager.get_host_id(server.server_id))
+        return server
+
+    await make_server("r1")
+    await make_server("r2")
+    await make_server("r3")
+
+    await manager.disable_tablet_balancing()
+
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in range(256)])
+
+        await make_server("r1")
+        target_server = servers[-1]
+        target_host = hosts_by_rack["r1"][-1]
+
+        replicas = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
+        assert len(replicas) == 1 and len(replicas[0].replicas) == 3
+        old_replica = next(r for r in replicas[0].replicas if r[0] in hosts_by_rack["r1"] and r[0] != target_host)
+
+        await manager.api.enable_injection(target_server.ip_addr, "migration_streaming_wait", one_shot=True)
+        migration_task = asyncio.create_task(manager.api.move_tablet(servers[0].ip_addr, ks, "test",
+                                                                     old_replica[0], old_replica[1],
+                                                                     target_host, 0,
+                                                                     replicas[0].last_token))
+        await manager.api.wait_for_injection_enter(target_server.ip_addr, "migration_streaming_wait")
+
+        # The injection is coordinator-side, so it has to be enabled on the topology coordinator
+        # rather than on the joining node or its rack. Pausing right after accepting the node
+        # proves bootstrap started without holding tablet streaming across bootstrap barriers.
+        coordinator_host = await get_topology_coordinator(manager)
+        coordinator_server = await manager.find_server_by_host_id(servers, coordinator_host)
+        bootstrap_started_injection = "topology_coordinator_pause_after_accept_node"
+        await manager.api.enable_injection(coordinator_server.ip_addr, bootstrap_started_injection, one_shot=True)
+        joining_server = await make_server("r2", start=False)
+        bootstrap_task = asyncio.create_task(manager.server_start(joining_server.server_id))
+
+        await manager.api.wait_for_injection_enter(coordinator_server.ip_addr, bootstrap_started_injection, deadline=time.time() + scale_timeout(60))
+        assert not migration_task.done()
+
+        await manager.api.message_injection(coordinator_server.ip_addr, bootstrap_started_injection)
+        await manager.api.message_injection(target_server.ip_addr, "migration_streaming_wait")
+
+        await bootstrap_task
+        await migration_task
+        await wait_for_no_pending_topology_transition(manager, time.time() + scale_timeout(60))
 
 
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])


### PR DESCRIPTION
The topology coordinator drives tablet migrations from a single global
transition state, tablet_migration. While that state is active, the main
loop stays in handle_tablet_migration() and never falls back to the branch
that picks up queued node operations. As a result a bootstrap join had to
wait until all in-flight tablet transitions finished, including ones stuck
for a long time in streaming, even when those transitions were confined to
a different rack and had nothing to do with the joining node.

Let a join request preempt the tablet_migration state when the active
tablet transitions do not intersect the joining node's rack. The rack check
uses the transition's streaming participants (read_from and written_to from
get_migration_streaming_info), so only racks that actually take part in an
ongoing transition are treated as conflicting. Preemption is restricted to
join requests; decommission and removenode, which contend with tablet
movement directly, keep serializing as before.

The decision is made under the same group0 guard used to read tablet
metadata (asserted via the write timestamp), so the read and the subsequent
handle_node_transition() start atomically.

The tablet transitions themselves are left untouched in tablet metadata;
nothing is cancelled or rolled back, and the background streaming fibers are
not restarted (advance_in_background() is idempotent across pump
iterations). tablet_migration is restored in two places:

  - when the preempting bootstrap reaches normal state, if transitions are
    still pending; and
  - in maybe_start_tablet_migration(), which re-enters tablet_migration
    whenever pending transitions exist with no higher-priority work. This
    also acts as a safety net if the bootstrap fails and exits through a
    path that clears the transition state.


Fixes https://scylladb.atlassian.net/browse/SCYLLADB-646

Backport is not required