### PR TITLE
dist/nix: update scylla-driver to 3.25.11

### DIFF
--- a/dist/nix/pkg/upstreamable/python-driver/default.nix
+++ b/dist/nix/pkg/upstreamable/python-driver/default.nix
@@ -6,7 +6,7 @@
 }:
 
 let
-  version = "3.25.10-scylla";
+  version = "3.25.11-scylla";
 in python3Packages.buildPythonPackage {
   pname = "scylla-driver";
   inherit version;
@@ -16,7 +16,7 @@ in python3Packages.buildPythonPackage {
     owner = "scylladb";
     repo = "python-driver";
     rev = version;
-    sha256 = "sha256-ib1XZPLcg5lCMfbUhDwjB968HYtGjt559JX5fxDADQc=";
+    sha256 = "sha256-URIKEJ879Izmcm88v2XEsvQ29DldFBuQ07Rv1jAwSZ0=";
   };
 
   postPatch = ''


### PR DESCRIPTION
Update the Nix-packaged scylla-driver from 3.25.10-scylla to 3.25.11-scylla.

The fetchFromGitHub source hash was refreshed for the new scylladb/python-driver tag.

No backport labels are added; this only updates the Nix package definition on master.

Tests:
- git diff --check
- Recomputed the recursive NAR hash for 3.25.11-scylla; validated the hashing method by matching the existing 3.25.10-scylla hash.