### PR TITLE
test: destroys buckets after stopping servers

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -206,7 +206,11 @@ async def manager_server(suite_log_dir: Path,
             yield server
         finally:
             stop_event.set()
-            future.result()
+            # Wait for the manager thread off the event loop.  Stopping the
+            # manager recycles the cluster, and recycling runs teardown
+            # callbacks that belong to this loop; blocking it here would
+            # deadlock them.
+            await asyncio.get_running_loop().run_in_executor(None, future.result)
 
 
 @pytest.fixture(scope="module")

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -411,7 +411,7 @@ def failure_detector_timeout(build_mode):
     return 5000 * MODES_TIMEOUT_FACTOR[build_mode]
 
 @pytest.fixture(params=[None, 's3', 'gs'], ids=['local', 's3', 'gs'])
-async def storage(request, pytestconfig, tmpdir, suite_log_dir):
+async def storage(request, pytestconfig, tmpdir, suite_log_dir, manager: ManagerClient):
     """Parametrize tests over local / S3 / GCS storage.
 
     When storage is None the test runs with local (filesystem) storage.
@@ -421,5 +421,5 @@ async def storage(request, pytestconfig, tmpdir, suite_log_dir):
         yield None
         return
 
-    async with make_object_storage(request.param, pytestconfig, tmpdir, suite_log_dir, request.node.name) as server:
+    async with make_object_storage(request.param, pytestconfig, tmpdir, suite_log_dir, request.node.name, manager) as server:
         yield server

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -406,7 +406,7 @@ def failure_detector_timeout(build_mode):
     return 5000 * MODES_TIMEOUT_FACTOR[build_mode]
 
 @pytest.fixture(params=[None, 's3', 'gs'], ids=['local', 's3', 'gs'])
-async def storage(request, pytestconfig, tmpdir):
+async def storage(request, pytestconfig, tmpdir, manager: ManagerClient):
     """Parametrize tests over local / S3 / GCS storage.
 
     When storage is None the test runs with local (filesystem) storage.
@@ -416,5 +416,5 @@ async def storage(request, pytestconfig, tmpdir):
         yield None
         return
 
-    async with make_object_storage(request.param, pytestconfig, tmpdir, request.node.name) as server:
+    async with make_object_storage(request.param, pytestconfig, tmpdir, request.node.name, manager) as server:
         yield server

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -198,7 +198,10 @@ async def manager_api_sock_path(suite_log_dir: Path,
         yield sock_path
 
         stop_event.set()
-        future.result()
+        # Wait for the manager thread off the event loop.  Stopping the manager
+        # recycles the cluster, and recycling runs teardown callbacks that
+        # belong to this loop; blocking it here would deadlock them.
+        await asyncio.get_running_loop().run_in_executor(None, future.result)
 
 
 @pytest.fixture(scope="module")

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -10,6 +10,7 @@ from contextlib import asynccontextmanager
 import pytest
 
 from test.pylib.connect_options import add_s3_options
+from test.pylib.manager_client import ManagerClient
 from test.pylib.object_storage import (
     format_tuples,
     keyspace_options,
@@ -29,43 +30,64 @@ def pytest_addoption(parser):
 
 
 @asynccontextmanager
-async def make_object_storage(kind, pytestconfig, tmpdir, log_dir, test_name):
+async def make_object_storage(kind, pytestconfig, tmpdir, log_dir, test_name, manager: ManagerClient):
     """Start an object-storage backend for a test.
 
     `tmpdir` holds the server's scratch data (per-test, discarded by CI), while
     `log_dir` must be a CI-archived directory (testlog) so that container logs
     survive for post-mortem analysis.
+
+    The bucket is destroyed and the server stopped from teardown callbacks,
+    that is after the harness has stopped the cluster, not on exit from this
+    context manager.
     """
     if kind == 'gs':
         server = create_gs_server(log_dir)
     else:
         server = create_s3_server(pytestconfig, tmpdir, log_dir)
 
-    bucket_created = False
+    await server.start()
+    # Registered first so that it fires last, since the deletes below need the
+    # server.  Nothing else frees the server until it is registered, hence the
+    # eager stop.
     try:
-        await server.start()
-        server.create_test_bucket(test_name)
-        bucket_created = True
-        yield server
-    finally:
-        if bucket_created:
-            server.destroy_test_bucket()
+        await manager.add_teardown_callback(server.stop, 'stop object storage server')
+    except BaseException:
         await server.stop()
+        raise
+
+    server.create_test_bucket(test_name)
+    # Emptying the bucket while a node is still running can abort an in-flight
+    # compaction, tablet migration or streaming operation (SCYLLADB-2471), so
+    # destroy it from a callback instead: it fires once the cluster is down.
+    try:
+        await manager.add_teardown_callback(server.destroy_test_bucket, 'destroy test bucket')
+    except BaseException:
+        # A failed registration does not say whether the manager got as far as
+        # recording the callback -- _call() shields the operation, so a
+        # timed-out or cancelled caller leaves it running.  Destroy the bucket
+        # here regardless: no node has been told about it yet, so this races
+        # with nothing, and destroy_test_bucket() is a no-op the second time if
+        # the callback did register and fires later.
+        server.destroy_test_bucket()
+        raise
+
+    yield server
 
 
 @pytest.fixture(scope="function", params=['s3', 'gs'])
-async def object_storage(request, pytestconfig, tmpdir, suite_log_dir):
-    async with make_object_storage(request.param, pytestconfig, tmpdir, suite_log_dir, request.node.name) as server:
+async def object_storage(request, pytestconfig, tmpdir, suite_log_dir, manager: ManagerClient):
+    async with make_object_storage(request.param, pytestconfig, tmpdir, suite_log_dir, request.node.name, manager) as server:
         yield server
 
 
 @pytest.fixture(scope="function")
-async def s3_storage(request, pytestconfig, tmpdir, suite_log_dir):
-    async with make_object_storage('s3', pytestconfig, tmpdir, suite_log_dir, request.node.name) as server:
+async def s3_storage(request, pytestconfig, tmpdir, suite_log_dir, manager: ManagerClient):
+    async with make_object_storage('s3', pytestconfig, tmpdir, suite_log_dir, request.node.name, manager) as server:
         yield server
 
 
 @pytest.fixture(scope="function")
-async def gs_storage(request, pytestconfig, tmpdir, suite_log_dir):
-    async with make_object_storage('gs', pytestconfig, tmpdir, suite_log_dir, request.node.name) as server:
+async def gs_storage(request, pytestconfig, tmpdir, suite_log_dir, manager: ManagerClient):
+    async with make_object_storage('gs', pytestconfig, tmpdir, suite_log_dir, request.node.name, manager) as server:
         yield server

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -21,7 +21,6 @@ from test.pylib.object_storage import (
     S3Server,
     S3_Server,
     MinioWrapper,
-    s3_server,
 )
 
 

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -10,6 +10,7 @@ from contextlib import asynccontextmanager
 import pytest
 
 from test.pylib.connect_options import add_s3_options
+from test.pylib.manager_client import ManagerClient
 from test.pylib.object_storage import (
     format_tuples,
     keyspace_options,
@@ -29,31 +30,44 @@ def pytest_addoption(parser):
 
 
 @asynccontextmanager
-async def make_object_storage(kind, pytestconfig, tmpdir, test_name):
+async def make_object_storage(kind, pytestconfig, tmpdir, test_name, manager: ManagerClient):
+    """Yield a started object-storage server with a fresh per-test bucket.
+
+    The bucket is destroyed and the server stopped from teardown callbacks,
+    that is after the harness has stopped the cluster, not on exit from this
+    context manager.
+    """
     if kind == 'gs':
         server = create_gs_server(tmpdir)
     else:
         server = create_s3_server(pytestconfig, tmpdir)
 
-    bucket_created = False
+    await server.start()
+    # Registered first so that it fires last, since the deletes below need the
+    # server.  Nothing else frees the server until it is registered, hence the
+    # eager stop.
     try:
-        await server.start()
-        server.create_test_bucket(test_name)
-        bucket_created = True
-        yield server
-    finally:
-        if bucket_created:
-            server.destroy_test_bucket()
+        await manager.add_teardown_callback(server.stop, 'stop object storage server')
+    except BaseException:
         await server.stop()
+        raise
+
+    server.create_test_bucket(test_name)
+    # Emptying the bucket while a node is still running can abort an in-flight
+    # compaction, tablet migration or streaming operation (SCYLLADB-2471), so
+    # destroy it from a callback instead: it fires once the cluster is down.
+    await manager.add_teardown_callback(server.destroy_test_bucket, 'destroy test bucket')
+
+    yield server
 
 
 @pytest.fixture(scope="function", params=['s3', 'gs'])
-async def object_storage(request, pytestconfig, tmpdir):
-    async with make_object_storage(request.param, pytestconfig, tmpdir, request.node.name) as server:
+async def object_storage(request, pytestconfig, tmpdir, manager: ManagerClient):
+    async with make_object_storage(request.param, pytestconfig, tmpdir, request.node.name, manager) as server:
         yield server
 
 
 @pytest.fixture(scope="function")
-async def s3_storage(request, pytestconfig, tmpdir):
-    async with make_object_storage('s3', pytestconfig, tmpdir, request.node.name) as server:
+async def s3_storage(request, pytestconfig, tmpdir, manager: ManagerClient):
+    async with make_object_storage('s3', pytestconfig, tmpdir, request.node.name, manager) as server:
         yield server

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -22,7 +22,7 @@ from test.pylib.log_browsing import ScyllaLogFile
 from test.pylib.rest_client import ScyllaRESTAPIClient, ScyllaMetricsClient
 from test.pylib.util import gather_safely, wait_for, wait_for_cql_and_get_hosts, universalasync_typed_wrap, Host
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
-from test.pylib.scylla_cluster import ReplaceConfig, ScyllaClusterManager, ScyllaServer, ScyllaVersionDescription
+from test.pylib.scylla_cluster import ReplaceConfig, ScyllaClusterManager, ScyllaServer, ScyllaVersionDescription, bind_to_current_loop
 from test.pylib.driver_utils import safe_driver_shutdown
 from cassandra.cluster import Session as CassandraSession, \
     ExecutionProfile, EXEC_PROFILE_DEFAULT  # type: ignore # pylint: disable=no-name-in-module
@@ -523,6 +523,33 @@ class ManagerClient:
                 ignored_server = await self.find_server_by_host_id(servers, ignored)
                 ignored_ips.append(ignored_server.ip_addr)
         return ignored_ips
+
+    async def add_teardown_callback(self, callback: Callable[[], Any], name: str | None = None) -> None:
+        """Register a callback to run once the cluster used by this test has
+        been stopped.
+
+        The callbacks belong to the cluster and fire from its
+        run_teardown_callbacks(), which recycle() calls right after the servers
+        are stopped.  They therefore run against a cluster that is down, and
+        may dispose of a resource it was using without racing against it: an
+        object storage bucket that an in-flight tablet migration could
+        otherwise still read from (SCYLLADB-2471).
+
+        Two consequences of firing that late are worth knowing.  The resource
+        the callback disposes of has to stay alive past the fixture that
+        created it, and a failure inside a callback is reported against the
+        test case that recycled the cluster, not necessarily the one that
+        registered the callback.
+
+        Callbacks fire in LIFO order; both plain callables and coroutine
+        functions are accepted.  Register them from a fixture rather than from
+        a test body, so that a coroutine is handed back to a loop that is still
+        alive when it is awaited.  `name` is what the cluster log calls this
+        callback, and defaults to the callable's qualified name.
+        """
+        await self._call(self._manager.add_teardown_callback(
+            bind_to_current_loop(callback),
+            name or getattr(callback, "__qualname__", repr(callback))))
 
     async def server_add(self,
                          replace_cfg: Optional[ReplaceConfig] = None,

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -21,7 +21,7 @@ from test.pylib.log_browsing import ScyllaLogFile
 from test.pylib.rest_client import UnixRESTClient, ScyllaRESTAPIClient, ScyllaMetricsClient
 from test.pylib.util import gather_safely, wait_for, wait_for_cql_and_get_hosts, universalasync_typed_wrap, Host
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
-from test.pylib.scylla_cluster import ReplaceConfig, ScyllaServer, ScyllaVersionDescription
+from test.pylib.scylla_cluster import ReplaceConfig, ScyllaServer, ScyllaVersionDescription, park_teardown_callback
 from test.pylib.driver_utils import safe_driver_shutdown
 from cassandra.cluster import Session as CassandraSession, \
     ExecutionProfile, EXEC_PROFILE_DEFAULT  # type: ignore # pylint: disable=no-name-in-module
@@ -564,6 +564,34 @@ class ManagerClient:
         if expected_server_up_state:
             data['expected_server_up_state'] = expected_server_up_state.name
         return data
+
+    async def add_teardown_callback(self, callback: Callable[[], Any], name: str | None = None) -> None:
+        """Register a callback to run once the cluster used by this test has
+        been stopped.
+
+        The callbacks belong to the cluster and fire from its
+        run_teardown_callbacks(), which recycle() calls right after the servers
+        are stopped.  They therefore run against a cluster that is down, and
+        may dispose of a resource it was using without racing against it: an
+        object storage bucket that an in-flight tablet migration could
+        otherwise still read from (SCYLLADB-2471).
+
+        Two consequences of firing that late are worth knowing.  The resource
+        the callback disposes of has to stay alive past the fixture that
+        created it, and a failure inside a callback is reported against the
+        test case that recycled the cluster, not necessarily the one that
+        registered the callback.
+
+        Callbacks fire in LIFO order; both plain callables and coroutine
+        functions are accepted.  Register them from a fixture rather than from
+        a test body, so that a coroutine is handed back to a loop that is still
+        alive when it is awaited.  `name` is what the cluster log calls this
+        callback, and defaults to the callable's qualified name.
+        """
+        handle = park_teardown_callback(callback)
+        await self.client.put_json("/cluster/teardown-callback",
+                                   {"handle": handle,
+                                    "name": name or getattr(callback, "__qualname__", repr(callback))})
 
     async def server_add(self,
                          replace_cfg: Optional[ReplaceConfig] = None,

--- a/test/pylib/object_storage.py
+++ b/test/pylib/object_storage.py
@@ -94,14 +94,25 @@ class S3Server:
         resource.Bucket(self.bucket_name).create()
 
     def destroy_test_bucket(self):
-        """Empty and delete the per-test bucket using boto3."""
+        """Empty and delete the per-test bucket using boto3.
+
+        A no-op once the bucket is gone, so a caller that cannot tell whether
+        its deferred destroy was registered may call this and let the callback
+        run too.  A failed destroy leaves the bucket on record, so whichever of
+        the two runs second retries it.
+        """
+        if not self.bucket_name:
+            return
         try:
             resource = self.get_resource()
             bucket = resource.Bucket(self.bucket_name)
             bucket.objects.all().delete()
             bucket.delete()
         except Exception as e:
+            # Keep the name so that a retry still has a bucket to delete.
             logging.warning("Failed to destroy test bucket %s: %s", self.bucket_name, e)
+            return
+        self.bucket_name = None
 
     async def start(self):
         pass
@@ -148,7 +159,11 @@ class MinioWrapper(S3Server):
 
     async def stop(self):
         try:
-            await self.server.stop()
+            if self.server is not None:
+                # Dropped only on success, so that a retry still has a
+                # server to stop.
+                await self.server.stop()
+                self.server = None
         finally:
             if self.leased_host is not None:
                 await self.host_registry.release_host(self.leased_host)
@@ -191,14 +206,25 @@ class GSFront:
         resource.Bucket(self.bucket_name).create()
 
     def destroy_test_bucket(self):
-        """Empty and delete the per-test bucket using boto3."""
+        """Empty and delete the per-test bucket using boto3.
+
+        A no-op once the bucket is gone, so a caller that cannot tell whether
+        its deferred destroy was registered may call this and let the callback
+        run too.  A failed destroy leaves the bucket on record, so whichever of
+        the two runs second retries it.
+        """
+        if not self.bucket_name:
+            return
         try:
             resource = self.get_resource()
             bucket = resource.Bucket(self.bucket_name)
             bucket.objects.all().delete()
             bucket.delete()
         except Exception as e:
+            # Keep the name so that a retry still has a bucket to delete.
             logging.warning("Failed to destroy test bucket %s: %s", self.bucket_name, e)
+            return
+        self.bucket_name = None
 
     async def start(self):
         pass
@@ -270,20 +296,32 @@ class GSServerImpl(GSFront):
             raise Exception(f'Could not create test bucket: {response}')
 
     def destroy_test_bucket(self):
-        """Empty and delete the per-test bucket using GCS HTTP API."""
+        """Empty and delete the per-test bucket using GCS HTTP API.
+
+        A no-op once the bucket is gone, see S3Server.destroy_test_bucket().
+        """
+        if not self.bucket_name:
+            return
         try:
             # List and delete all objects first using boto3 (listing works on fake GCS)
             resource = self.get_resource()
             bucket = resource.Bucket(self.bucket_name)
             bucket.objects.all().delete()
             # Delete the bucket via GCS HTTP API
-            requests.delete(f'{self.endpoint}/storage/v1/b/{self.bucket_name}', timeout=10)
+            response = requests.delete(f'{self.endpoint}/storage/v1/b/{self.bucket_name}', timeout=10)
+            response.raise_for_status()
         except Exception as e:
+            # Keep the name so that a retry still has a bucket to delete.
             logging.warning("Failed to destroy test bucket %s: %s", self.bucket_name, e)
+            return
+        self.bucket_name = None
 
     async def stop(self):
         if self.server:
+            # Dropped only on success, so that a retry still has a server to
+            # stop.
             await self.server.stop()
+            self.server = None
         self.unpublish()
 
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -74,6 +74,28 @@ async def async_rmtree(directory, *args, **kwargs):
     await loop.run_in_executor(io_executor, partial(shutil.rmtree, directory, *args, **kwargs))
 
 
+def bind_to_current_loop(callback: Callable[[], Any]) -> Callable[[], Awaitable[None]]:
+    """Wrap `callback` so that it can be awaited from any loop.
+
+    A cluster is recycled on the ScyllaClusterManager's own loop, in its own
+    thread, while the teardown callbacks own objects the fixtures created on a
+    different loop -- a subprocess handle awaited from the wrong loop hangs
+    instead of failing.  Binding here lets the cluster keep a plain awaitable
+    and fire it without knowing which loop is underneath.
+    """
+    owner = asyncio.get_running_loop()
+
+    async def invoke() -> None:
+        res = callback()
+        if asyncio.iscoroutine(res):
+            if asyncio.get_running_loop() is owner:
+                await res
+            else:
+                await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(res, owner))
+
+    return invoke
+
+
 class ReplaceConfig(NamedTuple):
     replaced_id: ServerNum
     reuse_ip_addr: bool
@@ -1180,6 +1202,10 @@ class ScyllaCluster:
         self.keyspace_count = 0
         self.api = ScyllaRESTAPIClient()
         self.stop_lock = asyncio.Lock()
+        # Cleanups a test registered through ManagerClient.add_teardown_callback(),
+        # as (callback, name) pairs.  They are fired by run_teardown_callbacks()
+        # when this cluster is recycled.
+        self.teardown_callbacks: List[Tuple[Callable[[], Awaitable[None]], str]] = []
         self.logger.info("Created new cluster %s", self.name)
 
     async def install_and_start(self) -> None:
@@ -1218,6 +1244,9 @@ class ScyllaCluster:
            by a failed test.
         """
         await self.stop()
+        # The servers are down, so a callback may now dispose of a resource
+        # they were using without racing against them.
+        await self.run_teardown_callbacks()
         for srv in self.servers.values():
             if srv.log_file is not None:
                 srv.log_file.close()
@@ -1227,6 +1256,39 @@ class ScyllaCluster:
             self.api.close()
             self.api = None
         await self.release_ips()
+
+    def add_teardown_callback(self, callback: Callable[[], Awaitable[None]], name: str) -> None:
+        """Register a cleanup to run when this cluster is recycled.
+
+        The callback arrives already bound to the loop it was registered on, so
+        this end only tracks which callbacks belong to this cluster and in what
+        order they were registered.
+        """
+        self.logger.info("Cluster %s registers teardown callback %s", self, name)
+        self.teardown_callbacks.append((callback, name))
+
+    async def run_teardown_callbacks(self) -> None:
+        """Fire the registered teardown callbacks in LIFO order.
+
+        Called from recycle(), once the servers are stopped, so that a callback
+        disposing of a resource they were using cannot race with them: an
+        object storage bucket an in-flight tablet migration could otherwise
+        still read from (SCYLLADB-2471).
+
+        An exception in one callback is logged and swallowed, so that it
+        neither hides the others nor aborts the rest of the teardown.
+        """
+        assert not self.running, \
+            f"Cluster {self} still has running servers, teardown callbacks must fire after it is stopped"
+        while self.teardown_callbacks:
+            callback, name = self.teardown_callbacks.pop()
+            self.logger.info("Cluster %s running teardown callback %s", self, name)
+            try:
+                await callback()
+            except Exception as e:
+                self.logger.warning("Cluster %s teardown callback %s failed: %s", self, name, e)
+            else:
+                self.logger.info("Cluster %s teardown callback %s done", self, name)
 
     async def release_ips(self) -> None:
         """Release all IPs leased from the host registry by this cluster.
@@ -1962,6 +2024,11 @@ class ScyllaClusterManager:
     async def server_unpause(self, server_id: ServerNum) -> None:
         """Unpause the specified server."""
         self.cluster.server_unpause(server_id)
+
+    @manager_op(blockable=True)
+    async def add_teardown_callback(self, callback: Callable[[], Awaitable[None]], name: str) -> None:
+        """Register a cleanup to run when the current cluster is recycled."""
+        self.cluster.add_teardown_callback(callback, name)
 
     @manager_op(blockable=True)
     async def server_add(self,

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -74,6 +74,28 @@ async def async_rmtree(directory, *args, **kwargs):
     await loop.run_in_executor(io_executor, partial(shutil.rmtree, directory, *args, **kwargs))
 
 
+# A teardown callback is a Python callable, so it cannot travel over the
+# manager API the way every other request does.  ManagerClient parks it here
+# and sends the handle; ScyllaCluster stores the handles it was given and
+# resolves them when it fires them.  This table is the wire, the cluster owns
+# the callbacks.
+#
+# Each entry also remembers the event loop the callback was registered on.  A
+# cluster is recycled on the ScyllaClusterManager's own loop, in its own
+# thread, while the callbacks own objects the fixtures created on a different
+# loop -- a subprocess handle awaited from the wrong loop hangs instead of
+# failing, so a coroutine is always handed back to the loop that produced it.
+_parked_teardown_callbacks: dict[int, tuple[asyncio.AbstractEventLoop, Callable[[], Any]]] = {}
+_teardown_callback_handles = itertools.count(1)
+
+
+def park_teardown_callback(callback: Callable[[], Any]) -> int:
+    """Park a teardown callback and return the handle to send to the manager."""
+    handle = next(_teardown_callback_handles)
+    _parked_teardown_callbacks[handle] = (asyncio.get_running_loop(), callback)
+    return handle
+
+
 class ReplaceConfig(NamedTuple):
     replaced_id: ServerNum
     reuse_ip_addr: bool
@@ -1176,6 +1198,10 @@ class ScyllaCluster:
         self.keyspace_count = 0
         self.api = ScyllaRESTAPIClient()
         self.stop_lock = asyncio.Lock()
+        # Cleanups a test registered through ManagerClient.add_teardown_callback(),
+        # as (handle, name) pairs.  They are fired by run_teardown_callbacks()
+        # when this cluster is recycled.
+        self.teardown_callbacks: List[Tuple[int, str]] = []
         self.logger.info("Created new cluster %s", self.name)
 
     async def install_and_start(self) -> None:
@@ -1214,6 +1240,9 @@ class ScyllaCluster:
            by a failed test.
         """
         await self.stop()
+        # The servers are down, so a callback may now dispose of a resource
+        # they were using without racing against them.
+        await self.run_teardown_callbacks()
         for srv in self.servers.values():
             if srv.log_file is not None:
                 srv.log_file.close()
@@ -1223,6 +1252,45 @@ class ScyllaCluster:
             self.api.close()
             self.api = None
         await self.release_ips()
+
+    def add_teardown_callback(self, handle: int, name: str) -> None:
+        """Register a cleanup to run when this cluster is recycled.
+
+        The callback itself is parked client-side by park_teardown_callback();
+        this end only tracks which callbacks belong to this cluster and in what
+        order they were registered.
+        """
+        self.logger.info("Cluster %s registers teardown callback %s", self, name)
+        self.teardown_callbacks.append((handle, name))
+
+    async def run_teardown_callbacks(self) -> None:
+        """Fire the registered teardown callbacks in LIFO order.
+
+        Called from recycle(), once the servers are stopped, so that a callback
+        disposing of a resource they were using cannot race with them: an
+        object storage bucket an in-flight tablet migration could otherwise
+        still read from (SCYLLADB-2471).
+
+        An exception in one callback is logged and swallowed, so that it
+        neither hides the others nor aborts the rest of the teardown.
+        """
+        assert not self.running, \
+            f"Cluster {self} still has running servers, teardown callbacks must fire after it is stopped"
+        while self.teardown_callbacks:
+            handle, name = self.teardown_callbacks.pop()
+            loop, callback = _parked_teardown_callbacks.pop(handle)
+            self.logger.info("Cluster %s running teardown callback %s", self, name)
+            try:
+                res = callback()
+                if asyncio.iscoroutine(res):
+                    if loop is asyncio.get_running_loop():
+                        await res
+                    else:
+                        await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(res, loop))
+            except Exception as e:
+                self.logger.warning("Cluster %s teardown callback %s failed: %s", self, name, e)
+            else:
+                self.logger.info("Cluster %s teardown callback %s done", self, name)
 
     async def release_ips(self) -> None:
         """Release all IPs leased from the host registry by this cluster.
@@ -1853,6 +1921,7 @@ class ScyllaClusterManager:
         add_put('/cluster/server/{server_id}/start', self._cluster_server_start)
         add_put('/cluster/server/{server_id}/pause', self._cluster_server_pause)
         add_put('/cluster/server/{server_id}/unpause', self._cluster_server_unpause)
+        add_put('/cluster/teardown-callback', self._cluster_add_teardown_callback)
         add_put('/cluster/addserver', self._cluster_server_add)
         add_put('/cluster/addservers', self._cluster_servers_add)
         add_put('/cluster/remove-node/{initiator}', self._cluster_remove_node)
@@ -2015,6 +2084,12 @@ class ScyllaClusterManager:
         assert self.cluster
         server_id = ServerNum(int(request.match_info["server_id"]))
         self.cluster.server_unpause(server_id)
+
+    async def _cluster_add_teardown_callback(self, request) -> None:
+        """Register a cleanup to run when the current cluster is recycled."""
+        assert self.cluster
+        data = await request.json()
+        self.cluster.add_teardown_callback(data["handle"], data["name"])
 
     async def _cluster_server_add(self, request) -> dict[str, object]:
         """Add a new server."""


### PR DESCRIPTION
### Problem

The `object_storage` / `s3_storage` / `storage` fixtures destroyed their per-test bucket in the `finally` of `make_object_storage`. Those fixtures are torn down *before* the `manager` they depend on, so the destroy ran while the Scylla cluster was still up. Any in-flight operation still touching the bucket — compaction, tablet migration, sstable streaming — could race with the teardown and abort a node, surfacing as unrelated flakiness in the *next* test case.

### Changes

A test registers a cleanup with `manager.add_teardown_callback()`. The callback belongs to the cluster that was leased when it was registered, and `ScyllaCluster.recycle()` fires it right after the servers are stopped, next to `release_ips()`. Every path that disposes of a cluster goes through `recycle()` — replacing a dirty cluster in `_before_test`, `ScyllaClusterManager.stop()`, the module fixture's `finally`, and failed-start cleanup — so no cluster is dropped with callbacks still pending, and nothing depends on the cluster happening to be dirty.

Registration follows the same chain as adding a server: `ManagerClient.add_teardown_callback()` → `ScyllaClusterManager.add_teardown_callback()` → `ScyllaCluster.add_teardown_callback()`. The cluster owns the callbacks and the order they were registered in. The callable is bound to its registering event loop on the way in — a cluster is recycled on the manager’s own loop, in its own thread, and awaiting a subprocess handle from a foreign loop hangs rather than fails — so what the cluster keeps is a plain awaitable it can fire without knowing which loop is underneath. Every registration and every fire is logged to the cluster log.

The object-storage fixtures register `server.stop` first and `destroy_test_bucket` second. Callbacks fire LIFO, so the bucket is emptied while the storage server is still up to serve the deletes, and the storage server is stopped last. Nothing in the fixture touches the cluster.

One harness change was needed to make the hook viable: `manager_server` waited for the manager thread with a bare `future.result()`, which blocks the fixture loop. Since stopping the manager recycles the cluster and runs callbacks that belong to that loop, the blocking wait moves into an executor — otherwise the last object-storage test of every module deadlocks.

Two consequences of firing at recycle time are documented on `add_teardown_callback()`: the resource a callback disposes of has to stay alive past the fixture that created it, and a failure inside a callback is reported against the test case that recycled the cluster, not necessarily the one that registered it.

If registering a callback fails, the fixture disposes of the resource itself and re-raises. A failed registration does not say whether the manager recorded the callback — `_call()` shields the operation, so a timed-out or cancelled caller leaves it running — so `destroy_test_bucket()` and `stop()` are made no-ops on a second run rather than relying on a delete of a missing bucket failing quietly.

Last, `test/cluster/object_store/conftest.py` imported the `s3_server` fixture from `test/pylib/object_storage.py`. Importing a fixture into a conftest publishes it to every test in that directory, so the suite had a second way to get object storage — one that still destroys its bucket while the cluster is up. No test under `test/cluster/` ever asked for it, so the import is dropped.

### Testing

`test/cluster/object_store/` on dev: 139 passed, 1 skipped, 0 failed, both before and after rebasing onto master. `test/cluster/test_encryption.py`, the only other user of the `storage` fixture, passes all three of its `local` / `s3` / `gs` parametrisations.

Comparing, across a logs-preserved run, the set of clusters that registered a callback against the set that ran one: 29 registered, 29 fired, 0 failures, no cluster in either set difference. A single cluster's timeline shows the ordering the fix is about — the bucket is destroyed with zero running servers:

```
registers teardown callback stop object storage server   (running: , stopped: )
registers teardown callback destroy test bucket          (running: , stopped: )
stopping                                                 (running: ScyllaServer, stopped: )
running teardown callback destroy test bucket            (running: , stopped: ScyllaServer)
teardown callback destroy test bucket done
```

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2471

### Backport

None — test-only change.
