### PR TITLE
test: Add debugging messages to HWLB flaky tests

### DIFF
--- a/test/boost/hwlb_test.cc
+++ b/test/boost/hwlb_test.cc
@@ -179,7 +179,9 @@ static void test_hit_rates(std::vector<float> hr, unsigned CL,
     // the statistics we get from these few requests can be inaccurate, so
     // such tests should use a higher number of iterations - or we can pick
     // a high-enough slack here.
-    BOOST_CHECK(max_misses/min_misses < 1.06);
+    BOOST_CHECK_MESSAGE(max_misses/min_misses < 1.06,
+        fmt::format("miss rate ratio {} >= 1.06 (hit rates: {}, CL={}, iterations={})",
+            max_misses/min_misses, fmt::join(hr, " "), CL, iterations));
 
     // While the primary design goal of HWLB is that it equalizes miss rates
     // of the different nodes, HWLB has a second design goal: to keep as many


### PR DESCRIPTION
The HWLB (heat-weighted load balancing) tests are inherently statistical - calling the low-level miss_equalizing_combination() many times and checking it comes close to the expected distribution.

Because of this, there is always a *probability* that one of these tests will fail because of sheer bad luck - e.g., if we run 100,000 die throws, there is a non-zero probability that all of them will fall on 3 ;-) But the chance that this happens should be extremely low. I got AI to do the calculations, and it calculated the chance that the highest risk test can fail is just 1 in 100 million runs. Which is negligible.

Yet, in SCYLLADB-2805 we saw one of the subtests in test_3_1() failing. The problem is that we don't know which one failed, or have any other information on why it failed. I couldn't reproduce the flakiness locally - I ran this test over 500 times locally, and it didn't fail even once... So in this patch I just add more debug messages if this test fails again, that will hopefully let us figure out what went wrong.

This patch only adds debugging messages - it doesn't fix anything, unfortunately.

Refs SCYLLADB-2805