### PR TITLE
test: re-enable test_tablet_repair_progress_merge

### DIFF
--- a/test/cluster/test_tablet_repair_scheduler.py
+++ b/test/cluster/test_tablet_repair_scheduler.py
@@ -114,10 +114,6 @@ async def test_tablet_repair_progress(manager: ManagerClient):
 async def test_tablet_repair_progress_split(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_split=True)
 
-@pytest.mark.skip_bug(
-    link="https://github.com/scylladb/scylladb/issues/26844",
-    reason="Tablet repair scheduler crashes",
-)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_progress_merge(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_merge=True)


### PR DESCRIPTION
The test was skipped due to https://github.com/scylladb/scylladb/issues/26844, which has since been closed. Remove the skip_bug marker to re-enable the test.

$ ./test.py --mode=dev test/cluster/test_tablet_repair_scheduler.py::test_tablet_repair_progress_merge --no-gather-metrics --repeat 100 --max-failures 1

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2728

Improvement. No backpot. 