### PR TITLE
utils: cached_file: avoid slicing copy of file_impl

### DIFF
--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -591,8 +591,7 @@ private:
     }
 public:
     cached_file_impl(cached_file& cf, tracing::trace_state_ptr trace_state = {})
-        : file_impl(*get_file_impl(cf.get_file()))
-        , _cf(cf)
+        : _cf(cf)
         , _trace_state(std::move(trace_state))
     { }
 


### PR DESCRIPTION
cached_file_impl initializes its base class file_impl using a copy of the file it is caching. This slices the object being copied, since it will have a derived type rather than file_impl. Fortunately this is harmless since file_impl doesn't have any state; the initialization has no effect. It does trigger a warning since file_impl's copy constructor is rightfully deprecated by the compiler.

Fix by switching to the default constructor.

Minor non-harmful issue, not worth backporting.