### PR TITLE
transport/server: drop expired responses waiting in the send queue

### DIFF
--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -16,6 +16,7 @@
 #include "timeout_config.hh"
 #include "service/pager/query_plan.hh"
 #include "service/raft/raft_group0_client.hh"
+#include "service/client_state.hh"
 #include "audit/audit.hh"
 #include "utils/chunked_string.hh"
 
@@ -23,7 +24,6 @@ namespace service {
 
 class storage_proxy;
 class query_state;
-class client_state;
 
 }
 
@@ -74,6 +74,15 @@ public:
     { }
 
     timeout_config_selector get_timeout_config_selector() const { return _timeout_info.selector; }
+
+    virtual db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const {
+        return state.get_timeout_config().*get_timeout_config_selector();
+    }
+
+    // The first call installs the deadline and the timeout context
+    // on the permit, making the response subject to send-queue timeout
+    // accounting.
+    db::timeout_clock::time_point get_deadline(const service::query_state& qs, const query_options& options) const;
 
     virtual uint32_t get_bound_terms() const = 0;
 
@@ -162,6 +171,9 @@ public:
     void set_audit_info(audit::audit_info_ptr&& info) { _audit_info = std::move(info); }
 
     virtual void sanitize_audit_info() {}
+
+protected:
+    void set_timeout_write_type(db::write_type wt) { _timeout_info.write_type = wt; }
 };
 
 }

--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -50,7 +50,7 @@ class query_options;
 using cql_warnings_vec = std::vector<sstring>;
 
 class cql_statement {
-    timeout_config_selector _timeout_config_selector;
+    timeout_info _timeout_info;
     audit::audit_info_ptr _audit_info;
 protected:
     // Result set metadata, unset for statements which return no result
@@ -67,13 +67,13 @@ public:
         return false;
     }
 
-    explicit cql_statement(timeout_config_selector timeout_selector) : _timeout_config_selector(timeout_selector) {}
+    explicit cql_statement(timeout_info ti) : _timeout_info(ti) {}
     cql_statement(cql_statement&& o) = default;
-    cql_statement(const cql_statement& o) : _timeout_config_selector(o._timeout_config_selector), _audit_info(o._audit_info ? std::make_unique<audit::audit_info>(*o._audit_info) : nullptr), _metadata(o._metadata) { }
+    cql_statement(const cql_statement& o) : _timeout_info(o._timeout_info), _audit_info(o._audit_info ? std::make_unique<audit::audit_info>(*o._audit_info) : nullptr), _metadata(o._metadata) { }
     virtual ~cql_statement()
     { }
 
-    timeout_config_selector get_timeout_config_selector() const { return _timeout_config_selector; }
+    timeout_config_selector get_timeout_config_selector() const { return _timeout_info.selector; }
 
     virtual uint32_t get_bound_terms() const = 0;
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -48,6 +48,23 @@ const sstring query_processor::CQL_VERSION = "3.3.1";
 
 const std::chrono::minutes prepared_statements_cache::entry_expiry = std::chrono::minutes(60);
 
+db::timeout_clock::time_point
+cql_statement::get_deadline(const service::query_state& qs, const query_options& options) const {
+    auto permit = qs.get_permit();
+    if (permit.deadline() != db::timeout_clock::time_point::max()) {
+        return permit.deadline();
+    }
+    auto start = permit.start_time().value_or(db::timeout_clock::now());
+    auto deadline = start + get_timeout(qs.get_client_state(), options);
+    permit.set_deadline(deadline);
+    permit.set_timeout_ctx(timeout_context{
+        .cl = options.get_consistency(),
+        .is_write = _timeout_info.is_write,
+        .wt = _timeout_info.write_type,
+    });
+    return deadline;
+}
+
 struct query_processor::remote {
     remote(service::migration_manager& mm, service::mapreduce_service& fwd,
            service::storage_service& ss, service::raft_group0_client& group0_client,

--- a/cql3/statements/authentication_statement.hh
+++ b/cql3/statements/authentication_statement.hh
@@ -19,7 +19,7 @@ namespace statements {
 
 class authentication_statement : public raw::parsed_statement, public cql_statement {
 public:
-    authentication_statement() : cql_statement(&timeout_config::other_timeout) {}
+    authentication_statement() : cql_statement(other_timeout_info) {}
 
     uint32_t get_bound_terms() const override;
 

--- a/cql3/statements/authorization_statement.hh
+++ b/cql3/statements/authorization_statement.hh
@@ -23,7 +23,7 @@ namespace statements {
 
 class authorization_statement : public raw::parsed_statement, public cql_statement {
 public:
-    authorization_statement() : cql_statement(&timeout_config::other_timeout) {}
+    authorization_statement() : cql_statement(other_timeout_info) {}
 
     uint32_t get_bound_terms() const override;
 

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -33,11 +33,15 @@ namespace statements {
 
 logging::logger batch_statement::_logger("BatchStatement");
 
-timeout_config_selector
+timeout_info
 timeout_for_type(batch_statement::type t) {
-    return t == batch_statement::type::COUNTER
-            ? &timeout_config::counter_write_timeout
-            : &timeout_config::write_timeout;
+    if (t == batch_statement::type::COUNTER) {
+        return counter_write_timeout_info;
+    } else if (t == batch_statement::type::UNLOGGED) {
+        return unlogged_batch_write_timeout_info;
+    } else {
+        return batch_write_timeout_info;
+    }
 }
 
 db::timeout_clock::duration batch_statement::get_timeout(const service::client_state& state, const query_options& options) const {

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -66,6 +66,8 @@ batch_statement::batch_statement(int bound_terms, type type_,
         // build_cas_result_set_metadata right from the constructor to avoid crash trying to access
         // uninitialized batch metadata.
         build_cas_result_set_metadata();
+        // CAS so a dropped response matches the storage proxy's CAS timeout.
+        set_timeout_write_type(db::write_type::CAS);
     }
 }
 
@@ -298,7 +300,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::do_
     ++_stats.batches;
     _stats.statements_in_batches += _statements.size();
 
-    auto timeout = db::timeout_clock::now() + get_timeout(query_state.get_client_state(), options);
+    auto timeout = get_deadline(query_state, options);
     auto violations = make_lw_shared<db::large_data_violation_type>(db::large_data_violation_type::none);
 
     return get_mutations(qp, options, timeout, local, now, query_state).then([this, &qp, cl, timeout, tr_state = query_state.get_trace_state(),
@@ -370,6 +372,8 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
     if (!cl_for_paxos) [[unlikely]] {
         return make_exception_future<shared_ptr<cql_transport::messages::result_message>>(std::move(cl_for_paxos).assume_error());
     }
+    // Record request deadline
+    get_deadline(qs, options);
     std::unique_ptr<cas_request> request;
     schema_ptr schema;
 

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -132,7 +132,7 @@ public:
     virtual future<shared_ptr<cql_transport::messages::result_message>> execute_without_checking_exception_message(
             query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
-    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
+    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const override;
 private:
     friend class batch_statement_executor;
     future<shared_ptr<cql_transport::messages::result_message>> do_execute(

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -515,7 +515,7 @@ std::vector<std::vector<managed_bytes_opt>> serialize_descriptions(utils::chunke
 
 
 // DESCRIBE STATEMENT
-describe_statement::describe_statement() : cql_statement(&timeout_config::other_timeout) {}
+describe_statement::describe_statement() : cql_statement(other_timeout_info) {}
 
 uint32_t describe_statement::get_bound_terms() const { return 0; }
 

--- a/cql3/statements/drop_index_statement.cc
+++ b/cql3/statements/drop_index_statement.cc
@@ -24,7 +24,7 @@ namespace cql3 {
 namespace statements {
 
 drop_index_statement::drop_index_statement(::shared_ptr<index_name> index_name, bool if_exists)
-    : schema_altering_statement{index_name->get_cf_name(), &timeout_config::truncate_timeout}
+    : schema_altering_statement{index_name->get_cf_name(), truncate_timeout_info}
     , _index_name{index_name->get_idx()}
     , _if_exists{if_exists}
 {

--- a/cql3/statements/drop_keyspace_statement.cc
+++ b/cql3/statements/drop_keyspace_statement.cc
@@ -24,7 +24,7 @@ namespace cql3 {
 namespace statements {
 
 drop_keyspace_statement::drop_keyspace_statement(const sstring& keyspace, bool if_exists)
-    : schema_altering_statement(&timeout_config::truncate_timeout)
+    : schema_altering_statement(truncate_timeout_info)
     , _keyspace{keyspace}
     , _if_exists{if_exists}
 {

--- a/cql3/statements/drop_table_statement.cc
+++ b/cql3/statements/drop_table_statement.cc
@@ -22,7 +22,7 @@ namespace cql3 {
 namespace statements {
 
 drop_table_statement::drop_table_statement(cf_name cf_name, bool if_exists)
-    : schema_altering_statement{std::move(cf_name), &timeout_config::truncate_timeout}
+    : schema_altering_statement{std::move(cf_name), truncate_timeout_info}
     , _if_exists{if_exists}
 {
 }

--- a/cql3/statements/drop_view_statement.cc
+++ b/cql3/statements/drop_view_statement.cc
@@ -22,7 +22,7 @@ namespace cql3 {
 namespace statements {
 
 drop_view_statement::drop_view_statement(cf_name view_name, bool if_exists)
-    : schema_altering_statement{std::move(view_name), &timeout_config::truncate_timeout}
+    : schema_altering_statement{std::move(view_name), truncate_timeout_info}
     , _if_exists{if_exists}
 {
 }

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -43,12 +43,12 @@ namespace cql3 {
 
 namespace statements {
 
-timeout_config_selector
+timeout_info
 modification_statement_timeout(const schema& s) {
     if (s.is_counter()) {
-        return &timeout_config::counter_write_timeout;
+        return counter_write_timeout_info;
     } else {
-        return &timeout_config::write_timeout;
+        return write_timeout_info;
     }
 }
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -356,7 +356,7 @@ modification_statement::do_execute(query_processor& qp, service::query_state& qs
 future<coordinator_result<>>
 modification_statement::execute_without_condition(query_processor& qp, service::query_state& qs, const query_options& options, json_cache_opt& json_cache, std::vector<dht::partition_range> keys, db::large_data_violation_type* violations) const {
     auto cl = options.get_consistency();
-    auto timeout = db::timeout_clock::now() + get_timeout(qs.get_client_state(), options);
+    auto timeout = get_deadline(qs, options);
     return get_mutations(qp, options, timeout, false, options.get_timestamp(qs), qs, json_cache, std::move(keys)).then([this, cl, timeout, &qp, &qs, &options, violations] (auto mutations) {
         if (mutations.empty()) {
             return make_ready_future<coordinator_result<>>(bo::success());
@@ -433,6 +433,8 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
     if (!cl_for_paxos) [[unlikely]] {
         return make_exception_future<shared_ptr<cql_transport::messages::result_message>>(std::move(cl_for_paxos).assume_error());
     }
+    // Record request deadline
+    get_deadline(qs, options);
     db::timeout_clock::time_point now = db::timeout_clock::now();
     const timeout_config& cfg = qs.get_client_state().get_timeout_config();
 
@@ -667,6 +669,10 @@ modification_statement::prepare(data_dictionary::database db, prepare_context& c
     // participate in the caching mechanism later.
     if (!prepared_stmt->has_conditions() && prepared_stmt->_restrictions) {
         ctx.clear_pk_function_calls_cache();
+    }
+    if (prepared_stmt->has_conditions()) {
+        // CAS so a dropped response matches the storage proxy's CAS timeout.
+        prepared_stmt->set_timeout_write_type(db::write_type::CAS);
     }
     prepared_stmt->_may_use_token_aware_routing = ctx.get_partition_key_bind_indexes(*schema).size() != 0;
     return prepared_stmt;

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -264,7 +264,7 @@ public:
 
     virtual json_cache_opt maybe_prepare_json_cache(const query_options& options) const;
 
-    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
+    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const override;
 
 protected:
     /**

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -22,15 +22,15 @@ namespace statements {
 
 static logging::logger logger("schema_altering_statement");
 
-schema_altering_statement::schema_altering_statement(timeout_config_selector timeout_selector)
+schema_altering_statement::schema_altering_statement(timeout_info ti)
     : cf_statement(cf_name())
-    , cql_statement(timeout_selector)
+    , cql_statement(ti)
     , _is_column_family_level{false} {
 }
 
-schema_altering_statement::schema_altering_statement(cf_name name, timeout_config_selector timeout_selector)
+schema_altering_statement::schema_altering_statement(cf_name name, timeout_info ti)
     : cf_statement{std::move(name)}
-    , cql_statement(timeout_selector)
+    , cql_statement(ti)
     , _is_column_family_level{true} {
 }
 

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -38,9 +38,9 @@ private:
     const bool _is_column_family_level;
 
 protected:
-    explicit schema_altering_statement(timeout_config_selector timeout_selector = &timeout_config::other_timeout);
+    explicit schema_altering_statement(timeout_info ti = other_timeout_info);
 
-    schema_altering_statement(cf_name name, timeout_config_selector timeout_selector = &timeout_config::other_timeout);
+    schema_altering_statement(cf_name name, timeout_info ti = other_timeout_info);
     
     virtual bool needs_guard(query_processor& qp, service::query_state& state) const override;
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -523,6 +523,8 @@ select_statement::do_execute(query_processor& qp,
         const auto token = key_ranges[0].start()->value().as_decorated_key().token();
         cas_shard.emplace(*_schema, token);
         if (!cas_shard->this_shard()) {
+            // Record request deadline before bouncing
+            get_deadline(state, options);
             return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(
                     qp.bounce_to_shard(cas_shard->shard(), std::move(const_cast<cql3::query_options&>(options).take_cached_pk_function_calls()))
                 );
@@ -564,8 +566,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
         const query_options& options, gc_clock::time_point now, int32_t page_size, bool aggregate, bool nonpaged_filtering,
         uint64_t limit, std::optional<service::cas_shard> cas_shard) const {
     command->slice.options.set<query::partition_slice::option::allow_short_read>();
-    auto timeout_duration = get_timeout(state.get_client_state(), options);
-    auto timeout = db::timeout_clock::now() + timeout_duration;
+    auto timeout = get_deadline(state, options);
     auto p = service::pager::query_pagers::pager(qp.proxy(), _query_schema, _selection,
             state, options, command, std::move(key_ranges), needs_post_filtering() ? _restrictions : nullptr, std::move(cas_shard));
 
@@ -720,7 +721,7 @@ view_indexed_table_select_statement::do_execute_base_query(
         lw_shared_ptr<const service::pager::paging_state> paging_state) const {
     using value_type = std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>;
     auto cmd = prepare_command_for_base_query(qp, options, state, now, bool(paging_state));
-    auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
+    auto timeout = get_deadline(state, options);
     uint32_t queried_ranges_count = partition_ranges.size();
     auto&& table = qp.proxy().local_db().find_column_family(_schema);
     auto erm = table.get_effective_replication_map();
@@ -830,7 +831,7 @@ view_indexed_table_select_statement::do_execute_base_query(
         lw_shared_ptr<const service::pager::paging_state> paging_state) const {
     using value_type = std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, lw_shared_ptr<query::read_command>>;
     auto cmd = prepare_command_for_base_query(qp, options, state, now, bool(paging_state));
-    auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
+    auto timeout = get_deadline(state, options);
 
     query::result_merger merger(cmd->get_row_limit(), query::max_partitions);
     std::vector<primary_key> keys = std::move(primary_keys);
@@ -925,7 +926,7 @@ select_statement::execute_without_checking_exception_message_non_aggregate_unpag
     // is specified we need to get "limit" rows from each partition since there
     // is no way to tell which of these rows belong to the query result before
     // doing post-query ordering.
-    auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
+    auto timeout = get_deadline(state, options);
     if (needs_post_query_ordering() && _limit) {
         return do_with(std::forward<dht::partition_range_vector>(partition_ranges), [this, &qp, &state, &options, cmd, timeout, cas_shard = std::move(cas_shard)](auto& prs) {
             throwing_assert(cmd->partition_limit == query::max_partitions);
@@ -1496,7 +1497,7 @@ view_indexed_table_select_statement::find_index_partition_ranges(query_processor
 {
     using value_type = std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>;
     auto now = gc_clock::now();
-    auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
+    auto timeout = get_deadline(state, options);
     bool is_paged = options.get_page_size() >= 0;
     constexpr size_t MAX_PARTITION_RANGES = 1000;
     // Check that `partition_range_vector` won't cause a large allocation (see #18536).
@@ -1570,7 +1571,7 @@ view_indexed_table_select_statement::find_index_clustering_rows(query_processor&
 {
     using value_type = std::tuple<std::vector<primary_key>, lw_shared_ptr<const service::pager::paging_state>>;
     auto now = gc_clock::now();
-    auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
+    auto timeout = get_deadline(state, options);
     const uint64_t limit = get_inner_loop_limit(get_limit(options, _limit), _selection->is_aggregate());
     return read_posting_list(qp, options, limit, state, now, timeout, true).then(utils::result_wrap(
             [this, &options] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
@@ -1777,8 +1778,8 @@ parallelized_select_statement::do_execute(
     }
 
     command->slice.options.set<query::partition_slice::option::allow_short_read>();
-    auto timeout_duration = get_timeout(state.get_client_state(), options);
-    auto timeout = lowres_system_clock::now() + timeout_duration;
+    auto remaining = get_deadline(state, options) - db::timeout_clock::now();
+    auto timeout = lowres_system_clock::now() + remaining;
     auto reductions = _selection->get_reductions();
 
     query::mapreduce_request req = {
@@ -1907,8 +1908,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
 
     auto key_ranges = _restrictions->get_partition_key_ranges(options);
 
-    auto timeout_duration = get_timeout(state.get_client_state(), options);
-    auto timeout = db::timeout_clock::now() + timeout_duration;
+    auto timeout = get_deadline(state, options);
 
     auto& tbl = qp.proxy().local_db().find_column_family(_underlying_schema);
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -177,12 +177,12 @@ select_statement::parameters::orderings_type const& select_statement::parameters
     return _orderings;
 }
 
-timeout_config_selector
+timeout_info
 select_timeout(const restrictions::statement_restrictions& restrictions) {
     if (restrictions.is_key_range()) {
-        return &timeout_config::range_read_timeout;
+        return range_read_timeout_info;
     } else {
-        return &timeout_config::read_timeout;
+        return read_timeout_info;
     }
 }
 

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -171,7 +171,7 @@ public:
 
     bool has_group_by() const { return _group_by_cell_indices && !_group_by_cell_indices->empty(); }
 
-    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
+    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const override;
 
 protected:
     // The plan this statement scans, recorded in the paging state it hands out

--- a/cql3/statements/service_level_statement.hh
+++ b/cql3/statements/service_level_statement.hh
@@ -41,7 +41,7 @@ public:
 
 class service_level_statement : public raw::parsed_statement, public cql_statement {
 public:
-    service_level_statement() : cql_statement(&timeout_config::other_timeout) {}
+    service_level_statement() : cql_statement(other_timeout_info) {}
 
     virtual bool needs_guard(query_processor& qp, service::query_state& state) const override;
 

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -51,7 +51,7 @@ future<shared_ptr<result_message>> batch_statement::execute_without_checking_exc
         co_return seastar::make_shared<result_message::void_message>();
     }
 
-    auto timeout = db::timeout_clock::now() + (_attrs->is_timeout_set() ? _attrs->get_timeout(options) : qs.get_client_state().get_timeout_config().write_timeout);
+    auto timeout = get_deadline(qs, options);
 
     // Build partition keys for all statements and validate they all target the same partition
     std::optional<dht::decorated_key> batch_key;
@@ -113,6 +113,10 @@ future<shared_ptr<result_message>> batch_statement::execute_without_checking_exc
     }
 
     co_return seastar::make_shared<result_message::void_message>();
+}
+
+db::timeout_clock::duration batch_statement::get_timeout(const service::client_state& state, const query_options& options) const {
+    return _attrs->is_timeout_set() ? _attrs->get_timeout(options) : cql_statement::get_timeout(state, options);
 }
 
 future<> batch_statement::check_access(query_processor& qp, const service::client_state& state) const {

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -21,7 +21,7 @@ namespace cql3::statements::strong_consistency {
 static logging::logger logger("sc_batch_statement");
 
 batch_statement::batch_statement(int bound_terms, type type_, std::vector<single_statement> statements, std::unique_ptr<attributes> attrs)
-    : cql_statement(&timeout_config::write_timeout)
+    : cql_statement(batch_write_timeout_info)
     , _bound_terms(bound_terms)
     , _statements(std::move(statements))
     , _attrs(std::move(attrs))

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -23,11 +23,10 @@ static logging::logger logger("sc_batch_statement");
 batch_statement::batch_statement(int bound_terms, type type_, std::vector<single_statement> statements, std::unique_ptr<attributes> attrs)
     : cql_statement(&timeout_config::write_timeout)
     , _bound_terms(bound_terms)
-    , _type(type_)
     , _statements(std::move(statements))
     , _attrs(std::move(attrs))
 {
-    validate();
+    validate(type_);
 }
 
 batch_statement::batch_statement(type type_, std::vector<single_statement> statements, std::unique_ptr<attributes> attrs)
@@ -134,9 +133,12 @@ bool batch_statement::depends_on(std::string_view ks_name, std::optional<std::st
     return std::ranges::any_of(_statements, [&ks_name, &cf_name] (auto&& s) { return s.statement->depends_on(ks_name, cf_name); });
 }
 
-void batch_statement::validate() const {
-    if (_type == type::COUNTER) {
+void batch_statement::validate(type t) const {
+    if (t == type::COUNTER) {
         throw exceptions::invalid_request_exception("Counter batches are not supported with strongly consistent tables");
+    }
+    if (t == type::UNLOGGED) {
+        throw exceptions::invalid_request_exception("Unlogged batches are not supported with strongly consistent tables");
     }
 
     schema_ptr batch_schema;

--- a/cql3/statements/strong_consistency/batch_statement.cc
+++ b/cql3/statements/strong_consistency/batch_statement.cc
@@ -140,6 +140,12 @@ void batch_statement::validate(type t) const {
     if (t == type::UNLOGGED) {
         throw exceptions::invalid_request_exception("Unlogged batches are not supported with strongly consistent tables");
     }
+    if (_attrs->is_time_to_live_set()) {
+        throw exceptions::invalid_request_exception("Global TTL on the BATCH statement is not supported.");
+    }
+    if (_attrs->is_timestamp_set()) {
+        throw exceptions::invalid_request_exception("Strongly consistent queries don't support user-provided timestamps");
+    }
 
     schema_ptr batch_schema;
     for (const auto& s: _statements) {

--- a/cql3/statements/strong_consistency/batch_statement.hh
+++ b/cql3/statements/strong_consistency/batch_statement.hh
@@ -34,7 +34,6 @@ public:
     };
 private:
     int _bound_terms;
-    type _type;
     std::vector<single_statement> _statements;
     std::unique_ptr<attributes> _attrs;
 
@@ -56,7 +55,7 @@ public:
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
-    void validate() const;
+    void validate(type t) const;
 
     virtual void validate(query_processor& qp, const service::client_state& state) const override;
 

--- a/cql3/statements/strong_consistency/batch_statement.hh
+++ b/cql3/statements/strong_consistency/batch_statement.hh
@@ -51,6 +51,8 @@ public:
 
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
+    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const override;
+
     virtual uint32_t get_bound_terms() const override;
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -22,7 +22,7 @@ namespace cql3::statements::strong_consistency {
 static logging::logger logger("sc_modification_statement");
 
 modification_statement::modification_statement(shared_ptr<base_statement> statement)
-    : cql_statement(&timeout_config::write_timeout)
+    : cql_statement(write_timeout_info)
     , _statement(std::move(statement))
 {
 }

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -62,7 +62,7 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
 {
     validate_consistency_level(options.get_consistency());
 
-    auto timeout = db::timeout_clock::now() + _statement->get_timeout(qs.get_client_state(), options);
+    auto timeout = get_deadline(qs, options);
     auto json_cache = base_statement::json_cache_opt{};
     const auto keys = _statement->build_partition_keys(options, json_cache);
     if (keys.size() != 1 || !query::is_single_partition(keys[0])) {
@@ -115,6 +115,10 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
 
 future<> modification_statement::check_access(query_processor& qp, const service::client_state& state) const {
     return _statement->check_access(qp, state);
+}
+
+db::timeout_clock::duration modification_statement::get_timeout(const service::client_state& state, const query_options& options) const {
+    return _statement->get_timeout(state, options);
 }
 
 void modification_statement::validate(query_processor& qp, const service::client_state& state) const {

--- a/cql3/statements/strong_consistency/modification_statement.hh
+++ b/cql3/statements/strong_consistency/modification_statement.hh
@@ -42,6 +42,8 @@ public:
 
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
 
+    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const override;
+
     void validate(query_processor& qp, const service::client_state& state) const override;
 
     uint32_t get_bound_terms() const override;

--- a/cql3/statements/strong_consistency/select_statement.cc
+++ b/cql3/statements/strong_consistency/select_statement.cc
@@ -57,7 +57,7 @@ future<::shared_ptr<result_message>> select_statement::do_execute(query_processo
         query_id::create_null_id(),
         query::is_first_page::no,
         options.get_timestamp(state));
-    const auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
+    const auto timeout = get_deadline(state, options);
     auto [coordinator, holder] = qp.acquire_strongly_consistent_coordinator();
     auto query_result = co_await coordinator.get().query(_query_schema, *read_command,
         key_ranges, read_type, state.get_trace_state(), timeout, state.get_client_state().get_abort_source());

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -48,7 +48,7 @@ std::unique_ptr<prepared_statement> truncate_statement::prepare(data_dictionary:
 } // namespace raw
 
 truncate_statement::truncate_statement(schema_ptr schema, std::unique_ptr<attributes> prepared_attrs, uint32_t bound_terms)
-    : cql_statement(&timeout_config::truncate_timeout)
+    : cql_statement(truncate_timeout_info)
     , _schema{std::move(schema)}
     , _attrs(std::move(prepared_attrs))
     , _bound_terms(bound_terms)

--- a/cql3/statements/truncate_statement.hh
+++ b/cql3/statements/truncate_statement.hh
@@ -49,7 +49,7 @@ public:
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 private:
-    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
+    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const override;
 };
 
 }

--- a/cql3/statements/use_statement.cc
+++ b/cql3/statements/use_statement.cc
@@ -19,7 +19,7 @@ namespace cql3 {
 namespace statements {
 
 use_statement::use_statement(sstring keyspace)
-        : cql_statement(&timeout_config::other_timeout)
+        : cql_statement(other_timeout_info)
         , _keyspace(keyspace)
 {
 }

--- a/service_permit.hh
+++ b/service_permit.hh
@@ -8,22 +8,59 @@
 
 #pragma once
 
+#include <optional>
+
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 
+#include "db/timeout_clock.hh"
+#include "timeout_config.hh"
+
 class service_permit {
-    seastar::lw_shared_ptr<seastar::semaphore_units<>> _permit;
-    service_permit(seastar::semaphore_units<>&& u) : _permit(seastar::make_lw_shared<seastar::semaphore_units<>>(std::move(u))) {}
+    struct impl {
+        seastar::semaphore_units<> units;
+        std::optional<db::timeout_clock::time_point> start_time;
+        db::timeout_clock::time_point deadline = db::timeout_clock::time_point::max();
+        timeout_context timeout_ctx;
+    };
+    seastar::lw_shared_ptr<impl> _permit;
+    service_permit(seastar::semaphore_units<>&& u) : _permit(seastar::make_lw_shared<impl>()) {
+        _permit->units = std::move(u);
+    }
     friend service_permit make_service_permit(seastar::semaphore_units<>&& permit);
     friend service_permit empty_service_permit();
 public:
-    size_t count() const { return _permit ? _permit->count() : 0; };
+    size_t count() const { return _permit ? _permit->units.count() : 0; };
     // Merge additional semaphore units into this permit.
     // Used to grow the permit after the actual resource cost is known.
     void adopt(seastar::semaphore_units<>&& units) {
         if (_permit) {
-            _permit->adopt(std::move(units));
+            _permit->units.adopt(std::move(units));
         }
+    }
+    void set_start_time(db::timeout_clock::time_point t) {
+        if (_permit) {
+            _permit->start_time = t;
+        }
+    }
+    std::optional<db::timeout_clock::time_point> start_time() const {
+        return _permit ? _permit->start_time : std::nullopt;
+    }
+    void set_deadline(db::timeout_clock::time_point d) {
+        if (_permit) {
+            _permit->deadline = d;
+        }
+    }
+    db::timeout_clock::time_point deadline() const {
+        return _permit ? _permit->deadline : db::timeout_clock::time_point::max();
+    }
+    void set_timeout_ctx(timeout_context ctx) {
+        if (_permit) {
+            _permit->timeout_ctx = ctx;
+        }
+    }
+    timeout_context timeout_ctx() const {
+        return _permit ? _permit->timeout_ctx : timeout_context{};
     }
 };
 

--- a/test/cluster/test_response_timeout_in_send_queue.py
+++ b/test/cluster/test_response_timeout_in_send_queue.py
@@ -1,0 +1,513 @@
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+"""
+Test that the response timeout accounting extends through the send queue.
+
+Responses that have already exceeded their request timeout while waiting
+in the send queue should be replaced with a typed timeout error
+(ReadTimeout/WriteTimeout) rather than sent to the client as a successful
+result. This prevents a cascade effect where expired responses block fresh
+ones, causing unnecessary additional timeouts.
+"""
+
+import asyncio
+import pytest
+
+from cassandra import ConsistencyLevel, WriteType  # type: ignore
+from cassandra.cluster import OperationTimedOut  # type: ignore
+from cassandra.protocol import ReadTimeout, WriteTimeout  # type: ignore
+from cassandra.query import SimpleStatement  # type: ignore
+
+from test import MODES_TIMEOUT_FACTOR
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+from test.pylib.rest_client import inject_error
+from test.pylib.tablets import get_tablet_replicas
+from test.pylib.util import gather_safely
+
+from .util import new_test_keyspace, new_test_table
+
+REQUESTS_DROPPED_METRIC = "scylla_transport_requests_dropped_due_to_timeout"
+REQUESTS_SENT_AFTER_TIMEOUT_METRIC = "scylla_transport_requests_sent_after_timeout"
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_read_response_replaced_with_read_timeout_in_send_queue(manager: ScyllaClusterManager):
+    """A SELECT whose response expires in the send queue must produce ReadTimeout."""
+    servers = await manager.servers_add(1)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            await cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1)")
+
+            metrics_before = await manager.metrics.query(host_ip)
+            dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+            # Force-expire the response at the send-queue exit - the server must
+            # replace the RESULT with ReadTimeout.
+            async with inject_error(manager.api, host_ip, "transport_expire_response_deadline"):
+                with pytest.raises(ReadTimeout, match="Request timeout exceeded"):
+                    await asyncio.wait_for(
+                        cql.run_async(f"SELECT * FROM {tbl} WHERE p = 1"), timeout=30.0)
+
+            metrics_after = await manager.metrics.query(host_ip)
+            dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+            assert dropped_after > dropped_before, (
+                f"Expected requests_dropped_due_to_timeout metric to increase, "
+                f"but it went from {dropped_before} to {dropped_after}."
+            )
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_write_response_replaced_with_write_timeout_in_send_queue(manager: ScyllaClusterManager):
+    """An INSERT whose response expires in the send queue must produce WriteTimeout."""
+    servers = await manager.servers_add(1)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            metrics_before = await manager.metrics.query(host_ip)
+            dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+            # Force-expire the response at the send-queue exit - the server must
+            # replace the RESULT with WriteTimeout.
+            async with inject_error(manager.api, host_ip, "transport_expire_response_deadline"):
+                with pytest.raises(WriteTimeout, match="Request timeout exceeded"):
+                    await asyncio.wait_for(
+                        cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (2, 2)"), timeout=30.0)
+
+            metrics_after = await manager.metrics.query(host_ip)
+            dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+            assert dropped_after > dropped_before, (
+                f"Expected requests_dropped_due_to_timeout metric to increase, "
+                f"but it went from {dropped_before} to {dropped_after}."
+            )
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_using_timeout_drives_send_queue_deadline(manager: ScyllaClusterManager, build_mode: str):
+    """USING TIMEOUT should drive the send-queue deadline, not the default server timeout."""
+    factor = MODES_TIMEOUT_FACTOR.get(build_mode, 1)
+    timeout_ms = 500 * factor
+    # Use a large default timeout - USING TIMEOUT should override it.
+    config = {
+        "read_request_timeout_in_ms": 60000,
+        "write_request_timeout_in_ms": 60000,
+        "range_read_request_timeout_in_ms": 60000,
+    }
+
+    servers = await manager.servers_add(1, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            await cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1)")
+
+            log = await manager.server_open_log(servers[0].server_id)
+
+            # The SELECT itself must complete within USING TIMEOUT; on an
+            # overloaded machine it may genuinely time out instead - retry.
+            for _ in range(10):
+                metrics_before = await manager.metrics.query(host_ip)
+                dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+                mark = await log.mark()
+
+                async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+                    # USING TIMEOUT overrides the 60s default.
+                    query_task = cql.run_async(f"SELECT * FROM {tbl} WHERE p = 1 USING TIMEOUT {timeout_ms}ms")
+
+                    await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+                    # Sleep past USING TIMEOUT but well below the configured default.
+                    await asyncio.sleep(1.5 * factor)
+
+                    await handler.message()
+
+                    # A ReadTimeout from the transport layer proves that USING
+                    # TIMEOUT drove the send-queue deadline.
+                    try:
+                        await asyncio.wait_for(query_task, timeout=10.0)
+                        pytest.fail(f"Expected the response to be dropped after "
+                                    f"USING TIMEOUT {timeout_ms}ms, but it was delivered.")
+                    except ReadTimeout as e:
+                        if "waiting in send queue" not in str(e):
+                            # A genuine coordinator timeout, not our replacement:
+                            # the SELECT outran its budget - retry.
+                            continue
+
+                metrics_after = await manager.metrics.query(host_ip)
+                dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+                assert dropped_after > dropped_before, (
+                    f"Expected requests_dropped_due_to_timeout metric to increase "
+                    f"when using USING TIMEOUT {timeout_ms}ms, but it went from "
+                    f"{dropped_before} to {dropped_after}."
+                )
+                break
+            else:
+                pytest.fail(f"SELECT never completed within USING TIMEOUT "
+                            f"{timeout_ms}ms in 10 attempts.")
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_using_timeout_drives_send_queue_deadline_strongly_consistent(manager: ScyllaClusterManager, build_mode: str):
+    """USING TIMEOUT must drive the send-queue deadline for strongly consistent
+    statements too: they enforce it during execution, so the deadline stamped
+    on the response has to follow it rather than the configured default."""
+    factor = MODES_TIMEOUT_FACTOR.get(build_mode, 1)
+    timeout_ms = 500 * factor
+    # Use a large default timeout - USING TIMEOUT should override it.
+    config = {
+        "write_request_timeout_in_ms": 60000,
+        "experimental_features": ["strongly-consistent-tables"],
+    }
+
+    servers = await manager.servers_add(1, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    ks_opts = ("WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+               "AND tablets = {'initial': 1} AND consistency = 'global'")
+    async with new_test_keyspace(manager, ks_opts, hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            # Warm up the tablet's raft group (leader election), so the timed
+            # INSERT below doesn't spend its USING TIMEOUT budget on bootstrap.
+            await cql.run_async(SimpleStatement(
+                f"INSERT INTO {tbl} (p, v) VALUES (0, 0)",
+                consistency_level=ConsistencyLevel.QUORUM))
+
+            log = await manager.server_open_log(servers[0].server_id)
+
+            # The INSERT itself must complete within USING TIMEOUT; on an
+            # overloaded machine it may genuinely time out instead - retry.
+            for _ in range(10):
+                metrics_before = await manager.metrics.query(host_ip)
+                dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+                mark = await log.mark()
+
+                async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+                    # USING TIMEOUT overrides the 60s default.
+                    query_task = cql.run_async(SimpleStatement(
+                        f"INSERT INTO {tbl} (p, v) VALUES (1, 1) USING TIMEOUT {timeout_ms}ms",
+                        consistency_level=ConsistencyLevel.QUORUM))
+
+                    await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+                    # Sleep past USING TIMEOUT but well below the configured default.
+                    await asyncio.sleep(1.5 * factor)
+
+                    await handler.message()
+
+                    # A WriteTimeout from the transport layer proves that USING
+                    # TIMEOUT drove the send-queue deadline.
+                    try:
+                        await asyncio.wait_for(query_task, timeout=10.0)
+                        pytest.fail(f"Expected the response to be dropped after "
+                                    f"USING TIMEOUT {timeout_ms}ms, but it was delivered.")
+                    except WriteTimeout as e:
+                        if "waiting in send queue" not in str(e):
+                            # A genuine coordinator timeout, not our replacement:
+                            # the INSERT outran its budget - retry.
+                            continue
+
+                metrics_after = await manager.metrics.query(host_ip)
+                dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+                assert dropped_after > dropped_before, (
+                    f"Expected requests_dropped_due_to_timeout metric to increase "
+                    f"when using USING TIMEOUT {timeout_ms}ms, but it went from "
+                    f"{dropped_before} to {dropped_after}."
+                )
+                break
+            else:
+                pytest.fail(f"INSERT never completed within USING TIMEOUT "
+                            f"{timeout_ms}ms in 10 attempts.")
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_fresh_response_not_dropped_in_send_queue(manager: ScyllaClusterManager):
+    """A response that has not exceeded its deadline must be delivered, not dropped.
+
+    With a large timeout the response is well within its deadline when it leaves
+    the send queue, so it must arrive intact and the dropped metric must not move.
+    """
+    config = {
+        "read_request_timeout_in_ms": 60000,
+        "write_request_timeout_in_ms": 60000,
+        "range_read_request_timeout_in_ms": 60000,
+    }
+
+    servers = await manager.servers_add(1, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            await cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1)")
+
+            metrics_before = await manager.metrics.query(host_ip)
+            dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+            log = await manager.server_open_log(servers[0].server_id)
+            mark = await log.mark()
+
+            async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+                query_task = cql.run_async(f"SELECT * FROM {tbl} WHERE p = 1")
+
+                await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+                # Release immediately - the brief hold is far below the 60s
+                # deadline, so the response must not be dropped.
+                await handler.message()
+
+                result = await asyncio.wait_for(query_task, timeout=10.0)
+                assert len(result) == 1 and result[0].v == 1, (
+                    f"Expected [(p=1, v=1)] but got {result}")
+
+            metrics_after = await manager.metrics.query(host_ip)
+            dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+            assert dropped_after == dropped_before, (
+                f"Expected requests_dropped_due_to_timeout metric to stay flat "
+                f"for a fresh response, but it went from {dropped_before} to {dropped_after}."
+            )
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_response_sent_after_timeout_is_counted(manager: ScyllaClusterManager, build_mode: str):
+    """Responses that expire during write/flush are sent but counted via requests_sent_after_timeout.
+
+    When a response's deadline expires during write_message()/flush(), we cannot
+    replace it (a partial CQL frame may already be on the wire). Instead, the
+    response is sent and counted via the requests_sent_after_timeout metric.
+    """
+    factor = MODES_TIMEOUT_FACTOR.get(build_mode, 1)
+    config = {
+        "read_request_timeout_in_ms": 500 * factor,
+        "write_request_timeout_in_ms": 500 * factor,
+        "range_read_request_timeout_in_ms": 500 * factor,
+    }
+
+    servers = await manager.servers_add(1, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            await cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1)")
+
+            log = await manager.server_open_log(servers[0].server_id)
+
+            # The SELECT must build its response within the configured timeout;
+            # on an overloaded machine it may genuinely time out instead - retry.
+            for _ in range(10):
+                metrics_before = await manager.metrics.query(host_ip)
+                sent_after_before = metrics_before.get(REQUESTS_SENT_AFTER_TIMEOUT_METRIC) or 0
+
+                mark = await log.mark()
+
+                # transport_pre_flush_delay fires after the frame header and body are
+                # written but before flush(), so the response can't be replaced (partial
+                # frame); the deadline expires mid-write and the response is sent but counted.
+                async with inject_error(manager.api, host_ip, "transport_pre_flush_delay") as handler:
+                    query_task = cql.run_async(f"SELECT * FROM {tbl} WHERE p = 1")
+
+                    await log.wait_for("transport_pre_flush_delay: waiting", from_mark=mark)
+
+                    # Sleep past the configured timeout while write is "in progress"
+                    await asyncio.sleep(1.5 * factor)
+
+                    await handler.message()
+
+                    # The response was SENT, not replaced: the deadline expired during
+                    # write/flush, which the server counts but can't abort. A ReadTimeout
+                    # here would mean it was replaced, which must not happen mid-write.
+                    # The driver's request_timeout (200s, see conftest) is far larger, so
+                    # the result usually still arrives; the metric is what we verify.
+                    try:
+                        result = await asyncio.wait_for(query_task, timeout=10.0)
+                        assert len(result) == 1 and result[0].v == 1, (
+                            f"Expected [(p=1, v=1)] but got {result}")
+                    except OperationTimedOut:
+                        # Driver gave up waiting; the server still sent it, metric still valid.
+                        pass
+                    except ReadTimeout:
+                        # The SELECT outran its budget before the response was built
+                        # (a genuine coordinator timeout) - retry.
+                        continue
+
+                metrics_after = await manager.metrics.query(host_ip)
+                sent_after_after = metrics_after.get(REQUESTS_SENT_AFTER_TIMEOUT_METRIC) or 0
+                assert sent_after_after > sent_after_before, (
+                    f"Expected requests_sent_after_timeout metric to increase, "
+                    f"but it went from {sent_after_before} to {sent_after_after}."
+                )
+                break
+            else:
+                pytest.fail("SELECT never completed within its request timeout in 10 attempts.")
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_truncate_and_drop_responses_not_dropped_in_send_queue(manager: ScyllaClusterManager):
+    """TRUNCATE and DROP responses must never be replaced with a timeout error.
+
+    They never bind a request deadline on their permit (only statements that
+    compute one via get_deadline() participate in send-queue dropping). With
+    transport_expire_response_deadline treating every deadline-carrying response
+    as already expired, a SELECT is dropped (control), while TRUNCATE and DROP
+    must still be delivered, since the operation was already performed.
+    """
+    servers = await manager.servers_add(1)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (p int PRIMARY KEY, v int)")
+        await cql.run_async(f"INSERT INTO {ks}.t (p, v) VALUES (1, 1)")
+
+        metrics_before = await manager.metrics.query(host_ip)
+        dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+        # The injection also drops the driver's schema-agreement probes, which
+        # would stall the DROP below for max_schema_agreement_wait; bypass it.
+        schema_agreement_wait = cql.cluster.max_schema_agreement_wait
+        cql.cluster.max_schema_agreement_wait = 0
+        try:
+            async with inject_error(manager.api, host_ip, "transport_expire_response_deadline"):
+                # Control: a read response carries a deadline, so it must be
+                # dropped - proving the injection covers the statements below.
+                with pytest.raises(ReadTimeout, match="Request timeout exceeded"):
+                    await asyncio.wait_for(
+                        cql.run_async(f"SELECT * FROM {ks}.t WHERE p = 1"), timeout=30.0)
+
+                # No send-queue deadline -> delivered despite the forced expiry.
+                await asyncio.wait_for(cql.run_async(f"TRUNCATE {ks}.t"), timeout=30.0)
+                await asyncio.wait_for(cql.run_async(f"DROP TABLE {ks}.t"), timeout=30.0)
+        finally:
+            cql.cluster.max_schema_agreement_wait = schema_agreement_wait
+
+        metrics_after = await manager.metrics.query(host_ip)
+        dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+        assert dropped_after > dropped_before, (
+            f"Expected the control SELECT to be dropped, but "
+            f"requests_dropped_due_to_timeout stayed at {dropped_before}."
+        )
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_shard_bounced_response_replaced_in_send_queue(manager: ScyllaClusterManager):
+    """A response built on a bounced-to shard must still be dropped if it expires.
+
+    An LWT can run on a different shard (a shard bounce), but its response is
+    written by the original shard, whose permit must have been stamped with the
+    request deadline before the statement bounced. Force a bounce and a forced
+    expiry: if the bounce lost the deadline, the response would be delivered
+    instead of the expected dropped+counted timeout.
+    """
+    servers = await manager.servers_add(1, cmdline=['--smp=2'])
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            await cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1)")
+
+            metrics_before = await manager.metrics.query(host_ip)
+            dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+            # Force the update to bounce to another shard (reached via invoke_on),
+            # the path that must carry the request start time across the boundary.
+            await manager.api.enable_injection(host_ip, "forced_bounce_to_shard_counter",
+                                               one_shot=False, parameters={'value': '2'})
+
+            async with inject_error(manager.api, host_ip, "transport_expire_response_deadline"):
+                # Conditional update -> LWT/CAS, runs on the cas_shard via a bounce.
+                with pytest.raises(WriteTimeout, match="Request timeout exceeded"):
+                    await asyncio.wait_for(
+                        cql.run_async(f"UPDATE {tbl} SET v = 2 WHERE p = 1 IF v = 1"), timeout=30.0)
+
+            metrics_after = await manager.metrics.query(host_ip)
+            dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+            assert dropped_after > dropped_before, (
+                f"Expected requests_dropped_due_to_timeout to increase for a "
+                f"shard-bounced response, but it went from {dropped_before} to {dropped_after}. "
+                f"This means the bounced response carried no send-queue deadline.")
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_cas_response_replaced_with_cas_write_timeout_in_send_queue(manager: ScyllaClusterManager):
+    """A dropped LWT (CAS) response must report write_type=CAS, not SIMPLE.
+
+    So a driver handles it like any other CAS timeout, matching the write_type
+    the storage proxy's CAS path reports.
+    """
+    # Single shard so the CAS runs locally (no bounce), isolating the write_type.
+    servers = await manager.servers_add(1, cmdline=['--smp=1'])
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            async with inject_error(manager.api, host_ip, "transport_expire_response_deadline"):
+                # Conditional INSERT -> LWT/CAS.
+                with pytest.raises(WriteTimeout, match="Request timeout exceeded") as excinfo:
+                    await asyncio.wait_for(
+                        cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1) IF NOT EXISTS"), timeout=30.0)
+                # Driver may expose write_type as code or name; accept either.
+                assert excinfo.value.write_type in (WriteType.CAS, "CAS"), (
+                    f"Expected write_type CAS for a dropped LWT response, "
+                    f"got {excinfo.value.write_type!r}.")
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_forwarded_response_replaced_in_send_queue(manager: ScyllaClusterManager):
+    """A forwarded response that expires in the send queue must be replaced.
+
+    An SC read issued on a non-leader node is forwarded to the leader and written
+    back from the receiving node. That node's permit carries the request deadline
+    and timeout context, recorded before the statement was forwarded. An expired
+    forwarded read must be a ReadTimeout, not a WriteTimeout.
+    """
+    config = {
+        'experimental_features': ['strongly-consistent-tables'],
+    }
+
+    servers = await manager.servers_add(2, config=config, auto_rack_dc='my_dc')
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+            "AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+        await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES (1, 10)")
+
+        # The single tablet has one replica, which is the Raft leader. An SC read
+        # issued on the other (non-replica) node is forwarded to that leader.
+        tablet_replicas = await get_tablet_replicas(manager, servers[0], ks, "test", 0)
+        replica_host_ids = {str(r[0]) for r in tablet_replicas}
+        non_replica_idx = next(i for i, hid in enumerate(host_ids)
+                               if str(hid) not in replica_host_ids)
+        non_replica_server = servers[non_replica_idx]
+        non_replica_host = hosts[non_replica_idx]
+        host_ip = non_replica_server.ip_addr
+
+        metrics_before = await manager.metrics.query(host_ip)
+        dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+        async with inject_error(manager.api, host_ip, "transport_expire_response_deadline"):
+            # Issued on the non-replica node -> forwarded to the leader.
+            with pytest.raises(ReadTimeout, match="Request timeout exceeded"):
+                await asyncio.wait_for(
+                    cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = 1", host=non_replica_host),
+                    timeout=30.0)
+
+        metrics_after = await manager.metrics.query(host_ip)
+        dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+        assert dropped_after > dropped_before, (
+            f"Expected requests_dropped_due_to_timeout to increase on the "
+            f"forwarding node, but it went from {dropped_before} to {dropped_after}.")

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -1635,6 +1635,7 @@ async def test_batch(manager: ScyllaClusterManager, batch_mode):
     - batch touching multiple tables,
     - batch touching multiple partitions,
     - statement touching multiple partition keys,
+    - unlogged batch,
     - counter batch.
     """
 
@@ -1723,7 +1724,7 @@ async def test_batch(manager: ScyllaClusterManager, batch_mode):
             await run_batch([
                 ("update", (99, 1, 1)),
                 ("delete", (1, 3)),
-            ], kind="unlogged")
+            ], kind="logged")
 
             rows = await cql.run_async(f"SELECT * FROM {table} WHERE pk = 1")
             assert len(rows) == 2
@@ -1734,23 +1735,28 @@ async def test_batch(manager: ScyllaClusterManager, batch_mode):
                 await run_batch([
                     ("insert", (1, 1, 10)),
                     ("insert", (2, 1, 20)),
-                ], kind="unlogged")
+                ], kind="logged")
 
             with pytest.raises(InvalidRequest, match="single partition"):
                 await run_batch([
                     ("delete_in", (1, 2, 1)),
+                ], kind="logged")
+
+            with pytest.raises(InvalidRequest, match="Unlogged batches are not supported"):
+                await run_batch([
+                    ("insert", (1, 1, 10)),
                 ], kind="unlogged")
 
             async with new_test_table(manager, ks, "pk int, ck int, v int, PRIMARY KEY (pk, ck)") as other_table:
                 with pytest.raises(InvalidRequest, match="same table"):
                     if batch_mode == "prepared":
-                        batch = BatchStatement(batch_type=BatchType.UNLOGGED)
+                        batch = BatchStatement(batch_type=BatchType.LOGGED)
                         batch.add(cql.prepare(f"INSERT INTO {table} (pk, ck, v) VALUES (?, ?, ?)"), (1, 1, 10))
                         batch.add(cql.prepare(f"INSERT INTO {other_table} (pk, ck, v) VALUES (?, ?, ?)"), (1, 1, 20))
                         await cql.run_async(batch)
                     else:
                         await cql.run_async(f"""
-                            BEGIN UNLOGGED BATCH
+                            BEGIN BATCH
                             INSERT INTO {table} (pk, ck, v) VALUES (1, 1, 10);
                             INSERT INTO {other_table} (pk, ck, v) VALUES (1, 1, 20);
                             APPLY BATCH

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -688,17 +688,31 @@ async def test_reject_user_provided_timestamps(manager: ScyllaClusterManager):
                 await cql.run_async(f"UPDATE {table} USING TIMESTAMP 23 SET v = 13 WHERE pk = 0")
             with pytest.raises(InvalidRequest, match=error_msg):
                 await cql.run_async(f"DELETE FROM {table} USING TIMESTAMP 23 WHERE pk = 0")
-            # FIXME(SCYLLADB-977):
-            # Add test cases for batches with timestamps. Remember to
-            # handle both whole-batch timestamps, e.g.
-            #   BEGIN BATCH USING TIMESTAMP ts
-            #     ...
-            #   APPLY BATCH
-            # as well as timestamps for individual items, e.g.
-            #   BEGIN BATCH
-            #     INSERT INTO ... USING TIMESTAMP st;
-            #     ...
-            #   APPLY BATCH
+            # A whole-batch timestamp, rejected when the batch statement is prepared.
+            with pytest.raises(InvalidRequest, match=error_msg):
+                await cql.run_async(f"""
+                    BEGIN BATCH USING TIMESTAMP 23
+                        INSERT INTO {table} (pk, v) VALUES (0, 13);
+                        INSERT INTO {table} (pk, v) VALUES (1, 13);
+                    APPLY BATCH
+                """)
+            # Timestamps on individual batch items, rejected when the inner
+            # statements are prepared.
+            with pytest.raises(InvalidRequest, match=error_msg):
+                await cql.run_async(f"""
+                    BEGIN BATCH
+                        INSERT INTO {table} (pk, v) VALUES (0, 13) USING TIMESTAMP 23;
+                        INSERT INTO {table} (pk, v) VALUES (1, 13);
+                    APPLY BATCH
+                """)
+            # A whole-batch TTL is rejected by the same validation, like the
+            # eventually consistent batch rejects it.
+            with pytest.raises(InvalidRequest, match="Global TTL on the BATCH statement is not supported"):
+                await cql.run_async(f"""
+                    BEGIN BATCH USING TTL 100
+                        INSERT INTO {table} (pk, v) VALUES (0, 13);
+                    APPLY BATCH
+                """)
 
 async def test_forward_cql_prepared_with_bound_values(manager: ScyllaClusterManager):
     """

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -950,7 +950,7 @@ async def test_timed_out_queries(manager: ScyllaClusterManager):
             return False
         except Exception as e:
             if isinstance(e, exception_type):
-                assert f"Query timed out for {table}" in str(e)
+                assert f"Query timed out for {table}" in str(e) or "waiting in send queue" in str(e)
                 return True
             pytest.fail(f"Unexpected exception: {e}")
 

--- a/timeout_config.hh
+++ b/timeout_config.hh
@@ -11,6 +11,7 @@
 
 #include "db/timeout_clock.hh"
 #include "db/write_type.hh"
+#include "db/consistency_level_type.hh"
 #include "utils/updateable_value.hh"
 
 namespace db { class config; }
@@ -70,3 +71,12 @@ constexpr timeout_info truncate_timeout_info = {.selector = &timeout_config::tru
 constexpr timeout_info other_timeout_info = {.selector = &timeout_config::other_timeout, .is_write = false, .write_type = db::write_type::SIMPLE};
 constexpr timeout_info batch_write_timeout_info = {.selector = &timeout_config::write_timeout, .is_write = true, .write_type = db::write_type::BATCH};
 constexpr timeout_info unlogged_batch_write_timeout_info = {.selector = &timeout_config::write_timeout, .is_write = true, .write_type = db::write_type::UNLOGGED_BATCH};
+
+// Context for building a typed timeout error (ReadTimeout/WriteTimeout) when a
+// response expires in the send queue. Captured at statement execution, kept on
+// the service_permit with the deadline.
+struct timeout_context {
+    db::consistency_level cl = db::consistency_level::ONE;
+    bool is_write = false;
+    db::write_type wt = db::write_type::SIMPLE; // only meaningful when is_write == true
+};

--- a/timeout_config.hh
+++ b/timeout_config.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "db/timeout_clock.hh"
+#include "db/write_type.hh"
 #include "utils/updateable_value.hh"
 
 namespace db { class config; }
@@ -54,3 +55,18 @@ struct updateable_timeout_config {
 using timeout_config_selector = db::timeout_clock::duration (timeout_config::*);
 
 extern const timeout_config infinite_timeout_config;
+
+struct timeout_info {
+    timeout_config_selector selector;
+    bool is_write;
+    db::write_type write_type = db::write_type::SIMPLE;
+};
+
+constexpr timeout_info read_timeout_info = {.selector = &timeout_config::read_timeout, .is_write = false};
+constexpr timeout_info range_read_timeout_info = {.selector = &timeout_config::range_read_timeout, .is_write = false};
+constexpr timeout_info write_timeout_info = {.selector = &timeout_config::write_timeout, .is_write = true};
+constexpr timeout_info counter_write_timeout_info = {.selector = &timeout_config::counter_write_timeout, .is_write = true, .write_type = db::write_type::COUNTER};
+constexpr timeout_info truncate_timeout_info = {.selector = &timeout_config::truncate_timeout, .is_write = true, .write_type = db::write_type::SIMPLE};
+constexpr timeout_info other_timeout_info = {.selector = &timeout_config::other_timeout, .is_write = false, .write_type = db::write_type::SIMPLE};
+constexpr timeout_info batch_write_timeout_info = {.selector = &timeout_config::write_timeout, .is_write = true, .write_type = db::write_type::BATCH};
+constexpr timeout_info unlogged_batch_write_timeout_info = {.selector = &timeout_config::write_timeout, .is_write = true, .write_type = db::write_type::UNLOGGED_BATCH};

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -93,6 +93,9 @@ public:
     cql_binary_opcode opcode() const {
         return _opcode;
     }
+    int16_t stream() const {
+        return _stream;
+    }
     size_t size() const {
         return _body.size();
     }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -372,6 +372,15 @@ cql_server::cql_server(sharded<cql3::query_processor>& qp, auth::service& auth_s
         sm::make_counter("requests_shed", _stats.requests_shed,
                         sm::description("Holds an incrementing counter with the requests that were shed due to overload (threshold configured via max_concurrent_requests_per_shard). "
                                             "The first derivative of this value shows how often we shed requests due to overload in the \"CQL transport\" component."))(basic_level),
+        sm::make_counter("requests_dropped_due_to_timeout", _stats.requests_dropped_due_to_timeout,
+                        sm::description("Holds an incrementing counter with the responses that were replaced with a timeout error "
+                                            "(ReadTimeout/WriteTimeout) because the request timeout was exceeded while the response "
+                                            "was waiting in the send queue. A growing value indicates send queue backpressure causing "
+                                            "response delivery to exceed the configured request timeout."))(basic_level).set_skip_when_empty(),
+        sm::make_counter("requests_sent_after_timeout", _stats.requests_sent_after_timeout,
+                        sm::description("Holds an incrementing counter with the responses that were sent to the client even though the request timeout "
+                                            "had expired during write/flush. These responses could not be dropped because a partial CQL frame "
+                                            "may already have been written to the socket."))(basic_level).set_skip_when_empty(),
         sm::make_counter("connections_shed", _shed_connections,
             sm::description("Holds an incrementing counter with the CQL connections that were shed due to concurrency semaphore timeout (threshold configured via uninitialized_connections_semaphore_cpu_concurrency). "
                                             "This typically can happen during connection storm. ")),
@@ -1298,6 +1307,8 @@ future<> cql_server::connection::process_request() {
           semaphore_units<> mem_permit = mem_permit_fut.get();
           return this->read_and_decompress_frame(length, flags).then([this, op, stream, flags, tracing_requested, mem_permit = make_service_permit(std::move(mem_permit)), request_start_time, request_start_timestamp] (fragmented_temporary_buffer buf) mutable {
 
+            mem_permit.set_start_time(request_start_time);
+
             ++_server._stats.requests_served;
             ++_server._stats.requests_serving;
             ++_server.get_cql_sg_stats()._requests_serving;
@@ -1347,7 +1358,7 @@ future<> cql_server::connection::process_request() {
                         }
                         pending_response_size = resp_size;
                         sg_stats._pending_response_memory += pending_response_size;
-                        write_response(std::move(response), _compression);
+                        write_response(std::move(response), mem_permit, _compression);
                     }
                     _ready_to_respond = _ready_to_respond.finally([leave = std::move(leave), permit = std::move(mem_permit), &sg_stats, pending_response_size, request_start_time] {
                         sg_stats._pending_response_memory -= pending_response_size;
@@ -2159,14 +2170,22 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
             auto sg = _config.bounce_request_smp_service_group;
             auto gcs = client_state.move_to_other_shard();
             auto gt = tracing::global_trace_state_ptr(trace_state);
-            msg = co_await container().invoke_on(shard, sg, [&, stream, dialect, version, request_start_timestamp] (cql_server& server) -> future<process_fn_return_type> {
+            // The service_permit can't cross shards. Carry the request start time
+            // by value to a fresh permit on the target shard. The re-executed
+            // statement then computes its deadline from the original start.
+            auto start_time = permit.start_time();
+            msg = co_await container().invoke_on(shard, sg, [&, stream, dialect, version, request_start_timestamp, start_time] (cql_server& server) -> future<process_fn_return_type> {
                 bytes_ostream linearization_buffer;
                 request_reader in(is, linearization_buffer);
                 auto local_client_state = gcs.get(&server._abort_source);
                 auto local_trace_state = gt.get();
                 auto& local_sg_stats = server.get_cql_sg_stats();
+                /* FIXME */ auto local_permit = empty_service_permit();
+                if (start_time) {
+                    local_permit.set_start_time(*start_time);
+                }
                 co_return co_await process_fn(local_client_state, server._query_processor, in, stream, version,
-                        /* FIXME */empty_service_permit(), std::move(local_trace_state), false, cached_vals, dialect, local_sg_stats, request_start_timestamp,
+                        std::move(local_permit), std::move(local_trace_state), false, cached_vals, dialect, local_sg_stats, request_start_timestamp,
                         server._memory_available);
             });
         } else {
@@ -2427,12 +2446,61 @@ cql_server::connection::make_client_routes_change_event(const event::client_rout
     return response;
 }
 
-void cql_server::connection::write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, cql_compression compression)
+void cql_server::connection::write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, service_permit permit, cql_compression compression)
 {
-    _ready_to_respond = _ready_to_respond.then([this, compression, response = std::move(response)] () mutable {
-        cql_server::response& r = *response;
-        auto del = make_deleter([response = std::move(response)] {});
-        return r.write_message(_write_buf, _version, compression, std::move(del));
+    _ready_to_respond = _ready_to_respond.then([this, compression, response = std::move(response), permit = std::move(permit)] () mutable {
+        auto do_write = [this, compression, response = std::move(response), permit = std::move(permit)] () mutable {
+            auto deadline = permit.deadline();
+            auto now = db::timeout_clock::now();
+            // Tests: treat any deadline-carrying response as already expired
+            utils::get_local_injector().inject("transport_expire_response_deadline", [&now] {
+                now = db::timeout_clock::time_point::max();
+            });
+            // A RESULT that exceeded its request timeout while waiting in the send
+            // queue is replaced with a typed timeout error, so it doesn't delay
+            // fresher responses behind it. Error responses are always sent as-is.
+            if (response->opcode() == cql_binary_opcode::RESULT && now > deadline) {
+                ++_server._stats.requests_dropped_due_to_timeout;
+                auto stream = response->stream();
+                auto ctx = permit.timeout_ctx();
+                auto err_code = ctx.is_write ? exceptions::exception_code::WRITE_TIMEOUT : exceptions::exception_code::READ_TIMEOUT;
+                try { ++_server._stats.errors[err_code]; } catch(...) {}
+                response = {};
+                std::unique_ptr<cql_server::response> err;
+                sstring msg = "Request timeout exceeded while response was waiting in send queue";
+                // Synthetic received=0/blockfor=1 (data_present=false for reads).
+                // The real counts are unknown here. These values make default
+                // driver retry policies not retry a request that already executed.
+                if (ctx.is_write) {
+                    err = _server.make_mutation_write_timeout_error(stream,
+                            exceptions::exception_code::WRITE_TIMEOUT, std::move(msg),
+                            ctx.cl, 0, 1, ctx.wt, tracing::trace_state_ptr());
+                } else {
+                    err = _server.make_read_timeout_error(stream,
+                            exceptions::exception_code::READ_TIMEOUT, std::move(msg),
+                            ctx.cl, 0, 1, false, tracing::trace_state_ptr());
+                }
+                cql_server::response& r = *err;
+                auto del = make_deleter([err = std::move(err)] {});
+                return r.write_message(_write_buf, _version, compression, std::move(del));
+            }
+            cql_server::response& r = *response;
+            auto del = make_deleter([response = std::move(response)] {});
+            auto write_fut = r.write_message(_write_buf, _version, compression, std::move(del));
+            if (deadline == db::timeout_clock::time_point::max()) {
+                return write_fut;
+            }
+            // A response that expires during write/flush cannot be dropped without
+            // corrupting the CQL framing, so it is sent but counted.
+            return std::move(write_fut).then([this, deadline] {
+                if (db::timeout_clock::now() > deadline) {
+                    ++_server._stats.requests_sent_after_timeout;
+                }
+            });
+        };
+        // Lets tests hold a ready response in the send queue until it expires
+        return utils::get_local_injector().inject("transport_write_response_delay",
+                utils::wait_for_message(60s)).then(std::move(do_write));
     });
 }
 
@@ -2449,7 +2517,12 @@ future<> cql_server::response::write_message(output_stream<char>& out, uint8_t v
             temporary_buffer<char> buf(reinterpret_cast<char*>(const_cast<signed char*>(fragment.data())), fragment.size(), del.share());
             return out.write(std::move(buf));
         }).then([&out] {
-            return out.flush();
+            // Lets tests expire a response mid-write. The frame is already in the
+            // output buffer, so it can't be dropped here.
+            return utils::get_local_injector().inject("transport_pre_flush_delay",
+                    utils::wait_for_message(60s)).then([&out] {
+                return out.flush();
+            });
         });
     });
 }

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -221,6 +221,8 @@ private:
         uint32_t requests_serving = 0;
         uint64_t requests_blocked_memory = 0;
         uint64_t requests_shed = 0;
+        uint64_t requests_dropped_due_to_timeout = 0;
+        uint64_t requests_sent_after_timeout = 0;
         // forwarding stats
         uint64_t requests_forwarded_successfully = 0;
         uint64_t requests_forwarded_failed = 0;
@@ -373,7 +375,7 @@ private:
 
         cql3::dialect get_dialect() const;
 
-        void write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, cql_compression compression = cql_compression::none);
+        void write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, service_permit permit = empty_service_permit(), cql_compression compression = cql_compression::none);
         
         void update_user_scheduling_group(const std::optional<auth::authenticated_user>& usr);
         void update_control_connection_scheduling_group();


### PR DESCRIPTION
Supersedes #29800, which was opened on another fork. I am taking the patch over. All prior review discussion is there, and the feedback from it has been addressed. The commits preserve the original authorship and have been rebased on current master.

Extend request timeout accounting to include the time a CQL response spends waiting in the send queue before being written to the OS socket. Currently, responses that have already exceeded their request timeout remain in the send queue, blocking fresher responses behind them and causing a cascade of timeouts. With this change, the transport layer checks the request deadline before writing each RESULT response and, if the deadline has passed, replaces it with a typed `ReadTimeout`/`WriteTimeout` error. This frees the client immediately with a proper CQL error instead of leaving it to wait for its driver-side timeout.

Additionally, responses that expire during write/flush (where we cannot abort without corrupting the CQL binary protocol framing) are tracked via a separate requests_sent_after_timeout metric.

The series is structured as:
- a mechanical refactor replacing the bare timeout_config_selector on cql_statement with a timeout_info struct carrying per-statement timeout metadata (no behavior change),
- the transport change that consumes it,
- cluster tests.

Key design points:

- The request start time is recorded on the service_permit when the request is first read. Statement execution stores the computed deadline back on the permit.
- CAS paths record the transport deadline via get_timeout() so that USING TIMEOUT is respected.
- Error responses are never dropped (they carry diagnostic information).
- The test delays use the standard error-injection framework (a no-op when injection is compiled out); the tests are skipped in release mode.
- Administrative operations (DDL, USE, auth, TRUNCATE, DROP) opt out of send-queue timeout accounting, so their responses are always delivered.

Note that the implementation deliberately replaces expired responses with a typed timeout error only before starting to write the CQL frame. Enforcing the timeout after write_message() has started would require aborting/closing the whole connection, because a partial CQL frame may already have been written and dropping only that response would corrupt the protocol stream. Closing the connection could fail unrelated in-flight requests on the same connection and may amplify retries, so this patch takes the safer approach: replace already-expired responses with a typed timeout error before they block fresher responses, and separately account for responses that expire during write/flush.

Fixes: SCYLLADB-1716

Enhancement, no need for backport.