### PR TITLE
Alternator: add authentication via TLS client certificates (mTLS)

### DIFF
--- a/alternator/auth.cc
+++ b/alternator/auth.cc
@@ -26,18 +26,24 @@ namespace alternator {
 
 static logging::logger alogger("alternator-auth");
 
-future<std::string> get_key_from_roles(service::storage_proxy& proxy, std::string username) {
+future<std::string> get_key_from_roles(service::storage_proxy& proxy, std::string username, bool get_password) {
     schema_ptr schema = proxy.data_dictionary().find_schema(db::system_keyspace::NAME, "roles");
     partition_key pk = partition_key::from_single_value(*schema, utf8_type->decompose(username));
     dht::partition_range_vector partition_ranges{dht::partition_range(dht::decorate_key(*schema, pk))};
     std::vector<query::clustering_range> bounds{query::clustering_range::make_open_ended_both_sides()};
-    const column_definition* salted_hash_col = schema->get_column_definition(bytes("salted_hash"));
     const column_definition* can_login_col = schema->get_column_definition(bytes("can_login"));
-    if (!salted_hash_col || !can_login_col) {
+    const column_definition* salted_hash_col = schema->get_column_definition(bytes("salted_hash"));
+    if (!can_login_col || (get_password && !salted_hash_col)) {
         co_await coroutine::return_exception(api_error::unrecognized_client(fmt::format("Credentials cannot be fetched for: {}", username)));
     }
-    auto selection = cql3::selection::selection::for_columns(schema, {salted_hash_col, can_login_col});
-    auto partition_slice = query::partition_slice(std::move(bounds), {}, query::column_id_vector{salted_hash_col->id, can_login_col->id}, selection->get_query_options());
+    std::vector<const column_definition*> columns{can_login_col};
+    query::column_id_vector col_ids{can_login_col->id};
+    if (get_password) {
+        columns.push_back(salted_hash_col);
+        col_ids.push_back(salted_hash_col->id);
+    }
+    auto selection = cql3::selection::selection::for_columns(schema, std::move(columns));
+    auto partition_slice = query::partition_slice(std::move(bounds), {}, std::move(col_ids), selection->get_query_options());
     auto command = ::make_lw_shared<query::read_command>(schema->id(), schema->version(), partition_slice,
             proxy.get_max_result_size(partition_slice), query::tombstone_limit(proxy.get_tombstone_limit()));
     auto cl = db::consistency_level::LOCAL_ONE;
@@ -54,13 +60,16 @@ future<std::string> get_key_from_roles(service::storage_proxy& proxy, std::strin
         co_await coroutine::return_exception(api_error::unrecognized_client(fmt::format("User not found: {}", username)));
     }
     const auto& result = result_set->rows().front();
-    bool can_login = result[1] && value_cast<bool>(boolean_type->deserialize(*result[1]));
+    bool can_login = result[0] && value_cast<bool>(boolean_type->deserialize(*result[0]));
     if (!can_login) {
         // This is a valid role name, but has "login=False" so should not be
         // usable for authentication (see #19735).
         co_await coroutine::return_exception(api_error::unrecognized_client(fmt::format("Role {} has login=false so cannot be used for login", username)));
     }
-    const managed_bytes_opt& salted_hash = result.front();
+    if (!get_password) {
+        co_return std::string();
+    }
+    const managed_bytes_opt& salted_hash = result[1];
     if (!salted_hash) {
         co_await coroutine::return_exception(api_error::unrecognized_client(fmt::format("No password found for user: {}", username)));
     }

--- a/alternator/auth.hh
+++ b/alternator/auth.hh
@@ -19,7 +19,14 @@ class storage_proxy;
 namespace alternator {
 
 using key_cache = utils::loading_cache<std::string, std::string, 1>;
+// Caches the result of validating that a role exists and has can_login=true,
+// for authentication methods (e.g. mTLS) that don't need the role's password.
+using role_cache = utils::loading_cache<std::string, bool, 1>;
 
-future<std::string> get_key_from_roles(service::storage_proxy& proxy, std::string username);
+// If get_password is true (the default), also verifies that a salted_hash
+// (password) exists and returns it. Set get_password=false for authentication
+// methods such as mTLS that do not use passwords; the function then only verifies
+// role existence and can_login=true, and returns an empty string.
+future<std::string> get_key_from_roles(service::storage_proxy& proxy, std::string username, bool get_password = true);
 
 }

--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -138,13 +138,16 @@ future<> controller::start_server() {
                 // to allow this, for backward compatibility.
                 opts = _config.server_encryption_options();
                 if (!opts.empty()) {
-                logger.warn("Setting server_encryption_options to configure "
-                        "Alternator's HTTPS encryption is deprecated. Please "
-                        "switch to setting alternator_encryption_options instead.");
+                    logger.warn("Setting server_encryption_options to configure "
+                            "Alternator's HTTPS encryption is deprecated. Please "
+                            "switch to setting alternator_encryption_options instead.");
+                    // server_encryption_options is for internode encryption.
+                    // Its require_client_auth and truststore settings must not
+                    // bleed into Alternator's client-facing HTTPS endpoint.
+                    opts.erase("require_client_auth");
+                    opts.erase("truststore");
                 }
             }
-            opts.erase("require_client_auth");
-            opts.erase("truststore");
             try {
                 utils::configure_tls_creds_builder(creds.value(), std::move(opts)).get();
             } catch(...) {

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -322,21 +322,29 @@ static void authentication_error(alternator::stats& stats, bool enforce_authoriz
 future<std::string> server::verify_signature(const request& req, const chunked_content& content) {
     if (!_enforce_authorization.get() && !_warn_authorization.get()) {
         slogger.debug("Skipping authorization");
-        return make_ready_future<std::string>();
+        co_return std::string();
+    }
+    // If the connection uses mTLS and presented a verified client certificate,
+    // authenticate using this certificate (using auth_certificate_role_queries
+    // to map the subject DN or SAN to a CQL role name).
+    // Only if the connection does *not* have a client certificate at all, do
+    // we fall through to the SigV4 signature verification below.
+    if (auto role = co_await try_mtls_authentication(req)) {
+        co_return std::move(*role);
     }
     auto host_it = req._headers.find("Host");
     if (host_it == req._headers.end()) {
         authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
             api_error::invalid_signature("Host header is mandatory for signature verification"), 
             "", req.get_client_address());
-        return make_ready_future<std::string>();
+        co_return std::string();
     }
     auto authorization_it = req._headers.find("Authorization");
     if (authorization_it == req._headers.end()) {
         authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
             api_error::missing_authentication_token("Authorization header is mandatory for signature verification"),
             "", req.get_client_address());
-        return make_ready_future<std::string>();
+        co_return std::string();
     }
     std::string host = host_it->second;
     std::string_view authorization_header = authorization_it->second;
@@ -345,7 +353,7 @@ future<std::string> server::verify_signature(const request& req, const chunked_c
         authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
             api_error::invalid_signature(fmt::format("Authorization header must use AWS4-HMAC-SHA256 algorithm: {}", authorization_header)),
             "", req.get_client_address());
-        return make_ready_future<std::string>();
+        co_return std::string();
     }
     authorization_header.remove_prefix(pos+1);
     std::string credential;
@@ -382,7 +390,7 @@ future<std::string> server::verify_signature(const request& req, const chunked_c
     if (credential_split.size() != 5) {
         authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
             api_error::validation(fmt::format("Incorrect credential information format: {}", credential)), "", req.get_client_address());
-        return make_ready_future<std::string>();
+        co_return std::string();
     }
     std::string user(credential_split[0]);
     std::string datestamp(credential_split[1]);
@@ -433,44 +441,89 @@ future<std::string> server::verify_signature(const request& req, const chunked_c
     auto cache_getter = [&proxy = _proxy] (std::string username) {
         return get_key_from_roles(proxy, std::move(username));
     };
-    return _key_cache.get_ptr(user, cache_getter).then_wrapped([this, &req, &content,
-                                                    user = std::move(user),
-                                                    host = std::move(host),
-                                                    datestamp = std::move(datestamp),
-                                                    signed_headers_str = std::move(signed_headers_str),
-                                                    signed_headers_map = std::move(signed_headers_map),
-                                                    modified_values = std::move(modified_values),
-                                                    region = std::move(region),
-                                                    service = std::move(service),
-                                                    user_signature = std::move(user_signature)] (future<key_cache::value_ptr> key_ptr_fut) {
-        key_cache::value_ptr key_ptr(nullptr);
-        try {
-            key_ptr = key_ptr_fut.get();
-        } catch (const api_error& e) {
-            authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
-                e, user, req.get_client_address());
-            return std::string();
-        }
-        std::string signature;
-        try {
-            signature = utils::aws::get_signature(user, *key_ptr, std::string_view(host), "/", req._method,
-                datestamp, signed_headers_str, signed_headers_map, &content, region, service, "");
-        } catch (const std::exception& e) {
-            authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
-                api_error::invalid_signature(fmt::format("invalid signature: {}", e.what())),
-                user, req.get_client_address());
-            return std::string();
-        }
+    key_cache::value_ptr key_ptr(nullptr);
+    try {
+        key_ptr = co_await _key_cache.get_ptr(user, cache_getter);
+    } catch (const api_error& e) {
+        authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
+            e, user, req.get_client_address());
+        co_return std::string();
+    }
+    std::string signature;
+    try {
+        signature = utils::aws::get_signature(user, *key_ptr, std::string_view(host), "/", req._method,
+            datestamp, signed_headers_str, signed_headers_map, &content, region, service, "");
+    } catch (const std::exception& e) {
+        authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
+            api_error::invalid_signature(fmt::format("invalid signature: {}", e.what())),
+            user, req.get_client_address());
+        co_return std::string();
+    }
+    if (signature != std::string_view(user_signature)) {
+        _key_cache.remove(user);
+        authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
+            api_error::unrecognized_client("wrong signature"),
+            user, req.get_client_address());
+        co_return std::string();
+    }
+    co_return user;
+}
 
-        if (signature != std::string_view(user_signature)) {
-            _key_cache.remove(user);
-            authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
-                api_error::unrecognized_client("wrong signature"),
-                user, req.get_client_address());
-            return std::string();
+future<std::optional<std::string>> server::try_mtls_authentication(const request& req) {
+    if (!req.tls_dn) {
+        co_return std::nullopt;
+    }
+    const std::string& subject = req.tls_dn->subject;
+    // Following the logic in auth::certificate_authenticator, we reformat the
+    // SAN list req.tls_san into a single comma-separated string altname_str
+    // and then pass regular expressions from auth_certificate_role_queries
+    // over this string. We only do this string formatting if there is any
+    // ALTNAME pattern in auth_certificate_role_queries that would need it.
+    std::optional<std::string> altname_str;
+    boost::smatch m;
+    for (const auto& [src, expr] : _cert_patterns) {
+        const std::string* source_str;
+        if (src == cert_pattern::source_type::subject) {
+            source_str = &subject;
+        } else {
+            if (!altname_str) {
+                altname_str = req.tls_san
+                    ? fmt::format("{}", fmt::join(*req.tls_san, ","))
+                    : std::string{};
+            }
+            source_str = &*altname_str;
         }
-        return user;
-    });
+        if (boost::regex_search(*source_str, m, expr) && m.size() > 1) {
+            std::string role = m[1].str();
+            // Before returning "role", verify that the role really exists
+            // and has can_login=true. This check is cached (see
+            // _mtls_role_cache) since on a long-lived connection it would
+            // otherwise be repeated on every single request.
+            auto cache_getter = [&proxy = _proxy] (std::string role) {
+                return get_key_from_roles(proxy, std::move(role), /*get_password=*/false).then([] (std::string) {
+                    return true;
+                });
+            };
+            try {
+                co_await _mtls_role_cache.get_ptr(role, cache_getter);
+            } catch (const api_error& e) {
+                authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
+                    e, role, req.get_client_address());
+                co_return std::string();
+            }
+            co_return role;
+        }
+    }
+    // A client certificate was presented and verified by the TLS layer,
+    // but it did not match any configured auth_certificate_role_queries
+    // pattern. Reject the request rather than falling through to SigV4:
+    // a client that presents a certificate must authenticate via mTLS.
+    authentication_error(_executor._stats, _enforce_authorization.get(), _warn_authorization.get(),
+        api_error::unrecognized_client(fmt::format(
+            "mTLS: client certificate subject '{}' did not match any auth_certificate_role_queries pattern",
+            subject)),
+        "", req.get_client_address());
+    co_return std::string();
 }
 
 static tracing::trace_state_ptr create_tracing_session(tracing::tracing& tracing_instance) {
@@ -862,6 +915,47 @@ server::server(executor& exec, service::storage_proxy& proxy, gms::gossiper& gos
         , _auth_service(auth_service)
         , _sl_controller(sl_controller)
         , _key_cache(1024, 1min, slogger)
+        , _mtls_role_cache(1024, 1min, slogger)
+        , _cert_patterns([&proxy]() {
+            // Pre-compile the patterns from auth_certificate_role_queries
+            // so verify_signature() can match mTLS certificate subjects and
+            // Subject Alternative Names without recompiling regexes on every
+            // request. Both SUBJECT and ALTNAME entries are accepted.
+            std::vector<cert_pattern> patterns;
+            for (const auto& q : proxy.data_dictionary().get_config().auth_certificate_role_queries()) {
+                auto source_it = q.find("source");
+                auto query_it  = q.find("query");
+                if (source_it == q.end() || query_it == q.end()) { continue; }
+                sstring source = source_it->second;
+                std::transform(source.begin(), source.end(), source.begin(), ::toupper);
+                cert_pattern::source_type src;
+                if (source == "SUBJECT") {
+                    src = cert_pattern::source_type::subject;
+                } else if (source == "ALTNAME") {
+                    src = cert_pattern::source_type::altname;
+                } else {
+                    throw std::invalid_argument(fmt::format(
+                        "auth_certificate_role_queries: source '{}' is not supported"
+                        " (supported values: SUBJECT, ALTNAME)",
+                        source_it->second));
+                }
+                boost::regex expr;
+                try {
+                    expr = boost::regex(std::string(query_it->second));
+                } catch (const boost::regex_error& e) {
+                    throw std::invalid_argument(fmt::format(
+                        "auth_certificate_role_queries: invalid regex '{}': {}",
+                        query_it->second, e.what()));
+                }
+                if (expr.mark_count() != 1) {
+                    throw std::invalid_argument(fmt::format(
+                        "auth_certificate_role_queries: pattern '{}' must have exactly one capture group (has {})",
+                        query_it->second, expr.mark_count()));
+                }
+                patterns.push_back({src, std::move(expr)});
+            }
+            return patterns;
+        }())
         , _max_users_query_size_in_trace_output(1024)
         , _enabled_servers{}
         , _pending_requests("alternator::server::pending_requests")

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -21,6 +21,7 @@
 #include "utils/small_vector.hh"
 #include "utils/updateable_value.hh"
 #include <seastar/core/units.hh>
+#include <boost/regex.hpp>
 
 struct client_data;
 
@@ -47,6 +48,17 @@ class server : public peering_sharded_service<server> {
     qos::service_level_controller& _sl_controller;
 
     key_cache _key_cache;
+    // Caches the result of try_mtls_authentication()'s role validation
+    // (role exists and has can_login=true), keyed by role name, so a
+    // long-lived mTLS connection doesn't re-read the roles table on
+    // every single request.
+    role_cache _mtls_role_cache;
+    // auth_certificate_role_queries patterns (SUBJECT and ALTNAME), compiled once at startup.
+    struct cert_pattern {
+        enum class source_type { subject, altname } source;
+        boost::regex regex;
+    };
+    std::vector<cert_pattern> _cert_patterns;
     utils::updateable_value<bool> _enforce_authorization;
     utils::updateable_value<bool> _warn_authorization;
     utils::updateable_value<uint64_t> _max_users_query_size_in_trace_output;
@@ -118,8 +130,18 @@ public:
     future<utils::chunked_vector<foreign_ptr<std::unique_ptr<client_data>>>> get_client_data();
 private:
     void set_routes(seastar::httpd::routes& r);
-    // If verification succeeds, returns the authenticated user's username
+    // If verification succeeds, returns the authenticated user's username.
+    // Throws an api_error if the verification fails.
     future<std::string> verify_signature(const seastar::http::request&, const chunked_content&);
+    // Attempt to authenticate via mTLS certificate matching. Returns the role
+    // name if a client certificate was presented and a valid role could be
+    // extracted using auth_certificate_role_queries patterns. Returns
+    // std::nullopt if no client certificate was presented at all (caller
+    // should fall through to SigV4). If a certificate was presented but a
+    // valid role could not be extracted, throws an authentication error when
+    // alternator_enforce_authorization is true, and otherwise returns an
+    // empty string (indicating an unauthenticated request).
+    future<std::optional<std::string>> try_mtls_authentication(const seastar::http::request&);
     future<executor::request_return_type> handle_api_request(std::unique_ptr<http::request> req);
 };
 

--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -77,6 +77,97 @@ either set one up, or set up the client library to do the load balancing
 itself. Instructions, code and examples for doing this can be found in the
 [Alternator Load Balancing project](https://github.com/scylladb/alternator-load-balancing/).
 
+### Mutual TLS (mTLS) for Alternator
+
+In addition to the usual SigV4 signature authentication, Alternator also
+supports mutual TLS (mTLS) authentication, where the client presents a
+certificate that the server validates. By default, the CN (Common Name) of
+the certificate's Subject DN is used as the role name. This mapping is
+configurable via the `auth_certificate_role_queries` option (described
+below), which also supports matching Subject Alternative Names (SANs).
+
+To configure mTLS, use the `alternator-encryption-options` configuration.
+Two settings control the behavior:
+
+* **`truststore`**: Path to a CA certificate file. The server uses this to
+  validate client certificates.
+
+* **`require_client_auth`**: Controls how strictly client certificates are
+  enforced. There are three modes:
+
+  * **`require_client_auth=true`** — The server *requires* a valid client
+    certificate. Clients without one (or with an untrusted certificate) are
+    rejected at the TLS handshake level. The certificate is mapped to a role
+    via `auth_certificate_role_queries`; if the mapping fails or the role
+    does not exist with `LOGIN=true`, the request is rejected. SigV4
+    authentication is not used. Example configuration:
+
+    ```text
+    --alternator-https-port 8043
+    --alternator-encryption-options certificate=/path/to/server.crt
+    --alternator-encryption-options keyfile=/path/to/server.key
+    --alternator-encryption-options truststore=/path/to/ca.crt
+    --alternator-encryption-options require_client_auth=true
+    ```
+
+  * **`require_client_auth=optional`** — The server *requests* a client
+    certificate but does not require one. Clients that present no certificate
+    fall back to SigV4 authentication. This allows both mTLS and SigV4 clients
+    to connect to the same HTTPS port. Clients that present a valid (CA-signed)
+    certificate must authenticate via mTLS: their certificate is mapped to a
+    role, and if the mapping fails or the role does not exist with `LOGIN=true`,
+    the request is rejected — there is no SigV4 fallback for certificate-bearing
+    clients. Example configuration:
+
+    ```text
+    --alternator-https-port 8043
+    --alternator-encryption-options certificate=/path/to/server.crt
+    --alternator-encryption-options keyfile=/path/to/server.key
+    --alternator-encryption-options truststore=/path/to/ca.crt
+    --alternator-encryption-options require_client_auth=optional
+    ```
+
+  * **`require_client_auth=false`** (default) — The server does not request
+    a client certificate at all. Only SigV4 authentication is used.
+
+When a client certificate is presented on a connection, SigV4 authentication
+is not needed, and if a SigV4 signature appears on any request sent over this
+connection, it is silently ignored. This means that when a connection uses
+mTLS, the same role applies to all requests on that connection and cannot be
+overridden on a per-request basis.
+
+**Mapping a certificate to a role** is controlled by the
+`auth_certificate_role_queries` configuration option (documented in detail in
+[Certificate-based Authentication](../operating-scylla/security/certificate-authentication.rst)).
+Each entry in the list has a `source` and a `query` (a regular expression
+with exactly one capture group). The first matching entry determines the
+role name.
+
+* **`source: SUBJECT`** — matches against the certificate's Subject DN
+  string (e.g. `"CN=alice,O=MyOrg"`). The default configuration uses this
+  source with the pattern `CN=([^,]+)` to extract the Common Name.
+
+* **`source: ALTNAME`** — matches against the certificate's Subject
+  Alternative Names (SANs), formatted as a comma-separated list of
+  `TYPE=value` entries (e.g. `"EMAIL=alice@example.com,DNS=host.example.com"`).
+  EMAIL SANs are the standard way to carry user identity in enterprise PKI.
+
+Example: to authenticate using an email SAN of the form `user@example.com`
+and map the local part to a role:
+
+```yaml
+auth_certificate_role_queries:
+  - source: ALTNAME
+    query: 'EMAIL=([^@,]+)@'
+```
+
+When using mTLS, set `alternator_enforce_authorization: true` and configure
+`authorizer: CassandraAuthorizer` so that the certificate-derived username is
+looked up and authorized against the role system (see the Authentication and
+Authorization section in compatibility.md). If SigV4 authentication is also
+used (i.e., `require_client_auth=optional`), additionally configure
+`authenticator: PasswordAuthenticator`.
+
 ## Alternator design and implementation
 
 This section provides only a very brief introduction to Alternator's

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -147,6 +147,17 @@ key ID, and the _salted hash_ of the role's password is the secret key.
 This secret key for role XYZ can be retrieved by the CQL request
 `SELECT salted_hash from system.roles WHERE role = XYZ;`.
 
+Alternator also supports mutual TLS (mTLS) as an alternative authentication
+method. When the HTTPS port is configured with `require_client_auth=true` or
+`require_client_auth=optional` (via `--alternator-encryption-options`), clients
+that present a valid certificate are authenticated using the subject fields
+(DN or SAN) of that certificate as the username — no SigV4 signature is
+required or checked. With `require_client_auth=true` client certificates are
+mandatory; with `require_client_auth=optional` they are optional, allowing both
+mTLS and SigV4 clients to share the same port. See the
+[Mutual TLS (mTLS) for Alternator](alternator.md#mutual-tls-mtls-for-alternator)
+section for full configuration details.
+
 Alternator also implements authorization, or _access control_ - defining
 which authenticated user is allowed to do which operation, such as reading
 or writing to a specific table. The way this is supported in Alternator is

--- a/test/alternator/README.md
+++ b/test/alternator/README.md
@@ -101,6 +101,37 @@ to allow the alternator HTTPS server to think it's been authorized and properly 
 Still, boto3 library issues warnings that the certificate used for communication is self-signed,
 and thus should not be trusted. For the sake of running local tests this warning is explicitly ignored.
 
+## Mutual TLS (mTLS) support
+
+To test client certificate authentication in addition to HTTPS, pass both
+`--https` and `--mtls` to `run` or `pytest`. The `run` script will
+automatically generate a CA certificate and a client certificate with
+CN `cassandra` (matching the role used for SigV4 authentication), and
+start ScyllaDB with `require_client_auth=true` and the generated CA as the
+truststore so that it verifies the client certificate.
+
+If you are running ScyllaDB manually, you need to set up the certificates
+yourself:
+
+```
+openssl genrsa 2048 > ca.key
+openssl req -new -x509 -nodes -sha256 -days 365 -subj "/CN=TestCA" -key ca.key -out ca.crt
+openssl genrsa 2048 > client.key
+openssl req -new -sha256 -subj "/CN=cassandra" -key client.key -out client.csr
+openssl x509 -req -sha256 -days 365 -in client.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out client.crt
+```
+
+Then start ScyllaDB with the additional alternator encryption options:
+```
+--alternator-encryption-options require_client_auth=true
+--alternator-encryption-options truststore=ca.crt
+```
+
+And run pytest with the client certificate options:
+```
+pytest --https --mtls --client-cert-file client.crt --client-key-file client.key
+```
+
 
 ## Authorization
 

--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -13,6 +13,7 @@ import pytest
 import boto3
 import requests
 import re
+from botocore import UNSIGNED
 
 from test.alternator.util import create_test_table, is_aws, scylla_log
 from test.conftest import dynamic_scope
@@ -49,6 +50,13 @@ def pytest_addoption(parser):
     parser.addoption("--https", action="store_true",
         help="communicate via HTTPS protocol on port 8043 instead of HTTP when"
             " running against a local Scylla installation", default=False)
+    parser.addoption("--mtls", action="store_true",
+        help="use mutual TLS (client certificate authentication) when running"
+            " with --https against a local Scylla installation", default=False)
+    parser.addoption("--client-cert-file", action="store",
+        help="path to the PEM client certificate file to use for mTLS", default=None)
+    parser.addoption("--client-key-file", action="store",
+        help="path to the PEM client private key file to use for mTLS", default=None)
     parser.addoption("--url", action="store",
         help="communicate with given URL instead of defaults", default=None)
     parser.addoption("--runveryslow", action="store_true",
@@ -57,6 +65,13 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "veryslow: mark test as very slow to run")
+    if config.getoption("mtls"):
+        if not config.getoption("https"):
+            raise pytest.UsageError("--mtls requires --https")
+        if config.getoption("aws"):
+            raise pytest.UsageError("--mtls cannot be used with --aws")
+        if not config.getoption("client_cert_file") or not config.getoption("client_key_file"):
+            raise pytest.UsageError("--mtls requires --client-cert-file and --client-key-file")
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runveryslow"):
@@ -140,10 +155,31 @@ def dynamodb(request, get_valid_alternator_role):
             local_url = 'https://localhost:8043' if request.config.getoption('https') else 'http://localhost:8000'
         # Disable verifying in order to be able to use self-signed TLS certificates
         verify = not request.config.getoption('https')
-        user, secret = get_valid_alternator_role(local_url)
-        res = boto3.resource('dynamodb', endpoint_url=local_url, verify=verify,
-            region_name='us-east-1', aws_access_key_id=user, aws_secret_access_key=secret,
-            config=boto_config.merge(botocore.client.Config(retries={"max_attempts": 0}, read_timeout=300)))
+        extra_config = botocore.client.Config(retries={"max_attempts": 0}, read_timeout=300)
+        if request.config.getoption('mtls'):
+            # The --mtls/--https CLI options are validated together in
+            # pytest_configure(), but local_url's scheme can still end up
+            # as plain http (e.g. via --url, or the "host" fixture branch
+            # above), in which case an mTLS client would silently send
+            # unsigned requests with no client certificate presented either
+            # (no TLS handshake at all) - i.e. fully unauthenticated. Fail
+            # loudly instead.
+            if urlparse(local_url).scheme != 'https':
+                raise pytest.UsageError(f"--mtls requires an https:// endpoint, got {local_url}")
+            # When using mTLS, send requests unsigned so that only the client
+            # certificate is used for authentication, not SigV4 credentials.
+            cert_file = request.config.getoption('client_cert_file')
+            key_file = request.config.getoption('client_key_file')
+            res = boto3.resource('dynamodb', endpoint_url=local_url, verify=verify,
+                region_name='us-east-1',
+                config=boto_config.merge(extra_config.merge(botocore.client.Config(
+                    signature_version=UNSIGNED,
+                    client_cert=(cert_file, key_file)))))
+        else:
+            user, secret = get_valid_alternator_role(local_url)
+            res = boto3.resource('dynamodb', endpoint_url=local_url, verify=verify,
+                region_name='us-east-1', aws_access_key_id=user, aws_secret_access_key=secret,
+                config=boto_config.merge(extra_config))
     yield res
     res.meta.client.close()
 
@@ -156,9 +192,26 @@ def new_dynamodb_session(request, dynamodb, get_valid_alternator_role):
         if request.config.getoption('aws'):
             return boto3.resource('dynamodb', config=conf)
         conf = conf.merge(botocore.client.Config(retries={"max_attempts": 0}, read_timeout=300))
-        user, secret = get_valid_alternator_role(dynamodb.meta.client._endpoint.host, role=user)
         region_name = dynamodb.meta.client.meta.region_name
-        return ses.resource('dynamodb', endpoint_url=dynamodb.meta.client._endpoint.host, verify=host.scheme != 'http',
+        if request.config.getoption('mtls'):
+            # Under mTLS, the identity is determined by the client
+            # certificate, not by the "user" parameter - there is no way to
+            # authenticate as a different role. Skip tests that request a
+            # non-default role instead of silently authenticating as the
+            # certificate's identity, which would test the wrong thing.
+            if user != 'cassandra':
+                skip_env("new_dynamodb_session role selection is not supported under mTLS")
+            # When using mTLS, send requests unsigned so that only the client
+            # certificate is used for authentication, not SigV4 credentials.
+            cert_file = request.config.getoption('client_cert_file')
+            key_file = request.config.getoption('client_key_file')
+            return ses.resource('dynamodb', endpoint_url=dynamodb.meta.client._endpoint.host, verify=host.scheme != 'https',
+                region_name=region_name,
+                config=conf.merge(botocore.client.Config(
+                    signature_version=UNSIGNED,
+                    client_cert=(cert_file, key_file))))
+        user, secret = get_valid_alternator_role(dynamodb.meta.client._endpoint.host, role=user)
+        return ses.resource('dynamodb', endpoint_url=dynamodb.meta.client._endpoint.host, verify=host.scheme != 'https',
             region_name=region_name, aws_access_key_id=user, aws_secret_access_key=secret,
             config=conf)
     return _new_dynamodb_session
@@ -185,10 +238,31 @@ def dynamodbstreams(request, get_valid_alternator_role):
             local_url = 'https://localhost:8043' if request.config.getoption('https') else 'http://localhost:8000'
         # Disable verifying in order to be able to use self-signed TLS certificates
         verify = not request.config.getoption('https')
-        user, secret = get_valid_alternator_role(local_url)
-        res = boto3.client('dynamodbstreams', endpoint_url=local_url, verify=verify,
-            region_name='us-east-1', aws_access_key_id=user, aws_secret_access_key=secret,
-            config=boto_config.merge(botocore.client.Config(retries={"max_attempts": 0}, read_timeout=300)))
+        extra_config = botocore.client.Config(retries={"max_attempts": 0}, read_timeout=300)
+        if request.config.getoption('mtls'):
+            # The --mtls/--https CLI options are validated together in
+            # pytest_configure(), but local_url's scheme can still end up
+            # as plain http (e.g. via --url, or the "host" fixture branch
+            # above), in which case an mTLS client would silently send
+            # unsigned requests with no client certificate presented either
+            # (no TLS handshake at all) - i.e. fully unauthenticated. Fail
+            # loudly instead.
+            if urlparse(local_url).scheme != 'https':
+                raise pytest.UsageError(f"--mtls requires an https:// endpoint, got {local_url}")
+            # When using mTLS, send requests unsigned so that only the client
+            # certificate is used for authentication, not SigV4 credentials.
+            cert_file = request.config.getoption('client_cert_file')
+            key_file = request.config.getoption('client_key_file')
+            res = boto3.client('dynamodbstreams', endpoint_url=local_url, verify=verify,
+                region_name='us-east-1',
+                config=boto_config.merge(extra_config.merge(botocore.client.Config(
+                    signature_version=UNSIGNED,
+                    client_cert=(cert_file, key_file)))))
+        else:
+            user, secret = get_valid_alternator_role(local_url)
+            res = boto3.client('dynamodbstreams', endpoint_url=local_url, verify=verify,
+                region_name='us-east-1', aws_access_key_id=user, aws_secret_access_key=secret,
+                config=boto_config.merge(extra_config))
     yield res
     res.close()
 
@@ -205,7 +279,11 @@ def dynamodb_test_connection(dynamodb, request, optional_rest_api):
         # We want to run a do-nothing DynamoDB command. The health-check
         # URL is the fastest one.
         url = dynamodb.meta.client._endpoint.host
-        response = requests.get(url, verify=False)
+        cert = None
+        if request.config.getoption('mtls'):
+            cert = (request.config.getoption('client_cert_file'),
+                    request.config.getoption('client_key_file'))
+        response = requests.get(url, verify=False, cert=cert)
         # We don't check response: In Alternator and DynamoDB, we expect
         # response.ok (200), but in recent versions of DynamoDB Local we can
         # get error code 400 because it only allows signed health requests

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -84,6 +84,14 @@ def run_alternator_cmd(pid, dir):
         ]
     else:
         cmd += ['--alternator-port', '8000']
+    if '--mtls' in sys.argv:
+        if '--https' not in sys.argv:
+            sys.exit('Error: --mtls requires --https')
+        run.setup_mtls_certificate(dir)
+        cmd += [
+            '--alternator-encryption-options', 'require_client_auth=true',
+            '--alternator-encryption-options', f'truststore={dir}/ca.crt',
+        ]
     if '--vs' in sys.argv:
         cmd += ['--vector-store-primary-uri', f'http://{ip}:6080']
     cmd += extra_scylla_options
@@ -108,6 +116,7 @@ def run_alternator_cmd(pid, dir):
 
 pid = run.run_with_temporary_dir(run_alternator_cmd)
 ip = run.pid_to_ip(pid)
+scylla_dir = run.pid_to_dir(pid)
 
 if '--https' in sys.argv:
     alternator_url=f"https://{ip}:8043"
@@ -162,7 +171,8 @@ if '--vs' in sys.argv:
 # CQL for setting up authentication.
 def check_alternator(url):
     try:
-        requests.get(url, verify=False)
+        cert = (f'{scylla_dir}/client.crt', f'{scylla_dir}/client.key') if '--mtls' in sys.argv else None
+        requests.get(url, verify=False, cert=cert)
     except requests.ConnectionError:
         raise run.NotYetUp
     # Any other exception may indicate a problem, and is passed to the caller.
@@ -173,7 +183,11 @@ run.wait_for_services(pid, [
 ])
 
 # Finally run pytest:
-success = run.run_pytest(sys.path[0], ['--url', alternator_url] + sys.argv[1:])
+pytest_args = ['--url', alternator_url]
+if '--mtls' in sys.argv:
+    pytest_args += [f'--client-cert-file={scylla_dir}/client.crt',
+                    f'--client-key-file={scylla_dir}/client.key']
+success = run.run_pytest(sys.path[0],  pytest_args + sys.argv[1:])
 
 run.summary = 'Alternator tests pass' if success else 'Alternator tests failure'
 

--- a/test/alternator/test_authorization.py
+++ b/test/alternator/test_authorization.py
@@ -11,7 +11,20 @@ import re
 import random
 from botocore.exceptions import ClientError
 
+from test.pylib.skip_types import skip_env
 from .util import get_signed_request
+
+# All the tests in this file are about SigV4 signature-based authentication
+# (wrong keys, expired/futuristic signatures, missing headers, header
+# canonicalization affecting the signature, etc.). Under mTLS, once a client
+# certificate is presented, the connection is authenticated by that
+# certificate and SigV4 signatures are not checked at all (and are silently
+# ignored if present) - so these tests don't apply and are skipped, instead
+# of spuriously passing (or failing) for the wrong reason.
+@pytest.fixture(autouse=True)
+def skip_if_mtls(request):
+    if request.config.getoption('mtls'):
+        skip_env("test_authorization.py tests SigV4 signatures, which are not checked under mTLS")
 
 
 # Test that trying to perform an operation signed with a wrong key

--- a/test/alternator/test_compressed_request.py
+++ b/test/alternator/test_compressed_request.py
@@ -34,8 +34,9 @@ import gzip
 import zlib
 import requests
 import pytest
+from botocore import UNSIGNED
 
-from .util import random_string
+from .util import random_string, get_cert
 from .test_manual_requests import get_signed_request
 
 # The compressed_req fixture is like the dynamodb fixture - providing a
@@ -47,21 +48,27 @@ from .test_manual_requests import get_signed_request
 #      tab = compressed_req.Table(test_table.name)
 # and use the new "tab" object to perform requests.
 @pytest.fixture(scope="module")
-def compressed_req(dynamodb):
-    # Copy URL, most configuration, and credentials from the existing
-    # "dynamodb" fixture:
+def compressed_req(request, dynamodb):
+    # Copy URL, most configuration, and credentials (or, under mTLS, the
+    # client certificate) from the existing "dynamodb" fixture:
     url = dynamodb.meta.client._endpoint.host
     config = dynamodb.meta.client._client_config
-    credentials = dynamodb.meta.client._request_signer._credentials
     verify = not url.startswith('https')
     region_name = dynamodb.meta.client.meta.region_name
     # By default, the SDK only bothers to compress requests larger than 10KB.
     # Let's drop that limit to 1 byte.
     config = config.merge(botocore.client.Config(request_min_compression_size_bytes=1))
-    ret = boto3.resource('dynamodb', endpoint_url=url, verify=verify,
-        aws_access_key_id=credentials.access_key,
-        aws_secret_access_key=credentials.secret_key,
-        region_name=region_name, config=config)
+    if request.config.getoption('mtls'):
+        cert = get_cert(dynamodb)
+        ret = boto3.resource('dynamodb', endpoint_url=url, verify=verify,
+            region_name=region_name,
+            config=config.merge(botocore.client.Config(signature_version=UNSIGNED, client_cert=cert)))
+    else:
+        credentials = dynamodb.meta.client._request_signer._credentials
+        ret = boto3.resource('dynamodb', endpoint_url=url, verify=verify,
+            aws_access_key_id=credentials.access_key,
+            aws_secret_access_key=credentials.secret_key,
+            region_name=region_name, config=config)
     # Unfortunately, request compression is currently not enabled by default
     # for DynamoDB requests, and there is no user-visible way to enable it.
     # Instead, compression needs to be chosen by botocore for each individual
@@ -128,7 +135,7 @@ def test_garbage_content_encoding(dynamodb, test_table):
     # but the server will not know how to decode the request.
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'garbage'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 500
     # Check the PutItem request really wasn't done
     assert 'Item' not in test_table.get_item(Key={'p': p, 'c': 'x'}, ConsistentRead=True)
@@ -147,7 +154,7 @@ def test_broken_gzip_content(dynamodb, test_table):
     # should fail decompressing it and return a 500 error
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'gzip'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 500
     # Check the PutItem request really wasn't done
     assert 'Item' not in test_table.get_item(Key={'p': p, 'c': 'x'}, ConsistentRead=True)
@@ -167,7 +174,7 @@ def test_gzip_request_valid(dynamodb, test_table):
     # payload is compressed:
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'gzip'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 200
     got = test_table.get_item(Key={'p': p, 'c': 'x'}, ConsistentRead=True)['Item']
     assert got == {'p': p, 'c': 'x', 'v': v}
@@ -186,7 +193,7 @@ def test_gzip_request_two_gzips(dynamodb, test_table):
     req = get_signed_request(dynamodb, 'PutItem', payload)
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'gzip'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 200
     got = test_table.get_item(Key={'p': p, 'c': 'x'}, ConsistentRead=True)['Item']
     assert got == {'p': p, 'c': 'x', 'v': v}
@@ -206,7 +213,7 @@ def test_gzip_request_with_extra_junk(dynamodb, test_table, dynamodb_bug):
     req = get_signed_request(dynamodb, 'PutItem', payload)
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'gzip'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 500
     assert 'Item' not in test_table.get_item(Key={'p': p, 'c': 'x'}, ConsistentRead=True)
 
@@ -222,7 +229,7 @@ def test_gzip_request_with_missing_character(dynamodb, test_table):
     req = get_signed_request(dynamodb, 'PutItem', payload)
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'gzip'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 500
     assert 'Item' not in test_table.get_item(Key={'p': p, 'c': 'x'}, ConsistentRead=True)
 
@@ -250,7 +257,7 @@ def test_gzip_request_oversized(dynamodb, test_table):
     req = get_signed_request(dynamodb, 'PutItem', payload)
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'gzip'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     # Alternator returns 413 (Content Too Large), DynamoDB currently returns
     # 500 (Internal Server Error), which is arguably less suitable but let's
     # accept both in the test. The important thing is that the oversized
@@ -266,7 +273,7 @@ def test_gzip_request_empty(dynamodb):
     req = get_signed_request(dynamodb, 'PutItem', '')
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'gzip'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 500
 
 # After testing requests compressed with "Content-Encoding: gzip", let's
@@ -282,7 +289,7 @@ def test_deflate_request_valid(dynamodb, test_table):
     req = get_signed_request(dynamodb, 'PutItem', payload)
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'deflate'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 200, f'Request failed: {r.content}'
     got = test_table.get_item(Key={'p': p, 'c': 'x'}, ConsistentRead=True)['Item']
     assert got == {'p': p, 'c': 'x', 'v': v}
@@ -296,7 +303,7 @@ def test_deflate_request_empty(dynamodb):
     req = get_signed_request(dynamodb, 'PutItem', '')
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'deflate'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 500
 
 # Like test_broken_gzip_content also when the content is not a valid deflate
@@ -312,7 +319,7 @@ def test_deflate_request_not_deflated(dynamodb, test_table):
     # Of course it isn't - it's an uncompressed request.
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'deflate'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 500
     # Check the PutItem request really wasn't done
     assert 'Item' not in test_table.get_item(Key={'p': p, 'c': 'x'}, ConsistentRead=True)
@@ -335,7 +342,7 @@ def test_deflate_request_two_deflates(dynamodb, test_table, scylla_only):
     req = get_signed_request(dynamodb, 'PutItem', payload)
     headers = dict(req.headers)
     headers.update({'Content-Encoding': 'deflate'})
-    r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 200
     got = test_table.get_item(Key={'p': p, 'c': 'x'}, ConsistentRead=True)['Item']
     assert got == {'p': p, 'c': 'x', 'v': v}

--- a/test/alternator/test_compressed_response.py
+++ b/test/alternator/test_compressed_response.py
@@ -283,7 +283,7 @@ def test_accept_encoding_header(dynamodb, test_table_s):
 # It turns out that in DynamoDB headers are correctly combined for signature verification,
 # but then it only uses the first Accept-Encoding header, which may be considered a bug.
 # In Alternator, having multiple Accept-Encoding works well.
-def test_multiple_accept_encoding_headers(dynamodb, test_table_s):
+def test_multiple_accept_encoding_headers(request, dynamodb, test_table_s):
     p = random_string()
     compressible_data = 'x' * DDB_RESPONSE_COMPRESSION_THRESHOLD
     test_table_s.put_item(Item={'p': p, 'x': compressible_data})
@@ -335,9 +335,14 @@ def test_multiple_accept_encoding_headers(dynamodb, test_table_s):
 
             # Now lets make it a part of signature
             # Replacing signed header causes signature errors in both DynamoDB and Alternator.
-            with request_custom_headers(dynamodb, {"Accept-Encoding": "identity"}):
-                with pytest.raises(ClientError, match="signature"): # InvalidSignatureException
-                    check_replaced_accept_encoding_headers([("Accept-Encoding", b'gzip')], expected_compression=None)
+            # This doesn't apply under mTLS, though: the connection is
+            # authenticated by the client certificate, and any SigV4
+            # signature (mismatched or not) is silently ignored, so no
+            # signature error is raised - skip this part of the test.
+            if not request.config.getoption('mtls'):
+                with request_custom_headers(dynamodb, {"Accept-Encoding": "identity"}):
+                    with pytest.raises(ClientError, match="signature"): # InvalidSignatureException
+                        check_replaced_accept_encoding_headers([("Accept-Encoding", b'gzip')], expected_compression=None)
 
             # We can split the header into multiple ones and it works with signing
             with request_custom_headers(dynamodb, {"Accept-Encoding": "gzip,identity"}):

--- a/test/alternator/test_cors.py
+++ b/test/alternator/test_cors.py
@@ -13,6 +13,8 @@
 
 import requests
 
+from .util import get_cert
+
 # If the request does not have a "Origin" header, the reply should not
 # have any of the CORS headers. We test this for the GET, POST and
 # OPTIONS methods.
@@ -25,8 +27,9 @@ def test_cors_not_used(dynamodb):
         'Access-Control-Allow-Methods',
         'Access-Control-Allow-Headers']
     url = dynamodb.meta.client._endpoint.host
+    cert = get_cert(dynamodb)
     for f in [requests.options, requests.get, requests.post]:
-        response = f(url, verify=False)
+        response = f(url, verify=False, cert=cert)
         for h in cors_headers:
             assert not h in response.headers
 
@@ -36,8 +39,9 @@ def test_cors_not_used(dynamodb):
 def test_cors_allow_origin(dynamodb):
     headers = {'Origin': 'http://example.com/'}
     url = dynamodb.meta.client._endpoint.host
+    cert = get_cert(dynamodb)
     for f in [requests.options, requests.get, requests.post]:
-        response = f(url, headers=headers, verify=False)
+        response = f(url, headers=headers, verify=False, cert=cert)
         assert 'Access-Control-Allow-Origin' in response.headers
         assert response.headers['Access-Control-Allow-Origin'] == '*'
         assert 'Access-Control-Expose-Headers' in response.headers
@@ -59,8 +63,9 @@ def test_cors_allow_requested(dynamodb):
         'Access-Control-Request-Headers': 'cat, meerkat, mouse'
     }
     url = dynamodb.meta.client._endpoint.host
+    cert = get_cert(dynamodb)
     for f in [requests.options, requests.get, requests.post]:
-        response = f(url, headers=headers, verify=False)
+        response = f(url, headers=headers, verify=False, cert=cert)
         assert 'Access-Control-Allow-Origin' in response.headers
         assert response.headers['Access-Control-Allow-Origin'] == '*'
         assert 'Access-Control-Expose-Headers' in response.headers

--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -22,7 +22,7 @@ from functools import cache
 import re
 
 from test.pylib.skip_types import skip_env
-from .util import unique_table_name, random_string, new_test_table
+from .util import unique_table_name, random_string, new_test_table, get_cert
 from .test_gsi_updatetable import wait_for_gsi, wait_for_gsi_gone
 from .test_gsi import assert_index_query
 
@@ -63,6 +63,13 @@ def new_role(cql, login=True, superuser=False):
 # and key.
 @contextmanager
 def new_dynamodb(dynamodb, role, key):
+    # Under mTLS, identity is determined solely by the client certificate
+    # presented on the connection (and SigV4 signatures, if any, are
+    # ignored) - so there is no way to authenticate as a different role
+    # using a role/key pair. Skip such tests instead of silently
+    # reconnecting as whatever identity the certificate maps to.
+    if get_cert(dynamodb):
+        skip_env("new_dynamodb() authenticates using SigV4 role/key pairs, which are not supported under mTLS")
     url = dynamodb.meta.client._endpoint.host
     config = dynamodb.meta.client._client_config
     region_name = dynamodb.meta.client.meta.region_name
@@ -77,6 +84,8 @@ def new_dynamodb(dynamodb, role, key):
 
 @contextmanager
 def new_dynamodb_streams(dynamodb, role, key):
+    if get_cert(dynamodb):
+        skip_env("new_dynamodb_streams() authenticates using SigV4 role/key pairs, which are not supported under mTLS")
     url = dynamodb.meta.client._endpoint.host
     config = dynamodb.meta.client._client_config
     region_name = dynamodb.meta.client.meta.region_name

--- a/test/alternator/test_describe_endpoints.py
+++ b/test/alternator/test_describe_endpoints.py
@@ -5,6 +5,10 @@
 # Test for the DescribeEndpoints operation
 
 import boto3
+import botocore
+from botocore import UNSIGNED
+
+from .util import get_cert
 
 # Test that the DescribeEndpoints operation works as expected: that it
 # returns one endpoint (it may return more, but it never does this in
@@ -26,6 +30,13 @@ def test_describe_endpoints(request, dynamodb, get_valid_alternator_role):
         url = prefix + address
         if address.endswith('.amazonaws.com'):
             boto3.client('dynamodb',endpoint_url=url, verify=verify).describe_endpoints()
+        elif request.config.getoption('mtls'):
+            # Under mTLS, identity comes from the client certificate, not
+            # from SigV4 credentials, so reconnect using the certificate
+            # instead of a role/key pair.
+            cert = get_cert(dynamodb)
+            boto3.client('dynamodb', endpoint_url=url, region_name='us-east-1', verify=verify,
+                config=botocore.client.Config(signature_version=UNSIGNED, client_cert=cert)).describe_endpoints()
         else:
             # Even though we connect to the local installation, Boto3 still
             # requires us to specify dummy region and credential parameters,

--- a/test/alternator/test_health.py
+++ b/test/alternator/test_health.py
@@ -6,10 +6,12 @@
 
 import requests
 
+from .util import get_cert
+
 # Test that a health check can be performed with a GET packet
 def test_health_works(dynamodb):
     url = dynamodb.meta.client._endpoint.host
-    response = requests.get(url, verify=False)
+    response = requests.get(url, verify=False, cert=get_cert(dynamodb))
     assert response.ok
     assert response.content.decode('utf-8').strip()  == 'healthy: {}'.format(url.replace('https://', '').replace('http://', ''))
 
@@ -18,5 +20,5 @@ def test_health_only_works_for_root_path(dynamodb):
     url = dynamodb.meta.client._endpoint.host
     for suffix in ['/abc', '/-', '/index.htm']:
         print(url + suffix)
-        response = requests.get(url + suffix, verify=False)
+        response = requests.get(url + suffix, verify=False, cert=get_cert(dynamodb))
         assert response.status_code in range(400, 405)

--- a/test/alternator/test_https.py
+++ b/test/alternator/test_https.py
@@ -15,6 +15,7 @@ import urllib.parse
 import ssl
 
 from test.pylib.skip_types import skip_env
+from .util import get_cert
 
 @pytest.fixture(scope="module")
 def https_url(dynamodb):
@@ -22,6 +23,17 @@ def https_url(dynamodb):
     if not url.startswith('https://'):
         skip_env("HTTPS-specific tests are skipped without the '--https' option")
     yield url
+
+# If running these tests with mTLS authentication (test/alternator/run
+# --https --mtls), this is the (cert_file, key_file) tuple to use as a
+# client certificate, or None if not using mTLS. The tests in this file
+# bypass boto3 and connect directly with urllib3, so unlike other tests,
+# they need to explicitly load this certificate themselves to authenticate
+# under mTLS - without it, the TLS handshake itself is rejected by a server
+# configured with require_client_auth=true.
+@pytest.fixture(scope="module")
+def https_cert(dynamodb):
+    yield get_cert(dynamodb)
 
 # Test which TLS versions are supported. We require that both TLS 1.2 and 1.3
 # must be supported, and the older TLS 1.1 version may either work or be
@@ -38,7 +50,7 @@ def https_url(dynamodb):
     ('TLSv1_1', False),
     ('TLSv1_2', True),
     ('TLSv1_3', True)])
-def test_tls_versions(https_url, tls_version_and_support_required):
+def test_tls_versions(https_url, https_cert, tls_version_and_support_required):
     tls_version, support_required = tls_version_and_support_required
     context = ssl.create_default_context()
     context.minimum_version = getattr(ssl.TLSVersion, tls_version)
@@ -47,6 +59,11 @@ def test_tls_versions(https_url, tls_version_and_support_required):
     # certificates in tests.
     context.check_hostname = False
     context.verify_mode = ssl.CERT_NONE
+    # Under mTLS, the server requires a client certificate at the TLS
+    # handshake level, regardless of what we're testing here (the supported
+    # TLS versions) - so load it if we're testing with --mtls.
+    if https_cert:
+        context.load_cert_chain(certfile=https_cert[0], keyfile=https_cert[1])
     with urllib3.PoolManager(ssl_context=context, retries=0) as pool:
         try:
             # preload_content=False tells the library not to read the content
@@ -79,7 +96,7 @@ def test_tls_versions(https_url, tls_version_and_support_required):
 # security reason for doing this, and doesn't want us to allow an unencrypted
 # HTTP request to be sent over the HTTPS port. So let's verify that an HTTP
 # request on an HTTPS port indeed does not work.
-def test_http_on_https(https_url):
+def test_http_on_https(https_url, https_cert):
     # Take an https URL, replace the https by http. If the port is not
     # explicitly specified we need to assume it is the default https port
     # (443) and need to add it explicitly, because it's not the default for
@@ -93,7 +110,11 @@ def test_http_on_https(https_url):
 
     # CERT_NONE causes the client to not verify the server certificate,
     # and is needed because we use self-signed certificates in tests.
-    with urllib3.PoolManager(retries=0, cert_reqs=ssl.CERT_NONE) as pool:
+    # Under mTLS, we also need to present our own client certificate, or
+    # else the https_url sanity-check request below will be rejected at
+    # the TLS handshake level.
+    cert_kwargs = {'cert_file': https_cert[0], 'key_file': https_cert[1]} if https_cert else {}
+    with urllib3.PoolManager(retries=0, cert_reqs=ssl.CERT_NONE, **cert_kwargs) as pool:
         # Sanity check: the original https:// URL works. This is useful to
         # know so that if the http:// URL does *not* work - as we expect -
         # we can be sure this is a real success of the test and not some

--- a/test/alternator/test_manual_requests.py
+++ b/test/alternator/test_manual_requests.py
@@ -38,7 +38,7 @@ def test_deeply_nested_put(dynamodb, test_table):
     # responded with a comprehensible message - it can be either
     # a success report or an error - both are acceptable as long as
     # the oversized message did not make the server crash.
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     print(response, response.text)
 
     # If the PutItem request above failed, the deeply nested item
@@ -112,7 +112,7 @@ def test_too_large_request_chunked(dynamodb, test_table):
     def generator(s):
         yield s
     try:
-        response = requests.post(req.url, headers=req.headers, data=generator(req.body), verify=False)
+        response = requests.post(req.url, headers=req.headers, data=generator(req.body), verify=False, cert=req.cert)
     # Until #12166 is fixed, we need this except. See comment above why.
     except requests.exceptions.ConnectionError as e:
         return
@@ -133,7 +133,7 @@ def test_too_large_request_content_length(dynamodb, test_table, mb):
     req = get_signed_request(dynamodb, 'PutItem',
         '{"TableName": "' + test_table.name + '", ' + spaces + '"Item": {"p": {"S": "x"}, "c": {"S": "x"}}}')
     try:
-        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     # Until #12166 is fixed, we need this except. See comment above why.
     except requests.exceptions.ConnectionError as e:
         return
@@ -154,14 +154,14 @@ def test_too_large_request_headers(dynamodb, test_table):
     # First prepare a valid signed request, which works:
     req = get_signed_request(dynamodb, 'PutItem',
         '{"TableName": "' + test_table.name + '", "Item": {"p": {"S": "x"}, "c": {"S": "x"}}}')
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert response.status_code == 200
     # Add to the valid request, two extra headers "header1" and "header2",
     # with short values. These extra headers are ignored (and do not change
     # the signature computation), and the request still works:
     headers = dict(req.headers)
     headers.update({'header1': 'dog', 'header2': 'cat'})
-    response = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert response.status_code == 200
     # Finally, make the two extra headers long - totaling more than 16 KB.
     # The request should now fail with a 400 Bad Request. Although such a
@@ -169,7 +169,7 @@ def test_too_large_request_headers(dynamodb, test_table):
     # between this request and the previous ones is the length of the extra
     # headers, so it proves the server caught the oversized headers.
     headers.update({'header1': 'x'*8192, 'header2': 'y'*8192})
-    response = requests.post(req.url, headers=headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
     assert response.status_code == 400
 
 # In addition to oversized request bodies and headers tested in the above
@@ -184,14 +184,14 @@ def test_too_large_request_line(dynamodb, test_table):
     # First prepare a valid signed request, which works:
     req = get_signed_request(dynamodb, 'PutItem',
         '{"TableName": "' + test_table.name + '", "Item": {"p": {"S": "x"}, "c": {"S": "x"}}}')
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert response.status_code == 200
     # Add to the valid request's URL some unnecessary garbage at the end,
     # but short. Because the URL is part of the signed data, we expect to
     # either get a InvalidSignatureException (this is what happens on AWS)
     # or a 404 error (this is what happens on Scylla).
     url = req.url + '/' + 'garbage'
-    response = requests.post(url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert response.status_code == 404 or 'InvalidSignatureException' in response.text
     # Finally, add some very long garbage to the end of the URL. Now we
     # don't want to the 404 or InvalidSignatureException that were fine
@@ -200,7 +200,7 @@ def test_too_large_request_line(dynamodb, test_table):
     # This time, we need to see a 400 Bad Request - but not one with a
     # InvalidSignatureException error in its body.
     url = req.url + '/' + 'x' * 17000
-    response = requests.post(url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert response.status_code == 400 and not 'InvalidSignatureException' in response.text
 
 def test_incorrect_json(dynamodb, test_table):
@@ -212,7 +212,7 @@ def test_incorrect_json(dynamodb, test_table):
     validate_resp = lambda t: "SerializationException" in t or "ValidationException" in t or "Page Not Found" in t
     for i in range(len(correct_req)):
         req = get_signed_request(dynamodb, 'PutItem', correct_req[:i])
-        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
         assert validate_resp(response.text)
 
     incorrect_reqs = [
@@ -221,14 +221,14 @@ def test_incorrect_json(dynamodb, test_table):
     ]
     for incorrect_req in incorrect_reqs:
         req = get_signed_request(dynamodb, 'PutItem', incorrect_req)
-        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
         assert validate_resp(response.text)
 
 # Test that the value returned by PutItem is always a JSON object, not an empty string (see #6568)
 def test_put_item_return_type(dynamodb, test_table):
     payload = '{"TableName": "' + test_table.name + '", "Item": {"p": {"S": "x"}, "c": {"S": "x"}}}'
     req = get_signed_request(dynamodb, 'PutItem', payload)
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert response.text
     # json::loads throws on invalid input
     json.loads(response.text)
@@ -238,10 +238,10 @@ def test_tags_return_empty_body(dynamodb, test_table):
     descr = test_table.meta.client.describe_table(TableName=test_table.name)['Table']
     arn =  descr['TableArn']
     req = get_signed_request(dynamodb, 'TagResource', '{"ResourceArn": "' + arn + '", "Tags": [{"Key": "k", "Value": "v"}]}')
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert not response.text
     req = get_signed_request(dynamodb, 'UntagResource', '{"ResourceArn": "' + arn + '", "TagKeys": ["k"]}')
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert not response.text
 
 # Test that incorrect number values are detected
@@ -249,7 +249,7 @@ def test_incorrect_numbers(dynamodb, test_table):
     for incorrect in ["NaN", "Infinity", "-Infinity", "-NaN", "dog", "-dog"]:
         payload = '{"TableName": "' + test_table.name + '", "Item": {"p": {"S": "x"}, "c": {"S": "x"}, "v": {"N": "' + incorrect + '"}}}'
         req = get_signed_request(dynamodb, 'PutItem', payload)
-        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
         assert "ValidationException" in response.text and "numeric" in response.text
 
 # Although the DynamoDB API responses are JSON, additional conventions apply
@@ -271,7 +271,7 @@ def test_content_type(dynamodb, test_table):
     # in the response (today, DynamoDB doesn't allow any other content type
     # in the request anyway).
     req = get_signed_request(dynamodb, 'PutItem', payload)
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert response.headers['Content-Type'] == 'application/x-amz-json-1.0'
 
 # Alternator implements long responses using a different code path - using a
@@ -287,7 +287,7 @@ def test_content_type_long(dynamodb, test_table):
             batch.put_item({'p': p, 'c': str(i), 'x': 'x'*10000})
     payload = '{"TableName": "' + test_table.name + '", "KeyConditions":  {"p": {"AttributeValueList": [{"S": "' + p + '"}], "ComparisonOperator": "EQ"}}}'
     req = get_signed_request(dynamodb, 'Query', payload)
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert response.status_code == 200
     assert len(response.text) > 200000
     assert response.headers['Content-Type'] == 'application/x-amz-json-1.0'
@@ -298,7 +298,7 @@ def test_content_type_error(dynamodb, test_table):
     # PutItem without a TableName will generate an error:
     payload = '{"Item": {"p": {"S": "x"}, "c": {"S": "x"}}}'
     req = get_signed_request(dynamodb, 'PutItem', payload)
-    r = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    r = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 400 and 'ValidationException' in r.text
     assert r.headers['Content-Type'] == 'application/x-amz-json-1.0'
 
@@ -306,7 +306,7 @@ def test_content_type_error(dynamodb, test_table):
 # An unknown operation should result with an UnknownOperationException:
 def test_unknown_operation(dynamodb):
     req = get_signed_request(dynamodb, 'BoguousOperationName', '{}')
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert response.status_code == 400
     assert 'UnknownOperationException' in response.text
     print(response.text)
@@ -337,7 +337,7 @@ def test_exception_escape(test_table_s):
 def test_exception_escape_raw(dynamodb, test_table_s):
     payload = '{"TableName": "' + test_table_s.name + '", "Key": {"p": {"S": "hello"}}, "UpdateExpression": "ADD n :inc", "ExpressionAttributeValues": {":inc": {"S": "1"}}}'
     req = get_signed_request(dynamodb, 'UpdateItem', payload)
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert response.status_code == 400
     # In issue #10278, the JSON parsing fails:
     r = json.loads(response.text)
@@ -346,7 +346,7 @@ def test_exception_escape_raw(dynamodb, test_table_s):
 def put_item_binary_data_in_key(dynamodb, test_table_b, item_data):
     payload = '{"TableName": "%s", "Item": {"p": {"B": "%s"}}}' % (test_table_b.name, item_data)
     req = get_signed_request(dynamodb, 'PutItem', payload)
-    return requests.post(req.url, headers=req.headers, data=req.body, verify=True)
+    return requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
 
 def put_item_binary_data_in_non_key(dynamodb, test_table_b, item_data):
     payload ='''{
@@ -361,7 +361,7 @@ def put_item_binary_data_in_non_key(dynamodb, test_table_b, item_data):
         }
     }''' % (test_table_b.name, base64.b64encode(random_bytes()).decode(), item_data)
     req = get_signed_request(dynamodb, 'PutItem', payload)
-    return requests.post(req.url, headers=req.headers, data=req.body, verify=True)
+    return requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
 
 # Reproduces issue #6487 where setting binary values with missing "=" padding characters
 # was allowed in Scylla.
@@ -394,7 +394,7 @@ def test_base64_malformed_255(dynamodb, test_table_b):
     table_name_bytes = test_table_b.name.encode('UTF-8')
     payload_bytes = b'{"TableName": "' + table_name_bytes + b'", "Item": {"p": {"B": "\xFFdog"}}}'
     req = get_signed_request(dynamodb, 'PutItem', payload_bytes)
-    r = requests.post(req.url, headers=req.headers, data=req.body, verify=True)
+    r = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     assert r.status_code == 400 and 'SerializationException' in r.text
 
 def update_item_binary_data(dynamodb, test_table_b, item_data):
@@ -405,7 +405,7 @@ def update_item_binary_data(dynamodb, test_table_b, item_data):
         "ExpressionAttributeValues": {":val": {"B": "%s"} }
     }''' % (test_table_b.name, base64.b64encode(random_bytes()).decode(), item_data)
     req = get_signed_request(dynamodb, 'UpdateItem', payload)
-    return requests.post(req.url, headers=req.headers, data=req.body, verify=True)
+    return requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
 
 # The same tests as above for invalid B (binary) values, just for UpdateItem
 # instead of PutItem, attempting to reproduce issue #17539.
@@ -427,7 +427,7 @@ def scan_with_binary_data_in_cond_expr(dynamodb, test_table_b, filter_expr, expr
         "ExpressionAttributeValues": { %s }
     }''' % (test_table_b.name, filter_expr, expr_attr_values)
     req = get_signed_request(dynamodb, 'Scan', payload)
-    return requests.post(req.url, headers=req.headers, data=req.body, verify=True)
+    return requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
 
 # Tests the case where malformed binary data is placed as part of filter expression
 def test_base64_malformed_cond_expr(dynamodb, test_table_b):
@@ -506,7 +506,7 @@ def test_batch_write_item_invalid_payload(dynamodb, test_table):
     for body in cases:
         body = body.replace("__TABLE__", test_table.name)
         req = get_signed_request(dynamodb, "BatchWriteItem", body)
-        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
         assert_validation_exception(response.text, f"payload: \'{body}\'", accept_serialization_exception=True)
 
 
@@ -521,17 +521,17 @@ def test_batch_write_item_empty_request_list(dynamodb, test_table, test_table_s)
     for body in cases:
         body = body.replace("__TABLE__", test_table.name).replace("__TABLE_S__", test_table_s.name)
         req = get_signed_request(dynamodb, "BatchWriteItem", body)
-        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
         assert_validation_exception(response.text, f"payload: \'{body}\'")
 
 # Tests that non-object payload of a request will result with ValidationException.
 def test_request_payload_must_be_object(dynamodb):
     for body in ['null', '[]']:
         req = get_signed_request(dynamodb, "ListTables", body)
-        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+        response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
         assert_validation_exception(response.text, f"payload: \'{body}\'", accept_serialization_exception=True)
     req = get_signed_request(dynamodb, "ListTables", '{}')
-    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    response = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     r = json.loads(response.text)
     assert "__type" not in r and "TableNames" in r
 
@@ -579,8 +579,8 @@ def test_keep_alive(dynamodb, test_table, use_keep_alive):
         # Note that by default (stream=False), post() reads the entire
         # response body before returning. So the connection should be
         # immediately reusable if the server kept it alive.
-        session.post(req.url, headers=req.headers, data=req.body, verify=False)
-        session.post(req.url, headers=req.headers, data=req.body, verify=False)
+        session.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
+        session.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
         if use_keep_alive:
             assert connect_count == 1 # one connection reused.
         else:

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -1034,7 +1034,7 @@ def test_batch_write_item_size_separate_tables_track_metrics_independently(dynam
 def test_unsupported_operation(dynamodb, metrics):
     with check_increases_metric(metrics, ['scylla_alternator_unsupported_operations', 'scylla_alternator_total_operations']):
         req = get_signed_request(dynamodb, 'BoguousOperationName', '{}')
-        requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+        requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
 
 # Test that also supported operations (such as DescribeEndPoints in this
 # example) increment the total_operations metric:
@@ -1554,7 +1554,7 @@ def test_system_errors(dynamodb, test_table_s, metrics):
         req = get_signed_request(dynamodb, 'DescribeEndpoints', payload)
         headers = dict(req.headers)
         headers.update({'Content-Encoding': 'garbage'})
-        r = requests.post(req.url, headers=headers, data=req.body, verify=False)
+        r = requests.post(req.url, headers=headers, data=req.body, verify=False, cert=req.cert)
         assert r.status_code == 500
 
 # Test that reads_before_write is incremented exactly once per RMW operation.

--- a/test/alternator/test_scylla.py
+++ b/test/alternator/test_scylla.py
@@ -10,13 +10,15 @@ import requests
 import json
 import urllib.parse
 
+from .util import get_cert
+
 # Test that the "/localnodes" request works, returning at least the one node.
 # See more elaborate tests for /localnodes, requiring multiple nodes,
 # datacenters, or different configurations, in
 # test_topology_experimental_raft/test_alternator.py
 def test_localnodes(scylla_only, dynamodb):
     url = dynamodb.meta.client._endpoint.host
-    response = requests.get(url + '/localnodes', verify=False)
+    response = requests.get(url + '/localnodes', verify=False, cert=get_cert(dynamodb))
     assert response.ok
     j = json.loads(response.content.decode('utf-8'))
     assert isinstance(j, list)
@@ -51,13 +53,13 @@ def this_rack(dynamodb, scylla_only):
 def test_localnodes_option_dc(scylla_only, dynamodb, this_dc):
     url = dynamodb.meta.client._endpoint.host
     # Using dc={this_dc} should work and return at least this node:
-    response = requests.get(url + f'/localnodes?dc={this_dc}', verify=False)
+    response = requests.get(url + f'/localnodes?dc={this_dc}', verify=False, cert=get_cert(dynamodb))
     assert response.ok
     j = json.loads(response.content.decode('utf-8'))
     assert isinstance(j, list)
     assert len(j) >= 1
     # Using dc=nonexistent_dc should return an empty list (not an error)
-    response = requests.get(url + f'/localnodes?dc=nonexistent_dc', verify=False)
+    response = requests.get(url + f'/localnodes?dc=nonexistent_dc', verify=False, cert=get_cert(dynamodb))
     assert response.ok
     j = json.loads(response.content.decode('utf-8'))
     assert isinstance(j, list)
@@ -69,13 +71,13 @@ def test_localnodes_option_dc(scylla_only, dynamodb, this_dc):
 def test_localnodes_option_rack(scylla_only, dynamodb, this_rack):
     url = dynamodb.meta.client._endpoint.host
     # Using rack={this_rack} should work and return at least this node:
-    response = requests.get(url + f'/localnodes?rack={this_rack}', verify=False)
+    response = requests.get(url + f'/localnodes?rack={this_rack}', verify=False, cert=get_cert(dynamodb))
     assert response.ok
     j = json.loads(response.content.decode('utf-8'))
     assert isinstance(j, list)
     assert len(j) >= 1
     # Using rack=nonexistent_rack should return an empty list (not an error)
-    response = requests.get(url + f'/localnodes?rack=nonexistent_rack', verify=False)
+    response = requests.get(url + f'/localnodes?rack=nonexistent_rack', verify=False, cert=get_cert(dynamodb))
     assert response.ok
     j = json.loads(response.content.decode('utf-8'))
     assert isinstance(j, list)

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -12,6 +12,7 @@ import requests
 import json
 import pytest
 from contextlib import contextmanager
+from botocore import UNSIGNED
 from botocore.hooks import HierarchicalEmitter
 
 from test.pylib.skip_types import skip_env
@@ -376,6 +377,19 @@ def scylla_config_temporary(dynamodb, name, value, nop = False):
     finally:
         scylla_config_write(dynamodb, name, original_value)
 
+# get_cert() returns the (cert_file, key_file) tuple that should be passed
+# as the "cert" parameter of requests.get()/post() to authenticate to the
+# given dynamodb connection's endpoint, or None if that connection does not
+# use a client certificate. Tests which send raw HTTP requests (i.e., not
+# through boto3) to the same endpoint as "dynamodb" - instead of through
+# get_signed_request()/manual_request() below - need to pass this "cert" too,
+# because under mTLS (--mtls) the TLS handshake itself will fail without it,
+# regardless of the request's content.
+def get_cert(dynamodb):
+    session = dynamodb.meta.client._endpoint.http_session
+    cert_file = getattr(session, '_cert_file', None)
+    return (cert_file, session._key_file) if cert_file else None
+
 # manual_request() can be used to send a DynamoDB API request without any
 # boto3 involvement in preparing the request - the operation name and
 # operation payload (a JSON string) are created by the caller. Use this
@@ -385,7 +399,7 @@ def scylla_config_temporary(dynamodb, name, value, nop = False):
 # sent by a real-life SDK.
 def manual_request(dynamodb, op, payload):
     req = get_signed_request(dynamodb, op, payload)
-    res = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    res = requests.post(req.url, headers=req.headers, data=req.body, verify=False, cert=req.cert)
     if res.status_code == 200:
         return json.loads(res.text)
     else:
@@ -419,10 +433,17 @@ def get_signed_request(dynamodb, op, payload, extra_headers=None):
         url=dynamodb.meta.client._endpoint.host
         headers={'X-Amz-Target': 'DynamoDB_20120810.' + op, 'Content-Type': 'application/x-amz-json-1.0'} | (extra_headers or {})
         body=payload_bytes
+        cert=get_cert(dynamodb)
         method='POST'
         context={}
         params={}
     req = Request()
     signer = dynamodb.meta.client._request_signer
-    signer.get_auth(signer.signing_name, signer.region_name).add_auth(request=req)
+    # Under mTLS, "dynamodb" is configured with signature_version=UNSIGNED
+    # (the client certificate is the sole authentication, and any SigV4
+    # signature is ignored) - so there is no signer to use, and trying to
+    # sign anyway raises UnknownSignatureVersionError. Leave the request
+    # unsigned in that case; it authenticates via req.cert instead.
+    if signer._signature_version != UNSIGNED:
+        signer.get_auth(signer.signing_name, signer.region_name).add_auth(request=req)
     return req

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -16,10 +16,11 @@
 import pytest
 import asyncio
 import logging
+import os
 import time
 import boto3
 import botocore
-from botocore.exceptions import ClientError
+from botocore.exceptions import ClientError, ConnectionClosedError, SSLError
 import requests
 import json
 from cassandra.auth import PlainTextAuthProvider
@@ -36,6 +37,10 @@ from test.pylib.tablets import get_all_tablet_replicas
 from test.pylib.tablets import get_tablet_replica
 
 logger = logging.getLogger(__name__)
+
+def system(cmd):
+    """Like os.system(), but asserts the command succeeded (exit code 0)."""
+    assert os.system(cmd) == 0, f'Command failed: {cmd}'
 
 # Convenience function to open a connection to Alternator usable by the
 # AWS SDK.
@@ -1520,3 +1525,563 @@ async def test_deferred_stream_enablement_on_tablets(manager: ManagerClient):
     finally:
         table.delete()
         table.meta.client.get_waiter('table_not_exists').wait(TableName=table.name)
+
+def make_ca(tmp_path, name='ca', cn='TestCA'):
+    """Generate a self-signed CA key and certificate (tmp_path/{name}.key,
+    tmp_path/{name}.crt), for use as an Alternator mTLS truststore or to
+    sign client certificates via make_client_cert() below."""
+    system(f'openssl genrsa 2048 > "{tmp_path}/{name}.key" 2>/dev/null')
+    system(f'openssl req -new -x509 -nodes -sha256 -days 365 '
+              f'-subj "/CN={cn}" -key "{tmp_path}/{name}.key" -out "{tmp_path}/{name}.crt" 2>/dev/null')
+
+def make_client_cert(tmp_path, name, cn=None, *, subj=None, ca='ca', extfile=None,
+                      serial=None, not_before=None, not_after=None):
+    """Generate a client key and certificate (tmp_path/{name}.key,
+    tmp_path/{name}.crt) signed by the CA created by make_ca(tmp_path, ca).
+    The subject defaults to "/CN={cn}"; pass subj= directly for a subject
+    that doesn't fit that shape (e.g. one with no CN at all). extfile= adds
+    a SAN (or other x509v3 extension) file. serial= uses a fixed serial
+    number instead of the default auto-incrementing one (needed when
+    signing more than one certificate with the same CA without
+    -CAcreateserial). not_before/not_after (openssl's "YYYYMMDDHHMMSSZ"
+    format) override the default 365-day validity period, e.g. to create an
+    already-expired certificate."""
+    if subj is None:
+        subj = f'/CN={cn}'
+    system(f'openssl genrsa 2048 > "{tmp_path}/{name}.key" 2>/dev/null')
+    system(f'openssl req -new -sha256 -subj "{subj}" '
+              f'-key "{tmp_path}/{name}.key" -out "{tmp_path}/{name}.csr" 2>/dev/null')
+    validity = f'-not_before {not_before} -not_after {not_after}' if not_before else '-days 365'
+    serial_opt = f'-set_serial {serial}' if serial is not None else '-CAcreateserial'
+    extfile_opt = f'-extfile "{extfile}" ' if extfile else ''
+    system(f'openssl x509 -req -sha256 {validity} {serial_opt} '
+              f'-in "{tmp_path}/{name}.csr" {extfile_opt}'
+              f'-CA "{tmp_path}/{ca}.crt" -CAkey "{tmp_path}/{ca}.key" '
+              f'-out "{tmp_path}/{name}.crt" 2>/dev/null')
+
+async def test_alternator_mtls(manager: ManagerClient, tmp_path):
+    """A regression test for mTLS (mutual TLS) authentication in Alternator.
+    We create an Alternator instance configured with require_client_auth=true,
+    providing a CA certificate as the truststore. We then verify that:
+    1. Requests with a valid client certificate (signed by the trusted CA)
+       succeed: basic CRUD operations (CreateTable, PutItem, GetItem,
+       DeleteTable) all work.
+    2. Requests without a client certificate are rejected during TLS handshake.
+    3. Requests with a client certificate signed by an untrusted CA are also
+       rejected.
+    4. Requests with an expired client certificate are also rejected.
+    """
+    # Generate a CA and a client certificate signed by it. The CN must match
+    # a valid CQL role name, since Alternator uses the CN as the username
+    # for authorization. We use "cassandra", the default superuser role.
+    make_ca(tmp_path)
+    make_client_cert(tmp_path, 'client', 'cassandra')
+    # Generate an untrusted CA and a client cert signed by it, for rejection
+    # tests.
+    make_ca(tmp_path, name='bad_ca', cn='BadCA')
+    make_client_cert(tmp_path, 'bad_client', 'cassandra', ca='bad_ca')
+    # Generate an expired client key and certificate: signed by the trusted CA
+    # but with validity dates in the distant past, for the expiry-rejection test.
+    make_client_cert(tmp_path, 'expired_client', 'cassandra',
+        not_before='20000101000000Z', not_after='20000102000000Z')
+
+    # Start a single Alternator node. The mTLS/HTTPS options are passed via
+    # cmdline rather than YAML config because the test framework's startup
+    # readiness check (ScyllaServer._alternator_ports) only discovers
+    # Alternator ports from the YAML config dict. The check probes each
+    # discovered port with unsigned requests that carry no client certificate,
+    # which would fail the TLS handshake on an mTLS port and cause server_add
+    # to time out. Keeping the HTTPS port in cmdline makes it invisible to
+    # that check, so only the plain HTTP port (8000) is probed. The HTTPS port
+    # is still guaranteed to be ready before server_add returns because Scylla
+    # sends sd_notify STATUS=serving only after all configured listeners are
+    # up.
+    servers = await manager.servers_add(1,
+        config=alternator_config | {
+            'alternator_enforce_authorization': True,
+            # CassandraAuthorizer is needed so that CQL roles can be used
+            # for Alternator authorization. We don't intend to check
+            # authorization in this test, but just doing CreateTable
+            # tries to auto-grant permissions to the table creator
+            # and refuses without CassandraAuthorizer: "GRANT operation
+            # is not supported by AllowAllAuthorizer".
+            'authorizer': 'CassandraAuthorizer',
+        },
+        cmdline=[
+            '--alternator-https-port', '8043',
+            '--alternator-encryption-options', 'certificate=conf/scylla.crt',
+            '--alternator-encryption-options', 'keyfile=conf/scylla.key',
+            '--alternator-encryption-options', 'require_client_auth=true',
+            '--alternator-encryption-options', f'truststore={tmp_path}/ca.crt',
+        ])
+    url = f"https://{servers[0].ip_addr}:8043"
+
+    # Helper: create a boto3 Alternator connection for mTLS.
+    # Authentication is via the client certificate (CN used as username),
+    # so we use botocore.UNSIGNED to avoid SigV4 signing. The server uses a
+    # self-signed TLS certificate, so we set verify=False.
+    def get_alternator_mtls(cert=None):
+        config_kwargs = dict(
+            retries={"max_attempts": 0},
+            read_timeout=300,
+            signature_version=botocore.UNSIGNED,
+        )
+        if cert:
+            config_kwargs['client_cert'] = cert
+        return boto3.resource('dynamodb', endpoint_url=url, verify=False,
+            region_name='us-east-1',
+            config=botocore.client.Config(**config_kwargs))
+
+    # Test 1: Requests with a valid client certificate should succeed.
+    alternator = get_alternator_mtls(
+        cert=(f'{tmp_path}/client.crt', f'{tmp_path}/client.key'))
+    table = alternator.create_table(TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N'}])
+    table.put_item(Item={'p': 42})
+    item = table.get_item(Key={'p': 42}, ConsistentRead=True)['Item']
+    assert item['p'] == 42
+    table.delete()
+
+    # Test 2: Requests without a client certificate should be rejected.
+    # With require_client_auth=true the TLS handshake fails if the client
+    # doesn't present a certificate signed by the trusted CA.
+    alternator_no_cert = get_alternator_mtls()
+    with pytest.raises(SSLError, match='certificate required'):
+        alternator_no_cert.meta.client.list_tables()
+
+    # Test 3: Requests with a client certificate signed by an untrusted CA
+    # should also be rejected.
+    # Ideally, the server should send a TLS alert, which Python would report
+    # as an SSLError mentioning "unknown ca". But in practice, right now the
+    # server just closes the connection in this case (see Seastar#3525)
+    # and we get ConnectionClosedError. In both cases, the important thing is
+    # that the request is *rejected*, so the certificate check was properly
+    # performed.
+    alternator_bad_cert = get_alternator_mtls(
+        cert=(f'{tmp_path}/bad_client.crt', f'{tmp_path}/bad_client.key'))
+    with pytest.raises((SSLError, ConnectionClosedError)):
+        alternator_bad_cert.meta.client.list_tables()
+
+    # Test 4: Requests with an expired client certificate (signed by the
+    # trusted CA but outside its validity period) should also be rejected.
+    # Ideally, the server should send a certificate_expired TLS alert, which
+    # Python would report as an SSLError mentioning "certificate expired".
+    # But in practice, right now the server just closes the connection in
+    # this case - we are not sure if this is a genuine bug in Seastar HTTPD
+    # or a timing issue in the TLS protocol (where the server closes the
+    # connection before the alert is received). In any case, the important
+    # thing is that the request is *rejected*, so the expiration check was
+    # properly performed.
+    alternator_expired = get_alternator_mtls(
+        cert=(f'{tmp_path}/expired_client.crt', f'{tmp_path}/expired_client.key'))
+    with pytest.raises((SSLError, ConnectionClosedError)):
+        alternator_expired.meta.client.list_tables()
+
+    # TODO: we should test that requests rejected by missing or bad client
+    # certificate are counted in a metric. However, currently no such metric
+    # exists - see https://github.com/scylladb/seastar/issues/3521.
+
+
+async def test_alternator_mtls_optional(manager: ManagerClient, tmp_path):
+    """Test Alternator over HTTPS with require_client_auth=optional, which allows both
+       mTLS and SigV4 authentication to coexist on the same port.
+       With require_client_auth=optional, Seastar uses optional (not required) client
+       certificate verification: it requests a client cert during the TLS handshake but
+       does not mandate one.
+       This test verifies the following three scenarios:
+       1. A client without a valid client certificate can still authenticate
+          via SigV4.
+       2. A client presenting a valid cert (signed by the configured CA)
+          does not need SigV4 signatures on requests.
+       3. A client with neither a cert nor a valid SigV4 signature is rejected.
+    """
+    # Generate a CA and a client certificate signed by it. The CN is the role
+    # name we want to use - "cassandra" (the default superuser).
+    make_ca(tmp_path)
+    make_client_cert(tmp_path, 'client', 'cassandra')
+
+    servers = await manager.servers_add(1,
+        config=alternator_config | {
+            'alternator_enforce_authorization': True,
+            # PasswordAuthenticator is needed just so the "cassandra"
+            # role will have a salted hash, to be used in the SigV4
+            # case we want to check.
+            'authenticator': 'PasswordAuthenticator',
+            # CassandraAuthorizer is needed so that CQL roles can be used
+            # for Alternator authorization. We don't intend to check
+            # authorization in this test, but just doing CreateTable
+            # tries to auto-grant permissions to the table creator
+            # and refuses without CassandraAuthorizer: "GRANT operation
+            # is not supported by AllowAllAuthorizer".
+            'authorizer': 'CassandraAuthorizer',
+        },
+        driver_connect_opts={'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra')},
+        cmdline=[
+            '--alternator-https-port', '8043',
+            '--alternator-encryption-options', 'certificate=conf/scylla.crt',
+            '--alternator-encryption-options', 'keyfile=conf/scylla.key',
+            # require_client_auth=optional asks the server to request (but not require)
+            # a client certificate. Clients without one use SigV4 instead.
+            '--alternator-encryption-options', 'require_client_auth=optional',
+            '--alternator-encryption-options', f'truststore={tmp_path}/ca.crt',
+        ])
+    url = f"https://{servers[0].ip_addr}:8043"
+
+    # Get the cassandra superuser's secret key (the salted_hash from the
+    # system tables), which is used as the SigV4 secret access key.
+    cql = manager.get_cql()
+    cassandra_key = await get_secret_key(cql, 'cassandra')
+
+    # Test 1: SigV4 request without a client certificate should work.
+    alternator_sigv4 = boto3.resource('dynamodb', endpoint_url=url, verify=False,
+        region_name='us-east-1',
+        aws_access_key_id='cassandra',
+        aws_secret_access_key=cassandra_key,
+        config=botocore.client.Config(retries={"max_attempts": 0}, read_timeout=300))
+    table = alternator_sigv4.create_table(TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N'}])
+    table.put_item(Item={'p': 42})
+    assert table.get_item(Key={'p': 42}, ConsistentRead=True)['Item']['p'] == 42
+    table.delete()
+
+    # Test 2: Certificate-based request (no SigV4) with a valid client cert
+    # should also work - the server validates the cert and uses its CN as
+    # the Alternator username, just as with require_client_auth=true.
+    alternator_cert = boto3.resource('dynamodb', endpoint_url=url, verify=False,
+        region_name='us-east-1',
+        config=botocore.client.Config(
+            retries={"max_attempts": 0},
+            read_timeout=300,
+            signature_version=botocore.UNSIGNED,
+            client_cert=(f'{tmp_path}/client.crt', f'{tmp_path}/client.key')))
+    table = alternator_cert.create_table(TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N'}])
+    table.put_item(Item={'p': 42})
+    assert table.get_item(Key={'p': 42}, ConsistentRead=True)['Item']['p'] == 42
+    table.delete()
+
+    # Test 3: A request with neither a client certificate nor a valid SigV4
+    # signature should be rejected. With alternator_enforce_authorization=true,
+    # every request must be authenticated by one of the two mechanisms.
+    alternator_no_auth = boto3.resource('dynamodb', endpoint_url=url, verify=False,
+        region_name='us-east-1',
+        config=botocore.client.Config(
+            retries={"max_attempts": 0},
+            read_timeout=300,
+            signature_version=botocore.UNSIGNED))
+    with pytest.raises(ClientError, match='MissingAuthenticationTokenException'):
+        alternator_no_auth.meta.client.list_tables()
+
+
+async def test_alternator_mtls_authorization(manager: ManagerClient, tmp_path):
+    """Test that when mTLS is active, the CN of the client certificate is used
+       as the CQL role name for Alternator authorization. A cert whose CN names
+       a role with limited privileges should succeed for unprivileged operations
+       (ListTables) but be denied for privileged ones (CreateTable).
+    """
+    # Generate a CA and two client certificates: one for the built-in superuser
+    # "cassandra" and one for a "limited_user" role we create below.
+    make_ca(tmp_path)
+    for serial, cn in enumerate(['cassandra', 'limited_user'], start=1):
+        make_client_cert(tmp_path, cn, cn, serial=serial)
+
+    servers = await manager.servers_add(1,
+        config=alternator_config | {
+            'alternator_enforce_authorization': True,
+            # 'authenticator' is not needed for Alternator, but we need it
+            # to use username/password authentication for CQL below...
+            'authenticator': 'PasswordAuthenticator',
+            'authorizer': 'CassandraAuthorizer',
+        },
+        driver_connect_opts={'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra')},
+        cmdline=[
+            '--alternator-https-port', '8043',
+            '--alternator-encryption-options', 'certificate=conf/scylla.crt',
+            '--alternator-encryption-options', 'keyfile=conf/scylla.key',
+            '--alternator-encryption-options', 'require_client_auth=true',
+            '--alternator-encryption-options', f'truststore={tmp_path}/ca.crt',
+        ])
+    url = f"https://{servers[0].ip_addr}:8043"
+
+    def get_alternator_mtls(cn):
+        return boto3.resource('dynamodb', endpoint_url=url, verify=False,
+            region_name='us-east-1',
+            config=botocore.client.Config(
+                retries={"max_attempts": 0},
+                read_timeout=300,
+                signature_version=botocore.UNSIGNED,
+                client_cert=(f'{tmp_path}/{cn}.crt', f'{tmp_path}/{cn}.key'),
+            ))
+
+    # Create a "limited_user" role with no permissions granted.
+    cql = manager.get_cql()
+    cql.execute("CREATE ROLE limited_user WITH LOGIN=TRUE")
+
+    # The cassandra superuser can create and use a table.
+    alternator_super = get_alternator_mtls('cassandra')
+    table = alternator_super.create_table(TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N'}])
+    try:
+        # limited_user can list tables (no special permission needed) ...
+        alternator_limited = get_alternator_mtls('limited_user')
+        alternator_limited.meta.client.list_tables()
+        # ... but is denied CreateTable (requires CREATE permission).
+        with pytest.raises(ClientError, match='AccessDeniedException'):
+            alternator_limited.create_table(TableName=unique_table_name(),
+                BillingMode='PAY_PER_REQUEST',
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N'}])
+    finally:
+        table.delete()
+
+
+async def test_alternator_mtls_role_checks(manager: ManagerClient, tmp_path):
+    """Test that mTLS authentication in Alternator validates the role given
+    by the certificate's CN - it must be a valid CQL role with LOGIN=TRUE.
+    Three failure cases are tested:
+    1. The CN names a role that does not exist in the database.
+    2. The CN names a role that exists but has LOGIN=FALSE.
+    3. The certificate's subject DN has no CN field, so the default
+       auth_certificate_role_queries pattern cannot extract a role name.
+    All three should be rejected with UnrecognizedClientException when
+    alternator_enforce_authorization=true.
+    """
+    # Generate a CA and one client certificate per test role.
+    make_ca(tmp_path)
+    for cn in ['nonexistent_user', 'no_login_user']:
+        make_client_cert(tmp_path, cn, cn)
+    # A cert whose subject has no CN field at all, so the default
+    # auth_certificate_role_queries pattern (CN=([^,]+)) cannot extract a role.
+    make_client_cert(tmp_path, 'no_cn', subj='/O=NoCNOrg')
+
+    servers = await manager.servers_add(1,
+        config=alternator_config | {
+            'alternator_enforce_authorization': True,
+            'authenticator': 'PasswordAuthenticator',
+            'authorizer': 'CassandraAuthorizer',
+        },
+        driver_connect_opts={'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra')},
+        cmdline=[
+            '--alternator-https-port', '8043',
+            '--alternator-encryption-options', 'certificate=conf/scylla.crt',
+            '--alternator-encryption-options', 'keyfile=conf/scylla.key',
+            '--alternator-encryption-options', 'require_client_auth=true',
+            '--alternator-encryption-options', f'truststore={tmp_path}/ca.crt',
+        ])
+    url = f"https://{servers[0].ip_addr}:8043"
+
+    def get_alternator_mtls(cn):
+        return boto3.resource('dynamodb', endpoint_url=url, verify=False,
+            region_name='us-east-1',
+            config=botocore.client.Config(
+                retries={"max_attempts": 0},
+                read_timeout=300,
+                signature_version=botocore.UNSIGNED,
+                client_cert=(f'{tmp_path}/{cn}.crt', f'{tmp_path}/{cn}.key'),
+            ))
+
+    # Test 1: CN names a role that does not exist in the database.
+    # Alternator must reject the request, not silently treat the CN as a
+    # valid username (which was the pre-fix behaviour).
+    with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        get_alternator_mtls('nonexistent_user').meta.client.list_tables()
+
+    # Test 2: CN names a role that exists but has LOGIN=FALSE.
+    # Such a role cannot be used for authentication, so the request must
+    # also be rejected even though the role entry is present in the table.
+    cql = manager.get_cql()
+    cql.execute("CREATE ROLE no_login_user WITH LOGIN=FALSE")
+    with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        get_alternator_mtls('no_login_user').meta.client.list_tables()
+
+    # Test 3: A cert whose subject DN has no CN field does not match the
+    # default auth_certificate_role_queries pattern (CN=([^,]+)), so no role
+    # can be extracted. The request must be rejected rather than falling back
+    # to SigV4 (which was the pre-fix behaviour).
+    with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        get_alternator_mtls('no_cn').meta.client.list_tables()
+
+    # Repeat Tests 1-3 with connections that carry the problematic client
+    # certificate but also have the potential to sign the requests with valid
+    # SigV4 credentials (cassandra's key). Because we do send a bad cert (not
+    # a missing cert), the entire request will fail - Alternator does *not*
+    # reach the check of SigV4 signature. It has to be this way, because in
+    # the simple case of a client certificate signed by an untrusted CA, the
+    # HTTPS server rejects the connection and Alternator doesn't even get a
+    # chance to fall back to checking SigV4 signatures.
+    cassandra_key = await get_secret_key(cql, 'cassandra')
+    def get_alternator_mtls_and_sigv4(cn):
+        return boto3.resource('dynamodb', endpoint_url=url, verify=False,
+            region_name='us-east-1',
+            aws_access_key_id='cassandra',
+            aws_secret_access_key=cassandra_key,
+            config=botocore.client.Config(
+                retries={"max_attempts": 0},
+                read_timeout=300,
+                client_cert=(f'{tmp_path}/{cn}.crt', f'{tmp_path}/{cn}.key'),
+            ))
+
+    with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        get_alternator_mtls_and_sigv4('nonexistent_user').meta.client.list_tables()
+    with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        get_alternator_mtls_and_sigv4('no_login_user').meta.client.list_tables()
+    with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        get_alternator_mtls_and_sigv4('no_cn').meta.client.list_tables()
+
+
+async def test_alternator_mtls_san(manager: ManagerClient, tmp_path):
+    """Test that mTLS authentication in Alternator can extract the role name
+    from a Subject Alternative Name (SAN) instead of the subject DN, using
+    auth_certificate_role_queries with source: ALTNAME.
+
+    The SAN list is formatted as a comma-separated "TYPE=value" string
+    (e.g. "EMAIL=cassandra@scylladb.example") and matched against the
+    configured regex. EMAIL SANs (rfc822Name) are the standard way to carry
+    user identity in client certificates in enterprise PKI.
+    Three scenarios are tested:
+    1. A cert with EMAIL SAN=cassandra@scylladb.example (but CN=irrelevant)
+       succeeds: the role is extracted from the local part of the email SAN,
+       not the CN.
+    2. A cert with EMAIL SAN naming a non-existent role is rejected.
+    3. A cert with CN=cassandra but no SAN is also rejected, because the
+       ALTNAME query produces an empty string that does not match the regex.
+    """
+    # Generate a CA.
+    make_ca(tmp_path)
+
+    # A cert with CN=irrelevant but EMAIL SAN=cassandra@scylladb.example.
+    # Using an email SAN to carry user identity is standard enterprise PKI practice.
+    san_ext = tmp_path / 'san_cassandra.ext'
+    san_ext.write_text('subjectAltName = email:cassandra@scylladb.example\n')
+    make_client_cert(tmp_path, 'san_client', 'irrelevant', extfile=san_ext, serial=1)
+
+    # A cert with an EMAIL SAN naming a role that does not exist.
+    san_bad_ext = tmp_path / 'san_bad.ext'
+    san_bad_ext.write_text('subjectAltName = email:nonexistent_role@scylladb.example\n')
+    make_client_cert(tmp_path, 'san_bad_client', 'also_irrelevant', extfile=san_bad_ext, serial=2)
+
+    # A cert with CN=cassandra but no SAN at all.
+    make_client_cert(tmp_path, 'no_san_client', 'cassandra', serial=3)
+
+    servers = await manager.servers_add(1,
+        config=alternator_config | {
+            'alternator_enforce_authorization': True,
+            'authorizer': 'CassandraAuthorizer',
+            # Use an ALTNAME query: extract the role from the local part of the EMAIL SAN.
+            'auth_certificate_role_queries': [{'source': 'ALTNAME', 'query': 'EMAIL=([^@,]+)@'}],
+        },
+        cmdline=[
+            '--alternator-https-port', '8043',
+            '--alternator-encryption-options', 'certificate=conf/scylla.crt',
+            '--alternator-encryption-options', 'keyfile=conf/scylla.key',
+            '--alternator-encryption-options', 'require_client_auth=true',
+            '--alternator-encryption-options', f'truststore={tmp_path}/ca.crt',
+        ])
+    url = f"https://{servers[0].ip_addr}:8043"
+
+    def get_alternator_mtls(cert_name):
+        return boto3.resource('dynamodb', endpoint_url=url, verify=False,
+            region_name='us-east-1',
+            config=botocore.client.Config(
+                retries={"max_attempts": 0},
+                read_timeout=300,
+                signature_version=botocore.UNSIGNED,
+                client_cert=(f'{tmp_path}/{cert_name}.crt', f'{tmp_path}/{cert_name}.key'),
+            ))
+
+    # Test 1: A cert whose EMAIL SAN is "cassandra@scylladb.example" authenticates as
+    # the cassandra superuser role (local part extracted via the ALTNAME query),
+    # even though the CN is "irrelevant" and would not match the default SUBJECT query.
+    alternator = get_alternator_mtls('san_client')
+    table = alternator.create_table(TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N'}])
+    table.put_item(Item={'p': 1})
+    assert table.get_item(Key={'p': 1}, ConsistentRead=True)['Item']['p'] == 1
+    table.delete()
+
+    # Test 2: A cert whose EMAIL SAN names a non-existent role should be rejected.
+    with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        get_alternator_mtls('san_bad_client').meta.client.list_tables()
+
+    # Test 3: A cert with CN=cassandra but no SAN should also be rejected:
+    # the ALTNAME query matches against the empty SAN string and does not
+    # extract a role, even though the CN would satisfy the default SUBJECT query.
+    with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        get_alternator_mtls('no_san_client').meta.client.list_tables()
+
+
+async def test_alternator_mtls_and_plain_http(manager: ManagerClient, tmp_path):
+    """Test that require_client_auth=true, configured for the Alternator
+    HTTPS port, has no effect on a separate, plain HTTP Alternator port
+    enabled at the same time.
+
+    The unencrypted HTTP port has no TLS handshake at all, so client
+    certificates are not applicable there - the only authentication
+    mechanism on that port is SigV4. This test verifies that SigV4
+    authentication keeps working normally on the HTTP port (a request
+    with the right secret key is accepted, one with a wrong secret key is
+    rejected) despite the HTTPS port's require_client_auth=true.
+    """
+    # Generate a CA, needed just to configure the HTTPS port with
+    # require_client_auth=true. We never actually send a client certificate
+    # in this test.
+    make_ca(tmp_path)
+
+    servers = await manager.servers_add(1,
+        config=alternator_config | {
+            'alternator_enforce_authorization': True,
+            'authenticator': 'PasswordAuthenticator',
+            # CassandraAuthorizer is needed so that CQL roles can be used
+            # for Alternator authorization. We don't intend to check
+            # authorization in this test, but just doing CreateTable
+            # tries to auto-grant permissions to the table creator
+            # and refuses without CassandraAuthorizer: "GRANT operation
+            # is not supported by AllowAllAuthorizer".
+            'authorizer': 'CassandraAuthorizer',
+        },
+        driver_connect_opts={'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra')},
+        cmdline=[
+            # The plain HTTP Alternator port (8000) is already enabled via
+            # alternator_config's 'alternator_port' above - here we just
+            # add an HTTPS port alongside it.
+            '--alternator-https-port', '8043',
+            '--alternator-encryption-options', 'certificate=conf/scylla.crt',
+            '--alternator-encryption-options', 'keyfile=conf/scylla.key',
+            '--alternator-encryption-options', 'require_client_auth=true',
+            '--alternator-encryption-options', f'truststore={tmp_path}/ca.crt',
+        ])
+
+    cql = manager.get_cql()
+    cassandra_key = await get_secret_key(cql, 'cassandra')
+
+    # A SigV4-authenticated request on the plain HTTP port with the correct
+    # secret key succeeds, even though the HTTPS port was configured with
+    # require_client_auth=true - that option only governs the TLS handshake
+    # on the HTTPS port and doesn't apply to the separate, unencrypted port.
+    alternator = get_alternator(servers[0].ip_addr, 'cassandra', cassandra_key)
+    table = alternator.create_table(TableName=unique_table_name(),
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N'}])
+    table.put_item(Item={'p': 42})
+    assert table.get_item(Key={'p': 42}, ConsistentRead=True)['Item']['p'] == 42
+    table.delete()
+
+    # A SigV4-authenticated request on the same HTTP port with a wrong
+    # secret key is rejected.
+    alternator_bad = get_alternator(servers[0].ip_addr, 'cassandra', 'wrong_secret_key')
+    with pytest.raises(ClientError, match='UnrecognizedClientException'):
+        alternator_bad.meta.client.list_tables()
+
+
+

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -562,3 +562,23 @@ def setup_ssl_certificate(dir):
     # FIXME: error checking (if "openssl" isn't found, for example)
     os.system(f'openssl genrsa 2048 > "{dir}/scylla.key"')
     os.system(f'openssl req -new -x509 -nodes -sha256 -days 365 -subj "/C=IL/ST=None/L=None/O=None/OU=None/CN=example.com" -key "{dir}/scylla.key" -out "{dir}/scylla.crt"')
+
+# Set up mTLS (mutual TLS) certificates for testing client certificate
+# authentication. Creates:
+#   dir/ca.key, dir/ca.crt    - a self-signed CA certificate
+#   dir/client.key, dir/client.crt - a client certificate with CN "cassandra",
+#                                    signed by the above CA
+# The CA certificate (dir/ca.crt) should be passed to Scylla as the truststore
+# so that Scylla can verify client certificates. The client key and certificate
+# can be used by test clients to authenticate themselves.
+def setup_mtls_certificate(dir):
+    # FIXME: error checking (if "openssl" isn't found, for example)
+    # Create a self-signed CA certificate
+    os.system(f'openssl genrsa 2048 > "{dir}/ca.key"')
+    os.system(f'openssl req -new -x509 -nodes -sha256 -days 365 -subj "/CN=TestCA" -key "{dir}/ca.key" -out "{dir}/ca.crt"')
+    # Create a client key and a certificate signing request with CN "cassandra",
+    # matching the role already used in Alternator tests.
+    os.system(f'openssl genrsa 2048 > "{dir}/client.key"')
+    os.system(f'openssl req -new -sha256 -subj "/CN=cassandra" -key "{dir}/client.key" -out "{dir}/client.csr"')
+    # Sign the client certificate with the CA
+    os.system(f'openssl x509 -req -sha256 -days 365 -in "{dir}/client.csr" -CA "{dir}/ca.crt" -CAkey "{dir}/ca.key" -CAcreateserial -out "{dir}/client.crt"')


### PR DESCRIPTION
Today Alternator does authentication like DynamoDB - with AWS's "Signature v4" protocol. In this protocol a client needs to sign every individual request, even if multiple requests are sent over the same connection.

If the client uses TLS, we have an opportunity to use **client certificates** (a.k.a. mTLS) to authenticate just once in the beginning of of the connection. The client presents a certificate signed by the certificate authority managed by the database administrator, and if this certificate checks out, it contains (in its DN or SAN) the name of the **role** that this client will be authenticated as.

The new mTLS authentication has multiple advantages over the old SigV4 authentication:

1. **Performance:** Authentication only happens once for a connection. If a connection is reused for many requests, we reduce a lot of the bandwidth needed for the lengthy signature (https://github.com/scylladb/scylladb/issues/23131 shows that for small requests, the signature overhead is substantial). Moreover, if TLS is already used, then it already does cryptographic computations ensure that requests are authentic and untempered, so the extra cryptographic computations that the AWS Signature v4 protocol does on top of that can be avoided. It is not obvious that for all workloads replacing AWS Signature v4 by TLS and client certificates will give better performance, but the benefit is clearer if the client already chose to use TLS (e.g., to prevent eavesdropping or to please some security standard), then using client certificates is always better (unless connections are never reused).
2. **Security**:  As explained in https://github.com/scylladb/scylladb/issues/5206, Amazon's "Signature v4" protocol is symmetric, requiring the server to have a plaintext copy of the user's secret key, which can open all sorts of security risks (the issue discusses how they can be mitigated, though). Conversely, SSL client certificates use asymmetric public-key cryptography: The server needs to know the client's public key, but never knows the client's private key.
3. **Convenience** for modern workflows: With mTLS the the customer can easily create their own certificates signed by their own their CA, including short-lived certificates, without involving ScyllaDB in creating or maintaining these certificates.

This PR includes the ScyllaDB code changes, documentation and tests. It relies on a prerequisite Seastar patch, https://github.com/scylladb/seastar/pull/3517, which must be merged first because it is required for the Seastar HTTP server (which Alternator uses) to tell us if the connection through which a request came is authenticated.

Fixes #23684
Fixes SCYLLADB-3193

This is a new feature, so it should not be backported.