### PR TITLE
compaction: Tax each sstable with a fixed cost in backlog accounting

### DIFF
--- a/compaction/compaction_backlog_manager.hh
+++ b/compaction/compaction_backlog_manager.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <unordered_set>
 #include <memory>
 #include "sstables/shared_sstable.hh"
@@ -18,6 +19,42 @@ class compaction_controller;
 namespace compaction {
 
 class compaction_backlog_manager;
+
+// Minimum size (in bytes) used when accounting for an SSTable's contribution to the
+// compaction backlog.
+//
+// The backlog formulas (see size_tiered_backlog_tracker and incremental_backlog_tracker)
+// are essentially a per-sstable sum of size * log(T/size), so tiny SSTables would barely
+// move the backlog needle. That is a real problem because early commitlog-driven flushes
+// (especially under tablets, where there can be multiple active memtables for a single
+// table on a given shard) can produce many very small SSTables. Many tiny SSTables hurt
+// read amplification badly, causing slow reads and memory pressure (each SSTable being
+// read from has a fixed memory overhead), so the controller must apply enough pressure
+// to compact them away promptly.
+//
+// To avoid the backlog underestimating that pressure, every SSTable is taxed with a
+// minimum size when computing its backlog contribution: its effective size is the
+// maximum of its actual data size and minimum_backlog_sstable_size. This gives even
+// tiny SSTables a meaningful weight without affecting the on-disk size accounting used
+// outside of the backlog calculation.
+//
+// Sizing rationale: a typical cloud node has about 8 GiB of memory per shard, of which
+// roughly ~50% is available for memtables. With ~100 tablet replicas sharing that budget,
+// each memtable is expected to be around ~40 MiB at full size. A full-size flush is thus
+// not "tiny" and should not be penalized. Half of that (~20 MiB) would still risk taxing
+// flushes from slightly under-provisioned deployments (smaller VMs, more tablet replicas,
+// or simply memtables flushed slightly early), so we pick a conservative 10 MiB threshold
+// that only kicks in for clearly tiny SSTables (e.g. produced by commitlog segment
+// flushes well before the memtable fills up).
+static constexpr uint64_t minimum_backlog_sstable_size = 10UL * 1024 * 1024;
+
+// Returns the effective size, in bytes, used by backlog trackers when accounting for an
+// SSTable (or sstable run) whose actual on-disk data size is data_size. Empty objects
+// (data_size == 0) are still treated as having zero contribution; non-empty ones are
+// taxed up to minimum_backlog_sstable_size. See the comment above for rationale.
+static inline uint64_t effective_backlog_size(uint64_t data_size) {
+    return data_size == 0 ? 0 : std::max(data_size, minimum_backlog_sstable_size);
+}
 
 // Read and write progress are provided by structures present in progress_manager.hh
 // However, we don't want to be tied to their lifetimes and for that reason we will not

--- a/compaction/compaction_backlog_manager.hh
+++ b/compaction/compaction_backlog_manager.hh
@@ -19,6 +19,29 @@ namespace compaction {
 
 class compaction_backlog_manager;
 
+// Fixed cost, in bytes, that each sstable adds to the backlog on top of its own size.
+//
+// The backlog of an sstable is (Si - Ci) * log4(T / Si), so tiny sstables barely move
+// the needle, even though log4(T / Si) is large for them. That worked well until
+// tablets, where commitlog driven flush can produce a tiny sstable per replica in a
+// shard. Read amplification suffers badly, as each sstable being read has a fixed
+// memory overhead, but the controller sees almost no backlog and won't apply pressure
+// to compact them away.
+//
+// The tax reflects the cost we pay per sstable regardless of its size. It's applied to
+// Si where it weighs the work, but not inside log4(T / Si), which estimates write
+// amplification and should be left alone. Taxing the log too would shrink the estimate
+// for exactly the sstables we want to make visible.
+//
+// 1M is a conservative starting point, well below the size of a full memtable flush.
+static constexpr uint64_t sstable_backlog_fixed_cost = 1UL * 1024 * 1024;
+
+// Size used to weigh the backlog of an sstable, or of a run of sstables, whose data
+// size is data_size. Empty objects contribute nothing.
+static inline uint64_t effective_backlog_size(uint64_t data_size, size_t sstables = 1) {
+    return data_size == 0 ? 0 : data_size + sstables * sstable_backlog_fixed_cost;
+}
+
 // Read and write progress are provided by structures present in progress_manager.hh
 // However, we don't want to be tied to their lifetimes and for that reason we will not
 // manipulate them directly in the backlog manager.

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -227,7 +227,7 @@ size_tiered_backlog_tracker::compacted_backlog(const compaction_backlog_tracker:
         }
         auto compacted = crp.second->compacted();
         in.total_bytes += compacted;
-        in.contribution += compacted * log4(crp.first->data_size());
+        in.contribution += compacted * log4(effective_backlog_size(crp.first->data_size()));
     }
     return in;
 }
@@ -253,7 +253,11 @@ size_tiered_backlog_tracker::sstables_backlog_contribution size_tiered_backlog_t
             continue;
         }
         contrib.value += std::ranges::fold_left(bucket | std::views::transform([] (const sstables::shared_sstable& sst) -> double {
-            return sst->data_size() * log4(sst->data_size());
+            // See effective_backlog_size in compaction_backlog_manager.hh: tiny SSTables (e.g. from
+            // early commitlog-driven flushes) are taxed with a minimum size so they still contribute
+            // meaningfully to the backlog.
+            auto size = effective_backlog_size(sst->data_size());
+            return size * log4(size);
         }), double(0.0f), std::plus{});
         // Controller is disabled if exception is caught during add / remove calls, so not making any effort to make this exception safe
         contrib.sstables.insert(bucket.begin(), bucket.end());
@@ -265,7 +269,9 @@ size_tiered_backlog_tracker::sstables_backlog_contribution size_tiered_backlog_t
 double size_tiered_backlog_tracker::backlog(const compaction_backlog_tracker::ongoing_writes& ow, const compaction_backlog_tracker::ongoing_compactions& oc) const {
     inflight_component compacted = compacted_backlog(oc);
 
-    auto total_backlog_bytes = std::ranges::fold_left(_contrib.sstables | std::views::transform(std::mem_fn(&sstables::sstable::data_size)), uint64_t(0), std::plus{});
+    auto total_backlog_bytes = std::ranges::fold_left(_contrib.sstables | std::views::transform([] (const sstables::shared_sstable& sst) {
+        return effective_backlog_size(sst->data_size());
+    }), uint64_t(0), std::plus{});
 
     // Bail out if effective backlog is zero, which happens in a small window where ongoing compaction exhausted
     // input files but is still sealing output files or doing managerial stuff like updating history table
@@ -298,7 +304,9 @@ void size_tiered_backlog_tracker::replace_sstables(const std::vector<sstables::s
         if (sst->data_size() > 0) {
             auto erased = tmp_all.erase(sst);
             if (erased) {
-                tmp_total_bytes -= sst->data_size();
+                // Mirror the taxation applied when this SSTable was added, so that _total_bytes
+                // stays consistent with the per-sstable sizes used in the backlog formula.
+                tmp_total_bytes -= effective_backlog_size(sst->data_size());
             }
         }
     }
@@ -306,7 +314,7 @@ void size_tiered_backlog_tracker::replace_sstables(const std::vector<sstables::s
         if (sst->data_size() > 0) {
             auto [_, inserted] = tmp_all.insert(sst);
             if (inserted) {
-                tmp_total_bytes += sst->data_size();
+                tmp_total_bytes += effective_backlog_size(sst->data_size());
             }
         }
     }

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -225,6 +225,10 @@ size_tiered_backlog_tracker::compacted_backlog(const compaction_backlog_tracker:
         if (!_contrib.sstables.contains(crp.first)) {
             continue;
         }
+        // Ci is left untaxed on purpose: the fixed cost belongs to the sstable existing,
+        // not to the compaction reading it, so it's only retired once the sstable leaves
+        // the set. Taxing Ci would cancel the tax added to Si for every sstable being
+        // compacted, and prorating it would only decay it earlier.
         auto compacted = crp.second->compacted();
         in.total_bytes += compacted;
         in.contribution += compacted * log4(crp.first->data_size());
@@ -253,7 +257,10 @@ size_tiered_backlog_tracker::sstables_backlog_contribution size_tiered_backlog_t
             continue;
         }
         contrib.value += std::ranges::fold_left(bucket | std::views::transform([] (const sstables::shared_sstable& sst) -> double {
-            return sst->data_size() * log4(sst->data_size());
+            // Si is taxed with the fixed per-sstable cost where it weighs the work, but
+            // not inside the log. See sstable_backlog_fixed_cost.
+            auto data_size = sst->data_size();
+            return effective_backlog_size(data_size) * log4(data_size);
         }), double(0.0f), std::plus{});
         // Controller is disabled if exception is caught during add / remove calls, so not making any effort to make this exception safe
         contrib.sstables.insert(bucket.begin(), bucket.end());
@@ -265,7 +272,9 @@ size_tiered_backlog_tracker::sstables_backlog_contribution size_tiered_backlog_t
 double size_tiered_backlog_tracker::backlog(const compaction_backlog_tracker::ongoing_writes& ow, const compaction_backlog_tracker::ongoing_compactions& oc) const {
     inflight_component compacted = compacted_backlog(oc);
 
-    auto total_backlog_bytes = std::ranges::fold_left(_contrib.sstables | std::views::transform(std::mem_fn(&sstables::sstable::data_size)), uint64_t(0), std::plus{});
+    auto total_backlog_bytes = std::ranges::fold_left(_contrib.sstables | std::views::transform([] (const sstables::shared_sstable& sst) {
+        return effective_backlog_size(sst->data_size());
+    }), uint64_t(0), std::plus{});
 
     // Bail out if effective backlog is zero, which happens in a small window where ongoing compaction exhausted
     // input files but is still sealing output files or doing managerial stuff like updating history table

--- a/compaction/incremental_backlog_tracker.cc
+++ b/compaction/incremental_backlog_tracker.cc
@@ -17,7 +17,7 @@ incremental_backlog_tracker::inflight_component incremental_backlog_tracker::com
         }
         auto compacted = crp.second->compacted();
         in.total_bytes += compacted;
-        in.contribution += compacted * log4((crp.first->data_size()));
+        in.contribution += compacted * log4(effective_backlog_size(crp.first->data_size()));
     }
     return in;
 }
@@ -38,8 +38,12 @@ incremental_backlog_tracker::calculate_sstables_backlog_contribution(const std::
             auto& run = *run_ptr;
             auto data_size = run.data_size();
             if (data_size > 0) {
-                total_backlog_bytes += data_size;
-                sstables_backlog_contribution += data_size * log4(data_size);
+                // See effective_backlog_size in compaction_backlog_manager.hh: tiny runs are
+                // taxed with a minimum size so they still contribute meaningfully to the
+                // backlog, instead of being practically invisible to the controller.
+                auto size = effective_backlog_size(data_size);
+                total_backlog_bytes += size;
+                sstables_backlog_contribution += size * log4(size);
                 sstable_runs_contributing_backlog.insert((*run.all().begin())->run_identifier());
             }
         }
@@ -95,7 +99,9 @@ void incremental_backlog_tracker::replace_sstables(const std::vector<sstables::s
     if (sst->data_size() > 0) {
         // note: we don't expect failed insertions since each sstable will be inserted once
         (void)all[sst->run_identifier()].insert(sst);
-        total_bytes += sst->data_size();
+        // Tax tiny SSTables so they still affect _total_bytes (used as T in log4(T) by
+        // backlog()). See effective_backlog_size in compaction_backlog_manager.hh.
+        total_bytes += effective_backlog_size(sst->data_size());
         // Deduce threshold from the last SSTable added to the set
         threshold = sst->get_schema()->min_compaction_threshold();
     }
@@ -108,7 +114,8 @@ void incremental_backlog_tracker::replace_sstables(const std::vector<sstables::s
         if (all[run_identifier].all().empty()) {
             all.erase(run_identifier);
         }
-        total_bytes -= sst->data_size();
+        // Mirror the taxation applied when this SSTable was added.
+        total_bytes -= effective_backlog_size(sst->data_size());
     }
     }
 

--- a/compaction/incremental_backlog_tracker.cc
+++ b/compaction/incremental_backlog_tracker.cc
@@ -15,6 +15,10 @@ incremental_backlog_tracker::inflight_component incremental_backlog_tracker::com
         if (!_sstable_runs_contributing_backlog.contains(crp.first->run_identifier())) {
             continue;
         }
+        // Ci is left untaxed on purpose: the fixed cost belongs to the sstable existing,
+        // not to the compaction reading it, so it's only retired once the sstable leaves
+        // the set. Taxing Ci would cancel the tax added to Si for every sstable being
+        // compacted, and prorating it would only decay it earlier.
         auto compacted = crp.second->compacted();
         in.total_bytes += compacted;
         in.contribution += compacted * log4((crp.first->data_size()));
@@ -38,8 +42,11 @@ incremental_backlog_tracker::calculate_sstables_backlog_contribution(const std::
             auto& run = *run_ptr;
             auto data_size = run.data_size();
             if (data_size > 0) {
-                total_backlog_bytes += data_size;
-                sstables_backlog_contribution += data_size * log4(data_size);
+                // Si is taxed with the fixed cost of every sstable in the run, where it
+                // weighs the work, but not inside the log. See sstable_backlog_fixed_cost.
+                auto size = effective_backlog_size(data_size, run.all().size());
+                total_backlog_bytes += size;
+                sstables_backlog_contribution += size * log4(data_size);
                 sstable_runs_contributing_backlog.insert((*run.all().begin())->run_identifier());
             }
         }

--- a/test/perf/perf_compaction_efficiency.cc
+++ b/test/perf/perf_compaction_efficiency.cc
@@ -14,15 +14,26 @@
 #include <json/json.h>
 
 #include <seastar/core/app-template.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/thread.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/timer.hh>
 
 #include "test/lib/cql_test_env.hh"
 #include "test/perf/perf.hh"
+#include "compaction/compaction_manager.hh"
+#include "compaction/compaction_group_view.hh"
 #include "db/config.hh"
 #include "replica/database.hh"
+#include "replica/memtable.hh"
 #include "sstables/sstables.hh"
 #include "schema/schema_builder.hh"
 #include "schema/schema_registry.hh"
+#include "utils/estimated_histogram.hh"
+#include "backlog_controller.hh"
 
 namespace {
 
@@ -46,6 +57,91 @@ struct test_config {
     std::map<sstring, sstring> compaction_options;
     sstring output_format = "text";
     bool verbose = false;
+
+    // Concurrent mode: writer fibers run against a periodic flush, so compaction runs
+    // alongside the write load and has to compete for CPU. The serial mode (flush, then
+    // wait for compaction) never lets that happen, so it cannot say anything about the
+    // compaction controller.
+    //
+    // Both inputs the comparison depends on are rate controlled: how many operations per
+    // second the writers issue, and how often a flush is triggered. Everything else about
+    // compaction's behaviour is an output.
+    bool concurrent_mode = false;
+    unsigned concurrent_writers = 16;
+    unsigned write_rate = 0;            // operations/s across all writers, 0 = unlimited
+    unsigned flush_rate = 10;           // flush triggers per second
+    double read_ratio = 0.1;            // fraction of operations that are reads
+    unsigned tablets = 1;               // tablets per shard, i.e. compaction groups
+    unsigned stats_interval_ms = 1000;
+    unsigned available_memory_mb = 0;   // 0 = default (memory::stats().total_memory())
+    float compaction_static_shares = 0; // >0 pins shares and disables the controller
+};
+
+// Time series of a scalar sampled at a fixed interval, reported as percentiles. Used to
+// answer "how bad did it get, and for how long", which a single final value can't.
+struct sample_series {
+    std::vector<double> samples;
+
+    void add(double v) { samples.push_back(v); }
+    bool empty() const { return samples.empty(); }
+    size_t size() const { return samples.size(); }
+
+    double percentile(double p) const {
+        if (samples.empty()) {
+            return 0;
+        }
+        auto sorted = samples;
+        std::sort(sorted.begin(), sorted.end());
+        auto idx = static_cast<size_t>(std::ceil(p / 100.0 * sorted.size()));
+        idx = std::min(idx ? idx - 1 : 0, sorted.size() - 1);
+        return sorted[idx];
+    }
+
+    double max() const {
+        return samples.empty() ? 0 : *std::ranges::max_element(samples);
+    }
+
+    double mean() const {
+        return samples.empty() ? 0
+            : std::accumulate(samples.begin(), samples.end(), 0.0) / samples.size();
+    }
+
+    // Percentile over the given half of the run. Comparing the two halves shows whether
+    // compaction is holding steady or falling behind over time.
+    double percentile_of_half(double p, bool second_half) const {
+        if (samples.size() < 2) {
+            return percentile(p);
+        }
+        auto mid = samples.begin() + samples.size() / 2;
+        sample_series half;
+        half.samples.assign(second_half ? mid : samples.begin(),
+                            second_half ? samples.end() : mid);
+        return half.percentile(p);
+    }
+
+    // Fraction of samples equal to v, within a relative tolerance. Used to tell whether
+    // the controller is pinned at an endpoint rather than tracking the backlog.
+    double fraction_at(double v) const {
+        if (samples.empty()) {
+            return 0;
+        }
+        auto n = std::ranges::count_if(samples, [v] (double s) {
+            return std::abs(s - v) <= std::max(1.0, std::abs(v) * 1e-6);
+        });
+        return double(n) / samples.size();
+    }
+
+    // Number of times consecutive samples differ, i.e. how often the controller moved.
+    // Zero means it never reacted over the whole run.
+    uint64_t changes() const {
+        uint64_t n = 0;
+        for (size_t i = 1; i < samples.size(); ++i) {
+            if (samples[i] != samples[i - 1]) {
+                ++n;
+            }
+        }
+        return n;
+    }
 };
 
 struct metrics {
@@ -163,7 +259,8 @@ struct metrics {
     }
 
     void write_json(const test_config& cfg, uint64_t final_sstable_count,
-                    uint64_t total_bytes_on_disk, uint64_t major_compacted_bytes) const {
+                    uint64_t total_bytes_on_disk, uint64_t major_compacted_bytes,
+                    const Json::Value* extra = nullptr) const {
         auto sorted_ra = read_amp_samples;
         std::sort(sorted_ra.begin(), sorted_ra.end());
 
@@ -217,6 +314,12 @@ struct metrics {
             root["compaction_efficiency_p95"] = fmt::format("{:.4f}", percentile_double(sorted_ce, 95));
             root["compaction_efficiency_p99"] = fmt::format("{:.4f}", percentile_double(sorted_ce, 99));
             root["compaction_efficiency_max"] = fmt::format("{:.4f}", sorted_ce.back());
+        }
+
+        if (extra) {
+            for (const auto& key : extra->getMemberNames()) {
+                root[key] = (*extra)[key];
+            }
         }
 
         Json::StreamWriterBuilder builder;
@@ -286,12 +389,20 @@ struct workload_state {
 
 using sstable_set_t = std::unordered_map<sstables::generation_type, uint64_t>;
 
-sstable_set_t get_sstable_set(sharded<replica::database>& db, const schema_ptr& s) {
-    return db.map_reduce0([gs = global_schema_ptr(s)] (replica::database& db) {
+// When origin is given, only sstables written by that producer are collected. Flush
+// accounting needs "memtable", otherwise sstables produced by a compaction that happened
+// to finish inside the same window are counted as flushed bytes, which inflates flush
+// bytes (and write amplification) by however busy compaction was at the time.
+sstable_set_t get_sstable_set(sharded<replica::database>& db, const schema_ptr& s,
+                              std::optional<sstring> origin = std::nullopt) {
+    return db.map_reduce0([gs = global_schema_ptr(s), origin] (replica::database& db) {
         sstable_set_t local;
         auto& cf = db.find_column_family(gs);
         auto sstables = cf.get_sstables();
         for (auto& sst : *sstables) {
+            if (origin && sst->get_origin() != *origin) {
+                continue;
+            }
             local[sst->generation()] = sst->bytes_on_disk();
         }
         return local;
@@ -300,6 +411,10 @@ sstable_set_t get_sstable_set(sharded<replica::database>& db, const schema_ptr& 
         return a;
     }).get();
 }
+
+// Bytes of sstables produced by memtable flushes, i.e. what the write path actually
+// wrote. Used as the denominator of write amplification.
+static const sstring memtable_origin = "memtable";
 
 // Compute sum of bytes_on_disk for SSTables in `current` that are not in `previous`
 uint64_t new_sstable_bytes(const sstable_set_t& previous, const sstable_set_t& current) {
@@ -426,9 +541,9 @@ void do_compaction_efficiency_test(cql_test_env& env, test_config& cfg) {
         "  v bigint,"
         "  PRIMARY KEY (pk, ck)"
         ") WITH compaction = {{{}}}"
-        " AND tablets = {{'min_per_shard_tablet_count': '1'}}"
+        " AND tablets = {{'min_per_shard_tablet_count': '{}'}}"
         " AND tombstone_gc = {{'mode': 'immediate'}}",
-        compaction_opts);
+        compaction_opts, cfg.tablets);
 
     if (cfg.default_time_to_live > 0) {
         create_table_cql += fmt::format(" AND default_time_to_live = {}",
@@ -634,6 +749,655 @@ void do_compaction_efficiency_test(cql_test_env& env, test_config& cfg) {
     }
 }
 
+// Sum of the per-view backlog for the given table across all shards. Used only for
+// observability; the value crosses trackers/shards additively, so it is representative
+// of the total pressure the compaction controller sees.
+double get_total_backlog(sharded<replica::database>& db, const schema_ptr& s) {
+    return db.map_reduce0([gs = global_schema_ptr(s)] (replica::database& db) -> future<double> {
+        auto& cf = db.find_column_family(gs);
+        double sum = 0;
+        co_await cf.parallel_foreach_compaction_group_view([&sum] (compaction::compaction_group_view& v) -> future<> {
+            sum += v.get_backlog_tracker().backlog();
+            co_return;
+        });
+        co_return sum;
+    }, double(0), std::plus<double>()).get();
+}
+
+// Sum of the shard-local compaction_manager backlog across all shards. This includes
+// every table's backlog (not just ours) but in a benchmark that runs a single table
+// it is effectively equivalent to get_total_backlog and — more importantly — it is
+// exactly the value the compaction controller sees when it computes shares:
+//     shares = f(compaction_manager.backlog() / available_memory())
+// (see backlog_controller::adjust / compaction_manager.cc).
+double get_cm_backlog_sum(sharded<replica::database>& db) {
+    return db.map_reduce0([] (replica::database& db) -> double {
+        return db.get_compaction_manager().backlog();
+    }, double(0), std::plus<double>()).get();
+}
+
+// available_memory() reported by the compaction manager on shard 0. The controller
+// normalises the backlog by this value before mapping it to a shares value on the
+// compaction scheduling group.
+size_t get_cm_available_memory(sharded<replica::database>& db) {
+    return db.invoke_on(0, [] (replica::database& db) {
+        return db.get_compaction_manager().available_memory();
+    }).get();
+}
+
+// Shares currently assigned to the compaction scheduling group. This is what the
+// controller sets in response to the observed backlog: higher backlog -> more shares
+// -> more CPU allocated to compaction relative to foreground writes. Sum across shards
+// so we get a single number to display in the timeline; on a single-shard run this
+// equals the per-shard value.
+double get_compaction_shares_sum(sharded<replica::database>& db) {
+    return db.map_reduce0([] (replica::database& db) -> double {
+        return db.get_compaction_manager().compaction_sg().get_shares();
+    }, double(0), std::plus<double>()).get();
+}
+
+// Number of compactions running, and queued waiting for an opportunity to run, across
+// all shards. A run where compaction is given plenty of shares but few jobs are active
+// is being held back by admission (weight class / fan-in gates), not by CPU.
+std::pair<uint64_t, int64_t> get_compaction_task_counts(sharded<replica::database>& db) {
+    return db.map_reduce0([] (replica::database& db) {
+        auto& st = db.get_compaction_manager().get_stats();
+        return std::make_pair(st.active_tasks, st.pending_tasks);
+    }, std::make_pair(uint64_t(0), int64_t(0)), [] (auto a, auto b) {
+        return std::make_pair(a.first + b.first, a.second + b.second);
+    }).get();
+}
+
+// Per-compaction facts for the run, read back from system.compaction_history: how much
+// each job read and wrote, how many sstables it merged, and how long it took. This is
+// what tells apart "compaction got more CPU and used it well" from "compaction got more
+// CPU and spent it rewriting the same data".
+struct compaction_job_stats {
+    uint64_t jobs = 0;
+    uint64_t bytes_in = 0;
+    uint64_t bytes_out = 0;
+    sample_series fan_in;
+    sample_series duration_ms;
+};
+
+compaction_job_stats get_compaction_job_stats(cql_test_env& env, const sstring& cf_name) {
+    compaction_job_stats st;
+    auto msg = env.execute_cql(
+        "SELECT columnfamily_name, bytes_in, bytes_out, rows_merged, started_at, compacted_at "
+        "FROM system.compaction_history").get();
+    auto res = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
+    if (!res) {
+        return st;
+    }
+    auto rows = res->rs().result_set().rows();
+    for (const auto& row : rows) {
+        if (!row[0] || value_cast<sstring>(utf8_type->deserialize(*row[0])) != cf_name) {
+            continue;
+        }
+        ++st.jobs;
+        if (row[1]) {
+            st.bytes_in += value_cast<int64_t>(long_type->deserialize(*row[1]));
+        }
+        if (row[2]) {
+            st.bytes_out += value_cast<int64_t>(long_type->deserialize(*row[2]));
+        }
+        if (row[3]) {
+            // rows_merged maps "number of sstables this row came from" -> row count, so
+            // the largest key is the job's fan-in.
+            auto mt = map_type_impl::get_instance(int32_type, long_type, false);
+            auto v = value_cast<map_type_impl::native_type>(mt->deserialize(*row[3]));
+            int32_t fan_in = 0;
+            for (const auto& [k, _] : v) {
+                fan_in = std::max(fan_in, value_cast<int32_t>(k));
+            }
+            if (fan_in) {
+                st.fan_in.add(double(fan_in));
+            }
+        }
+        if (row[4] && row[5]) {
+            auto started = value_cast<db_clock::time_point>(timestamp_type->deserialize(*row[4]));
+            auto ended = value_cast<db_clock::time_point>(timestamp_type->deserialize(*row[5]));
+            st.duration_ms.add(double(std::chrono::duration_cast<std::chrono::milliseconds>(
+                ended - started).count()));
+        }
+    }
+    return st;
+}
+
+// Concurrent variant of the compaction efficiency benchmark. Unlike the sequential mode
+// (which flushes and awaits compactions synchronously), this mode continuously drives
+// N writer fibers per shard while a background timer forces periodic flushes without
+// waiting for compaction. This creates sustained pressure on the compaction manager
+// and its backlog controller: compactions run concurrently with the write load and
+// have to compete for CPU shares, which is what the backlog signal is used for.
+//
+// This mode is the appropriate one for measuring the impact of changes to the backlog
+// controller or to the backlog formula itself.
+void do_concurrent_compaction_test(cql_test_env& env, test_config& cfg) {
+    using clk = std::chrono::steady_clock;
+
+    // Create table with configured compaction strategy (same shape as the serial mode).
+    sstring compaction_opts = fmt::format("'class': '{}'", cfg.compaction_strategy);
+    for (auto& [k, v] : cfg.compaction_options) {
+        compaction_opts += fmt::format(", '{}': '{}'", k, v);
+    }
+
+    sstring create_table_cql = fmt::format(
+        "CREATE TABLE ks.perf_compaction ("
+        "  pk bigint,"
+        "  ck bigint,"
+        "  v bigint,"
+        "  PRIMARY KEY (pk, ck)"
+        ") WITH compaction = {{{}}}"
+        " AND tablets = {{'min_per_shard_tablet_count': '{}'}}"
+        " AND tombstone_gc = {{'mode': 'immediate'}}",
+        compaction_opts, cfg.tablets);
+
+    if (cfg.default_time_to_live > 0) {
+        create_table_cql += fmt::format(" AND default_time_to_live = {}",
+                                         cfg.default_time_to_live);
+    }
+
+    env.execute_cql(create_table_cql).get();
+
+    auto& cf = env.local_db().find_column_family("ks", "perf_compaction");
+    auto s = cf.schema();
+
+    // Prepared statements shared by all writer fibers.
+    auto insert_id = env.prepare(
+        "INSERT INTO ks.perf_compaction (pk, ck, v) VALUES (?, ?, ?)").get();
+    auto delete_id = env.prepare(
+        "DELETE FROM ks.perf_compaction WHERE pk = ? AND ck = ?").get();
+    // Tiny sstables matter because of read amplification, so the benchmark has to read.
+    // The table keeps an sstables-per-read histogram; these reads are what populate it.
+    auto select_id = env.prepare(
+        "SELECT v FROM ks.perf_compaction WHERE pk = ? AND ck = ?").get();
+
+    metrics m;
+
+    // Timing histogram and counters. Everything below runs on shard 0 (via cql_test_env),
+    // so plain integers and a single histogram are safe: no cross-shard sharing.
+    utils::estimated_histogram write_lat_hist;
+    uint64_t writes_completed = 0;
+    uint64_t reads_completed = 0;
+    uint64_t writes_failed = 0;
+    bool stop_requested = false;
+    // Fibers below sleep for their whole interval, which can be much longer than the
+    // time we're willing to spend shutting down. Abort the sleeps instead of waiting
+    // them out, otherwise the run keeps flushing long after the writers are done.
+    seastar::abort_source stop_as;
+
+    // What the benchmark controls is how often a flush is *triggered*, together with the
+    // write rate. How many of those triggers turn into completed flushes is a dependent
+    // variable: as compaction takes more CPU, flushes take longer, and the achieved flush
+    // rate drops on its own. That's expected, so it's measured rather than forced.
+    //
+    // Flushes may overlap up to a bound. Accounting stays correct regardless, because
+    // sstables are counted by generation and a generation is only counted once however
+    // many snapshots observe it. The bound exists so a slow flush path cannot pile up
+    // unbounded concurrency; a trigger arriving when the bound is reached is dropped and
+    // counted, and a high skip rate means the creation rate was set by flush latency
+    // rather than by --flush-rate.
+    uint64_t flush_triggers = 0;
+    uint64_t flush_skipped = 0;
+    uint64_t total_flushes = 0;
+    constexpr unsigned max_flushes_in_flight = 8;
+    unsigned flushes_in_flight = 0;
+    seastar::gate flush_gate;
+
+    // Every memtable-origin sstable this run produced, counted once. Tracking generations
+    // instead of diffing sizes per flush means an sstable can never be counted twice, and
+    // it gives the real number of sstables handed to compaction — which is the input the
+    // runs need to share for a comparison to be fair, and which the flush trigger count
+    // is not a substitute for.
+    std::unordered_set<sstables::generation_type> flushed_generations;
+    uint64_t total_flush_bytes = 0;
+    auto observe_flushed = [&] (const sstable_set_t& snapshot) {
+        for (const auto& [gen, bytes] : snapshot) {
+            if (flushed_generations.insert(gen).second) {
+                total_flush_bytes += bytes;
+            }
+        }
+    };
+
+    auto do_flush = [&] {
+        if (flush_gate.is_closed()) {
+            return;
+        }
+        ++flush_triggers;
+        if (flushes_in_flight >= max_flushes_in_flight) {
+            ++flush_skipped;
+            return;
+        }
+        ++flushes_in_flight;
+        (void)with_gate(flush_gate, [&] {
+            return async([&] {
+                replica::database::flush_table_on_all_shards(env.db(), "ks", "perf_compaction").get();
+                // Observe immediately on completion, so this flush's own output is seen
+                // before compaction can remove it.
+                observe_flushed(get_sstable_set(env.db(), s, memtable_origin));
+                ++total_flushes;
+            }).handle_exception([] (std::exception_ptr) {
+            }).finally([&] {
+                --flushes_in_flight;
+            });
+        });
+    };
+
+    timer<> flusher;
+    flusher.set_callback([&] { do_flush(); });
+
+    // Time series sampled independently of (and more finely than) the stats printout,
+    // so the percentiles below describe the whole run rather than the printed rows.
+    //
+    // sstable_count answers whether compaction keeps up with the flush rate: if it does,
+    // the count oscillates around a plateau; if it doesn't, the count keeps climbing and
+    // the second half's p90 is well above the first half's.
+    //
+    // shares and norm_backlog answer whether the controller is reacting at all. A run
+    // where shares never changes, or sits at the first control point the whole time,
+    // means the backlog signal never left the lazy region.
+    // Fixed sampling period: fine enough to describe a run, not worth a knob.
+    constexpr auto sample_interval = std::chrono::milliseconds(200);
+    sample_series sstable_count_series;
+    sample_series shares_series;
+    sample_series norm_backlog_series;
+    sample_series active_compactions_series;
+    sample_series pending_compactions_series;
+    auto sampler_fiber = seastar::async([&] {
+        while (!stop_requested) {
+            try {
+                seastar::sleep_abortable(sample_interval, stop_as).get();
+            } catch (const seastar::sleep_aborted&) {
+                break;
+            }
+            if (stop_requested) {
+                break;
+            }
+            sstable_count_series.add(get_sstable_count(env.db(), s));
+            shares_series.add(get_compaction_shares_sum(env.db()));
+            auto am = get_cm_available_memory(env.db());
+            norm_backlog_series.add(am > 0 ? get_cm_backlog_sum(env.db()) / am : 0.0);
+            auto [active, pending] = get_compaction_task_counts(env.db());
+            active_compactions_series.add(double(active));
+            pending_compactions_series.add(double(pending));
+        }
+    });
+
+    // Periodic stats printer, run as a seastar::thread fiber (NOT a timer callback):
+    // fetching the sstable count / backlog / shares requires cross-shard invocations
+    // whose futures we then .get(), and .get() from a non-thread context aborts.
+    // Emits a snapshot of the interesting quantities so the controller's behaviour
+    // can be inspected over time. Includes both the raw backlog (bytes) and the
+    // normalized backlog (backlog / available_memory), which is what the compaction
+    // controller actually uses to interpolate CPU shares. The current compaction
+    // scheduling group shares are also printed so you can see the controller
+    // reacting to the backlog signal in real time.
+    auto prev_time = clk::now();
+    uint64_t prev_writes = 0;
+    uint64_t prev_flushes = 0;
+    auto avail_mem = get_cm_available_memory(env.db());
+    fmt::print("\n=== Concurrent mode: per-{}ms samples (available_memory={:.1f} MiB) ===\n",
+               cfg.stats_interval_ms, avail_mem / (1024.0 * 1024.0));
+    fmt::print("{:>8} {:>10} {:>10} {:>10} {:>11} {:>14} {:>10} {:>8} {:>10} {:>10} {:>10}\n",
+               "elapsed", "wr/s", "flush/s", "sstables", "avg_flush_kb", "backlog", "norm_bl", "shares",
+               "wr_p50_us", "wr_p95_us", "wr_p99_us");
+    auto prev_flush_bytes = uint64_t(0);
+    auto stats_fiber = seastar::async([&] {
+        while (!stop_requested) {
+            try {
+                seastar::sleep_abortable(std::chrono::milliseconds(cfg.stats_interval_ms), stop_as).get();
+            } catch (const seastar::sleep_aborted&) {
+                break;
+            }
+            if (stop_requested) {
+                break;
+            }
+            auto now = clk::now();
+            auto elapsed_since_prev = std::chrono::duration<double>(now - prev_time).count();
+            auto elapsed_total = std::chrono::duration<double>(now - m.start_time).count();
+            auto wr_rate = elapsed_since_prev > 0
+                ? (writes_completed - prev_writes) / elapsed_since_prev : 0.0;
+            auto flushes_since_prev = total_flushes - prev_flushes;
+            auto flush_rate = elapsed_since_prev > 0
+                ? flushes_since_prev / elapsed_since_prev : 0.0;
+            auto bytes_since_prev = total_flush_bytes - prev_flush_bytes;
+            auto avg_flush_kb = flushes_since_prev > 0
+                ? bytes_since_prev / double(flushes_since_prev) / 1024.0 : 0.0;
+
+            auto sst_count = get_sstable_count(env.db(), s);
+            auto backlog = get_total_backlog(env.db(), s);
+            // The controller normalises backlog per-shard by that shard's
+            // available_memory, then interpolates control points to pick shares.
+            // Reproduce that here for display purposes (single-shard runs only;
+            // multi-shard sums are an upper bound).
+            auto norm_backlog = avail_mem > 0
+                ? get_cm_backlog_sum(env.db()) / avail_mem : 0.0;
+            auto shares = get_compaction_shares_sum(env.db());
+
+            fmt::print("{:>8.1f} {:>10.0f} {:>10.1f} {:>10} {:>11.1f} {:>14.2f} {:>10.3f} {:>8.1f} {:>10} {:>10} {:>10}\n",
+                       elapsed_total, wr_rate, flush_rate, sst_count, avg_flush_kb,
+                       backlog, norm_backlog, shares,
+                       write_lat_hist.percentile(0.5),
+                       write_lat_hist.percentile(0.95),
+                       write_lat_hist.percentile(0.99));
+            std::fflush(stdout);
+
+            prev_time = now;
+            prev_writes = writes_completed;
+            prev_flushes = total_flushes;
+            prev_flush_bytes = total_flush_bytes;
+            // Reset the histogram so each sample reflects the last interval only.
+            write_lat_hist.clear();
+        }
+    });
+
+    // Writer fibers: all run on shard 0 (the app-template thread) and dispatch
+    // writes/deletes through env.execute_prepared, which routes them to the owning
+    // shard via the storage proxy. concurrent_writers fibers concurrently issue
+    // requests, so compaction has to compete with foreground work for CPU shares.
+    // Each fiber loops until stop_requested is set.
+    // Write rate limiter. Without it the writers run flat out and the size of each
+    // flushed sstable is whatever the machine happens to manage in a flush period,
+    // which makes runs incomparable and can make it impossible for compaction to ever
+    // catch up. Paced as a shared deadline advanced by one slot per operation, so the
+    // aggregate rate is bounded regardless of the number of fibers.
+    auto write_period = cfg.write_rate > 0
+        ? std::chrono::duration_cast<clk::duration>(std::chrono::duration<double>(1.0 / cfg.write_rate))
+        : clk::duration::zero();
+    auto next_write_slot = clk::now();
+    auto pace_write = [&] {
+        if (write_period == clk::duration::zero()) {
+            return;
+        }
+        auto now = clk::now();
+        if (next_write_slot < now) {
+            next_write_slot = now;
+        }
+        auto slot = next_write_slot;
+        next_write_slot += write_period;
+        if (slot > now) {
+            seastar::sleep(slot - now).get();
+        }
+    };
+
+    auto make_writer_fiber = [&] (unsigned fiber_idx) {
+        return seastar::async([&, fiber_idx] {
+            auto rng = std::mt19937_64(cfg.random_seed + fiber_idx);
+            std::uniform_real_distribution<double> u01(0.0, 1.0);
+            std::uniform_int_distribution<int64_t> pk_dist(0, cfg.partitions - 1);
+            // Rows per partition is bounded, so keys repeat: writes overwrite earlier
+            // ones and deletes land on rows that exist. With an ever-increasing clustering
+            // key nothing is ever superseded, sstables never overlap, and compaction has
+            // nothing to reclaim -- which makes space amplification and compaction
+            // efficiency meaningless.
+            constexpr int64_t rows_per_partition = 64;
+            std::uniform_int_distribution<int64_t> ck_dist(0, rows_per_partition - 1);
+            while (!stop_requested) {
+                pace_write();
+                if (stop_requested) {
+                    break;
+                }
+                double r = u01(rng);
+                int64_t pk = pk_dist(rng);
+                int64_t ck = ck_dist(rng);
+                int64_t v = static_cast<int64_t>(rng());
+
+                // r partitions the operation mix: reads first, then deletes, then writes.
+                // A read of a random key is what exercises read amplification.
+                bool is_read = r < cfg.read_ratio;
+                bool is_delete = !is_read && r < cfg.read_ratio + cfg.delete_ratio;
+                bool is_rewrite = !is_read && !is_delete;
+
+                auto t0 = clk::now();
+                try {
+                    if (is_read) {
+                        env.execute_prepared(select_id, {
+                            {cql3::raw_value::make_value(long_type->decompose(pk)),
+                             cql3::raw_value::make_value(long_type->decompose(ck))}
+                        }).get();
+                        ++reads_completed;
+                    } else if (is_delete) {
+                        env.execute_prepared(delete_id, {
+                            {cql3::raw_value::make_value(long_type->decompose(pk)),
+                             cql3::raw_value::make_value(long_type->decompose(ck))}
+                        }).get();
+                        ++m.deletes;
+                    } else {
+                        env.execute_prepared(insert_id, {
+                            {cql3::raw_value::make_value(long_type->decompose(pk)),
+                             cql3::raw_value::make_value(long_type->decompose(ck)),
+                             cql3::raw_value::make_value(long_type->decompose(v))}
+                        }).get();
+                        ++m.rewrites;
+                        (void)is_rewrite;
+                    }
+                    auto us = std::chrono::duration_cast<std::chrono::microseconds>(
+                                  clk::now() - t0).count();
+                    write_lat_hist.add(us);
+                    ++writes_completed;
+                    ++m.total_operations;
+                } catch (...) {
+                    ++writes_failed;
+                }
+            }
+        });
+    };
+
+    m.start_time = clk::now();
+    prev_time = m.start_time;
+
+    flusher.arm_periodic(std::chrono::milliseconds(std::max(1u, 1000 / cfg.flush_rate)));
+
+    // Launch concurrent writer fibers and let them run for the configured duration.
+    // The main coroutine sleeps for `duration`; fibers observe stop_requested between
+    // iterations to terminate promptly.
+    std::vector<future<>> writer_fibers;
+    writer_fibers.reserve(cfg.concurrent_writers);
+    for (unsigned i = 0; i < cfg.concurrent_writers; ++i) {
+        writer_fibers.push_back(make_writer_fiber(i));
+    }
+    seastar::sleep(std::chrono::seconds(cfg.duration_in_seconds)).get();
+
+    stop_requested = true;
+    stop_as.request_abort();
+    for (auto& f : writer_fibers) {
+        f.get();
+    }
+    // Stop producing sstables before joining anything else, so nothing is attributed to
+    // the run after the writers stopped.
+    flusher.cancel();
+    stats_fiber.get();
+    sampler_fiber.get();
+    // Wait for any in-flight background flushes to finish before mutating the local
+    // metrics from the drain phase below.
+    flush_gate.close().get();
+
+    m.end_time = clk::now();
+
+    // Drain: force one final flush and wait for outstanding compactions so the final
+    // metrics reflect a settled state.
+    {
+        replica::database::flush_table_on_all_shards(env.db(), "ks", "perf_compaction").get();
+        auto after_flush = get_sstable_set(env.db(), s, memtable_origin);
+        observe_flushed(after_flush);
+        m.flush_bytes_written += total_flush_bytes;
+        m.total_flushes = total_flushes + 1;
+        await_compactions(env.db(), s, m, after_flush);
+    }
+
+    auto final_sstable_count = get_sstable_count(env.db(), s);
+    auto total_bytes_on_disk = get_total_bytes_on_disk(env.db(), s);
+
+    // Major compaction so we can report space amplification.
+    env.db().invoke_on_all([gs = global_schema_ptr(s)] (replica::database& db) {
+        auto& cf = db.find_column_family(gs);
+        auto& cm = db.get_compaction_manager();
+        return cf.parallel_foreach_compaction_group_view([&cm] (compaction::compaction_group_view& v) {
+            return cm.perform_major_compaction(v, tasks::task_info{});
+        });
+    }).get();
+    auto major_compacted_bytes = get_total_bytes_on_disk(env.db(), s);
+
+    fmt::print("\nWrites failed: {}\n", writes_failed);
+
+    auto observed_flush_rate = m.duration_seconds() > 0 ? total_flushes / m.duration_seconds() : 0.0;
+    auto trigger_rate = m.duration_seconds() > 0 ? flush_triggers / m.duration_seconds() : 0.0;
+    auto sstables_created = flushed_generations.size();
+    auto creation_rate = m.duration_seconds() > 0 ? sstables_created / m.duration_seconds() : 0.0;
+    auto observed_flush_kb = sstables_created > 0 ? total_flush_bytes / double(sstables_created) / 1024.0 : 0.0;
+    // The first control point's output is the shares the controller assigns at zero
+    // backlog, i.e. the floor it sits at when it sees nothing to do.
+    auto shares_floor = compaction_controller::default_control_points.front().output;
+    auto shares_ceiling = compaction_controller::default_control_points.back().output;
+
+    fmt::print("\n=== Flush, controller reaction and read amplification ===\n");
+    // Triggers are the controlled input; flushes and skips are how the system responded.
+    // sstables created is the real input to compaction, and the number two runs must
+    // share before their sstable counts can be compared.
+    fmt::print("Flush triggers: {} ({:.1f}/s)   completed: {} ({:.1f}/s)   skipped: {} ({:.1f}%)\n",
+               flush_triggers, trigger_rate, total_flushes, observed_flush_rate,
+               flush_skipped, flush_triggers ? 100.0 * flush_skipped / flush_triggers : 0.0);
+    fmt::print("SSTables created by flush: {} ({:.1f}/s, avg {:.1f} KB, {:.1f} MB total)\n",
+               sstables_created, creation_rate, observed_flush_kb,
+               total_flush_bytes / 1048576.0);
+    // Flush latency grows as compaction takes CPU, so a high skip rate means the sstable
+    // creation rate was decided by the treatment rather than by the trigger cadence. Two
+    // runs whose creation rates differ are not comparable on sstable count, however
+    // similar their configuration looks: lower the trigger rate until skips are rare.
+    if (flush_triggers && flush_skipped * 100 > flush_triggers * 10) {
+        fmt::print("  WARNING: {:.1f}% of flush triggers were skipped; the sstable creation\n"
+                   "           rate is limited by flush latency, not by --flush-rate.\n"
+                   "           Compare sstables-created across runs before trusting sstable counts.\n",
+                   100.0 * flush_skipped / flush_triggers);
+    }
+    fmt::print("Configured: {} flush triggers/s, {} ops/s, read ratio {:.2f}, {} tablet(s)/shard\n",
+               cfg.flush_rate,
+               cfg.write_rate ? fmt::format("{}", cfg.write_rate) : "unlimited",
+               cfg.read_ratio, cfg.tablets);
+    fmt::print("Samples: {} every {}ms\n", sstable_count_series.size(), sample_interval.count());
+    fmt::print("\n");
+    fmt::print("SSTable count (mean/p50/p90/p99/max): {:.1f}/{:.0f}/{:.0f}/{:.0f}/{:.0f}\n",
+               sstable_count_series.mean(),
+               sstable_count_series.percentile(50), sstable_count_series.percentile(90),
+               sstable_count_series.percentile(99), sstable_count_series.max());
+    fmt::print("  90% of the time sstable count was below {:.0f}\n",
+               sstable_count_series.percentile(90));
+    fmt::print("  p90 first half / second half: {:.0f} / {:.0f}{}\n",
+               sstable_count_series.percentile_of_half(90, false),
+               sstable_count_series.percentile_of_half(90, true),
+               sstable_count_series.percentile_of_half(90, true) >
+                   1.2 * sstable_count_series.percentile_of_half(90, false)
+                   ? "   <-- compaction is falling behind" : "");
+    fmt::print("\n");
+    fmt::print("Normalized backlog (mean/p50/p90/p99/max): {:.3f}/{:.3f}/{:.3f}/{:.3f}/{:.3f}\n",
+               norm_backlog_series.mean(),
+               norm_backlog_series.percentile(50), norm_backlog_series.percentile(90),
+               norm_backlog_series.percentile(99), norm_backlog_series.max());
+    fmt::print("Compaction shares (mean/p50/p90/max): {:.1f}/{:.1f}/{:.1f}/{:.1f}\n",
+               shares_series.mean(),
+               shares_series.percentile(50), shares_series.percentile(90),
+               shares_series.max());
+    fmt::print("  changed {} times over {} samples ({:.1f}% at floor {:.0f}, {:.1f}% at max {:.0f})\n",
+               shares_series.changes(), shares_series.size(),
+               100.0 * shares_series.fraction_at(shares_floor), shares_floor,
+               100.0 * shares_series.fraction_at(shares_ceiling), shares_ceiling);
+    if (shares_series.changes() == 0 && !shares_series.empty()) {
+        fmt::print("  WARNING: shares never changed, the controller did not react at all\n");
+    }
+    fmt::print("Active compactions (mean/p50/p90/max): {:.2f}/{:.0f}/{:.0f}/{:.0f}\n",
+               active_compactions_series.mean(), active_compactions_series.percentile(50),
+               active_compactions_series.percentile(90), active_compactions_series.max());
+    fmt::print("Pending compactions (mean/p50/p90/max): {:.2f}/{:.0f}/{:.0f}/{:.0f}\n",
+               pending_compactions_series.mean(), pending_compactions_series.percentile(50),
+               pending_compactions_series.percentile(90), pending_compactions_series.max());
+
+    // Read amplification, straight from the histogram the table maintains for
+    // single-partition reads. This is the quantity tiny sstables actually hurt, and
+    // sstable count is only a proxy for it.
+    {
+        auto& ra = env.local_db().find_column_family("ks", "perf_compaction")
+                        .get_stats().estimated_sstable_per_read;
+        fmt::print("\nReads: {}\n", reads_completed);
+        if (reads_completed) {
+            fmt::print("SSTables per read (p50/p90/p95/p99/max): {}/{}/{}/{}/{}\n",
+                       ra.percentile(0.5), ra.percentile(0.9), ra.percentile(0.95),
+                       ra.percentile(0.99), ra.max());
+        }
+    }
+
+    // Read back what each compaction actually did, so the shares the controller handed
+    // out can be compared against the work they bought.
+    auto jobs = get_compaction_job_stats(env, "perf_compaction");
+    // The summary below derives write amplification from compaction_bytes_written, which
+    // is only populated by the serial mode's await_compactions(). Feed it the real number
+    // so concurrent runs don't report a write amplification of zero.
+    m.compaction_bytes_written = jobs.bytes_out;
+    fmt::print("\nCompaction jobs: {}\n", jobs.jobs);
+    if (jobs.jobs) {
+        fmt::print("  bytes in/out: {:.1f} / {:.1f} MB\n",
+                   jobs.bytes_in / 1048576.0, jobs.bytes_out / 1048576.0);
+        fmt::print("  write amplification (compaction out / flushed): {:.2f}x\n",
+                   m.flush_bytes_written > 0 ? jobs.bytes_out / double(m.flush_bytes_written) : 0.0);
+        fmt::print("  fan-in (p50/p90/max): {:.0f}/{:.0f}/{:.0f}\n",
+                   jobs.fan_in.percentile(50), jobs.fan_in.percentile(90), jobs.fan_in.max());
+        fmt::print("  duration ms (p50/p90/max): {:.0f}/{:.0f}/{:.0f}\n",
+                   jobs.duration_ms.percentile(50), jobs.duration_ms.percentile(90),
+                   jobs.duration_ms.max());
+    }
+
+    if (cfg.output_format == "json") {
+        Json::Value storm;
+        storm["configured_flush_rate"] = cfg.flush_rate;
+        storm["tablets"] = cfg.tablets;
+        storm["read_ratio"] = cfg.read_ratio;
+        storm["configured_write_rate"] = cfg.write_rate;
+        storm["flush_triggers"] = Json::Value::UInt64(flush_triggers);
+        storm["flush_skipped"] = Json::Value::UInt64(flush_skipped);
+        storm["observed_flush_rate"] = fmt::format("{:.2f}", observed_flush_rate);
+        storm["sstables_created"] = Json::Value::UInt64(sstables_created);
+        storm["sstable_creation_rate"] = fmt::format("{:.2f}", creation_rate);
+        storm["avg_created_sstable_kb"] = fmt::format("{:.2f}", observed_flush_kb);
+        storm["flushed_bytes"] = Json::Value::UInt64(total_flush_bytes);
+        storm["samples"] = Json::Value::UInt64(sstable_count_series.size());
+        storm["sstable_count_mean"] = fmt::format("{:.2f}", sstable_count_series.mean());
+        storm["sstable_count_p50"] = fmt::format("{:.0f}", sstable_count_series.percentile(50));
+        storm["sstable_count_p90"] = fmt::format("{:.0f}", sstable_count_series.percentile(90));
+        storm["sstable_count_p99"] = fmt::format("{:.0f}", sstable_count_series.percentile(99));
+        storm["sstable_count_max"] = fmt::format("{:.0f}", sstable_count_series.max());
+        storm["sstable_count_p90_first_half"] = fmt::format("{:.0f}", sstable_count_series.percentile_of_half(90, false));
+        storm["sstable_count_p90_second_half"] = fmt::format("{:.0f}", sstable_count_series.percentile_of_half(90, true));
+        storm["norm_backlog_mean"] = fmt::format("{:.4f}", norm_backlog_series.mean());
+        storm["norm_backlog_p50"] = fmt::format("{:.4f}", norm_backlog_series.percentile(50));
+        storm["norm_backlog_p90"] = fmt::format("{:.4f}", norm_backlog_series.percentile(90));
+        storm["norm_backlog_p99"] = fmt::format("{:.4f}", norm_backlog_series.percentile(99));
+        storm["norm_backlog_max"] = fmt::format("{:.4f}", norm_backlog_series.max());
+        storm["shares_mean"] = fmt::format("{:.2f}", shares_series.mean());
+        storm["shares_p50"] = fmt::format("{:.2f}", shares_series.percentile(50));
+        storm["shares_p90"] = fmt::format("{:.2f}", shares_series.percentile(90));
+        storm["shares_max"] = fmt::format("{:.2f}", shares_series.max());
+        storm["shares_changes"] = Json::Value::UInt64(shares_series.changes());
+        storm["shares_fraction_at_floor"] = fmt::format("{:.4f}", shares_series.fraction_at(shares_floor));
+        storm["shares_fraction_at_max"] = fmt::format("{:.4f}", shares_series.fraction_at(shares_ceiling));
+        storm["active_compactions_mean"] = fmt::format("{:.2f}", active_compactions_series.mean());
+        storm["active_compactions_max"] = fmt::format("{:.0f}", active_compactions_series.max());
+        storm["pending_compactions_mean"] = fmt::format("{:.2f}", pending_compactions_series.mean());
+        storm["pending_compactions_max"] = fmt::format("{:.0f}", pending_compactions_series.max());
+        storm["compaction_jobs"] = Json::Value::UInt64(jobs.jobs);
+        storm["compaction_bytes_in"] = Json::Value::UInt64(jobs.bytes_in);
+        storm["compaction_bytes_out"] = Json::Value::UInt64(jobs.bytes_out);
+        storm["compaction_fan_in_p50"] = fmt::format("{:.0f}", jobs.fan_in.percentile(50));
+        storm["compaction_fan_in_p90"] = fmt::format("{:.0f}", jobs.fan_in.percentile(90));
+        storm["compaction_fan_in_max"] = fmt::format("{:.0f}", jobs.fan_in.max());
+        storm["compaction_duration_ms_p50"] = fmt::format("{:.0f}", jobs.duration_ms.percentile(50));
+        storm["compaction_duration_ms_p90"] = fmt::format("{:.0f}", jobs.duration_ms.percentile(90));
+        storm["compaction_duration_ms_max"] = fmt::format("{:.0f}", jobs.duration_ms.max());
+        m.write_json(cfg, final_sstable_count, total_bytes_on_disk, major_compacted_bytes, &storm);
+    } else {
+        m.print_results(cfg, final_sstable_count, total_bytes_on_disk, major_compacted_bytes);
+    }
+}
+
 } // anonymous namespace
 
 namespace perf {
@@ -676,6 +1440,37 @@ int scylla_compaction_efficiency_main(int argc, char** argv) {
             "output format: text, json")
         ("verbose", bpo::bool_switch()->default_value(false),
             "print per-shard sstable state after each flush and compaction")
+        ("concurrent-mode", bpo::bool_switch()->default_value(false),
+            "run writer fibers against a periodic flush, so compaction runs concurrently "
+            "with the write load and competes for CPU. The serial mode never lets that "
+            "happen, so use this to measure anything about the compaction controller")
+        ("concurrent-writers", bpo::value<unsigned>()->default_value(16),
+            "number of concurrent writer fibers")
+        ("write-rate", bpo::value<unsigned>()->default_value(0),
+            "cap on operations per second across all writers (0 = unlimited). Fixing it "
+            "is what makes two runs comparable")
+        ("flush-rate", bpo::value<unsigned>()->default_value(10),
+            "flush triggers per second. Only one flush runs at a time; a trigger arriving "
+            "while one is in flight is dropped and counted. Lower it until skipped "
+            "triggers are rare, otherwise the sstable creation rate is decided by flush "
+            "latency (which grows with compaction load) instead of by this option")
+        ("read-ratio", bpo::value<double>()->default_value(0.1),
+            "fraction of operations that are single-partition reads, which is what "
+            "populates the sstables-per-read histogram reported at the end")
+        ("tablets", bpo::value<unsigned>()->default_value(1),
+            "tablets per shard, i.e. compaction groups sharing the shard's backlog. Tiny "
+            "sstables spread over many groups is the case worth measuring")
+        ("compaction-static-shares", bpo::value<float>()->default_value(0),
+            "pin the compaction scheduling group to this many shares, disabling the "
+            "backlog controller (0 = controller enabled). Use it to separate what shares "
+            "buy from what the backlog formula does")
+        ("stats-interval-ms", bpo::value<unsigned>()->default_value(1000),
+            "period between per-interval stats printouts in concurrent mode")
+        ("available-memory-mb", bpo::value<unsigned>()->default_value(0),
+            "override the compaction manager's available_memory (0 = machine default). "
+            "The controller divides backlog by this, so on a machine with lots of RAM a "
+            "realistic backlog normalises to ~0 and the controller never leaves its "
+            "minimum shares")
         ;
 
     set_abort_on_internal_error(true);
@@ -695,6 +1490,24 @@ int scylla_compaction_efficiency_main(int argc, char** argv) {
             db_cfg->memtable_total_space_in_mb(1 << 20); // ~1TB
             cql_test_config cql_cfg(db_cfg);
             cql_cfg.initial_tablets = 1; // Enable tablets for the default keyspace
+
+            // If the user asked to shrink the compaction manager's view of available
+            // memory (used by the controller to normalise backlog), install a custom
+            // database_config with that value. Everything else is left unset so the test
+            // env keeps its defaults; scheduling groups are overwritten by cql_test_env.
+            // Pin the compaction scheduling group's shares, bypassing the controller.
+            // Lets the effect of shares on compaction be measured on its own, without the
+            // backlog formula in the loop.
+            auto static_shares = app.configuration()["compaction-static-shares"].as<float>();
+            if (static_shares > 0) {
+                db_cfg->compaction_static_shares(static_shares);
+            }
+            auto available_memory_mb = app.configuration()["available-memory-mb"].as<unsigned>();
+            if (available_memory_mb > 0) {
+                replica::database_config dbcfg;
+                dbcfg.available_memory = size_t(available_memory_mb) * 1024 * 1024;
+                cql_cfg.dbcfg = std::move(dbcfg);
+            }
 
             do_with_cql_env_thread([&app, seed] (auto& env) {
                 test_config cfg;
@@ -731,14 +1544,43 @@ int scylla_compaction_efficiency_main(int argc, char** argv) {
                 }
                 cfg.output_format = app.configuration()["output-format"].as<std::string>();
                 cfg.verbose = app.configuration()["verbose"].as<bool>();
+                cfg.concurrent_mode = app.configuration()["concurrent-mode"].as<bool>();
+                cfg.concurrent_writers = app.configuration()["concurrent-writers"].as<unsigned>();
+                cfg.stats_interval_ms = app.configuration()["stats-interval-ms"].as<unsigned>();
+                cfg.available_memory_mb = app.configuration()["available-memory-mb"].as<unsigned>();
+                cfg.write_rate = app.configuration()["write-rate"].as<unsigned>();
+                cfg.flush_rate = app.configuration()["flush-rate"].as<unsigned>();
+                cfg.read_ratio = app.configuration()["read-ratio"].as<double>();
+                cfg.tablets = app.configuration()["tablets"].as<unsigned>();
+                cfg.compaction_static_shares = app.configuration()["compaction-static-shares"].as<float>();
+                if (cfg.concurrent_mode) {
+                    if (cfg.flush_rate == 0) {
+                        throw std::invalid_argument("--flush-rate must be > 0");
+                    }
+                    if (cfg.tablets == 0) {
+                        throw std::invalid_argument("--tablets must be > 0");
+                    }
+                    if (cfg.read_ratio < 0 || cfg.read_ratio >= 1.0) {
+                        throw std::invalid_argument("--read-ratio must be in [0, 1)");
+                    }
+                    if (cfg.read_ratio + cfg.delete_ratio >= 1.0) {
+                        throw std::invalid_argument("--read-ratio plus --delete-ratio must be < 1");
+                    }
+                }
                 if (cfg.output_format != "text" && cfg.output_format != "json") {
                     throw std::invalid_argument(fmt::format("invalid value for output-format: {}", cfg.output_format));
                 }
                 if (cfg.distribution != "gaussian" && cfg.distribution != "uniform" && cfg.distribution != "zipfian") {
                     throw std::invalid_argument(fmt::format("invalid value for distribution: {}", cfg.distribution));
                 }
-                if (cfg.operations == 0 && cfg.duration_in_seconds == 0) {
+                if (cfg.operations == 0 && cfg.duration_in_seconds == 0 && !cfg.concurrent_mode) {
                     throw std::invalid_argument("at least one of --operations or --duration must be non-zero");
+                }
+                if (cfg.concurrent_mode && cfg.duration_in_seconds == 0) {
+                    throw std::invalid_argument("--concurrent-mode requires --duration");
+                }
+                if (cfg.concurrent_mode && cfg.concurrent_writers == 0) {
+                    throw std::invalid_argument("--concurrent-writers must be > 0 in concurrent mode");
                 }
                 if (cfg.rewrite_ratio < 0 || cfg.rewrite_ratio > 1.0) {
                     throw std::invalid_argument(fmt::format("rewrite-ratio must be in [0, 1], got {}", cfg.rewrite_ratio));
@@ -768,9 +1610,30 @@ int scylla_compaction_efficiency_main(int argc, char** argv) {
                     if (cfg.default_time_to_live > 0) {
                         fmt::print("  default-time-to-live: {}s\n", cfg.default_time_to_live);
                     }
+                    if (cfg.concurrent_mode) {
+                        fmt::print("  concurrent-mode: true\n");
+                        fmt::print("  concurrent-writers: {}\n", cfg.concurrent_writers);
+                        fmt::print("  write-rate: {}\n", cfg.write_rate);
+                        fmt::print("  flush-rate: {}\n", cfg.flush_rate);
+                        fmt::print("  read-ratio: {}\n", cfg.read_ratio);
+                        fmt::print("  tablets (per shard): {}\n", cfg.tablets);
+                        fmt::print("  stats-interval-ms: {}\n", cfg.stats_interval_ms);
+                        if (cfg.available_memory_mb > 0) {
+                            fmt::print("  available-memory-mb (compaction controller): {}\n",
+                                       cfg.available_memory_mb);
+                        }
+                        if (cfg.compaction_static_shares > 0) {
+                            fmt::print("  compaction-static-shares: {} (controller disabled)\n",
+                                       cfg.compaction_static_shares);
+                        }
+                    }
                 }
 
-                do_compaction_efficiency_test(env, cfg);
+                if (cfg.concurrent_mode) {
+                    do_concurrent_compaction_test(env, cfg);
+                } else {
+                    do_compaction_efficiency_test(env, cfg);
+                }
             }, std::move(cql_cfg)).get();
         });
     });


### PR DESCRIPTION
The backlog of an sstable is (Si - Ci) * log(T / Si), so tiny sstables
barely move the needle, even though log(T / Si) is large for them.

That worked well until tablets, where commitlog driven flush can produce
a tiny sstable per replica in a shard. Read amplification suffers badly,
as each sstable being read has a fixed memory overhead, but the
controller sees almost no backlog and won't apply pressure to compact
them away.

Fix it by taxing each sstable with a fixed cost of 1M, reflecting the
cost we pay per sstable regardless of its size:

    Bi = (Si + 1M - Ci) * log(T / Si)

The tax is only added to Si, where it weighs the work. log(T / Si)
estimates write amplification and is left alone, otherwise the estimate
would shrink for exactly the sstables we want to make visible, and the
backlog would drop to zero when all sstables are tiny. Ci is left alone
too, as the cost belongs to the sstable existing rather than to the
compaction reading it, so it's only retired once the sstable leaves the
set. That also leaves the subtraction headroom for compacted(), which is
a reader position and may overshoot the sstable's size.

STCS, TWCS (per window) and LCS (L0) share size_tiered_backlog_tracker,
and ICS has its own, so both are taxed. ICS taxes per sstable in a run,
as the cost is paid per sstable.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2970.

Performance test:

perf-compaction-efficiency --smp 1 -m 2G --concurrent-mode --duration 300 --write-rate 20000 --read-ratio 0 --delete-ratio 0 --partitions 2000000 --tablets 1 --flush-rate 40 --available-memory-mb 256 --concurrent-writers 32 --stats-interval-ms 300000 --random-seed 42

```
+===================+==============+==============+==============+===================+
|                   | sstables p90 | sstables p99 | sstables max | shares mean / max |
+===================+==============+==============+==============+===================+
| current (neither) |          181 |          207 |          221 |           63 / 72 |
| d118              |           75 |          118 |          149 |           54 / 67 |
| d118 + tax 1MiB   |           71 |          106 |          127 |          80 / 168 |
+===================+==============+==============+==============+===================+
```
details: single shard, single tablet, append-only, flushes producing ~25 KB sstables, duration of 300s.

Results show that commit https://github.com/scylladb/scylladb/commit/d118c4255ade387dc109b786b0af03c26c42af03 had a very positive effect on keeping flush storm (producing tiny sstables) under control, and tax 1MiB also had a positive effect since it removes controller blindness on the cost of tiny sstables due to the fixed sstable writing cost.
