### PR TITLE
test: dtest: run schema_management_test in dev mode only and fix a schema-visibility race

### DIFF
--- a/test/cluster/dtest/dtest_class.py
+++ b/test/cluster/dtest/dtest_class.py
@@ -7,16 +7,20 @@
 import logging
 import re
 import time
+from functools import singledispatch
 
 import cassandra
 import pytest
 import requests
 from cassandra import ConsistencyLevel
 from cassandra.auth import PlainTextAuthProvider
-from cassandra.cluster import ExecutionProfile
+from cassandra.cluster import ExecutionProfile, Session
 from cassandra.policies import RetryPolicy
 
+from test.cluster.dtest.ccmlib.scylla_node import ScyllaNode
 from test.cluster.dtest.tools.misc import retry_till_success
+from test.pylib.internal_types import IPAddress
+from test.pylib.rest_client import read_barrier as read_barrier_via_api
 
 
 logger = logging.getLogger(__name__)
@@ -170,13 +174,26 @@ def create_ks_query(session, name, query):
     session.execute(f"USE {name}")
 
 
-def read_barrier(session):
+@singledispatch
+def read_barrier(session_or_node) -> None:
+    raise NotImplementedError("Unsupported argument type")
+
+
+@read_barrier.register
+def _(session_or_node: Session) -> None:
     """To issue a read barrier it is sufficient to attempt dropping a
     non-existing table. We need to use `if exists`, otherwise the statement
     would fail on prepare/validate step which happens before a read barrier is
     performed.
     """
-    session.execute("drop table if exists nosuchkeyspace.nosuchtable")
+    session_or_node.execute("drop table if exists nosuchkeyspace.nosuchtable")
+
+
+@read_barrier.register
+def _(session_or_node: ScyllaNode) -> None:
+    """Issue a read barrier on the specific host using REST API."""
+
+    read_barrier_via_api(api=session_or_node.cluster.manager.api, node_ip=IPAddress(session_or_node.address()))
 
 
 def get_auth_provider(user, password):

--- a/test/cluster/dtest/schema_management_test.py
+++ b/test/cluster/dtest/schema_management_test.py
@@ -267,6 +267,12 @@ class TestSchemaManagement(Tester):
             try:
                 logger.debug("Creating table")
                 create_c1c2_table(session)
+
+                # When create_c1c2_table() completes, only node1 is guaranteed to see the new table.  But node3 can
+                # handle requests before it sees the latest schema.  To fix this we need to add a read barrier for
+                # this node.
+                read_barrier(node3)
+
                 logger.debug("Populating")
                 insert_c1c2(session, n=10)
             except AlreadyExists:

--- a/test/cluster/test_config.yaml
+++ b/test/cluster/test_config.yaml
@@ -23,7 +23,6 @@ skip_in_release:
   - test_raft_cluster_features
   - test_cluster_features
   - dtest/limits_test
-  - dtest/schema_management_test
 skip_in_debug:
   - test_shutdown_hang
   - test_replace
@@ -47,5 +46,6 @@ run_in_dev:
   - dtest/commitlog_test
   - dtest/cfid_test
   - dtest/rebuild_test
+  - dtest/schema_management_test
 run_in_debug:
   - random_failures/test_random_failures

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -16,7 +16,7 @@ from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from typing import Any, Optional, AsyncIterator
 
-import pytest
+import universalasync
 from aiohttp import request, BaseConnector, UnixConnector, ClientTimeout
 from cassandra.pool import Host                          # type: ignore # pylint: disable=no-name-in-module
 
@@ -777,6 +777,7 @@ async def inject_error_one_shot(api: ScyllaRESTAPIClient, node_ip: IPAddress, in
     return InjectionHandler(api, injection, node_ip)
 
 
+@universalasync.async_to_sync_wraps
 async def read_barrier(api: ScyllaRESTAPIClient, node_ip: IPAddress, group_id: Optional[str] = None,
                        timeout: Optional[int] = None) -> None:
     """ Issue a read barrier on the specific host for the group_id.


### PR DESCRIPTION
## What
- Restrict the migrated `dtest/schema_management_test` module to `dev` mode (see dtest -> test.py migration docs)
- Fix the `flaky test_update_schema_while_node_is_killed[create_table]` by issuing a `group0` read barrier on `node3` after creating the table and before inserting.
- Add supporting infrastructure: make `read_barrier()` accept a specific node (via the REST `/raft/read_barrier` endpoint), not just a CQL Session.
## Why
In the `create_table` case the table is created while `node2` is killed, then an `INSERT` is prepared. When `create_c1c2_table()` returns, only the coordinator (`node1`) is guaranteed to have applied the new schema -- a live follower (`node3`) applies the committed `group0` command asynchronously. The session's keyless `prepare()` round-robins across live nodes, so it can land on `node3` before it has applied and fail with:
`cassandra.InvalidRequest: Error from server: code=2200 [Invalid query] message="unconfigured table cf"`
This is expected behavior, not a product bug: schema reads are served from local (eventually consistent) schema, and strong cross-node schema reads require a group0 read barrier -- which the CQL prepare/validate path intentionally does not perform. The window is normally masked by the driver's best-effort schema agreement, which is defeated by the concurrent ungraceful kill. It surfaces most easily under the slower debug/sanitize timing.

Fixes SCYLLADB-2955