### PR TITLE
test: change two skipped tests that listed closed issue as their reason

### DIFF
--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -1279,10 +1279,6 @@ def test_wait_for_vector_index_active(vs, needs_vector_store):
 # and this test used to fail before this was fixed.
 # To save a bit of time, we don't test all combinations of hash and range
 # key types but test each type at least once as a hash key and a range key.
-@pytest.mark.skip_bug(
-    link="https://scylladb.atlassian.net/browse/VECTOR-374",
-    reason="Bug in vector store for non-string keys, fails very slowly",
-)
 @pytest.mark.parametrize('hash_type,range_type', [
     ('N', None), ('B', None), ('S', 'N'),  ('S', 'B'),
 ], ids=[
@@ -1307,7 +1303,8 @@ def test_query_vector_prefill_key_types(vs, needs_vector_store, hash_type, range
              'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
         wait_for_vector_index_active(table, 'vind')
         result = table.query(IndexName='vind',
-            VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1)
+            VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1,
+            Select='ALL_ATTRIBUTES')
         assert len(result['Items']) == 1 and result['Items'] == [item]
 
 # Same as test_query_vector_prefill but whereas in test_query_vector_prefill

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -233,10 +233,11 @@ def test_ann_ordering_not_allowed_without_index_where_indexed_column_exists_in_q
             "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
         )
 
-@pytest.mark.skip_bug(
-    link="https://scylladb.atlassian.net/browse/VECTOR-374",
-    reason="Restricted queries are passed to vector store and pytest does not support vector store",
-)
+# This test is skipped because although Scylla does support vector indexes,
+# this test framework doesn't run the vector store, so the request will fail
+# with "Vector Store is disabled" and not the error message that the test
+# expects to see.
+@pytest.mark.skip_env(reason="Vector store is disabled in this test framework")
 def test_cannot_post_filter_on_non_indexed_column_with_ann_ordering(cql, test_keyspace):
     ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = (
         SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else CASSANDRA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE


### PR DESCRIPTION
Recent changes to our nightly CI runs forced us to:

* connect every skipped test to a specific issue, and
* when this issue is closed but the test is still skipped, the nightly CI complains

This PR fixes two skipped tests that refer to https://scylladb.atlassian.net/browse/VECTOR-374 which was recently closed.

One of these tests can now really pass (but had a bug that needed to be fixed) so the patch removes the "skip" and fixes the bug.

The other test still needs to be skipped, because the test/cqlpy framework has no way right now run a vector store. So the test is still skipped, but without referring to [VECTOR-374](https://scylladb.atlassian.net/browse/VECTOR-374).

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2724

[VECTOR-374]: https://scylladb.atlassian.net/browse/VECTOR-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ