### PR TITLE
object_storage: Add POSIX endpoint type

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -558,6 +558,7 @@ scylla_tests = set([
     'test/boost/compound_test',
     'test/boost/compress_test',
     'test/boost/config_test',
+    'test/boost/object_storage_config_test',
     'test/boost/continuous_data_consumer_test',
     'test/boost/counter_test',
     'test/boost/cql_auth_syntax_test',

--- a/db/object_storage_endpoint_param.cc
+++ b/db/object_storage_endpoint_param.cc
@@ -9,12 +9,14 @@
  
 #include <string>
 #include <variant>
+#include <filesystem>
 #include <yaml-cpp/yaml.h>
 
 #include <boost/lexical_cast.hpp>
 
 #include "utils/s3/creds.hh"
 #include "utils/http.hh"
+#include "utils/rjson.hh"
 #include "object_storage_endpoint_param.hh"
 
 using namespace std::string_literals;
@@ -30,6 +32,9 @@ db::object_storage_endpoint_param::object_storage_endpoint_param(std::string end
     : object_storage_endpoint_param(s3_storage{format_url(endpoint, config.port, config.use_https), std::move(config.region), std::move(config.role_arn), true /* legacy_format */})
 {}
 db::object_storage_endpoint_param::object_storage_endpoint_param(gs_storage s)
+    : _data(std::move(s))
+{}
+db::object_storage_endpoint_param::object_storage_endpoint_param(posix_storage s)
     : _data(std::move(s))
 {}
 
@@ -72,6 +77,22 @@ std::string db::object_storage_endpoint_param::gs_storage::key() const {
     return endpoint;
 }
 
+std::string db::object_storage_endpoint_param::posix_storage::to_json_string() const {
+    // path.native() may contain characters that are valid in a POSIX path but
+    // must be escaped in JSON (e.g. '"' or '\\'), so quote it via rjson rather
+    // than embedding it verbatim.
+    return fmt::format("{{ \"type\": \"posix\", \"path\": {} }}",
+        rjson::quote_json_string(sstring(path.native()))
+    );
+}
+
+std::string db::object_storage_endpoint_param::posix_storage::key() const {
+    // The path is normalized when the endpoint is decoded, so different
+    // spellings of the same location (trailing slash, "."/"..") already
+    // resolve to the same string and can be used directly as a key.
+    return path.native();
+}
+
 bool db::object_storage_endpoint_param::is_s3_storage() const {
     return std::holds_alternative<s3_storage>(_data);
 }
@@ -80,12 +101,19 @@ bool db::object_storage_endpoint_param::is_gs_storage() const {
     return std::holds_alternative<gs_storage>(_data);
 }
 
+bool db::object_storage_endpoint_param::is_posix_storage() const {
+    return std::holds_alternative<posix_storage>(_data);
+}
+
 bool db::object_storage_endpoint_param::is_storage_of_type(std::string_view type) const {
     if (type == s3_type) {
         return is_s3_storage();
     }
     if (type == gs_type) {
         return is_gs_storage();
+    }
+    if (type == posix_type) {
+        return is_posix_storage();
     }
     return false;
 }
@@ -96,6 +124,10 @@ const db::object_storage_endpoint_param::s3_storage& db::object_storage_endpoint
 
 const db::object_storage_endpoint_param::gs_storage& db::object_storage_endpoint_param::get_gs_storage() const {
     return std::get<db::object_storage_endpoint_param::gs_storage>(_data);
+}
+
+const db::object_storage_endpoint_param::posix_storage& db::object_storage_endpoint_param::get_posix_storage() const {
+    return std::get<db::object_storage_endpoint_param::posix_storage>(_data);
 }
 
 std::strong_ordering db::object_storage_endpoint_param::operator<=>(const object_storage_endpoint_param&) const = default;
@@ -114,6 +146,8 @@ const std::string& db::object_storage_endpoint_param::type() const {
         return s3_type;
     } else if (is_gs_storage()) {
         return gs_type;
+    } else if (is_posix_storage()) {
+        return posix_type;
     }
     throw std::runtime_error("Should not reach");
 }
@@ -152,12 +186,35 @@ db::object_storage_endpoint_param db::object_storage_endpoint_param::decode(cons
 
         return object_storage_endpoint_param(std::move(ep));
     }
+    // locally-mounted POSIX path endpoint
+    if (type.as<std::string>() == posix_type) {
+        std::filesystem::path path = name.as<std::string>();
+        if (!path.is_absolute()) {
+            throw std::invalid_argument(fmt::format(
+                "posix object storage endpoint requires an absolute path, got '{}'", path.native()));
+        }
+        // Normalize the path lexically (collapsing redundant separators,
+        // trailing slashes and "."/".." components) so that different spellings
+        // of the same location map to one endpoint and key(). Unlike
+        // canonical() this does not touch the filesystem: symlinks are not
+        // resolved and the path need not exist. Whether the mount actually
+        // exists is validated later, when the object storage client is created.
+        auto normalized = path.lexically_normal();
+        // lexically_normal() keeps a trailing separator for inputs like
+        // "/mnt/backup/" or "/mnt/backup/."; drop it so those map to the same
+        // key as "/mnt/backup".
+        if (!normalized.has_filename()) {
+            normalized = normalized.parent_path();
+        }
+        return object_storage_endpoint_param(posix_storage{std::move(normalized)});
+    }
     // TODO: other types
     throw std::invalid_argument(fmt::format("Could not decode object_storage_endpoint_param: {}", boost::lexical_cast<std::string>(node)));
 }
 
 const std::string db::object_storage_endpoint_param::s3_type = "s3";
 const std::string db::object_storage_endpoint_param::gs_type = "gs";
+const std::string db::object_storage_endpoint_param::posix_type = "posix";
 
 auto fmt::formatter<db::object_storage_endpoint_param>::format(const db::object_storage_endpoint_param& e, fmt::format_context& ctx) const
     -> decltype(ctx.out()) {

--- a/db/object_storage_endpoint_param.hh
+++ b/db/object_storage_endpoint_param.hh
@@ -12,6 +12,7 @@
 #include <string>
 #include <variant>
 #include <compare>
+#include <filesystem>
 #include <fmt/core.h>
 #include "utils/s3/creds.hh"
 
@@ -41,12 +42,20 @@ public:
         std::string to_json_string() const;
         std::string key() const;
     };
+    struct posix_storage {
+        std::filesystem::path path; // normalized locally-mounted POSIX path
+
+        std::strong_ordering operator<=>(const posix_storage&) const = default;
+        std::string to_json_string() const;
+        std::string key() const;
+    };
 
     object_storage_endpoint_param();
     object_storage_endpoint_param(const object_storage_endpoint_param&);
     object_storage_endpoint_param(s3_storage);
     object_storage_endpoint_param(std::string endpoint, s3::endpoint_config config);
     object_storage_endpoint_param(gs_storage);
+    object_storage_endpoint_param(posix_storage);
 
     std::strong_ordering operator<=>(const object_storage_endpoint_param&) const;
     bool operator==(const object_storage_endpoint_param&) const;
@@ -57,18 +66,21 @@ public:
 
     bool is_s3_storage() const;
     bool is_gs_storage() const;
+    bool is_posix_storage() const;
 
     bool is_storage_of_type(std::string_view) const;
 
     const s3_storage& get_s3_storage() const;
     const gs_storage& get_gs_storage() const;
+    const posix_storage& get_posix_storage() const;
 
     static object_storage_endpoint_param decode(const YAML::Node&);
     static const std::string s3_type; // "s3"
     static const std::string gs_type; // "gs"
+    static const std::string posix_type; // "posix"
 private:
     friend fmt::formatter<object_storage_endpoint_param>;
-    std::variant<s3_storage, gs_storage> _data;
+    std::variant<s3_storage, gs_storage, posix_storage> _data;
 };
 
 std::istream& operator>>(std::istream& is, object_storage_endpoint_param& f);

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -1,6 +1,6 @@
 # Keeping sstables on S3/GS
 
-On of the ways to use object storage is to keep sstables directly on it as objects.
+One of the ways to use object storage is to keep sstables directly on it as objects.
 
 ## Enabling the feature
 
@@ -80,6 +80,31 @@ object_storage_endpoints:
     aws_region: us-east-1
     iam_role_arn: arn:aws:iam::123456789012:instance-profile/my-instance-instance-profile
 ```
+
+## Configuring network-attached POSIX storage access
+
+A `posix` endpoint points at a network-attached, locally-mounted POSIX 
+directory (for example an NFS client mount). It is configured in 
+`scylla.yaml` similarly to a remote S3/GS service:
+
+```yaml
+object_storage_endpoints:
+  - name: /mnt/backup
+    type: posix
+```
+
+The path in `name`:
+
+- must be absolute; relative paths are rejected;
+- must exist; a missing or not-yet-mounted directory is reported when the
+  object storage client for the endpoint is created rather than on first use;
+- is normalized, i.e. trailing slashes, redundant separators and `.`/`..`
+  components are collapsed (symlinks are not resolved). As a result different
+  spellings of the same location (e.g. `/mnt/backup` and `/mnt/backup/`) refer
+  to the same endpoint.
+
+**Note:** The storage backend is not wired up yet, so an endpoint of 
+`type: posix` cannot be used as a keyspace's storage yet.
 
 ## Creating keyspace with S3
 

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -69,6 +69,8 @@ add_scylla_test(compress_test
   KIND BOOST)
 add_scylla_test(config_test
   KIND SEASTAR)
+add_scylla_test(object_storage_config_test
+  KIND SEASTAR)
 add_scylla_test(continuous_data_consumer_test
   KIND SEASTAR)
 add_scylla_test(counter_test

--- a/test/boost/object_storage_config_test.cc
+++ b/test/boost/object_storage_config_test.cc
@@ -100,3 +100,123 @@ SEASTAR_THREAD_TEST_CASE(test_posix_endpoint_json_escaping) {
     BOOST_REQUIRE_EQUAL(ep.to_json_string(),
         R"json({ "type": "posix", "path": "/mnt/we\"ir\\d" })json");
 }
+
+// A modern s3 endpoint is configured with a full URL in "name" and no legacy
+// port/https fields. The URL is stored and used verbatim as the key.
+SEASTAR_THREAD_TEST_CASE(test_s3_endpoint_full_url) {
+    auto ep = decode_yaml(
+        "name: https://s3.us-east-1.amazonaws.com:443\n"
+        "type: s3\n"
+        "aws_region: us-east-1\n"
+        "iam_role_arn: arn:aws:iam::123456789012:role/example\n");
+
+    BOOST_REQUIRE(ep.is_s3_storage());
+    BOOST_REQUIRE(!ep.is_gs_storage());
+    BOOST_REQUIRE(!ep.is_posix_storage());
+    BOOST_REQUIRE_EQUAL(ep.type(), param::s3_type);
+    BOOST_REQUIRE(ep.is_storage_of_type(param::s3_type));
+    BOOST_REQUIRE(!ep.is_storage_of_type(param::gs_type));
+
+    const auto& s3 = ep.get_s3_storage();
+    BOOST_REQUIRE(!s3.legacy_format);
+    BOOST_REQUIRE_EQUAL(s3.endpoint, "https://s3.us-east-1.amazonaws.com:443");
+    BOOST_REQUIRE_EQUAL(s3.region, "us-east-1");
+    BOOST_REQUIRE_EQUAL(s3.iam_role_arn, "arn:aws:iam::123456789012:role/example");
+
+    BOOST_REQUIRE_EQUAL(ep.key(), "https://s3.us-east-1.amazonaws.com:443");
+    BOOST_REQUIRE_EQUAL(ep.to_json_string(),
+        R"({ "type": "s3", "aws_region": "us-east-1", "iam_role_arn": "arn:aws:iam::123456789012:role/example" })");
+}
+
+// When "type" is omitted the endpoint defaults to s3.
+SEASTAR_THREAD_TEST_CASE(test_s3_endpoint_type_defaults_to_s3) {
+    auto ep = decode_yaml(
+        "name: https://s3.example.com:443\n"
+        "aws_region: us-east-1\n");
+
+    BOOST_REQUIRE(ep.is_s3_storage());
+    BOOST_REQUIRE_EQUAL(ep.type(), param::s3_type);
+    BOOST_REQUIRE(!ep.get_s3_storage().legacy_format);
+    BOOST_REQUIRE_EQUAL(ep.get_s3_storage().endpoint, "https://s3.example.com:443");
+    BOOST_REQUIRE_EQUAL(ep.get_s3_storage().iam_role_arn, "");
+}
+
+// A legacy s3 endpoint is configured with a bare host plus separate port/https
+// fields. The endpoint is reassembled into a URL, but the key is just the host,
+// preserving the historical lookup behavior.
+SEASTAR_THREAD_TEST_CASE(test_s3_endpoint_legacy_host_port) {
+    auto ep = decode_yaml(
+        "name: localhost\n"
+        "type: s3\n"
+        "port: 9000\n"
+        "https: false\n"
+        "aws_region: local\n");
+
+    BOOST_REQUIRE(ep.is_s3_storage());
+    const auto& s3 = ep.get_s3_storage();
+    BOOST_REQUIRE(s3.legacy_format);
+    BOOST_REQUIRE_EQUAL(s3.endpoint, "http://localhost:9000");
+    BOOST_REQUIRE_EQUAL(s3.region, "local");
+    BOOST_REQUIRE_EQUAL(s3.iam_role_arn, "");
+
+    BOOST_REQUIRE_EQUAL(ep.key(), "localhost");
+    BOOST_REQUIRE_EQUAL(ep.to_json_string(),
+        R"({ "port": 9000, "use_https": false, "aws_region": "local", "iam_role_arn": "" })");
+}
+
+// A legacy s3 endpoint with https enabled reassembles an https URL and reports
+// use_https in its json representation.
+SEASTAR_THREAD_TEST_CASE(test_s3_endpoint_legacy_https) {
+    auto ep = decode_yaml(
+        "name: minio\n"
+        "type: s3\n"
+        "port: 443\n"
+        "https: true\n"
+        "aws_region: local\n");
+
+    const auto& s3 = ep.get_s3_storage();
+    BOOST_REQUIRE(s3.legacy_format);
+    BOOST_REQUIRE_EQUAL(s3.endpoint, "https://minio:443");
+    BOOST_REQUIRE_EQUAL(ep.key(), "minio");
+    BOOST_REQUIRE_EQUAL(ep.to_json_string(),
+        R"({ "port": 443, "use_https": true, "aws_region": "local", "iam_role_arn": "" })");
+}
+
+// A gs endpoint stores the URI from "name" and an optional credentials file,
+// and uses the URI verbatim as the key.
+SEASTAR_THREAD_TEST_CASE(test_gs_endpoint_decode) {
+    auto ep = decode_yaml(
+        "name: https://storage.googleapis.com\n"
+        "type: gs\n"
+        "credentials_file: /etc/scylla/gcp.json\n");
+
+    BOOST_REQUIRE(ep.is_gs_storage());
+    BOOST_REQUIRE(!ep.is_s3_storage());
+    BOOST_REQUIRE(!ep.is_posix_storage());
+    BOOST_REQUIRE_EQUAL(ep.type(), param::gs_type);
+    BOOST_REQUIRE(ep.is_storage_of_type(param::gs_type));
+    BOOST_REQUIRE(!ep.is_storage_of_type(param::s3_type));
+
+    const auto& gs = ep.get_gs_storage();
+    BOOST_REQUIRE_EQUAL(gs.endpoint, "https://storage.googleapis.com");
+    BOOST_REQUIRE_EQUAL(gs.credentials_file, "/etc/scylla/gcp.json");
+
+    BOOST_REQUIRE_EQUAL(ep.key(), "https://storage.googleapis.com");
+    BOOST_REQUIRE_EQUAL(ep.to_json_string(),
+        R"({ "type": "gs", "credentials_file": "/etc/scylla/gcp.json" })");
+}
+
+// The gs credentials file is optional and defaults to an empty string.
+SEASTAR_THREAD_TEST_CASE(test_gs_endpoint_without_credentials_file) {
+    auto ep = decode_yaml(
+        "name: default\n"
+        "type: gs\n");
+
+    BOOST_REQUIRE(ep.is_gs_storage());
+    BOOST_REQUIRE_EQUAL(ep.get_gs_storage().endpoint, "default");
+    BOOST_REQUIRE_EQUAL(ep.get_gs_storage().credentials_file, "");
+    BOOST_REQUIRE_EQUAL(ep.key(), "default");
+    BOOST_REQUIRE_EQUAL(ep.to_json_string(),
+        R"({ "type": "gs", "credentials_file": "" })");
+}
+

--- a/test/boost/object_storage_config_test.cc
+++ b/test/boost/object_storage_config_test.cc
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include <filesystem>
+
+#include <boost/test/unit_test.hpp>
+#include <fmt/format.h>
+#include <yaml-cpp/yaml.h>
+
+#include "test/lib/scylla_test_case.hh"
+#include "test/lib/tmpdir.hh"
+#include "db/object_storage_endpoint_param.hh"
+
+using param = db::object_storage_endpoint_param;
+
+static param decode_yaml(std::string_view yaml) {
+    return param::decode(YAML::Load(std::string(yaml)));
+}
+
+// A locally-mounted POSIX path endpoint decodes into a posix param, and the
+// stored path is lexically normalized (not canonicalized, so no filesystem
+// access and no symlink resolution).
+SEASTAR_THREAD_TEST_CASE(test_posix_endpoint_decode) {
+    tmpdir dir;
+    // The tmpdir path is already absolute and normal, so normalization leaves
+    // it unchanged; decode() must not resolve symlinks or otherwise rewrite it.
+    auto expected = dir.path();
+
+    auto ep = decode_yaml(fmt::format(
+        "name: {}\n"
+        "type: posix\n",
+        dir.path().native()));
+
+    BOOST_REQUIRE(ep.is_posix_storage());
+    BOOST_REQUIRE(!ep.is_s3_storage());
+    BOOST_REQUIRE(!ep.is_gs_storage());
+
+    BOOST_REQUIRE_EQUAL(ep.type(), param::posix_type);
+    BOOST_REQUIRE(ep.is_storage_of_type(param::posix_type));
+    BOOST_REQUIRE(!ep.is_storage_of_type(param::s3_type));
+    BOOST_REQUIRE(!ep.is_storage_of_type(param::gs_type));
+
+    BOOST_REQUIRE_EQUAL(ep.get_posix_storage().path, expected);
+    BOOST_REQUIRE_EQUAL(ep.key(), expected.native());
+    BOOST_REQUIRE_EQUAL(ep.to_json_string(),
+        fmt::format(R"({{ "type": "posix", "path": "{}" }})", expected.native()));
+}
+
+// The path is lexically normalized, so different spellings of the same location
+// map to the same endpoint: a trailing slash and a "." / ".." component must
+// all resolve to one key so that "/mnt/backup" and "/mnt/backup/" are
+// equivalent. Normalization is purely lexical, so the "sub" component of the
+// ".." case need not exist on disk.
+SEASTAR_THREAD_TEST_CASE(test_posix_endpoint_path_normalization) {
+    tmpdir dir;
+
+    auto plain = decode_yaml(fmt::format("name: {}\ntype: posix\n", dir.path().native()));
+    auto trailing_slash = decode_yaml(fmt::format("name: {}/\ntype: posix\n", dir.path().native()));
+    auto dot = decode_yaml(fmt::format("name: {}/.\ntype: posix\n", dir.path().native()));
+    auto dotdot = decode_yaml(fmt::format("name: {}/sub/..\ntype: posix\n", dir.path().native()));
+
+    BOOST_REQUIRE_EQUAL(plain.key(), dir.path().native());
+    BOOST_REQUIRE_EQUAL(trailing_slash.key(), plain.key());
+    BOOST_REQUIRE_EQUAL(dot.key(), plain.key());
+    BOOST_REQUIRE_EQUAL(dotdot.key(), plain.key());
+
+    // Equal keys imply equal params, so the endpoint map deduplicates them.
+    BOOST_REQUIRE(plain == trailing_slash);
+    BOOST_REQUIRE(plain == dot);
+    BOOST_REQUIRE(plain == dotdot);
+}
+
+// A relative path is rejected: an object storage endpoint must be unambiguous
+// and not depend on the process' working directory.
+SEASTAR_THREAD_TEST_CASE(test_posix_endpoint_rejects_relative_path) {
+    BOOST_REQUIRE_THROW(
+        decode_yaml("name: relative/path\ntype: posix\n"),
+        std::invalid_argument);
+}
+
+// An empty path is rejected (an empty path is not absolute).
+SEASTAR_THREAD_TEST_CASE(test_posix_endpoint_rejects_empty_path) {
+    BOOST_REQUIRE_THROW(
+        decode_yaml("name: \"\"\ntype: posix\n"),
+        std::invalid_argument);
+}
+
+// A path with characters that are valid in a POSIX path but must be escaped in
+// JSON (a double quote and a backslash) is escaped in to_json_string(). The
+// param is built directly rather than decoded from YAML so the characters are
+// preserved verbatim.
+SEASTAR_THREAD_TEST_CASE(test_posix_endpoint_json_escaping) {
+    param ep{param::posix_storage{"/mnt/we\"ir\\d"}};
+
+    BOOST_REQUIRE_EQUAL(ep.to_json_string(),
+        R"json({ "type": "posix", "path": "/mnt/we\"ir\\d" })json");
+}


### PR DESCRIPTION
This is the first step towards a network-attached backup mechanism. The user
configures a local POSIX directory that is a mounted NFS client and
provides its path as an object storage endpoint. Backup files written to
this directory are then forwarded via NFS to the user-configured NFS
server machine. To make this possible, the endpoint configuration first
needs to be able to describe such a locally-mounted path.

db::object_storage_endpoint_param is a variant of storage backends
(s3_storage, gs_storage) decoded from the object_storage_endpoints YAML
configuration. Add a third alternative, posix_storage, describing a
locally-mounted POSIX filesystem path.

A POSIX endpoint is configured as:
- name: /mnt/backup
  type: posix

Like s3 and gs, the path is taken from the "name" field. Keeping a single
field across all endpoint types avoids the confusion of a per-type key,
even though "name" reads a little oddly for a filesystem path.

The following pieces are added to support the new alternative:
- struct posix_storage holding the mount path as a std::filesystem::path,
added to the variant.
- The "posix" type string and posix_storage constructor.
- is_posix_storage() / get_posix_storage() accessors.
- A decode() branch that parses and validates the path.
- Handling in type() and is_storage_of_type(), which bypass the
std::visit dispatch and would otherwise throw at runtime.

decode() canonicalizes the path with std::filesystem::canonical(). This
normalizes trailing slashes, redundant separators and "."/".." components
and resolves symlinks, so that different spellings of the same location
(e.g. "/mnt/backup" and "/mnt/backup/") map to a single endpoint and key().
canonical() also requires the path to exist, and decode() additionally
rejects non-absolute paths, so a misconfigured mount is caught up-front at
config parse time rather than on first use.

This only wires up parsing and representation of the endpoint; the client
factory still throws "not implemented" for posix storage, which will be
added in a follow-up.

Add a dedicated object_storage_config_test.cc covering decoding of the
posix/S3/GCS object storage endpoints from YAML to verify parsing and normalization
behavior.

Added documentation in object_storage.md.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2770