### PR TITLE
sstables/mx/writer: avoid writing huge index pages (in BIG sstables)

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1455,6 +1455,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , unspooled_dirty_soft_limit(this, "unspooled_dirty_soft_limit", value_status::Used, 0.6, "Soft limit of unspooled dirty memory expressed as a portion of the hard limit.")
     , sstable_summary_ratio(this, "sstable_summary_ratio", value_status::Used, 0.0005, "Enforces that 1 byte of summary is written for every N (2000 by default)"
         "bytes written to data file. Value must be between 0 and 1.")
+    , sstable_summary_max_partitions_per_page(this, "sstable_summary_max_partitions_per_page", liveness::LiveUpdate, value_status::Used, 10000,
+        "Hard limit on the number of partition keys covered by a single sstable summary entry. "
+        "A summary entry is forced (breaking the index page) once this many partitions accumulate, which prevents "
+        "pathologically large index pages.")
     , components_memory_reclaim_threshold(this, "components_memory_reclaim_threshold", liveness::LiveUpdate, value_status::Used, .2, "Ratio of available memory for all in-memory components of SSTables in a shard beyond which the memory will be reclaimed from components until it falls back under the threshold. Currently, this limit is only enforced for bloom filters.")
     , large_memory_allocation_warning_threshold(this, "large_memory_allocation_warning_threshold", value_status::Used, (size_t(128) << 10) + 1, "Warn about memory allocations above this size; set to zero to disable.")
     , enable_deprecated_partitioners(this, "enable_deprecated_partitioners", value_status::Used, false, "Enable the byteordered and random partitioners. These partitioners are deprecated and will be removed in a future version.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -439,6 +439,7 @@ public:
     named_value<unsigned> murmur3_partitioner_ignore_msb_bits;
     named_value<double> unspooled_dirty_soft_limit;
     named_value<double> sstable_summary_ratio;
+    named_value<uint64_t> sstable_summary_max_partitions_per_page;
     named_value<double> components_memory_reclaim_threshold;
     named_value<size_t> large_memory_allocation_warning_threshold;
     named_value<bool> enable_deprecated_partitioners;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -379,6 +379,7 @@ static auto configure_sstables_manager(const db::config& cfg, const database_con
         .enable_sstable_key_validation = cfg.enable_sstable_key_validation(),
         .enable_data_integrity_check = cfg.enable_sstable_data_integrity_check(),
         .sstable_summary_ratio = cfg.sstable_summary_ratio(),
+        .sstable_summary_max_partitions_per_page = cfg.sstable_summary_max_partitions_per_page,
         .column_index_size = cfg.column_index_size_in_kb() * 1024,
         .column_index_auto_scale_threshold_in_kb = cfg.column_index_auto_scale_threshold_in_kb,
         .memory_reclaim_threshold = cfg.components_memory_reclaim_threshold,

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -887,6 +887,7 @@ public:
         _pi_write_m.promoted_index_block_size = cfg.promoted_index_block_size;
         _pi_write_m.promoted_index_auto_scale_threshold = cfg.promoted_index_auto_scale_threshold;
         _index_sampling_state.summary_byte_cost = _cfg.summary_byte_cost;
+        _index_sampling_state.max_partitions_per_page = _cfg.summary_max_partitions_per_page;
       if (_index_writer) {
         prepare_summary(_sst._components->summary, estimated_partitions, _schema.min_index_interval());
       }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2304,12 +2304,15 @@ void seal_statistics(sstable_version_types v, statistics& s, metadata_collector&
 void maybe_add_summary_entry(summary& s, const dht::token& token, bytes_view key, uint64_t data_offset,
         uint64_t index_offset, index_sampling_state& state) {
     state.partition_count++;
-    // generates a summary entry when possible (= keep summary / data size ratio within reasonable limits)
-    if (data_offset >= state.next_data_offset_to_write_summary) {
-        auto entry_size = 8 + 2 + key.size();  // offset + key_size.size + key.size
-        state.next_data_offset_to_write_summary += state.summary_byte_cost * entry_size;
+    state.partitions_since_last_summary_entry++;
+    auto entry_size = 8 + 2 + key.size();  // offset + key_size.size + key.size
+    if (s.entries.empty()
+            || data_offset - state.last_data_offset_in_summary >= state.summary_byte_cost * entry_size
+            || state.partitions_since_last_summary_entry >= state.max_partitions_per_page) {
         auto key_data = s.add_summary_data(key);
         s.entries.push_back(summary_entry{ token, key_data, index_offset });
+        state.last_data_offset_in_summary = data_offset;
+        state.partitions_since_last_summary_entry = 0;
     }
 }
 
@@ -2620,8 +2623,9 @@ future<> sstable::generate_summary() {
     public:
         std::optional<key> first_key, last_key;
 
-        summary_generator(const dht::i_partitioner& p, summary& s, double summary_ratio) : _partitioner(p), _summary(s) {
+        summary_generator(const dht::i_partitioner& p, summary& s, double summary_ratio, uint64_t max_partitions_per_page) : _partitioner(p), _summary(s) {
             _state.summary_byte_cost = summary_byte_cost(summary_ratio);
+            _state.max_partitions_per_page = max_partitions_per_page;
         }
         bool should_continue() {
             return true;
@@ -2655,7 +2659,7 @@ future<> sstable::generate_summary() {
         file_input_stream_options options;
         options.buffer_size = sstable_buffer_size;
 
-        auto s = summary_generator(_schema->get_partitioner(), _components->summary, _manager.get_config().sstable_summary_ratio);
+        auto s = summary_generator(_schema->get_partitioner(), _components->summary, _manager.get_config().sstable_summary_ratio, _manager.get_config().sstable_summary_max_partitions_per_page());
             auto ctx = make_lw_shared<index_consume_entry_context<summary_generator>>(
                     *this, sem.make_tracking_only_permit(_schema, "generate-summary", db::no_timeout, {}), s, trust_promoted_index::yes,
                     make_file_input_stream(index_file, 0, index_size, std::move(options)), 0, index_size,

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -122,6 +122,7 @@ struct sstable_writer_config {
     write_monitor* monitor = &default_write_monitor();
     run_id run_identifier = run_id::create_random_id();
     size_t summary_byte_cost;
+    uint64_t summary_max_partitions_per_page;
     sstring origin;
     bool correct_pi_block_width = true;
     uint32_t large_data_records_per_sstable = 10;
@@ -1233,11 +1234,16 @@ future<validate_checksums_result> validate_checksums(shared_sstable sst, reader_
 
 struct index_sampling_state {
     static constexpr size_t default_summary_byte_cost = 2000;
+    static constexpr uint64_t default_max_partitions_per_page = 10000;
 
-    uint64_t next_data_offset_to_write_summary = 0;
+    uint64_t last_data_offset_in_summary = 0;
     uint64_t partition_count = 0;
+    // Number of partitions added since the last summary entry was emitted.
+    uint64_t partitions_since_last_summary_entry = 0;
     // Enforces ratio of summary to data of 1 to N.
     size_t summary_byte_cost = default_summary_byte_cost;
+    // Hard limit on the number of partitions per index page.
+    uint64_t max_partitions_per_page = default_max_partitions_per_page;
 };
 
 future<> init_metrics();

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -259,6 +259,7 @@ sstable_writer_config sstables_manager::configure_writer(sstring origin) const {
             ? mutation_fragment_stream_validation_level::clustering_key
             : mutation_fragment_stream_validation_level::token;
     cfg.summary_byte_cost = summary_byte_cost(_config.sstable_summary_ratio);
+    cfg.summary_max_partitions_per_page = _config.sstable_summary_max_partitions_per_page();
 
     cfg.origin = std::move(origin);
     cfg.large_data_records_per_sstable = _config.large_data_records_per_sstable();

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -116,6 +116,7 @@ public:
         bool enable_sstable_key_validation = false;
         bool enable_data_integrity_check = false;
         double sstable_summary_ratio = 0.0005;
+        utils::updateable_value<uint64_t> sstable_summary_max_partitions_per_page = utils::updateable_value<uint64_t>(10000);
         size_t column_index_size = 64 << 10;
         utils::updateable_value<uint32_t> column_index_auto_scale_threshold_in_kb = utils::updateable_value<uint32_t>(10240);
         utils::updateable_value<double> memory_reclaim_threshold = utils::updateable_value<double>(0.2);

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2372,6 +2372,42 @@ SEASTAR_TEST_CASE(sstable_partition_estimation_sanity_test) {
     });
 }
 
+SEASTAR_TEST_CASE(sstable_summary_max_partitions_per_page_test) {
+    // Verifies that the hard limit on the number of partitions per index page
+    // (sstable_summary_max_partitions_per_page) forces summary entries even when
+    // the partitions are tiny enough that the summary/data ratio alone would
+    // place them all in a single page.
+    return test_env::do_with_async([] (test_env& env) {
+        constexpr uint32_t max_partitions_per_page = 100;
+        constexpr int total_partitions = 1000;
+        env.db_config().sstable_summary_max_partitions_per_page(max_partitions_per_page);
+        env.db_config().sstable_summary_ratio(std::numeric_limits<double>::max());
+
+        auto builder = schema_builder(this_smp_shard_count(), "tests", "test")
+                .with_column("id", utf8_type, column_kind::partition_key);
+        builder.set_compressor_params(compression_parameters::no_compression());
+        auto s = builder.build(schema_builder::compact_storage::no);
+
+        utils::chunked_vector<mutation> mutations;
+        for (int i = 0; i < total_partitions; i++) {
+            auto key = to_bytes("key" + to_sstring(i));
+            mutation m(s, partition_key::from_exploded(*s, {std::move(key)}));
+            mutations.push_back(std::move(m));
+        }
+        // The summary/index pair only exists in the legacy ("me") format; the
+        // newer BTI format uses a trie partition index instead.
+        auto sst = make_sstable_containing(env.make_sstable(s, sstable_version_types::me), std::move(mutations)).get();
+
+        const summary& sum = sst->get_summary();
+        // The first partition always gets an entry, then one is forced for every
+        // max_partitions_per_page partitions. Without the hard limit this would
+        // be a single entry, so checking against total/limit confirms it kicked in.
+        const size_t expected = total_partitions / max_partitions_per_page;
+        BOOST_REQUIRE_GE(sum.entries.size(), expected);
+        BOOST_REQUIRE_LE(sum.entries.size(), expected + 2);
+    });
+}
+
 SEASTAR_TEST_CASE(sstable_timestamp_metadata_correcness_with_negative) {
     BOOST_REQUIRE(this_smp_shard_count() == 1);
     return test_env::do_with_async([] (test_env& env) {

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -259,6 +259,7 @@ test_env::impl::impl(test_env_config cfg, sstable_compressor_factory& scfarg, ss
             sstables::sstables_manager::config{
                 .available_memory = cfg.available_memory,
                 .enable_sstable_key_validation = db_config->enable_sstable_key_validation(),
+                .sstable_summary_max_partitions_per_page = db_config->sstable_summary_max_partitions_per_page,
                 .memory_reclaim_threshold = db_config->components_memory_reclaim_threshold,
                 .data_file_directories = db_config->data_file_directories(),
                 .format = db_config->sstable_format,


### PR DESCRIPTION
sstables/mx/writer: avoid writing huge index pages (in BIG sstables)
Index pages (i.e. the contiguous pieces of Index.db which correspond to
a gap between neighboring Summary.db entries) are intended to have a few
hundred partition entries, maybe a few thousand at worst.

But with the current writer logic, the size of a page is functionally unlimited.
That logic is, paraphrased:
```
if (data_offset >= state.next_data_offset_to_write_summary) {
    ...add an entry to summary...
    state.next_data_offset_to_write_summary += state.summary_byte_cost * entry_size;
}
```
Where summary_byte_cost is 2000 by default (and is almost never adjusted).

This means that if an abnormally large partition key happens to be written to Summary,
the next index page will be abnormally large. For example, if a 1kB key
is written to Summary, the following index page will span
2000 * 1kB = 2 MB of the data file, which can fit hundreds of thousands of
tiny partitions. And since `data_file_offset` is the size of the data
file *after* compression, this is further multiplied by the compression ratio.

This patch modifies the writer logic to the following:
```
if (first_partition || data_offset - state.last_data_offset_in_summary > state.summary_byte_cost * entry_size) {
        ...add entry to summary...
    state.last_data_offset_in_summary = data_offset
}
```
Which means that, instead of picking an entry and then paying
for its "debt", we pick the first entry that has already been earned.

This should naturally avoid large pages (proof left as an exercise to the
reader, but the gist is that, once an average size of the index page has been
reached, the likelihood of a long run of entries which don't match the condition
should be shrinking exponentially with the length of the run)
while still preserving the summary:data ratio.
(Up to one entry anyway, because after the change, the first entry is considered
"free". Hopefully that's not a problem. It shouldn't be).

Additionally we add a configurable hard cap for the number of entries in a page,
just to make sure that an index page doesn't grow too big regardless
of Data.db compression ratio.
When the cap is exceeded, we force-add an entry.

Fixes: [SCYLLADB-2679](https://scylladb.atlassian.net/browse/SCYLLADB-2679)

[SCYLLADB-2679]: https://scylladb.atlassian.net/browse/SCYLLADB-2679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ