### PR TITLE
[Backport 2025.1] service: assert that tables updated via group0 use schema commitlog

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -106,7 +106,7 @@ namespace {
         schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
             if (ks_name == schema_tables::NAME) {
                 // all schema tables are group0 tables
-                props.is_group0_table = true;
+                props.set_is_group0_table();
             }
         });
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -80,27 +80,15 @@ namespace {
         static const std::unordered_set<sstring> tables = {
             schema_tables::SCYLLA_TABLE_SCHEMA_HISTORY,
             system_keyspace::BROADCAST_KV_STORE,
-            system_keyspace::CDC_GENERATIONS_V3,
             system_keyspace::RAFT,
             system_keyspace::RAFT_SNAPSHOTS,
             system_keyspace::RAFT_SNAPSHOT_CONFIG,
             system_keyspace::GROUP0_HISTORY,
             system_keyspace::DISCOVERY,
-            system_keyspace::TABLETS,
-            system_keyspace::TOPOLOGY,
-            system_keyspace::TOPOLOGY_REQUESTS,
             system_keyspace::LOCAL,
             system_keyspace::PEERS,
-            system_keyspace::SCYLLA_LOCAL,
             system_keyspace::COMMITLOG_CLEANUPS,
-            system_keyspace::SERVICE_LEVELS_V2,
-            system_keyspace::VIEW_BUILD_STATUS_V2,
-            system_keyspace::ROLES,
-            system_keyspace::ROLE_MEMBERS,
-            system_keyspace::ROLE_ATTRIBUTES,
-            system_keyspace::ROLE_PERMISSIONS,
             system_keyspace::v3::CDC_LOCAL,
-            system_keyspace::DICTS
         };
         if (ks_name == system_keyspace::NAME && tables.contains(cf_name)) {
             props.enable_schema_commitlog();
@@ -127,7 +115,7 @@ namespace {
                 system_keyspace::DICTS,
             };
             if (ks_name == system_keyspace::NAME && tables.contains(cf_name)) {
-                props.is_group0_table = true;
+                props.set_is_group0_table();
             }
         });
 }

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -496,6 +496,10 @@ struct schema_static_props {
         use_null_sharder = true; // schema commitlog lives only on the null shard
     }
     bool is_group0_table = false; // the table is a group 0 table
+    void set_is_group0_table() {
+        is_group0_table = true;
+        enable_schema_commitlog();
+    }
 };
 
 class schema_describe_helper {

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -231,6 +231,10 @@ static void ensure_group0_schema(const group0_command& cmd, const replica::datab
             if (!schema->static_props().is_group0_table) {
                 on_internal_error(slogger, fmt::format("ensure_group0_schema: schema is not group0: {}", schema->cf_name()));
             }
+
+            if (!schema->static_props().use_schema_commitlog) {
+                on_internal_error(slogger, fmt::format("ensure_group0_schema: group0 table {} does not use schema commitlog", schema->cf_name()));
+            }
         }
     };
 

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -252,7 +252,7 @@ SEASTAR_TEST_CASE(test_group0_batch) {
         // (group0 mutations are not allowed on non-group0 tables)
         schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
             if (cf_name == "test_group0_batch") {
-                props.is_group0_table = true;
+                props.set_is_group0_table();
             }
         });
 
@@ -342,6 +342,31 @@ SEASTAR_TEST_CASE(test_group0_batch) {
         // nop without mutations nor generator
         auto mc1 = service::group0_batch::unused();
         co_await std::move(mc1).commit(rclient, as, ::service::raft_timeout{});
+    });
+}
+
+SEASTAR_TEST_CASE(test_group0_tables_use_schema_commitlog) {
+    return do_with_cql_env([] (cql_test_env& e) {
+        schema_builder::register_static_configurator([](const sstring& ks_name, const sstring& cf_name, schema_static_props& props) {
+            if (cf_name == "test_group0_tables_use_schema_commitlog1") {
+                props.set_is_group0_table();
+            }
+        });
+
+        auto test_group0_tables_use_schema_commitlog1 = schema_builder("test", "test_group0_tables_use_schema_commitlog1")
+            .with_column("pk", utf8_type, column_kind::partition_key)
+            .build();
+
+        auto test_group0_tables_use_schema_commitlog2 = schema_builder("test", "test_group0_tables_use_schema_commitlog2")
+            .with_column("pk", utf8_type, column_kind::partition_key)
+            .build();
+
+        BOOST_REQUIRE(test_group0_tables_use_schema_commitlog1->static_props().is_group0_table);
+        BOOST_REQUIRE(test_group0_tables_use_schema_commitlog1->static_props().use_schema_commitlog);
+        BOOST_REQUIRE(!test_group0_tables_use_schema_commitlog2->static_props().is_group0_table);
+        BOOST_REQUIRE(!test_group0_tables_use_schema_commitlog2->static_props().use_schema_commitlog);
+
+        return make_ready_future();
     });
 }
 


### PR DESCRIPTION
Set enable_schema_commitlog for each group0 tables.
    
Assert that group0 tables use schema commitlog in ensure_group0_schema
(per each command).
    
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-914.
    
Needs backport to all live releases as all are vulnerable
    
Closes scylladb/scylladb#28876
    
 (cherry picked from commit 0c786045ff89b23d5093efce596ad282475f7694)
    
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-937.
