### PR TITLE
test: add auto soft/hard pytest timeouts and mark long tests slow

### DIFF
--- a/test/boost/gcp_object_storage_test.cc
+++ b/test/boost/gcp_object_storage_test.cc
@@ -304,7 +304,7 @@ SEASTAR_FIXTURE_TEST_CASE(test_merge_objects, local_gcs_wrapper, *check_gcp_stor
 }
 
 
-SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_read_large_object_iov, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {
+SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_read_large_object_iov, local_gcs_wrapper, *check_gcp_storage_test_enabled() * boost::unit_test::label("slow")) {
     auto& c = client();
     auto name = make_name();
     std::vector<temporary_buffer<char>> written;

--- a/test/boost/index_with_paging_test.cc
+++ b/test/boost/index_with_paging_test.cc
@@ -17,7 +17,7 @@
 
 BOOST_AUTO_TEST_SUITE(index_with_paging_test)
 
-SEASTAR_TEST_CASE(test_index_with_paging) {
+SEASTAR_TEST_CASE(test_index_with_paging, *boost::unit_test::label("slow")) {
     return do_with_cql_env_thread([] (auto& e) {
         e.execute_cql("CREATE TABLE tab (pk int, ck text, v int, v2 int, v3 text, PRIMARY KEY (pk, ck))").get();
         e.execute_cql("CREATE INDEX ON tab (v)").get();

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2163,7 +2163,7 @@ SEASTAR_TEST_CASE(time_window_strategy_correctness_test) {
     return test_env::do_with_async([](test_env& env) { time_window_strategy_correctness_fn(env); });
 }
 
-SEASTAR_TEST_CASE(time_window_strategy_correctness_s3_test, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+SEASTAR_TEST_CASE(time_window_strategy_correctness_s3_test, *boost::unit_test::precondition(tests::has_scylla_test_env) * boost::unit_test::label("slow")) {
     return test_env::do_with_async([](test_env& env) { time_window_strategy_correctness_fn(env); },
                                    test_env_config{.storage = make_test_object_storage_options("S3")});
 }
@@ -4185,7 +4185,7 @@ SEASTAR_TEST_CASE(sstable_run_based_compaction_test) {
     return test_env::do_with_async([](test_env& env) { sstable_run_based_compaction_fn(env); });
 }
 
-SEASTAR_TEST_CASE(sstable_run_based_compaction_test_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+SEASTAR_TEST_CASE(sstable_run_based_compaction_test_s3, *boost::unit_test::precondition(tests::has_scylla_test_env) * boost::unit_test::label("slow")) {
     return test_env::do_with_async([](test_env& env) { sstable_run_based_compaction_fn(env); },
                                    test_env_config{.storage = make_test_object_storage_options("S3")});
 }
@@ -5758,7 +5758,7 @@ SEASTAR_TEST_CASE(max_ongoing_compaction_test) {
     return test_env::do_with_async([](test_env& env) { max_ongoing_compaction_fn(env); });
 }
 
-SEASTAR_TEST_CASE(max_ongoing_compaction_test_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+SEASTAR_TEST_CASE(max_ongoing_compaction_test_s3, *boost::unit_test::precondition(tests::has_scylla_test_env) * boost::unit_test::label("slow")) {
     return test_env::do_with_async([](test_env& env) { max_ongoing_compaction_fn(env); }, test_env_config{.storage = make_test_object_storage_options("S3")});
 }
 
@@ -6882,7 +6882,7 @@ SEASTAR_TEST_CASE(cleanup_incremental_compaction_test) {
     });
 }
 
-SEASTAR_TEST_CASE(cleanup_incremental_compaction_s3_test, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+SEASTAR_TEST_CASE(cleanup_incremental_compaction_s3_test, *boost::unit_test::precondition(tests::has_scylla_test_env) * boost::unit_test::label("slow")) {
     return run_incremental_compaction_test(
         sstables::offstrategy::no,
         [](table_for_tests& t, compaction::owned_ranges_ptr owned_ranges) -> future<> {
@@ -6907,7 +6907,7 @@ SEASTAR_TEST_CASE(offstrategy_incremental_compaction_test) {
     });
 }
 
-SEASTAR_TEST_CASE(offstrategy_incremental_compaction_s3_test, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+SEASTAR_TEST_CASE(offstrategy_incremental_compaction_s3_test, *boost::unit_test::precondition(tests::has_scylla_test_env) * boost::unit_test::label("slow")) {
     return run_incremental_compaction_test(
         sstables::offstrategy::yes,
         [](table_for_tests& t, compaction::owned_ranges_ptr owned_ranges) -> future<> {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -4532,7 +4532,7 @@ allocate_replicas_in_racks(const std::vector<endpoint_dc_rack>& racks, int rf,
     return replica_hosts;
 }
 
-SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load, *boost::unit_test::label("slow")) {
   auto do_test_case = [] (const shard_id rf) {
     cql_test_config cfg;
     cfg.need_remote_proxy = true;
@@ -5293,7 +5293,7 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_option_and_config_changes) {
     }, cfg).get();
 }
 
-SEASTAR_THREAD_TEST_CASE(test_creating_lots_of_tables_doesnt_overflow_metadata) {
+SEASTAR_THREAD_TEST_CASE(test_creating_lots_of_tables_doesnt_overflow_metadata, *boost::unit_test::label("slow")) {
     auto cfg = tablet_cql_test_config();
     cfg.db_config->tablets_initial_scale_factor(10.0);
     cfg.db_config->tablets_per_shard_goal(100);
@@ -5731,7 +5731,7 @@ static void do_test_load_balancing_merge_colocation(cql_test_env& e, const int n
     e.execute_cql(fmt::format("drop keyspace {}", ks_name)).get();
 }
 
-SEASTAR_THREAD_TEST_CASE(test_load_balancing_merge_colocation_with_random_load) {
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_merge_colocation_with_random_load, *boost::unit_test::label("slow")) {
     cql_test_config cfg;
     cfg.need_remote_proxy = true;
     do_with_cql_env_thread([] (auto& e) {

--- a/test/cluster/dtest/commitlog_test.py
+++ b/test/cluster/dtest/commitlog_test.py
@@ -723,6 +723,7 @@ class TestCommitLog(Tester):
         assert not node1.grep_log(f"large_data - Writing large row {self.ks}/{self.cf}")
         assert in_table == []
 
+    @pytest.mark.slow
     def test_pinned_cl_segment_doesnt_resurrect_data(self):
         """
         The tested scenario is as follows:

--- a/test/cluster/dtest/limits_test.py
+++ b/test/cluster/dtest/limits_test.py
@@ -275,6 +275,7 @@ class TestLimits(Tester):
 
         session.execute("""TRUNCATE test1""")
 
+    @pytest.mark.slow
     def test_max_cells(self):
         if self.cluster.scylla_mode == "debug":
             skip_env("client times out in debug mode")

--- a/test/cluster/dtest/rebuild_test.py
+++ b/test/cluster/dtest/rebuild_test.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 class TestRebuildStreamingAbortRepro(Tester):
     @pytest.mark.cluster_options(allowed_repair_based_node_ops="")
+    @pytest.mark.slow
     def test_rebuild_stream_abort_repro(self):
         """2-DC cluster parallel non-RBNO rebuild failure when expanding RF in DC2 (#27804.)
 

--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -133,6 +133,7 @@ async def run_random_resizes(
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='debug mode is too slow for this test')
+@pytest.mark.slow
 async def test_multi_column_lwt_during_split_merge(manager: ManagerClient, scale_timeout):
     """
     Test scenario:

--- a/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
+++ b/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
@@ -294,6 +294,7 @@ async def run_random_resizes(
 
 
 @pytest.mark.skip_mode("debug", "debug mode is too slow for this test")
+@pytest.mark.slow
 async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClient, scale_timeout):
 
     cfg = {

--- a/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 # remote view updates.
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.skip_mode(mode='debug', reason='node replace needs to wait for tablet rebuild, which takes a lot of time in debug mode')
+@pytest.mark.slow
 async def test_mv_tablets_empty_ip(manager: ManagerClient):
     cfg = {'tablets_mode_for_new_keyspaces': 'enabled'}
     servers = await manager.servers_add(4, config = cfg, property_file=[

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -657,6 +657,7 @@ class SSTablesOnObjectStorage:
         topo(rf = 3, nodes = 6, racks = 2, dcs = 1),
         topo(rf = 2, nodes = 8, racks = 4, dcs = 2)
     ])
+@pytest.mark.slow
 async def test_restore_with_streaming_scopes(build_mode: str, manager: ManagerClient, object_storage, topology):
     '''Check that restoring of a cluster with stream scopes works'''
     await do_test_streaming_scopes(build_mode, manager, topology, SSTablesOnObjectStorage(object_storage))
@@ -735,6 +736,7 @@ async def do_test_streaming_scopes(build_mode: str, manager: ManagerClient, topo
             await cql.run_async(f"DROP TABLE {ks}.test")
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("topology", [
         topo(rf = 1, nodes = 3, racks = 1, dcs = 1),
         topo(rf = 2, nodes = 2, racks = 2, dcs = 1),
@@ -912,6 +914,7 @@ async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: Ma
     (1, 1, 2, 2),
     (4, 4, 2, 2),
 ])
+@pytest.mark.slow
 async def test_restore_tablets_with_different_tablet_hints(build_mode: str, manager: ManagerClient, object_storage,
                                                            min_tablet_count_before_backup, max_tablet_count_before_backup,
                                                            min_tablet_count_before_restore, max_tablet_count_before_restore):

--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -70,6 +70,7 @@ global_cmdline = ["--disk-space-monitor-normal-polling-interval-in-seconds", "1"
                   ]
 
 
+@pytest.mark.slow
 async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, hosts = await manager.get_ready_cql(servers)
@@ -121,6 +122,7 @@ async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Ca
                 await cql.run_async(SimpleStatement(next(wgen), consistency_level=ConsistencyLevel.ALL))
 
 
+@pytest.mark.slow
 async def test_autotoggle_compaction(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmdline = [*global_cmdline,
                "--logger-log-level", "compaction=debug"]
@@ -166,6 +168,7 @@ async def test_autotoggle_compaction(manager: ManagerClient, volumes_factory: Ca
                 await log.wait_for(rf"Major {ks}\.{table} .* Compacted .* sstables to .*", from_mark=mark)
 
 
+@pytest.mark.slow
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_critical_utilization_during_decommission(manager: ManagerClient, volumes_factory: Callable) -> None:
     """
@@ -221,6 +224,7 @@ async def test_critical_utilization_during_decommission(manager: ManagerClient, 
 
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_reject_split_compaction(manager: ManagerClient, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, _ = await manager.get_ready_cql(servers)
@@ -248,6 +252,7 @@ async def test_reject_split_compaction(manager: ManagerClient, volumes_factory: 
                     await log.wait_for(f"Split task .* for table {cf} .* stopped, reason: Compaction for {cf} was stopped due to: drain", from_mark=mark)
 
 
+@pytest.mark.slow
 async def test_split_compaction_not_triggered(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
            "--logger-log-level", "compaction=debug"]
@@ -281,6 +286,7 @@ async def test_split_compaction_not_triggered(manager: ManagerClient, volumes_fa
                     assert await s1_log.grep(f"compaction.*Split {cf}", from_mark=s1_mark) == []
 
 
+@pytest.mark.slow
 async def test_tablet_repair(manager: ManagerClient, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, _ = await manager.get_ready_cql(servers)
@@ -347,6 +353,7 @@ async def test_tablet_repair(manager: ManagerClient, volumes_factory: Callable) 
                 await manager.api.wait_task(servers[0].ip_addr, task_id)
 
 
+@pytest.mark.slow
 async def test_autotoggle_reject_incoming_migrations(manager: ManagerClient, volumes_factory: Callable) -> None:
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         await manager.disable_tablet_balancing()
@@ -406,6 +413,7 @@ async def test_autotoggle_reject_incoming_migrations(manager: ManagerClient, vol
                 mark, _ = await log.wait_for("Streaming for tablet migration .* successful", from_mark=mark)
 
 
+@pytest.mark.slow
 async def test_node_restart_while_tablet_split(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
            "--logger-log-level", "compaction=debug"]
@@ -474,6 +482,7 @@ async def test_node_restart_while_tablet_split(manager: ManagerClient, volumes_f
 
 # Verify that new sstable produced by repair cannot be split, if disk utilization level is critical.
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_repair_failure_on_split_rejection(manager: ManagerClient, volumes_factory: Callable) -> None:
     cmd = [*global_cmdline,
            "--logger-log-level", "compaction=debug"]
@@ -560,6 +569,7 @@ global_cmdline_with_disabled_monitor = [
     "--tablet-load-stats-refresh-interval-in-seconds", "1",
 ]
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_sstables_incrementally_released_during_streaming(manager: ManagerClient, volumes_factory: Callable) -> None:
     """
     Test that source node will not run out of space if major compaction rewrites the sstables being streamed.
@@ -641,6 +651,7 @@ async def test_sstables_incrementally_released_during_streaming(manager: Manager
 
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_load_and_stream_rejected_on_critical_disk(manager: ManagerClient, volumes_factory: Callable) -> None:
     """
     Test that load-and-stream (nodetool refresh --load-and-stream) is blocked

--- a/test/cluster/test_commitlog_segment_data_resurrection.py
+++ b/test/cluster/test_commitlog_segment_data_resurrection.py
@@ -138,6 +138,7 @@ async def test_pinned_cl_segment_doesnt_resurrect_data(manager: ManagerClient):
 
 
 @pytest.mark.asyncio
+@pytest.mark.slow
 async def test_pinned_cl_segment_doesnt_resurrect_data_but_repair_ensures_tombstone_gc(manager: ManagerClient):
     """
     """

--- a/test/cluster/test_crash_coordinator_before_streaming.py
+++ b/test/cluster/test_crash_coordinator_before_streaming.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_kill_coordinator_during_op(manager: ManagerClient, failure_detector_timeout: int, scale_timeout: callable) -> None:
     """ Kill coordinator with error injection while topology operation is running for cluster: decommission,
     bootstrap, removenode, replace.

--- a/test/cluster/test_encryption.py
+++ b/test/cluster/test_encryption.py
@@ -280,7 +280,7 @@ async def test_encryption_table_compression(manager, tmpdir, compression, scylla
                           ciphers={"AES/CBC/PKCS5Padding": [128]},
                           compression=compression)
 
-
+@pytest.mark.slow
 async def test_reboot(manager, key_provider):
     """Tests SIGKILL restart of 3-node cluster"""
     async def restart(manager: ManagerClient, servers: list[ServerInfo], table_names: list[str]):

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -432,6 +432,7 @@ async def test_hint_to_pending(manager: ManagerClient):
         assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = 0")) == [(0,)]
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_hint_to_leaving_when_reducing_rf(manager: ManagerClient):
     '''
     This test checks if hint_sender sends a mutation to a leaving replica if the mutation

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -442,6 +442,7 @@ async def test_tablet_incremental_repair_and_upgradesstables(manager: ManagerCli
 async def test_tablet_incremental_repair_and_major(manager: ManagerClient):
     await do_tablet_incremental_repair_and_ops(manager, 'major')
 
+@pytest.mark.slow
 async def test_tablet_incremental_repair_and_minor(manager: ManagerClient):
     nr_keys = 100
     servers, cql, hosts, ks, table_id, logs, repaired_keys, unrepaired_keys, current_key, token = await prepare_cluster_for_incremental_repair(manager, nr_keys)
@@ -574,6 +575,7 @@ async def test_tablet_incremental_repair_existing_and_repair_produced_sstable(ma
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_tablet_incremental_repair_merge_higher_repaired_at_number(manager):
     nr_keys = 100
     servers, cql, hosts, ks, table_id, logs, repaired_keys, unrepaired_keys, current_key, token = await prepare_cluster_for_incremental_repair(manager, nr_keys)
@@ -685,6 +687,7 @@ async def do_test_tablet_incremental_repair_merge_error(manager, error):
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_tablet_incremental_repair_merge_error_in_merge_finalization(manager):
     await do_test_tablet_incremental_repair_merge_error(manager, 'handle_tablet_resize_finalization_for_merge_error')
 
@@ -752,6 +755,7 @@ async def test_incremental_repair_tablet_time_metrics(manager: ManagerClient):
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/26346
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_incremental_repair_finishes_when_tablet_skips_end_repair_stage(manager):
     servers = await manager.servers_add(3, auto_rack_dc="dc1")
 
@@ -872,6 +876,7 @@ async def test_incremental_retry_end_repair_stage(manager):
 # with appending sstables produced by repair to a list work correctly with
 # multishard writer when the shard count is different.
 @pytest.mark.parametrize("use_tablet", [False, True])
+@pytest.mark.slow
 async def test_repair_sigsegv_with_diff_shard_count(manager: ManagerClient, use_tablet):
     cmdline0 = [ '--smp', '2']
     cmdline1 = [ '--smp', '3']
@@ -1212,6 +1217,7 @@ async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, to
     return current_key
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_incremental_repair_race_window_promotes_unrepaired_data(manager: ManagerClient):
     cmdline = ['--hinted-handoff-enabled', '0']
     servers, cql, hosts, _, _, _, _, _, _, _ = \

--- a/test/cluster/test_lwt_semaphore.py
+++ b/test/cluster/test_lwt_semaphore.py
@@ -14,6 +14,7 @@ from test.cluster.util import new_test_keyspace
 
 
 @pytest.mark.skip_mode(mode='debug', reason='aarch64/debug is unpredictably slow', platform_key='aarch64')
+@pytest.mark.slow
 async def test_cas_semaphore(manager):
     """ This is a regression test for scylladb/scylladb#19698 """
     servers = await manager.servers_add(1, cmdline=['--smp', '1'])

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -399,6 +399,7 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
         for task in [*valid_keyspaces, *invalid_keyspaces]:
             _ = tg.create_task(task)
 
+@pytest.mark.slow
 async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces(manager: ManagerClient):
     """
     This test verifies that starting a Scylla node fails when there's an RF-rack-invalid keyspace.

--- a/test/cluster/test_raft_recovery_entry_loss.py
+++ b/test/cluster/test_raft_recovery_entry_loss.py
@@ -30,6 +30,7 @@ async def get_local_schema_version(cql: Session, h: Host) -> UUID:
     assert(rs)
     return rs[0].schema_version
 
+@pytest.mark.slow
 async def test_raft_recovery_entry_loss(manager: ManagerClient):
     """
     Test that the Raft-based recovery procedure works correctly if some committed group 0 entry has been permanently

--- a/test/cluster/test_raft_recovery_user_data.py
+++ b/test/cluster/test_raft_recovery_user_data.py
@@ -25,6 +25,7 @@ from test.cluster.util import check_system_topology_and_cdc_generations_v3_consi
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("remove_dead_nodes_with", ["remove", "replace"])
+@pytest.mark.slow
 async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes_with: str):
     """
     Test that the Raft-based recovery procedure works correctly with the user data. It involves testing:

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -152,6 +152,7 @@ async def test_tombstone_gc_for_streaming_and_repair(manager):
     check_nodes_have_data(True, True)
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_repair_succeeds_with_unitialized_bm(manager):
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
     cql = manager.get_cql()

--- a/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
+++ b/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
@@ -19,6 +19,7 @@ def verify_data(response, expected_data):
 
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_reversed_queries_during_upgrade(manager: ManagerClient) -> None:
     """
     Use `suppress_features` error injection to simulate cluster upgrade process

--- a/test/cluster/test_split_after_merge_repair_race.py
+++ b/test/cluster/test_split_after_merge_repair_race.py
@@ -119,6 +119,7 @@ async def _wait_for_pattern_any(logs, marks, pattern, timeout):
 
 @pytest.mark.asyncio
 @pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_split_bypass_race_with_repair_after_merge(manager: ManagerClient):
     """
     Deterministic reproducer of the unlinked-sstable abort in the split

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -588,6 +588,7 @@ async def test_sc_persistence_after_crash(manager: ManagerClient):
     await manager.server_stop_gracefully(server.server_id)
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_no_schema_when_apply_write(manager: ManagerClient):
     servers = await manager.servers_add(2, config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE, auto_rack_dc='my_dc')
     # We don't want `servers[2]` to be a Raft leader (for both group0 and strong consistency groups),
@@ -907,6 +908,7 @@ async def test_drop_table_during_insert(manager: ManagerClient):
 
 
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+@pytest.mark.slow
 async def test_timed_out_queries(manager: ManagerClient):
     """
     A simple test verifying that we don't get stuck for an indefinite amount

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -527,6 +527,7 @@ async def test_numeric_rf_to_rack_list_conversion(request: pytest.FixtureRequest
     assert repl['dc2'][0] == 'rack2a'
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_enforce_rack_list_option(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     async def get_replication_options(ks: str, host, ip_addr):
         await read_barrier(manager.api, ip_addr)
@@ -637,6 +638,7 @@ async def check_system_schema_keyspaces(manager, keyspace, replication, next_rep
     else:
         assert res[0].next_replication is None
 
+@pytest.mark.slow
 async def test_multi_rf_change_multi_dc_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """Test RF changes where each DC transitions only between 0 and N replicas."""
     config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}
@@ -916,6 +918,7 @@ async def test_multi_rf_decrease_abort_0_N(request: pytest.FixtureRequest, manag
             assert rep[0] in dc1_host_ids
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """Test concurrent 0->N RF changes across multiple keyspaces."""
     config = {"tablets_mode_for_new_keyspaces": "enabled", "rf_rack_valid_keyspaces": "false", "tablet_load_stats_refresh_interval_in_seconds": 1}

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -373,6 +373,7 @@ async def test_tablet_merge_cross_rack_migrations(manager: ManagerClient, racks)
 
 # Reproduces #23284
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_tablet_split_merge_with_many_tables(build_mode: str, manager: ManagerClient, racks = 2):
     cmdline = ['--smp', '4', '-m', '2G', '--target-tablet-size-in-bytes', '30000', '--max-task-backlog', '200', '--logger-log-level', 'load_balancer=debug']
     config = {'tablet_load_stats_refresh_interval_in_seconds': 1}

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -117,6 +117,7 @@ async def test_tablet_transition_sanity(manager: ManagerClient, action):
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
 @pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new", "cleanup", "cleanup_target", "end_migration", "revert_migration"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.slow
 async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage):
     if fail_stage == 'cleanup' and fail_replica == 'destination':
         skip_env('Failing destination during cleanup is pointless')

--- a/test/cluster/test_tablets_removenode.py
+++ b/test/cluster/test_tablets_removenode.py
@@ -60,6 +60,7 @@ async def test_removenode_with_coordinator_restart(manager: ManagerClient):
     await manager.remove_node(servers[1].server_id, servers[2].server_id)
 
 
+@pytest.mark.slow
 async def test_replace(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cmdline = [

--- a/test/cluster/test_tls.py
+++ b/test/cluster/test_tls.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
+@pytest.mark.slow
 async def test_upgrade_to_ssl(manager: ManagerClient) -> None:
     """Tests rolling upgrade/downgrade from non-SSL to SSL and back
     """

--- a/test/cluster/test_topology_ops.py
+++ b/test/cluster/test_topology_ops.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.parametrize("tablets_enabled", [True, False])
+@pytest.mark.slow
 async def test_topology_ops(request, manager: ManagerClient, tablets_enabled: bool):
     """Test basic topology operations using the topology coordinator."""
     rf_rack_cfg = {'rf_rack_valid_keyspaces': False}

--- a/test/cluster/test_topology_ops_encrypted.py
+++ b/test/cluster/test_topology_ops_encrypted.py
@@ -19,6 +19,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize("tablets_enabled", [True, False])
+@pytest.mark.slow
 async def test_topology_ops_encrypted(request, manager: ManagerClient, tablets_enabled: bool, tmp_path):
     """Test basic topology operations using the topology coordinator. But encrypted."""
     d = tmp_path / "keys"

--- a/test/cluster/test_truncate_concurrent_writes.py
+++ b/test/cluster/test_truncate_concurrent_writes.py
@@ -19,6 +19,7 @@ import os
 
 logger = logging.getLogger(__name__)
 
+@pytest.mark.slow
 async def test_validate_truncate_with_concurrent_writes(manager: ManagerClient):
 
     # This test validates that all the data before a truncate started has been deleted,

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -125,6 +125,14 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption('--exe-url', default=False,
                      dest="exe_url", action="store",
                      help="URL to download the relocatable executable. Not working with `mode`")
+    parser.addoption('--test-timeout-soft', action='store', default=None, type=int,
+                     help='Default per-test timeout in seconds for tests without slow/nightly marker')
+    parser.addoption('--test-timeout-hard', action='store', default=None, type=int,
+                     help='Per-test timeout in seconds for tests marked as slow or nightly')
+    parser.addoption('--disable-auto-test-timeout', action='store_true', default=False,
+                     help='Disable automatic timeout marker injection for collected tests')
+    parser.addini('test_timeout_soft', 'Default timeout in seconds for tests without slow/nightly marker', default='300')
+    parser.addini('test_timeout_hard', 'Timeout in seconds for tests marked as slow/nightly', default='1800')
 
 # Stores the per-phase test reports so that fixtures and hooks can inspect the
 # outcome of each phase (setup / call / teardown) independently.
@@ -340,6 +348,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Confi
     run_ids = defaultdict(lambda: count(start=int(config.getoption("--run_id") or 1)))
     for item in items:
         modify_pytest_item(item=item, run_ids=run_ids)
+        _add_auto_timeout_marker(item=item, config=config)
 
     suites_order = defaultdict(count().__next__)  # number suites in order of appearance
 
@@ -348,6 +357,40 @@ def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Confi
         return suites_order[suite], suite and item.path.stem not in suite.cfg.get("run_first", [])
 
     items.sort(key=sort_key)
+
+
+def _get_test_timeout_seconds(config: pytest.Config, option_name: str, ini_name: str) -> int:
+    option_value = config.getoption(option_name)
+    if option_value is not None:
+        timeout = option_value
+    else:
+        timeout = int(config.getini(ini_name))
+    if timeout <= 0:
+        raise pytest.UsageError(f"{option_name} / {ini_name} must be > 0, got {timeout}")
+    return timeout
+
+
+def _get_timeout_scale_factor(item: pytest.Item) -> int:
+    build_mode = item.stash.get(BUILD_MODE, item.config.build_modes[0])
+    return 3 if build_mode == "debug" else 1
+
+
+def _add_auto_timeout_marker(item: pytest.Item, config: pytest.Config) -> None:
+    if config.getoption("--disable-auto-test-timeout"):
+        return
+    if not (config.pluginmanager.hasplugin("timeout") or config.pluginmanager.hasplugin("pytest_timeout")):
+        return
+    if any(mark.name == "timeout" for mark in item.iter_markers("timeout")):
+        return
+
+    is_hard_timeout = any(mark.name in ("slow", "nightly") for mark in item.iter_markers())
+    timeout = _get_test_timeout_seconds(
+        config=config,
+        option_name="--test-timeout-hard" if is_hard_timeout else "--test-timeout-soft",
+        ini_name="test_timeout_hard" if is_hard_timeout else "test_timeout_soft",
+    )
+
+    item.add_marker(pytest.mark.timeout(timeout * _get_timeout_scale_factor(item)))
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -6,6 +6,9 @@ addopts = --strict-markers  --strict-config
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
 
+test_timeout_soft = 90
+test_timeout_hard = 900
+
 junit_logging = all
 junit_log_passing_tests = False
 
@@ -20,7 +23,7 @@ log_level=INFO
 log_file_level = INFO
 
 markers =
-    slow: tests that take more than 30 seconds to run
+    slow: tests that take more than 120 seconds in Debug mode and more than 60 seconds in Dev/Release mode to run
     replication_factor: replication factor for RandomTables
     without_scylla: run without attaching to a scylla process
     enable_tablets: create keyspace with tablets enabled or disabled

--- a/test/scylla_gdb/test_basic_commands.py
+++ b/test/scylla_gdb/test_basic_commands.py
@@ -64,6 +64,7 @@ pytestmark = [
         "prepared-statements",
     ],
 )
+@pytest.mark.slow
 def test_scylla_commands(gdb_cmd, command):
     result = execute_gdb_command(gdb_cmd, command)
     assert result.returncode == 0, (

--- a/test/scylla_gdb/test_schema_commands.py
+++ b/test/scylla_gdb/test_schema_commands.py
@@ -30,6 +30,7 @@ pytestmark = [
         "schema (const schema *)",  # `schema` requires type-casted pointer
     ],
 )
+@pytest.mark.slow
 def test_schema(gdb_cmd, command):
     result = execute_gdb_command(gdb_cmd, f"{command} $get_schema()")
     assert result.returncode == 0, (
@@ -37,6 +38,7 @@ def test_schema(gdb_cmd, command):
     )
 
 
+@pytest.mark.slow
 def test_generate_object_graph(gdb_cmd, request):
     tmpdir = request.config.getoption("--tmpdir")
     result = execute_gdb_command(

--- a/test/scylla_gdb/test_task_commands.py
+++ b/test/scylla_gdb/test_task_commands.py
@@ -24,6 +24,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.slow
 def test_coroutine_frame(gdb_cmd):
     """
     Offsets the pointer by two words to shift from the outer coroutine frame


### PR DESCRIPTION
Add automatic timeout markers via pytest-timeout with configurable soft/hard limits and debug-only x3 scaling.

Also mark long-running tests with @pytest.mark.slow so they use the hard timeout tier and avoid CI regressions.

Fixes: SCYLLADB-638
