### PR TITLE
test: optimize test_truncate_during_topology_change to use event-based injection

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1210,6 +1210,7 @@ private:
             group0_command g0_cmd = _group0_client.prepare_command(std::move(change), guard, reason);
             try {
                 co_await _group0_client.add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
+                co_await utils::get_local_injector().inject("do_topology_request/request_added", utils::wait_for_message(5min));
                 break;
             } catch (group0_concurrent_modification&) {
                 slogger.debug("{}: concurrent modification, retrying", origin);

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -12,7 +12,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, HTTPError, read_barrier
 from test.pylib.util import wait_for_cql_and_get_hosts, unique_name, wait_for
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_count, TabletReplicas
-from test.cluster.util import reconnect_driver, create_new_test_keyspace, new_test_keyspace, get_topology_version
+from test.cluster.util import reconnect_driver, create_new_test_keyspace, new_test_keyspace, get_topology_version, get_topology_coordinator
 from test.cqlpy.cassandra_tests.validation.entities.secondary_index_test import dotestCreateAndDropIndex
 
 import pytest
@@ -1645,7 +1645,6 @@ async def test_drop_table_during_streaming(manager: ManagerClient, streaming_mod
         except HTTPError as e:
             logger.info("Tablet migration failed after drop as expected: %s", e.message)
 
-@pytest.mark.nightly
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_truncate_during_topology_change(manager: ManagerClient):
     """Test truncate operation during topology change."""
@@ -1653,6 +1652,7 @@ async def test_truncate_during_topology_change(manager: ManagerClient):
     # Start 3 node cluster
     servers = await manager.servers_add(3, config = { 'enable_tablets': True }, auto_rack_dc="dc1")
     cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (k int PRIMARY KEY, v int)")
 
@@ -1662,16 +1662,46 @@ async def test_truncate_during_topology_change(manager: ManagerClient):
         await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(10000)))
         await manager.api.keyspace_flush(servers[0].ip_addr, ks, "test")
 
-        async def truncate_table():
-            await asyncio.sleep(10)
-            logger.info("Executing truncate during bootstrap")
-            await cql.run_async(SimpleStatement(f"TRUNCATE {ks}.test USING TIMEOUT 4m", retry_policy=FallthroughRetryPolicy()))
+        # Find the topology coordinator and pause it after bootstrap streaming completes
+        # but before the topology transitions out of write_both_read_old state.
+        coord_host_id = await get_topology_coordinator(manager)
+        coord = await manager.find_server_by_host_id(servers, coord_host_id)
+        logger.info(f"Topology coordinator is {coord}")
+        await manager.api.enable_injection(coord.ip_addr,
+                                           'topology_coordinator/write_both_read_old/before_version_increment',
+                                           one_shot=True)
 
-        truncate_task = asyncio.create_task(truncate_table())
-        logger.info("Adding fourth node")
-        new_server = await manager.server_add(config={'error_injections_at_startup': ['delay_bootstrap_120s'], 'enable_tablets': True},
-                                              property_file=servers[0].property_file())
-        await truncate_task
+        logger.info("Adding fourth node in background")
+        bootstrap_task = asyncio.create_task(
+            manager.server_add(config={'enable_tablets': True},
+                               property_file=servers[0].property_file()))
+
+        # Wait until the topology is in write_both_read_old state (bootstrap streaming done)
+        logger.info("Waiting for topology coordinator to reach write_both_read_old injection point")
+        await manager.api.wait_for_injection_enter(coord.ip_addr,
+                                                   "topology_coordinator/write_both_read_old/before_version_increment")
+
+        # Issue truncate while the topology is in a transitional state.
+        # Enable an injection that fires after the truncate request has been
+        # committed to group0 but before waiting for its completion. This lets
+        # us deterministically confirm the request is queued before releasing
+        # the topology coordinator.
+        await manager.api.enable_injection(servers[1].ip_addr, 'do_topology_request/request_added', one_shot=True)
+
+        logger.info("Executing truncate during bootstrap")
+        truncate_future = cql.run_async(SimpleStatement(f"TRUNCATE {ks}.test USING TIMEOUT 4m",
+                                        retry_policy=FallthroughRetryPolicy()), host=hosts[1])
+
+        # Wait for the truncate request to be committed to group0
+        await manager.api.wait_for_injection_enter(servers[1].ip_addr, "do_topology_request/request_added")
+        await manager.api.message_injection(servers[1].ip_addr, 'do_topology_request/request_added')
+
+        logger.info("Releasing topology coordinator")
+        await manager.api.message_injection(coord.ip_addr,
+                                            "topology_coordinator/write_both_read_old/before_version_increment")
+
+        new_server = await bootstrap_task
+        await truncate_future
 
         # Wait for bootstrap completion
         await wait_for_cql_and_get_hosts(cql, servers + [new_server], time.time() + 60)


### PR DESCRIPTION
The test was taking ~136s in dev mode (exceeding the 60s threshold) because it used the delay_bootstrap_120s error injection which causes a hardcoded 120-second sleep during bootstrap on the joining node, combined with a 10-second asyncio.sleep to guess when bootstrap is in progress.

Replace with the topology_coordinator/write_both_read_old/before_version_increment injection on the topology coordinator, which uses the wait_for_message pattern. This allows the test to:
1. Deterministically wait for the topology to enter the transitional state (write_both_read_old) via wait_for_injection_enter, instead of guessing with a sleep.
2. Issue TRUNCATE while the topology coordinator is paused in that state.
3. Release the injection via message_injection to let bootstrap complete.

The test logic is preserved: a 3-node RF=3 cluster with tablets is populated with data, a 4th node starts bootstrapping, TRUNCATE is issued while the topology is in a transitional state, and the table is verified empty after both bootstrap and truncate complete.

Expected runtime is reduced from ~136s to ~20-30s.

Also remove @pytest.mark.nightly since the test now completes well within the 60s threshold.

Backport is not required, it is an improvement

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2252