### PR TITLE
cql3: re-validate the indexed predicate on base rows read via an index

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1481,7 +1481,7 @@ void statement_restrictions::calculate_column_defs_for_filtering_and_erase_restr
         data_dictionary::database db,
         const single_column_predicate_vectors& sc_pk_pred_vectors,
         const single_column_predicate_vectors& sc_ck_pred_vectors,
-        const single_column_predicate_vectors& sc_nonpk_pred_vectors) {
+        const single_column_predicate_vectors& /* sc_nonpk_pred_vectors */) {
     std::vector<const column_definition*> column_defs_for_filtering;
     if (need_filtering()) {
         std::optional<secondary_index::index> opt_idx;
@@ -1522,13 +1522,16 @@ void statement_restrictions::calculate_column_defs_for_filtering_and_erase_restr
                 }
             }
         }
-        for (auto it = _single_column_nonprimary_key_restrictions.begin(); it != _single_column_nonprimary_key_restrictions.end();) {
-            auto&& [cdef, cur_restr] = *it;
-            if (!column_uses_indexing(sc_nonpk_pred_vectors, cdef)) {
-                column_defs_for_filtering.emplace_back(cdef);
-                ++it;
-            } else {
-                it = _single_column_nonprimary_key_restrictions.erase(it);
+        for (const column_definition* cdef : _single_column_nonprimary_key_restrictions | std::ranges::views::keys) {
+            column_defs_for_filtering.emplace_back(cdef);
+        }
+    }
+    // Fetch the indexed column for its re-validation against the base row (SCYLLADB-2817).
+    if (_uses_secondary_indexing && _idx_opt) {
+        const column_definition* idx_col = _schema->get_column_definition(to_bytes(_idx_opt->target_column()));
+        if (idx_col && (idx_col->is_regular() || idx_col->is_static())) {
+            if (std::ranges::find(column_defs_for_filtering, idx_col) == column_defs_for_filtering.end()) {
+                column_defs_for_filtering.push_back(idx_col);
             }
         }
     }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -1602,7 +1602,7 @@ void statement_restrictions::calculate_column_defs_for_filtering_and_erase_restr
         data_dictionary::database db,
         const single_column_predicate_vectors& sc_pk_pred_vectors,
         const single_column_predicate_vectors& sc_ck_pred_vectors,
-        const single_column_predicate_vectors& sc_nonpk_pred_vectors) {
+        const single_column_predicate_vectors& /* sc_nonpk_pred_vectors */) {
     std::vector<const column_definition*> column_defs_for_filtering;
     if (need_filtering()) {
         std::optional<secondary_index::index> opt_idx;
@@ -1643,13 +1643,16 @@ void statement_restrictions::calculate_column_defs_for_filtering_and_erase_restr
                 }
             }
         }
-        for (auto it = _single_column_nonprimary_key_restrictions.begin(); it != _single_column_nonprimary_key_restrictions.end();) {
-            auto&& [cdef, cur_restr] = *it;
-            if (!column_uses_indexing(sc_nonpk_pred_vectors, cdef)) {
-                column_defs_for_filtering.emplace_back(cdef);
-                ++it;
-            } else {
-                it = _single_column_nonprimary_key_restrictions.erase(it);
+        for (const column_definition* cdef : _single_column_nonprimary_key_restrictions | std::ranges::views::keys) {
+            column_defs_for_filtering.emplace_back(cdef);
+        }
+    }
+    // Fetch the indexed column for its re-validation against the base row (SCYLLADB-2817).
+    if (_uses_secondary_indexing && _idx_opt) {
+        const column_definition* idx_col = _schema->get_column_definition(to_bytes(_idx_opt->target_column()));
+        if (idx_col && (idx_col->is_regular() || idx_col->is_static())) {
+            if (!std::ranges::contains(column_defs_for_filtering, idx_col)) {
+                column_defs_for_filtering.push_back(idx_col);
             }
         }
     }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -673,6 +673,14 @@ generate_base_key_from_index_pk(const partition_key& index_pk, const std::option
     return KeyType::from_range(exploded_base_key);
 }
 
+bool view_indexed_table_select_statement::needs_post_filtering() const {
+    const column_definition* cdef = _schema->get_column_definition(to_bytes(_index.target_column()));
+    if (cdef && (cdef->is_regular() || cdef->is_static())) {
+        return true;
+    }
+    return select_statement::needs_post_filtering();
+}
+
 lw_shared_ptr<query::read_command>
 view_indexed_table_select_statement::prepare_command_for_base_query(query_processor& qp, const query_options& options,
         service::query_state& state, gc_clock::time_point now, bool use_paging) const {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -685,6 +685,14 @@ generate_base_key_from_index_pk(const partition_key& index_pk, const std::option
     return KeyType::from_range(exploded_base_key);
 }
 
+bool view_indexed_table_select_statement::needs_post_filtering() const {
+    const column_definition* cdef = _schema->get_column_definition(to_bytes(_index.target_column()));
+    if (cdef && (cdef->is_regular() || cdef->is_static())) {
+        return true;
+    }
+    return select_statement::needs_post_filtering();
+}
+
 lw_shared_ptr<query::read_command>
 view_indexed_table_select_statement::prepare_command_for_base_query(query_processor& qp, const query_options& options,
         service::query_state& state, gc_clock::time_point now, bool use_paging) const {

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -232,7 +232,9 @@ public:
 private:
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(query_processor& qp,
             service::query_state& state, const query_options& options) const override;
-            
+
+    bool needs_post_filtering() const override;
+
     future<::shared_ptr<cql_transport::messages::result_message>> actually_do_execute(query_processor& qp,
             service::query_state& state, const query_options& options) const;
 

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -250,7 +250,9 @@ protected:
 private:
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(query_processor& qp,
             service::query_state& state, const query_options& options) const override;
-            
+
+    bool needs_post_filtering() const override;
+
     future<::shared_ptr<cql_transport::messages::result_message>> actually_do_execute(query_processor& qp,
             service::query_state& state, const query_options& options) const;
 

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -414,6 +414,14 @@ future<> view_update_generator::populate_views(const replica::table& table,
                 err = std::make_exception_ptr(std::runtime_error("Timeout a view building update"));
                 continue;
             }
+            // Lets tests interleave reads between the generation of backfill
+            // updates and their application.
+            co_await utils::get_local_injector().inject("populate_views_pause_before_apply",
+                    [] (auto& handler) -> future<> {
+                vug_logger.info("populate_views: paused before applying updates, waiting for message");
+                co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes(2));
+                vug_logger.info("populate_views: released, applying updates");
+            });
             co_await mutate_MV(schema, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(),
                     tracing::trace_state_ptr(), std::move(memory_units), service::allow_hints::no, wait_for_all_updates::yes);
         } catch (...) {
@@ -521,6 +529,8 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
         }
 
         try {
+            utils::get_local_injector().inject("view_update_generation_failure",
+                [] { throw std::runtime_error("Error injection: failing view update generation"); });
             co_await mutate_MV(base, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(), tr_state,
                 std::move(memory_units), service::allow_hints::yes, wait_for_all_updates::no);
         } catch (...) {

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -419,6 +419,14 @@ future<> view_update_generator::populate_views(const replica::table& table,
                 err = std::make_exception_ptr(std::runtime_error("Timeout a view building update"));
                 continue;
             }
+            // Lets tests interleave reads between the generation of backfill
+            // updates and their application.
+            co_await utils::get_local_injector().inject("populate_views_pause_before_apply",
+                    [] (auto& handler) -> future<> {
+                vug_logger.info("populate_views: paused before applying updates, waiting for message");
+                co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes(2));
+                vug_logger.info("populate_views: released, applying updates");
+            });
             co_await mutate_MV(schema, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(),
                     tracing::trace_state_ptr(), std::move(memory_units), service::allow_hints::no, wait_for_all_updates::yes);
         } catch (...) {
@@ -526,6 +534,8 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
         }
 
         try {
+            utils::get_local_injector().inject("view_update_generation_failure",
+                [] { throw std::runtime_error("Error injection: failing view update generation"); });
             co_await mutate_MV(base, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(), tr_state,
                 std::move(memory_units), service::allow_hints::yes, wait_for_all_updates::no);
         } catch (...) {

--- a/test/boost/cql_auth_query_test.cc
+++ b/test/boost/cql_auth_query_test.cc
@@ -346,7 +346,7 @@ SEASTAR_TEST_CASE(modify_table_with_index) {
             cquery_nofail(env, "INSERT INTO t (p, v) values (14, 'aaa')");
         });
         assert_that(cquery_nofail(env, "SELECT p FROM t WHERE v='aaa' ALLOW FILTERING;")).is_rows().with_rows(
-                {{int32_type->decompose(14)}});
+                {{int32_type->decompose(14), utf8_type->decompose(sstring("aaa"))}});
     }, db_config_with_auth());
 }
 

--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -768,9 +768,9 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_secondary_index) {
 
         eventually([&] {
             auto msg = cquery_nofail(e, "SELECT SUM(e) FROM t WHERE c = 5 AND b = 911 ALLOW FILTERING;");
-            assert_that(msg).is_rows().with_rows({{ int32_type->decompose(0), {} }});
+            assert_that(msg).is_rows().with_rows({{ int32_type->decompose(0), {}, {} }});
             msg = cquery_nofail(e, "SELECT e FROM t WHERE c = 5 AND b = 3 ALLOW FILTERING;");
-            assert_that(msg).is_rows().with_rows({{ int32_type->decompose(9), int32_type->decompose(3) }});
+            assert_that(msg).is_rows().with_rows({{ int32_type->decompose(9), int32_type->decompose(3), int32_type->decompose(5) }});
         });
     });
 }

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -39,8 +39,8 @@ SEASTAR_TEST_CASE(test_secondary_index_regular_column_query) {
 
         shared_ptr<cql_transport::messages::result_message> msg = co_await e.execute_cql("SELECT email FROM users WHERE country = 'France';");
         assert_that(msg).is_rows().with_rows({
-            { utf8_type->decompose(sstring("dcurrorw@techcrunch.com")) },
-            { utf8_type->decompose(sstring("beassebyv@house.gov")) },
+            { utf8_type->decompose(sstring("dcurrorw@techcrunch.com")), utf8_type->decompose(sstring("France")) },
+            { utf8_type->decompose(sstring("beassebyv@house.gov")), utf8_type->decompose(sstring("France")) },
         });
     });
 }
@@ -640,49 +640,61 @@ SEASTAR_TEST_CASE(test_secondary_index_collections) {
         e.execute_cql(insert_into + "(2, {2},    {3: 'three', 7: 'five'},             [3, 4, 5], {2}, {3: 'three'},            [3, 4, 5])").get();
         e.execute_cql(insert_into + "(3, {2, 3}, {3: 'three', 5: 'five', 7: 'seven'}, [2, 8, 9], {3}, {5: 'five', 7: 'seven'}, [7, 8, 9])").get();
 
+        auto set_of = [&] (std::vector<data_value> v) { return set_type->decompose(make_set_value(set_type, std::move(v))); };
+        auto map_of = [&] (map_type_impl::native_type v) { return map_type->decompose(make_map_value(map_type, std::move(v))); };
+        auto list_of = [&] (std::vector<data_value> v) { return list_type->decompose(make_list_value(list_type, std::move(v))); };
+        auto p = [] (int32_t v) { return int32_type->decompose(v); };
+        const auto s1_2 = set_of({data_value(2)}), s1_3 = set_of({data_value(2), data_value(3)});
+        const auto m1_2 = map_of({{data_value(3), data_value(sstring("three"))}, {data_value(7), data_value(sstring("five"))}});
+        const auto m1_3 = map_of({{data_value(3), data_value(sstring("three"))}, {data_value(5), data_value(sstring("five"))}, {data_value(7), data_value(sstring("seven"))}});
+        const auto l1_1 = list_of({data_value(2)}), l1_3 = list_of({data_value(2), data_value(8), data_value(9)});
+        const auto s2_2 = set_of({data_value(2)});
+        const auto m2_3 = map_of({{data_value(5), data_value(sstring("five"))}, {data_value(7), data_value(sstring("seven"))}});
+        const auto l2_1 = list_of({data_value(2)});
+
         auto res = e.execute_cql("SELECT p from t where s1 CONTAINS 2").get();
-        assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(2)}}}, {{{int32_type->decompose(3)}}}});
+        assert_that(res).is_rows().with_rows_ignore_order({{p(2), s1_2}, {p(3), s1_3}});
         res = e.execute_cql("SELECT p from t where s1 CONTAINS 4").get();
         assert_that(res).is_rows().with_size(0);
 
         res = e.execute_cql("SELECT p from t where m1 CONTAINS 'three'").get();
-        assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(2)}}}, {{{int32_type->decompose(3)}}}});
+        assert_that(res).is_rows().with_rows_ignore_order({{p(2), m1_2}, {p(3), m1_3}});
         res = e.execute_cql("SELECT p from t where m1 CONTAINS 'seven'").get();
-        assert_that(res).is_rows().with_rows({{{{int32_type->decompose(3)}}}});
+        assert_that(res).is_rows().with_rows({{p(3), m1_3}});
         res = e.execute_cql("SELECT p from t where m1 CONTAINS 'ten'").get();
         assert_that(res).is_rows().with_size(0);
 
         res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 3").get();
-        assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(2)}}}, {{{int32_type->decompose(3)}}}});
+        assert_that(res).is_rows().with_rows_ignore_order({{p(2), m1_2}, {p(3), m1_3}});
         res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 5").get();
-        assert_that(res).is_rows().with_rows({{{{int32_type->decompose(3)}}}});
+        assert_that(res).is_rows().with_rows({{p(3), m1_3}});
         res = e.execute_cql("SELECT p from t where m1 CONTAINS KEY 10").get();
         assert_that(res).is_rows().with_size(0);
 
         res = e.execute_cql("SELECT p from t where m1[3] = 'three'").get();
-        assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(3)}}}, {{{int32_type->decompose(2)}}}});
+        assert_that(res).is_rows().with_rows_ignore_order({{p(3), m1_3}, {p(2), m1_2}});
         res = e.execute_cql("SELECT p from t where m1[7] = 'seven'").get();
-        assert_that(res).is_rows().with_rows({{{{int32_type->decompose(3)}}}});
+        assert_that(res).is_rows().with_rows({{p(3), m1_3}});
         res = e.execute_cql("SELECT p from t where m1[3] = 'five'").get();
         assert_that(res).is_rows().with_size(0);
 
         res = e.execute_cql("SELECT p from t where l1 CONTAINS 2").get();
-        assert_that(res).is_rows().with_rows_ignore_order({{{{int32_type->decompose(1)}}}, {{{int32_type->decompose(3)}}}});
+        assert_that(res).is_rows().with_rows_ignore_order({{p(1), l1_1}, {p(3), l1_3}});
         res = e.execute_cql("SELECT p from t where l1 CONTAINS 1").get();
         assert_that(res).is_rows().with_size(0);
 
         res = e.execute_cql("SELECT p from t where s2 = {2}").get();
-        assert_that(res).is_rows().with_rows({{{int32_type->decompose(2)}}});
+        assert_that(res).is_rows().with_rows({{p(2), s2_2}});
         res = e.execute_cql("SELECT p from t where s2 = {}").get();
         assert_that(res).is_rows().with_size(0);
 
         res = e.execute_cql("SELECT p from t where m2 = {5: 'five', 7: 'seven'}").get();
-        assert_that(res).is_rows().with_rows({{{int32_type->decompose(3)}}});
+        assert_that(res).is_rows().with_rows({{p(3), m2_3}});
         res = e.execute_cql("SELECT p from t where m2 = {1: 'one', 2: 'three'}").get();
         assert_that(res).is_rows().with_size(0);
 
         res = e.execute_cql("SELECT p from t where l2 = [2]").get();
-        assert_that(res).is_rows().with_rows({{{int32_type->decompose(1)}}});
+        assert_that(res).is_rows().with_rows({{p(1), l2_1}});
         res = e.execute_cql("SELECT p from t where l2 = [3]").get();
         assert_that(res).is_rows().with_size(0);
     });
@@ -1198,13 +1210,14 @@ SEASTAR_TEST_CASE(test_secondary_index_on_partition_key_with_filtering) {
 // Verifies that both "SELECT * [rest_of_query]" and "SELECT count(*) [rest_of_query]" 
 // return expected count of rows.
 void assert_select_count_and_select_rows_has_size(
-        cql_test_env& e, 
-        const sstring& rest_of_query, int64_t expected_count, 
+        cql_test_env& e,
+        const sstring& rest_of_query, int64_t expected_count,
+        std::vector<bytes_opt> appended_filtering_columns = {},
         const std::source_location& loc = std::source_location::current()) {
-    eventually([&] { 
-        require_rows(e, "SELECT count(*) " + rest_of_query, {
-            { long_type->decompose(expected_count) }
-        }, loc);
+    std::vector<bytes_opt> expected_row = { long_type->decompose(expected_count) };
+    expected_row.insert(expected_row.end(), appended_filtering_columns.begin(), appended_filtering_columns.end());
+    eventually([&] {
+        require_rows(e, "SELECT count(*) " + rest_of_query, { expected_row }, loc);
         auto res = cquery_nofail(e, "SELECT * " + rest_of_query, nullptr, loc);
         try {
             assert_that(res).is_rows().with_size(expected_count);
@@ -1427,12 +1440,12 @@ SEASTAR_TEST_CASE(test_secondary_index_on_non_pk_ck_column_and_aggregation) {
             cquery_nofail(e, format("INSERT INTO t(pk, ck, v) VALUES ({}, {}, 1)", 
                 current_row, current_row % 20).c_str());
         }, [&](int rows_inserted) {
-            assert_select_count_and_select_rows_has_size(e, "FROM t WHERE v = 1", rows_inserted);
+            assert_select_count_and_select_rows_has_size(e, "FROM t WHERE v = 1", rows_inserted, { int32_type->decompose(1) });
           eventually([&] { 
             auto res = cquery_nofail(e, "SELECT pk FROM t WHERE v = 1 GROUP BY pk");
             assert_that(res).is_rows().with_size(rows_inserted);
             require_rows(e, "SELECT sum(v) FROM t WHERE v = 1", {
-                { int32_type->decompose(int32_t(rows_inserted)) }
+                { int32_type->decompose(int32_t(rows_inserted)), int32_type->decompose(1) }
             });
           });
         });
@@ -1445,12 +1458,12 @@ SEASTAR_TEST_CASE(test_secondary_index_on_non_pk_ck_column_and_aggregation) {
         test_with_different_page_scenarios([&](int current_row) {
             cquery_nofail(e, format("INSERT INTO t2(pk, v) VALUES ({}, 1)", current_row).c_str());
         }, [&](int rows_inserted) {
-            assert_select_count_and_select_rows_has_size(e, "FROM t2 WHERE v = 1", rows_inserted);
+            assert_select_count_and_select_rows_has_size(e, "FROM t2 WHERE v = 1", rows_inserted, { int32_type->decompose(1) });
           eventually([&] { 
             auto res = cquery_nofail(e, "SELECT pk FROM t2 WHERE v = 1 GROUP BY pk");
             assert_that(res).is_rows().with_size(rows_inserted);
             require_rows(e, "SELECT sum(pk) FROM t2 WHERE v = 1", {
-                { int32_type->decompose(int32_t(rows_inserted * (rows_inserted - 1) / 2)) }
+                { int32_type->decompose(int32_t(rows_inserted * (rows_inserted - 1) / 2)), int32_type->decompose(1) }
             });
           });
         });
@@ -1462,14 +1475,14 @@ SEASTAR_TEST_CASE(test_secondary_index_on_non_pk_ck_column_and_aggregation) {
         test_with_different_page_scenarios([&](int current_row) {
             cquery_nofail(e, format("INSERT INTO t3(pk, ck, v) VALUES (1, {}, 1)", current_row).c_str());
         }, [&](int rows_inserted) {
-            assert_select_count_and_select_rows_has_size(e, "FROM t3 WHERE v = 1", rows_inserted);
+            assert_select_count_and_select_rows_has_size(e, "FROM t3 WHERE v = 1", rows_inserted, { int32_type->decompose(1) });
           eventually([&] { 
             auto res = cquery_nofail(e, "SELECT pk FROM t3 WHERE v = 1 GROUP BY pk");
             assert_that(res).is_rows().with_size(1);
             res = cquery_nofail(e, "SELECT pk, ck FROM t3 WHERE v = 1 GROUP BY pk, ck");
             assert_that(res).is_rows().with_size(rows_inserted);
             require_rows(e, "SELECT max(ck) FROM t3 WHERE v = 1", {
-                { int32_type->decompose(int32_t(rows_inserted - 1)) }
+                { int32_type->decompose(int32_t(rows_inserted - 1)), int32_type->decompose(1) }
             });
           });
         });
@@ -1541,7 +1554,11 @@ SEASTAR_TEST_CASE(test_token_order) {
             auto index_order = cquery_nofail(e, "SELECT pk FROM t WHERE v = 1");
 
             assert_that(nonindex_order).is_rows().with_rows(testset_pks);
-            assert_that(index_order).is_rows().with_rows(testset_pks);
+            auto pks_with_v = testset_pks;
+            for (auto& row : pks_with_v) {
+                row.push_back(int32_type->decompose(1));
+            }
+            assert_that(index_order).is_rows().with_rows(pks_with_v);
         });
     });
 }
@@ -1782,7 +1799,7 @@ SEASTAR_TEST_CASE(test_filtering_indexed_column) {
         eventually([&] {
             auto msg = cquery_nofail(e, "select c,e from ks.test_index where d = 44 ALLOW FILTERING;");
             assert_that(msg).is_rows().with_rows({
-                {int32_type->decompose(33), int32_type->decompose(55)}
+                {int32_type->decompose(33), int32_type->decompose(55), int32_type->decompose(44)}
             });
         });
         eventually([&] {

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -13,6 +13,8 @@ import pytest
 import os
 from contextlib import ExitStack
 from . import rest_api
+from . import nodetool
+from test.pylib.skip_types import skip_env
 from cassandra.protocol import InvalidRequest, ConfigurationException, ReadFailure
 from cassandra.query import SimpleStatement
 from .cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order
@@ -2393,3 +2395,112 @@ def test_regular_row_update_with_static_set_index(cql, test_keyspace):
         cql.execute(f"UPDATE {table} SET x = 4 WHERE pk = 1 AND ck = 2")
         assert [(1, 2, {'test'}, 4)] == list(cql.execute(f"SELECT * FROM {table} WHERE pk = 1 AND ck = 2"))
         assert [(1, 2, {'test'}, 4)] == list(cql.execute(f"SELECT * FROM {table} WHERE s CONTAINS 'test'"))
+
+# Reproducer for SCYLLADB-2817: force the index (a materialized view) to
+# diverge from the base table, then check that an indexed query still returns
+# only rows matching the WHERE clause. The orchestration, via error injections:
+#  1. Write rows and flush BEFORE creating the index - backfill reads the
+#     sstable snapshot, which has (1,1,1,1) = v3.
+#  2. Create the index and step the builder with two pauses, pinning the
+#     ordering: it scans the flushed snapshot now (before the overwrites
+#     below), but holds the generated postings unapplied.
+#  3. Overwrite (1,1,1,1) to v=4 then v=5, with the v=4 view update dropped
+#     by an injected, swallowed failure - so no tombstone will cover the
+#     builder's stale v=3 posting. Re-insert the other v=3 rows normally.
+#  4. Query (correct), release the builder: the stale v=3 -> (1,1,1,1)
+#     posting lands, pointing at a base row that has v=5.
+#  5. Query again: the stale posting must not produce a v=5 row for "v = 3".
+@pytest.mark.xfail(reason="SCYLLADB-2817: the index read does not re-validate the indexed column against the base row", strict=True)
+def test_index_query_with_stale_index_entry(cql, test_keyspace, scylla_only):
+    def inj_enable(err, one_shot=False):
+        rest_api.post_request(cql, f'v2/error_injection/injection/{err}?one_shot={one_shot}')
+        if err not in rest_api.get_request(cql, 'v2/error_injection/injection'):
+            skip_env("error injection not enabled in this build")
+    def inj_disable(err):
+        rest_api.delete_request(cql, f'v2/error_injection/injection/{err}')
+    def inj_message(err):
+        rest_api.post_request(cql, f'v2/error_injection/injection/{err}/message')
+    def inj_enters(err):
+        try:
+            return int(rest_api.get_request(cql, f'v2/error_injection/injection/{err}/enters'))
+        except Exception:
+            return -1
+    def wait_for(what, cond):
+        deadline = time.time() + 60
+        while not cond():
+            assert time.time() < deadline, f"timed out waiting for {what}"
+            time.sleep(0.2)
+
+    pause_scan = "view_building_worker_pause_build_range_task"
+    pause_apply = "populate_views_pause_before_apply"
+    fail_update = "view_update_generation_failure"
+
+    schema = 'pk int, c1 int, c2 int, c3 int, v int, PRIMARY KEY (pk, c1, c2, c3)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        ins = f"INSERT INTO {table} (pk, c1, c2, c3, v) VALUES"
+        q_range = f"SELECT * FROM {table} WHERE pk = 1 AND c1 > 0 AND c1 < 5 AND c2 = 1 AND v = 3 ALLOW FILTERING"
+        q_in = f"SELECT * FROM {table} WHERE pk = 1 AND c1 IN(0,1,2) AND c2 = 1 AND v = 3 ALLOW FILTERING"
+        expected = [(1, 1, 1, 3, 3)]
+        try:
+            # (1) data before the index exists; flush - backfill reads sstables.
+            for i in (1, 2, 3):
+                cql.execute(f"{ins} (1, 1, 1, 1, {i})")
+                cql.execute(f"{ins} (1, 1, 1, {i}, {i})")
+                cql.execute(f"{ins} (1, 1, {i}, {i}, {i})")
+                cql.execute(f"{ins} (1, {i}, {i}, {i}, {i})")
+            nodetool.flush(cql, table)
+
+            # (2) create the index; pause the builder before its scan...
+            inj_enable(pause_scan)
+            inj_enable(pause_apply)
+            cql.execute(f"CREATE INDEX v_idx_2817 ON {table} (v)")
+            wait_for("builder to reach the scan pause", lambda: inj_enters(pause_scan) >= 1)
+
+            # ...release the scan; generation runs and parks before apply.
+            inj_message(pause_scan)
+            inj_disable(pause_scan)
+            wait_for("builder to reach the apply pause", lambda: inj_enters(pause_apply) >= 1)
+
+            # (3) legit v3 rows via the regular write path...
+            cql.execute(f"{ins} (1, 1, 1, 3, 3)")
+            cql.execute(f"{ins} (1, 1, 3, 3, 3)")
+            cql.execute(f"{ins} (1, 3, 3, 3, 3)")
+            # ...and the overwrites; the v=4 write's view update is swallowed.
+            inj_enable(fail_update, one_shot=True)
+            cql.execute(f"{ins} (1, 1, 1, 1, 4)")
+            cql.execute(f"{ins} (1, 1, 1, 4, 4)")
+            cql.execute(f"{ins} (1, 1, 4, 4, 4)")
+            cql.execute(f"{ins} (1, 4, 4, 4, 4)")
+            for i in (5,):
+                cql.execute(f"{ins} (1, 1, 1, 1, {i})")
+                cql.execute(f"{ins} (1, 1, 1, {i}, {i})")
+                cql.execute(f"{ins} (1, 1, {i}, {i}, {i})")
+                cql.execute(f"{ins} (1, {i}, {i}, {i}, {i})")
+
+            # The base is correct: (1,1,1,1) has v=5.
+            assert [r.v for r in cql.execute(f"SELECT v FROM {table} WHERE pk=1 AND c1=1 AND c2=1 AND c3=1")] == [5]
+
+            # (4) before the stale posting lands, both queries are correct.
+            assert sorted(tuple(r) for r in cql.execute(q_range)) == expected
+            assert sorted(tuple(r) for r in cql.execute(q_in)) == expected
+
+            # (5) release the apply; wait until the stale v=3 posting for
+            # (1,1,1,1) is in the index view.
+            inj_message(pause_apply)
+            inj_disable(pause_apply)
+            ks = table.split('.')[0]
+            viewq = f'SELECT pk, c1, c2, c3 FROM {ks}."v_idx_2817_index" WHERE v = 3'
+            wait_for("stale posting to land",
+                     lambda: (1, 1, 1, 1) in [tuple(r) for r in cql.execute(viewq)])
+
+            # The index has now diverged from the base: it claims (1,1,1,1)
+            # has v=3, the base says v=5. The queries must still be correct -
+            # a returned row must match the WHERE clause.
+            assert sorted(tuple(r) for r in cql.execute(q_in)) == expected
+            assert sorted(tuple(r) for r in cql.execute(q_range)) == expected
+        finally:
+            for err in (pause_scan, pause_apply, fail_update):
+                try:
+                    inj_disable(err)
+                except Exception:
+                    pass

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -2410,7 +2410,8 @@ def test_regular_row_update_with_static_set_index(cql, test_keyspace):
 #  4. Query (correct), release the builder: the stale v=3 -> (1,1,1,1)
 #     posting lands, pointing at a base row that has v=5.
 #  5. Query again: the stale posting must not produce a v=5 row for "v = 3".
-@pytest.mark.xfail(reason="SCYLLADB-2817: the index read does not re-validate the indexed column against the base row", strict=True)
+#     The read path re-validates the indexed column against the base row, so
+#     the stale posting stays in the view but is filtered out of the result.
 def test_index_query_with_stale_index_entry(cql, test_keyspace, scylla_only):
     def inj_enable(err, one_shot=False):
         rest_api.post_request(cql, f'v2/error_injection/injection/{err}?one_shot={one_shot}')

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -2976,7 +2976,8 @@ def test_is_null_with_secondary_index(cql, test_keyspace, scylla_only):
 #  4. Query (correct), release the builder: the stale v=3 -> (1,1,1,1)
 #     posting lands, pointing at a base row that has v=5.
 #  5. Query again: the stale posting must not produce a v=5 row for "v = 3".
-@pytest.mark.xfail(reason="SCYLLADB-2817: the index read does not re-validate the indexed column against the base row", strict=True)
+#     The read path re-validates the indexed column against the base row, so
+#     the stale posting stays in the view but is filtered out of the result.
 def test_index_query_with_stale_index_entry(cql, test_keyspace, scylla_only):
     def inj_enable(err, one_shot=False):
         rest_api.post_request(cql, f'v2/error_injection/injection/{err}?one_shot={one_shot}')

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -13,6 +13,8 @@ import pytest
 import os
 from contextlib import ExitStack
 from . import rest_api
+from . import nodetool
+from test.pylib.skip_types import skip_env
 from cassandra.protocol import InvalidRequest, ConfigurationException, ReadFailure
 from cassandra.query import SimpleStatement
 from .cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order
@@ -2959,3 +2961,112 @@ def test_is_null_with_secondary_index(cql, test_keyspace, scylla_only):
         # Regular EQ query on indexed column should work without ALLOW FILTERING
         result = list(cql.execute(f"SELECT * FROM {table} WHERE v = 10"))
         assert {(r.p, r.c) for r in result} == {(1, 1), (2, 1)}
+
+# Reproducer for SCYLLADB-2817: force the index (a materialized view) to
+# diverge from the base table, then check that an indexed query still returns
+# only rows matching the WHERE clause. The orchestration, via error injections:
+#  1. Write rows and flush BEFORE creating the index - backfill reads the
+#     sstable snapshot, which has (1,1,1,1) = v3.
+#  2. Create the index and step the builder with two pauses, pinning the
+#     ordering: it scans the flushed snapshot now (before the overwrites
+#     below), but holds the generated postings unapplied.
+#  3. Overwrite (1,1,1,1) to v=4 then v=5, with the v=4 view update dropped
+#     by an injected, swallowed failure - so no tombstone will cover the
+#     builder's stale v=3 posting. Re-insert the other v=3 rows normally.
+#  4. Query (correct), release the builder: the stale v=3 -> (1,1,1,1)
+#     posting lands, pointing at a base row that has v=5.
+#  5. Query again: the stale posting must not produce a v=5 row for "v = 3".
+@pytest.mark.xfail(reason="SCYLLADB-2817: the index read does not re-validate the indexed column against the base row", strict=True)
+def test_index_query_with_stale_index_entry(cql, test_keyspace, scylla_only):
+    def inj_enable(err, one_shot=False):
+        rest_api.post_request(cql, f'v2/error_injection/injection/{err}?one_shot={one_shot}')
+        if err not in rest_api.get_request(cql, 'v2/error_injection/injection'):
+            skip_env("error injection not enabled in this build")
+    def inj_disable(err):
+        rest_api.delete_request(cql, f'v2/error_injection/injection/{err}')
+    def inj_message(err):
+        rest_api.post_request(cql, f'v2/error_injection/injection/{err}/message')
+    def inj_enters(err):
+        try:
+            return int(rest_api.get_request(cql, f'v2/error_injection/injection/{err}/enters'))
+        except Exception:
+            return -1
+    def wait_for(what, cond):
+        deadline = time.time() + 60
+        while not cond():
+            assert time.time() < deadline, f"timed out waiting for {what}"
+            time.sleep(0.2)
+
+    pause_scan = "view_building_worker_pause_build_range_task"
+    pause_apply = "populate_views_pause_before_apply"
+    fail_update = "view_update_generation_failure"
+
+    schema = 'pk int, c1 int, c2 int, c3 int, v int, PRIMARY KEY (pk, c1, c2, c3)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        ins = f"INSERT INTO {table} (pk, c1, c2, c3, v) VALUES"
+        q_range = f"SELECT * FROM {table} WHERE pk = 1 AND c1 > 0 AND c1 < 5 AND c2 = 1 AND v = 3 ALLOW FILTERING"
+        q_in = f"SELECT * FROM {table} WHERE pk = 1 AND c1 IN(0,1,2) AND c2 = 1 AND v = 3 ALLOW FILTERING"
+        expected = [(1, 1, 1, 3, 3)]
+        try:
+            # (1) data before the index exists; flush - backfill reads sstables.
+            for i in (1, 2, 3):
+                cql.execute(f"{ins} (1, 1, 1, 1, {i})")
+                cql.execute(f"{ins} (1, 1, 1, {i}, {i})")
+                cql.execute(f"{ins} (1, 1, {i}, {i}, {i})")
+                cql.execute(f"{ins} (1, {i}, {i}, {i}, {i})")
+            nodetool.flush(cql, table)
+
+            # (2) create the index; pause the builder before its scan...
+            inj_enable(pause_scan)
+            inj_enable(pause_apply)
+            cql.execute(f"CREATE INDEX v_idx_2817 ON {table} (v)")
+            wait_for("builder to reach the scan pause", lambda: inj_enters(pause_scan) >= 1)
+
+            # ...release the scan; generation runs and parks before apply.
+            inj_message(pause_scan)
+            inj_disable(pause_scan)
+            wait_for("builder to reach the apply pause", lambda: inj_enters(pause_apply) >= 1)
+
+            # (3) legit v3 rows via the regular write path...
+            cql.execute(f"{ins} (1, 1, 1, 3, 3)")
+            cql.execute(f"{ins} (1, 1, 3, 3, 3)")
+            cql.execute(f"{ins} (1, 3, 3, 3, 3)")
+            # ...and the overwrites; the v=4 write's view update is swallowed.
+            inj_enable(fail_update, one_shot=True)
+            cql.execute(f"{ins} (1, 1, 1, 1, 4)")
+            cql.execute(f"{ins} (1, 1, 1, 4, 4)")
+            cql.execute(f"{ins} (1, 1, 4, 4, 4)")
+            cql.execute(f"{ins} (1, 4, 4, 4, 4)")
+            for i in (5,):
+                cql.execute(f"{ins} (1, 1, 1, 1, {i})")
+                cql.execute(f"{ins} (1, 1, 1, {i}, {i})")
+                cql.execute(f"{ins} (1, 1, {i}, {i}, {i})")
+                cql.execute(f"{ins} (1, {i}, {i}, {i}, {i})")
+
+            # The base is correct: (1,1,1,1) has v=5.
+            assert [r.v for r in cql.execute(f"SELECT v FROM {table} WHERE pk=1 AND c1=1 AND c2=1 AND c3=1")] == [5]
+
+            # (4) before the stale posting lands, both queries are correct.
+            assert sorted(tuple(r) for r in cql.execute(q_range)) == expected
+            assert sorted(tuple(r) for r in cql.execute(q_in)) == expected
+
+            # (5) release the apply; wait until the stale v=3 posting for
+            # (1,1,1,1) is in the index view.
+            inj_message(pause_apply)
+            inj_disable(pause_apply)
+            ks = table.split('.')[0]
+            viewq = f'SELECT pk, c1, c2, c3 FROM {ks}."v_idx_2817_index" WHERE v = 3'
+            wait_for("stale posting to land",
+                     lambda: (1, 1, 1, 1) in [tuple(r) for r in cql.execute(viewq)])
+
+            # The index has now diverged from the base: it claims (1,1,1,1)
+            # has v=3, the base says v=5. The queries must still be correct -
+            # a returned row must match the WHERE clause.
+            assert sorted(tuple(r) for r in cql.execute(q_in)) == expected
+            assert sorted(tuple(r) for r in cql.execute(q_range)) == expected
+        finally:
+            for err in (pause_scan, pause_apply, fail_update):
+                try:
+                    inj_disable(err)
+                except Exception:
+                    pass


### PR DESCRIPTION
### Cause and fix

A secondary index read can return rows that violate the WHERE clause.

A secondary index is a materialized view. It can diverge from the base table:  replication lag with more than one replica, or a view update failure swallowed by the base write path (by design, even with `synchronous_updates`). The read path trusted the index blindly - the indexed predicate was erased from the post-filter, so a stale posting was returned to the client as a row that contradicts the query. This is the failure class seen in the rare `testFilteringWithSecondaryIndex` CI failure (SCYLLADB-2817). Their cause is SCYLLADB-4337, confirmed with its reproducer, and it is fixed separately.

The problem of index having stale data is handled by verifying the value from the index against the base row, whatever put the stale data there.

### Performance

Measured with perf-cql-raw (release, no PGO, single pinned shard, medians of 60s runs, index value matching 10 rows).

After the fix, `WHERE v=?` costs what `WHERE v=? AND anything_else=?` already costs today. The fix moves single-predicate indexed reads onto the existing filtering path. It does not add a new cost class. Evidence: fixed `WHERE v=?` = 553.0k insns/op vs master `WHERE v1=? AND v2=?` = 538.6k. On a wide 12-column ~1.2KB row schema, fixed `WHERE v=?` = 699.6k vs master `WHERE v=? AND state=?` = 699.1k (0.07% apart).

| Query class | Δ insns/op | Δ tps |
|---|---|---|
| indexed read, no other predicate (simple / wide row) | +17.5% / +24.7% | −11.5% / −15.7% |
| indexed read that already filtered (2nd predicate, indexed or not) | +2–3% | −1–1.5% |
| not index-driven: pk read, write, plain filtering, ck-column index | ≤0.06% | noise |

Row 1: comparison of an indexed query before (using the fast path) and after (using the post-filtering path), hence the performance drop.
Row 2: comparison of a query using slow post-filtering path before and after the fix. This result tells us that the first row performance drop is the fast/slow path difference, and queries already using the slow path are more or less of the same performance.
Row 3: comparison of a query the fix does not touch.

Fixes SCYLLADB-2817

This is a correctness bug fix. Backport is needed.