### PR TITLE
alternator: avoid exception unwinding on read failure paths

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -19,6 +19,7 @@
 #include "auth/service.hh"
 #include "cql3/cql3_type.hh"
 #include "db/config.hh"
+#include "db/consistency_level_type.hh"
 #include "db/view/view_build_status.hh"
 #include "locator/tablets.hh"
 #include "mutation/tombstone.hh"
@@ -382,7 +383,7 @@ static rjson::value generate_arn_for_index(const schema& schema, std::string_vie
 // In theory, there can be a period during upgrading an old cluster when this
 // table is not yet available. However, since the IndexStatus is a new feature
 // too, it is acceptable that it doesn't yet work in the middle of the update.
-static future<bool> is_view_built(
+static future<std::variant<bool, api_error>> is_view_built(
         view_ptr view,
         service::storage_proxy& proxy,
         service::client_state& client_state,
@@ -409,14 +410,18 @@ static future<bool> is_view_built(
         schema->id(), schema->version(), partition_slice,
         proxy.get_max_result_size(partition_slice),
         query::tombstone_limit(proxy.get_tombstone_limit()));
-    service::storage_proxy::coordinator_query_result qr =
-        co_await proxy.query(
-            schema, std::move(command), std::move(partition_ranges),
-            db::consistency_level::LOCAL_ONE,
-            service::storage_proxy::coordinator_query_options(
-                executor::default_timeout(), std::move(permit), client_state, trace_state));
+
+    service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr =
+            co_await proxy.query_result(
+                schema, std::move(command), std::move(partition_ranges),
+                db::consistency_level::LOCAL_ONE,
+                service::storage_proxy::coordinator_query_options(
+                    executor::default_timeout(), std::move(permit), client_state, trace_state));
+    if (!rqr) {
+        co_return create_api_error_from_coordinators_exception(std::move(rqr).assume_error());
+    }
     query::result_set rs = query::result_set::from_raw_result(
-        schema, partition_slice, *qr.query_result);
+        schema, partition_slice, *rqr.assume_value().query_result);
     std::unordered_map<locator::host_id, sstring> statuses;
     for (auto&& r : rs.rows()) {
         auto host_id = r.get<utils::UUID>("host_id");
@@ -447,7 +452,6 @@ static future<bool> is_view_built(
             }
         });
     co_return all_built;
-
 }
 
 future<> executor::cache_newly_calculated_size_on_all_shards(schema_ptr schema, std::uint64_t size_in_bytes, std::chrono::nanoseconds ttl) {
@@ -481,7 +485,7 @@ future<> executor::fill_table_size(rjson::value &table_description, schema_ptr s
     rjson::add(table_description, "TableSizeBytes", total_size);
 }
 
-future<rjson::value> executor::fill_table_description(schema_ptr schema, table_status tbl_status, service::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit)
+future<std::variant<rjson::value, api_error>> executor::fill_table_description(schema_ptr schema, table_status tbl_status, service::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit)
 {
     rjson::value table_description = rjson::empty_object();
     auto tags_ptr = db::get_tags_of_table(schema);
@@ -568,7 +572,11 @@ future<rjson::value> executor::fill_table_description(schema_ptr schema, table_s
                 // (for a built view) or CREATING+Backfilling (if view building
                 // is in progress).
                 if (!is_lsi) {
-                    if (co_await is_view_built(vptr, _proxy, client_state, trace_state, permit)) {
+                    auto is_view_build_result = co_await is_view_built(vptr, _proxy, client_state, trace_state, permit);
+                    if (auto error = std::get_if<api_error>(&is_view_build_result)) {
+                        co_return std::move(*error);
+                    }
+                    if (std::get<bool>(is_view_build_result)) {
                         rjson::add(view_entry, "IndexStatus", "ACTIVE");
                     } else {
                         rjson::add(view_entry, "IndexStatus", "CREATING");
@@ -668,9 +676,12 @@ future<executor::request_return_type> executor::describe_table(client_state& cli
     get_stats_from_schema(_proxy, *schema)->api_operations.describe_table++;
     tracing::add_alternator_table_name(trace_state, schema->cf_name());
 
-    rjson::value table_description = co_await fill_table_description(schema, table_status::active, client_state, trace_state, permit);
+    std::variant<rjson::value, api_error> table_description_result = co_await fill_table_description(schema, table_status::active, client_state, trace_state, permit);
+    if (auto error = std::get_if<api_error>(&table_description_result)) {
+        co_return std::move(*error);
+    }
     rjson::value response = rjson::empty_object();
-    rjson::add(response, "Table", std::move(table_description));
+    rjson::add(response, "Table", std::move(std::get<rjson::value>(table_description_result)));
     elogger.trace("returning {}", response);
     co_return rjson::print(std::move(response));
 }
@@ -688,7 +699,10 @@ future<executor::request_return_type> executor::delete_table(client_state& clien
     auto& p = _proxy.container();
 
     schema_ptr schema = get_table(_proxy, request);
-    rjson::value table_description = co_await fill_table_description(schema, table_status::deleting, client_state, trace_state, permit);
+    std::variant<rjson::value, api_error> table_description_result = co_await fill_table_description(schema, table_status::deleting, client_state, trace_state, permit);
+    if (auto error = std::get_if<api_error>(&table_description_result)) {
+        co_return std::move(*error);
+    }
     co_await verify_permission(_enforce_authorization, _warn_authorization, client_state, schema, auth::permission::DROP, _stats);
     co_await _mm.container().invoke_on(0, [&, cs = client_state.move_to_other_shard()] (service::migration_manager& mm) -> future<> {
         size_t retries = mm.get_concurrent_ddl_retries();
@@ -745,7 +759,7 @@ future<executor::request_return_type> executor::delete_table(client_state& clien
     });
 
     rjson::value response = rjson::empty_object();
-    rjson::add(response, "TableDescription", std::move(table_description));
+    rjson::add(response, "TableDescription", std::move(std::get<rjson::value>(table_description_result)));
     elogger.trace("returning {}", response);
     co_return rjson::print(std::move(response));
 }
@@ -2892,7 +2906,7 @@ static executor::request_return_type rmw_operation_return(rjson::value&& attribu
     return rjson::print(std::move(ret));
 }
 
-static future<std::unique_ptr<rjson::value>> get_previous_item(
+static future<std::variant<std::unique_ptr<rjson::value>, api_error>> get_previous_item(
             service::storage_proxy& proxy,
             service::client_state& client_state,
             schema_ptr schema,
@@ -2905,20 +2919,22 @@ static future<std::unique_ptr<rjson::value>> get_previous_item(
         auto selection = cql3::selection::selection::wildcard(schema);
         auto command = previous_item_read_command(proxy, schema, ck, selection);
         command->allow_limit = db::allow_per_partition_rate_limit::yes;
-        return proxy.query(schema, command, to_partition_ranges(*schema, pk), cl, service::storage_proxy::coordinator_query_options(executor::default_timeout(), std::move(permit), client_state)).then(
-            [schema, command, selection = std::move(selection), &item_length] (service::storage_proxy::coordinator_query_result qr) {
-        auto previous_item = describe_single_item(schema, command->slice, *selection, *qr.query_result, {}, &item_length);
-        if (previous_item) {
-            return make_ready_future<std::unique_ptr<rjson::value>>(std::make_unique<rjson::value>(std::move(*previous_item)));
-        } else {
-            return make_ready_future<std::unique_ptr<rjson::value>>();
+        service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr = 
+                co_await proxy.query_result(
+                    schema, command, to_partition_ranges(*schema, pk), cl,
+                    service::storage_proxy::coordinator_query_options(executor::default_timeout(), std::move(permit), client_state));
+        if (!rqr) {
+            co_return create_api_error_from_coordinators_exception(std::move(rqr).assume_error());
         }
-    });
+        auto previous_item = describe_single_item(schema, command->slice, *selection, *rqr.assume_value().query_result, {}, &item_length);
+        if (previous_item) {
+            co_return std::make_unique<rjson::value>(std::move(*previous_item));
+        } else {
+            co_return std::unique_ptr<rjson::value>();
+        }
 }
 
-
-
-static future<uint64_t> get_previous_item_size(
+static future<std::variant<uint64_t, api_error>> get_previous_item_size(
             service::storage_proxy& proxy,
             service::client_state& client_state,
             schema_ptr schema,
@@ -2928,7 +2944,10 @@ static future<uint64_t> get_previous_item_size(
     uint64_t item_length = 0;
     // The use of get_previous_item here is for DynamoDB calculation compatibility mode,
     // and the actual value is ignored. For performance reasons, we use CL_LOCAL_ONE.
-    co_await  get_previous_item(proxy, client_state, schema, pk, ck, permit, db::consistency_level::LOCAL_ONE, item_length);
+    auto res = co_await get_previous_item(proxy, client_state, schema, pk, ck, permit, db::consistency_level::LOCAL_ONE, item_length);
+    if (auto error = std::get_if<api_error>(&res)) {
+        co_return std::move(*error);
+    }
     co_return item_length;
 }
 
@@ -2955,7 +2974,11 @@ future<executor::request_return_type> rmw_operation::execute(service::storage_pr
             // This is the old, unsafe, read before write which does first
             // a read, then a write. TODO: remove this mode entirely.
             return get_previous_item(proxy, client_state, schema(), _pk, _ck, permit, db::consistency_level::LOCAL_QUORUM, _consumed_capacity._total_bytes).then(
-                    [this, &proxy, &wcu_total, &global_stats, &per_table_stats, trace_state, permit = std::move(permit), cdc_opts = std::move(cdc_opts)] (std::unique_ptr<rjson::value> previous_item) mutable {
+                    [this, &proxy, &wcu_total, &global_stats, &per_table_stats, trace_state, permit = std::move(permit), cdc_opts = std::move(cdc_opts)] (std::variant<std::unique_ptr<rjson::value>, api_error> previous_item_result) mutable {
+                if (auto error = std::get_if<api_error>(&previous_item_result)) {
+                    return make_ready_future<executor::request_return_type>(std::move(*error));
+                }
+                auto previous_item = std::move(std::get<std::unique_ptr<rjson::value>>(previous_item_result));
                 std::optional<mutation> m = apply(std::move(previous_item), api::new_timestamp(), cdc_opts);
                 if (!m) {
                     global_stats.conditional_check_failed++;
@@ -3539,7 +3562,7 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
     // If alternator_force_read_before_write is true we will first get the previous item size
     // and only then do send the mutation.
     if (_proxy.data_dictionary().get_config().alternator_force_read_before_write()) {
-        std::vector<future<uint64_t>> previous_items_sizes;
+        std::vector<future<std::variant<uint64_t, api_error>>> previous_items_sizes;
         previous_items_sizes.reserve(mutation_builders.size());
 
         // Parallel get all previous item sizes
@@ -3555,7 +3578,13 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
         size_t pos = 0;
         // We are going to wait for all the requests
         for (auto&& pi : previous_items_sizes) {
-            auto res = co_await std::move(pi);
+            auto res_result = co_await std::move(pi);
+
+            if (auto error = std::get_if<api_error>(&res_result)) {
+                co_return std::move(*error);
+            }
+            auto res = std::get<uint64_t>(res_result);
+
             if (mutation_builders[pos].second.length_in_bytes() < res) {
                 mutation_builders[pos].second.set_length_in_bytes(res);
             }

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -186,7 +186,7 @@ private:
                      std::optional<db::consistency_level> cl = std::nullopt,
                      std::optional<audit::audit_table_set> alternator_batch_tables = std::nullopt);
 
-    future<rjson::value> fill_table_description(schema_ptr schema, table_status tbl_status, service::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit);
+    future<std::variant<rjson::value, api_error>> fill_table_description(schema_ptr schema, table_status tbl_status, service::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit);
     future<executor::request_return_type> create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, bool enforce_authorization,
             bool warn_authorization, const db::tablets_mode_t::mode tablets_mode, std::unique_ptr<audit::audit_info_alternator>& audit_info);
 

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1598,12 +1598,16 @@ static future<executor::request_return_type> query_vector(
                 base_schema->id(), base_schema->version(), partition_slice,
                 proxy.get_max_result_size(partition_slice),
                 query::tombstone_limit(proxy.get_tombstone_limit()));
-        service::storage_proxy::coordinator_query_result qr =
-                co_await proxy.query(base_schema, command,
+        service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr =
+                co_await proxy.query_result(base_schema, command,
                         {dht::partition_range(pkey.partition)},
                         db::consistency_level::LOCAL_ONE,
                         service::storage_proxy::coordinator_query_options(
                                 timeout, permit, client_state, trace_state));
+        if (!rqr) {
+            co_return create_api_error_from_coordinators_exception(std::move(rqr).assume_error());
+        }
+        auto qr = std::move(rqr).assume_value();
         auto opt_item = describe_single_item(base_schema, partition_slice,
                 *selection, *qr.query_result, *attrs_to_get);
         if (opt_item && (!flt || flt.check(*opt_item))) {
@@ -1867,10 +1871,14 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
     verify_all_are_used(expression_attribute_names, used_attribute_names, "ExpressionAttributeNames", "GetItem");
     rcu_consumed_capacity_counter add_capacity(request, cl == db::consistency_level::LOCAL_QUORUM);
     co_await verify_permission(_enforce_authorization, _warn_authorization, client_state, schema, auth::permission::SELECT, _stats);
-    service::storage_proxy::coordinator_query_result qr =
-        co_await _proxy.query(
-            schema, std::move(command), std::move(partition_ranges), cl,
-            service::storage_proxy::coordinator_query_options(executor::default_timeout(), std::move(permit), client_state, trace_state));
+    service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr =
+            co_await _proxy.query_result(
+                schema, std::move(command), std::move(partition_ranges), cl,
+                service::storage_proxy::coordinator_query_options(executor::default_timeout(), std::move(permit), client_state, trace_state));
+    if (!rqr) {
+        co_return create_api_error_from_coordinators_exception(std::move(rqr).assume_error());
+    }
+    auto qr = std::move(rqr).assume_value();
     per_table_stats->api_operations.get_item_latency.mark(std::chrono::steady_clock::now() - start_time);
     _stats.api_operations.get_item_latency.mark(std::chrono::steady_clock::now() - start_time);
     uint64_t rcu_half_units = 0;
@@ -1952,7 +1960,8 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     _stats.api_operations.batch_get_item_histogram.add(batch_size);
     // If we got here, all "requests" are valid, so let's start the
     // requests for the different partitions all in parallel.
-    std::vector<future<std::vector<rjson::value>>> response_futures;
+    using batch_get_item_result = service::storage_proxy::result<std::vector<rjson::value>>;
+    std::vector<future<batch_get_item_result>> response_futures;
     std::vector<uint64_t> consumed_rcu_half_units_per_table(requests.size());
     for (size_t i = 0; i < requests.size(); i++) {
         const table_requests& rs = requests[i];
@@ -1984,11 +1993,18 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
                     per_table_stats->operation_sizes.batch_get_item_op_size_kb.add(bytes_to_kb_ceil(size));
                 }
             };
-            future<std::vector<rjson::value>> f = _proxy.query(rs.schema, std::move(command), std::move(partition_ranges), rs.cl,
-                    service::storage_proxy::coordinator_query_options(executor::default_timeout(), permit, client_state, trace_state)).then(
-                    [schema = rs.schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = rs.attrs_to_get, item_callback = std::move(item_callback)] (service::storage_proxy::coordinator_query_result qr) mutable {
+            future<batch_get_item_result> f = 
+                    _proxy.query_result(rs.schema, std::move(command), std::move(partition_ranges), rs.cl,
+                        service::storage_proxy::coordinator_query_options(executor::default_timeout(), permit, client_state, trace_state)).then(
+                    [schema = rs.schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = rs.attrs_to_get, item_callback = std::move(item_callback)] (service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr) mutable -> future<batch_get_item_result> {
+                if (!rqr) {
+                    return make_ready_future<batch_get_item_result>(std::move(rqr).as_failure());
+                }
+                auto qr = std::move(rqr).assume_value();
                 utils::get_local_injector().inject("alternator_batch_get_item", [] { throw std::runtime_error("batch_get_item injection"); });
-                return describe_multi_item(std::move(schema), std::move(partition_slice), std::move(selection), std::move(qr.query_result), std::move(attrs_to_get), std::move(item_callback));
+                return describe_multi_item(std::move(schema), std::move(partition_slice), std::move(selection), std::move(qr.query_result), std::move(attrs_to_get), std::move(item_callback)).then([] (std::vector<rjson::value> result) {
+                    return make_ready_future<batch_get_item_result>(std::move(result));
+                });
             });
             response_futures.push_back(std::move(f));
         }
@@ -1998,6 +2014,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     // In case of full failure (no reads succeeded), an arbitrary error
     // from one of the operations will be returned.
     bool some_succeeded = false;
+    std::optional<exceptions::coordinator_exception_container> query_error;
     std::exception_ptr eptr;
     audit::audit_table_set audited_table_names;
     bool only_audited_tables = true;
@@ -2007,6 +2024,27 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     rjson::add(response, "UnprocessedKeys", rjson::empty_object());
     auto fut_it = response_futures.begin();
     rjson::value consumed_capacity = rjson::empty_array();
+    auto add_unprocessed_keys = [&] (const std::string& table, const auto& cks) {
+        // Read failed on item represented by `cks` key(s), we need to add it to UnprocessedKeys field in reply object.
+        // We create `UnprocessedKeys` object on first failure - multiple items might fail for the same BatchGetItem call.
+        if (!response["UnprocessedKeys"].HasMember(table)) {
+            // Add the table's entry in UnprocessedKeys. Need to copy all the table's parameters from the request except the
+            // Keys field, which we start empty and then build below.
+            rjson::add_with_string_name(response["UnprocessedKeys"], table, rjson::empty_object());
+            rjson::value& unprocessed_item = response["UnprocessedKeys"][table];
+            rjson::value& request_item = request_items[table];
+            for (auto it = request_item.MemberBegin(); it != request_item.MemberEnd(); ++it) {
+                if (it->name != "Keys") {
+                    rjson::add_with_string_name(unprocessed_item,
+                        rjson::to_string_view(it->name), rjson::copy(it->value));
+                }
+            }
+            rjson::add_with_string_name(unprocessed_item, "Keys", rjson::empty_array());
+        }
+        for (auto& ck : cks) {
+            rjson::push_back(response["UnprocessedKeys"][table]["Keys"], std::move(*ck.second));
+        }
+    };
     for (size_t i = 0; i < requests.size(); i++) {
         const table_requests& rs = requests[i];
         std::string table = rs.schema->cf_name();
@@ -2021,7 +2059,18 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
             auto& fut = *fut_it;
             ++fut_it;
             try {
-                std::vector<rjson::value> results = co_await std::move(fut);
+                // The future here (`storage_proxy::result`, which is a `bo::result`) might contain an error as value
+                // or it might contain an exception (which will be rethrown on `co_await` call).
+                // We need to handle both failures in the same way.
+                batch_get_item_result result = co_await std::move(fut);
+                if (!result) {
+                    if (!query_error) {
+                        query_error.emplace(std::move(result).assume_error());
+                    }
+                    add_unprocessed_keys(table, cks);
+                    continue;
+                }
+                std::vector<rjson::value> results = std::move(result).assume_value();
                 some_succeeded = true;
                 if (!response["Responses"].HasMember(table)) {
                     rjson::add_with_string_name(response["Responses"], table, rjson::empty_array());
@@ -2031,26 +2080,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
                 }
             } catch(...) {
                 eptr = std::current_exception();
-                // This read of potentially several rows in one partition,
-                // failed. We need to add the row key(s) to UnprocessedKeys.
-                if (!response["UnprocessedKeys"].HasMember(table)) {
-                    // Add the table's entry in UnprocessedKeys. Need to copy
-                    // all the table's parameters from the request except the
-                    // Keys field, which we start empty and then build below.
-                    rjson::add_with_string_name(response["UnprocessedKeys"], table, rjson::empty_object());
-                    rjson::value& unprocessed_item = response["UnprocessedKeys"][table];
-                    rjson::value& request_item = request_items[table];
-                    for (auto it = request_item.MemberBegin(); it != request_item.MemberEnd(); ++it) {
-                        if (it->name != "Keys") {
-                            rjson::add_with_string_name(unprocessed_item,
-                                rjson::to_string_view(it->name), rjson::copy(it->value));
-                        }
-                    }
-                    rjson::add_with_string_name(unprocessed_item, "Keys", rjson::empty_array());
-                }
-                for (auto& ck : cks) {
-                    rjson::push_back(response["UnprocessedKeys"][table]["Keys"], std::move(*ck.second));
-                }
+                add_unprocessed_keys(table, cks);
             }
         }
         uint64_t rcu_half_units = consumed_rcu_half_units_per_table[i];
@@ -2084,6 +2114,9 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     }
     if (!some_succeeded && eptr) {
         co_await coroutine::return_exception_ptr(std::move(eptr));
+    }
+    if (!some_succeeded && query_error) {
+        co_return create_api_error_from_coordinators_exception(*query_error);
     }
     auto duration = std::chrono::steady_clock::now() - start_time;
     _stats.api_operations.batch_get_item_latency.mark(duration);

--- a/alternator/executor_util.cc
+++ b/alternator/executor_util.cc
@@ -20,6 +20,7 @@
 #include "serialization.hh"
 #include "service/storage_proxy.hh"
 #include "types/map.hh"
+#include "utils/overloaded_functor.hh"
 #include <fmt/format.h>
 
 namespace alternator {
@@ -571,4 +572,17 @@ void filter_batch_request_items_by_tbl_name(rjson::value& request, const audit::
     }
 }
 
+api_error create_api_error_from_coordinators_exception(const exceptions::coordinator_exception_container& exc) {
+    return exc.accept(overloaded_functor {
+        [] (const exceptions::rate_limit_exception& ex) {
+            return api_error::request_limit_exceeded(ex.what());
+        },
+        [] (const exceptions::overloaded_exception& ex) {
+            return api_error::request_limit_exceeded(ex.what());
+        },
+        [] (const auto& ex) {
+            return api_error::internal(format("Internal server error: {}", ex.what()));
+        }
+    });
+}
 } // namespace alternator

--- a/alternator/executor_util.hh
+++ b/alternator/executor_util.hh
@@ -34,6 +34,7 @@
 #include "alternator/attribute_path.hh"
 #include "audit/audit.hh"
 #include "utils/managed_bytes.hh"
+#include "exceptions/coordinator_result.hh"
 
 namespace query { class partition_slice; class result; }
 namespace cql3::selection { class selection; }
@@ -41,6 +42,7 @@ namespace data_dictionary { class database; }
 namespace service { class storage_proxy; class client_state; }
 
 namespace alternator {
+class api_error;
 
 /// The body_writer is used for streaming responses - where the response body
 /// is written in chunks to the output_stream. This allows for efficient
@@ -250,4 +252,6 @@ std::optional<rjson::value> describe_single_item(schema_ptr,
 /// help avoid large allocations/many re-allocs.
 body_writer make_streamed(rjson::value&&);
 
+/// Convert an exception from the coordinator_exception_container to an api_error with proper error message.
+api_error create_api_error_from_coordinators_exception(const exceptions::coordinator_exception_container &exc);
 } // namespace alternator

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1326,7 +1326,12 @@ future<executor::request_return_type> executor::get_records(client_state& client
     auto command = ::make_lw_shared<query::read_command>(schema->id(), schema->version(), partition_slice, _proxy.get_max_result_size(partition_slice),
             query::tombstone_limit(_proxy.get_tombstone_limit()), query::row_limit(limit * mul));
 
-    service::storage_proxy::coordinator_query_result qr = co_await _proxy.query(schema, std::move(command), std::move(partition_ranges), cl, service::storage_proxy::coordinator_query_options(default_timeout(), std::move(permit), client_state));
+    service::storage_proxy::result<service::storage_proxy::coordinator_query_result> rqr =
+            co_await _proxy.query_result(schema, std::move(command), std::move(partition_ranges), cl, service::storage_proxy::coordinator_query_options(default_timeout(), std::move(permit), client_state));
+    if (!rqr) {
+        co_return create_api_error_from_coordinators_exception(std::move(rqr).assume_error());
+    }
+    auto qr = std::move(rqr).assume_value();
     cql3::selection::result_set_builder builder(*selection, gc_clock::now());
     query::result_view::consume(*qr.query_result, partition_slice, cql3::selection::result_set_builder::visitor(builder, *schema, *selection));
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6762,6 +6762,19 @@ storage_proxy::query_result(schema_ptr query_schema,
     storage_proxy::coordinator_query_options query_options,
     std::optional<cas_shard> shard)
 {
+    // First we check if the table_name from injected error matches, then we 'enter' it - the latter will consume `one-shot` injections,
+    // that's why we need to validate table_name first.
+    const auto &injection_params = utils::get_local_injector().get_injection_parameters("alternator_query_result_timeout");
+    if (!injection_params.empty()) {
+        auto it = injection_params.find(sstring{ "table_name" });
+        if (it != injection_params.end() && it->second == query_schema->cf_name() && utils::get_local_injector().enter("alternator_query_result_timeout")) {
+            return make_ready_future<result<coordinator_query_result>>(
+                // Note: we don't care about the actual values of the exception fields, since this is just for testing Alternator's error handling.
+                exceptions::read_timeout_exception{ "Alternator's error injection: timeout", cl, 0, 1, false }
+            );
+        }
+
+    }
     if (slogger.is_enabled(logging::log_level::trace) || qlogger.is_enabled(logging::log_level::trace)) {
         static thread_local int next_id = 0;
         auto query_id = next_id++;

--- a/test/alternator/test_no_exception.py
+++ b/test/alternator/test_no_exception.py
@@ -1,0 +1,169 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+# Test that common error scenarios are propagated internally in Alternator's without
+# throwing exceptions. Throwing exceptions is significantly slower than returning a
+# value and can cause throughput to collapse:
+#  1. A node is slightly overloaded which result in some timeouts
+#  2. These timeouts are implemented with exceptions, which is slow, causing the
+#      node to become even more overloaded.
+#  3. The even more overloaded node results in even more timeouts, and more exceptions.
+#
+# So in this test we check some scenarios, like timeouts, which in the past caused exception
+# throwing in Alternator's implementation, and we want to verify no longer throw exceptions.
+#
+# All tests here are scylla_only: The question of whether an exception was thrown inside the
+# implementation has no parallel in DynamoDB, and also these tests rely on two Alternator-only
+# features:
+# 1. The Alternator-specific `scylla_reactor_cpp_exceptions` metric to count C++ exceptions thrown inside the implementation.
+# 2. The Alternator-specific "injections" that allow us to simulate timeouts.
+
+import pytest
+from botocore.exceptions import ClientError
+
+from test.alternator.test_streams import create_stream_test_table, wait_for_active_stream
+from test.alternator.test_metrics import check_increases_metric_exact, metrics
+from test.alternator.util import multiset, new_test_table, random_string, scylla_inject_error
+
+# Test for checking that returning partial results as UnprocessedKeys
+# is properly handled. This test relies on error injection available
+# only in Scylla compiled with appropriate flags (present in dev/debug/sanitize
+# modes) and is skipped otherwise.
+def test_batch_get_item_partial_no_exception_thrown(scylla_only, dynamodb, rest_api, test_table_sn, metrics):
+    p = random_string()
+    content = random_string()
+    # prepare "count" rows in "partitions" partitions
+    count = 10
+    partitions = 3
+    with test_table_sn.batch_writer() as batch:
+        for i in range(count):
+            batch.put_item(Item={
+                'p': p + str(i % partitions), 'c': i, 'content': content})
+
+    # We trigger read_timeout_exception in batch_get_item (when item is being read) here - 
+    # not thrown, no stack unwinding, see SCYLLADB-2960 - which uses different code path
+    # that test_batch_get_item_partial (which throws an exception).
+    # The return value should be properly created and returned to the user (including UnprocessedKeys),
+    # no exception should be thrown and no internal server error should be returned to the user.
+    responses = []
+    to_read = { test_table_sn.name: {'Keys': [{'p': p + str(c % partitions), 'c': c} for c in range(count)], 'ConsistentRead': True } }
+    with scylla_inject_error(rest_api, 'alternator_query_result_timeout', one_shot=True, parameters={ 'table_name': test_table_sn.name }):
+        with check_increases_metric_exact(metrics, 'scylla_reactor_cpp_exceptions', [[0, None]]):
+            some_keys_were_unprocessed = False
+            while to_read:
+                reply = test_table_sn.meta.client.batch_get_item(RequestItems = to_read)
+                assert 'UnprocessedKeys' in reply
+                to_read = reply['UnprocessedKeys']
+                # The UnprocessedKeys should not only list the keys, it should
+                # also copy the additional parameters used in the original read.
+                # In this example this was "ConsistentRead".
+                for tbl in to_read:
+                    assert 'ConsistentRead' in to_read[tbl]
+                some_keys_were_unprocessed = some_keys_were_unprocessed or len(to_read) > 0
+                print("Left to read:", to_read)
+                assert 'Responses' in reply
+                assert test_table_sn.name in reply['Responses']
+                responses.extend(reply['Responses'][test_table_sn.name])
+            assert multiset(responses) == multiset(
+                [{'p': p + str(i % partitions), 'c': i, 'content': content} for i in range(count)])
+            assert some_keys_were_unprocessed
+
+# Test that if the batch read failure is total, i.e. all read requests
+# failed, it's reported as an error and not as a regular response with
+# UnprocessedKeys set to all given keys.
+def test_batch_get_item_full_failure_no_exception_thrown(scylla_only, dynamodb, rest_api, test_table_sn, metrics):
+    p = random_string()
+    content = random_string()
+    count = 10
+    with test_table_sn.batch_writer() as batch:
+        for i in range(count):
+            batch.put_item(Item={
+                'p': p, 'c': i, 'content': content})
+    # We trigger read_timeout_exception in batch_get_item (when item is being read) here - 
+    # not thrown, no stack unwinding, see SCYLLADB-2960 - which uses different code path
+    # that test_batch_get_item_partial (which throws an exception).
+    # The return value should be properly created and returned to the user (including UnprocessedKeys)
+    # and no internal server error should be returned to the user.
+    to_read = { test_table_sn.name: {'Keys': [{'p': p, 'c': c} for c in range(count)], 'ConsistentRead': True } }
+    with scylla_inject_error(rest_api, 'alternator_query_result_timeout', one_shot=True, parameters={ 'table_name': test_table_sn.name }):
+        with check_increases_metric_exact(metrics, 'scylla_reactor_cpp_exceptions', [[0, None]]):
+            with pytest.raises(ClientError, match="InternalServerError.*Alternator's error injection: timeout"):
+                test_table_sn.meta.client.batch_get_item(RequestItems = to_read)
+
+# Verify that timeout exception is properly returned to the user when the error is passed by value (instead of being thrown).
+# We try `get_item` path here - uses query_result directly.
+# Regression test for SCYLLADB-2960
+def test_getitem_timeout_is_propagated_to_user_no_exception(dynamodb, test_table, rest_api, metrics):
+    p = random_string()
+    c = random_string()
+    with check_increases_metric_exact(metrics, 'scylla_reactor_cpp_exceptions', [[0, None]]):
+        with pytest.raises(ClientError, match="InternalServerError.*Alternator's error injection: timeout"):
+            with scylla_inject_error(rest_api, 'alternator_query_result_timeout', one_shot=True, parameters={ 'table_name': test_table.name }):
+                test_table.get_item(Key={'p': p, 'c': c}, ConsistentRead=True)
+
+# Verify that timeout exception is properly returned to the user when error is passed by value (instead of being thrown).
+# We try `put_item` path here, only in `unsafe_rmw` mode
+# Regression test for SCYLLADB-2960
+def test_putitem_timeout_is_propagated_to_user_no_exception(dynamodb, rest_api, metrics):
+    p = random_string()
+    c = random_string()
+
+    with new_test_table(dynamodb,
+        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                    { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+        ],
+        AttributeDefinitions=[
+                    { 'AttributeName': 'p', 'AttributeType': 'S' },
+                    { 'AttributeName': 'c', 'AttributeType': 'S' },
+        ],
+        Tags=[{'Key': 'system:write_isolation', 'Value': 'unsafe_rmw'}]) as table:
+        with check_increases_metric_exact(metrics, 'scylla_reactor_cpp_exceptions', [[0, None]]):
+            with pytest.raises(ClientError, match="InternalServerError.*Alternator's error injection: timeout"):
+                with scylla_inject_error(rest_api, 'alternator_query_result_timeout', one_shot=True, parameters={ 'table_name': table.name }):
+                    # We don't care about exact expected value - timeout error happens before the expected value is checked.
+                    table.put_item(Item={'p': p, 'c': c}, Expected={'a': {'Value': 1}})
+
+# Test that timeout error injected and passed by value (instead of being thrown) is correctly handled by get_records.
+# This is a regression test for SCYLLADB-2960.
+def test_get_records_timeout_error_no_exception(dynamodb, dynamodbstreams, scylla_only, rest_api, metrics):
+    with create_stream_test_table(dynamodb, StreamViewType='NEW_AND_OLD_IMAGES') as table:
+        (arn, label) = wait_for_active_stream(dynamodbstreams, table)
+        shard = dynamodbstreams.describe_stream(StreamArn=arn, Limit=1)['StreamDescription']['Shards'][0]
+        shard_id = shard['ShardId']
+        iter = dynamodbstreams.get_shard_iterator(StreamArn=arn, ShardId=shard_id, ShardIteratorType='LATEST')['ShardIterator']
+
+        with pytest.raises(ClientError, match="InternalServerError.*Alternator's error injection: timeout"):
+            with check_increases_metric_exact(metrics, 'scylla_reactor_cpp_exceptions', [[0, None]]):
+                # We need a `_scylla_cdc_log` appended to a table, because query_result is used for readign from CDC table, which name is
+                # table_name + '_scylla_cdc_log'.
+                with scylla_inject_error(rest_api, 'alternator_query_result_timeout', one_shot=True, parameters={ 'table_name': table.name + '_scylla_cdc_log' }):
+                    dynamodbstreams.get_records(ShardIterator=iter)
+
+# Test that DescribeTable returns an InternalServerError with a timeout message if the is_view_built query times out and
+# the error is passed by value (instead of being thrown).
+# Regression test for SCYLLADB-2960
+def test_describe_table_with_timeout_in_is_view_built_no_exception(dynamodb, rest_api, metrics):
+    with new_test_table(dynamodb,
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'},
+                   {'AttributeName': 'c', 'KeyType': 'RANGE'}],
+        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' },
+                               { 'AttributeName': 'c', 'AttributeType': 'S' },
+                               { 'AttributeName': 'x', 'AttributeType': 'S' }],
+        GlobalSecondaryIndexes=[
+            {   'IndexName': 'hello',
+                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
+                'Projection': { 'ProjectionType': 'ALL' }
+            }],
+        LocalSecondaryIndexes=[
+            {   'IndexName': 'hithere',
+                'KeySchema': [{'AttributeName': 'p', 'KeyType': 'HASH'},
+                              {'AttributeName': 'x', 'KeyType': 'RANGE'}],
+                'Projection': { 'ProjectionType': 'ALL' }
+            }]
+    ) as table:
+        with scylla_inject_error(rest_api, 'alternator_query_result_timeout', one_shot=True, parameters={ 'table_name': 'view_build_status_v2' }):
+            with check_increases_metric_exact(metrics, 'scylla_reactor_cpp_exceptions', [[0, None]]):
+                with pytest.raises(ClientError, match='InternalServerError.*timeout'):
+                    table.meta.client.describe_table(TableName=table.name)['Table']
+

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -246,8 +246,8 @@ def get_region(dynamodb):
 # and only in specific build modes (dev, debug, sanitize), so this function
 # will trigger a test to be skipped if it cannot be executed.
 @contextmanager
-def scylla_inject_error(rest_api, err, one_shot=False):
-    requests.post(f'{rest_api}/v2/error_injection/injection/{err}?one_shot={one_shot}')
+def scylla_inject_error(rest_api, err, one_shot=False, parameters={}):
+    requests.post(f'{rest_api}/v2/error_injection/injection/{err}?one_shot={one_shot}', json=parameters)
     response = requests.get(f'{rest_api}/v2/error_injection/injection')
     print("Enabled error injections:", response.content.decode('utf-8'))
     if response.content.decode('utf-8') == "[]":

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -610,11 +610,12 @@ public:
         }
     }
 
-    error_injection_parameters get_injection_parameters(std::string_view name) {
+    const error_injection_parameters &get_injection_parameters(std::string_view name) {
         if (auto data = get_data(name); data) {
             return data->shared_data->parameters;
         }
-        return {};
+        static error_injection_parameters empty;
+        return empty;
     }
 
     future<> enable_on_all(const std::string_view& injection_name, bool one_shot = false, error_injection_parameters parameters = {}) {
@@ -775,8 +776,9 @@ public:
     void set_parameter(std::string_view injection_name, sstring parameter_name, sstring parameter_value) { }
 
     [[gnu::always_inline]]
-    error_injection_parameters get_injection_parameters(std::string_view name) {
-        return {};
+    const error_injection_parameters &get_injection_parameters(std::string_view name) {
+        static error_injection_parameters empty;
+        return empty;
     }
 
     [[gnu::always_inline]]


### PR DESCRIPTION
`_proxy.query()` call can throw an exception. Stack unwinding is costly. If the exception is thrown often, cpu pressure from stack unwinding can amplify an already existing overload into catastrophic failure.
    
We resolve the issue by replacing call to `query()` with sibling `query_result()`. The `query_result()` call returns `boost_result` object, which can return either a value (call was successful) or some failure object (call failed).
`query_result()` as a failure directly returns an exception object, sidestepping costly stack unwind. Some functions that previously used `query()` had no way to return a failure - the return types of those were updated
to use `std::variant` with `api_error` type for an error. The error value was also converted from an exception object returned via `query_result()` to `api_error` expected by Alternator's `server.cc` error handling logic.
    
NOTE: `query_result()` is still a throwing function, it just tries hard to return common exceptions via value. The caller still needs to be ready to handle thrown exception in a standard way (including exception types
returned as error reply from `query_result()` call).
    
The list of allowed exceptions to be returned via value is in `exceptions/coordinator_result.hh` file.
    
Not all call sites in alternator were updated:
- `get_key_from_roles` in `auth.cc` - used in a cache, when a miss happens (thus should be called rarely), cache interface is frozen - we have no easy way to pass a failure exception as value anyway,
   
Added tests for new code path, using scylla's injection mechanism.

Performance result (inserted hard-coded timeout in `get_previous_item`
function and run `scylla perf-alternator --workload write_rmw ...`:

| what                | instructions per op |
| vanilla, no error   | 570824              |
| vaniia, err thrown  | 439716              |
| PR, no error        | 570897              |
| PR, err thrown      | 427196              |
| PR, err by value    | 247460              |

Fixes: SCYLLADB-2960

Backport: none - performance improvement.