### PR TITLE
uuid: use formatter<tagged_uuid> only after it is defined

### DIFF
--- a/utils/UUID.hh
+++ b/utils/UUID.hh
@@ -223,9 +223,7 @@ struct tagged_uuid {
         return id;
     }
 
-    sstring to_sstring() const {
-        return fmt::to_string(id);
-    }
+    sstring to_sstring() const;
 };
 } // namespace utils
 
@@ -292,3 +290,13 @@ struct fmt::formatter<utils::tagged_uuid<Tag>> : fmt::formatter<string_view> {
         return fmt::format_to(ctx.out(), "{}", id.id);
     }
 };
+
+namespace utils {
+
+template <typename Tag>
+sstring
+tagged_uuid<Tag>::to_sstring() const {
+    return fmt::to_string(id);
+}
+
+} // namespace utils


### PR DESCRIPTION
tagged_uuid::to_string uses the formatter (via fmt::to_string), but the formatter is only defined later in the file. Clang 22 doesn't care, but clang 23 does. Fix by defining to_string() out-of-line, after the formatter was defined.

Forward-looking fix for a new compiler, older releases unaffected.