### PR TITLE
service: strong_consistency: Fix computing tablet_version

### DIFF
--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -37,6 +37,7 @@ static raft::server_id to_server_id(host_id host_id) {
     return raft::server_id{host_id.uuid()};
 };
 
+// Precondition: The passed group_leader must be a non-trivial raft::server_id.
 static std::optional<locator::tablet_replica_set> prepare_replicas_for_sc_tablet_version(locator::tablet_replica_set replicas, raft::server_id group_leader) {
     std::ranges::sort(replicas);
     const auto leader_host_id = locator::host_id{group_leader.uuid()};
@@ -550,6 +551,11 @@ std::optional<locator::tablet_routing_info_v2> groups_manager::check_tablet_vers
     }
 
     const raft::server_id group_leader = state.server->current_leader();
+    if (group_leader == raft::server_id{}) [[unlikely]] {
+        // The leader hasn't been elected yet. We cannot compute the tablet version.
+        return std::nullopt;
+    }
+
     const auto& tablet_info = tablet_map.get_tablet_info(tablet_id);
     auto maybe_replicas = prepare_replicas_for_sc_tablet_version(tablet_info.replicas, group_leader);
 


### PR DESCRIPTION
In 58ab555, we introduced a new protocol extension,
TABLETS_ROUTING_V2_EXPERIMENTAL, that brought the notion of tablet
version.

Unfortunately, the way we compute it for strongly consistent tablets
has a bug: we could pass a trivial raft::server_id to the function
prepare_replicas_for_sc_tablet_version, which would then lead to
a crash or a runtime exception, which we didn't intend. It could happen
during an election.

We fix that by first checking if the leader is trivial and branch on
it. We also add a precondition to the function mentioned above.

Refs: SCYLLADB-288

Backport: no. The offending commit is only present on master.