### PR TITLE
api: make validate the default mode in /storage_service/keyspace_scrub

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1181,7 +1181,7 @@
          "operations":[
             {
                "method":"GET",
-               "summary":"Scrub (deserialize + reserialize at the latest version, resolving corruptions if any) the given keyspace. If columnFamilies array is empty, all CFs are scrubbed. Scrubbed CFs will be snapshotted first, if disableSnapshot is false. Scrub has the following modes: Abort (default) - abort scrub if corruption is detected; Skip (same as `skip_corrupted=true`) skip over corrupt data, omitting them from the output; Segregate - segregate data into multiple sstables if needed, such that each sstable contains data with valid order; Validate - read (no rewrite) and validate data, logging any problems found.",
+               "summary":"Scrub (deserialize + reserialize at the latest version, resolving corruptions if any) the given keyspace. If columnFamilies array is empty, all CFs are scrubbed. Scrubbed CFs will be snapshotted first, if disableSnapshot is false. Scrub has the following modes: Abort - abort scrub if corruption is detected; Skip (same as `skip_corrupted=true`) skip over corrupt data, omitting them from the output; Segregate - segregate data into multiple sstables if needed, such that each sstable contains data with valid order; Validate (default) - read (no rewrite) and validate data, logging any problems found.",
                "type": "long",
                "nickname":"scrub",
                "produces":[

--- a/api/api-doc/tasks.json
+++ b/api/api-doc/tasks.json
@@ -124,7 +124,7 @@
          "operations":[
             {
                "method":"GET",
-               "summary":"Scrub (deserialize + reserialize at the latest version, resolving corruptions if any) the given keyspace asynchronously, returns uuid which can be used to check progress with task manager. If columnFamilies array is empty, all CFs are scrubbed. Scrubbed CFs will be snapshotted first, if disableSnapshot is false. Scrub has the following modes: Abort (default) - abort scrub if corruption is detected; Skip (same as `skip_corrupted=true`) skip over corrupt data, omitting them from the output; Segregate - segregate data into multiple sstables if needed, such that each sstable contains data with valid order; Validate - read (no rewrite) and validate data, logging any problems found.",
+               "summary":"Scrub (deserialize + reserialize at the latest version, resolving corruptions if any) the given keyspace asynchronously, returns uuid which can be used to check progress with task manager. If columnFamilies array is empty, all CFs are scrubbed. Scrubbed CFs will be snapshotted first, if disableSnapshot is false. Scrub has the following modes: Abort - abort scrub if corruption is detected; Skip (same as `skip_corrupted=true`) skip over corrupt data, omitting them from the output; Segregate - segregate data into multiple sstables if needed, such that each sstable contains data with valid order; Validate (default) - read (no rewrite) and validate data, logging any problems found.",
                "type": "string",
                "nickname":"scrub_async",
                "produces":[

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -232,7 +232,7 @@ scrub_info parse_scrub_options(const http_context& ctx, std::unique_ptr<http::re
     info.keyspace = std::move(keyspace);
     info.column_families = table_infos | std::views::transform(&table_info::name) | std::ranges::to<std::vector>();
     auto scrub_mode_str = req->get_query_param("scrub_mode");
-    auto scrub_mode = compaction::compaction_type_options::scrub::mode::abort;
+    auto scrub_mode = compaction::compaction_type_options::scrub::mode::validate;
 
     if (scrub_mode_str.empty()) {
         const auto skip_corrupted = validate_bool_x(req->get_query_param("skip_corrupted"), false);

--- a/docs/operating-scylla/nodetool-commands/scrub.rst
+++ b/docs/operating-scylla/nodetool-commands/scrub.rst
@@ -23,7 +23,7 @@ SYNOPSIS
                    [--drop-unfixable-sstables]
                    [--] <keyspace> [<table...>]
 
-   Supported scrub modes: ABORT, SKIP, SEGREGATE, VALIDATE
+   Supported scrub modes: VALIDATE, ABORT, SKIP, SEGREGATE
    Supported quarantine modes: INCLUDE, EXCLUDE, ONLY
 
 OPTIONS
@@ -37,7 +37,7 @@ Parameter                                                             Descriptio
 ``-s`` / ``--skip-corrupted``                                         Skip corrupted rows or partitions even when scrubbing counter tables.
                                                                       (Deprecated, use ``--mode`` instead. default false)
 --------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------
-``-m <scrub_mode>`` / ``--mode <scrub_mode>``                         How to handle corrupt data (one of: ABORT|SKIP|SEGREGATE|VALIDATE, default ABORT; overrides ``--skip-corrupted``)
+``-m <scrub_mode>`` / ``--mode <scrub_mode>``                         How to handle corrupt data (one of: VALIDATE|ABORT|SKIP|SEGREGATE, default VALIDATE; overrides ``--skip-corrupted``)
 --------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------
 ``-q <quarantine_mode>`` / ``--quarantine-mode <quarantine_mode>``    How to handle quarantined SSTables (one of: INCLUDE|EXCLUDE|ONLY, default INCLUDE)
 --------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------
@@ -56,16 +56,17 @@ SCRUB MODES
 ====================================================================  ==================================================================================================================
 Scrub mode                                                            Description
 ====================================================================  ==================================================================================================================
-ABORT                                                                 Abort scrubbing when the first validation error occurs. (default).
+VALIDATE                                                              Read-only mode: report any corruptions found while scrubbing but do not fix them.
+                                                                      By default, corrupt SSTables are moved into a "quarantine" subdirectory so they will not be subject to compaction.
+                                                                      (default).
+--------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------
+ABORT                                                                 Abort scrubbing when the first validation error occurs.
 --------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------
 SKIP                                                                  Skip corrupted rows or partitions. (equivalent to the legacy --skip-corrupted option).
                                                                       **Warning**: This mode can cause data loss by removing invalid data portions or entire
                                                                       SSTables if severely corrupted (e.g., digest mismatch detected).
 --------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------
 SEGREGATE                                                             Sort out-of-order rows or partitions by segregating them into additional SSTables.
---------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------
-VALIDATE                                                              Read-only mode: report any corruptions found while scrubbing but do not fix them.
-                                                                      By default, corrupt SSTables are moved into a "quarantine" subdirectory so they will not be subject to compaction.
 ====================================================================  ==================================================================================================================
 
 QUARANTINE MODES
@@ -107,7 +108,7 @@ Scrub **a** specific table (mytable) in a keyspace (mykeyspace) in VALIDATE mode
 
 .. code-block:: shell
 
-   > nodetool scrub -m VALIDATE --no-snapshot mykeyspace mytable
+   > nodetool scrub --no-snapshot mykeyspace mytable
 
 Scrub **a** specific table (mytable) in a keyspace (mykeyspace) in SEGREGATE mode dropping unfixable SSTables
 
@@ -125,7 +126,7 @@ Method 1: Quarantine and Drop
 
 .. code-block:: shell
 
-   > nodetool scrub -m VALIDATE keyspace_name table_name
+   > nodetool scrub keyspace_name table_name
 
 This will move corrupted SSTables to a ``quarantine`` directory.
 The ``quarantine`` directory is a sub-directory of the table's respective data directory.

--- a/test/rest_api/rest_util.py
+++ b/test/rest_api/rest_util.py
@@ -107,6 +107,21 @@ def set_tmp_user_task_ttl(rest_api, seconds):
         resp = rest_api.send("POST", "task_manager/user_ttl", { "user_ttl" : old_ttl })
         resp.raise_for_status()
 
+@contextmanager
+def set_logger_level(rest_api, logger, level):
+    resp = rest_api.send("GET", f"system/logger/{logger}")
+    resp.raise_for_status()
+    old_level = resp.json()
+
+    resp = rest_api.send("POST", f"system/logger/{logger}", {"level": level})
+    resp.raise_for_status()
+
+    try:
+        yield
+    finally:
+        resp = rest_api.send("POST", f"system/logger/{logger}", {"level": old_level})
+        resp.raise_for_status()
+
 # Unfortunately by default Python threads print their exceptions
 # (e.g., assertion failures) but don't propagate them to the join(),
 # so the overall test doesn't fail. The following Thread wrapper

--- a/test/rest_api/test_storage_service.py
+++ b/test/rest_api/test_storage_service.py
@@ -9,7 +9,8 @@ import time
 
 # Use the util.py library from ../cqlpy:
 from ..cqlpy.util import unique_name, new_test_table, new_test_keyspace, new_materialized_view, new_secondary_index
-from test.rest_api.rest_util import new_test_snapshot, scylla_inject_error, ThreadWrapper
+from test.rest_api.rest_util import new_test_snapshot, scylla_inject_error, ThreadWrapper, set_logger_level
+from test.cqlpy.test_logs import wait_for_log, logfile, logfile_path
 
 # "keyspace" function: Creates and returns a temporary keyspace to be
 # used in tests that need a keyspace. The keyspace is created with RF=1,
@@ -926,3 +927,47 @@ def test_drop_quarantined_sstables(cql, this_dc, rest_api):
                                    params={"keyspace": keyspace, "tables": f"{test_tables[0]},non_existent_table"})
                 assert resp.status_code == requests.codes.bad_request
                 assert "Can't find a column family non_existent_table in keyspace" in resp.json()["message"]
+
+@pytest.mark.parametrize("tablets_enabled, compaction_type", [
+    ("true", "VALIDATE"),
+    ("true", "ABORT"),
+    ("true", "SCRUB"),
+    ("false", "CLEANUP"),
+    ("false", "VALIDATE"),
+    ("false", "ABORT"),
+    ("false", "SCRUB"),
+])
+def test_disable_autocompaction_doesnt_block_user_initiated_compactions(cql, this_dc, rest_api, logfile, compaction_type: str, skip_without_tablets, tablets_enabled):
+    with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }}  AND TABLETS = {{ 'enabled': {tablets_enabled} }}") as keyspace1:
+        with new_test_table(cql, keyspace1, 'p int PRIMARY KEY') as table1:
+            with set_logger_level(rest_api, "compaction", "debug"):
+                cf = table1.split('.')[1]
+
+                resp = rest_api.send("DELETE", f"storage_service/auto_compaction/{keyspace1}", {"cf": cf})
+                resp.raise_for_status()
+
+                stmt = cql.prepare(f"INSERT INTO {table1} (p) VALUES (?)")
+                for i in range(1000):
+                    cql.execute(stmt, [i])
+
+                resp = rest_api.send("POST", f"storage_service/keyspace_flush/{keyspace1}")
+                resp.raise_for_status()
+
+                match compaction_type:
+                    case "CLEANUP":
+                        cql.execute(f"ALTER KEYSPACE {keyspace1} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 0 }}")
+                        resp = rest_api.send("POST", f"storage_service/keyspace_cleanup/{keyspace1}")
+                        to_find = r"Cleaned \d* sstables to"
+                    case "VALIDATE":
+                        resp = rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace1}", { "cf": cf, "scrub_mode": "VALIDATE" })
+                        to_find = "Finished scrubbing in validate mode"
+                    case "SCRUB":
+                        resp = rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace1}", { "cf": cf })
+                        to_find = "Finished scrubbing in validate mode"
+                    case "ABORT":
+                        resp = rest_api.send("GET", f"storage_service/keyspace_scrub/{keyspace1}", { "cf": cf, "scrub_mode": "ABORT" })
+                        to_find = "Finished scrubbing in abort mode"
+
+                resp.raise_for_status()
+
+                wait_for_log(logfile, to_find, timeout=180)

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -4816,7 +4816,7 @@ For more information, see: {}
                 {
                     typed_option<>("no-snapshot", "Do not take a snapshot of scrubbed tables before starting scrub (default false)"),
                     typed_option<>("skip-corrupted,s", "Skip corrupted rows or partitions, even when scrubbing counter tables (deprecated, use ‘–-mode’ instead, default false)"),
-                    typed_option<sstring>("mode,m", "How to handle corrupt data (one of: ABORT|SKIP|SEGREGATE|VALIDATE, default ABORT; overrides ‘–-skip-corrupted’)"),
+                    typed_option<sstring>("mode,m", "How to handle corrupt data (one of: VALIDATE|ABORT|SKIP|SEGREGATE, default VALIDATE; overrides ‘–-skip-corrupted’)"),
                     typed_option<sstring>("quarantine-mode,q", "How to handle quarantined sstables (one of: INCLUDE|EXCLUDE|ONLY, default INCLUDE)"),
                     typed_option<>("no-validate,n", "Do not validate columns using column validator (unused)"),
                     typed_option<>("reinsert-overflowed-ttl,r", "Rewrites rows with overflowed expiration date (unused)"),


### PR DESCRIPTION
Change the default REST API `/storage_service/keyspace_scrub` mode from `ABORT` to `VALIDATE`.
Change the default `nodetool scrub` mode from `abort` to `validate`.
Add api and nodetool tests to test the new default bahavior.
Update docs to reflect the new default.

Closes: https://scylladb.atlassian.net/browse/SCYLLADB-2886
Closes: https://scylladb.atlassian.net/browse/SCYLLADB-2887

no backport - new feature