### PR TITLE
docs: update CassIO link in secondary indexes manual

### DIFF
--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -281,7 +281,7 @@ Cassandra SAI Compatibility for Vector Search
 
 ScyllaDB accepts the Cassandra ``StorageAttachedIndex`` (SAI) class name in ``CREATE CUSTOM INDEX``
 statements **for vector columns**. Cassandra libraries such as
-`CassIO <https://cassio.org/>`_ and `LangChain <https://www.langchain.com/>`_ use SAI to create
+`CassIO <https://github.com/CassioML>`_ and `LangChain <https://www.langchain.com/>`_ use SAI to create
 vector indexes; ScyllaDB recognizes these statements for compatibility.
 
 When ScyllaDB encounters an SAI class name on a **vector column**, the index is automatically


### PR DESCRIPTION
Automated docs link checking reported that `https://cassio.org/` times out from the secondary indexes manual page.

### Change
- Update the CassIO reference in `docs/cql/secondary-indexes.rst` to `https://github.com/CassioML` (the maintained project location).
- Leave the surrounding SAI / vector-index documentation unchanged.

Backport: 2026.2 (the version that delivered this documentation).

Fixes https://github.com/scylladb/scylladb/issues/30645
