### PR TITLE
test: fix flaky test_sstables_incrementally_released_during_streaming

### DIFF
--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -239,7 +239,8 @@ async def test_reject_split_compaction(manager: ManagerClient, volumes_factory: 
                 await manager.api.enable_injection(servers[0].ip_addr, "split_sstable_rewrite", one_shot=False)
                 cql.execute_async(f"ALTER KEYSPACE {ks} WITH tablets = {{'initial': 32}}")
 
-                await manager.api.wait_for_injection_enter(servers[0].ip_addr, "split_sstable_rewrite")
+                await manager.api.wait_for_injection_enter(servers[0].ip_addr, "split_sstable_rewrite",
+                                                           deadline=time.time() + 600.0)
 
                 logger.info("Create a big file on the target node to reach critical disk utilization level")
                 disk_info = psutil.disk_usage(workdir)
@@ -620,7 +621,8 @@ async def test_sstables_incrementally_released_during_streaming(manager: Manager
 
                 decomm_task = asyncio.create_task(manager.decommission_node(servers[1].server_id))
                 await manager.enable_tablet_balancing()
-                await manager.api.wait_for_injection_enter(servers[1].ip_addr, "tablet_stream_files_end_wait")
+                await manager.api.wait_for_injection_enter(servers[1].ip_addr, "tablet_stream_files_end_wait",
+                                                           deadline=time.time() + 600.0)
 
                 disk_info = psutil.disk_usage(workdir)
                 with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):


### PR DESCRIPTION
test_sstables_incrementally_released_during_streaming was flaky under heavy load / slow (dev-mode) builds because tablet migration streaming might not reach the tablet_stream_files_end_wait injection point within the 60-second default timeout of wait_for_injection_enter. When the wait timed out, the test's own teardown (DROP TABLE) raced with the still in-flight streaming and produced a misleading stream_blob_cmd::error, but the actual root cause was the tight timeout: streaming was healthy and making steady incremental progress right up to the deadline.

This is the same regression introduced by dee5896343 ("Replace log-scanning with wait_for_injection_enter()"), which silently reduced the effective wait from log.wait_for()'s 600s default to wait_for_injection_enter()'s 60s default for three tests in this file. One of them, test_repair_failure_on_split_rejection, was already fixed in 45d920b132.

Also apply the same fix to test_reject_split_compaction, which has the identical unpatched pattern and is exposed to the same regression.

Increase the wait_for_injection_enter deadline from 60s to 600s in both tests.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2991
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1872

No backport needed. Fixes a flaky test on master.