### PR TITLE
sstables_loader: restore original tablet hints after tablet-aware restore is done or if it fails

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1224,9 +1224,24 @@ protected:
         auto max_tablet_count = current_schema->tablet_options().max_tablet_count;
         co_await loader._ss.local().alter_table_with_tablet_hints(_tid, _tablet_count, _tablet_count);
 
-        co_await loader._ss.local().restore_tablets(_tid, _snap_name);
+        std::exception_ptr eptr;
+        try {
+            co_await loader._ss.local().restore_tablets(_tid, _snap_name);
+        } catch (...) {
+            llog.error("Failed to restore tablets for table_id {}. Error: {}", _tid, std::current_exception());
+            eptr = std::current_exception();
+        }
 
-        co_await loader._ss.local().alter_table_with_tablet_hints(_tid, min_tablet_count, max_tablet_count, false);
+        try {
+            llog.info("Restoring table with tid {} to the original schema", _tid);
+            co_await loader._ss.local().alter_table_with_tablet_hints(_tid, min_tablet_count, max_tablet_count, false);
+        } catch (...) {
+            llog.error("Failed to restore original schema for table_id {}. Error: {}", _tid, std::current_exception());
+        }
+
+        if (eptr) {
+            std::rethrow_exception(eptr);
+        }
     }
 };
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -1144,7 +1144,7 @@ static future<size_t> process_manifest(input_stream<char>& is, sstring keyspace,
         // Insert the snapshot sstable metadata into system_distributed.snapshot_sstables with a TTL of 3 days, that should be enough
         // for any snapshot restore operation to complete, and after that the metadata will be automatically cleaned up from the table
         co_await sth.insert_snapshot_sstable(snapshot_name, keyspace, table, datacenter, rack, id, first_token, last_token,
-                                             toc_name, prefix, locator::host_id::create_null_id(), tablet_id, db::snapshot_state::remote, 
+                                             toc_name, prefix, locator::host_id::create_null_id(), tablet_id, db::snapshot_state::remote,
                                              repaired_at, data_size, index_size, cl);
     }
 
@@ -1185,14 +1185,16 @@ class sstables_loader::tablet_restore_task_impl : public tasks::task_manager::ta
     sharded<sstables_loader>& _loader;
     table_id _tid;
     sstring _snap_name;
+    size_t _tablet_count;
 
 public:
     tablet_restore_task_impl(tasks::task_manager::module_ptr module, sharded<sstables_loader>& loader, sstring ks,
-            table_id tid, sstring snap_name) noexcept
+            table_id tid, sstring snap_name, size_t tablet_count) noexcept
         : tasks::task_manager::task::impl(module, tasks::task_id::create_random_id(), 0, "node", ks, "", "", tasks::task_id::create_null_id())
         , _loader(loader)
         , _tid(std::move(tid))
         , _snap_name(std::move(snap_name))
+        , _tablet_count(tablet_count)
     {
         _status.progress_units = "batches";
     }
@@ -1216,7 +1218,15 @@ public:
 protected:
     virtual future<> run() override {
         auto& loader = _loader.local();
+
+        auto current_schema = loader.local_db().find_schema(_tid);
+        auto min_tablet_count = current_schema->tablet_options().min_tablet_count;
+        auto max_tablet_count = current_schema->tablet_options().max_tablet_count;
+        co_await loader._ss.local().alter_table_with_tablet_hints(_tid, _tablet_count, _tablet_count);
+
         co_await loader._ss.local().restore_tablets(_tid, _snap_name);
+
+        co_await loader._ss.local().alter_table_with_tablet_hints(_tid, min_tablet_count, max_tablet_count, false);
     }
 };
 
@@ -1229,9 +1239,6 @@ future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring ke
     // TODO: update state when all restored...
     co_await sth.insert_snapshot_remote_location(snap_name, datacenter, endpoint, bucket, prefix, db::snapshot_state::remote);
 
-    co_await container().invoke_on(0, [tid, tablet_count] (auto& sl) -> future<> {
-        co_await sl._ss.local().alter_table_with_tablet_hints(tid, tablet_count, tablet_count);
-    });
-    auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name));
+    auto task = co_await _task_manager_module->make_and_start_task<tablet_restore_task_impl>({}, container(), keyspace, tid, std::move(snap_name), tablet_count);
     co_return task->id();
 }

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -153,6 +153,10 @@ public:
 
     future<tasks::task_id> restore_tablets(table_id, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, sstring prefix, utils::chunked_vector<sstring> manifests);
 
+    replica::database& local_db() {
+        return _db.local();
+    }
+
     class download_task_impl;
     class tablet_restore_task_impl;
 };

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -956,14 +956,10 @@ async def test_restore_tablets_with_different_tablet_hints(build_mode: str, mana
         await manager.disable_tablet_balancing()
         await check_mutation_replicas(cql, manager, servers, range(num_keys), topology, logger, ks, 'test')
 
-        # Verify that restore used the tablet hints from the backup manifest,
-        # not the ones set on the pre-restore table.
-        # FIXME: this check will be removed as it's irelevant after we implement the cleanup phase of tablet aware restore
-        # but the test will remain relevant as it was designed to fail if the restore code doesnt properly fix the tablet
-        # count to what was written in the backup manifest.
+        # Verify that restore altered the table back with the tablet hints set before restore started
         desc = (await cql.run_async(f"DESC TABLE {ks}.test"))[0].create_statement
-        assert f"'min_tablet_count': '{min_tablet_count_before_backup}'" in desc, f"Expected min_tablet_count={min_tablet_count_before_backup} in: {desc}"
-        assert f"'max_tablet_count': '{max_tablet_count_before_backup}'" in desc, f"Expected max_tablet_count={max_tablet_count_before_backup} in: {desc}"
+        assert f"'min_tablet_count': '{min_tablet_count_before_restore}'" in desc, f"Expected min_tablet_count={min_tablet_count_before_restore} in: {desc}"
+        assert f"'max_tablet_count': '{max_tablet_count_before_restore}'" in desc, f"Expected max_tablet_count={max_tablet_count_before_restore} in: {desc}"
 
 async def test_restore_with_non_existing_sstable(manager: ManagerClient, object_storage):
     '''Check that restore task fails well when given a non-existing sstable'''


### PR DESCRIPTION
Takeover PR https://github.com/scylladb/scylladb/pull/30224

During tablet-aware-restore, the table's tablet hints are temporarily altered to pin the tablet count to match the backup manifest. After restore completes, or if it fails, the table should be returned to its original tablet hints.

This PR adds a cleanup phase to the tablet restore task that captures the table's original min/max tablet hints from the live schema before pinning, and calls `alter_table_with_tablet_hints` again at the end of the task to restore those original values. If the original schema had no tablet hints, `alter_table_with_tablet_hints` is a no-op.

Both the pinning and the subsequent restoration of the tablet count hints now happen inside `tablet_restore_task_impl::run()`, so both `alter_table_with_tablet_hints` calls live in the same function. Exception handling ensures the original hints are restored even if the transitioning phase fails; if the second `alter_table_with_tablet_hints` itself also fails, the restore error takes precedence.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-986

No backport needed since this is a new feature targeting tablet-aware restore.