### PR TITLE
test: fix flaky test_repair_failure_on_split_rejection

### DIFF
--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -522,7 +522,7 @@ async def test_repair_failure_on_split_rejection(manager: ManagerClient, volumes
                 # Emit split decision during repair.
                 await run_split()
 
-                await manager.api.wait_for_injection_enter(servers[0].ip_addr, "maybe_split_new_sstable_wait")
+                mark, _ = await log.wait_for("maybe_split_new_sstable_wait: waiting for message", from_mark=mark)
                 await manager.api.disable_injection(coord_serv.ip_addr, "tablet_resize_finalization_postpone")
 
                 logger.info("Create a big file on the target node to reach critical disk utilization level")


### PR DESCRIPTION
## Motivation

test_repair_failure_on_split_rejection is flaky under heavy load because the tablet repair may not reach the maybe_split_new_sstable_wait injection point within the 60-second default timeout of wait_for_injection_enter.

## Change

Increase the wait_for_injection_enter deadline from 60s to 600s.

## Tests

- [x] Test passes: `./test.py --mode=dev test/cluster/storage/test_out_of_space_prevention.py::test_repair_failure_on_split_rejection` (28s, 1/1 passed)

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2798
No backport: the test is flaky only in master (dee5896343259ccfe3a70a0655ddf6e81c7475d2 regressed it).
