### PR TITLE
strong consistency: calculate min_applied_timestamp

### DIFF
--- a/idl/strong_consistency/groups_manager.idl.hh
+++ b/idl/strong_consistency/groups_manager.idl.hh
@@ -8,5 +8,7 @@
 
 #include "idl/raft_storage.idl.hh"
 #include "idl/uuid.idl.hh"
+#include "idl/storage_service.idl.hh"
 
 verb [[with_timeout]] wait_for_raft_groups_to_start(raft::server_id dst_id, table_id table);
+verb [[cancellable]] get_local_applied_timestamps(raft::server_id dst_id, service::fencing_token fence, std::vector<locator::global_tablet_id> tablets) -> std::unordered_map<locator::global_tablet_id, api::timestamp_type>;

--- a/idl/strong_consistency/groups_manager.idl.hh
+++ b/idl/strong_consistency/groups_manager.idl.hh
@@ -12,3 +12,4 @@
 
 verb [[with_timeout]] wait_for_raft_groups_to_start(raft::server_id dst_id, table_id table);
 verb [[cancellable]] get_local_applied_timestamps(raft::server_id dst_id, service::fencing_token fence, std::vector<locator::global_tablet_id> tablets) -> std::unordered_map<locator::global_tablet_id, api::timestamp_type>;
+verb [[cancellable]] set_stable_timestamp(raft::server_id dst_id, service::fencing_token fence, std::unordered_map<locator::global_tablet_id, api::timestamp_type> stable_timestamps);

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -304,6 +304,11 @@ bool tablet_info::operator==(const tablet_info& o) const {
         && sstables_repaired_at == o.sstables_repaired_at;
 }
 
+const tablet_replica* tablet_info::maybe_find_replica(host_id host) const {
+    auto it = std::ranges::find_if(replicas, [&](const auto& r) { return r.host == host; });
+    return it != replicas.end() ? it : nullptr;
+}
+
 std::optional<tablet_info> merge_tablet_info(tablet_info a, tablet_info b) {
     static const tablet_task_info empty_task_info;
     auto repair_task_info = tablet_task_info::merge_repair_tasks(

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -326,6 +326,8 @@ struct tablet_info {
     tablet_info& operator=(tablet_info&&) noexcept = default;
 
     bool operator==(const tablet_info&) const;
+
+    const tablet_replica* maybe_find_replica(host_id) const;
 };
 
 /// Reft-related information for strongly-consistent tablets.

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -771,6 +771,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::RESTORE_TABLET:
     case messaging_verb::WAIT_FOR_RAFT_GROUPS_TO_START:
     case messaging_verb::GET_LOCAL_APPLIED_TIMESTAMPS:
+    case messaging_verb::SET_STABLE_TIMESTAMP:
         return 1;
     case messaging_verb::CLIENT_ID:
     case messaging_verb::MUTATION:

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -770,6 +770,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::SNAPSHOT_WITH_TABLETS:
     case messaging_verb::RESTORE_TABLET:
     case messaging_verb::WAIT_FOR_RAFT_GROUPS_TO_START:
+    case messaging_verb::GET_LOCAL_APPLIED_TIMESTAMPS:
         return 1;
     case messaging_verb::CLIENT_ID:
     case messaging_verb::MUTATION:

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -219,7 +219,8 @@ enum class messaging_verb : int32_t {
     CLONE_SSTABLE = 90,
     FETCH_COLUMN_MAPPINGS = 91,
     REPAIR_GET_TABLE_SIZE = 92,
-    LAST = 93,
+    GET_LOCAL_APPLIED_TIMESTAMPS = 93,
+    LAST = 94,
 };
 
 } // namespace netw

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -220,7 +220,8 @@ enum class messaging_verb : int32_t {
     FETCH_COLUMN_MAPPINGS = 91,
     REPAIR_GET_TABLE_SIZE = 92,
     GET_LOCAL_APPLIED_TIMESTAMPS = 93,
-    LAST = 94,
+    SET_STABLE_TIMESTAMP = 94,
+    LAST = 95,
 };
 
 } // namespace netw

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -128,6 +128,7 @@ schema_ptr make_raft_schema(sstring name, bool is_group0) {
         // id of the most recent persisted snapshot
         .with_column("snapshot_id", uuid_type, column_kind::static_column)
         .with_column("commit_idx", long_type, column_kind::static_column)
+        .with_column("stable_timestamp", long_type, column_kind::static_column)
 
         .with_hash_version()
         .set_caching_options(caching_options::get_disabled_caching_options());

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -637,8 +637,10 @@ private:
     // This is the main function that other functions call. It compares the version from the 
     // fencing_token with the fence_version on the local node/shard and returns an instance of
     // stale_topology_exception if the request coordinator is lagging behind.
+public:
     std::optional<replica::stale_topology_exception> check_fence(fencing_token token,
         locator::host_id caller_address) noexcept;
+private:
 
     // Checks the fence_token when the future is ready.
     //

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -27,12 +27,16 @@
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/sleep.hh>
 
 namespace service::strong_consistency {
 
 using namespace locator;
 
 static logging::logger logger("sc_groups_manager");
+
+// How often the leader refreshes stable_timestamp for the groups it leads.
+static constexpr auto stable_timestamp_refresh_interval = std::chrono::seconds(60);
 
 static raft::server_id to_server_id(host_id host_id) {
     return raft::server_id{host_id.uuid()};
@@ -141,6 +145,7 @@ groups_manager::groups_manager(netw::messaging_service& ms,
     , _features(features)
     , _gossiper(gossiper)
     , _raft_replay_buffer(raft_replay_buffer)
+    , _stable_timestamp_tracker(_db, _ms, _raft_groups)
 {
     init_messaging_service();
 }
@@ -463,6 +468,133 @@ future<> groups_manager::leader_info_updater(raft_group_state& state, global_tab
     }
 }
 
+future<> groups_manager::stable_timestamp_tracker::run() {
+    while (!_as.abort_requested()) {
+        try {
+            co_await seastar::sleep_abortable(stable_timestamp_refresh_interval, _as);
+        } catch (const seastar::sleep_aborted&) {
+            co_return;
+        }
+        try {
+            co_await refresh();
+        } catch (...) {
+            logger.warn("stable_timestamp_tracker::run: unexpected error: {}", std::current_exception());
+        }
+    }
+}
+
+groups_manager::stable_timestamp_tracker::stable_timestamp_tracker(replica::database& db,
+        netw::messaging_service& ms, std::unordered_map<raft::group_id, raft_group_state>& raft_groups)
+    : _db(db)
+    , _ms(ms)
+    , _raft_groups(raft_groups)
+{}
+
+void groups_manager::stable_timestamp_tracker::start() {
+    // Idempotent: update() calls this on every token_metadata update because the
+    // strongly_consistent_tables feature may only become enabled after
+    // groups_manager::start() has run, and the fiber must be launched then.
+    if (_fiber.available()) {
+        _fiber = run();
+    }
+}
+
+future<> groups_manager::stable_timestamp_tracker::stop() {
+    _as.request_abort();
+    co_await std::move(_fiber);
+}
+
+void groups_manager::stable_timestamp_tracker::advance(raft_group_state& state, api::timestamp_type candidate) {
+    if (candidate <= state.stable_timestamp) {
+        return;
+    }
+    state.stable_timestamp = candidate;
+}
+
+future<> groups_manager::stable_timestamp_tracker::refresh() {
+    auto tm = _db.get_token_metadata_ptr();
+    const auto my_host = _db.get_token_metadata().get_my_id();
+    // Our topology version, sent with the RPCs below so a receiver can fence out
+    // this request if we turn out to be lagging behind the current topology.
+    const auto fence = service::fencing_token{tm->get_version()};
+
+    std::unordered_map<host_id, std::vector<global_tablet_id>> host_tablets;
+    auto sc_tables = tm->tablets().all_tables_ungrouped() | std::views::keys | std::views::filter([&tm] (auto table) { return tm->tablets().get_tablet_map(table).has_raft_info(); }) | std::ranges::to<std::vector<table_id>>();
+    for (const auto& table : sc_tables) {
+        _as.check();
+        const auto& tmap = tm->tablets().get_tablet_map(table);
+        co_await tmap.for_each_tablet([&, my_host = my_host](tablet_id tid, const tablet_info& ti) -> future<> {
+            auto group_id = tmap.get_tablet_raft_info(tid).group_id;
+            auto git = _raft_groups.find(group_id);
+            if (git == _raft_groups.end()) {
+                return make_ready_future<>(); // Skip stable_timestamp refresh.
+            }
+
+            auto& state = git->second;
+            if (!state.leader_info) {
+                return make_ready_future<>();  // Skip stable_timestamp refresh.
+            }
+
+            if (contains(ti.replicas, {my_host, this_shard_id()})) {
+                for (const auto& replica : ti.replicas) {
+                    host_tablets[replica.host].push_back(global_tablet_id{table, tid});
+                }
+            }
+            return make_ready_future<>();
+        });
+    }
+
+    std::unordered_map<host_id, applied_timestamp_per_tablet> host_timestamps;
+    _as.check();
+    co_await coroutine::parallel_for_each(host_tablets, [&](const auto& entry) -> future<> {
+        auto& [host, tablets] = entry;
+        if (host == my_host) {
+            host_timestamps[my_host] = co_await get_applied_timestamps(_db, std::move(tablets));
+        } else {
+            auto dst = raft::server_id(host.uuid());
+            try {
+                abort_on_expiry aoe{lowres_clock::now() + std::chrono::seconds(5)};
+                auto subscription = _as.subscribe([&aoe] () noexcept {
+                    aoe.abort_source().request_abort();
+                });
+                host_timestamps[host] = co_await ser::groups_manager_rpc_verbs::send_get_local_applied_timestamps(&_ms, host, aoe.abort_source(), dst, fence, std::move(tablets));
+            } catch (...) {
+                static thread_local logger::rate_limit rate_limit{std::chrono::seconds(5)};
+                logger.log(log_level::warn, rate_limit, "stable_timestamp_tracker::refresh: failed to get timestamps from {}: {}", host, std::current_exception());
+            }
+        }
+    });
+
+    for (const auto& table : sc_tables) {
+        _as.check();
+        const auto& tmap = tm->tablets().get_tablet_map(table);
+        co_await tmap.for_each_tablet([&](tablet_id tid, const tablet_info& ti) -> future<> {
+            auto group_id = tmap.get_tablet_raft_info(tid).group_id;
+            auto git = _raft_groups.find(group_id);
+            if (git == _raft_groups.end()) {
+                return make_ready_future<>(); // Skip stable_timestamp refresh.
+            }
+
+            auto& state = git->second;
+            if (!state.leader_info) {
+                return make_ready_future<>(); // Skip stable_timestamp refresh.
+            }
+
+            auto replica_ts = [&](const tablet_replica& r) -> api::timestamp_type {
+                auto host_it = host_timestamps.find(r.host);
+                if (host_it == host_timestamps.end()) {
+                    return api::min_timestamp;
+                }
+                auto ts_it = host_it->second.find(global_tablet_id{table, tid});
+                return ts_it == host_it->second.end() ? api::min_timestamp : ts_it->second;
+            };
+            api::timestamp_type min_ts = std::ranges::min(ti.replicas | std::views::transform(replica_ts));
+            advance(git->second, min_ts);
+            return make_ready_future<>();
+        });
+    }
+}
+
 void groups_manager::update(token_metadata_ptr new_tm) {
     if (!_features.strongly_consistent_tables) {
         return;
@@ -472,6 +604,10 @@ void groups_manager::update(token_metadata_ptr new_tm) {
         _pending_tm = new_tm;
         return;
     }
+
+    // The strongly_consistent_tables feature may have become enabled only after
+    // start() ran, so launch the periodic refresh fiber here. Idempotent.
+    _stable_timestamp_tracker.start();
 
     for (auto& [id, state]: _raft_groups) {
         state.has_tablet = false;
@@ -602,6 +738,8 @@ void groups_manager::start() {
     if (_pending_tm) {
         update(std::move(_pending_tm));
     }
+
+    _stable_timestamp_tracker.start();
 }
 
 future<> groups_manager::stop() {
@@ -612,6 +750,8 @@ future<> groups_manager::stop() {
     }
 
     logger.info("stop() enter");
+
+    co_await _stable_timestamp_tracker.stop();
 
     schedule_raft_groups_deletion(true);
 

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -287,6 +287,19 @@ future<> groups_manager::wait_for_groups_to_start(lowres_clock::time_point timeo
     }
 }
 
+using applied_timestamp_per_tablet = std::unordered_map<global_tablet_id, api::timestamp_type>;
+
+static future<applied_timestamp_per_tablet> get_applied_timestamps(const replica::database& db, const std::vector<global_tablet_id>& tablets) {
+    applied_timestamp_per_tablet res;
+    res.reserve(tablets.size());
+    for (const auto& tablet : tablets) {
+        auto table = db.get_tables_metadata().get_table_if_exists(tablet.table);
+        res[tablet] = table ? table->get_max_timestamp_for_tablet(tablet.tablet) : api::min_timestamp;
+        co_await coroutine::maybe_yield();
+    }
+    co_return res;
+}
+
 void groups_manager::init_messaging_service() {
     ser::groups_manager_rpc_verbs::register_wait_for_raft_groups_to_start(&_ms,
         [this] (rpc::opt_time_point timeout, raft::server_id dst_id, table_id table) -> future<> {
@@ -297,6 +310,51 @@ void groups_manager::init_messaging_service() {
             co_await container().invoke_on_all([timeout] (groups_manager& gm) {
                 return gm.wait_for_groups_to_start(*timeout);
             });
+        }
+    );
+    ser::groups_manager_rpc_verbs::register_get_local_applied_timestamps(&_ms,
+        [this] (raft::server_id dst_id, service::fencing_token fence, std::vector<global_tablet_id> tablets) -> future<applied_timestamp_per_tablet> {
+            if (_raft_gr.get_my_raft_id() != dst_id) {
+                throw raft_destination_id_not_correct{_raft_gr.get_my_raft_id(), dst_id};
+            }
+            const auto tm = _db.get_token_metadata_ptr();
+            const auto my_host = tm->get_my_id();
+            if (auto stale = _qp.proxy().check_fence(fence, my_host); stale) {
+                throw std::move(*stale);
+            }
+
+            applied_timestamp_per_tablet result;
+            std::unordered_map<shard_id, std::vector<global_tablet_id>> by_shard;
+            for (const auto& tablet : tablets) {
+                co_await coroutine::maybe_yield();
+                if (!tm->tablets().has_tablet_map(tablet.table)) {
+                    result[tablet] = api::min_timestamp;
+                    continue;
+                }
+                auto& tmap = tm->tablets().get_tablet_map(tablet.table);
+                if (size_t(tablet.tablet) >= tmap.tablet_count()) {
+                    result[tablet] = api::min_timestamp;
+                    continue;
+                }
+                auto& info = tmap.get_tablet_info(tablet.tablet);
+                if (auto replica = info.maybe_find_replica(my_host); replica) {
+                    by_shard[replica->shard].push_back(tablet);
+                } else {
+                    result[tablet] = api::min_timestamp;
+                }
+            }
+
+            co_await coroutine::parallel_for_each(by_shard, [&] (this auto, const auto& entry) -> future<> {
+                const auto& [shard, local_tablets] = entry;
+                auto timestamps = co_await container().invoke_on(shard, [&local_tablets] (groups_manager& gm) -> future<foreign_ptr<std::unique_ptr<applied_timestamp_per_tablet>>> {
+                    co_return make_foreign(std::make_unique<applied_timestamp_per_tablet>(co_await get_applied_timestamps(gm._db, local_tablets)));
+                });
+                for (const auto& [tablet, ts] : *timestamps) {
+                    result[tablet] = ts;
+                    co_await coroutine::maybe_yield();
+                }
+            });
+            co_return result;
         }
     );
 }

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -21,6 +21,7 @@
 #include "service/storage_proxy.hh"
 #include "replica/database.hh"
 #include "db/config.hh"
+#include "utils/error_injection.hh"
 #include "idl/strong_consistency/groups_manager.dist.hh"
 #include "utils/error_injection.hh"
 #include <seastar/coroutine/parallel_for_each.hh>
@@ -516,8 +517,12 @@ future<> groups_manager::leader_info_updater(raft_group_state& state, global_tab
 
 future<> groups_manager::stable_timestamp_tracker::run() {
     while (!_as.abort_requested()) {
+        auto interval = std::chrono::duration_cast<std::chrono::milliseconds>(stable_timestamp_refresh_interval);
+        if (utils::get_local_injector().is_enabled("sc_short_stable_timestamp_refresh")) {
+            interval = std::chrono::milliseconds(200);
+        }
         try {
-            co_await seastar::sleep_abortable(stable_timestamp_refresh_interval, _as);
+            co_await seastar::sleep_abortable(interval, _as);
         } catch (const seastar::sleep_aborted&) {
             co_return;
         }

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -145,7 +145,7 @@ groups_manager::groups_manager(netw::messaging_service& ms,
     , _features(features)
     , _gossiper(gossiper)
     , _raft_replay_buffer(raft_replay_buffer)
-    , _stable_timestamp_tracker(_db, _ms, _raft_groups)
+    , _stable_timestamp_tracker(_db, _ms, _qp, _raft_groups)
 {
     init_messaging_service();
 }
@@ -402,7 +402,7 @@ void groups_manager::init_messaging_service() {
                         if (git == gm._raft_groups.end()) {
                             continue; // Group no longer hosted here; drop the update.
                         }
-                        gm._stable_timestamp_tracker.advance(git->second, ts);
+                        co_await gm._stable_timestamp_tracker.advance(git->second, group_id, ts);
                     }
                 });
             });
@@ -530,9 +530,11 @@ future<> groups_manager::stable_timestamp_tracker::run() {
 }
 
 groups_manager::stable_timestamp_tracker::stable_timestamp_tracker(replica::database& db,
-        netw::messaging_service& ms, std::unordered_map<raft::group_id, raft_group_state>& raft_groups)
+        netw::messaging_service& ms, cql3::query_processor& qp,
+        std::unordered_map<raft::group_id, raft_group_state>& raft_groups)
     : _db(db)
     , _ms(ms)
+    , _qp(qp)
     , _raft_groups(raft_groups)
 {}
 
@@ -550,11 +552,13 @@ future<> groups_manager::stable_timestamp_tracker::stop() {
     co_await std::move(_fiber);
 }
 
-void groups_manager::stable_timestamp_tracker::advance(raft_group_state& state, api::timestamp_type candidate) {
+future<> groups_manager::stable_timestamp_tracker::advance(raft_group_state& state, raft::group_id group_id, api::timestamp_type candidate) {
     if (candidate <= state.stable_timestamp) {
-        return;
+        co_return;
     }
     state.stable_timestamp = candidate;
+    // Persist the advanced value so it survives restarts and never regresses.
+    co_await raft_groups_storage::store_stable_timestamp(_qp, group_id, this_shard_id(), state.stable_timestamp);
 }
 
 future<> groups_manager::stable_timestamp_tracker::refresh() {
@@ -619,12 +623,12 @@ future<> groups_manager::stable_timestamp_tracker::refresh() {
             auto group_id = tmap.get_tablet_raft_info(tid).group_id;
             auto git = _raft_groups.find(group_id);
             if (git == _raft_groups.end()) {
-                return make_ready_future<>(); // Skip stable_timestamp refresh.
+                co_return; // Skip stable_timestamp refresh.
             }
 
             auto& state = git->second;
             if (!state.leader_info) {
-                return make_ready_future<>(); // Skip stable_timestamp refresh.
+                co_return; // Skip stable_timestamp refresh.
             }
 
             auto replica_ts = [&](const tablet_replica& r) -> api::timestamp_type {
@@ -636,14 +640,13 @@ future<> groups_manager::stable_timestamp_tracker::refresh() {
                 return ts_it == host_it->second.end() ? api::min_timestamp : ts_it->second;
             };
             api::timestamp_type min_ts = std::ranges::min(ti.replicas | std::views::transform(replica_ts));
-            advance(state, min_ts);
+            co_await advance(state, group_id, min_ts);
 
             for (const auto& replica : ti.replicas) {
                 if (replica.host != my_host) {
                     stable_timestamps[replica.host][global_tablet_id{table, tid}] = min_ts;
                 }
             }
-            return make_ready_future<>();
         });
     }
 
@@ -717,6 +720,10 @@ void groups_manager::update(token_metadata_ptr new_tm) {
                 co_await state.server_control_op.get_future();
                 co_await start_raft_group(tablet, id, std::move(new_tm));
                 state.server = &_raft_gr.get_server(id);
+
+                // Restore persisted stable_timestamp so the value survives restarts and never regresses.
+                state.stable_timestamp = co_await raft_groups_storage::load_stable_timestamp(_qp, id, this_shard_id());
+
                 state.leader_info_updater = leader_info_updater(state, tablet, id);
 
                 // We want to make sure the server is ready to serve requests before

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -362,6 +362,52 @@ void groups_manager::init_messaging_service() {
             co_return result;
         }
     );
+    ser::groups_manager_rpc_verbs::register_set_stable_timestamp(&_ms,
+        [this] (raft::server_id dst_id, service::fencing_token fence, applied_timestamp_per_tablet stable_timestamps) -> future<> {
+            if (_raft_gr.get_my_raft_id() != dst_id) {
+                throw raft_destination_id_not_correct{_raft_gr.get_my_raft_id(), dst_id};
+            }
+            const auto tm = _db.get_token_metadata_ptr();
+            const auto my_host = tm->get_my_id();
+            if (auto stale = _qp.proxy().check_fence(fence, my_host); stale) {
+                throw std::move(*stale);
+            }
+
+            // Group the tablets by the shard that hosts their local replica, so we
+            // hop to each shard at most once.
+            std::unordered_map<shard_id, applied_timestamp_per_tablet> by_shard;
+            for (const auto& [tablet, ts] : stable_timestamps) {
+                co_await coroutine::maybe_yield();
+                if (!tm->tablets().has_tablet_map(tablet.table)) {
+                    continue;
+                }
+                auto& tmap = tm->tablets().get_tablet_map(tablet.table);
+                if (size_t(tablet.tablet) >= tmap.tablet_count()) {
+                    continue;
+                }
+                auto& info = tmap.get_tablet_info(tablet.tablet);
+                if (auto replica = info.maybe_find_replica(my_host); replica) {
+                    by_shard[replica->shard][tablet] = ts;
+                }
+            }
+
+            co_await coroutine::parallel_for_each(by_shard, [&] (const auto& entry) -> future<> {
+                const auto& [shard, local_timestamps] = entry;
+                co_await container().invoke_on(shard, [&local_timestamps] (this auto, groups_manager& gm) -> future<> {
+                    auto& tablets = gm._db.get_token_metadata().tablets();
+                    for (const auto& [tablet, ts] : local_timestamps) {
+                        co_await coroutine::maybe_yield();
+                        auto group_id = tablets.get_tablet_map(tablet.table).get_tablet_raft_info(tablet.tablet).group_id;
+                        auto git = gm._raft_groups.find(group_id);
+                        if (git == gm._raft_groups.end()) {
+                            continue; // Group no longer hosted here; drop the update.
+                        }
+                        gm._stable_timestamp_tracker.advance(git->second, ts);
+                    }
+                });
+            });
+        }
+    );
 }
 
 future<> groups_manager::uninit_messaging_service() {
@@ -565,6 +611,7 @@ future<> groups_manager::stable_timestamp_tracker::refresh() {
         }
     });
 
+    std::unordered_map<host_id, applied_timestamp_per_tablet> stable_timestamps;
     for (const auto& table : sc_tables) {
         _as.check();
         const auto& tmap = tm->tablets().get_tablet_map(table);
@@ -589,10 +636,33 @@ future<> groups_manager::stable_timestamp_tracker::refresh() {
                 return ts_it == host_it->second.end() ? api::min_timestamp : ts_it->second;
             };
             api::timestamp_type min_ts = std::ranges::min(ti.replicas | std::views::transform(replica_ts));
-            advance(git->second, min_ts);
+            advance(state, min_ts);
+
+            for (const auto& replica : ti.replicas) {
+                if (replica.host != my_host) {
+                    stable_timestamps[replica.host][global_tablet_id{table, tid}] = min_ts;
+                }
+            }
             return make_ready_future<>();
         });
     }
+
+    _as.check();
+    co_await coroutine::parallel_for_each(stable_timestamps, [&](const auto& entry) -> future<> {
+        auto& [host, timestamps] = entry;
+        auto dst = raft::server_id(host.uuid());
+        try {
+            abort_on_expiry aoe{lowres_clock::now() + std::chrono::seconds(5)};
+            auto subscription = _as.subscribe([&aoe] () noexcept {
+                aoe.abort_source().request_abort();
+            });
+            co_await ser::groups_manager_rpc_verbs::send_set_stable_timestamp(
+                &_ms, host, aoe.abort_source(), dst, fence, std::move(timestamps));
+        } catch (...) {
+            static thread_local logger::rate_limit rate_limit{std::chrono::seconds(5)};
+            logger.log(log_level::warn, rate_limit, "stable_timestamp_tracker::refresh: failed to scatter stable_timestamp to {}: {}", host, std::current_exception());
+        }
+    });
 }
 
 void groups_manager::update(token_metadata_ptr new_tm) {

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -144,6 +144,7 @@ class groups_manager : public peering_sharded_service<groups_manager> {
     class stable_timestamp_tracker {
         replica::database& _db;
         netw::messaging_service& _ms;
+        cql3::query_processor& _qp;
         std::unordered_map<raft::group_id, raft_group_state>& _raft_groups;
 
         // Drives shutdown of the periodic refresh fiber.
@@ -161,6 +162,7 @@ class groups_manager : public peering_sharded_service<groups_manager> {
 
     public:
         stable_timestamp_tracker(replica::database& db, netw::messaging_service& ms,
+            cql3::query_processor& qp,
             std::unordered_map<raft::group_id, raft_group_state>& raft_groups);
 
         // Idempotently launches the background refresh fiber (no-op if already
@@ -172,8 +174,9 @@ class groups_manager : public peering_sharded_service<groups_manager> {
         // Requests shutdown and waits for the background fiber to finish.
         future<> stop();
 
-        // Bumps state.stable_timestamp to candidate if it is greater.
-        void advance(raft_group_state& state, api::timestamp_type candidate);
+        // Bumps state.stable_timestamp to candidate if it is greater, persisting
+        // the advanced value so it survives restarts and never regresses.
+        future<> advance(raft_group_state& state, raft::group_id group_id, api::timestamp_type candidate);
     };
 
     netw::messaging_service& _ms;

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -15,6 +15,8 @@
 #include "cql3/query_processor.hh"
 #include "db/commitlog/raft_commitlog_replay_buffer.hh"
 
+#include <seastar/core/abort_source.hh>
+
 namespace db {
 class system_keyspace;
 class raft_commitlog_replay_buffer;
@@ -100,6 +102,7 @@ public:
 class groups_manager : public peering_sharded_service<groups_manager> {
     class state_machine_impl;
     class rpc_impl;
+    class stable_timestamp_tracker;
 
     friend class raft_server;
 
@@ -127,6 +130,50 @@ class groups_manager : public peering_sharded_service<groups_manager> {
         std::optional<leader_info> leader_info = std::nullopt;
         condition_variable leader_info_cond = condition_variable();
         future<> leader_info_updater = make_ready_future<>();
+
+        api::timestamp_type stable_timestamp = api::min_timestamp;
+    };
+
+    /// Periodically refreshes the stable_timestamp of the raft groups this node leads.
+    ///
+    /// stable_timestamp of a group is the minimum, taken across all of its replicas,
+    /// of the highest timestamp each replica has applied. Equivalently, it is the
+    /// highest timestamp such that every replica has already applied all mutations up
+    /// to and including it. A leader can therefore safely serve reads at any timestamp
+    /// not exceeding it without a read barrier.
+    class stable_timestamp_tracker {
+        replica::database& _db;
+        netw::messaging_service& _ms;
+        std::unordered_map<raft::group_id, raft_group_state>& _raft_groups;
+
+        // Drives shutdown of the periodic refresh fiber.
+        abort_source _as;
+        // The background fiber that periodically refreshes stable_timestamp.
+        future<> _fiber = make_ready_future<>();
+
+        // Bumps state.stable_timestamp to candidate if it is greater.
+        void advance(raft_group_state& state, api::timestamp_type candidate);
+
+        // A single refresh pass: for every tablet of a group led by this node,
+        // collects applied timestamps from all replicas and advances the group's
+        // stable_timestamp to the minimum across replicas.
+        future<> refresh();
+
+        // The loop driving refresh() on a fixed interval until aborted.
+        future<> run();
+
+    public:
+        stable_timestamp_tracker(replica::database& db, netw::messaging_service& ms,
+            std::unordered_map<raft::group_id, raft_group_state>& raft_groups);
+
+        // Idempotently launches the background refresh fiber (no-op if already
+        // running). Called from groups_manager::update() because the
+        // strongly_consistent_tables feature may only become enabled after
+        // groups_manager::start() has run.
+        void start();
+
+        // Requests shutdown and waits for the background fiber to finish.
+        future<> stop();
     };
 
     netw::messaging_service& _ms;
@@ -144,6 +191,8 @@ class groups_manager : public peering_sharded_service<groups_manager> {
     bool _started = false;
 
     tablet_group_leader_cache _leader_cache;
+
+    stable_timestamp_tracker _stable_timestamp_tracker;
 
     // Should be called on the shard that hosts the Raft group
     future<> start_raft_group(locator::global_tablet_id tablet,

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -151,9 +151,6 @@ class groups_manager : public peering_sharded_service<groups_manager> {
         // The background fiber that periodically refreshes stable_timestamp.
         future<> _fiber = make_ready_future<>();
 
-        // Bumps state.stable_timestamp to candidate if it is greater.
-        void advance(raft_group_state& state, api::timestamp_type candidate);
-
         // A single refresh pass: for every tablet of a group led by this node,
         // collects applied timestamps from all replicas and advances the group's
         // stable_timestamp to the minimum across replicas.
@@ -174,6 +171,9 @@ class groups_manager : public peering_sharded_service<groups_manager> {
 
         // Requests shutdown and waits for the background fiber to finish.
         future<> stop();
+
+        // Bumps state.stable_timestamp to candidate if it is greater.
+        void advance(raft_group_state& state, api::timestamp_type candidate);
     };
 
     netw::messaging_service& _ms;

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -225,6 +225,20 @@ future<> raft_groups_storage::store_snapshot_index(cql3::query_processor& qp, ra
     );
 }
 
+future<> raft_groups_storage::store_stable_timestamp(cql3::query_processor& qp, raft::group_id gid, shard_id shard, api::timestamp_type ts) {
+    static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, stable_timestamp) VALUES (?, ?, ?)", db::system_keyspace::RAFT_GROUPS);
+    co_await qp.execute_internal(store_cql, {int16_t(shard), gid.id, int64_t(ts)}, cql3::query_processor::cache_internal::yes);
+}
+
+future<api::timestamp_type> raft_groups_storage::load_stable_timestamp(cql3::query_processor& qp, raft::group_id gid, shard_id shard) {
+    static const auto load_cql = format("SELECT stable_timestamp FROM system.{} WHERE shard = ? AND group_id = ? LIMIT 1", db::system_keyspace::RAFT_GROUPS);
+    auto rs = co_await qp.execute_internal(load_cql, {int16_t(shard), gid.id}, cql3::query_processor::cache_internal::yes);
+    if (rs->empty() || !rs->one().has("stable_timestamp")) {
+        co_return api::min_timestamp;
+    }
+    co_return api::timestamp_type(rs->one().get_as<int64_t>("stable_timestamp"));
+}
+
 future<> raft_groups_storage::execute_with_linearization_point(std::function<future<>()> f) {
     promise<> task_promise;
     auto pending_fut = std::exchange(_pending_op_fut, task_promise.get_future());

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "raft/raft.hh"
+#include "mutation/timestamp.hh"
 
 #include <vector>
 #include <functional>
@@ -80,6 +81,10 @@ public:
     // re-apply already applied entries on restart. Only writes if the new
     // index is higher than the existing one (safe to call on repeated replays).
     static future<> store_snapshot_index(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap);
+
+    // Persist stable_timestamp so the value survives restarts.
+    static future<> store_stable_timestamp(cql3::query_processor& qp, raft::group_id gid, shard_id shard, api::timestamp_type ts);
+    static future<api::timestamp_type> load_stable_timestamp(cql3::query_processor& qp, raft::group_id gid, shard_id shard);
 
     std::vector<index_and_replay_position> acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries);
 

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -118,6 +118,27 @@ async def get_table_raft_group_id(manager: ManagerClient, ks: str, table: str):
     rows = await manager.get_cql().run_async(f"SELECT raft_group_id FROM system.tablets where table_id = {table_id}")
     return str(rows[0].raft_group_id)
 
+SC_MIN_TIMESTAMP = -(2**63) + 1
+
+async def read_stable_timestamp(cql, host, group_id: str):
+    """Read the persisted stable_timestamp for a raft group on a given host.
+    Returns None if there is no row/value yet (never written).
+    """
+    rows = await cql.run_async(
+        "SELECT DISTINCT shard, group_id, stable_timestamp FROM system.raft_groups",
+        host=host)
+    for row in rows:
+        if str(row.group_id) == str(group_id) and row.stable_timestamp is not None:
+            return row.stable_timestamp
+    return None
+
+async def wait_for_stable_timestamp(cql, host, group_id: str, predicate, deadline_s: float = 60):
+    """Poll stable_timestamp on host until predicate(value) is true."""
+    async def check():
+        value = await read_stable_timestamp(cql, host, group_id)
+        return value if (value is not None and predicate(value)) else None
+    return await wait_for(check, time.time() + deadline_s)
+
 async def test_basic_write_read(manager: ManagerClient, build_mode: str):
 
     logger.info("Bootstrapping cluster")
@@ -1608,3 +1629,58 @@ async def test_write_from_non_replica_after_leader_down(manager: ManagerClient):
             rows = await cql.run_async(f"SELECT * FROM {table} WHERE pk = 2", host=non_replica_host)
             assert len(rows) == 1
             assert rows[0].c == 2
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_stable_timestamp_leader_refresh(manager: ManagerClient):
+    """Verify that the tablet group leader correctly and regularly advances
+    stable_timestamp.
+    """
+    cmdline = DEFAULT_CMDLINE + ['--smp=1']
+    config = dict(DEFAULT_CONFIG)
+    config['error_injections_at_startup'] = ['sc_short_stable_timestamp_refresh']
+    servers = await manager.servers_add(3, config=config, cmdline=cmdline, auto_rack_dc='my_dc')
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
+
+    def host_by_id(hid):
+        return [h for h in hosts if str(h.host_id) == str(hid)][0]
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}"
+            " AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, c int") as table:
+            table_name = table.split('.')[-1]
+            group_id = await get_table_raft_group_id(manager, ks, table_name)
+
+            # Identify the leader replica.
+            leader_host_id = await wait_for_leader(manager, servers[0], group_id)
+            leader_host = host_by_id(leader_host_id)
+            logger.info(f"group {group_id}: leader={leader_host_id}")
+
+            initial = await read_stable_timestamp(cql, leader_host, group_id)
+            assert initial is None or initial == SC_MIN_TIMESTAMP, f"unexpected initial stable_timestamp: {initial}"
+
+            for pk in range(10):
+                await cql.run_async(f"INSERT INTO {table} (pk, c) VALUES ({pk}, {pk})", host=leader_host)
+            wt_rows = await cql.run_async(f"SELECT WRITETIME(c) AS wt FROM {table} WHERE pk = 9", host=leader_host)
+            ref_ts_1 = wt_rows[0].wt
+            assert ref_ts_1 > SC_MIN_TIMESTAMP
+
+            leader_ts_1 = await wait_for_stable_timestamp(
+                cql, leader_host, group_id, lambda v: v >= ref_ts_1)
+            logger.info(f"leader advanced to {leader_ts_1} (>= ref {ref_ts_1})")
+            assert leader_ts_1 > SC_MIN_TIMESTAMP
+
+            for pk in range(10, 20):
+                await cql.run_async(f"INSERT INTO {table} (pk, c) VALUES ({pk}, {pk})", host=leader_host)
+            wt_rows = await cql.run_async(f"SELECT WRITETIME(c) AS wt FROM {table} WHERE pk = 19", host=leader_host)
+            ref_ts_2 = wt_rows[0].wt
+            assert ref_ts_2 > ref_ts_1
+
+            leader_ts_2 = await wait_for_stable_timestamp(
+                cql, leader_host, group_id, lambda v: v >= ref_ts_2)
+            logger.info(f"leader advanced further to {leader_ts_2} (>= ref {ref_ts_2})")
+            assert leader_ts_2 > leader_ts_1
+
+    await gather_safely(*[manager.server_stop_gracefully(s.server_id) for s in servers])

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -514,6 +514,35 @@ SEASTAR_TEST_CASE(test_groups_store_snapshot_index) {
     });
 }
 
+SEASTAR_TEST_CASE(test_groups_store_stable_timestamp) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        auto& cl = *env.local_db().commitlog();
+        auto dummy_table = table_id(utils::UUID_gen::get_time_UUID());
+        raft::group_id gid{utils::UUID_gen::get_time_UUID()};
+
+        raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
+                cl, dummy_table, {});
+
+        // No row yet: load must return api::min_timestamp (the in-memory default),
+        // so a freshly-started group never observes a spurious non-min value.
+        auto ts0 = co_await raft_groups_storage::load_stable_timestamp(qp, gid, test_shard);
+        BOOST_CHECK_EQUAL(ts0, api::min_timestamp);
+
+        // Store a value and read it back.
+        const api::timestamp_type ts_a = 1000;
+        co_await raft_groups_storage::store_stable_timestamp(qp, gid, test_shard, ts_a);
+        auto ts1 = co_await raft_groups_storage::load_stable_timestamp(qp, gid, test_shard);
+        BOOST_CHECK_EQUAL(ts1, ts_a);
+
+        // Store a larger value (the common case: the timestamp advances) and read it back.
+        const api::timestamp_type ts_b = 2000;
+        co_await raft_groups_storage::store_stable_timestamp(qp, gid, test_shard, ts_b);
+        auto ts2 = co_await raft_groups_storage::load_stable_timestamp(qp, gid, test_shard);
+        BOOST_CHECK_EQUAL(ts2, ts_b);
+    });
+}
+
 // Test store_log_entries -> acquire_replay_position_handles_for roundtrip:
 // entries written to the commitlog produce valid replay position handles.
 SEASTAR_TEST_CASE(test_groups_store_and_get_replay_positions) {


### PR DESCRIPTION
Introduce min_applied_timestamp for strongly consistent tablets: 
a per-group lower bound on the write timestamp that every replica 
has applied.

The leader periodically gathers each replica's max applied timestamp, 
takes the minimum across replicas, and monotonically advances the group's 
value. A second RPC lets followers query it from the leader. The value
is persisted in a new min_applied_timestamp column of system.raft_groups, 
so it survives restarts and never regresses.

Nothing consumes min_applied_timestamp yet; this only adds the computation, 
the query path, and the persistence. It will be used by [Optimized snapshot transfer](https://scylladb.atlassian.net/wiki/spaces/RND/pages/211353650/Optimized+snapshot+transfer) 
and [Thin Replication](https://scylladb.atlassian.net/wiki/spaces/RND/pages/332103714/Thin+Replication).

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2897.

No backport; new feature 