### PR TITLE
treewide: mark input functions to defer() and similar noexcept

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -2193,7 +2193,7 @@ static future<compaction_result> scrub_sstables_validate_mode(compaction_descrip
 
 future<compaction_result> scrub_sstables_validate_mode(compaction_descriptor descriptor, compaction_data& cdata, compaction_group_view& table_s, compaction_progress_monitor& progress_monitor) {
     progress_monitor.set_generator(std::make_unique<compaction_read_monitor_generator>(table_s, use_backlog_tracker::no));
-    auto d = defer([&] { progress_monitor.reset_generator(); });
+    auto d = defer([&] noexcept { progress_monitor.reset_generator(); });
     auto res = co_await scrub_sstables_validate_mode(descriptor, cdata, table_s, *progress_monitor._generator);
     co_return res;
 }

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -626,7 +626,7 @@ requires (compaction_manager& cm, throw_if_stopping do_throw_if_stopping, Args&&
 future<compaction_manager::compaction_stats_opt> compaction_manager::perform_compaction(throw_if_stopping do_throw_if_stopping, tasks::task_info parent_info, Args&&... args) {
     auto task_executor = seastar::make_shared<TaskExecutor>(*this, do_throw_if_stopping, std::forward<Args>(args)...);
     _tasks.push_back(*task_executor);
-    auto unregister_task = defer([task_executor] {
+    auto unregister_task = defer([task_executor] noexcept {
         task_executor->unlink();
         task_executor->switch_state(compaction_task_executor::state::none);
     });
@@ -1185,7 +1185,7 @@ void compaction_manager::stop_tasks(const std::vector<shared_ptr<compaction_task
 
 future<> compaction_manager::await_tasks(std::vector<shared_ptr<compaction_task_executor>> tasks, bool task_stopped) const noexcept {
     co_await coroutine::parallel_for_each(tasks, [task_stopped] (auto& task) -> future<> {
-        auto unlink_task = deferred_action([task, task_stopped] { if (task_stopped) { task->unlink(); } });
+        auto unlink_task = deferred_action([task, task_stopped] noexcept { if (task_stopped) { task->unlink(); } });
         try {
             co_await task->compaction_done();
         } catch (compaction_stopped_exception&) {
@@ -1276,7 +1276,7 @@ future<> compaction_manager::start(const db::config& cfg, utils::disk_space_moni
     return make_ready_future<>();
 }
 
-future<> compaction_manager::stop() {
+future<> compaction_manager::stop() noexcept {
     do_stop();
     if (_stop_future) {
         co_await std::exchange(*_stop_future, make_ready_future());

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -316,7 +316,7 @@ public:
 
     // Stop all fibers. Ongoing compactions will be waited. Should only be called
     // once, from main teardown path.
-    future<> stop();
+    future<> stop() noexcept;
     future<> start(const db::config& cfg, utils::disk_space_monitor* dsm);
 
     // cancels all running compactions and moves the compaction manager into disabled state.

--- a/db/row_cache.cc
+++ b/db/row_cache.cc
@@ -1048,7 +1048,7 @@ future<> row_cache::do_update(external_updater eu, replica::memtable& m, Updater
             _prev_snapshot = {};
         });
         utils::coroutine update; // Destroy before cleanup to release snapshots before invalidating.
-        auto destroy_update = defer([&] {
+        auto destroy_update = defer([&] noexcept {
             with_allocator(_tracker.allocator(), [&] {
                 update = {};
             });

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2226,7 +2226,7 @@ future<> view_builder::start_in_background(service::migration_manager& mm, utils
     auto step_fiber = make_ready_future<>();
     try {
         view_builder_init_state vbi;
-        auto fail = defer([&barrier] mutable { barrier.abort(); });
+        auto fail = defer([&barrier] mutable noexcept { barrier.abort(); });
         // Semaphore usage invariants:
         // - One unit of _sem serializes all per-shard bookkeeping that mutates view-builder state
         //   (_base_to_build_step, _built_views, build_status, reader resets).
@@ -3073,7 +3073,7 @@ public:
             _fragments.emplace_front(*reader().schema(), permit(), partition_start(get_current_key(), tombstone()));
             auto base_schema = base()->schema();
             auto fragments_reader = make_mutation_reader_from_fragments(reader().schema(), permit(), std::move(_fragments));
-            auto close_reader = defer([&fragments_reader] { fragments_reader.close().get(); });
+            auto close_reader = defer([&fragments_reader] noexcept { fragments_reader.close().get(); });
             fragments_reader.upgrade_schema(base_schema);
             _gen->populate_views(
                     *base(),

--- a/db/view/view_consumer.cc
+++ b/db/view/view_consumer.cc
@@ -48,7 +48,7 @@ void view_consumer::flush_fragments() {
         _fragments.emplace_front(*reader().schema(), permit(), partition_start(get_current_key(), tombstone()));
         auto base_schema = base()->schema();
         auto fragments_reader = make_mutation_reader_from_fragments(reader().schema(), permit(), std::move(_fragments));
-        auto close_reader = defer([&fragments_reader] { fragments_reader.close().get(); });
+        auto close_reader = defer([&fragments_reader] noexcept { fragments_reader.close().get(); });
         fragments_reader.upgrade_schema(base_schema);
         _gen->populate_views(
                 *base(),

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -80,7 +80,7 @@ public:
         _inactive_pending_work += sst->data_size();
     }
 
-    void on_sstables_deregistration(const std::vector<sstables::shared_sstable>& ssts) {
+    void on_sstables_deregistration(const std::vector<sstables::shared_sstable>& ssts) noexcept {
         for (auto& sst : ssts) {
             if (_monitors.contains(sst)) {
                 _monitors.erase(sst);
@@ -242,7 +242,7 @@ future<> view_update_generator::process_staging_sstables(lw_shared_ptr<replica::
     for (auto& sst : sstables) {
         _progress_tracker->on_sstable_registration(sst);
     }
-    auto deregister_sstables = defer([this, &sstables] {
+    auto deregister_sstables = defer([this, &sstables] noexcept {
         _progress_tracker->on_sstables_deregistration(sstables);
     });
 

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -316,7 +316,7 @@ future<> gossiper::handle_ack_msg(locator::host_id id, gossip_digest_ack ack_msg
     if (count_as_msg_processing) {
         _msg_processing++;
     }
-    auto mp = defer([count_as_msg_processing, this] {
+    auto mp = defer([count_as_msg_processing, this] noexcept {
         if (count_as_msg_processing) {
             _msg_processing--;
         }
@@ -425,7 +425,7 @@ future<> gossiper::handle_ack2_msg(locator::host_id from, gossip_digest_ack2 msg
     if (count_as_msg_processing) {
         _msg_processing++;
     }
-    auto mp = defer([count_as_msg_processing, this] {
+    auto mp = defer([count_as_msg_processing, this] noexcept {
         if (count_as_msg_processing) {
             _msg_processing--;
         }

--- a/main.cc
+++ b/main.cc
@@ -580,7 +580,7 @@ static void checkpoint(stop_signal& stop, sstring what, bool ready = false) {
 
 template <typename Func>
 static auto defer_verbose_shutdown(const char* what, Func&& func) {
-    auto vfunc = [what, func = std::forward<Func>(func)] () mutable {
+    auto vfunc = [what, func = std::forward<Func>(func)] () mutable noexcept {
         startlog.info("Shutting down {}", what);
         try {
             func();
@@ -1723,7 +1723,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 tm.set_host_id(host_id);
                 tm.init_ms_handlers(messaging.local());
             }).get();
-            auto uninit_tm_ms_handlers = defer([&task_manager] () {
+            auto uninit_tm_ms_handlers = defer([&task_manager] () noexcept {
                 task_manager.invoke_on_all([] (auto& tm) {
                     return tm.uninit_ms_handlers();
                 }).get();
@@ -1876,7 +1876,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             audit::audit::start_audit(*cfg, token_metadata, qp, mm).handle_exception([&] (auto&& e) {
                 startlog.error("audit start failed: {}", e);
             }).get();
-            auto audit_stop = defer([] {
+            auto audit_stop = defer([] noexcept {
                 audit::audit::stop_audit().get();
             });
 
@@ -2477,7 +2477,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // to create its keyspace and table.
             checkpoint(stop_signal, "starting audit storage");
             audit::audit::start_storage(*cfg).get();
-            auto audit_storage_stop = defer([] {
+            auto audit_storage_stop = defer([] noexcept {
                 audit::audit::stop_storage().get();
             });
 
@@ -2556,7 +2556,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
 
             // Reproducer of scylladb/scylladb#24792.
-            auto i24792_reproducer = defer([] {
+            auto i24792_reproducer = defer([] noexcept {
                 if (utils::get_local_injector().enter("reload_service_level_cache_after_auth_service_is_stopped")) {
                     sl_controller.local().update_cache(qos::update_both_cache_levels::yes).get();
                 }
@@ -2590,7 +2590,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 controller.register_auth_integration(auth_service.local());
             }).get();
 
-            auto unregister_sl_controller_integration = defer([] {
+            auto unregister_sl_controller_integration = defer([] noexcept {
                 sl_controller.invoke_on_all([] (qos::service_level_controller& controller) {
                     return controller.unregister_auth_integration();
                 }).get();

--- a/message/advanced_rpc_compressor.cc
+++ b/message/advanced_rpc_compressor.cc
@@ -363,7 +363,7 @@ rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf d
     auto algo = get_algo_for_next_msg(data.size);
 
     auto& stats = _tracker->_stats[algo.idx()];
-    auto update_time_stats = defer([&, nanos_before = now] {
+    auto update_time_stats = defer([&, nanos_before = now] noexcept {
         stats.compression_cpu_nanos += _tracker->get_steady_nanos() - nanos_before;
     });
 
@@ -452,7 +452,7 @@ rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
     auto algo = compression_algorithm(header_byte & 0x3f);
 
     auto& stats = _tracker->_stats[algo.idx()];
-    auto update_time_stats = defer([&, nanos_before = _tracker->get_steady_nanos()] {
+    auto update_time_stats = defer([&, nanos_before = _tracker->get_steady_nanos()] noexcept {
         stats.decompression_cpu_nanos += _tracker->get_steady_nanos() - nanos_before;
     });
     auto compressed_size = data.size;

--- a/message/dict_trainer.cc
+++ b/message/dict_trainer.cc
@@ -25,7 +25,7 @@ namespace netw {
 seastar::logger dict_trainer_logger("dict_training");
 
 future<std::vector<dict_sampler::page_type>> dict_sampler::sample(request req, abort_source& as) {
-    auto ensure_reset = defer([this] {
+    auto ensure_reset = defer([this] noexcept {
         dict_trainer_logger.debug("Sampling finished.");
         reset();
     });

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -616,10 +616,10 @@ future<> messaging_service::stop_nontls_server() {
 }
 
 future<> messaging_service::stop_client() {
-    auto d = defer([] { mlogger.info("Stopped clients"); });
+    auto d = defer([] noexcept { mlogger.info("Stopped clients"); });
     auto stop_clients = [] (auto& clients) ->future<> {
         co_await coroutine::parallel_for_each(clients, [] (auto& m) -> future<> {
-            auto d = defer([&m] {
+            auto d = defer([&m] noexcept {
                 // no new clients should be added by get_rpc_client(), as it
                 // asserts that _shutting_down is true
                 m.clear();
@@ -1479,7 +1479,7 @@ future<> messaging_service::unregister_repair_get_full_row_hashes_with_rpc_strea
 unsigned messaging_service::add_statement_tenant(sstring tenant_name, scheduling_group sg) {
     auto idx = _clients.size();
     auto scheduling_info_for_connection_index_size = _scheduling_info_for_connection_index.size();
-    auto undo = defer([&] {
+    auto undo = defer([&] noexcept {
         _clients.resize(idx);
         _clients_with_host_id.resize(idx);
         _scheduling_info_for_connection_index.resize(scheduling_info_for_connection_index_size);

--- a/mutation/mutation_cleaner.hh
+++ b/mutation/mutation_cleaner.hh
@@ -72,13 +72,13 @@ public:
     }
     auto pause() {
         _worker_state->merging_paused += 1;
-        return defer([this] {
+        return defer([this] noexcept {
             _worker_state->merging_paused -= 1;
             _worker_state->cv.signal();
         });
     };
     auto make_region_space_guard() {
-        return defer([&, dirty_before = _region.occupancy().total_space()] {
+        return defer([&, dirty_before = _region.occupancy().total_space()] noexcept{
             auto dirty_after = _region.occupancy().total_space();
             if (_on_space_freed && dirty_before > dirty_after) {
                 _on_space_freed(dirty_before - dirty_after);

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -211,7 +211,7 @@ stop_iteration mutation_partition_v2::apply_monotonically(const schema& s, const
     // The sentinel never has a clustering key position, so it carries no row information.
     alloc_strategy_unique_ptr<rows_entry> p_sentinel;
     alloc_strategy_unique_ptr<rows_entry> this_sentinel;
-    auto insert_sentinel_back = defer([&] {
+    auto insert_sentinel_back = defer([&] noexcept {
         // Note: this lambda will be run by a destructor (of the `defer` guard),
         // so it mustn't throw, or else it will crash the node.
         //

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1317,7 +1317,7 @@ void server_impl::send_snapshot(server_id dst, install_snapshot&& snp) {
         // one in-flight snapshot transfer per destination.
         SCYLLA_ASSERT(inserted);
 
-        auto cleanup = seastar::defer([this, dst, &as] {
+        auto cleanup = seastar::defer([this, dst, &as] noexcept {
             // Only erase the map entry if it still points to our abort_source.
             // A new transfer for the same dst may have already replaced it.
             auto it = _snapshot_abort_sources.find(dst);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1147,7 +1147,7 @@ future<tasks::task_manager::task::progress> repair::shard_repair_task_impl::get_
 future<> repair::shard_repair_task_impl::run() {
     _topology_guard = {_frozen_topology_guard};
     rs.get_repair_module().add_shard_task_id(global_repair_id.id, _status.id);
-    auto remove_shard_task_id = defer([this] {
+    auto remove_shard_task_id = defer([this] noexcept {
         rs.get_repair_module().remove_shard_task_id(global_repair_id.id);
     });
     try {
@@ -1383,7 +1383,7 @@ future<> repair::user_requested_repair_task_impl::run() {
             rlogger.info("repair[{}]: Finished to shutdown off-strategy compaction updater", uuid);
         });
 
-        auto cleanup_repair_range_history = defer([&rs, uuid] () mutable {
+        auto cleanup_repair_range_history = defer([&rs, uuid] () mutable noexcept {
             try {
                 rs.cleanup_history(tasks::task_id{uuid.uuid()}).get();
             } catch (...) {
@@ -2399,7 +2399,7 @@ future<> repair::tablet_repair_task_impl::run() {
             rlogger.info("repair[{}]: Finished to shutdown off-strategy compaction updater", uuid);
         });
 
-        auto cleanup_repair_range_history = defer([&rs, uuid = id.uuid()] () mutable {
+        auto cleanup_repair_range_history = defer([&rs, uuid = id.uuid()] () mutable noexcept {
             try {
                 rs.cleanup_history(tasks::task_id{uuid.uuid()}).get();
             } catch (...) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3500,7 +3500,7 @@ public:
                     _topo_guard,
                     repaired_at,
                     _shard_task.sched_info.incremental_mode);
-            auto auto_stop_master = defer([&master] {
+            auto auto_stop_master = defer([&master] noexcept {
                 try {
                     master.stop().get();
                 } catch (...) {
@@ -3624,7 +3624,7 @@ future<> repair_cf_range_row_level(repair::shard_repair_task_impl& shard_task,
     bool is_tablet = shard_task.db.local().find_column_family(table_id).uses_tablets();
     bool is_tablet_rebuild = shard_task.sched_info.for_tablet_rebuild;
     auto t = std::chrono::steady_clock::now();
-    auto update_time = seastar::defer([&] {
+    auto update_time = seastar::defer([&] noexcept {
         if (is_tablet && !is_tablet_rebuild) {
             auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - t);
             _metrics.tablet_time_ms += duration.count();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2407,7 +2407,7 @@ future<> database::do_apply_many(const utils::chunked_vector<frozen_mutation>& m
 future<db::large_data_violation_type> database::do_apply(schema_ptr s, const frozen_mutation& m, tracing::trace_state_ptr tr_state, db::timeout_clock::time_point timeout, db::commitlog::force_sync sync, db::per_partition_rate_limit::info rate_limit_info, bool skip_large_data_guardrails) {
     ++_stats->total_writes;
     // assume failure until proven otherwise
-    auto update_writes_failed = defer([&] { ++_stats->total_writes_failed; });
+    auto update_writes_failed = defer([&] noexcept { ++_stats->total_writes_failed; });
 
     co_await utils::get_local_injector().inject("database_apply", [&s] (auto& handler) -> future<> {
         if (s->ks_name() != handler.get("ks_name") || s->cf_name() != handler.get("cf_name")) {
@@ -2738,7 +2738,7 @@ schema_ptr database::find_indexed_table(const sstring& ks_name, const sstring& i
 }
 
 future<> database::close_tables(table_kind kind_to_close) {
-    auto b = defer([this] { _stop_barrier.abort(); });
+    auto b = defer([this] noexcept { _stop_barrier.abort(); });
     co_await _tables_metadata.parallel_for_each_table(coroutine::lambda([this, kind_to_close] (table_id, lw_shared_ptr<table> table) -> future<> {
         auto& s = table->schema();
         table_kind k = is_system_table(*s) || _cfg.extensions().is_extension_internal_keyspace(s->ks_name()) ? table_kind::system : table_kind::user;
@@ -2829,7 +2829,7 @@ future<> database::start(sharded<qos::service_level_controller>& sl_controller, 
 
 future<> database::shutdown() {
     _shutdown = true;
-    auto b = defer([this] { _stop_barrier.abort(); });
+    auto b = defer([this] noexcept { _stop_barrier.abort(); });
     co_await _stop_barrier.arrive_and_wait();
     b.cancel();
 
@@ -3468,7 +3468,7 @@ future<> database::flush_system_column_families() {
 }
 
 future<> database::drain() {
-    auto b = defer([this] { _stop_barrier.abort(); });
+    auto b = defer([this] noexcept { _stop_barrier.abort(); });
     // Interrupt on going compaction and shutdown to prevent further compaction
     co_await _compaction_manager.drain();
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1115,7 +1115,7 @@ public:
             std::optional<querier>* saved_querier = { });
 
     void start();
-    future<> stop();
+    future<> stop() noexcept;
     future<> flush(std::optional<db::replay_position> = {});
     bool needs_flush() const;
     future<> clear(); // discards memtable(s) without flushing them to disk.

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -963,7 +963,7 @@ future<> segment_manager_impl::write(write_buffer& wb) {
         auto& desc = get_segment_descriptor(seg->id());
 
         // if we wrote a record to the segment but failed to write it to the separator, the segment should not be freed.
-        auto write_to_separator_failed = defer([seg_ref] mutable {
+        auto write_to_separator_failed = defer([seg_ref] mutable noexcept {
             seg_ref.set_flush_failure();
         });
 
@@ -1899,7 +1899,7 @@ future<> segment_manager_impl::add_segment_to_compaction_group(replica::database
 
     if (need_separator) {
         auto seg_ref = make_segment_ref(seg_id);
-        auto write_to_separator_failed = defer([seg_ref] mutable {
+        auto write_to_separator_failed = defer([seg_ref] mutable noexcept {
             seg_ref.set_flush_failure();
         });
         co_await for_each_record(seg_id,

--- a/replica/multishard_query.cc
+++ b/replica/multishard_query.cc
@@ -861,7 +861,7 @@ static future<std::tuple<foreign_ptr<lw_shared_ptr<typename ResultBuilder::resul
     const auto& erm = table.get_effective_replication_map();
     auto query_method = erm->get_replication_strategy().uses_tablets() ? do_query_tablets<ResultBuilder> : do_query_vnodes<ResultBuilder>;
 
-    auto account_failed_read = defer([&stats] {
+    auto account_failed_read = defer([&stats] noexcept {
         ++stats.total_reads_failed;
     });
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2162,7 +2162,7 @@ table::start() {
 }
 
 future<>
-table::stop() {
+table::stop() noexcept {
     if (_async_gate.is_closed()) {
         co_return;
     }
@@ -2527,7 +2527,7 @@ compaction_group::update_sstable_sets_on_compaction_completion(compaction::compa
     // After we are done, unconditionally remove compacted sstables from _sstables_compacted_but_not_deleted,
     // or they could stay forever in the set, resulting in deleted files remaining
     // opened and disk space not being released until shutdown.
-    auto undo_compacted_but_not_deleted = defer([&] {
+    auto undo_compacted_but_not_deleted = defer([&] noexcept {
         std::erase_if(sstables_compacted_but_not_deleted, [&] (sstables::shared_sstable sst) {
             return s.contains(sst);
         });
@@ -2535,7 +2535,7 @@ compaction_group::update_sstable_sets_on_compaction_completion(compaction::compa
     });
 
     _t.get_stats().pending_sstable_deletions++;
-    auto undo_stats = defer([this] {
+    auto undo_stats = defer([this] noexcept {
         _t.get_stats().pending_sstable_deletions--;
     });
 
@@ -2966,7 +2966,7 @@ future<> table::drop_quarantined_sstables() {
 
 
     _stats.pending_sstable_deletions++;
-    auto undo_stats = defer([this] {
+    auto undo_stats = defer([this] noexcept {
         _stats.pending_sstable_deletions--;
     });
 
@@ -4733,7 +4733,7 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
     std::unordered_map<size_t, std::vector<removed_sstable>> per_cg_remove;
 
     _stats.pending_sstable_deletions++;
-    auto undo_stats = defer([this] {
+    auto undo_stats = defer([this] noexcept {
         _stats.pending_sstable_deletions--;
     });
 

--- a/service/direct_failure_detector/failure_detector.cc
+++ b/service/direct_failure_detector/failure_detector.cc
@@ -295,9 +295,9 @@ future<> failure_detector::impl::remove_endpoint(pinger::endpoint_id ep) {
 
 void failure_detector::impl::create_worker(pinger::endpoint_id ep) {
     // To provide strong exception guarantee.
-    std::vector<deferred_action<noncopyable_function<void()>>> guards;
+    std::vector<deferred_action<noncopyable_function<void() noexcept>>> guards;
 
-    guards.emplace_back([this, ep] { _shard_workers.erase(ep); });
+    guards.emplace_back([this, ep] noexcept { _shard_workers.erase(ep); });
     auto [worker_it, inserted] = _shard_workers.try_emplace(ep, *this, ep);
     if (!inserted) {
         // `failure_detector::impl::add_endpoint` checks `_workers` before creating a worker.
@@ -308,7 +308,7 @@ void failure_detector::impl::create_worker(pinger::endpoint_id ep) {
     }
 
     for (auto& [_, l]: _listeners_liveness) {
-        guards.emplace_back([&l = l, ep] { l.endpoint_liveness.erase(ep); });
+        guards.emplace_back([&l = l, ep] noexcept { l.endpoint_liveness.erase(ep); });
         auto [it, inserted] = l.endpoint_liveness.emplace(ep, endpoint_liveness{});
         if (!inserted) {
             // `endpoint_liveness` entries in the `liveness` maps are created and destroyed together with `endpoint_workers`,

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -92,7 +92,7 @@ future<prepare_response> paxos_state::prepare(storage_proxy& sp, paxos_store& pa
     utils::latency_counter lc;
     lc.start();
 
-    auto stats_updater = defer([&sp, schema, lc] () mutable {
+    auto stats_updater = defer([&sp, schema, lc] () mutable noexcept {
         if (auto table = sp.get_db().local().get_tables_metadata().get_table_if_exists(schema->id())) {
             auto& stats = table->get_stats();
             stats.cas_prepare.mark(lc.stop().latency());
@@ -182,7 +182,7 @@ future<bool> paxos_state::accept(storage_proxy& sp, paxos_store& paxos_store, tr
     utils::latency_counter lc;
     lc.start();
 
-    auto stats_updater = defer([&sp, schema, lc] () mutable {
+    auto stats_updater = defer([&sp, schema, lc] () mutable noexcept {
         if (auto table = sp.get_db().local().get_tables_metadata().get_table_if_exists(schema->id())) {
             auto& stats = table->get_stats();
             stats.cas_accept.mark(lc.stop().latency());
@@ -226,7 +226,7 @@ future<> paxos_state::learn(storage_proxy& sp, paxos_store& paxos_store, schema_
     utils::latency_counter lc;
     lc.start();
 
-    auto stats_updater = defer([&sp, schema, lc] () mutable {
+    auto stats_updater = defer([&sp, schema, lc] () mutable noexcept {
         if (auto table = sp.get_db().local().get_tables_metadata().get_table_if_exists(schema->id())) {
             auto& stats = table->get_stats();
             stats.cas_learn.mark(lc.stop().latency());

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -588,7 +588,7 @@ private:
             tracing::trace(trace_state_ptr, "Message received from /{}", src_addr);
         }
 
-        auto trace_done = defer([&] {
+        auto trace_done = defer([&] noexcept {
             tracing::trace(trace_state_ptr, "Mutation handling is done");
         });
 
@@ -1071,7 +1071,7 @@ private:
 
         co_await _sp.apply_fence(fence_opt, src_addr);
 
-        auto handling_done = defer([tr_state, src_addr] {
+        auto handling_done = defer([tr_state, src_addr] noexcept {
             if (tr_state) {
                 tracing::trace(tr_state, "paxos_accept: handling is done, sending a response to /{}", src_addr);
             }
@@ -1122,7 +1122,7 @@ private:
         }
 
         pruning++;
-        auto d = defer([] { pruning--; });
+        auto d = defer([] noexcept { pruning--; });
         auto schema = co_await get_schema_for_read(schema_id, src_addr, src_shard, *timeout);
         dht::token token = dht::get_token(*schema, key);
 
@@ -7019,7 +7019,7 @@ future<storage_proxy::cas_result> storage_proxy::cas(schema_ptr schema, cas_shar
     db::large_data_violation_type large_data_violations = db::large_data_violation_type::none;
 
     try {
-        auto update_stats = seastar::defer ([&] {
+        auto update_stats = seastar::defer ([&] noexcept {
             get_stats().cas_foreground--;
             write ? get_stats().cas_write.mark(lc.stop().latency()) : get_stats().cas_read.mark(lc.stop().latency());
             if (contentions > 0) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -651,7 +651,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
 #ifdef SEASTAR_DEBUG
     static bool running = false;
     SCYLLA_ASSERT(!running); // The function is not re-entrant
-    auto d = defer([] {
+    auto d = defer([] noexcept {
         running = false;
     });
     running = true;
@@ -5185,7 +5185,7 @@ future<tablet_operation_result> storage_service::do_tablet_operation(locator::gl
     _tablet_ops.emplace(tablet, tablet_operation {
         op_name, seastar::shared_future<tablet_operation_result>(p.get_future())
     });
-    auto erase_registry_entry = seastar::defer([&] {
+    auto erase_registry_entry = seastar::defer([&] noexcept {
         _tablet_ops.erase(tablet);
     });
 

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -295,7 +295,7 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
 
     utils::latency_counter lc;
     lc.start();
-    auto mark_write_latency = defer([this, &lc] { _stats.write.mark(lc.stop().latency()); });
+    auto mark_write_latency = defer([this, &lc] noexcept { _stats.write.mark(lc.stop().latency()); });
 
     locator::tablet_id tid{-1};
     raft::term_t term;
@@ -432,7 +432,7 @@ auto coordinator::query(schema_ptr schema,
 
     auto& read_stats = (rtype == read_type::linearizable)
         ? _stats.linearizable_read : _stats.non_linearizable_read;
-    auto mark_read_latency = defer([&read_stats, &lc] () mutable { read_stats.mark(lc.stop().latency()); });
+    auto mark_read_latency = defer([&read_stats, &lc] () mutable noexcept { read_stats.mark(lc.stop().latency()); });
 
     auto filter_error = [&] (std::exception_ptr ex) -> std::exception_ptr {
         // Unfortunately, timeouts can materialize in different forms depending

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1521,7 +1521,7 @@ public:
                 std::pop_heap(nodes_by_load_dst.begin(), nodes_by_load_dst.end(), nodes_dst_cmp);
                 auto target = nodes_by_load_dst.back();
                 auto& target_info = nodes[target];
-                auto push_back_target_node = seastar::defer([&] {
+                auto push_back_target_node = seastar::defer([&] noexcept {
                     std::push_heap(nodes_by_load_dst.begin(), nodes_by_load_dst.end(), nodes_dst_cmp);
                 });
 
@@ -3434,7 +3434,7 @@ public:
                 dst = sketch.get_least_loaded_shard(host);
             }
 
-            auto push_back = seastar::defer([&] {
+            auto push_back = seastar::defer([&] noexcept {
                 // When shuffling, src_shards is not a heap.
                 if (!shuffle) {
                     std::push_heap(src_shards.begin(), src_shards.end(), node_load.shards_by_load_cmp());
@@ -4031,13 +4031,13 @@ public:
                 continue;
             }
 
-            auto push_back_node_candidate = seastar::defer([&] {
+            auto push_back_node_candidate = seastar::defer([&] noexcept {
                 std::push_heap(nodes_by_load.begin(), nodes_by_load.end(), nodes_cmp);
             });
 
             tablet_replica src;
 
-            auto push_back_shard_candidate = seastar::defer([&] {
+            auto push_back_shard_candidate = seastar::defer([&] noexcept {
                 std::push_heap(src_node_info.shards_by_load.begin(), src_node_info.shards_by_load.end(), src_node_info.shards_by_load_cmp());
             });
 
@@ -4085,7 +4085,7 @@ public:
             std::pop_heap(nodes_by_load_dst.begin(), nodes_by_load_dst.end(), nodes_dst_cmp);
             target = nodes_by_load_dst.back();
             auto& target_info = nodes[target];
-            auto push_back_target_node = seastar::defer([&] {
+            auto push_back_target_node = seastar::defer([&] noexcept {
                 std::push_heap(nodes_by_load_dst.begin(), nodes_by_load_dst.end(), nodes_dst_cmp);
             });
 
@@ -4346,7 +4346,7 @@ public:
         _rack = rack;
         _location = fmt::format("{}{}", dc, rack ? fmt::format("/{}", *rack) : "");
         _current_stats = _stats.for_dc(dc);
-        auto _ = seastar::defer([&] { _current_stats = nullptr; });
+        auto _ = seastar::defer([&] noexcept { _current_stats = nullptr; });
         _migrating_candidates = 0;
 
         auto node_filter = [&] (const locator::node& node) {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -438,7 +438,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         rtlogger.debug("send {} command with term {} and index {} to {}",
             cmd.cmd, _term, cmd_index, id);
         _topology_cmd_rpc_tracker.active_dst.emplace(id);
-        auto _ = seastar::defer([this, id] { _topology_cmd_rpc_tracker.active_dst.erase(id); });
+        auto _ = seastar::defer([this, id] noexcept { _topology_cmd_rpc_tracker.active_dst.erase(id); });
 
         auto result = _db.get_token_metadata().get_topology().is_me(to_host_id(id)) ?
                     co_await _raft_topology_cmd_handler(_term, cmd_index, cmd) :
@@ -1970,7 +1970,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         bool has_transitions = false;
 
         shared_promise barrier;
-        auto fail_barrier = seastar::defer([&] {
+        auto fail_barrier = seastar::defer([&] noexcept {
             if (needs_barrier) {
                 barrier.set_exception(seastar::broken_promise());
             }

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -68,7 +68,7 @@ public:
     future<index_list> finalize() {
         index_list result;
         // In case of exception, need to deallocate under region allocator.
-        auto delete_result = seastar::defer([&] {
+        auto delete_result = seastar::defer([&] noexcept {
             with_allocator(_region.allocator(), [&] {
                 result._entries = {};
                 result._promoted_indexes = {};

--- a/sstables/partition_index_cache.hh
+++ b/sstables/partition_index_cache.hh
@@ -249,7 +249,7 @@ public:
     future<> evict_gently() {
         auto i = _cache.begin();
         std::optional<partition_index_page> partial_page;
-        auto clear_on_exception = defer([&] {
+        auto clear_on_exception = defer([&] noexcept {
             with_allocator(_region.allocator(), [&] {
                 partial_page.reset();
             });

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -383,7 +383,7 @@ bool partitioned_sstable_set::insert(shared_sstable sst) {
     }
     auto size_stats = sst->get_file_size_stats();
     add_file_size_stats(size_stats);
-    auto undo_all_insert = defer([&] () {
+    auto undo_all_insert = defer([&] noexcept {
         _all->erase(sst);
         sub_file_size_stats(size_stats);
     });
@@ -403,7 +403,7 @@ bool partitioned_sstable_set::insert(shared_sstable sst) {
                     sst->get_filename(), sst->run_identifier());
         sst->generate_new_run_identifier();
     }
-    auto undo_all_runs_insert = defer([&] () { _all_runs[sst->run_identifier()]->erase(sst); });
+    auto undo_all_runs_insert = defer([&] noexcept { _all_runs[sst->run_identifier()]->erase(sst); });
 
     if (store_as_unleveled(sst)) {
         _unleveled_sstables.push_back(sst);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1906,7 +1906,7 @@ void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions) {
                 downcast_ptr<utils::filter::bloom_filter>(optimal_filter.get())->bits().memory_size(), _origin);
 
     auto index_file = open_file(component_type::Index, open_flags::ro).get();
-    auto index_file_closer = deferred_action([&index_file] {
+    auto index_file_closer = deferred_action([&index_file] noexcept {
         try {
             index_file.close().get();
         } catch (...) {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -456,7 +456,7 @@ future<utils::chunked_vector<sstable_snapshot_metadata>> sstables_manager::take_
     co_return sstables_metadata;
 }
 
-future<> sstables_manager::close() {
+future<> sstables_manager::close() noexcept {
     _closing = true;
     maybe_done();
     co_await _done.get_future();

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -255,7 +255,7 @@ public:
     //
     // Note that close() will not complete until all references to all
     // sstables have been destroyed.
-    future<> close();
+    future<> close() noexcept;
     directory_semaphore& dir_semaphore() noexcept { return _dir_semaphore; }
 
     void plug_sstables_registry(std::unique_ptr<sstables_registry>) noexcept;

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -250,7 +250,7 @@ future<> stream_blob_handler(replica::database& db,
 
     try {
         if (utils::get_local_injector().is_enabled("stream_mutation_fragments")) {
-            log_done = make_lw_shared<std::any>(seastar::make_shared(seastar::defer([] {
+            log_done = make_lw_shared<std::any>(seastar::make_shared(seastar::defer([] noexcept {
                 blogger.info("stream_mutation_fragments: done (tablets)");
             })));
         }
@@ -879,7 +879,7 @@ future<stream_files_response> clone_sstable_handler(replica::database& db, db::v
     // "stream_mutation_fragments: waiting" prefix that tests wait_for().
     lw_shared_ptr<std::any> log_done;
     if (utils::get_local_injector().is_enabled("stream_mutation_fragments")) {
-        log_done = make_lw_shared<std::any>(seastar::make_shared(seastar::defer([] {
+        log_done = make_lw_shared<std::any>(seastar::make_shared(seastar::defer([] noexcept {
             blogger.info("stream_mutation_fragments: done (clone)");
         })));
     }

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -143,7 +143,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
             // Will log a message when streaming is done. Used to synchronize tests.
             lw_shared_ptr<std::any> log_done;
             if (utils::get_local_injector().is_enabled("stream_mutation_fragments")) {
-                log_done = make_lw_shared<std::any>(seastar::make_shared(seastar::defer([] {
+                log_done = make_lw_shared<std::any>(seastar::make_shared(seastar::defer([] noexcept {
                     sslog.info("stream_mutation_fragments: done");
                 })));
             }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -155,7 +155,7 @@ static future<> abort_children(task_manager::module_ptr module, task_id parent_i
     if (!entered) {
         co_return;
     }
-    auto leave_gate = defer([&module] () {
+    auto leave_gate = defer([&module] () noexcept {
         module->async_gate().leave();
     });
     co_await module->get_task_manager().container().invoke_on_all([parent_id] (task_manager& tm) {

--- a/test/boost/address_map_test.cc
+++ b/test/boost/address_map_test.cc
@@ -43,7 +43,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
     {
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.add_or_update_entry(id1, addr1);
@@ -62,7 +62,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // m.add_or_update_entry() adds an expiring entry
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.add_or_update_entry(id1, addr1);
@@ -77,7 +77,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // automatic rearming of expiration timer after the first one expires.
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.add_or_update_entry(id1, addr1);
@@ -97,7 +97,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // - happens when IP address changes after a node restart
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept{ m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.add_or_update_entry(id1, addr1);
@@ -110,7 +110,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // to expiring.
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept{ m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.add_or_update_entry(id1, addr1);
@@ -123,7 +123,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // Check that set_expiring() doesn't insert a new entry
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.set_expiring(id1);
@@ -134,7 +134,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // entry is missing
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.set_nonexpiring(id1);
@@ -152,7 +152,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // Check that add_or_update_entry() throws when called without an actual IP address
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         scoped_no_abort_on_internal_error abort_guard;
@@ -162,7 +162,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // Check that opt_add_entry() throws when called without an actual IP address
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         scoped_no_abort_on_internal_error abort_guard;
@@ -173,7 +173,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // with an obsolete one
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.add_or_update_entry(id1, addr1, gms::generation_type(1));
@@ -185,7 +185,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // doesn't have it regardless of the generation number
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.set_nonexpiring(id1);
@@ -196,7 +196,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // Check the basic functionality of find_by_addr()
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         BOOST_CHECK(!m.find_by_addr(addr1));
@@ -211,7 +211,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // Check that find_by_addr() properly updates timestamps of entries
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.add_or_update_entry(id1, addr1);
@@ -228,7 +228,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // Check that find_by_addr() throws when called without an actual IP address
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         scoped_no_abort_on_internal_error abort_guard;
@@ -239,7 +239,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_operations) {
         // but other way around works
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.add_or_update_entry(id1, addr1, gms::generation_type{2});
@@ -272,7 +272,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_replication) {
     {
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         // Add entry on both shards, replicate non-expiration
@@ -365,7 +365,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_replication_efficiency) {
 
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         std::atomic<bool> stopped;
@@ -409,7 +409,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_expiry_change_keeps_addr_mapping) {
 
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         m.add_or_update_entry(id1, addr1);
@@ -429,7 +429,7 @@ SEASTAR_THREAD_TEST_CASE(test_address_map_exception_safety) {
 
         sharded<address_map_t<manual_clock>> m_svc;
         m_svc.start().get();
-        auto stop_map = defer([&m_svc] { m_svc.stop().get(); });
+        auto stop_map = defer([&m_svc] noexcept { m_svc.stop().get(); });
         auto& m = m_svc.local();
 
         seastar::memory::with_allocation_failures([&] {

--- a/test/boost/alternator_unit_test.cc
+++ b/test/boost/alternator_unit_test.cc
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(test_allocator_fail_gracefully) {
     BOOST_REQUIRE_THROW(allocator.Malloc(too_large_alloc_size), rjson::error);
     // So should impossible reallocation
     void* memory = allocator.Malloc(1);
-    auto release = defer([memory] { rjson::allocator::Free(memory); });
+    auto release = defer([memory] noexcept { rjson::allocator::Free(memory); });
     BOOST_REQUIRE_THROW(allocator.Realloc(memory, 1, too_large_alloc_size), rjson::error);
     // Internal rapidjson stack should also throw
     // and also be destroyed gracefully later

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -951,8 +951,8 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
         sstables::file_writer partitions_db_writer(make_file_output_stream(partitions_db).get());
         sstables::file_writer rows_db_writer(make_file_output_stream(rows_db).get());
 
-        auto close_partitions_db = defer([&] { partitions_db_writer.close(); });
-        auto close_rows_db = defer([&] { rows_db_writer.close(); });
+        auto close_partitions_db = defer([&] noexcept { partitions_db_writer.close(); });
+        auto close_rows_db = defer([&] noexcept { rows_db_writer.close(); });
 
         auto partition_index_writer = sstables::trie::bti_partition_index_writer(sst_ver, partitions_db_writer);
         auto row_index_writer = sstables::trie::bti_row_index_writer(rows_db_writer);
@@ -1113,7 +1113,7 @@ SEASTAR_THREAD_TEST_CASE(test_read_row_index_header) {
     memory_data_sink_buffers bufs;
     {
         sstables::file_writer fw(data_sink(std::make_unique<memory_data_sink>(bufs)));
-        auto close_fw = defer([&] { fw.close(); });
+        auto close_fw = defer([&] noexcept{ fw.close(); });
         sstables::trie::write_row_index_header(
             sstables::sstable_version_types::mt,
             fw,

--- a/test/boost/bti_key_translation_test.cc
+++ b/test/boost/bti_key_translation_test.cc
@@ -428,7 +428,7 @@ static std::generator<position_in_partition_view> generate_pipvs(const schema& s
         co_yield position_in_partition_view(ckp, bound_weight(-1));
         for (const auto& ck2 : all_strings) {
             components.emplace_back(ck2);
-            auto _pop = defer([&] { components.pop_back(); });
+            auto _pop = defer([&] noexcept { components.pop_back(); });
 
             auto ck = clustering_key_prefix::from_deeply_exploded(string_pair_ck_schema, components);
             for (int weight = -1; weight <= 1; ++weight) {

--- a/test/boost/cached_file_test.cc
+++ b/test/boost/cached_file_test.cc
@@ -83,7 +83,7 @@ test_file make_test_file(size_t size) {
     testlog.debug("file contents: {}", contents);
 
     output_stream<char> out = make_file_output_stream(f).get();
-    auto close_out = defer([&] { out.close().get(); });
+    auto close_out = defer([&] noexcept{ out.close().get(); });
     out.write(contents.begin(), contents.size()).get();
     out.flush().get();
 

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -955,7 +955,8 @@ static void test_collection(cql_test_env& e, data_type val_type, data_type del_t
 SEASTAR_THREAD_TEST_CASE(test_map_logging) {
     do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, val map<text, text>, PRIMARY KEY((pk, pk2), ck)) WITH cdc = {'enabled':'true', 'preimage':'true', 'postimage':'true' }"s);
-        auto cleanup = defer([&] {
+        auto cleanup = defer([&] noexcept {
+            // Can in fact throw, will terminate test
             e.execute_cql("DROP TABLE ks.tbl").get();
         });
 
@@ -1039,7 +1040,8 @@ SEASTAR_THREAD_TEST_CASE(test_map_logging) {
 SEASTAR_THREAD_TEST_CASE(test_set_logging) {
     do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, val set<text>, PRIMARY KEY((pk, pk2), ck)) WITH cdc = {'enabled':'true', 'preimage':'true', 'postimage':'true' }"s);
-        auto cleanup = defer([&] {
+        auto cleanup = defer([&] noexcept {
+            // Can in fact throw, will terminate test
             e.execute_cql("DROP TABLE ks.tbl").get();
         });
 
@@ -1110,7 +1112,8 @@ SEASTAR_THREAD_TEST_CASE(test_set_logging) {
 SEASTAR_THREAD_TEST_CASE(test_list_logging) {
     do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, val list<text>, PRIMARY KEY((pk, pk2), ck)) WITH cdc = {'enabled':'true', 'preimage':'true', 'postimage':'true' }"s);
-        auto cleanup = defer([&] {
+        auto cleanup = defer([&] noexcept {
+            // Can in fact throw, will terminate test
             e.execute_cql("DROP TABLE ks.tbl").get();
         });
 
@@ -1203,7 +1206,8 @@ SEASTAR_THREAD_TEST_CASE(test_udt_logging) {
     do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "CREATE TYPE ks.mytype (field0 int, field1 text)"s);
         cquery_nofail(e, "CREATE TABLE ks.tbl (pk int, pk2 int, ck int, val mytype, PRIMARY KEY((pk, pk2), ck)) WITH cdc = {'enabled':'true', 'preimage':'true', 'postimage':'true' }"s);
-        auto cleanup = defer([&] {
+        auto cleanup = defer([&] noexcept {
+            // Can in fact throw, will terminate test
             e.execute_cql("DROP TABLE ks.tbl").get();
             e.execute_cql("DROP TYPE ks.mytype").get();
         });

--- a/test/boost/cql_auth_query_test.cc
+++ b/test/boost/cql_auth_query_test.cc
@@ -69,7 +69,7 @@ static void with_user(cql_test_env& env, std::string_view user_name, noncopyable
     create_user_if_not_exists(env, user_name);
     cs.set_login(auth::authenticated_user(sstring(user_name)));
 
-    const auto reset = defer([&cs, old_user = std::move(old_user)] mutable {
+    const auto reset = defer([&cs, old_user = std::move(old_user)] mutable noexcept {
         cs.set_login(std::move(*old_user));
     });
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5414,7 +5414,10 @@ SEASTAR_TEST_CASE(timeuuid_fcts_prepared_re_evaluation) {
         for (const auto& t : sub_tests) {
             BOOST_TEST_CHECKPOINT(t.first);
             e.execute_cql(seastar::format("CREATE TABLE test_{} (pk {} PRIMARY KEY)", t.first, t.second)).get();
-            auto drop_test_table = defer([&e, &t] { e.execute_cql(seastar::format("DROP TABLE test_{}", t.first)).get(); });
+            auto drop_test_table = defer([&e, &t] noexcept {
+                // May throw; will terminate test
+                e.execute_cql(seastar::format("DROP TABLE test_{}", t.first)).get();
+            });
             auto insert_stmt = e.prepare(seastar::format("INSERT INTO test_{0} (pk) VALUES ({0}())", t.first)).get();
             e.execute_prepared(insert_stmt, {}).get();
             sleep(1ms).get();

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1270,7 +1270,7 @@ SEASTAR_THREAD_TEST_CASE(reader_concurrency_semaphore_selection_test) {
     cql_test_config cfg;
 
     scheduling_group unknown_scheduling_group = create_scheduling_group("unknown", 800).get();
-    auto cleanup_unknown_scheduling_group = defer([&unknown_scheduling_group] {
+    auto cleanup_unknown_scheduling_group = defer([&unknown_scheduling_group] noexcept {
         destroy_scheduling_group(unknown_scheduling_group).get();
     });
 
@@ -1316,7 +1316,7 @@ SEASTAR_THREAD_TEST_CASE(max_result_size_for_query_selection_test) {
     cfg.db_config->max_memory_for_unlimited_query_hard_limit(2 * 1024 * 1024, utils::config_file::config_source::CommandLine);
 
     scheduling_group unknown_scheduling_group = create_scheduling_group("unknown", 800).get();
-    auto cleanup_unknown_scheduling_group = defer([&unknown_scheduling_group] {
+    auto cleanup_unknown_scheduling_group = defer([&unknown_scheduling_group] noexcept {
         destroy_scheduling_group(unknown_scheduling_group).get();
     });
 
@@ -1371,7 +1371,7 @@ SEASTAR_THREAD_TEST_CASE(max_result_size_for_query_selection_test) {
 SEASTAR_TEST_CASE(multipage_range_scan_semaphore_mismatch) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         const auto do_abort = set_abort_on_internal_error(false);
-        auto reset_abort = defer([do_abort] {
+        auto reset_abort = defer([do_abort] noexcept {
             set_abort_on_internal_error(do_abort);
         });
         e.execute_cql("CREATE TABLE ks.tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck));").get();

--- a/test/boost/disk_space_monitor_test.cc
+++ b/test/boost/disk_space_monitor_test.cc
@@ -33,7 +33,7 @@ SEASTAR_THREAD_TEST_CASE(test_capacity_override) {
     auto data_dir_path = data_dir.path().string();
 
     utils::disk_space_monitor dsm(as, data_dir_path, dsm_cfg);
-    auto stop_dsm = defer([&dsm] { dsm.stop().get(); });
+    auto stop_dsm = defer([&dsm] noexcept { dsm.stop().get(); });
 
     std::filesystem::space_info orig_space = {
         .capacity = 100,
@@ -98,7 +98,7 @@ SEASTAR_THREAD_TEST_CASE(test_subscription_options) {
     auto data_dir_path = data_dir.path().string();
 
     utils::disk_space_monitor dsm(as, data_dir_path, dsm_cfg);
-    auto stop_dsm = defer([&dsm] { dsm.stop().get(); });
+    auto stop_dsm = defer([&dsm] noexcept { dsm.stop().get(); });
 
     float disk_utilization = 0.1;
     auto registration = dsm.set_space_source([&] {

--- a/test/boost/loading_cache_test.cc
+++ b/test/boost/loading_cache_test.cc
@@ -193,7 +193,7 @@ SEASTAR_TEST_CASE(test_loading_cache_disable_and_enable) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring, 1, utils::loading_cache_reload_enabled::yes> loading_cache({num_loaders, 1h, 50ms}, testlog, loader.get());
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         loading_cache.get(0).discard_result().get();
         loading_cache.get(0).discard_result().get();
@@ -223,7 +223,7 @@ SEASTAR_TEST_CASE(test_loading_cache_reset) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring> loading_cache(num_loaders, 1h, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         for (int i = 0; i < num_loaders; ++i) {
             loading_cache.get_ptr(i, loader.get()).discard_result().get();
@@ -242,7 +242,7 @@ SEASTAR_TEST_CASE(test_loading_cache_update_config) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring, 1, utils::loading_cache_reload_enabled::yes> loading_cache({num_loaders, 1h, 1h}, testlog, loader.get());
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         for (int i = 0; i < num_loaders; ++i) {
             loading_cache.get_ptr(i, loader.get()).discard_result().get();
@@ -268,7 +268,7 @@ SEASTAR_TEST_CASE(test_loading_cache_loading_same_key) {
         std::vector<int> ivec(num_loaders);
         loader loader;
         loading_cache_for_test<int, sstring> loading_cache(num_loaders, 1s, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         std::fill(ivec.begin(), ivec.end(), 0);
 
@@ -286,7 +286,7 @@ SEASTAR_THREAD_TEST_CASE(test_loading_cache_removing_key) {
     using namespace std::chrono;
     loader loader;
     loading_cache_for_test<int, sstring> loading_cache(num_loaders, 100s, testlog);
-    auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+    auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
     loading_cache.get_ptr(0, loader.get()).discard_result().get();
     BOOST_REQUIRE_EQUAL(loader.load_count(), 1);
@@ -302,7 +302,7 @@ SEASTAR_TEST_CASE(test_loading_cache_loading_different_keys) {
         std::vector<int> ivec(num_loaders);
         loader loader;
         loading_cache_for_test<int, sstring> loading_cache(num_loaders, 1h, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         std::iota(ivec.begin(), ivec.end(), 0);
 
@@ -320,7 +320,7 @@ SEASTAR_TEST_CASE(test_loading_cache_loading_expiry_eviction) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring, 1> loading_cache(num_loaders, 20ms, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         loading_cache.get_ptr(0, loader.get()).discard_result().get();
 
@@ -343,7 +343,7 @@ SEASTAR_TEST_CASE(test_loading_cache_loading_expiry_reset_on_sync_op) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring> loading_cache(num_loaders, 30ms, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         loading_cache.get_ptr(0, loader.get()).discard_result().get();
         auto vp = loading_cache.find(0);
@@ -375,7 +375,7 @@ SEASTAR_TEST_CASE(test_loading_cache_move_item_to_mru_list_front_on_sync_op) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring> loading_cache(2, 1h, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         for (int i = 0; i < 2; ++i) {
             loading_cache.get_ptr(i, loader.get()).discard_result().get();
@@ -400,7 +400,7 @@ SEASTAR_TEST_CASE(test_loading_cache_loading_reloading_privileged_gen) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring, 1, utils::loading_cache_reload_enabled::yes> loading_cache({num_loaders, 100ms, 20ms}, testlog, loader.get());
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
         // Push the entry into the privileged section. Make sure it's being reloaded.
         loading_cache.get_ptr(0).discard_result().get();
         loading_cache.get_ptr(0).discard_result().get();
@@ -414,7 +414,7 @@ SEASTAR_TEST_CASE(test_loading_cache_loading_reloading_unprivileged) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring, 1, utils::loading_cache_reload_enabled::yes> loading_cache({num_loaders, 100ms, 20ms}, testlog, loader.get());
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
         // Load one entry into the unprivileged section.
         // Make sure it's reloaded.
         loading_cache.get_ptr(0).discard_result().get();
@@ -428,7 +428,7 @@ SEASTAR_TEST_CASE(test_loading_cache_max_size_eviction) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring> loading_cache(1, 1s, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         for (int i = 0; i < num_loaders; ++i) {
             loading_cache.get_ptr(i % 2, loader.get()).discard_result().get();
@@ -444,7 +444,7 @@ SEASTAR_TEST_CASE(test_loading_cache_max_size_eviction_unprivileged_first) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring, 1> loading_cache(4, 1h, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         // Touch the value with the key "-1" twice
         loading_cache.get_ptr(-1, loader.get()).discard_result().get();
@@ -466,7 +466,7 @@ SEASTAR_TEST_CASE(test_loading_cache_eviction_unprivileged) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring, 1> loading_cache(4, 10ms, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         // Touch the value with the key "-1" twice
         loading_cache.get_ptr(-1, loader.get()).discard_result().get();
@@ -498,7 +498,7 @@ SEASTAR_TEST_CASE(test_loading_cache_eviction_unprivileged_minimum_size) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring, 1> loading_cache(50, 1h, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         // Add 49 elements to privileged section
         for (int i = 0; i < 49; i++) {
@@ -536,7 +536,7 @@ SEASTAR_TEST_CASE(test_loading_cache_section_size_correctly_calculated) {
 
         using namespace std::chrono;
         loading_cache_for_test<int, sstring, 1, utils::loading_cache_reload_enabled::no, sstring_length_entry_size> loading_cache(100, 1h, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         BOOST_REQUIRE_EQUAL(loading_cache.privileged_section_memory_footprint(), 0);
         BOOST_REQUIRE_EQUAL(loading_cache.unprivileged_section_memory_footprint(), 0);
@@ -643,7 +643,7 @@ SEASTAR_TEST_CASE(test_loading_cache_reload_during_eviction) {
         using namespace std::chrono;
         loader loader;
         loading_cache_for_test<int, sstring, 0, utils::loading_cache_reload_enabled::yes> loading_cache({1, 100ms, 10ms}, testlog, loader.get());
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         auto curr_time = manual_clock::now();
         int i = 0;
@@ -667,7 +667,7 @@ SEASTAR_THREAD_TEST_CASE(test_loading_cache_remove_leaves_no_old_entries_behind)
 
     {
         loading_cache_for_test<int, sstring> loading_cache(num_loaders, 100s, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
         //
         // Test remove() concurrent with loading
@@ -705,7 +705,7 @@ SEASTAR_THREAD_TEST_CASE(test_loading_cache_remove_leaves_no_old_entries_behind)
     // Test remove_if()
     {
         loading_cache_for_test<int, sstring> loading_cache(num_loaders, 100s, testlog);
-        auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+        auto stop_cache_reload = seastar::defer([&loading_cache] noexcept{ loading_cache.stop().get(); });
 
         //
         // Test remove_if() concurrent with loading
@@ -827,7 +827,7 @@ SEASTAR_THREAD_TEST_CASE(test_loading_cache_insert) {
     using namespace std::chrono;
     loader loader;
     loading_cache_for_test<int, sstring> loading_cache(num_loaders, 1h, testlog);
-    auto stop_cache = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+    auto stop_cache = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
     // insert() must populate the cache and invoke the loader exactly once.
     loading_cache.insert(0, loader.get()).get();
@@ -850,7 +850,7 @@ SEASTAR_THREAD_TEST_CASE(test_loading_cache_insert_caching_disabled) {
     using namespace std::chrono;
     loader loader;
     loading_cache_for_test<int, sstring> loading_cache(num_loaders, 0ms, testlog);
-    auto stop_cache = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
+    auto stop_cache = seastar::defer([&loading_cache] noexcept { loading_cache.stop().get(); });
 
     auto f = loading_cache.insert(0, loader.get());
     loading_cache.insert(0, loader.get()).get();

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -44,7 +44,7 @@ SEASTAR_THREAD_TEST_CASE(test_add_node) {
     auto topo = topology(cfg);
 
     set_abort_on_internal_error(false);
-    auto reset_on_internal_abort = seastar::defer([] {
+    auto reset_on_internal_abort = seastar::defer([] noexcept {
         set_abort_on_internal_error(true);
     });
 
@@ -107,7 +107,7 @@ SEASTAR_THREAD_TEST_CASE(test_update_node) {
     auto topo = topology(cfg);
 
     set_abort_on_internal_error(false);
-    auto reset_on_internal_abort = seastar::defer([] {
+    auto reset_on_internal_abort = seastar::defer([] noexcept {
         set_abort_on_internal_error(true);
     });
 
@@ -329,7 +329,7 @@ SEASTAR_THREAD_TEST_CASE(test_left_node_is_kept_outside_dc) {
     auto topo = topology(cfg);
 
     set_abort_on_internal_error(false);
-    auto reset_on_internal_abort = seastar::defer([] {
+    auto reset_on_internal_abort = seastar::defer([] noexcept {
         set_abort_on_internal_error(true);
     });
 

--- a/test/boost/logalloc_test.cc
+++ b/test/boost/logalloc_test.cc
@@ -139,7 +139,7 @@ SEASTAR_TEST_CASE(test_compaction_with_multiple_regions) {
         std::vector<managed_ref<int>> allocated1;
         std::vector<managed_ref<int>> allocated2;
 
-        auto clear_vectors = defer([&] {
+        auto clear_vectors = defer([&] noexcept {
             with_allocator(reg1.allocator(), [&] {
                 allocated1.clear();
             });
@@ -554,7 +554,7 @@ SEASTAR_THREAD_TEST_CASE(test_hold_reserve) {
 
             // Fill the entire available memory with LSA objects.
             list entries;
-            auto clean_up = defer([&entries] {
+            auto clean_up = defer([&entries] noexcept {
                 entries.clear_and_dispose([] (entry *e) {current_allocator().destroy(e);});
             });
             auto alloc_entry = [] () {

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -99,7 +99,7 @@ static future<> test_memtable(void (*run_tests)(populate_fn_ex, bool)) {
                 readers.clear();
             }).get();
         };
-        auto cleanup_readers = defer([&] { clear_readers(); });
+        auto cleanup_readers = defer([&] noexcept { clear_readers(); });
         std::deque<dht::partition_range> ranges_storage;
         lw_shared_ptr<bool> finished = make_lw_shared(false);
         auto full_compaction_in_background = seastar::do_until([finished] {return *finished;}, [] {
@@ -518,7 +518,7 @@ SEASTAR_TEST_CASE(test_exception_safety_of_flush_reads) {
 
         auto mt = make_memtable(s, ms).get();
         memory::with_allocation_failures([&] {
-            auto revert = defer([&] {
+            auto revert = defer([&] noexcept {
                 mt->revert_flushed_memory();
             });
             assert_that(mt->make_flush_reader(s, semaphore.make_permit()))
@@ -561,7 +561,7 @@ SEASTAR_THREAD_TEST_CASE(test_tombstone_compaction_during_flush) {
 
     auto rd1 = mt->make_mutation_reader(ss.schema(), semaphore.make_permit(), pr, s->full_slice(),
                                     nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-    auto close_rd1 = defer([&] { rd1.close().get(); });
+    auto close_rd1 = defer([&] noexcept { rd1.close().get(); });
 
     rd1.fill_buffer().get();
 
@@ -571,14 +571,14 @@ SEASTAR_THREAD_TEST_CASE(test_tombstone_compaction_during_flush) {
 
     auto rd2 = mt->make_mutation_reader(ss.schema(), semaphore.make_permit(), pr, s->full_slice(),
                                     nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-    auto close_rd2 = defer([&] { rd2.close().get(); });
+    auto close_rd2 = defer([&] noexcept { rd2.close().get(); });
 
     rd2.fill_buffer().get();
 
     mt->apply(rt_m); // whatever
 
     auto flush_rd = mt->make_flush_reader(ss.schema(), semaphore.make_permit());
-    auto close_flush_rd = defer([&] { flush_rd.close().get(); });
+    auto close_flush_rd = defer([&] noexcept { flush_rd.close().get(); });
 
     while (!flush_rd.is_end_of_stream()) {
         flush_rd().get();
@@ -638,7 +638,7 @@ SEASTAR_THREAD_TEST_CASE(test_tombstone_merging_with_multiple_versions) {
 
     auto rd1 = mt->make_mutation_reader(s, semaphore.make_permit(), pr, s->full_slice(),
                                     nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-    auto close_rd1 = defer([&] { rd1.close().get(); });
+    auto close_rd1 = defer([&] noexcept { rd1.close().get(); });
 
     rd1.fill_buffer().get();
     BOOST_REQUIRE(!rd1.is_end_of_stream()); // rd1 must keep the m1 version alive
@@ -647,7 +647,7 @@ SEASTAR_THREAD_TEST_CASE(test_tombstone_merging_with_multiple_versions) {
 
     auto rd2 = mt->make_mutation_reader(s, semaphore.make_permit(), pr, s->full_slice(),
                                     nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-    auto close_r2 = defer([&] { rd2.close().get(); });
+    auto close_r2 = defer([&] noexcept { rd2.close().get(); });
 
     rd2.fill_buffer().get();
     BOOST_REQUIRE(!rd2.is_end_of_stream()); // rd2 must keep the m1 version alive
@@ -686,7 +686,7 @@ SEASTAR_THREAD_TEST_CASE(test_tombstone_merging_with_mvcc_and_preemption) {
     std::optional<mutation_reader> rd0 = mt->make_mutation_reader(
             s, semaphore.make_permit(), pr, s->full_slice(),
             nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-    auto close_rd0 = defer([&] { rd0->close().get(); });
+    auto close_rd0 = defer([&] noexcept { rd0->close().get(); });
     rd0->fill_buffer().get();
     BOOST_REQUIRE(!rd0->is_end_of_stream());
 
@@ -700,7 +700,7 @@ SEASTAR_THREAD_TEST_CASE(test_tombstone_merging_with_mvcc_and_preemption) {
     std::optional<mutation_reader> rd1 = mt->make_mutation_reader(
             s, semaphore.make_permit(), pr, s->full_slice(),
             nullptr, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-    auto close_rd1 = defer([&] { rd1->close().get(); });
+    auto close_rd1 = defer([&] noexcept { rd1->close().get(); });
     rd1->fill_buffer().get();
     BOOST_REQUIRE(!rd1->is_end_of_stream());
 

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -2959,7 +2959,7 @@ void check_evictable_reader_validation_is_triggered(
 
 SEASTAR_THREAD_TEST_CASE(test_evictable_reader_self_validation) {
     set_abort_on_internal_error(false);
-    auto reset_on_internal_abort = defer([] {
+    auto reset_on_internal_abort = defer([] noexcept {
         set_abort_on_internal_error(true);
     });
 
@@ -4330,7 +4330,7 @@ SEASTAR_TEST_CASE(test_multishard_reader_safe_to_create_with_admitted_permit) {
                         1 * 1024 * 1024));
             });
         }).get();
-        auto stop_semaphores = defer([&semaphores] {
+        auto stop_semaphores = defer([&semaphores] noexcept {
             parallel_for_each(std::views::iota(0u, this_smp_shard_count()), [&semaphores] (shard_id shard) {
                 return smp::submit_to(shard, [&semaphores] () -> future<> {
                     auto semaphore = semaphores[this_shard_id()].release();

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1199,7 +1199,8 @@ SEASTAR_TEST_CASE(test_apply_monotonically_is_monotonic) {
             mutation m = target;
             auto m2 = mutation_partition(*m.schema(), second.partition());
             memory::with_allocation_failures([&] {
-                auto d = defer([&] {
+                auto d = defer([&] noexcept {
+                    // Might actually throw, will abort the test.
                     auto&& s = *gen.schema();
                     auto c1 = m.partition().get_continuity(s);
                     auto c2 = m2.get_continuity(s);
@@ -1306,15 +1307,16 @@ SEASTAR_TEST_CASE(test_v2_apply_monotonically_is_monotonic_on_alloc_failures) {
             auto m = mutation_partition_v2(s, target.partition());
             auto m2 = mutation_partition_v2(s, second.partition());
             memory::with_allocation_failures([&] {
-                auto reset_m = defer([&] {
+                auto reset_m = defer([&] noexcept {
                     m = mutation_partition_v2(s, target.partition());
                     m2 = mutation_partition_v2(s, second.partition());
                 });
-                auto check = defer([&] {
+                auto check = defer([&] noexcept {
                     m.apply(s, std::move(m2));
                     assert_that(target.schema(), m).is_equal_to_compacted(expected.partition());
                 });
-                auto continuity_check = defer([&] {
+                auto continuity_check = defer([&] noexcept {
+                    // Might actually throw, will abort the test.
                     auto c1 = m.get_continuity(s);
                     auto c2 = m2.get_continuity(s);
                     clustering_interval_set actual;
@@ -2445,7 +2447,7 @@ SEASTAR_TEST_CASE(test_v2_merging_in_evictable_snapshot) {
 
         tracker.insert(m1_v2);
         tracker.insert(m2_v2);
-        auto drop_entries = defer([&] {
+        auto drop_entries = defer([&] noexcept {
             // Don't let the cleaner free them. He assumes entries are allocated using its region() and they're not.
             clear(tracker, s, m1_v2);
             clear(tracker, s, m2_v2);
@@ -2453,7 +2455,7 @@ SEASTAR_TEST_CASE(test_v2_merging_in_evictable_snapshot) {
 
         auto result_v2 = mutation_partition_v2(s, m1_v2);
         tracker.insert(result_v2);
-        auto clear_result_v2 = defer([&] {
+        auto clear_result_v2 = defer([&] noexcept {
             clear(tracker, s, result_v2);
         });
         apply_resume res;
@@ -3810,7 +3812,7 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_detach_state) {
 
 SEASTAR_THREAD_TEST_CASE(test_compactor_validator) {
     const auto abort_ie = set_abort_on_internal_error(false);
-    auto reset_abort_ie = defer([abort_ie] {
+    auto reset_abort_ie = defer([abort_ie] noexcept {
         set_abort_on_internal_error(abort_ie);
     });
 
@@ -4283,7 +4285,7 @@ SEASTAR_THREAD_TEST_CASE(test_serialized_mutation_empty_and_nonfull_keys) {
         assert_that(fm.unfreeze(schema)).is_equal_to(mut);
     }
 
-    auto reset_abort = defer([abort = set_abort_on_internal_error(false)] {
+    auto reset_abort = defer([abort = set_abort_on_internal_error(false)] noexcept {
         set_abort_on_internal_error(abort);
     });
 
@@ -4329,7 +4331,7 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_empty_and_nonfull_keys) {
 
     testlog.info("Random schema:\n{}", random_schema.cql());
 
-    auto reset_abort = defer([abort = set_abort_on_internal_error(false)] {
+    auto reset_abort = defer([abort = set_abort_on_internal_error(false)] noexcept {
         set_abort_on_internal_error(abort);
     });
 
@@ -4384,7 +4386,7 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_partition_v2_empty_and_nonfull_keys) {
 
     testlog.info("Random schema:\n{}", random_schema.cql());
 
-    auto reset_abort = defer([abort = set_abort_on_internal_error(false)] {
+    auto reset_abort = defer([abort = set_abort_on_internal_error(false)] noexcept {
         set_abort_on_internal_error(abort);
     });
 

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -553,7 +553,7 @@ SEASTAR_THREAD_TEST_CASE(test_partition_based_splitting_mutation_writer) {
     };
     auto check_and_reset = [&] {
         std::vector<mutation_reader> readers;
-        auto close_readers = defer([&] {
+        auto close_readers = defer([&] noexcept {
             for (auto& rd : readers) {
                 rd.close().get();
             }

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -271,7 +271,7 @@ void simple_test() {
     cfg.broadcast_address = my_address;
     sharded<snitch_ptr> snitch;
     snitch.start(cfg).get();
-    auto stop_snitch = defer([&snitch] { snitch.stop().get(); });
+    auto stop_snitch = defer([&snitch] noexcept { snitch.stop().get(); });
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
     locator::token_metadata::config tm_cfg;
@@ -357,7 +357,7 @@ void heavy_origin_test() {
     cfg.broadcast_address = my_address;
     sharded<snitch_ptr> snitch;
     snitch.start(cfg).get();
-    auto stop_snitch = defer([&snitch] { snitch.stop().get(); });
+    auto stop_snitch = defer([&snitch] noexcept { snitch.stop().get(); });
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
     locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); },
@@ -441,7 +441,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
     cfg.name = "RackInferringSnitch";
     sharded<snitch_ptr> snitch;
     snitch.start(cfg).get();
-    auto stop_snitch = defer([&snitch] { snitch.stop().get(); });
+    auto stop_snitch = defer([&snitch] noexcept { snitch.stop().get(); });
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
     locator::token_metadata::config tm_cfg;
@@ -653,7 +653,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablet_allocation_balancing_tes
     cfg.name = "RackInferringSnitch";
     sharded<snitch_ptr> snitch;
     snitch.start(cfg).get();
-    auto stop_snitch = defer([&snitch] { snitch.stop().get(); });
+    auto stop_snitch = defer([&snitch] noexcept { snitch.stop().get(); });
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
     for (auto i = 0; i < 100; ++i) {
@@ -1386,7 +1386,7 @@ SEASTAR_THREAD_TEST_CASE(tablets_simple_rack_aware_view_pairing_test) {
     cfg.name = "RackInferringSnitch";
     sharded<snitch_ptr> snitch;
     snitch.start(cfg).get();
-    auto stop_snitch = defer([&snitch] { snitch.stop().get(); });
+    auto stop_snitch = defer([&snitch] noexcept { snitch.stop().get(); });
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
     locator::token_metadata::config tm_cfg;

--- a/test/boost/querier_cache_test.cc
+++ b/test/boost/querier_cache_test.cc
@@ -788,7 +788,7 @@ SEASTAR_THREAD_TEST_CASE(test_unique_inactive_read_handle) {
     BOOST_REQUIRE(!sem1.unregister_inactive_read(reader_concurrency_semaphore::inactive_read_handle{}));
 
     set_abort_on_internal_error(false);
-    auto reset_on_internal_abort = defer([] {
+    auto reset_on_internal_abort = defer([] noexcept {
         set_abort_on_internal_error(true);
     });
     BOOST_REQUIRE_THROW(sem1.unregister_inactive_read(std::move(sem2_h1)), std::runtime_error);
@@ -832,7 +832,7 @@ SEASTAR_THREAD_TEST_CASE(test_semaphore_mismatch) {
     // Other semaphore, other is not a "user" semaphore
     {
         bool abort = set_abort_on_internal_error(false);
-        auto reset_abort = defer([abort] {
+        auto reset_abort = defer([abort] noexcept {
             set_abort_on_internal_error(abort);
         });
         is_user_semaphore = false;

--- a/test/boost/range_tombstone_list_test.cc
+++ b/test/boost/range_tombstone_list_test.cc
@@ -898,7 +898,8 @@ BOOST_AUTO_TEST_CASE(test_exception_safety) {
     // test apply_monotonically()
     memory::with_allocation_failures([&] () {
         auto list = original;
-        auto d = defer([&] {
+        auto d = defer([&] noexcept {
+            // May throw, aborting the test
             memory::scoped_critical_alloc_section dfg;
             assert_that(*s, list).has_no_less_information_than(original);
         });
@@ -909,7 +910,8 @@ BOOST_AUTO_TEST_CASE(test_exception_safety) {
     // test apply_reversibly()
     memory::with_allocation_failures([&] () {
         auto list = original;
-        auto d = defer([&] () {
+        auto d = defer([&] noexcept {
+            // May throw, aborting the test
             memory::scoped_critical_alloc_section dfg;
             assert_that(*s, list).is_equal_to_either(original, expected);
         });

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -57,7 +57,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_clear_inactive_reads)
     {
         reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::no_limits{}, get_name(), reader_concurrency_semaphore::register_metrics::no);
         auto stop_sem = deferred_stop(semaphore);
-        auto clear_permits = defer([&permits] { permits.clear(); });
+        auto clear_permits = defer([&permits] noexcept { permits.clear(); });
 
         for (int i = 0; i < 10; ++i) {
             permits.emplace_back(semaphore.make_tracking_only_permit(s.schema(), get_name(), db::no_timeout, {}));
@@ -1400,9 +1400,9 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_shared_pool) {
     auto stop_sem = deferred_stop(sem_group);
 
     auto sg1 = create_scheduling_group("test_sg1", 1000).get();
-    auto destroy_sg1 = defer([&] { destroy_scheduling_group(sg1).get(); });
+    auto destroy_sg1 = defer([&] noexcept { destroy_scheduling_group(sg1).get(); });
     auto sg2 = create_scheduling_group("test_sg2", 1000).get();
-    auto destroy_sg2 = defer([&] { destroy_scheduling_group(sg2).get(); });
+    auto destroy_sg2 = defer([&] noexcept { destroy_scheduling_group(sg2).get(); });
 
     sem_group.add_or_update(sg1, 1000);
     sem_group.add_or_update(sg2, 1000);
@@ -1462,9 +1462,9 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_multiple_borrow
     auto stop_sem = deferred_stop(sem_group);
 
     auto sg1 = create_scheduling_group("test_sg1", 1000).get();
-    auto destroy_sg1 = defer([&] { destroy_scheduling_group(sg1).get(); });
+    auto destroy_sg1 = defer([&] noexcept { destroy_scheduling_group(sg1).get(); });
     auto sg2 = create_scheduling_group("test_sg2", 1000).get();
-    auto destroy_sg2 = defer([&] { destroy_scheduling_group(sg2).get(); });
+    auto destroy_sg2 = defer([&] noexcept { destroy_scheduling_group(sg2).get(); });
 
     sem_group.add_or_update(sg1, 1000);
     sem_group.add_or_update(sg2, 1000);
@@ -1738,7 +1738,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_shared_pool_wakes_mul
     // teardown does both in order, regardless of how the test exits.
     std::vector<reader_permit_opt> actives;
     std::vector<reader_permit_opt> admitted;
-    auto teardown = defer([&] {
+    auto teardown = defer([&] noexcept {
         actives.clear();
         admitted.clear();
         for (auto& sem : sems) {
@@ -1794,7 +1794,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_zero_shared_poo
     auto stop_sem = deferred_stop(sem_group);
 
     auto sg = create_scheduling_group("test_sg", 1000).get();
-    auto destroy_sg = defer([&] { destroy_scheduling_group(sg).get(); });
+    auto destroy_sg = defer([&] noexcept { destroy_scheduling_group(sg).get(); });
 
     sem_group.add_or_update(sg, 1000);
     sem_group.wait_adjust_complete().get();
@@ -1824,9 +1824,9 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_shared_pool_liv
     auto stop_sem = deferred_stop(sem_group);
 
     auto sg1 = create_scheduling_group("test_sg1", 1000).get();
-    auto destroy_sg1 = defer([&] { destroy_scheduling_group(sg1).get(); });
+    auto destroy_sg1 = defer([&] noexcept { destroy_scheduling_group(sg1).get(); });
     auto sg2 = create_scheduling_group("test_sg2", 1000).get();
-    auto destroy_sg2 = defer([&] { destroy_scheduling_group(sg2).get(); });
+    auto destroy_sg2 = defer([&] noexcept { destroy_scheduling_group(sg2).get(); });
 
     sem_group.add_or_update(sg1, 1000);
     sem_group.add_or_update(sg2, 1000);

--- a/test/boost/replicator_test.cc
+++ b/test/boost/replicator_test.cc
@@ -78,10 +78,10 @@ SEASTAR_THREAD_TEST_CASE(replicator_model) {
 
     seastar::sharded<map_container> c;
     c.start().get();
-    auto stop_c = seastar::defer([&c] { c.stop().get(); });
+    auto stop_c = seastar::defer([&c] noexcept { c.stop().get(); });
 
     replicator<map_type, map_container> r(c.local());
-    auto stop_r = seastar::defer([&r] { r.stop().get(); });
+    auto stop_r = seastar::defer([&r] noexcept { r.stop().get(); });
 
     r.apply_to_all(key_setter{2, 29});
     seastar::thread::yield();
@@ -116,7 +116,7 @@ SEASTAR_THREAD_TEST_CASE(replicator_stress) {
 
     seastar::sharded<map_container> c;
     c.start().get();
-    auto stop_c = seastar::defer([&c] { c.stop().get(); });
+    auto stop_c = seastar::defer([&c] noexcept { c.stop().get(); });
 
     c.invoke_on_all([] (map_container& con) {
         con._on_apply = [] {
@@ -127,7 +127,7 @@ SEASTAR_THREAD_TEST_CASE(replicator_stress) {
     }).get();
 
     replicator<map_type, map_container> r(c.local());
-    auto stop_r = seastar::defer([&r] { r.stop().get(); });
+    auto stop_r = seastar::defer([&r] noexcept { r.stop().get(); });
 
     for (int i = 0; i < 1000; ++i) {
         try {

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -1686,7 +1686,7 @@ SEASTAR_TEST_CASE(test_mvcc) {
             auto m12 = m1 + m2;
 
             mutation_reader_opt mt1_reader_opt;
-            auto close_mt1_reader = defer([&mt1_reader_opt] {
+            auto close_mt1_reader = defer([&mt1_reader_opt] noexcept {
                 if (mt1_reader_opt) {
                     mt1_reader_opt->close().get();
                 }
@@ -2650,13 +2650,14 @@ SEASTAR_TEST_CASE(test_exception_safety_of_update_from_memtable) {
             }
             auto rd1_v1 = assert_that(make_reader(population_range));
             mutation_reader_opt snap;
-            auto close_snap = defer([&snap] {
+            auto close_snap = defer([&snap] noexcept {
                 if (snap) {
                     snap->close().get();
                 }
             });
 
-            auto d = defer([&] {
+            auto d = defer([&] noexcept {
+                // May throw; will terminate the test.
                 memory::scoped_critical_alloc_section dfg;
                 assert_that(cache.make_reader(cache.schema(), semaphore.make_permit()))
                     .produces(orig)
@@ -3658,7 +3659,7 @@ SEASTAR_TEST_CASE(test_alter_then_preempted_update_then_memtable_read) {
         auto update_f = cache.update(row_cache::external_updater([&] () noexcept {
             underlying.apply(m2);
         }), *mt2);
-        auto wait_for_update = defer([&] { update_f.get(); });
+        auto wait_for_update = defer([&] noexcept { update_f.get(); });
 
         // Wait for cache update to enter the partition
         while (tracker.get_stats().partition_merges == 0) {

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -471,7 +471,8 @@ SEASTAR_TEST_CASE(test_notifications) {
         return seastar::async([&] {
             counting_migration_listener listener;
             e.local_mnotifier().register_listener(&listener);
-            auto listener_lease = defer([&e, &listener] { e.local_mnotifier().register_listener(&listener); });
+            // May throw, but zero probability in a test
+            auto listener_lease = defer([&e, &listener] noexcept { e.local_mnotifier().register_listener(&listener); });
 
             e.execute_cql("create keyspace tests with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };").get();
 

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -112,7 +112,7 @@ SEASTAR_THREAD_TEST_CASE(subscriber_simple) {
     auto stop_tm = deferred_stop(tm);
     sharded<abort_source> as;
     as.start().get();
-    auto stop_as = defer([&as] { as.stop().get(); });
+    auto stop_as = defer([&as] noexcept { as.stop().get(); });
     sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, scheduling_supergroup(), default_scheduling_group).get();
     qos_configuration_change_suscriber_simple ccss;
     sl_controller.local().register_subscriber(&ccss);
@@ -180,7 +180,7 @@ SEASTAR_THREAD_TEST_CASE(too_many_service_levels) {
     auto stop_tm = deferred_stop(tm);
     sharded<abort_source> as;
     as.start().get();
-    auto stop_as = defer([&as] { as.stop().get(); });
+    auto stop_as = defer([&as] noexcept { as.stop().get(); });
     sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, scheduling_supergroup(), default_scheduling_group, true).get();
     sl_controller.local().set_distributed_data_accessor(test_accessor);
     int service_level_id = 0;
@@ -257,7 +257,7 @@ SEASTAR_THREAD_TEST_CASE(add_remove_bad_sequence) {
     auto stop_tm = deferred_stop(tm);
     sharded<abort_source> as;
     as.start().get();
-    auto stop_as = defer([&as] { as.stop().get(); });
+    auto stop_as = defer([&as] noexcept { as.stop().get(); });
     sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, scheduling_supergroup(), default_scheduling_group, true).get();
     service_level_options slo;
     slo.shares.emplace<int32_t>(500);
@@ -285,7 +285,7 @@ SEASTAR_THREAD_TEST_CASE(verify_unset_shares_in_cache_when_service_level_created
     sharded<abort_source> as;
 
     as.start().get();
-    auto stop_as = defer([&as] { as.stop().get(); });
+    auto stop_as = defer([&as] noexcept { as.stop().get(); });
     sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, scheduling_supergroup(), default_scheduling_group).get();
 
     using timeout_duration = typename seastar::lowres_clock::duration;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5668,7 +5668,7 @@ void max_ongoing_compaction_fn(test_env& env) {
     constexpr size_t num_tables = 10;
     std::vector<schema_ptr> schemas;
     std::vector<table_for_tests> tables;
-    auto stop_tables = defer([&tables] {
+    auto stop_tables = defer([&tables] noexcept {
         for (auto& t : tables) {
             t->stop().get();
         }
@@ -5976,7 +5976,7 @@ void basic_ics_controller_correctness_fn(test_env& env) {
     auto backlog = [&env] (compaction::compaction_backlog_tracker backlog_tracker, uint64_t max_fragment_size) {
             auto schema = table_for_tests::make_default_schema();
         table_for_tests cf = env.make_table_for_tests(schema);
-        auto stop_cf = defer([&] { cf.stop().get(); });
+        auto stop_cf = defer([&] noexcept { cf.stop().get(); });
 
         uint64_t current_sstable_size = default_fragment_size;
         uint64_t data_set_size = 0;
@@ -6105,7 +6105,7 @@ future<> run_controller_test(compaction::compaction_strategy_type compaction_str
             .available_memory = available_memory,
         };
         auto manager = compaction::compaction_manager(std::move(cfg), as, task_manager);
-        auto stop_manager = defer([&] {
+        auto stop_manager = defer([&] noexcept {
             if (manager.is_running()) {
                 manager.stop().get();
             } else {

--- a/test/boost/sstable_compressor_factory_test.cc
+++ b/test/boost/sstable_compressor_factory_test.cc
@@ -34,7 +34,7 @@ void test_one_numa_topology(std::span<unsigned> shard_to_numa_mapping) {
     };
     sharded<default_sstable_compressor_factory> sstable_compressor_factory;
     sstable_compressor_factory.start(std::cref(config)).get();
-    auto stop_compressor_factory = defer([&sstable_compressor_factory] { sstable_compressor_factory.stop().get(); });
+    auto stop_compressor_factory = defer([&sstable_compressor_factory] noexcept { sstable_compressor_factory.stop().get(); });
 
     // The factory keeps recommended dicts (i.e. dicts for writing) per table ID.
     auto table = table_id::create_random_id();

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -294,7 +294,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reversing_reader_random_schema) {
                     auto r1 = source.make_mutation_reader(query_schema, semaphore.make_permit(), prange,
                             slice, nullptr,
                             streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-                    auto close_r1 = deferred_action([&r1] { r1.close().get(); });
+                    auto close_r1 = deferred_action([&r1] noexcept { r1.close().get(); });
 
                     auto r2 = rev_source.make_mutation_reader(query_schema, semaphore.make_permit(), prange,
                             rev_slice, nullptr,
@@ -307,7 +307,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reversing_reader_random_schema) {
                 auto r1 = source.make_mutation_reader(query_schema, semaphore.make_permit(), prange,
                         query_schema->full_slice(), nullptr,
                         streamed_mutation::forwarding::yes, mutation_reader::forwarding::no);
-                auto close_r1 = deferred_action([&r1] { r1.close().get(); });
+                auto close_r1 = deferred_action([&r1] noexcept { r1.close().get(); });
 
                 auto r2 = rev_source.make_mutation_reader(query_schema, semaphore.make_permit(), prange,
                         rev_full_slice, nullptr,

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2681,7 +2681,7 @@ SEASTAR_TEST_CASE(test_missing_partition_end_fragment) {
         auto pkeys = ss.make_pkeys(2);
 
         set_abort_on_internal_error(false);
-        auto enable_aborts = defer([] { set_abort_on_internal_error(true); }); // FIXME: restore to previous value
+        auto enable_aborts = defer([] noexcept { set_abort_on_internal_error(true); }); // FIXME: restore to previous value
 
         for (const auto version : writable_sstable_versions) {
             testlog.info("version={}", version);
@@ -2857,7 +2857,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                 BOOST_REQUIRE(res.has_digest);
 
                 auto sst_file = open_file_dma(test(sst).filename(sstables::component_type::Data).native(), open_flags::wo).get();
-                auto close_sst_file = defer([&sst_file] { sst_file.close().get(); });
+                auto close_sst_file = defer([&sst_file] noexcept { sst_file.close().get(); });
 
                 testlog.info("Validating digest-corrupted {}", sst->get_filename());
                 auto valid_digest = sst->read_digest().get();
@@ -2924,7 +2924,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                     testlog.info("Validating pre-load minor truncation (last byte removed) on {}", sst->get_filename());
 
                     auto sst_file = open_file_dma(test(sst).filename(sstables::component_type::Data).native(), open_flags::wo).get();
-                    auto close_sst_file = defer([&sst_file] { sst_file.close().get(); });
+                    auto close_sst_file = defer([&sst_file] noexcept { sst_file.close().get(); });
                     sst_file.truncate(sst_file.size().get() - 1).get();
 
                     sst->load(sst->get_schema()->get_sharder()).get();
@@ -2940,7 +2940,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                     testlog.info("Validating pre-load major truncation (half of data removed) on {}", sst->get_filename());
 
                     auto sst_file = open_file_dma(test(sst).filename(sstables::component_type::Data).native(), open_flags::wo).get();
-                    auto close_sst_file = defer([&sst_file] { sst_file.close().get(); });
+                    auto close_sst_file = defer([&sst_file] noexcept { sst_file.close().get(); });
                     sst_file.truncate(sst_file.size().get() / 2).get();
 
                     sst->load(sst->get_schema()->get_sharder()).get();
@@ -2956,7 +2956,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                     testlog.info("Validating appended {}", sst->get_filename());
 
                     auto sst_file = open_file_dma(test(sst).filename(sstables::component_type::Data).native(), open_flags::rw).get();
-                    auto close_sst_file = defer([&sst_file] { sst_file.close().get(); });
+                    auto close_sst_file = defer([&sst_file] noexcept { sst_file.close().get(); });
                     auto buf = temporary_buffer<char>::aligned(sst_file.disk_write_dma_alignment(), 2 * 64 * 1024);
                     std::fill(buf.get_write(), buf.get_write() + buf.size(), 0xba);
                     auto fsize = sst_file.size().get();

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -135,7 +135,7 @@ static void with_sstable_directory(
     testlog.debug("with_sstable_directory: {}/{}", path, state);
 
     sharded<sstable_directory> sstdir;
-    auto stop_sstdir = defer([&sstdir] {
+    auto stop_sstdir = defer([&sstdir] noexcept {
         // The func is allowed to stop sstdir, and some tests actually do it
         if (sstdir.local_is_initialized()) {
             sstdir.stop().get();
@@ -162,7 +162,7 @@ static void with_sstable_directory(sharded<replica::database>& db,
     sharded<sstable_directory> sstdir;
     auto gtable = replica::get_table_on_all_shards(db, ks, cf).get();
     sstdir.start(gtable.as_sharded_parameter(), state, default_io_error_handler_gen()).get();
-    auto stop_sstdir = defer([&sstdir] { sstdir.stop().get(); });
+    auto stop_sstdir = defer([&sstdir] noexcept { sstdir.stop().get(); });
     func(sstdir);
 }
 

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -38,7 +38,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
 
     auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     auto env = test_env({}, *scf);
-    auto stop_env = defer([&env] { env.stop().get(); });
+    auto stop_env = defer([&env] noexcept { env.stop().get(); });
 
     sstables::sstable_generation_generator gen_generator;
     auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), sstables::generation_type(1));
@@ -64,7 +64,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_idempotent) {
 
     auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     auto env = test_env({}, *scf);
-    auto stop_env = defer([&env] { env.stop().get(); });
+    auto stop_env = defer([&env] noexcept { env.stop().get(); });
 
     auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), sstables::generation_type(1));
     sstring old_path = sst->get_storage().prefix();
@@ -108,7 +108,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_replay) {
     tmpdir tmp;
     auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     auto env = test_env({}, *scf);
-    auto stop_env = defer([&env] { env.stop().get(); });
+    auto stop_env = defer([&env] noexcept { env.stop().get(); });
 
     sstables::sstable_generation_generator gen_generator;
     auto [ sst, cur_dir ] = copy_sst_to_tmpdir(tmp.path(), env, uncompressed_schema(), fs::path(uncompressed_dir()), sstables::generation_type(1));
@@ -131,7 +131,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_exists_failure) {
 
     auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     auto env = test_env({}, *scf);
-    auto stop_env = defer([&env] { env.stop().get(); });
+    auto stop_env = defer([&env] noexcept { env.stop().get(); });
     sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
 
     // please note, the SSTables used by this test are stored under
@@ -151,7 +151,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_exists_failure) {
 SEASTAR_THREAD_TEST_CASE(test_sstable_clone_preserves_staging_state) {
     auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     test_env env({}, *scf);
-    auto stop_env = defer([&env] { env.stop().get(); });
+    auto stop_env = defer([&env] noexcept { env.stop().get(); });
 
     simple_schema ss;
     auto schema = ss.schema();

--- a/test/boost/sstable_partition_index_cache_test.cc
+++ b/test/boost/sstable_partition_index_cache_test.cc
@@ -44,7 +44,7 @@ static void add_entry(logalloc::region& r,
 
 static partition_index_page make_page0(logalloc::region& r, simple_schema& s) {
     partition_index_page page;
-    auto destroy_page = defer([&] {
+    auto destroy_page = defer([&] noexcept {
         with_allocator(r.allocator(), [&] {
            auto p = std::move(page);
         });
@@ -156,7 +156,7 @@ SEASTAR_THREAD_TEST_CASE(test_sparse_promoted_index) {
 
     auto page0_loader = [&] (partition_index_cache::key_type k) -> future<partition_index_page> {
         partition_index_page page;
-        auto destroy_page = defer([&] {
+        auto destroy_page = defer([&] noexcept {
             with_allocator(r.allocator(), [&] {
                 auto p = std::move(page);
             });
@@ -218,7 +218,7 @@ SEASTAR_THREAD_TEST_CASE(test_exception_while_loading) {
     partition_index_cache_stats stats;
     partition_index_cache cache(lru, r, stats);
 
-    auto clear_lru = defer([&] {
+    auto clear_lru = defer([&] noexcept {
         with_allocator(r.allocator(), [&] {
             lru.evict_all();
         });

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -4147,7 +4147,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_shuffle_mode) {
     BOOST_REQUIRE(e.get_tablet_allocator().local().balance_tablets(stm.get(), nullptr, nullptr, topo.get_load_stats()).get().empty());
 
     utils::get_local_injector().enable("tablet_allocator_shuffle");
-    auto disable_injection = seastar::defer([&] {
+    auto disable_injection = seastar::defer([&] noexcept {
         utils::get_local_injector().disable("tablet_allocator_shuffle");
     });
 
@@ -6315,7 +6315,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
     cfg.name = "RackInferringSnitch";
     sharded<snitch_ptr> snitch;
     snitch.start(cfg).get();
-    auto stop_snitch = defer([&snitch] { snitch.stop().get(); });
+    auto stop_snitch = defer([&snitch] noexcept { snitch.stop().get(); });
     snitch.invoke_on_all(&snitch_ptr::start).get();
 
     static constexpr size_t tablet_count = 8;

--- a/test/boost/test_audit.cc
+++ b/test/boost/test_audit.cc
@@ -38,7 +38,7 @@ SEASTAR_TEST_CASE(test_audit_storage_stop_drains_in_flight_write) {
 
     return do_with_cql_env_thread([] (cql_test_env& env) {
         audit::audit::start_audit(env.db_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).get();
-        auto audit_stop = defer([] {
+        auto audit_stop = defer([] noexcept {
             audit::audit::stop_audit().get();
         });
 
@@ -90,7 +90,7 @@ SEASTAR_TEST_CASE(test_audit_storage_stop_rejects_late_write) {
 
     return do_with_cql_env_thread([] (cql_test_env& env) {
         audit::audit::start_audit(env.db_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).get();
-        auto audit_stop = defer([] {
+        auto audit_stop = defer([] noexcept {
             audit::audit::stop_audit().get();
         });
 
@@ -108,7 +108,7 @@ SEASTAR_TEST_CASE(test_audit_storage_stop_rejects_late_write) {
 
         std::ostringstream captured;
         seastar::logger::set_ostream(captured);
-        auto restore_ostream = defer([] {
+        auto restore_ostream = defer([] noexcept {
             seastar::logger::set_ostream(std::cerr);
         });
 
@@ -137,7 +137,7 @@ SEASTAR_TEST_CASE(test_audit_write_awaits_table_recovery) {
 
     return do_with_cql_env_thread([] (cql_test_env& env) {
         audit::audit::start_audit(env.db_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).get();
-        auto audit_stop = defer([] {
+        auto audit_stop = defer([] noexcept {
             audit::audit::stop_audit().get();
         });
 

--- a/test/boost/tracing_test.cc
+++ b/test/boost/tracing_test.cc
@@ -20,7 +20,7 @@ future<> do_with_tracing_env(std::function<future<>(cql_test_env&)> func, cql_te
     return do_with_cql_env_thread([func](auto &env) {
         sharded<tracing::tracing>& tracing = tracing::tracing::tracing_instance();
         tracing.start(sstring("trace_keyspace_helper")).get();
-        auto stop = defer([&tracing] { tracing.stop().get(); });
+        auto stop = defer([&tracing] noexcept { tracing.stop().get(); });
         tracing.invoke_on_all(&tracing::tracing::start, std::ref(env.qp()), std::ref(env.migration_manager())).get();
         func(env).get();
     }, std::move(cfg_in));

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -1129,7 +1129,7 @@ SEASTAR_TEST_CASE(test_user_function_filtering) {
                 LANGUAGE Lua \
                 AS 'return now - 60000 * ago';").get();
         set_abort_on_internal_error(false);
-        auto reset_on_internal_abort = defer([] {
+        auto reset_on_internal_abort = defer([] noexcept {
             set_abort_on_internal_error(true);
         });
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("SELECT val FROM my_table WHERE key = 'foo' AND t <= toTimestamp(now()) AND t >= minutesAgo(1, toTimestamp(now())) ALLOW FILTERING;").get(),

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -722,7 +722,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_stop_during_process_staging_
         table->add_sstable_and_update_cache(sst).get();
 
         constexpr std::string_view injection = "view_update_generator_pause_before_processing";
-        auto disable_injection = defer([injection] {
+        auto disable_injection = defer([injection] noexcept {
             utils::get_local_injector().disable(injection);
         });
 

--- a/test/ldap/ldap_connection_test.cc
+++ b/test/ldap/ldap_connection_test.cc
@@ -89,7 +89,7 @@ future<ldap_msg_ptr> bind(ldap_connection& conn) {
 void with_ldap_connection(seastar::connected_socket&& socket, std::function<void(ldap_connection&)> f) {
     mylog.trace("with_ldap_connection");
     ldap_connection c(std::move(socket));
-    auto do_close = defer([&] { c.close().get(); });
+    auto do_close = defer([&] noexcept { c.close().get(); });
     mylog.trace("with_ldap_connection: invoking f");
     f(c);
     mylog.trace("with_ldap_connection done");

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -482,14 +482,14 @@ public:
             if (!active.compare_exchange_strong(old_active, true)) {
                 throw std::runtime_error("Starting more than one cql_test_env at a time not supported due to singletons.");
             }
-            auto deactivate = defer([] {
+            auto deactivate = defer([] noexcept {
                 bool old_active = true;
                 auto success = active.compare_exchange_strong(old_active, false);
                 SCYLLA_ASSERT(success);
             });
 
             // FIXME: make the function storage non static
-            auto clear_funcs = defer([] {
+            auto clear_funcs = defer([] noexcept {
                 smp::invoke_on_all([] () {
                     cql3::functions::change_batch batch;
                     batch.clear_functions();
@@ -509,7 +509,7 @@ public:
 
 private:
     static auto defer_verbose_shutdown(const char* what, std::function<void()> func) {
-        return defer([what, func = std::move(func)] {
+        return defer([what, func = std::move(func)] noexcept {
             testlog.info("Shutting down {}", what);
             try {
                 func();
@@ -533,10 +533,10 @@ private:
             sharded<abort_source> abort_sources;
             abort_sources.start().get();
             // FIXME: handle signals (SIGINT, SIGTERM) - request aborts
-            auto stop_abort_sources = defer([&] { abort_sources.stop().get(); });
+            auto stop_abort_sources = defer([&] noexcept { abort_sources.stop().get(); });
 
             debug::the_database = &_db;
-            auto reset_db_ptr = defer([] {
+            auto reset_db_ptr = defer([] noexcept {
                 debug::the_database = nullptr;
             });
             auto cfg = cfg_in.db_config;
@@ -1200,7 +1200,7 @@ private:
                 controller.register_auth_integration(auth_service.local());
             }).get();
 
-            auto unregister_sl_controller_integration = defer([this] {
+            auto unregister_sl_controller_integration = defer([this] noexcept {
                 _sl_controller.invoke_on_all([] (qos::service_level_controller& controller) {
                     return controller.unregister_auth_integration();
                 }).get();

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -188,7 +188,7 @@ public:
         return seastar::async([func = std::move(func)] {
             auto scf = make_sstable_compressor_factory_for_tests_in_thread();
             test_env env({}, *scf);
-            auto stop = defer([&] { env.stop().get(); });
+            auto stop = defer([&] noexcept { env.stop().get(); });
             return func(env);
         });
     }

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -167,7 +167,7 @@ compaction::compaction_group_view& table_for_tests::as_compaction_group_view() n
     return *_data->table_s;
 }
 
-future<> table_for_tests::stop() {
+future<> table_for_tests::stop() noexcept {
     auto data = _data;
     co_await data->cf->get_compaction_manager().remove(*data->table_s);
     co_await data->cf->stop();
@@ -373,10 +373,10 @@ future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, te
         return seastar::async([func = std::move(func), cfg = std::move(cfg), db_cfg = std::move(db_cfg)] () mutable {
             sharded<sstables::storage_manager> sstm;
             sstm.start(std::ref(*db_cfg), sstables::storage_manager::config{}).get();
-            auto stop_sstm = defer([&] { sstm.stop().get(); });
+            auto stop_sstm = defer([&] noexcept { sstm.stop().get(); });
             auto scf = make_sstable_compressor_factory_for_tests_in_thread();
             test_env env(std::move(cfg), *scf, &sstm.local());
-            auto close_env = defer([&] { env.stop().get(); });
+            auto close_env = defer([&] noexcept { env.stop().get(); });
             env.manager().plug_sstables_registry(std::make_unique<mock_sstables_registry>());
             func(env);
         });
@@ -385,7 +385,7 @@ future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, te
     return seastar::async([func = std::move(func), cfg = std::move(cfg)] () mutable {
         auto scf = make_sstable_compressor_factory_for_tests_in_thread();
         test_env env(std::move(cfg), *scf);
-        auto close_env = defer([&] { env.stop().get(); });
+        auto close_env = defer([&] noexcept { env.stop().get(); });
         func(env);
     });
 }
@@ -540,7 +540,7 @@ test_env::do_with_sharded_async(noncopyable_function<void (sharded<test_env>&)> 
         sharded<test_env> env;
         auto scf = make_sstable_compressor_factory_for_tests_in_thread();
         env.start(test_env_config{}, std::ref(*scf), nullptr, &tdir).get();
-        auto stop = defer([&] { env.stop().get(); });
+        auto stop = defer([&] noexcept { env.stop().get(); });
         func(env);
     });
 }
@@ -605,7 +605,7 @@ void test_env_compaction_manager::propagate_replacement(compaction::compaction_g
 // Test version of compaction_manager::perform_compaction<>()
 future<> test_env_compaction_manager::perform_compaction(shared_ptr<compaction::compaction_task_executor> task) {
     _cm._tasks.push_back(*task);
-    auto unregister_task = defer([task] {
+    auto unregister_task = defer([task] noexcept {
         if (!task->is_linked()) {
             testlog.error("compaction_manager_test: deregister_compaction uuid={}: task not found", task->compaction_data().compaction_uuid);
         }
@@ -658,7 +658,7 @@ std::pair<int, char**> scylla_tests_cmdline_options_processor::process_cmdline_o
 
     // Removes -- (intended to separate boost suite args from seastar ones) which confuses boost::program_options.
     auto [new_argc, new_argv] = rebuild_arg_list_without(argc, argv, "--");
-    auto _ = defer([argc = new_argc, argv = new_argv] {
+    auto _ = defer([argc = new_argc, argv = new_argv] noexcept {
         free_arg_list(argc, argv);
     });
 

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -64,7 +64,7 @@ struct table_for_tests {
 
     compaction::compaction_group_view& as_compaction_group_view() noexcept;
 
-    future<> stop();
+    future<> stop() noexcept;
 
     void set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept;
     void set_repair_sstable_classifier(replica::repair_classifier_func repair_sstable_classifier);

--- a/test/manual/bti_cassandra_compatibility_test.cc
+++ b/test/manual/bti_cassandra_compatibility_test.cc
@@ -496,11 +496,11 @@ void do_test(const test_config& cfg) {
             auto partitions_db = open_file_dma(bti_partitions_path.c_str(), open_flags::create | open_flags::wo | open_flags::truncate).get();
             auto partitions_db_stream = make_file_output_stream(partitions_db, file_output_stream_options{}).get();
             auto partitions_db_writer = sstables::file_writer(std::move(partitions_db_stream));
-            auto close_partitions_db = defer([&] () { partitions_db_writer.close(); });
+            auto close_partitions_db = defer([&] () noexcept { partitions_db_writer.close(); });
             auto rows_db = open_file_dma(bti_rows_path.c_str(), open_flags::create | open_flags::wo | open_flags::truncate).get();
             auto rows_db_stream = make_file_output_stream(rows_db, file_output_stream_options{}).get();
             auto rows_db_writer = sstables::file_writer(std::move(rows_db_stream));
-            auto close_rows_db = defer([&] () { rows_db_writer.close(); });
+            auto close_rows_db = defer([&] () noexcept { rows_db_writer.close(); });
 
             // Construct BTI index writers on top of the `file_writer`s.
             auto bti_partition_index_writer = sstables::trie::bti_partition_index_writer(bti_version, partitions_db_writer);

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -71,20 +71,20 @@ int main(int ac, char ** av) {
             topo_sm.start().get();
 
             abort_sources.start().get();
-            auto stop_abort_source = defer([&] { abort_sources.stop().get(); });
+            auto stop_abort_source = defer([&] noexcept { abort_sources.stop().get(); });
 
             locator::token_metadata::config tm_cfg;
             auto my_address = gms::inet_address("localhost");
             tm_cfg.topo_cfg.this_endpoint = my_address;
             tm_cfg.topo_cfg.this_cql_address = my_address;
             token_metadata.start([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg).get();
-            auto stop_token_mgr = defer([&] { token_metadata.stop().get(); });
+            auto stop_token_mgr = defer([&] noexcept { token_metadata.stop().get(); });
             locator::shared_token_metadata tm({}, {});
             sharded<qos::service_level_controller> sl_controller;
             scheduling_group default_scheduling_group = create_scheduling_group("sl_default_sg", 1.0).get();
             sharded<abort_source> as;
             as.start().get();
-            auto stop_as = defer([&as] { as.stop().get(); });
+            auto stop_as = defer([&as] noexcept { as.stop().get(); });
             sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), qos::service_level_options{.shares = 1000}, scheduling_supergroup(), default_scheduling_group).get();
             compressor_tracker.start([] { return netw::walltime_compressor_tracker::config{}; }).get();
             auto stop_compressor_tracker = deferred_stop(compressor_tracker);

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -198,7 +198,7 @@ int main(int ac, char ** av) {
             auto default_scheduling_group = create_scheduling_group("sl_default_sg", 1.0).get();
             sharded<abort_source> as;
             as.start().get();
-            auto stop_as = defer([&as] { as.stop().get(); });
+            auto stop_as = defer([&as] noexcept { as.stop().get(); });
             sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), qos::service_level_options{.shares = 1000}, scheduling_supergroup(), default_scheduling_group).get();
             seastar::sharded<netw::walltime_compressor_tracker> compressor_tracker;
             compressor_tracker.start([] { return netw::walltime_compressor_tracker::config{}; }).get();
@@ -219,7 +219,7 @@ int main(int ac, char ** av) {
             auto port = testers.local().port();
             test_logger.info("Messaging server listening on {} port {}", listen, port);
             testers.invoke_on_all(&tester::init_handler).get();
-            auto deinit_testers = deferred_action([&testers] {
+            auto deinit_testers = deferred_action([&testers] noexcept {
                 testers.invoke_on_all(&tester::deinit_handler).get();
             });
             messaging.invoke_on_all(&netw::messaging_service::start_listen, std::ref(token_metadata), [] (gms::inet_address ip){ return locator::host_id{}; }).get();

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -237,7 +237,7 @@ std::vector<Res> time_parallel_ex(Func func, unsigned concurrency_per_core, int 
         sharded<executor<Func>> exec;
         Res result;
         exec.start(concurrency_per_core, func, std::move(end_at), operations_per_shard, stop_on_error, operations_count_per_iteration).get();
-        auto stop_exec = defer([&exec] {
+        auto stop_exec = defer([&exec] noexcept {
             exec.stop().get();
         });
         auto stats = exec.map_reduce0(std::mem_fn(&executor<Func>::run),

--- a/test/perf/perf_alternator.cc
+++ b/test/perf/perf_alternator.cc
@@ -82,7 +82,7 @@ static void wait_for_alternator(const test_config& c, abort_source& as) {
         as.check();
         try {
             auto cli = get_client(c);
-            auto close = defer([&] { cli.close().get(); });
+            auto close = defer([&] noexcept { cli.close().get(); });
             make_request(cli, "ListTables", "{}").get();
             return;
         } catch (...) {
@@ -393,7 +393,8 @@ void workload_main(const test_config& c, sharded<abort_source>* as) {
     wait_for_alternator(c, as->local());
 
     auto cli = get_client(c);
-    auto finally = defer([&] {
+    auto finally = defer([&] noexcept {
+        // Might throw, will terminate test
         delete_alternator_table(cli);
         cli.close().get();
     });
@@ -429,7 +430,7 @@ void workload_main(const test_config& c, sharded<abort_source>* as) {
         cli_pool = make_client_pool(c);
     }).get();
     // Cleanup thread-local connections to avoid destruction issues at exit
-    auto close_pools = defer([] {
+    auto close_pools = defer([] noexcept {
         smp::invoke_on_all([] {
             return parallel_for_each(cli_pool, [] (auto& cli) {
                 return cli.close();

--- a/test/perf/perf_cache_eviction.cc
+++ b/test/perf/perf_cache_eviction.cc
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
             auto reads_enabled = !app.configuration().contains("no-reads");
             auto seconds = app.configuration()["seconds"].as<unsigned>();
 
-            auto stop_test = defer([] {
+            auto stop_test = defer([] noexcept {
                 cancelled = true;
             });
 

--- a/test/perf/perf_cql_raw.cc
+++ b/test/perf/perf_cql_raw.cc
@@ -727,9 +727,9 @@ static void wait_for_cql(const raw_cql_test_config& cfg, abort_source& as) {
 
 static void workload_main(const raw_cql_test_config& cfg, sharded<abort_source>* as) {
     fmt::print("Running test with config: {}\n", cfg);
-    auto cleanup = defer([] {
+    auto cleanup = defer([] noexcept {
         // Cleanup thread-local connections to avoid destruction issues at exit
-        smp::invoke_on_all([] {
+        smp::invoke_on_all([] noexcept {
             return parallel_for_each(tl_conns, [](std::unique_ptr<raw_cql_connection>& c) {
                     return c->stop();
             }).then([] {

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -1950,7 +1950,7 @@ auto make_compaction_disabling_guard(replica::database& db, std::vector<replica:
             return f.get_future();
         });
     }
-    return seastar::defer([pr = std::move(pr)] () mutable {
+    return seastar::defer([pr = std::move(pr)] () mutable noexcept {
         pr.set_value();
     });
 }
@@ -2099,7 +2099,7 @@ int scylla_fast_forward_main(int argc, char** argv) {
 
                     sleep(1s).get(); // wait for system table flushes to quiesce
 
-                    auto stop_test = defer([] {
+                    auto stop_test = defer([] noexcept {
                         cancel = true;
                     });
 

--- a/test/perf/perf_row_cache_reads.cc
+++ b/test/perf/perf_row_cache_reads.cc
@@ -223,7 +223,7 @@ int main(int argc, char** argv) {
     app_template app;
     return app.run(argc, argv, [] {
         return seastar::async([&] {
-            auto stop_test = defer([] {
+            auto stop_test = defer([] noexcept {
                 cancelled = true;
             });
             logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();

--- a/test/perf/perf_row_cache_update.cc
+++ b/test/perf/perf_row_cache_update.cc
@@ -93,7 +93,7 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen, std::f
         // going away after memtable was merged to cache.
         auto rd = std::make_unique<mutation_fragment_v1_stream>(
             mutation_fragment_v1_stream(make_combined_reader(s, permit, cache.make_reader(s, permit), mt->make_mutation_reader(s, permit))));
-        auto close_rd = defer([&rd] { rd->close().get(); });
+        auto close_rd = defer([&rd] noexcept { rd->close().get(); });
         rd->set_max_buffer_size(1);
         rd->fill_buffer().get();
 
@@ -312,7 +312,7 @@ int scylla_row_cache_update_main(int argc, char** argv) {
     app_template app;
     return app.run(argc, argv, [] {
         return seastar::async([&] {
-            auto stop_test = defer([] {
+            auto stop_test = defer([] noexcept {
                 cancelled = true;
             });
             logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -440,10 +440,10 @@ int scylla_simple_query_main(int argc, char** argv) {
                 fmt::print("audit start failed: {}", e);
             }).get();
             audit::audit::start_storage(env.local_db().get_config()).get();
-            auto audit_stop = defer([] {
+            auto audit_stop = defer([] noexcept {
                 audit::audit::stop_audit().get();
             });
-            auto audit_storage_stop = defer([] {
+            auto audit_storage_stop = defer([] noexcept {
                 audit::audit::stop_storage().get();
             });
             audit::audit::audit_instance().invoke_on_all([] (audit::audit& a) {

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -213,7 +213,7 @@ int scylla_tablets_main(int argc, char** argv) {
                 logging::logger_registry().set_all_loggers_level(seastar::log_level::warn);
                 logging::logger_registry().set_logger_level("testlog", testlog_level);
             }
-            auto stop_test = defer([] {
+            auto stop_test = defer([] noexcept {
                 aborted.request_abort();
             });
             logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -765,7 +765,7 @@ int scylla_tablet_load_balancing_main(int argc, char** argv) {
     tool_app_template app(std::move(app_cfg));
 
     return app.run_async(argc, argv, [] (const operation& operation, const bpo::variables_map& app_config) {
-        auto stop_test = defer([] {
+        auto stop_test = defer([] noexcept {
             aborted.request_abort();
         });
         try {

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -64,7 +64,7 @@ SEASTAR_THREAD_TEST_CASE(test_release_memory_if_add_entry_throws) {
     };
     auto cluster = get_default_cluster(std::move(test_config));
     cluster.start_all().get();
-    auto stop = defer([&cluster] { cluster.stop_all().get(); });
+    auto stop = defer([&cluster] noexcept { cluster.stop_all().get(); });
 
     utils::get_local_injector().enable("fsm::add_entry/test-failure", true);
     auto check_error = [](const std::runtime_error& e) {
@@ -87,7 +87,7 @@ SEASTAR_THREAD_TEST_CASE(test_release_memory_if_add_entry_throws) {
 SEASTAR_THREAD_TEST_CASE(test_aborting_wait_for_state_change) {
     auto cluster = get_default_cluster(test_case{ .nodes = 1 });
     cluster.start_all().get();
-    auto stop = defer([&cluster] { cluster.stop_all().get(); });
+    auto stop = defer([&cluster] noexcept { cluster.stop_all().get(); });
 
     auto& server = cluster.get_server(0);
     server.wait_for_leader(nullptr).get();
@@ -253,7 +253,7 @@ static void test_add_entry_load_snapshot_before_wait_aux(raft::wait_type type, b
         0, false, tick_delay, rpc_config{}
     };
     cluster.start_all().get();
-    auto stop = defer([&cluster] { cluster.stop_all().get(); });
+    auto stop = defer([&cluster] noexcept { cluster.stop_all().get(); });
 
     cluster.add_entries(5, 0).get();
 
@@ -346,7 +346,7 @@ static void test_add_entry_wait_resolved_via_drop_waiters_aux(raft::wait_type ty
         0, false, tick_delay, rpc_config{}
     };
     cluster.start_all().get();
-    auto stop = defer([&cluster] { cluster.stop_all().get(); });
+    auto stop = defer([&cluster] noexcept { cluster.stop_all().get(); });
 
     // Add a few entries so all nodes are caught up.
     cluster.add_entries(5, 0).get();

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -197,7 +197,7 @@ public:
             auto cmd_id = utils::make_random_uuid();
             SCYLLA_ASSERT(_output_channels.emplace(cmd_id, std::move(p)).second);
 
-            auto guard = defer([this, cmd_id] {
+            auto guard = defer([this, cmd_id] noexcept {
                 auto it = _output_channels.find(cmd_id);
                 if (it != _output_channels.end()) {
                     it->second.set_exception(output_channel_dropped{});
@@ -728,7 +728,7 @@ public:
             promise<raft::snapshot_reply> p;
             auto f = p.get_future();
             _reply_promises.emplace(id, std::move(p));
-            auto guard = defer([this, id] { _reply_promises.erase(id); });
+            auto guard = defer([this, id] noexcept { _reply_promises.erase(id); });
 
             _send(dst, snapshot_message{
                 .ins = ins,
@@ -763,7 +763,7 @@ public:
             promise<raft::add_entry_reply> p;
             auto f = p.get_future();
             _reply_promises.emplace(id, std::move(p));
-            auto guard = defer([this, id] { _reply_promises.erase(id); });
+            auto guard = defer([this, id] noexcept { _reply_promises.erase(id); });
 
             _send(dst, add_entry_message{
                 .cmd = cmd,
@@ -788,7 +788,7 @@ public:
             promise<raft::add_entry_reply> p;
             auto f = p.get_future();
             _reply_promises.emplace(id, std::move(p));
-            auto guard = defer([this, id] { _reply_promises.erase(id); });
+            auto guard = defer([this, id] noexcept { _reply_promises.erase(id); });
 
             _send(dst, modify_config_message{
                 .add = add,
@@ -812,7 +812,7 @@ public:
             promise<raft::read_barrier_reply> p;
             auto f = p.get_future();
             _reply_promises.emplace(id, std::move(p));
-            auto guard = defer([this, id] { _reply_promises.erase(id); });
+            auto guard = defer([this, id] noexcept { _reply_promises.erase(id); });
 
             _send(dst, execute_barrier_on_leader {
                 .reply_id = id
@@ -838,7 +838,7 @@ public:
             promise<> p;
             auto f = p.get_future();
             _reply_promises.emplace(id, std::move(p));
-            auto guard = defer([this, id] { _reply_promises.erase(id); });
+            auto guard = defer([this, id] noexcept { _reply_promises.erase(id); });
             auto sub = as.subscribe([this, id] () noexcept {
                 auto it = _reply_promises.find(id);
                 if (it == _reply_promises.end()) {

--- a/test/unit/cross_shard_barrier_test.cc
+++ b/test/unit/cross_shard_barrier_test.cc
@@ -69,7 +69,7 @@ public:
     }
 
     future<> loop_with_error() {
-        auto b = seastar::defer([this] { _barrier.abort(); });
+        auto b = seastar::defer([this] noexcept { _barrier.abort(); });
 
         while (true) {
             if (_rndgen() % 3 == 0) {

--- a/test/unit/lsa_async_eviction_test.cc
+++ b/test/unit/lsa_async_eviction_test.cc
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
             logalloc::region r;
 
             with_allocator(r.allocator(), [&] {
-                auto clear_refs = defer([&refs] { refs.clear(); });
+                auto clear_refs = defer([&refs] noexcept { refs.clear(); });
 
                 r.make_evictable([&] {
                     return with_allocator(r.allocator(), [&] {

--- a/test/unit/row_cache_stress_test.cc
+++ b/test/unit/row_cache_stress_test.cc
@@ -294,7 +294,7 @@ int main(int argc, char** argv) {
             row_cache_stress_test::table t(partitions, rows);
             auto stop_t = deferred_stop(t);
 
-            auto stop_test = defer([] {
+            auto stop_test = defer([] noexcept {
                 cancelled = true;
             });
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1633,10 +1633,10 @@ void decompress_operation(schema_ptr schema, reader_permit permit, const std::ve
         file_output_stream_options options;
         options.buffer_size = 4096;
         auto ostream = make_file_output_stream(std::move(ofile), options).get();
-        auto close_ostream = defer([&ostream] { ostream.close().get(); });
+        auto close_ostream = defer([&ostream] noexcept { ostream.close().get(); });
 
         auto istream = sst->data_stream(0, sst->data_size(), permit, nullptr, nullptr).get();
-        auto close_istream = defer([&istream] { istream.close().get(); });
+        auto close_istream = defer([&istream] noexcept { istream.close().get(); });
 
         istream.consume([&] (temporary_buffer<char> buf) {
             return ostream.write(buf.get(), buf.size()).then([] {
@@ -3009,7 +3009,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
         stm_cfg.skip_metrics_registration = true;
         sharded<sstables::storage_manager> sstm;
         sstm.start(std::ref(dbcfg), stm_cfg).get();
-        auto stop_sstm = defer([&sstm] { sstm.stop().get(); });
+        auto stop_sstm = defer([&sstm] noexcept { sstm.stop().get(); });
 
         db::nop_large_data_handler large_data_handler;
         db::nop_corrupt_data_handler corrupt_data_handler(db::corrupt_data_handler::register_metrics::no);

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -273,10 +273,10 @@ future<> controller::do_start_server() {
         });
 
         cserver->start(std::ref(_qp), std::ref(_auth_service), std::ref(_mem_limiter), std::move(get_cql_server_config), std::ref(_sl_controller), std::ref(_gossiper), _cql_opcode_stats_key, _used_by_maintenance_socket, std::ref(_messaging)).get();
-        auto on_error = defer([&cserver] { cserver->stop().get(); });
+        auto on_error = defer([&cserver] noexcept { cserver->stop().get(); });
 
         subscribe_server(*cserver).get();
-        auto on_error_unsub = defer([this, &cserver] {
+        auto on_error_unsub = defer([this, &cserver] noexcept {
             unsubscribe_server(*cserver).get();
         });
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1059,7 +1059,7 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
         default:                               return make_exception_future<process_fn_return_type>(exceptions::protocol_exception(format("Unknown opcode {:d}", int(cqlop))));
         }
     }).then_wrapped([this, cqlop, &cql_stats, stream, &client_state, linearization_buffer = std::move(linearization_buffer), trace_state] (future<process_fn_return_type> f) {
-        auto stop_trace = defer([&] {
+        auto stop_trace = defer([&] noexcept {
             tracing::stop_foreground(trace_state);
         });
         return seastar::futurize_invoke([&] () {
@@ -1302,7 +1302,7 @@ future<> cql_server::connection::process_request() {
 
             _pending_requests_gate.enter();
             auto& sg_stats = _server.get_cql_sg_stats();
-            auto leave = defer([this, &sg_stats] {
+            auto leave = defer([this, &sg_stats] noexcept {
                 --_server._stats.requests_serving;
                 --sg_stats._requests_serving;
                 _shedding_timer.cancel();

--- a/utils/atomic_vector.hh
+++ b/utils/atomic_vector.hh
@@ -41,7 +41,7 @@ public:
     // preemption.
     void thread_for_each(seastar::noncopyable_function<void(T)> func) const {
         _vec_lock.for_read().lock().get();
-        auto unlock = seastar::defer([this] {
+        auto unlock = seastar::defer([this] noexcept {
             _vec_lock.for_read().unlock();
         });
         // We grab a lock in remove(), but not in add(), so we

--- a/utils/bptree.hh
+++ b/utils/bptree.hh
@@ -429,7 +429,7 @@ public:
         }
 
         data* d = data::create(std::forward<Args>(args)...);
-        auto x = seastar::defer([&d] { data::destroy(*d, default_dispose<T>); });
+        auto x = seastar::defer([&d] noexcept { data::destroy(*d, default_dispose<T>); });
         n.insert(i, std::move(k), d, _less);
         SCYLLA_ASSERT(d->attached());
         x.cancel();
@@ -736,7 +736,7 @@ public:
             SCYLLA_ASSERT(i >= 0);
 
             data* d = data::create(std::forward<Args>(args)...);
-            auto x = seastar::defer([&d] { data::destroy(*d, default_dispose<T>); });
+            auto x = seastar::defer([&d] noexcept { data::destroy(*d, default_dispose<T>); });
             leaf->insert(i, std::move(key(d)), d, less);
             SCYLLA_ASSERT(d->attached());
             x.cancel();

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -233,7 +233,7 @@ void utils::config_file::add(cfg_ref cfg, std::unique_ptr<any_value> value) {
         throw std::runtime_error("Can only add config_src to config_file during initialization");
     }
     _cfgs.emplace_back(cfg);
-    auto undo = defer([&] { _cfgs.pop_back(); });
+    auto undo = defer([&] noexcept { _cfgs.pop_back(); });
     cfg.get()._per_shard_values_offset = _per_shard_values[0].size();
     _per_shard_values[0].emplace_back(std::move(value));
     undo.cancel();

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -556,7 +556,7 @@ public:
         injection_handler handler(data->shared_data, share_messages);
         data->handlers.push_back(handler);
 
-        auto disable_one_shot = defer([this, one_shot, name = sstring(name)] {
+        auto disable_one_shot = defer([this, one_shot, name = sstring(name)] noexcept {
             if (one_shot) {
                 disable(name);
             }

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1966,7 +1966,7 @@ file client::make_readable_file(sstring object_name, seastar::abort_source* as) 
     return file(make_shared<readable_file>(shared_from_this(), std::move(object_name), as));
 }
 
-future<> client::close() {
+future<> client::close() noexcept {
     s3l.info("Closing S3 client...");
 
     co_await _config_update_gate.close();

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -253,7 +253,7 @@ public:
         future<> close() noexcept override;
     };
 
-    future<> close();
+    future<> close() noexcept;
 };
 
 std::pair<unsigned, size_t> calc_part_size(size_t total_size, size_t part_size);


### PR DESCRIPTION
Since [1], Seastar's defer() is expected to enforce that function inputs are noexcept. However, due to a bug, it does not.

As a result, the tree is filled with violations. If/when we fix the bug, it will not build. To prevent that, fix the violations proactively.

In most cases this is just adding `noexcept` the the input of defer, and it is easy to verify that it does not throw. Note that even if we are mistaken and it does throw, the behavior does not change - deffered_action's destructor is noexcept in any case and would have terminated on an exception.

In a few cases, in tests, the deferred action can indeed throw. It does not (or the test would have failed). We mark the discrepancy with a comment but don't attempt to fix it, as it is benign.

For deferred_stop/deferred_close, we mark a few stop()/close() methods as noexcept. It is easy to verify that they indeed don't throw (and would have called std::terminate() if they did.

[1] https://github.com/scylladb/seastar/commit/09f552804c8223cb53ebcd1da70c0b58c503b20f

This change is preparing for a Seastar fix, which itself won't be backported, so it doesn't need backporting.