### PR TITLE
strong_consistency: test group startup has no raft-tick delays; fix double gate close

### DIFF
--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -366,7 +366,7 @@ future<> raft_group_registry::send_raft_read_barrier(raft::group_id gid, raft::s
     co_await ser::raft_util_rpc_verbs::send_raft_read_barrier(&_ms, locator::host_id{dst.uuid()}, timeout, gid, _my_id, dst);
 }
 
-future<> raft_group_registry::start_server_for_group(raft_server_for_group new_grp) {
+future<> raft_group_registry::start_server_for_group(raft_server_for_group new_grp, raft_ticker_type::duration tick_interval) {
     auto gid = new_grp.gid;
 
     const auto is_group0 = this_shard_id() == 0 && !_group0_id;
@@ -399,7 +399,7 @@ future<> raft_group_registry::start_server_for_group(raft_server_for_group new_g
             _group0_id = gid;
         }
 
-        it->second.ticker->arm_periodic(raft_tick_interval);
+        it->second.ticker->arm_periodic(tick_interval);
     } catch (...) {
         ex = std::current_exception();
     }

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -187,8 +187,9 @@ public:
     raft_server_with_timeouts group0_with_timeouts();
 
     // Start raft server instance, store in the map of raft servers and
-    // arm the associated timer to tick the server.
-    future<> start_server_for_group(raft_server_for_group grp);
+    // arm the associated timer to tick the server. The ticker fires
+    // raft::server::tick() every tick_interval (defaults to raft_tick_interval).
+    future<> start_server_for_group(raft_server_for_group grp, raft_ticker_type::duration tick_interval = raft_tick_interval);
     unsigned shard_for_group(const raft::group_id& gid) const;
     shared_ptr<raft::failure_detector> failure_detector();
     direct_failure_detector::failure_detector& direct_fd() { return _direct_fd; }

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -22,6 +22,7 @@
 #include "replica/database.hh"
 #include "db/config.hh"
 #include "idl/strong_consistency/groups_manager.dist.hh"
+#include "utils/error_injection.hh"
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
@@ -195,6 +196,14 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
 
     // initialize the corresponding timer to tick the raft server instance
     auto ticker = std::make_unique<raft_ticker_type>([srv = server.get()] { srv->tick(); });
+
+    // Tests may lengthen the tick interval via error injection so that any
+    // unwanted waiting on a raft tick becomes visible as a large delay.
+    const auto tick_interval = utils::get_local_injector()
+            .inject_parameter<int64_t>("strongly-consistent-raft-group-tick-interval-in-ms")
+            .transform([](int64_t ms) { return raft_ticker_type::duration{std::chrono::milliseconds{ms}}; })
+            .value_or(raft_tick_interval);
+
     co_await _raft_gr.start_server_for_group(raft_server_for_group {
         .gid = group_id,
         .server = std::move(server),
@@ -202,7 +211,7 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
         .rpc = rpc_ref,
         .persistence = persistence_ref,
         .state_machine = state_machine_ref
-    });
+    }, tick_interval);
 }
 
 void groups_manager::schedule_raft_group_deletion(raft::group_id id, raft_group_state& state) {

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -210,18 +210,24 @@ void groups_manager::schedule_raft_group_deletion(raft::group_id id, raft_group_
         return;
     }
     logger.info("schedule_raft_group_deletion(): group id {}: scheduling", id);
-    state.server_control_op = futurize_invoke([this, &state, id, g = state.gate](this auto) -> future<> {
+
+    // Close the gate synchronously so state.gate->is_closed() flips immediately
+    // and a concurrent schedule_raft_group_deletion() for the same group bails
+    // out at the guard above. Closing inside the operation instead would let a
+    // second deletion slip past the guard, and both would call gate::close() on
+    // the same gate - the second call aborts the process.
+    //
+    // close() doesn't block here; the operation waits for the gate below. The
+    // gate won't drain until all holders are released, but in-flight writes may
+    // be stuck in add_entry awaiting a quorum that will never come (other nodes
+    // already destroyed their servers). Aborting the raft server releases those
+    // holders by making the stuck operations throw raft::stopped_error.
+    auto gate_fut = state.gate->close();
+    logger.debug("schedule_raft_group_deletion(): group id {}: gate close initiated", id);
+
+    state.server_control_op = futurize_invoke([this, &state, id, g = state.gate, gate_fut = std::move(gate_fut)](this auto) -> future<> {
         co_await state.server_control_op.get_future();
         logger.debug("schedule_raft_group_deletion(): group id {}: starting", id);
-
-        // Initiate gate close, then abort the raft server, then wait for the
-        // gate. Gate close alone would block until all holders are released,
-        // but in-flight writes may be stuck in add_entry waiting for quorum
-        // that will never come (other nodes already destroyed their servers).
-        // Aborting the server causes those stuck operations to throw
-        // raft::stopped_error, releasing their holders and unblocking the gate.
-        auto gate_fut = g->close();
-        logger.debug("schedule_raft_group_deletion(): group id {}: gate close initiated", id);
 
         co_await _raft_gr.abort_server(id);
         logger.debug("schedule_raft_group_deletion(): group id {}: server aborted", id);
@@ -436,7 +442,15 @@ void groups_manager::update(token_metadata_ptr new_tm) {
                 // we report it as started in wait_for_groups_to_start().
                 abort_on_expiry aoe(lowres_clock::now() + std::chrono::seconds(60));
                 while (true) {
-                    auto srv = raft_server(state, state.gate->hold());
+                    // Use try_hold() rather than hold(): a concurrent
+                    // schedule_raft_group_deletion() may have closed the gate
+                    // while we were waiting for a leader below. In that case the
+                    // group is being deleted, so stop trying to make it ready.
+                    auto holder = state.gate->try_hold();
+                    if (!holder) {
+                        break;
+                    }
+                    auto srv = raft_server(state, std::move(*holder));
                     auto res = srv.begin_mutate(aoe.abort_source());
                     if (auto w = get_if<raft_server::need_wait_for_leader>(&res)) {
                         auto f = co_await coroutine::as_future(std::move(w->future));
@@ -479,6 +493,11 @@ future<raft_server> groups_manager::acquire_server(table_id table_id, raft::grou
     // schedule_raft_group_deletion). Since there's no scheduling point
     // between the column_family_exists check and try_hold below, the gate
     // cannot be closed if the table exists.
+    //
+    // Node shutdown also closes gates (groups_manager::stop() closes every gate
+    // regardless of table existence), but it cannot race with us either: the
+    // strongly consistent coordinator, the only caller of acquire_server, is
+    // destroyed before groups_manager::stop() runs.
     if (!_db.column_family_exists(table_id)) {
         return make_exception_future<raft_server>(
             replica::no_such_column_family(table_id));

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -4,9 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 
-from typing import Tuple
 import re
 from datetime import datetime
+from typing import Tuple
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import gather_safely, wait_for, Host
@@ -121,8 +121,17 @@ async def get_table_raft_group_id(manager: ManagerClient, ks: str, table: str):
 async def test_basic_write_read(manager: ManagerClient, build_mode: str):
 
     logger.info("Bootstrapping cluster")
-    cmdline = DEFAULT_CMDLINE + ['--logger-log-level', 'raft_commitlog=debug']
-    servers = await manager.servers_add(3, config=DEFAULT_CONFIG, cmdline=cmdline, auto_rack_dc='my_dc')
+    cmdline = DEFAULT_CMDLINE
+    # In dev mode, stretch the strongly consistent raft group tick interval to
+    # 20s so that any unwanted waiting on a raft tick during group startup shows
+    # up as a multi-second delay, caught by the <10s assertion below.
+    default_config = DEFAULT_CONFIG | {'error_injections_at_startup': []}
+    config_with_big_ticks = DEFAULT_CONFIG | {'error_injections_at_startup': [{
+        'name': 'strongly-consistent-raft-group-tick-interval-in-ms',
+        'value': '20000'
+    }]}
+    config = config_with_big_ticks if build_mode == "dev" else default_config
+    servers = await manager.servers_add(3, config=config, cmdline=cmdline, auto_rack_dc='my_dc')
     (cql, hosts) = await manager.get_ready_cql(servers)
 
     logger.info("Load host_id-s for servers")
@@ -157,19 +166,14 @@ async def test_basic_write_read(manager: ManagerClient, build_mode: str):
             leader_host_id = await wait_for_leader(manager, servers[1], group_id)
         leader_host = host_by_host_id(leader_host_id)
 
-        # Verify that SC raft group bootstrap (election + read_barrier) completed
+        # Verify that strongly consistent raft group bootstrap (election + read_barrier) completed
         # quickly on both replicas. With the start_as_candidate and retry_now
-        # optimizations, this should be nearly instant. Without them, it takes
-        # 1-2 seconds (election timeout) + 100ms (tick wait in read_barrier).
-        # Only check in dev mode — other builds have different performance.
-        #
-        # Sum the wall-clock bootstrap time across both replicas, then subtract
-        # raft log persistence (store_log_entries) which is I/O-bound and
-        # unrelated to the protocol optimization. Assert the adjusted sum < 100ms.
+        # optimizations, this should be nearly instant. Without them, the huge
+        # raft tick interval configured above makes startup depend on a 10s tick.
+        # Only check in dev mode because the test uses error injection.
         if build_mode == "dev":
             ts_pattern = r'(\d{2}:\d{2}:\d{2},\d{3})'
             total_startup_ms = 0.0
-            total_io_ms = 0.0
             replicas_checked = 0
             for i, (log, mark) in enumerate(zip(server_logs, marks)):
                 matches = await log.grep(
@@ -191,33 +195,20 @@ async def test_basic_write_read(manager: ManagerClient, build_mode: str):
                 t1 = datetime.strptime(done_ts.group(1), "%H:%M:%S,%f")
                 elapsed_ms = (t1 - t0).total_seconds() * 1000
                 total_startup_ms += elapsed_ms
-
-                # Accumulate store_log_entries persistence that falls within [t0, t1].
-                store_starts = await log.grep(
-                    f"raft_commitlog - store_log_entries: group_id={group_id}",
-                    from_mark=mark)
-                store_ends = await log.grep(
-                    "raft_commitlog - store_log_entries completed:",
-                    from_mark=mark)
-                for s, e in zip(store_starts, store_ends):
-                    s_ts = re.search(ts_pattern, s[0])
-                    e_ts = re.search(ts_pattern, e[0])
-                    if s_ts and e_ts:
-                        s_t = datetime.strptime(s_ts.group(1), "%H:%M:%S,%f")
-                        e_t = datetime.strptime(e_ts.group(1), "%H:%M:%S,%f")
-                        if s_t >= t0 and e_t <= t1:
-                            total_io_ms += (e_t - s_t).total_seconds() * 1000
-
                 replicas_checked += 1
 
             assert replicas_checked == 2, (
-                f"Expected 2 replicas with SC raft group logs, found {replicas_checked}")
-            logger.info(f"SC raft group startup: total={total_startup_ms:.0f}ms, "
-                        f"io={total_io_ms:.0f}ms, adjusted={total_startup_ms - total_io_ms:.0f}ms")
-            assert total_startup_ms - total_io_ms < 100, (
-                f"SC raft group startup took {total_startup_ms - total_io_ms:.0f}ms "
-                f"(total {total_startup_ms:.0f}ms minus {total_io_ms:.0f}ms io), "
-                f"expected <100ms (start_as_candidate + retry_now optimizations)")
+                f"Expected 2 replicas with strongly consistent raft group logs, found {replicas_checked}")
+            logger.info(f"Strongly consistent raft group startup: total={total_startup_ms:.0f}ms")
+
+            # Under normal conditions this should finish in <10 milliseconds, but we can't trust
+            # anything regarding time and random delays in our CI infrastructure, so we use
+            # this absurdly high limit instead. Thanks to the injected tick_period of 20 seconds,
+            # this check should still find a problem if we ever rely on raft ticks in
+            # strongly consistent group startup.
+            assert total_startup_ms < 10000, (
+                f"Strongly consistent raft group startup took {total_startup_ms:.0f}ms, "
+                f"expected <10000ms with raft tick interval set to 20s")
 
         logger.info(f"Get the non-leader replica for the group {group_id}")
         non_leader_replica_host_id = [host_id for host_id in replica_host_ids if str(host_id) != str(leader_host_id)][0]
@@ -327,7 +318,13 @@ async def test_basic_write_read(manager: ManagerClient, build_mode: str):
             for metric_name in metrics_after[host].keys():
                 assert metrics_after[host][metric_name] > metrics_before[host][metric_name]
 
-        # Check that we can restart a server with an active tablets raft group
+        # Check that we can restart a server with an active tablets raft group.
+        # A restarting replica re-creates its raft group and must rediscover a
+        # leader, which legitimately depends on raft ticks. Restore the default
+        # (short) tick interval on this server first; with the stretched 10s tick
+        # the reboot would stall for the whole leader-wait timeout.
+        if build_mode == "dev":
+            await manager.server_update_config(servers[2].server_id, config_options=default_config)
         await manager.server_restart(servers[2].server_id)
 
     # To check that the servers can be stopped gracefully. By default the test runner just kills them.


### PR DESCRIPTION
Two related changes to strongly consistent tablet raft groups.

1. Fix double gate close on raft group deletion. The `schedule_raft_group_deletion()` guarded re-entry with `state.gate->is_closed()`, but the gate was closed only later, inside the scheduled operation. Two deletions for the same group (e.g. a topology update racing shutdown) could both pass the guard and both call `gate::close()` on the same gate, aborting the process with "gate::close() cannot be called more than once". The gate is now closed synchronously when the deletion is scheduled, so is_closed() flips immediately and a concurrent call bails out. The in-flight start path switches from hold() to try_hold() to stop cleanly if the gate was closed while it was waiting for a leader. Also documents why acquire_server()'s try_hold() cannot fail during shutdown (the coordinator, its only caller, is destroyed before groups_manager::stop()).
2. This part is a follow-up for [this PR](https://github.com/scylladb/scylladb/pull/30099). The PR introduced a test that group startup does not wait on a raft tick. This test turned out to be flaky, since CI can introduce arbitrary delays. This PR stabilizes the test by introducing a new error injection, `strongly-consistent-raft-group-tick-interval-in-ms`, which overrides the raft ticker period for strongly consistent groups (group0 keeps the default); start_server_for_group() gains an optional tick_interval parameter. test_basic_write_read sets a 20s tick and asserts startup across both replicas completes in under 10s: any reintroduced tick wait would take ~20s and fail. The injection is removed before the replica-restart step, since a rebooting replica legitimately needs ticks to rediscover a leader. This only proves the absence of raft-tick delays. Other, non-tick delays (e.g. cross-node coordination) are not caught and startup can still take tens of ms; we could not think of a better way to test this without virtualizing time.

Fixes: SCYLLADB-2957

backports: no need, strong consistency is a new feature