### PR TITLE
cql3: secondary index: intersect posting lists for multi-column queries (SCYLLADB-3139)

### DIFF
--- a/cql3/cql_config.hh
+++ b/cql3/cql_config.hh
@@ -33,6 +33,7 @@ struct cql_config {
     utils::updateable_value<uint32_t> batch_size_fail_threshold_in_kb;
     utils::updateable_value<bool> restrict_future_timestamp;
     utils::updateable_value<bool> enable_create_table_with_compact_storage;
+    utils::updateable_value<uint32_t> secondary_index_intersection_skip_max_rows;
 
     explicit cql_config(const db::config& cfg)
         : restrictions(cfg)
@@ -46,6 +47,7 @@ struct cql_config {
         , batch_size_fail_threshold_in_kb(cfg.batch_size_fail_threshold_in_kb)
         , restrict_future_timestamp(cfg.restrict_future_timestamp)
         , enable_create_table_with_compact_storage(cfg.enable_create_table_with_compact_storage)
+        , secondary_index_intersection_skip_max_rows(cfg.secondary_index_intersection_skip_max_rows)
     {}
     struct default_tag{};
     cql_config(default_tag)
@@ -60,6 +62,7 @@ struct cql_config {
         , batch_size_fail_threshold_in_kb(1024)
         , restrict_future_timestamp(true)
         , enable_create_table_with_compact_storage(false)
+        , secondary_index_intersection_skip_max_rows(100)
     {}
 };
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1436,44 +1436,8 @@ static do_find_idx_result do_find_idx(
         return 1;
     };
 
-    // Estimate the relative selectivity of the restriction(s) an index would
-    // serve, based only on the restriction's operator - never on runtime data -
-    // so that the estimate is a pure function of the query. It is therefore
-    // identical on every coordinator and stable over time, which paged index
-    // queries rely on (see the determinism note below and issue #7969).
-    //
-    // A scalar equality (`col = v`, or a map element `m[k] = v`) matches a
-    // single value of a single-valued column and is the most selective a
-    // secondary index gets. A collection membership restriction
-    // (`col CONTAINS v` / `CONTAINS KEY v`) is typically far less selective: a
-    // given element value can appear in the collections of arbitrarily many
-    // rows. This operator-based estimate only breaks ties in the *deterministic*
-    // choice of a single index here at prepare time; when several indexed columns
-    // are restricted, the query executor additionally intersects their posting
-    // lists and, at execution time, drives the query with the index whose posting
-    // list is actually smallest (see the multi-index handling for CUSTOMER-303 in
-    // view_indexed_table_select_statement). Keeping this estimate a pure function
-    // of the query preserves the determinism that paged index queries rely on
-    // (see the note below and issue #7969).
-    auto selectivity_rank = [] (const std::vector<predicate>& preds) -> int {
-        // Higher is more selective. Scalar/map-element equality beats
-        // collection membership; anything else stays in between so its relative
-        // order is unchanged.
-        int rank = 1;
-        for (const auto& pred : preds) {
-            if (pred.equality) {
-                return 2;
-            }
-            if (pred.op == expr::oper_t::CONTAINS || pred.op == expr::oper_t::CONTAINS_KEY) {
-                rank = 0;
-            }
-        }
-        return rank;
-    };
-
     std::optional<secondary_index::index> chosen_index;
     int chosen_index_score = 0;
-    int chosen_index_selectivity = -1;
     expr::expression chosen_index_restrictions = expr::conjunction({});
     std::vector<predicate> chosen_index_predicates;
 
@@ -1484,22 +1448,20 @@ static do_find_idx_result do_find_idx(
     // (sorted) order so the set is a pure function of the query.
     std::map<sstring, std::pair<secondary_index::index, std::vector<predicate>>> eq_global_indexes;
 
-    // Several indexes may be usable for this query. We pick one by, in order of
-    // decreasing priority: the index score (local indexes covering the full
-    // partition key are preferred over global ones), then the estimated
-    // selectivity of the restriction the index serves, and finally the order of
-    // the columns mentioned in the restriction expression. The exact tie-break
-    // order isn't important on its own, but it is critical that two coordinators
-    // - or the same coordinator over time - choose the same index for the same
-    // query; otherwise paging can break (see issue #7969). All three criteria
-    // above are pure functions of the query, so this holds.
+    // Several indexes may be usable for this query. When their score is tied,
+    // let's pick one by order of the columns mentioned in the restriction
+    // expression. This specific order isn't important, but it is critical that
+    // two coordinators - or the same coordinator over time (including across a
+    // rolling upgrade) - choose the same index for the same query. Otherwise,
+    // paging can break (see issue #7969). Any cost-based refinement of this
+    // choice must therefore be gated behind a cluster feature and pinned in the
+    // paging state; see view_indexed_table_select_statement (CUSTOMER-303).
     for (const auto& group : search_groups) {
         // Iterate columns in WHERE-clause order (from the restriction expression)
         // rather than schema-position order (from the pred_vectors map).  When
-        // score and selectivity are tied the first column visited wins (strict >),
-        // so the iteration order determines which index is chosen for otherwise
-        // equal candidates -- matching the old expression-based do_find_idx
-        // behaviour.
+        // scores are tied the first column visited wins (strict >), so the
+        // iteration order determines which index is chosen for equal-score
+        // candidates -- matching the old expression-based do_find_idx behaviour.
         expr::for_each_expression<expr::column_value>(group.restriction_expr, [&](const expr::column_value& cval) {
             auto it = group.pred_vectors.find(cval.col);
             if (it == group.pred_vectors.end()) {
@@ -1511,29 +1473,17 @@ static do_find_idx_result do_find_idx(
                         !are_predicates_supported_by(preds, index)) {
                     continue;
                 }
-                const int score = index_score(index);
-                if (score == 0) {
-                    // Unusable index (e.g. a local index without the full
-                    // partition key restricted); never pick it.
-                    continue;
-                }
-                const int selectivity = selectivity_rank(preds);
-                // Remember every global index restricted by an equality; these are
-                // the candidates for posting-list intersection once the primary
-                // index is chosen.
+                // Remember every global equality-restricted index; these become the
+                // candidates for posting-list intersection once the primary index
+                // is chosen (CUSTOMER-303). This does not influence the choice below,
+                // so the deterministic single-index selection is unchanged.
                 if (!index.metadata().local()
                         && std::ranges::any_of(preds, [] (const predicate& p) { return p.equality; })) {
                     eq_global_indexes.insert_or_assign(index.metadata().name(), std::make_pair(index, preds));
                 }
-                // Compare (score, selectivity) lexicographically. A strict '>'
-                // keeps the first candidate visited - i.e. the earliest column
-                // in WHERE-clause order - when both are equal.
-                const bool better = score > chosen_index_score
-                        || (score == chosen_index_score && selectivity > chosen_index_selectivity);
-                if (better) {
+                if (index_score(index) > chosen_index_score) {
                     chosen_index = index;
-                    chosen_index_score = score;
-                    chosen_index_selectivity = selectivity;
+                    chosen_index_score = index_score(index);
                     chosen_index_restrictions = group.restriction_expr;
                     chosen_index_predicates = preds;
                 }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -819,6 +819,11 @@ struct do_find_idx_result {
     std::optional<secondary_index::index> index;
     expr::expression restrictions;
     std::vector<predicate> indexed_column_predicates;
+    // Additional global indexes (other than the chosen one) whose target column is
+    // restricted by an equality in this query. Their posting lists can be
+    // intersected with the chosen index's to avoid reading base-table rows that
+    // don't match every indexed restriction (CUSTOMER-303 phase 2).
+    std::vector<std::pair<secondary_index::index, std::vector<predicate>>> additional_eq_indexes;
 };
 
 static do_find_idx_result do_find_idx(
@@ -826,6 +831,8 @@ static do_find_idx_result do_find_idx(
         const secondary_index::secondary_index_manager& sim,
         std::span<const index_search_group> search_groups,
         allow_local_index allow_local);
+
+static get_singleton_value_fn_t build_value_fn_from_predicates(std::vector<predicate> preds);
 
 
 bool is_empty_restriction(const expression& e) {
@@ -1244,6 +1251,10 @@ statement_restrictions::statement_restrictions(private_tag,
             _idx_opt = std::make_unique<secondary_index::index>(std::move(*idx_result.index));
         }
         _idx_column_predicates = std::move(idx_result.indexed_column_predicates);
+        for (auto& [idx, preds] : idx_result.additional_eq_indexes) {
+            _intersection_indexes.push_back(idx);
+            _intersection_index_value_fns.push_back(build_value_fn_from_predicates(std::move(preds)));
+        }
     }
 
     calculate_column_defs_for_filtering_and_erase_restrictions_used_for_index(db, sc_pk_pred_vectors, sc_ck_pred_vectors, sc_nonpk_pred_vectors);
@@ -1465,6 +1476,13 @@ static do_find_idx_result do_find_idx(
     expr::expression chosen_index_restrictions = expr::conjunction({});
     std::vector<predicate> chosen_index_predicates;
 
+    // All usable global indexes whose target column is restricted by an equality,
+    // keyed by index name (so each index is collected once). After the primary
+    // index is chosen below, the rest become candidates for posting-list
+    // intersection (CUSTOMER-303 phase 2). Keyed and later returned in a stable
+    // (sorted) order so the set is a pure function of the query.
+    std::map<sstring, std::pair<secondary_index::index, std::vector<predicate>>> eq_global_indexes;
+
     // Several indexes may be usable for this query. We pick one by, in order of
     // decreasing priority: the index score (local indexes covering the full
     // partition key are preferred over global ones), then the estimated
@@ -1499,6 +1517,13 @@ static do_find_idx_result do_find_idx(
                     continue;
                 }
                 const int selectivity = selectivity_rank(preds);
+                // Remember every global index restricted by an equality; these are
+                // the candidates for posting-list intersection once the primary
+                // index is chosen.
+                if (!index.metadata().local()
+                        && std::ranges::any_of(preds, [] (const predicate& p) { return p.equality; })) {
+                    eq_global_indexes.insert_or_assign(index.metadata().name(), std::make_pair(index, preds));
+                }
                 // Compare (score, selectivity) lexicographically. A strict '>'
                 // keeps the first candidate visited - i.e. the earliest column
                 // in WHERE-clause order - when both are equal.
@@ -1514,7 +1539,19 @@ static do_find_idx_result do_find_idx(
             }
         });
     }
-    return {chosen_index, chosen_index_restrictions, std::move(chosen_index_predicates)};
+    std::vector<std::pair<secondary_index::index, std::vector<predicate>>> additional_eq_indexes;
+    if (chosen_index) {
+        for (auto& [name, idx_and_preds] : eq_global_indexes) {
+            // Skip the chosen index itself, and any other index on the same base
+            // column (intersecting a column with itself is pointless).
+            if (name == chosen_index->metadata().name()
+                    || idx_and_preds.first.target_column() == chosen_index->target_column()) {
+                continue;
+            }
+            additional_eq_indexes.push_back(idx_and_preds);
+        }
+    }
+    return {chosen_index, chosen_index_restrictions, std::move(chosen_index_predicates), std::move(additional_eq_indexes)};
 }
 
 std::optional<secondary_index::index>
@@ -2770,14 +2807,16 @@ std::vector<query::clustering_range> statement_restrictions::get_local_index_clu
     return _get_local_index_clustering_ranges_fn(options);
 }
 
-get_singleton_value_fn_t
-statement_restrictions::build_value_for_index_partition_key_fn() const {
-    if (_idx_column_predicates.empty()) {
+// Builds a function that, given query options, solves a column's equality
+// predicate(s) to the single value used as the index view's partition key.
+// Shared by the chosen index and by the additional intersection indexes.
+static get_singleton_value_fn_t build_value_fn_from_predicates(std::vector<predicate> preds) {
+    if (preds.empty()) {
         return {};
     }
-    auto merged = _idx_column_predicates[0];
-    for (size_t i = 1; i < _idx_column_predicates.size(); ++i) {
-        merged = make_conjunction(std::move(merged), _idx_column_predicates[i]);
+    auto merged = preds[0];
+    for (size_t i = 1; i < preds.size(); ++i) {
+        merged = make_conjunction(std::move(merged), preds[i]);
     }
     return [merged = std::move(merged)] (const query_options& options) -> bytes_opt {
         value_set possible_vals = solve(merged, options);
@@ -2798,6 +2837,11 @@ statement_restrictions::build_value_for_index_partition_key_fn() const {
             }
         }, possible_vals);
     };
+}
+
+get_singleton_value_fn_t
+statement_restrictions::build_value_for_index_partition_key_fn() const {
+    return build_value_fn_from_predicates(_idx_column_predicates);
 }
 
 bytes_opt

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1425,24 +1425,62 @@ static do_find_idx_result do_find_idx(
         return 1;
     };
 
+    // Estimate the relative selectivity of the restriction(s) an index would
+    // serve, based only on the restriction's operator - never on runtime data -
+    // so that the estimate is a pure function of the query. It is therefore
+    // identical on every coordinator and stable over time, which paged index
+    // queries rely on (see the determinism note below and issue #7969).
+    //
+    // A scalar equality (`col = v`, or a map element `m[k] = v`) matches a
+    // single value of a single-valued column and is the most selective a
+    // secondary index gets. A collection membership restriction
+    // (`col CONTAINS v` / `CONTAINS KEY v`) is typically far less selective: a
+    // given element value can appear in the collections of arbitrarily many
+    // rows. When a query restricts several indexed columns we can still only
+    // use one index and must read every base-table row it points at, filtering
+    // the rest in memory - so picking the more selective index reads fewer base
+    // rows. This is a first, statistics-free step towards the multi-index
+    // handling requested in CUSTOMER-303; a cost-based choice using per-index
+    // statistics, and intersecting several posting lists instead of filtering,
+    // are left for follow-up work.
+    auto selectivity_rank = [] (const std::vector<predicate>& preds) -> int {
+        // Higher is more selective. Scalar/map-element equality beats
+        // collection membership; anything else stays in between so its relative
+        // order is unchanged.
+        int rank = 1;
+        for (const auto& pred : preds) {
+            if (pred.equality) {
+                return 2;
+            }
+            if (pred.op == expr::oper_t::CONTAINS || pred.op == expr::oper_t::CONTAINS_KEY) {
+                rank = 0;
+            }
+        }
+        return rank;
+    };
+
     std::optional<secondary_index::index> chosen_index;
     int chosen_index_score = 0;
+    int chosen_index_selectivity = -1;
     expr::expression chosen_index_restrictions = expr::conjunction({});
     std::vector<predicate> chosen_index_predicates;
 
-    // Several indexes may be usable for this query. When their score is tied,
-    // let's pick one by order of the columns mentioned in the restriction
-    // expression. This specific order isn't important (and maybe in the
-    // future we could plan a better order based on the specificity of each
-    // index), but it is critical that two coordinators - or the same
-    // coordinator over time - must choose the same index for the same query.
-    // Otherwise, paging can break (see issue #7969).
+    // Several indexes may be usable for this query. We pick one by, in order of
+    // decreasing priority: the index score (local indexes covering the full
+    // partition key are preferred over global ones), then the estimated
+    // selectivity of the restriction the index serves, and finally the order of
+    // the columns mentioned in the restriction expression. The exact tie-break
+    // order isn't important on its own, but it is critical that two coordinators
+    // - or the same coordinator over time - choose the same index for the same
+    // query; otherwise paging can break (see issue #7969). All three criteria
+    // above are pure functions of the query, so this holds.
     for (const auto& group : search_groups) {
         // Iterate columns in WHERE-clause order (from the restriction expression)
         // rather than schema-position order (from the pred_vectors map).  When
-        // scores are tied the first column visited wins (strict >), so the
-        // iteration order determines which index is chosen for equal-score
-        // candidates -- matching the old expression-based do_find_idx behaviour.
+        // score and selectivity are tied the first column visited wins (strict >),
+        // so the iteration order determines which index is chosen for otherwise
+        // equal candidates -- matching the old expression-based do_find_idx
+        // behaviour.
         expr::for_each_expression<expr::column_value>(group.restriction_expr, [&](const expr::column_value& cval) {
             auto it = group.pred_vectors.find(cval.col);
             if (it == group.pred_vectors.end()) {
@@ -1450,11 +1488,26 @@ static do_find_idx_result do_find_idx(
             }
             const auto& [col, preds] = *it;
             for (const auto& index : sim.list_indexes()) {
-                if (col->name_as_text() == index.target_column() &&
-                        are_predicates_supported_by(preds, index) &&
-                        index_score(index) > chosen_index_score) {
+                if (col->name_as_text() != index.target_column() ||
+                        !are_predicates_supported_by(preds, index)) {
+                    continue;
+                }
+                const int score = index_score(index);
+                if (score == 0) {
+                    // Unusable index (e.g. a local index without the full
+                    // partition key restricted); never pick it.
+                    continue;
+                }
+                const int selectivity = selectivity_rank(preds);
+                // Compare (score, selectivity) lexicographically. A strict '>'
+                // keeps the first candidate visited - i.e. the earliest column
+                // in WHERE-clause order - when both are equal.
+                const bool better = score > chosen_index_score
+                        || (score == chosen_index_score && selectivity > chosen_index_selectivity);
+                if (better) {
                     chosen_index = index;
-                    chosen_index_score = index_score(index);
+                    chosen_index_score = score;
+                    chosen_index_selectivity = selectivity;
                     chosen_index_restrictions = group.restriction_expr;
                     chosen_index_predicates = preds;
                 }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1447,13 +1447,14 @@ static do_find_idx_result do_find_idx(
     // secondary index gets. A collection membership restriction
     // (`col CONTAINS v` / `CONTAINS KEY v`) is typically far less selective: a
     // given element value can appear in the collections of arbitrarily many
-    // rows. When a query restricts several indexed columns we can still only
-    // use one index and must read every base-table row it points at, filtering
-    // the rest in memory - so picking the more selective index reads fewer base
-    // rows. This is a first, statistics-free step towards the multi-index
-    // handling requested in CUSTOMER-303; a cost-based choice using per-index
-    // statistics, and intersecting several posting lists instead of filtering,
-    // are left for follow-up work.
+    // rows. This operator-based estimate only breaks ties in the *deterministic*
+    // choice of a single index here at prepare time; when several indexed columns
+    // are restricted, the query executor additionally intersects their posting
+    // lists and, at execution time, drives the query with the index whose posting
+    // list is actually smallest (see the multi-index handling for CUSTOMER-303 in
+    // view_indexed_table_select_statement). Keeping this estimate a pure function
+    // of the query preserves the determinism that paged index queries rely on
+    // (see the note below and issue #7969).
     auto selectivity_rank = [] (const std::vector<predicate>& preds) -> int {
         // Higher is more selective. Scalar/map-element equality beats
         // collection membership; anything else stays in between so its relative

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -234,6 +234,14 @@ private:
     get_clustering_bounds_fn_t _get_global_index_token_clustering_ranges_fn;
     get_clustering_bounds_fn_t _get_local_index_clustering_ranges_fn;
     get_singleton_value_fn_t _value_for_index_partition_key_fn;
+    /// Additional global secondary indexes (besides the chosen one) whose target
+    /// column is restricted by an equality in this query. Their posting lists can
+    /// be intersected with the chosen index's to avoid reading base-table rows
+    /// that don't satisfy every indexed restriction (CUSTOMER-303 phase 2).
+    std::vector<secondary_index::index> _intersection_indexes;
+    /// Parallel to _intersection_indexes: solves each index's equality value
+    /// (i.e. its posting-list partition key) from the query options.
+    std::vector<get_singleton_value_fn_t> _intersection_index_value_fns;
 public:
     /**
      * Creates a new empty <code>StatementRestrictions</code>.
@@ -378,6 +386,15 @@ public:
     const column_definition& unrestricted_column(column_kind kind) const;
 
     schema_ptr get_view_schema() const { return _view_schema; }
+
+    /// Additional global indexes (besides the chosen one) that can be intersected
+    /// with the chosen index's posting list for this query (CUSTOMER-303 phase 2).
+    const std::vector<secondary_index::index>& intersection_indexes() const { return _intersection_indexes; }
+    /// The equality value (posting-list partition key) of the i-th intersection
+    /// index for these query options. std::nullopt if the value is NULL (no match).
+    bytes_opt value_for_intersection_index(size_t i, const query_options& options) const {
+        return _intersection_index_value_fns.at(i)(options);
+    }
 private:
     void process_partition_key_restrictions(bool for_view, bool allow_filtering, statements::statement_type type);
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -968,6 +968,13 @@ view_indexed_table_select_statement::process_base_query_results(
 {
     if (paging_state) {
         paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options, internal_page_size, primary);
+        if (primary && paging_state) {
+            // CUSTOMER-303: pin the chosen driving index so the next page (possibly
+            // on another coordinator) continues with the same plan.
+            auto ps = make_lw_shared<service::pager::paging_state>(*paging_state);
+            ps->set_query_plan_index(primary->index.metadata().name());
+            paging_state = std::move(ps);
+        }
         _selection->get_result_metadata()->maybe_set_paging_state(std::move(paging_state));
     }
     return process_results(std::move(results), std::move(cmd), options, now);
@@ -1303,54 +1310,63 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
         }
     }
 
-    // CUSTOMER-303 phase 3: when several equality-indexed columns can be
-    // intersected, pick the one with the smallest posting list to drive the scan
-    // and paging. On the first page we probe posting-list sizes; on later pages we
-    // recover the same choice from the paging cursor (whose partition key is the
-    // chosen index's indexed value), so paging stays consistent with no
-    // wire-format change. `candidates`/`others` live for the whole call (this is a
-    // coroutine), so the `primary` pointer and `others` reference threaded below
-    // stay valid across every co_await.
-    // When the cost-chosen driver already matches at most this many rows, reading
-    // those base rows and post-filtering is cheaper than the extra (sequential)
-    // index reads the intersection would add - so we skip the intersection and
-    // just use the driver as a plain index. This mirrors PostgreSQL preferring a
-    // plain index scan over a BitmapAnd for a selective-enough index. The
-    // threshold is the (live-updatable) secondary_index_intersection_skip_max_rows
-    // scylla.yaml option; 0 disables the skip (always intersect).
-    const uint64_t intersection_skip_max_driver_size = qp.get_cql_config().secondary_index_intersection_skip_max_rows.get();
+    // CUSTOMER-303: when several equality-indexed columns are restricted, drive
+    // the query with a cost-chosen index and intersect the others' posting lists.
+    // This changes the query plan, so it is gated behind the
+    // SECONDARY_INDEX_INTERSECTION cluster feature (enabled only once every node
+    // is upgraded) and the chosen plan (the driving index) is pinned in the paging
+    // state, so any coordinator continues a paged query with the same plan - even
+    // across a rolling upgrade. A query that started before the feature was
+    // enabled carries no pinned plan and stays on the legacy single-index path for
+    // its whole life. `candidates`/`others` live for the whole call (a coroutine),
+    // so the `primary` pointer and `others` reference threaded below stay valid
+    // across every co_await.
     std::vector<index_candidate> candidates = build_index_candidates(options);
     const index_candidate* primary = nullptr;
     std::vector<index_candidate> others;
+    // The driving index pinned by a previous page, if any.
+    const sstring pinned_index = options.get_paging_state()
+            ? options.get_paging_state()->get_query_plan_index() : sstring();
     if (!candidates.empty()) {
-        size_t primary_idx = 0;
+        std::optional<size_t> primary_idx;
         bool skip_intersection = false;
-        if (options.get_paging_state()) {
-            primary_idx = recover_primary_index(candidates, *options.get_paging_state());
-        } else {
-            auto [idx, driver_size] = co_await choose_primary_index(qp, state, options, candidates, intersection_skip_max_driver_size);
-            primary_idx = idx;
-            skip_intersection = driver_size <= intersection_skip_max_driver_size;
-        }
-        primary = &candidates[primary_idx];
-        if (skip_intersection) {
-            // Correct regardless: post-filtering applies the other indexed
-            // restrictions to the base rows. Skipping only changes which base
-            // rows are read, never the result. Paging stays consistent because
-            // the driver is unchanged; a later page (no probe) may intersect, and
-            // mixing is still correct - the driver keys are processed in order and
-            // never skipped.
-            tracing::trace(state.get_trace_state(),
-                    "primary index is {}; selective enough, skipping posting-list intersection",
-                    primary->index.metadata().name());
-        } else {
+        if (!pinned_index.empty()) {
+            // Continuation of a paged intersection query: reuse the pinned plan
+            // verbatim (the candidate set is a pure function of the query, so it
+            // is identical on every page/coordinator).
             for (size_t i = 0; i < candidates.size(); i++) {
-                if (i != primary_idx) {
-                    others.push_back(candidates[i]);
+                if (candidates[i].index.metadata().name() == pinned_index) {
+                    primary_idx = i;
+                    break;
                 }
             }
-            tracing::trace(state.get_trace_state(), "Intersecting {} indexes; primary index is {}",
-                    candidates.size(), primary->index.metadata().name());
+        } else if (!options.get_paging_state() && qp.proxy().features().secondary_index_intersection) {
+            // First page of a new query, cluster fully upgraded: choose the driver
+            // by probing posting-list sizes. When the driver already matches at
+            // most secondary_index_intersection_skip_max_rows rows, reading those
+            // few base rows and post-filtering is cheaper than the extra index
+            // reads, so skip the intersection (cf. PostgreSQL preferring an index
+            // scan over a BitmapAnd); the driver is still pinned so later pages
+            // continue with the same plan.
+            const uint64_t skip_max = qp.get_cql_config().secondary_index_intersection_skip_max_rows.get();
+            auto [idx, driver_size] = co_await choose_primary_index(qp, state, options, candidates, skip_max);
+            primary_idx = idx;
+            skip_intersection = driver_size <= skip_max;
+        }
+        // Otherwise (feature off on the first page, or a legacy paged query with
+        // no pinned plan) primary stays null -> today's single-index behaviour.
+        if (primary_idx) {
+            primary = &candidates[*primary_idx];
+            if (!skip_intersection) {
+                for (size_t i = 0; i < candidates.size(); i++) {
+                    if (i != *primary_idx) {
+                        others.push_back(candidates[i]);
+                    }
+                }
+            }
+            tracing::trace(state.get_trace_state(),
+                    "Secondary-index query plan: driving index {}, intersecting {} other posting list(s)",
+                    primary->index.metadata().name(), others.size());
         }
     }
 
@@ -1376,6 +1392,12 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
                     // Translate the cursor in the *driver* index's view (with a
                     // cost-based primary this may not be the statement's _index).
                     paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options, internal_page_size, primary);
+                    if (primary && paging_state) {
+                        // Pin the chosen plan so a later client page continues identically.
+                        auto ps = make_lw_shared<service::pager::paging_state>(*paging_state);
+                        ps->set_query_plan_index(primary->index.metadata().name());
+                        paging_state = std::move(ps);
+                    }
                 }
                 internal_options.reset(new cql3::query_options(std::move(internal_options), paging_state ? make_lw_shared<service::pager::paging_state>(*paging_state) : nullptr));
                 if (needs_post_filtering()) {
@@ -1799,19 +1821,9 @@ view_indexed_table_select_statement::build_index_candidates(const query_options&
         }
         candidates.push_back({_intersection_indexes[i].first, _intersection_indexes[i].second, std::move(*v)});
     }
-    // The primary is recovered on later pages by matching the paging cursor's
-    // (view) partition key against each candidate's view partition key. If two
-    // candidates would yield the same view partition key, that recovery would be
-    // ambiguous, so disable cost-based selection and fall back to the chosen index.
-    for (size_t i = 0; i < candidates.size(); i++) {
-        auto pk_i = partition_key::from_single_value(*candidates[i].view_schema, candidates[i].value);
-        for (size_t k = i + 1; k < candidates.size(); k++) {
-            auto pk_k = partition_key::from_single_value(*candidates[k].view_schema, candidates[k].value);
-            if (pk_i.representation() == pk_k.representation()) {
-                return {};
-            }
-        }
-    }
+    // The candidate set is a pure function of the query, so it is identical on
+    // every page and coordinator. On later pages the driving index is looked up
+    // here by the name pinned in the paging state.
     return candidates;
 }
 
@@ -1857,23 +1869,6 @@ view_indexed_table_select_statement::choose_primary_index(query_processor& qp, s
         }
     }
     co_return std::pair<size_t, uint64_t>(best, best_size);
-}
-
-// CUSTOMER-303 phase 3: recover which candidate drove paging on the previous
-// page. The paging cursor's partition key is the primary index's view partition
-// key (= its indexed value), so match it against the candidates.
-size_t view_indexed_table_select_statement::recover_primary_index(const std::vector<index_candidate>& candidates,
-        const service::pager::paging_state& paging_state) const {
-    const auto& cursor_pk = paging_state.get_partition_key();
-    for (size_t i = 0; i < candidates.size(); i++) {
-        auto pk = partition_key::from_single_value(*candidates[i].view_schema, candidates[i].value);
-        if (pk.representation() == cursor_pk.representation()) {
-            return i;
-        }
-    }
-    // Shouldn't happen given the collision guard in build_index_candidates; fall
-    // back to the chosen index (candidate 0) to stay correct.
-    return 0;
 }
 
 // Note: the partitions keys returned by this function are sorted

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1552,16 +1552,36 @@ view_indexed_table_select_statement::read_posting_list(query_processor& qp,
     }));
 }
 
-// CUSTOMER-303 phase 2: read the base primary keys present in an additional
-// index's posting list, restricted to the base-token span of the current page.
-// The keys come back in base-token (view clustering) order, matching the order
-// of the candidate keys produced from the primary index, so the callers can
-// intersect the two with a single merge pass.
+// Builds the clustering-key prefix that a given base key maps to in a global
+// index's view: (computed base token, base partition key, [base clustering key]).
+// The indexed (target) column is a regular column here, so the whole base key is
+// present in the view's clustering key.
+static clustering_key_prefix make_view_clustering_prefix(const schema& base_schema, const schema& view_schema,
+        const column_definition& target_cdef, const partition_key& base_pk, const clustering_key_prefix* base_ck) {
+    std::vector<managed_bytes_view> exploded;
+    exploded.reserve(view_schema.clustering_key_size());
+    bytes token_bytes = view_schema.clustering_column_at(0).get_computation().compute_value(base_schema, base_pk);
+    exploded.push_back(bytes_view(token_bytes));
+    append_base_key_to_index_ck<partition_key>(exploded, base_pk, target_cdef);
+    if (base_ck) {
+        append_base_key_to_index_ck<clustering_key>(exploded, *base_ck, target_cdef);
+    }
+    return clustering_key_prefix::from_range(exploded);
+}
+
+// CUSTOMER-303 phase 2/4: read the base primary keys present in an additional
+// index's posting list. The caller passes clustering ranges that target exactly
+// the current page's candidate base keys (phase 4), so the storage engine's
+// promoted (row) index skips over the posting-list entries between candidates
+// instead of scanning the whole token span - the "skip list" optimisation from
+// idea #2, using the SSTable index we already have. The keys come back in
+// base-token (view clustering) order, matching the candidate order, so the
+// callers can intersect the two with a single merge pass.
 future<coordinator_result<std::vector<primary_key>>>
 view_indexed_table_select_statement::read_intersection_index_keys(
         query_processor& qp, service::query_state& state, const query_options& options,
         schema_ptr view_schema, const bytes& indexed_value,
-        const partition_key& first_base_pk, const partition_key& last_base_pk,
+        std::vector<query::clustering_range> clustering_ranges,
         bool include_base_clustering_key) const {
     using ret = coordinator_result<std::vector<primary_key>>;
     auto now = gc_clock::now();
@@ -1572,21 +1592,8 @@ view_indexed_table_select_statement::read_intersection_index_keys(
     auto view_dk = dht::decorate_key(*view_schema, view_pk);
     dht::partition_range_vector partition_ranges { dht::partition_range::make_singular(view_dk) };
 
-    // Restrict the read to the base-token span [token(first), token(last)] of the
-    // current page. The view's first clustering column is the computed base
-    // token, so a single-column clustering range on it bounds the scan to that
-    // token span. It is a safe *superset* of the page's candidate keys:
-    // correctness comes from the merge-intersection in the callers and from the
-    // post-filtering that runs on the base rows regardless.
-    const column_definition& token_col = view_schema->clustering_column_at(0);
-    bytes lo_token = token_col.get_computation().compute_value(*_schema, first_base_pk);
-    bytes hi_token = token_col.get_computation().compute_value(*_schema, last_base_pk);
-    auto lo_ck = clustering_key_prefix::from_single_value(*view_schema, lo_token);
-    auto hi_ck = clustering_key_prefix::from_single_value(*view_schema, hi_token);
     query::partition_slice partition_slice = partition_slice_builder(*view_schema)
-            .with_ranges({query::clustering_range::make(
-                    query::clustering_range::bound(std::move(lo_ck), true),
-                    query::clustering_range::bound(std::move(hi_ck), true))})
+            .with_ranges(std::move(clustering_ranges))
             .build();
 
     auto cmd = ::make_lw_shared<query::read_command>(
@@ -1636,8 +1643,10 @@ view_indexed_table_select_statement::read_intersection_index_keys(
     co_return ret(std::move(keys));
 }
 
-// CUSTOMER-303 phase 2: shrink the whole-partition candidates from the primary
-// index to those that also appear in every additional index's posting list.
+// CUSTOMER-303 phase 2/4: shrink the whole-partition candidates from the primary
+// index to those that also appear in every additional index's posting list. The
+// other posting lists are probed only at the candidates' base keys (phase 4), so
+// the promoted index skips the entries in between.
 future<coordinator_result<dht::partition_range_vector>>
 view_indexed_table_select_statement::intersect_partition_ranges(
         query_processor& qp, service::query_state& state, const query_options& options,
@@ -1649,11 +1658,19 @@ view_indexed_table_select_statement::intersect_partition_ranges(
     auto candidate_dk = [] (const dht::partition_range& r) -> dht::decorated_key {
         return r.start()->value().as_decorated_key();
     };
-    const partition_key first_pk = candidate_dk(candidates.front()).key();
-    const partition_key last_pk = candidate_dk(candidates.back()).key();
     for (const auto& other : others) {
+        const column_definition* target_cdef = _schema->get_column_definition(to_bytes(other.index.target_column()));
+        // One singular clustering range per candidate partition, targeting that
+        // base partition in the other index's view (any base clustering key).
+        std::vector<query::clustering_range> ranges;
+        ranges.reserve(candidates.size());
+        for (const auto& cand : candidates) {
+            auto dk = candidate_dk(cand);
+            ranges.push_back(query::clustering_range::make_singular(
+                    make_view_clustering_prefix(*_schema, *other.view_schema, *target_cdef, dk.key(), nullptr)));
+        }
         auto keys = co_await read_intersection_index_keys(qp, state, options, other.view_schema, other.value,
-                first_pk, last_pk, /*include_base_clustering_key=*/false);
+                std::move(ranges), /*include_base_clustering_key=*/false);
         if (!keys) {
             co_return ret(std::move(keys).as_failure());
         }
@@ -1679,8 +1696,10 @@ view_indexed_table_select_statement::intersect_partition_ranges(
     co_return ret(std::move(candidates));
 }
 
-// CUSTOMER-303 phase 2: shrink the individual-row candidates from the primary
-// index to those that also appear in every additional index's posting list.
+// CUSTOMER-303 phase 2/4: shrink the individual-row candidates from the primary
+// index to those that also appear in every additional index's posting list. The
+// other posting lists are probed only at the candidates' base keys (phase 4), so
+// the promoted index skips the entries in between.
 future<coordinator_result<std::vector<primary_key>>>
 view_indexed_table_select_statement::intersect_primary_keys(
         query_processor& qp, service::query_state& state, const query_options& options,
@@ -1695,11 +1714,18 @@ view_indexed_table_select_statement::intersect_primary_keys(
         }
         return clustering_key_prefix::tri_compare(*_schema)(a.clustering, b.clustering);
     };
-    const partition_key first_pk = candidates.front().partition.key();
-    const partition_key last_pk = candidates.back().partition.key();
     for (const auto& other : others) {
+        const column_definition* target_cdef = _schema->get_column_definition(to_bytes(other.index.target_column()));
+        // One singular clustering range per candidate row, targeting that exact
+        // base row (partition + clustering key) in the other index's view.
+        std::vector<query::clustering_range> ranges;
+        ranges.reserve(candidates.size());
+        for (const auto& cand : candidates) {
+            ranges.push_back(query::clustering_range::make_singular(
+                    make_view_clustering_prefix(*_schema, *other.view_schema, *target_cdef, cand.partition.key(), &cand.clustering)));
+        }
         auto keys = co_await read_intersection_index_keys(qp, state, options, other.view_schema, other.value,
-                first_pk, last_pk, /*include_base_clustering_key=*/true);
+                std::move(ranges), /*include_base_clustering_key=*/true);
         if (!keys) {
             co_return ret(std::move(keys).as_failure());
         }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1311,24 +1311,46 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
     // wire-format change. `candidates`/`others` live for the whole call (this is a
     // coroutine), so the `primary` pointer and `others` reference threaded below
     // stay valid across every co_await.
+    // When the cost-chosen driver already matches at most this many rows, reading
+    // those base rows and post-filtering is cheaper than the extra (sequential)
+    // index reads the intersection would add - so we skip the intersection and
+    // just use the driver as a plain index. This mirrors PostgreSQL preferring a
+    // plain index scan over a BitmapAnd for a selective-enough index. The value is
+    // a heuristic (a candidate for the statistics-based cost model follow-up).
+    constexpr uint64_t intersection_skip_max_driver_size = 100;
     std::vector<index_candidate> candidates = build_index_candidates(options);
     const index_candidate* primary = nullptr;
     std::vector<index_candidate> others;
     if (!candidates.empty()) {
         size_t primary_idx = 0;
+        bool skip_intersection = false;
         if (options.get_paging_state()) {
             primary_idx = recover_primary_index(candidates, *options.get_paging_state());
         } else {
-            primary_idx = co_await choose_primary_index(qp, state, options, candidates);
+            auto [idx, driver_size] = co_await choose_primary_index(qp, state, options, candidates);
+            primary_idx = idx;
+            skip_intersection = driver_size <= intersection_skip_max_driver_size;
         }
         primary = &candidates[primary_idx];
-        for (size_t i = 0; i < candidates.size(); i++) {
-            if (i != primary_idx) {
-                others.push_back(candidates[i]);
+        if (skip_intersection) {
+            // Correct regardless: post-filtering applies the other indexed
+            // restrictions to the base rows. Skipping only changes which base
+            // rows are read, never the result. Paging stays consistent because
+            // the driver is unchanged; a later page (no probe) may intersect, and
+            // mixing is still correct - the driver keys are processed in order and
+            // never skipped.
+            tracing::trace(state.get_trace_state(),
+                    "primary index is {}; selective enough, skipping posting-list intersection",
+                    primary->index.metadata().name());
+        } else {
+            for (size_t i = 0; i < candidates.size(); i++) {
+                if (i != primary_idx) {
+                    others.push_back(candidates[i]);
+                }
             }
+            tracing::trace(state.get_trace_state(), "Intersecting {} indexes; primary index is {}",
+                    candidates.size(), primary->index.metadata().name());
         }
-        tracing::trace(state.get_trace_state(), "Intersecting {} indexes; primary index is {}",
-                candidates.size(), primary->index.metadata().name());
     }
 
     // Aggregated and paged filtering needs to aggregate the results from all pages
@@ -1793,7 +1815,7 @@ view_indexed_table_select_statement::build_index_candidates(const query_options&
 // CUSTOMER-303 phase 3: probe each candidate's posting-list size (bounded, so a
 // huge list costs no more than reading the cap) and return the index of the
 // smallest - the one that should drive the scan and paging.
-future<size_t>
+future<std::pair<size_t, uint64_t>>
 view_indexed_table_select_statement::choose_primary_index(query_processor& qp, service::query_state& state,
         const query_options& options, const std::vector<index_candidate>& candidates) const {
     constexpr uint64_t probe_cap = 10001;
@@ -1828,7 +1850,7 @@ view_indexed_table_select_statement::choose_primary_index(query_processor& qp, s
             best = i;
         }
     }
-    co_return best;
+    co_return std::pair<size_t, uint64_t>(best, best_size);
 }
 
 // CUSTOMER-303 phase 3: recover which candidate drove paging on the previous

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1315,9 +1315,10 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
     // those base rows and post-filtering is cheaper than the extra (sequential)
     // index reads the intersection would add - so we skip the intersection and
     // just use the driver as a plain index. This mirrors PostgreSQL preferring a
-    // plain index scan over a BitmapAnd for a selective-enough index. The value is
-    // a heuristic (a candidate for the statistics-based cost model follow-up).
-    constexpr uint64_t intersection_skip_max_driver_size = 100;
+    // plain index scan over a BitmapAnd for a selective-enough index. The
+    // threshold is the (live-updatable) secondary_index_intersection_skip_max_rows
+    // scylla.yaml option; 0 disables the skip (always intersect).
+    const uint64_t intersection_skip_max_driver_size = qp.get_cql_config().secondary_index_intersection_skip_max_rows.get();
     std::vector<index_candidate> candidates = build_index_candidates(options);
     const index_candidate* primary = nullptr;
     std::vector<index_candidate> others;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -708,8 +708,13 @@ view_indexed_table_select_statement::do_execute_base_query(
         service::query_state& state,
         const query_options& options,
         gc_clock::time_point now,
-        lw_shared_ptr<const service::pager::paging_state> paging_state) const {
+        lw_shared_ptr<const service::pager::paging_state> paging_state,
+        const index_candidate* primary) const {
     using value_type = std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>;
+    // The paging cursor is expressed in the primary index's view (CUSTOMER-303
+    // phase 3), so translate it back to base keys using that view's schema.
+    const secondary_index::index& index = primary ? primary->index : _index;
+    const schema& view_schema = primary ? *primary->view_schema : *_view_schema;
     auto cmd = prepare_command_for_base_query(qp, options, state, now, bool(paging_state));
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
     uint32_t queried_ranges_count = partition_ranges.size();
@@ -730,7 +735,7 @@ view_indexed_table_select_statement::do_execute_base_query(
         base_query_state(const base_query_state&) = delete;
     };
 
-    const column_definition* target_cdef = _schema->get_column_definition(to_bytes(_index.target_column()));
+    const column_definition* target_cdef = _schema->get_column_definition(to_bytes(index.target_column()));
     if (!target_cdef) {
         throw exceptions::invalid_request_exception("Indexed column not found in schema");
     }
@@ -752,11 +757,11 @@ view_indexed_table_select_statement::do_execute_base_query(
             auto old_paging_state = options.get_paging_state();
             if (old_paging_state && concurrency == 1) {
                 auto base_pk = generate_base_key_from_index_pk<partition_key>(old_paging_state->get_partition_key(),
-                        old_paging_state->get_clustering_key(), *_schema, *_view_schema);
+                        old_paging_state->get_clustering_key(), *_schema, view_schema);
                 auto row_ranges = command->slice.default_row_ranges();
                 if (old_paging_state->get_clustering_key() && _schema->clustering_key_size() > 0 && !target_cdef->is_static()) {
                     auto base_ck = generate_base_key_from_index_pk<clustering_key>(old_paging_state->get_partition_key(),
-                            old_paging_state->get_clustering_key(), *_schema, *_view_schema);
+                            old_paging_state->get_clustering_key(), *_schema, view_schema);
 
                     query::trim_clustering_row_ranges_to(*_schema, row_ranges, base_ck);
                     command->slice.set_range(*_schema, base_pk, row_ranges);
@@ -803,11 +808,12 @@ view_indexed_table_select_statement::execute_base_query(
         service::query_state& state,
         const query_options& options,
         gc_clock::time_point now,
-        lw_shared_ptr<const service::pager::paging_state> paging_state) const {
-    return do_execute_base_query(qp, std::move(partition_ranges), state, options, now, paging_state).then(wrap_result_to_error_message(
-            [this, &state, &options, now, paging_state = std::move(paging_state), internal_page_size = qp.get_cql_config().select_internal_page_size.get()] (std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>> result_and_cmd) {
+        lw_shared_ptr<const service::pager::paging_state> paging_state,
+        const index_candidate* primary) const {
+    return do_execute_base_query(qp, std::move(partition_ranges), state, options, now, paging_state, primary).then(wrap_result_to_error_message(
+            [this, &state, &options, now, paging_state = std::move(paging_state), primary, internal_page_size = qp.get_cql_config().select_internal_page_size.get()] (std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>> result_and_cmd) {
         auto&& [result, cmd] = result_and_cmd;
-        return process_base_query_results(std::move(result), std::move(cmd), state, options, now, std::move(paging_state), internal_page_size);
+        return process_base_query_results(std::move(result), std::move(cmd), state, options, now, std::move(paging_state), internal_page_size, primary);
     }));
 }
 
@@ -818,7 +824,11 @@ view_indexed_table_select_statement::do_execute_base_query(
         service::query_state& state,
         const query_options& options,
         gc_clock::time_point now,
-        lw_shared_ptr<const service::pager::paging_state> paging_state) const {
+        lw_shared_ptr<const service::pager::paging_state> paging_state,
+        const index_candidate* primary) const {
+    // Reads base rows for the given primary keys directly, so it is independent of
+    // which index produced them (`primary` is unused here, kept for signature
+    // symmetry with the partition-range overload).
     using value_type = std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>;
     auto cmd = prepare_command_for_base_query(qp, options, state, now, bool(paging_state));
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
@@ -883,11 +893,12 @@ view_indexed_table_select_statement::execute_base_query(
         service::query_state& state,
         const query_options& options,
         gc_clock::time_point now,
-        lw_shared_ptr<const service::pager::paging_state> paging_state) const {
-    return do_execute_base_query(qp, std::move(primary_keys), state, options, now, paging_state).then(wrap_result_to_error_message(
-            [this, &state, &options, now, paging_state = std::move(paging_state), internal_page_size = qp.get_cql_config().select_internal_page_size.get()] (std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>> result_and_cmd){
+        lw_shared_ptr<const service::pager::paging_state> paging_state,
+        const index_candidate* primary) const {
+    return do_execute_base_query(qp, std::move(primary_keys), state, options, now, paging_state, primary).then(wrap_result_to_error_message(
+            [this, &state, &options, now, paging_state = std::move(paging_state), primary, internal_page_size = qp.get_cql_config().select_internal_page_size.get()] (std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>> result_and_cmd){
         auto&& [result, cmd] = result_and_cmd;
-        return process_base_query_results(std::move(result), std::move(cmd), state, options, now, std::move(paging_state), internal_page_size);
+        return process_base_query_results(std::move(result), std::move(cmd), state, options, now, std::move(paging_state), internal_page_size, primary);
     }));
 }
 
@@ -952,10 +963,11 @@ view_indexed_table_select_statement::process_base_query_results(
         const query_options& options,
         gc_clock::time_point now,
         lw_shared_ptr<const service::pager::paging_state> paging_state,
-        uint32_t internal_page_size) const
+        uint32_t internal_page_size,
+        const index_candidate* primary) const
 {
     if (paging_state) {
-        paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options, internal_page_size);
+        paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options, internal_page_size, primary);
         _selection->get_result_metadata()->maybe_set_paging_state(std::move(paging_state));
     }
     return process_results(std::move(results), std::move(cmd), options, now);
@@ -1162,8 +1174,14 @@ bytes view_indexed_table_select_statement::compute_idx_token(const partition_key
 }
 
 lw_shared_ptr<const service::pager::paging_state> view_indexed_table_select_statement::generate_view_paging_state_from_base_query_results(lw_shared_ptr<const service::pager::paging_state> paging_state,
-        const foreign_ptr<lw_shared_ptr<query::result>>& results, service::query_state& state, const query_options& options, uint32_t internal_page_size) const {
-    const column_definition* cdef = _schema->get_column_definition(to_bytes(_index.target_column()));
+        const foreign_ptr<lw_shared_ptr<query::result>>& results, service::query_state& state, const query_options& options, uint32_t internal_page_size,
+        const index_candidate* primary) const {
+    // With a runtime-chosen primary (CUSTOMER-303 phase 3) the paging cursor lives
+    // in that index's (global) view; otherwise use the statement's own index.
+    const secondary_index::index& index = primary ? primary->index : _index;
+    const schema& view_schema = primary ? *primary->view_schema : *_view_schema;
+    const bool is_local = !primary && _index.metadata().local();
+    const column_definition* cdef = _schema->get_column_definition(to_bytes(index.target_column()));
     if (!cdef) {
         throw exceptions::invalid_request_exception("Indexed column not found in schema");
     }
@@ -1177,21 +1195,21 @@ lw_shared_ptr<const service::pager::paging_state> view_indexed_table_select_stat
     auto& last_base_pk = last_pos.partition;
     auto* last_base_ck = last_pos.position.has_key() ? &last_pos.position.key() : nullptr;
 
-    bytes_opt indexed_column_value = _restrictions->value_for_index_partition_key(options);
+    bytes_opt indexed_column_value = primary ? bytes_opt(primary->value) : _restrictions->value_for_index_partition_key(options);
 
     auto index_pk = [&]() {
-        if (_index.metadata().local()) {
+        if (is_local) {
             return last_base_pk;
         } else {
-            return partition_key::from_single_value(*_view_schema, *indexed_column_value);
+            return partition_key::from_single_value(view_schema, *indexed_column_value);
         }
     }();
 
     std::vector<managed_bytes_view> exploded_index_ck;
-    exploded_index_ck.reserve(_view_schema->clustering_key_size());
+    exploded_index_ck.reserve(view_schema.clustering_key_size());
 
     bytes token_bytes;
-    if (_index.metadata().local()) {
+    if (is_local) {
         exploded_index_ck.push_back(bytes_view(*indexed_column_value));
     } else {
         token_bytes = compute_idx_token(last_base_pk);
@@ -1203,8 +1221,8 @@ lw_shared_ptr<const service::pager::paging_state> view_indexed_table_select_stat
     }
 
     auto index_ck = clustering_key::from_range(std::move(exploded_index_ck));
-    if (partition_key::tri_compare(*_view_schema)(paging_state->get_partition_key(), index_pk) == 0
-            && (!paging_state->get_clustering_key() || clustering_key::prefix_equal_tri_compare(*_view_schema)(*paging_state->get_clustering_key(), index_ck) == 0)) {
+    if (partition_key::tri_compare(view_schema)(paging_state->get_partition_key(), index_pk) == 0
+            && (!paging_state->get_clustering_key() || clustering_key::prefix_equal_tri_compare(view_schema)(*paging_state->get_clustering_key(), index_ck) == 0)) {
         return paging_state;
     }
 
@@ -1285,6 +1303,34 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
         }
     }
 
+    // CUSTOMER-303 phase 3: when several equality-indexed columns can be
+    // intersected, pick the one with the smallest posting list to drive the scan
+    // and paging. On the first page we probe posting-list sizes; on later pages we
+    // recover the same choice from the paging cursor (whose partition key is the
+    // chosen index's indexed value), so paging stays consistent with no
+    // wire-format change. `candidates`/`others` live for the whole call (this is a
+    // coroutine), so the `primary` pointer and `others` reference threaded below
+    // stay valid across every co_await.
+    std::vector<index_candidate> candidates = build_index_candidates(options);
+    const index_candidate* primary = nullptr;
+    std::vector<index_candidate> others;
+    if (!candidates.empty()) {
+        size_t primary_idx = 0;
+        if (options.get_paging_state()) {
+            primary_idx = recover_primary_index(candidates, *options.get_paging_state());
+        } else {
+            primary_idx = co_await choose_primary_index(qp, state, options, candidates);
+        }
+        primary = &candidates[primary_idx];
+        for (size_t i = 0; i < candidates.size(); i++) {
+            if (i != primary_idx) {
+                others.push_back(candidates[i]);
+            }
+        }
+        tracing::trace(state.get_trace_state(), "Intersecting {} indexes; primary index is {}",
+                candidates.size(), primary->index.metadata().name());
+    }
+
     // Aggregated and paged filtering needs to aggregate the results from all pages
     // in order to avoid returning partial per-page results (issue #4540).
     // It's a little bit more complicated than regular aggregation, because each paging state
@@ -1320,12 +1366,12 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
 
             if (whole_partitions || partition_slices) {
                 tracing::trace(state.get_trace_state(), "Consulting index {} for a single slice of keys, aggregation query", _index.metadata().name());
-                auto result_partition_ranges_and_paging_state = co_await find_index_partition_ranges(qp, state, *internal_options);
+                auto result_partition_ranges_and_paging_state = co_await find_index_partition_ranges(qp, state, *internal_options, primary, others);
                 if (result_partition_ranges_and_paging_state.has_error()) {
                     co_return failed_result_to_result_message(std::move(result_partition_ranges_and_paging_state));
                 }
                 auto&& [partition_ranges, paging_state] = result_partition_ranges_and_paging_state.assume_value();
-                auto result_results_and_cmd = co_await do_execute_base_query(qp, std::move(partition_ranges), state, *internal_options, now, paging_state);
+                auto result_results_and_cmd = co_await do_execute_base_query(qp, std::move(partition_ranges), state, *internal_options, now, paging_state, primary);
                 if (result_results_and_cmd.has_error()) {
                     co_return failed_result_to_result_message(std::move(result_results_and_cmd));
                 }
@@ -1333,12 +1379,12 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
                 stop = consume_results(std::move(results), std::move(cmd), std::move(paging_state));
             } else {
                 tracing::trace(state.get_trace_state(), "Consulting index {} for a list of rows containing keys, aggregation query", _index.metadata().name());
-                auto result_primary_keys_paging_state = co_await find_index_clustering_rows(qp, state, *internal_options);
+                auto result_primary_keys_paging_state = co_await find_index_clustering_rows(qp, state, *internal_options, primary, others);
                 if (result_primary_keys_paging_state.has_error()) {
                     co_return failed_result_to_result_message(std::move(result_primary_keys_paging_state));
                 }
                 auto&& [primary_keys, paging_state] = result_primary_keys_paging_state.assume_value();
-                auto result_results_cmd = co_await this->do_execute_base_query(qp, std::move(primary_keys), state, *internal_options, now, paging_state);
+                auto result_results_cmd = co_await this->do_execute_base_query(qp, std::move(primary_keys), state, *internal_options, now, paging_state, primary);
                 if (result_results_cmd.has_error()) {
                     co_return failed_result_to_result_message(std::move(result_results_cmd));
                 }
@@ -1358,25 +1404,25 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
         tracing::trace(state.get_trace_state(), "Consulting index {} for a single slice of keys", _index.metadata().name());
         // In this case, can use our normal query machinery, which retrieves
         // entire partitions or the same slice for many partitions.
-        coordinator_result<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>> result = co_await find_index_partition_ranges(qp, state, options);
+        coordinator_result<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>> result = co_await find_index_partition_ranges(qp, state, options, primary, others);
         if (result.has_error()) {
             co_return failed_result_to_result_message(std::move(result));
         }
         {
             auto&& [partition_ranges, paging_state] = result.assume_value();
-            co_return co_await this->execute_base_query(qp, std::move(partition_ranges), state, options, now, std::move(paging_state));
+            co_return co_await this->execute_base_query(qp, std::move(partition_ranges), state, options, now, std::move(paging_state), primary);
         }
     } else {
         tracing::trace(state.get_trace_state(), "Consulting index {} for a list of rows containing keys", _index.metadata().name());
         // In this case, we need to retrieve a list of rows (not entire
         // partitions) and then retrieve those specific rows.
-        coordinator_result<std::tuple<std::vector<primary_key>, lw_shared_ptr<const service::pager::paging_state>>> result = co_await find_index_clustering_rows(qp, state, options);
+        coordinator_result<std::tuple<std::vector<primary_key>, lw_shared_ptr<const service::pager::paging_state>>> result = co_await find_index_clustering_rows(qp, state, options, primary, others);
         if (result.has_error()) {
             co_return failed_result_to_result_message(std::move(result));
         }
         {
             auto&& [primary_keys, paging_state] = result.assume_value();
-            co_return co_await this->execute_base_query(qp, std::move(primary_keys), state, options, now, std::move(paging_state));
+            co_return co_await this->execute_base_query(qp, std::move(primary_keys), state, options, now, std::move(paging_state), primary);
         }
     }
 }
@@ -1437,14 +1483,31 @@ view_indexed_table_select_statement::read_posting_list(query_processor& qp,
                   service::query_state& state,
                   gc_clock::time_point now,
                   db::timeout_clock::time_point timeout,
-                  bool include_base_clustering_key) const
+                  bool include_base_clustering_key,
+                  const index_candidate* primary) const
 {
-    dht::partition_range_vector partition_ranges = _get_partition_ranges_for_posting_list(options);
-    auto partition_slice = _get_partition_slice_for_posting_list(options);
+    // When a runtime-chosen primary is supplied (CUSTOMER-303 phase 3), read that
+    // index's posting list: partition = its indexed value, clustering slice = the
+    // base-partition-key-derived ranges (identical for every global index view, so
+    // reusing the chosen index's ranges is correct). Otherwise use the statement's
+    // own posting-list accessors (the unchanged single-index path).
+    schema_ptr view_schema = primary ? primary->view_schema : _view_schema;
+    dht::partition_range_vector partition_ranges;
+    query::partition_slice partition_slice = [&] {
+        if (primary) {
+            auto pk = partition_key::from_single_value(*view_schema, primary->value);
+            partition_ranges.push_back(dht::partition_range::make_singular(dht::decorate_key(*view_schema, pk)));
+            return partition_slice_builder(*view_schema)
+                    .with_ranges(_restrictions->get_global_index_clustering_ranges(options))
+                    .build();
+        }
+        partition_ranges = _get_partition_ranges_for_posting_list(options);
+        return _get_partition_slice_for_posting_list(options);
+    }();
 
     auto cmd = ::make_lw_shared<query::read_command>(
-            _view_schema->id(),
-            _view_schema->version(),
+            view_schema->id(),
+            view_schema->version(),
             partition_slice,
             qp.proxy().get_max_result_size(partition_slice),
             query::tombstone_limit(qp.proxy().get_tombstone_limit()),
@@ -1458,29 +1521,29 @@ view_indexed_table_select_statement::read_posting_list(query_processor& qp,
 
     std::vector<const column_definition*> columns;
     for (const column_definition& cdef : _schema->partition_key_columns()) {
-        columns.emplace_back(_view_schema->get_column_definition(cdef.name()));
+        columns.emplace_back(view_schema->get_column_definition(cdef.name()));
     }
     if (include_base_clustering_key) {
         for (const column_definition& cdef : _schema->clustering_key_columns()) {
-            columns.emplace_back(_view_schema->get_column_definition(cdef.name()));
+            columns.emplace_back(view_schema->get_column_definition(cdef.name()));
         }
     }
-    auto selection = selection::selection::for_columns(_view_schema, columns);
+    auto selection = selection::selection::for_columns(view_schema, columns);
 
     int32_t page_size = options.get_page_size();
-    if (page_size <= 0 || !service::pager::query_pagers::may_need_paging(*_view_schema, page_size, *cmd, partition_ranges)) {
-        return qp.proxy().query_result(_view_schema, cmd, std::move(partition_ranges), options.get_consistency(), {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()})
-        .then(utils::result_wrap([this, now, &options, selection = std::move(selection), partition_slice = std::move(partition_slice)] (service::storage_proxy::coordinator_query_result qr)
+    if (page_size <= 0 || !service::pager::query_pagers::may_need_paging(*view_schema, page_size, *cmd, partition_ranges)) {
+        return qp.proxy().query_result(view_schema, cmd, std::move(partition_ranges), options.get_consistency(), {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()})
+        .then(utils::result_wrap([view_schema, now, &options, selection = std::move(selection), partition_slice = std::move(partition_slice)] (service::storage_proxy::coordinator_query_result qr)
                 -> coordinator_result<::shared_ptr<cql_transport::messages::result_message::rows>> {
             cql3::selection::result_set_builder builder(*selection, now, &options);
             query::result_view::consume(*qr.query_result,
                                         std::move(partition_slice),
-                                        cql3::selection::result_set_builder::visitor(builder, *_view_schema, *selection));
+                                        cql3::selection::result_set_builder::visitor(builder, *view_schema, *selection));
             return ::make_shared<cql_transport::messages::result_message::rows>(result(builder.build()));
         }));
     }
 
-    auto p = service::pager::query_pagers::pager(qp.proxy(), _view_schema, selection,
+    auto p = service::pager::query_pagers::pager(qp.proxy(), view_schema, selection,
             state, options, cmd, std::move(partition_ranges), nullptr);
     return p->fetch_page_result(options.get_page_size(), now, timeout).then(utils::result_wrap([p = std::move(p)] (std::unique_ptr<cql3::result_set> rs)
             -> coordinator_result<::shared_ptr<cql_transport::messages::result_message::rows>> {
@@ -1578,9 +1641,9 @@ view_indexed_table_select_statement::read_intersection_index_keys(
 future<coordinator_result<dht::partition_range_vector>>
 view_indexed_table_select_statement::intersect_partition_ranges(
         query_processor& qp, service::query_state& state, const query_options& options,
-        dht::partition_range_vector candidates) const {
+        dht::partition_range_vector candidates, const std::vector<index_candidate>& others) const {
     using ret = coordinator_result<dht::partition_range_vector>;
-    if (_intersection_indexes.empty() || candidates.empty()) {
+    if (others.empty() || candidates.empty()) {
         co_return ret(std::move(candidates));
     }
     auto candidate_dk = [] (const dht::partition_range& r) -> dht::decorated_key {
@@ -1588,14 +1651,8 @@ view_indexed_table_select_statement::intersect_partition_ranges(
     };
     const partition_key first_pk = candidate_dk(candidates.front()).key();
     const partition_key last_pk = candidate_dk(candidates.back()).key();
-    for (size_t i = 0; i < _intersection_indexes.size(); i++) {
-        const schema_ptr& view_schema = _intersection_indexes[i].second;
-        bytes_opt value = _restrictions->value_for_intersection_index(i, options);
-        if (!value) {
-            // e.g. the indexed column is restricted to NULL: nothing matches.
-            co_return ret(dht::partition_range_vector{});
-        }
-        auto keys = co_await read_intersection_index_keys(qp, state, options, view_schema, *value,
+    for (const auto& other : others) {
+        auto keys = co_await read_intersection_index_keys(qp, state, options, other.view_schema, other.value,
                 first_pk, last_pk, /*include_base_clustering_key=*/false);
         if (!keys) {
             co_return ret(std::move(keys).as_failure());
@@ -1627,9 +1684,9 @@ view_indexed_table_select_statement::intersect_partition_ranges(
 future<coordinator_result<std::vector<primary_key>>>
 view_indexed_table_select_statement::intersect_primary_keys(
         query_processor& qp, service::query_state& state, const query_options& options,
-        std::vector<primary_key> candidates) const {
+        std::vector<primary_key> candidates, const std::vector<index_candidate>& others) const {
     using ret = coordinator_result<std::vector<primary_key>>;
-    if (_intersection_indexes.empty() || candidates.empty()) {
+    if (others.empty() || candidates.empty()) {
         co_return ret(std::move(candidates));
     }
     auto cmp = [this] (const primary_key& a, const primary_key& b) -> std::strong_ordering {
@@ -1640,13 +1697,8 @@ view_indexed_table_select_statement::intersect_primary_keys(
     };
     const partition_key first_pk = candidates.front().partition.key();
     const partition_key last_pk = candidates.back().partition.key();
-    for (size_t i = 0; i < _intersection_indexes.size(); i++) {
-        const schema_ptr& view_schema = _intersection_indexes[i].second;
-        bytes_opt value = _restrictions->value_for_intersection_index(i, options);
-        if (!value) {
-            co_return ret(std::vector<primary_key>{});
-        }
-        auto keys = co_await read_intersection_index_keys(qp, state, options, view_schema, *value,
+    for (const auto& other : others) {
+        auto keys = co_await read_intersection_index_keys(qp, state, options, other.view_schema, other.value,
                 first_pk, last_pk, /*include_base_clustering_key=*/true);
         if (!keys) {
             co_return ret(std::move(keys).as_failure());
@@ -1671,12 +1723,113 @@ view_indexed_table_select_statement::intersect_primary_keys(
     co_return ret(std::move(candidates));
 }
 
+// CUSTOMER-303 phase 3: gather the equality-indexed candidate columns for this
+// query (chosen index + intersection indexes) with their posting-list partition
+// values solved from the bound parameters. Returns empty when cost-based
+// intersection does not apply.
+std::vector<view_indexed_table_select_statement::index_candidate>
+view_indexed_table_select_statement::build_index_candidates(const query_options& options) const {
+    // Only for the global-index intersection case established at prepare time.
+    if (_intersection_indexes.empty() || _index.metadata().local()) {
+        return {};
+    }
+    std::vector<index_candidate> candidates;
+    bytes_opt chosen_value = _restrictions->value_for_index_partition_key(options);
+    if (!chosen_value) {
+        return {};
+    }
+    candidates.push_back({_index, _view_schema, std::move(*chosen_value)});
+    for (size_t i = 0; i < _intersection_indexes.size(); i++) {
+        bytes_opt v = _restrictions->value_for_intersection_index(i, options);
+        if (!v) {
+            // A column restricted to NULL matches nothing; leave it to the normal
+            // path (which handles the empty result correctly).
+            return {};
+        }
+        candidates.push_back({_intersection_indexes[i].first, _intersection_indexes[i].second, std::move(*v)});
+    }
+    // The primary is recovered on later pages by matching the paging cursor's
+    // (view) partition key against each candidate's view partition key. If two
+    // candidates would yield the same view partition key, that recovery would be
+    // ambiguous, so disable cost-based selection and fall back to the chosen index.
+    for (size_t i = 0; i < candidates.size(); i++) {
+        auto pk_i = partition_key::from_single_value(*candidates[i].view_schema, candidates[i].value);
+        for (size_t k = i + 1; k < candidates.size(); k++) {
+            auto pk_k = partition_key::from_single_value(*candidates[k].view_schema, candidates[k].value);
+            if (pk_i.representation() == pk_k.representation()) {
+                return {};
+            }
+        }
+    }
+    return candidates;
+}
+
+// CUSTOMER-303 phase 3: probe each candidate's posting-list size (bounded, so a
+// huge list costs no more than reading the cap) and return the index of the
+// smallest - the one that should drive the scan and paging.
+future<size_t>
+view_indexed_table_select_statement::choose_primary_index(query_processor& qp, service::query_state& state,
+        const query_options& options, const std::vector<index_candidate>& candidates) const {
+    constexpr uint64_t probe_cap = 10001;
+    auto now = gc_clock::now();
+    auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
+    size_t best = 0;
+    uint64_t best_size = std::numeric_limits<uint64_t>::max();
+    for (size_t i = 0; i < candidates.size(); i++) {
+        const auto& c = candidates[i];
+        auto pk = partition_key::from_single_value(*c.view_schema, c.value);
+        dht::partition_range_vector ranges { dht::partition_range::make_singular(dht::decorate_key(*c.view_schema, pk)) };
+        auto slice = partition_slice_builder(*c.view_schema)
+                .with_ranges(_restrictions->get_global_index_clustering_ranges(options))
+                .build();
+        auto cmd = ::make_lw_shared<query::read_command>(
+                c.view_schema->id(), c.view_schema->version(), slice,
+                qp.proxy().get_max_result_size(slice),
+                query::tombstone_limit(qp.proxy().get_tombstone_limit()),
+                query::row_limit(probe_cap), query::partition_limit(query::max_partitions),
+                now, tracing::make_trace_info(state.get_trace_state()),
+                query_id::create_null_id(), query::is_first_page::no, options.get_timestamp(state));
+        auto rqr = co_await qp.proxy().query_result(c.view_schema, cmd, std::move(ranges),
+                options.get_consistency(),
+                {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()});
+        if (!rqr) {
+            // Best-effort probe: on error just skip this candidate.
+            continue;
+        }
+        uint64_t sz = rqr.value().query_result->row_count().value_or(0);
+        if (sz < best_size) {
+            best_size = sz;
+            best = i;
+        }
+    }
+    co_return best;
+}
+
+// CUSTOMER-303 phase 3: recover which candidate drove paging on the previous
+// page. The paging cursor's partition key is the primary index's view partition
+// key (= its indexed value), so match it against the candidates.
+size_t view_indexed_table_select_statement::recover_primary_index(const std::vector<index_candidate>& candidates,
+        const service::pager::paging_state& paging_state) const {
+    const auto& cursor_pk = paging_state.get_partition_key();
+    for (size_t i = 0; i < candidates.size(); i++) {
+        auto pk = partition_key::from_single_value(*candidates[i].view_schema, candidates[i].value);
+        if (pk.representation() == cursor_pk.representation()) {
+            return i;
+        }
+    }
+    // Shouldn't happen given the collision guard in build_index_candidates; fall
+    // back to the chosen index (candidate 0) to stay correct.
+    return 0;
+}
+
 // Note: the partitions keys returned by this function are sorted
 // in token order. See issue #3423.
 future<coordinator_result<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>>>
 view_indexed_table_select_statement::find_index_partition_ranges(query_processor& qp,
                                              service::query_state& state,
-                                             const query_options& options) const
+                                             const query_options& options,
+                                             const index_candidate* primary,
+                                             const std::vector<index_candidate>& others) const
 {
     using value_type = std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>;
     auto now = gc_clock::now();
@@ -1702,8 +1855,9 @@ view_indexed_table_select_statement::find_index_partition_ranges(query_processor
     // FIXME: Indent.
     const query_options& _options = paging_adjusted_options ? *paging_adjusted_options : options;
     const uint64_t limit = get_inner_loop_limit(get_limit(options, _limit), _selection->is_aggregate());
-    return read_posting_list(qp, _options, limit, state, now, timeout, false).then(utils::result_wrap(
-            [this, &qp, &state, &_options, max_vector_size] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
+    return read_posting_list(qp, _options, limit, state, now, timeout, false, primary).then(utils::result_wrap(
+            [this, &qp, &state, &_options, max_vector_size, primary, &others] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
+        const schema& primary_view = primary ? *primary->view_schema : *_view_schema;
         auto rs = cql3::untyped_result_set(rows);
         dht::partition_range_vector partition_ranges;
         partition_ranges.reserve(std::min(rs.size(), max_vector_size));
@@ -1716,7 +1870,7 @@ view_indexed_table_select_statement::find_index_partition_ranges(query_processor
         if (_options.get_paging_state()) {
             auto paging_state = _options.get_paging_state();
             auto base_pk = generate_base_key_from_index_pk<partition_key>(paging_state->get_partition_key(),
-                paging_state->get_clustering_key(), *_schema, *_view_schema);
+                paging_state->get_clustering_key(), *_schema, primary_view);
             last_dk = dht::decorate_key(*_schema, base_pk);
         }
         for (size_t i = 0; i < rs.size(); i++) {
@@ -1746,7 +1900,7 @@ view_indexed_table_select_statement::find_index_partition_ranges(query_processor
         // additional index's posting list. Paging is still driven by the primary
         // index (paging_state is untouched), so this only shrinks the current
         // page's candidates - which is what avoids reading the extra base rows.
-        return intersect_partition_ranges(qp, state, _options, std::move(partition_ranges)).then(
+        return intersect_partition_ranges(qp, state, _options, std::move(partition_ranges), others).then(
                 [paging_state = std::move(paging_state)] (coordinator_result<dht::partition_range_vector> res) mutable -> coordinator_result<value_type> {
             if (!res) {
                 return coordinator_result<value_type>(std::move(res).as_failure());
@@ -1760,15 +1914,21 @@ view_indexed_table_select_statement::find_index_partition_ranges(query_processor
 // Note: the partitions keys returned by this function are sorted
 // in token order. See issue #3423.
 future<coordinator_result<std::tuple<std::vector<primary_key>, lw_shared_ptr<const service::pager::paging_state>>>>
-view_indexed_table_select_statement::find_index_clustering_rows(query_processor& qp, service::query_state& state, const query_options& options) const
+view_indexed_table_select_statement::find_index_clustering_rows(query_processor& qp, service::query_state& state, const query_options& options,
+        const index_candidate* primary, const std::vector<index_candidate>& others) const
 {
     using value_type = std::tuple<std::vector<primary_key>, lw_shared_ptr<const service::pager::paging_state>>;
     auto now = gc_clock::now();
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
     const uint64_t limit = get_inner_loop_limit(get_limit(options, _limit), _selection->is_aggregate());
-    return read_posting_list(qp, options, limit, state, now, timeout, true).then(utils::result_wrap(
-            [this, &qp, &state, &options] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
+    return read_posting_list(qp, options, limit, state, now, timeout, true, primary).then(utils::result_wrap(
+            [this, &qp, &state, &options, primary, &others] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
 
+        // With a cost-based primary (phase 3) the primary is a regular-column
+        // global index; the collection-values special-casing only concerns the
+        // statement's own index and never fires in that case.
+        const secondary_index::index& index = primary ? primary->index : _index;
+        const schema& primary_view = primary ? *primary->view_schema : *_view_schema;
         auto rs = cql3::untyped_result_set(rows);
         std::vector<primary_key> primary_keys;
         primary_keys.reserve(rs.size());
@@ -1779,14 +1939,14 @@ view_indexed_table_select_statement::find_index_clustering_rows(query_processor&
         // indexing map values. We have a test for this with paging:
         // test_secondary_index.py::test_index_map_values_paging.
         std::optional<primary_key> page_start_primary_key;
-        if (_index.target_type() == cql3::statements::index_target::target_type::collection_values &&
+        if (index.target_type() == cql3::statements::index_target::target_type::collection_values &&
             options.get_paging_state()) {
             auto paging_state = options.get_paging_state();
             auto base_pk = generate_base_key_from_index_pk<partition_key>(paging_state->get_partition_key(),
-                paging_state->get_clustering_key(), *_schema, *_view_schema);
+                paging_state->get_clustering_key(), *_schema, primary_view);
             auto base_dk = dht::decorate_key(*_schema, base_pk);
             auto base_ck = generate_base_key_from_index_pk<clustering_key>(paging_state->get_partition_key(),
-                paging_state->get_clustering_key(), *_schema, *_view_schema);
+                paging_state->get_clustering_key(), *_schema, primary_view);
             page_start_primary_key = primary_key{std::move(base_dk), std::move(base_ck)};
             last_primary_key = *page_start_primary_key;
         }
@@ -1802,7 +1962,7 @@ view_indexed_table_select_statement::find_index_clustering_rows(query_processor&
             });
             auto ck = clustering_key::from_range(ck_columns);
 
-            if (_index.target_type() == cql3::statements::index_target::target_type::collection_values) {
+            if (index.target_type() == cql3::statements::index_target::target_type::collection_values) {
                 // The index on collection values is special in a way, as its' clustering key contains not only the
                 // base primary key, but also a column that holds the keys of the cells in the collection, which
                 // allows to distinguish cells with different keys but the same value.
@@ -1825,7 +1985,7 @@ view_indexed_table_select_statement::find_index_clustering_rows(query_processor&
         // additional index's posting list. Paging is still driven by the primary
         // index (paging_state is untouched); this only shrinks the current
         // page's candidate rows so we read fewer base-table rows.
-        return intersect_primary_keys(qp, state, options, std::move(primary_keys)).then(
+        return intersect_primary_keys(qp, state, options, std::move(primary_keys), others).then(
                 [paging_state = std::move(paging_state)] (coordinator_result<std::vector<primary_key>> res) mutable -> coordinator_result<value_type> {
             if (!res) {
                 return coordinator_result<value_type>(std::move(res).as_failure());

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1067,6 +1067,28 @@ view_indexed_table_select_statement::prepare(data_dictionary::database db,
 
     schema_ptr view_schema = restrictions->get_view_schema();
 
+    // CUSTOMER-303 phase 2: resolve the view schemas of the additional global
+    // indexes whose posting lists we'll intersect with the chosen index's. Only
+    // applicable when the chosen index is global (local-index paging works
+    // differently and is left on the existing single-index path).
+    std::vector<std::pair<secondary_index::index, schema_ptr>> intersection_indexes;
+    if (!index_opt->metadata().local()) {
+        for (const auto& idx : restrictions->intersection_indexes()) {
+            if (idx.metadata().local()) {
+                continue;
+            }
+            sstring idx_view_name = idx.metadata().name() + "_index";
+            try {
+                schema_ptr idx_view_schema = db.find_schema(schema->ks_name(), idx_view_name);
+                intersection_indexes.emplace_back(idx, std::move(idx_view_schema));
+            } catch (const data_dictionary::no_such_column_family&) {
+                // The index view is missing (e.g. still being built or dropped
+                // concurrently). Skip intersection for it; correctness is
+                // preserved by the post-filtering that runs regardless.
+            }
+        }
+    }
+
     return ::make_shared<cql3::statements::view_indexed_table_select_statement>(
             schema,
             bound_terms,
@@ -1081,6 +1103,7 @@ view_indexed_table_select_statement::prepare(data_dictionary::database db,
             stats,
             *index_opt,
             view_schema,
+            std::move(intersection_indexes),
             std::move(attrs));
 
 }
@@ -1097,10 +1120,12 @@ view_indexed_table_select_statement::view_indexed_table_select_statement(schema_
                                                            cql_stats &stats,
                                                            const secondary_index::index& index,
                                                            schema_ptr view_schema,
+                                                           std::vector<std::pair<secondary_index::index, schema_ptr>> intersection_indexes,
                                                            std::unique_ptr<attributes> attrs)
     : select_statement{schema, bound_terms, parameters, selection, restrictions, group_by_cell_indices, is_reversed, ordering_comparator, limit, per_partition_limit, stats, std::move(attrs)}
     , _index{index}
     , _view_schema(view_schema)
+    , _intersection_indexes(std::move(intersection_indexes))
 {
     throwing_assert(_view_schema);
     if (_index.metadata().local()) {
@@ -1464,6 +1489,188 @@ view_indexed_table_select_statement::read_posting_list(query_processor& qp,
     }));
 }
 
+// CUSTOMER-303 phase 2: read the base primary keys present in an additional
+// index's posting list, restricted to the base-token span of the current page.
+// The keys come back in base-token (view clustering) order, matching the order
+// of the candidate keys produced from the primary index, so the callers can
+// intersect the two with a single merge pass.
+future<coordinator_result<std::vector<primary_key>>>
+view_indexed_table_select_statement::read_intersection_index_keys(
+        query_processor& qp, service::query_state& state, const query_options& options,
+        schema_ptr view_schema, const bytes& indexed_value,
+        const partition_key& first_base_pk, const partition_key& last_base_pk,
+        bool include_base_clustering_key) const {
+    using ret = coordinator_result<std::vector<primary_key>>;
+    auto now = gc_clock::now();
+    auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
+
+    // The posting list for this index value is a single partition in the view.
+    auto view_pk = partition_key::from_single_value(*view_schema, indexed_value);
+    auto view_dk = dht::decorate_key(*view_schema, view_pk);
+    dht::partition_range_vector partition_ranges { dht::partition_range::make_singular(view_dk) };
+
+    // Restrict the read to the base-token span [token(first), token(last)] of the
+    // current page. The view's first clustering column is the computed base
+    // token, so a single-column clustering range on it bounds the scan to that
+    // token span. It is a safe *superset* of the page's candidate keys:
+    // correctness comes from the merge-intersection in the callers and from the
+    // post-filtering that runs on the base rows regardless.
+    const column_definition& token_col = view_schema->clustering_column_at(0);
+    bytes lo_token = token_col.get_computation().compute_value(*_schema, first_base_pk);
+    bytes hi_token = token_col.get_computation().compute_value(*_schema, last_base_pk);
+    auto lo_ck = clustering_key_prefix::from_single_value(*view_schema, lo_token);
+    auto hi_ck = clustering_key_prefix::from_single_value(*view_schema, hi_token);
+    query::partition_slice partition_slice = partition_slice_builder(*view_schema)
+            .with_ranges({query::clustering_range::make(
+                    query::clustering_range::bound(std::move(lo_ck), true),
+                    query::clustering_range::bound(std::move(hi_ck), true))})
+            .build();
+
+    auto cmd = ::make_lw_shared<query::read_command>(
+            view_schema->id(), view_schema->version(), partition_slice,
+            qp.proxy().get_max_result_size(partition_slice),
+            query::tombstone_limit(qp.proxy().get_tombstone_limit()),
+            query::row_limit(query::max_rows), query::partition_limit(query::max_partitions),
+            now, tracing::make_trace_info(state.get_trace_state()),
+            query_id::create_null_id(), query::is_first_page::no, options.get_timestamp(state));
+
+    std::vector<const column_definition*> columns;
+    for (const column_definition& cdef : _schema->partition_key_columns()) {
+        columns.emplace_back(view_schema->get_column_definition(cdef.name()));
+    }
+    if (include_base_clustering_key) {
+        for (const column_definition& cdef : _schema->clustering_key_columns()) {
+            columns.emplace_back(view_schema->get_column_definition(cdef.name()));
+        }
+    }
+    auto selection = selection::selection::for_columns(view_schema, std::move(columns));
+
+    auto rqr = co_await qp.proxy().query_result(view_schema, cmd, std::move(partition_ranges),
+            options.get_consistency(),
+            {timeout, state.get_permit(), state.get_client_state(), state.get_trace_state()});
+    if (!rqr) {
+        co_return ret(std::move(rqr).as_failure());
+    }
+    cql3::untyped_result_set rs(*view_schema, std::move(rqr.value().query_result), *selection, partition_slice);
+    std::vector<primary_key> keys;
+    keys.reserve(rs.size());
+    for (size_t i = 0; i < rs.size(); i++) {
+        const auto& row = rs.at(i);
+        auto pk_columns = _schema->partition_key_columns() | std::views::transform([&] (auto& cdef) {
+            return row.get_blob_unfragmented(cdef.name_as_text());
+        });
+        auto pk = partition_key::from_range(pk_columns);
+        auto dk = dht::decorate_key(*_schema, pk);
+        clustering_key_prefix ck = clustering_key_prefix::make_empty();
+        if (include_base_clustering_key) {
+            auto ck_columns = _schema->clustering_key_columns() | std::views::transform([&] (auto& cdef) {
+                return row.get_blob_unfragmented(cdef.name_as_text());
+            });
+            ck = clustering_key::from_range(ck_columns);
+        }
+        keys.push_back(primary_key{std::move(dk), std::move(ck)});
+    }
+    co_return ret(std::move(keys));
+}
+
+// CUSTOMER-303 phase 2: shrink the whole-partition candidates from the primary
+// index to those that also appear in every additional index's posting list.
+future<coordinator_result<dht::partition_range_vector>>
+view_indexed_table_select_statement::intersect_partition_ranges(
+        query_processor& qp, service::query_state& state, const query_options& options,
+        dht::partition_range_vector candidates) const {
+    using ret = coordinator_result<dht::partition_range_vector>;
+    if (_intersection_indexes.empty() || candidates.empty()) {
+        co_return ret(std::move(candidates));
+    }
+    auto candidate_dk = [] (const dht::partition_range& r) -> dht::decorated_key {
+        return r.start()->value().as_decorated_key();
+    };
+    const partition_key first_pk = candidate_dk(candidates.front()).key();
+    const partition_key last_pk = candidate_dk(candidates.back()).key();
+    for (size_t i = 0; i < _intersection_indexes.size(); i++) {
+        const schema_ptr& view_schema = _intersection_indexes[i].second;
+        bytes_opt value = _restrictions->value_for_intersection_index(i, options);
+        if (!value) {
+            // e.g. the indexed column is restricted to NULL: nothing matches.
+            co_return ret(dht::partition_range_vector{});
+        }
+        auto keys = co_await read_intersection_index_keys(qp, state, options, view_schema, *value,
+                first_pk, last_pk, /*include_base_clustering_key=*/false);
+        if (!keys) {
+            co_return ret(std::move(keys).as_failure());
+        }
+        const auto& matching = keys.value();
+        dht::partition_range_vector filtered;
+        filtered.reserve(std::min(candidates.size(), matching.size()));
+        // Merge the two token-ordered lists, keeping candidates present in both.
+        size_t j = 0;
+        for (auto& cand : candidates) {
+            const dht::decorated_key& dk = candidate_dk(cand);
+            while (j < matching.size() && matching[j].partition.tri_compare(*_schema, dk) < 0) {
+                j++;
+            }
+            if (j < matching.size() && matching[j].partition.tri_compare(*_schema, dk) == 0) {
+                filtered.push_back(std::move(cand));
+            }
+        }
+        candidates = std::move(filtered);
+        if (candidates.empty()) {
+            break;
+        }
+    }
+    co_return ret(std::move(candidates));
+}
+
+// CUSTOMER-303 phase 2: shrink the individual-row candidates from the primary
+// index to those that also appear in every additional index's posting list.
+future<coordinator_result<std::vector<primary_key>>>
+view_indexed_table_select_statement::intersect_primary_keys(
+        query_processor& qp, service::query_state& state, const query_options& options,
+        std::vector<primary_key> candidates) const {
+    using ret = coordinator_result<std::vector<primary_key>>;
+    if (_intersection_indexes.empty() || candidates.empty()) {
+        co_return ret(std::move(candidates));
+    }
+    auto cmp = [this] (const primary_key& a, const primary_key& b) -> std::strong_ordering {
+        if (auto c = a.partition.tri_compare(*_schema, b.partition); c != 0) {
+            return c;
+        }
+        return clustering_key_prefix::tri_compare(*_schema)(a.clustering, b.clustering);
+    };
+    const partition_key first_pk = candidates.front().partition.key();
+    const partition_key last_pk = candidates.back().partition.key();
+    for (size_t i = 0; i < _intersection_indexes.size(); i++) {
+        const schema_ptr& view_schema = _intersection_indexes[i].second;
+        bytes_opt value = _restrictions->value_for_intersection_index(i, options);
+        if (!value) {
+            co_return ret(std::vector<primary_key>{});
+        }
+        auto keys = co_await read_intersection_index_keys(qp, state, options, view_schema, *value,
+                first_pk, last_pk, /*include_base_clustering_key=*/true);
+        if (!keys) {
+            co_return ret(std::move(keys).as_failure());
+        }
+        const auto& matching = keys.value();
+        std::vector<primary_key> filtered;
+        filtered.reserve(std::min(candidates.size(), matching.size()));
+        size_t j = 0;
+        for (auto& cand : candidates) {
+            while (j < matching.size() && cmp(matching[j], cand) < 0) {
+                j++;
+            }
+            if (j < matching.size() && cmp(matching[j], cand) == 0) {
+                filtered.push_back(std::move(cand));
+            }
+        }
+        candidates = std::move(filtered);
+        if (candidates.empty()) {
+            break;
+        }
+    }
+    co_return ret(std::move(candidates));
+}
+
 // Note: the partitions keys returned by this function are sorted
 // in token order. See issue #3423.
 future<coordinator_result<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>>>
@@ -1496,7 +1703,7 @@ view_indexed_table_select_statement::find_index_partition_ranges(query_processor
     const query_options& _options = paging_adjusted_options ? *paging_adjusted_options : options;
     const uint64_t limit = get_inner_loop_limit(get_limit(options, _limit), _selection->is_aggregate());
     return read_posting_list(qp, _options, limit, state, now, timeout, false).then(utils::result_wrap(
-            [this, &_options, max_vector_size] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
+            [this, &qp, &state, &_options, max_vector_size] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
         auto rs = cql3::untyped_result_set(rows);
         dht::partition_range_vector partition_ranges;
         partition_ranges.reserve(std::min(rs.size(), max_vector_size));
@@ -1535,7 +1742,17 @@ view_indexed_table_select_statement::find_index_partition_ranges(query_processor
             }
         }
         auto paging_state = rows->rs().get_metadata().paging_state();
-        return make_ready_future<coordinator_result<value_type>>(value_type(std::move(partition_ranges), std::move(paging_state)));
+        // CUSTOMER-303 phase 2: keep only partitions that also appear in every
+        // additional index's posting list. Paging is still driven by the primary
+        // index (paging_state is untouched), so this only shrinks the current
+        // page's candidates - which is what avoids reading the extra base rows.
+        return intersect_partition_ranges(qp, state, _options, std::move(partition_ranges)).then(
+                [paging_state = std::move(paging_state)] (coordinator_result<dht::partition_range_vector> res) mutable -> coordinator_result<value_type> {
+            if (!res) {
+                return coordinator_result<value_type>(std::move(res).as_failure());
+            }
+            return coordinator_result<value_type>(value_type(std::move(res).value(), std::move(paging_state)));
+        });
     }));
     });
 }
@@ -1550,7 +1767,7 @@ view_indexed_table_select_statement::find_index_clustering_rows(query_processor&
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
     const uint64_t limit = get_inner_loop_limit(get_limit(options, _limit), _selection->is_aggregate());
     return read_posting_list(qp, options, limit, state, now, timeout, true).then(utils::result_wrap(
-            [this, &options] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
+            [this, &qp, &state, &options] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
 
         auto rs = cql3::untyped_result_set(rows);
         std::vector<primary_key> primary_keys;
@@ -1604,7 +1821,17 @@ view_indexed_table_select_statement::find_index_clustering_rows(query_processor&
             last_primary_key = primary_keys.back();
         }
         auto paging_state = rows->rs().get_metadata().paging_state();
-        return make_ready_future<coordinator_result<value_type>>(value_type(std::move(primary_keys), std::move(paging_state)));
+        // CUSTOMER-303 phase 2: keep only rows that also appear in every
+        // additional index's posting list. Paging is still driven by the primary
+        // index (paging_state is untouched); this only shrinks the current
+        // page's candidate rows so we read fewer base-table rows.
+        return intersect_primary_keys(qp, state, options, std::move(primary_keys)).then(
+                [paging_state = std::move(paging_state)] (coordinator_result<std::vector<primary_key>> res) mutable -> coordinator_result<value_type> {
+            if (!res) {
+                return coordinator_result<value_type>(std::move(res).as_failure());
+            }
+            return coordinator_result<value_type>(value_type(std::move(res).value(), std::move(paging_state)));
+        });
     }));
 }
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1328,7 +1328,7 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
         if (options.get_paging_state()) {
             primary_idx = recover_primary_index(candidates, *options.get_paging_state());
         } else {
-            auto [idx, driver_size] = co_await choose_primary_index(qp, state, options, candidates);
+            auto [idx, driver_size] = co_await choose_primary_index(qp, state, options, candidates, intersection_skip_max_driver_size);
             primary_idx = idx;
             skip_intersection = driver_size <= intersection_skip_max_driver_size;
         }
@@ -1371,9 +1371,11 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
         auto internal_page_size = qp.get_cql_config().select_internal_page_size.get();
         internal_options.reset(new cql3::query_options(std::move(internal_options), options.get_paging_state(), internal_page_size));
         do {
-            auto consume_results = [this, &builder, &options, &internal_options, &state, internal_page_size] (foreign_ptr<lw_shared_ptr<query::result>> results, lw_shared_ptr<query::read_command> cmd, lw_shared_ptr<const service::pager::paging_state> paging_state) -> stop_iteration {
+            auto consume_results = [this, &builder, &options, &internal_options, &state, internal_page_size, primary] (foreign_ptr<lw_shared_ptr<query::result>> results, lw_shared_ptr<query::read_command> cmd, lw_shared_ptr<const service::pager::paging_state> paging_state) -> stop_iteration {
                 if (paging_state) {
-                    paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options, internal_page_size);
+                    // Translate the cursor in the *driver* index's view (with a
+                    // cost-based primary this may not be the statement's _index).
+                    paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options, internal_page_size, primary);
                 }
                 internal_options.reset(new cql3::query_options(std::move(internal_options), paging_state ? make_lw_shared<service::pager::paging_state>(*paging_state) : nullptr));
                 if (needs_post_filtering()) {
@@ -1815,11 +1817,14 @@ view_indexed_table_select_statement::build_index_candidates(const query_options&
 
 // CUSTOMER-303 phase 3: probe each candidate's posting-list size (bounded, so a
 // huge list costs no more than reading the cap) and return the index of the
-// smallest - the one that should drive the scan and paging.
+// smallest - the one that should drive the scan and paging - together with its
+// probed size. The cap is at least skip_threshold + 1 so that a returned size
+// <= skip_threshold is exact (never a truncated count), which the caller relies
+// on to decide whether to skip the intersection.
 future<std::pair<size_t, uint64_t>>
 view_indexed_table_select_statement::choose_primary_index(query_processor& qp, service::query_state& state,
-        const query_options& options, const std::vector<index_candidate>& candidates) const {
-    constexpr uint64_t probe_cap = 10001;
+        const query_options& options, const std::vector<index_candidate>& candidates, uint64_t skip_threshold) const {
+    const uint64_t probe_cap = std::max<uint64_t>(10001, skip_threshold + 1);
     auto now = gc_clock::now();
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
     size_t best = 0;

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -381,9 +381,11 @@ private:
     // sizes and returns the index of the smallest (the paging driver).
     std::vector<index_candidate> build_index_candidates(const query_options& options) const;
     // Best-effort: probe posting-list sizes and return the smallest candidate's
-    // index. Probe read errors are swallowed (that candidate is just skipped), so
-    // this never fails the query - the optimization degrades to the chosen index.
-    future<size_t> choose_primary_index(query_processor& qp, service::query_state& state,
+    // index and its (probed, capped) size. Probe read errors are swallowed (that
+    // candidate is just skipped), so this never fails the query - the optimization
+    // degrades to the chosen index. The size lets the caller decide whether the
+    // driver is already so selective that intersecting is not worth it.
+    future<std::pair<size_t, uint64_t>> choose_primary_index(query_processor& qp, service::query_state& state,
             const query_options& options, const std::vector<index_candidate>& candidates) const;
     size_t recover_primary_index(const std::vector<index_candidate>& candidates,
             const service::pager::paging_state& paging_state) const;

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -387,8 +387,6 @@ private:
     // driver is already so selective that intersecting is not worth it.
     future<std::pair<size_t, uint64_t>> choose_primary_index(query_processor& qp, service::query_state& state,
             const query_options& options, const std::vector<index_candidate>& candidates, uint64_t skip_threshold) const;
-    size_t recover_primary_index(const std::vector<index_candidate>& candidates,
-            const service::pager::paging_state& paging_state) const;
 
     dht::partition_range_vector get_partition_ranges_for_local_index_posting_list(const query_options& options) const;
     dht::partition_range_vector get_partition_ranges_for_global_index_posting_list(const query_options& options) const;

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -197,6 +197,11 @@ class view_indexed_table_select_statement : public select_statement {
     schema_ptr _view_schema;
     noncopyable_function<dht::partition_range_vector(const query_options&)> _get_partition_ranges_for_posting_list;
     noncopyable_function<query::partition_slice(const query_options&)> _get_partition_slice_for_posting_list;
+    // Additional global indexes (with their view schemas) whose posting lists are
+    // intersected with the primary index's, so we only read base rows that match
+    // every indexed equality restriction (CUSTOMER-303 phase 2). Empty when the
+    // primary index is local or no additional equality-indexed columns apply.
+    std::vector<std::pair<secondary_index::index, schema_ptr>> _intersection_indexes;
 public:
     static constexpr size_t max_base_table_query_concurrency = 4096;
 
@@ -227,6 +232,7 @@ public:
                                    cql_stats &stats,
                                    const secondary_index::index& index,
                                    schema_ptr view_schema,
+                                   std::vector<std::pair<secondary_index::index, schema_ptr>> intersection_indexes,
                                    std::unique_ptr<cql3::attributes> attrs);
 
 private:
@@ -317,6 +323,28 @@ private:
             gc_clock::time_point now,
             db::timeout_clock::time_point timeout,
             bool include_base_clustering_key) const;
+
+    // CUSTOMER-303 phase 2: posting-list intersection helpers.
+    //
+    // read_intersection_index_keys() reads the base primary keys present in an
+    // additional index's posting list (partition = indexed_value) restricted to
+    // the base-token span [first_base_pk, last_base_pk] of the current page. The
+    // returned keys are in base-token (view-clustering) order.
+    future<coordinator_result<std::vector<primary_key>>> read_intersection_index_keys(
+            query_processor& qp, service::query_state& state, const query_options& options,
+            schema_ptr view_schema, const bytes& indexed_value,
+            const partition_key& first_base_pk, const partition_key& last_base_pk,
+            bool include_base_clustering_key) const;
+
+    // Filters the candidate base keys from the primary index down to those that
+    // also appear in every additional index's posting list (a streaming merge
+    // over the shared base-token order). No-op when _intersection_indexes is empty.
+    future<coordinator_result<dht::partition_range_vector>> intersect_partition_ranges(
+            query_processor& qp, service::query_state& state, const query_options& options,
+            dht::partition_range_vector candidates) const;
+    future<coordinator_result<std::vector<primary_key>>> intersect_primary_keys(
+            query_processor& qp, service::query_state& state, const query_options& options,
+            std::vector<primary_key> candidates) const;
 
     dht::partition_range_vector get_partition_ranges_for_local_index_posting_list(const query_options& options) const;
     dht::partition_range_vector get_partition_ranges_for_global_index_posting_list(const query_options& options) const;

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -202,6 +202,17 @@ class view_indexed_table_select_statement : public select_statement {
     // every indexed equality restriction (CUSTOMER-303 phase 2). Empty when the
     // primary index is local or no additional equality-indexed columns apply.
     std::vector<std::pair<secondary_index::index, schema_ptr>> _intersection_indexes;
+
+    // CUSTOMER-303 phase 3: a global equality-indexed column participating in an
+    // intersection, resolved for a particular query (its posting-list partition
+    // key `value` is solved from the bound parameters). When several such indexes
+    // apply, the one with the smallest posting list is chosen at execution time
+    // to drive paging (see choose_primary_index()); the rest are intersected in.
+    struct index_candidate {
+        secondary_index::index index;
+        schema_ptr view_schema;
+        bytes value;
+    };
 public:
     static constexpr size_t max_base_table_query_concurrency = 4096;
 
@@ -242,16 +253,27 @@ private:
     future<::shared_ptr<cql_transport::messages::result_message>> actually_do_execute(query_processor& qp,
             service::query_state& state, const query_options& options) const;
 
+    // Throughout the pipeline below, `primary` selects which index drives the
+    // scan/paging. When nullptr the statement's own _index / _view_schema are used
+    // (the ordinary single-index path, unchanged). When non-null it points at a
+    // runtime-chosen global equality index (CUSTOMER-303 phase 3 cost-based
+    // selection); `others` are the remaining equality-indexed columns whose
+    // posting lists are intersected in.
     lw_shared_ptr<const service::pager::paging_state> generate_view_paging_state_from_base_query_results(lw_shared_ptr<const service::pager::paging_state> paging_state,
-            const foreign_ptr<lw_shared_ptr<query::result>>& results, service::query_state& state, const query_options& options, uint32_t internal_page_size) const;
+            const foreign_ptr<lw_shared_ptr<query::result>>& results, service::query_state& state, const query_options& options, uint32_t internal_page_size,
+            const index_candidate* primary = nullptr) const;
 
     future<coordinator_result<std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>>> find_index_partition_ranges(query_processor& qp,
                                                                     service::query_state& state,
-                                                                    const query_options& options) const;
+                                                                    const query_options& options,
+                                                                    const index_candidate* primary = nullptr,
+                                                                    const std::vector<index_candidate>& others = {}) const;
 
     future<coordinator_result<std::tuple<std::vector<primary_key>, lw_shared_ptr<const service::pager::paging_state>>>> find_index_clustering_rows(query_processor& qp,
                                                                 service::query_state& state,
-                                                                const query_options& options) const;
+                                                                const query_options& options,
+                                                                const index_candidate* primary = nullptr,
+                                                                const std::vector<index_candidate>& others = {}) const;
 
     future<shared_ptr<cql_transport::messages::result_message>>
     process_base_query_results(
@@ -261,7 +283,8 @@ private:
             const query_options& options,
             gc_clock::time_point now,
             lw_shared_ptr<const service::pager::paging_state> paging_state,
-            uint32_t internal_page_size) const;
+            uint32_t internal_page_size,
+            const index_candidate* primary = nullptr) const;
 
     lw_shared_ptr<query::read_command>
     prepare_command_for_base_query(query_processor& qp, const query_options& options, service::query_state& state, gc_clock::time_point now,
@@ -274,7 +297,8 @@ private:
             service::query_state& state,
             const query_options& options,
             gc_clock::time_point now,
-            lw_shared_ptr<const service::pager::paging_state> paging_state) const;
+            lw_shared_ptr<const service::pager::paging_state> paging_state,
+            const index_candidate* primary = nullptr) const;
     future<shared_ptr<cql_transport::messages::result_message>>
     execute_base_query(
             query_processor& qp,
@@ -282,7 +306,8 @@ private:
             service::query_state& state,
             const query_options& options,
             gc_clock::time_point now,
-            lw_shared_ptr<const service::pager::paging_state> paging_state) const;
+            lw_shared_ptr<const service::pager::paging_state> paging_state,
+            const index_candidate* primary = nullptr) const;
 
     // Function for fetching the selected columns from a list of clustering rows.
     // It is currently used only in our Secondary Index implementation - ordinary
@@ -300,7 +325,8 @@ private:
             service::query_state& state,
             const query_options& options,
             gc_clock::time_point now,
-            lw_shared_ptr<const service::pager::paging_state> paging_state) const;
+            lw_shared_ptr<const service::pager::paging_state> paging_state,
+            const index_candidate* primary = nullptr) const;
     future<shared_ptr<cql_transport::messages::result_message>>
     execute_base_query(
             query_processor& qp,
@@ -308,7 +334,8 @@ private:
             service::query_state& state,
             const query_options& options,
             gc_clock::time_point now,
-            lw_shared_ptr<const service::pager::paging_state> paging_state) const;
+            lw_shared_ptr<const service::pager::paging_state> paging_state,
+            const index_candidate* primary = nullptr) const;
 
     virtual void update_stats_rows_read(int64_t rows_read) const override {
         _stats.rows_read += rows_read;
@@ -322,9 +349,10 @@ private:
             service::query_state& state,
             gc_clock::time_point now,
             db::timeout_clock::time_point timeout,
-            bool include_base_clustering_key) const;
+            bool include_base_clustering_key,
+            const index_candidate* primary = nullptr) const;
 
-    // CUSTOMER-303 phase 2: posting-list intersection helpers.
+    // CUSTOMER-303 phase 2/3: posting-list intersection helpers.
     //
     // read_intersection_index_keys() reads the base primary keys present in an
     // additional index's posting list (partition = indexed_value) restricted to
@@ -337,14 +365,27 @@ private:
             bool include_base_clustering_key) const;
 
     // Filters the candidate base keys from the primary index down to those that
-    // also appear in every additional index's posting list (a streaming merge
-    // over the shared base-token order). No-op when _intersection_indexes is empty.
+    // also appear in every `others` index's posting list (a streaming merge over
+    // the shared base-token order). No-op when `others` is empty.
     future<coordinator_result<dht::partition_range_vector>> intersect_partition_ranges(
             query_processor& qp, service::query_state& state, const query_options& options,
-            dht::partition_range_vector candidates) const;
+            dht::partition_range_vector candidates, const std::vector<index_candidate>& others) const;
     future<coordinator_result<std::vector<primary_key>>> intersect_primary_keys(
             query_processor& qp, service::query_state& state, const query_options& options,
-            std::vector<primary_key> candidates) const;
+            std::vector<primary_key> candidates, const std::vector<index_candidate>& others) const;
+
+    // CUSTOMER-303 phase 3: builds the equality-indexed candidate columns for this
+    // query (chosen index + intersection indexes, with values solved from options),
+    // returns empty if cost-based intersection doesn't apply; probes posting-list
+    // sizes and returns the index of the smallest (the paging driver).
+    std::vector<index_candidate> build_index_candidates(const query_options& options) const;
+    // Best-effort: probe posting-list sizes and return the smallest candidate's
+    // index. Probe read errors are swallowed (that candidate is just skipped), so
+    // this never fails the query - the optimization degrades to the chosen index.
+    future<size_t> choose_primary_index(query_processor& qp, service::query_state& state,
+            const query_options& options, const std::vector<index_candidate>& candidates) const;
+    size_t recover_primary_index(const std::vector<index_candidate>& candidates,
+            const service::pager::paging_state& paging_state) const;
 
     dht::partition_range_vector get_partition_ranges_for_local_index_posting_list(const query_options& options) const;
     dht::partition_range_vector get_partition_ranges_for_global_index_posting_list(const query_options& options) const;

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -386,7 +386,7 @@ private:
     // degrades to the chosen index. The size lets the caller decide whether the
     // driver is already so selective that intersecting is not worth it.
     future<std::pair<size_t, uint64_t>> choose_primary_index(query_processor& qp, service::query_state& state,
-            const query_options& options, const std::vector<index_candidate>& candidates) const;
+            const query_options& options, const std::vector<index_candidate>& candidates, uint64_t skip_threshold) const;
     size_t recover_primary_index(const std::vector<index_candidate>& candidates,
             const service::pager::paging_state& paging_state) const;
 

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -355,13 +355,14 @@ private:
     // CUSTOMER-303 phase 2/3: posting-list intersection helpers.
     //
     // read_intersection_index_keys() reads the base primary keys present in an
-    // additional index's posting list (partition = indexed_value) restricted to
-    // the base-token span [first_base_pk, last_base_pk] of the current page. The
-    // returned keys are in base-token (view-clustering) order.
+    // additional index's posting list (partition = indexed_value). The clustering
+    // ranges target exactly the current page's candidate base keys (phase 4), so
+    // the promoted index skips the entries in between. The returned keys are in
+    // base-token (view-clustering) order.
     future<coordinator_result<std::vector<primary_key>>> read_intersection_index_keys(
             query_processor& qp, service::query_state& state, const query_options& options,
             schema_ptr view_schema, const bytes& indexed_value,
-            const partition_key& first_base_pk, const partition_key& last_base_pk,
+            std::vector<query::clustering_range> clustering_ranges,
             bool include_base_clustering_key) const;
 
     // Filters the candidate base keys from the primary index down to those that

--- a/db/config.cc
+++ b/db/config.cc
@@ -1592,6 +1592,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Maximum number of relations allowed in a WHERE clause. Queries with too many relations can cause quadratic complexity.")
     , select_internal_page_size(this, "select_internal_page_size", liveness::LiveUpdate, value_status::Used, 10000,
             "SELECT statements with aggregation or GROUP BYs or a secondary index may use this page size for their internal reading data, not the page size specified in the query options.")
+    , secondary_index_intersection_skip_max_rows(this, "secondary_index_intersection_skip_max_rows", liveness::LiveUpdate, value_status::Used, 100,
+            "When a SELECT restricts several indexed columns with equality, ScyllaDB drives the query with the most selective index and intersects the others' posting lists. If that most selective index matches at most this many rows, the intersection is skipped and the index is used alone (its rows are read from the base table and filtered), because reading a few rows is cheaper than the extra index reads. Set to 0 to always intersect.")
     , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port.")
     , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port.")
     , alternator_port_proxy_protocol(this, "alternator_port_proxy_protocol", value_status::Used, 0,

--- a/db/config.hh
+++ b/db/config.hh
@@ -503,6 +503,7 @@ public:
     named_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
     named_value<uint32_t> max_relations_in_where_clause;
     named_value<uint32_t> select_internal_page_size;
+    named_value<uint32_t> secondary_index_intersection_skip_max_rows;
 
     named_value<uint16_t> alternator_port;
     named_value<uint16_t> alternator_https_port;

--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -97,6 +97,47 @@ given table. A name for the index itself can be specified before the ``ON`` keyw
 for the column, it will be indexed asynchronously. After the index is created, new data for the column is indexed
 automatically at insertion time.
 
+.. _querying-multiple-indexed-columns:
+
+Querying multiple indexed columns
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When a query restricts several indexed columns with equality — for example
+``WHERE a = ? AND b = ?`` where both ``a`` and ``b`` have a secondary index —
+ScyllaDB uses the indexes together. It reads each index's posting list,
+intersects them by the base table's primary key, and reads from the base table
+only the rows that match *all* of the indexed restrictions. This avoids reading
+every row that matches one restriction only to discard most of them.
+
+Example:
+
+.. code-block:: cql
+
+   CREATE TABLE orders (id int PRIMARY KEY, customer int, status int);
+   CREATE INDEX ON orders (customer);
+   CREATE INDEX ON orders (status);
+
+   -- The posting lists for `customer = 42` and `status = 1` are intersected,
+   -- so only the orders matching both are read from the base table.
+   SELECT * FROM orders WHERE customer = 42 AND status = 1 ALLOW FILTERING;
+
+ScyllaDB drives the query with the most selective index (the one whose value
+matches the fewest rows) and intersects the other indexes into it. If that most
+selective index already matches only a few rows, the intersection is skipped and
+that index is used on its own, since reading those few rows and filtering is
+cheaper than the extra index reads. The row-count threshold for this decision is
+controlled by the
+:ref:`secondary_index_intersection_skip_max_rows <confprop_secondary_index_intersection_skip_max_rows>`
+configuration parameter (set it to ``0`` to always intersect).
+
+.. note::
+
+   Index intersection combines independent secondary indexes at query time and
+   is subject to the same eventual consistency as the indexes themselves. For a
+   known, frequent query pattern on a fixed set of columns, modeling the table
+   (or a :doc:`materialized view </features/materialized-views>`) around that
+   pattern is typically more efficient than relying on intersection.
+
 Local Secondary Index
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -113,6 +113,11 @@ public:
     gms::feature truncate_as_topology_operation { *this, "TRUNCATE_AS_TOPOLOGY_OPERATION"sv };
     gms::feature snapshot_as_topology_operation { *this, "SNAPSHOT_AS_TOPOLOGY_OPERATION"sv };
     gms::feature secondary_indexes_on_static_columns { *this, "SECONDARY_INDEXES_ON_STATIC_COLUMNS"sv };
+    // When enabled cluster-wide (i.e. every node is upgraded), a query restricting
+    // several equality-indexed columns may intersect their posting lists and drive
+    // the scan with a cost-chosen index. The chosen plan is pinned in the paging
+    // state so every coordinator continues a paged query identically (CUSTOMER-303).
+    gms::feature secondary_index_intersection { *this, "SECONDARY_INDEX_INTERSECTION"sv };
     gms::feature tablets { *this, "TABLETS"sv };
     gms::feature table_digest_insensitive_to_expiry { *this, "TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"sv };
     gms::feature supports_consistent_topology_changes { *this, "SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"sv };

--- a/idl/paging_state.idl.hh
+++ b/idl/paging_state.idl.hh
@@ -37,6 +37,7 @@ class paging_state {
     uint32_t get_rows_fetched_for_last_partition_high_bits() [[version 4.3]] = 0;
     bound_weight get_clustering_key_weight() [[version 5.1]] = bound_weight::equal;
     partition_region get_partition_region() [[version 5.1]] = partition_region::clustered;
+    sstring get_query_plan_index() [[version 2026.3]] = "";
 };
 }
 }

--- a/service/pager/paging_state.cc
+++ b/service/pager/paging_state.cc
@@ -28,7 +28,8 @@ service::pager::paging_state::paging_state(partition_key pk,
         uint32_t rem_high_bits,
         uint32_t rows_fetched_for_last_partition_high_bits,
         bound_weight ck_weight,
-        partition_region region)
+        partition_region region,
+        sstring query_plan_index)
     : _partition_key(std::move(pk))
     , _clustering_key(std::move(ck))
     , _remaining_low_bits(rem_low_bits)
@@ -40,6 +41,7 @@ service::pager::paging_state::paging_state(partition_key pk,
     , _rows_fetched_for_last_partition_high_bits(rows_fetched_for_last_partition_high_bits)
     , _ck_weight(ck_weight)
     , _region(region)
+    , _query_plan_index(std::move(query_plan_index))
 { }
 
 service::pager::paging_state::paging_state(partition_key pk,

--- a/service/pager/paging_state.hh
+++ b/service/pager/paging_state.hh
@@ -39,6 +39,13 @@ private:
     uint32_t _rows_fetched_for_last_partition_high_bits;
     bound_weight _ck_weight = bound_weight::equal;
     partition_region _region = partition_region::partition_start;
+    // CUSTOMER-303: name of the secondary index chosen to drive a multi-index
+    // (posting-list intersection) query. Pinned here so every coordinator
+    // continues a paged query with the same plan. Empty means "no such plan"
+    // (legacy single-index behaviour) - which is also what a paging state
+    // produced by a node without the SECONDARY_INDEX_INTERSECTION feature
+    // deserializes to.
+    sstring _query_plan_index;
 
 public:
     // IDL ctor
@@ -52,7 +59,8 @@ public:
             uint32_t remaining_ext,
             uint32_t rows_fetched_for_last_partition_high_bits,
             bound_weight ck_weight,
-            partition_region region);
+            partition_region region,
+            sstring query_plan_index = "");
 
     paging_state(partition_key pk,
             position_in_partition_view pos,
@@ -76,6 +84,15 @@ public:
     void set_remaining(uint64_t remaining) {
         _remaining_low_bits = static_cast<uint32_t>(remaining);
         _remaining_high_bits = static_cast<uint32_t>(remaining >> 32);
+    }
+
+    // CUSTOMER-303: the secondary index chosen to drive a multi-index query;
+    // empty for legacy single-index queries. See _query_plan_index.
+    void set_query_plan_index(sstring index_name) {
+        _query_plan_index = std::move(index_name);
+    }
+    const sstring& get_query_plan_index() const {
+        return _query_plan_index;
     }
 
     /**

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -487,8 +487,11 @@ SEASTAR_TEST_CASE(index_selection) {
         // --- H. Double CONTAINS on same column: CollectionYes && CollectionYes = No ---
         verify(check("s1 CONTAINS 1 AND s1 CONTAINS 2"), {"", none, false, true});
 
-        // --- I. Collection + regular column tiebreak (WHERE-clause order) ---
-        verify(check("s1 CONTAINS 1 AND v1 = 1"), {"", idx("idx_s1"), true, true});
+        // --- I. Collection + regular column: the more selective restriction wins.
+        //        A scalar equality (v1 = 1) is preferred over collection membership
+        //        (s1 CONTAINS 1) regardless of the order they appear in the WHERE
+        //        clause (CUSTOMER-303 selectivity-aware selection).
+        verify(check("s1 CONTAINS 1 AND v1 = 1"), {"", idx("idx_v1"), true, true});
         verify(check("v1 = 1 AND s1 CONTAINS 1"), {"", idx("idx_v1"), true, true});
 
         // --- J. CK group beats collection in non-PK group ---
@@ -938,19 +941,25 @@ SEASTAR_TEST_CASE(combinatorial_restrictions) {
             } else if (full_pk && has_v3) {
                 // Local index scores 2, beats any global (score 1).
                 expected_idx = "comb_v3_local";
-            } else if (has_v1) {
+            }
+            // Among the same-score (global) non-PK indexes, CUSTOMER-303 selects
+            // the more selective restriction first: a scalar/map-element equality
+            // (v1, m3_entries, fs) beats collection membership (s1, m1_values,
+            // m2_keys). Within each selectivity tier, WHERE-clause order (== bit
+            // order here) breaks the tie: v1 < m3_entries < fs, and
+            // s1 < m1_values < m2_keys. (v3 without full_pk scores 0 and is skipped.)
+            else if (has_v1) {
                 expected_idx = "comb_v1";
+            } else if (has_m_ent) {
+                expected_idx = "comb_m3_entries";
+            } else if (has_fs) {
+                expected_idx = "comb_fs";
             } else if (has_s1) {
-                // v3 without full_pk scores 0 and is skipped.
                 expected_idx = "comb_s1";
             } else if (has_m_val) {
                 expected_idx = "comb_m1_values";
             } else if (has_m_key) {
                 expected_idx = "comb_m2_keys";
-            } else if (has_m_ent) {
-                expected_idx = "comb_m3_entries";
-            } else if (has_fs) {
-                expected_idx = "comb_fs";
             }
             // else: no indexable column (v3 alone without full_pk scores 0)
 

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -487,11 +487,12 @@ SEASTAR_TEST_CASE(index_selection) {
         // --- H. Double CONTAINS on same column: CollectionYes && CollectionYes = No ---
         verify(check("s1 CONTAINS 1 AND s1 CONTAINS 2"), {"", none, false, true});
 
-        // --- I. Collection + regular column: the more selective restriction wins.
-        //        A scalar equality (v1 = 1) is preferred over collection membership
-        //        (s1 CONTAINS 1) regardless of the order they appear in the WHERE
-        //        clause (CUSTOMER-303 selectivity-aware selection).
-        verify(check("s1 CONTAINS 1 AND v1 = 1"), {"", idx("idx_v1"), true, true});
+        // --- I. Collection + regular column tiebreak (WHERE-clause order) ---
+        // The deterministic single-index choice is by WHERE-clause order (it must
+        // stay stable across coordinators/upgrades). The cost-based intersection
+        // that prefers the more selective index is decided at execution time behind
+        // a cluster feature, not here.
+        verify(check("s1 CONTAINS 1 AND v1 = 1"), {"", idx("idx_s1"), true, true});
         verify(check("v1 = 1 AND s1 CONTAINS 1"), {"", idx("idx_v1"), true, true});
 
         // --- J. CK group beats collection in non-PK group ---
@@ -941,25 +942,19 @@ SEASTAR_TEST_CASE(combinatorial_restrictions) {
             } else if (full_pk && has_v3) {
                 // Local index scores 2, beats any global (score 1).
                 expected_idx = "comb_v3_local";
-            }
-            // Among the same-score (global) non-PK indexes, CUSTOMER-303 selects
-            // the more selective restriction first: a scalar/map-element equality
-            // (v1, m3_entries, fs) beats collection membership (s1, m1_values,
-            // m2_keys). Within each selectivity tier, WHERE-clause order (== bit
-            // order here) breaks the tie: v1 < m3_entries < fs, and
-            // s1 < m1_values < m2_keys. (v3 without full_pk scores 0 and is skipped.)
-            else if (has_v1) {
+            } else if (has_v1) {
                 expected_idx = "comb_v1";
-            } else if (has_m_ent) {
-                expected_idx = "comb_m3_entries";
-            } else if (has_fs) {
-                expected_idx = "comb_fs";
             } else if (has_s1) {
+                // v3 without full_pk scores 0 and is skipped.
                 expected_idx = "comb_s1";
             } else if (has_m_val) {
                 expected_idx = "comb_m1_values";
             } else if (has_m_key) {
                 expected_idx = "comb_m2_keys";
+            } else if (has_m_ent) {
+                expected_idx = "comb_m3_entries";
+            } else if (has_fs) {
+                expected_idx = "comb_fs";
             }
             // else: no indexable column (v3 alone without full_pk scores 0)
 

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -129,6 +129,98 @@ def test_index_selection_prefers_more_selective_restriction(scylla_only, cql, te
                       f"SELECT p FROM {table} WHERE v = 1 AND s CONTAINS 1 ALLOW FILTERING"]:
             assert sorted([row.p for row in cql.execute(query)]) == expected
 
+# Helper for the intersection tests below: run a query both unpaged and with
+# several small page sizes, and return the sorted list of a single selected
+# column across all pages. Posting-list intersection can legitimately produce
+# short pages, so paging is driven to completion by the paging_state, not by the
+# page fill level.
+def _all_rows_all_pagings(cql, query, column):
+    results = [sorted(getattr(row, column) for row in cql.execute(query))]
+    for page_size in [1, 2, 7]:
+        stmt = SimpleStatement(query, fetch_size=page_size)
+        got = []
+        page = cql.execute(stmt)
+        got.extend(getattr(row, column) for row in page.current_rows)
+        while page.paging_state is not None:
+            page = cql.execute(stmt, paging_state=page.paging_state)
+            got.extend(getattr(row, column) for row in page.current_rows)
+        results.append(sorted(got))
+    return results
+
+# CUSTOMER-303 phase 2: posting-list intersection. When a query restricts two (or
+# more) indexed columns with equality, ScyllaDB reads each index's posting list
+# and intersects them by base primary key, so it only reads the base-table rows
+# matching *all* the indexed restrictions - instead of reading every row matching
+# one restriction and filtering the rest from the base table. The result set must
+# be exactly the same as plain filtering, both unpaged and across paging, for
+# tables with and without a clustering key.
+def test_index_intersection_correctness(cql, test_keyspace):
+    for schema, has_ck in [
+            ('p int primary key, a int, b int, d int', False),
+            ('p int, c int, a int, b int, d int, primary key (p, c)', True)]:
+        with new_test_table(cql, test_keyspace, schema) as table:
+            cql.execute(f"CREATE INDEX ON {table}(a)")
+            cql.execute(f"CREATE INDEX ON {table}(b)")
+            data = []
+            n = 60
+            if has_ck:
+                insert = cql.prepare(f"INSERT INTO {table}(p, c, a, b, d) VALUES (?, ?, ?, ?, ?)")
+                for i in range(n):
+                    cql.execute(insert, [i // 6, i, i % 3, i % 4, i])
+                    data.append((i % 3, i % 4, i))
+            else:
+                insert = cql.prepare(f"INSERT INTO {table}(p, a, b, d) VALUES (?, ?, ?, ?)")
+                for i in range(n):
+                    cql.execute(insert, [i, i % 3, i % 4, i])
+                    data.append((i % 3, i % 4, i))
+            for a in range(3):
+                for b in range(4):
+                    expected = sorted(d for (ra, rb, d) in data if ra == a and rb == b)
+                    query = f"SELECT d FROM {table} WHERE a = {a} AND b = {b} ALLOW FILTERING"
+                    for got in _all_rows_all_pagings(cql, query, 'd'):
+                        assert got == expected
+
+# Intersection must also work with three (or more) indexed equality restrictions,
+# i.e. more than one additional posting list intersected with the primary one.
+def test_index_intersection_three_columns(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'p int primary key, a int, b int, c int, d int') as table:
+        for col in ['a', 'b', 'c']:
+            cql.execute(f"CREATE INDEX ON {table}({col})")
+        insert = cql.prepare(f"INSERT INTO {table}(p, a, b, c, d) VALUES (?, ?, ?, ?, ?)")
+        data = []
+        for i in range(80):
+            cql.execute(insert, [i, i % 2, i % 3, i % 4, i])
+            data.append((i % 2, i % 3, i % 4, i))
+        for (a, b, c) in [(0, 0, 0), (1, 2, 3), (0, 1, 2), (1, 0, 1)]:
+            expected = sorted(d for (ra, rb, rc, d) in data if ra == a and rb == b and rc == c)
+            query = f"SELECT d FROM {table} WHERE a = {a} AND b = {b} AND c = {c} ALLOW FILTERING"
+            for got in _all_rows_all_pagings(cql, query, 'd'):
+                assert got == expected
+
+# CUSTOMER-303 phase 2: the whole point of intersecting posting lists is to read
+# fewer base-table rows. Here every row has a = 1 but only a handful also have
+# b = 2. Intersection must read only the (few) matching base rows, not all the
+# a = 1 rows. We verify this via the filtered_rows_read_total metric, which counts
+# base rows read by filtered (ALLOW FILTERING) queries.
+def test_index_intersection_reads_fewer_base_rows(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, 'p int primary key, a int, b int') as table:
+        cql.execute(f"CREATE INDEX ON {table}(a)")
+        cql.execute(f"CREATE INDEX ON {table}(b)")
+        insert = cql.prepare(f"INSERT INTO {table}(p, a, b) VALUES (?, ?, ?)")
+        total = 200
+        matching = sorted(i for i in range(total) if i % 50 == 0)  # 4 rows with b=2
+        for i in range(total):
+            cql.execute(insert, [i, 1, 2 if i % 50 == 0 else 7])
+        metric = 'scylla_query_processor_filtered_rows_read_total'
+        before = ScyllaMetrics.query(cql).get(metric) or 0
+        got = sorted(row.p for row in cql.execute(f"SELECT p FROM {table} WHERE a = 1 AND b = 2 ALLOW FILTERING"))
+        after = ScyllaMetrics.query(cql).get(metric) or 0
+        assert got == matching
+        base_rows_read = after - before
+        # With intersection we read only the ~4 matching base rows, not all 200
+        # a = 1 rows. Allow generous slack but require it to be far below 200.
+        assert base_rows_read <= 20, f"read {base_rows_read} base rows for {len(matching)} matches (intersection not applied?)"
+
 # Indexes can be created without an explicit name, in which case a default name is chosen.
 # However, due to #8620 it was possible to break the index creation mechanism by creating
 # a properly named regular table, which conflicts with the generated index name.

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -261,33 +261,33 @@ def test_index_intersection_cost_based_selection(cql, test_keyspace, scylla_only
         matching = [0, 1, 2]
         for i in range(300):
             cql.execute(insert, [i, 1, 7 if i < 3 else 8])
-        def primary_index_desc(query):
+        def driving_index_desc(query):
             events = cql.execute(query, trace=True).get_query_trace().events
             for e in events:
-                if 'primary index is' in e.description:
+                if 'driving index' in e.description:
                     return e.description
             return None
         # The smaller posting list (cost_b, 3 entries) must be chosen over cost_a
         # (300 entries) either way the query is written, and the result is correct.
         for q in [f"SELECT p FROM {table} WHERE a = 1 AND b = 7 ALLOW FILTERING",
                   f"SELECT p FROM {table} WHERE b = 7 AND a = 1 ALLOW FILTERING"]:
-            desc = primary_index_desc(q)
+            desc = driving_index_desc(q)
             assert desc is not None and 'cost_b' in desc, f"expected cost_b to drive the query, got: {desc}"
             assert sorted(row.p for row in cql.execute(q)) == matching
-        # The chosen primary must survive paging (it is recovered from the paging
-        # cursor on each page), so results are correct across small page sizes too.
+        # The chosen plan must survive paging (it is pinned in the paging state and
+        # reused on each page), so results are correct across small page sizes too.
         for got in _all_rows_all_pagings(cql, f"SELECT p FROM {table} WHERE a = 1 AND b = 7 ALLOW FILTERING", 'p'):
             assert got == matching
         # cost_b's posting list is tiny (3), so by default the query skips the
-        # intersection. Setting secondary_index_intersection_skip_max_rows to 0
-        # disables that skip, forcing a real intersection - and results must stay
-        # correct either way.
+        # intersection (drives with cost_b alone -> "intersecting 0"). Setting
+        # secondary_index_intersection_skip_max_rows to 0 disables that skip,
+        # forcing a real intersection - results must stay correct either way.
         q = f"SELECT p FROM {table} WHERE a = 1 AND b = 7 ALLOW FILTERING"
         def trace_has(query, needle):
             return any(needle in e.description for e in cql.execute(query, trace=True).get_query_trace().events)
-        assert trace_has(q, 'skipping posting-list intersection')
+        assert trace_has(q, 'intersecting 0 other posting list')
         with config_value_context(cql, 'secondary_index_intersection_skip_max_rows', '0'):
-            assert trace_has(q, 'Intersecting')
+            assert trace_has(q, 'intersecting 1 other posting list')
             assert sorted(row.p for row in cql.execute(q)) == matching
 
 # CUSTOMER-303 phase 3 cost heuristic: when the cost-chosen driver already matches
@@ -311,9 +311,10 @@ def test_index_intersection_skip_when_driver_selective(cql, test_keyspace, scyll
                 matching.append((i % 20, i))
         expected = sorted(matching)
         query = f"SELECT p, c FROM {table} WHERE a = 1 AND b = 9 ALLOW FILTERING"
-        # The tiny driver (b = 9) makes the query skip the intersection.
+        # The tiny driver (b = 9) makes the query skip the intersection: it drives
+        # with b alone, so the plan intersects 0 other posting lists.
         events = cql.execute(query, trace=True).get_query_trace().events
-        assert any('skipping posting-list intersection' in e.description for e in events), \
+        assert any('intersecting 0 other posting list' in e.description for e in events), \
             "expected the selective driver to skip the intersection"
         # Correct results regardless, unpaged and across paging.
         assert sorted((r.p, r.c) for r in cql.execute(query)) == expected
@@ -2108,13 +2109,8 @@ def test_paging_and_create_index(cql, test_keyspace):
 
 # This test is the same as the previous one, but in this test the request
 # filters on both v1 and v2 is already using an index for column v2, and
-# now between the pages we add an index for v1. Used to reproduce #18992:
-# Scylla preferred the index for the first column in the query and switched
-# from v2 to v1 mid-paging, getting confused by the v2-based paging state.
-# CUSTOMER-303 phase 3 fixes this: the index driving a paged indexed query is
-# recovered from the paging cursor (whose partition key is that index's value),
-# so it stays consistent across pages even when another index appears between
-# pages.
+# now between the pages we add an index for v1. Reproduces #18992.
+@pytest.mark.xfail(reason="issue #18992")
 def test_paging_and_create_index2(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -147,6 +147,22 @@ def _all_rows_all_pagings(cql, query, column):
         results.append(sorted(got))
     return results
 
+# Pages `query` at several page sizes plus unpaged, returning the sorted list of
+# `column` across all pages each time. Intersection may produce short pages, so
+# paging is driven to completion by the paging_state, not by the fill level.
+def _paged_column(cql, query, column, page_sizes):
+    results = [sorted(getattr(row, column) for row in cql.execute(query))]
+    for page_size in page_sizes:
+        stmt = SimpleStatement(query, fetch_size=page_size)
+        got = []
+        page = cql.execute(stmt)
+        got.extend(getattr(row, column) for row in page.current_rows)
+        while page.paging_state is not None:
+            page = cql.execute(stmt, paging_state=page.paging_state)
+            got.extend(getattr(row, column) for row in page.current_rows)
+        results.append(sorted(got))
+    return results
+
 # CUSTOMER-303 phase 2: posting-list intersection. When a query restricts two (or
 # more) indexed columns with equality, ScyllaDB reads each index's posting list
 # and intersects them by base primary key, so it only reads the base-table rows
@@ -154,6 +170,9 @@ def _all_rows_all_pagings(cql, query, column):
 # one restriction and filtering the rest from the base table. The result set must
 # be exactly the same as plain filtering, both unpaged and across paging, for
 # tables with and without a clustering key.
+# Each single-column value here matches enough rows that its posting list exceeds
+# the phase-3 "skip intersection when the driver is tiny" threshold, so the query
+# genuinely intersects two posting lists rather than using one index alone.
 def test_index_intersection_correctness(cql, test_keyspace):
     for schema, has_ck in [
             ('p int primary key, a int, b int, d int', False),
@@ -162,46 +181,54 @@ def test_index_intersection_correctness(cql, test_keyspace):
             cql.execute(f"CREATE INDEX ON {table}(a)")
             cql.execute(f"CREATE INDEX ON {table}(b)")
             data = []
-            n = 60
+            # a and b each take 2 values (~120 rows each -> large posting lists),
+            # varied independently so a=x AND b=y is a real intersection.
+            n = 240
             if has_ck:
                 insert = cql.prepare(f"INSERT INTO {table}(p, c, a, b, d) VALUES (?, ?, ?, ?, ?)")
                 for i in range(n):
-                    cql.execute(insert, [i // 6, i, i % 3, i % 4, i])
-                    data.append((i % 3, i % 4, i))
+                    cql.execute(insert, [i % 20, i, i % 2, (i // 2) % 2, i])
+                    data.append((i % 2, (i // 2) % 2, i))
             else:
                 insert = cql.prepare(f"INSERT INTO {table}(p, a, b, d) VALUES (?, ?, ?, ?)")
                 for i in range(n):
-                    cql.execute(insert, [i, i % 3, i % 4, i])
-                    data.append((i % 3, i % 4, i))
-            for a in range(3):
-                for b in range(4):
+                    cql.execute(insert, [i, i % 2, (i // 2) % 2, i])
+                    data.append((i % 2, (i // 2) % 2, i))
+            for a in range(2):
+                for b in range(2):
                     expected = sorted(d for (ra, rb, d) in data if ra == a and rb == b)
                     query = f"SELECT d FROM {table} WHERE a = {a} AND b = {b} ALLOW FILTERING"
-                    for got in _all_rows_all_pagings(cql, query, 'd'):
+                    for got in _paged_column(cql, query, 'd', [3, 40]):
                         assert got == expected
 
 # Intersection must also work with three (or more) indexed equality restrictions,
 # i.e. more than one additional posting list intersected with the primary one.
+# Values are chosen so every single-column posting list is large (above the skip
+# threshold), forcing a genuine three-way intersection.
 def test_index_intersection_three_columns(cql, test_keyspace):
     with new_test_table(cql, test_keyspace, 'p int primary key, a int, b int, c int, d int') as table:
         for col in ['a', 'b', 'c']:
             cql.execute(f"CREATE INDEX ON {table}({col})")
         insert = cql.prepare(f"INSERT INTO {table}(p, a, b, c, d) VALUES (?, ?, ?, ?, ?)")
         data = []
-        for i in range(80):
-            cql.execute(insert, [i, i % 2, i % 3, i % 4, i])
-            data.append((i % 2, i % 3, i % 4, i))
-        for (a, b, c) in [(0, 0, 0), (1, 2, 3), (0, 1, 2), (1, 0, 1)]:
+        # a, b, c take independent bits of i (~120 rows per value).
+        for i in range(240):
+            a, b, c = i % 2, (i // 2) % 2, (i // 4) % 2
+            cql.execute(insert, [i, a, b, c, i])
+            data.append((a, b, c, i))
+        for (a, b, c) in [(0, 0, 0), (1, 1, 1), (0, 1, 0), (1, 0, 1)]:
             expected = sorted(d for (ra, rb, rc, d) in data if ra == a and rb == b and rc == c)
             query = f"SELECT d FROM {table} WHERE a = {a} AND b = {b} AND c = {c} ALLOW FILTERING"
-            for got in _all_rows_all_pagings(cql, query, 'd'):
+            for got in _paged_column(cql, query, 'd', [3, 40]):
                 assert got == expected
 
-# CUSTOMER-303 phase 2: the whole point of intersecting posting lists is to read
-# fewer base-table rows. Here every row has a = 1 but only a handful also have
-# b = 2. Intersection must read only the (few) matching base rows, not all the
-# a = 1 rows. We verify this via the filtered_rows_read_total metric, which counts
-# base rows read by filtered (ALLOW FILTERING) queries.
+# CUSTOMER-303: the point of the whole feature is to read fewer base-table rows.
+# Here every row has a = 1 but only a handful also have b = 2. Whether by
+# intersecting posting lists (phase 2) or - since the b = 2 driver is tiny - by
+# the phase-3 skip heuristic using b = 2 as a plain index, we must read only the
+# few matching base rows, not all the a = 1 rows. Verified via the
+# filtered_rows_read_total metric, which counts base rows read by filtered
+# (ALLOW FILTERING) queries.
 def test_index_intersection_reads_fewer_base_rows(cql, test_keyspace, scylla_only):
     with new_test_table(cql, test_keyspace, 'p int primary key, a int, b int') as table:
         cql.execute(f"CREATE INDEX ON {table}(a)")
@@ -252,14 +279,14 @@ def test_index_intersection_cost_based_selection(cql, test_keyspace, scylla_only
         for got in _all_rows_all_pagings(cql, f"SELECT p FROM {table} WHERE a = 1 AND b = 7 ALLOW FILTERING", 'p'):
             assert got == matching
 
-# CUSTOMER-303 phase 4: skip-assisted intersection. The other index's posting
-# list is probed only at the current page's candidate base keys (via clustering
-# ranges that let the promoted index skip the entries in between), rather than
-# scanning the whole token span. This stresses that path with a large, scattered
-# posting list and a clustering key (so each candidate maps to a multi-column
-# clustering-range prefix and a read has many such ranges), and checks the result
-# is exactly correct - unpaged and across paging.
-def test_index_intersection_skip_large_scattered(cql, test_keyspace):
+# CUSTOMER-303 phase 3 cost heuristic: when the cost-chosen driver already matches
+# very few rows, reading those base rows and post-filtering is cheaper than the
+# extra index reads an intersection would add, so the intersection is skipped and
+# the driver is used as a plain index (cf. PostgreSQL preferring an index scan over
+# a BitmapAnd). Every row here has a = 1 (large posting list) but only a scattered
+# ~1/13 have b = 9 (tiny posting list) - the driver - so the query must skip the
+# intersection, and must still return exactly the right rows across paging.
+def test_index_intersection_skip_when_driver_selective(cql, test_keyspace, scylla_only):
     with new_test_table(cql, test_keyspace, 'p int, c int, a int, b int, primary key (p, c)') as table:
         cql.execute(f"CREATE INDEX ON {table}(a)")
         cql.execute(f"CREATE INDEX ON {table}(b)")
@@ -267,14 +294,17 @@ def test_index_intersection_skip_large_scattered(cql, test_keyspace):
         n = 200
         matching = []
         for i in range(n):
-            # Every row has a = 1 (a large posting list); b = 9 lands on a
-            # scattered subset (~1/13 of the rows).
             b = 9 if i % 13 == 0 else 4
             cql.execute(insert, [i % 20, i, 1, b])
             if b == 9:
                 matching.append((i % 20, i))
         expected = sorted(matching)
         query = f"SELECT p, c FROM {table} WHERE a = 1 AND b = 9 ALLOW FILTERING"
+        # The tiny driver (b = 9) makes the query skip the intersection.
+        events = cql.execute(query, trace=True).get_query_trace().events
+        assert any('skipping posting-list intersection' in e.description for e in events), \
+            "expected the selective driver to skip the intersection"
+        # Correct results regardless, unpaged and across paging.
         assert sorted((r.p, r.c) for r in cql.execute(query)) == expected
         for page_size in [1, 3, 10]:
             stmt = SimpleStatement(query, fetch_size=page_size)

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -327,6 +327,30 @@ def test_index_intersection_skip_when_driver_selective(cql, test_keyspace, scyll
                 got.extend((r.p, r.c) for r in page.current_rows)
             assert sorted(got) == expected
 
+# CUSTOMER-303 phases 2-3, aggregate path: an aggregating query (COUNT) over an
+# intersection whose result spans several internal pages, with a cost-based
+# driver. The internal aggregation paging loop must translate the cursor through
+# the *driver's* view (not the statement's original index), or later internal
+# pages resume from the wrong position and the count is wrong.
+def test_index_intersection_aggregate_paging(cql, test_keyspace, small_select_internal_page_size):
+    with new_test_table(cql, test_keyspace, 'p int primary key, a int, b int') as table:
+        cql.execute(f"CREATE INDEX ON {table}(a)")
+        cql.execute(f"CREATE INDEX ON {table}(b)")
+        insert = cql.prepare(f"INSERT INTO {table}(p, a, b) VALUES (?, ?, ?)")
+        # a and b each match ~120 rows (large posting lists -> real intersection);
+        # a = 0 AND b = 0 matches ~60 rows, more than one internal page (50), so
+        # the aggregation pages internally more than once.
+        n = 240
+        expected = 0
+        for i in range(n):
+            a, b = i % 2, (i // 2) % 2
+            cql.execute(insert, [i, a, b])
+            if a == 0 and b == 0:
+                expected += 1
+        assert expected > small_select_internal_page_size
+        rows = list(cql.execute(f"SELECT count(*) AS n FROM {table} WHERE a = 0 AND b = 0 ALLOW FILTERING"))
+        assert rows[0].n == expected
+
 # Indexes can be created without an explicit name, in which case a default name is chosen.
 # However, due to #8620 it was possible to break the index creation mechanism by creating
 # a properly named regular table, which conflicts with the generated index name.

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -98,6 +98,37 @@ def test_order_of_indexes(scylla_only, cql, test_keyspace):
         index_used(f"SELECT * FROM {table} WHERE p = 1 and v1 = 1 and v3 = 2 and v2 = 2 allow filtering", "my_v2_idx")
         index_used(f"SELECT * FROM {table} WHERE p = 1 and v2 = 1 and v1 = 2 allow filtering", "my_v2_idx")
 
+# When a query restricts several indexed columns, only one index is used and the
+# remaining restrictions are applied by reading matching rows from the base table
+# and filtering them. Reading fewer base rows is better, so when the candidate
+# indexes are otherwise tied we should prefer the one whose restriction is more
+# selective. A scalar equality (v = ...) matches a single value and is more
+# selective than collection membership (s CONTAINS ...), where one element value
+# can appear in arbitrarily many rows. This is a first, statistics-free step
+# towards the multi-indexing requested in CUSTOMER-303.
+# The choice must remain a pure function of the query (consistent across
+# coordinators and time) so that paged index queries keep working (see #7969).
+def test_index_selection_prefers_more_selective_restriction(scylla_only, cql, test_keyspace):
+    schema = 'p int primary key, v int, s set<int>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE INDEX my_v_idx ON {table}(v)")
+        cql.execute(f"CREATE INDEX my_s_idx ON {table}(s)")
+        # A few rows so the traced query actually consults an index.
+        for p in range(5):
+            cql.execute(f"INSERT INTO {table}(p, v, s) VALUES ({p}, {p % 2}, {{1, 2}})")
+        def index_used(query, index_name):
+            assert any([index_name in event.description for event in cql.execute(query, trace=True).get_query_trace().events])
+        # The scalar-equality index on v is preferred over the collection-membership
+        # index on s regardless of the order the columns appear in the WHERE clause.
+        index_used(f"SELECT * FROM {table} WHERE s CONTAINS 1 AND v = 1 ALLOW FILTERING", "my_v_idx")
+        index_used(f"SELECT * FROM {table} WHERE v = 1 AND s CONTAINS 1 ALLOW FILTERING", "my_v_idx")
+        # Whichever index is used, the result set must be identical: v = 1 selects
+        # the odd-p rows, and every row's set contains 1.
+        expected = sorted([p for p in range(5) if p % 2 == 1])
+        for query in [f"SELECT p FROM {table} WHERE s CONTAINS 1 AND v = 1 ALLOW FILTERING",
+                      f"SELECT p FROM {table} WHERE v = 1 AND s CONTAINS 1 ALLOW FILTERING"]:
+            assert sorted([row.p for row in cql.execute(query)]) == expected
+
 # Indexes can be created without an explicit name, in which case a default name is chosen.
 # However, due to #8620 it was possible to break the index creation mechanism by creating
 # a properly named regular table, which conflicts with the generated index name.

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -252,6 +252,40 @@ def test_index_intersection_cost_based_selection(cql, test_keyspace, scylla_only
         for got in _all_rows_all_pagings(cql, f"SELECT p FROM {table} WHERE a = 1 AND b = 7 ALLOW FILTERING", 'p'):
             assert got == matching
 
+# CUSTOMER-303 phase 4: skip-assisted intersection. The other index's posting
+# list is probed only at the current page's candidate base keys (via clustering
+# ranges that let the promoted index skip the entries in between), rather than
+# scanning the whole token span. This stresses that path with a large, scattered
+# posting list and a clustering key (so each candidate maps to a multi-column
+# clustering-range prefix and a read has many such ranges), and checks the result
+# is exactly correct - unpaged and across paging.
+def test_index_intersection_skip_large_scattered(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'p int, c int, a int, b int, primary key (p, c)') as table:
+        cql.execute(f"CREATE INDEX ON {table}(a)")
+        cql.execute(f"CREATE INDEX ON {table}(b)")
+        insert = cql.prepare(f"INSERT INTO {table}(p, c, a, b) VALUES (?, ?, ?, ?)")
+        n = 200
+        matching = []
+        for i in range(n):
+            # Every row has a = 1 (a large posting list); b = 9 lands on a
+            # scattered subset (~1/13 of the rows).
+            b = 9 if i % 13 == 0 else 4
+            cql.execute(insert, [i % 20, i, 1, b])
+            if b == 9:
+                matching.append((i % 20, i))
+        expected = sorted(matching)
+        query = f"SELECT p, c FROM {table} WHERE a = 1 AND b = 9 ALLOW FILTERING"
+        assert sorted((r.p, r.c) for r in cql.execute(query)) == expected
+        for page_size in [1, 3, 10]:
+            stmt = SimpleStatement(query, fetch_size=page_size)
+            got = []
+            page = cql.execute(stmt)
+            got.extend((r.p, r.c) for r in page.current_rows)
+            while page.paging_state is not None:
+                page = cql.execute(stmt, paging_state=page.paging_state)
+                got.extend((r.p, r.c) for r in page.current_rows)
+            assert sorted(got) == expected
+
 # Indexes can be created without an explicit name, in which case a default name is chosen.
 # However, due to #8620 it was possible to break the index creation mechanism by creating
 # a properly named regular table, which conflicts with the generated index name.

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -278,6 +278,17 @@ def test_index_intersection_cost_based_selection(cql, test_keyspace, scylla_only
         # cursor on each page), so results are correct across small page sizes too.
         for got in _all_rows_all_pagings(cql, f"SELECT p FROM {table} WHERE a = 1 AND b = 7 ALLOW FILTERING", 'p'):
             assert got == matching
+        # cost_b's posting list is tiny (3), so by default the query skips the
+        # intersection. Setting secondary_index_intersection_skip_max_rows to 0
+        # disables that skip, forcing a real intersection - and results must stay
+        # correct either way.
+        q = f"SELECT p FROM {table} WHERE a = 1 AND b = 7 ALLOW FILTERING"
+        def trace_has(query, needle):
+            return any(needle in e.description for e in cql.execute(query, trace=True).get_query_trace().events)
+        assert trace_has(q, 'skipping posting-list intersection')
+        with config_value_context(cql, 'secondary_index_intersection_skip_max_rows', '0'):
+            assert trace_has(q, 'Intersecting')
+            assert sorted(row.p for row in cql.execute(q)) == matching
 
 # CUSTOMER-303 phase 3 cost heuristic: when the cost-chosen driver already matches
 # very few rows, reading those base rows and post-filtering is cheaper than the

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -221,6 +221,37 @@ def test_index_intersection_reads_fewer_base_rows(cql, test_keyspace, scylla_onl
         # a = 1 rows. Allow generous slack but require it to be far below 200.
         assert base_rows_read <= 20, f"read {base_rows_read} base rows for {len(matching)} matches (intersection not applied?)"
 
+# CUSTOMER-303 phase 3: cost-based index selection. When several equality-indexed
+# columns can be intersected, the one with the smallest posting list should drive
+# the scan/paging (fewest matches -> smallest posting-list scan and fewest
+# near-empty pages), regardless of the order columns appear in the WHERE clause.
+def test_index_intersection_cost_based_selection(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, 'p int primary key, a int, b int') as table:
+        cql.execute(f"CREATE INDEX cost_a ON {table}(a)")
+        cql.execute(f"CREATE INDEX cost_b ON {table}(b)")
+        insert = cql.prepare(f"INSERT INTO {table}(p, a, b) VALUES (?, ?, ?)")
+        # a = 1 matches 300 rows; only the first 3 of them also have b = 7.
+        matching = [0, 1, 2]
+        for i in range(300):
+            cql.execute(insert, [i, 1, 7 if i < 3 else 8])
+        def primary_index_desc(query):
+            events = cql.execute(query, trace=True).get_query_trace().events
+            for e in events:
+                if 'primary index is' in e.description:
+                    return e.description
+            return None
+        # The smaller posting list (cost_b, 3 entries) must be chosen over cost_a
+        # (300 entries) either way the query is written, and the result is correct.
+        for q in [f"SELECT p FROM {table} WHERE a = 1 AND b = 7 ALLOW FILTERING",
+                  f"SELECT p FROM {table} WHERE b = 7 AND a = 1 ALLOW FILTERING"]:
+            desc = primary_index_desc(q)
+            assert desc is not None and 'cost_b' in desc, f"expected cost_b to drive the query, got: {desc}"
+            assert sorted(row.p for row in cql.execute(q)) == matching
+        # The chosen primary must survive paging (it is recovered from the paging
+        # cursor on each page), so results are correct across small page sizes too.
+        for got in _all_rows_all_pagings(cql, f"SELECT p FROM {table} WHERE a = 1 AND b = 7 ALLOW FILTERING", 'p'):
+            assert got == matching
+
 # Indexes can be created without an explicit name, in which case a default name is chosen.
 # However, due to #8620 it was possible to break the index creation mechanism by creating
 # a properly named regular table, which conflicts with the generated index name.
@@ -1978,8 +2009,13 @@ def test_paging_and_create_index(cql, test_keyspace):
 
 # This test is the same as the previous one, but in this test the request
 # filters on both v1 and v2 is already using an index for column v2, and
-# now between the pages we add an index for v1. Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
+# now between the pages we add an index for v1. Used to reproduce #18992:
+# Scylla preferred the index for the first column in the query and switched
+# from v2 to v1 mid-paging, getting confused by the v2-based paging state.
+# CUSTOMER-303 phase 3 fixes this: the index driving a paged indexed query is
+# recovered from the paging cursor (whose partition key is that index's value),
+# so it stays consistent across pages even when another index appears between
+# pages.
 def test_paging_and_create_index2(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -224,29 +224,34 @@ def test_index_intersection_three_columns(cql, test_keyspace):
 
 # CUSTOMER-303: the point of the whole feature is to read fewer base-table rows.
 # Here every row has a = 1 but only a handful also have b = 2. Whether by
-# intersecting posting lists (phase 2) or - since the b = 2 driver is tiny - by
-# the phase-3 skip heuristic using b = 2 as a plain index, we must read only the
-# few matching base rows, not all the a = 1 rows. Verified via the
-# filtered_rows_read_total metric, which counts base rows read by filtered
-# (ALLOW FILTERING) queries.
+# intersecting posting lists or - since the b = 2 driver is tiny - by driving
+# with the b = 2 index alone, we must read only the few matching base rows, not
+# all the a = 1 rows. Verified via the filtered_rows_read_total metric, which
+# counts base rows read by filtered (ALLOW FILTERING) queries.
 def test_index_intersection_reads_fewer_base_rows(cql, test_keyspace, scylla_only):
-    with new_test_table(cql, test_keyspace, 'p int primary key, a int, b int') as table:
+    with new_test_table(cql, test_keyspace, 'p int primary key, a int, b int, c int') as table:
         cql.execute(f"CREATE INDEX ON {table}(a)")
         cql.execute(f"CREATE INDEX ON {table}(b)")
-        insert = cql.prepare(f"INSERT INTO {table}(p, a, b) VALUES (?, ?, ?)")
+        insert = cql.prepare(f"INSERT INTO {table}(p, a, b, c) VALUES (?, ?, ?, ?)")
         total = 200
         matching = sorted(i for i in range(total) if i % 50 == 0)  # 4 rows with b=2
         for i in range(total):
-            cql.execute(insert, [i, 1, 2 if i % 50 == 0 else 7])
-        metric = 'scylla_query_processor_filtered_rows_read_total'
+            cql.execute(insert, [i, 1, 2 if i % 50 == 0 else 7, 0])
+        # c is never indexed and 'c >= 0' is always true, which forces post-filtering
+        # on so filtered_rows_read_total actually counts the base rows read. With
+        # only indexed restrictions (a, b) the query needs no post-filtering and the
+        # counter would stay at 0 - passing the assertion below vacuously.
+        metric = 'scylla_cql_filtered_rows_read_total'
+        query = f"SELECT p FROM {table} WHERE a = 1 AND b = 2 AND c >= 0 ALLOW FILTERING"
         before = ScyllaMetrics.query(cql).get(metric) or 0
-        got = sorted(row.p for row in cql.execute(f"SELECT p FROM {table} WHERE a = 1 AND b = 2 ALLOW FILTERING"))
+        got = sorted(row.p for row in cql.execute(query))
         after = ScyllaMetrics.query(cql).get(metric) or 0
         assert got == matching
         base_rows_read = after - before
-        # With intersection we read only the ~4 matching base rows, not all 200
-        # a = 1 rows. Allow generous slack but require it to be far below 200.
-        assert base_rows_read <= 20, f"read {base_rows_read} base rows for {len(matching)} matches (intersection not applied?)"
+        # Read only the ~4 rows matching the selective b = 2 restriction, not all
+        # 200 a = 1 rows: the unselective a = 1 index must not be the one scanned.
+        # The lower bound guards against the metric silently reading nothing.
+        assert 0 < base_rows_read <= 20, f"read {base_rows_read} base rows for {len(matching)} matches (drove by the wrong index / full scan?)"
 
 # CUSTOMER-303 phase 3: cost-based index selection. When several equality-indexed
 # columns can be intersected, the one with the smallest posting list should drive


### PR DESCRIPTION
Ref: [SCYLLADB-3139](https://scylladb.atlassian.net/browse/SCYLLADB-3139) — "Multi-column secondary-index queries: intersect posting lists instead of ALLOW FILTERING the base table" (customer request: [CUSTOMER-303](https://scylladb.atlassian.net/browse/CUSTOMER-303), "Multi Indexing").

## Problem

When a query restricts several indexed columns — `WHERE a = ? AND b = ?` with a secondary index on each — ScyllaDB today picks *one* index, reads that index's entire posting list, fetches every one of those rows from the base table, and applies the remaining restrictions as post-filtering (`ALLOW FILTERING`). The base-table I/O is proportional to the size of the driving index's posting list, not to how selective the *combination* is. When each column is individually unselective but the combination is narrow, this reads far more base rows than necessary.

## Use case (Superbrowse ad retrieval)

We wants ScyllaDB for the *retrieval* stage of filtered search-results ("Superbrowse") pages — searching "blue area rugs" lands on a filtered results page. They push complexity to the indexing side (precompute fields such as an `is_sponsored` boolean) and keep the query simple: filter on a handful of fields (category, attributes/color, in-stock, internal booleans), retrieve the matching documents, then rerank downstream. The requirement: **queries must use several indexes together without turning into a base-table scan** — filtering done in one go using the indexes.

```sql
CREATE TABLE ads (
    product_id   bigint PRIMARY KEY,
    category     text,      -- e.g. 'area_rugs'
    color        text,      -- e.g. 'blue'
    in_stock     boolean,
    is_sponsored boolean,   -- precomputed by the caller
    score        float
);
CREATE INDEX ON ads(category);
CREATE INDEX ON ads(color);

-- "blue area rugs": both filters are individually broad, jointly narrow
SELECT product_id FROM ads WHERE category = 'area_rugs' AND color = 'blue';
```

## Approach

When several equality-indexed columns are restricted, intersect their posting lists by base primary key and read only the base rows matching *every* restriction (idea 1 on the ticket — the favoured one). Because index views are clustered in base-primary-key order, the intersection probes each other index only at the driver's current base keys, so the on-disk (promoted) row index skips over the entries in between — the "skip list" behaviour (idea 2), realised with the index ScyllaDB already has rather than a new format. The index that drives the scan/paging is chosen by actual posting-list size (probed per query, bounded), not `WHERE`-clause order (idea 3). When the driver is already very selective, reading its few rows and post-filtering is cheaper than the extra index reads, so the intersection is skipped and the driver is used alone (cf. PostgreSQL choosing an index scan over a `BitmapAnd`); the threshold is the live-updatable `scylla.yaml` option `secondary_index_intersection_skip_max_rows` (default 100; `0` = always intersect). Post-filtering remains a correctness backstop throughout, so results are identical either way.

## Mixed-version / paging safety

A paged query can start on one coordinator and continue on another, including during a rolling upgrade, so every coordinator must choose the *same* plan (issue #7969). The multi-index plan is therefore:

- **gated behind a new `SECONDARY_INDEX_INTERSECTION` cluster feature**, enabled only once every node is upgraded and understands it; and
- **pinned in the paging-state cookie** — the driving index chosen on page 1 is recorded and reused verbatim on every later page. A query that started before the feature was enabled carries no pinned plan and stays on the legacy single-index path for its whole life.

The deterministic single-index selection (`do_find_idx`) is unchanged from master, so the ungated/legacy plan is byte-identical to what ships today. The paging-state gains one optional, version-gated field; a cookie from a non-upgraded node deserializes to "no pinned plan" (legacy behaviour).

## Performance — reduced I/O

Representative test (single node): 15,000 products; `category = 'area_rugs'` on 2,500 of them, `color = 'blue'` on 2,500, overlapping on 60 ("blue area rugs"). Same query and data, measured via `scylla_cql_filtered_rows_read_total`:

| Approach | Base rows read |
|---|---|
| Index one column, `ALLOW FILTERING` the other (today) | 2,500 |
| Index both, intersect posting lists (this PR) | 60 |

**~42× fewer base-table rows read** — exactly `|category posting list| / |category ∩ color|`. The reduction grows with how much less selective each single index is than the combination.

## Docs

New "Querying multiple indexed columns" section in the CQL secondary-index reference; the config option is auto-documented from its `db::config` description.

## Testing

- `test/cqlpy/test_secondary_index.py` against the `dev` binary: **74 passed, 1 skipped, 22 xfailed** — no regressions. New/updated tests cover: intersection correctness (unpaged and across paging; with/without a clustering key; three intersected indexes); a metric test asserting only matching base rows are read (hardened in this PR so it can no longer pass vacuously); cost-based driver selection via trace; the skip heuristic; and flipping `secondary_index_intersection_skip_max_rows` to `0` to force a real intersection.
- `test/boost/statement_restrictions_test.cc` (index selection / restriction handling): `*** No errors detected`.

> [!NOTE]
> The intersection makes a query trust both index views rather than one view plus the base table (consistent with secondary indexes being eventually consistent) — flagged for reviewer attention. Post-filtering against the base table remains a correctness backstop.

## Note on the commit history

An earlier commit ("prefer more selective index when several are usable") refined the *deterministic* index choice by an estimated selectivity. Review correctly pointed out that changing the deterministic plan is unsafe across mixed-version coordinators, so a later commit reverts it and moves the cost-based choice behind the cluster feature + paging-state pin described above. The revert is kept as its own commit to preserve the review trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[SCYLLADB-3139]: https://scylladb.atlassian.net/browse/SCYLLADB-3139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CUSTOMER-303]: https://scylladb.atlassian.net/browse/CUSTOMER-303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ