### PR TITLE
LWT: avoid oversized contiguous allocation in save_paxos_proposal/decision

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -872,7 +872,7 @@ std::pair<std::reference_wrapper<struct query_processor::remote>, gate::holder> 
 
 query_options query_processor::make_internal_options(
         const statements::prepared_statement::checked_weak_ptr& p,
-        const std::vector<data_value_or_unset>& values,
+        std::vector<data_value_or_unset> values,
         db::consistency_level cl,
         int32_t page_size,
         service::node_local_only node_local_only) const {
@@ -887,9 +887,9 @@ query_options query_processor::make_internal_options(
     for (auto& var : values) {
         auto& n = *ni;
         std::visit(overloaded_functor {
-            [&] (const data_value& v) {
+            [&] (data_value&& v) {
                 if (v.type() == bytes_type) {
-                    bound_values.values.emplace_back(cql3::raw_value::make_value(value_cast<bytes>(v)));
+                    bound_values.values.emplace_back(cql3::raw_value::make_value(value_cast<bytes>(std::move(v))));
                 } else if (v.is_null()) {
                     bound_values.values.emplace_back(cql3::raw_value::make_null());
                 } else {
@@ -898,10 +898,10 @@ query_options query_processor::make_internal_options(
             }, [&] (const unset_value&) {
                 bound_values.values.emplace_back(cql3::raw_value::make_null());
                 bound_values.unset[std::distance(p->bound_names.begin(), ni)] = true;
-            }, [&] (const managed_bytes& mb) {
-                bound_values.values.emplace_back(cql3::raw_value::make_value(mb));
+            }, [&] (managed_bytes&& mb) {
+                bound_values.values.emplace_back(cql3::raw_value::make_value(std::move(mb)));
             }
-        }, var);
+        }, std::move(var));
         ++ni;
     }
     return query_options(
@@ -1048,7 +1048,7 @@ future<utils::chunked_vector<mutation>> query_processor::get_mutations_internal(
     if (!mod_stmt) {
         on_internal_error(log, "Only modification statement is supported in get_mutations_internal");
     }
-    auto opts = make_internal_options(stmt, values, db::consistency_level::LOCAL_ONE);
+    auto opts = make_internal_options(stmt, std::move(values), db::consistency_level::LOCAL_ONE);
     auto json_cache = mod_stmt->maybe_prepare_json_cache(opts);
     auto keys = mod_stmt->build_partition_keys(opts, json_cache);
     // timeout only applies when modification requires read

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -898,6 +898,8 @@ query_options query_processor::make_internal_options(
             }, [&] (const unset_value&) {
                 bound_values.values.emplace_back(cql3::raw_value::make_null());
                 bound_values.unset[std::distance(p->bound_names.begin(), ni)] = true;
+            }, [&] (const managed_bytes& mb) {
+                bound_values.values.emplace_back(cql3::raw_value::make_value(mb));
             }
         }, var);
         ++ni;

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -546,7 +546,7 @@ public:
 
     query_options make_internal_options(
             const statements::prepared_statement::checked_weak_ptr& p,
-            const std::vector<data_value_or_unset>& values,
+            std::vector<data_value_or_unset> values,
             db::consistency_level,
             int32_t page_size = -1,
             service::node_local_only node_local_only = service::node_local_only::no) const;

--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -778,6 +778,14 @@ Buffer serialize_to_buffer(const T& v, size_t head_space) {
     return ret;
 }
 
+// Serializes v into a managed_bytes (fragmented), avoiding a large contiguous allocation.
+template<typename T>
+managed_bytes serialize_to_managed_bytes(const T& v) {
+    bytes_ostream buf;
+    ser::serialize(buf, v);
+    return std::move(buf).to_managed_bytes();
+}
+
 template<typename T, typename Buffer>
 T deserialize_from_buffer(const Buffer& buf, std::type_identity<T> type, size_t head_space) {
     seastar::simple_input_stream in(reinterpret_cast<const char*>(buf.begin() + head_space), buf.size() - head_space);

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 #include <exception>
+#include <type_traits>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/all.hh>
 #include <seastar/coroutine/exception.hh>
@@ -469,9 +470,18 @@ template <typename... Args>
 future<cql3::untyped_result_set> paxos_store::execute_cql_with_timeout(sstring req,
         db::timeout_clock::time_point timeout,
         Args&&... args) {
+    auto make_dv = []<typename T>(T&& v) -> data_value_or_unset {
+        if constexpr (std::is_same_v<std::remove_cvref_t<T>, managed_bytes>)
+            return std::forward<T>(v);
+        else
+            return data_value(std::forward<T>(v));
+    };
+    std::vector<data_value_or_unset> values;
+    values.reserve(sizeof...(args));
+    (values.emplace_back(make_dv(std::forward<Args>(args))), ...);
     return do_execute_cql_with_timeout(std::move(req),
         timeout,
-        { data_value(std::forward<Args>(args))... },
+        std::move(values),
         _sys_ks.query_processor()
     );
 }
@@ -603,7 +613,7 @@ future<> paxos_store::save_paxos_proposal(const schema& s, const proposal& propo
             paxos_ttl_sec(s),
             proposal.ballot,
             proposal.ballot,
-            ser::serialize_to_buffer<bytes>(proposal.update),
+            ser::serialize_to_managed_bytes(proposal.update),
             to_legacy(*key.get_compound_type(s), key.representation())
         );
 }
@@ -628,7 +638,7 @@ future<> paxos_store::save_paxos_decision(const schema& s, const proposal& decis
             utils::UUID_gen::micros_timestamp(decision.ballot),
             paxos_ttl_sec(s),
             decision.ballot,
-            ser::serialize_to_buffer<bytes>(decision.update),
+            ser::serialize_to_managed_bytes(decision.update),
             to_legacy(*key.get_compound_type(s), key.representation())
         );
 }

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -458,7 +458,7 @@ static future<cql3::untyped_result_set> do_execute_cql_with_timeout(sstring req,
     // Each paxos state query returns at most one row, so paging never kicks in.
     // LIMIT 1 in the query causes may_need_paging() to short-circuit to false
     // (row_limit <= 1), avoiding pager allocation overhead entirely.
-    const auto qo = qp.make_internal_options(ps_ptr, values, db::consistency_level::ONE,
+    const auto qo = qp.make_internal_options(ps_ptr, std::move(values), db::consistency_level::ONE,
         1000, service::node_local_only::yes);
     const auto st = ps_ptr->statement;
 

--- a/test/alternator/test_logs.py
+++ b/test/alternator/test_logs.py
@@ -35,7 +35,7 @@ from botocore.exceptions import ClientError
 
 from test.pylib.skip_types import skip_env
 
-from .util import new_test_table, scylla_config_temporary
+from .util import new_test_table, scylla_config_temporary, random_string, full_query
 from .test_cql_rbac import new_dynamodb, new_role
 
 # Utility function for trying to find a local process which is listening to
@@ -158,7 +158,7 @@ def wait_for_log(logfile, pattern, re_flags=re.MULTILINE, timeout=5):
     contents = logfile.read()
     prog = re.compile(pattern, re_flags)
     if prog.search(contents):
-        return
+        return contents
     end = time.time() + timeout
     while time.time() < end:
         s = logfile.read()
@@ -168,7 +168,7 @@ def wait_for_log(logfile, pattern, re_flags=re.MULTILINE, timeout=5):
             # the entire content since the beginning of this wait :-(
             contents = contents + s
             if prog.search(contents):
-                return
+                return contents
         time.sleep(0.1)
     pytest.fail(f'Timed out ({timeout} seconds) looking for {pattern} in log file. Got:\n' + contents)
 
@@ -273,3 +273,36 @@ def test_log_authorization_failure(dynamodb, cql, logfile, test_table_s, enforce
                 else:
                     assert operation_succeeded
                 wait_for_log(logfile, f'^WARN .*SELECT access on table.*{test_table_s.name} is denied to role {role}.*client address')
+
+
+# A variant of test_batch.py::test_batch_write_item_large that uses the
+# always_use_lwt write isolation mode, so the large batch is guaranteed
+# to be written using LWT. This reproduced issue #8183: a large LWT write
+# from BatchWriteItem could cause an oversized contiguous allocation inside
+# paxos_response_handler::accept_proposal. Before the fix for #8183, this
+# test would elicit an "oversized allocation" error in Scylla's log, which
+# this test detects.
+def test_batch_write_item_large_lwt_allocation(dynamodb, logfile):
+    with new_test_table(dynamodb,
+            Tags=[{'Key': 'system:write_isolation', 'Value': 'always_use_lwt'}],
+            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, { 'AttributeName': 'c', 'AttributeType': 'N' } ]) as table:
+        long_content = 'x'*50000
+        p = random_string()
+        request_items = {
+            table.name: [{'PutRequest': {'Item': {'p': p, 'c': i, 'content': long_content}}} for i in range(25)]
+        }
+        write_reply = table.meta.client.batch_write_item(RequestItems=request_items)
+        # In Alternator (all tests in this file are scylla_only) so the
+        # entire batch write is accepted - there are no WCU limits.
+        assert write_reply['UnprocessedItems'] == {}
+        # Sanity check - check that the write was successfully done by
+        # reading the items back.
+        assert full_query(table, KeyConditionExpression='p=:p', ExpressionAttributeValues={':p': p}
+            ) == [{'p': p, 'c': i, 'content': long_content} for i in range(25)]
+    # Wait for the log message about the table being dropped. Any log
+    # messages related to the earlier batch write will have to have been
+    # flushed earlier and we'll be able to see them.
+    contents = wait_for_log(logfile, f'Dropping keyspace alternator_{table.name}')
+    # Check that no "oversized allocation" error was logged.
+    assert 'oversized allocation' not in contents

--- a/types/types.hh
+++ b/types/types.hh
@@ -1124,7 +1124,7 @@ struct unset_value {
     bool operator==(const unset_value&) const noexcept { return true; }
 };
 
-using data_value_or_unset = std::variant<data_value, unset_value>;
+using data_value_or_unset = std::variant<data_value, unset_value, managed_bytes>;
 
 template <>
 struct fmt::formatter<unset_value> : fmt::formatter<string_view> {
@@ -1144,6 +1144,9 @@ struct fmt::formatter<data_value_or_unset> : fmt::formatter<string_view> {
             },
             [&ctx] (const unset_value& u) {
                 return fmt::format_to(ctx.out(), "{}", u);
+            },
+            [&ctx] (const managed_bytes& mb) {
+                return fmt::format_to(ctx.out(), "{}", mb);
             }
         }, var);
     }


### PR DESCRIPTION
This patch fixes an oversized contiguous allocation when LWT is used to write a large mutation. The large allocation was reported in issue #8183 in the context of Alternator: a large `BatchWriteItem` request that uses `always_use_lwt` write isolation mode triggered an oversized allocation warning.

`paxos_store::save_paxos_proposal` and `save_paxos_decision` previously serialized the `frozen_mutation` as a CQL blob parameter using `ser::serialize_to_buffer<bytes>()`. Because `bytes` is a contiguous sstring, this allocated a single buffer large enough to hold the entire serialized mutation. For a large `BatchWriteItem` request going through the `always_use_lwt` write isolation mode (25 items × ~50 KB each), this produced a ~1.2 MB contiguous allocation per item, triggering seastar's oversized-allocation warnings. Reported as issue #8183.

The fix extends the internal CQL binding mechanism to accept fragmented `managed_bytes` parameters directly:

- A new `ser::serialize_to_managed_bytes(v)` helper serializes a value into a `bytes_ostream` (which grows in small fragments, never doing a large contiguous allocation) and then converts it to `managed_bytes`.

- A new `managed_bytes_blob` wrapper struct is added alongside `data_value_or_unset`. It holds a `managed_bytes` and has a single non-explicit constructor taking only `managed_bytes`. This wrapper is needed to prevent ambiguity in the variant's converting constructor: types like `sstring` that can reach `managed_bytes` via a chain of two implicit conversions would otherwise make the construction ambiguous. C++ allows at most one user-defined conversion per implicit sequence, so `managed_bytes`→`managed_bytes_blob` is accepted (one step) while `sstring`→`managed_bytes`→`managed_bytes_blob` is rejected (two steps).

- `data_value_or_unset` is widened from `std::variant<data_value, unset_value>` to `std::variant<data_value, unset_value, managed_bytes_blob>`.

- `make_internal_options()` gains a third branch to handle the new `managed_bytes_blob` alternative, mapping it directly to `raw_value::make_value(mb.data)`.

- `save_paxos_proposal` and `save_paxos_decision` now pass `ser::serialize_to_managed_bytes(proposal.update)` as the blob parameter, keeping the clean CQL-based implementation.

This change is confined to the internal CQL execution path (`execute_internal` / `make_internal_options`). User requests arrive as `raw_value` objects directly via the transport layer and never touch `data_value_or_unset`. Adding a third variant alternative does not increase `sizeof(data_value_or_unset)`: `data_value` (the largest alternative) already dominates, so the variant size is unchanged.

Note: the bug was not reproducible since commit 76a766cab0 (Apr 2024), which switched the Alternator test suite from `always_use_lwt` to `only_rmw_uses_lwt`, causing plain writes to bypass the Paxos path entirely. A new test `test_batch_write_item_large_lwt_allocation` in `test/alternator/test_logs.py` explicitly exercises the `always_use_lwt` mode to reproduce the bug and verify its fix - the test looks for the "oversized allocation" message in the log.

Fixes #8183

No need to backport this patch, this problem is known for five years and the sky didn't fall.