### PR TITLE
gcp::object_storage: Bump version of mock server to 1.54

### DIFF
--- a/test/boost/gcp_object_storage_test.cc
+++ b/test/boost/gcp_object_storage_test.cc
@@ -162,7 +162,7 @@ SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_list_objects, local_gcs_wrapper, *che
     auto& env = *this;
     auto& c = env.client();
     std::unordered_map<std::string, uint64_t> names;
-    for (size_t i = 0; i < 10; ++i) {
+    for (size_t i = 0; i < 50; ++i) {
         auto name = make_name();
         auto size = tests::random::get_int(size_t(1), size_t(2*1024*1024));
         env.objects_to_delete.emplace_back(name);
@@ -170,24 +170,32 @@ SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_list_objects, local_gcs_wrapper, *che
         names.emplace(name, size);
     }
 
-    utils::gcp::storage::bucket_paging paging;
-    size_t n_found = 0;
 
-    for (;;) {
-        auto infos = co_await c.list_objects(env.bucket, "", paging);
+    for (size_t page_size = 4;; page_size *= 2) {
+        utils::gcp::storage::bucket_paging paging{page_size};
+        size_t n_found = 0;
 
-        for (auto& info : infos) {
-            auto i = names.find(info.name);
-            if (i != names.end()) {
-                BOOST_REQUIRE_EQUAL(info.size, i->second);
-                ++n_found;
+        for (;;) {
+            auto infos = co_await c.list_objects(env.bucket, "", paging);
+
+            for (auto& info : infos) {
+                auto i = names.find(info.name);
+                if (i != names.end()) {
+                    BOOST_REQUIRE_EQUAL(info.size, i->second);
+                    ++n_found;
+                }
+            }
+            if (infos.empty()) {
+                break;
             }
         }
-        if (infos.empty()) {
+
+        BOOST_REQUIRE_EQUAL(n_found, names.size());
+
+        if (page_size >= names.size()) {
             break;
         }
     }
-    BOOST_REQUIRE_EQUAL(n_found, names.size());
 }
 
 SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_delete_object, local_gcs_wrapper, *check_gcp_storage_test_enabled()) {

--- a/test/lib/gcs_fixture.cc
+++ b/test/lib/gcs_fixture.cc
@@ -45,7 +45,7 @@ static future<std::optional<google_credentials>> credentials(const std::string& 
 
 static future<std::tuple<tp::process_fixture, int>> start_fake_gcs_server(const tmpdir& tmp) {
     return tp::start_docker_service("fake-gcs-server"
-        , "docker.io/fsouza/fake-gcs-server:1.52.3"
+        , "docker.io/fsouza/fake-gcs-server:1.54.0"
         , {}
         , [](std::string_view line) {
             if (line.find("server started at") != std::string::npos) {

--- a/test/pylib/object_storage.py
+++ b/test/pylib/object_storage.py
@@ -240,7 +240,7 @@ class GSServerImpl(GSFront):
         return ["-scheme", "http", "-log-level", "debug", "--port", f'{port}', '-public-host', '127.0.0.1']
 
     async def start(self):
-        self.server = DockerizedServer("docker.io/fsouza/fake-gcs-server:1.52.3", self.tmpdir,
+        self.server = DockerizedServer("docker.io/fsouza/fake-gcs-server:1.54.0", self.tmpdir,
                                        logfilenamebase="fake-gcs-server",
                                        image_args=self._image_args,
                                        success_string="server started at",

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -1108,15 +1108,15 @@ future<utils::chunked_vector<utils::gcp::storage::object_info>> utils::gcp::stor
     auto psep = "?";
     if (!prefix.empty()) {
         path += fmt::format("{}prefix={}", psep, prefix);
-        psep = "&&";
+        psep = "&";
     }
     if (pager.max_results != 0) {
         path += fmt::format("{}maxResults={}", psep, pager.max_results);
-        psep = "&&";
+        psep = "&";
     }
     if (!pager.token.empty()) {
         path += fmt::format("{}pageToken={}", psep, pager.token);
-        psep = "&&";
+        psep = "&";
     }
 
     co_await _impl->send_with_retry(path


### PR DESCRIPTION
Fixes SCYLLADB-3138

The 1.52 version used by scylla does not properly support paged listing. Bump version to fix.

Also enhances unit test to verify that the paging does in fact work, and remove extraenous '&' chars in listing query.

Backport to 2026.2, just for future testing. 