### PR TITLE
test: perf_vint: harden against branch prediction

### DIFF
--- a/test/perf/perf_vint.cc
+++ b/test/perf/perf_vint.cc
@@ -16,7 +16,7 @@
 
 class vint {
 public:
-    static constexpr size_t count = 1000;
+    static constexpr size_t count = 100000;
 private:
     std::vector<uint64_t> _integers;
     bytes _serialized;
@@ -26,8 +26,8 @@ public:
         , _serialized(bytes::initialized_later{}, count * max_vint_length)
     {
         auto eng = seastar::testing::local_random_engine;
-        auto dist = std::uniform_int_distribution<uint64_t>{};
-        std::generate_n(_integers.begin(), count, [&] { return dist(eng); });
+        auto dist = std::uniform_real_distribution<long double>{0, 64};
+        std::generate_n(_integers.begin(), count, [&] { return std::exp2(dist(eng)); });
 
         auto dst = _serialized.data();
         for (auto v : _integers) {


### PR DESCRIPTION
perf_vint operates on random integers in a uniform distribution. The problem is that these are predominantly very large numbers (the vast majority having log2(n) > 56. This means that vint serialization will always take the same path with perfectly predicted branches.

Make the test more realistic by choosing a log-uniform distribution. The logarithm of the numbers is uniformly distributed, making branches on the size of the encoding loop poorly predicted.

Also increase the size of the pre-generated test vector, so the branch predictor doesn't learn the branch history by heart.

Results:

before

```
test                  iters            runtime     allocs      tasks       inst     cycles   overhead
vint.serialize    158697000     6.30ns ± 0.12%      0.000      0.000     107.00       29.2      0.000
vint.deserialize  255556000     3.93ns ± 0.06%      0.000      0.000      48.19       18.3      0.000
```

after

```
test                  iters            runtime     allocs      tasks       inst     cycles   overhead
vint.serialize     86000000    11.55ns ± 0.16%      0.000      0.000      82.79       53.9      0.000
vint.deserialize  225600000     4.43ns ± 0.16%      0.000      0.000      44.78       20.6      0.000
```

Instructions-per-encode decreases (since the loop sometimes terminates earlier) but cycles increase, since the branch predictor doesn't give perfect predictions.

Note log-uniform is likely worse than real-life, which will encode many zeros and other small numbers. But it's more realistic than uniform.

Tiny benchmark improvement, not meriting a backport.