### PR TITLE
[Backport 2026.2] test/pylib: fix starting server cleanup race

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1351,7 +1351,9 @@ class ScyllaCluster:
             await handle_join_failure()
             raise
         finally:
-            del self.starting[server.server_id]
+            # server_stop() may have already removed the starting server
+            # if it interrupted this add_server() operation.
+            self.starting.pop(server.server_id, None)
 
         if expected_error:
             await handle_join_failure()
@@ -1502,7 +1504,9 @@ class ScyllaCluster:
             self.running.pop(server_id)
             self.stopped[server_id] = server
         else:
-            self.starting.pop(server_id)
+            # Starting servers are removed from self.starting by add_server()
+            # in its cleanup path. This is a fallback if server_stop() wins the race.
+            self.starting.pop(server_id, None)
 
     def server_mark_removed(self, server_id: ServerNum) -> None:
         """Mark server as removed."""


### PR DESCRIPTION
## Problem
`test_localnodes_joining_nodes` intentionally starts second node in background delayed bootstrap, checks `/localnodes`, stops still-starting server avoid waiting for full injection delay. creates race in test cluster manager. Stopping process can make background `add_server()` request fail run cleanup path first, removing server from `ScyllaCluster.starting`. When `/cluster/server/{id}/stop` request later resumes, try remove same entry raise `KeyError`, returned test HTTP 500. reverse ordering possible too: `server_stop()` remove starting entry before `add_server()` reaches its `finally` block.

## Solution
Make cleanup `ScyllaCluster.starting` idempotent in paths:

- `add_server()` still performs normal cleanup in its `finally` block, but tolerates entry already removed by an interrupting stop request.
- `server_stop()` keeps fallback cleanup starting servers, but tolerates entry already removed by `add_server()`.

Fixes: SCYLLADB-3150

- (cherry picked from master commit 21f1380df1a4a4aca07ead1972c57b0f81b03d8c)

Parent PR: #30128

The fix is already present in the older branches: 2026.1 and 2025.4, where this problem occurred. No further backport needed.