### PR TITLE
s3: handle missing nodes in multipart upload response parsers

### DIFF
--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -1019,6 +1019,41 @@ BOOST_AUTO_TEST_CASE(s3_fqn_manipulation) {
     BOOST_REQUIRE_EQUAL(object_name, "prefix1/prefix2/foo.bar");
 }
 
+// Regression test for a SEGV in s3::parse_multipart_copy_upload_etag.
+// When an UploadPartCopy request returns a well-formed XML body that is not a
+// <CopyPartResult> (typically an S3 <Error> document), the parser used to
+// dereference the nullptr returned by first_node("CopyPartResult"), crashing
+// the node. It must instead throw so the caller can handle the error.
+// Reproduces: https://scylladb.atlassian.net/browse/SCYLLADB-2965
+// Observed in Argus runs a0272423-d456-4a57-83d9-37bd0a558602 and
+// c8c78e05-4e70-4934-b964-29aed04d58e3.
+BOOST_AUTO_TEST_CASE(parse_multipart_copy_upload_etag_test) {
+    // Happy path: a real <CopyPartResult> with an <ETag>.
+    {
+        sstring body = R"(<?xml version="1.0" encoding="UTF-8"?><CopyPartResult><ETag>"abc123"</ETag></CopyPartResult>)";
+        BOOST_REQUIRE_EQUAL(s3::parse_multipart_copy_upload_etag(body), "\"abc123\"");
+    }
+
+    // Well-formed XML but an <Error> document (missing <CopyPartResult>):
+    // must throw, not crash.
+    {
+        sstring body = R"(<?xml version="1.0" encoding="UTF-8"?><Error><Code>InternalError</Code><Message>We encountered an internal error.</Message></Error>)";
+        BOOST_REQUIRE_THROW(s3::parse_multipart_copy_upload_etag(body), std::runtime_error);
+    }
+
+    // <CopyPartResult> present but no <ETag> child: must throw, not crash.
+    {
+        sstring body = R"(<?xml version="1.0" encoding="UTF-8"?><CopyPartResult></CopyPartResult>)";
+        BOOST_REQUIRE_THROW(s3::parse_multipart_copy_upload_etag(body), std::runtime_error);
+    }
+
+    // Non-XML body: parse error path, returns empty (caller treats as failure).
+    {
+        sstring body = "this is not xml";
+        BOOST_REQUIRE_EQUAL(s3::parse_multipart_copy_upload_etag(body), "");
+    }
+}
+
 BOOST_AUTO_TEST_CASE(part_size_calculation_test) {
     BOOST_REQUIRE_EXCEPTION(s3::calc_part_size(490_GiB, s3::minimum_part_size), std::runtime_error, [](const std::runtime_error& e) {
         return std::string(e.what()).starts_with(format("too many parts: 100352 > {}", s3::maximum_parts_in_piece));

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -815,6 +815,17 @@ future<> client::delete_bucket_with_objects(sstring bucket_name, seastar::abort_
     co_await delete_bucket(bucket_name, as);
 }
 
+// Looks up a required child node, throwing a descriptive error if it is
+// missing. Shared by the multipart-upload response parsers below to avoid
+// dereferencing the nullptr that rapidxml returns for absent nodes.
+static const rapidxml::xml_node<>* get_node_safe(const rapidxml::xml_node<>* node, std::string_view node_name, std::string_view response_name) {
+    auto child = node->first_node(node_name.data());
+    if (!child) {
+        throw std::runtime_error(seastar::format("'{}' node is missing in {} response", node_name, response_name));
+    }
+    return child;
+}
+
 sstring parse_multipart_copy_upload_etag(sstring& body) {
     auto doc = std::make_unique<rapidxml::xml_document<>>();
     try {
@@ -825,8 +836,8 @@ sstring parse_multipart_copy_upload_etag(sstring& body) {
         // and handle the error the way it prefers
         return "";
     }
-    auto root_node = doc->first_node("CopyPartResult");
-    auto etag_node = root_node->first_node("ETag");
+    auto root_node = get_node_safe(doc.get(), "CopyPartResult", "CopyPartResult");
+    auto etag_node = get_node_safe(root_node, "ETag", "CopyPartResult");
     return etag_node->value();
 }
 
@@ -982,14 +993,6 @@ public:
 };
 
 sstring parse_multipart_upload_id(sstring& body) {
-    auto get_node_safe = []<typename T>(const T* node, const std::string_view node_name) {
-        auto child = node->first_node(node_name.data());
-        if (!child) {
-            throw std::runtime_error(seastar::format("'{}' node is missing in InitiateMultipartUploadResult response", node_name));
-        }
-        return child;
-    };
-
     auto doc = std::make_unique<rapidxml::xml_document<>>();
     try {
         doc->parse<0>(body.data());
@@ -999,8 +1002,8 @@ sstring parse_multipart_upload_id(sstring& body) {
         // and handle the error the way it prefers
         return "";
     }
-    auto root_node = get_node_safe(doc.get(), "InitiateMultipartUploadResult");
-    auto uploadid_node = get_node_safe(root_node, "UploadId");
+    auto root_node = get_node_safe(doc.get(), "InitiateMultipartUploadResult", "InitiateMultipartUploadResult");
+    auto uploadid_node = get_node_safe(root_node, "UploadId", "InitiateMultipartUploadResult");
     return uploadid_node->value();
 }
 

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -258,6 +258,14 @@ public:
 
 std::pair<unsigned, size_t> calc_part_size(size_t total_size, size_t part_size);
 
+// Parses the ETag out of an S3 UploadPartCopy <CopyPartResult> response body.
+// Returns an empty string if the body is not well-formed XML. Throws
+// std::runtime_error if the body is valid XML but lacks the expected
+// <CopyPartResult>/<ETag> nodes (e.g. an S3 <Error> document). Callers must
+// handle both the empty result and the exception as upload failures.
+// Exposed for unit testing.
+sstring parse_multipart_copy_upload_etag(sstring& body);
+
 } // namespace s3
 
 template <>


### PR DESCRIPTION
## Problem

`s3::parse_multipart_copy_upload_etag()` (`utils/s3/client.cc`) parsed the S3
UploadPartCopy response with rapidxml and then dereferenced
`first_node("CopyPartResult")` without a null check. When S3 returns a
well-formed XML body that is **not** a `<CopyPartResult>` document — typically
an `<Error>` document (NoSuchUpload / SlowDown / InternalError / AccessDenied /
…) — `first_node()` returns `nullptr` and the next line crashes the DB node
with a SEGV (`si_addr 0x30`) in `rapidxml::xml_node::first_node`, called from
`s3::client::multipart_upload::upload_part`.

`parse<0>()` succeeds in this case (no `parse_error` is thrown), so the body is
valid XML — just not the expected element — and the existing `parse_error`
guard does not catch it.

Observed on the `s3_keyspace` branch (ScyllaDB 2026.3.0~dev) in two SCT runs:
- https://argus.scylladb.com/tests/scylla-cluster-tests/a0272423-d456-4a57-83d9-37bd0a558602
- https://argus.scylladb.com/tests/scylla-cluster-tests/c8c78e05-4e70-4934-b964-29aed04d58e3

## Changes

- The sibling parser `parse_multipart_upload_id()` already guards missing nodes
  via a local `get_node_safe()` lambda that throws a descriptive
  `std::runtime_error`. Lift that helper to file scope and use it in **both**
  parsers, so missing `<CopyPartResult>` / `<ETag>` nodes throw instead of
  dereferencing null.
- Both call sites of `parse_multipart_copy_upload_etag()` already treat the
  failure as an aborted part upload (they check for an empty ETag and run
  inside `handle_exception`), so no caller changes are needed.
- Add a unit test in `test/boost/s3_test.cc` that reproduces the crash (SEGV
  before the fix) and covers the happy path, the `<Error>`-document path, the
  missing-`<ETag>` path, and the non-XML path. The function is declared in
  `client.hh` so the test can exercise it directly.

## Issue

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2965


## Backport

Master is the 2026.3 development line, so this lands there directly. The
vulnerable parser (introduced 2025-04-16) is also present in the supported
released lines, and this is a node-crashing null dereference, so backport to
`2026.2` and `2026.1`

