### PR TITLE
ci: add gh_api_retry helper, unify CI trigger workflows, and add workflow_dispatch

### DIFF
--- a/.github/workflows/scylla-ci-route.yaml
+++ b/.github/workflows/scylla-ci-route.yaml
@@ -2,21 +2,27 @@ name: Scylla CI Route
 
 on:
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, unlabeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  statuses: write
 
 jobs:
   route-ci:
-    # Skip draft PRs
-    if: ${{ !github.event.pull_request.draft }}
+    # Run on:
+    # 1. PR events (opened/reopened/synchronize/ready_for_review) for non-draft PRs
+    # 2. PR unlabeled event when 'conflicts' label is removed
+    # 3. issue_comment event when a non-bot org member comments '@scylladbbot trigger-ci'
+    if: |
+      (github.event_name == 'pull_request_target' && github.event.action != 'unlabeled' && !github.event.pull_request.draft) ||
+      (github.event_name == 'pull_request_target' && github.event.action == 'unlabeled' && github.event.label.name == 'conflicts') ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.user.login != 'scylladbbot')
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 30
     env:
-      PR_NUMBER: ${{ github.event.pull_request.number }}
-      PR_REPO: ${{ github.repository }}
-      BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
-      PR_USER: ${{ github.event.pull_request.user.login }}
-      PR_SHA: ${{ github.event.pull_request.head.sha }}
-      PR_URL: ${{ github.event.pull_request.html_url }}
       JENKINS_URL: "https://jenkins.scylladb.com"
 
     steps:
@@ -71,36 +77,108 @@ jobs:
           RETRY_EOF
           echo "BASH_ENV=$HELPERS_FILE" >> "$GITHUB_ENV"
 
-      - name: Check for code changes on synchronize
-        if: github.event.action == 'synchronize'
-        id: code-changes
+      - name: Validate comment trigger
+        if: github.event_name == 'issue_comment'
+        id: comment-check
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+        shell: bash
         run: |
-          BEFORE="${{ github.event.before }}"
-          AFTER="${{ github.event.after }}"
-          if [ -z "$BEFORE" ] || [ -z "$AFTER" ]; then
-            echo "has_code_changes=true" >> "$GITHUB_OUTPUT"
+          # Check org membership
+          if [[ "$COMMENT_ASSOCIATION" != "MEMBER" && "$COMMENT_ASSOCIATION" != "OWNER" ]]; then
+            echo "::warning::Comment author is not an org member (association: $COMMENT_ASSOCIATION); skipping CI trigger."
+            echo "valid=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Use the GitHub API to compare trees
-          BEFORE_TREE=$(gh_api_retry "repos/$PR_REPO/git/commits/$BEFORE" --jq '.tree.sha' 2>/dev/null || true)
-          AFTER_TREE=$(gh_api_retry "repos/$PR_REPO/git/commits/$AFTER" --jq '.tree.sha' 2>/dev/null || true)
+          # Strip quoted lines and check for trigger keywords.
+          # `|| true` because grep exits non-zero when every line is quoted
+          # (no lines left), which would otherwise fail the step under `bash -e`.
+          CLEAN_BODY=$(echo "$COMMENT_BODY" | grep -v '^[[:space:]]*>' || true)
 
-          if [ -n "$BEFORE_TREE" ] && [ -n "$AFTER_TREE" ] && [ "$BEFORE_TREE" = "$AFTER_TREE" ]; then
-            echo "No code changes detected (commit message edit only), skipping CI"
-            echo "has_code_changes=false" >> "$GITHUB_OUTPUT"
+          if echo "$CLEAN_BODY" | grep -qi '@scylladbbot' && echo "$CLEAN_BODY" | grep -qi 'trigger-ci'; then
+            echo "valid=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Code changes detected"
-            echo "has_code_changes=true" >> "$GITHUB_OUTPUT"
+            echo "valid=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Resolve PR context
+        if: github.event_name != 'issue_comment' || steps.comment-check.outputs.valid == 'true'
+        id: resolve-pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          # PR event context
+          PR_NUMBER_FROM_EVENT: ${{ github.event.pull_request.number }}
+          PR_REPO_FROM_EVENT: ${{ github.repository }}
+          PR_SHA_FROM_EVENT: ${{ github.event.pull_request.head.sha }}
+          PR_USER_FROM_EVENT: ${{ github.event.pull_request.user.login }}
+          PR_DRAFT_FROM_EVENT: ${{ github.event.pull_request.draft }}
+          PR_BASE_FROM_EVENT: ${{ github.event.pull_request.base.ref }}
+          PR_URL_FROM_EVENT: ${{ github.event.pull_request.html_url }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.event.after }}
+          # Comment event context
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        shell: bash
+        run: |
+          PR_REPO="$PR_REPO_FROM_EVENT"
+
+          if [ "$EVENT_NAME" = "issue_comment" ]; then
+            # For comment events, fetch PR details from the API
+            PR_NUMBER="$ISSUE_NUMBER"
+            PR_JSON=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER")
+            PR_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+            PR_USER=$(echo "$PR_JSON" | jq -r '.user.login')
+            PR_DRAFT=$(echo "$PR_JSON" | jq -r '.draft')
+            BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.base.ref')
+            PR_URL=$(echo "$PR_JSON" | jq -r '.html_url')
+          else
+            PR_NUMBER="$PR_NUMBER_FROM_EVENT"
+            PR_SHA="$PR_SHA_FROM_EVENT"
+            PR_USER="$PR_USER_FROM_EVENT"
+            PR_DRAFT="$PR_DRAFT_FROM_EVENT"
+            BASE_BRANCH="$PR_BASE_FROM_EVENT"
+            PR_URL="$PR_URL_FROM_EVENT"
+          fi
+
+          # Skip draft PRs
+          if [ "$PR_DRAFT" = "true" ]; then
+            echo "::warning::PR #$PR_NUMBER is a draft, skipping CI trigger"
+            echo "should_continue=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Check for code changes on synchronize (skip commit-message-only pushes)
+          if [ "$EVENT_ACTION" = "synchronize" ]; then
+            if [ -n "$BEFORE_SHA" ] && [ -n "$AFTER_SHA" ]; then
+              BEFORE_TREE=$(gh_api_retry "repos/$PR_REPO/git/commits/$BEFORE_SHA" --jq '.tree.sha' 2>/dev/null || true)
+              AFTER_TREE=$(gh_api_retry "repos/$PR_REPO/git/commits/$AFTER_SHA" --jq '.tree.sha' 2>/dev/null || true)
+              if [ -n "$BEFORE_TREE" ] && [ -n "$AFTER_TREE" ] && [ "$BEFORE_TREE" = "$AFTER_TREE" ]; then
+                echo "No code changes detected (commit message edit only), skipping CI"
+                echo "should_continue=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+          fi
+
+          echo "should_continue=true" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_repo=$PR_REPO" >> "$GITHUB_OUTPUT"
+          echo "pr_sha=$PR_SHA" >> "$GITHUB_OUTPUT"
+          echo "pr_user=$PR_USER" >> "$GITHUB_OUTPUT"
+          echo "base_branch=$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
 
       - name: Check if docs-only PR
-        if: steps.code-changes.outputs.has_code_changes != 'false'
+        if: steps.resolve-pr.outputs.should_continue == 'true'
         id: docs-check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
+          PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
         run: |
           echo "Fetching PR #$PR_NUMBER files from $PR_REPO..."
           ALL_DOCS=true
@@ -142,10 +220,12 @@ jobs:
           echo "trigger_docs_ci=$TRIGGER_DOCS_CI" >> "$GITHUB_OUTPUT"
 
       - name: Trigger docs-CI
-        if: steps.code-changes.outputs.has_code_changes != 'false' && steps.docs-check.outputs.trigger_docs_ci == 'true'
+        if: steps.resolve-pr.outputs.should_continue == 'true' && steps.docs-check.outputs.trigger_docs_ci == 'true'
         env:
           JENKINS_USER: ${{ secrets.JENKINS_USERNAME }}
           JENKINS_API_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+          PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
+          PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
         run: |
           DOCS_CI_JOB="releng/job/scylladb-docs-CI"
           JOB_URL="$JENKINS_URL/job/$DOCS_CI_JOB/api/json"
@@ -163,10 +243,13 @@ jobs:
           fi
 
       - name: Get PR details
-        if: steps.code-changes.outputs.has_code_changes != 'false' && steps.docs-check.outputs.is_docs_only != 'true'
+        if: steps.resolve-pr.outputs.should_continue == 'true' && steps.docs-check.outputs.is_docs_only != 'true'
         id: pr-details
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
+          PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
+          PR_URL: ${{ steps.resolve-pr.outputs.pr_url }}
         run: |
           echo "Fetching PR #$PR_NUMBER details..."
           PR_JSON=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER")
@@ -214,8 +297,10 @@ jobs:
           echo "pytest_extra_options=$PYTEST_EXTRA_OPTIONS" >> "$GITHUB_OUTPUT"
 
       - name: Determine target folder
-        if: steps.code-changes.outputs.has_code_changes != 'false' && steps.docs-check.outputs.is_docs_only != 'true'
+        if: steps.resolve-pr.outputs.should_continue == 'true' && steps.docs-check.outputs.is_docs_only != 'true'
         id: target-folder
+        env:
+          BASE_BRANCH: ${{ steps.resolve-pr.outputs.base_branch }}
         run: |
           FOLDER=""
           if [ "$BASE_BRANCH" = "master" ] || [ "$BASE_BRANCH" = "next" ]; then
@@ -240,10 +325,12 @@ jobs:
           echo "Target folder: $FOLDER"
 
       - name: Check required CI types
-        if: steps.code-changes.outputs.has_code_changes != 'false' && steps.docs-check.outputs.is_docs_only != 'true'
+        if: steps.resolve-pr.outputs.should_continue == 'true' && steps.docs-check.outputs.is_docs_only != 'true'
         id: required-checks
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
+          PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
         run: |
           # Fetch all PR files for pattern matching
           ALL_FILES=""
@@ -343,10 +430,13 @@ jobs:
           echo "Required checks: build=$BUILD_REQUIRED dtest=$DTEST_REQUIRED unittest=$UNITTEST_REQUIRED artifacts=$ARTIFACTS_REQUIRED gdb=$GDB_REQUIRED"
 
       - name: Check trusted contributor
-        if: steps.code-changes.outputs.has_code_changes != 'false' && steps.docs-check.outputs.is_docs_only != 'true'
+        if: steps.resolve-pr.outputs.should_continue == 'true' && steps.docs-check.outputs.is_docs_only != 'true' && github.event_name != 'issue_comment'
         id: trust-check
         env:
           GH_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
+          PR_USER: ${{ steps.resolve-pr.outputs.pr_user }}
+          PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
+          PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
         run: |
           TRUSTED=false
 
@@ -375,9 +465,9 @@ jobs:
 
       - name: Trigger scylla-ci
         if: |
-          steps.code-changes.outputs.has_code_changes != 'false' &&
+          steps.resolve-pr.outputs.should_continue == 'true' &&
           steps.docs-check.outputs.is_docs_only != 'true' &&
-          steps.trust-check.outputs.trusted == 'true' &&
+          (steps.trust-check.outputs.trusted == 'true' || github.event_name == 'issue_comment') &&
           steps.pr-details.outputs.has_conflicts != 'true' &&
           steps.required-checks.outputs.build_required == 'true' &&
           steps.target-folder.outputs.folder != ''
@@ -385,6 +475,9 @@ jobs:
           JENKINS_USER: ${{ secrets.JENKINS_USERNAME }}
           JENKINS_API_TOKEN: ${{ secrets.JENKINS_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
+          PR_REPO: ${{ steps.resolve-pr.outputs.pr_repo }}
+          PR_SHA: ${{ steps.resolve-pr.outputs.pr_sha }}
         run: |
           TARGET_FOLDER="${{ steps.target-folder.outputs.folder }}"
           RUN_DTEST="${{ steps.required-checks.outputs.dtest_required }}"
@@ -462,6 +555,8 @@ jobs:
         if: failure()
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          PR_NUMBER: ${{ steps.resolve-pr.outputs.pr_number }}
+          PR_URL: ${{ steps.resolve-pr.outputs.pr_url }}
         run: |
           # Send Slack notification
           curl -X POST -H 'Content-type: application/json' \

--- a/.github/workflows/scylla-ci-route.yaml
+++ b/.github/workflows/scylla-ci-route.yaml
@@ -5,6 +5,17 @@ on:
     types: [opened, reopened, synchronize, ready_for_review, unlabeled]
   issue_comment:
     types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to trigger CI for'
+        required: true
+        type: string
+      target_repo:
+        description: 'Repository owner/name (default: scylladb/scylladb)'
+        required: false
+        default: 'scylladb/scylladb'
+        type: string
 
 permissions:
   contents: read
@@ -16,7 +27,9 @@ jobs:
     # 1. PR events (opened/reopened/synchronize/ready_for_review) for non-draft PRs
     # 2. PR unlabeled event when 'conflicts' label is removed
     # 3. issue_comment event when a non-bot org member comments '@scylladbbot trigger-ci'
+    # 4. workflow_dispatch (manual trigger for testing)
     if: |
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' && github.event.action != 'unlabeled' && !github.event.pull_request.draft) ||
       (github.event_name == 'pull_request_target' && github.event.action == 'unlabeled' && github.event.label.name == 'conflicts') ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.user.login != 'scylladbbot')
@@ -122,11 +135,24 @@ jobs:
           AFTER_SHA: ${{ github.event.after }}
           # Comment event context
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          # Manual dispatch context
+          DISPATCH_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          DISPATCH_TARGET_REPO: ${{ github.event.inputs.target_repo }}
         shell: bash
         run: |
           PR_REPO="$PR_REPO_FROM_EVENT"
 
-          if [ "$EVENT_NAME" = "issue_comment" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            # For manual dispatch, use the target repo input (defaults to scylladb/scylladb)
+            PR_REPO="$DISPATCH_TARGET_REPO"
+            PR_NUMBER="$DISPATCH_PR_NUMBER"
+            PR_JSON=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER")
+            PR_SHA=$(echo "$PR_JSON" | jq -r '.head.sha')
+            PR_USER=$(echo "$PR_JSON" | jq -r '.user.login')
+            PR_DRAFT=$(echo "$PR_JSON" | jq -r '.draft')
+            BASE_BRANCH=$(echo "$PR_JSON" | jq -r '.base.ref')
+            PR_URL=$(echo "$PR_JSON" | jq -r '.html_url')
+          elif [ "$EVENT_NAME" = "issue_comment" ]; then
             # For comment events, fetch PR details from the API
             PR_NUMBER="$ISSUE_NUMBER"
             PR_JSON=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER")
@@ -430,7 +456,7 @@ jobs:
           echo "Required checks: build=$BUILD_REQUIRED dtest=$DTEST_REQUIRED unittest=$UNITTEST_REQUIRED artifacts=$ARTIFACTS_REQUIRED gdb=$GDB_REQUIRED"
 
       - name: Check trusted contributor
-        if: steps.resolve-pr.outputs.should_continue == 'true' && steps.docs-check.outputs.is_docs_only != 'true' && github.event_name != 'issue_comment'
+        if: steps.resolve-pr.outputs.should_continue == 'true' && steps.docs-check.outputs.is_docs_only != 'true' && github.event_name != 'issue_comment' && github.event_name != 'workflow_dispatch'
         id: trust-check
         env:
           GH_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
@@ -467,7 +493,7 @@ jobs:
         if: |
           steps.resolve-pr.outputs.should_continue == 'true' &&
           steps.docs-check.outputs.is_docs_only != 'true' &&
-          (steps.trust-check.outputs.trusted == 'true' || github.event_name == 'issue_comment') &&
+          (steps.trust-check.outputs.trusted == 'true' || github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch') &&
           steps.pr-details.outputs.has_conflicts != 'true' &&
           steps.required-checks.outputs.build_required == 'true' &&
           steps.target-folder.outputs.folder != ''

--- a/.github/workflows/scylla-ci-route.yaml
+++ b/.github/workflows/scylla-ci-route.yaml
@@ -20,6 +20,57 @@ jobs:
       JENKINS_URL: "https://jenkins.scylladb.com"
 
     steps:
+      - name: Set up gh api retry helper
+        shell: bash
+        run: |
+          # Write a reusable retry wrapper for gh api calls.
+          # We write to a known file and set BASH_ENV so subsequent steps source it.
+          HELPERS_FILE="$RUNNER_TEMP/.bash_helpers"
+          cat > "$HELPERS_FILE" << 'RETRY_EOF'
+          gh_api_retry() {
+            local max_attempts=4 attempt=1 delay=1 output rc http_code
+            while [ $attempt -le $max_attempts ]; do
+              # Capture the exit code immediately: after `if cmd; then ...; fi`
+              # with a false condition and no else, bash resets $? to 0, which
+              # would make a failed call look successful.
+              output=$(gh api "$@" 2>&1)
+              rc=$?
+              if [ $rc -eq 0 ]; then
+                # Only emit when there is output: --silent calls produce none,
+                # and an unconditional trailing newline would corrupt callers
+                # that read the result via "$(gh_api_retry ...)".
+                [ -n "$output" ] && printf '%s\n' "$output"
+                return 0
+              fi
+              # On HTTP errors gh prints "... (HTTP NNN)" on stderr. Extract the
+              # numeric status rather than matching a fragile substring, so we
+              # can decide per-class whether the failure is worth retrying.
+              http_code=$(printf '%s' "$output" | grep -oE 'HTTP [0-9]{3}' | tail -1 | grep -oE '[0-9]{3}')
+              case "$http_code" in
+                # 403 and 429 mean rate limiting (per GitHub REST API docs) and
+                # 5xx are transient server errors: retry these.
+                403|429|5??) ;;
+                # Any other 4xx (e.g. a 404 for a non-member) is a definitive
+                # answer, not a transient failure: bail out immediately instead
+                # of wasting retries or masking the result for membership checks.
+                4??)
+                  printf '%s\n' "$output" >&2
+                  return $rc
+                  ;;
+              esac
+              if [ $attempt -eq $max_attempts ]; then
+                printf '%s\n' "$output" >&2
+                return $rc
+              fi
+              echo "gh api attempt $attempt failed, retrying in ${delay}s..." >&2
+              sleep $delay
+              delay=$((delay * 2))
+              attempt=$((attempt + 1))
+            done
+          }
+          RETRY_EOF
+          echo "BASH_ENV=$HELPERS_FILE" >> "$GITHUB_ENV"
+
       - name: Check for code changes on synchronize
         if: github.event.action == 'synchronize'
         id: code-changes
@@ -32,8 +83,8 @@ jobs:
           fi
 
           # Use the GitHub API to compare trees
-          BEFORE_TREE=$(gh api "repos/$PR_REPO/git/commits/$BEFORE" --jq '.tree.sha' 2>/dev/null || true)
-          AFTER_TREE=$(gh api "repos/$PR_REPO/git/commits/$AFTER" --jq '.tree.sha' 2>/dev/null || true)
+          BEFORE_TREE=$(gh_api_retry "repos/$PR_REPO/git/commits/$BEFORE" --jq '.tree.sha' 2>/dev/null || true)
+          AFTER_TREE=$(gh_api_retry "repos/$PR_REPO/git/commits/$AFTER" --jq '.tree.sha' 2>/dev/null || true)
 
           if [ -n "$BEFORE_TREE" ] && [ -n "$AFTER_TREE" ] && [ "$BEFORE_TREE" = "$AFTER_TREE" ]; then
             echo "No code changes detected (commit message edit only), skipping CI"
@@ -59,12 +110,13 @@ jobs:
           # Fetch all pages of PR files
           PAGE=1
           while true; do
-            FILES=$(gh api "repos/$PR_REPO/pulls/$PR_NUMBER/files?per_page=100&page=$PAGE" --jq '.[].filename')
+            FILES=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER/files?per_page=100&page=$PAGE" --jq '.[].filename')
             if [ -z "$FILES" ]; then
               break
             fi
 
             while IFS= read -r FILE; do
+              [ -z "$FILE" ] && continue
               # Check for docs files that DON'T need Sphinx build
               # (.github/*, docs/dev/*, README.md, docs/*.py, top-level *.md)
               if echo "$FILE" | grep -qE '^docs/dev/|(/)?README\.md$|^docs/.*\.py$|^\.github|^[a-zA-Z0-9]+\.md$'; then
@@ -117,7 +169,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Fetching PR #$PR_NUMBER details..."
-          PR_JSON=$(gh api "repos/$PR_REPO/pulls/$PR_NUMBER")
+          PR_JSON=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER")
 
           MERGEABLE_STATE=$(echo "$PR_JSON" | jq -r '.mergeable_state')
           LABELS=$(echo "$PR_JSON" | jq -r '[.labels[].name] | join(",")')
@@ -197,7 +249,7 @@ jobs:
           ALL_FILES=""
           PAGE=1
           while true; do
-            FILES=$(gh api "repos/$PR_REPO/pulls/$PR_NUMBER/files?per_page=100&page=$PAGE" --jq '.[].filename')
+            FILES=$(gh_api_retry "repos/$PR_REPO/pulls/$PR_NUMBER/files?per_page=100&page=$PAGE" --jq '.[].filename')
             if [ -z "$FILES" ]; then
               break
             fi
@@ -212,6 +264,7 @@ jobs:
           # build: required if any file does NOT match scripts/pull_github_pr.sh
           BUILD_REQUIRED=false
           while IFS= read -r FILE; do
+            [ -z "$FILE" ] && continue
             if [ "$FILE" != "scripts/pull_github_pr.sh" ]; then
               BUILD_REQUIRED=true
               break
@@ -221,6 +274,7 @@ jobs:
           # dtest: required if any file does NOT match test*, dist/docker/*, dist/common/scripts/*
           DTEST_REQUIRED=false
           while IFS= read -r FILE; do
+            [ -z "$FILE" ] && continue
             if ! echo "$FILE" | grep -qE '^(test(\.py|/)|dist/docker/|dist/common/scripts/)'; then
               DTEST_REQUIRED=true
               break
@@ -230,6 +284,7 @@ jobs:
           # unittest: required if any file does NOT match dist/docker/*, dist/common/scripts*
           UNITTEST_REQUIRED=false
           while IFS= read -r FILE; do
+            [ -z "$FILE" ] && continue
             if ! echo "$FILE" | grep -qE '^(dist/docker/|dist/common/scripts)'; then
               UNITTEST_REQUIRED=true
               break
@@ -239,6 +294,7 @@ jobs:
           # artifacts: required if any file matches dist/* or tools/toolchain*
           ARTIFACTS_REQUIRED=false
           while IFS= read -r FILE; do
+            [ -z "$FILE" ] && continue
             if echo "$FILE" | grep -qE '^(dist|tools/toolchain)'; then
               ARTIFACTS_REQUIRED=true
               break
@@ -294,13 +350,14 @@ jobs:
         run: |
           TRUSTED=false
 
-          # Check if user is a ScyllaDB org member
-          HTTP_CODE=$(gh api "orgs/scylladb/members/$PR_USER" --silent 2>/dev/null && echo "204" || echo "other")
-          if [ "$HTTP_CODE" = "204" ]; then
+          # Check if user is a ScyllaDB org member (204 -> success/exit 0,
+          # 404 -> not a member -> non-zero). Rely on the return code rather
+          # than parsing stdout, which is empty for these --silent calls.
+          if gh_api_retry "orgs/scylladb/members/$PR_USER" --silent >/dev/null 2>&1; then
             TRUSTED=true
           else
             # Check if user is in the external-contributors team
-            TEAM_STATE=$(gh api "orgs/scylladb/teams/external-contributors/memberships/$PR_USER" --jq '.state' 2>/dev/null || echo "none")
+            TEAM_STATE=$(gh_api_retry "orgs/scylladb/teams/external-contributors/memberships/$PR_USER" --jq '.state' 2>/dev/null || echo "none")
             if [ "$TEAM_STATE" = "active" ]; then
               TRUSTED=true
             fi
@@ -309,7 +366,7 @@ jobs:
           if [ "$TRUSTED" = "false" ]; then
             echo "::warning::PR submitted by external contributor ($PR_USER), CI will not trigger automatically"
             TARGET_FOLDER="${{ steps.target-folder.outputs.folder }}"
-            gh api "repos/$PR_REPO/issues/$PR_NUMBER/comments" \
+            gh_api_retry "repos/$PR_REPO/issues/$PR_NUMBER/comments" \
               -f body="@scylladb/scylla-maint please review and trigger CI for this pull request
           **CI Build:** https://jenkins.scylladb.com/job/${TARGET_FOLDER}/job/scylla-ci/parambuild/?PR_NUMBER=${PR_NUMBER}"
           fi
@@ -395,7 +452,7 @@ jobs:
           fi
 
           # Set pending commit status
-          gh api "repos/$PR_REPO/statuses/$PR_SHA" \
+          gh_api_retry "repos/$PR_REPO/statuses/$PR_SHA" \
             -f state="pending" \
             -f context="Checkout" \
             -f description="Waiting for CI to start" \


### PR DESCRIPTION
## Fix gh_api_retry, unify CI triggers, and add manual dispatch

This PR re-submits the CI workflow unification (originally #30475, reverted on `next`) with the bugs fixed, plus a new `workflow_dispatch` trigger.

### Problem

1. The previous `gh_api_retry` helper wrote directly to `$BASH_ENV`, which is not guaranteed to be set before the first step runs, causing `No such file or directory` errors.
2. The comment-based CI trigger (`@scylladbbot trigger-ci`) lived in a separate `trigger_ci.yaml` workflow that bypassed all smart routing logic (file analysis, label checks, folder resolution, commit-status posting).
3. There was no way to manually trigger the CI routing workflow for debugging.

### Changes

**Commit 1: Add gh_api_retry helper and robustness fixes**
- Add `gh_api_retry()` shell function with exponential backoff (4 attempts) to all `gh api` calls
- Write the helper to `$RUNNER_TEMP/.bash_helpers` and set `BASH_ENV` via `$GITHUB_ENV` (fixes the previous `$BASH_ENV` bug)
- Add empty-line guards in file-iteration loops to prevent false positives

**Commit 2: Unify CI trigger workflows**
- Merge `trigger_ci.yaml` into `scylla-ci-route.yaml`
- Add `issue_comment` and `unlabeled` event triggers
- Add `Resolve PR context` step that handles both PR events and comment events
- Skip trust check for comment triggers (org membership already validated)

**Commit 3: Add workflow_dispatch for manual testing**
- Add `workflow_dispatch` trigger with `pr_number` and `target_repo` inputs
- Defaults to `scylladb/scylladb` for the target repo

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2719
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2858

### Testing

Verified end-to-end on a fork using `workflow_dispatch` against PR #30479 on `scylladb/scylladb`:
- Workflow run: https://github.com/yaronkaikov/scylla/actions/runs/28081837641/job/83138979106
- Jenkins build successfully triggered: https://jenkins.scylladb.com/job/scylla-master/job/scylla-ci/30529/

**Need to backport to all active releases for supporting trigger CI by comment**
