### PR TITLE
vector-search: allow creating local indexes with non-primary-key partition columns

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -566,12 +566,26 @@ void create_index_statement::validate_for_local_index(const schema& schema) cons
                 auto const is_vector_index = _idx_properties->custom_class && is_vector_capable_class(*_idx_properties->custom_class);
                 auto remaining_base_pk_columns = schema.partition_key_columns();
                 auto next_expected_base_column = remaining_base_pk_columns.begin();
+                auto used_columns = std::set<bytes>();
                 for (const auto& ident : base_pk_identifiers) {
                     auto it = schema.columns_by_name().find(ident->name());
-                    if (it == schema.columns_by_name().end() || !it->second->is_partition_key()) {
-                        if (is_vector_index) {
-                            throw exceptions::invalid_request_exception(format("Local vector index definition must contain partition key's columns only. Redundant column: {}", ident->to_string()));
+
+                    if (is_vector_index) {
+                        if (it == schema.columns_by_name().end() || !(it->second->is_primary_key() || it->second->is_regular())) {
+                            throw exceptions::invalid_request_exception(format(
+                                    "Local vector index definition must contain primary key or regular columns. Redundant column: {}", ident->to_string()));
                         }
+
+                        if (used_columns.contains(ident->name())) {
+                            throw exceptions::invalid_request_exception(format("Duplicate column definition in local vector index: {}", ident->to_string()));
+                        }
+                        used_columns.insert(ident->name());
+
+                        // For vector indexes, we only check that the proper columns exist in the table, but we don't require them to be partition key columns.
+                        continue;
+                    }
+
+                    if (it == schema.columns_by_name().end() || !it->second->is_partition_key()) {
                         throw exceptions::invalid_request_exception(format("Local index definition must contain full partition key only. Redundant column: {}", ident->to_string()));
                     }
                     if (next_expected_base_column == remaining_base_pk_columns.end()) {

--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -143,13 +143,15 @@ ScyllaDB supports creating vector indexes on tables, allowing queries on the tab
 similarity search on vector data. Vector indexes can be a global index for indexing vectors per table or a local
 index for indexing vectors per partition.
 
-The vector index is the only custom type index supported in ScyllaDB. It is created using
-the ``CUSTOM`` keyword and specifying the index type as ``vector_index``. It is also possible to
-add additional columns to the index for filtering the search results. The partition column
-specified in the global vector index definition must be the vector column, and any subsequent
-columns are treated as filtering columns. The local vector index requires that the partition key
-of the index is a subset of the table's partition key columns and the vector column is the first
-one from the following columns.
+The vector index is one of the custom indexes supported in ScyllaDB. It is
+created using the ``CUSTOM`` keyword and specifying the index type as
+``vector_index``. It is also possible to add additional columns to the index
+for filtering the search results. The first column specified in the global
+vector index definition must be the vector column, and any subsequent columns
+are treated as filtering columns. The local vector index requires that the
+partition key of the index is of a type allowed for filtering columns and the
+vector column is the first one after the partition key definition, and any
+subsequent columns are filtering columns.
 
 ScyllaDB allows creating multiple **named** vector indexes on the same vector column.
 This can be used to create a replacement index before dropping an older one.
@@ -192,13 +194,13 @@ Example of a local vector index:
 The vector column (``embedding``) is indexed for similarity search (a local
 index) and additional columns are added for filtering the search results. The
 filtering is possible on ``category``, ``info`` and all primary key columns of
-the base table. The partition key of the base table must contains both columns
-``id`` and ``created_at``. It is allowed to create a local vector index using
-only a part of the partition key columns of the base table.
+the base table. It is allowed to create a local vector index using
+primary key columns of the base table or non-primary-key columns.
 
-Vector indexes support additional filtering columns of native data types
-(excluding counter and duration). The indexed column itself must be a vector
-column, while the extra columns can be used to filter search results.
+Vector indexes support a local index partition key or additional filtering
+columns of native data types (excluding counter and duration). The first column
+after the partition key definition must be a vector column, while the extra
+columns can be used to filter search results.
 
 The supported types are:
 

--- a/test/cqlpy/test_vector_index.py
+++ b/test/cqlpy/test_vector_index.py
@@ -121,13 +121,45 @@ def test_create_vector_search_local_index_with_filtering_columns(cql, test_keysp
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE CUSTOM INDEX ON {table}((p1, p2), v, f1, f2) USING 'vector_index'")
 
-def test_create_vector_search_local_index_with_part_of_partition_key(cql, test_keyspace, scylla_only, skip_without_tablets):
+def test_create_vector_search_local_index(cql, test_keyspace, scylla_only, skip_without_tablets):
     schema = 'p1 int, p2 int, c1 int, c2 int, v1 vector<float, 3>, v2 vector<float, 3>, f1 int, f2 int, primary key ((p1, p2), c1, c2)'
     with new_test_table(cql, test_keyspace, schema) as table:
-        with pytest.raises(InvalidRequest, match="Local vector index definition must contain partition key's columns only. Redundant column: c1"):
-            cql.execute(f"CREATE CUSTOM INDEX ON {table}((p1, c1), v, f1, f2) USING 'vector_index'")
-        cql.execute(f"CREATE CUSTOM INDEX ON {table}((p1), v1, f1, f2) USING 'vector_index'")
-        cql.execute(f"CREATE CUSTOM INDEX ON {table}((p2), v2, f1, f2) USING 'vector_index'")
+        # The full partition key
+        cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p1, p2), v1, f1, f2) USING 'vector_index'")
+        cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
+        # The full primary key
+        cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p1, p2, c1, c2), v1, f1, f2) USING 'vector_index'")
+        cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
+        # The first partition key column
+        cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p1), v1, f1, f2) USING 'vector_index'")
+        cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
+        # The not-first partition key column
+        cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p2), v2, f1, f2) USING 'vector_index'")
+        cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
+        # The single partition key column + the single clustering key column
+        cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p2, c2), v1, f1, f2) USING 'vector_index'")
+        cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
+        # The single clustering key column
+        cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((c1), v1, f1, f2) USING 'vector_index'")
+        cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
+        # The single partition key column + the single filtering column
+        cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p1, f1), v1, f2) USING 'vector_index'")
+        cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
+        # The single clustering key column + the single filtering column
+        cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((c2, f2), v1, f1) USING 'vector_index'")
+        cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
+        # The single filtering column
+        cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((f1), v1, f2) USING 'vector_index'")
+        cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
 
 def test_create_vector_search_local_index_with_filtering_columns_on_nonvector_column(cql, test_keyspace, scylla_only, skip_without_tablets):
     schema = 'p1 int, p2 int, c1 int, c2 int, v int, f1 int, f2 int, primary key ((p1, p2), c1, c2)'
@@ -138,18 +170,32 @@ def test_create_vector_search_local_index_with_filtering_columns_on_nonvector_co
 def test_create_vector_search_index_with_supported_and_unsupported_filtering_columns(cql, test_keyspace, scylla_only, skip_without_tablets):
     supported_columns = ', '.join([f's{idx} {typ}' for idx, typ in enumerate(supported_filtering_types)])
     unsupported_columns = ', '.join([f'u{idx} {typ}' for idx, typ in enumerate(unsupported_filtering_types)])
-    schema = f'p int, c int, v vector<float, 3>, {supported_columns}, {unsupported_columns}, primary key (p, c)'
+    schema = f'p int, c int, v vector<float, 3>, {supported_columns}, {unsupported_columns}, stat INT static, primary key (p, c)'
     with new_test_table(cql, test_keyspace, schema) as table:
         for idx in range(len(supported_filtering_types)):
             cql.execute(f"CREATE CUSTOM INDEX global_idx ON {table}(v, s{idx}) USING 'vector_index'")
             cql.execute(f"DROP INDEX {test_keyspace}.global_idx")
+
             cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p), v, s{idx}) USING 'vector_index'")
             cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
+            cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((s{idx}), v) USING 'vector_index'")
+            cql.execute(f"DROP INDEX {test_keyspace}.local_idx")
+
         for idx in range(len(unsupported_filtering_types)):
             with pytest.raises(InvalidRequest, match=f"Unsupported vector index filtering column u{idx} type|Secondary indexes are not supported"):
                 cql.execute(f"CREATE CUSTOM INDEX global_idx ON {table}(v, u{idx}) USING 'vector_index'")
             with pytest.raises(InvalidRequest, match=f"Unsupported vector index filtering column u{idx} type|Secondary indexes are not supported"):
                 cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p), v, u{idx}) USING 'vector_index'")
+            with pytest.raises(InvalidRequest, match=f"Unsupported vector index filtering column u{idx} type|Secondary indexes are not supported"):
+                cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((u{idx}), v) USING 'vector_index'")
+
+        with pytest.raises(InvalidRequest, match=f"Local vector index definition must contain primary key or regular columns. Redundant column: wrongname|Secondary indexes are not supported"):
+            cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p, wrongname), v) USING 'vector_index'")
+        with pytest.raises(InvalidRequest, match=f"Local vector index definition must contain primary key or regular columns. Redundant column: stat|Secondary indexes are not supported"):
+            cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p, stat), v) USING 'vector_index'")
+        with pytest.raises(InvalidRequest, match=f"Duplicate column definition in local vector index: p|Secondary indexes are not supported"):
+            cql.execute(f"CREATE CUSTOM INDEX local_idx ON {table}((p, p), v) USING 'vector_index'")
 
 def test_create_vector_search_local_index_with_unsupported_partition_columns(cql, test_keyspace, scylla_only, skip_without_tablets):
     for filter_type in unsupported_filtering_types:


### PR DESCRIPTION
Currently local vector indexes can be based on partition key columns of the table. This commit loosens this restriction and let users create vector search local indexes based on any column which is of a type allowed for filtering columns.

The commit removes one validation check for local vector indexes, refactors pytests and improves documentation.

There is ongoing work on vector-store side to support such indexes - it ought to be finished before releasing this patch.

Fixes: SCYLLADB-3102

This is a new feature, no need to backport.