### PR TITLE
test: limits: reduce test_max_cells to boundary case

### DIFF
--- a/test/cluster/dtest/limits_test.py
+++ b/test/cluster/dtest/limits_test.py
@@ -6,6 +6,7 @@
 
 import logging
 import math
+from enum import Enum
 
 import pytest
 
@@ -40,6 +41,10 @@ MAX_CELLS = 16777216
 # MAX_CELLS_COLUMNS = 100
 # MAX_CELLS_BATCH_SIZE = 100
 # MAX_CELLS = 1000
+
+class CellWidth(Enum):
+    FULL = MAX_CELLS_COLUMNS
+    PARTIAL = MAX_CELLS_COLUMNS - 1
 
 
 @pytest.mark.single_node
@@ -247,31 +252,31 @@ class TestLimits(Tester):
             self._do_test_max_batch_size(session, node, size - 1)
 
     def _create_max_cell_count_table(self, session):
-        keys_create = ""
-        for i in range(MAX_CELLS_COLUMNS):
-            keys_create += "key" + str(i) + " int, "
+        keys_create = ", ".join([f"key{i} int" for i in range(MAX_CELLS_COLUMNS)])
 
-        c = """CREATE TABLE test1 (%s blub int PRIMARY KEY,)""" % keys_create
+        c = f"CREATE TABLE test1 ({keys_create}, blub int PRIMARY KEY)"
         session.execute(c)
 
-    def _prepare_max_cell_count_insert(self, session):
-        keys = ""
-        columns = MAX_CELLS_COLUMNS
-        for i in range(columns):
-            keys += "key" + str(i) + ", "
+    def _prepare_max_cell_count_insert(self, session, cell_width: CellWidth):
+        columns = cell_width.value
+        keys = ", ".join([f"key{i}" for i in range(columns)])
+        values = ", ".join(["?"] * columns)
 
-        values = "?, " * columns
-        c = "insert into ks.test1 (%s blub) values (%s ?)" % (keys, values)
+        c = f"insert into ks.test1 ({keys}, blub) values ({values}, ?)"
         return session.prepare(c)
 
-    def _do_test_max_cell_count(self, session, stmt, cells):
+    def _do_test_max_cell_count(self, session, stmt):
+        cells = MAX_CELLS - 1
         print("Testing max cells count for %i" % cells)
-        columns = MAX_CELLS_COLUMNS
-        values = (1,) * columns
+        values = (1,) * CellWidth.FULL.value
 
-        rows = cells // columns
-        for i in range(rows):
+        full_rows = cells // CellWidth.FULL.value
+        for i in range(full_rows):
             session.execute(stmt, values + (i,))
+
+        partial_stmt = self._prepare_max_cell_count_insert(session, CellWidth.PARTIAL)
+        partial_values = (1,) * CellWidth.PARTIAL.value
+        session.execute(partial_stmt, partial_values + (full_rows,))
 
         session.execute("""TRUNCATE test1""")
 
@@ -286,9 +291,5 @@ class TestLimits(Tester):
         session = self.patient_cql_connection(node)
         create_ks(session, "ks", 1)
         self._create_max_cell_count_table(session)
-        stmt = self._prepare_max_cell_count_insert(session)
-
-        cells = MAX_CELLS_COLUMNS
-        while cells <= MAX_CELLS:
-            self._do_test_max_cell_count(session, stmt, cells - 1)
-            cells <<= 1
+        stmt = self._prepare_max_cell_count_insert(session, CellWidth.FULL)
+        self._do_test_max_cell_count(session, stmt)


### PR DESCRIPTION
test_max_cells used to sweep powers of two from MAX_CELLS_COLUMNS up to MAX_CELLS.

After the test was changed to use a reusable schema and a prepared statement, all iterations exercise the same write path. The smaller cases do not add meaningful coverage for the max-cells boundary, but they roughly double the amount of wide-row data written.

Also build the large CREATE/INSERT CQL strings with join-based list comprehensions instead of repeated string concatenation.

the call-time average dropped from about 53.5s to about 26.2s ~x2 faster.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2263

backport: not needed test improvement