### PR TITLE
Reduce group0 command size for tablet metadata updates

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -34,6 +34,7 @@
 #include "cdc/log.hh"
 #include "gms/feature_service.hh"
 #include "service/migration_listener.hh"
+#include "service/raft/group0_state_machine.hh"
 
 extern logging::logger cdc_log;
 
@@ -643,7 +644,7 @@ future<mutation> get_switch_streams_mutation(table_id table, db_clock::time_poin
     co_return std::move(m);
 }
 
-future<> generation_service::generate_tablet_resize_update(utils::chunked_vector<canonical_mutation>& muts, table_id table, const locator::tablet_map& new_tablet_map, api::timestamp_type ts) {
+future<> generation_service::generate_tablet_resize_update(service::group0_update_collector& muts, table_id table, const locator::tablet_map& new_tablet_map, api::timestamp_type ts) {
     if (!_cdc_metadata.get_all_tablet_streams().contains(table)) {
         // not a CDC table
         co_return;
@@ -669,7 +670,7 @@ future<> generation_service::generate_tablet_resize_update(utils::chunked_vector
 
     auto diff = co_await _cdc_metadata.generate_stream_diff(current_streams.streams, new_streams);
     auto mut = co_await get_switch_streams_mutation(table, new_ts, std::move(diff), ts);
-    muts.emplace_back(std::move(mut));
+    co_await muts.add(std::move(mut));
 }
 
 future<utils::chunked_vector<mutation>> get_cdc_stream_gc_mutations(table_id table, db_clock::time_point base_ts, const utils::chunked_vector<cdc::stream_id>& base_stream_set, api::timestamp_type ts) {

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -16,6 +16,10 @@ namespace db {
 class system_keyspace;
 }
 
+namespace service {
+class group0_update_collector;
+}
+
 namespace locator {
 class tablet_map;
 class token_metadata;
@@ -63,7 +67,7 @@ public:
     future<> query_cdc_timestamps(table_id table, bool ascending, noncopyable_function<future<>(db_clock::time_point)> f);
     future<> query_cdc_streams(table_id table, noncopyable_function<future<>(db_clock::time_point, const utils::chunked_vector<cdc::stream_id>& current, cdc::cdc_stream_diff)> f);
 
-    future<> generate_tablet_resize_update(utils::chunked_vector<canonical_mutation>& muts, table_id table, const locator::tablet_map& new_tablet_map, api::timestamp_type ts);
+    future<> generate_tablet_resize_update(service::group0_update_collector& muts, table_id table, const locator::tablet_map& new_tablet_map, api::timestamp_type ts);
 
     // Check for tables with enable_requested CDC option and finalize their
     // stream enablement if no in-progress tablet merges remain.

--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -588,7 +588,7 @@ future<> view_building_coordinator::stop() {
     });
 }
 
-void view_building_coordinator::generate_tablet_migration_updates(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, const locator::tablet_map& tmap, locator::global_tablet_id gid, const locator::tablet_transition_info& trinfo) {
+void view_building_coordinator::generate_tablet_migration_updates(service::group0_update_collector& out, const service::group0_guard& guard, const locator::tablet_map& tmap, locator::global_tablet_id gid, const locator::tablet_transition_info& trinfo) {
     vbc_logger.debug("Generating updates for tablet migration for table {}", gid.table);
     
     if (!_vb_sm.building_state.tasks_state.contains(gid.table)) {
@@ -657,10 +657,10 @@ void view_building_coordinator::generate_tablet_migration_updates(utils::chunked
         }
     }
 
-    out.emplace_back(builder.build());
+    out.add_small(builder.build());
 }
 
-void view_building_coordinator::generate_tablet_resize_updates(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, table_id table_id, const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap) {
+void view_building_coordinator::generate_tablet_resize_updates(service::group0_update_collector& out, const service::group0_guard& guard, table_id table_id, const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap) {
     vbc_logger.debug("Generating updates for tablet resize for table {}", table_id);
     if (!_vb_sm.building_state.tasks_state.contains(table_id)) {
         vbc_logger.debug("No view building tasks for table {} - skipping tablet migration updates generation", table_id);
@@ -734,10 +734,10 @@ void view_building_coordinator::generate_tablet_resize_updates(utils::chunked_ve
         resize_task_map(replica_tasks.staging_tasks);
     }
 
-    out.emplace_back(builder.build());
+    out.add_small(builder.build());
 }
 
-void view_building_coordinator::abort_tasks(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, table_id table_id) {
+void view_building_coordinator::abort_tasks(service::group0_update_collector& out, const service::group0_guard& guard, table_id table_id) {
     if (!_vb_sm.building_state.tasks_state.contains(table_id)) {
         return;
     }
@@ -758,15 +758,15 @@ void view_building_coordinator::abort_tasks(utils::chunked_vector<canonical_muta
         abort_task_map(replica_tasks.staging_tasks);
     }
 
-    out.emplace_back(builder.build());
+    out.add_small(builder.build());
 }
 
-void view_building_coordinator::abort_tasks(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, table_id table_id, locator::tablet_replica replica, dht::token last_token) {
+void view_building_coordinator::abort_tasks(service::group0_update_collector& out, const service::group0_guard& guard, table_id table_id, locator::tablet_replica replica, dht::token last_token) {
     return abort_view_building_tasks(_vb_sm, out, guard.write_timestamp(), table_id, replica, last_token);
 }
 
 void abort_view_building_tasks(const view_building_state_machine& vb_sm,
-        utils::chunked_vector<canonical_mutation>& out, api::timestamp_type write_timestamp, table_id table_id, const locator::tablet_replica& replica, dht::token last_token) {
+        service::group0_update_collector& out, api::timestamp_type write_timestamp, table_id table_id, const locator::tablet_replica& replica, dht::token last_token) {
     if (!vb_sm.building_state.tasks_state.contains(table_id) || !vb_sm.building_state.tasks_state.at(table_id).contains(replica)) {
         return;
     }
@@ -788,7 +788,7 @@ void abort_view_building_tasks(const view_building_state_machine& vb_sm,
     }
     abort_task_map(replica_tasks.staging_tasks);
 
-    out.emplace_back(builder.build());
+    out.add_small(builder.build());
 }
 
 static void rollback_task_map(view_building_task_mutation_builder& builder, const task_map& task_map) {
@@ -809,7 +809,7 @@ static void rollback_task_map(view_building_task_mutation_builder& builder, cons
     }
 }
 
-void view_building_coordinator::rollback_aborted_tasks(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, table_id table_id) {
+void view_building_coordinator::rollback_aborted_tasks(service::group0_update_collector& out, const service::group0_guard& guard, table_id table_id) {
     if (!_vb_sm.building_state.tasks_state.contains(table_id)) {
         return;
     }
@@ -823,10 +823,10 @@ void view_building_coordinator::rollback_aborted_tasks(utils::chunked_vector<can
         rollback_task_map(builder, replica_tasks.staging_tasks);
     }
 
-    out.emplace_back(builder.build());
+    out.add_small(builder.build());
 }
 
-void view_building_coordinator::rollback_aborted_tasks(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, table_id table_id, locator::tablet_replica replica, dht::token last_token) {
+void view_building_coordinator::rollback_aborted_tasks(service::group0_update_collector& out, const service::group0_guard& guard, table_id table_id, locator::tablet_replica replica, dht::token last_token) {
     if (!_vb_sm.building_state.tasks_state.contains(table_id) || !_vb_sm.building_state.tasks_state.at(table_id).contains(replica)) {
         return;
     }
@@ -838,7 +838,7 @@ void view_building_coordinator::rollback_aborted_tasks(utils::chunked_vector<can
     }
     rollback_task_map(builder, replica_tasks.staging_tasks);
 
-    out.emplace_back(builder.build());
+    out.add_small(builder.build());
 }
 
 future<> view_building_coordinator::mark_view_build_statuses_on_node_join(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, locator::host_id host_id) {

--- a/db/view/view_building_coordinator.hh
+++ b/db/view/view_building_coordinator.hh
@@ -35,6 +35,7 @@ class gossiper;
 
 namespace service {
 class group0_guard;
+class group0_update_collector;
 class raft_group0;
 }
 
@@ -68,13 +69,13 @@ public:
     future<> run();
     future<> stop();
 
-    void generate_tablet_migration_updates(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, const locator::tablet_map& tmap, locator::global_tablet_id gid, const locator::tablet_transition_info& trinfo);
-    void generate_tablet_resize_updates(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, table_id table_id, const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap);
+    void generate_tablet_migration_updates(service::group0_update_collector& out, const service::group0_guard& guard, const locator::tablet_map& tmap, locator::global_tablet_id gid, const locator::tablet_transition_info& trinfo);
+    void generate_tablet_resize_updates(service::group0_update_collector& out, const service::group0_guard& guard, table_id table_id, const locator::tablet_map& old_tmap, const locator::tablet_map& new_tmap);
 
-    void abort_tasks(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, table_id table_id);
-    void abort_tasks(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, table_id table_id, locator::tablet_replica replica, dht::token last_token);
-    void rollback_aborted_tasks(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, table_id table_id);
-    void rollback_aborted_tasks(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, table_id table_id, locator::tablet_replica replica, dht::token last_token);
+    void abort_tasks(service::group0_update_collector& out, const service::group0_guard& guard, table_id table_id);
+    void abort_tasks(service::group0_update_collector& out, const service::group0_guard& guard, table_id table_id, locator::tablet_replica replica, dht::token last_token);
+    void rollback_aborted_tasks(service::group0_update_collector& out, const service::group0_guard& guard, table_id table_id);
+    void rollback_aborted_tasks(service::group0_update_collector& out, const service::group0_guard& guard, table_id table_id, locator::tablet_replica replica, dht::token last_token);
 
     future<> mark_view_build_statuses_on_node_join(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, locator::host_id host_id);
     future<> remove_view_build_statuses_on_left_node(utils::chunked_vector<canonical_mutation>& out, const service::group0_guard& guard, locator::host_id host_id);
@@ -105,7 +106,7 @@ private:
 };
 
 void abort_view_building_tasks(const db::view::view_building_state_machine& vb_sm,
-        utils::chunked_vector<canonical_mutation>& out, api::timestamp_type write_timestamp, table_id table_id, const locator::tablet_replica& replica, dht::token last_token);
+        service::group0_update_collector& out, api::timestamp_type write_timestamp, table_id table_id, const locator::tablet_replica& replica, dht::token last_token);
 
 }
 

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -140,6 +140,19 @@ mutation::upgrade(const schema_ptr& new_schema) {
     }
 }
 
+future<> mutation::apply_gently(mutation&& m) {
+    if (m.schema()->version() != schema()->version()) {
+        // FIXME: this is not gentle
+        m.partition().upgrade(*m.schema(), *schema());
+    }
+    apply_resume res;
+    mutation_application_stats app_stats;
+    while (partition().apply_monotonically(*schema(), std::move(m.partition()), nullptr, app_stats,
+                                           is_preemptible::yes, res) == stop_iteration::no) {
+        co_await coroutine::maybe_yield();
+    }
+}
+
 void mutation::apply(mutation&& m) {
     mutation_application_stats app_stats;
     partition().apply(*schema(), std::move(m.partition()), *m.schema(), app_stats);

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -388,7 +388,7 @@ auto mutation::consume_gently(Consumer& consumer, consume_in_reverse reverse, mu
 
 struct mutation_equals_by_key {
     bool operator()(const mutation& m1, const mutation& m2) const {
-        return m1.schema() == m2.schema()
+        return m1.schema()->version() == m2.schema()->version()
                 && m1.decorated_key().equal(*m1.schema(), m2.decorated_key());
     }
 };
@@ -396,7 +396,8 @@ struct mutation_equals_by_key {
 struct mutation_hash_by_key {
     size_t operator()(const mutation& m) const {
         auto dk_hash = std::hash<dht::decorated_key>();
-        return dk_hash(m.decorated_key());
+        return utils::hash_combine(dk_hash(m.decorated_key()),
+                                   std::hash<table_schema_version>()(m.schema()->version()));
     }
 };
 

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -131,6 +131,7 @@ public:
     const mutation_partition& partition() const { return _ptr->_p; }
     mutation_partition& partition() { return _ptr->_p; }
     const table_id& column_family_id() const { return _ptr->_schema->id(); }
+    bool empty() const { return _ptr->_p.empty(); }
     // Consistent with hash<canonical_mutation>
     bool operator==(const mutation&) const;
 public:
@@ -167,6 +168,7 @@ public:
     void apply(mutation&&);
     void apply(const mutation&);
     void apply(const mutation_fragment&);
+    future<> apply_gently(mutation&&);
 
     mutation operator+(const mutation& other) const;
     mutation& operator+=(const mutation& other);

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -54,6 +54,10 @@ public:
     tablet_mutation_builder& del_snapshot_name(dht::token last_token);
 
 
+    bool empty() const {
+        return _m.partition().empty();
+    }
+
     mutation build() {
         return std::move(_m);
     }

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -15,6 +15,7 @@
 #include "dht/token.hh"
 #include "message/messaging_service.hh"
 #include "mutation/canonical_mutation.hh"
+#include "mutation/mutation.hh"
 #include "mutation/async_utils.hh"
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/on_internal_error.hh>
@@ -615,6 +616,115 @@ future<> group0_state_machine::transfer_snapshot(raft::server_id from_id, raft::
 future<> group0_state_machine::abort() {
     _abort_source.request_abort();
     return _gate.close();
+}
+
+mutation* group0_update_collector::locate_for_merge(mutation& m) {
+    auto m_size = m.memory_usage(*m.schema());
+    if (m_size >= _max_mutation_size) {
+        _closed_mutations.emplace_back(std::move(m), m_size);
+        return nullptr;
+    }
+
+    auto it = _mutations.find(m);
+    if (it == _mutations.end()) {
+        _mutations.emplace(std::move(m), m_size);
+        return nullptr;
+    }
+    if (it->second + m_size > _max_mutation_size) {
+        // Merging would grow the accumulated mutation past the limit. Seal the larger mutation of the two.
+        if (it->second >= m_size) {
+            auto nh = _mutations.extract(it);
+            _closed_mutations.emplace_back(std::move(nh.key()), nh.mapped());
+            _mutations.emplace(std::move(m), m_size);
+        } else {
+            _closed_mutations.emplace_back(std::move(m), m_size);
+        }
+        return nullptr;
+    }
+    it->second += m_size;
+    return &const_cast<mutation&>(it->first);
+}
+
+future<> group0_update_collector::add(mutation m) {
+    if (m.empty()) {
+        co_return;
+    }
+    ++_change_counter;
+    if (auto* existing = locate_for_merge(m)) {
+        co_await existing->apply_gently(std::move(m));
+    }
+}
+
+void group0_update_collector::add_small(mutation m) {
+    if (m.empty()) {
+        return;
+    }
+    ++_change_counter;
+    if (auto* existing = locate_for_merge(m)) {
+        existing->apply(std::move(m));
+    }
+}
+
+void group0_update_collector::add_large(mutation m) {
+    if (m.empty()) {
+        return;
+    }
+    ++_change_counter;
+    _closed_mutations.emplace_back(std::move(m), m.memory_usage(*m.schema()));
+}
+
+void group0_update_collector::add(utils::chunked_vector<canonical_mutation> muts) {
+    ++_change_counter;
+    for (auto& m : muts) {
+        _frozen_mutations.emplace_back(std::move(m));
+    }
+}
+
+void group0_update_collector::add(canonical_mutation m) {
+    ++_change_counter;
+    _frozen_mutations.emplace_back(std::move(m));
+}
+
+void group0_update_collector::clear() {
+    ++_change_counter;
+    _mutations.clear();
+    _closed_mutations.clear();
+    _frozen_mutations.clear();
+}
+
+future<utils::chunked_vector<canonical_mutation>> group0_update_collector::collect() {
+    utils::chunked_vector<canonical_mutation> result;
+    result.reserve(_closed_mutations.size() + _mutations.size() + _frozen_mutations.size());
+
+    for (auto& [m, m_size] : _closed_mutations) {
+        if (m_size <= _max_mutation_size) {
+            result.emplace_back(co_await make_canonical_mutation_gently(m));
+        } else {
+            // A single mutation can still exceed the limit (e.g. one large add()).
+            // Split it into row-subsets; the pieces are merged back into the same
+            // partition when the command is applied.
+            utils::chunked_vector<mutation> split_mutations;
+            co_await split_mutation(std::move(m), split_mutations, _max_mutation_size);
+            for (auto& sm : split_mutations) {
+                result.emplace_back(co_await make_canonical_mutation_gently(sm));
+            }
+        }
+    }
+    _closed_mutations.clear();
+
+    while (!_mutations.empty()) {
+        auto m = std::move(_mutations.extract(_mutations.begin()).key());
+        result.emplace_back(co_await make_canonical_mutation_gently(m));
+    }
+
+    for (auto& m : _frozen_mutations) {
+        result.emplace_back(std::move(m));
+    }
+    _frozen_mutations.clear();
+
+    ++_change_counter;
+
+    co_return std::move(result);
 }
 
 } // end of namespace service

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -9,6 +9,7 @@
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/abort_source.hh>
+#include <unordered_map>
 
 #include "data_dictionary/data_dictionary.hh"
 #include "keys/keys.hh"
@@ -16,6 +17,7 @@
 #include "raft/raft.hh"
 #include "service/raft/group0_state_id_handler.hh"
 #include "mutation/canonical_mutation.hh"
+#include "mutation/mutation.hh"
 #include "service/raft/raft_state_machine.hh"
 #include "gms/feature.hh"
 #include "gms/inet_address.hh"
@@ -56,6 +58,97 @@ struct mixed_change {
 // mutations' table_id.
 struct write_mutations {
     utils::chunked_vector<canonical_mutation> mutations;
+};
+
+
+/// Collects updates to the group0 state machine
+/// Merges mutations of the same partition in order to minimize output mutation.
+///
+/// Abstracts away details like what is the optimal split size of the output mutation,
+/// how to merge mutations of the same partition, how to store them without causing reactor stalls,
+/// and what is the serialized format of the output mutations (canonical_mutation).
+class group0_update_collector {
+    // Upper bound on the size of a single output mutation. add() keeps the
+    // accumulated per-partition mutations within this bound, and collect()
+    // splits any mutation that still exceeds it.
+    const size_t _max_mutation_size;
+
+    // Currently accumulating mutation per partition, together with a running
+    // upper-bound estimate of its size. Kept within _max_mutation_size by add().
+    std::unordered_map<mutation, size_t, mutation_hash_by_key, mutation_equals_by_key> _mutations;
+
+    // Mutations that reached _max_mutation_size and are no longer merged into,
+    // together with their running upper-bound size estimate.
+    utils::chunked_vector<std::pair<mutation, size_t>> _closed_mutations;
+    utils::chunked_vector<canonical_mutation> _frozen_mutations;
+    uint64_t _change_counter = 0;
+
+    // Locates the accumulating mutation that `m` should be merged into,
+    // accounting its size against it. Returns nullptr if `m` was instead stored
+    // as a new accumulation bucket - either because there was none for its
+    // partition, or the existing one was sealed to keep it within
+    // _max_mutation_size. In the nullptr cases `m` is moved-from.
+    mutation* locate_for_merge(mutation& m);
+
+public:
+    /// Default upper bound on the size of a single output canonical_mutation.
+    /// Should be large enough to amortize the per canonical_mutation memory overhead,
+    /// but small enough to avoid reactor stalls when (de)serializing and applying the mutation to memtables.
+    /// There is a lot of code which calls non-yielding canonical_mutation::to_mutation() and canonical_mutation(cons mutation&)
+    /// on group0 command fragments. Until that's fixed, the splitting before group0 command is built must be there.
+    static constexpr size_t default_max_mutation_size = 1 * 1024 * 1024;
+
+    explicit group0_update_collector(size_t max_mutation_size = default_max_mutation_size)
+        : _max_mutation_size(max_mutation_size) {}
+
+    /// Adds a mutation to the collector.
+    /// The mutation is merged with already collected mutations of the same
+    /// partition, without letting the accumulated mutation grow beyond
+    /// max_mutation_size.
+    future<> add(mutation);
+
+    /// Like add() but assumes the mutation is small-enough to not need yielding.
+    /// For places which don't want to defer due to future<>.
+    void add_small(mutation);
+
+    /// Like add() but assumes the mutation is large-enough to not need merging.
+    /// It may be split later in collect().
+    void add_large(mutation);
+
+    /// Adds a canonical mutation to the collector.
+    /// Not merged with other mutations and not split.
+    /// This is available for interoperability with old code, prefer add(mutation).
+    void add(canonical_mutation);
+
+    /// Adds a vector of canonical mutations to the collector.
+    /// Not merged with other mutations and not split.
+    /// This is available for interoperability with old code, prefer add(mutation).
+    void add(utils::chunked_vector<canonical_mutation>);
+
+    /// Returns a reference to the vector of canonical_mutations that have been added to the collector.
+    /// This is available for interoperability with old code, prefer add(mutation).
+    utils::chunked_vector<canonical_mutation>& frozen_mutations() {
+        return _frozen_mutations;
+    }
+
+    /// Converts accumulated mutations into a vector of canonical_mutations.
+    /// Any collected mutation whose (in-memory) size exceeds max_mutation_size
+    /// is split into several smaller mutations of the same partition, so that no
+    /// single output mutation is much larger than max_mutation_size.
+    /// It's a destructive conversion, the collected mutations are cleared.
+    future<utils::chunked_vector<canonical_mutation>> collect();
+
+    /// Clears the collected mutations.
+    void clear();
+
+    /// The change counter is incremented each time observable state of the collector changes.
+    uint64_t change_counter() const {
+        return _change_counter;
+    }
+
+    bool empty() const {
+        return _mutations.empty() && _closed_mutations.empty() && _frozen_mutations.empty();
+    }
 };
 
 struct group0_command {

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -120,6 +120,13 @@ public:
     /// This is available for interoperability with old code, prefer add(mutation).
     void add(canonical_mutation);
 
+    /// Adds a canonical mutation to the collector, without merging or splitting.
+    /// Vector-like alias for add(canonical_mutation), so that call sites which
+    /// used to emplace_back() into a canonical_mutation vector stay unchanged.
+    void emplace_back(canonical_mutation&& cm) {
+        add(std::move(cm));
+    }
+
     /// Adds a vector of canonical mutations to the collector.
     /// Not merged with other mutations and not split.
     /// This is available for interoperability with old code, prefer add(mutation).

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5786,6 +5786,7 @@ future<> storage_service::del_repair_tablet_request(table_id table, locator::tab
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
         group0_update_collector updates;
 
+        auto builder = tablet_mutation_builder_for_base_table(guard.write_timestamp(), table);
         co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) -> future<> {
             auto& tinfo = tmap.get_tablet_info(tid);
             if (!tinfo.repair_task_info || tinfo.repair_task_info->tablet_task_id != tablet_task_id) {
@@ -5793,13 +5794,12 @@ future<> storage_service::del_repair_tablet_request(table_id table, locator::tab
             }
             auto last_token = tmap.get_last_token(tid);
             auto* trinfo = tmap.get_tablet_transition_info(tid);
-            auto update = tablet_mutation_builder_for_base_table(guard.write_timestamp(), table)
-                            .del_repair_task_info(last_token, _feature_service);
+            builder.del_repair_task_info(last_token, _feature_service);
             if (trinfo && trinfo->transition == locator::tablet_transition_kind::repair) {
-                update.del_session(last_token);
+                builder.del_session(last_token);
             }
-            updates.add_small(update.build());
         });
+        co_await updates.add(builder.build());
 
         sstring reason = format("Deleting tablet repair request by API request tablet_id={} tablet_task_id={}", table, tablet_task_id);
         if (co_await exec_tablet_update(std::move(guard), std::move(updates), std::move(reason))) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5819,8 +5819,7 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
         });
     }
 
-    co_await transit_tablet(table, token, [=, this] (const locator::tablet_map& tmap, api::timestamp_type write_timestamp) {
-        utils::chunked_vector<canonical_mutation> updates;
+    co_await transit_tablet(table, token, [=, this] (group0_update_collector& updates, const locator::tablet_map& tmap, api::timestamp_type write_timestamp) {
         auto tid = tmap.get_tablet_id(token);
         auto& tinfo = tmap.get_tablet_info(tid);
         auto last_token = tmap.get_last_token(tid);
@@ -5839,7 +5838,7 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
 
         if (src == dst) {
             sstring reason = format("No-op move of tablet {} to {}", gid, dst);
-            return std::make_tuple(std::move(updates), std::move(reason));
+            return reason;
         }
 
         if (src.host != dst.host && locator::contains(tinfo.replicas, dst.host)) {
@@ -5866,7 +5865,7 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
             : locator::tablet_task_info::make_migration_request();
         migration_task_info.sched_nr++;
         migration_task_info.sched_time = db_clock::now();
-        updates.emplace_back(tablet_mutation_builder_for_base_table(write_timestamp, table)
+        updates.add_small(tablet_mutation_builder_for_base_table(write_timestamp, table)
             .set_new_replicas(last_token, locator::replace_replica(tinfo.replicas, src, dst))
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
             .set_transition(last_token, src.host == dst.host ? locator::tablet_transition_kind::intranode_migration
@@ -5874,12 +5873,12 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
             .set_migration_task_info(last_token, std::move(migration_task_info), _feature_service)
             .build());
         if (_feature_service.view_building_coordinator) {
-            db::view::abort_view_building_tasks(_view_building_state_machine, updates, write_timestamp, table, src, last_token);
+            db::view::abort_view_building_tasks(_view_building_state_machine, updates.frozen_mutations(), write_timestamp, table, src, last_token);
         }
 
         sstring reason = format("Moving tablet {} from {} to {}", gid, src, dst);
 
-        return std::make_tuple(std::move(updates), std::move(reason));
+        return reason;
     });
 }
 
@@ -5893,8 +5892,7 @@ future<> storage_service::add_tablet_replica(table_id table, dht::token token, l
         });
     }
 
-    co_await transit_tablet(table, token, [=, this] (const locator::tablet_map& tmap, api::timestamp_type write_timestamp) {
-        utils::chunked_vector<canonical_mutation> updates;
+    co_await transit_tablet(table, token, [=, this] (group0_update_collector& updates, const locator::tablet_map& tmap, api::timestamp_type write_timestamp) {
         auto tid = tmap.get_tablet_id(token);
         auto& tinfo = tmap.get_tablet_info(tid);
         auto last_token = tmap.get_last_token(tid);
@@ -5915,7 +5913,7 @@ future<> storage_service::add_tablet_replica(table_id table, dht::token token, l
         locator::tablet_replica_set new_replicas(tinfo.replicas);
         new_replicas.push_back(dst);
 
-        updates.emplace_back(tablet_mutation_builder_for_base_table(write_timestamp, table)
+        updates.add_small(tablet_mutation_builder_for_base_table(write_timestamp, table)
             .set_new_replicas(last_token, new_replicas)
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
             .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
@@ -5923,7 +5921,7 @@ future<> storage_service::add_tablet_replica(table_id table, dht::token token, l
 
         sstring reason = format("Adding replica to tablet {}, node {}", gid, dst);
 
-        return std::make_tuple(std::move(updates), std::move(reason));
+        return reason;
     });
 }
 
@@ -5937,8 +5935,7 @@ future<> storage_service::del_tablet_replica(table_id table, dht::token token, l
         });
     }
 
-    co_await transit_tablet(table, token, [=, this] (const locator::tablet_map& tmap, api::timestamp_type write_timestamp) {
-        utils::chunked_vector<canonical_mutation> updates;
+    co_await transit_tablet(table, token, [=, this] (group0_update_collector& updates, const locator::tablet_map& tmap, api::timestamp_type write_timestamp) {
         auto tid = tmap.get_tablet_id(token);
         auto& tinfo = tmap.get_tablet_info(tid);
         auto last_token = tmap.get_last_token(tid);
@@ -5960,18 +5957,18 @@ future<> storage_service::del_tablet_replica(table_id table, dht::token token, l
         new_replicas.reserve(tinfo.replicas.size() - 1);
         std::copy_if(tinfo.replicas.begin(), tinfo.replicas.end(), std::back_inserter(new_replicas), [&dst] (auto r) { return r != dst; });
 
-        updates.emplace_back(tablet_mutation_builder_for_base_table(write_timestamp, table)
+        updates.add_small(tablet_mutation_builder_for_base_table(write_timestamp, table)
             .set_new_replicas(last_token, new_replicas)
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
             .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
             .build());
         if (_feature_service.view_building_coordinator) {
-            db::view::abort_view_building_tasks(_view_building_state_machine, updates, write_timestamp, table, dst, last_token);
+            db::view::abort_view_building_tasks(_view_building_state_machine, updates.frozen_mutations(), write_timestamp, table, dst, last_token);
         }
 
         sstring reason = format("Removing replica from tablet {}, node {}", gid, dst);
 
-        return std::make_tuple(std::move(updates), std::move(reason));
+        return reason;
     });
 }
 
@@ -6168,7 +6165,7 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
     co_return std::move(load_stats);
 }
 
-future<> storage_service::transit_tablet(table_id table, dht::token token, noncopyable_function<std::tuple<utils::chunked_vector<canonical_mutation>, sstring>(const locator::tablet_map&, api::timestamp_type)> prepare_mutations) {
+future<> storage_service::transit_tablet(table_id table, dht::token token, noncopyable_function<sstring(group0_update_collector&, const locator::tablet_map&, api::timestamp_type)> prepare_mutations) {
     auto success = co_await try_transit_tablet(table, token, std::move(prepare_mutations));
     if (!success) {
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
@@ -6183,7 +6180,7 @@ future<> storage_service::transit_tablet(table_id table, dht::token token, nonco
     });
 }
 
-future<bool> storage_service::try_transit_tablet(table_id table, dht::token token, noncopyable_function<std::tuple<utils::chunked_vector<canonical_mutation>, sstring>(const locator::tablet_map&, api::timestamp_type)> prepare_mutations) {
+future<bool> storage_service::try_transit_tablet(table_id table, dht::token token, noncopyable_function<sstring(group0_update_collector&, const locator::tablet_map&, api::timestamp_type)> prepare_mutations) {
     while (true) {
         auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
         bool topology_busy;
@@ -6206,10 +6203,10 @@ future<bool> storage_service::try_transit_tablet(table_id table, dht::token toke
             co_return false;
         }
 
-        auto [ updates, reason ] = prepare_mutations(tmap, guard.write_timestamp());
+        group0_update_collector uc;
+        auto reason = prepare_mutations(uc, tmap, guard.write_timestamp());
 
         rtlogger.info("{}", reason);
-        rtlogger.trace("do update {} reason {}", updates, reason);
 
         {
             topology_mutation_builder builder(guard.write_timestamp());
@@ -6220,8 +6217,11 @@ future<bool> storage_service::try_transit_tablet(table_id table, dht::token toke
                 builder.set_transition_state(topology::transition_state::tablet_migration);
             }
             builder.set_version(_topology_state_machine._topology.version + 1);
-            updates.push_back(builder.build());
+            uc.emplace_back(builder.build());
         }
+
+        auto updates = co_await uc.collect();
+        rtlogger.trace("do update {} reason {}", updates, reason);
 
         topology_change change{std::move(updates)};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, reason);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5873,7 +5873,7 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
             .set_migration_task_info(last_token, std::move(migration_task_info), _feature_service)
             .build());
         if (_feature_service.view_building_coordinator) {
-            db::view::abort_view_building_tasks(_view_building_state_machine, updates.frozen_mutations(), write_timestamp, table, src, last_token);
+            db::view::abort_view_building_tasks(_view_building_state_machine, updates, write_timestamp, table, src, last_token);
         }
 
         sstring reason = format("Moving tablet {} from {} to {}", gid, src, dst);
@@ -5963,7 +5963,7 @@ future<> storage_service::del_tablet_replica(table_id table, dht::token token, l
             .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
             .build());
         if (_feature_service.view_building_coordinator) {
-            db::view::abort_view_building_tasks(_view_building_state_machine, updates.frozen_mutations(), write_timestamp, table, dst, last_token);
+            db::view::abort_view_building_tasks(_view_building_state_machine, updates, write_timestamp, table, dst, last_token);
         }
 
         sstring reason = format("Removing replica from tablet {}, node {}", gid, dst);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4313,7 +4313,7 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
         // To maintain atomicity against concurrent migration requests
         // (e.g., finalization) and prevent failures from group0 conflicts, we
         // should turn this into a topology request.
-        utils::chunked_vector<canonical_mutation> updates;
+        group0_update_collector updates;
 
         auto append_tablet_map_mutations = [&] (table_id tid, const sstring& cf_name, const locator::tablet_map& tmap, size_t target_pow2) -> future<> {
             slogger.info("Built tablet map for table {}.{} with {} tablet(s) (target pow2={})",
@@ -4347,7 +4347,7 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
             }
         }
 
-        topology_change change{std::move(updates)};
+        topology_change change{co_await updates.collect()};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,
             fmt::format("migrate keyspace {} to tablets", ks_name));
 
@@ -5612,8 +5612,9 @@ future<service::group0_guard> storage_service::get_guard_for_tablet_update() {
     co_return guard;
 }
 
-future<bool> storage_service::exec_tablet_update(service::group0_guard guard, utils::chunked_vector<canonical_mutation> updates, sstring reason) {
+future<bool> storage_service::exec_tablet_update(service::group0_guard guard, group0_update_collector uc, sstring reason) {
     rtlogger.info("{}", reason);
+    auto updates = co_await uc.collect();
     rtlogger.trace("do update {} reason {}", updates, reason);
     updates.emplace_back(topology_mutation_builder(guard.write_timestamp())
             .set_version(_topology_state_machine._topology.version + 1)
@@ -5684,7 +5685,7 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
         }
 
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
-        utils::chunked_vector<canonical_mutation> updates;
+        group0_update_collector updates;
 
         if (all_tokens) {
             tokens.clear();
@@ -5697,7 +5698,6 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
 
         auto ts = db_clock::now();
         auto builder = tablet_mutation_builder_for_base_table(guard.write_timestamp(), table);
-        std::optional<mutation> repair_task_update;
         for (const auto& token : tokens) {
             auto tid = tmap.get_tablet_id(token);
             auto& tinfo = tmap.get_tablet_info(tid);
@@ -5718,22 +5718,10 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
             };
             if (_feature_service.tablet_repair_tasks_table) {
                 auto m = co_await _sys_ks.local().get_update_repair_task_mutation(entry, guard.write_timestamp());
-                if (repair_task_update) {
-                    if (!m.decorated_key().equal(*m.schema(), repair_task_update->decorated_key())) {
-                        on_internal_error(rtlogger, "add_repair_tablet_request(): repair task mutations have different partition keys");
-                    }
-                    repair_task_update->apply(std::move(m));
-                } else {
-                    repair_task_update = std::move(m);
-                }
+                updates.add_small(std::move(m));
             }
         }
-        if (repair_task_update) {
-            updates.emplace_back(std::move(*repair_task_update));
-        }
-        if (!tokens.empty()) {
-            updates.emplace_back(builder.build());
-        }
+        updates.add_large(builder.build());
 
         sstring reason = format("Repair tablet by API request tokens={} tablet_task_id={}", tokens, repair_task_info.tablet_task_id);
         if (co_await exec_tablet_update(std::move(guard), std::move(updates), std::move(reason))) {
@@ -5796,7 +5784,7 @@ future<> storage_service::del_repair_tablet_request(table_id table, locator::tab
         }
 
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
-        utils::chunked_vector<canonical_mutation> updates;
+        group0_update_collector updates;
 
         co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) -> future<> {
             auto& tinfo = tmap.get_tablet_info(tid);
@@ -5810,7 +5798,7 @@ future<> storage_service::del_repair_tablet_request(table_id table, locator::tab
             if (trinfo && trinfo->transition == locator::tablet_transition_kind::repair) {
                 update.del_session(last_token);
             }
-            updates.emplace_back(update.build());
+            updates.add_small(update.build());
         });
 
         sstring reason = format("Deleting tablet repair request by API request tablet_id={} tablet_task_id={}", table, tablet_task_id);
@@ -6002,8 +5990,8 @@ future<> storage_service::abort_restore_tablets(table_id table) {
         auto guard = co_await get_guard_for_tablet_update();
 
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
-        utils::chunked_vector<canonical_mutation> updates;
-
+        group0_update_collector updates;
+        auto builder = tablet_mutation_builder_for_base_table(guard.write_timestamp(), table);
         co_await tmap.for_each_tablet([&] (locator::tablet_id tid, const locator::tablet_info& info) -> future<> {
             auto* trinfo = tmap.get_tablet_transition_info(tid);
             if (!trinfo || trinfo->transition != locator::tablet_transition_kind::restore || !trinfo->session_id) {
@@ -6012,10 +6000,10 @@ future<> storage_service::abort_restore_tablets(table_id table) {
             auto last_token = tmap.get_last_token(tid);
             // Deleting the session aborts the restore: see the restore handling in the
             // topology coordinator.
-            updates.emplace_back(tablet_mutation_builder_for_base_table(guard.write_timestamp(), table)
-                .del_session(last_token)
-                .build());
+            builder.del_session(last_token);
         });
+
+        co_await updates.add(builder.build());
 
         if (updates.empty()) {
             break;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -981,7 +981,7 @@ private:
     future<> transit_tablet(table_id, dht::token, noncopyable_function<std::tuple<utils::chunked_vector<canonical_mutation>, sstring>(const locator::tablet_map& tmap, api::timestamp_type)> prepare_mutations);
     future<bool> try_transit_tablet(table_id, dht::token, noncopyable_function<std::tuple<utils::chunked_vector<canonical_mutation>, sstring>(const locator::tablet_map& tmap, api::timestamp_type)> prepare_mutations);
     future<service::group0_guard> get_guard_for_tablet_update();
-    future<bool> exec_tablet_update(service::group0_guard guard, utils::chunked_vector<canonical_mutation> updates, sstring reason);
+    future<bool> exec_tablet_update(service::group0_guard guard, group0_update_collector updates, sstring reason);
 public:
     struct all_tokens_tag {};
     future<std::unordered_map<sstring, sstring>> add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant, std::unordered_set<locator::host_id> hosts_filter, std::unordered_set<sstring> dcs_filter, bool await_completion, locator::tablet_repair_incremental_mode incremental_mode);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -978,8 +978,8 @@ private:
     // Tracks progress of the upgrade to topology coordinator.
     future<> _upgrade_to_topology_coordinator_fiber = make_ready_future<>();
 
-    future<> transit_tablet(table_id, dht::token, noncopyable_function<std::tuple<utils::chunked_vector<canonical_mutation>, sstring>(const locator::tablet_map& tmap, api::timestamp_type)> prepare_mutations);
-    future<bool> try_transit_tablet(table_id, dht::token, noncopyable_function<std::tuple<utils::chunked_vector<canonical_mutation>, sstring>(const locator::tablet_map& tmap, api::timestamp_type)> prepare_mutations);
+    future<> transit_tablet(table_id, dht::token, noncopyable_function<sstring(group0_update_collector&, const locator::tablet_map& tmap, api::timestamp_type)> prepare_mutations);
+    future<bool> try_transit_tablet(table_id, dht::token, noncopyable_function<sstring(group0_update_collector&, const locator::tablet_map& tmap, api::timestamp_type)> prepare_mutations);
     future<service::group0_guard> get_guard_for_tablet_update();
     future<bool> exec_tablet_update(service::group0_guard guard, group0_update_collector updates, sstring reason);
 public:

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1160,7 +1160,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                             if (abandoning_replicas.size() != 1) {
                                                 on_internal_error(rtlogger, fmt::format("Keyspace RF abandons {} replicas for table {} and tablet id {}", abandoning_replicas.size(), table_or_mv->id(), tablet_id));
                                             }
-                                            _vb_coordinator->abort_tasks(updates.frozen_mutations(), guard, table_or_mv->id(), *abandoning_replicas.begin(), last_token);
+                                            _vb_coordinator->abort_tasks(updates, guard, table_or_mv->id(), *abandoning_replicas.begin(), last_token);
                                         }
 
                                         co_await coroutine::maybe_yield();
@@ -2161,7 +2161,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::write_both_read_old);
                         auto leaving_replica = get_leaving_replica(tmap.get_tablet_info(gid.tablet), trinfo);
                         if (leaving_replica) {
-                            _vb_coordinator->abort_tasks(updates.frozen_mutations(), guard, gid.table, *leaving_replica, last_token);
+                            _vb_coordinator->abort_tasks(updates, guard, gid.table, *leaving_replica, last_token);
                         }
                         get_mutation_builder()
                             .set_stage(last_token, locator::tablet_transition_stage::write_both_read_old)
@@ -2400,7 +2400,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                 .del_migration_task_info(last_token, _feature_service);
                         auto leaving_replica = get_leaving_replica(tmap.get_tablet_info(gid.tablet), trinfo);
                         if (leaving_replica) {
-                            _vb_coordinator->rollback_aborted_tasks(updates.frozen_mutations(), guard, gid.table, *leaving_replica, last_token);
+                            _vb_coordinator->rollback_aborted_tasks(updates, guard, gid.table, *leaving_replica, last_token);
                         }
                     }
                     break;
@@ -2417,7 +2417,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                 .del_transition(last_token)
                                 .set_replicas(last_token, trinfo.next)
                                 .del_migration_task_info(last_token, _feature_service);
-                        _vb_coordinator->generate_tablet_migration_updates(updates.frozen_mutations(), guard, tmap, gid, trinfo);
+                        _vb_coordinator->generate_tablet_migration_updates(updates, guard, tmap, gid, trinfo);
                     }
                 }
                     break;
@@ -2793,7 +2793,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
             // Clears the resize decision for a table.
             generate_resize_update(updates, guard, table_id, locator::resize_decision{});
-            _vb_coordinator->generate_tablet_resize_updates(updates.frozen_mutations(), guard, table_id, tm->tablets().get_tablet_map(table_id), new_tablet_map);
+            _vb_coordinator->generate_tablet_resize_updates(updates, guard, table_id, tm->tablets().get_tablet_map(table_id), new_tablet_map);
 
             for (auto table_id : tm->tablets().all_table_groups().at(table_id)) {
                 co_await _cdc_gens.generate_tablet_resize_update(updates, table_id, new_tablet_map, guard.write_timestamp());

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1150,12 +1150,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                                 ks.get_replication_strategy().get_replication_factor(*tmptr), old_tablet_info.replicas));
                                         }
 
-                                        updates.add_small(
-                                                replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
-                                                        .set_new_replicas(last_token, tablet_info.replicas)
-                                                        .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-                                                        .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
-                                                        .build());
+                                        tablet_mutation_builder
+                                                .set_new_replicas(last_token, tablet_info.replicas)
+                                                .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+                                                .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service));
 
                                         // Calculate abandoning replica and abort view building tasks on them
                                         if (!abandoning_replicas.empty()) {
@@ -1167,6 +1165,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
                                         co_await coroutine::maybe_yield();
                                     });
+                                    co_await updates.add(tablet_mutation_builder.build());
                                 }
                             }
                             auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
@@ -1737,7 +1736,24 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         return _topo_sm._topology.excluded_tablet_nodes.contains(server_id);
     }
 
-    void generate_migration_update(group0_update_collector& out, const group0_guard& guard, const tablet_migration_info& mig) {
+    // Coalesces tablet mutations targeting the same table into a single mutation.
+    // The system.tablets table is partitioned by table_id, so updates for many
+    // tablets of the same table share a partition and can be merged into one
+    // mutation.
+    using tablet_builder_map = std::unordered_map<table_id, replica::tablet_mutation_builder>;
+
+    replica::tablet_mutation_builder& get_tablet_builder(tablet_builder_map& builders, const group0_guard& guard, table_id table) {
+        return builders.try_emplace(table, guard.write_timestamp(), table).first->second;
+    }
+
+    future<> flush_tablet_builders(group0_update_collector& out, tablet_builder_map& builders) {
+        for (auto& [table, builder] : builders) {
+            co_await out.add(builder.build());
+        }
+        builders.clear();
+    }
+
+    void generate_migration_update(tablet_builder_map& builders, const group0_guard& guard, const tablet_migration_info& mig) {
         const auto& tmap = get_token_metadata_ptr()->tablets().get_tablet_map(mig.tablet.table);
         auto last_token = tmap.get_last_token(mig.tablet.tablet);
         if (tmap.get_tablet_transition_info(mig.tablet.tablet)) {
@@ -1748,16 +1764,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             : locator::tablet_task_info::make_intranode_migration_request();
         migration_task_info.sched_nr++;
         migration_task_info.sched_time = db_clock::now();
-        out.add_small(
-            replica::tablet_mutation_builder(guard.write_timestamp(), mig.tablet.table)
-                .set_new_replicas(last_token, locator::get_new_replicas(tmap.get_tablet_info(mig.tablet.tablet), mig))
-                .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-                .set_transition(last_token, mig.kind)
-                .set_migration_task_info(last_token, std::move(migration_task_info), _feature_service)
-                .build());
+        get_tablet_builder(builders, guard, mig.tablet.table)
+            .set_new_replicas(last_token, locator::get_new_replicas(tmap.get_tablet_info(mig.tablet.tablet), mig))
+            .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+            .set_transition(last_token, mig.kind)
+            .set_migration_task_info(last_token, std::move(migration_task_info), _feature_service);
     }
 
-    void generate_repair_update(group0_update_collector& out, const group0_guard& guard, const locator::global_tablet_id& gid, db_clock::time_point sched_time) {
+    void generate_repair_update(tablet_builder_map& builders, const group0_guard& guard, const locator::global_tablet_id& gid, db_clock::time_point sched_time) {
         auto& tmap = get_token_metadata_ptr()->tablets().get_tablet_map(gid.table);
         auto last_token = tmap.get_last_token(gid.tablet);
         if (tmap.get_tablet_transition_info(gid.tablet)) {
@@ -1770,14 +1784,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             : locator::tablet_task_info::make_auto_repair_request();
         repair_task_info.sched_nr++;
         repair_task_info.sched_time = db_clock::now();
-        out.add_small(
-            replica::tablet_mutation_builder(guard.write_timestamp(), gid.table)
-                .set_new_replicas(last_token, tmap.get_tablet_info(gid.tablet).replicas)
-                .set_stage(last_token, locator::tablet_transition_stage::repair)
-                .set_transition(last_token, locator::tablet_transition_kind::repair)
-                .set_repair_task_info(last_token, repair_task_info, _feature_service)
-                .set_session(last_token, session_id(utils::UUID_gen::get_time_UUID()))
-                .build());
+        get_tablet_builder(builders, guard, gid.table)
+            .set_new_replicas(last_token, tmap.get_tablet_info(gid.tablet).replicas)
+            .set_stage(last_token, locator::tablet_transition_stage::repair)
+            .set_transition(last_token, locator::tablet_transition_kind::repair)
+            .set_repair_task_info(last_token, repair_task_info, _feature_service)
+            .set_session(last_token, session_id(utils::UUID_gen::get_time_UUID()));
     }
 
     void generate_resize_update(group0_update_collector& out, const group0_guard& guard, table_id table_id, locator::resize_decision resize_decision) {
@@ -1880,6 +1892,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
     }
 
     future<> generate_migration_updates(group0_update_collector& out, const group0_guard& guard, const migration_plan& plan) {
+        tablet_builder_map migration_builders;
+
         if (plan.resize_plan().finalize_resize.empty() || plan.has_nodes_to_drain()) {
             // schedule tablet migration only if there are no pending resize finalisations or if the node is draining.
 
@@ -1894,7 +1908,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             } else {
                 for (const tablet_migration_info& mig: plan.migrations()) {
                     co_await coroutine::maybe_yield();
-                    generate_migration_update(out, guard, mig);
+                    generate_migration_update(migration_builders, guard, mig);
                 }
             }
 
@@ -1908,8 +1922,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         auto sched_time = db_clock::now();
         for (const auto& gid : plan.repair_plan().repairs()) {
             co_await coroutine::maybe_yield();
-            generate_repair_update(out, guard, gid, sched_time);
+            generate_repair_update(migration_builders, guard, gid, sched_time);
         }
+
+        co_await flush_tablet_builders(out, migration_builders);
 
         for (auto [table_id, resize_decision] : plan.resize_plan().resize) {
             co_await coroutine::maybe_yield();
@@ -2032,6 +2048,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         group0_update_collector updates;
         bool needs_barrier = false;
         bool has_transitions = false;
+        tablet_builder_map tablet_builders;
 
         shared_promise barrier;
         auto fail_barrier = seastar::defer([&] noexcept {
@@ -2081,15 +2098,16 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             auto last_token = tmap.get_last_token(gid.tablet);
             auto& tablet_state = _tablets[gid];
 
-            auto get_mutation_builder = [&] () {
-                return replica::tablet_mutation_builder(guard.write_timestamp(), base_table);
+            // Returns the shared per-table builder accumulating all tablet transitions of this co-location
+            // group's base table. The builders are flushed into `updates` after the loop.
+            auto get_mutation_builder = [&] () -> replica::tablet_mutation_builder& {
+                return get_tablet_builder(tablet_builders, guard, base_table);
             };
 
             auto transition_to = [&] (locator::tablet_transition_stage stage) {
                 rtlogger.debug("Will set tablet {} stage to {}", gid, stage);
-                updates.add_small(get_mutation_builder()
-                        .set_stage(last_token, stage)
-                        .build());
+                get_mutation_builder()
+                        .set_stage(last_token, stage);
             };
 
             auto do_barrier = [&] {
@@ -2145,12 +2163,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         if (leaving_replica) {
                             _vb_coordinator->abort_tasks(updates.frozen_mutations(), guard, gid.table, *leaving_replica, last_token);
                         }
-                        updates.add_small(get_mutation_builder()
+                        get_mutation_builder()
                             .set_stage(last_token, locator::tablet_transition_stage::write_both_read_old)
                             // Create session a bit earlier to avoid adding barrier
                             // to the streaming stage to create sessions on replicas.
-                            .set_session(last_token, session_id(utils::UUID_gen::get_time_UUID()))
-                            .build());
+                            .set_session(last_token, session_id(utils::UUID_gen::get_time_UUID()));
                     }
                     break;
                 case locator::tablet_transition_stage::write_both_read_old:
@@ -2174,10 +2191,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         bool fail = utils::get_local_injector().enter("rebuild_repair_stage_fail");
                         if (fail || check_excluded_replicas()) {
                             rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::cleanup_target);
-                            updates.add_small(get_mutation_builder()
+                            get_mutation_builder()
                                     .set_stage(last_token, locator::tablet_transition_stage::cleanup_target)
-                                    .del_session(last_token)
-                                    .build());
+                                    .del_session(last_token);
                             break;
                         }
                     }
@@ -2205,9 +2221,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         });
                     })) {
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::streaming);
-                        updates.add_small(get_mutation_builder()
-                            .set_stage(last_token, locator::tablet_transition_stage::streaming)
-                            .build());
+                        get_mutation_builder()
+                            .set_stage(last_token, locator::tablet_transition_stage::streaming);
                     }
                 }
                     break;
@@ -2251,10 +2266,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
                         if (rollback) {
                             rtlogger.debug("Will set tablet {} stage to {}: {}", gid, locator::tablet_transition_stage::cleanup_target, *rollback);
-                            updates.add_small(get_mutation_builder()
+                            get_mutation_builder()
                                 .set_stage(last_token, locator::tablet_transition_stage::cleanup_target)
-                                .del_session(last_token)
-                                .build());
+                                .del_session(last_token);
                             break;
                         }
                     }
@@ -2278,10 +2292,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         });
                     })) {
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::write_both_read_new);
-                        updates.add_small(get_mutation_builder()
+                        get_mutation_builder()
                             .set_stage(last_token, locator::tablet_transition_stage::write_both_read_new)
-                            .del_session(last_token)
-                            .build());
+                            .del_session(last_token);
                     }
                 }
                     break;
@@ -2382,10 +2395,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     // See do_tablet_operation() doc.
                     if (do_barrier()) {
                         _tablets.erase(gid);
-                        updates.add_small(get_mutation_builder()
+                        get_mutation_builder()
                                 .del_transition(last_token)
-                                .del_migration_task_info(last_token, _feature_service)
-                                .build());
+                                .del_migration_task_info(last_token, _feature_service);
                         auto leaving_replica = get_leaving_replica(tmap.get_tablet_info(gid.tablet), trinfo);
                         if (leaving_replica) {
                             _vb_coordinator->rollback_aborted_tasks(updates.frozen_mutations(), guard, gid.table, *leaving_replica, last_token);
@@ -2401,11 +2413,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     bool defer_transition = utils::get_local_injector().enter("handle_tablet_migration_end_migration");
                     if (!defer_transition && do_barrier()) {
                         _tablets.erase(gid);
-                        updates.add_small(get_mutation_builder()
+                        get_mutation_builder()
                                 .del_transition(last_token)
                                 .set_replicas(last_token, trinfo.next)
-                                .del_migration_task_info(last_token, _feature_service)
-                                .build());
+                                .del_migration_task_info(last_token, _feature_service);
                         _vb_coordinator->generate_tablet_migration_updates(updates.frozen_mutations(), guard, tmap, gid, trinfo);
                     }
                 }
@@ -2416,10 +2427,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         if (do_barrier()) {
                             auto& tinfo = tmap.get_tablet_info(gid.tablet);
                             _tablet_ops_metrics.inc_failed(tinfo.repair_task_info ? tinfo.repair_task_info->request_type : locator::tablet_task_type::none);
-                            updates.add_small(get_mutation_builder()
+                            get_mutation_builder()
                                     .set_stage(last_token, locator::tablet_transition_stage::end_repair)
-                                    .del_session(last_token)
-                                    .build());
+                                    .del_session(last_token);
                         }
                         break;
                     }
@@ -2490,7 +2500,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         auto incremental = valid && tinfo.repair_task_info->repair_incremental_mode != locator::tablet_repair_incremental_mode::disabled;
                         bool is_filter_off = hosts_filter.empty() && dcs_filter.empty();
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::end_repair);
-                        auto update = get_mutation_builder()
+                        auto& update = get_mutation_builder()
                                         .set_stage(last_token, locator::tablet_transition_stage::end_repair)
                                         .del_repair_task_info(last_token, _feature_service)
                                         .del_session(last_token);
@@ -2515,7 +2525,6 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             rtlogger.debug("Set tablet repair time sched_time={} repair_time={} sstables_repaired_at={} last_token={}",
                                     sched_time, time, repaired_at, last_token);
                         }
-                        updates.add_small(update.build());
                         _tablet_ops_metrics.inc_succeeded(tinfo.repair_task_info ? tinfo.repair_task_info->request_type : locator::tablet_task_type::none);
                     }
                 }
@@ -2528,7 +2537,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         auto ep = tablet_state.restore->get_exception();
                         rtlogger.debug("Clearing restore transition for {} due to error", gid);
                         _tablets.erase(gid);
-                        updates.add_small(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).del_session(last_token).build());
+                        get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).del_session(last_token);
                         // Record error on the ongoing restore request so it's propagated to the caller.
                         if (auto it = restore_request_for_table.find(gid.table); it != restore_request_for_table.end()) {
                             updates.add(
@@ -2553,7 +2562,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     })) {
                         rtlogger.debug("Clearing restore transition for {}", gid);
                         _tablets.erase(gid);
-                        updates.add_small(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).del_session(last_token).build());
+                        get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).del_session(last_token);
                     }
                 }
                     break;
@@ -2591,13 +2600,15 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                 rtlogger.info("The end_repair stage finished for tablet repair tablet_id={} session_id={}", gid, tablet_state.session_id);
                             }
                             _tablets.erase(gid);
-                            updates.add_small(get_mutation_builder().del_transition(last_token).build());
+                            get_mutation_builder().del_transition(last_token);
                         }
                     }
                 }
                     break;
             }
         });
+
+        co_await flush_tablet_builders(updates, tablet_builders);
 
         // In order to keep the cluster saturated, ask the load balancer for more transitions.
         // Unless there is a pending topology change operation.
@@ -4664,14 +4675,12 @@ future<bool> topology_coordinator::maybe_retry_failed_rf_change_tablet_rebuilds(
                 auto new_replicas = replicas;
                 new_replicas.push_back(*it);
                 auto last_token = new_tablet_map.get_last_token(tablet_id);
-                updates.add_small(
-                        replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
-                                .set_new_replicas(last_token, new_replicas)
-                                .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-                                .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
-                                .build()
-                );
+                tablet_mutation_builder
+                        .set_new_replicas(last_token, new_replicas)
+                        .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+                        .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service));
             });
+            co_await updates.add(tablet_mutation_builder.build());
         }
 
         if (!updates.empty()) {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -430,6 +430,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         }
     }
 
+    future<> update_topology_state(group0_guard guard, group0_update_collector&& updates, const sstring& reason) {
+        co_await update_topology_state(std::move(guard), co_await updates.collect(), reason);
+    }
+
+    future<> update_topology_state_with_mixed_change(group0_guard guard, group0_update_collector&& updates, const sstring& reason) {
+        co_await update_topology_state_with_mixed_change(std::move(guard), co_await updates.collect(), reason);
+    }
+
     raft::server_id parse_replaced_node(const std::optional<request_param>& req_param) const {
         return service::topology::parse_replaced_node(req_param);
     }
@@ -1094,7 +1102,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 return tbuilder;
             };
 
-            utils::chunked_vector<canonical_mutation> updates;
+            group0_update_collector updates;
+
             sstring error;
             if (_db.has_keyspace(ks_name)) {
                 try {
@@ -1141,20 +1150,19 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                                 ks.get_replication_strategy().get_replication_factor(*tmptr), old_tablet_info.replicas));
                                         }
 
-                                        updates.emplace_back(co_await make_canonical_mutation_gently(
+                                        updates.add_small(
                                                 replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
                                                         .set_new_replicas(last_token, tablet_info.replicas)
                                                         .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
                                                         .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
-                                                        .build()
-                                        ));
+                                                        .build());
 
                                         // Calculate abandoning replica and abort view building tasks on them
                                         if (!abandoning_replicas.empty()) {
                                             if (abandoning_replicas.size() != 1) {
                                                 on_internal_error(rtlogger, fmt::format("Keyspace RF abandons {} replicas for table {} and tablet id {}", abandoning_replicas.size(), table_or_mv->id(), tablet_id));
                                             }
-                                            _vb_coordinator->abort_tasks(updates, guard, table_or_mv->id(), *abandoning_replicas.begin(), last_token);
+                                            _vb_coordinator->abort_tasks(updates.frozen_mutations(), guard, table_or_mv->id(), *abandoning_replicas.begin(), last_token);
                                         }
 
                                         co_await coroutine::maybe_yield();
@@ -1163,20 +1171,20 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             }
                             auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
                             for (auto& m: schema_muts) {
-                                updates.emplace_back(m);
+                                updates.add_large(std::move(m));
                             }
 
-                            updates.push_back(canonical_mutation(tbuilder_with_request_drop().build()));
-                            updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(req_id)
+                            updates.add(tbuilder_with_request_drop().build());
+                            updates.add(topology_request_tracking_mutation_builder(req_id)
                                                         .done()
-                                                        .build()));
+                                                        .build());
                             break;
                         }
                         case keyspace_rf_change_kind::conversion_to_rack_list: {
                             rtlogger.info("keyspace_rf_change for keyspace {} postponed for colocation", ks_name);
                             topology_mutation_builder tbuilder = tbuilder_with_request_drop();
                             tbuilder.pause_rf_change_request(req_id);
-                            updates.push_back(canonical_mutation(tbuilder.build()));
+                            updates.add(tbuilder.build());
                             break;
                         }
                         case keyspace_rf_change_kind::multi_rf_change: {
@@ -1185,12 +1193,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             ks_md->set_strategy_options(ks.metadata()->strategy_options()); // start from the old strategy
                             auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
                             for (auto& m: schema_muts) {
-                                updates.emplace_back(m);
+                                updates.add_large(std::move(m));
                             }
 
                             topology_mutation_builder tbuilder = tbuilder_with_request_drop();
                             tbuilder.start_rf_change_migrations(req_id);
-                            updates.push_back(canonical_mutation(tbuilder.build()));
+                            updates.add(tbuilder.build());
                             break;
                         }
                     }
@@ -1205,15 +1213,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             }
 
             if (error != "") {
-                updates.push_back(canonical_mutation(tbuilder_with_request_drop().build()));
-                updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(req_id)
+                updates.add(tbuilder_with_request_drop().build());
+                updates.add(topology_request_tracking_mutation_builder(req_id)
                                                          .done(error)
-                                                         .build()));
+                                                         .build());
             }
 
             sstring reason = seastar::format("ALTER tablets KEYSPACE called with options: {}", saved_ks_props);
-            rtlogger.trace("do update {} reason {}", updates, reason);
-            mixed_change change{std::move(updates)};
+            mixed_change change{co_await updates.collect()};
             group0_command g0_cmd = _group0.client().prepare_command(std::move(change), guard, reason);
             co_await utils::get_local_injector().inject("wait-before-committing-rf-change-event", utils::wait_for_message(30s));
             co_await _group0.client().add_entry(std::move(g0_cmd), std::move(guard), _as);
@@ -1246,7 +1253,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         break;
         case global_topology_request::quiesce: {
             std::optional<sstring> error;
-            utils::chunked_vector<canonical_mutation> updates;
+            group0_update_collector updates;
             bool requires_schema_changes = false;
 
             try {
@@ -1272,15 +1279,15 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 updates.clear();
             }
 
-            updates.push_back(canonical_mutation(
+            updates.emplace_back(
                     topology_mutation_builder(guard.write_timestamp())
                          .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id)
-                         .build()));
-            updates.push_back(canonical_mutation(
+                         .build());
+            updates.emplace_back(
                     topology_request_tracking_mutation_builder(req_id)
                          .set("start_time", db_clock::now())
                          .done(error)
-                         .build()));
+                         .build());
             if (error) {
                 auto reason = fmt::format("quiesce request deferred: {}", *error);
                 if (requires_schema_changes) {
@@ -1730,7 +1737,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         return _topo_sm._topology.excluded_tablet_nodes.contains(server_id);
     }
 
-    void generate_migration_update(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, const tablet_migration_info& mig) {
+    void generate_migration_update(group0_update_collector& out, const group0_guard& guard, const tablet_migration_info& mig) {
         const auto& tmap = get_token_metadata_ptr()->tablets().get_tablet_map(mig.tablet.table);
         auto last_token = tmap.get_last_token(mig.tablet.tablet);
         if (tmap.get_tablet_transition_info(mig.tablet.tablet)) {
@@ -1741,7 +1748,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             : locator::tablet_task_info::make_intranode_migration_request();
         migration_task_info.sched_nr++;
         migration_task_info.sched_time = db_clock::now();
-        out.emplace_back(
+        out.add_small(
             replica::tablet_mutation_builder(guard.write_timestamp(), mig.tablet.table)
                 .set_new_replicas(last_token, locator::get_new_replicas(tmap.get_tablet_info(mig.tablet.tablet), mig))
                 .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
@@ -1750,7 +1757,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 .build());
     }
 
-    void generate_repair_update(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, const locator::global_tablet_id& gid, db_clock::time_point sched_time) {
+    void generate_repair_update(group0_update_collector& out, const group0_guard& guard, const locator::global_tablet_id& gid, db_clock::time_point sched_time) {
         auto& tmap = get_token_metadata_ptr()->tablets().get_tablet_map(gid.table);
         auto last_token = tmap.get_last_token(gid.tablet);
         if (tmap.get_tablet_transition_info(gid.tablet)) {
@@ -1763,7 +1770,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             : locator::tablet_task_info::make_auto_repair_request();
         repair_task_info.sched_nr++;
         repair_task_info.sched_time = db_clock::now();
-        out.emplace_back(
+        out.add_small(
             replica::tablet_mutation_builder(guard.write_timestamp(), gid.table)
                 .set_new_replicas(last_token, tmap.get_tablet_info(gid.tablet).replicas)
                 .set_stage(last_token, locator::tablet_transition_stage::repair)
@@ -1773,7 +1780,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 .build());
     }
 
-    void generate_resize_update(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, table_id table_id, locator::resize_decision resize_decision) {
+    void generate_resize_update(group0_update_collector& out, const group0_guard& guard, table_id table_id, locator::resize_decision resize_decision) {
             // FIXME: indent.
             auto s = _db.find_schema(table_id);
             const auto& tmap = get_token_metadata_ptr()->tablets().get_tablet_map(table_id);
@@ -1781,13 +1788,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             resize_decision.sequence_number = tmap.resize_decision().next_sequence_number();
             rtlogger.debug("Generating resize decision for table {} of type {} and sequence number {}",
                            table_id, resize_decision.type_name(), resize_decision.sequence_number);
-            out.emplace_back(
+            out.add_small(
                 replica::tablet_mutation_builder(guard.write_timestamp(), table_id)
                     .set_resize_decision(std::move(resize_decision), _feature_service)
                     .build());
     }
 
-    void generate_rf_change_resume_update(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, utils::UUID request_to_resume) {
+    void generate_rf_change_resume_update(group0_update_collector& out, const group0_guard& guard, utils::UUID request_to_resume) {
         rtlogger.debug("Generating RF change resume for request id {}", request_to_resume);
         out.emplace_back(topology_mutation_builder(guard.write_timestamp())
                 .queue_global_topology_request_id(request_to_resume)
@@ -1797,7 +1804,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
     // Updates keyspace properties; removes system_schema.keyspaces::next_replication;
     // finishes RF change request; Removes request from system.topology::ongoing_rf_changes.
-    void generate_rf_change_completion_update(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, const rf_change_completion_info& completion) {
+    void generate_rf_change_completion_update(group0_update_collector& out, const group0_guard& guard, const rf_change_completion_info& completion) {
         if (rtlogger.is_enabled(seastar::log_level::debug)) {
             sstring props_str;
             for (const auto& [key, value] : completion.saved_ks_props) {
@@ -1817,7 +1824,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
                 auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
                 for (auto& m: schema_muts) {
-                    out.emplace_back(m);
+                    out.add_small(std::move(m));
                 }
             } else {
                 auto ks_md = make_lw_shared<data_dictionary::keyspace_metadata>(*ks.metadata());
@@ -1825,7 +1832,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
                 auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
                 for (auto& m: schema_muts) {
-                    out.emplace_back(m);
+                    out.add_small(std::move(m));
                 }
             }
         }
@@ -1834,14 +1841,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 .finish_rf_change_migrations(_topo_sm._topology.ongoing_rf_changes, completion.request_id)
                 .build());
 
-        out.push_back(canonical_mutation(topology_request_tracking_mutation_builder(completion.request_id)
+        out.emplace_back(topology_request_tracking_mutation_builder(completion.request_id)
                 .done(error)
-                .build()));
+                .build());
     }
 
     // Sets next_replication to current_replication and sets error on the topology request.
     // Similar to storage_service::abort_rf_change for the ongoing_rf_changes case.
-    void generate_rf_change_abort_update(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, const rf_change_abort_info& abort_info) {
+    void generate_rf_change_abort_update(group0_update_collector& out, const group0_guard& guard, const rf_change_abort_info& abort_info) {
         rtlogger.debug("generate_rf_change_abort_update: request_id={}, ks_name={}, error='{}'", abort_info.request_id, abort_info.ks_name, abort_info.error);
 
         if (!_db.has_keyspace(abort_info.ks_name)) {
@@ -1854,15 +1861,15 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
         auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
         for (auto& m : schema_muts) {
-            out.emplace_back(m);
+            out.add_small(m);
         }
 
-        out.push_back(canonical_mutation(topology_request_tracking_mutation_builder(abort_info.request_id)
+        out.add(topology_request_tracking_mutation_builder(abort_info.request_id)
                 .abort(abort_info.error)
-                .build()));
+                .build());
     }
 
-    future<> generate_rf_change_updates(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, const keyspace_rf_change_plan& rf_change_plan) {
+    future<> generate_rf_change_updates(group0_update_collector& out, const group0_guard& guard, const keyspace_rf_change_plan& rf_change_plan) {
         for (const auto& abort_info : rf_change_plan.aborts) {
             co_await coroutine::maybe_yield();
             generate_rf_change_abort_update(out, guard, abort_info);
@@ -1872,7 +1879,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         }
     }
 
-    future<> generate_migration_updates(utils::chunked_vector<canonical_mutation>& out, const group0_guard& guard, const migration_plan& plan) {
+    future<> generate_migration_updates(group0_update_collector& out, const group0_guard& guard, const migration_plan& plan) {
         if (plan.resize_plan().finalize_resize.empty() || plan.has_nodes_to_drain()) {
             // schedule tablet migration only if there are no pending resize finalisations or if the node is draining.
 
@@ -1882,7 +1889,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 for (auto&& drain_fail : plan.drain_failures()) {
                     co_await coroutine::maybe_yield();
                     auto server_id = raft::server_id(drain_fail.node().uuid());
-                    _topo_sm.generate_cancel_request_update(out, _feature_service, guard, server_id, drain_fail.reason());
+                    _topo_sm.generate_cancel_request_update(out.frozen_mutations(), _feature_service, guard, server_id, drain_fail.reason());
                 }
             } else {
                 for (const tablet_migration_info& mig: plan.migrations()) {
@@ -2022,7 +2029,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         // and wait for notification.
 
         rtlogger.debug("handle_tablet_migration()");
-        utils::chunked_vector<canonical_mutation> updates;
+        group0_update_collector updates;
         bool needs_barrier = false;
         bool has_transitions = false;
 
@@ -2080,7 +2087,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
             auto transition_to = [&] (locator::tablet_transition_stage stage) {
                 rtlogger.debug("Will set tablet {} stage to {}", gid, stage);
-                updates.emplace_back(get_mutation_builder()
+                updates.add_small(get_mutation_builder()
                         .set_stage(last_token, stage)
                         .build());
             };
@@ -2120,7 +2127,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 if (!_topo_sm._topology.paused_requests.contains(raft_server)) {
                     return;
                 }
-                _topo_sm.generate_cancel_request_update(updates, _feature_service, guard, raft_server,
+                _topo_sm.generate_cancel_request_update(updates.frozen_mutations(), _feature_service, guard, raft_server,
                     fmt::format("tablet draining failed: {}, moving {} to {}, due to {}", gid, replica, trinfo.pending_replica, reason));
             };
 
@@ -2136,9 +2143,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::write_both_read_old);
                         auto leaving_replica = get_leaving_replica(tmap.get_tablet_info(gid.tablet), trinfo);
                         if (leaving_replica) {
-                            _vb_coordinator->abort_tasks(updates, guard, gid.table, *leaving_replica, last_token);
+                            _vb_coordinator->abort_tasks(updates.frozen_mutations(), guard, gid.table, *leaving_replica, last_token);
                         }
-                        updates.emplace_back(get_mutation_builder()
+                        updates.add_small(get_mutation_builder()
                             .set_stage(last_token, locator::tablet_transition_stage::write_both_read_old)
                             // Create session a bit earlier to avoid adding barrier
                             // to the streaming stage to create sessions on replicas.
@@ -2167,7 +2174,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         bool fail = utils::get_local_injector().enter("rebuild_repair_stage_fail");
                         if (fail || check_excluded_replicas()) {
                             rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::cleanup_target);
-                            updates.emplace_back(get_mutation_builder()
+                            updates.add_small(get_mutation_builder()
                                     .set_stage(last_token, locator::tablet_transition_stage::cleanup_target)
                                     .del_session(last_token)
                                     .build());
@@ -2198,7 +2205,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         });
                     })) {
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::streaming);
-                        updates.emplace_back(get_mutation_builder()
+                        updates.add_small(get_mutation_builder()
                             .set_stage(last_token, locator::tablet_transition_stage::streaming)
                             .build());
                     }
@@ -2244,7 +2251,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
                         if (rollback) {
                             rtlogger.debug("Will set tablet {} stage to {}: {}", gid, locator::tablet_transition_stage::cleanup_target, *rollback);
-                            updates.emplace_back(get_mutation_builder()
+                            updates.add_small(get_mutation_builder()
                                 .set_stage(last_token, locator::tablet_transition_stage::cleanup_target)
                                 .del_session(last_token)
                                 .build());
@@ -2271,7 +2278,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         });
                     })) {
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::write_both_read_new);
-                        updates.emplace_back(get_mutation_builder()
+                        updates.add_small(get_mutation_builder()
                             .set_stage(last_token, locator::tablet_transition_stage::write_both_read_new)
                             .del_session(last_token)
                             .build());
@@ -2375,13 +2382,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     // See do_tablet_operation() doc.
                     if (do_barrier()) {
                         _tablets.erase(gid);
-                        updates.emplace_back(get_mutation_builder()
+                        updates.add_small(get_mutation_builder()
                                 .del_transition(last_token)
                                 .del_migration_task_info(last_token, _feature_service)
                                 .build());
                         auto leaving_replica = get_leaving_replica(tmap.get_tablet_info(gid.tablet), trinfo);
                         if (leaving_replica) {
-                            _vb_coordinator->rollback_aborted_tasks(updates, guard, gid.table, *leaving_replica, last_token);
+                            _vb_coordinator->rollback_aborted_tasks(updates.frozen_mutations(), guard, gid.table, *leaving_replica, last_token);
                         }
                     }
                     break;
@@ -2394,12 +2401,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     bool defer_transition = utils::get_local_injector().enter("handle_tablet_migration_end_migration");
                     if (!defer_transition && do_barrier()) {
                         _tablets.erase(gid);
-                        updates.emplace_back(get_mutation_builder()
+                        updates.add_small(get_mutation_builder()
                                 .del_transition(last_token)
                                 .set_replicas(last_token, trinfo.next)
                                 .del_migration_task_info(last_token, _feature_service)
                                 .build());
-                        _vb_coordinator->generate_tablet_migration_updates(updates, guard, tmap, gid, trinfo);
+                        _vb_coordinator->generate_tablet_migration_updates(updates.frozen_mutations(), guard, tmap, gid, trinfo);
                     }
                 }
                     break;
@@ -2409,7 +2416,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         if (do_barrier()) {
                             auto& tinfo = tmap.get_tablet_info(gid.tablet);
                             _tablet_ops_metrics.inc_failed(tinfo.repair_task_info ? tinfo.repair_task_info->request_type : locator::tablet_task_type::none);
-                            updates.emplace_back(get_mutation_builder()
+                            updates.add_small(get_mutation_builder()
                                     .set_stage(last_token, locator::tablet_transition_stage::end_repair)
                                     .del_session(last_token)
                                     .build());
@@ -2488,7 +2495,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                         .del_repair_task_info(last_token, _feature_service)
                                         .del_session(last_token);
                         if (tablet_state.repair_task_updates) {
-                            updates.push_back(canonical_mutation(*tablet_state.repair_task_updates));
+                            updates.add_small(*tablet_state.repair_task_updates);
                         }
                         // Skip update repair time in case hosts filter or dcs filter is set.
                         if (valid && is_filter_off) {
@@ -2508,7 +2515,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             rtlogger.debug("Set tablet repair time sched_time={} repair_time={} sstables_repaired_at={} last_token={}",
                                     sched_time, time, repaired_at, last_token);
                         }
-                        updates.emplace_back(update.build());
+                        updates.add_small(update.build());
                         _tablet_ops_metrics.inc_succeeded(tinfo.repair_task_info ? tinfo.repair_task_info->request_type : locator::tablet_task_type::none);
                     }
                 }
@@ -2521,10 +2528,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                         auto ep = tablet_state.restore->get_exception();
                         rtlogger.debug("Clearing restore transition for {} due to error", gid);
                         _tablets.erase(gid);
-                        updates.emplace_back(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).del_session(last_token).build());
+                        updates.add_small(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).del_session(last_token).build());
                         // Record error on the ongoing restore request so it's propagated to the caller.
                         if (auto it = restore_request_for_table.find(gid.table); it != restore_request_for_table.end()) {
-                            updates.emplace_back(
+                            updates.add(
                                 topology_request_tracking_mutation_builder(it->second)
                                     .set("error", format("Restore failed for tablet {}: {}", gid, ep))
                                     .build());
@@ -2546,7 +2553,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     })) {
                         rtlogger.debug("Clearing restore transition for {}", gid);
                         _tablets.erase(gid);
-                        updates.emplace_back(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).del_session(last_token).build());
+                        updates.add_small(get_mutation_builder().del_transition(last_token).del_snapshot_name(last_token).del_session(last_token).build());
                     }
                 }
                     break;
@@ -2584,7 +2591,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                 rtlogger.info("The end_repair stage finished for tablet repair tablet_id={} session_id={}", gid, tablet_state.session_id);
                             }
                             _tablets.erase(gid);
-                            updates.emplace_back(get_mutation_builder().del_transition(last_token).build());
+                            updates.add_small(get_mutation_builder().del_transition(last_token).build());
                         }
                     }
                 }
@@ -2757,8 +2764,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         auto tm = get_token_metadata_ptr();
         auto plan = co_await _tablet_allocator.balance_tablets(tm, &_topo_sm._topology, &_sys_ks, {}, get_dead_nodes());
 
-        utils::chunked_vector<canonical_mutation> updates;
-        updates.reserve(plan.resize_plan().finalize_resize.size() * 2 + 1);
+        group0_update_collector updates;
 
         for (auto& table_id : plan.resize_plan().finalize_resize) {
             auto s = _db.find_schema(table_id);
@@ -2776,7 +2782,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
             // Clears the resize decision for a table.
             generate_resize_update(updates, guard, table_id, locator::resize_decision{});
-            _vb_coordinator->generate_tablet_resize_updates(updates, guard, table_id, tm->tablets().get_tablet_map(table_id), new_tablet_map);
+            _vb_coordinator->generate_tablet_resize_updates(updates.frozen_mutations(), guard, table_id, tm->tablets().get_tablet_map(table_id), new_tablet_map);
 
             for (auto table_id : tm->tablets().all_table_groups().at(table_id)) {
                 co_await _cdc_gens.generate_tablet_resize_update(updates, table_id, new_tablet_map, guard.write_timestamp());
@@ -4427,19 +4433,19 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
     // Returns true if migration updates were generated.
     // Appends migration mutations + tablet_migration transition state to `updates`.
     future<bool> generate_tablet_migration_state_updates(
-            utils::chunked_vector<canonical_mutation>& updates, const group0_guard& guard, migration_plan& plan);
+            group0_update_collector& updates, const group0_guard& guard, migration_plan& plan);
 
     // Generates tablet migration or resize finalization mutations from a non-empty plan.
     // Appends to `updates`. Does not commit. Caller is responsible for committing.
     // Returns true if updates were generated, false if nothing was produced (injection postponed).
     // Precondition: !plan.empty().
     future<bool> generate_tablet_transition_updates(
-            utils::chunked_vector<canonical_mutation>& updates, const group0_guard& guard, migration_plan& plan);
+            group0_update_collector& updates, const group0_guard& guard, migration_plan& plan);
 
     // Generates a single resize finalization mutation (set tstate + version bump).
     // Appends to `updates`. Does not commit.
     void generate_tablet_resize_finalization_update(
-            utils::chunked_vector<canonical_mutation>& updates, const group0_guard& guard) {
+            group0_update_collector& updates, const group0_guard& guard) {
         auto resize_finalization_transition_state = [this] {
             return _feature_service.tablet_merge ? topology::transition_state::tablet_resize_finalization : topology::transition_state::tablet_split_finalization;
         };
@@ -4570,7 +4576,7 @@ future<std::optional<group0_guard>> topology_coordinator::maybe_start_tablet_mig
         co_return std::move(guard);
     }
 
-    utils::chunked_vector<canonical_mutation> updates;
+    group0_update_collector updates;
     if (!co_await generate_tablet_transition_updates(updates, guard, plan)) {
         co_return std::move(guard);
     }
@@ -4584,11 +4590,11 @@ future<std::optional<group0_guard>> topology_coordinator::maybe_start_tablet_mig
 }
 
 future<bool> topology_coordinator::generate_tablet_migration_state_updates(
-        utils::chunked_vector<canonical_mutation>& updates, const group0_guard& guard, migration_plan& plan) {
-    auto initial_size = updates.size();
+        group0_update_collector& updates, const group0_guard& guard, migration_plan& plan) {
+    auto initial_change_counter = updates.change_counter();
     co_await generate_migration_updates(updates, guard, plan);
 
-    if (updates.size() > initial_size) {
+    if (updates.change_counter() != initial_change_counter) {
         updates.emplace_back(
             topology_mutation_builder(guard.write_timestamp())
                 .set_transition_state(topology::transition_state::tablet_migration)
@@ -4600,7 +4606,7 @@ future<bool> topology_coordinator::generate_tablet_migration_state_updates(
 }
 
 future<bool> topology_coordinator::generate_tablet_transition_updates(
-        utils::chunked_vector<canonical_mutation>& updates, const group0_guard& guard, migration_plan& plan) {
+        group0_update_collector& updates, const group0_guard& guard, migration_plan& plan) {
     if (co_await generate_tablet_migration_state_updates(updates, guard, plan)) {
         co_return true;
     }
@@ -4631,7 +4637,7 @@ future<bool> topology_coordinator::maybe_retry_failed_rf_change_tablet_rebuilds(
         co_return false;
     }
 
-    utils::chunked_vector<canonical_mutation> updates;
+    group0_update_collector updates;
     for (auto& ks_name : _db.get_tablets_keyspaces()) {
         auto& ks = _db.find_keyspace(ks_name);
         auto& strategy = ks.get_replication_strategy();
@@ -4658,13 +4664,13 @@ future<bool> topology_coordinator::maybe_retry_failed_rf_change_tablet_rebuilds(
                 auto new_replicas = replicas;
                 new_replicas.push_back(*it);
                 auto last_token = new_tablet_map.get_last_token(tablet_id);
-                updates.emplace_back(co_await make_canonical_mutation_gently(
+                updates.add_small(
                         replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
                                 .set_new_replicas(last_token, new_replicas)
                                 .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
                                 .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
                                 .build()
-                ));
+                );
             });
         }
 

--- a/test/boost/group0_cmd_merge_test.cc
+++ b/test/boost/group0_cmd_merge_test.cc
@@ -11,6 +11,7 @@
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>
 #include "test/lib/cql_test_env.hh"
+#include "test/lib/make_random_string.hh"
 
 #include "db/config.hh"
 #include "db/system_keyspace.hh"
@@ -24,6 +25,10 @@
 #include "idl/group0_state_machine.dist.impl.hh"
 #include "utils/error_injection.hh"
 #include "test/lib/expr_test_utils.hh"
+#include "test/lib/simple_schema.hh"
+#include "test/lib/mutation_assertions.hh"
+#include "test/lib/mutation_source_test.hh"
+#include <seastar/core/thread.hh>
 
 BOOST_AUTO_TEST_SUITE(group0_cmd_merge_test)
 
@@ -122,6 +127,154 @@ SEASTAR_TEST_CASE(test_group0_cmd_merge) {
         BOOST_REQUIRE_EQUAL(mm.canonical_mutation_merge_count - merges, 2);
     }, cfg);
 #endif
+}
+
+// Verifies that group0_update_collector::collect() splits an oversized partition
+// into several smaller mutations, each within the requested size limit, and that
+// the pieces merge back into the original mutation.
+SEASTAR_TEST_CASE(test_group0_update_collector_splits_oversized_mutations) {
+    return seastar::async([] {
+        simple_schema ss;
+        auto s = ss.schema();
+
+        // Build a single partition large enough to require splitting.
+        auto mut = ss.new_mutation("pk0");
+        const uint32_t row_count = 64;
+        const sstring big_value(8 * 1024, 'x');
+        for (uint32_t i = 0; i < row_count; ++i) {
+            ss.add_row(mut, ss.make_ckey(i), big_value);
+        }
+
+        const size_t max_size = 64 * 1024;
+        BOOST_REQUIRE_GT(mut.memory_usage(*s), max_size);
+
+        service::group0_update_collector collector(max_size);
+        collector.add_small(mut);
+        auto cms = collector.collect().get();
+
+        // The oversized partition must be split into more than one mutation.
+        BOOST_REQUIRE_GT(cms.size(), 1u);
+
+        utils::chunked_vector<mutation> pieces;
+        for (auto& cm : cms) {
+            BOOST_REQUIRE_EQUAL(cm.column_family_id(), s->id());
+            auto m = cm.to_mutation(s);
+            BOOST_REQUIRE(!m.partition().empty());
+            if (m.memory_usage(*s) > max_size) {
+                // A single row may exceed the limit; we don't split rows into cells.
+                const auto rows_count = m.partition().row_count() +
+                                        (m.partition().static_row().empty() ? 0 : 1);
+                BOOST_REQUIRE_EQUAL(rows_count, 1);
+            }
+            pieces.push_back(std::move(m));
+        }
+
+        // The pieces must merge back into the original mutation.
+        auto squashed = squash_mutations(std::move(pieces));
+        BOOST_REQUIRE_EQUAL(squashed.size(), 1u);
+        assert_that(squashed.front()).is_equal_to(mut);
+
+        // With a large enough limit the same mutation is returned as a single
+        // canonical mutation, i.e. it is not split.
+        service::group0_update_collector collector2(mut.memory_usage(*s) * 2);
+        collector2.add_small(mut);
+        auto cms2 = collector2.collect().get();
+        BOOST_REQUIRE_EQUAL(cms2.size(), 1u);
+        assert_that(cms2.front().to_mutation(s)).is_equal_to(mut);
+    });
+}
+
+// Verifies that group0_update_collector::add(canonical_mutation) accepts canonical_mutations
+// and collect() returns them unchanged.
+SEASTAR_TEST_CASE(test_group0_update_collector_accepts_canonical_mutations) {
+    return seastar::async([] {
+        simple_schema ss;
+        auto s = ss.schema();
+
+        service::group0_update_collector collector;
+
+        auto mut = ss.new_mutation("pk0");
+        ss.add_row(mut, ss.make_ckey(0), make_random_string(64));
+        collector.add(canonical_mutation(mut));
+
+        auto mut2 = ss.new_mutation("pk1");
+        ss.add_row(mut2, ss.make_ckey(0), make_random_string(32));
+        collector.add(canonical_mutation(mut2));
+
+        auto cms = collector.collect().get();
+
+        BOOST_REQUIRE_EQUAL(cms.size(), 2u);
+
+        assert_that(cms[0].to_mutation(s)).is_equal_to(mut);
+        assert_that(cms[1].to_mutation(s)).is_equal_to(mut2);
+    });
+}
+
+// Verifies that adding many small mutations of the same partition through
+// add()/add_small() keeps the accumulated mutation bounded: collect() returns
+// several mutations, each within the size limit, that merge back into the union
+// of everything that was added.
+SEASTAR_TEST_CASE(test_group0_update_collector_bounds_accumulated_mutations) {
+    return seastar::async([] {
+        simple_schema ss;
+        auto s = ss.schema();
+
+        const size_t max_size = 64 * 1024;
+        const uint32_t row_count = 64;
+        const sstring big_value(8 * 1024, 'x');
+
+        // Exercise both the gently (add) and non-gently (add_small) paths.
+        auto run = [&] (bool use_gently) {
+            BOOST_TEST_CONTEXT("use_gently=" << use_gently) {
+                service::group0_update_collector collector(max_size);
+
+                // Feed many small single-row mutations of the same partition,
+                // keeping copies so we can compute the expected union independently
+                // (add_row() advances a shared timestamp, so the expected mutation
+                // must be built from the very same mutations that were added).
+                utils::chunked_vector<mutation> added;
+                for (uint32_t i = 0; i < row_count; ++i) {
+                    auto m = ss.new_mutation("pk0");
+                    ss.add_row(m, ss.make_ckey(i), big_value);
+                    added.push_back(m);
+                    if (use_gently) {
+                        collector.add(m).get();
+                    } else {
+                        collector.add_small(m);
+                    }
+                }
+
+                auto cms = collector.collect().get();
+
+                // The accumulation must have been split rather than grown unbounded.
+                BOOST_REQUIRE_GT(cms.size(), 1u);
+
+                utils::chunked_vector<mutation> pieces;
+                for (auto& cm : cms) {
+                    BOOST_REQUIRE_EQUAL(cm.column_family_id(), s->id());
+                    auto m = cm.to_mutation(s);
+                    BOOST_REQUIRE(!m.partition().empty());
+                    if (m.memory_usage(*s) > max_size) {
+                        // A single row may exceed the limit; we don't split rows.
+                        const auto rows_count = m.partition().row_count() +
+                                                (m.partition().static_row().empty() ? 0 : 1);
+                        BOOST_REQUIRE_EQUAL(rows_count, 1);
+                    }
+                    pieces.push_back(std::move(m));
+                }
+
+                // The pieces must merge back into the union of everything added.
+                auto expected = squash_mutations(std::move(added));
+                BOOST_REQUIRE_EQUAL(expected.size(), 1u);
+                auto squashed = squash_mutations(std::move(pieces));
+                BOOST_REQUIRE_EQUAL(squashed.size(), 1u);
+                assert_that(squashed.front()).is_equal_to(expected.front());
+            }
+        };
+
+        run(false); // add_small()
+        run(true);  // add()
+    });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -8,6 +8,7 @@
 
 #include "utils/assert.hh"
 #include <fmt/ranges.h>
+#include <limits>
 
 #include <seastar/core/sharded.hh>
 #include <seastar/core/app-template.hh>
@@ -23,11 +24,16 @@
 #include "db/config.hh"
 #include "schema/schema_builder.hh"
 #include "service/storage_proxy.hh"
+#include "service/raft/group0_state_machine.hh"
+#include "service/raft/raft_group0_client.hh"
+#include "raft/raft.hh"
 #include "db/system_keyspace.hh"
+#include "mutation/async_utils.hh"
 
 #include "test/perf/perf.hh"
 #include "test/lib/log.hh"
 #include "test/lib/cql_test_env.hh"
+#include "test/lib/topology_builder.hh"
 
 using namespace locator;
 using namespace replica;
@@ -37,19 +43,41 @@ seastar::abort_source aborted;
 static const size_t MiB = 1 << 20;
 
 static
-cql_test_config tablet_cql_test_config() {
+cql_test_config tablet_cql_test_config(unsigned schema_commitlog_segment_size_mb) {
     cql_test_config c;
     c.db_config->tablets_mode_for_new_keyspaces.set(db::tablets_mode_t::mode::enabled);
+    // The tablet allocator scales a table's initial tablet count down when the
+    // average number of tablet replicas per shard would exceed this goal (see
+    // load_balancer::make_sizing_plan). The test pins each table to an exact
+    // tablet count via tablet options, so raise the goal out of the way to keep
+    // the count from being scaled down at creation time.
+    c.db_config->tablets_per_shard_goal.set(std::numeric_limits<unsigned>::max());
+    // The group0 raft command size limit is derived from the schema commitlog
+    // segment size (roughly a quarter of it). Allow it to be raised so we can
+    // apply tablet metadata commands several times larger than the ~32 MiB
+    // default cap as a single command.
+    if (schema_commitlog_segment_size_mb) {
+        c.db_config->schema_commitlog_segment_size_in_mb.set(uint32_t(schema_commitlog_segment_size_mb));
+    }
     return c;
 }
 
 static
-future<table_id> add_table(cql_test_env& e) {
+future<table_id> add_table(cql_test_env& e, int tablet_count) {
     auto id = table_id(utils::UUID_gen::get_time_UUID());
-    co_await e.create_table([id] (std::string_view ks_name) {
+    co_await e.create_table([id, tablet_count] (std::string_view ks_name) {
         return *schema_builder(this_smp_shard_count(), ks_name, id.to_sstring(), id)
                 .with_column("p1", utf8_type, column_kind::partition_key)
                 .with_column("r1", int32_type)
+                // Create the table with exactly `tablet_count` tablets so that the
+                // generated tablet metadata matches the table's tablet map and
+                // applying it doesn't look like a tablet split/merge. pow2_count=false
+                // lets us pin an arbitrary count without power-of-2 rounding.
+                .set_tablet_options({
+                    {"min_tablet_count", format("{}", tablet_count)},
+                    {"max_tablet_count", format("{}", tablet_count)},
+                    {"pow2_count", "false"},
+                })
                 .build();
     });
     co_return id;
@@ -59,19 +87,39 @@ static future<> test_basic_operations(app_template& app) {
     return do_with_cql_env_thread([&] (cql_test_env& e) {
         tablet_metadata tm;
 
-        auto h1 = host_id(utils::UUID_gen::get_time_UUID());
-        auto h2 = host_id(utils::UUID_gen::get_time_UUID());
+        // Drive tablet metadata explicitly: the test pins each table's tablet
+        // count via tablet options and spreads replicas across the fabricated
+        // nodes built below. Disable the tablet load balancer so it doesn't
+        // migrate or rebalance the tablets underneath the test once the metadata
+        // is applied via group0.
+        e.get_storage_service().local().set_tablet_balancing_enabled(false).get();
 
         int nr_tables = app.configuration()["tables"].as<int>();
         int tablets_per_table = app.configuration()["tablets-per-table"].as<int>();
         int rf = app.configuration()["rf"].as<int>();
+        int nr_nodes = app.configuration()["nodes"].as<int>();
+        if (nr_nodes == 0) {
+            nr_nodes = rf;
+        }
+        if (nr_nodes < rf) {
+            throw std::runtime_error(format("nodes ({}) must be >= rf ({})", nr_nodes, rf));
+        }
+
+        const auto shard_count = this_smp_shard_count();
+        topology_builder topo(e);
+        std::vector<host_id> nodes;
+        nodes.reserve(nr_nodes);
+        for (int i = 0; i < nr_nodes; ++i) {
+            nodes.push_back(topo.add_node(service::node_state::normal, shard_count));
+        }
+        testlog.info("Added {} nodes to the topology", nodes.size());
 
         size_t total_tablets = 0;
 
         std::vector<table_id> ids;
         ids.resize(nr_tables);
         for (int i = 0; i < nr_tables; ++i) {
-            ids[i] = add_table(e).get();
+            ids[i] = add_table(e, tablets_per_table).get();
         }
 
         testlog.info("Generating tablet metadata");
@@ -84,7 +132,8 @@ static future<> test_basic_operations(app_template& app) {
                 thread::maybe_yield();
                 tablet_replica_set replicas;
                 for (int k = 0; k < rf; ++k) {
-                    replicas.push_back({h1, 0});
+                    const auto host = nodes[(total_tablets + k) % nodes.size()];
+                    replicas.push_back({host, 0});
                 }
                 SCYLLA_ASSERT(std::cmp_equal(replicas.size(), rf));
                 tmap.set_tablet(j, tablet_info{std::move(replicas)});
@@ -147,12 +196,64 @@ static future<> test_basic_operations(app_template& app) {
 
         testlog.info("Size of canonical mutations: {:.6f} [MiB]", double(cm_size) / MiB);
 
+        // Measure the group0 command size and the time to apply it when tablet
+        // mutations are routed through group0_update_collector, the way the write
+        // path builds and commits the command.
+        {
+            const size_t max_mutation_size = app.configuration()["command-max-mutation-size-mb"].as<size_t>() * MiB;
+            const auto tablets_schema = db::system_keyspace::tablets();
+
+            utils::chunked_vector<mutation> unfrozen_muts;
+            unfrozen_muts.reserve(muts.size());
+            for (const auto& cm : muts) {
+                unfrozen_muts.push_back(to_mutation_gently(cm, tablets_schema).get());
+            }
+
+            service::group0_update_collector collector(max_mutation_size);
+            utils::chunked_vector<canonical_mutation> collected;
+            auto time_to_collect = duration_in_seconds([&] {
+                for (auto& m : unfrozen_muts) {
+                    collector.add(std::move(m)).get();
+                }
+                collected = collector.collect().get();
+            });
+
+            size_t collected_size = 0;
+            size_t max_piece_size = 0;
+            for (const auto& cm : collected) {
+                collected_size += cm.representation().size();
+                max_piece_size = std::max<size_t>(max_piece_size, cm.representation().size());
+            }
+
+            testlog.info("Size of group0 command via group0_update_collector (max_mutation_size={} MiB): "
+                         "{:.6f} [MiB] ({} serialized mutations, max {:.6f} MiB), collected in {:.6f} [ms]",
+                         max_mutation_size / MiB, double(collected_size) / MiB, collected.size(),
+                         double(max_piece_size) / MiB, time_to_collect.count() * 1000);
+
+            auto& group0_client = e.get_raft_group0_client();
+            seastar::abort_source as;
+            try {
+                auto time_to_apply = duration_in_seconds([&] {
+                    auto guard = group0_client.start_operation(as).get();
+                    auto cmd = group0_client.prepare_command(
+                            service::topology_change{.mutations{std::move(collected)}}, guard, "Apply whole tablet metadata");
+                    group0_client.add_entry(std::move(cmd), std::move(guard), as).get();
+                });
+                testlog.info("Applied whole tablet metadata to group0 in {:.6f} [ms]", time_to_apply.count() * 1000);
+            } catch (const raft::command_is_too_big_error& ex) {
+                testlog.error("Could not apply tablet metadata to group0 as a single command: {}", ex);
+            }
+        }
+
         auto&& tablets_table = e.local_db().find_column_family(db::system_keyspace::tablets());
         testlog.info("Disk space used by system.tablets: {:.6f} [MiB]", double(tablets_table.get_stats().live_disk_space_used.on_disk) / MiB);
 
         locator::tablet_metadata_change_hint hint;
 
-        // Migrate one tablet to h2
+        // Migrate one tablet to a different shard on its first replica's node.
+        // This is a valid intra-node migration (the destination host still
+        // exists in the topology) and exercises the tablet_metadata_change_hint
+        // / partial reload path below.
         {
             const auto last_table_id = ids.back();
             const auto& tmap = tm.get_tablet_map(last_table_id);
@@ -163,11 +264,12 @@ static future<> test_basic_operations(app_template& app) {
             replica::tablet_mutation_builder builder(ts++, last_table_id);
             const auto token = tmap.get_last_token(tb);
 
-            builder.set_new_replicas(token,
-                tablet_replica_set {
-                    tablet_replica {h2, 0},
-                }
-            );
+            // Move the first replica to a different shard on the same node,
+            // leaving the other replicas in place.
+            auto new_replicas = tmap.get_tablet_info(tb).replicas;
+            const auto dst_shard = shard_id(shard_count > 1 ? (new_replicas.front().shard ^ 1) : new_replicas.front().shard);
+            new_replicas.front() = tablet_replica {new_replicas.front().host, dst_shard};
+            builder.set_new_replicas(token, std::move(new_replicas));
             builder.set_stage(token, tablet_transition_stage::streaming);
             builder.set_transition(token, tablet_transition_kind::migration);
 
@@ -192,7 +294,7 @@ static future<> test_basic_operations(app_template& app) {
         assert(tm == tm_full_reload);
 
         testlog.info("Tablet metadata reload:\nfull    {:>8.2f}ms\npartial {:>8.2f}ms", full_reload_duration.count(), partial_reload_duration.count());
-    }, tablet_cql_test_config());
+    }, tablet_cql_test_config(app.configuration()["schema-commitlog-segment-size-mb"].as<unsigned>()));
 }
 
 namespace perf {
@@ -204,6 +306,15 @@ int scylla_tablets_main(int argc, char** argv) {
             ("tables", bpo::value<int>()->default_value(8), "Number of tables to create.")
             ("tablets-per-table", bpo::value<int>()->default_value(16384), "Number of tablets per table.")
             ("rf", bpo::value<int>()->default_value(3), "Number of replicas per tablet.")
+            ("nodes", bpo::value<int>()->default_value(0),
+                    "Number of nodes to add to the topology and spread tablet replicas over "
+                    "(0 = use rf). Must be >= rf.")
+            ("command-max-mutation-size-mb", bpo::value<size_t>()->default_value(service::group0_update_collector::default_max_mutation_size / MiB),
+                    "Max in-memory size of a single mutation in the group0 command built via group0_update_collector (controls splitting).")
+            ("schema-commitlog-segment-size-mb", bpo::value<unsigned>()->default_value(0),
+                    "Override schema_commitlog_segment_size_in_mb (0 = leave the default). The group0 raft "
+                    "command size limit is roughly a quarter of this, so raising it allows applying larger "
+                    "tablet metadata commands as a single command (see SCYLLADB-2856).")
             ("verbose", "Enables standard logging")
             ;
     return app.run(argc, argv, [&] {


### PR DESCRIPTION
Refs SCYLLADB-2856.
Refs SCYLLADB-2434.

## Motivation

It was observed that starting repair for a couple thousand tablets overflows the group0 command size limit. The reason was a combination of factors:
1) the command contained a single mutation per tablet, and canonical_mutation overhead dominated the footprint

    For perspective, the size of canonical_mutations representing tablet metadata for 81920 tablets (10 tables x 8192 tablets):

     * canonical_mutations in tablet metadata group0 snapshot : 21.25 MiB
     * one canonical_mutation per tablet:	330.63 MiB
     * with group0_update_collector after this series (max 1 MiB): 21.09 MiB

2) canonical_mutation serialization format adds a lot of overhead: column mapping (part of schema), object framing for extensible IDL types containing field length, exacerbated by nested structure of objects. For example, perf_tablets show that tablet metadata is 7 MB on disk for a 200 MB command (with large canonical_mutations). This gets much worse when group0 command contains one mutation per tablet. 

This PR aims to solve it in a systematic way, not just for repair but for all group0 transactions.

Group0 updates are currently gathered into a `chunked_vector<canonical_mutation>` that is passed around and appended to. This exposes callers to several problems:

* Appending many small mutations bloats the command. Per-`canonical_mutation` overhead dominates. For example, `add_repair_tablet_request` emitted one `canonical_mutation` per tablet.
* It leaks serialization details: `canonical_mutation` is the group0 wire format, and `chunked_vector` is needed to avoid reactor stalls.
* They cannot be inspected inside `add_entry()`, so command validation has to deserialize them.
* Large mutations are easily cast to `canonical_mutation` without preemption, which may cause reactor stalls if batching is actually done somewhere.
* Splitting large mutations to avoid apply-path reactor stalls is left to each caller, which makes the logic inconsistent and duplicated.

## What this phase does

This change introduces `group0_update_collector`, which accumulates plain `mutation` objects and handles the problems above.

The collector:

* Merges mutations for the same partition.
* Splits mutations both on-the-fly and at serialization time to stay within a size bound.
* Hides the `canonical_mutation` / `chunked_vector` details behind a small API.

Since `system.tablets` is partitioned by `table_id`, all tablet updates for a table can now coalesce into one mutation.

All tablet and view-building producers are converted to use the collector:

* `topology_coordinator`

  * Tablet migration and repair updates flow through the collector.
  * View-building task-status updates and repair-task updates are merged per table.
  * `add_repair_tablet_request` no longer emits `O(tablets)` `canonical_mutation`s.

* `storage_service`

  * `transit_tablet` and the repair-request API paths, `add_repair_tablet_request` and `del_repair_tablet_request`, use a shared per-table builder.
  * The builder accumulates one mutation per table instead of one mutation per tablet.

* `view_building_coordinator`

  * Per-table tablet-update generators coalesce same-partition mutations into a single mutation.

## Net effect

The group0 command for tablet-metadata updates goes from `O(tablets)` `canonical_mutation`s to `O(tables)` merged, size-bounded mutations.

This removes the command-size blow-up behind SCYLLADB-2856 for starting repair while keeping the apply path safe: the collector still splits mutations so it does not regress the existing non-preemptive apply-path serialization behavior.

Other tablet-related actions benefit as well and should generate smaller group0 commands: RF-change related actions, regular tablet load balancing. 

## Follow-up phases

`group0_update_collector` deliberately still exposes temporary `canonical_mutation`-based APIs to bridge unconverted code. Subsequent phases will:

* Convert the remaining group0 producers:

  * `migration_manager`, including `schema_change` and `mixed_change`.
  * The generic `group0_batch` path used by auth, CQL DDL, service levels, Alternator, and compression dictionaries.

* Remove the redundant, non-gentle deserialization on the commit path, for example tablet-metadata validation in `prepare_command`.

* Drop the temporary `canonical_mutation`-based collector APIs once every caller uses mutations.

* Change the group0 command serialization format.

  The format can be switched to a more compact representation, e.g. sstable format.

Backport because fixes potential latency / progress issues in group0.