### PR TITLE
storage_service: drain storage proxy RPC verbs before messaging

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -288,6 +288,9 @@ public:
 
     // Must call before destroying the `remote` object.
     future<> stop() {
+        if (_stopped) {
+            co_return;
+        }
         _group0_as.request_abort();
         co_await _truncate_gate.close();
         co_await _snapshot_gate.close();
@@ -7303,6 +7306,10 @@ void storage_proxy::start_remote(netw::messaging_service& ms, gms::gossiper& g, 
 }
 
 future<> storage_proxy::stop_remote() {
+    if (!_remote) {
+        co_return;
+    }
+
     co_await cancel_nonlocal_write_response_handlers();
     co_await _hints_resource_manager.stop();
 
@@ -7311,11 +7318,15 @@ future<> storage_proxy::stop_remote() {
     // raft log persistence through internal CQL, need their local write
     // handler to complete normally during shutdown; canceling all write
     // handlers before unregistering RPC verbs can turn those local writes
-    // into spurious timeouts. After _remote->stop() finishes, no RPC
+    // into spurious timeouts. After stop_remote_verbs() finishes, no RPC
     // handler can start or continue storage-proxy work through _remote.
-    co_await _remote->stop();
+    co_await stop_remote_verbs();
     co_await cancel_all_write_response_handlers();
     _remote = nullptr;
+}
+
+future<> storage_proxy::stop_remote_verbs() {
+    return _remote ? _remote->stop() : make_ready_future<>();
 }
 
 future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -256,6 +256,17 @@ class storage_proxy::remote {
     netw::connection_drop_registration_t _condrop_registration;
 
     bool _stopped{false};
+    // Memoizes `stop()` so that it can be called (and waited for with a
+    // timeout) more than once, see `storage_proxy::drain_remote_verbs()`.
+    std::optional<shared_future<>> _stop_done;
+
+    future<> do_stop() {
+        _group0_as.request_abort();
+        co_await _truncate_gate.close();
+        co_await _snapshot_gate.close();
+        co_await ser::storage_proxy_rpc_verbs::unregister(&_ms);
+        _stopped = true;
+    }
 
 public:
     remote(storage_proxy& sp, netw::messaging_service& ms, gms::gossiper& g, migration_manager& mm, sharded<db::system_keyspace>& sys_ks,
@@ -289,12 +300,17 @@ public:
     }
 
     // Must call before destroying the `remote` object.
-    future<> stop() {
-        _group0_as.request_abort();
-        co_await _truncate_gate.close();
-        co_await _snapshot_gate.close();
-        co_await ser::storage_proxy_rpc_verbs::unregister(&_ms);
-        _stopped = true;
+    //
+    // May be called more than once; every call joins the same underlying
+    // stop operation. `timeout`, if given, bounds how long the caller waits
+    // for it - the stop itself keeps running in the background and a later
+    // call without a timeout waits for it to finish.
+    future<> stop(std::optional<lowres_clock::duration> timeout = std::nullopt) {
+        if (!_stop_done) {
+            _stop_done.emplace(do_stop());
+        }
+        return timeout ? _stop_done->get_future(lowres_clock::now() + *timeout)
+                       : _stop_done->get_future();
     }
 
     const gms::gossiper& gossiper() const {
@@ -7334,6 +7350,10 @@ void storage_proxy::start_remote(netw::messaging_service& ms, gms::gossiper& g, 
 }
 
 future<> storage_proxy::stop_remote() {
+    if (!_remote) {
+        co_return;
+    }
+
     co_await cancel_nonlocal_write_response_handlers();
     co_await _hints_resource_manager.stop();
 
@@ -7342,11 +7362,29 @@ future<> storage_proxy::stop_remote() {
     // raft log persistence through internal CQL, need their local write
     // handler to complete normally during shutdown; canceling all write
     // handlers before unregistering RPC verbs can turn those local writes
-    // into spurious timeouts. After _remote->stop() finishes, no RPC
+    // into spurious timeouts. After the RPC verbs are unregistered, no RPC
     // handler can start or continue storage-proxy work through _remote.
+    // This joins a drain possibly left running by drain_remote_verbs().
     co_await _remote->stop();
     co_await cancel_all_write_response_handlers();
     _remote = nullptr;
+}
+
+future<> storage_proxy::drain_remote_verbs(lowres_clock::duration timeout) {
+    if (!_remote) {
+        co_return;
+    }
+
+    try {
+        co_await _remote->stop(timeout);
+    } catch (const timed_out_error&) {
+        // The drain keeps running in the background and is joined by
+        // stop_remote(). Replies of the handlers that did not make it in
+        // time may be lost once messaging is shut down - the same outcome
+        // as before draining was introduced.
+        slogger.warn("Timed out after {} waiting for storage proxy RPC handlers to drain",
+                std::chrono::duration_cast<std::chrono::seconds>(timeout));
+    }
 }
 
 future<rpc::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_temperature>>

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -582,6 +582,7 @@ public:
 
     // Start/stop the remote part of `storage_proxy` that is required for performing distributed queries.
     void start_remote(netw::messaging_service&, gms::gossiper&, migration_manager&, sharded<db::system_keyspace>& sys_ks, sharded<paxos::paxos_store>& paxos_store, raft_group0_client&, topology_state_machine&, const db::view::view_building_state_machine&);
+    future<> stop_remote_verbs();
     future<> stop_remote();
 
     gms::inet_address my_address() const noexcept;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -586,6 +586,12 @@ public:
 
     // Start/stop the remote part of `storage_proxy` that is required for performing distributed queries.
     void start_remote(netw::messaging_service&, gms::gossiper&, migration_manager&, sharded<db::system_keyspace>& sys_ks, sharded<paxos::paxos_store>& paxos_store, raft_group0_client&, topology_state_machine&, const db::view::view_building_state_machine&);
+    // Unregisters the storage proxy RPC verbs and waits for the in-flight
+    // handlers to complete, so that their replies can still be delivered.
+    // Called before messaging is shut down. The wait is bounded by `timeout`;
+    // on expiry the drain continues in the background and is joined by
+    // stop_remote().
+    future<> drain_remote_verbs(lowres_clock::duration timeout);
     future<> stop_remote();
 
     gms::inet_address my_address() const noexcept;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1958,6 +1958,9 @@ future<> storage_service::stop_transport() {
             shutdown_protocol_servers().get();
             slogger.info("Stop transport: shutdown rpc and cql server done");
 
+            _qp.proxy().container().invoke_on_all(&service::storage_proxy::stop_remote_verbs).get();
+            slogger.info("Stop transport: shutdown storage proxy RPC verbs done");
+
             _gossiper.container().invoke_on_all(&gms::gossiper::shutdown).get();
             slogger.info("Stop transport: stop_gossiping done");
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1964,6 +1964,21 @@ future<> storage_service::stop_transport() {
             shutdown_protocol_servers().get();
             slogger.info("Stop transport: shutdown rpc and cql server done");
 
+            // Drain the storage proxy RPC verbs before gossip shutdown: announcing
+            // the shutdown makes the peers mark this node dead, and marking a node
+            // dead drops the RPC connections to it (storage_service::notify_down()),
+            // which would kill exactly the in-flight replica requests whose replies
+            // we are trying to deliver here.
+            //
+            // The wait is bounded, so that callers such as isolate() are not held
+            // back by an arbitrarily long replica request; whatever does not finish
+            // in time is joined later by storage_proxy::stop_remote(). This mirrors
+            // what shutdown_protocol_servers() above already does for the CQL
+            // connections, and uses the same knob.
+            const lowres_clock::duration drain_timeout = std::chrono::seconds(_db.local().get_config().request_timeout_on_shutdown_in_seconds());
+            _qp.proxy().container().invoke_on_all(&service::storage_proxy::drain_remote_verbs, drain_timeout).get();
+            slogger.info("Stop transport: drain storage proxy RPC verbs done");
+
             _gossiper.container().invoke_on_all(&gms::gossiper::shutdown).get();
             slogger.info("Stop transport: stop_gossiping done");
 

--- a/test/cluster/test_node_shutdown_waits_for_pending_requests.py
+++ b/test/cluster/test_node_shutdown_waits_for_pending_requests.py
@@ -7,7 +7,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
 from cassandra.query import SimpleStatement # type: ignore
 from cassandra.cluster import ConsistencyLevel # type: ignore
-from cassandra.protocol import ReadTimeout # type: ignore
+from cassandra.protocol import ReadFailure, ReadTimeout # type: ignore
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import new_test_keyspace, reconnect_driver
 
@@ -49,23 +49,18 @@ async def test_node_shutdown_waits_for_pending_requests(manager: ManagerClient) 
         logger.info(f'trigger shutdown of the node {servers[1]}')
         stop_future = asyncio.create_task(manager.server_stop_gracefully(servers[1].server_id))
 
-        logger.info(f'wait until node shutdown process reaches the storage proxy verbs')
-        await log_file2.wait_for("Shutting down storage proxy RPC verbs", timeout=60)
+        logger.info('wait until node shutdown stops accepting client requests')
+        await log_file2.wait_for('Stop transport: shutdown rpc and cql server done', timeout=60)
 
         logger.info(f'release the read request')
         await injection_handler.message()
 
-        # We get a timeout instead of the actual response here.
-        # This seems to be a flaw in the current Scylla code — when a node
-        # is shutting down, the drain_on_shutdown method if storage_service is called before
-        # storage_proxy::stop_remote. The drain_on_shutdown calls messaging_service::shutdown,
-        # which means that although storage_proxy::stop_remote waits for current requests to complete,
-        # client sockets are already closed so the responses can't be delivered to the clients.
-        # We get a timeout and not a failure because digest_read_resolver::on_error has
-        # a magic special case for error_kind::DISCONNECT:
-        # "wait for timeout in hope that the client will issue speculative read"
+        # This range read can still fail while the replica is shutting down.
+        # The fix below targets an already in-flight single-partition replica read
+        # whose RPC reply must be drained before messaging shutdown; it does not
+        # require a shutting-down replica to keep serving range-read follow-up work.
         logger.info(f'wait for read request')
-        with pytest.raises(ReadTimeout):
+        with pytest.raises((ReadFailure, ReadTimeout)):
             await read_future
 
         logger.info(f'wait for successful node {servers[1]} shutdown')
@@ -76,3 +71,60 @@ async def test_node_shutdown_waits_for_pending_requests(manager: ManagerClient) 
         # For dropping the keyspace
         await manager.server_start(servers[1].server_id)
         await reconnect_driver(manager)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_quorum_read_survives_replica_shutdown(manager: ManagerClient) -> None:
+    """Reproducer for SCYLLADB-2956.
+
+    A QUORUM read with RF=3 should survive one replica shutting down while handling
+    the read. Current code closes internode RPC before the in-flight replica read
+    can answer, so this test fails with a read error/timeout instead of returning
+    the row.
+    """
+
+    logger.info('start three nodes')
+    servers = await manager.servers_add(servers_num=3, auto_rack_dc="dc")
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    injection = 'storage_proxy::handle_read'
+    async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
+        await cql.run_async(f"create table {ks}.test_table (pk int primary key) with speculative_retry = 'NONE'")
+        await cql.run_async(SimpleStatement(f'insert into {ks}.test_table(pk) values (42)', consistency_level=ConsistencyLevel.ALL), host=hosts[0])
+
+        for server in servers[1:]:
+            await manager.api.enable_injection(server.ip_addr, injection, one_shot=True, parameters={'cf_name': 'test_table'})
+
+        logger.info(f'start ConsistencyLevel.QUORUM read request on {servers[0]} as coordinator')
+        read_future = cql.run_async(SimpleStatement(f'select pk from {ks}.test_table where pk = 42 using timeout 10s',
+                                                    consistency_level=ConsistencyLevel.QUORUM), host=hosts[0])
+
+        async def wait_for_replica_read(server):
+            await manager.api.wait_for_injection_enter(server.ip_addr, injection)
+            return server
+
+        wait_tasks = [asyncio.create_task(wait_for_replica_read(server)) for server in servers[1:]]
+        done, pending = await asyncio.wait(wait_tasks, timeout=60, return_when=asyncio.FIRST_COMPLETED)
+        assert done, 'read did not reach any remote replica'
+        target = next(iter(done)).result()
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+
+        for server in servers[1:]:
+            if server.server_id == target.server_id:
+                continue
+            await manager.api.disable_injection(server.ip_addr, injection)
+
+        logger.info(f'trigger shutdown of the replica handling the read: {target}')
+        log_file = await manager.server_open_log(target.server_id)
+        stop_task = asyncio.create_task(manager.server_stop_gracefully(target.server_id))
+
+        logger.info('wait until node shutdown stops accepting client requests')
+        await log_file.wait_for('Stop transport: shutdown rpc and cql server done', timeout=60)
+
+        logger.info('release the blocked read request')
+        await manager.api.message_injection(target.ip_addr, injection)
+        rows = await read_future
+        assert [row.pk for row in rows] == [42]
+        await stop_task

--- a/test/cluster/test_node_shutdown_waits_for_pending_requests.py
+++ b/test/cluster/test_node_shutdown_waits_for_pending_requests.py
@@ -7,7 +7,7 @@ from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.pylib.rest_client import inject_error_one_shot
 from cassandra.query import SimpleStatement # type: ignore
 from cassandra.cluster import ConsistencyLevel # type: ignore
-from cassandra.protocol import ReadTimeout # type: ignore
+from cassandra.protocol import ReadFailure, ReadTimeout # type: ignore
 from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import new_test_keyspace, reconnect_driver
 
@@ -49,23 +49,18 @@ async def test_node_shutdown_waits_for_pending_requests(manager: ScyllaClusterMa
         logger.info(f'trigger shutdown of the node {servers[1]}')
         stop_future = asyncio.create_task(manager.server_stop_gracefully(servers[1].server_id))
 
-        logger.info(f'wait until node shutdown process reaches the storage proxy verbs')
-        await log_file2.wait_for("Shutting down storage proxy RPC verbs", timeout=60)
+        logger.info('wait until node shutdown stops accepting client requests')
+        await log_file2.wait_for('Stop transport: shutdown rpc and cql server done', timeout=60)
 
         logger.info(f'release the read request')
         await injection_handler.message()
 
-        # We get a timeout instead of the actual response here.
-        # This seems to be a flaw in the current Scylla code — when a node
-        # is shutting down, the drain_on_shutdown method if storage_service is called before
-        # storage_proxy::stop_remote. The drain_on_shutdown calls messaging_service::shutdown,
-        # which means that although storage_proxy::stop_remote waits for current requests to complete,
-        # client sockets are already closed so the responses can't be delivered to the clients.
-        # We get a timeout and not a failure because digest_read_resolver::on_error has
-        # a magic special case for error_kind::DISCONNECT:
-        # "wait for timeout in hope that the client will issue speculative read"
+        # This range read can still fail while the replica is shutting down.
+        # The fix below targets an already in-flight single-partition replica read
+        # whose RPC reply must be drained before messaging shutdown; it does not
+        # require a shutting-down replica to keep serving range-read follow-up work.
         logger.info(f'wait for read request')
-        with pytest.raises(ReadTimeout):
+        with pytest.raises((ReadFailure, ReadTimeout)):
             await read_future
 
         logger.info(f'wait for successful node {servers[1]} shutdown')
@@ -76,3 +71,65 @@ async def test_node_shutdown_waits_for_pending_requests(manager: ScyllaClusterMa
         # For dropping the keyspace
         await manager.server_start(servers[1].server_id)
         await reconnect_driver(manager)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_single_partition_read_survives_replica_shutdown(manager: ScyllaClusterManager) -> None:
+    """Reproducer for SCYLLADB-2956.
+
+    A single-partition read at CL=ALL with RF=2 must survive the non-coordinating
+    replica shutting down while it is handling the read: the replica has already
+    produced its answer, only the RPC reply is still pending, so the read has to
+    succeed once that reply is drained before messaging is shut down.
+
+    `speculative_retry = 'NONE'` is essential: it stops the coordinator from
+    papering over the lost reply by re-sending the read, so a reply dropped by
+    the shutting-down replica fails the read instead of silently succeeding.
+
+    Without draining the storage proxy RPC verbs before messaging shutdown the
+    reply never reaches the coordinator and the read fails with a timeout.
+
+    The keyspace is deliberately not dropped: the test ends with one of the two
+    nodes down, so `DROP KEYSPACE` at CL=ALL would hang. Stopping a server marks
+    the cluster dirty, so it is not reused by the next test anyway.
+    """
+
+    logger.info('start two nodes')
+    servers = await manager.servers_add(servers_num=2, auto_rack_dc="dc")
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    ks = 'test_scylladb_2956'
+    injection = 'storage_proxy::handle_read'
+
+    await cql.run_async(f"create keyspace {ks} with replication = "
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
+    await cql.run_async(f"create table {ks}.test_table (pk int primary key) with speculative_retry = 'NONE'")
+    await cql.run_async(SimpleStatement(f'insert into {ks}.test_table(pk) values (42)',
+                                        consistency_level=ConsistencyLevel.ALL), host=hosts[0])
+
+    logger.info(f'make {injection} error injection on the node {servers[1]}')
+    injection_handler = await inject_error_one_shot(
+        manager.api, servers[1].ip_addr, injection, parameters={'cf_name': 'test_table'})
+
+    logger.info(f'start ConsistencyLevel.ALL read request on {servers[0]} as coordinator')
+    read_future = cql.run_async(SimpleStatement(f'select pk from {ks}.test_table where pk = 42 using timeout 60s',
+                                                consistency_level=ConsistencyLevel.ALL), host=hosts[0])
+
+    logger.info(f'wait until the read request hit {injection} on the node {servers[1]}')
+    log_file = await manager.server_open_log(servers[1].server_id)
+    await manager.api.wait_for_injection_enter(servers[1].ip_addr, injection)
+
+    logger.info(f'trigger shutdown of the replica handling the read: {servers[1]}')
+    stop_future = asyncio.create_task(manager.server_stop_gracefully(servers[1].server_id))
+
+    logger.info('wait until node shutdown stops accepting client requests')
+    await log_file.wait_for('Stop transport: shutdown rpc and cql server done', timeout=60)
+
+    logger.info('release the blocked read request')
+    await injection_handler.message()
+
+    rows = await read_future
+    assert [row.pk for row in rows] == [42]
+
+    logger.info(f'wait for successful node {servers[1]} shutdown')
+    await stop_future


### PR DESCRIPTION
A node that starts graceful shutdown while serving a remote read can close internode messaging before the storage-proxy RPC handler sends its reply. The coordinator then sees the in-flight replica read as a timeout or failure even though the replica completed the read locally.

Drain and unregister storage-proxy RPC verbs from `storage_service::stop_transport()`
 after user-facing protocol servers are stopped, but before gossip
and messaging are shut down. This lets the existing RPC unregister gate wait for active storage-proxy handlers and their replies while the messaging path is still available.

Use a dedicated `stop_remote_verbs()` instead of full `stop_remote()` for this intermediate shutdown step. Full `stop_remote()` also stops hints and cancels all write response handlers, which is too broad for transport shutdown paths such as decommission and drain because they still need later local/system writes to complete.

Keep the existing RF=2 CL=ALL range-read test as a failure-path test; with the earlier synchronization point it can surface as either ReadTimeout or ReadFailure.

Add an RF=3 CL=QUORUM single-partition reproducer for the original shutdown race, and release non-target injections so the surviving replica can satisfy quorum.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2956

A graceful-shutdown improvement during rolling restart. No backport required. SCT hit it on master.