### PR TITLE
Add cargo retry for transient crates.io fetch failures

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2640,7 +2640,7 @@ def write_build_file(f,
               description = TEST {mode}
             # This rule is unused for PGO stages. They use the rust lib from the parent mode.
             rule rust_lib.{mode}
-              command = CARGO_BUILD_DEP_INFO_BASEDIR='.' {rustc_wrapper}cargo build --locked --manifest-path=rust/Cargo.toml --target-dir=$builddir/{mode} --profile=rust-{mode} $
+              command = CARGO_BUILD_DEP_INFO_BASEDIR='.' CARGO_NET_RETRY=10 {rustc_wrapper}cargo build --locked --manifest-path=rust/Cargo.toml --target-dir=$builddir/{mode} --profile=rust-{mode} $
                         && touch $out
               description = RUST_LIB $out
             ''').format(mode=mode, antlr3_exec=args.antlr3_exec, fmt_lib=fmt_lib, test_repeat=args.test_repeat, test_timeout=args.test_timeout, rustc_wrapper=rustc_wrapper, **modeval))


### PR DESCRIPTION
The aarch64 release build failed when cargo hit a transient SSL
error while fetching the cc crate from crates.io. Bump
CARGO_NET_RETRY to 10 for the rust_lib build rule so cargo retries
these transient network failures instead of failing the build
outright.

Fixes: RELENG-699

**Improvement, no need for backport**