### PR TITLE
logstor: space accounting improvements

### DIFF
--- a/replica/logstor/index.hh
+++ b/replica/logstor/index.hh
@@ -111,6 +111,9 @@ private:
     // call non-const methods on the tracker (touch, insert) for LRU accounting.
     mutable cache_tracker* _cache_tracker = nullptr;
 
+    // Currently we support a single subscriber for space accounting which is the segment manager.
+    space_accounting_subscriber& _space_accounting;
+
     void on_entry_added(const primary_index_entry& e) noexcept {
         _memory_usage += e.memory_usage();
         ++_key_count;
@@ -124,8 +127,11 @@ private:
     auto make_entry_disposer() noexcept {
         return [this] (primary_index_entry* e) noexcept {
             if (_cache_tracker) {
-                _cache_tracker->evict(*e);
+                try {
+                    _cache_tracker->evict(*e);
+                } catch (...) {}
             }
+            _space_accounting.on_free_record(e->_e.location);
             on_entry_removed(*e);
         };
     }
@@ -152,9 +158,10 @@ private:
     }
 
 public:
-    explicit primary_index(schema_ptr schema)
+    explicit primary_index(schema_ptr schema, space_accounting_subscriber& space_accounting)
         : _partitions(dht::raw_token_less_comparator{})
         , _schema(std::move(schema))
+        , _space_accounting(space_accounting)
         {}
 
     void set_schema(schema_ptr s) {
@@ -208,6 +215,8 @@ public:
         if (it != _partitions.end()) {
             if (it->_e.location == old_location) {
                 it->_e.location = new_location;
+                _space_accounting.on_free_record(old_location);
+                _space_accounting.on_add_record(new_location);
                 // The cached mutation is still valid (same data, new location on
                 // disk after compaction moved it) — do not evict the cache here.
                 return true;
@@ -233,12 +242,15 @@ public:
                 }
                 auto old_entry = i->_e;
                 i->_e = std::move(new_entry);
+                _space_accounting.on_free_record(old_entry.location);
+                _space_accounting.on_add_record(i->_e.location);
                 return {true, std::make_optional(old_entry)};
             } else {
                 return {false, std::make_optional(i->_e)};
             }
         } else {
             auto it = _partitions.emplace_before(i, key.dk.token().raw(), hint, key.dk, std::move(new_entry));
+            _space_accounting.on_add_record(it->_e.location);
             on_entry_added(*it);
             return {true, std::nullopt};
         }

--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -89,6 +89,14 @@ const compaction_manager& logstor::get_compaction_manager() const noexcept {
     return _segment_manager.get_compaction_manager();
 }
 
+std::unique_ptr<primary_index> logstor::make_primary_index(schema_ptr schema, bool cache_enabled) {
+    auto index = std::make_unique<primary_index>(schema, _segment_manager);
+    if (cache_enabled) {
+        index->set_cache_tracker(&_cache_tracker);
+    }
+    return index;
+}
+
 future<> logstor::write(const mutation& m, compaction_group& cg, seastar::gate::holder cg_holder, db::timeout_clock::time_point timeout) {
     primary_index_key key(m.decorated_key());
     table_id table = m.schema()->id();
@@ -105,22 +113,13 @@ future<> logstor::write(const mutation& m, compaction_group& cg, seastar::gate::
         .mut = canonical_mutation(m)
     };
 
-    return _write_buffer.write(std::move(record), timeout, &cg, std::move(cg_holder)).then_unpack([this, index_ptr = &index, ts, key = std::move(key)]
+    return _write_buffer.write(std::move(record), timeout, &cg, std::move(cg_holder)).then_unpack([index_ptr = &index, ts, key = std::move(key)]
             (log_location location, seastar::gate::holder op) {
         index_entry new_entry {
             .location = location,
             .timestamp = ts,
         };
-
-        auto [inserted, prev_entry] = index_ptr->insert(key, std::move(new_entry));
-
-        if (!inserted) {
-            // A newer entry already exists; free the record we just wrote.
-            _segment_manager.free_record(location);
-        } else if (prev_entry) {
-            // Overwrote an older entry; free it.
-            _segment_manager.free_record(prev_entry->location);
-        }
+        index_ptr->insert(key, std::move(new_entry));
     }).handle_exception([] (std::exception_ptr ep) {
         logstor_logger.error("Error writing mutation: {}", ep);
         return make_exception_future<>(ep);

--- a/replica/logstor/logstor.hh
+++ b/replica/logstor/logstor.hh
@@ -62,12 +62,7 @@ public:
     compaction_manager& get_compaction_manager() noexcept;
     const compaction_manager& get_compaction_manager() const noexcept;
 
-    cache_tracker& get_cache_tracker() noexcept {
-        return _cache_tracker;
-    }
-    const cache_tracker& get_cache_tracker() const noexcept {
-        return _cache_tracker;
-    }
+    std::unique_ptr<primary_index> make_primary_index(schema_ptr schema, bool cache_enabled);
 
     future<> write(const mutation&, compaction_group&, seastar::gate::holder cg_holder, db::timeout_clock::time_point timeout);
 

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -638,6 +638,8 @@ class segment_manager_impl {
         uint64_t compaction_data_bytes_written{0};
         uint64_t separator_bytes_written{0};
         uint64_t separator_data_bytes_written{0};
+        uint64_t live_record_bytes{0};
+        uint64_t live_record_count{0};
     };
 
     file_manager _file_mgr;
@@ -946,6 +948,10 @@ segment_manager_impl::segment_manager_impl(segment_manager_config config)
                        sm::description("Counts number of segments currently in use.")),
         sm::make_gauge("free_segments", [this] { return available_segment_count(); },
                        sm::description("Counts number of free segments currently available.")),
+        sm::make_gauge("live_record_bytes", [this] { return _stats.live_record_bytes; },
+                       sm::description("Counts the durable live record bytes currently referenced by the primary index.")),
+        sm::make_gauge("live_record_count", [this] { return _stats.live_record_count; },
+                   sm::description("Counts the durable live records currently referenced by the primary index.")),
         sm::make_gauge("segment_pool_size", [this] { return _segment_pool.size(); },
                        sm::description("Counts number of segments in the segment pool.")),
         sm::make_counter("segment_pool_segments_put", _segment_pool.get_stats().segments_put,
@@ -1129,11 +1135,15 @@ future<> segment_manager_impl::write_full_segment(write_buffer& wb, compaction_g
 void segment_manager_impl::on_add_record(log_location location) noexcept {
     auto& desc = get_segment_descriptor(location);
     desc.on_write(location);
+    _stats.live_record_bytes += location.size;
+    _stats.live_record_count++;
 }
 
 void segment_manager_impl::on_free_record(log_location location) noexcept {
     auto& desc = get_segment_descriptor(location);
     desc.on_free(location);
+    _stats.live_record_bytes -= location.size;
+    _stats.live_record_count--;
     if (desc.owner) {
         try {
             desc.owner->update_segment(desc);

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -709,7 +709,8 @@ public:
 
     future<log_record> read(log_location);
 
-    void free_record(log_location);
+    void on_add_record(log_location) noexcept;
+    void on_free_record(log_location) noexcept;
 
     future<> for_each_record(log_segment_id segment_id,
                             std::function<want_data(log_location, const log_record_header&)> on_header,
@@ -1065,8 +1066,6 @@ future<> segment_manager_impl::write(write_buffer& wb) {
         auto seg_ref = seg->ref();
         auto seq_num = seg->seq_num();
         auto write_op = _writes_phaser.start();
-        auto& desc = get_segment_descriptor(seg->id());
-
         // if we wrote a record to the segment but failed to write it to the separator, the segment should not be freed.
         auto write_to_separator_failed = defer([seg_ref] mutable noexcept {
             seg_ref.set_flush_failure();
@@ -1079,8 +1078,6 @@ future<> segment_manager_impl::write(write_buffer& wb) {
 
         auto loc = co_await seg->append(data);
         sem_units.return_all();
-
-        desc.on_write(wb.net_data_size(), wb.record_count());
 
         _stats.bytes_written[static_cast<size_t>(source)] += data.size();
         _stats.data_bytes_written[static_cast<size_t>(source)] += wb.net_data_size();
@@ -1111,8 +1108,6 @@ future<> segment_manager_impl::write_full_segment(write_buffer& wb, compaction_g
     }
 
     auto seg = co_await get_segment(source);
-    auto& desc = get_segment_descriptor(seg->id());
-
     logstor_logger.trace("Write full segment {} seq {} from {}", seg->id(), seg->seq_num(), write_source_to_string(source));
 
     wb.seal(seg->seq_num(), cg.schema()->id(), block_alignment);
@@ -1120,22 +1115,31 @@ future<> segment_manager_impl::write_full_segment(write_buffer& wb, compaction_g
 
     auto loc = co_await seg->append(data);
 
-    desc.on_write(wb.net_data_size(), wb.record_count());
-
     _stats.bytes_written[static_cast<size_t>(source)] += data.size();
     _stats.data_bytes_written[static_cast<size_t>(source)] += wb.net_data_size();
 
     co_await wb.complete_writes(loc);
     co_await seg->stop();
 
+    // add the segment after all index updates are completed.
+    auto& desc = get_segment_descriptor(seg->id());
     cg.add_logstor_segment(desc);
 }
 
-void segment_manager_impl::free_record(log_location location) {
+void segment_manager_impl::on_add_record(log_location location) noexcept {
+    auto& desc = get_segment_descriptor(location);
+    desc.on_write(location);
+}
+
+void segment_manager_impl::on_free_record(log_location location) noexcept {
     auto& desc = get_segment_descriptor(location);
     desc.on_free(location);
     if (desc.owner) {
-        desc.owner->update_segment(desc);
+        try {
+            desc.owner->update_segment(desc);
+        } catch (...) {
+            logstor_logger.warn("Failed to update segments histogram: {}", std::current_exception());
+        }
     }
     _stats.bytes_freed += location.size;
 }
@@ -1289,7 +1293,9 @@ future<> segment_manager_impl::discard_segments(segment_set& ss) {
         }
 
         // the index should be cleared before discarding segments, so no data should be reachable
-        desc.reset(_cfg.segment_size);
+        if (desc.net_data_size(_cfg.segment_size) != 0) {
+            on_internal_error(logstor_logger, format("Discarding segment {} that has data", seg_id));
+        }
 
         segments.push_back(seg_id);
     }
@@ -1532,13 +1538,10 @@ struct compaction_buffer {
         auto write_and_update_index = buf->write(std::move(writer)).then_unpack(
                 [this, index_ptr, key = std::move(key), read_location]
                 (log_location new_location, seastar::gate::holder op) {
-
             if (index_ptr->update_record_location(key, read_location, new_location)) {
-                sm.free_record(read_location);
                 stats.records_rewritten++;
             } else {
                 // another write updated this key
-                sm.free_record(new_location);
                 stats.records_skipped++;
             }
         });
@@ -1728,12 +1731,8 @@ future<> segment_manager_impl::write_to_separator(write_buffer& wb, segment_ref 
         }
 
         buf.pending_updates.push_back(
-            buf.write(std::move(w.writer)).then_unpack([this, index_ptr, key = std::move(key), prev_loc] (log_location new_loc, seastar::gate::holder op) {
-                if (index_ptr->update_record_location(key, prev_loc, new_loc)) {
-                    free_record(prev_loc);
-                } else {
-                    free_record(new_loc);
-                }
+            buf.write(std::move(w.writer)).then_unpack([index_ptr, key = std::move(key), prev_loc] (log_location new_loc, seastar::gate::holder op) {
+                index_ptr->update_record_location(key, prev_loc, new_loc);
             }
         ));
     }
@@ -1751,12 +1750,8 @@ void segment_manager_impl::write_to_separator(table& t, log_location prev_loc, l
     }
 
     buf.pending_updates.push_back(
-        buf.write(std::move(writer)).then_unpack([this, index_ptr, key = std::move(key), prev_loc] (log_location new_loc, seastar::gate::holder op) {
-            if (index_ptr->update_record_location(key, prev_loc, new_loc)) {
-                free_record(prev_loc);
-            } else {
-                free_record(new_loc);
-            }
+        buf.write(std::move(writer)).then_unpack([index_ptr, key = std::move(key), prev_loc] (log_location new_loc, seastar::gate::holder op) {
+            index_ptr->update_record_location(key, prev_loc, new_loc);
         })
     );
 }
@@ -1955,7 +1950,7 @@ future<> segment_manager_impl::recover_segment(replica::database& db, log_segmen
             on_header(seg_hdr);
             return make_ready_future<>();
         },
-        [this, &desc, &db, &cmp] (log_location loc, const log_record_header& header) -> want_data {
+        [&db, &cmp] (log_location loc, const log_record_header& header) -> want_data {
             logstor_logger.trace("Recovery: read record at {} key {} ts {}", loc, header.key, header.timestamp);
 
             index_entry new_entry {
@@ -1968,13 +1963,7 @@ future<> segment_manager_impl::recover_segment(replica::database& db, log_segmen
                 if (!t.uses_logstor()) {
                     return want_data::no;
                 }
-                auto [inserted, prev_entry] = t.logstor_index().insert(header.key, new_entry, cmp);
-                if (inserted) {
-                    desc.on_write(loc);
-                    if (prev_entry) {
-                        get_segment_descriptor(prev_entry->location).on_free(prev_entry->location);
-                    }
-                }
+                t.logstor_index().insert(header.key, new_entry, cmp);
             } catch (const replica::no_such_column_family&) {
                 // ignore record
             }
@@ -1985,6 +1974,14 @@ future<> segment_manager_impl::recover_segment(replica::database& db, log_segmen
             // we don't read record data, only headers.
             return make_ready_future<>();
         });
+}
+
+void segment_manager::on_add_record(log_location location) noexcept {
+    get_impl().on_add_record(location);
+}
+
+void segment_manager::on_free_record(log_location location) noexcept {
+    get_impl().on_free_record(location);
 }
 
 future<> segment_manager_impl::add_segment_to_compaction_group(replica::database& db, segment_descriptor& desc) {
@@ -2099,10 +2096,6 @@ future<> segment_manager::write(write_buffer& wb) {
 
 future<log_record> segment_manager::read(log_location location) {
     return _impl->read(location);
-}
-
-void segment_manager::free_record(log_location location) {
-    _impl->free_record(location);
 }
 
 void segment_manager::set_trigger_compaction_hook(std::function<void()> fn) {

--- a/replica/logstor/segment_manager.hh
+++ b/replica/logstor/segment_manager.hh
@@ -100,7 +100,7 @@ public:
 class segment_manager_impl;
 class log_index;
 
-class segment_manager {
+class segment_manager : public space_accounting_subscriber {
     std::unique_ptr<segment_manager_impl> _impl;
 private:
     segment_manager_impl& get_impl() noexcept;
@@ -122,7 +122,8 @@ public:
 
     future<log_record> read(log_location location);
 
-    void free_record(log_location location);
+    void on_add_record(log_location location) noexcept override;
+    void on_free_record(log_location location) noexcept override;
 
     compaction_manager& get_compaction_manager() noexcept;
     const compaction_manager& get_compaction_manager() const noexcept;

--- a/replica/logstor/types.hh
+++ b/replica/logstor/types.hh
@@ -79,6 +79,13 @@ enum class segment_kind : uint8_t {
     full = 1,
 };
 
+class space_accounting_subscriber {
+public:
+    virtual ~space_accounting_subscriber() = default;
+    virtual void on_add_record(log_location location) noexcept = 0;
+    virtual void on_free_record(log_location location) noexcept = 0;
+};
+
 }
 
 // Format specialization declarations and implementations

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4588,11 +4588,7 @@ void table::mark_ready_for_writes(db::commitlog* cl) {
 
 void table::init_logstor(logstor::logstor* ls) {
     _logstor = ls;
-    _logstor_index = std::make_unique<logstor::primary_index>(_schema);
-
-    if (cache_enabled()) {
-        _logstor_index->set_cache_tracker(&ls->get_cache_tracker());
-    }
+    _logstor_index = ls->make_primary_index(_schema, cache_enabled());
 }
 
 size_t table::get_logstor_memory_usage() const {

--- a/test/boost/logstor_cache_test.cc
+++ b/test/boost/logstor_cache_test.cc
@@ -8,6 +8,7 @@
 #include <boost/test/unit_test.hpp>
 #include <optional>
 
+#include "replica/logstor/types.hh"
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 
@@ -30,6 +31,13 @@ struct shared_logstor_cache {
         , logstor_tracker(shared_tracker) {
     }
 };
+
+struct noop_space_accounting_subscriber final : space_accounting_subscriber {
+    void on_add_record(log_location) noexcept override {}
+    void on_free_record(log_location) noexcept override {}
+};
+
+inline noop_space_accounting_subscriber noop_space_accounting{};
 
 index_entry make_index_entry(uint32_t segment, uint32_t offset, uint32_t size, api::timestamp_type timestamp) {
     return index_entry{
@@ -109,7 +117,7 @@ std::vector<dht::decorated_key> insert_same_token_keys(primary_index& index, sim
 
 SEASTAR_THREAD_TEST_CASE(test_logstor_primary_index_cache_invalidation_and_eviction) {
     simple_schema schema(simple_schema::with_static::no);
-    primary_index index(schema.schema());
+    primary_index index(schema.schema(), noop_space_accounting);
     shared_logstor_cache cache;
     index.set_cache_tracker(&cache.logstor_tracker);
 
@@ -195,7 +203,7 @@ SEASTAR_THREAD_TEST_CASE(test_logstor_primary_index_cache_invalidation_and_evict
 
 SEASTAR_THREAD_TEST_CASE(test_logstor_primary_index_drain_cache_preserves_index_entries) {
     simple_schema schema(simple_schema::with_static::no);
-    primary_index index(schema.schema());
+    primary_index index(schema.schema(), noop_space_accounting);
     shared_logstor_cache cache;
     index.set_cache_tracker(&cache.logstor_tracker);
 
@@ -223,7 +231,7 @@ SEASTAR_THREAD_TEST_CASE(test_logstor_primary_index_drain_cache_preserves_index_
 
 SEASTAR_THREAD_TEST_CASE(test_logstor_primary_index_cache_survives_index_rebalancing) {
     simple_schema schema(simple_schema::with_static::no);
-    primary_index index(schema.schema());
+    primary_index index(schema.schema(), noop_space_accounting);
     shared_logstor_cache cache;
     index.set_cache_tracker(&cache.logstor_tracker);
 
@@ -284,7 +292,7 @@ SEASTAR_THREAD_TEST_CASE(test_logstor_primary_index_cache_survives_index_rebalan
 
 SEASTAR_THREAD_TEST_CASE(test_logstor_cache_survives_lsa_compaction_before_exchange) {
     simple_schema schema(simple_schema::with_static::no);
-    primary_index index(schema.schema());
+    primary_index index(schema.schema(), noop_space_accounting);
     shared_logstor_cache cache;
     index.set_cache_tracker(&cache.logstor_tracker);
 
@@ -329,7 +337,7 @@ SEASTAR_THREAD_TEST_CASE(test_logstor_cache_survives_lsa_compaction_before_excha
 
 SEASTAR_THREAD_TEST_CASE(test_logstor_cache_upgrades_cached_partition_after_schema_change) {
     simple_schema schema(simple_schema::with_static::no);
-    primary_index index(schema.schema());
+    primary_index index(schema.schema(), noop_space_accounting);
     shared_logstor_cache cache;
     index.set_cache_tracker(&cache.logstor_tracker);
 

--- a/test/boost/logstor_test.cc
+++ b/test/boost/logstor_test.cc
@@ -13,6 +13,7 @@
 #include <seastar/util/memory-data-source.hh>
 #include <seastar/util/defer.hh>
 
+#include "replica/logstor/index.hh"
 #include "replica/logstor/ondisk.hh"
 #include "replica/logstor/write_buffer.hh"
 #include <seastar/testing/thread_test_case.hh>
@@ -188,6 +189,257 @@ SEASTAR_THREAD_TEST_CASE(test_logstor_write_buffer_accepts_record_at_max_record_
     wb.seal(segment_sequence{29}, std::nullopt, ondisk::block_alignment);
 
     BOOST_REQUIRE_EQUAL(wb.serialized_size(), ondisk::block_alignment);
+}
+
+// Checks that primary_index accounting callbacks track live bytes across
+// inserts, overwrites, relocations, erases, range erases, and clear().
+SEASTAR_THREAD_TEST_CASE(test_logstor_primary_index_space_accounting) {
+    auto schema = make_kv_schema();
+    struct accounting_subscriber : space_accounting_subscriber {
+        ssize_t live_bytes = 0;
+        size_t add_calls = 0;
+        size_t free_calls = 0;
+        std::vector<log_location> added_locations;
+        std::vector<log_location> freed_locations;
+
+        bool is_live(log_location loc) const {
+            return std::count(added_locations.begin(), added_locations.end(), loc)
+                 > std::count(freed_locations.begin(), freed_locations.end(), loc);
+        }
+
+        size_t live_location_count() const {
+            return std::count_if(added_locations.begin(), added_locations.end(), [&] (log_location loc) {
+                return is_live(loc);
+            });
+        }
+
+        void on_add_record(log_location loc) noexcept override {
+            live_bytes += loc.size;
+            ++add_calls;
+            added_locations.push_back(loc);
+        }
+
+        void on_free_record(log_location loc) noexcept override {
+            live_bytes -= loc.size;
+            ++free_calls;
+            BOOST_REQUIRE(is_live(loc));
+            freed_locations.push_back(loc);
+        }
+    } accounting;
+
+    primary_index index(schema, accounting);
+
+    const auto pk0 = primary_index_key{make_kv_mutation(schema, "pk0", "v0").decorated_key()};
+    const auto pk1 = primary_index_key{make_kv_mutation(schema, "pk1", "v1").decorated_key()};
+    const auto pk2 = primary_index_key{make_kv_mutation(schema, "pk2", "v2").decorated_key()};
+
+    const log_location loc0{.segment = log_segment_id{1}, .offset = 0, .size = 11};
+    const log_location loc0_old{.segment = log_segment_id{1}, .offset = 16, .size = 7};
+    const log_location loc1{.segment = log_segment_id{2}, .offset = 0, .size = 17};
+    const log_location loc2{.segment = log_segment_id{3}, .offset = 0, .size = 13};
+    const log_location loc3{.segment = log_segment_id{4}, .offset = 0, .size = 19};
+    const log_location loc4{.segment = log_segment_id{5}, .offset = 0, .size = 23};
+    const log_location loc5{.segment = log_segment_id{6}, .offset = 0, .size = 29};
+
+    // insert(pk0, loc0): new entry, succeeds, no previous entry to free  →  {pk0: loc0}
+    auto [inserted0, prev0] = index.insert(pk0, index_entry{.location = loc0, .timestamp = api::timestamp_type(10)});
+    BOOST_REQUIRE(inserted0);
+    BOOST_REQUIRE(!prev0);
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(loc0.size));
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 1u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 0u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 1);
+    BOOST_REQUIRE(accounting.is_live(loc0));
+
+    // insert(pk0, loc0_old): older timestamp, rejected, no accounting change  →  {pk0: loc0}
+    auto [inserted_old, prev_old] = index.insert(pk0, index_entry{.location = loc0_old, .timestamp = api::timestamp_type(9)});
+    BOOST_REQUIRE(!inserted_old);
+    BOOST_REQUIRE(prev_old);
+    BOOST_REQUIRE(prev_old->location == loc0);
+    BOOST_REQUIRE_EQUAL(prev_old->timestamp, api::timestamp_type(10));
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(loc0.size));
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 1u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 0u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 1);
+    BOOST_REQUIRE(accounting.is_live(loc0));
+
+    // insert(pk0, loc1): newer timestamp, replaces loc0, old location freed via accounting  →  {pk0: loc1}
+    auto [inserted1, prev1] = index.insert(pk0, index_entry{.location = loc1, .timestamp = api::timestamp_type(11)});
+    BOOST_REQUIRE(inserted1);
+    BOOST_REQUIRE(prev1);
+    BOOST_REQUIRE(prev1->location == loc0);
+    BOOST_REQUIRE_EQUAL(prev1->timestamp, api::timestamp_type(10));
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(loc1.size));
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 2u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 1u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 1);
+    BOOST_REQUIRE(accounting.is_live(loc1));
+    BOOST_REQUIRE(!accounting.is_live(loc0));
+    BOOST_REQUIRE(accounting.added_locations.back() == loc1);
+    BOOST_REQUIRE(accounting.freed_locations.back() == loc0);
+
+    // insert(pk1, loc2): new key, succeeds, adds to live bytes  →  {pk0: loc1, pk1: loc2}
+    auto [inserted2, prev2] = index.insert(pk1, index_entry{.location = loc2, .timestamp = api::timestamp_type(7)});
+    BOOST_REQUIRE(inserted2);
+    BOOST_REQUIRE(!prev2);
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(loc1.size + loc2.size));
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 3u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 1u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 2);
+    BOOST_REQUIRE(accounting.is_live(loc1));
+    BOOST_REQUIRE(accounting.is_live(loc2));
+
+    // erase(pk1, loc1): location mismatch, returns false, no accounting change  →  {pk0: loc1, pk1: loc2}
+    BOOST_REQUIRE(!index.erase(pk1, loc1));
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(loc1.size + loc2.size));
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 3u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 1u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 2);
+
+    // update_record_location(pk0, loc1 -> loc3): old location matches, succeeds, frees loc1 adds loc3  →  {pk0: loc3, pk1: loc2}
+    BOOST_REQUIRE(index.update_record_location(pk0, loc1, loc3));
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(loc2.size + loc3.size));
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 4u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 2u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 2);
+    BOOST_REQUIRE(accounting.is_live(loc2));
+    BOOST_REQUIRE(accounting.is_live(loc3));
+    BOOST_REQUIRE(!accounting.is_live(loc1));
+    BOOST_REQUIRE(accounting.added_locations.back() == loc3);
+    BOOST_REQUIRE(accounting.freed_locations.back() == loc1);
+
+    // update_record_location(pk0, loc1 -> loc4): old location no longer current, fails, no accounting change  →  {pk0: loc3, pk1: loc2}
+    BOOST_REQUIRE(!index.update_record_location(pk0, loc1, loc4));
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(loc2.size + loc3.size));
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 4u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 2u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 2);
+
+    // erase(pk1, loc2): location matches, succeeds, frees loc2  →  {pk0: loc3}
+    BOOST_REQUIRE(index.erase(pk1, loc2));
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(loc3.size));
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 4u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 3u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 1);
+    BOOST_REQUIRE(accounting.is_live(loc3));
+    BOOST_REQUIRE(!accounting.is_live(loc2));
+    BOOST_REQUIRE(accounting.freed_locations.back() == loc2);
+
+    // insert(pk1, loc4): new entry for pk1 (previously erased), succeeds  →  {pk0: loc3, pk1: loc4}
+    auto [inserted4, prev4] = index.insert(pk1, index_entry{.location = loc4, .timestamp = api::timestamp_type(12)});
+    BOOST_REQUIRE(inserted4);
+    BOOST_REQUIRE(!prev4);
+    // insert(pk2, loc5): new key, succeeds  →  {pk0: loc3, pk1: loc4, pk2: loc5}
+    auto [inserted5, prev5] = index.insert(pk2, index_entry{.location = loc5, .timestamp = api::timestamp_type(13)});
+    BOOST_REQUIRE(inserted5);
+    BOOST_REQUIRE(!prev5);
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(loc3.size + loc4.size + loc5.size));
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 6u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 3u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 3);
+
+    // range erase pk1: removes pk1 entry (loc4), frees via accounting  →  {pk0: loc3, pk2: loc5}
+    index.erase(dht::partition_range::make_singular(pk1.dk)).get();
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(loc3.size + loc5.size));
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 6u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 4u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 2);
+    BOOST_REQUIRE(!accounting.is_live(loc4));
+    BOOST_REQUIRE(accounting.is_live(loc3));
+    BOOST_REQUIRE(accounting.is_live(loc5));
+    BOOST_REQUIRE(accounting.freed_locations.back() == loc4);
+
+    // clear(): removes all remaining entries (pk0->loc3, pk2->loc5), all freed  →  {}
+    index.clear().get();
+    BOOST_REQUIRE(index.empty());
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, 0);
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 6u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 6u);
+    BOOST_REQUIRE_EQUAL(accounting.live_location_count(), 0);
+    BOOST_REQUIRE_EQUAL(accounting.freed_locations.size(), 6u);
+}
+
+// Checks that range erase and clear() account for freed log locations correctly.
+SEASTAR_THREAD_TEST_CASE(test_logstor_primary_index_range_erase_and_clear_space_accounting) {
+    auto schema = make_kv_schema();
+    struct accounting_subscriber : space_accounting_subscriber {
+        ssize_t live_bytes = 0;
+        size_t add_calls = 0;
+        size_t free_calls = 0;
+        std::vector<log_location> freed_locations;
+
+        void on_add_record(log_location loc) noexcept override {
+            live_bytes += loc.size;
+            ++add_calls;
+        }
+
+        void on_free_record(log_location loc) noexcept override {
+            live_bytes -= loc.size;
+            ++free_calls;
+            freed_locations.push_back(loc);
+        }
+    } accounting;
+
+    primary_index index(schema, accounting);
+
+    struct entry {
+        primary_index_key key;
+        log_location loc;
+    };
+
+    std::vector<entry> entries = {
+        { primary_index_key{make_kv_mutation(schema, "pk0", "v0").decorated_key()}, {.segment = log_segment_id{11}, .offset = 0, .size = 5} },
+        { primary_index_key{make_kv_mutation(schema, "pk1", "v1").decorated_key()}, {.segment = log_segment_id{12}, .offset = 0, .size = 7} },
+        { primary_index_key{make_kv_mutation(schema, "pk2", "v2").decorated_key()}, {.segment = log_segment_id{13}, .offset = 0, .size = 11} },
+        { primary_index_key{make_kv_mutation(schema, "pk3", "v3").decorated_key()}, {.segment = log_segment_id{14}, .offset = 0, .size = 13} },
+        { primary_index_key{make_kv_mutation(schema, "pk4", "v4").decorated_key()}, {.segment = log_segment_id{15}, .offset = 0, .size = 17} },
+    };
+
+    std::sort(entries.begin(), entries.end(), [&] (const entry& a, const entry& b) {
+        return dht::decorated_key::less_comparator(schema)(a.key.dk, b.key.dk);
+    });
+
+    auto insert = [&] (const entry& e, api::timestamp_type ts) {
+        auto [inserted, prev] = index.insert(e.key, index_entry{.location = e.loc, .timestamp = ts});
+        BOOST_REQUIRE(inserted);
+        BOOST_REQUIRE(!prev);
+    };
+
+    insert(entries[0], api::timestamp_type(10));
+    insert(entries[1], api::timestamp_type(11));
+    insert(entries[2], api::timestamp_type(12));
+    insert(entries[3], api::timestamp_type(13));
+    insert(entries[4], api::timestamp_type(14));
+
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 5u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 0u);
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(entries[0].loc.size + entries[1].loc.size + entries[2].loc.size + entries[3].loc.size + entries[4].loc.size));
+
+    index.erase(dht::partition_range(
+            dht::partition_range::bound(entries[1].key.dk, true),
+            dht::partition_range::bound(entries[3].key.dk, true))).get();
+
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 5u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 3u);
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, ssize_t(entries[0].loc.size + entries[4].loc.size));
+    BOOST_REQUIRE(index.find(entries[0].key.dk) != index.end());
+    BOOST_REQUIRE(index.find(entries[1].key.dk) == index.end());
+    BOOST_REQUIRE(index.find(entries[2].key.dk) == index.end());
+    BOOST_REQUIRE(index.find(entries[3].key.dk) == index.end());
+    BOOST_REQUIRE(index.find(entries[4].key.dk) != index.end());
+    BOOST_REQUIRE_EQUAL(std::count(accounting.freed_locations.begin(), accounting.freed_locations.end(), entries[1].loc), 1);
+    BOOST_REQUIRE_EQUAL(std::count(accounting.freed_locations.begin(), accounting.freed_locations.end(), entries[2].loc), 1);
+    BOOST_REQUIRE_EQUAL(std::count(accounting.freed_locations.begin(), accounting.freed_locations.end(), entries[3].loc), 1);
+
+    index.clear().get();
+
+    BOOST_REQUIRE(index.empty());
+    BOOST_REQUIRE_EQUAL(accounting.add_calls, 5u);
+    BOOST_REQUIRE_EQUAL(accounting.free_calls, 5u);
+    BOOST_REQUIRE_EQUAL(accounting.live_bytes, 0);
+    BOOST_REQUIRE_EQUAL(accounting.freed_locations.size(), 5u);
+    BOOST_REQUIRE_EQUAL(std::count(accounting.freed_locations.begin(), accounting.freed_locations.end(), entries[0].loc), 1);
+    BOOST_REQUIRE_EQUAL(std::count(accounting.freed_locations.begin(), accounting.freed_locations.end(), entries[4].loc), 1);
 }
 
 // Checks that scan_segment() returns mixed-buffer log locations that can be used to read back the expected records.

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -569,6 +569,113 @@ async def test_shrink_logstor_disk_size_live_data(manager: ManagerClient):
             assert rows[0].v == value, f"Wrong value for key {i} after attempted shrink with live data"
 
 
+async def test_space_accounting_metrics(manager: ManagerClient):
+    """
+    Verify the space accounting metrics scylla_logstor_sm_live_record_bytes and
+    scylla_logstor_sm_live_record_count are correct after writes, overwrites,
+    restarts, and table drops.
+    """
+    disk_size_mb = 4
+    file_size_mb = 1
+    key_count = 100
+    value_size = 2000
+    max_value_overhead = 500
+
+    cmdline = ['--logger-log-level', 'logstor=trace', '--smp=1']
+    cfg = {
+        'logstor_disk_size_in_mb': disk_size_mb,
+        'logstor_file_size_in_mb': file_size_mb,
+        'experimental_features': ['logstor']
+    }
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    server = servers[0]
+    cql = manager.get_cql()
+
+    async def get_live_record_metrics() -> tuple[int, int]:
+        metrics = await manager.metrics.query(server.ip_addr)
+        live_record_bytes = metrics.get("scylla_logstor_sm_live_record_bytes")
+        live_record_count = metrics.get("scylla_logstor_sm_live_record_count")
+        assert live_record_bytes is not None
+        assert live_record_count is not None
+        return int(live_record_bytes), int(live_record_count)
+
+    def make_value(tag: str) -> str:
+        return tag + ('x' * (value_size - len(tag)))
+
+    async with new_test_keyspace(manager, "WITH tablets={'initial':1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        insert = cql.prepare(f"INSERT INTO {ks}.test (pk, v) VALUES (?, ?)")
+
+        initial_value = make_value("initial_")
+        await asyncio.gather(*[cql.run_async(insert, [pk, initial_value]) for pk in range(key_count)])
+
+        await manager.api.logstor_flush(server.ip_addr)
+
+        baseline_live_record_bytes, baseline_live_record_count = await get_live_record_metrics()
+        logger.info(f"baseline live_record_bytes={baseline_live_record_bytes}, baseline_live_record_count={baseline_live_record_count}, avg overhead per record={(baseline_live_record_bytes / baseline_live_record_count) - value_size}")
+
+        assert baseline_live_record_count == key_count, (
+            f"expected live_record_count to be {key_count}, got {baseline_live_record_count}"
+        )
+
+        assert baseline_live_record_bytes >= key_count * value_size, (
+            f"expected live_record_bytes to be at least {key_count * value_size}, "
+            f"got {baseline_live_record_bytes}"
+        )
+        # live_record_bytes tracks full durable record bytes, so allow room for
+        # mutation and log record metadata on top of the raw value payload.
+        assert baseline_live_record_bytes <= key_count * (value_size + max_value_overhead), (
+            f"expected live_record_bytes to be at most {key_count * (value_size + max_value_overhead)}, "
+            f"got {baseline_live_record_bytes}"
+        )
+
+        # overwrite few keys and verify that the live_record_bytes and live_record_count remain unchanged
+        for i in range(10):
+            overwrite_value = make_value(f"overwrite_{i}_")
+            await asyncio.gather(*[cql.run_async(insert, [pk, overwrite_value]) for pk in range(key_count)])
+
+        live_record_bytes_after_overwrites, live_record_count_after_overwrites = await get_live_record_metrics()
+        assert live_record_bytes_after_overwrites == baseline_live_record_bytes, (
+            f"expected live_record_bytes to remain {baseline_live_record_bytes} after overwrites, "
+            f"got {live_record_bytes_after_overwrites}"
+        )
+        assert live_record_count_after_overwrites == baseline_live_record_count, (
+            f"expected live_record_count to remain {baseline_live_record_count} after overwrites, "
+            f"got {live_record_count_after_overwrites}"
+        )
+
+        # restart the server and verify that after recovery the live_record_bytes and live_record_count are correct
+        await manager.server_stop_gracefully(server.server_id)
+        await manager.server_start(server.server_id)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        final_live_record_bytes_after_restart, final_live_record_count_after_restart = await get_live_record_metrics()
+        logger.info(f"final_live_record_bytes_after_restart={final_live_record_bytes_after_restart}, final_live_record_count_after_restart={final_live_record_count_after_restart}")
+
+        assert final_live_record_count_after_restart == key_count, (
+            f"expected live_record_count to remain {key_count} after restart, "
+            f"got {final_live_record_count_after_restart}"
+        )
+
+        assert final_live_record_bytes_after_restart == baseline_live_record_bytes, (
+            f"expected live_record_bytes to remain {baseline_live_record_bytes} after restart, "
+            f"got {final_live_record_bytes_after_restart}"
+        )
+
+        # drop the table and verify the space accounting metrics are cleared to 0
+        await cql.run_async(f"DROP TABLE {ks}.test")
+
+        final_live_record_bytes_after_drop, final_live_record_count_after_drop = await get_live_record_metrics()
+        assert final_live_record_bytes_after_drop == 0, (
+            f"expected live_record_bytes to be 0 after table drop, "
+            f"got {final_live_record_bytes_after_drop}"
+        )
+        assert final_live_record_count_after_drop == 0, (
+            f"expected live_record_count to be 0 after table drop, "
+            f"got {final_live_record_count_after_drop}"
+        )
+
 async def test_compaction(manager: ManagerClient):
     """
     Test log compaction by creating dead data and verifying space reclamation.


### PR DESCRIPTION
improve the space accounting in logstor by refactoring it to a simpler
and safer interface. the space accounting is now directly integrated in
the logstor index - the index invokes space accounting update functions
atomically whenever a record becomes live or dead.

currently there is a single space accounting subscriber in the index
which is the segment manager that has two functions on_add_record and
on_free_record. on_add_record is called when a record in a specified
location becomes referenced by the index, and on_free_record is called
when a record is no longer referenced by the index.

the segment manager subscribes and implements these operations to keep
track of how much live data each segment has. it updates the free space
counters in the segment descriptors and updates the heap of histogram
which is used for compaction to find segments with low occupied space.

Refs https://scylladb.atlassian.net/browse/SCYLLADB-770

no backport - logstor is a new feature