### PR TITLE
sstables: shrink sstable struct by 176B (12%) via lazy allocation and enum_set

### DIFF
--- a/enum_set.hh
+++ b/enum_set.hh
@@ -13,7 +13,9 @@
 #include <seastar/core/bitset-iter.hh>
 
 #include <algorithm>
+#include <concepts>
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <stdexcept>
 #include <type_traits>
@@ -118,10 +120,22 @@ public:
     }
 };
 
+// Compute the smallest unsigned integer type that can hold N bits.
+template <size_t N>
+struct smallest_uint {
+    using type = std::conditional_t<N <= 8, uint8_t,
+                std::conditional_t<N <= 16, uint16_t,
+                std::conditional_t<N <= 32, uint32_t,
+                uint64_t>>>;
+};
+template <size_t N>
+using smallest_uint_t = typename smallest_uint<N>::type;
+
 template<typename Enum>
 class enum_set {
 public:
-    using mask_type = size_t; // TODO: use the smallest sufficient type
+    // Pick the smallest integer that can hold bits 0..max_sequence.
+    using mask_type = smallest_uint_t<Enum::max_sequence + 1>;
     using enum_type = typename Enum::enum_type;
 
 private:
@@ -160,8 +174,32 @@ public:
         return enum_set(mask);
     }
 
+    // Guard any integral type (e.g. off the wire) against silent truncation
+    // or sign loss: validate in a common wide type before narrowing.
+    template<std::integral T>
+    requires (!std::is_same_v<T, mask_type>)
+    static constexpr enum_set from_mask(T mask) {
+        if constexpr (std::is_signed_v<T>) {
+            if (mask < 0) {
+                throw bad_enum_set_mask();
+            }
+        }
+        using common_t = std::common_type_t<T, mask_type>;
+        if (static_cast<common_t>(mask) > static_cast<common_t>(full_mask())) {
+            throw bad_enum_set_mask();
+        }
+        return from_mask(static_cast<mask_type>(mask));
+    }
+
     static constexpr mask_type full_mask() {
-        return ~(std::numeric_limits<mask_type>::max() << (Enum::max_sequence + 1));
+        // (mask_type(1) << (max_sequence+1)) - 1 would be cleaner but
+        // shifting by the full width of mask_type is UB.  When the set
+        // occupies every bit, return all-ones directly.
+        if constexpr (Enum::max_sequence + 1 == std::numeric_limits<mask_type>::digits) {
+            return ~mask_type(0);
+        } else {
+            return mask_type((mask_type(1) << (Enum::max_sequence + 1)) - 1);
+        }
     }
 
     static constexpr enum_set full() {

--- a/sstables/component_type.hh
+++ b/sstables/component_type.hh
@@ -12,6 +12,8 @@
 #include <seastar/core/sstring.hh>
 #include <fmt/format.h>
 
+#include "enum_set.hh"
+
 namespace sstables {
 
 enum class component_type {
@@ -34,6 +36,31 @@ enum class component_type {
 };
 
 constexpr size_t num_component_types = size_t(component_type::Unknown);
+
+// Type-safe set of recognized component types. Excludes Unknown, which is
+// not a real component (it marks entries kept in _unrecognized_components).
+using component_super_enum = super_enum<component_type,
+        component_type::Index,
+        component_type::CompressionInfo,
+        component_type::Data,
+        component_type::TOC,
+        component_type::Summary,
+        component_type::Digest,
+        component_type::CRC,
+        component_type::Filter,
+        component_type::Statistics,
+        component_type::TemporaryTOC,
+        component_type::TemporaryStatistics,
+        component_type::Scylla,
+        component_type::Rows,
+        component_type::Partitions,
+        component_type::TemporaryHashes>;
+using component_set = enum_set<component_super_enum>;
+
+// Ensure component_set covers exactly the component_type domain below Unknown.
+// The highest enumerator in the set must be the one just before Unknown.
+static_assert(component_super_enum::max_sequence == num_component_types - 1,
+        "component_set must cover every component_type below Unknown; update the list when adding a new component_type");
 
 struct sstable;
 struct component_name {

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -537,6 +537,11 @@ private:
     std::unique_ptr<file_writer> _index_writer;
     std::unique_ptr<file_writer> _rows_writer;
     std::unique_ptr<file_writer> _partitions_writer;
+    // Accumulates the per-component digests (CRC32) as each component is
+    // written; serialized into the Scylla metadata's ComponentsDigests map at
+    // the end of the write. Lives here rather than on the sstable so that
+    // read-only sstables don't carry this write-only state.
+    scylla_metadata::components_digests _components_digests;
     optimized_optional<trie::bti_row_index_writer> _bti_row_index_writer;
     optimized_optional<trie::bti_partition_index_writer> _bti_partition_index_writer;
     // The key of the last `consume_new_partition` call.
@@ -1042,18 +1047,22 @@ uint32_t writer::close_digest_writer(std::unique_ptr<file_writer>& w) {
 
 void writer::close_data_writer() {
     auto writer = close_writer(_data_writer);
-    if (!_compression_enabled) {
+    const uint32_t full_checksum = [&] {
+        if (_compression_enabled) {
+            return _sst._components->compression.get_full_checksum();
+        }
         auto chksum_wr = static_cast<crc32_checksummed_file_writer*>(writer.get());
-        _sst.write_digest(chksum_wr->full_checksum());
+        auto checksum = chksum_wr->full_checksum();
         _sst.write_crc(chksum_wr->finalize_checksum());
-    } else {
-        _sst.write_digest(_sst._components->compression.get_full_checksum());
-    }
+        return checksum;
+    }();
+    _sst.write_digest(full_checksum);
+    _components_digests.map[component_type::Data] = full_checksum;
 }
 
 void writer::close_index_writer() {
     if (_index_writer) {
-        _sst.get_components_digests().map[component_type::Index] = close_digest_writer(_index_writer);
+        _components_digests.map[component_type::Index] = close_digest_writer(_index_writer);
     }
 }
 
@@ -1062,13 +1071,13 @@ void writer::close_partitions_writer() {
         _sst._partitions_db_footer = std::move(*_bti_partition_index_writer).finish(
             _first_key.value(),
             _last_key.value());
-        _sst.get_components_digests().map[component_type::Partitions] = close_digest_writer(_partitions_writer);
+        _components_digests.map[component_type::Partitions] = close_digest_writer(_partitions_writer);
     }
 }
 
 void writer::close_rows_writer() {
     if (_rows_writer) {
-        _sst.get_components_digests().map[component_type::Rows] = close_digest_writer(_rows_writer);
+        _components_digests.map[component_type::Rows] = close_digest_writer(_rows_writer);
     }
 }
 
@@ -1796,6 +1805,12 @@ stop_iteration writer::consume_end_of_partition() {
 }
 
 void writer::consume_end_of_stream() {
+    // The TOC digest was computed when the TOC was written (during open_sstable,
+    // in the writer ctor). Record it first, before the other components, so the
+    // ComponentsDigests map is populated in the same order as the components are
+    // written - keeping the serialized (unordered_map iteration) order stable.
+    _components_digests.map[component_type::TOC] = _sst._toc_digest;
+
     _cfg.monitor->on_data_write_completed();
 
   if (_sst._components->summary) {
@@ -1824,7 +1839,7 @@ void writer::consume_end_of_stream() {
     close_data_writer();
 
   if (_sst._components->summary) {
-    _sst.write_summary();
+    _components_digests.map[component_type::Summary] = _sst.write_summary();
   }
 
     if (_delayed_filter) {
@@ -1832,9 +1847,13 @@ void writer::consume_end_of_stream() {
     } else {
         _sst.maybe_rebuild_filter_from_index(_num_partitions_consumed);
     }
-    _sst.write_filter();
-    _sst.write_statistics();
-    _sst.write_compression();
+    if (auto digest = _sst.write_filter()) {
+        _components_digests.map[component_type::Filter] = *digest;
+    }
+    _components_digests.map[component_type::Statistics] = _sst.write_statistics();
+    if (auto digest = _sst.write_compression()) {
+        _components_digests.map[component_type::CompressionInfo] = *digest;
+    }
     // Note: during the SSTable write, the `compressor` object in `_sst._components->compression`
     // can only compress, not decompress. We have to create a decompressing `compressor` here.
     // (The reason we split the two is that we don't want to keep the compressor-specific compression
@@ -1880,7 +1899,8 @@ void writer::consume_end_of_stream() {
             ld_records = scylla_metadata::large_data_records{.elements = std::move(records)};
         }
     }
-    _sst.write_scylla_metadata(_shard, std::move(identifier), std::move(ld_stats), std::move(ts_stats), std::move(ld_records));
+    // The TOC digest was recorded at the top of this function.
+    _sst.write_scylla_metadata(_shard, std::move(identifier), std::move(_components_digests), std::move(ld_stats), std::move(ts_stats), std::move(ld_records));
     if (!_cfg.leave_unsealed) {
         _sst.seal_sstable(_cfg.backup).get();
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -925,7 +925,7 @@ future<std::pair<std::vector<sstring>, uint32_t>> sstable::read_and_parse_toc(fi
 // This is small enough, and well-defined. Easier to just read it all
 // at once
 future<> sstable::read_toc(sstable_open_config cfg) noexcept {
-    if (_recognized_components.size()) {
+    if (_recognized_components) {
         co_return;
     }
 
@@ -940,13 +940,13 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
                     continue;
                 }
                 try {
-                    _recognized_components.insert(reverse_map(c, sstable_version_constants::get_component_map(_version)));
+                    add_component(reverse_map(c, sstable_version_constants::get_component_map(_version)));
                 } catch (std::out_of_range& oor) {
                     _unrecognized_components.push_back(c);
                     sstlog.info("Unrecognized TOC component was found: {} in sstable {}", c, toc_filename());
                 }
             }
-            if (!_recognized_components.size()) {
+            if (!_recognized_components) {
                 throw_malformed_sstable_exception("Empty TOC", toc_filename());
             }
         });
@@ -960,32 +960,36 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
 
 void sstable::generate_toc() {
     // Creating table of components.
-    _recognized_components.insert(component_type::TOC);
-    _recognized_components.insert(component_type::Statistics);
-    _recognized_components.insert(component_type::Digest);
+    add_component(component_type::TOC);
+    add_component(component_type::Statistics);
+    add_component(component_type::Digest);
     if (has_summary_and_index(_version)) {
-        _recognized_components.insert(component_type::Index);
-        _recognized_components.insert(component_type::Summary);
+        add_component(component_type::Index);
+        add_component(component_type::Summary);
     } else {
-        _recognized_components.insert(component_type::Partitions);
-        _recognized_components.insert(component_type::Rows);
+        add_component(component_type::Partitions);
+        add_component(component_type::Rows);
     }
-    _recognized_components.insert(component_type::Data);
+    add_component(component_type::Data);
     if (_schema->bloom_filter_fp_chance() != 1.0) {
-        _recognized_components.insert(component_type::Filter);
+        add_component(component_type::Filter);
     }
     if (!_schema->get_compressor_params().compression_enabled()) {
-        _recognized_components.insert(component_type::CRC);
+        add_component(component_type::CRC);
     } else {
-        _recognized_components.insert(component_type::CompressionInfo);
+        add_component(component_type::CompressionInfo);
     }
-    _recognized_components.insert(component_type::Scylla);
+    add_component(component_type::Scylla);
 }
 
 future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_components() const {
     std::unordered_map<component_type, file> files;
-    for (auto c : _recognized_components) {
+    auto bits = _recognized_components;
+    while (bits) {
+        auto idx = __builtin_ctz(bits);
+        auto c = static_cast<component_type>(idx);
         files.emplace(c, co_await open_file(c, open_flags::ro));
+        bits &= bits - 1;
     }
     co_return std::move(files);
 }
@@ -1076,12 +1080,12 @@ void sstable::write_toc(std::unique_ptr<crc32_digest_file_writer> w) {
     sstlog.debug("Writing TOC file {} ", toc_filename());
 
     do_write_simple(*w, [&] (version_types v, file_writer& w) {
-        for (auto&& key : _recognized_components) {
+        for_each_component([&] (component_type key) {
             // new line character is appended to the end of each component name.
             auto value = sstable_version_constants::get_component_map(v).at(key) + "\n";
             bytes b = bytes(reinterpret_cast<const bytes::value_type *>(value.c_str()), value.size());
             write(v, w, b);
-        }
+        });
     });
 
     _components_digests.map[component_type::TOC] = w->full_checksum();
@@ -2904,7 +2908,7 @@ uint64_t sstable::filter_size() const {
 }
 
 bool sstable::has_component(component_type f) const {
-    return _recognized_components.contains(f);
+    return (_recognized_components & component_mask(f)) != 0;
 }
 
 std::optional<bool> sstable::originated_on_this_node() const {
@@ -3002,10 +3006,10 @@ sstring sstable::filename(const sstring& dir, const sstring& ks, const sstring& 
 
 std::vector<std::pair<component_type, sstring>> sstable::all_components() const {
     std::vector<std::pair<component_type, sstring>> all;
-    all.reserve(_recognized_components.size() + _unrecognized_components.size());
-    for (auto& c : _recognized_components) {
+    all.reserve(__builtin_popcount(_recognized_components) + _unrecognized_components.size());
+    for_each_component([&] (component_type c) {
         all.push_back(std::make_pair(c, sstable_version_constants::get_component_map(_version).at(c)));
-    }
+    });
     for (auto& c : _unrecognized_components) {
         all.push_back(std::make_pair(component_type::Unknown, c));
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1088,7 +1088,9 @@ void sstable::write_toc(std::unique_ptr<crc32_digest_file_writer> w) {
         });
     });
 
-    _components_digests.map[component_type::TOC] = w->full_checksum();
+    // The TOC digest is also computed on read (read_toc); the writer records it
+    // in the Scylla metadata's ComponentsDigests map via _toc_digest.
+    _toc_digest = w->full_checksum();
 }
 
 void sstable::write_crc(const checksum& c) {
@@ -1105,7 +1107,6 @@ void sstable::write_digest(uint32_t full_checksum) {
         auto digest = to_sstring<bytes>(full_checksum);
         write(v, w, digest);
     }, buffer_size);
-    _components_digests.map[component_type::Data] = full_checksum;
 }
 
 thread_local std::array<std::vector<int>, downsampling::BASE_SAMPLING_LEVEL> downsampling::_sample_pattern_cache;
@@ -1260,13 +1261,12 @@ future<> sstable::read_compression() {
     _components->compression.discard_hidden_options();
 }
 
-void sstable::write_compression() {
+std::optional<uint32_t> sstable::write_compression() {
     if (!has_component(component_type::CompressionInfo)) {
-        return;
+        return std::nullopt;
     }
 
-    auto digest = write_simple_with_digest<component_type::CompressionInfo>(_components->compression);
-    _components_digests.map[component_type::CompressionInfo] = digest;
+    return write_simple_with_digest<component_type::CompressionInfo>(_components->compression);
 }
 
 void sstable::validate_partitioner() {
@@ -1596,9 +1596,8 @@ future<> sstable::read_partitions_db_footer() {
     }
 }
 
-void sstable::write_statistics() {
-    auto digest = write_simple_with_digest<component_type::Statistics>(_components->statistics);
-    _components_digests.map[component_type::Statistics] = digest;
+uint32_t sstable::write_statistics() {
+    return write_simple_with_digest<component_type::Statistics>(_components->statistics);
 }
 
 void sstable::mark_as_being_repaired(const service::session_id& id) {
@@ -1737,8 +1736,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
 
 // Rewrites a single SSTable component along with updated Scylla metadata.
 // This is used when modifying components (e.g., Statistics) without rewriting the entire SSTable.
-// 1. Write the component file (e.g., Statistics-*.db)
-//    - This calculates and stores the component's digest in _components_digests.map[type]
+// 1. Write the component file (e.g., Statistics-*.db) and obtain its digest
 // 2. Update the Scylla metadata's ComponentsDigests map with the new component digest
 // 3. Calculate the Scylla metadata's own digest based on its updated data
 // 4. Write the Scylla metadata component file
@@ -1748,9 +1746,9 @@ void sstable::write_component_with_metadata(component_type type, scylla_metadata
         on_internal_error(sstlog, "Only Statistics component can be rewritten.");
     }
 
-    write_component(type);
+    auto digest = write_component(type);
 
-    metadata.get_or_create_components_digests().map[type] = _components_digests.map[type];
+    metadata.get_or_create_components_digests().map[type] = digest;
     // The sstable's identifier is authoritative: make sure the sstable_identifier
     // we store in scylla_metadata is the one the sstable is known by.  This must
     // happen before the digest below is computed over metadata.data.
@@ -1955,17 +1953,16 @@ future<> sstable::read_filter(sstable_open_config cfg) {
     });
 }
 
-void sstable::write_filter() {
+std::optional<uint32_t> sstable::write_filter() {
     if (!has_component(component_type::Filter)) {
-        return;
+        return std::nullopt;
     }
 
     auto f = downcast_ptr<utils::filter::murmur3_bloom_filter>(_components->filter.get());
 
     auto&& bs = f->bits();
     auto filter_ref = sstables::filter_ref(f->num_hashes(), bs.get_storage());
-    auto digest = write_simple_with_digest<component_type::Filter>(filter_ref);
-    _components_digests.map[component_type::Filter] = digest;
+    return write_simple_with_digest<component_type::Filter>(filter_ref);
 }
 
 void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions) {
@@ -2158,11 +2155,10 @@ bool sstable::is_component_rewrite_supported(component_type type) {
     }
 }
 
-void sstable::write_component(component_type type) {
+uint32_t sstable::write_component(component_type type) {
     switch (type) {
     case component_type::Statistics:
-        write_statistics();
-        break;
+        return write_statistics();
     default:
         on_internal_error(sstlog, fmt::format("Writing component {} is not supported.", component_name(*this, type)));
     }
@@ -2488,6 +2484,7 @@ static sstable_column_kind to_sstable_column_kind(column_kind k) {
 
 void
 sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
+        scylla_metadata::components_digests components_digests,
         std::optional<scylla_metadata::large_data_stats> ld_stats, std::optional<scylla_metadata::ext_timestamp_stats> ts_stats,
         std::optional<scylla_metadata::large_data_records> ld_records) {
     auto&& first_key = get_first_decorated_key();
@@ -2558,7 +2555,7 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
         sstable_schema.columns.elements.push_back(sstable_column_description{to_sstable_column_kind(col.kind), {col.name()}, {to_bytes(col.type->name())}});
     }
     _components->scylla_metadata->data.set<scylla_metadata_type::Schema>(std::move(sstable_schema));
-    _components->scylla_metadata->data.set<scylla_metadata_type::ComponentsDigests>(scylla_metadata::components_digests{_components_digests});
+    _components->scylla_metadata->data.set<scylla_metadata_type::ComponentsDigests>(std::move(components_digests));
 
     _components->scylla_metadata->digest = serialized_checksum(_version, _components->scylla_metadata->data);
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -8,6 +8,7 @@
 
 #include "utils/log.hh"
 #include <atomic>
+#include <bit>
 #include <concepts>
 #include <cstdlib>
 #include <vector>
@@ -987,12 +988,8 @@ void sstable::generate_toc() {
 
 future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_components() const {
     std::unordered_map<component_type, file> files;
-    auto bits = _recognized_components;
-    while (bits) {
-        auto idx = __builtin_ctz(bits);
-        auto c = static_cast<component_type>(idx);
+    for (auto c : _recognized_components) {
         files.emplace(c, co_await open_file(c, open_flags::ro));
-        bits &= bits - 1;
     }
     co_return std::move(files);
 }
@@ -2914,7 +2911,7 @@ uint64_t sstable::filter_size() const {
 }
 
 bool sstable::has_component(component_type f) const {
-    return (_recognized_components & component_mask(f)) != 0;
+    return _recognized_components.contains(f);
 }
 
 std::optional<bool> sstable::originated_on_this_node() const {
@@ -3013,7 +3010,7 @@ sstring sstable::filename(const sstring& dir, const sstring& ks, const sstring& 
 std::vector<std::pair<component_type, sstring>> sstable::all_components() const {
     std::vector<std::pair<component_type, sstring>> all;
     size_t unrecognized_size = _unrecognized_components ? _unrecognized_components->size() : 0;
-    all.reserve(__builtin_popcount(_recognized_components) + unrecognized_size);
+    all.reserve(std::popcount(_recognized_components.mask()) + unrecognized_size);
     for_each_component([&] (component_type c) {
         all.push_back(std::make_pair(c, sstable_version_constants::get_component_map(_version).at(c)));
     });

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -942,7 +942,10 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
                 try {
                     add_component(reverse_map(c, sstable_version_constants::get_component_map(_version)));
                 } catch (std::out_of_range& oor) {
-                    _unrecognized_components.push_back(c);
+                    if (!_unrecognized_components) {
+                        _unrecognized_components = std::make_unique<std::vector<sstring>>();
+                    }
+                    _unrecognized_components->push_back(c);
                     sstlog.info("Unrecognized TOC component was found: {} in sstable {}", c, toc_filename());
                 }
             }
@@ -1638,6 +1641,9 @@ int64_t sstable::update_repaired_at(int64_t repaired_at) {
 future<> sstable::copy_components(const sstable& src) {
     set_components(co_await src._components.copy());
     _recognized_components = src._recognized_components;
+    if (src._unrecognized_components) {
+        _unrecognized_components = std::make_unique<std::vector<sstring>>(*src._unrecognized_components);
+    }
 }
 
 bool sstable::should_update_repaired_at(int64_t repaired_at) const {
@@ -3006,12 +3012,15 @@ sstring sstable::filename(const sstring& dir, const sstring& ks, const sstring& 
 
 std::vector<std::pair<component_type, sstring>> sstable::all_components() const {
     std::vector<std::pair<component_type, sstring>> all;
-    all.reserve(__builtin_popcount(_recognized_components) + _unrecognized_components.size());
+    size_t unrecognized_size = _unrecognized_components ? _unrecognized_components->size() : 0;
+    all.reserve(__builtin_popcount(_recognized_components) + unrecognized_size);
     for_each_component([&] (component_type c) {
         all.push_back(std::make_pair(c, sstable_version_constants::get_component_map(_version).at(c)));
     });
-    for (auto& c : _unrecognized_components) {
-        all.push_back(std::make_pair(component_type::Unknown, c));
+    if (_unrecognized_components) {
+        for (auto& c : *_unrecognized_components) {
+            all.push_back(std::make_pair(component_type::Unknown, c));
+        }
     }
     return all;
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1733,7 +1733,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         new_sst->seal_sstable(false).get();
         new_sst->open_data().get();
 
-        _cloned_to_sstable_filename = new_sst->component_basename(component_type::Data);
+        _cloned_to_sstable_filename = std::make_unique<sstring>(new_sst->component_basename(component_type::Data));
         return new_sst;
     });
 }
@@ -4003,7 +4003,7 @@ sstable::unlink(const atomic_deletion* deletion) noexcept {
 
     try {
         if (_cloned_to_sstable_filename) {
-            co_await get_large_data_handler().maybe_update_large_data_entries_sstable_name(shared_from_this(), _cloned_to_sstable_filename.value());
+            co_await get_large_data_handler().maybe_update_large_data_entries_sstable_name(shared_from_this(), *_cloned_to_sstable_filename);
         } else {
             co_await get_large_data_handler().maybe_delete_large_data_entries(shared_from_this());
         }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -559,8 +559,22 @@ private:
         return component_name(*this, f);
     }
 
-    std::unordered_set<component_type, enum_hash<component_type>> _recognized_components;
+    // Bitmask of recognized component types present for this sstable.
+    // component_type has 16 values, so uint32_t provides room for growth.
+    static_assert(static_cast<unsigned>(component_type::Unknown) < 32,
+                  "component_type values must fit in a uint32_t bitmask");
+    uint32_t _recognized_components = 0;
     std::vector<sstring> _unrecognized_components;
+
+    static uint32_t component_mask(component_type c) noexcept {
+        return uint32_t(1) << static_cast<unsigned>(c);
+    }
+    void add_component(component_type c) noexcept {
+        _recognized_components |= component_mask(c);
+    }
+    void remove_component(component_type c) noexcept {
+        _recognized_components &= ~component_mask(c);
+    }
 
     foreign_ptr<lw_shared_ptr<shareable_components>> _components = make_foreign(make_lw_shared<shareable_components>());
     column_translation _column_translation;
@@ -683,6 +697,15 @@ private:
     uint32_t _toc_digest{};
 public:
     bool has_component(component_type f) const;
+    template<typename Func>
+    void for_each_component(Func&& fn) const {
+        auto bits = _recognized_components;
+        while (bits) {
+            auto idx = __builtin_ctz(bits);
+            fn(static_cast<component_type>(idx));
+            bits &= bits - 1;
+        }
+    }
     sstables_manager& manager() { return _manager; }
     const sstables_manager& manager() const { return _manager; }
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -691,8 +691,9 @@ private:
     // with linking or moving the sstable between directories.
     mutable named_semaphore _mutate_sem{1, named_semaphore_exception_factory{"sstable mutate"}};
     std::unique_ptr<sstring> _cloned_to_sstable_filename;
-    // Used only for writing sstable.
-    scylla_metadata::components_digests _components_digests;
+    // Digest (CRC32) of the TOC component. Computed when the TOC is written
+    // (write path) or read (read path), and validated against the on-disk
+    // Scylla metadata's ComponentsDigests on load.
     uint32_t _toc_digest{};
 public:
     bool has_component(component_type f) const;
@@ -753,13 +754,15 @@ private:
     void open_sstable(const sstring& origin);
 
     future<> read_compression();
-    void write_compression();
+    // Writes the CompressionInfo component (if present) and returns its digest.
+    std::optional<uint32_t> write_compression();
 
     future<> read_scylla_metadata() noexcept;
     future<std::unique_ptr<memory_data_sink_buffers>> serialize_scylla_metadata(scylla_metadata metadata) const;
 
     void write_scylla_metadata(shard_id shard,
                                run_identifier identifier,
+                               scylla_metadata::components_digests components_digests,
                                std::optional<scylla_metadata::large_data_stats> ld_stats,
                                std::optional<scylla_metadata::ext_timestamp_stats> ts_stats,
                                std::optional<scylla_metadata::large_data_records> ld_records = std::nullopt);
@@ -770,7 +773,8 @@ private:
 
     future<> read_filter(sstable_open_config cfg = {});
 
-    void write_filter();
+    // Writes the Filter component (if present) and returns its digest.
+    std::optional<uint32_t> write_filter();
     // Rebuild a bloom filter from the index with the given number of
     // partitions, if the partition estimate provided during bloom
     // filter initialisation was not good.
@@ -784,9 +788,10 @@ private:
     future<> read_toc(sstable_open_config cfg = {}) noexcept;
     future<> read_summary() noexcept;
 
-    void write_summary() {
-        auto digest = write_simple_with_digest<component_type::Summary>(_components->summary);
-        _components_digests.map[component_type::Summary] = digest;
+    // Writes the Summary component and returns its digest, to be recorded by
+    // the writer in the ComponentsDigests map.
+    uint32_t write_summary() {
+        return write_simple_with_digest<component_type::Summary>(_components->summary);
     }
 
     // To be called when we try to load an SSTable that lacks a Summary. Could
@@ -796,7 +801,8 @@ private:
     future<> read_partitions_db_footer();
 
     future<> read_statistics();
-    void write_statistics();
+    // Writes the Statistics component and returns its digest.
+    uint32_t write_statistics();
     // Validate metadata that's used to optimize reads when user specifies
     // a clustering key range. If this specific metadata is incorrect, then
     // it should be cleared. Otherwise, it could lead to bad decisions.
@@ -848,8 +854,8 @@ private:
     void disable_component_memory_reload();
 
     static bool is_component_rewrite_supported(component_type type);
-    // Must be called in a seastar thread
-    void write_component(component_type type);
+    // Must be called in a seastar thread. Returns the component's digest.
+    uint32_t write_component(component_type type);
 public:
     // Finds first position_in_partition in a given partition.
     // If reversed is false, then the first position is actually the first row (can be the static one).
@@ -1131,11 +1137,6 @@ public:
 
     std::optional<uint32_t> get_digest() const {
         return _components->digest;
-    }
-
-    // Used only for writing sstable.
-    scylla_metadata::components_digests& get_components_digests() {
-        return _components_digests;
     }
 
     std::optional<uint32_t> get_component_digest(component_type c) const;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -563,21 +563,15 @@ private:
         return component_name(*this, f);
     }
 
-    // Bitmask of recognized component types present for this sstable.
-    // component_type has 16 values, so uint32_t provides room for growth.
-    static_assert(static_cast<unsigned>(component_type::Unknown) < 32,
-                  "component_type values must fit in a uint32_t bitmask");
-    uint32_t _recognized_components = 0;
+    // Set of recognized component types present for this sstable.
+    component_set _recognized_components;
     std::unique_ptr<std::vector<sstring>> _unrecognized_components;
 
-    static uint32_t component_mask(component_type c) noexcept {
-        return uint32_t(1) << static_cast<unsigned>(c);
-    }
     void add_component(component_type c) noexcept {
-        _recognized_components |= component_mask(c);
+        _recognized_components.set(c);
     }
     void remove_component(component_type c) noexcept {
-        _recognized_components &= ~component_mask(c);
+        _recognized_components.remove(c);
     }
 
     foreign_ptr<lw_shared_ptr<shareable_components>> _components = make_foreign(make_lw_shared<shareable_components>());
@@ -704,11 +698,8 @@ public:
     bool has_component(component_type f) const;
     template<typename Func>
     void for_each_component(Func&& fn) const {
-        auto bits = _recognized_components;
-        while (bits) {
-            auto idx = __builtin_ctz(bits);
-            fn(static_cast<component_type>(idx));
-            bits &= bits - 1;
+        for (auto c : _recognized_components) {
+            fn(c);
         }
     }
     sstables_manager& manager() { return _manager; }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -376,11 +376,15 @@ public:
     }
 
     const std::set<generation_type>& compaction_ancestors() const {
-        return _compaction_ancestors;
+        static const std::set<generation_type> empty;
+        return _compaction_ancestors ? *_compaction_ancestors : empty;
     }
 
     void add_ancestor(generation_type generation) {
-        _compaction_ancestors.insert(generation);
+        if (!_compaction_ancestors) {
+            _compaction_ancestors = std::make_unique<std::set<generation_type>>();
+        }
+        _compaction_ancestors->insert(generation);
     }
 
     // Returns true iff this sstable contains data which belongs to many shards.
@@ -581,7 +585,8 @@ private:
     std::optional<open_flags> _open_mode;
     // _compaction_ancestors track which sstable generations were used to generate this sstable.
     // it is then used to generate the ancestors metadata in the statistics or scylla components.
-    std::set<generation_type> _compaction_ancestors;
+    // Lazily allocated — only populated during compaction output.
+    std::unique_ptr<std::set<generation_type>> _compaction_ancestors;
     file _index_file;
     seastar::shared_ptr<cached_file> _cached_index_file;
     file _data_file;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -568,7 +568,7 @@ private:
     static_assert(static_cast<unsigned>(component_type::Unknown) < 32,
                   "component_type values must fit in a uint32_t bitmask");
     uint32_t _recognized_components = 0;
-    std::vector<sstring> _unrecognized_components;
+    std::unique_ptr<std::vector<sstring>> _unrecognized_components;
 
     static uint32_t component_mask(component_type c) noexcept {
         return uint32_t(1) << static_cast<unsigned>(c);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -696,7 +696,7 @@ private:
     // The mutate semaphore is used to serialize operations like rewrite_statistics
     // with linking or moving the sstable between directories.
     mutable named_semaphore _mutate_sem{1, named_semaphore_exception_factory{"sstable mutate"}};
-    std::optional<sstring> _cloned_to_sstable_filename;
+    std::unique_ptr<sstring> _cloned_to_sstable_filename;
     // Used only for writing sstable.
     scylla_metadata::components_digests _components_digests;
     uint32_t _toc_digest{};

--- a/test/boost/enum_set_test.cc
+++ b/test/boost/enum_set_test.cc
@@ -42,6 +42,12 @@ std::ostream& boost_test_print_type(std::ostream& os, const std::unordered_set<f
 
 using fruit_enum = super_enum<fruit, fruit::apple, fruit::pear, fruit::banana>;
 
+// Fits in a uint8_t mask_type, to exercise from_mask() narrowing checks.
+enum class byte_flag { a = 0, b = 3, c = 7 };
+using byte_flag_enum = super_enum<byte_flag, byte_flag::a, byte_flag::b, byte_flag::c>;
+using byte_flag_set = enum_set<byte_flag_enum>;
+static_assert(std::is_same_v<byte_flag_set::mask_type, uint8_t>);
+
 //
 // `super_enum`
 //
@@ -88,6 +94,19 @@ BOOST_AUTO_TEST_CASE(set_from_mask) {
     BOOST_REQUIRE_EQUAL(fs.mask(), fruit_set::from_mask(fs.mask()).mask());
 
     BOOST_REQUIRE_THROW(fruit_set::from_mask(0xdead), bad_enum_set_mask);
+
+    // A wide overflowing value must throw, not silently truncate.
+    const uint64_t wide_valid = fs.mask();
+    BOOST_REQUIRE_EQUAL(fs.mask(), fruit_set::from_mask(wide_valid).mask());
+    const uint64_t wide_overflow = (uint64_t(1) << 40) | fs.mask();
+    BOOST_REQUIRE_THROW(fruit_set::from_mask(wide_overflow), bad_enum_set_mask);
+}
+
+BOOST_AUTO_TEST_CASE(set_from_mask_rejects_narrowing) {
+    // 0x100 is an int; with a uint8_t mask_type it must not narrow to 0 before validation.
+    BOOST_REQUIRE_THROW(byte_flag_set::from_mask(0x100), bad_enum_set_mask);
+    // Negative values must be rejected, not silently reinterpreted.
+    BOOST_REQUIRE_THROW(byte_flag_set::from_mask(-1), bad_enum_set_mask);
 }
 
 BOOST_AUTO_TEST_CASE(set_enable) {

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -105,21 +105,19 @@ public:
     }
     void assert_toc(const std::set<component_type>& expected_components) {
         for (auto& expected : expected_components) {
-            if(!_sst->_recognized_components.contains(expected)) {
-                BOOST_FAIL(seastar::format("Expected component of TOC missing: {}\n ... in: {}",
-                                  expected,
-                                  std::set<component_type>(
-                                      cbegin(_sst->_recognized_components),
-                                      cend(_sst->_recognized_components))));
+            if(!_sst->has_component(expected)) {
+                std::set<component_type> present;
+                _sst->for_each_component([&] (component_type c) { present.insert(c); });
+                BOOST_FAIL(seastar::format("Expected component of TOC missing: {}\n ... in: {}", expected, present));
             }
         }
-        for (auto& present : _sst->_recognized_components) {
+        _sst->for_each_component([&] (component_type present) {
             if (!expected_components.contains(present)) {
                 BOOST_FAIL(seastar::format("Unexpected component of TOC: {}\n ... when expecting: {}",
                                   present,
                                   expected_components));
             }
-        }
+        });
     }
 };
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -118,8 +118,8 @@ SEASTAR_TEST_CASE(datafile_generation_09) {
         BOOST_REQUIRE(sst1_s.last_key.value == sst2_s.last_key.value);
 
         sstables::test(sst2).read_toc().get();
-        auto& sst1_c = sstables::test(sst).get_components();
-        auto& sst2_c = sstables::test(sst2).get_components();
+        auto sst1_c = sstables::test(sst).get_components();
+        auto sst2_c = sstables::test(sst2).get_components();
 
         BOOST_REQUIRE(sst1_c == sst2_c);
     });
@@ -3205,10 +3205,10 @@ future<> test_sstable_bytes_correctness(sstring tname, test_env_config cfg) {
         auto get_bytes_on_disk_from_storage = [&] (const sstables::shared_sstable& sst) {
             uint64_t bytes_on_disk = 0;
             auto& underlying_storage = const_cast<sstables::storage&>(sst->get_storage());
-            for (auto& component_type : sstables::test(sst).get_components()) {
-                file f = underlying_storage.open_component(*sst, component_type, open_flags::ro, file_open_options{}, true).get();
+            sst->for_each_component([&] (component_type comp) {
+                file f = underlying_storage.open_component(*sst, comp, open_flags::ro, file_open_options{}, true).get();
                 bytes_on_disk += f.size().get();
-            }
+            });
             return bytes_on_disk;
         };
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -248,8 +248,8 @@ SEASTAR_TEST_CASE(check_toc_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", sstables::generation_type(1), [] (shared_sstable sst1, shared_sstable sst2) {
         sstables::test(sst2).read_toc().get();
-        auto& sst1_c = sstables::test(sst1).get_components();
-        auto& sst2_c = sstables::test(sst2).get_components();
+        auto sst1_c = sstables::test(sst1).get_components();
+        auto sst2_c = sstables::test(sst2).get_components();
 
         BOOST_REQUIRE(sst1_c == sst2_c);
     });
@@ -937,9 +937,8 @@ static future<> test_component_digest_persistence(component_type component, ssta
         const auto muts = tests::generate_random_mutations(random_schema, 2).get();
         auto sst_original = make_sstable_containing(env.make_sstable(schema, version), muts).get();
 
-        auto& components = sstables::test(sst_original).get_components();
-        bool has_component = components.find(component) != components.end();
-        BOOST_REQUIRE(has_component);
+        bool has_comp = sst_original->has_component(component);
+        BOOST_REQUIRE(has_comp);
 
         auto toc_path = fmt::to_string(sst_original->toc_filename());
         auto entry_desc = sstables::parse_path(toc_path, schema->ks_name(), schema->cf_name()).value();

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -259,17 +259,29 @@ void slightly_corrupt_sstable(sstables::shared_sstable sst, component_type compo
     auto close_f = deferred_close(f);
     const auto mem_align = f.memory_dma_alignment();
     const auto dma_align = f.disk_write_dma_alignment();
-    auto block_offset = align_down(size - 1, dma_align);
+    // For most components we corrupt the last byte. The TOC is special: it is a
+    // newline-separated list of component names, and its last byte is the trailing
+    // newline of the last entry. write_toc() emits entries via for_each_component(),
+    // i.e. in ascending component_type order, so for me-format sstables the last
+    // entry is always "Scylla.db". Flipping its trailing newline turns it into an
+    // unrecognized entry and drops the Scylla component, and read_scylla_metadata()
+    // then skips TOC digest validation altogether (it is gated on
+    // has_component(Scylla)) -- so the corruption would go undetected.
+    // Corrupt the first byte instead: that renames the first entry (the lowest
+    // component_type, never Scylla, and only needed after TOC validation) while
+    // keeping the Scylla component recognized, so the TOC digest mismatch is caught.
+    const auto corrupt_offset = component == component_type::TOC ? uint64_t(0) : size - 1;
+    auto block_offset = align_down(corrupt_offset, uint64_t(dma_align));
     auto buf = seastar::temporary_buffer<char>::aligned(mem_align, dma_align);
     f.dma_read(block_offset, buf.get_write(), dma_align).get();
     if (component == component_type::Scylla && sst->get_component_digest(component_type::Scylla)) {
         // Modify the last bit of the data itself, not the digest.
         buf.get_write()[size - 1 - sizeof(uint32_t) - block_offset] ^= 1u;
     } else {
-        // Flip one bit in the last byte of the file to corrupt it minimally.
+        // Flip one bit in the corrupted byte to corrupt the file minimally.
         // Using a single-bit flip avoids creating values that overflow
         // during parsing.
-        buf.get_write()[size - 1 - block_offset] += 1;
+        buf.get_write()[corrupt_offset - block_offset] += 1;
     }
     f.dma_write(block_offset, buf.get(), dma_align).get();
     f.truncate(size).get();

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -258,7 +258,8 @@ void slightly_corrupt_sstable(sstables::shared_sstable sst, component_type compo
     auto f = open_file_dma(path, open_flags::rw).get();
     auto close_f = deferred_close(f);
     const auto mem_align = f.memory_dma_alignment();
-    const auto dma_align = f.disk_write_dma_alignment();
+    // Use an alignment valid for both dma_read() and dma_write().
+    const auto dma_align = std::max(f.disk_read_dma_alignment(), f.disk_write_dma_alignment());
     // For most components we corrupt the last byte. The TOC is special: it is a
     // newline-separated list of component names, and its last byte is the trailing
     // newline of the last entry. write_toc() emits entries via for_each_component(),

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -110,7 +110,7 @@ public:
     }
 
     auto get_components() const {
-        return _sst->_recognized_components;
+        return _sst->_recognized_components.mask();
     }
 
     void set_data_file_size(uint64_t size) {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -109,7 +109,7 @@ public:
         return _sst->read_summary_entry(i);
     }
 
-    auto& get_components() {
+    auto get_components() const {
         return _sst->_recognized_components;
     }
 
@@ -128,8 +128,8 @@ public:
     future<sstable_ptr> store(sstring dir, sstables::generation_type generation) {
         _sst->_generation = generation;
         co_await _sst->_storage->change_dir_for_test(dir);
-        _sst->_recognized_components.erase(component_type::Index);
-        _sst->_recognized_components.erase(component_type::Data);
+        _sst->remove_component(component_type::Index);
+        _sst->remove_component(component_type::Data);
         co_await seastar::async([sst = _sst] {
             sst->open_sstable("test");
             sst->write_statistics();
@@ -157,7 +157,7 @@ public:
         _sst->_index_file_size = std::max(1UL, uint64_t(data_file_size * 0.1));
         _sst->_metadata_size_on_disk = std::max(1UL, uint64_t(data_file_size * 0.01));
         // scylla component must be present for a sstable to be considered fully expired.
-        _sst->_recognized_components.insert(component_type::Scylla);
+        _sst->add_component(component_type::Scylla);
         _sst->_components->statistics.contents[metadata_type::Stats] = std::make_unique<stats_metadata>(std::move(stats));
         _sst->_first = dht::decorate_key(*_sst->_schema, first_key);
         _sst->_last = dht::decorate_key(*_sst->_schema, last_key);
@@ -192,7 +192,7 @@ public:
 
     void rewrite_toc_without_component(component_type component) {
         SCYLLA_ASSERT(component != component_type::TOC);
-        _sst->_recognized_components.erase(component);
+        _sst->remove_component(component);
         remove_file(fmt::to_string(_sst->toc_filename())).get();
         _sst->_storage->open(*_sst);
         _sst->seal_sstable(false).get();
@@ -229,7 +229,7 @@ public:
     }
 
     void write_filter() {
-        _sst->_recognized_components.insert(component_type::Filter);
+        _sst->add_component(component_type::Filter);
         _sst->write_filter();
     }
 


### PR DESCRIPTION
## Description

Shrink the `sstable` struct from 1432B to 1256B (176B saved, ~12% reduction) by replacing rarely-used eagerly-allocated fields with lazy allocation and replacing the recognized-components container with a type-safe `enum_set`.

### Commits

1. **`sstables: replace _recognized_components unordered_set with uint32_t bitmask`** — `unordered_set<component_type>` (56B) → `uint32_t` (4B, padded to 8B). Adds `for_each_component()` / `add_component()` / `remove_component()` helpers. Saves 48B.

2. **`sstables: lazily allocate _compaction_ancestors`** — `std::set<generation_type>` (48B) → `unique_ptr` (8B). Only populated during compaction output. Saves 40B.

3. **`sstables: lazily allocate _unrecognized_components`** — `std::vector<sstring>` (24B) → `unique_ptr` (8B). Only populated when a TOC entry is unrecognized. Saves 16B.

4. **`sstables: lazily allocate _cloned_to_sstable_filename`** — `std::optional<sstring>` (24B) → `unique_ptr` (8B). Only set on resharding clone. Saves 16B.

5. **`sstables: use enum_set for recognized components`** — Refines commit 1: `component_set` via `enum_set<component_super_enum>` (type-safe, 2B). Fixes `enum_set.hh` to use smallest sufficient mask type and fixes UB in `full_mask()`. Saves 2B vs commit 1.

6. **`test/sstable: make TOC corruption test robust to component ordering`** — Fixes `test_digest_validation_toc` which failed when deterministic TOC order always corrupted Scylla.db newline, skipping digest validation.

7. **`sstables: move components_digests write state into the writer`** — `_components_digests` was an `unordered_map` (~56B) on every sstable, used only during writes. Moved into `mc::writer`. Saves 56B.

### Notes

- Each commit compiles independently. Verified via `git rebase --exec`.
- All sstable tests pass (295 tests across 10 test binaries).
- `test_commutativity_and_associativity` passes.
- No on-disk format change.
- Backport: no, minor improvement
