### PR TITLE
packaging: obsolete tuned-profiles-oci in scylla-kernel-conf

### DIFF
--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -188,6 +188,12 @@ Summary:        Scylla configuration package for the Linux kernel
 Requires:       kmod sed
 # tuned overwrites our sysctl settings
 Obsoletes:      tuned >= 2.11.0
+# tuned-profiles-oci (preinstalled on OCI images) hard-requires an exact
+# version of tuned, which blocks the Obsoletes above unless it is removed too.
+# tuned-profiles-oci-recommend in turn hard-requires tuned-profiles-oci, so it
+# must be obsoleted in the same transaction as well.
+Obsoletes:      tuned-profiles-oci
+Obsoletes:      tuned-profiles-oci-recommend
 Provides:       scylla-enterprise-kernel-conf = %{version}-%{release}
 Obsoletes:      scylla-enterprise-kernel-conf < 2025.1.0
 


### PR DESCRIPTION
On Oracle Cloud Infrastructure images (both OL9 and OL10), Oracle
preinstalls tuned-profiles-oci from the ol9_oci_included /
ol10_oci_included repo, and that package hard-requires an exact
version of tuned, e.g.:

  tuned-profiles-oci-2.25.1-1.0.1.el10.noarch requires tuned = 2.25.1-1.0.1.el10

scylla-kernel-conf already obsoletes tuned (>= 2.11.0) so it can own
the sysctl tuning instead of tuned, but once tuned is obsoleted there
is no way to satisfy tuned-profiles-oci's pinned requirement, so
installing scylla fails with "conflicting requests":

  - package tuned-profiles-oci-2.25.1-1.0.1.el10.noarch from ol10_oci_included requires tuned = 2.25.1-1.0.1.el10, but none of the providers can be installed
  - package scylla-kernel-conf-... obsoletes tuned >= 2.11.0 provided by tuned-2.26.0-1.0.1.el10_1.1.noarch from @System
  - conflicting requests

This only surfaced once the OL9/OL10 artifacts tests were switched to
run on OCI instances, since tuned-profiles-oci isn't installed on
non-OCI images.

Obsolete tuned-profiles-oci alongside tuned so both get removed in
the same transaction. It's a no-op on systems where the package isn't
installed.

### Testing
- [x] https://jenkins.scylladb.com/job/scylla-staging/job/valerii/job/vp-artifacts-oel10-oci/5/

**Based on https://github.com/scylladb/scylladb/pull/30648#issuecomment-4901300146 we should backport this to 2026.2 and 2026.1**

Fixes: SCYLLADB-2518