### PR TITLE
fix: replace bytes with std::array<uint8_t, 16> in cql_metadata_id_type

### DIFF
--- a/cql3/statements/prepared_statement.hh
+++ b/cql3/statements/prepared_statement.hh
@@ -15,6 +15,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/core/checked_ptr.hh>
+#include <algorithm>
 #include <array>
 #include <vector>
 
@@ -32,16 +33,11 @@ struct cql_metadata_id_type {
 
     cql_metadata_id_type() : _id{} {}
     explicit cql_metadata_id_type(bytes_view metadata_id) : _id{} {
-        if (metadata_id.size() != size) {
-            throw exceptions::protocol_exception(
-                fmt::format("Expected metadata_id of {} bytes, got {}", size, metadata_id.size()));
-        }
-        std::copy_n(metadata_id.begin(), size, _id.begin());
+        std::copy_n(metadata_id.begin(), std::min(metadata_id.size(), size), _id.begin());
     }
 
     bool operator==(const cql_metadata_id_type& other) const = default;
 
-    // For wire protocol: return a view for write_short_bytes
     bytes_view to_bytes_view() const {
         return bytes_view(reinterpret_cast<const bytes::value_type*>(_id.data()), size);
     }

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -795,6 +795,30 @@ BOOST_AUTO_TEST_CASE(metadata_id_with_udt) {
     verify_metadata_id_is_stable(h6, "02f16bdc4b235791a44983fe56618006");
 }
 
+BOOST_AUTO_TEST_CASE(metadata_id_accepts_any_input_size) {
+    // Empty input: zero-initialized 16 bytes
+    cql3::cql_metadata_id_type from_empty{bytes_view{}};
+    bytes zero_16(bytes::initialized_later(), 16);
+    std::fill(zero_16.begin(), zero_16.end(), int8_t(0));
+    BOOST_REQUIRE_EQUAL(from_empty.to_bytes_view(), bytes_view(zero_16));
+
+    // Smaller than 16 bytes: zero-padded to 16
+    bytes small = {int8_t(1), int8_t(2), int8_t(3), int8_t(4), int8_t(5)};
+    cql3::cql_metadata_id_type from_small{bytes_view(small)};
+    bytes small_expected(bytes::initialized_later(), 16);
+    auto it = std::copy(small.begin(), small.end(), small_expected.begin());
+    std::fill(it, small_expected.end(), int8_t(0));
+    BOOST_REQUIRE_EQUAL(from_small.to_bytes_view(), bytes_view(small_expected));
+
+    // Larger than 16 bytes: first 16 bytes stored, rest discarded
+    bytes large(bytes::initialized_later(), 32);
+    std::fill(large.begin(), large.end(), int8_t(0x42));
+    cql3::cql_metadata_id_type from_large{bytes_view(large)};
+    bytes expected_16(bytes::initialized_later(), 16);
+    std::fill(expected_16.begin(), expected_16.end(), int8_t(0x42));
+    BOOST_REQUIRE_EQUAL(from_large.to_bytes_view(), bytes_view(expected_16));
+}
+
 cql3::cql_metadata_id_type get_metadata_id(cql_test_env& e, sstring const& table) {
     auto msg = e.execute_cql(format("SELECT * FROM {};", table)).get();
     auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1717,7 +1717,7 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
         if (!metadata_id_bytes) {
             return make_exception_future<cql_server::process_fn_return_type>(std::move(metadata_id_bytes).assume_error());
         }
-        metadata_id = cql_metadata_id_wrapper(cql3::cql_metadata_id_type(metadata_id_bytes.assume_value()), prepared->get_metadata_id());
+        metadata_id = cql_metadata_id_wrapper(cql3::cql_metadata_id_type(bytes_view(metadata_id_bytes.assume_value())), prepared->get_metadata_id());
     }
 
     auto q_state = std::make_unique<cql_query_state>(client_state, trace_state, std::move(permit));


### PR DESCRIPTION
## Motivation

Replace `bytes` (basic_sstring, 32 bytes inline) with `std::array<uint8_t, 16>` in `cql_metadata_id_type` for memory savings in the prepared statement cache and in-flight EXECUTE requests. The previous attempt (PR #30022) added a strict 16-byte validation in the constructor that threw `protocol_exception` for non-16-byte inputs. However, the v5 CQL native protocol spec defines `result_metadata_id` as `[short bytes]` — a variable-length field with no size constraint. A client sending a differently-sized metadata_id should be handled gracefully, not rejected.

## Change

- Replace storage from `bytes` to `std::array<uint8_t, 16>` (16 bytes, no heap)
- Constructor accepts any-size `bytes_view` — copies up to 16 bytes, zero-fills the rest, never throws
- Add `to_bytes_view()` for wire serialization
- Change `write_short_bytes` to take `bytes_view` instead of `bytes` (avoids copy)
- Update call sites and tests

## Tests

- `schema_change_test` metadata_id suite: 9 tests pass (8 existing + new `metadata_id_accepts_any_input_size` covering empty, partial, and overflow input)
- `transport_test`: 1 test passes

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2984