### PR TITLE
cql3: Add IS NULL and IS NOT NULL support in WHERE clause

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1925,6 +1925,8 @@ relation returns [uexpression e]
       | type=relationType t=term { $e = binary_operator(unresolved_identifier{std::move(name)}, type, std::move(t)); }
       | K_IS K_NOT K_NULL {
             $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IS_NOT, make_untyped_null()); }
+      | K_IS K_NULL {
+            $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IS, make_untyped_null()); }
       | K_IN marker1=marker
           { $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IN, std::move(marker1)); }
       | K_IN in_values=singleColumnInValues

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1947,6 +1947,8 @@ relation returns [uexpression e]
       | type=relationType t=term { $e = binary_operator(unresolved_identifier{std::move(name)}, type, std::move(t)); }
       | K_IS K_NOT K_NULL {
             $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IS_NOT, make_untyped_null()); }
+      | K_IS K_NULL {
+            $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IS, make_untyped_null()); }
       | K_IN marker1=marker
           { $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IN, std::move(marker1)); }
       | K_IN in_values=singleColumnInValues

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -330,7 +330,8 @@ bool_or_null limits(const expression& lhs, oper_t op, null_handling_style null_h
             case oper_t::CONTAINS:
             case oper_t::CONTAINS_KEY:
             case oper_t::LIKE:
-            case oper_t::IS_NOT: // IS_NOT doesn't really belong here, luckily this is never reached.
+            case oper_t::IS:
+            case oper_t::IS_NOT: // IS and IS_NOT operators are handled separately in their dedicated evaluation functions
                 throw exceptions::invalid_request_exception(fmt::format("Invalid comparison with null for operator \"{}\"", op));
             case oper_t::EQ:
                 return !sides_bytes.first == !sides_bytes.second;
@@ -563,6 +564,15 @@ bool is_not_null(const expression& lhs, const expression& rhs, const evaluation_
         throw exceptions::invalid_request_exception("IS NOT operator accepts only NULL as its right side");
     }
     return !lhs_val.is_null();
+}
+
+bool is_null(const expression& lhs, const expression& rhs, const evaluation_inputs& inputs) {
+    cql3::raw_value lhs_val = evaluate(lhs, inputs);
+    cql3::raw_value rhs_val = evaluate(rhs, inputs);
+    if (!rhs_val.is_null()) {
+        throw exceptions::invalid_request_exception("IS operator accepts only NULL as its right side");
+    }
+    return lhs_val.is_null();
 }
 
 } // anonymous namespace
@@ -1253,6 +1263,9 @@ cql3::raw_value do_evaluate(const binary_operator& binop, const evaluation_input
             break;
         case oper_t::NOT_IN:
             binop_result = is_none_of(binop.lhs, binop.rhs, inputs, binop.null_handling);
+            break;
+        case oper_t::IS:
+            binop_result = is_null(binop.lhs, binop.rhs, inputs);
             break;
         case oper_t::IS_NOT:
             binop_result = is_not_null(binop.lhs, binop.rhs, inputs);
@@ -2776,6 +2789,8 @@ std::string_view fmt::formatter<cql3::expr::oper_t>::to_string(const cql3::expr:
         return "CONTAINS";
     case oper_t::CONTAINS_KEY:
         return "CONTAINS KEY";
+    case oper_t::IS:
+        return "IS";
     case oper_t::IS_NOT:
         return "IS NOT";
     case oper_t::LIKE:

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -330,7 +330,8 @@ bool_or_null limits(const expression& lhs, oper_t op, null_handling_style null_h
             case oper_t::CONTAINS:
             case oper_t::CONTAINS_KEY:
             case oper_t::LIKE:
-            case oper_t::IS_NOT: // IS_NOT doesn't really belong here, luckily this is never reached.
+            case oper_t::IS:
+            case oper_t::IS_NOT: // IS and IS_NOT operators are handled separately in their dedicated evaluation functions
                 throw exceptions::invalid_request_exception(fmt::format("Invalid comparison with null for operator \"{}\"", op));
             case oper_t::EQ:
                 return !sides_bytes.first == !sides_bytes.second;
@@ -563,6 +564,15 @@ bool is_not_null(const expression& lhs, const expression& rhs, const evaluation_
         throw exceptions::invalid_request_exception("IS NOT operator accepts only NULL as its right side");
     }
     return !lhs_val.is_null();
+}
+
+bool is_null(const expression& lhs, const expression& rhs, const evaluation_inputs& inputs) {
+    cql3::raw_value lhs_val = evaluate(lhs, inputs);
+    cql3::raw_value rhs_val = evaluate(rhs, inputs);
+    if (!rhs_val.is_null()) {
+        throw exceptions::invalid_request_exception("IS operator accepts only NULL as its right side");
+    }
+    return lhs_val.is_null();
 }
 
 } // anonymous namespace
@@ -1263,6 +1273,9 @@ cql3::raw_value do_evaluate(const binary_operator& binop, const evaluation_input
             break;
         case oper_t::NOT_IN:
             binop_result = is_none_of(binop.lhs, binop.rhs, inputs, binop.null_handling);
+            break;
+        case oper_t::IS:
+            binop_result = is_null(binop.lhs, binop.rhs, inputs);
             break;
         case oper_t::IS_NOT:
             binop_result = is_not_null(binop.lhs, binop.rhs, inputs);
@@ -2786,6 +2799,8 @@ std::string_view fmt::formatter<cql3::expr::oper_t>::to_string(const cql3::expr:
         return "CONTAINS";
     case oper_t::CONTAINS_KEY:
         return "CONTAINS KEY";
+    case oper_t::IS:
+        return "IS";
     case oper_t::IS_NOT:
         return "IS NOT";
     case oper_t::LIKE:

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -226,7 +226,7 @@ const column_value& get_subscripted_column(const subscript&);
 /// Only columns can be subscripted in CQL, so we can expect that the subscripted expression is a column_value.
 const column_value& get_subscripted_column(const expression&);
 
-enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, NOT_IN, CONTAINS, CONTAINS_KEY, IS_NOT, LIKE, ADD, SUB };
+enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, NOT_IN, CONTAINS, CONTAINS_KEY, IS, IS_NOT, LIKE, ADD, SUB };
 
 /// The operator of a unary expression.
 enum class unary_oper_t { NEG };

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -2315,14 +2315,14 @@ binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::
     lw_shared_ptr<column_specification> rhs_receiver = get_rhs_receiver(lhs_receiver, binop.op);
     expression prepared_rhs = prepare_expression(binop.rhs, db, table_schema.ks_name(), &table_schema, rhs_receiver);
 
-    // IS NOT NULL requires an additional check that the RHS is NULL.
-    // Otherwise things like `int_col IS NOT 123` would be allowed - the types match, but the value is wrong.
-    if (binop.op == oper_t::IS_NOT) {
+    // IS NULL and IS NOT NULL require an additional check that the RHS is NULL.
+    // Otherwise things like `int_col IS 123` or `int_col IS NOT 123` would be allowed - the types match, but the value is wrong.
+    if (binop.op == oper_t::IS || binop.op == oper_t::IS_NOT) {
         bool rhs_is_null = is<constant>(prepared_rhs) && as<constant>(prepared_rhs).is_null();
 
         if (!rhs_is_null) {
             throw exceptions::invalid_request_exception(format(
-                "IS NOT NULL is the only expression that is allowed when using IS NOT. Invalid binary operator: {:user}",
+                "IS NULL and IS NOT NULL are the only expressions that are allowed when using IS/IS NOT. Invalid binary operator: {:user}",
                 binop));
         }
     }

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -2359,14 +2359,14 @@ binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::
     lw_shared_ptr<column_specification> rhs_receiver = get_rhs_receiver(lhs_receiver, binop.op, d);
     expression prepared_rhs = prepare_expression(binop.rhs, db, table_schema.ks_name(), &table_schema, rhs_receiver);
 
-    // IS NOT NULL requires an additional check that the RHS is NULL.
-    // Otherwise things like `int_col IS NOT 123` would be allowed - the types match, but the value is wrong.
-    if (binop.op == oper_t::IS_NOT) {
+    // IS NULL and IS NOT NULL require an additional check that the RHS is NULL.
+    // Otherwise things like `int_col IS 123` or `int_col IS NOT 123` would be allowed - the types match, but the value is wrong.
+    if (binop.op == oper_t::IS || binop.op == oper_t::IS_NOT) {
         bool rhs_is_null = is<constant>(prepared_rhs) && as<constant>(prepared_rhs).is_null();
 
         if (!rhs_is_null) {
             throw exceptions::invalid_request_exception(format(
-                "IS NOT NULL is the only expression that is allowed when using IS NOT. Invalid binary operator: {:user}",
+                "IS NULL and IS NOT NULL are the only expressions that are allowed when using IS/IS NOT. Invalid binary operator: {:user}",
                 binop));
         }
     }

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -150,11 +150,11 @@ void preliminary_binop_vaidation_checks(const binary_operator& binop) {
         throw exceptions::invalid_request_exception(format("Unsupported \"!=\" relation: {:user}", binop));
     }
 
-    if (binop.op == oper_t::IS_NOT) {
+    if (binop.op == oper_t::IS || binop.op == oper_t::IS_NOT) {
         bool rhs_is_null = (is<untyped_constant>(binop.rhs) && as<untyped_constant>(binop.rhs).partial_type == untyped_constant::type_class::null)
                            || (is<constant>(binop.rhs) && as<constant>(binop.rhs).is_null());
         if (!rhs_is_null) {
-            throw exceptions::invalid_request_exception(format("Unsupported \"IS NOT\" relation: {:user}", binop));
+            throw exceptions::invalid_request_exception(format("Unsupported \"IS\" or \"IS NOT\" relation: {:user}", binop));
         }
     }
 

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -25,7 +25,11 @@ extern logging::logger expr_logger;
 namespace {
 
 bool is_legal_relation_for_non_frozen_collection(oper_t oper, bool is_lhs_col_indexed) {
-    return oper == oper_t::CONTAINS_KEY || oper == oper_t::CONTAINS || (oper == oper_t::EQ && is_lhs_col_indexed);
+    // IS NULL / IS NOT NULL don't compare the collection against a value, they
+    // only test whether the column has any live cells at all, so they are
+    // meaningful for non-frozen collections too.
+    return oper == oper_t::CONTAINS_KEY || oper == oper_t::CONTAINS || (oper == oper_t::EQ && is_lhs_col_indexed)
+           || oper == oper_t::IS || oper == oper_t::IS_NOT;
 }
 
 void validate_single_column_relation(const column_value& lhs, oper_t oper, const schema& schema, bool is_lhs_subscripted) {

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -64,7 +64,8 @@ interval<clustering_key_prefix> to_range(oper_t op, const clustering_key_prefix&
 
 inline bool needs_filtering(oper_t op) {
     return (op == oper_t::CONTAINS) || (op == oper_t::CONTAINS_KEY) || (op == oper_t::LIKE) ||
-           (op == oper_t::IS_NOT) || (op == oper_t::NEQ) || (op == oper_t::NOT_IN);
+           (op == oper_t::NEQ) || (op == oper_t::NOT_IN) ||
+           (op == oper_t::IS) || (op == oper_t::IS_NOT);  // identity operators, currently restricted to NULL
 }
 
 static
@@ -422,6 +423,17 @@ to_predicates(
                                     .filter = oper,
                                     .on = on_column{col.col},
                                     .is_singleton = false,
+                                    .order = oper.order,
+                                    .op = oper.op,
+                                });
+                            } else if (oper.op == oper_t::IS) {
+                                // This predicate restricts null presence, but value_set can only represent
+                                // concrete non-null values or non-null value ranges. Treat it as
+                                // range-unbounded here; the row filter evaluates the null check.
+                                return to_vector(predicate{
+                                    .solve_for = [] (const query_options&) { return unbounded_value_set; },
+                                    .filter = oper,
+                                    .on = on_column{col.col},
                                     .order = oper.order,
                                     .op = oper.op,
                                 });
@@ -874,12 +886,12 @@ statement_restrictions::statement_restrictions(private_tag,
     single_column_predicate_vectors sc_ck_pred_vectors;
     single_column_predicate_vectors sc_nonpk_pred_vectors;
     for (auto& pred : predicates) {
-        if (pred.is_not_null_single_column) {
+        if ((pred.op == oper_t::IS || pred.is_not_null_single_column) && for_view) {
             auto* col = require_on_single_column(pred);
-            _not_null_columns.insert(col);
-
-            if (!for_view) {
-                throw exceptions::invalid_request_exception(format("restriction '{}' is only supported in materialized view creation", pred.filter));
+            if (pred.op == oper_t::IS) {
+                _null_columns.insert(col);
+            } else {
+                _not_null_columns.insert(col);
             }
         } else if (pred.is_multi_column) {
             // Multi column restrictions are only allowed on clustering columns
@@ -1064,7 +1076,7 @@ statement_restrictions::statement_restrictions(private_tag,
             throw exceptions::invalid_request_exception(format("Unhandled restriction: {}", pred.filter));
         }
 
-        if (!pred.is_not_null_single_column) {
+        if (!(for_view && pred.is_not_null_single_column)) {
             _where.push_back(pred.filter);
         }
         // Subscript EQ (e.g. m[1] = 'a') is not considered an EQ on the column
@@ -1348,6 +1360,10 @@ statement_restrictions::ck_restrictions_need_filtering() const {
 
 bool
 statement_restrictions::is_restricted(const column_definition* cdef) const {
+    if (_null_columns.contains(cdef)) {
+        return true;
+    }
+
     if (_not_null_columns.contains(cdef)) {
         return true;
     }
@@ -2749,6 +2765,10 @@ void statement_restrictions::validate_primary_key(const query_options& options) 
     validate_primary_key_restrictions(options, _clustering_prefix_restrictions | std::views::transform(&predicate::filter));
 }
 
+
+const std::unordered_set<const column_definition*> statement_restrictions::get_null_columns() const {
+    return _null_columns;
+}
 
 const std::unordered_set<const column_definition*> statement_restrictions::get_not_null_columns() const {
     return _not_null_columns;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -65,7 +65,8 @@ interval<clustering_key_prefix> to_range(oper_t op, const clustering_key_prefix&
 
 inline bool needs_filtering(oper_t op) {
     return (op == oper_t::CONTAINS) || (op == oper_t::CONTAINS_KEY) || (op == oper_t::LIKE) ||
-           (op == oper_t::IS_NOT) || (op == oper_t::NEQ) || (op == oper_t::NOT_IN);
+           (op == oper_t::NEQ) || (op == oper_t::NOT_IN) ||
+           (op == oper_t::IS) || (op == oper_t::IS_NOT);  // identity operators, currently restricted to NULL
 }
 
 static
@@ -373,6 +374,15 @@ to_predicates(
                                     .filter = oper,
                                     .on = on_column{col.col},
                                     .is_not_null_single_column = is_null_constant(oper.rhs),
+                                    .op = oper.op,
+                                });
+                            } else if (oper.op == oper_t::IS) {
+                                // This predicate constrains LHS to NULL, but we can't represent it in solve_for.
+                                return to_vector(predicate{
+                                    .solve_for = nullptr,
+                                    .filter = oper,
+                                    .on = on_column{col.col},
+                                    .order = oper.order,
                                     .op = oper.op,
                                 });
                             }
@@ -927,13 +937,44 @@ statement_restrictions::statement_restrictions(private_tag,
     single_column_predicate_vectors sc_ck_pred_vectors;
     single_column_predicate_vectors sc_nonpk_pred_vectors;
     for (auto& pred : predicates) {
-        if (pred.is_not_null_single_column) {
-            auto* col = require_on_single_column(pred);
-            _not_null_columns.insert(col);
-
-            if (!for_view) {
-                throw exceptions::invalid_request_exception(format("restriction '{}' is only supported in materialized view creation", pred.filter));
+        if ((pred.op == oper_t::IS || pred.op == oper_t::IS_NOT) && (type.is_update() || type.is_delete())) {
+            // The WHERE clause of a mutation has to name the rows to write, and
+            // IS [NOT] NULL cannot name one: it tests whether a column has a
+            // value instead of saying which value it has, so it never yields a
+            // concrete key. So reject them - otherwise the restriction would
+            // silently be ignored and the statement would write more than was
+            // asked for, e.g. DELETE ... WHERE p = 1 AND c IS NULL deleting the
+            // whole partition.
+            throw exceptions::invalid_request_exception(format(
+                    "Restriction '{:user}' is not supported in {} statements", pred.filter, type));
+        }
+        if ((pred.op == oper_t::IS || pred.is_not_null_single_column) && for_view) {
+            if (pred.op == oper_t::IS) {
+                // A view row exists only for base rows whose view key columns
+                // are all non-null, so IS NULL on a view key column could only
+                // ever select an empty view. On any other column it would be a
+                // filter on a non-key column, which views don't support. Either
+                // way there is nothing useful to do with it.
+                throw exceptions::invalid_request_exception(format(
+                        "Restriction '{:user}' is not supported in materialized view creation. Only IS NOT NULL is allowed.",
+                        pred.filter));
             }
+            _not_null_columns.insert(require_on_single_column(pred));
+        } else if (pred.is_not_null_single_column && require_on_single_column(pred)->is_partition_key()) {
+            // A partition key column is never null, so IS NOT NULL on one matches
+            // every row. The restriction carries no information, so drop it - in
+            // particular it must not make the query require ALLOW FILTERING.
+            //
+            // This does not extend to a clustering key column. A partition with
+            // no clustering rows still has a static row, and SELECT returns it
+            // with every clustering key column null - so "c IS NOT NULL" does
+            // carry information there, and has to be evaluated like any other
+            // restriction on c rather than dropped.
+            //
+            // A schema with no static columns has no such rows, which would make
+            // the restriction a tautology again, but we deliberately don't make
+            // use of that: it isn't worth a second, schema-dependent rule.
+            continue;
         } else if (pred.is_multi_column) {
             // Multi column restrictions are only allowed on clustering columns
             if (ck_is_empty) {
@@ -1117,7 +1158,7 @@ statement_restrictions::statement_restrictions(private_tag,
             throw exceptions::invalid_request_exception(format("Unhandled restriction: {}", pred.filter));
         }
 
-        if (!pred.is_not_null_single_column) {
+        if (!(for_view && pred.is_not_null_single_column)) {
             _where.push_back(pred.filter);
         }
         // Subscript EQ (e.g. m[1] = 'a') is not considered an EQ on the column

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -168,6 +168,7 @@ private:
     std::vector<expr::binary_operator> _scoring_function_restrictions;
 
 
+    std::unordered_set<const column_definition*> _null_columns;
     std::unordered_set<const column_definition*> _not_null_columns;
 
     /**
@@ -335,6 +336,9 @@ public:
     const expr::expression& get_nonprimary_key_restrictions() const {
         return _nonprimary_key_restrictions;
     }
+
+    // Get a set of columns restricted by the IS NULL restriction.
+    const std::unordered_set<const column_definition*> get_null_columns() const;
 
     // Get a set of columns restricted by the IS NOT NULL restriction.
     // IS NOT NULL is a special case that is handled separately from other restrictions.

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -295,10 +295,10 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     }
 
     // The unique feature of a filter by a non-key column is that the
-    // value of such column can be updated - and also be expired with TTL
+    // value of such a column can be updated - and also be expired with TTL
     // and cause the view row to appear and disappear. We don't currently
-    // support support this case - see issue #3430, and neither does
-    // Cassandra - see see CASSANDRA-13798 and CASSANDRA-13832.
+    // support this case - see issue #3430, and neither does
+    // Cassandra - see CASSANDRA-13798 and CASSANDRA-13832.
     // Actually, as CASSANDRA-13798 explains, the problem is "the liveness of
     // view row is now depending on multiple base columns (multiple filtered
     // non-pk base column + base column used in view pk)". When the filtered

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -18,6 +18,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include "cql3/column_identifier.hh"
+#include "cql3/expr/expr-utils.hh"
 #include "cql3/restrictions/statement_restrictions.hh"
 #include "cql3/statements/create_view_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
@@ -305,6 +306,20 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     // column *is* the base column added to the view pk, we don't have this
     // problem. And this case actually works correctly.
     const expr::single_column_restrictions_map& non_pk_restrictions = restrictions->get_non_pk_restriction();
+    std::vector<std::string_view> invalid_is_null_column_names;
+    for (const column_definition* null_cdef : restrictions->get_null_columns()) {
+        if (!target_primary_keys.contains(null_cdef)) {
+            invalid_is_null_column_names.push_back(null_cdef->name_as_text());
+        }
+    }
+
+    if (!invalid_is_null_column_names.empty()) {
+        throw exceptions::invalid_request_exception(seastar::format(
+                "Non-primary key columns cannot be restricted in the SELECT statement used for materialized view {} creation (got restrictions on: {})",
+                column_family(),
+                fmt::join(invalid_is_null_column_names, ", ")));
+    }
+
     if (non_pk_restrictions.size() == 1 && has_non_pk_column &&
             target_primary_keys.contains(non_pk_restrictions.cbegin()->first)) {
         // This case (filter by new PK column of the view) works, as explained above
@@ -320,6 +335,12 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     for (const column_definition* not_null_cdef : restrictions->get_not_null_columns()) {
         if (!target_primary_keys.contains(not_null_cdef)) {
             invalid_not_null_column_names.push_back(not_null_cdef->name_as_text());
+        }
+    }
+
+    for (const column_definition* null_cdef : restrictions->get_null_columns()) {
+        if (target_primary_keys.contains(null_cdef)) {
+            throw exceptions::invalid_request_exception(format("Restriction '{} IS null' is not supported in materialized view creation. Only IS NOT NULL is allowed.", null_cdef->name_as_text()));
         }
     }
 

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -298,10 +298,10 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     }
 
     // The unique feature of a filter by a non-key column is that the
-    // value of such column can be updated - and also be expired with TTL
+    // value of such a column can be updated - and also be expired with TTL
     // and cause the view row to appear and disappear. We don't currently
-    // support support this case - see issue #3430, and neither does
-    // Cassandra - see see CASSANDRA-13798 and CASSANDRA-13832.
+    // support this case - see issue #3430, and neither does
+    // Cassandra - see CASSANDRA-13798 and CASSANDRA-13832.
     // Actually, as CASSANDRA-13798 explains, the problem is "the liveness of
     // view row is now depending on multiple base columns (multiple filtered
     // non-pk base column + base column used in view pk)". When the filtered

--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -253,9 +253,9 @@ TRUE but `TRUE AND FALSE` is FALSE.
 
 Because `x = NULL` always evaluates to NULL, a `SELECT` filter `WHERE x = NULL`
 matches no row (_matching_ means evaluating to TRUE). It does **not** match
-rows where x is missing. If you really want to match rows with missing x,
-SQL offers a different syntax `x IS NULL` (and similarly, also `x IS NOT
-NULL`), Scylla does not yet implement this syntax.
+rows where x is missing. If you want to match rows with missing x, you can use
+`x IS NULL` (and similarly, `x IS NOT NULL` for rows where x is present).
+These operators require `ALLOW FILTERING` to be specified.
 
 In contrast, Cassandra is less consistent in its handling of nulls.
 The example `x = NULL` is considered an error, not a valid expression
@@ -299,6 +299,51 @@ Scylla. The result of the pattern match is `FALSE`.
 For more details, see:
 - [Lightweight Transactions](../features/lwt.rst)
 - [How does ScyllaDB LWT Differ from Apache Cassandra?](../kb/lwt-differences.rst)
+
+## IS NULL and IS NOT NULL in WHERE clause
+
+ScyllaDB supports `IS NULL` and `IS NOT NULL` operators in the WHERE clause of SELECT
+statements. These operators allow filtering rows based on whether a column value is present or absent:
+
+- `IS NULL` returns rows where the column has no value (is null).
+- `IS NOT NULL` returns rows where the column has a value.
+
+These operators generally require `ALLOW FILTERING` to be specified, as they may need to scan the data
+to check for null values.
+
+Like other Scylla filtering predicates, they can also be combined with additional
+restrictions on the same column. The result follows ordinary conjunction semantics:
+contradictory predicates such as `x IS NULL AND x = 3` match no rows, while
+compatible predicates such as `x IS NOT NULL AND x = 3` work normally.
+
+> **Note:** Primary key columns are never null in CQL. Using `IS NULL` on a primary key column will always
+> return no rows, while `IS NOT NULL` will match all rows.
+
+**Example:**
+
+```cql
+CREATE TABLE users (id int PRIMARY KEY, name text, email text);
+INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com');
+INSERT INTO users (id, name) VALUES (2, 'Bob');
+
+SELECT * FROM users WHERE email IS NULL ALLOW FILTERING;
+
+ id | email | name
+----+-------+------
+  2 |  null |  Bob
+
+SELECT * FROM users WHERE email IS NOT NULL ALLOW FILTERING;
+
+ id | email             | name
+----+-------------------+-------
+  1 | alice@example.com | Alice
+```
+
+**Usage in Materialized Views:**
+
+`IS NOT NULL` is also used in materialized view definitions to ensure that columns
+included in the view's primary key are not null. This usage does not require `ALLOW FILTERING`.
+`IS NULL` is not supported in materialized view definitions.
 
 ## REDUCEFUNC for UDA
 

--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -326,9 +326,11 @@ TRUE but `TRUE AND FALSE` is FALSE.
 
 Because `x = NULL` always evaluates to NULL, a `SELECT` filter `WHERE x = NULL`
 matches no row (_matching_ means evaluating to TRUE). It does **not** match
-rows where x is missing. If you really want to match rows with missing x,
-SQL offers a different syntax `x IS NULL` (and similarly, also `x IS NOT
-NULL`), Scylla does not yet implement this syntax.
+rows where x is missing. If you want to match rows with missing x, you can use
+`x IS NULL` (and similarly, `x IS NOT NULL` for rows where x is present).
+On a regular or static column these operators require `ALLOW FILTERING` to be specified;
+on a primary key column the rules differ per column kind. See
+[IS NULL and IS NOT NULL in WHERE clause](#is-null-and-is-not-null-in-where-clause).
 
 In contrast, Cassandra is less consistent in its handling of nulls.
 The example `x = NULL` is considered an error, not a valid expression
@@ -372,6 +374,121 @@ Scylla. The result of the pattern match is `FALSE`.
 For more details, see:
 - [Lightweight Transactions](../features/lwt.rst)
 - [How does ScyllaDB LWT Differ from Apache Cassandra?](../kb/lwt-differences.rst)
+
+## IS NULL and IS NOT NULL in WHERE clause
+
+ScyllaDB supports `IS NULL` and `IS NOT NULL` operators in the WHERE clause of SELECT
+statements. These operators allow filtering rows based on whether a column value is present or absent:
+
+- `IS NULL` returns rows where the column has no value.
+- `IS NOT NULL` returns rows where the column has a value.
+
+Whether these operators require `ALLOW FILTERING` depends on the column:
+
+- On a **partition key column**, `IS NOT NULL` never requires `ALLOW FILTERING`. Such a
+  column can never be null, so the restriction matches every row and is dropped entirely.
+  Being dropped, it also doesn't count as restricting the partition key for the rules
+  below. `IS NULL` on a partition key column matches no row, but it is still a
+  restriction, so it requires `ALLOW FILTERING`.
+- On a **clustering key column**, both operators are ordinary restrictions on that column
+  and neither is dropped, because a clustering key column *can* read as null - see below.
+  They therefore need the partition key fully restricted by `=` or `IN` (a `token()` range
+  is not enough) and every preceding clustering key column restricted; otherwise they
+  require `ALLOW FILTERING`.
+- On any **other column** - regular or static - both operators require `ALLOW FILTERING`,
+  because every row's value has to be inspected. This holds even when the column is
+  indexed: the index is not consulted for a null check.
+
+A clustering key column reads as null in one case: a partition that holds a static row but
+no clustering rows is returned as a single row whose clustering key columns are all null.
+So on a clustering key column `IS NULL` selects exactly those static-only rows, and
+`IS NOT NULL` selects exactly the clustering rows. In a table with no static columns there
+are no such rows, which makes `IS NULL` match nothing and `IS NOT NULL` match everything -
+but the two are still ordinary restrictions there, subject to the same rules.
+
+```cql
+CREATE TABLE events (p int, c int, v int, PRIMARY KEY (p, c));
+
+-- no ALLOW FILTERING needed: p is a partition key column, so IS NOT NULL is
+-- dropped and this is a full scan
+SELECT * FROM events WHERE p IS NOT NULL;
+
+-- no ALLOW FILTERING needed: the partition key is fixed, so IS [NOT] NULL on
+-- the clustering key is an ordinary clustering key restriction
+SELECT * FROM events WHERE p = 1 AND c IS NOT NULL;
+SELECT * FROM events WHERE p = 1 AND c IS NULL;
+
+-- ALLOW FILTERING needed: no partition key restriction to anchor the clustering
+-- key restriction
+SELECT * FROM events WHERE c IS NOT NULL ALLOW FILTERING;
+SELECT * FROM events WHERE c IS NULL ALLOW FILTERING;
+
+-- ALLOW FILTERING needed: v is a regular column
+SELECT * FROM events WHERE p = 1 AND v IS NULL ALLOW FILTERING;
+```
+
+Like other Scylla filtering predicates, they can also be combined with additional
+restrictions on the same column. The result follows ordinary conjunction semantics:
+contradictory predicates such as `x IS NULL AND x = 3` match no rows, while
+compatible predicates such as `x IS NOT NULL AND x = 3` work normally.
+
+> **Note:** In a materialized view definition `IS NOT NULL` on a base table primary key column is a no-op,
+> because a view row is only ever built from a base clustering row, and such a row has a value for every one
+> of the base table's primary key columns. This is why a view definition may name those columns with
+> `IS NOT NULL` freely. On a regular base table column
+> promoted into the view's primary key it is *not* a no-op - see **Usage in Materialized Views** below.
+> For the `SELECT` rules, which differ between partition key and clustering key columns, see the list
+> above rather than this note.
+
+Unlike the other filtering operators, `IS NULL` and `IS NOT NULL` may also be used on
+non-frozen collection columns, because they only test whether the column has a value
+rather than compare it against one. Note that a non-frozen collection with no elements
+is indistinguishable from a missing one, so an empty collection is considered null:
+
+```cql
+CREATE TABLE tags (id int PRIMARY KEY, tags set<text>);
+INSERT INTO tags (id, tags) VALUES (1, {'a'});
+INSERT INTO tags (id, tags) VALUES (2, {});
+
+SELECT * FROM tags WHERE tags IS NULL ALLOW FILTERING;
+
+ id | tags
+----+------
+  2 | null
+```
+
+**Example:**
+
+```cql
+CREATE TABLE users (id int PRIMARY KEY, name text, email text);
+INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com');
+INSERT INTO users (id, name) VALUES (2, 'Bob');
+
+SELECT * FROM users WHERE email IS NULL ALLOW FILTERING;
+
+ id | email | name
+----+-------+------
+  2 |  null |  Bob
+
+SELECT * FROM users WHERE email IS NOT NULL ALLOW FILTERING;
+
+ id | email             | name
+----+-------------------+-------
+  1 | alice@example.com | Alice
+```
+
+**Usage in Materialized Views:**
+
+`IS NOT NULL` is also used in materialized view definitions to ensure that columns
+included in the view's primary key are not null. This usage does not require `ALLOW FILTERING`.
+On a base table primary key column the restriction is a no-op, because a view row is only ever
+built from a base clustering row, and such a row has a value for every one of the base table's
+primary key columns. On a regular base table column promoted into the view's primary key it is
+not a no-op: it is what excludes the base rows
+where that column is null from the view.
+`IS NULL` is not supported in materialized view definitions, and neither operator can be
+used in a view definition on a column that is not part of the view's primary key - views
+do not support filtering on non-key columns.
 
 ## REDUCEFUNC for UDA
 

--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -35,6 +35,7 @@ Querying data from data is done using a ``SELECT`` statement:
    relation: `column_name` `operator` `term`
            : '(' `column_name` ( ',' `column_name` )* ')' `operator` `tuple_literal`
            : TOKEN '(' `column_name` ( ',' `column_name` )* ')' `operator` `term`
+           : `column_name` IS [ NOT ] NULL
    operator: '=' | '<' | '>' | '<=' | '>=' | IN | NOT IN | CONTAINS | CONTAINS KEY
    ordering_clause: `column_name` [ ASC | DESC ] ( ',' `column_name` [ ASC | DESC ] )*
    timeout: `duration`
@@ -805,6 +806,51 @@ This table contains some commonly used ``LIKE`` filters and the matches you can 
      - asphalt, adapt, at
 
 
+.. _is-null-operator:
+
+IS NULL and IS NOT NULL Operators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``IS NULL`` and ``IS NOT NULL`` operators allow you to filter rows based on whether a column value is present or absent.
+
+- ``IS NULL`` returns rows where the column has no value (is null).
+- ``IS NOT NULL`` returns rows where the column has a value.
+
+These operators generally require ``ALLOW FILTERING`` to be specified, as they may need to scan the data to check for null values.
+
+Like other Scylla filtering predicates, they can also be combined with additional restrictions on the same column.
+The result follows ordinary conjunction semantics: contradictory predicates such as ``x IS NULL AND x = 3`` match
+no rows, while compatible predicates such as ``x IS NOT NULL AND x = 3`` work normally.
+
+.. note:: Primary key columns are never null in CQL. Using ``IS NULL`` on a primary key column will always
+   return no rows, while ``IS NOT NULL`` will match all rows.
+
+**Example**
+
+.. code-block:: cql
+
+   CREATE TABLE users (id int PRIMARY KEY, name text, email text);
+   INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com');
+   INSERT INTO users (id, name) VALUES (2, 'Bob');
+
+   SELECT * FROM users WHERE email IS NULL ALLOW FILTERING;
+
+    id | email | name
+   ----+-------+------
+     2 |  null |  Bob
+
+   SELECT * FROM users WHERE email IS NOT NULL ALLOW FILTERING;
+
+    id | email             | name
+   ----+-------------------+-------
+     1 | alice@example.com | Alice
+
+**Usage in Materialized Views**
+
+The ``IS NOT NULL`` restriction is required in materialized view definitions for all columns that are part of the
+view's primary key, as primary key columns cannot be null. See :ref:`Materialized Views <materialized-views>` for
+more details. This usage does not require ``ALLOW FILTERING``.
+``IS NULL`` is not supported in materialized view definitions.
 
 :doc:`Apache Cassandra Query Language (CQL) Reference </cql/index>`
 

--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -35,6 +35,7 @@ Querying data from data is done using a ``SELECT`` statement:
    relation: `column_name` `operator` `term`
            : '(' `column_name` ( ',' `column_name` )* ')' `operator` `tuple_literal`
            : TOKEN '(' `column_name` ( ',' `column_name` )* ')' `operator` `term`
+           : `column_name` IS [ NOT ] NULL
    operator: '=' | '<' | '>' | '<=' | '>=' | IN | NOT IN | CONTAINS | CONTAINS KEY
    ordering_clause: `column_name` [ ASC | DESC ] ( ',' `column_name` [ ASC | DESC ] )*
    timeout: `duration`
@@ -841,6 +842,105 @@ This table contains some commonly used ``LIKE`` filters and the matches you can 
      - asphalt, adapt, at
 
 
+.. _is-null-operator:
+
+IS NULL and IS NOT NULL Operators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``IS NULL`` and ``IS NOT NULL`` operators allow you to filter rows based on whether a column value is present or absent.
+
+- ``IS NULL`` returns rows where the column has no value (is null).
+- ``IS NOT NULL`` returns rows where the column has a value.
+
+Whether these operators require ``ALLOW FILTERING`` depends on the column:
+
+- On a **partition key column**, ``IS NOT NULL`` never requires ``ALLOW FILTERING``. Such a column can never be
+  null, so the restriction matches every row and is dropped entirely. Being dropped, it also doesn't count as
+  restricting the partition key for the rules below. ``IS NULL`` on a partition key column matches no row, but it
+  is still a restriction, so it requires ``ALLOW FILTERING``.
+- On a **clustering key column**, both operators are ordinary restrictions on that column and neither is dropped,
+  because a clustering key column *can* read as null - see below. They therefore need the partition key fully
+  restricted by ``=`` or ``IN`` (a ``token()`` range is not enough) and every preceding clustering key column
+  restricted; otherwise they require ``ALLOW FILTERING``.
+- On any **other column** - regular or static - both operators require ``ALLOW FILTERING``, because every row's
+  value has to be inspected. This holds even when the column is indexed: the index is not consulted for a null
+  check.
+
+A clustering key column reads as null in one case: a partition that holds a static row but no clustering rows is
+returned as a single row whose clustering key columns are all null. So on a clustering key column ``IS NULL``
+selects exactly those static-only rows, and ``IS NOT NULL`` selects exactly the clustering rows. In a table with
+no static columns there are no such rows, which makes ``IS NULL`` match nothing and ``IS NOT NULL`` match
+everything - but the two are still ordinary restrictions there, subject to the same rules.
+
+.. code-block:: cql
+
+   CREATE TABLE events (p int, c int, v int, PRIMARY KEY (p, c));
+
+   -- no ALLOW FILTERING needed: p is a partition key column, so IS NOT NULL is
+   -- dropped and this is a full scan
+   SELECT * FROM events WHERE p IS NOT NULL;
+
+   -- no ALLOW FILTERING needed: the partition key is fixed, so IS [NOT] NULL on
+   -- the clustering key is an ordinary clustering key restriction
+   SELECT * FROM events WHERE p = 1 AND c IS NOT NULL;
+   SELECT * FROM events WHERE p = 1 AND c IS NULL;
+
+   -- ALLOW FILTERING needed: no partition key restriction to anchor the
+   -- clustering key restriction
+   SELECT * FROM events WHERE c IS NOT NULL ALLOW FILTERING;
+   SELECT * FROM events WHERE c IS NULL ALLOW FILTERING;
+
+   -- ALLOW FILTERING needed: v is a regular column
+   SELECT * FROM events WHERE p = 1 AND v IS NULL ALLOW FILTERING;
+
+Like other Scylla filtering predicates, they can also be combined with additional restrictions on the same column.
+The result follows ordinary conjunction semantics: contradictory predicates such as ``x IS NULL AND x = 3`` match
+no rows, while compatible predicates such as ``x IS NOT NULL AND x = 3`` work normally.
+
+.. note:: In a materialized view definition ``IS NOT NULL`` on a base table primary key column is a no-op,
+   because a view row is only ever built from a base clustering row, and such a row has a value for every one
+   of the base table's primary key columns. This is why a view definition may name those columns with
+   ``IS NOT NULL`` freely. On a regular base table column
+   promoted into the view's primary key it is *not* a no-op - see **Usage in Materialized Views** below. For
+   the ``SELECT`` rules, which differ between partition key and clustering key columns, see the list above
+   rather than this note.
+
+Unlike the other filtering operators, ``IS NULL`` and ``IS NOT NULL`` may also be used on non-frozen collection
+columns, because they only test whether the column has a value rather than compare it against one. Note that a
+non-frozen collection with no elements is indistinguishable from a missing one, so an empty collection is
+considered null.
+
+**Example**
+
+.. code-block:: cql
+
+   CREATE TABLE users (id int PRIMARY KEY, name text, email text);
+   INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com');
+   INSERT INTO users (id, name) VALUES (2, 'Bob');
+
+   SELECT * FROM users WHERE email IS NULL ALLOW FILTERING;
+
+    id | email | name
+   ----+-------+------
+     2 |  null |  Bob
+
+   SELECT * FROM users WHERE email IS NOT NULL ALLOW FILTERING;
+
+    id | email             | name
+   ----+-------------------+-------
+     1 | alice@example.com | Alice
+
+**Usage in Materialized Views**
+
+The ``IS NOT NULL`` restriction is required in materialized view definitions for all columns that are part of the
+view's primary key, as primary key columns cannot be null. See :ref:`Materialized Views <materialized-views>` for
+more details. This usage does not require ``ALLOW FILTERING``. On a base table primary key column the restriction
+is a no-op, because a view row is only ever built from a base clustering row, and such a row has a value for every
+one of the base table's primary key columns. On a regular base table column promoted into the view's primary key it
+is not a no-op: it is what excludes the base rows where that column is null from the view.
+``IS NULL`` is not supported in materialized view definitions, and neither operator can be used in a view
+definition on a column that is not part of the view's primary key - views do not support filtering on non-key
+columns.
 
 :doc:`Apache Cassandra Query Language (CQL) Reference </cql/index>`
 

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -3514,6 +3514,22 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_is_not) {
     BOOST_REQUIRE_EQUAL(evaluate(empty_is_not_null, evaluation_inputs{}), make_bool_raw(true));
 }
 
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_is) {
+    expression false_is_binop = binary_operator(make_int_const(1), oper_t::IS, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(false_is_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression true_is_binop =
+        binary_operator(constant::make_null(int32_type), oper_t::IS, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(true_is_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression forbidden_is_binop = binary_operator(make_int_const(1), oper_t::IS, make_int_const(2));
+    BOOST_REQUIRE_THROW(evaluate(forbidden_is_binop, evaluation_inputs{}), exceptions::invalid_request_exception);
+
+    expression empty_is_null =
+        binary_operator(make_empty_const(int32_type), oper_t::IS, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_is_null, evaluation_inputs{}), make_bool_raw(false));
+}
+
 BOOST_AUTO_TEST_CASE(evaluate_binary_operator_like) {
     expression true_like_binop = binary_operator(make_text_const("some_text"), oper_t::LIKE, make_text_const("some_%"));
     BOOST_REQUIRE_EQUAL(evaluate(true_like_binop, evaluation_inputs{}), make_bool_raw(true));
@@ -4272,6 +4288,8 @@ enum struct expected_rhs_type {
     float_in_list,
     // list<tuple<float, int, text, double>
     multi_column_tuple_in_list,
+    // IS allows only NULL as the RHS, everything else is invalid
+    is_null_rhs,
     // IS_NOT allows only NULL as the RHS, everything else is invalid
     is_not_null_rhs
 };
@@ -4989,6 +5007,28 @@ BOOST_AUTO_TEST_CASE(prepare_binary_operator_is_not_null) {
         test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
 
         test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::is_not_null_rhs, db,
+                                                        table_schema);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(prepare_binary_operator_is_null) {
+    schema_ptr table_schema = schema_builder(1, "test_ks", "test_cf")
+                                  .with_column("pk", int32_type, column_kind::partition_key)
+                                  .with_column("float_col", float_type, column_kind::regular_column)
+                                  .build();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+        expression to_prepare =
+            binary_operator(unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("float_col", false)},
+                            oper_t::IS, make_null_untyped(), comp_order);
+
+        expression expected = binary_operator(column_value(table_schema->get_column_definition("float_col")),
+                                              oper_t::IS, constant::make_null(float_type), comp_order);
+
+        test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+        test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::is_null_rhs, db,
                                                         table_schema);
     }
 }

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -4373,6 +4373,13 @@ std::vector<expression> get_invalid_rhs_values(expected_rhs_type expected_rhs) {
         invalid_rhs_vals.push_back(
             collection_constructor{.style = collection_constructor::style_type::list_or_vector, .elements = {}});
     }
+
+    // A bind marker is a valid RHS for the other operators, but IS NOT requires the RHS to be a NULL literal,
+    // so a bind marker is invalid there.
+    if (expected_rhs == expected_rhs_type::is_not_null_rhs) {
+        invalid_rhs_vals.push_back(bind_variable{.bind_index = 0});
+    }
+
     return invalid_rhs_vals;
 }
 

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -3514,6 +3514,22 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_is_not) {
     BOOST_REQUIRE_EQUAL(evaluate(empty_is_not_null, evaluation_inputs{}), make_bool_raw(true));
 }
 
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_is) {
+    expression false_is_binop = binary_operator(make_int_const(1), oper_t::IS, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(false_is_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression true_is_binop =
+        binary_operator(constant::make_null(int32_type), oper_t::IS, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(true_is_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression forbidden_is_binop = binary_operator(make_int_const(1), oper_t::IS, make_int_const(2));
+    BOOST_REQUIRE_THROW(evaluate(forbidden_is_binop, evaluation_inputs{}), exceptions::invalid_request_exception);
+
+    expression empty_is_null =
+        binary_operator(make_empty_const(int32_type), oper_t::IS, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_is_null, evaluation_inputs{}), make_bool_raw(false));
+}
+
 BOOST_AUTO_TEST_CASE(evaluate_binary_operator_like) {
     expression true_like_binop = binary_operator(make_text_const("some_text"), oper_t::LIKE, make_text_const("some_%"));
     BOOST_REQUIRE_EQUAL(evaluate(true_like_binop, evaluation_inputs{}), make_bool_raw(true));
@@ -4272,6 +4288,8 @@ enum struct expected_rhs_type {
     float_in_list,
     // list<tuple<float, int, text, double>
     multi_column_tuple_in_list,
+    // IS allows only NULL as the RHS, everything else is invalid
+    is_null_rhs,
     // IS_NOT allows only NULL as the RHS, everything else is invalid
     is_not_null_rhs
 };
@@ -4374,9 +4392,9 @@ std::vector<expression> get_invalid_rhs_values(expected_rhs_type expected_rhs) {
             collection_constructor{.style = collection_constructor::style_type::list_or_vector, .elements = {}});
     }
 
-    // A bind marker is a valid RHS for the other operators, but IS NOT requires the RHS to be a NULL literal,
+    // A bind marker is a valid RHS for the other operators, but IS/IS NOT require the RHS to be a NULL literal,
     // so a bind marker is invalid there.
-    if (expected_rhs == expected_rhs_type::is_not_null_rhs) {
+    if (expected_rhs == expected_rhs_type::is_null_rhs || expected_rhs == expected_rhs_type::is_not_null_rhs) {
         invalid_rhs_vals.push_back(bind_variable{.bind_index = 0});
     }
 
@@ -4996,6 +5014,28 @@ BOOST_AUTO_TEST_CASE(prepare_binary_operator_is_not_null) {
         test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
 
         test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::is_not_null_rhs, db,
+                                                        table_schema);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(prepare_binary_operator_is_null) {
+    schema_ptr table_schema = schema_builder(1, "test_ks", "test_cf")
+                                  .with_column("pk", int32_type, column_kind::partition_key)
+                                  .with_column("float_col", float_type, column_kind::regular_column)
+                                  .build();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+        expression to_prepare =
+            binary_operator(unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("float_col", false)},
+                            oper_t::IS, make_null_untyped(), comp_order);
+
+        expression expected = binary_operator(column_value(table_schema->get_column_definition("float_col")),
+                                              oper_t::IS, constant::make_null(float_type), comp_order);
+
+        test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+        test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::is_null_rhs, db,
                                                         table_schema);
     }
 }

--- a/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -10,6 +10,7 @@
 
 from ...porting import *
 from cassandra.query import UNSET_VALUE
+from ....util import is_scylla
 
 def testInvalidCollectionEqualityRelation(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b set<int>, c list<int>, d map<int, int>)") as table:
@@ -602,7 +603,14 @@ def testInvalidNonFrozenUDTRelation(cql, test_keyspace):
             assert_invalid_message(cql, table, "Unsupported \"!=\" relation",
                              "SELECT * FROM %s WHERE b != {a: 0}", udt)
             # Reproduces #10632:
-            assert_invalid_message(cql, table, "b IS NOT",
-                             "SELECT * FROM %s WHERE b IS NOT NULL", udt)
+            # Scylla now supports IS NOT NULL on non-frozen UDT columns in
+            # regular SELECT queries (with ALLOW FILTERING), so the restriction
+            # itself is no longer rejected with "b IS NOT NULL is only supported
+            # in materialized view creation".
+            if is_scylla(cql):
+                assert_empty(execute(cql, table, "SELECT * FROM %s WHERE b IS NOT NULL ALLOW FILTERING"))
+            else:
+                assert_invalid_message(cql, table, "b IS NOT",
+                                 "SELECT * FROM %s WHERE b IS NOT NULL", udt)
             assert_invalid_message(cql, table, "Cannot use CONTAINS on non-collection column",
                              "SELECT * FROM %s WHERE b CONTAINS ?", udt)

--- a/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -10,6 +10,7 @@
 
 from ...porting import *
 from cassandra.query import UNSET_VALUE
+from ....util import is_scylla
 
 def testInvalidCollectionEqualityRelation(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b set<int>, c list<int>, d map<int, int>)") as table:
@@ -42,11 +43,18 @@ def testInvalidCollectionNonEQRelation(cql, test_keyspace):
                              "SELECT * FROM %s WHERE c = 0 AND b IN (?)", {0})
         assert_invalid_message(cql, table, "Unsupported \"!=\" relation: b != 5",
                 "SELECT * FROM %s WHERE c = 0 AND b != 5")
-        # different error message in Scylla and Cassandra. Note that in the
-        # future, Scylla may want to support this restriction so the error
-        # message will change again.
-        assert_invalid_message(cql, table, "IS NOT",
-                "SELECT * FROM %s WHERE c = 0 AND b IS NOT NULL")
+        # Scylla now supports IS NOT NULL on non-frozen collection columns in
+        # regular SELECT queries (with ALLOW FILTERING) - the predicate only
+        # tests whether the column has any value, so unlike the relations above
+        # it is meaningful for non-frozen collections. Cassandra still rejects
+        # it outside of materialized view creation.
+        if is_scylla(cql):
+            assert_invalid_message(cql, table, "ALLOW FILTERING",
+                    "SELECT * FROM %s WHERE c = 0 AND b IS NOT NULL")
+            assert_row_count(execute(cql, table, "SELECT * FROM %s WHERE c = 0 AND b IS NOT NULL ALLOW FILTERING"), 1)
+        else:
+            assert_invalid_message(cql, table, "IS NOT",
+                    "SELECT * FROM %s WHERE c = 0 AND b IS NOT NULL")
 
 def testClusteringColumnRelations(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a text, b int, c int, d int, primary key (a, b, c))") as table:
@@ -602,7 +610,14 @@ def testInvalidNonFrozenUDTRelation(cql, test_keyspace):
             assert_invalid_message(cql, table, "Unsupported \"!=\" relation",
                              "SELECT * FROM %s WHERE b != {a: 0}", udt)
             # Reproduces #10632:
-            assert_invalid_message(cql, table, "b IS NOT",
-                             "SELECT * FROM %s WHERE b IS NOT NULL", udt)
+            # Scylla now supports IS NOT NULL on non-frozen UDT columns in
+            # regular SELECT queries (with ALLOW FILTERING), so the restriction
+            # itself is no longer rejected with "b IS NOT NULL is only supported
+            # in materialized view creation".
+            if is_scylla(cql):
+                assert_empty(execute(cql, table, "SELECT * FROM %s WHERE b IS NOT NULL ALLOW FILTERING"))
+            else:
+                assert_invalid_message(cql, table, "b IS NOT",
+                                 "SELECT * FROM %s WHERE b IS NOT NULL", udt)
             assert_invalid_message(cql, table, "Cannot use CONTAINS on non-collection column",
                              "SELECT * FROM %s WHERE b CONTAINS ?", udt)

--- a/test/cqlpy/test_is_null.py
+++ b/test/cqlpy/test_is_null.py
@@ -1,0 +1,342 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+#############################################################################
+# Tests for IS NULL and IS NOT NULL in WHERE clauses
+#
+# CQL, as defined in: cassandra.apache.org/doc/4.0/cassandra/cql/dml.html,
+# doesn't support IS [NOT] NULL (except MVs), it's our CQL extension,
+# so these tests will fail with Cassandra, thus are marked as `scylla_only`.
+#############################################################################
+
+import pytest
+from cassandra.protocol import InvalidRequest, SyntaxException
+from .util import new_test_table, unique_name, unique_key_int
+
+
+# All tests in this file check Scylla-only IS [NOT] NULL support in WHERE clauses,
+# so let's mark them all scylla_only with an autouse fixture.
+@pytest.fixture(scope="function", autouse=True)
+def all_tests_are_scylla_only(scylla_only):
+    pass
+
+@pytest.fixture(scope="module")
+def table1(cql, test_keyspace):
+    """Shared table for tests with the same schema"""
+    table = test_keyspace + "." + unique_name()
+    cql.execute(f"CREATE TABLE {table} (p int, c int, v int, s text, PRIMARY KEY (p, c))")
+    yield table
+    cql.execute(f"DROP TABLE {table}")
+
+
+def test_is_null_regular_column(cql, table1):
+    """Test IS NULL on regular columns"""
+    p = unique_key_int()
+    # Insert some test data
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 4, NULL, 'c')")  # v is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 5, NULL, NULL)")  # both v and s are null
+    
+    # Test IS NULL on regular column with ALLOW FILTERING
+    result = cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL ALLOW FILTERING")
+    assert {r.c for r in result} == {4, 5}
+
+    # Test IS NULL on text column
+    result = cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND s IS NULL ALLOW FILTERING")
+    assert {r.c for r in result} == {3, 5}
+
+
+def test_is_not_null_regular_column(cql, table1):
+    """Test IS NOT NULL on regular columns"""
+    p = unique_key_int()
+    # Insert some test data
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 4, NULL, 'c')")  # v is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 5, NULL, NULL)")  # both v and s are null
+    
+    # Test IS NOT NULL on regular column with ALLOW FILTERING
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT NULL ALLOW FILTERING"))
+    assert len(result) == 3
+    assert {r.c for r in result} == {1, 2, 3}
+    
+
+def test_is_null_with_prepared_statement(cql, table1):
+    """Test IS NULL with prepared statements"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, NULL)")  # s is null
+    
+    stmt = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND s IS NULL ALLOW FILTERING")
+    result = list(cql.execute(stmt, [p]))
+    assert len(result) == 1
+    assert result[0].c == 2
+
+
+def test_is_not_null_with_prepared_statement(cql, table1):
+    """Test IS NOT NULL with prepared statements"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, NULL)")  # s is null
+    
+    stmt = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND s IS NOT NULL ALLOW FILTERING")
+    result = list(cql.execute(stmt, [p]))
+    assert len(result) == 1
+    assert result[0].c == 1
+
+
+def test_is_null_combined_with_other_restrictions_on_different_columns(cql, table1):
+    """Test IS NULL combined with other WHERE conditions"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 4, NULL, 'd')")  # v is null
+    
+    # Combine IS NULL with value comparison
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c > 1 AND s IS NULL ALLOW FILTERING"))
+    assert len(result) == 2
+    assert {r.c for r in result} == {2, 3}
+    
+    # Multiple IS NULL conditions
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL AND s IS NOT NULL ALLOW FILTERING"))
+    assert len(result) == 1
+    assert result[0].c == 4
+
+
+def test_is_null_combined_with_other_restrictions_on_the_same_column(cql, table1):
+    """Test IS NULL combined with other WHERE conditions applied to the same column"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 4, NULL, 'd')")  # v is null
+
+    # Combine IS [NOT] NULL with value comparison
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND s IS NOT NULL AND s IS NULL ALLOW FILTERING"))
+    assert len(result) == 0
+
+    # Double IS [NOT] NULL with value comparison
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL AND v IS NULL ALLOW FILTERING"))
+    assert len(result) == 1
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT NULL AND v IS NOT NULL ALLOW FILTERING"))
+    assert len(result) == 3
+
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL AND v = 10 ALLOW FILTERING"))
+    assert len(result) == 0
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT NULL AND v = 10 ALLOW FILTERING"))
+    assert len(result) == 1
+    assert result[0].c == 1
+
+    # Multiple IS NULL conditions
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v > 1 AND v IS NOT NULL AND s IS NULL ALLOW FILTERING"))
+    assert len(result) == 2
+    assert {r.c for r in result} == {2, 3}
+
+
+def test_is_null_on_partition_key(cql, table1):
+    """Test IS NULL and IS NOT NULL on partition key columns
+
+    Key columns can never be null, so:
+    - IS NULL should always return no rows
+    - IS NOT NULL should always be true
+    Both operations still require ALLOW FILTERING, which is tested separately.
+    """
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+    
+    # IS NULL on partition key should return no rows (keys can never be null)
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p IS NULL ALLOW FILTERING"))
+    assert len(result) == 0
+    
+    # IS NOT NULL on partition key should match all rows
+    # Since partition keys can never be null, this is always true
+    result = cql.execute(f"SELECT * FROM {table1} WHERE p IS NOT NULL ALLOW FILTERING")
+    # This returns all rows from all partitions, so we should at least see our 2 rows
+    assert sum(1 for r in result if r.p == p) == 2
+
+
+def test_is_null_on_clustering_key(cql, table1):
+    """Test IS NULL and IS NOT NULL on clustering key columns
+
+    Key columns can never be null, so:
+    - IS NULL should always return no rows
+    - IS NOT NULL should always be true
+    Both operations still require ALLOW FILTERING, which is tested separately.
+    """
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+    
+    # IS NULL on clustering key should return no rows (keys can never be null)
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NULL ALLOW FILTERING"))
+    assert len(result) == 0
+    
+    # IS NOT NULL on clustering key with partition key specified
+    # Since clustering keys can never be null, this is always true
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NOT NULL ALLOW FILTERING"))
+    assert len(result) == 2
+
+
+def test_is_null_on_compound_partition_key(cql, test_keyspace):
+    """Test IS NULL and IS NOT NULL on compound partition key columns"""
+    with new_test_table(cql, test_keyspace, "p1 int, p2 int, c int, v int, PRIMARY KEY ((p1, p2), c)") as table:
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (1, 2, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (1, 2, 2, 20)")
+        
+        # IS NULL on first partition key component should return no rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p1 IS NULL ALLOW FILTERING"))
+        assert len(result) == 0
+        
+        # IS NULL on second partition key component should return no rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p2 IS NULL ALLOW FILTERING"))
+        assert len(result) == 0
+        
+        # IS NOT NULL on partition key components should match all rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p1 IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 2
+        
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p2 IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 2
+
+
+def test_is_null_on_compound_clustering_key(cql, test_keyspace):
+    """Test IS NULL and IS NOT NULL on compound clustering key columns"""
+    with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, v int, PRIMARY KEY (p, c1, c2)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c1, c2, v) VALUES (1, 2, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p, c1, c2, v) VALUES (1, 2, 2, 20)")
+
+        # IS NULL on first clustering key component should return no rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE c1 IS NULL ALLOW FILTERING"))
+        assert len(result) == 0
+
+        # IS NULL on second clustering key component should return no rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE c2 IS NULL ALLOW FILTERING"))
+        assert len(result) == 0
+
+        # IS NOT NULL on clustering key components should match all rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE c1 IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 2
+
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE c2 IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 2
+
+
+def test_is_null_without_filtering_error(cql, table1):
+    """Test that IS NULL without ALLOW FILTERING on a regular column raises an error"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v) VALUES ({p}, 1, 10)")
+
+    # IS NULL on a regular column without ALLOW FILTERING should fail
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE v IS NULL")
+
+
+def test_is_not_null_without_filtering_error(cql, table1):
+    """Test that IS NOT NULL without ALLOW FILTERING on a regular column raises an error"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v) VALUES ({p}, 1, 10)")
+
+    # IS NOT NULL on a regular column without ALLOW FILTERING should fail
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE v IS NOT NULL")
+
+
+def test_is_null_on_key_column_without_filtering(cql, table1):
+    """Test IS [NOT] NULL on key columns without ALLOW FILTERING.
+
+    Key columns are never null, so IS NULL can never match and IS NOT NULL
+    always matches. For partition keys, null checks still require ALLOW FILTERING
+    because they don't restrict the partition range. For clustering keys, once the
+    partition key is fixed, null checks can be evaluated without ALLOW FILTERING.
+    """
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v) VALUES ({p}, 1, 10)")
+
+    # IS [NOT] NULL on a partition key column without ALLOW FILTERING should fail.
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE p IS NULL")
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE p IS NOT NULL")
+
+    # IS [NOT] NULL on a clustering key can be evaluated without ALLOW FILTERING
+    # if the partition key is restricted.
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NULL")) == []
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NOT NULL"))
+    assert len(result) == 1
+    assert result[0].p == p
+    assert result[0].c == 1
+    assert result[0].v == 10
+
+    # Without a partition-key restriction, the same clustering-key predicates need filtering.
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE c IS NULL")
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE c IS NOT NULL")
+
+
+def test_is_null_with_invalid_syntax(cql, table1):
+    """Test that IS NULL only accepts NULL as RHS"""
+    p = unique_key_int()
+    # IS NULL with non-null value should fail with syntax error
+    # (the grammar only allows IS NULL, not IS <value>)
+    with pytest.raises(SyntaxException):
+        cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS 123 ALLOW FILTERING")
+    
+    # IS NOT with non-null value should fail with syntax error
+    with pytest.raises(SyntaxException):
+        cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT 123 ALLOW FILTERING")
+
+
+def test_null_equality_returns_empty(cql, table1):
+    """Test that WHERE x = null returns no results (as per SQL semantics)"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, NULL, NULL)")  # v is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v) VALUES ({p}, 2, 10)")
+    
+    # x = null should return nothing (not the same as IS NULL)
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v = null ALLOW FILTERING"))
+    assert len(result) == 0
+
+
+def test_is_null_multiple_columns(cql, test_keyspace):
+    """Test IS NULL on multiple columns"""
+    with new_test_table(cql, test_keyspace, "p int, c int, v1 int, v2 int, v3 text, PRIMARY KEY (p, c)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 1, 10, 20, 'a')")
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 2, 10, 20, NULL)")  # v3 is null
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 3, 10, NULL, NULL)")  # v2 and v3 are null
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 4, NULL, NULL, NULL)")  # all regular columns are null
+        
+        # Test multiple IS NULL conditions
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND v2 IS NULL AND v3 IS NULL ALLOW FILTERING"))
+        assert len(result) == 2
+        assert {r.c for r in result} == {3, 4}
+        
+        # Mix IS NULL and IS NOT NULL
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND v1 IS NOT NULL AND v2 IS NULL ALLOW FILTERING"))
+        assert len(result) == 1
+        assert result[0].c == 3
+
+
+def test_is_null_empty_vs_null(cql, test_keyspace):
+    """Test that empty string is not treated as NULL"""
+    with new_test_table(cql, test_keyspace, "p int, c int, s text, PRIMARY KEY (p, c)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c, s) VALUES (1, 1, '')")  # empty string
+        cql.execute(f"INSERT INTO {table} (p, c, s) VALUES (1, 2, NULL)")  # null
+        cql.execute(f"INSERT INTO {table} (p, c, s) VALUES (1, 3, NULL)")  # also null
+        
+        # IS NULL should only return truly null values, not empty strings
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND s IS NULL ALLOW FILTERING"))
+        assert len(result) == 2
+        assert {r.c for r in result} == {2, 3}
+        
+        # IS NOT NULL should include empty string
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND s IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 1
+        assert result[0].c == 1
+        assert result[0].s == ''

--- a/test/cqlpy/test_is_null.py
+++ b/test/cqlpy/test_is_null.py
@@ -1,0 +1,640 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+#############################################################################
+# Tests for IS NULL and IS NOT NULL in WHERE clauses - issue #8517.
+#
+# CQL, as defined in: cassandra.apache.org/doc/4.0/cassandra/cql/dml.html,
+# doesn't support IS [NOT] NULL (except MVs), it's our CQL extension,
+# so these tests will fail with Cassandra, thus are marked as `scylla_only`.
+#
+# The rules these tests pin down, in one place so the individual tests need not
+# restate them:
+#  - On a partition key column, which is never null, IS NOT NULL matches every
+#    row and is dropped entirely, so it never requires ALLOW FILTERING and does
+#    not count as restricting the partition key; IS NULL matches no row but is
+#    still a restriction, so it does require ALLOW FILTERING.
+#  - On a clustering key column neither operator is dropped, because a
+#    clustering key column can read as null: a partition holding a static row
+#    and no clustering rows is returned as one row whose clustering key columns
+#    are all null. Both are therefore ordinary restrictions on the column,
+#    obeying the usual clustering key prefix and ALLOW FILTERING rules.
+#  - On a regular or static column both always require ALLOW FILTERING.
+#############################################################################
+
+import pytest
+from cassandra.protocol import InvalidRequest, SyntaxException
+from .util import new_test_table, unique_name, unique_key_int
+
+
+# All tests in this file check Scylla-only IS [NOT] NULL support in WHERE clauses,
+# so let's mark them all scylla_only with an autouse fixture.
+@pytest.fixture(scope="function", autouse=True)
+def all_tests_are_scylla_only(scylla_only):
+    pass
+
+# Shared table for tests with the same schema
+@pytest.fixture(scope="module")
+def table1(cql, test_keyspace):
+    table = test_keyspace + "." + unique_name()
+    cql.execute(f"CREATE TABLE {table} (p int, c int, v int, s text, PRIMARY KEY (p, c))")
+    yield table
+    cql.execute(f"DROP TABLE {table}")
+
+
+# Populate partition p with rows covering every combination of null v and s
+def insert_null_test_data(cql, table, p):
+    cql.execute(f"INSERT INTO {table} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+    cql.execute(f"INSERT INTO {table} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table} (p, c, v, s) VALUES ({p}, 4, NULL, 'c')")  # v is null
+    cql.execute(f"INSERT INTO {table} (p, c, v, s) VALUES ({p}, 5, NULL, NULL)")  # both v and s are null
+
+
+# Test IS NULL on regular columns, unprepared and prepared
+def test_is_null_regular_column(cql, table1):
+    p = unique_key_int()
+    insert_null_test_data(cql, table1, p)
+
+    # Test IS NULL on regular column with ALLOW FILTERING
+    result = cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL ALLOW FILTERING")
+    assert {r.c for r in result} == {4, 5}
+
+    # Test IS NULL on text column
+    result = cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND s IS NULL ALLOW FILTERING")
+    assert {r.c for r in result} == {3, 5}
+
+    # The same query as a prepared statement, binding the partition key
+    stmt = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND s IS NULL ALLOW FILTERING")
+    assert {r.c for r in cql.execute(stmt, [p])} == {3, 5}
+
+
+# Test IS NOT NULL on regular columns, unprepared and prepared
+def test_is_not_null_regular_column(cql, table1):
+    p = unique_key_int()
+    insert_null_test_data(cql, table1, p)
+
+    # Test IS NOT NULL on regular column with ALLOW FILTERING
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT NULL ALLOW FILTERING"))
+    assert {r.c for r in result} == {1, 2, 3}
+
+    # Test IS NOT NULL on text column
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND s IS NOT NULL ALLOW FILTERING"))
+    assert {r.c for r in result} == {1, 2, 4}
+
+    # The same query as a prepared statement, binding the partition key
+    stmt = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND s IS NOT NULL ALLOW FILTERING")
+    assert {r.c for r in cql.execute(stmt, [p])} == {1, 2, 4}
+
+
+# IS [NOT] NULL on a static column, unprepared and prepared.
+#
+# A static column belongs to the partition, not to the row, so it is filtered on
+# a different path than a regular column - but the outcome must be the same: a
+# partition that never had the static column set reads it as null, and its rows
+# match IS NULL and not IS NOT NULL. Both still require ALLOW FILTERING, since
+# a static column can be null.
+def test_is_null_static_column(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, s int static, v int, PRIMARY KEY (p, c)") as table:
+        p_set = unique_key_int()
+        p_unset = unique_key_int()
+        p_deleted = unique_key_int()
+        for p in [p_set, p_unset, p_deleted]:
+            cql.execute(f"INSERT INTO {table} (p, c, v) VALUES ({p}, 1, 10)")
+            cql.execute(f"INSERT INTO {table} (p, c, v) VALUES ({p}, 2, 20)")
+        cql.execute(f"UPDATE {table} SET s = 7 WHERE p = {p_set}")
+        # A static column that was set and then deleted reads as null again
+        cql.execute(f"UPDATE {table} SET s = 7 WHERE p = {p_deleted}")
+        cql.execute(f"DELETE s FROM {table} WHERE p = {p_deleted}")
+
+        def keys(where):
+            return {(r.p, r.c) for r in cql.execute(f"SELECT * FROM {table} WHERE {where} ALLOW FILTERING")
+                    if r.p in (p_set, p_unset, p_deleted)}
+
+        assert keys("s IS NOT NULL") == {(p_set, 1), (p_set, 2)}
+        assert keys("s IS NULL") == {(p_unset, 1), (p_unset, 2), (p_deleted, 1), (p_deleted, 2)}
+
+        # The same, restricted to one partition, and combined with other
+        # restrictions on the row and on the static column itself
+        assert keys(f"p = {p_set} AND s IS NOT NULL") == {(p_set, 1), (p_set, 2)}
+        assert keys(f"p = {p_set} AND s IS NULL") == set()
+        assert keys(f"p = {p_unset} AND s IS NULL") == {(p_unset, 1), (p_unset, 2)}
+        assert keys(f"p = {p_set} AND c = 2 AND s IS NOT NULL") == {(p_set, 2)}
+        assert keys(f"p = {p_set} AND s IS NOT NULL AND s = 7") == {(p_set, 1), (p_set, 2)}
+        assert keys(f"p = {p_set} AND s IS NULL AND s = 7") == set()
+
+        # The same queries as prepared statements
+        stmt = cql.prepare(f"SELECT * FROM {table} WHERE p = ? AND s IS NULL ALLOW FILTERING")
+        assert {r.c for r in cql.execute(stmt, [p_unset])} == {1, 2}
+        assert {r.c for r in cql.execute(stmt, [p_set])} == set()
+        stmt = cql.prepare(f"SELECT * FROM {table} WHERE p = ? AND s IS NOT NULL ALLOW FILTERING")
+        assert {r.c for r in cql.execute(stmt, [p_set])} == {1, 2}
+        assert {r.c for r in cql.execute(stmt, [p_unset])} == set()
+
+
+# A partition can hold a static row with no clustering rows at all. SELECT still
+# returns one row for such a partition, with the clustering key columns null, so
+# IS [NOT] NULL on the static column has to filter that row like any other.
+def test_is_null_static_column_static_only_partition(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, s int static, v int, PRIMARY KEY (p, c)") as table:
+        p = unique_key_int()
+        cql.execute(f"UPDATE {table} SET s = 7 WHERE p = {p}")
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = {p} AND s IS NOT NULL ALLOW FILTERING"))
+        assert [(r.c, r.s) for r in result] == [(None, 7)]
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE p = {p} AND s IS NULL ALLOW FILTERING")) == []
+
+        # And with the static column deleted the static-only row is gone
+        # altogether, so neither predicate has anything left to match.
+        cql.execute(f"DELETE s FROM {table} WHERE p = {p}")
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE p = {p} AND s IS NOT NULL ALLOW FILTERING")) == []
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE p = {p} AND s IS NULL ALLOW FILTERING")) == []
+
+
+# Test IS NULL combined with other WHERE conditions
+def test_is_null_combined_with_other_restrictions_on_different_columns(cql, table1):
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 4, NULL, 'd')")  # v is null
+    
+    # Combine IS NULL with value comparison
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c > 1 AND s IS NULL ALLOW FILTERING"))
+    assert {r.c for r in result} == {2, 3}
+    
+    # Multiple IS NULL conditions
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL AND s IS NOT NULL ALLOW FILTERING"))
+    assert {r.c for r in result} == {4}
+
+
+# Test IS NULL combined with other WHERE conditions applied to the same column
+def test_is_null_combined_with_other_restrictions_on_the_same_column(cql, table1):
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 4, NULL, 'd')")  # v is null
+
+    # Combine IS [NOT] NULL with value comparison
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND s IS NOT NULL AND s IS NULL ALLOW FILTERING"))
+    assert result == []
+
+    # Double IS [NOT] NULL with value comparison
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL AND v IS NULL ALLOW FILTERING"))
+    assert {r.c for r in result} == {4}
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT NULL AND v IS NOT NULL ALLOW FILTERING"))
+    assert {r.c for r in result} == {1, 2, 3}
+
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL AND v = 10 ALLOW FILTERING"))
+    assert result == []
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT NULL AND v = 10 ALLOW FILTERING"))
+    assert {r.c for r in result} == {1}
+
+    # IS [NOT] NULL together with a slice on the very same column
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v > 10 AND v IS NOT NULL ALLOW FILTERING"))
+    assert {r.c for r in result} == {2, 3}
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v > 10 AND v IS NULL ALLOW FILTERING"))
+    assert result == []
+
+
+# Test IS NULL and IS NOT NULL on partition key columns
+#
+# A partition key column can never be null, so:
+# - IS NULL should always return no rows, and still needs ALLOW FILTERING
+# - IS NOT NULL should always be true, and needs no ALLOW FILTERING
+def test_is_null_on_partition_key(cql, table1):
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+
+    # IS NULL on partition key should return no rows (keys can never be null)
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p IS NULL ALLOW FILTERING"))
+    assert result == []
+
+    # IS NOT NULL on partition key should match all rows. Since partition keys
+    # can never be null the restriction is dropped, so no ALLOW FILTERING is
+    # needed - the query is just a full scan.
+    result = cql.execute(f"SELECT * FROM {table1} WHERE p IS NOT NULL")
+    # This returns all rows from all partitions, so we should at least see our 2 rows
+    assert sum(1 for r in result if r.p == p) == 2
+
+
+# Test IS NULL and IS NOT NULL on clustering key columns
+#
+# A clustering key column is never null in a clustering row, so within a
+# partition that has any, IS NULL selects none of them and IS NOT NULL selects
+# all of them. (A partition with no clustering rows at all is a different
+# story - see test_is_null_on_clustering_key_of_static_row.)
+def test_is_null_on_clustering_key(cql, table1):
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+
+    # IS NULL on the clustering key returns no rows: every row in this
+    # partition is a clustering row, and table1 has no static column
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NULL"))
+    assert result == []
+
+    # ... so IS NOT NULL, with the partition key specified, returns all of them
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NOT NULL"))
+    assert {r.c for r in result} == {1, 2}
+
+
+# Test IS NULL and IS NOT NULL on compound partition key columns.
+#
+# The components of a compound partition key can never be null so IS NULL
+# and IS NOT NULL are trivially false and true, respectively.
+def test_is_null_on_compound_partition_key(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p1 int, p2 int, c int, v int, PRIMARY KEY ((p1, p2), c)") as table:
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (1, 2, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (1, 2, 2, 20)")
+        
+        # IS NULL on first partition key component should return no rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p1 IS NULL ALLOW FILTERING"))
+        assert result == []
+        
+        # IS NULL on second partition key component should return no rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p2 IS NULL ALLOW FILTERING"))
+        assert result == []
+        
+        # IS NOT NULL on partition key components should match all rows, and
+        # needs no ALLOW FILTERING even on a single component of a compound key
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p1 IS NOT NULL"))
+        assert {(r.p1, r.p2, r.c) for r in result} == {(1, 2, 1), (1, 2, 2)}
+
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p2 IS NOT NULL"))
+        assert {(r.p1, r.p2, r.c) for r in result} == {(1, 2, 1), (1, 2, 2)}
+
+
+# Test IS NULL and IS NOT NULL on compound clustering key columns
+#
+# In a table with no static columns every row is a clustering row, so no
+# component of the clustering key is ever null: IS NULL matches nothing and
+# IS NOT NULL matches everything. Both are ordinary restrictions on the column
+# though, so a whole-table query needs ALLOW FILTERING either way.
+def test_is_null_on_compound_clustering_key(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, v int, PRIMARY KEY (p, c1, c2)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c1, c2, v) VALUES (1, 2, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p, c1, c2, v) VALUES (1, 2, 2, 20)")
+
+        # IS NULL on either clustering key component returns no rows
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE c1 IS NULL ALLOW FILTERING")) == []
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE c2 IS NULL ALLOW FILTERING")) == []
+
+        # IS NOT NULL on either component matches every row
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE c1 IS NOT NULL ALLOW FILTERING"))
+        assert {(r.c1, r.c2) for r in result} == {(2, 1), (2, 2)}
+
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE c2 IS NOT NULL ALLOW FILTERING"))
+        assert {(r.c1, r.c2) for r in result} == {(2, 1), (2, 2)}
+
+        # Within a single partition neither operator needs ALLOW FILTERING
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND c1 IS NOT NULL"))
+        assert {(r.c1, r.c2) for r in result} == {(2, 1), (2, 2)}
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND c1 IS NULL")) == []
+
+
+# Test that IS NULL without ALLOW FILTERING on a regular column raises an error
+def test_is_null_without_filtering_error(cql, table1):
+    # IS NULL on a regular column without ALLOW FILTERING should fail
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE v IS NULL")
+
+
+# Test that IS NOT NULL without ALLOW FILTERING on a regular column raises an error
+def test_is_not_null_without_filtering_error(cql, table1):
+    # IS NOT NULL on a regular column without ALLOW FILTERING should fail
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE v IS NOT NULL")
+
+
+# Test IS [NOT] NULL on key columns without ALLOW FILTERING.
+#
+# A partition key column is never null, so IS NOT NULL on one matches every row
+# and is dropped entirely - it never requires ALLOW FILTERING. Nothing else is
+# dropped: IS NULL on a partition key, and either operator on a clustering key,
+# are ordinary restrictions on the column, so on a partition key they need
+# ALLOW FILTERING and on a clustering key they need the partition key restricted.
+def test_is_null_on_key_column_without_filtering(cql, table1):
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v) VALUES ({p}, 1, 10)")
+
+    # IS NOT NULL on a partition key column never needs ALLOW FILTERING.
+    assert sum(1 for r in cql.execute(f"SELECT * FROM {table1} WHERE p IS NOT NULL") if r.p == p) == 1
+
+    # On a clustering key it does, unless the partition key is restricted.
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE c IS NOT NULL")
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NOT NULL"))
+    assert {(r.p, r.c, r.v) for r in result} == {(p, 1, 10)}
+
+    # IS NULL on a partition key column does need ALLOW FILTERING.
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE p IS NULL")
+
+    # IS NULL on a clustering key needs the partition key to be restricted,
+    # exactly like any other clustering key restriction.
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NULL")) == []
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE c IS NULL")
+
+
+# Test that IS NULL only accepts NULL as RHS
+def test_is_null_with_invalid_syntax(cql, table1):
+    p = unique_key_int()
+    # IS NULL with non-null value should fail with syntax error
+    # (the grammar only allows IS NULL, not IS <value>)
+    with pytest.raises(SyntaxException):
+        cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS 123 ALLOW FILTERING")
+
+    # IS NOT with non-null value should fail with syntax error
+    with pytest.raises(SyntaxException):
+        cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT 123 ALLOW FILTERING")
+
+    # The same holds when preparing the statement rather than executing it.
+    with pytest.raises(SyntaxException):
+        cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND v IS 123 ALLOW FILTERING")
+    with pytest.raises(SyntaxException):
+        cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND v IS NOT 123 ALLOW FILTERING")
+
+    # A bind marker cannot be used to sneak a non-NULL right side past the
+    # grammar: NULL has to be spelled out, so IS ? is a syntax error too.
+    with pytest.raises(SyntaxException):
+        cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND v IS ? ALLOW FILTERING")
+    with pytest.raises(SyntaxException):
+        cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND v IS NOT ? ALLOW FILTERING")
+
+    # Spelled out, both prepare fine.
+    cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND v IS NULL ALLOW FILTERING")
+    cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND v IS NOT NULL ALLOW FILTERING")
+
+
+# Test IS NULL on multiple columns
+def test_is_null_multiple_columns(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, v1 int, v2 int, v3 text, PRIMARY KEY (p, c)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 1, 10, 20, 'a')")
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 2, 10, 20, NULL)")  # v3 is null
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 3, 10, NULL, NULL)")  # v2 and v3 are null
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 4, NULL, NULL, NULL)")  # all regular columns are null
+        
+        # Test multiple IS NULL conditions
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND v2 IS NULL AND v3 IS NULL ALLOW FILTERING"))
+        assert {r.c for r in result} == {3, 4}
+        
+        # Mix IS NULL and IS NOT NULL
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND v1 IS NOT NULL AND v2 IS NULL ALLOW FILTERING"))
+        assert {r.c for r in result} == {3}
+
+
+# Test that empty string is not treated as NULL
+def test_is_null_empty_vs_null(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, s text, PRIMARY KEY (p, c)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c, s) VALUES (1, 1, '')")  # empty string
+        cql.execute(f"INSERT INTO {table} (p, c, s) VALUES (1, 2, NULL)")  # null
+        cql.execute(f"INSERT INTO {table} (p, c, s) VALUES (1, 3, NULL)")  # also null
+        
+        # IS NULL should only return truly null values, not empty strings
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND s IS NULL ALLOW FILTERING"))
+        assert {r.c for r in result} == {2, 3}
+        
+        # IS NOT NULL should include empty string
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND s IS NOT NULL ALLOW FILTERING"))
+        assert result[0].c == 1
+        assert result[0].s == ''
+
+
+# The IS [NOT] NULL predicates don't compare the column against a value, they
+# only check whether it has any value at all, so unlike other relations they
+# are also allowed on non-frozen collections. A non-frozen collection with no
+# live elements is indistinguishable from an unset one - both read as NULL -
+# so both are expected to match IS NULL.
+@pytest.mark.parametrize("coltype,full,empty", [
+    ("set<int>", "{1, 2}", "{}"),
+    ("list<int>", "[1, 2]", "[]"),
+    ("map<int, int>", "{1: 2}", "{}"),
+])
+def test_is_null_nonfrozen_collection(cql, test_keyspace, coltype, full, empty):
+    with new_test_table(cql, test_keyspace, f"p int, c int, v {coltype}, PRIMARY KEY (p, c)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 1, {full})")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 2, NULL)")
+        cql.execute(f"INSERT INTO {table} (p, c) VALUES (1, 3)")
+        # An empty non-frozen collection is stored as no cells at all, i.e. NULL.
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 4, {empty})")
+        # So is a collection whose every element was deleted.
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 5, {full})")
+        cql.execute(f"UPDATE {table} SET v = {empty} WHERE p = 1 AND c = 5")
+
+        result = cql.execute(f"SELECT c FROM {table} WHERE p = 1 AND v IS NULL ALLOW FILTERING")
+        assert {r.c for r in result} == {2, 3, 4, 5}
+
+        result = cql.execute(f"SELECT c FROM {table} WHERE p = 1 AND v IS NOT NULL ALLOW FILTERING")
+        assert {r.c for r in result} == {1}
+
+
+@pytest.mark.parametrize("coltype,full", [
+    ("frozen<set<int>>", "{1, 2}"),
+    ("frozen<list<int>>", "[1, 2]"),
+    ("frozen<map<int, int>>", "{1: 2}"),
+])
+def test_is_null_frozen_collection(cql, test_keyspace, coltype, full):
+    with new_test_table(cql, test_keyspace, f"p int, c int, v {coltype}, PRIMARY KEY (p, c)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 1, {full})")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 2, NULL)")
+        cql.execute(f"INSERT INTO {table} (p, c) VALUES (1, 3)")
+
+        result = cql.execute(f"SELECT c FROM {table} WHERE p = 1 AND v IS NULL ALLOW FILTERING")
+        assert {r.c for r in result} == {2, 3}
+
+        result = cql.execute(f"SELECT c FROM {table} WHERE p = 1 AND v IS NOT NULL ALLOW FILTERING")
+        assert {r.c for r in result} == {1}
+
+
+# IS [NOT] NULL can be combined with other relations on the same non-frozen collection
+def test_is_null_nonfrozen_collection_with_contains(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, v set<int>, PRIMARY KEY (p, c)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 1, {{1, 2}})")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 2, {{3}})")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 3, NULL)")
+
+        result = cql.execute(f"SELECT c FROM {table} WHERE p = 1 AND v IS NOT NULL AND v CONTAINS 1 ALLOW FILTERING")
+        assert {r.c for r in result} == {1}
+
+
+# IS [NOT] NULL on a non-frozen UDT column
+def test_is_null_nonfrozen_udt(cql, test_keyspace):
+    type_name = test_keyspace + "." + unique_name()
+    cql.execute(f"CREATE TYPE {type_name} (a int, b int)")
+    try:
+        with new_test_table(cql, test_keyspace, f"p int, c int, v {type_name}, PRIMARY KEY (p, c)") as table:
+            cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 1, {{a: 1, b: 2}})")
+            cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 2, NULL)")
+            cql.execute(f"INSERT INTO {table} (p, c) VALUES (1, 3)")
+            # A UDT with only some fields set is still not NULL.
+            cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 4, {{a: 1}})")
+
+            result = cql.execute(f"SELECT c FROM {table} WHERE p = 1 AND v IS NULL ALLOW FILTERING")
+            assert {r.c for r in result} == {2, 3}
+
+            result = cql.execute(f"SELECT c FROM {table} WHERE p = 1 AND v IS NOT NULL ALLOW FILTERING")
+            assert {r.c for r in result} == {1, 4}
+    finally:
+        cql.execute(f"DROP TYPE {type_name}")
+
+
+# IS NOT NULL on a partition key column is a tautology, so it never forces
+# ALLOW FILTERING.
+#
+# A partition key column can never be null, so the restriction carries no
+# information and is dropped altogether. Because it is gone, it neither helps
+# nor hinders the rest of the WHERE clause: it does not restrict the partition
+# key for the purpose of the ALLOW FILTERING rules.
+def test_is_not_null_on_partition_key_never_needs_filtering(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p1 int, p2 int, c1 int, c2 int, s int static, v int, PRIMARY KEY ((p1, p2), c1, c2)") as table:
+        cql.execute(f"INSERT INTO {table} (p1, p2, c1, c2, s, v) VALUES (1, 2, 3, 4, 7, 5)")
+
+        def keys(where):
+            return {(r.c1, r.c2) for r in cql.execute(f"SELECT * FROM {table} WHERE " + where)}
+
+        # A whole-table scan, with or without the tautologies spelled out.
+        assert keys("p1 IS NOT NULL AND p2 IS NOT NULL") == {(3, 4)}
+        assert keys("p1 IS NOT NULL") == {(3, 4)}
+        # Alongside a fully restricted primary key it changes nothing.
+        assert keys("p1 = 1 AND p2 = 2 AND c1 = 3 AND c2 = 4 AND p1 IS NOT NULL") == {(3, 4)}
+
+        # Being dropped, it does not restrict the partition key: with only p1
+        # given by =, the partition key is not fully restricted and the
+        # clustering key restrictions need ALLOW FILTERING.
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE p1 IS NOT NULL AND p2 = 2 AND c1 = 3 AND c2 = 4")
+
+        # A static or regular column can be null, so it keeps filtering.
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE p1 = 1 AND p2 = 2 AND s IS NOT NULL")
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE p1 = 1 AND p2 = 2 AND v IS NOT NULL")
+
+
+# A static row's clustering key columns read as null.
+#
+# A partition can hold a static row and no clustering rows at all. SELECT
+# returns one row for such a partition, with every clustering key column null,
+# so a clustering key column is not always non-null after all: IS NULL selects
+# exactly those static-only rows and IS NOT NULL selects exactly the clustering
+# rows. This is why neither operator can be treated as a constant on a
+# clustering key column.
+def test_is_null_on_clustering_key_of_static_row(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, s int static, v int, PRIMARY KEY (p, c1, c2)") as table:
+        p_rows = unique_key_int()
+        p_static = unique_key_int()
+        cql.execute(f"INSERT INTO {table} (p, c1, c2, s, v) VALUES ({p_rows}, 3, 4, 7, 5)")
+        cql.execute(f"UPDATE {table} SET s = 9 WHERE p = {p_static}")
+
+        # In the static-only partition the one row has null c1 and c2, so it is
+        # IS NULL that matches it and IS NOT NULL that does not.
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = {p_static} AND c1 IS NULL"))
+        assert [(r.c1, r.c2, r.s) for r in result] == [(None, None, 9)]
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE p = {p_static} AND c1 IS NOT NULL")) == []
+        # Every component of the clustering key is null there, not just the first
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = {p_static} AND c1 IS NULL AND c2 IS NULL"))
+        assert [(r.c1, r.c2) for r in result] == [(None, None)]
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE p = {p_static} AND c1 IS NULL AND c2 IS NOT NULL")) == []
+
+        # In the partition that does have a clustering row it is the other way
+        # around - the static row is not returned separately.
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = {p_rows} AND c1 IS NOT NULL"))
+        assert [(r.c1, r.c2) for r in result] == [(3, 4)]
+        assert list(cql.execute(f"SELECT * FROM {table} WHERE p = {p_rows} AND c1 IS NULL")) == []
+
+        # And across the whole table the two operators partition the rows.
+        def keys(where):
+            return {(r.p, r.c1) for r in cql.execute(f"SELECT * FROM {table} WHERE {where} ALLOW FILTERING")
+                    if r.p in (p_rows, p_static)}
+
+        assert keys("c1 IS NULL") == {(p_static, None)}
+        assert keys("c1 IS NOT NULL") == {(p_rows, 3)}
+
+
+# IS [NOT] NULL restricts a clustering key column, so the usual key rules apply.
+#
+# Neither operator can be dropped on a clustering key column - a static row's
+# clustering key columns read as null, so both carry information - and both are
+# handled like any other restriction on the column: they need the partition key
+# fully restricted by = or IN, and they need the preceding clustering key
+# columns restricted as well.
+@pytest.mark.parametrize("op", ["IS NULL", "IS NOT NULL"])
+def test_is_null_on_clustering_key_needs_partition_key(cql, test_keyspace, op):
+    with new_test_table(cql, test_keyspace, "p1 int, p2 int, c1 int, c2 int, v int, PRIMARY KEY ((p1, p2), c1, c2)") as table:
+        cql.execute(f"INSERT INTO {table} (p1, p2, c1, c2, v) VALUES (1, 2, 3, 4, 5)")
+        # The single row has non-null c1 and c2, so IS NULL matches nothing and
+        # IS NOT NULL matches it. Neither answer is the point here: what matters
+        # is which queries are accepted without ALLOW FILTERING.
+        expected = {(3, 4)} if op == "IS NOT NULL" else set()
+
+        def keys(where):
+            return {(r.c1, r.c2) for r in cql.execute(f"SELECT * FROM {table} WHERE " + where)}
+
+        # Whole partition key restricted by = or IN: no ALLOW FILTERING needed.
+        assert keys(f"p1 = 1 AND p2 = 2 AND c1 {op}") == expected
+        assert keys(f"p1 IN (1, 9) AND p2 = 2 AND c1 {op}") == expected
+        assert keys(f"p1 = 1 AND p2 = 2 AND c1 {op} AND c2 {op}") == expected
+
+        # Without a fully restricted partition key it needs ALLOW FILTERING.
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE c1 {op}")
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE p1 = 1 AND c1 {op}")
+        # A token() range doesn't restrict the partition key well enough.
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE token(p1, p2) >= -9223372036854775808 AND c1 {op}")
+        # Neither does IS NOT NULL on the partition key, which is dropped.
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE p1 IS NOT NULL AND p2 IS NOT NULL AND c1 {op}")
+
+        # Skipping a clustering key column is rejected as it is for any other
+        # clustering key restriction - not with an ALLOW FILTERING suggestion.
+        with pytest.raises(InvalidRequest, match='c2'):
+            cql.execute(f"SELECT * FROM {table} WHERE p1 = 1 AND p2 = 2 AND c2 {op}")
+        # So is restricting it after a slice on the preceding column.
+        with pytest.raises(InvalidRequest, match='c2'):
+            cql.execute(f"SELECT * FROM {table} WHERE p1 = 1 AND p2 = 2 AND c1 > 0 AND c2 {op}")
+
+        # With ALLOW FILTERING all of these work.
+        assert keys(f"c1 {op} ALLOW FILTERING") == expected
+        assert keys(f"p1 = 1 AND c1 {op} ALLOW FILTERING") == expected
+
+
+# IS [NOT] NULL is a filter, so UPDATE and DELETE must reject it.
+#
+# The WHERE clause of a mutation names the rows to be written, and IS [NOT] NULL
+# cannot name one: it tests whether a column has a value instead of saying which
+# value it has, so it never yields a concrete key. Scylla rejects the other
+# relations a mutation cannot express - "c != 3", for instance - and these must
+# be rejected the same way, rather than being silently ignored and turning the
+# statement into an unintended whole-partition write.
+def test_is_null_rejected_in_mutation_where_clause(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, v int, s int static, PRIMARY KEY (p, c)") as table:
+        for where in ["p = {p} AND c IS NULL",
+                      "p = {p} AND c IS NOT NULL",
+                      "p = {p} AND c = 1 AND v IS NULL",
+                      "p = {p} AND c = 1 AND v IS NOT NULL",
+                      "p = {p} AND c = 1 AND s IS NULL",
+                      "p IS NULL AND c = 1",
+                      "p IS NOT NULL AND c = 1",
+                      ]:
+            for stmt in [f"DELETE FROM {table} WHERE {where}",
+                         f"DELETE v FROM {table} WHERE {where}",
+                         f"DELETE FROM {table} WHERE {where} IF EXISTS",
+                         f"UPDATE {table} SET v = 99 WHERE {where}",
+                         f"UPDATE {table} SET v = 99 WHERE {where} IF EXISTS",
+                         ]:
+                p = unique_key_int()
+                for c in [1, 2, 3]:
+                    cql.execute(f"INSERT INTO {table} (p, c, v) VALUES ({p}, {c}, {c * 10})")
+                try:
+                    cql.execute(stmt.format(p=p))
+                    pytest.fail(f"statement was not rejected: {stmt.format(p=p)}")
+                except InvalidRequest:
+                    pass
+                # The rejected statement must not have modified anything
+                assert {(r.c, r.v) for r in cql.execute(f"SELECT c, v FROM {table} WHERE p = {p}")} == {(1, 10), (2, 20), (3, 30)}

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -302,6 +302,36 @@ def test_is_not_operator_must_be_null(cql, test_keyspace):
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
 
+# Using IS NULL on either view's pk or regular column is not supported.
+def test_mv_with_is_null_on_view_column(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, 'pk int primary key, mv_pk int, regular_col int') as table:
+        mv_null = unique_name()
+        try:
+            with pytest.raises(InvalidRequest, match="IS null.*not supported.*Only IS NOT NULL"):
+                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv_null} AS SELECT * FROM {table} WHERE pk IS NOT NULL AND mv_pk IS NULL PRIMARY KEY (mv_pk, pk)")
+            with pytest.raises(InvalidRequest, match="Non-primary"):
+                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv_null} AS SELECT * FROM {table} WHERE pk IS NOT NULL AND regular_col IS NULL AND mv_pk IS NOT NULL PRIMARY KEY (mv_pk, pk)")
+        finally:
+            cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv_null}")
+
+# Using IS NOT NULL is supported for columns that are part of the view's primary key.
+def test_mv_with_is_not_null_on_view_column(cql, test_keyspace, scylla_only):
+    # Test IS NOT NULL on a base regular column that becomes a view PK column.
+    with new_test_table(cql, test_keyspace, 'p int primary key, xyz int') as table:
+        mv_not_null = unique_name()
+        try:
+            cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv_not_null} AS SELECT * FROM {table} WHERE p IS NOT NULL AND xyz IS NOT NULL PRIMARY KEY (xyz, p)")
+            cql.execute(f"INSERT INTO {table} (p, xyz) VALUES (1, 100)")
+            cql.execute(f"INSERT INTO {table} (p) VALUES (2)")  # xyz is null
+            cql.execute(f"INSERT INTO {table} (p, xyz) VALUES (3, 300)")  # xyz is not null
+            cql.execute(f"INSERT INTO {table} (p, xyz) VALUES (4, 400)")  # both not null
+
+            # Only rows with non-null xyz should appear in the view
+            result = sorted(cql.execute(f"SELECT p, xyz FROM {test_keyspace}.{mv_not_null}"))
+            assert result == [(1, 100), (3, 300), (4, 400)]
+        finally:
+            cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv_not_null}")
+
 # The IS NOT NULL operator was first added to Cassandra and Scylla for use
 # just in key columns in materialized views. It was not supported in general
 # filters in SELECT (see issue #8517), and in particular cannot be used in
@@ -324,16 +354,6 @@ def test_is_not_null_allowed_in_filter(cql, test_keyspace, scylla_only):
         try:
             with pytest.raises(InvalidRequest, match="xyz"):
                 cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT NULL AND xyz IS NOT NULL PRIMARY KEY (p)")
-                # There is no need to continue the test - if the CREATE
-                # MATERIALIZED VIEW above succeeded, it is already not what we
-                # expect without #8517. However, let's demonstrate that it's
-                # even worse - not only does the "xyz IS NOT NULL" not generate
-                # an error, it is outright ignored and not used in the filter.
-                # If it weren't ignored, it should filter out partition 124
-                # in the following example:
-                cql.execute(f"INSERT INTO {table} (p,xyz) VALUES (123, 456)")
-                cql.execute(f"INSERT INTO {table} (p) VALUES (124)")
-                assert sorted(list(cql.execute(f"SELECT p FROM {test_keyspace}.{mv}")))==[(123,)]
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
 
@@ -1468,7 +1488,7 @@ def test_alter_table_add_select_star(cql, test_keyspace):
             cql.execute(f'INSERT INTO {base} (p,a,b,c) VALUES (0,1,2,3)')
             assert {(0,1,2,3),(1,2,3,None)} == set(cql.execute(f"SELECT p,a,b,c FROM {base}"))
             assert {(0,1,2,3),(1,2,3,None)} == set(cql.execute(f"SELECT p,a,b,c FROM {mv}"))
-            
+
 # Test that if a view is created with "SELECT *", DESC MATERIALIZED VIEW operation shows it
 # as "SELECT *" instead of expanding it (explicitly showing each column).
 # Reproduces issue #21154

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -7,6 +7,7 @@
 import time
 import pytest
 from . import rest_api
+from .cassandra_tests.porting import assert_empty
 
 from .util import new_test_table, unique_name, new_materialized_view, new_secondary_index
 from cassandra.protocol import ConfigurationException, InvalidRequest, SyntaxException
@@ -308,19 +309,14 @@ def test_is_not_operator_must_be_null(cql, test_keyspace):
 # if this usage is not allowed, we expect to see a clear error and not silently
 # ignoring the IS NOT NULL condition as happens in issue #10365.
 #
-# NOTE: if issue #8517 (IS NOT NULL in filters) is implemented, we will need to
-# replace this test by a test that checks that the filter works as expected,
-# both in ordinary base-table SELECT and in materialized-view definition.
-def test_is_not_null_forbidden_in_filter(cql, test_keyspace, cassandra_bug):
+# As #8517 (IS NOT NULL in filters) is implemented, this is scylla_only.
+def test_is_not_null_allowed_in_filter(cql, test_keyspace, scylla_only):
     with new_test_table(cql, test_keyspace, 'p int primary key, xyz int') as table:
-        # Check that "IS NOT NULL" is not supported in a regular (base table)
+        # Check that "IS NOT NULL" is allowed in a regular (base table)
         # SELECT filter. Cassandra reports an InvalidRequest: "Unsupported
-        # restriction: xyz IS NOT NULL". In Scylla the message is different:
-        # "restriction '(xyz) IS NOT { null }' is only supported in materialized
-        # view creation".
+        # restriction: xyz IS NOT NULL". Scylla allows it.
         #
-        with pytest.raises(InvalidRequest, match="xyz"):
-            cql.execute(f'SELECT * FROM {table} WHERE xyz IS NOT NULL ALLOW FILTERING')
+        assert_empty(cql.execute(f'SELECT * FROM {table} WHERE xyz IS NOT NULL ALLOW FILTERING'))
         # Check that "xyz IS NOT NULL" is also not supported in a
         # materialized-view definition (where xyz is not a key column)
         # Reproduces #8517

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -309,20 +309,12 @@ def test_is_not_operator_must_be_null(cql, test_keyspace):
 # if this usage is not allowed, we expect to see a clear error and not silently
 # ignoring the IS NOT NULL condition as happens in issue #10365.
 #
-# NOTE: if issue #8517 (IS NOT NULL in filters) is implemented, we will need to
-# replace this test by a test that checks that the filter works as expected,
-# both in ordinary base-table SELECT and in materialized-view definition.
+# Note that since #8517 was implemented, "xyz IS NOT NULL" *is* a valid filter
+# in a base-table SELECT (see test_is_null.py) - but a materialized view still
+# cannot filter on a non-key column, so it must still be rejected here.
 def test_is_not_null_forbidden_in_filter(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace, 'p int primary key, xyz int') as table:
-        # Check that "IS NOT NULL" is not supported in a regular (base table)
-        # SELECT filter. Cassandra reports an InvalidRequest: "Unsupported
-        # restriction: xyz IS NOT NULL". In Scylla the message is different:
-        # "restriction '(xyz) IS NOT { null }' is only supported in materialized
-        # view creation".
-        #
-        with pytest.raises(InvalidRequest, match="xyz"):
-            cql.execute(f'SELECT * FROM {table} WHERE xyz IS NOT NULL ALLOW FILTERING')
-        # Check that "xyz IS NOT NULL" is also not supported in a
+        # Check that "xyz IS NOT NULL" is not supported in a
         # materialized-view definition (where xyz is not a key column)
         # Reproduces #8517
         mv = unique_name()

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -302,6 +302,25 @@ def test_is_not_operator_must_be_null(cql, test_keyspace):
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
 
+# Using IS NULL on either view's pk or regular column is not supported. On a view
+# key column it could only ever select an empty view, because a view row exists
+# only for base rows whose view key columns are all non-null; on a regular column
+# it would be a filter on a non-key column, which views don't support. Either way
+# it is rejected with the same error.
+def test_mv_with_is_null_on_view_column(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, 'pk int primary key, mv_pk int, regular_col int') as table:
+        mv_null = unique_name()
+        try:
+            with pytest.raises(InvalidRequest, match="mv_pk IS null.*not supported.*Only IS NOT NULL"):
+                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv_null} AS SELECT * FROM {table} WHERE pk IS NOT NULL AND mv_pk IS NULL PRIMARY KEY (mv_pk, pk)")
+            with pytest.raises(InvalidRequest, match="regular_col IS null.*not supported.*Only IS NOT NULL"):
+                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv_null} AS SELECT * FROM {table} WHERE pk IS NOT NULL AND regular_col IS NULL AND mv_pk IS NOT NULL PRIMARY KEY (mv_pk, pk)")
+            # Also rejected on a base primary key column, where IS NOT NULL is required.
+            with pytest.raises(InvalidRequest, match="pk IS null.*not supported.*Only IS NOT NULL"):
+                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv_null} AS SELECT * FROM {table} WHERE pk IS NULL AND mv_pk IS NOT NULL PRIMARY KEY (mv_pk, pk)")
+        finally:
+            cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv_null}")
+
 # The IS NOT NULL operator was first added to Cassandra and Scylla for use
 # just in key columns in materialized views. It was not supported in general
 # filters in SELECT (see issue #8517), and in particular cannot be used in
@@ -1481,7 +1500,7 @@ def test_alter_table_add_select_star(cql, test_keyspace):
             cql.execute(f'INSERT INTO {base} (p,a,b,c) VALUES (0,1,2,3)')
             assert {(0,1,2,3),(1,2,3,None)} == set(cql.execute(f"SELECT p,a,b,c FROM {base}"))
             assert {(0,1,2,3),(1,2,3,None)} == set(cql.execute(f"SELECT p,a,b,c FROM {mv}"))
-            
+
 # Test that if a view is created with "SELECT *", DESC MATERIALIZED VIEW operation shows it
 # as "SELECT *" instead of expanding it (explicitly showing each column).
 # Reproduces issue #21154

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -2393,3 +2393,49 @@ def test_regular_row_update_with_static_set_index(cql, test_keyspace):
         cql.execute(f"UPDATE {table} SET x = 4 WHERE pk = 1 AND ck = 2")
         assert [(1, 2, {'test'}, 4)] == list(cql.execute(f"SELECT * FROM {table} WHERE pk = 1 AND ck = 2"))
         assert [(1, 2, {'test'}, 4)] == list(cql.execute(f"SELECT * FROM {table} WHERE s CONTAINS 'test'"))
+
+# Test that IS NULL and IS NOT NULL operators work on indexed columns
+# but require ALLOW FILTERING since secondary indexes cannot efficiently
+# support null checks. The materialized view backing the secondary index
+# has a partition for each value of the indexed column, but does not have
+# a partition for the NULL key (NULL cannot be a key in a materialized view).
+# Reproducer for issue #8517
+def test_is_null_with_secondary_index(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)") as table:
+        # Create secondary index on v
+        cql.execute(f"CREATE INDEX ON {table}(v)")
+        
+        # Insert test data with some NULL values in indexed column
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 2, 20)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 3, NULL)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (2, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (2, 2, NULL)")
+        
+        # IS NULL on indexed column should require ALLOW FILTERING
+        # because the index cannot efficiently support it
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE v IS NULL")
+        
+        # IS NOT NULL on indexed column should also require ALLOW FILTERING
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE v IS NOT NULL")
+        
+        # With ALLOW FILTERING, IS NULL should work correctly
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE v IS NULL ALLOW FILTERING"))
+        assert len(result) == 2
+        assert {(r.p, r.c) for r in result} == {(1, 3), (2, 2)}
+        
+        # With ALLOW FILTERING, IS NOT NULL should work correctly
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE v IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 3
+        assert {(r.p, r.c) for r in result} == {(1, 1), (1, 2), (2, 1)}
+        
+        # Can combine IS NULL with partition key restriction
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND v IS NULL ALLOW FILTERING"))
+        assert len(result) == 1
+        assert result[0].c == 3
+        
+        # Regular EQ query on indexed column should work without ALLOW FILTERING
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE v = 10"))
+        assert len(result) == 2

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -2913,3 +2913,49 @@ def test_regular_row_update_with_static_set_index(cql, test_keyspace):
         cql.execute(f"UPDATE {table} SET x = 4 WHERE pk = 1 AND ck = 2")
         assert [(1, 2, {'test'}, 4)] == list(cql.execute(f"SELECT * FROM {table} WHERE pk = 1 AND ck = 2"))
         assert [(1, 2, {'test'}, 4)] == list(cql.execute(f"SELECT * FROM {table} WHERE s CONTAINS 'test'"))
+
+# Test that IS NULL and IS NOT NULL operators work on indexed columns
+# but require ALLOW FILTERING since secondary indexes cannot efficiently
+# support null checks. The materialized view backing the secondary index
+# has a partition for each value of the indexed column, but does not have
+# a partition for the NULL key (NULL cannot be a key in a materialized view).
+# IS [NOT] NULL in a regular SELECT filter is a Scylla extension - Cassandra
+# only accepts IS NOT NULL in materialized view creation - so the test is
+# scylla_only.
+# Reproducer for issue #8517
+def test_is_null_with_secondary_index(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)") as table:
+        # Create secondary index on v
+        cql.execute(f"CREATE INDEX ON {table}(v)")
+
+        # Insert test data with some NULL values in indexed column
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 2, 20)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 3, NULL)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (2, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (2, 2, NULL)")
+
+        # IS NULL on indexed column should require ALLOW FILTERING
+        # because the index cannot efficiently support it
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE v IS NULL")
+
+        # IS NOT NULL on indexed column should also require ALLOW FILTERING
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE v IS NOT NULL")
+
+        # With ALLOW FILTERING, IS NULL should work correctly
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE v IS NULL ALLOW FILTERING"))
+        assert {(r.p, r.c) for r in result} == {(1, 3), (2, 2)}
+
+        # With ALLOW FILTERING, IS NOT NULL should work correctly
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE v IS NOT NULL ALLOW FILTERING"))
+        assert {(r.p, r.c) for r in result} == {(1, 1), (1, 2), (2, 1)}
+
+        # Can combine IS NULL with partition key restriction
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND v IS NULL ALLOW FILTERING"))
+        assert [r.c for r in result] == [3]
+
+        # Regular EQ query on indexed column should work without ALLOW FILTERING
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE v = 10"))
+        assert {(r.p, r.c) for r in result} == {(1, 1), (2, 1)}


### PR DESCRIPTION
This patch series implements support for IS NULL and IS NOT NULL operators
in CQL's WHERE clause for both SELECT queries.

Since CREATE MATERIALIZED VIEW shares there WHERE clause grammar with SELECT, 
IS NULL is now part of the grammar there as well, but it is rejected by the semantic
analysis.

An example usage:

```
   CREATE TABLE users (id int PRIMARY KEY, name text, email text);
   INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com');
   INSERT INTO users (id, name) VALUES (2, 'Bob');

   SELECT * FROM users WHERE email IS NULL ALLOW FILTERING;

    id | email | name
   ----+-------+------
     2 |  null |  Bob

   SELECT * FROM users WHERE email IS NOT NULL ALLOW FILTERING;

    id | email             | name
   ----+-------------------+-------
     1 | alice@example.com | Alice
```

Fixes https://github.com/scylladb/scylladb/issues/8517

New feature, no need to backport.