### PR TITLE
transport: Relax advertising TABLETS_ROUTING_V2_EXPRIMENTAL

### DIFF
--- a/docs/dev/protocol-extensions.md
+++ b/docs/dev/protocol-extensions.md
@@ -340,11 +340,8 @@ The feature is identified by the `TABLETS_ROUTING_V2_EXPERIMENTAL` key, which is
 meant to be sent in the SUPPORTED message.
 
 Unlike `TABLETS_ROUTING_V1`, the server advertises
-`TABLETS_ROUTING_V2_EXPERIMENTAL` only once the `STRONGLY_CONSISTENT_TABLES`
-cluster feature is enabled — that is, once every node in the cluster supports it.
-Gating on the cluster feature rather than on a single node's local configuration
-ensures that, during a rolling upgrade, connections to different nodes cannot
-negotiate the extension inconsistently. The `_EXPERIMENTAL` suffix indicates the
+`TABLETS_ROUTING_V2_EXPERIMENTAL` only when the `strongly-consistent-tables`
+experimental feature is enabled. The `_EXPERIMENTAL` suffix indicates the
 feature is still under development and its format may change.
 
 ## Negotiate sending metadata id

--- a/docs/dev/tablets-routing-v2.md
+++ b/docs/dev/tablets-routing-v2.md
@@ -85,7 +85,7 @@ During connection setup, the driver and server negotiate `TABLETS_ROUTING_V2` su
 
 `TABLETS_ROUTING_V2` subsumes `TABLETS_ROUTING_V1`. A driver that negotiates v2 **does not** negotiate v1. If a driver only negotiates v1, the server falls back to the existing v1 behavior.
 
-The extension is gated behind the cluster feature `STRONGLY_CONSISTENT_TABLES`.
+The extension is gated behind the experimental feature `strongly-consistent-tables`.
 
 **Note:** We temporarily use a different name for the protocol extension: `TABLETS_ROUTING_V2_EXPERIMENTAL`.
 The name explicitly conveys that the feature is still experimental and may be modified.

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -971,7 +971,7 @@ std::unique_ptr<cql_server::response> cql_server::handle_exception(int16_t strea
 
 cql_protocol_extension_enum_set cql_server::connection::supported_cql_protocol_extensions() const {
     auto exts = cql_protocol_extension_enum_set::full();
-    const bool strongly_consistent_tables = _server._query_processor.local().proxy().features().strongly_consistent_tables;
+    const bool strongly_consistent_tables = _server._query_processor.local().db().get_config().check_experimental(db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES);
     if (!strongly_consistent_tables) {
         exts.remove(cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
     }


### PR DESCRIPTION
Originally, in 58ab555, the protocol extension was gated behind the
cluster feature STRONGLY_CONSISTENT_TABLES. We relax this requirement
and gate it behind the experimental feature strongly-consistent-tables
instead.

This change makes it more convenient for the driver -- previously, it
could have multiple active connections to a single host where some used
the protocol extension, while others did not: consider a rolling upgrade
and connecting to the the host when the cluster feature was being
enabled.

Note that to enable the cluster feature STRONGLY_CONSISTENT_TABLES, we
need to enable the experimental feature strongly-consistent-tables as
well.

Refs: SCYLLADB-288
Refs: SCYLLADB-291

Backport: no. The relevant code is only present on 2026.3, which hasn't been branched yet.