### PR TITLE
test: enable sstable_cleanup_correctness_{s3,gcs}_test

### DIFF
--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2694,30 +2694,34 @@ SEASTAR_TEST_CASE(sstable_cleanup_correctness_test) {
     return do_with_cql_env([](auto& e) { return test_env::do_with_async([&e](test_env& env) { sstable_cleanup_correctness_fn(e, env); }); });
 }
 
+// Runs sstable_cleanup_correctness_fn on a cql_test_env that is configured
+// with the given object-storage backend. cql_test_env owns the sharded
+// storage_manager for the object-storage endpoints; the sstable-level test_env
+// is constructed to share that same storage_manager (rather than starting its
+// own sharded storage_manager, which would conflict on the same endpoints).
+static future<> run_sstable_cleanup_correctness_with_storage(data_dictionary::storage_options storage) {
+    auto db_cfg = make_shared<db::config>();
+    db_cfg->experimental_features({db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS});
+    db_cfg->object_storage_endpoints(make_storage_options_config(storage));
+
+    cql_test_config cql_cfg;
+    cql_cfg.db_config = db_cfg;
+
+    return do_with_cql_env_thread([storage = std::move(storage)] (cql_test_env& e) {
+        auto scf = make_sstable_compressor_factory_for_tests_in_thread();
+        test_env env(test_env_config{.storage = storage}, *scf, &e.get_sstorage_manager().local());
+        auto close_env = defer([&] { env.stop().get(); });
+        env.plug_mock_sstables_registry();
+        sstable_cleanup_correctness_fn(e, env);
+    }, std::move(cql_cfg));
+}
+
 SEASTAR_TEST_CASE(sstable_cleanup_correctness_s3_test, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
-    // TODO: When configuring object storage it is not possible to use cql_env and test_env together since they both initiate storage, which causes conflicts.
-    // Needs deeper investigation to figure out how to properly configure storage for both environments.
-    testlog.info("sstable_cleanup_correctness_s3_test is not supported for S3 storage yet, skipping test");
-    return make_ready_future();
-#if 0
-    return do_with_cql_env([](auto& e) {
-        return test_env::do_with_async([&e](test_env& env) { sstable_cleanup_correctness_fn(e, env); },
-                                       test_env_config{.storage = make_test_object_storage_options("S3")});
-    });
-#endif
+    return run_sstable_cleanup_correctness_with_storage(make_test_object_storage_options("S3"));
 }
 
 SEASTAR_FIXTURE_TEST_CASE(sstable_cleanup_correctness_gcs_test, gcs_fixture, *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
-    // TODO: When configuring object storage it is not possible to use cql_env and test_env together since they both initiate storage, which causes conflicts.
-    // Needs deeper investigation to figure out how to properly configure storage for both environments.
-    testlog.info("sstable_cleanup_correctness_gcs_test is not supported for GCS storage yet, skipping test");
-    return make_ready_future();
-#if 0
-    return do_with_cql_env([](auto& e) {
-        return test_env::do_with_async([&e](test_env& env) { sstable_cleanup_correctness_fn(e, env); },
-                                       test_env_config{.storage = make_test_object_storage_options("GS")});
-    });
-#endif
+    return run_sstable_cleanup_correctness_with_storage(make_test_object_storage_options("GS"));
 }
 
 future<> foreach_compaction_group_view_with_thread(table_for_tests& table, std::function<void(compaction::compaction_group_view&)> action) {

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -112,6 +112,14 @@ public:
 
     void maybe_start_compaction_manager(bool enable = true);
 
+    // Plug a mock sstables_registry into the underlying sstables_manager.
+    // Required when running against object storage: sstable creation asserts
+    // that a registry is plugged. do_with_async() does this automatically for
+    // the non-local storage path; callers that construct test_env manually
+    // (e.g. to share a storage_manager with cql_test_env) must call this
+    // themselves after construction.
+    void plug_mock_sstables_registry();
+
     explicit test_env(test_env_config cfg, sstable_compressor_factory&, sstables::storage_manager* sstm = nullptr, tmpdir* tmp = nullptr);
     ~test_env();
     test_env(test_env&&) noexcept;

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -377,7 +377,7 @@ future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, te
             auto scf = make_sstable_compressor_factory_for_tests_in_thread();
             test_env env(std::move(cfg), *scf, &sstm.local());
             auto close_env = defer([&] { env.stop().get(); });
-            env.manager().plug_sstables_registry(std::make_unique<mock_sstables_registry>());
+            env.plug_mock_sstables_registry();
             func(env);
         });
     }
@@ -388,6 +388,10 @@ future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, te
         auto close_env = defer([&] { env.stop().get(); });
         func(env);
     });
+}
+
+void test_env::plug_mock_sstables_registry() {
+    _impl->mgr.plug_sstables_registry(std::make_unique<mock_sstables_registry>());
 }
 
 sstables::generation_type


### PR DESCRIPTION
### Problem

`sstable_cleanup_correctness_s3_test` and `sstable_cleanup_correctness_gcs_test` were stubbed out with a `testlog.info(... "skipping test")` and a `#if 0` block. The TODO in the code explained: nesting `test_env::do_with_async` inside `do_with_cql_env` starts a second sharded `sstables::storage_manager` for the same object-storage endpoints, which conflicts with the one already owned by `cql_test_env`. As a result these two tests never ran.

### Changes

The fix mirrors the pattern already in `test/boost/tablet_aware_restore_test.cc`: configure the object-storage endpoints on the `cql_test_env`'s `db::config` (with the `KEYSPACE_STORAGE_OPTIONS` experimental feature enabled) and construct `test_env` manually, passing it a pointer to the storage_manager that `cql_test_env` already owns (`env.get_sstorage_manager().local()`), instead of letting `test_env::do_with_async` start a second one.

The mock `sstables_registry` that object-storage sstables require was previously plugged inline inside `test_env::do_with_async`. This series exposes it as a public helper `test_env::plug_mock_sstables_registry()` so callers that build `test_env` manually can plug it too — the underlying `mock_sstables_registry` class is file-local in `test/lib/test_services.cc` and cannot be constructed from outside.

Split into two commits:
1. `test/lib: add test_env::plug_mock_sstables_registry() helper` — pure refactoring, `do_with_async()` now uses the helper.
2. `test: enable sstable_cleanup_correctness_{s3,gcs}_test` — replaces the two skipped stubs with a shared `run_sstable_cleanup_correctness_with_storage(storage)` helper.

### Verification

- `sstable_cleanup_correctness_s3_test`: 1000/1000 passes with `--repeat 1000 --max-failures 1` (`./test.py --mode=dev`).
- `sstable_cleanup_correctness_test` (local, unchanged): still passes.


Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2022

No backport needed — these tests never ran before, so there is nothing to backport.