### PR TITLE
test/boost/compaction: re-enable cleanup_during_offstrategy_incremental_compaction_test on S3/GCS

### DIFF
--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -35,20 +35,23 @@ using namespace utils;
 
 static logging::logger osclog("object_storage_client");
 
+sstables::object_name::object_name(std::string object_location)
+    : _name(std::move(object_location))
+{}
 
 sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, std::string_view type)
-    : _name(fmt::format("/{}/{}/{}", bucket, prefix, type))
+    : object_name(fmt::format("/{}/{}/{}", bucket, prefix, type))
 {}
 
 sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, const sstable_id& sid, std::string_view type)
-    : _name(fmt::format("/{}/{}/{}/{}", bucket, prefix, sid, type))
+    : object_name(fmt::format("/{}/{}/{}/{}", bucket, prefix, sid, type))
 {
     if (!sid) {
         on_internal_error(sstlog, fmt::format("SSTable identifier is required for object storage: bucket={} prefix={}", bucket, prefix));
     }
 }
 sstables::object_name::object_name(std::string_view bucket, std::string_view object) 
-    : _name(fmt::format("/{}/{}", bucket, object))
+    : object_name(fmt::format("/{}/{}", bucket, object))
 {}
 
 sstables::object_name::object_name(const object_name&) = default;

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -49,6 +49,9 @@ class object_name {
 public:
     object_name(const object_name&);
     object_name(object_name&&);
+    // Designed for consumers that already hold a full "/bucket/object" location and
+    // therefore have nothing to format, e.g. sstables::storage::exists(const std::string&).
+    explicit object_name(std::string object_location);
     // Used by native backup/restore with externally supplied prefixes
     // following the foreign Scylla Manager bucket layout.
     object_name(std::string_view bucket, std::string_view prefix, std::string_view type);

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -113,9 +113,15 @@ public:
     future<size_t> num_references(const sstable& sst) const override;
 
     virtual std::string_view prefix() const override { return _dir.native(); }
+    sstring component_fqn(const sstable& sst, component_type type) const override {
+        return sst.get_filename(type).format();
+    }
     bool is_object_storage() const override { return false; }
     future<bool> exists(const sstable& sst, component_type type) const override {
-        return file_exists(sst.get_filename(type).format());
+        return exists(sst.get_filename(type).format());
+    }
+    future<bool> exists(const std::string& component_location) const override {
+        return file_exists(component_location);
     }
 };
 
@@ -743,8 +749,16 @@ public:
         return _prefix;
     }
 
+    sstring component_fqn(const sstable& sst, component_type type) const override {
+        return make_object_name(sst, type).str();
+    }
+
     future<bool> exists(const sstable& sst, component_type type) const override {
-        return _client->object_exists(make_object_name(sst, type), abort_source());
+        return exists(make_object_name(sst, type));
+    }
+
+    future<bool> exists(const std::string& component_location) const override {
+        return _client->object_exists(object_name(component_location), abort_source());
     }
 
     future<size_t> num_references(sstable_id sid) const;

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -143,7 +143,9 @@ public:
     virtual future<size_t> num_references(const sstable& sst) const = 0;
 
     virtual std::string_view prefix() const  = 0;
+    virtual sstring component_fqn(const sstable& sst, component_type type) const  = 0;
     virtual future<bool> exists(const sstable& sst, component_type type) const = 0;
+    virtual future<bool> exists(const std::string& component_location) const = 0;
 
     // Returns true if this storage backend uses object storage (S3/GCS).
     // Used to decide per-SSTable whether to clone or byte-stream during tablet migration.

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -71,6 +71,7 @@
 #include "utils/assert.hh"
 #include "utils/pretty_printers.hh"
 #include "sstables/exceptions.hh"
+#include "sstables/storage.hh"
 
 BOOST_AUTO_TEST_SUITE(sstable_compaction_test)
 
@@ -6968,10 +6969,10 @@ void cleanup_during_offstrategy_incremental_compaction_fn(test_env& env) {
         return m;
     };
 
-    std::vector<utils::observer<sstable&>> observers;
     std::vector<shared_sstable> ssts;
     size_t sstables_closed = 0;
-    size_t sstables_missing_on_delete = 0;
+    size_t sstables_deleted = 0;
+    std::vector<sstring> deleted_filenames;
     static constexpr size_t sstables_nr = 10;
 
     dht::token_range_vector owned_token_ranges;
@@ -7010,10 +7011,29 @@ void cleanup_during_offstrategy_incremental_compaction_fn(test_env& env) {
         gens.insert(ssts[i]->generation());
     }
 
+    // Build an independent storage instance so we can query for file/object
+    // existence after all input sstables (and their owned per-sstable storage)
+    // have been destroyed. component_fqn() and exists() derive the target path
+    // from the sstable (dir/generation/schema/version) combined with the
+    // storage's connection config (dir for local, bucket+location+client for
+    // S3/GCS). Because env.make_storage(s) constructs an instance from the
+    // same env storage options as the input sstables, it produces the same
+    // paths and can query the same locations.
+    auto owned_storage = env.make_storage(s);
+    const storage& scylla_storage = *owned_storage;
+    for (const auto& sst : ssts) {
+        auto component_fqn = scylla_storage.component_fqn(*sst, component_type::Data);
+        BOOST_REQUIRE_MESSAGE(scylla_storage.exists(component_fqn).get(),
+            fmt::format("{} doesnt exist even before cleanup", component_fqn));
+    }
     {
         auto t = env.make_table_for_tests(s);
         auto& cm = t->get_compaction_manager();
         auto stop = deferred_stop(t);
+        // Declared after `stop` so the handlers below, which capture `t` by reference,
+        // are disconnected before t->stop() runs and before ~t. Nothing outside this
+        // scope reads the observers -- only the counters they update, which outlive it.
+        std::vector<utils::observer<sstable&>> observers;
         t->disable_auto_compaction().get();
         const dht::token_range_vector empty_owned_ranges;
         for (auto&& sst : ssts) {
@@ -7024,28 +7044,53 @@ void cleanup_during_offstrategy_incremental_compaction_fn(test_env& env) {
                 testlog.info("Closing sstable of generation {}, table set size: {}", sst.generation(), sstables->size());
                 sstables_closed++;
             }));
-                observers.push_back(sst->add_on_delete_handler([&] (sstable& sst) mutable {
-                // ATTN -- the _on_delete callback is not necessarily running in thread
-                    auto missing = (::access(fmt::to_string(sst.get_filename()).c_str(), F_OK) != 0);
-                    testlog.info("Deleting sstable of generation {}: missing={}", sst.generation(), missing);
-                    sstables_missing_on_delete += missing;
+            observers.push_back(sst->add_on_delete_handler([&] (sstable& sst) mutable {
+                // The _on_delete callback runs on the reactor (not in a seastar::thread),
+                // so it must be purely synchronous. Just capture the fully-qualified
+                // component path here and verify its actual removal later, via scylla_storage.exists().
+                deleted_filenames.emplace_back(scylla_storage.component_fqn(sst, component_type::Data));
+                sstables_deleted++;
             }));
         }
-        ssts = {}; // releases references
         auto owned_ranges_ptr = make_lw_shared<const dht::token_range_vector>(std::move(owned_token_ranges));
         t->perform_cleanup_compaction(std::move(owned_ranges_ptr), tasks::task_info{}).get();
         BOOST_REQUIRE(cm.sstables_requiring_cleanup(t->try_get_compaction_group_view_with_static_sharding()).empty());
         testlog.info("Cleanup has finished");
+        ssts = {}; // release test-side references; remaining refs are dropped
+                   // when the table/compaction manager tear down at block exit.
+        // _on_delete is raised by sstable::unlink(), which every path to it awaits:
+        // atomic_deletion::execute() during the compaction above, or close_files()
+        // when the last reference goes away just now. Either way the callbacks have
+        // already fired, so there is nothing to wait for -- and a deletion that never
+        // happened must fail the test rather than spin here forever.
+        BOOST_REQUIRE_EQUAL(sstables_deleted, sstables_nr);
     }
 
-    while (sstables_closed != sstables_nr) {
-        yield().get();
-    }
-
-    testlog.info("Closed sstables {}, missing on delete {}", sstables_closed, sstables_missing_on_delete);
+    testlog.info("Closed sstables {}, deleted {}", sstables_closed, sstables_deleted);
 
     BOOST_REQUIRE_EQUAL(sstables_closed, sstables_nr);
-    BOOST_REQUIRE_EQUAL(sstables_missing_on_delete, 0);
+
+    // For filesystem_storage, wipe() (invoked from unlink() during compaction's
+    // delete_atomically) has already removed the on-disk files by the time the
+    // _on_delete callback fires, so the checks below are effectively a
+    // regression tripwire.
+    //
+    // For object_storage backends (S3/GCS), wipe() only marks the sstable for
+    // deletion and updates its registry entry; the actual DELETE requests are
+    // issued later from _storage->destroy(), which runs fire-and-forget from
+    // sstables_manager::deactivate() when the last shared_sstable reference is
+    // dropped. So `sstables_deleted == sstables_nr` (i.e., all _on_delete
+    // callbacks fired) does not imply the objects have been deleted from the
+    // bucket. Poll exists() with a bounded retry budget to let the fire-and-
+    // forget destroy chain complete.
+    using namespace std::chrono_literals;
+    for (const auto& component_location : deleted_filenames) {
+        for (int i = 0; i < 100 && scylla_storage.exists(component_location).get(); ++i) {
+            seastar::sleep(10ms).get();
+        }
+        BOOST_REQUIRE_MESSAGE(!scylla_storage.exists(component_location).get(),
+            fmt::format("{} still exists after cleanup", component_location));
+    }
 }
 
 SEASTAR_TEST_CASE(cleanup_during_offstrategy_incremental_compaction_test) {
@@ -7053,25 +7098,15 @@ SEASTAR_TEST_CASE(cleanup_during_offstrategy_incremental_compaction_test) {
 }
 
 SEASTAR_TEST_CASE(cleanup_during_offstrategy_incremental_compaction_test_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
-    // TODO: Figure out how to make the `add_on_delete_handler` synchronous
-    testlog.info("cleanup_during_offstrategy_incremental_compaction_test_s3 is not supported for S3 storage yet, skipping test");
-    return make_ready_future();
-#if 0
     return test_env::do_with_async([](test_env& env) { cleanup_during_offstrategy_incremental_compaction_fn(env); },
                                    test_env_config{.storage = make_test_object_storage_options("S3")});
-#endif
 }
 
 SEASTAR_FIXTURE_TEST_CASE(cleanup_during_offstrategy_incremental_compaction_test_gcs,
                           gcs_fixture,
                           *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
-    // TODO: Figure out how to make the `add_on_delete_handler` synchronous
-    testlog.info("cleanup_during_offstrategy_incremental_compaction_test_gcs is not supported for S3 storage yet, skipping test");
-    return make_ready_future();
-#if 0
     return test_env::do_with_async([](test_env& env) { cleanup_during_offstrategy_incremental_compaction_fn(env); },
                                    test_env_config{.storage = make_test_object_storage_options("GS")});
-#endif
 }
 
 future<> test_sstables_excluding_staging_correctness(test_env_config cfg) {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -32,6 +32,8 @@ class compaction_task_executor;
 
 namespace sstables {
 
+class storage;
+
 class test_env_sstables_manager : public sstables_manager {
     using sstables_manager::sstables_manager;
     std::optional<size_t> _promoted_index_block_size;
@@ -181,6 +183,16 @@ public:
     db::config& db_config();
     tmpdir& tempdir() noexcept;
     data_dictionary::storage_options get_storage_options() const noexcept;
+
+    // Build a standalone storage instance from the env's storage options,
+    // patching in the fields that would normally be filled by
+    // init_table_storage (schema id -> object_storage.location) and by
+    // per-sstable factories (dir -> local.dir). Useful for tests that need
+    // to query sstable files/objects after all sstables (and their owned
+    // per-sstable storage) have been destroyed. If `dir` is empty, the env's
+    // tempdir is used for the local variant.
+    std::unique_ptr<sstables::storage> make_storage(schema_ptr s, sstring dir = "",
+            sstables::sstable_state state = sstables::sstable_state::normal);
 
     reader_permit make_reader_permit(const schema_ptr &s, const char* n, db::timeout_clock::time_point timeout);
     reader_permit make_reader_permit(db::timeout_clock::time_point timeout = db::no_timeout);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -28,6 +28,7 @@
 #include <fmt/ranges.h>
 #include <seastar/util/defer.hh>
 #include "sstables/generation_type.hh"
+#include "sstables/storage.hh"
 
 static const sstring some_keyspace("ks");
 static const sstring some_column_family("cf");
@@ -523,6 +524,19 @@ test_env::tempdir() noexcept {
 data_dictionary::storage_options
 test_env::get_storage_options() const noexcept {
     return _impl->storage;
+}
+
+std::unique_ptr<sstables::storage>
+test_env::make_storage(schema_ptr s, sstring dir, sstables::sstable_state state) {
+    auto storage_opts = _impl->storage;
+    if (dir.empty()) {
+        dir = _impl->dir.path().native();
+    }
+    std::visit(overloaded_functor{
+        [&dir] (data_dictionary::storage_options::local& loc) { loc.dir = dir; },
+        [] (data_dictionary::storage_options::object_storage& os) { os.location = std::nullopt; },
+    }, storage_opts.value);
+    return sstables::make_storage(_impl->mgr, s, storage_opts, state);
 }
 
 reader_permit


### PR DESCRIPTION
### Problem

`cleanup_during_offstrategy_incremental_compaction_test_s3` and `cleanup_during_offstrategy_incremental_compaction_test_gcs` were disabled with `#if 0` and an early `return make_ready_future()`. The TODO blamed the `_on_delete` callback for not being synchronous, but the real obstacle was different: the test verified deletion by calling `::access()` on a local filesystem path inside the `_on_delete` callback, which is meaningless on object storage. The callback itself is fine — it runs synchronously on the reactor.

There is also a real backend asymmetry the original test was blind to. For `filesystem_storage`, `wipe()` removes the on-disk files during compaction's `delete_atomically`, so by the time `_on_delete` fires the files are gone. For `object_storage_base` (S3/GCS), `wipe()` only marks the sstable for deletion and updates its registry entry to `removing`; the actual `DELETE` requests are issued later from `_storage->destroy()`, which runs **fire-and-forget** from `sstables_manager::deactivate()` when the last `shared_sstable` reference is dropped. So `_on_delete` firing does not imply "objects gone" on object storage.

### Changes

- **`sstables: add object_name(std::string) constructor`** — extract a delegating constructor that accepts a pre-built `/bucket/…` location string. No behavior change; used by the new by-location `exists()` overload.
- **`sstables: add component_fqn() and by-location exists() to storage`** — two new virtual methods on `sstables::storage`. `component_fqn(sst, type)` returns the storage-native location of an sstable component (filesystem path or `/bucket/…/component` object name). `exists(std::string component_location)` checks existence by full location string, without needing a live `sstable`. Existing `exists(sst, type)` is retained and now delegates.
- **`test: sstable_test_env: add make_storage() helper`** — `env.make_storage(schema, dir, state)` returns a standalone `std::unique_ptr<sstables::storage>` built from the env's options, with the fields normally filled by `init_table_storage` (`object_storage.location` ← schema id) and by per-sstable factories (`local.dir` ← argument, defaulting to the env's tempdir) patched in. Independent of any sstable, so it outlives them and can be used to query on-storage state after every input sstable has been destroyed.
- **`test/boost/compaction: re-enable S3/GCS variants of the offstrategy cleanup test`** — the `_on_delete` callback now captures the component location via `scylla_storage.component_fqn(sst, component_type::Data)` (synchronous string build, safe on the reactor) instead of the local `::access()` call. Verification happens post-cleanup from the `seastar::thread` context via `scylla_storage.exists(location)`. To tolerate the fire-and-forget destroy chain on object storage, each check is polled with a bounded budget (100 × 10 ms). Both S3 and GCS variants have the early return and `#if 0` guards removed.

### Test results

Run in `dev` mode:

- `cleanup_during_offstrategy_incremental_compaction_test` (local) — 20/20 passes
- `cleanup_during_offstrategy_incremental_compaction_test_s3` — 20/20 passes
- Every commit in the series builds `combined_tests` cleanly on its own (bisectability verified)

The GCS variant is gated behind `ENABLE_GCP_STORAGE_TEST=1` and was not exercised locally; the code path is identical to S3 modulo the storage type string, so it is expected to work once the corresponding GCS test env is available.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2020

No backport needed — these test variants have never actually run.

### Test execution time
cleanup_during_offstrategy_incremental_compaction_test_s3 adds 8s
cleanup_during_offstrategy_incremental_compaction_test_gcs adds 9s
all in dev mode