### PR TITLE
test: Speed up test_timed_out_queries

### DIFF
--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -106,6 +106,11 @@ auto raft_server::begin_mutate(abort_source& as) -> begin_mutate_result {
         // before the updater gets a chance to run.
         return need_wait_for_leader{wait_with_abort_source(_state.leader_info_cond, as)};
     }
+    if (utils::get_local_injector().enter("sc_begin_mutate_wait_for_leader")) {
+        // Test-only: emulate a leader whose leader_info never becomes available,
+        // so callers wait on leader_info_cond until their own deadline fires.
+        return need_wait_for_leader{wait_with_abort_source(_state.leader_info_cond, as)};
+    }
     const auto new_ts = std::max(api::new_timestamp(), _state.leader_info->last_timestamp + 1);
     _state.leader_info->last_timestamp = new_ts;
     return timestamp_with_term{new_ts, term};
@@ -338,9 +343,6 @@ future<> groups_manager::leader_info_updater(raft_group_state& state, global_tab
                 // The same will happen when the node is shutting down.
                 // There's no reason to abort this operation in any other case.
                 co_await state.server->read_barrier(nullptr);
-
-                co_await utils::get_local_injector().inject("sc_leader_info_updater_wait_before_setting_leader_info",
-                    utils::wait_for_message(5min));
 
                 state.leader_info = leader_info {
                     .term = current_term,

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -996,14 +996,11 @@ async def test_timed_out_queries(manager: ManagerClient):
             await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (17, 7)")
 
     # Case 3: Waiting for the leader during a write.
-
-    # To trigger the timeout we want, we need to make sure that
-    # groups_manager::begin_mutate will want to return need_wait_for_leader,
-    # and that it will never succeed. This will do the job.
-    await manager.api.enable_injection(s1.ip_addr, "sc_leader_info_updater_wait_before_setting_leader_info", one_shot=True)
-
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
         async with new_test_table(manager, ks, "pk int PRIMARY KEY, v int") as table:
+            # We can only emulate the leader not being chosen yet. Otherwise, we would
+            # prolong completing creating the table (cf. groups_manager::update).
+            await manager.api.enable_injection(s1.ip_addr, "sc_begin_mutate_wait_for_leader", one_shot=False)
             with pytest.raises(WriteTimeout, match=f"Query timed out for {table}"):
                 await cql.run_async(f"INSERT INTO {table} (pk, v) VALUES (11, 13) USING TIMEOUT 100ms")
 


### PR DESCRIPTION
One of the scenarios the test simulates is a write timing out while waiting for the leader being elected. We achieve that by getting stuck in the leader loop in groups_manager via an error injection. This way, raft_server::begin_mutate returns need_wait_for_leader that will eventually time out.

Unfortunately, this approach has a side effect on
groups_manager::update, which also calls raft_server::begin_mutate and awaits the result. It's executed when creating a strongly consistent table. Since the error injection needs to be enabled *before* creating the table to prevent the leader from stepping up and since we cannot depose it (because it's the only node in the cluster), the consequence is that creating the table takes about 60 seconds (the default timeout that groups_manager::update uses).

To speed up the test, we get rid of the injection and replace it with another one in raft_server::begin_mutate. Although more artificial, this approach lets us enable the injection only after creating the table, effectively avoiding getting stuck in groups_manager::update. Thanks to that, the test finishes in reasonable time again.

Fixes: SCYLLADB-2274

Backport: no. There's no bug, these changes just speed up the test.