### PR TITLE
view_building_worker: read flushed views list before the actual flush

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -436,6 +436,8 @@ future<> view_building_worker::run_view_building_state_observer() {
         bool sleep = false;
         try {
             vbw_logger.trace("view_building_state_observer() iteration");
+            co_await utils::get_local_injector().inject("view_building_worker_pause_state_observer",
+                    utils::wait_for_message(std::chrono::minutes(5)));
             auto read_apply_mutex_holder = co_await _group0.client().hold_read_apply_mutex(_as);
 
             co_await update_built_views();
@@ -612,9 +614,12 @@ future<> view_building_worker::state::flush_base_table(replica::database& db, ta
     vbw_logger.debug("Awaiting penging writes and streams on base table {}.{}", cf->schema()->ks_name(), cf->schema()->cf_name());
     co_await when_all(cf->await_pending_writes(), cf->await_pending_streams());
     vbw_logger.debug("Flushing base table {}.{}", cf->schema()->ks_name(), cf->schema()->cf_name());
+    auto views_to_flush = get_ids_of_all_views(db, base_table_id);
     co_await flush_base(cf, as);
+    co_await utils::get_local_injector().inject("view_building_worker_pause_after_flush_before_recording_flushed_views",
+            utils::wait_for_message(std::chrono::minutes(5)));
     processing_base_table = base_table_id;
-    flushed_views = get_ids_of_all_views(db, base_table_id);
+    flushed_views = std::move(views_to_flush);
     vbw_logger.debug("Flushed base table {}.{} for views: {}", cf->schema()->ks_name(), cf->schema()->cf_name(), flushed_views);
 }
 

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -202,6 +202,41 @@ async def test_add_view_while_build_in_progress(manager: ManagerClient):
         await check_view_contents(cql, ks, "tab", "mv_cf_view2")
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_add_view_after_view_build_flush_races_with_delete(manager: ManagerClient):
+    server = await manager.server_add(cmdline=cmdline_loggers, property_file={"dc": "dc1", "rack": "r1"})
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v text, PRIMARY KEY (key, c))")
+        await cql.run_async(f"INSERT INTO {ks}.tab (key, c, v) VALUES (0, 0, '0')")
+
+        log = await manager.server_open_log(server.server_id)
+        mark = await log.mark()
+        await manager.api.enable_injection(server.ip_addr, "view_building_worker_pause_state_observer", one_shot=False)
+        await manager.api.enable_injection(server.ip_addr, "view_building_worker_pause_after_flush_before_recording_flushed_views", one_shot=True)
+
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv_cf_view1 AS SELECT * FROM {ks}.tab "
+                        "WHERE c IS NOT NULL and key IS NOT NULL AND v IS NOT NULL PRIMARY KEY (c, key, v) ")
+
+        await log.wait_for("view_building_worker_pause_after_flush_before_recording_flushed_views: waiting for message", from_mark=mark, timeout=60)
+
+        try:
+            # The delete happens after the base-table flush used for view building, but before the
+            # second view exists. The first view gets a normal delete update; the second one must be
+            # built from a later flush, otherwise it can resurrect the deleted row from the flushed SSTable.
+            await cql.run_async(f"DELETE FROM {ks}.tab WHERE key = 0 AND c = 0")
+            await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv_cf_view2 AS SELECT * FROM {ks}.tab "
+                            "WHERE c IS NOT NULL and key IS NOT NULL AND v IS NOT NULL PRIMARY KEY (c, key, v) ")
+        finally:
+            await manager.api.disable_injection(server.ip_addr, "view_building_worker_pause_after_flush_before_recording_flushed_views")
+            await manager.api.disable_injection(server.ip_addr, "view_building_worker_pause_state_observer")
+
+        await wait_for_view(cql, 'mv_cf_view1', 1)
+        await wait_for_view(cql, 'mv_cf_view2', 1)
+        await check_view_contents(cql, ks, "tab", "mv_cf_view1")
+        await check_view_contents(cql, ks, "tab", "mv_cf_view2")
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_remove_some_view_while_build_in_progress(manager: ManagerClient):
     node_count = 3
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers)


### PR DESCRIPTION
When we flush the base table for view building, we record the views for which the flushed sstables have all data needed for view building. However, we currently record them after the flush. If we perform an update just after the flush, it won't be in the flushed sstables. If additionally a new view is created just after the flush, it will be recorded as one of the views for which the sstables have all relevant data. So the write performed in between will not generate a view update for the second view: it's not in the sstables for view building and no update is generated during the write because the new view did not exist yet.

We fix this by recording for which views is the flush data sufficient before the actual view, and updating flushed_views with the recorded list after the flush.

We also add a test that reproduces the issue.

Fixes: SCYLLADB-2781