### PR TITLE
test: fix test_node_failure_during_tablet_migration exceeding 60s threshold

### DIFF
--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -11,7 +11,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.skip_types import skip_env
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_info
-from test.pylib.util import start_writes
+from test.pylib.util import start_writes, scale_timeout_by_mode
 from test.cluster.util import wait_for_cql_and_get_hosts, new_test_keyspace, reconnect_driver, wait_for
 import time
 import pytest
@@ -117,14 +117,20 @@ async def test_tablet_transition_sanity(manager: ManagerClient, action):
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
 @pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new", "cleanup", "cleanup_target", "end_migration", "revert_migration"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage):
+async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage, build_mode):
     if fail_stage == 'cleanup' and fail_replica == 'destination':
         skip_env('Failing destination during cleanup is pointless')
     if fail_stage == 'cleanup_target' and fail_replica == 'source':
         skip_env('Failing source during target cleanup is pointless')
 
     logger.info("Bootstrapping cluster")
-    cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
+    request_timeout_ms = scale_timeout_by_mode(build_mode, 5000)
+    cfg = {
+        'enable_user_defined_functions': False,
+        'tablets_mode_for_new_keyspaces': 'enabled',
+        'write_request_timeout_in_ms': request_timeout_ms,
+        'read_request_timeout_in_ms': request_timeout_ms,
+    }
     host_ids = []
     servers = []
 


### PR DESCRIPTION
The test runs start_writes() which issues continuous QUORUM writes with read-your-writes verification throughout the entire test, including across the node kill. Each write/read handler holds a reference to the effective replication map (ERM), which in turn pins the current token-metadata version via a version_tracker.

When a node is killed during tablet migration, the topology coordinator issues a barrier_and_drain command to all nodes before advancing to the next migration stage. This command calls stale_versions_in_use(), which blocks until all holders of the previous token-metadata version release their references.

The in-flight write-response handlers and read executors from start_writes hold those references until their own timeout fires. The test framework sets write_request_timeout_in_ms = 30s * mode_factor for all cluster tests (scylla_cluster.py), which evaluates to 60s in dev mode and 90s in debug mode. This causes a ~60s stall per node failure on all live nodes simultaneously (confirmed in logs across 5 nodes: "topology version 22 held for 58.963 [s] past expiry").

Variants that kill the source replica (which is still an active write target at that migration stage) pay the full stall. Variants that kill the destination (not yet a write target) do not. This explains why:
- streaming-source, write_both_read_old-source, etc. took ~75s
- allow_write_both_read_old-destination, cleanup-source took ~15s
- revert_migration-source took ~143s (two sequential node kills)

The regular CQL write handlers are created with is_cancellable::no , so the existing storage_proxy::on_down() cancellation path that fires on node conviction does not reach them. The drain/shutdown path has a dedicated cancel_nonlocal_write_response_handlers() call for this reason, but no equivalent exists in the migration recovery path.

Fix: override write_request_timeout_in_ms and read_request_timeout_in_ms in this test's config using scale_timeout_by_mode with a base of 5000ms (vs the framework's 30000ms).
  dev:   5000 * 2 = 10s   (was 60s)
  debug: 5000 * 3 = 15s   (was 90s)

    Measured results in dev:
    
                                                      Before: After:
      revert_migration-source        142.9s  38.0s
      cleanup_target-destination      80.4s  29.1s
      revert_migration-destination    78.4s  27.8s
      end_migration-destination       76.6s  22.2s
      write_both_read_new-source      76.4s  21.8s
      write_both_read_old-source      75.8s  22.4s
      streaming-source                75.6s  22.7s
      allow_wbro-source               75.0s  22.1s
      use_new-destination             74.4s  22.5s
      write_both_read_new-dest        73.0s  22.7s
      streaming-destination           72.5s  23.6s
      write_both_read_old-dest        72.2s  24.1s
      cleanup-source                  15.7s  14.7s  (no stall, unchanged)
      allow_wbro-destination          14.9s  14.8s  (no stall, unchanged)
    
      Suite wall time                231.5s  93.0s

Backport is not required, this is an improvement.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2251