### PR TITLE
schema_tables: migrate column mappings with tablet

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -901,6 +901,22 @@ future<> store_column_mapping(sharded<service::storage_proxy>& proxy, schema_ptr
     co_await proxy.local().mutate_locally(std::move(muts), tracing::trace_state_ptr());
 }
 
+future<column_mapping_version_list> get_column_mapping_versions(db::system_keyspace& sys_ks, table_id cf_id) {
+    static const auto query = format("SELECT schema_version FROM {}.{} WHERE cf_id = ? GROUP BY schema_version",
+            db::system_keyspace::NAME, SCYLLA_TABLE_SCHEMA_HISTORY);
+    const auto results = co_await sys_ks.query_processor().execute_internal(
+            query,
+            db::consistency_level::LOCAL_ONE,
+            {cf_id.uuid()},
+            cql3::query_processor::cache_internal::yes);
+    column_mapping_version_list versions;
+    versions.reserve(results->size());
+    for (const auto& row : *results) {
+        versions.push_back(table_schema_version(row.get_as<utils::UUID>("schema_version")));
+    }
+    co_return std::move(versions);
+}
+
 future<lw_shared_ptr<query::result_set>> extract_scylla_specific_keyspace_info(sharded<service::storage_proxy>& proxy, const schema_result_value_type& partition) {
     lw_shared_ptr<query::result_set> scylla_specific_rs;
     if (proxy.local().local_db().has_schema(NAME, SCYLLA_KEYSPACES)) {

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -14,6 +14,7 @@
 #include "schema/schema_fwd.hh"
 #include "schema_features.hh"
 #include "utils/hashing.hh"
+#include "utils/small_vector.hh"
 #include "schema/schema_mutations.hh"
 #include "types/map.hh"
 #include "query/query-result-set.hh"
@@ -298,6 +299,10 @@ std::optional<std::map<K, V>> get_map(const query::result_set_row& row, const ss
 /// Can be used to insert entries with TTL (equal to DEFAULT_GC_GRACE_SECONDS) in case we are
 /// overwriting an existing column mapping to garbage collect obsolete entries.
 future<> store_column_mapping(sharded<service::storage_proxy>& proxy, schema_ptr s, bool with_ttl);
+/// Returns the schema versions present in the local scylla_table_schema_history
+/// partition for the given table. Usually one, hence small_vector.
+using column_mapping_version_list = utils::small_vector<table_schema_version, 1>;
+future<column_mapping_version_list> get_column_mapping_versions(db::system_keyspace& sys_ks, table_id cf_id);
 /// Query column mapping for a given version of the table locally.
 future<column_mapping> get_column_mapping(db::system_keyspace& sys_ks, table_id table_id, table_schema_version version);
 /// Returns the same result as `get_column_mapping()` wrapped in optional and returns nullopt if the mapping doesn't exist.

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -187,6 +187,7 @@ public:
     gms::feature view_building_tasks_min_task_id { *this, "VIEW_BUILDING_TASKS_MIN_TASK_ID"sv };
     gms::feature quiesce_topology_enhanced { *this, "QUIESCE_TOPOLOGY_ENHANCED"sv };
     gms::feature tablet_pow2_convergence { *this, "TABLET_POW2_CONVERGENCE"sv };
+    gms::feature fetch_column_mappings_on_tablet_migration { *this, "FETCH_COLUMN_MAPPINGS_ON_TABLET_MIGRATION"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/idl/migration_manager.idl.hh
+++ b/idl/migration_manager.idl.hh
@@ -7,6 +7,7 @@
  */
 
 #include "utils/chunked_vector.hh"
+#include "utils/small_vector.hh"
 
 #include "idl/frozen_mutation.idl.hh"
 #include "idl/frozen_schema.idl.hh"
@@ -15,3 +16,4 @@
 verb [[with_client_info, cancellable]] migration_request (netw::schema_pull_options options [[version 3.2.0]]) -> utils::chunked_vector<frozen_mutation>, utils::chunked_vector<canonical_mutation> [[version 3.2.0]]
 verb get_schema_version (unsigned shard, table_schema_version version) -> frozen_schema
 verb [[cancellable]] schema_check () -> table_schema_version
+verb [[cancellable]] fetch_column_mappings (table_id cf_id, utils::small_vector<table_schema_version, 1> versions_present [[ref]]) -> std::optional<frozen_mutation>

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -791,6 +791,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::PAXOS_PRUNE:
     case messaging_verb::FORWARD_CQL_EXECUTE:
     case messaging_verb::FORWARD_CQL_PREPARE:
+    case messaging_verb::FETCH_COLUMN_MAPPINGS:
         return 2;
     case messaging_verb::MUTATION_DONE:
     case messaging_verb::MUTATION_FAILED:

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -217,7 +217,8 @@ enum class messaging_verb : int32_t {
     RESTORE_TABLET = 88,
     WAIT_FOR_RAFT_GROUPS_TO_START = 89,
     CLONE_SSTABLE = 90,
-    LAST = 91,
+    FETCH_COLUMN_MAPPINGS = 91,
+    LAST = 92,
 };
 
 } // namespace netw

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -34,8 +34,10 @@
 #include "gms/gossiper.hh"
 #include "view_info.hh"
 #include "schema/schema_builder.hh"
+#include "partition_slice_builder.hh"
 #include "replica/database.hh"
 #include "replica/tablets.hh"
+#include "replica/query.hh"
 #include "db/schema_applier.hh"
 #include "db/schema_tables.hh"
 #include "types/user.hh"
@@ -159,6 +161,37 @@ void migration_manager::init_messaging_service()
             mlogger.debug("Schema version request for {}", v);
             return local_schema_registry().get_frozen(v);
         });
+    });
+    ser::migration_manager_rpc_verbs::register_fetch_column_mappings(&_messaging, [this] (table_id cf_id, db::schema_tables::column_mapping_version_list versions_present) -> future<std::optional<frozen_mutation>> {
+        using namespace db::schema_tables;
+
+        auto missing_versions = co_await get_column_mapping_versions(_sys_ks.local(), cf_id);
+        const auto removed = std::ranges::remove_if(missing_versions, [&] (const auto& v) {
+            return std::ranges::contains(versions_present, v);
+        });
+        missing_versions.erase(removed.begin(), removed.end());
+        if (missing_versions.empty()) {
+            co_return std::nullopt;
+        }
+
+        const auto s = scylla_table_schema_history();
+        std::vector<query::clustering_range> ranges;
+        ranges.reserve(missing_versions.size());
+        for (const auto& v : missing_versions) {
+            ranges.emplace_back(query::clustering_range::make_singular(
+                    clustering_key_prefix::from_single_value(*s, uuid_type->decompose(v.uuid()))));
+        }
+
+        const auto pk = partition_key::from_exploded(*s, {uuid_type->decompose(cf_id.uuid())});
+        auto rs = co_await replica::query_mutations(_storage_proxy.get_db(),
+            s,
+            dht::partition_range::make_singular(dht::decorate_key(*s, pk)),
+            partition_slice_builder(*s).with_ranges(std::move(ranges)).build(),
+            db::no_timeout);
+        if (rs->partitions().empty()) {
+            co_return std::nullopt;
+        }
+        co_return std::move(rs->partitions()[0].mut());
     });
 }
 
@@ -1153,12 +1186,38 @@ future<> migration_manager::sync_schema(const replica::database& db, const std::
     co_await _group0_barrier.trigger(_as);
 }
 
-future<column_mapping> get_column_mapping(db::system_keyspace& sys_ks, table_id table_id, table_schema_version v) {
-    schema_ptr s = local_schema_registry().get_or_null(v);
-    if (s) {
-        return make_ready_future<column_mapping>(s->get_column_mapping());
+future<> migration_manager::fetch_column_mappings(table_id cf_id,
+        host_id_vector_replica_set replicas,
+        bool ignore_down_replicas,
+        abort_source& as)
+{
+    if (!_feat.fetch_column_mappings_on_tablet_migration) {
+        co_return;
     }
-    return db::schema_tables::get_column_mapping(sys_ks, table_id, v);
+
+    const auto versions_present = co_await db::schema_tables::get_column_mapping_versions(_sys_ks.local(), cf_id);
+    co_await coroutine::parallel_for_each(replicas, [&] (locator::host_id host) -> future<> {
+        if (ignore_down_replicas && !_gossiper.is_alive(host)) {
+            mlogger.info("fetch_column_mappings[{}]: skipping replica [{}] because it is down", 
+                cf_id, host);
+            co_return;
+        }
+
+        try {
+            const auto fm = co_await ser::migration_manager_rpc_verbs::send_fetch_column_mappings(
+                    &_messaging, host, as, cf_id, versions_present);
+            if (fm) {
+                co_await _storage_proxy.mutate_locally(db::schema_tables::scylla_table_schema_history(),
+                        *fm, nullptr, db::commitlog::force_sync::no);
+            }
+        } catch (...) {
+            if (!ignore_down_replicas) {
+                throw;
+            }
+            mlogger.info("fetch_column_mappings[{}]: failed for replica [{}], error: {}",
+                cf_id, host, std::current_exception());
+        }
+    });
 }
 
 future<> migration_manager::on_join(gms::inet_address endpoint, locator::host_id id, gms::endpoint_state_ptr ep_state, gms::permit_id) {

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -177,6 +177,13 @@ public:
     // Intended to be used in the write path, which relies on synchronized schema.
     future<schema_ptr> get_schema_for_write(table_schema_version, locator::host_id from, unsigned shard, netw::messaging_service& ms, abort_source& as);
 
+    // Fetches the column mappings (system.scylla_table_schema_history entries) for table
+    // `cf_id` that are missing on this node from the other replicas.
+    future<> fetch_column_mappings(table_id cf_id,
+        host_id_vector_replica_set replicas,
+        bool ignore_down_replicas,
+        abort_source& as);
+
 private:
     virtual future<> on_join(gms::inet_address endpoint,locator::host_id id,  gms::endpoint_state_ptr ep_state, gms::permit_id) override;
     virtual future<> on_change(gms::inet_address endpoint, locator::host_id id, const gms::application_state_map& states, gms::permit_id) override;
@@ -196,9 +203,6 @@ extern template
 future<> migration_manager::announce<schema_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description, std::optional<raft_timeout> timeout = std::nullopt);
 extern template
 future<> migration_manager::announce<topology_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description, std::optional<raft_timeout> timeout = std::nullopt);
-
-
-future<column_mapping> get_column_mapping(db::system_keyspace& sys_ks, table_id, table_schema_version v);
 
 utils::chunked_vector<mutation> prepare_keyspace_update_announcement(replica::database& db, lw_shared_ptr<keyspace_metadata> ksm, api::timestamp_type ts);
 

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -26,6 +26,7 @@
 #include "db/schema_tables.hh"
 #include "service/migration_manager.hh"
 #include "gms/feature_service.hh"
+#include "schema/schema_registry.hh"
 
 #include "idl/frozen_mutation.dist.hh"
 #include "idl/frozen_mutation.dist.impl.hh"
@@ -175,7 +176,7 @@ future<prepare_response> paxos_state::prepare(storage_proxy& sp, paxos_store& pa
             co_await coroutine::return_exception(utils::injected_error("injected_error_after_save_promise"));
         }
 
-        auto upgrade_if_needed = [schema = std::move(schema), &paxos_store] (std::optional<proposal> p) -> future<std::optional<proposal>> {
+        auto upgrade_if_needed = [schema = std::move(schema), token, &paxos_store, timeout] (std::optional<proposal> p) -> future<std::optional<proposal>> {
             if (!p || p->update.schema_version() == schema->version()) {
                 co_return std::move(p);
             }
@@ -187,7 +188,7 @@ future<prepare_response> paxos_state::prepare(storage_proxy& sp, paxos_store& pa
             // for that version and upgrade the mutation with it.
             logger.debug("Stored mutation references outdated schema version. "
                 "Trying to upgrade the accepted proposal mutation to the most recent schema version.");
-            const column_mapping& cm = co_await paxos_store.get_column_mapping(p->update.column_family_id(), p->update.schema_version());
+            const column_mapping& cm = co_await paxos_store.get_column_mapping(*schema, token, p->update.schema_version(), timeout);
 
             co_return std::make_optional(proposal(p->ballot, freeze(p->update.unfreeze_upgrading(schema, cm))));
         };
@@ -505,8 +506,36 @@ future<cql3::untyped_result_set> paxos_store::execute_cql_with_timeout(sstring r
     );
 }
 
-future<column_mapping> paxos_store::get_column_mapping(table_id table_id, table_schema_version version) {
-    return service::get_column_mapping(_sys_ks, table_id, version);
+future<column_mapping> paxos_store::get_column_mapping(const schema& query_schema,
+        dht::token token, table_schema_version version, clock_type::time_point timeout)
+{
+    if (const auto s = local_schema_registry().get_or_null(version); s) {
+        co_return s->get_column_mapping();
+    }
+
+    if (auto cm = co_await db::schema_tables::get_column_mapping_if_exists(_sys_ks, query_schema.id(), version)) {
+        co_return std::move(*cm);
+    }
+
+    // The mapping is missing locally. This happens on a pending tablet replica that
+    // received migrated paxos state referencing an old schema version before the
+    // schema history for that version was synced to this node. Auto-heal by fetching
+    // the missing mappings from the tablet's other replicas, then retry the lookup
+    // (which now throws if the version is genuinely gone, e.g. cleaned up as too old).
+    if (const auto& t = query_schema.table(); t.uses_tablets()) {
+        key_lock_map<table_id>::guard g(_table_lock_map, query_schema.id());
+        const auto skip_fetch = g.sem().current() == 0;
+        co_await g.lock(timeout);
+        if (!skip_fetch) {
+            abort_on_expiry aoe(timeout);
+            co_await _mm.fetch_column_mappings(query_schema.id(),
+                t.get_effective_replication_map()->get_natural_replicas(token),
+                true /* ignore_down_replicas */,
+                aoe.abort_source());
+        }
+    }
+
+    co_return co_await db::schema_tables::get_column_mapping(_sys_ks, query_schema.id(), version);
 }
 
 future<schema_ptr> paxos_store::get_paxos_state_schema(const schema& s, db::timeout_clock::time_point timeout) const {

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -33,26 +33,55 @@
 namespace service::paxos {
 
 logging::logger paxos_state::logger("paxos");
-thread_local paxos_state::key_lock_map paxos_state::_paxos_table_lock;
-thread_local paxos_state::key_lock_map paxos_state::_coordinator_lock;
+thread_local token_lock_map paxos_state::_paxos_table_lock(true);
+thread_local token_lock_map paxos_state::_coordinator_lock(true);
 
-paxos_state::key_lock_map::key_lock_map() {
-    // preallocate 8K pointers and set max_load_factor to 8 to support around 1M outstanding requests
-    // without re-allocations
-    _locks.reserve(8 * 1024);
-    _locks.max_load_factor(8);
-}
-
-paxos_state::key_lock_map::semaphore& paxos_state::key_lock_map::get_semaphore_for_key(const dht::token& key) {
-    return _locks.try_emplace(key, 1).first->second;
-}
-
-void paxos_state::key_lock_map::release_semaphore_for_key(const dht::token& key) {
-    auto it = _locks.find(key);
-    if (it != _locks.end() && (*it).second.current() == 1) {
-        _locks.erase(it);
+template <typename Key>
+key_lock_map<Key>::key_lock_map(bool preallocate) {
+    if (preallocate) {
+        // preallocate 8K pointers and set max_load_factor to 8 to support around 1M outstanding requests
+        // without re-allocations
+        _locks.reserve(8 * 1024);
+        _locks.max_load_factor(8);
     }
 }
+
+template <typename Key>
+key_lock_map<Key>::guard::guard(key_lock_map<Key>& map, const Key& key)
+    : _map(map._locks)
+    , _entry(&*_map.try_emplace(key).first)
+    , _locked(false)
+{
+    ++_entry->second.refs;
+}
+
+template <typename Key>
+key_lock_map<Key>::guard::guard(guard&& o) noexcept
+    : _map(o._map)
+    , _entry(std::exchange(o._entry, nullptr))
+    , _locked(std::exchange(o._locked, false))
+{
+}
+
+template <typename Key>
+key_lock_map<Key>::guard::~guard() {
+    if (!_entry) {
+        return;
+    }
+    if (_locked) {
+        sem().signal(1);
+    }
+    if (--_entry->second.refs == 0) {
+        _map.erase(key());
+    }
+}
+
+template <typename Key>
+future<> key_lock_map<Key>::guard::lock(clock_type::time_point timeout) {
+    return sem().wait(timeout, 1).then([this] { _locked = true; });
+}
+
+template class key_lock_map<dht::token>;
 
 future<paxos_state::replica_guard> paxos_state::get_replica_lock(const schema& s, const dht::token& token,
         clock_type::time_point timeout)
@@ -71,18 +100,18 @@ future<paxos_state::replica_guard> paxos_state::get_replica_lock(const schema& s
     replica_guard replica_guard;
     replica_guard.resize(shards.size());
     for (size_t i = 0; i < shards.size(); ++i) {
-        replica_guard[i] = co_await smp::submit_to(shards[i], [token, timeout] {
-            auto g = make_lw_shared<guard>(_paxos_table_lock, token, timeout);
-            return g->lock().then([g]{ return make_foreign(std::move(g)); });
+        replica_guard[i] = co_await smp::submit_to(shards[i], [token, timeout] -> future<token_guard_foreign_ptr> {
+            auto g = make_lw_shared<token_guard>(_paxos_table_lock, token);
+            return g->lock(timeout).then([g]{ return make_foreign(std::move(g)); });
         });
     }
     co_return replica_guard;
 }
 
-future<paxos_state::guard> paxos_state::get_cas_lock(const dht::token& key, clock_type::time_point timeout) {
-    guard m(_coordinator_lock, key, timeout);
-    co_await m.lock();
-    co_return m;
+future<token_guard> paxos_state::get_cas_lock(const dht::token& key, clock_type::time_point timeout) {
+    token_guard m(_coordinator_lock, key);
+    co_await m.lock(timeout);
+    co_return std::move(m);
 }
 
 future<prepare_response> paxos_state::prepare(storage_proxy& sp, paxos_store& paxos_store, tracing::trace_state_ptr tr_state, schema_ptr schema,

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -123,6 +123,7 @@ class paxos_store:
     replica::database& _db;
     migration_manager& _mm;
     bool _stopped = false;
+    key_lock_map<table_id> _table_lock_map{false};
 
     template <typename... Args>
     future<cql3::untyped_result_set> execute_cql_with_timeout(sstring req, db::timeout_clock::time_point timeout, Args&&... args);
@@ -138,7 +139,7 @@ public:
     future<> ensure_initialized(const schema& s, db::timeout_clock::time_point timeout);
     static std::optional<std::string_view> try_get_base_table(std::string_view cf_name);
 
-    future<column_mapping> get_column_mapping(table_id, table_schema_version v);
+    future<column_mapping> get_column_mapping(const schema& query_schema, dht::token token, table_schema_version version, clock_type::time_point timeout);
     future<service::paxos::paxos_state> load_paxos_state(partition_key_view key, schema_ptr s, gc_clock::time_point now,
         db::timeout_clock::time_point timeout);
     future<> save_paxos_promise(const schema& s, const partition_key& key, const utils::UUID& ballot, db::timeout_clock::time_point timeout);

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -35,57 +35,51 @@ namespace service::paxos {
 
 using clock_type = db::timeout_clock;
 
+template <typename Key>
+class key_lock_map {
+    using semaphore = basic_semaphore<semaphore_default_exception_factory, clock_type>;
+    struct lock {
+        semaphore sem{1};
+        unsigned refs{0};
+    };
+    using map = std::unordered_map<Key, lock>;
+    map _locks;
+public:
+    key_lock_map(bool preallocate);
+
+    class guard {
+        map& _map;
+        map::value_type* _entry;
+        bool _locked;
+    public:
+        guard(key_lock_map<Key>& map, const Key& key);
+        guard(guard&& o) noexcept;
+        guard(const guard&) = delete;
+        ~guard();
+        future<> lock(clock_type::time_point timeout);
+        const Key& key() const { return _entry->first; }
+        semaphore& sem() { return _entry->second.sem; }
+    };
+};
+using token_lock_map = key_lock_map<dht::token>;
+using token_guard = token_lock_map::guard;
+
 class paxos_store;
 
 // The state of a CAS update of a given primary key as persisted in the paxos table.
 class paxos_state {
 private:
-    class guard;
-
-    class key_lock_map {
-        using semaphore = basic_semaphore<semaphore_default_exception_factory, clock_type>;
-        using semaphore_units = semaphore_units<semaphore_default_exception_factory, clock_type>;
-        using map = std::unordered_map<dht::token, semaphore>;
-
-        semaphore& get_semaphore_for_key(const dht::token& key);
-        void release_semaphore_for_key(const dht::token& key);
-
-        map _locks;
-    public:
-
-        key_lock_map();
-        
-        friend class guard;
-    };
-
-    class guard {
-        key_lock_map& _map;
-        dht::token _key;
-        clock_type::time_point _timeout;
-        key_lock_map::semaphore_units _units;
-    public:
-        future<> lock () {
-            return get_units(_map.get_semaphore_for_key(_key), 1, _timeout).then([this] (auto&& u) { _units = std::move(u); });
-        }
-        guard(key_lock_map& map, const dht::token& key, clock_type::time_point timeout) : _map(map), _key(key), _timeout(timeout) {};
-        guard(guard&& o) = default;
-        ~guard() {
-            _units.return_all();
-            _map.release_semaphore_for_key(_key);
-        }
-    };
-
     // Locks are local to the shard which owns the corresponding token range.
     // Protects concurrent reads and writes of the same row in system.paxos table.
-    static thread_local key_lock_map _paxos_table_lock;
+    static thread_local token_lock_map _paxos_table_lock;
     // Taken by the coordinator code to allow only one instance of PAXOS to run for each key.
     // This prevents contantion between multiple clients trying to modify the
     // same key through the same coordinator and stealing the ballot from
     // each other.
-    static thread_local key_lock_map _coordinator_lock;
+    static thread_local token_lock_map _coordinator_lock;
 
-    using guard_foreign_ptr = foreign_ptr<lw_shared_ptr<guard>>;
-    using replica_guard = boost::container::static_vector<guard_foreign_ptr, 2>;
+    using token_guard_foreign_ptr = foreign_ptr<lw_shared_ptr<token_guard>>;
+    using replica_guard = boost::container::static_vector<token_guard_foreign_ptr, 2>;
     static future<replica_guard> get_replica_lock(const schema& s, const dht::token& token,
         clock_type::time_point timeout);
 
@@ -95,7 +89,7 @@ private:
 
 public:
 
-    static future<guard> get_cas_lock(const dht::token& key, clock_type::time_point timeout);
+    static future<token_guard> get_cas_lock(const dht::token& key, clock_type::time_point timeout);
 
     static logging::logger logger;
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5463,6 +5463,19 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
 
       } // Traditional streaming vs file-based streaming.
 
+        const auto schema = _db.local().find_column_family(tablet.table).schema();
+
+        co_await utils::get_local_injector().inject("pause_after_streaming_tablet_before_fetch_column_mappings",
+                [schema] (auto& handler) -> future<> {
+            const auto ks = handler.get("keyspace");
+            const auto cf = handler.get("table");
+            if (ks == schema->ks_name() && cf == schema->cf_name()) {
+                slogger.info("pause_after_streaming_tablet_before_fetch_column_mappings: waiting for message");
+                co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{1});
+                slogger.info("pause_after_streaming_tablet_before_fetch_column_mappings: message received");
+            }
+        });
+
         // If new pending tablet replica needs splitting, streaming waits for it to complete.
         // That's to provide a guarantee that once migration is over, the coordinator can finalize
         // splitting under the promise that compaction groups of tablets are all split, ready

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -73,6 +73,7 @@
 #include "utils/user_provided_param.hh"
 #include "version.hh"
 #include "streaming/stream_blob.hh"
+#include "service/paxos/paxos_state.hh"
 #include "dht/range_streamer.hh"
 #include <boost/range/algorithm.hpp>
 #include <boost/range/join.hpp>
@@ -5344,7 +5345,8 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
         std::optional<locator::tablet_replica> leaving_replica = locator::get_leaving_replica(tinfo, *trinfo);
         locator::tablet_migration_streaming_info streaming_info = get_migration_streaming_info(tm->get_topology(), tinfo, *trinfo);
         locator::tablet_replica_set read_from{streaming_info.read_from.begin(), streaming_info.read_from.end()};
-        if (trinfo->transition == locator::tablet_transition_kind::rebuild_v2) {
+        const auto transition = trinfo->transition;
+        if (transition == locator::tablet_transition_kind::rebuild_v2) {
             auto nearest_hosts = read_from | std::views::transform([] (const auto& tr) {
                 return tr.host;
             }) | std::ranges::to<host_id_vector_replica_set>();
@@ -5362,13 +5364,13 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
         }
 
         streaming::stream_reason reason = std::invoke([&] {
-            switch (trinfo->transition) {
+            switch (transition) {
                 case locator::tablet_transition_kind::migration: return streaming::stream_reason::tablet_migration;
                 case locator::tablet_transition_kind::intranode_migration: return streaming::stream_reason::tablet_migration;
                 case locator::tablet_transition_kind::rebuild: return streaming::stream_reason::rebuild;
                 case locator::tablet_transition_kind::rebuild_v2: return streaming::stream_reason::rebuild;
                 default:
-                    throw std::runtime_error(fmt::format("stream_tablet(): Invalid tablet transition: {}", trinfo->transition));
+                    throw std::runtime_error(fmt::format("stream_tablet(): Invalid tablet transition: {}", transition));
             }
         });
 
@@ -5378,12 +5380,11 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
             throw std::runtime_error(fmt::format("Table {}.{} uses logstor, which requires file streaming to be enabled", table.schema()->ks_name(), table.schema()->cf_name()));
         }
 
-        if (file_stream_enabled && (trinfo->transition != locator::tablet_transition_kind::intranode_migration || table.uses_logstor())) {
+        if (file_stream_enabled && (transition != locator::tablet_transition_kind::intranode_migration || table.uses_logstor())) {
             co_await utils::get_local_injector().inject("migration_streaming_wait", utils::wait_for_message{std::chrono::minutes(2)});
 
             auto dst_node = trinfo->pending_replica->host;
             auto dst_shard_id = trinfo->pending_replica->shard;
-            auto transition = trinfo->transition;
 
             // Release token_metadata_ptr early so it will no block barriers for other migrations
             // Don't access trinfo after this.
@@ -5413,7 +5414,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
       } else { // Caution: following code is intentionally unindented to be in sync with OSS
 
 
-        if (trinfo->transition == locator::tablet_transition_kind::intranode_migration) {
+        if (transition == locator::tablet_transition_kind::intranode_migration) {
             if (!leaving_replica || leaving_replica->host != tm->get_my_id()) {
                 throw std::runtime_error(fmt::format("Invalid leaving replica for intra-node migration, tablet: {}, leaving: {}",
                                                      tablet, leaving_replica));
@@ -5443,7 +5444,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
             auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, std::move(tm),
                                                                 guard.get_abort_source(),
                                                                 my_id, _snitch.local()->get_location(),
-                                                                format("Tablet {}", trinfo->transition),
+                                                                format("Tablet {}", transition),
                                                                 reason,
                                                                 topo_guard,
                                                                 std::move(tables));
@@ -5462,7 +5463,6 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
         }
 
       } // Traditional streaming vs file-based streaming.
-
         const auto schema = _db.local().find_column_family(tablet.table).schema();
 
         co_await utils::get_local_injector().inject("pause_after_streaming_tablet_before_fetch_column_mappings",
@@ -5475,6 +5475,25 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
                 slogger.info("pause_after_streaming_tablet_before_fetch_column_mappings: message received");
             }
         });
+
+        // After streaming completes, sync column mapping history from the source replicas
+        // to the destination. This ensures that if the migrated $paxos tablet contains
+        // proposals tagged with an old schema version V, the destination also holds
+        // mapping(V) so that upgrade_if_needed can decode those proposals.
+        // Only relevant for $paxos tables (identified by try_get_base_table returning
+        // a non-null result) and not for intranode migrations.
+        if (transition != locator::tablet_transition_kind::intranode_migration) {
+            const auto base_table_name = service::paxos::paxos_store::try_get_base_table(schema->cf_name());
+            if (base_table_name) {
+                co_await _migration_manager.local().fetch_column_mappings(
+                    _db.local().find_uuid(schema->ks_name(), *base_table_name),
+                    read_from
+                        | std::views::transform([] (const auto& tr) { return tr.host;})
+                        | std::ranges::to<host_id_vector_replica_set>(),
+                    false /* ignore_down_replicas */,
+                    _abort_source);
+            }
+        }
 
         // If new pending tablet replica needs splitting, streaming waits for it to complete.
         // That's to provide a guarantee that once migration is over, the coordinator can finalize

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -963,3 +963,181 @@ async def test_tablets_merge_waits_for_lwt(manager: ManagerClient, scale_timeout
 
         logger.info("Wait for the LWT to finish")
         await lwt
+
+
+@pytest.mark.xfail(reason="Column mapping migration not yet implemented (CUSTOMER-509)")
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_column_mapping_migrated_with_tablet(manager: ManagerClient):
+    """Reproducer for CUSTOMER-509: after tablet migration, the destination node
+    must hold column mappings for schema versions referenced in the migrated
+    $paxos state.
+
+    The fix has two complementary mechanisms:
+    (a) Data plane fetch: when an LWT encounters a missing column mapping, it
+        fetches from the tablet's current replicas on the fly (paxos_state.cc).
+    (b) Streaming fetch: after streaming completes during tablet migration, the
+        destination proactively fetches column mappings from source replicas
+        (storage_service.cc), so future LWTs don't have to rely on the source
+        being reachable.
+
+    This test verifies both mechanisms:
+
+    Part 1 — Data plane fetch works even before streaming fetch completes:
+      1. Single node n1, rf=1, one tablet. Run an LWT that persists a paxos
+         proposal tagged with schema version V (inject error so the round fails).
+      2. ALTER TABLE to supersede V with V2.
+      3. Add node n2 (bootstraps from group0 snapshot, only stores mapping(V2)).
+      4. Start migrating the tablet n1 -> n2, but pause after streaming finishes
+         and before the column mappings fetch runs.
+      5. While the fetch is paused, run an LWT — it must succeed because the data
+         plane fetch retrieves mapping(V) from n1 (still a replica during migration).
+      6. Resume the injection, let migration complete.
+
+    Part 2 — Streaming fetch persists mappings for future use:
+      7. Inject a paxos error on n2 and run an LWT — persists a stale proposal
+         tagged with V2.
+      8. ALTER TABLE to supersede V2 with V3.
+      9. Add node n3 (only knows mapping(V3)).
+     10. Migrate the tablet n2 -> n3. The streaming fetch must copy mapping(V2)
+         from n2 to n3.
+     11. Run an LWT on n3 — must succeed. Since rf=1, data plane fetch only queries
+         n3 itself (the sole replica), so if streaming fetch hadn't persisted
+         mapping(V2) on n3, the LWT would fail.
+    """
+    logger.info("Start node n1")
+    cmdline = ['--logger-log-level', 'paxos=trace']
+    servers = [await manager.server_add(cmdline=cmdline)]
+    cql = manager.get_cql()
+    logger.info("Disable tablet balancing")
+    await manager.disable_tablet_balancing()
+    logger.info("Create keyspace with rf=1 and a single tablet")
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int);")
+
+        # ──────────────────────────────────────────────────────────────────────
+        # Part 1: Data plane fetch works before streaming fetch completes
+        # ──────────────────────────────────────────────────────────────────────
+
+        # Step 1: Persist a paxos proposal tagged with schema version V, then fail the round.
+        logger.info("Inject paxos_error_after_save_proposal on n1")
+        await inject_error_on(manager, 'paxos_error_after_save_proposal', servers)
+        logger.info("Execute LWT (expect failure due to injection)")
+        with pytest.raises(WriteFailure, match="injected_error_after_save_proposal"):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES (1, 1) IF NOT EXISTS")
+        logger.info("Disable injection")
+        await disable_injection_on(manager, 'paxos_error_after_save_proposal', servers)
+
+        # Step 2: ALTER TABLE to create a new schema version V2, superseding V.
+        logger.info("ALTER TABLE to supersede schema version V with V2")
+        await cql.run_async(f"ALTER TABLE {ks}.test ADD v2 int;")
+
+        # Step 3: Add node n2. It bootstraps from group0 snapshot and only stores mapping(V2).
+        logger.info("Add node n2")
+        servers += [await manager.server_add(cmdline=cmdline)]
+        hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+        # Step 4: Migrate the tablet from n1 to n2, pausing after streaming but
+        # before column mappings fetch. The injection is parameterized with the
+        # $paxos table name so it only fires for the paxos tablet (which holds
+        # the stale proposal), not for the base table tablet.
+        paxos_table = "test$paxos"
+        logger.info("Enable pause_after_streaming_tablet_before_fetch_column_mappings on n2")
+        await manager.api.enable_injection(
+            servers[1].ip_addr, 'pause_after_streaming_tablet_before_fetch_column_mappings',
+            one_shot=False, parameters={"keyspace": ks, "table": paxos_table})
+
+        logger.info("Migrate tablet n1 -> n2")
+        n1_host_id = await manager.get_host_id(servers[0].server_id)
+        n2_host_id = await manager.get_host_id(servers[1].server_id)
+        tablets = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
+        assert len(tablets) == 1
+        tablet = tablets[0]
+        n1_replica = next(r for r in tablet.replicas if r[0] == n1_host_id)
+
+        log = await manager.server_open_log(servers[1].server_id)
+        migration_task = asyncio.create_task(manager.api.move_tablet(
+            servers[0].ip_addr, ks, "test", *n1_replica, *(n2_host_id, 0), tablet.last_token))
+
+        logger.info("Wait for injection to fire ($paxos streaming done, fetch paused)")
+        await log.wait_for('pause_after_streaming_tablet_before_fetch_column_mappings: waiting for message')
+
+        # Step 5: Run an LWT while the streaming fetch is paused. The data plane
+        # fetch in paxos_state.cc retrieves mapping(V) from n1 (still a natural
+        # replica during the in-progress migration).
+        logger.info("Execute LWT (should succeed via data plane fetch from n1)")
+        result = await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES (1, 1) IF NOT EXISTS")
+        logger.info(f"LWT result: {result}")
+
+        # Step 6: Release the injection and let migration complete (including the
+        # streaming fetch that proactively persists mappings on n2).
+        logger.info("Release injection, let migration complete")
+        await manager.api.message_injection(
+            servers[1].ip_addr, 'pause_after_streaming_tablet_before_fetch_column_mappings')
+        await migration_task
+        await manager.api.disable_injection(
+            servers[1].ip_addr, 'pause_after_streaming_tablet_before_fetch_column_mappings')
+
+        # Verify n2 holds the old schema version mapping after migration.
+        table_id_rows = await cql.run_async(
+            f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 'test'")
+        assert len(table_id_rows) == 1
+        cf_id = table_id_rows[0].id
+        history_rows = await cql.run_async(
+            f"SELECT schema_version FROM system.scylla_table_schema_history WHERE cf_id = {cf_id}",
+            host=hosts[1])
+        versions_on_n2 = set(row.schema_version for row in history_rows)
+        logger.info(f"Schema versions on n2 for table {cf_id}: {versions_on_n2}")
+        assert len(versions_on_n2) >= 2, \
+            f"Expected at least 2 schema versions on n2 (old V + current V2), got {len(versions_on_n2)}: {versions_on_n2}"
+
+        # ──────────────────────────────────────────────────────────────────────
+        # Part 2: Streaming fetch persists mappings for future use
+        # ──────────────────────────────────────────────────────────────────────
+
+        # Step 7: Persist a paxos proposal tagged with schema version V2 on n2,
+        # then fail the round.
+        logger.info("Inject paxos_error_after_save_proposal on n2")
+        await inject_error_on(manager, 'paxos_error_after_save_proposal', servers[1:])
+        logger.info("Execute LWT (expect failure due to injection)")
+        with pytest.raises(WriteFailure, match="injected_error_after_save_proposal"):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES (1, 2) IF NOT EXISTS")
+        await disable_injection_on(manager, 'paxos_error_after_save_proposal', servers[1:])
+
+        # Step 8: ALTER TABLE to create schema version V3, superseding V2.
+        logger.info("ALTER TABLE to supersede schema version V2 with V3")
+        await cql.run_async(f"ALTER TABLE {ks}.test ADD v3 int;")
+
+        # Step 9: Add node n3. It bootstraps and only stores mapping(V3).
+        logger.info("Add node n3")
+        servers += [await manager.server_add(cmdline=cmdline)]
+        hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+        # Step 10: Migrate tablet n2 -> n3. The streaming fetch must copy
+        # mapping(V2) from n2 to n3.
+        logger.info("Migrate tablet n2 -> n3")
+        n3_host_id = await manager.get_host_id(servers[2].server_id)
+        tablets = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
+        assert len(tablets) == 1
+        tablet = tablets[0]
+        n2_replica = next(r for r in tablet.replicas if r[0] == n2_host_id)
+        await manager.api.move_tablet(
+            servers[0].ip_addr, ks, "test", *n2_replica, *(n3_host_id, 0), tablet.last_token)
+
+        # Step 11: Run an LWT targeting n3. The tablet is now on n3 (rf=1), so
+        # data plane fetch only queries n3 itself — it cannot retrieve mapping(V2)
+        # from n2. If the streaming fetch hadn't persisted mapping(V2) on n3,
+        # this would fail with "Failed to look up column mapping for schema version".
+        logger.info("Execute LWT on n3 (should succeed if streaming fetch persisted mapping)")
+        result = await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES (1, 2) IF NOT EXISTS")
+        logger.info(f"LWT result: {result}")
+
+        # Verify n3 holds the old schema version mapping.
+        history_rows = await cql.run_async(
+            f"SELECT schema_version FROM system.scylla_table_schema_history WHERE cf_id = {cf_id}",
+            host=hosts[2])
+        versions_on_n3 = set(row.schema_version for row in history_rows)
+        logger.info(f"Schema versions on n3 for table {cf_id}: {versions_on_n3}")
+        # n3 must have at least 3 versions: V (from n1->n2 streaming fetch, then n2->n3),
+        # V2 (from n2->n3 streaming fetch), and V3 (from bootstrap).
+        assert len(versions_on_n3) >= 3, \
+            f"Expected at least 3 schema versions on n3 (V + V2 + V3), got {len(versions_on_n3)}: {versions_on_n3}"

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -965,7 +965,6 @@ async def test_tablets_merge_waits_for_lwt(manager: ManagerClient, scale_timeout
         await lwt
 
 
-@pytest.mark.xfail(reason="Column mapping migration not yet implemented (CUSTOMER-509)")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_column_mapping_migrated_with_tablet(manager: ManagerClient):
     """Reproducer for CUSTOMER-509: after tablet migration, the destination node


### PR DESCRIPTION
When a tablet migrates, the destination node may lack column mappings for schema versions referenced in the transferred paxos state. This causes 'Failed to look up column mapping' errors on subsequent LWT operations.

After streaming completes, the destination now asks each source replica for the column mapping partition (scylla_table_schema_history) via a new get_missing_column_mappings RPC verb. The source reads the partition directly via query_mutations and returns it as a frozen_mutation. The destination applies it locally.

The sync is skipped for intranode migrations (history already local) and gated behind the SCHEMA_HISTORY_ON_TABLET_MIGRATION cluster feature for rolling-upgrade safety.

Fixes CUSTOMER-509
Fixes SCYLLADB-3094

backport: this is a bug in LWT for tablets, need to backport to all versions starting from 2025.4