### PR TITLE
Implement time leases for raft

### DIFF
--- a/idl/raft.idl.hh
+++ b/idl/raft.idl.hh
@@ -54,6 +54,11 @@ struct append_reply {
     raft::term_t current_term;
     raft::index_t commit_idx;
     std::variant<raft::append_reply::rejected, raft::append_reply::accepted> result;
+    // Trailing optional field: a peer that predates it simply omits it, and we
+    // decode false, which is the conservative value (it only ever suppresses a
+    // leadership transfer). A plain bool with a default rather than an optional:
+    // "not sent" and "clock unhealthy" mean the same thing to every consumer.
+    bool clock_ok [[version 2026.3]] = false;
 };
 
 struct append_request {

--- a/idl/raft_storage.idl.hh
+++ b/idl/raft_storage.idl.hh
@@ -41,12 +41,18 @@ struct configuration {
     std::unordered_set<raft::config_member, raft::config_member_hash, std::equal_to<void>> previous;
 };
 
+struct time_bounds {
+    raft::lease_clock::time_point earliest;
+    raft::lease_clock::time_point latest;
+};
+
 struct log_entry {
     struct dummy {};
 
     raft::term_t term;
     raft::index_t idx;
     std::variant<bytes_ostream, raft::configuration, raft::log_entry::dummy> data;
+    std::optional<raft::time_bounds> lease_time [[version 2026.3]];
 };
 
 }

--- a/raft/bounded_clock.hh
+++ b/raft/bounded_clock.hh
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <ratio>
+#include <type_traits>
+
+namespace raft {
+
+// The clock LeaseGuard time intervals are expressed in.
+//
+// This is a distinct clock type rather than std::chrono::system_clock because
+// these time points are persisted in the raft log and shipped between nodes,
+// and system_clock's period is implementation-defined (nanoseconds on
+// libstdc++, microseconds on libc++). The generic serializer writes a
+// time_point as the raw count of its duration with no unit tag, so a raw
+// system_clock::time_point would encode differently depending on the standard
+// library it was built against -- and a reader that decoded a nanosecond count
+// as microseconds would see a lease 1000x younger than it is and serve a stale
+// local read. Pinning rep and period here makes the wire format a property of
+// the type instead of the toolchain.
+//
+// Nanoseconds is exact for every clock source we have (ClockBound reports a
+// timespec, adjtimex reports microseconds), so no source has to decide which
+// way to round; int64 nanoseconds spans +/-292 years around the epoch.
+class lease_clock final {
+public:
+    using base = std::chrono::system_clock;
+    using rep = int64_t;
+    using period = std::nano;
+    using duration = std::chrono::duration<rep, period>;
+    using time_point = std::chrono::time_point<lease_clock, duration>;
+
+    static constexpr bool is_steady = base::is_steady;
+
+    static time_point now() noexcept {
+        return time_point(std::chrono::duration_cast<duration>(base::now().time_since_epoch()));
+    }
+};
+
+// The wire format of a lease interval. Changing either of these changes how
+// every persisted log entry's lease_time is interpreted, so they are pinned
+// here rather than left to the standard library. Note that a serialization
+// round-trip test cannot catch a regression in this: both ends of a round trip
+// share a standard library, which is exactly the assumption being removed.
+static_assert(std::is_same_v<lease_clock::period, std::nano>,
+        "raft::lease_clock::period is the on-disk unit of log_entry::lease_time");
+static_assert(sizeof(lease_clock::rep) == 8,
+        "raft::lease_clock::rep is the on-disk width of log_entry::lease_time");
+
+// A reading of a bounded-uncertainty (physical) clock.
+//
+// A call to bounded_clock::interval_now() returns [earliest, latest] such that
+// the true time was somewhere in this interval for at least a moment between
+// the call's invocation and completion. This is the primitive used by
+// LeaseGuard (see raft/README.md) to decide whether a time recorded on another
+// node is now "more than delta old" or "less than delta old", without relying
+// on synchronized wall-clock reads.
+//
+// Unlike raft::logical_clock (which counts ticks for election/heartbeat
+// timeouts), this clock carries real time with an explicit uncertainty window.
+struct time_bounds {
+    using clock = lease_clock;
+    clock::time_point earliest;
+    clock::time_point latest;
+
+    using duration = clock::duration;
+
+    // True if this interval is *definitely* more than `delta` old relative to
+    // the current-time reading `now`, i.e. even in the most pessimistic case
+    // (our recorded upper bound vs. the current lower bound) at least `delta`
+    // has elapsed. This is the conservative test a new leader uses to decide a
+    // deposed leader's lease has expired before committing.
+    bool older_than(duration delta, const time_bounds& now) const {
+        return latest + delta < now.earliest;
+    }
+
+    // True if this interval is *definitely* less than `delta` old relative to
+    // the current-time reading `now`, i.e. even in the most pessimistic case
+    // (our recorded lower bound vs. the current upper bound) less than `delta`
+    // has elapsed. This is the conservative test a leaseholder uses to decide
+    // its lease is still valid before serving a local read.
+    bool younger_than(duration delta, const time_bounds& now) const {
+        return earliest + delta > now.latest;
+    }
+};
+
+// Abstract source of bounded-uncertainty time readings.
+//
+// interval_now() returns std::nullopt when the clock cannot provide trustworthy
+// bounds (e.g. the local clock is not synchronized). Callers must treat nullopt
+// as "no lease information available" and fall back to the safe path (quorum
+// reads / no lease), never as a zero-width interval.
+//
+// This library only defines the abstraction and a test backend; concrete
+// backends that read a real clock (e.g. service::bounded_clock_adjtimex, which
+// reads the Linux kernel's NTP error bounds) live outside the raft library so
+// that raft itself stays platform-independent.
+class bounded_clock {
+public:
+    virtual ~bounded_clock() = default;
+    virtual std::optional<time_bounds> interval_now() = 0;
+};
+
+// Test backend with an explicit, injectable reading. Lets fsm unit tests drive
+// deterministic time and clock skew without touching the real clock.
+class bounded_clock_mock final : public bounded_clock {
+    std::optional<time_bounds> _now;
+public:
+    bounded_clock_mock() = default;
+    explicit bounded_clock_mock(time_bounds now) : _now(now) {}
+
+    // Set the interval returned by the next interval_now() calls.
+    void set(time_bounds now) {
+        _now = now;
+    }
+
+    // Set a symmetric interval [center - error, center + error].
+    void set(time_bounds::clock::time_point center, time_bounds::duration error) {
+        _now = time_bounds{center - error, center + error};
+    }
+
+    // Make the clock report as unsynchronized (interval_now() returns nullopt).
+    void set_unsynchronized() {
+        _now = std::nullopt;
+    }
+
+    std::optional<time_bounds> interval_now() override {
+        return _now;
+    }
+};
+
+} // end of namespace raft

--- a/raft/bounded_clock.hh
+++ b/raft/bounded_clock.hh
@@ -56,6 +56,28 @@ static_assert(std::is_same_v<lease_clock::period, std::nano>,
 static_assert(sizeof(lease_clock::rep) == 8,
         "raft::lease_clock::rep is the on-disk width of log_entry::lease_time");
 
+// An elapsed-physical-time source, used by LeaseGuard's deferred commit to bound
+// how long it has been leader without needing to know what time it is.
+//
+// Only DIFFERENCES between readings taken by one node are meaningful: the epoch
+// is arbitrary and is not comparable across nodes, restarts, or even instances.
+// Nothing here is ever persisted or put on the wire, so unlike lease_clock the
+// rep/period are an internal detail rather than a format commitment.
+//
+// This is deliberately a separate concept from lease_clock rather than a second
+// use of it: lease_clock answers "what time is it", which requires a
+// synchronized clock and can therefore be unavailable, while this answers "how
+// much time has passed", which never is.
+class mono_clock final {
+public:
+    using rep = int64_t;
+    using period = std::nano;
+    using duration = std::chrono::duration<rep, period>;
+    using time_point = std::chrono::time_point<mono_clock, duration>;
+
+    static constexpr bool is_steady = true;
+};
+
 // A reading of a bounded-uncertainty (physical) clock.
 //
 // A call to bounded_clock::interval_now() returns [earliest, latest] such that
@@ -108,12 +130,35 @@ class bounded_clock {
 public:
     virtual ~bounded_clock() = default;
     virtual std::optional<time_bounds> interval_now() = 0;
+
+    // Elapsed physical time (see mono_clock). Unlike interval_now() this cannot
+    // fail: it measures a duration rather than an absolute position, so it does
+    // not depend on the clock being synchronized. This is what lets a leader
+    // whose wall clock is unusable still bound how long ago it was elected, and
+    // so discharge LeaseGuard's deferred commit instead of stalling.
+    //
+    // Backends MUST implement this with a clock source whose *rate* is not
+    // disciplined by NTP -- CLOCK_MONOTONIC_RAW, not CLOCK_MONOTONIC. The
+    // difference matters: CLOCK_MONOTONIC is immune to clock steps but not to
+    // slewing, and a daemon correcting a large offset may legitimately run it
+    // several percent fast (chrony's default maxslewrate is 8.33%). That is the
+    // exact situation this function is used in -- a clock that was unsynchronized
+    // and is now being corrected -- so the safety margin its caller applies must
+    // not have to cover it.
+    //
+    // Deliberately pure virtual with no default implementation: a default reading
+    // a real clock would silently leak real time into simulated-time tests.
+    virtual mono_clock::time_point monotonic_now() = 0;
 };
 
 // Test backend with an explicit, injectable reading. Lets fsm unit tests drive
 // deterministic time and clock skew without touching the real clock.
 class bounded_clock_mock final : public bounded_clock {
     std::optional<time_bounds> _now;
+    // Elapsed-time reading. Independent of _now on purpose: a node whose clock
+    // is unsynchronized still has a working monotonic clock, and tests need to
+    // model that.
+    mono_clock::time_point _mono_now{};
 public:
     bounded_clock_mock() = default;
     explicit bounded_clock_mock(time_bounds now) : _now(now) {}
@@ -133,8 +178,24 @@ public:
         _now = std::nullopt;
     }
 
+    // Set the elapsed-time reading. Note set_unsynchronized() deliberately does
+    // NOT reset this: losing clock synchronization does not stop the monotonic
+    // clock, and a test that modelled it that way would not be testing anything
+    // real.
+    void set_monotonic(mono_clock::time_point now) {
+        _mono_now = now;
+    }
+
+    void advance_monotonic(mono_clock::duration d) {
+        _mono_now += d;
+    }
+
     std::optional<time_bounds> interval_now() override {
         return _now;
+    }
+
+    mono_clock::time_point monotonic_now() override {
+        return _mono_now;
     }
 };
 

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -143,7 +143,11 @@ const log_entry& fsm::add_entry(T command) {
     utils::get_local_injector().inject("fsm::add_entry/test-failure",
                                        [] { throw std::runtime_error("fsm::add_entry/test-failure"); });
 
-    _log.emplace_back(seastar::make_lw_shared<log_entry>({_current_term, _log.next_idx(), std::move(command)}));
+    // LeaseGuard: stamp the entry with the leader's current time interval so
+    // that future leaders can reason about this lease's age. Empty when leases
+    // are disabled or the clock is unsynchronized.
+    _log.emplace_back(seastar::make_lw_shared<log_entry>(
+            {_current_term, _log.next_idx(), std::move(command), lease_time_now()}));
     _sm_events.signal();
 
     if constexpr (std::is_same_v<T, configuration>) {
@@ -521,7 +525,12 @@ void fsm::maybe_commit() {
             configuration cfg(_log.get_configuration());
             cfg.leave_joint();
             logger.trace("[{}] appending non-joint config entry at {}: {}", _tag, _log.next_idx(), cfg);
-            _log.emplace_back(seastar::make_lw_shared<log_entry>({_current_term, _log.next_idx(), std::move(cfg)}));
+            // LeaseGuard: stamp it like any other entry we create (add_entry()
+            // does the same). An unstamped entry would silently drop our lease
+            // once it becomes the newest committed entry, and would force the
+            // next leader onto the conservative full-delta wait.
+            _log.emplace_back(seastar::make_lw_shared<log_entry>(
+                    {_current_term, _log.next_idx(), std::move(cfg), lease_time_now()}));
             leader_state().tracker.set_configuration(_log.get_configuration(), _log.last_idx());
             // Leaving joint configuration may commit more entries
             // even if we had no new acks. Imagine the cluster is

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -221,6 +221,19 @@ void fsm::become_leader() {
 
     _last_election_time = _clock.now();
     _ping_leader = false;
+
+    // LeaseGuard: at election time every existing log entry predates this
+    // leader's term, so the newest of them is the deposed leader's lease. Record
+    // its index (before we append our own dummy entry below) and the current
+    // time, so we can defer committing until that lease is more than delta old.
+    if (leaseguard_enabled()) {
+        leader_state().last_prev_term_idx = _log.last_idx();
+        leader_state().lease_wait_start = lease_time_now();
+        // No prior-term entry means no deposed lease to wait for, so the
+        // deferred-commit restriction does not apply for this leadership term.
+        leader_state().lease_wait_done = leader_state().last_prev_term_idx == index_t{0};
+    }
+
     // a new leader needs to commit at least one entry to make sure that
     // all existing entries in its log are committed as well. Also it should
     // send append entries RPC as soon as possible to establish its leadership
@@ -508,6 +521,23 @@ void fsm::maybe_commit() {
             _tag, _log[new_commit_idx.value()]->term, _current_term);
         return;
     }
+
+    // LeaseGuard deferred commit: committing this current-term entry would
+    // indirectly commit all prior-term entries, including the deposed leader's
+    // lease. Do not advance the commit index until that lease is more than delta
+    // old, so the deposed leader can no longer serve linearizable reads from
+    // stale data. The writes stay replicated and durable meanwhile; a later
+    // tick retries this commit once the lease expires.
+    if (leaseguard_enabled() && !leader_state().lease_wait_done) {
+        if (prev_term_lease_expired()) {
+            leader_state().lease_wait_done = true;
+        } else {
+            logger.trace("maybe_commit[{}]: deferring commit to {}, deposed leader's lease "
+                "not yet expired", _tag, new_commit_idx);
+            return;
+        }
+    }
+
     logger.trace("maybe_commit[{}]: commit {}", _tag, new_commit_idx);
 
     _commit_idx = new_commit_idx;
@@ -575,6 +605,38 @@ void fsm::maybe_commit() {
             broadcast_read_quorum(leader_state().last_read_id);
         }
     }
+}
+
+bool fsm::prev_term_lease_expired() {
+    const auto now = _config.leaseguard->clock.interval_now();
+    if (!now) {
+        // The clock is unsynchronized: we cannot bound any time, so we cannot
+        // prove the deposed leader's lease has expired. Defer conservatively;
+        // tick_leader() steps down if this persists.
+        return false;
+    }
+    const auto delta = _config.leaseguard->delta;
+    auto& state = leader_state();
+    // Record the first available clock reading since becoming leader. Every
+    // prior-term entry was created before the election, so this is a safe upper
+    // bound on their age when the deposed leader's own entry is unavailable.
+    if (!state.lease_wait_start) {
+        state.lease_wait_start = now;
+    }
+    // Prefer the deposed leader's own recorded interval when its entry is still
+    // present in the in-memory log (above the snapshot); this lets us commit as
+    // soon as that specific entry is more than delta old.
+    const auto prev_idx = state.last_prev_term_idx;
+    if (prev_idx > _log.get_snapshot().idx) {
+        const auto& lease_entry = *_log[prev_idx.value()];
+        if (lease_entry.lease_time) {
+            return lease_entry.lease_time->older_than(delta, *now);
+        }
+    }
+    // The deposed leader's entry is folded into a snapshot, the log was empty at
+    // election, or the entry carries no interval of its own. Fall back to
+    // waiting a full delta since we became leader.
+    return state.lease_wait_start->older_than(delta, *now);
 }
 
 void fsm::tick_leader() {
@@ -648,6 +710,29 @@ void fsm::tick_leader() {
             logger.trace("tick[{}]: resend timeout_now", _tag);
             // resend timeout now in case it was lost
             send_to(*state.timeout_now_sent, timeout_now{_current_term});
+        }
+    }
+
+    // LeaseGuard: while a deposed leader's lease may still be valid we defer
+    // committing. Retry now that physical time has advanced; once the lease has
+    // expired this commits the pending, already-replicated entries without
+    // needing any new messages from followers. If the clock stays unavailable we
+    // cannot bound the lease, so step down to let a node with a healthy clock
+    // take over instead of stalling here indefinitely.
+    if (leaseguard_enabled() && !leader_state().lease_wait_done) {
+        auto& state = leader_state();
+        if (_config.leaseguard->clock.interval_now()) {
+            state.clock_unavailable_since.reset();
+            maybe_commit();
+        } else if (!state.clock_unavailable_since) {
+            state.clock_unavailable_since = _clock.now();
+            logger.warn("[{}]: LeaseGuard clock is unsynchronized while a commit is deferred; "
+                "commits are stalled and this leader will step down if it persists", _tag);
+        } else if (_clock.now() - *state.clock_unavailable_since >= ELECTION_TIMEOUT) {
+            logger.error("[{}]: LeaseGuard clock has been unsynchronized for over an election "
+                "timeout; stepping down so a node with a healthy clock can lead", _tag);
+            become_follower(server_id{});
+            return;
         }
     }
 }

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -229,6 +229,10 @@ void fsm::become_leader() {
     if (leaseguard_enabled()) {
         leader_state().last_prev_term_idx = _log.last_idx();
         leader_state().lease_wait_start = lease_time_now();
+        // Anchor the elapsed-time fallback. Taken here, after the election has
+        // completed, so it is a conservative lower bound on how long ago every
+        // prior-term entry was created.
+        leader_state().lease_wait_mono_start = _config.leaseguard->clock.monotonic_now();
         // No prior-term entry means no deposed lease to wait for, so the
         // deferred-commit restriction does not apply for this leadership term.
         leader_state().lease_wait_done = leader_state().last_prev_term_idx == index_t{0};
@@ -607,16 +611,44 @@ void fsm::maybe_commit() {
     }
 }
 
+// Safety margin on the elapsed-time deferred-commit wait below, as a divisor of
+// delta: we wait delta + delta/8 (12.5%) of monotonic time instead of delta.
+//
+// It covers the rate error of the monotonic clock, which bounded_clock requires
+// to be an NTP-undisciplined source (CLOCK_MONOTONIC_RAW): raw oscillator plus
+// boot calibration, on the order of 100-200ppm. 12.5% is therefore ~100x
+// headroom. It is only ever paid when the wall clock is unusable, so there is no
+// reason to trim it closer.
+static constexpr int mono_wait_margin_div = 8;
+
 bool fsm::prev_term_lease_expired() {
-    const auto now = _config.leaseguard->clock.interval_now();
-    if (!now) {
-        // The clock is unsynchronized: we cannot bound any time, so we cannot
-        // prove the deposed leader's lease has expired. Defer conservatively;
-        // tick_leader() steps down if this persists.
-        return false;
-    }
     const auto delta = _config.leaseguard->delta;
     auto& state = leader_state();
+
+    // Elapsed-time path. Every prior-term entry was created before our election
+    // (a deposed leader cannot commit or renew afterwards: that needs a quorum,
+    // and the quorum that elected us is in a higher term), and the deposed leader
+    // measures its own lease against its own bounded clock, so it stops serving
+    // by delta after that entry was created. Waiting delta of physical time since
+    // the election is therefore sufficient.
+    //
+    // Crucially this needs no synchronized clock, only elapsed time, so it always
+    // eventually fires. That is what keeps a leader with an unusable clock making
+    // progress -- without it such a leader can commit nothing, and since its
+    // commit index then stays on a prior-term entry, start_read_barrier() fails
+    // its current-term check too and the group serves neither reads nor writes.
+    if (_config.leaseguard->clock.monotonic_now() - state.lease_wait_mono_start
+            >= delta + delta / mono_wait_margin_div) {
+        return true;
+    }
+
+    const auto now = _config.leaseguard->clock.interval_now();
+    if (!now) {
+        // The clock is unsynchronized, so we cannot bound absolute time and the
+        // sharper tests below are unavailable. Defer; the elapsed-time path above
+        // will discharge this shortly after delta has passed since the election.
+        return false;
+    }
     // Record the first available clock reading since becoming leader. Every
     // prior-term entry was created before the election, so this is a safe upper
     // bound on their age when the deposed leader's own entry is unavailable.
@@ -733,28 +765,27 @@ void fsm::tick_leader() {
     // LeaseGuard: while a deposed leader's lease may still be valid we defer
     // committing. Retry now that physical time has advanced; once the lease has
     // expired this commits the pending, already-replicated entries without
-    // needing any new messages from followers. If the clock stays unavailable we
-    // cannot bound the lease, so step down to let a node with a healthy clock
-    // take over instead of stalling here indefinitely.
+    // needing any new messages from followers.
+    //
+    // An unsynchronized clock delays this but does not block it: the
+    // elapsed-time path in prev_term_lease_expired() discharges the wait a little
+    // over delta after the election. We do not step down for a clock failure --
+    // it would not avoid the delta wait, only move it onto the successor (which
+    // inherits our unstamped entries and must then wait a full delta from its own
+    // election), on top of an election timeout and an election.
     if (leaseguard_enabled() && !leader_state().lease_wait_done) {
         auto& state = leader_state();
-        if (_config.leaseguard->clock.interval_now()) {
-            state.clock_unavailable_since.reset();
-            maybe_commit();
-            // maybe_commit() may have stepped us down (committing a C_new that
-            // removes this node calls transfer_leadership()), destroying the
-            // leader state `state` refers to. Nothing below may run then.
-            if (!is_leader()) {
-                return;
-            }
-        } else if (!state.clock_unavailable_since) {
-            state.clock_unavailable_since = _clock.now();
-            logger.warn("[{}]: LeaseGuard clock is unsynchronized while a commit is deferred; "
-                "commits are stalled and this leader will step down if it persists", _tag);
-        } else if (_clock.now() - *state.clock_unavailable_since >= ELECTION_TIMEOUT) {
-            logger.error("[{}]: LeaseGuard clock has been unsynchronized for over an election "
-                "timeout; stepping down so a node with a healthy clock can lead", _tag);
-            become_follower(server_id{});
+        if (!_config.leaseguard->clock.interval_now() && !state.clock_unavailable_warned) {
+            state.clock_unavailable_warned = true;
+            logger.warn("[{}]: LeaseGuard clock is unsynchronized while a commit is deferred. "
+                "Commits proceed once delta has elapsed since this node was elected, and reads "
+                "fall back to quorum barriers until the clock recovers.", _tag);
+        }
+        maybe_commit();
+        // maybe_commit() may have stepped us down (committing a C_new that
+        // removes this node calls transfer_leadership()), destroying the leader
+        // state `state` refers to. Nothing below may run then.
+        if (!is_leader()) {
             return;
         }
     }

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -233,6 +233,12 @@ void fsm::become_leader() {
         // completed, so it is a conservative lower bound on how long ago every
         // prior-term entry was created.
         leader_state().lease_wait_mono_start = _config.leaseguard->clock.monotonic_now();
+        // Spread clock-loss leadership transfers across groups; see
+        // clock_stepdown_jitter.
+        static thread_local std::default_random_engine re{std::random_device{}()};
+        leader_state().clock_stepdown_jitter = mono_clock::duration{
+                std::uniform_int_distribution<mono_clock::rep>{
+                        0, _config.leaseguard->delta.count()}(re)};
         // No prior-term entry means no deposed lease to wait for, so the
         // deferred-commit restriction does not apply for this leadership term.
         leader_state().lease_wait_done = leader_state().last_prev_term_idx == index_t{0};
@@ -381,7 +387,7 @@ void fsm::send_ping_messages() {
         for (auto s : cfg.current) {
             if (s.can_vote && s.addr.id != _my_id && _failure_detector.is_alive(s.addr.id)) {
                 logger.trace("[{}]: searching for a leader. Pinging {}", _tag, s.addr.id);
-                send_to(s.addr.id, append_reply{_current_term, _commit_idx, append_reply::rejected{index_t{0}, index_t{0}}});
+                send_to(s.addr.id, append_reply{_current_term, _commit_idx, append_reply::rejected{index_t{0}, index_t{0}}, _clock_ok});
             }
         }
     }
@@ -688,6 +694,57 @@ bool fsm::can_serve_lease_read() {
     return entry.lease_time && entry.lease_time->younger_than(_config.leaseguard->delta, *now);
 }
 
+// How long our clock must stay unusable before we hand leadership away, as a
+// multiple of delta (a per-group jitter is added on top). Long enough that a
+// brief unsync -- a chrony restart, a resync -- does not move leadership, since
+// the transfer is not free: the successor inherits our unstamped entries and
+// must itself wait out a delta before it can commit. Short enough that a real
+// outage is not paid for indefinitely.
+static constexpr int clock_stepdown_delta_multiple = 2;
+
+void fsm::maybe_transfer_leadership_on_clock_loss() {
+    auto& state = leader_state();
+
+    if (_clock_ok) {
+        // Usable again: cancel any wait in progress. A clock that flaps in and
+        // out therefore never accumulates enough time to move leadership, which
+        // is what we want -- each transfer costs the group a delta.
+        state.clock_unusable_since.reset();
+        return;
+    }
+
+    const auto now = _config.leaseguard->clock.monotonic_now();
+    if (!state.clock_unusable_since) {
+        state.clock_unusable_since = now;
+        return;
+    }
+    const auto wait = _config.leaseguard->delta * clock_stepdown_delta_multiple
+            + state.clock_stepdown_jitter;
+    if (now - *state.clock_unusable_since < wait) {
+        return;
+    }
+
+    // Only worth moving if the target can actually do what we cannot. Checking
+    // first also guarantees transfer_leadership() finds a candidate, so it
+    // cannot throw no_other_voting_member (which needs a lone voter, and we have
+    // just found another one).
+    const bool have_target = std::ranges::any_of(state.tracker, [this](const auto& e) {
+        const auto& p = e.second;
+        return p.id != _my_id && p.can_vote && p.clock_ok && p.match_idx == _log.last_idx();
+    });
+    if (!have_target) {
+        return;
+    }
+
+    logger.info("[{}]: LeaseGuard clock has been unusable for too long; transferring leadership "
+        "to a replica whose clock works, so the group can serve local reads again", _tag);
+    // Re-arm before initiating: if the transfer does not complete, the stepdown
+    // times out and we stay leader, and we should then back off a full window
+    // rather than retry on the next tick.
+    state.clock_unusable_since = now;
+    transfer_leadership(ELECTION_TIMEOUT);
+}
+
 void fsm::tick_leader() {
     if (election_elapsed() >= ELECTION_TIMEOUT) {
         // 6.2 Routing requests to the leader
@@ -769,13 +826,11 @@ void fsm::tick_leader() {
     //
     // An unsynchronized clock delays this but does not block it: the
     // elapsed-time path in prev_term_lease_expired() discharges the wait a little
-    // over delta after the election. We do not step down for a clock failure --
-    // it would not avoid the delta wait, only move it onto the successor (which
-    // inherits our unstamped entries and must then wait a full delta from its own
-    // election), on top of an election timeout and an election.
+    // over delta after the election. So a clock failure is never a reason to give
+    // up leadership for liveness -- we make progress either way.
     if (leaseguard_enabled() && !leader_state().lease_wait_done) {
         auto& state = leader_state();
-        if (!_config.leaseguard->clock.interval_now() && !state.clock_unavailable_warned) {
+        if (!_clock_ok && !state.clock_unavailable_warned) {
             state.clock_unavailable_warned = true;
             logger.warn("[{}]: LeaseGuard clock is unsynchronized while a commit is deferred. "
                 "Commits proceed once delta has elapsed since this node was elected, and reads "
@@ -785,6 +840,19 @@ void fsm::tick_leader() {
         // maybe_commit() may have stepped us down (committing a C_new that
         // removes this node calls transfer_leadership()), destroying the leader
         // state `state` refers to. Nothing below may run then.
+        if (!is_leader()) {
+            return;
+        }
+    }
+
+    // LeaseGuard: what a clock failure does cost is the leases themselves. With
+    // no clock we serve no local reads, stamp no entries and renew nothing, so
+    // the group silently pays a quorum round-trip on every read for as long as
+    // the outage lasts, and nothing but the clock returning fixes it. If a
+    // replica's clock still works, give it the leadership. Before the renewal
+    // block below, which correctly refuses to append once stepdown is set.
+    if (leaseguard_enabled() && !leader_state().stepdown) {
+        maybe_transfer_leadership_on_clock_loss();
         if (!is_leader()) {
             return;
         }
@@ -853,6 +921,12 @@ void fsm::tick_leader() {
 void fsm::tick() {
     _clock.advance();
 
+    // Refresh the clock-health bit we report to the leader. Here rather than in
+    // the reply path so that append_entries costs no clock read; see _clock_ok.
+    if (leaseguard_enabled()) {
+        _clock_ok = _config.leaseguard->clock.interval_now().has_value();
+    }
+
     auto has_stable_leader = [this]() {
         // A leader that is not voting member of a current configuration
         // has likely have stepped down.  Since the failure
@@ -900,7 +974,7 @@ void fsm::append_entries(server_id from, append_request&& request) {
                 _tag, request.prev_log_idx, request.prev_log_term, term);
         // Reply false if log doesn't contain an entry at
         // prevLogIndex whose term matches prevLogTerm (§5.3).
-        send_to(from, append_reply{_current_term, _commit_idx, append_reply::rejected{request.prev_log_idx, _log.last_idx()}});
+        send_to(from, append_reply{_current_term, _commit_idx, append_reply::rejected{request.prev_log_idx, _log.last_idx()}, _clock_ok});
         return;
     }
 
@@ -917,7 +991,7 @@ void fsm::append_entries(server_id from, append_request&& request) {
     // mark outdated entries as committed (see #9965).
     advance_commit_idx(std::min(request.leader_commit_idx, last_new_idx));
 
-    send_to(from, append_reply{_current_term, _commit_idx, append_reply::accepted{last_new_idx}});
+    send_to(from, append_reply{_current_term, _commit_idx, append_reply::accepted{last_new_idx}, _clock_ok});
 }
 
 void fsm::append_entries_reply(server_id from, append_reply&& reply) {
@@ -930,6 +1004,12 @@ void fsm::append_entries_reply(server_id from, append_reply&& reply) {
         return;
     }
     follower_progress& progress = *opt_progress;
+
+    // Track whether this replica could hold a lease, so that if our own clock
+    // fails we know whether handing leadership over would restore lease reads.
+    // Recorded for rejected replies too: a follower that is behind may well
+    // catch up, and its clock health is unrelated to log matching.
+    progress.clock_ok = reply.clock_ok;
 
     if (progress.state == follower_progress::state::PIPELINE) {
         if (progress.in_flight) {
@@ -1289,11 +1369,20 @@ void fsm::transfer_leadership(logical_clock::duration timeout) {
     leader_state().stepdown = _clock.now() + timeout;
     // Stop new requests from coming in
     leader_state().log_limiter_semaphore->consume(_config.max_log_size);
-    // If there is a fully up-to-date voting replica make it start an election
-    for (auto&& [_, p] : leader_state().tracker) {
-        if (p.id != _my_id && p.can_vote && p.match_idx == _log.last_idx()) {
-            send_timeout_now(p.id);
-            break;
+    // If there is a fully up-to-date voting replica make it start an election.
+    //
+    // Prefer one whose clock still works: the reason we transfer automatically
+    // is that ours does not, and moving to another clockless node would not
+    // restore lease reads. The second pass keeps the original behaviour for an
+    // operator-requested transfer, which has no opinion about clocks (and for
+    // which every peer reports clock_ok == false when leases are disabled).
+    for (const bool require_clock_ok : {true, false}) {
+        for (auto&& [_, p] : leader_state().tracker) {
+            if (p.id != _my_id && p.can_vote && p.match_idx == _log.last_idx()
+                    && (!require_clock_ok || p.clock_ok)) {
+                send_timeout_now(p.id);
+                return;
+            }
         }
     }
 }

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -741,6 +741,12 @@ void fsm::tick_leader() {
         if (_config.leaseguard->clock.interval_now()) {
             state.clock_unavailable_since.reset();
             maybe_commit();
+            // maybe_commit() may have stepped us down (committing a C_new that
+            // removes this node calls transfer_leadership()), destroying the
+            // leader state `state` refers to. Nothing below may run then.
+            if (!is_leader()) {
+                return;
+            }
         } else if (!state.clock_unavailable_since) {
             state.clock_unavailable_since = _clock.now();
             logger.warn("[{}]: LeaseGuard clock is unsynchronized while a commit is deferred; "
@@ -750,6 +756,65 @@ void fsm::tick_leader() {
                 "timeout; stepping down so a node with a healthy clock can lead", _tag);
             become_follower(server_id{});
             return;
+        }
+    }
+
+    // LeaseGuard automatic lease extension (arXiv:2512.15659 "Raft Leases Done
+    // Right", Section 5.1). A lease is only refreshed by committing entries, so
+    // under a read-only workload the newest committed entry would age past delta
+    // and every read would fall back to a quorum barrier. While reads are
+    // flowing, proactively commit a no-op that keeps can_serve_lease_read() true.
+    // The no-op is an ordinary lease-stamped entry, so safety is unchanged (a
+    // future leader defers commit for it like any other prior-term entry) and the
+    // "log is the lease" gray-failure protection is preserved: a leader that
+    // cannot replicate cannot renew.
+    //
+    // Renewal both EXTENDS a lease that is about to expire and RE-ESTABLISHES one
+    // that has already lapsed (Section 5.1: the leader writes a no-op "whenever
+    // needed to serve a read"). Re-establishing matters because a leader can end
+    // up leaseless with no write traffic to fix it: right after a failover (the
+    // dummy entry is stamped at election time but only commits once the deposed
+    // lease expires), after a snapshot moves the commit index, after a clock
+    // outage spanning delta, or when the newest committed entry carries no
+    // interval at all. Without this, a read-only workload would fall back to a
+    // quorum barrier for every read, permanently.
+    //
+    // Renewal is still gated to avoid destabilizing a cluster under stress: only
+    // when the log is fully committed (nothing in flight), so at most one renewal
+    // no-op is outstanding and a leader that cannot commit (partitioned or
+    // churning under failovers) does not pile up no-ops -- which would grow the
+    // log without bound and can livelock the group. `read_since_renewal` means an
+    // idle group appends nothing.
+    //
+    // A leader that is stepping down must not append at all (3.10), and
+    // add_entry() enforces that by throwing not_a_leader, which would escape
+    // tick(). Note this is not covered by the is_leader() check above: stepdown
+    // is a state of a node that is still the leader, and it can be entered
+    // either by the maybe_commit() above or by an earlier leadership transfer.
+    if (leaseguard_enabled() && leader_state().lease_wait_done && leader_state().read_since_renewal
+            && !leader_state().stepdown && _commit_idx == _log.last_idx()) {
+        if (auto now = _config.leaseguard->clock.interval_now()) {
+            const auto delta = _config.leaseguard->delta;
+            // The newest committed entry, when it is still in the in-memory log.
+            // Once it has been folded into a snapshot its interval is gone, which
+            // is indistinguishable from holding no lease -- and note this is a
+            // state a read-only workload cannot leave on its own, since only a new
+            // entry can restore a lease. So treat it like an unstamped entry and
+            // renew. (The bounds check also keeps _log[] indexing in range.)
+            const log_entry* newest = _commit_idx > _log.get_snapshot().idx
+                    ? &*_log[_commit_idx.value()] : nullptr;
+            // Renew once the newest committed entry is past half the lease
+            // duration -- early enough that a still-valid lease stays valid
+            // across the replication + commit round-trip, and late enough that a
+            // steady read stream costs at most one no-op per delta/2. An entry
+            // with no recorded interval gives us no lease at all, so renew
+            // immediately.
+            if (!newest || !newest->lease_time || newest->lease_time->older_than(delta / 2, *now)) {
+                logger.trace("tick[{}]: LeaseGuard renewing lease with a no-op at idx {}",
+                    _tag, _log.next_idx());
+                add_entry(log_entry::dummy());
+                leader_state().read_since_renewal = false;
+            }
         }
     }
 }
@@ -1259,6 +1324,14 @@ void fsm::handle_read_quorum_reply(server_id from, const read_quorum_reply& repl
 
 std::optional<std::pair<read_id, index_t>> fsm::start_read_barrier(server_id requester) {
     check_is_leader();
+
+    // LeaseGuard: record that a read is being served this term so tick_leader()
+    // proactively renews the lease under a read-only workload. Set for both the
+    // lease-served and quorum-barrier paths below, since either way keeping the
+    // lease warm avoids future quorum round-trips.
+    if (leaseguard_enabled()) {
+        leader_state().read_since_renewal = true;
+    }
 
     // Make sure that only a leader or a node that is part of the config can request read barrier
     // Nodes outside of the config may never get the data, so they will not be able to read it.

--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -639,6 +639,23 @@ bool fsm::prev_term_lease_expired() {
     return state.lease_wait_start->older_than(delta, *now);
 }
 
+bool fsm::can_serve_lease_read() {
+    if (!leaseguard_enabled()) {
+        return false;
+    }
+    // The committed entry must be present in the in-memory log (not folded into
+    // a snapshot) for its recorded interval to be available.
+    if (_commit_idx <= _log.get_snapshot().idx) {
+        return false;
+    }
+    const auto now = _config.leaseguard->clock.interval_now();
+    if (!now) {
+        return false;
+    }
+    const auto& entry = *_log[_commit_idx.value()];
+    return entry.lease_time && entry.lease_time->younger_than(_config.leaseguard->delta, *now);
+}
+
 void fsm::tick_leader() {
     if (election_elapsed() >= ELECTION_TIMEOUT) {
         // 6.2 Routing requests to the leader
@@ -1270,6 +1287,22 @@ std::optional<std::pair<read_id, index_t>> fsm::start_read_barrier(server_id req
     }
 
     read_id id = next_read_id();
+
+    if (can_serve_lease_read()) {
+        // We hold a valid lease. LeaseGuard guarantees no other leader is
+        // committing writes while our lease is valid, so our committed state is
+        // the most recent in the group and this read is linearizable without
+        // contacting followers. Resolve it locally by marking its id as having
+        // reached quorum, and suppress the read_quorum broadcast that
+        // next_read_id() would otherwise trigger in get_output().
+        leader_state().last_read_id_changed = false;
+        leader_state().max_read_id_with_quorum = id;
+        _output.max_read_id_with_quorum = id;
+        logger.trace("start_read_barrier[{}] lease read, resolving id {} locally at commit idx {}",
+            _tag, id, _commit_idx);
+        return std::make_pair(id, _commit_idx);
+    }
+
     logger.trace("start_read_barrier[{}] starting read barrier with id {}", _tag, id);
     return std::make_pair(id, _commit_idx);
 }

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -132,6 +132,12 @@ struct leader {
     bool last_read_id_changed = false;
     read_id max_read_id_with_quorum{0};
 
+    // LeaseGuard: a linearizable read was served in this leadership term since
+    // the last lease-renewal no-op. Gates proactive lease extension in
+    // tick_leader() so that a read-only workload keeps the lease alive, while an
+    // idle group (no reads) appends nothing.
+    bool read_since_renewal = false;
+
     // LeaseGuard: index of the newest log entry that predates this leader's
     // term (i.e. the deposed leader's lease), captured at election time as
     // last_idx(). Non-zero whenever the group has any prior entry -- including

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -132,6 +132,33 @@ struct leader {
     bool last_read_id_changed = false;
     read_id max_read_id_with_quorum{0};
 
+    // LeaseGuard: index of the newest log entry that predates this leader's
+    // term (i.e. the deposed leader's lease), captured at election time as
+    // last_idx(). Non-zero whenever the group has any prior entry -- including
+    // when the in-memory log is empty but a snapshot covers earlier entries, in
+    // which case it equals the snapshot index. Zero only for a genesis cluster
+    // with no entries at all (in memory or snapshot), where there is no deposed
+    // lease to wait for.
+    index_t last_prev_term_idx{0};
+    // LeaseGuard: a bounded-uncertainty time reading taken at or shortly after
+    // this node became leader. Every prior-term entry was created before the
+    // election, so once this reading is more than delta old the deposed lease is
+    // guaranteed expired. Used as the age reference when the deposed leader's
+    // entry is not available in memory (folded into a snapshot, empty log at
+    // election, or no recorded interval of its own). Set lazily on the first
+    // available clock reading, so it may be empty until then.
+    std::optional<time_bounds> lease_wait_start;
+    // LeaseGuard: set once the deferred-commit restriction no longer applies
+    // for this leadership term -- either because there was no deposed lease to
+    // wait for (no prior-term entry at election) or because that lease has
+    // expired.
+    bool lease_wait_done = false;
+    // LeaseGuard: logical time at which the clock first became unsynchronized
+    // while a commit was deferred, or empty while the clock is available. If the
+    // clock stays unavailable for an election timeout the leader steps down, so
+    // that a node with a healthy clock can take over instead of stalling.
+    std::optional<logical_clock::time_point> clock_unavailable_since;
+
     leader(size_t max_log_size, const class fsm& fsm_) : fsm(fsm_), log_limiter_semaphore(std::make_unique<seastar::semaphore>(max_log_size)) {}
     leader(leader&&) = default;
     ~leader();
@@ -266,6 +293,13 @@ private:
     // Signals _sm_events. May resign leadership if we committed
     // a configuration change.
     void maybe_commit();
+    // LeaseGuard: true if the deposed leader's lease is known to be more than
+    // delta old, so it is safe to advance the commit index past all prior-term
+    // entries. Uses the deposed entry's own recorded interval when it is still
+    // in the in-memory log, otherwise a delta wait since this node became
+    // leader. Returns false (defer) when the clock is unsynchronized.
+    // Precondition: is_leader(), leases enabled, last_prev_term_idx > 0.
+    bool prev_term_lease_expired();
     // Check if the randomized election timeout has expired.
     bool is_past_election_timeout() const {
         return election_elapsed() >= _randomized_election_timeout;

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -170,6 +170,17 @@ struct leader {
     // commit is deferred, so the warning is emitted once per leadership term
     // rather than once per tick.
     bool clock_unavailable_warned = false;
+    // LeaseGuard: elapsed-time reading at which our clock last became unusable,
+    // or empty while it is usable. A leader with no clock can serve no local
+    // reads, stamp nothing and renew nothing, so once this has persisted we hand
+    // leadership to a replica whose clock works. Measured on the monotonic clock
+    // precisely because the clock being judged is the one that failed.
+    std::optional<mono_clock::time_point> clock_unusable_since;
+    // LeaseGuard: per-group delay added to that wait. Scylla runs one raft group
+    // per strongly-consistent tablet, so without it a single node's clock
+    // failure would transfer every group it leads at the same instant -- and
+    // again in reverse when the clock recovers. Drawn once per leadership term.
+    mono_clock::duration clock_stepdown_jitter{0};
 
     leader(size_t max_log_size, const class fsm& fsm_) : fsm(fsm_), log_limiter_semaphore(std::make_unique<seastar::semaphore>(max_log_size)) {}
     leader(leader&&) = default;
@@ -241,6 +252,16 @@ class fsm {
     // Set if we want to actively search for a leader.
     // Can be true only if the leader is not known
     bool _ping_leader = false;
+    // LeaseGuard: whether our bounded clock was usable at the last tick, i.e.
+    // whether we could hold a lease. Reported to the leader in
+    // append_reply::clock_ok so it can hand leadership to a node that still can.
+    //
+    // Sampled once per tick rather than per reply on purpose: append_entries is
+    // the hottest path in raft and a follower otherwise never reads the clock
+    // (interval_now() is a syscall on the adjtimex backend), while the value
+    // only feeds a leadership decision gated on the failure persisting for
+    // multiples of delta -- a tick of staleness cannot matter.
+    bool _clock_ok = false;
 
     // Stores the last state observed by get_output().
     // Is updated with the actual state of the FSM after
@@ -320,6 +341,10 @@ private:
     // delta old. When true the leader may serve a linearizable read locally
     // without a quorum round-trip. Precondition: is_leader().
     bool can_serve_lease_read();
+    // LeaseGuard: hand leadership to a replica whose clock still works, if ours
+    // has been unusable long enough and such a replica exists. A no-op unless
+    // leases are enabled. Precondition: is_leader(), not already stepping down.
+    void maybe_transfer_leadership_on_clock_loss();
     // Check if the randomized election timeout has expired.
     bool is_past_election_timeout() const {
         return election_elapsed() >= _randomized_election_timeout;

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -70,6 +70,20 @@ struct fsm_config {
     // selects the smallest-id voter. When unset (the default), fast bootstrap is
     // disabled and a bare fsm starts as a follower; raft::server sets it.
     std::optional<uint64_t> fast_bootstrap_seed;
+    // LeaseGuard leader-lease parameters. Absent unless leases are enabled for
+    // this server. When present, the leader records `clock.interval_now()` in
+    // each log entry it creates, defers committing writes until a deposed
+    // leader's lease has expired, and may serve linearizable reads locally
+    // while its own lease is valid.
+    struct leaseguard_config {
+        // Source of bounded-uncertainty time readings. Non-owning: must outlive
+        // the fsm.
+        bounded_clock& clock;
+        // Lease duration (Δ). Should be on the order of the election timeout.
+        // (arXiv:2512.15659 "Raft Leases Done  Right", Section 5.2)
+        lease_clock::duration delta;
+    };
+    std::optional<leaseguard_config> leaseguard;
 };
 
 class fsm;
@@ -267,6 +281,19 @@ private:
 
     // A helper to update the FSM's current term.
     void update_current_term(term_t current_term);
+
+    // True if LeaseGuard leader leases are enabled for this fsm.
+    bool leaseguard_enabled() const noexcept {
+        return _config.leaseguard.has_value();
+    }
+    // The bounded-uncertainty time interval to stamp on a new log entry, or
+    // nullopt when leases are disabled or the clock is unsynchronized.
+    std::optional<time_bounds> lease_time_now() const {
+        if (!_config.leaseguard) {
+            return std::nullopt;
+        }
+        return _config.leaseguard->clock.interval_now();
+    }
 
     void check_is_leader() const {
         if (!is_leader()) {

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -154,16 +154,22 @@ struct leader {
     // election, or no recorded interval of its own). Set lazily on the first
     // available clock reading, so it may be empty until then.
     std::optional<time_bounds> lease_wait_start;
+    // LeaseGuard: elapsed-time reading taken when this node became leader. Every
+    // prior-term entry was created before the election, so once delta of physical
+    // time has passed since this anchor the deposed lease is certainly expired.
+    // Unlike lease_wait_start this needs no synchronized clock, so it is the path
+    // that lets a leader with an unusable clock make progress at all rather than
+    // stalling. See prev_term_lease_expired().
+    mono_clock::time_point lease_wait_mono_start{};
     // LeaseGuard: set once the deferred-commit restriction no longer applies
     // for this leadership term -- either because there was no deposed lease to
     // wait for (no prior-term entry at election) or because that lease has
     // expired.
     bool lease_wait_done = false;
-    // LeaseGuard: logical time at which the clock first became unsynchronized
-    // while a commit was deferred, or empty while the clock is available. If the
-    // clock stays unavailable for an election timeout the leader steps down, so
-    // that a node with a healthy clock can take over instead of stalling.
-    std::optional<logical_clock::time_point> clock_unavailable_since;
+    // LeaseGuard: true once we have warned that the clock is unusable while a
+    // commit is deferred, so the warning is emitted once per leadership term
+    // rather than once per tick.
+    bool clock_unavailable_warned = false;
 
     leader(size_t max_log_size, const class fsm& fsm_) : fsm(fsm_), log_limiter_semaphore(std::make_unique<seastar::semaphore>(max_log_size)) {}
     leader(leader&&) = default;
@@ -303,7 +309,9 @@ private:
     // delta old, so it is safe to advance the commit index past all prior-term
     // entries. Uses the deposed entry's own recorded interval when it is still
     // in the in-memory log, otherwise a delta wait since this node became
-    // leader. Returns false (defer) when the clock is unsynchronized.
+    // leader. An unsynchronized clock only delays this -- the elapsed-time path
+    // still discharges it a little over delta after the election -- so it never
+    // defers indefinitely.
     // Precondition: is_leader(), leases enabled, last_prev_term_idx > 0.
     bool prev_term_lease_expired();
     // LeaseGuard: true if this leader currently holds a valid lease, i.e. its

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -300,6 +300,12 @@ private:
     // leader. Returns false (defer) when the clock is unsynchronized.
     // Precondition: is_leader(), leases enabled, last_prev_term_idx > 0.
     bool prev_term_lease_expired();
+    // LeaseGuard: true if this leader currently holds a valid lease, i.e. its
+    // newest committed entry (which the caller has verified is in the current
+    // term) is present in memory, carries a recorded interval, and is less than
+    // delta old. When true the leader may serve a linearizable read locally
+    // without a quorum round-trip. Precondition: is_leader().
+    bool can_serve_lease_read();
     // Check if the randomized election timeout has expired.
     bool is_past_election_timeout() const {
         return election_elapsed() >= _randomized_election_timeout;

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -18,6 +18,7 @@
 #include "bytes_ostream.hh"
 #include "internal.hh"
 #include "logical_clock.hh"
+#include "bounded_clock.hh"
 
 namespace raft {
 // Keeps user defined command. A user is responsible to serialize
@@ -240,6 +241,13 @@ struct log_entry {
     term_t term;
     index_t idx;
     std::variant<command, configuration, dummy> data;
+    // LeaseGuard: the leader's bounded-uncertainty time interval, recorded when
+    // the entry was created. Empty unless the leader had leases enabled (and a
+    // synchronized clock) at creation time. Used to reason about the age of a
+    // deposed leader's lease; nullopt means "no lease information" and callers
+    // must fall back to the safe path. Not persisted by all storage backends;
+    // reloaded entries may have this empty even if it was set originally.
+    std::optional<time_bounds> lease_time;
 
     size_t get_size() const;
 };

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -400,6 +400,17 @@ struct append_reply {
     // as a heartbeat.
     index_t commit_idx;
     std::variant<rejected, accepted> result;
+    // LeaseGuard: true if this node's bounded clock was usable as of its last
+    // tick, i.e. it could hold a lease and serve local reads were it the leader.
+    // Lets a leader whose own clock has failed hand leadership to a node that
+    // can still use leases, rather than lead a group that has silently lost
+    // them.
+    //
+    // Purely advisory: it is never used to prove anything about time, only to
+    // pick a leadership-transfer target, so a wrong value costs a pointless
+    // transfer and nothing more. False on a node with leases disabled, and on
+    // one that predates this field.
+    bool clock_ok = false;
 };
 
 struct vote_request {

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -398,12 +398,25 @@ future<> server_impl::start() {
     if (commit_idx > stable_idx) {
         on_internal_error(logger, "Raft init failed: committed index cannot be larger then persisted one");
     }
+
+    // Set up the fsm-level lease configuration, if leases are enabled for this
+    // server. The clock is owned by the caller via _config and must outlive the
+    // fsm, which only holds a reference to it.
+    std::optional<fsm_config::leaseguard_config> fsm_leaseguard;
+    if (_config.leaseguard) {
+        fsm_leaseguard.emplace(fsm_config::leaseguard_config{
+            .clock = _config.leaseguard->clock.get(),
+            .delta = _config.leaseguard->delta,
+        });
+    }
+
     _fsm = std::make_unique<fsm>(_id, _tag, term, vote, std::move(log), commit_idx, *_failure_detector,
                                  fsm_config {
                                      .append_request_threshold = _config.append_request_threshold,
                                      .max_log_size = _config.max_log_size,
                                      .enable_prevoting = _config.enable_prevoting,
-                                     .fast_bootstrap_seed = _config.fast_bootstrap_seed
+                                     .fast_bootstrap_seed = _config.fast_bootstrap_seed,
+                                     .leaseguard = fsm_leaseguard,
                                  },
                                  _events);
 

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -8,6 +8,7 @@
 #pragma once
 #include <seastar/core/abort_source.hh>
 #include "raft.hh"
+#include <functional>
 
 namespace raft {
 
@@ -67,6 +68,7 @@ public:
         // Helps distinguish raft instances when multiple groups share the
         // same server_id. If empty, server_id is used as the default.
         sstring tag;
+
         // Selects which voting member fast-bootstraps as the initial leader on
         // a fresh group: the one at rank (fast_bootstrap_seed % number_of_voters)
         // in ascending server_id order. Callers that manage many groups (e.g.
@@ -76,6 +78,22 @@ public:
         // always enables fast bootstrap (unlike a bare fsm, which disables it
         // when no seed is provided).
         uint64_t fast_bootstrap_seed = 0;
+
+        // LeaseGuard leader leases. When set, the leader serves linearizable
+        // reads locally (no quorum round-trip) while its lease is valid, and
+        // defers committing writes until a deposed leader's lease has expired.
+        // Requires a bounded-uncertainty clock; see raft/bounded_clock.hh.
+        struct leaseguard_configuration {
+            // Lease duration (Δ). Should be on the order of the election
+            // timeout.
+            lease_clock::duration delta;
+            // Clock providing bounded-uncertainty time readings. The caller owns
+            // it and must keep it alive for the lifetime of the server. A
+            // reference_wrapper (rather than a plain reference) is used so that
+            // configuration remains copy-assignable. See raft/bounded_clock.hh.
+            std::reference_wrapper<bounded_clock> clock;
+        };
+        std::optional<leaseguard_configuration> leaseguard;
     };
 
     virtual ~server() {}

--- a/raft/tracker.hh
+++ b/raft/tracker.hh
@@ -34,6 +34,12 @@ public:
     // is_voter::yes if the follower is a voting one
     raft::is_voter can_vote = raft::is_voter::yes;
 
+    // LeaseGuard: the follower's clock health as of its last append_reply. A
+    // leader whose own clock has failed uses this to find a replica that can
+    // still hold a lease and hand leadership to it. Starts false, so a follower
+    // we have not heard from is never chosen.
+    bool clock_ok = false;
+
     enum class state {
         // In this state only one append entry is send until matching index is found
         PROBE,

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -49,6 +49,21 @@ raft::log_entry_ptr make_command_entry(raft::term_t term, raft::index_t idx) {
     return make_lw_shared<raft::log_entry>(raft::log_entry{.term = term, .idx = idx, .data = std::move(cmd)});
 }
 
+// A LeaseGuard-stamped entry. The bounds are deliberately not whole
+// microseconds: raft::lease_clock fixes the wire unit at nanoseconds, so if that
+// ever coarsened these digits would be lost rather than the change passing
+// unnoticed.
+constexpr int64_t lease_earliest_ns = 1'234'567'891;
+constexpr int64_t lease_latest_ns = 1'234'567'893;
+
+raft::log_entry_ptr make_lease_entry(raft::term_t term, raft::index_t idx) {
+    return make_lw_shared<raft::log_entry>(raft::log_entry{.term = term, .idx = idx,
+            .data = raft::log_entry::dummy{},
+            .lease_time = raft::time_bounds{
+                    raft::lease_clock::time_point(std::chrono::nanoseconds(lease_earliest_ns)),
+                    raft::lease_clock::time_point(std::chrono::nanoseconds(lease_latest_ns))}});
+}
+
 raft::log_entry_ptr make_config_entry(raft::term_t term, raft::index_t idx) {
     return make_lw_shared<raft::log_entry>(raft::log_entry{.term = term,
             .idx = idx,
@@ -96,7 +111,16 @@ future<rp_handle> write_raft_entry_to_commitlog(commitlog& cl, table_id tid, raf
 
 // Test commitlog_raft_log_entry_writer: size computation is consistent with
 // the serialized output, and a write/read roundtrip preserves all fields
-// for every entry type (command, configuration, dummy).
+// for every entry type (command, configuration, dummy, LeaseGuard-stamped).
+//
+// This is the *persisted* encoding, which is not the same byte format as the
+// plain ser::serialize/ser::deserialize pair -- see the SCYLLADB-1029 note in
+// db/commitlog/commitlog_entry.cc: the writer path
+// (ser::writer_of_commitlog_entry) and the "manual" deserializer are not binary
+// compatible, which is why replay reads through the view deserializer. So a
+// field surviving ser::serialize says nothing about it surviving here, and
+// log_entry::lease_time has to be asserted on this path too. The last entry
+// below carries an interval and the others do not, covering both cases.
 SEASTAR_TEST_CASE(test_commitlog_raft_log_entry_writer) {
     return cl_test([](commitlog& log) -> future<> {
         auto gid = make_group_id();
@@ -106,6 +130,7 @@ SEASTAR_TEST_CASE(test_commitlog_raft_log_entry_writer) {
                 make_command_entry(raft::term_t(1), raft::index_t(1)),
                 make_config_entry(raft::term_t(2), raft::index_t(2)),
                 make_dummy_entry(raft::term_t(3), raft::index_t(3)),
+                make_lease_entry(raft::term_t(4), raft::index_t(4)),
         };
 
         // Verify size() and accessor for each entry type, then write to commitlog.
@@ -150,6 +175,18 @@ SEASTAR_TEST_CASE(test_commitlog_raft_log_entry_writer) {
                         BOOST_REQUIRE_EQUAL(rle.entry->term, expected->term);
                         BOOST_REQUIRE_EQUAL(rle.entry->idx, expected->idx);
                         BOOST_REQUIRE_EQUAL(rle.entry->data.index(), expected->data.index());
+                        // A LeaseGuard interval must survive the envelope intact,
+                        // and an entry written without one must not gain one.
+                        BOOST_REQUIRE_EQUAL(rle.entry->lease_time.has_value(),
+                                expected->lease_time.has_value());
+                        if (expected->lease_time) {
+                            BOOST_REQUIRE_EQUAL(
+                                    rle.entry->lease_time->earliest.time_since_epoch().count(),
+                                    lease_earliest_ns);
+                            BOOST_REQUIRE_EQUAL(
+                                    rle.entry->lease_time->latest.time_since_epoch().count(),
+                                    lease_latest_ns);
+                        }
                         ++found;
                         co_return;
                     });
@@ -1808,6 +1845,48 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
         BOOST_REQUIRE(entries2.empty());
         co_return;
     });
+}
+
+// The other encoding of lease_time: the plain ser::serialize/ser::deserialize
+// pair, which is what idl/raft.idl.hh uses for append_request::entries. That is
+// the replication path, and for LeaseGuard it is the primary one -- "the log is
+// the lease" reaches a new leader over append_entries, not off disk. The
+// persisted encoding is a different byte format and is covered by
+// test_commitlog_raft_log_entry_writer above; neither test substitutes for the
+// other.
+//
+// A misread here is silent and unsafe: a lease decoded as younger than it is
+// lets a deposed leader serve a stale local read. So the encoding must be a
+// fixed unit rather than whatever std::chrono::system_clock::period happens to
+// be for the build (see raft::lease_clock). The bounds are deliberately not
+// whole microseconds, so a coarsened unit drops digits here. Cross-build
+// divergence is what the static_asserts in raft/bounded_clock.hh guard -- a
+// round trip cannot see it, since both ends share a standard library.
+BOOST_AUTO_TEST_CASE(test_log_entry_lease_time_round_trip) {
+    constexpr int64_t earliest_ns = lease_earliest_ns;
+    constexpr int64_t latest_ns = lease_latest_ns;
+
+    raft::log_entry_ptr entry = make_lease_entry(raft::term_t(7), raft::index_t(11));
+
+    bytes_ostream buf;
+    ser::serialize(buf, entry);
+    auto bv = buf.linearize();
+    auto in = ser::as_input_stream(bv);
+    auto decoded = ser::deserialize(in, std::type_identity<raft::log_entry_ptr>());
+
+    BOOST_REQUIRE(decoded->lease_time);
+    BOOST_REQUIRE_EQUAL(decoded->lease_time->earliest.time_since_epoch().count(), earliest_ns);
+    BOOST_REQUIRE_EQUAL(decoded->lease_time->latest.time_since_epoch().count(), latest_ns);
+
+    // An absent interval must stay absent (leases disabled, or an unsynchronized
+    // clock at the time the entry was created).
+    raft::log_entry_ptr no_lease = make_lw_shared<raft::log_entry>(raft::log_entry{
+            .term = raft::term_t(7), .idx = raft::index_t(12), .data = raft::log_entry::dummy{}});
+    bytes_ostream buf2;
+    ser::serialize(buf2, no_lease);
+    auto bv2 = buf2.linearize();
+    auto in2 = ser::as_input_stream(bv2);
+    BOOST_REQUIRE(!ser::deserialize(in2, std::type_identity<raft::log_entry_ptr>())->lease_time);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2600,3 +2600,210 @@ BOOST_AUTO_TEST_CASE(test_no_resend_to_responded_peer) {
     }
     BOOST_CHECK(resent_to_c);
 }
+
+// ---------------------------------------------------------------------------
+// LeaseGuard leader-lease tests.
+// ---------------------------------------------------------------------------
+
+using namespace std::chrono_literals;
+
+namespace {
+
+// A fixed reference point well after the epoch, so we can subtract the
+// uncertainty without underflowing.
+const auto lease_t0 = raft::lease_clock::time_point(std::chrono::hours(24 * 365));
+const auto lease_err = 1ms;
+const auto lease_delta = 10s;
+
+raft::time_bounds make_bounds(raft::lease_clock::time_point center,
+        raft::lease_clock::duration error = lease_err) {
+    return raft::time_bounds{center - error, center + error};
+}
+
+raft::fsm_config make_lease_cfg(raft::bounded_clock& clock) {
+    return raft::fsm_config{
+        .append_request_threshold = 1,
+        .enable_prevoting = false,
+        .leaseguard = raft::fsm_config::leaseguard_config{.clock = clock, .delta = lease_delta},
+    };
+}
+
+} // anonymous namespace
+
+// The conservative interval comparisons underpinning LeaseGuard's safety, plus
+// the mock clock used by the remaining tests.
+BOOST_AUTO_TEST_CASE(test_leaseguard_time_bounds) {
+    const raft::time_bounds e = make_bounds(lease_t0);
+
+    // At creation the entry is provably younger than delta and not provably older.
+    raft::time_bounds now = make_bounds(lease_t0);
+    BOOST_CHECK(e.younger_than(lease_delta, now));
+    BOOST_CHECK(!e.older_than(lease_delta, now));
+
+    // Exactly delta later, uncertainty means we cannot yet prove it is older.
+    now = make_bounds(lease_t0 + lease_delta);
+    BOOST_CHECK(!e.older_than(lease_delta, now));
+
+    // Well past delta plus twice the uncertainty: provably older, and no longer
+    // provably younger. There is deliberately no instant where both hold.
+    now = make_bounds(lease_t0 + lease_delta + 1s);
+    BOOST_CHECK(e.older_than(lease_delta, now));
+    BOOST_CHECK(!e.younger_than(lease_delta, now));
+
+    // The mock clock reports what it is set to, and nullopt when unsynchronized.
+    raft::bounded_clock_mock clock;
+    BOOST_CHECK(!clock.interval_now());
+    clock.set(lease_t0, lease_err);
+    const auto iv = clock.interval_now();
+    BOOST_REQUIRE(iv);
+    BOOST_CHECK(iv->earliest == lease_t0 - lease_err);
+    BOOST_CHECK(iv->latest == lease_t0 + lease_err);
+    clock.set_unsynchronized();
+    BOOST_CHECK(!clock.interval_now());
+}
+
+// A newly elected leader must not commit (and thus apply) its writes until the
+// deposed leader's lease has expired.
+BOOST_AUTO_TEST_CASE(test_leaseguard_deferred_commit) {
+    raft::bounded_clock_mock clock;
+    clock.set(lease_t0, lease_err);
+
+    server_id id1 = id();
+    raft::configuration cfg = config_from_ids({id1});
+    raft::log log{raft::snapshot_descriptor{.config = cfg}};
+
+    // A deposed leader's lease: an entry from a previous term stamped with a
+    // recent time interval, already durable in this node's log.
+    log.emplace_back(seastar::make_lw_shared<raft::log_entry>(
+            raft::log_entry{term_t{1}, index_t{1}, raft::log_entry::dummy{}, make_bounds(lease_t0)}));
+    log.stable_to(log.last_idx());
+
+    // A single-node cluster elects itself on construction, in term 2.
+    fsm_debug fsm(id1, term_t{1}, server_id{}, std::move(log), trivial_failure_detector, make_lease_cfg(clock));
+    BOOST_REQUIRE(fsm.is_leader());
+
+    // Draining the output stabilizes the leader's dummy entry and attempts to
+    // commit, but the commit is deferred while the deposed leader's lease (entry
+    // 1) is still less than delta old.
+    (void)fsm.get_output();
+    BOOST_CHECK(fsm.get_output().committed.empty());
+    for (int i = 0; i < 5; i++) {
+        fsm.tick();
+        BOOST_CHECK(fsm.get_output().committed.empty());
+    }
+
+    // Once the lease is more than delta old, a tick commits the deferred,
+    // already-durable entries without any further messages.
+    clock.set(lease_t0 + lease_delta + 1s, lease_err);
+    fsm.tick();
+    const auto output = fsm.get_output();
+    BOOST_CHECK(!output.committed.empty());
+    BOOST_CHECK(output.messages.empty());
+}
+
+// When the clock is unsynchronized the age of the deposed leader's lease cannot
+// be bounded, so the commit stays deferred until the clock recovers.
+BOOST_AUTO_TEST_CASE(test_leaseguard_deferred_commit_unsynchronized) {
+    raft::bounded_clock_mock clock;
+    clock.set_unsynchronized();
+
+    server_id id1 = id();
+    raft::configuration cfg = config_from_ids({id1});
+    raft::log log{raft::snapshot_descriptor{.config = cfg}};
+    log.emplace_back(seastar::make_lw_shared<raft::log_entry>(
+            raft::log_entry{term_t{1}, index_t{1}, raft::log_entry::dummy{}, make_bounds(lease_t0)}));
+    log.stable_to(log.last_idx());
+
+    fsm_debug fsm(id1, term_t{1}, server_id{}, std::move(log), trivial_failure_detector, make_lease_cfg(clock));
+    BOOST_REQUIRE(fsm.is_leader());
+
+    (void)fsm.get_output();
+    for (int i = 0; i < 5; i++) {
+        fsm.tick();
+        BOOST_CHECK(fsm.get_output().committed.empty());
+    }
+
+    // Clock recovers and enough time has passed: commit proceeds.
+    clock.set(lease_t0 + lease_delta + 1s, lease_err);
+    fsm.tick();
+    BOOST_CHECK(!fsm.get_output().committed.empty());
+}
+
+// A leader holding a valid lease serves reads locally, with no read_quorum
+// round-trip; once the lease expires it falls back to the quorum read barrier.
+BOOST_AUTO_TEST_CASE(test_leaseguard_local_lease_read) {
+    raft::bounded_clock_mock clock;
+    clock.set(lease_t0, lease_err);
+
+    server_id id1 = id(), id2 = id();
+    raft::configuration cfg = config_from_ids({id1, id2});
+    fsm_debug fsm1(id1, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+            trivial_failure_detector, make_lease_cfg(clock));
+    fsm_debug fsm2(id2, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+            trivial_failure_detector, make_lease_cfg(clock));
+
+    // Elect fsm1 and commit its dummy entry (in its own term), establishing a
+    // lease.
+    election_timeout(fsm1);
+    communicate(fsm1, fsm2);
+    BOOST_REQUIRE(fsm1.is_leader());
+    (void)fsm1.get_output();
+
+    auto has_read_quorum = [](const raft::fsm_output& o) {
+        return std::ranges::any_of(o.messages, [](const auto& m) {
+            return std::holds_alternative<raft::read_quorum>(m.second);
+        });
+    };
+
+    // Valid lease: the read is resolved locally (its id reaches quorum
+    // immediately) and no read_quorum message is broadcast.
+    auto rid = fsm1.start_read_barrier(id1);
+    BOOST_REQUIRE(rid);
+    auto output = fsm1.get_output();
+    BOOST_REQUIRE(output.max_read_id_with_quorum);
+    BOOST_CHECK_EQUAL(*output.max_read_id_with_quorum, rid->first);
+    BOOST_CHECK(!has_read_quorum(output));
+
+    // Expired lease: the read falls back to the quorum barrier, broadcasting a
+    // read_quorum to the follower and not resolving locally.
+    clock.set(lease_t0 + lease_delta + 1s, lease_err);
+    auto rid2 = fsm1.start_read_barrier(id1);
+    BOOST_REQUIRE(rid2);
+    output = fsm1.get_output();
+    BOOST_CHECK(!output.max_read_id_with_quorum);
+    BOOST_CHECK(has_read_quorum(output));
+}
+
+// A leader whose clock stays unsynchronized while a commit is deferred cannot
+// bound the deposed leader's lease, so instead of stalling forever it steps down
+// after an election timeout to let a node with a healthy clock take over.
+BOOST_AUTO_TEST_CASE(test_leaseguard_steps_down_on_clock_loss) {
+    raft::bounded_clock_mock clock;
+    clock.set_unsynchronized();
+
+    server_id id1 = id(), id2 = id();
+    raft::configuration cfg = config_from_ids({id1, id2});
+    // Both nodes carry a prior-term entry, so the new leader has a deposed lease
+    // to wait for and will defer committing.
+    auto make_log = [&] {
+        raft::log log{raft::snapshot_descriptor{.config = cfg}};
+        log.emplace_back(seastar::make_lw_shared<raft::log_entry>(
+                raft::log_entry{term_t{1}, index_t{1}, raft::log_entry::dummy{}, make_bounds(lease_t0)}));
+        log.stable_to(log.last_idx());
+        return log;
+    };
+    fsm_debug fsm1(id1, term_t{1}, server_id{}, make_log(), trivial_failure_detector, make_lease_cfg(clock));
+    fsm_debug fsm2(id2, term_t{1}, server_id{}, make_log(), trivial_failure_detector, make_lease_cfg(clock));
+
+    election_timeout(fsm1);
+    communicate(fsm1, fsm2);
+    BOOST_REQUIRE(fsm1.is_leader());
+
+    // With the clock unsynchronized the deposed lease's age cannot be bounded,
+    // so the deferred commit never proceeds. After an election timeout worth of
+    // ticks the leader steps down instead of stalling indefinitely.
+    for (int i = 0; i < 3 * 10 && fsm1.is_leader(); i++) {
+        fsm1.tick();
+    }
+    BOOST_CHECK(!fsm1.is_leader());
+}

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2615,6 +2615,13 @@ const auto lease_t0 = raft::lease_clock::time_point(std::chrono::hours(24 * 365)
 const auto lease_err = 1ms;
 const auto lease_delta = 10s;
 
+// Elapsed time after which a leader may discharge its deferred commit without a
+// synchronized clock: delta plus the safety margin fsm.cc applies to it. Cast to
+// the monotonic duration before dividing -- computing it as `lease_delta / 8`
+// would be integer division on seconds and silently yield 1s instead of 1.25s.
+const auto lease_mono_wait =
+        std::chrono::duration_cast<raft::mono_clock::duration>(lease_delta) * 9 / 8;
+
 raft::time_bounds make_bounds(raft::lease_clock::time_point center,
         raft::lease_clock::duration error = lease_err) {
     return raft::time_bounds{center - error, center + error};
@@ -2702,7 +2709,11 @@ BOOST_AUTO_TEST_CASE(test_leaseguard_deferred_commit) {
 }
 
 // When the clock is unsynchronized the age of the deposed leader's lease cannot
-// be bounded, so the commit stays deferred until the clock recovers.
+// be bounded from the recorded interval, so the commit stays deferred until
+// either the clock recovers or enough elapsed time has been measured. This
+// covers the near side of that boundary: just under the elapsed-time threshold
+// nothing may commit. test_leaseguard_commits_after_delta_without_clock covers
+// the far side; without both, a broken margin or a missing anchor passes.
 BOOST_AUTO_TEST_CASE(test_leaseguard_deferred_commit_unsynchronized) {
     raft::bounded_clock_mock clock;
     clock.set_unsynchronized();
@@ -2718,6 +2729,14 @@ BOOST_AUTO_TEST_CASE(test_leaseguard_deferred_commit_unsynchronized) {
     BOOST_REQUIRE(fsm.is_leader());
 
     (void)fsm.get_output();
+    for (int i = 0; i < 5; i++) {
+        fsm.tick();
+        BOOST_CHECK(fsm.get_output().committed.empty());
+    }
+
+    // Elapsed time just short of the threshold (delta plus the safety margin)
+    // is still not enough, however many ticks it is spread over.
+    clock.advance_monotonic(lease_mono_wait - 1ms);
     for (int i = 0; i < 5; i++) {
         fsm.tick();
         BOOST_CHECK(fsm.get_output().committed.empty());
@@ -2774,10 +2793,14 @@ BOOST_AUTO_TEST_CASE(test_leaseguard_local_lease_read) {
     BOOST_CHECK(has_read_quorum(output));
 }
 
-// A leader whose clock stays unsynchronized while a commit is deferred cannot
-// bound the deposed leader's lease, so instead of stalling forever it steps down
-// after an election timeout to let a node with a healthy clock take over.
-BOOST_AUTO_TEST_CASE(test_leaseguard_steps_down_on_clock_loss) {
+// A leader whose clock never synchronizes still commits. It cannot bound the
+// deposed lease from that lease's recorded interval, but it does not need to:
+// every prior-term entry predates its election, so delta of *elapsed* time since
+// the election proves the lease is gone. Elapsed time needs no synchronized
+// clock, so the leader keeps making progress instead of stalling -- and it stays
+// leader, since stepping down would only move the same delta wait onto whoever
+// replaces it, after an election timeout and an election.
+BOOST_AUTO_TEST_CASE(test_leaseguard_commits_after_delta_without_clock) {
     raft::bounded_clock_mock clock;
     clock.set_unsynchronized();
 
@@ -2798,14 +2821,28 @@ BOOST_AUTO_TEST_CASE(test_leaseguard_steps_down_on_clock_loss) {
     election_timeout(fsm1);
     communicate(fsm1, fsm2);
     BOOST_REQUIRE(fsm1.is_leader());
+    (void)fsm1.get_output();
 
-    // With the clock unsynchronized the deposed lease's age cannot be bounded,
-    // so the deferred commit never proceeds. After an election timeout worth of
-    // ticks the leader steps down instead of stalling indefinitely.
-    for (int i = 0; i < 3 * 10 && fsm1.is_leader(); i++) {
+    // No elapsed time yet: the commit is deferred, but the node keeps leading.
+    for (int i = 0; i < 3 * 10; i++) {
         fsm1.tick();
+        BOOST_CHECK(fsm1.get_output().committed.empty());
+        BOOST_REQUIRE(fsm1.is_leader());
     }
-    BOOST_CHECK(!fsm1.is_leader());
+
+    // One millisecond short of the threshold: still nothing.
+    clock.advance_monotonic(lease_mono_wait - 1ms);
+    fsm1.tick();
+    BOOST_CHECK(fsm1.get_output().committed.empty());
+    BOOST_REQUIRE(fsm1.is_leader());
+
+    // Past it: the deferred, already-replicated entries commit, with the clock
+    // still reporting nothing.
+    clock.advance_monotonic(2ms);
+    fsm1.tick();
+    BOOST_CHECK(!fsm1.get_output().committed.empty());
+    BOOST_CHECK(fsm1.is_leader());
+    BOOST_CHECK(!clock.interval_now());
 }
 
 // LeaseGuard automatic lease extension (arXiv:2512.15659, Section 5.1). Under a

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2845,6 +2845,123 @@ BOOST_AUTO_TEST_CASE(test_leaseguard_commits_after_delta_without_clock) {
     BOOST_CHECK(!clock.interval_now());
 }
 
+namespace {
+
+// Drive a single-node-quorum-of-two fsm to leadership with a caught-up follower,
+// and tell it whether that follower's clock works. Returns the fsm ready for the
+// clock-loss tests below.
+struct clock_loss_fixture {
+    server_id id1 = id(), id2 = id();
+    raft::configuration cfg = config_from_ids({id1, id2});
+    fsm_debug fsm;
+
+    clock_loss_fixture(raft::bounded_clock_mock& clock, bool follower_clock_ok)
+        : fsm(id1, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+                trivial_failure_detector, make_lease_cfg(clock)) {
+        election_timeout(fsm);
+        (void)fsm.get_output();
+        fsm.step(id2, raft::vote_reply{fsm.get_current_term(), true});
+        BOOST_REQUIRE(fsm.is_leader());
+        auto output = fsm.get_output();
+        const auto append = std::get<raft::append_request>(output.messages.back().second);
+        const auto idx = append.entries.back()->idx;
+        // Follower is fully caught up, and reports its clock health.
+        fsm.step(id2, raft::append_reply{fsm.get_current_term(), index_t{},
+                raft::append_reply::accepted{idx}, follower_clock_ok});
+        (void)fsm.get_output();
+    }
+};
+
+bool sent_timeout_now(const raft::fsm_output& o) {
+    return std::ranges::any_of(o.messages, [](const auto& m) {
+        return std::holds_alternative<raft::timeout_now>(m.second);
+    });
+}
+
+// The wait is 2*delta plus a per-group jitter of at most delta, and the jitter is
+// drawn randomly, so tests assert either side of that range rather than an exact
+// boundary. Both bounds hold for every possible jitter.
+const auto lease_below_stepdown_wait =
+        std::chrono::duration_cast<raft::mono_clock::duration>(lease_delta) * 2;
+const auto lease_above_stepdown_wait =
+        std::chrono::duration_cast<raft::mono_clock::duration>(lease_delta) * 3;
+
+} // anonymous namespace
+
+// A leader whose clock fails keeps making progress, but silently loses leases:
+// no local reads, no stamped entries, no renewal, for as long as the outage
+// lasts. If a caught-up voter's clock still works, hand leadership over so the
+// group gets them back.
+BOOST_AUTO_TEST_CASE(test_leaseguard_transfers_leadership_on_clock_loss) {
+    raft::bounded_clock_mock clock;
+    clock.set(lease_t0, lease_err);
+    clock_loss_fixture f(clock, true /* follower's clock works */);
+
+    // Our clock fails. The first tick observes it and starts the clock.
+    clock.set_unsynchronized();
+    f.fsm.tick();
+    BOOST_CHECK(!sent_timeout_now(f.fsm.get_output()));
+
+    // Short of the wait, leadership must not move however many ticks pass: a
+    // clock that recovers quickly is not worth a transfer, which costs the
+    // successor a delta of deferred commits.
+    clock.advance_monotonic(lease_below_stepdown_wait - 1ms);
+    for (int i = 0; i < 5; i++) {
+        f.fsm.tick();
+        BOOST_CHECK(!sent_timeout_now(f.fsm.get_output()));
+    }
+    BOOST_REQUIRE(f.fsm.is_leader());
+
+    // Past it, leadership is handed to the follower.
+    clock.advance_monotonic(lease_above_stepdown_wait);
+    f.fsm.tick();
+    BOOST_CHECK(sent_timeout_now(f.fsm.get_output()));
+}
+
+// ... but only if the target can actually do what we cannot. A follower whose
+// clock is equally broken is no improvement, so we keep leading.
+BOOST_AUTO_TEST_CASE(test_leaseguard_no_transfer_when_follower_clock_also_broken) {
+    raft::bounded_clock_mock clock;
+    clock.set(lease_t0, lease_err);
+    clock_loss_fixture f(clock, false /* follower's clock is broken too */);
+
+    // Arm the wait first, then let the time pass: the wait is measured from the
+    // tick that observes the failure, so advancing before that first tick would
+    // leave zero elapsed time and the test would pass without proving anything.
+    clock.set_unsynchronized();
+    f.fsm.tick();
+    BOOST_CHECK(!sent_timeout_now(f.fsm.get_output()));
+
+    clock.advance_monotonic(lease_above_stepdown_wait * 2);
+    for (int i = 0; i < 5; i++) {
+        f.fsm.tick();
+        BOOST_CHECK(!sent_timeout_now(f.fsm.get_output()));
+    }
+    BOOST_CHECK(f.fsm.is_leader());
+}
+
+// A clock that flaps must not ping-pong leadership: every recovery cancels the
+// wait, so a node that is unsynchronized half the time never accumulates enough
+// consecutive failure to trigger a transfer.
+BOOST_AUTO_TEST_CASE(test_leaseguard_clock_recovery_cancels_transfer) {
+    raft::bounded_clock_mock clock;
+    clock.set(lease_t0, lease_err);
+    clock_loss_fixture f(clock, true);
+
+    for (int i = 0; i < 5; i++) {
+        clock.set_unsynchronized();
+        f.fsm.tick();
+        BOOST_CHECK(!sent_timeout_now(f.fsm.get_output()));
+        // Nearly long enough, but the clock comes back before the wait elapses.
+        clock.advance_monotonic(lease_below_stepdown_wait - 1ms);
+        clock.set(lease_t0, lease_err);
+        f.fsm.tick();
+        BOOST_CHECK(!sent_timeout_now(f.fsm.get_output()));
+        clock.advance_monotonic(lease_above_stepdown_wait);
+    }
+    BOOST_CHECK(f.fsm.is_leader());
+}
+
 // LeaseGuard automatic lease extension (arXiv:2512.15659, Section 5.1). Under a
 // read-only workload the lease would otherwise expire (no writes to refresh it)
 // and every read would fall back to a quorum barrier. While reads are flowing,

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2807,3 +2807,196 @@ BOOST_AUTO_TEST_CASE(test_leaseguard_steps_down_on_clock_loss) {
     }
     BOOST_CHECK(!fsm1.is_leader());
 }
+
+// LeaseGuard automatic lease extension (arXiv:2512.15659, Section 5.1). Under a
+// read-only workload the lease would otherwise expire (no writes to refresh it)
+// and every read would fall back to a quorum barrier. While reads are flowing,
+// tick_leader() proactively commits a no-op before the newest entry reaches
+// delta, so every read keeps being served locally with no read_quorum.
+BOOST_AUTO_TEST_CASE(test_leaseguard_lease_renewal) {
+    raft::bounded_clock_mock clock;
+    clock.set(lease_t0, lease_err);
+
+    server_id id1 = id(), id2 = id();
+    raft::configuration cfg = config_from_ids({id1, id2});
+    fsm_debug fsm1(id1, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+            trivial_failure_detector, make_lease_cfg(clock));
+    fsm_debug fsm2(id2, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+            trivial_failure_detector, make_lease_cfg(clock));
+
+    // Elect fsm1 and commit its dummy entry, establishing a lease (genesis log,
+    // so there is no deposed lease to defer for).
+    election_timeout(fsm1);
+    communicate(fsm1, fsm2);
+    BOOST_REQUIRE(fsm1.is_leader());
+    (void)fsm1.get_output();
+
+    auto has_read_quorum = [](const raft::fsm_output& o) {
+        return std::ranges::any_of(o.messages, [](const auto& m) {
+            return std::holds_alternative<raft::read_quorum>(m.second);
+        });
+    };
+
+    // Simulate a read-only workload for well over delta. Each step advances the
+    // clock by more than delta/2 (the renewal threshold) and performs one read.
+    auto t = lease_t0;
+    for (int step = 0; step < 6; step++) {
+        t += lease_delta / 2 + 1s;
+        clock.set(t, lease_err);
+
+        // The read is served locally from the (renewed) committed entry: its id
+        // reaches quorum immediately and no read_quorum message is broadcast.
+        auto rid = fsm1.start_read_barrier(id1);
+        BOOST_REQUIRE(rid);
+        auto output = fsm1.get_output();
+        BOOST_REQUIRE(output.max_read_id_with_quorum);
+        BOOST_CHECK_EQUAL(*output.max_read_id_with_quorum, rid->first);
+        BOOST_CHECK(!has_read_quorum(output));
+
+        // The following tick renews the lease with a no-op; replicate and commit
+        // it so it becomes the new, fresh basis for the next step's lease read.
+        const auto idx_before = fsm1.log_last_idx();
+        fsm1.tick();
+        BOOST_CHECK_EQUAL(fsm1.log_last_idx(), idx_before + index_t{1});
+        communicate(fsm1, fsm2);
+        (void)fsm1.get_output();
+    }
+}
+
+// Without reads there is nothing to keep warm, so an idle leader must not append
+// renewal no-ops; and once the lease has expired a read falls back to the quorum
+// barrier as usual.
+BOOST_AUTO_TEST_CASE(test_leaseguard_no_renewal_without_reads) {
+    raft::bounded_clock_mock clock;
+    clock.set(lease_t0, lease_err);
+
+    server_id id1 = id(), id2 = id();
+    raft::configuration cfg = config_from_ids({id1, id2});
+    fsm_debug fsm1(id1, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+            trivial_failure_detector, make_lease_cfg(clock));
+    fsm_debug fsm2(id2, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+            trivial_failure_detector, make_lease_cfg(clock));
+
+    election_timeout(fsm1);
+    communicate(fsm1, fsm2);
+    BOOST_REQUIRE(fsm1.is_leader());
+    (void)fsm1.get_output();
+
+    const auto idx_before = fsm1.log_last_idx();
+
+    // Advance far past delta and tick repeatedly, but issue no reads.
+    clock.set(lease_t0 + 10 * lease_delta, lease_err);
+    for (int i = 0; i < 20; i++) {
+        fsm1.tick();
+        communicate(fsm1, fsm2);
+    }
+    // No read activity => no renewal no-ops were appended.
+    BOOST_CHECK_EQUAL(fsm1.log_last_idx(), idx_before);
+
+    // The lease is now stale, so a read falls back to the quorum read barrier.
+    auto has_read_quorum = [](const raft::fsm_output& o) {
+        return std::ranges::any_of(o.messages, [](const auto& m) {
+            return std::holds_alternative<raft::read_quorum>(m.second);
+        });
+    };
+    auto rid = fsm1.start_read_barrier(id1);
+    BOOST_REQUIRE(rid);
+    auto output = fsm1.get_output();
+    BOOST_CHECK(!output.max_read_id_with_quorum);
+    BOOST_CHECK(has_read_quorum(output));
+}
+
+// Renewal must RE-ESTABLISH a lapsed lease, not only extend a live one
+// (arXiv:2512.15659, Section 5.1: a no-op is written "whenever needed to serve a
+// read"). A leader can end up leaseless with no write traffic to fix it -- right
+// after a failover, after a snapshot, or after a clock outage spanning delta --
+// and if renewal required an already-valid lease, a read-only workload would
+// then fall back to a quorum barrier for every read, permanently.
+BOOST_AUTO_TEST_CASE(test_leaseguard_renewal_reestablishes_expired_lease) {
+    raft::bounded_clock_mock clock;
+    clock.set(lease_t0, lease_err);
+
+    server_id id1 = id(), id2 = id();
+    raft::configuration cfg = config_from_ids({id1, id2});
+    fsm_debug fsm1(id1, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+            trivial_failure_detector, make_lease_cfg(clock));
+    fsm_debug fsm2(id2, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+            trivial_failure_detector, make_lease_cfg(clock));
+
+    election_timeout(fsm1);
+    communicate(fsm1, fsm2);
+    BOOST_REQUIRE(fsm1.is_leader());
+    (void)fsm1.get_output();
+
+    auto has_read_quorum = [](const raft::fsm_output& o) {
+        return std::ranges::any_of(o.messages, [](const auto& m) {
+            return std::holds_alternative<raft::read_quorum>(m.second);
+        });
+    };
+
+    // Let the lease lapse completely: far past delta, so the committed entry is
+    // not merely stale but provably older than a full lease duration.
+    clock.set(lease_t0 + 10 * lease_delta, lease_err);
+
+    // The first read after the lapse cannot be served locally.
+    auto rid = fsm1.start_read_barrier(id1);
+    BOOST_REQUIRE(rid);
+    auto output = fsm1.get_output();
+    BOOST_CHECK(!output.max_read_id_with_quorum);
+    BOOST_CHECK(has_read_quorum(output));
+
+    // But it marks the term as read-active, so the next tick appends a renewal
+    // no-op even though there is no lease left to extend.
+    const auto idx_before = fsm1.log_last_idx();
+    fsm1.tick();
+    BOOST_REQUIRE_EQUAL(fsm1.log_last_idx(), idx_before + index_t{1});
+    communicate(fsm1, fsm2);
+    (void)fsm1.get_output();
+
+    // The no-op is committed and freshly stamped, so the lease is back and reads
+    // are served locally again with no quorum round-trip.
+    auto rid2 = fsm1.start_read_barrier(id1);
+    BOOST_REQUIRE(rid2);
+    output = fsm1.get_output();
+    BOOST_REQUIRE(output.max_read_id_with_quorum);
+    BOOST_CHECK_EQUAL(*output.max_read_id_with_quorum, rid2->first);
+    BOOST_CHECK(!has_read_quorum(output));
+}
+
+// A leader that is stepping down must not append renewal no-ops (3.10). It is
+// still the leader, so tick_leader() keeps running and every other renewal
+// condition can hold -- but add_entry() refuses to append during stepdown by
+// throwing not_a_leader, and tick() has no caller that would catch it.
+BOOST_AUTO_TEST_CASE(test_leaseguard_no_renewal_during_stepdown) {
+    raft::bounded_clock_mock clock;
+    clock.set(lease_t0, lease_err);
+
+    server_id id1 = id(), id2 = id();
+    raft::configuration cfg = config_from_ids({id1, id2});
+    fsm_debug fsm1(id1, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+            trivial_failure_detector, make_lease_cfg(clock));
+    fsm_debug fsm2(id2, term_t{}, server_id{}, raft::log{raft::snapshot_descriptor{.config = cfg}},
+            trivial_failure_detector, make_lease_cfg(clock));
+
+    election_timeout(fsm1);
+    communicate(fsm1, fsm2);
+    BOOST_REQUIRE(fsm1.is_leader());
+    (void)fsm1.get_output();
+
+    // Set up the state renewal wants: the log is fully committed, a read has
+    // happened this term, and the lease is past its renewal threshold.
+    BOOST_REQUIRE(fsm1.start_read_barrier(id1));
+    (void)fsm1.get_output();
+    clock.set(lease_t0 + 10 * lease_delta, lease_err);
+
+    // Now start a leadership transfer. Use a timeout long enough that the tick
+    // below does not cancel the stepdown before reaching the renewal code.
+    const auto idx_before = fsm1.log_last_idx();
+    fsm1.transfer_leadership(raft::logical_clock::duration(5));
+    BOOST_REQUIRE(fsm1.is_leader());
+    (void)fsm1.get_output();
+
+    // The tick must neither throw nor append.
+    BOOST_REQUIRE_NO_THROW(fsm1.tick());
+    BOOST_CHECK_EQUAL(fsm1.log_last_idx(), idx_before);
+}

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1677,6 +1677,11 @@ class environment : public seastar::weakly_referencable<environment<M>> {
         // [-error, +error]. Node-scoped like the clock itself, so a restart does
         // not silently resynchronize the node.
         raft::lease_clock::duration _clock_skew{0};
+        // LeaseGuard: origin of this node's elapsed-time (monotonic) readings.
+        // Deliberately different per node: only differences within one node are
+        // meaningful, so any code that compared these across nodes would be
+        // wrong, and a shared origin would hide it.
+        raft::mono_clock::time_point _mono_epoch{};
     };
 
     // Passed to newly created failure detectors.
@@ -1803,10 +1808,18 @@ public:
         const auto ticks = (now - raft::logical_clock::min()).count();
         const auto t = _leaseguard->epoch + ticks * _leaseguard->tick_duration;
         for (auto& [id, r] : _routes) {
+            // Elapsed time keeps running on every node, including one whose
+            // clock is "broken": losing synchronization does not stop the
+            // monotonic clock. Modelling it otherwise would make the simulated
+            // failure stronger than any real one and hide the recovery path.
+            r._clock.set_monotonic(r._mono_epoch
+                    + std::chrono::duration_cast<raft::mono_clock::duration>(
+                            ticks * _leaseguard->tick_duration));
             if (r._clock_broken) {
                 // Simulated clock failure: the node cannot bound the current
-                // time. LeaseGuard must fall back to the safe path (defer / no
-                // lease reads / step down).
+                // time. LeaseGuard must fall back to the safe path (defer
+                // commits until enough elapsed time has passed / no lease
+                // reads).
                 r._clock.set_unsynchronized();
             } else {
                 r._clock.set(t + r._clock_skew, _leaseguard->error);
@@ -1855,6 +1868,10 @@ public:
             const auto err = _leaseguard->error.count();
             it->second._clock_skew = raft::lease_clock::duration{
                     std::uniform_int_distribution<raft::lease_clock::rep>{-err, err}(_clock_skew_rnd)};
+            it->second._mono_epoch = raft::mono_clock::time_point{
+                    raft::mono_clock::duration{
+                            std::uniform_int_distribution<raft::mono_clock::rep>{
+                                    0, 1'000'000'000}(_clock_skew_rnd)}};
             it->second._cfg.leaseguard.emplace(raft::server::configuration::leaseguard_configuration{
                 .delta = _leaseguard->delta,
                 .clock = it->second._clock,

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1631,9 +1631,10 @@ struct environment_config {
     // with leader leases, backed by a per-node simulated bounded-uncertainty
     // clock. The clocks are driven from simulated (logical) time by
     // environment::update_lease_clocks(), mapping one logical tick to
-    // `tick_duration` of physical time. All nodes report the same interval
-    // [now - error, now + error], so the bounds always contain the true
-    // simulated time and leases are safe.
+    // `tick_duration` of physical time. Each node is given a fixed skew drawn
+    // from [-error, +error] and reports [now + skew - error, now + skew + error],
+    // so nodes genuinely disagree about the current time while their bounds still
+    // contain the true simulated time -- exactly the model LeaseGuard assumes.
     struct leaseguard_config {
         raft::lease_clock::duration delta;
         raft::lease_clock::duration error;
@@ -1664,10 +1665,26 @@ class environment : public seastar::weakly_referencable<environment<M>> {
         raft::server::configuration _cfg;
         lw_shared_ptr<persistence<state_t>> _persistence;
         std::unique_ptr<raft_server<M>> _server;
+        // LeaseGuard: per-node simulated bounded-uncertainty clock. Node-scoped
+        // so it survives crash/stop/restart, keeping the reference stored in
+        // `_cfg.leaseguard` valid across server instances.
+        raft::bounded_clock_mock _clock;
+        // LeaseGuard: this node's fixed clock skew, drawn once from
+        // [-error, +error]. Node-scoped like the clock itself, so a restart does
+        // not silently resynchronize the node.
+        raft::lease_clock::duration _clock_skew{0};
     };
 
     // Passed to newly created failure detectors.
     const raft::logical_clock::duration _fd_convict_threshold;
+
+    // LeaseGuard configuration applied to every node, if enabled.
+    const std::optional<environment_config::leaseguard_config> _leaseguard;
+
+    // LeaseGuard: draws each node's fixed clock skew. Separate from the network's
+    // generator so that adding/removing skew does not reshuffle network delays.
+    // Declared (and so initialized) before `_network`, which consumes cfg.rnd.
+    std::mt19937 _clock_skew_rnd;
 
     // Used to deliver messages coming from the network to appropriate servers and their failure detectors.
     // Also keeps the servers and the failure detectors alive (owns them).
@@ -1705,6 +1722,8 @@ class environment : public seastar::weakly_referencable<environment<M>> {
 public:
     environment(environment_config cfg)
             : _fd_convict_threshold(cfg.fd_convict_threshold)
+            , _leaseguard(cfg.leaseguard)
+            , _clock_skew_rnd(cfg.rnd)
             , _network(std::move(cfg.network_delay), std::move(cfg.rnd),
         [this] (raft::server_id src, raft::server_id dst, const message_t& m) {
             auto& n = _routes.at(dst);
@@ -1751,6 +1770,24 @@ public:
         tick_crashing_servers();
     }
 
+    // LeaseGuard: advance every node's simulated physical clock to match the
+    // current simulated (logical) time. Called from the ticker each iteration.
+    // Each node reports [t + skew - error, t + skew + error] for its own fixed
+    // skew in [-error, +error]; since |skew| <= error the interval always
+    // contains the true simulated time t, so these are valid bounded-uncertainty
+    // clocks -- but nodes disagree about "now" by up to 2*error, which is what
+    // exercises the earliest/latest asymmetry LeaseGuard relies on.
+    void update_lease_clocks(raft::logical_clock::time_point now) {
+        if (!_leaseguard) {
+            return;
+        }
+        const auto ticks = (now - raft::logical_clock::min()).count();
+        const auto t = _leaseguard->epoch + ticks * _leaseguard->tick_duration;
+        for (auto& [id, r] : _routes) {
+            r._clock.set(t + r._clock_skew, _leaseguard->error);
+        }
+    }
+
     // A 'node' is a container for a Raft server, its storage ('persistence') and failure detector.
     // At a given point in time at most one Raft server instance can be running on a node.
     // Different instances may be running at different points in time, but they will all have
@@ -1771,6 +1808,20 @@ public:
             ._server = nullptr,
         });
         SCYLLA_ASSERT(inserted);
+
+        // LeaseGuard: point the node's lease configuration at its own stable,
+        // node-scoped clock (emplace: the reference member makes the optional
+        // non-assignable), and give it a fixed clock skew within its declared
+        // error bound so that nodes disagree about the current time.
+        if (_leaseguard) {
+            const auto err = _leaseguard->error.count();
+            it->second._clock_skew = raft::lease_clock::duration{
+                    std::uniform_int_distribution<raft::lease_clock::rep>{-err, err}(_clock_skew_rnd)};
+            it->second._cfg.leaseguard.emplace(raft::server::configuration::leaseguard_configuration{
+                .delta = _leaseguard->delta,
+                .clock = it->second._clock,
+            });
+        }
 
         return id;
     }
@@ -3323,6 +3374,9 @@ static future<> run_basic_generator_test(
         t.start([&, dist = std::uniform_int_distribution<size_t>(0, 9)] (uint64_t tick) mutable {
             env.tick_network();
             timer.tick();
+            // LeaseGuard: advance every node's simulated physical clock to the
+            // current simulated time (no-op unless leases are enabled).
+            env.update_lease_clocks(timer.now());
             env.for_each_server([&] (raft::server_id, raft_server<AppendReg>* srv) {
                 // Tick each server with probability 1/10.
                 // Thus each server is ticked, on average, once every 10 timer/network ticks.
@@ -3368,7 +3422,8 @@ static future<> run_basic_generator_test(
                 .enable_forwarding = forwarding,
             };
 
-        tlogger.info("basic_generator_test: forwarding: {}, frequent snapshotting: {}", forwarding, frequent_snapshotting);
+        tlogger.info("basic_generator_test: seed: {}, forwarding: {}, frequent snapshotting: {}, leaseguard: {}",
+                seed, forwarding, frequent_snapshotting, leaseguard.has_value());
 
         auto leader_id = co_await env.new_server(true, srv_cfg);
 
@@ -3678,4 +3733,31 @@ SEASTAR_TEST_CASE(basic_generator_test) {
             50_t /* fd_convict_threshold */,
             std::nullopt /* leaseguard */,
             std::nullopt /* force_forwarding */);
+}
+
+SEASTAR_TEST_CASE(basic_generator_test_leaseguard) {
+    // LeaseGuard: run the full nemesis (partitions/failovers, crashes+restarts,
+    // reconfigurations, snapshotting) with leader leases enabled and a per-node
+    // simulated bounded-uncertainty clock, and check linearizability. Leases
+    // being safe means the existing model must never observe a stale read, even
+    // when a deposed leader serves local lease reads during a partition.
+    //
+    // Δ must exceed the cluster's failover time so that a deposed leader still
+    // holds a valid lease (and may serve local reads) while a newly elected
+    // leader defers committing -- otherwise the old lease always expires before
+    // a new leader appears and neither the deferred-commit nor the concurrent
+    // lease-read path is exercised. We therefore shorten failure detection for
+    // this test and pick Δ above the resulting failover time. 1_t maps to 10ms
+    // of simulated physical time.
+    constexpr auto tick = std::chrono::milliseconds{10};
+    co_await run_basic_generator_test(
+            tests::random::get_int<int32_t>(),
+            20_t /* fd_convict_threshold */,
+            environment_config::leaseguard_config{
+                .delta = 400 * tick,
+                .error = 20 * tick,
+                .tick_duration = tick,
+                .epoch = raft::lease_clock::time_point{std::chrono::hours{24 * 365}},
+            },
+            true /* force_forwarding */);
 }

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1690,6 +1690,12 @@ class environment : public seastar::weakly_referencable<environment<M>> {
     // Declared (and so initialized) before `_network`, which consumes cfg.rnd.
     std::mt19937 _clock_skew_rnd;
 
+    // LeaseGuard: number of read_quorum messages that crossed the network. A
+    // lease-served read is resolved locally and sends none, so this is a direct
+    // measure of how often the lease was NOT held when a read arrived. Note the
+    // leader broadcasts to every voter, so one un-leased read contributes several.
+    uint64_t _read_quorum_msgs = 0;
+
     // Used to deliver messages coming from the network to appropriate servers and their failure detectors.
     // Also keeps the servers and the failure detectors alive (owns them).
     // Before we show a Raft server to others we must add it to this map.
@@ -1733,10 +1739,19 @@ public:
             auto& n = _routes.at(dst);
             SCYLLA_ASSERT(n._persistence);
 
+            if (std::holds_alternative<raft::read_quorum>(m)) {
+                ++_read_quorum_msgs;
+            }
+
             if (n._server) {
                 n._server->deliver(src, m);
             }
         }) {
+    }
+
+    // LeaseGuard: see `_read_quorum_msgs`.
+    uint64_t read_quorum_msgs() const {
+        return _read_quorum_msgs;
     }
 
     ~environment() {
@@ -3461,7 +3476,8 @@ static future<> run_basic_generator_test(
         int32_t seed,
         raft::logical_clock::duration fd_convict_threshold,
         std::optional<environment_config::leaseguard_config> leaseguard,
-        std::optional<bool> force_forwarding) {
+        std::optional<bool> force_forwarding,
+        bool read_only_tail = false) {
     using op_type = operation::invocable<operation::either_of<
             raft_call<AppendReg>,
             raft_read<AppendReg>,
@@ -3516,11 +3532,24 @@ static future<> run_basic_generator_test(
         bool frequent_snapshotting = bdist(random_engine);
 
         bool nemesis_partitions = true;
-        bool nemesis_reconfigurations = true;
+        // Reconfiguration is disabled whenever leases are enabled. With leases a
+        // cluster is legitimately less available under chaos (a new leader defers
+        // committing for delta after every failover, and steps down if its clock
+        // is lost), and reconfiguration retries interact badly with that leader
+        // instability -- a reconfiguration that cannot commit is retried against a
+        // constantly-changing leader, churning without ever settling ("server
+        // already exists in configuration ..."). Reconfiguration is exercised
+        // heavily by the non-lease basic_generator_test; here we keep the core
+        // LeaseGuard coverage (failovers -> deferred commit, concurrent leaders ->
+        // no stale reads) via partitions and crashes.
+        bool nemesis_reconfigurations = !leaseguard.has_value();
         bool nemesis_crashes = true;
         // LeaseGuard clock-failure nemesis is only meaningful (and only enabled)
-        // when leases are on.
-        bool nemesis_clock_failures = leaseguard.has_value();
+        // when leases are on. Disable it in the read-only-tail variant: with no
+        // client writes to commit, a leader whose clock is broken while deferring
+        // steps down, and the resulting continuous failover livelocks a cluster
+        // that never gets to make progress.
+        bool nemesis_clock_failures = leaseguard.has_value() && !read_only_tail;
 
         // TODO: randomize the snapshot thresholds between different servers for more chaos.
         const auto max_command_size = 2 * sizeof(raft::log_entry);
@@ -3538,8 +3567,8 @@ static future<> run_basic_generator_test(
                 .enable_forwarding = forwarding,
             };
 
-        tlogger.info("basic_generator_test: seed: {}, forwarding: {}, frequent snapshotting: {}, leaseguard: {}",
-                seed, forwarding, frequent_snapshotting, leaseguard.has_value());
+        tlogger.info("basic_generator_test: seed: {}, forwarding: {}, frequent snapshotting: {}, leaseguard: {}, read_only_tail: {}",
+                seed, forwarding, frequent_snapshotting, leaseguard.has_value(), read_only_tail);
 
         auto leader_id = co_await env.new_server(true, srv_cfg);
 
@@ -3649,6 +3678,12 @@ static future<> run_basic_generator_test(
         // we will set request timeout 600_t ~= 6s and partition every 1200_t ~= 12s
 
         auto num_ops = 500;
+        // LeaseGuard read-only tail: cap writes to an initial burst so the rest
+        // of the run is read-only for far longer than Δ. This exercises automatic
+        // lease extension -- without renewal no-ops the lease would expire and
+        // every read would fall back to a quorum barrier (and a new leader with
+        // no client writes would never re-establish a read lease).
+        const auto write_op_limit = read_only_tail ? num_ops / 5 : num_ops;
         auto gen = op_limit(num_ops,
             pin(partition_thread,
                 op_limit(nemesis_partitions ? num_ops : 0,
@@ -3696,11 +3731,13 @@ static future<> run_basic_generator_test(
                                 )
                             ),
                             either(
-                                stagger(seed, timer.now(), 0_t, 50_t,
-                                    sequence(1, [] (int32_t i) {
-                                        SCYLLA_ASSERT(i > 0);
-                                        return op_type{raft_call<AppendReg>{AppendReg::append{i}, 200_t}};
-                                    })
+                                op_limit(write_op_limit,
+                                    stagger(seed, timer.now(), 0_t, 50_t,
+                                        sequence(1, [] (int32_t i) {
+                                            SCYLLA_ASSERT(i > 0);
+                                            return op_type{raft_call<AppendReg>{AppendReg::append{i}, 200_t}};
+                                        })
+                                    )
                                 ),
                                 op_limit(forwarding ? num_ops : 0 /* only produce raft_reads in forwarding mode */,
                                     stagger(seed, timer.now(), 0_t, 200_t,
@@ -3721,6 +3758,9 @@ static future<> run_basic_generator_test(
             size_t successes{0};
             size_t failures{0};
             size_t skipped_applies{0};
+            // LeaseGuard: read invocations, to compare against the number of
+            // read_quorum messages the leases were supposed to avoid.
+            size_t reads{0};
         };
 
         class consistency_checker {
@@ -3738,6 +3778,7 @@ static future<> run_basic_generator_test(
                     _model.invocation(call_op->input.x);
                 } else if (auto read_op = std::get_if<raft_read<AppendReg>>(&o.op)) {
                     ++_stats.invocations;
+                    ++_stats.reads;
                     _model.start_read(read_op->read_id);
                 }
             }
@@ -3816,6 +3857,11 @@ static future<> run_basic_generator_test(
         tlogger.info("Finished generator run, time: {}, invocations: {}, successes: {}, failures: {}, skipped applies: {}, total: {}",
                 timer.now(), stats.invocations, stats.successes, stats.failures, stats.skipped_applies, stats.successes + stats.failures + stats.skipped_applies);
 
+        if (leaseguard) {
+            tlogger.info("LeaseGuard: {} reads, {} read_quorum messages on the wire",
+                    stats.reads, env.read_quorum_msgs());
+        }
+
         // Liveness check: we must be able to obtain a final response after all the nemeses have stopped.
         // Due to possible multiple leaders at this point and the cluster stabilizing (for example there
         // may be no leader right now, the current leader may be stepping down etc.) we may need to try
@@ -3862,6 +3908,78 @@ static future<> run_basic_generator_test(
             if (std::holds_alternative<typename AppendReg::ret>(res)) {
                 tlogger.info("Obtained last result");
                 tlogger.debug("Last result: {}", res);
+
+                if (leaseguard && read_only_tail) {
+                    // LeaseGuard automatic lease extension (Section 5.1), checked
+                    // deterministically now that the nemeses have stopped and the
+                    // cluster is quiescent. The statistics gathered during the
+                    // chaotic phase are far too noisy to assert on -- whether a
+                    // lease is held there is mostly a function of how the
+                    // partitions fell -- but here the only thing that can cost us
+                    // a lease is the protocol itself.
+                    //
+                    // First let the lease lapse completely: no writes for well
+                    // over delta. Renewal must then RE-ESTABLISH it from a read
+                    // alone. If renewal could only extend an already-valid lease,
+                    // every subsequent read would fall back to a quorum barrier
+                    // forever, since nothing in this phase writes.
+                    //
+                    // Sleep 2*delta, not delta: a renewal triggered by the last
+                    // read of the chaotic phase may land anywhere in the first
+                    // delta of this window, and we need the lease to have lapsed
+                    // by the end of it no matter when that was.
+                    const auto delta_ticks = raft::logical_clock::duration{
+                            leaseguard->delta / leaseguard->tick_duration};
+                    co_await timer.sleep(2 * delta_ticks + delta_ticks / 4);
+
+                    // Warm-up read: expected to miss (the lease has lapsed) but it
+                    // marks the term read-active, so the next leader tick appends
+                    // and commits a renewal no-op.
+                    (void)co_await env.read(leader, timer.now() + 200_t, timer);
+                    co_await timer.sleep(delta_ticks / 4);
+
+                    // From here on every read must be served from the lease, with
+                    // no read_quorum on the wire, for a span of several delta.
+                    //
+                    // Count reads that missed the lease, not read_quorum messages.
+                    // The message cost of a single miss is not bounded by the
+                    // configuration size: a barrier that does not reach quorum
+                    // straight away is re-broadcast by tick_leader() on every
+                    // subsequent tick. So a message budget cannot be reconciled
+                    // with a tolerance expressed in reads -- one slow miss could
+                    // outweigh the whole budget while a systematic fallback with
+                    // prompt replies stays inside it.
+                    constexpr int reads = 10;
+                    // Tolerate a couple of stragglers -- a snapshot or a late tick
+                    // can cost a single lease -- but nothing beyond that. Both
+                    // failures and lease misses are measured against this same
+                    // tolerance: a read that failed was not served from a lease
+                    // either, and counting it as anything softer would let a run
+                    // pass the failure check and then trip the lease check.
+                    constexpr int max_missed_reads = 2;
+                    int missed = 0, failed = 0;
+                    for (int i = 0; i < reads; ++i) {
+                        const auto quorum_msgs_before = env.read_quorum_msgs();
+                        auto r = co_await env.read(leader, timer.now() + 200_t, timer);
+                        if (env.read_quorum_msgs() != quorum_msgs_before) {
+                            ++missed;
+                        }
+                        // Guard against a vacuous pass: a read that never gets far
+                        // enough to send a read_quorum would otherwise look like a
+                        // lease hit.
+                        if (!std::holds_alternative<typename AppendReg::state_t>(r)) {
+                            ++failed;
+                        }
+                        co_await timer.sleep(delta_ticks / 4);
+                    }
+                    tlogger.info("LeaseGuard quiescent-phase check: {}/{} reads served from the lease, "
+                            "{} failed, over {} ticks", reads - missed, reads, failed,
+                            reads * (delta_ticks / 4).count());
+
+                    SCYLLA_ASSERT(missed <= max_missed_reads);
+                    SCYLLA_ASSERT(failed <= max_missed_reads);
+                }
+
                 co_return;
             }
 
@@ -3906,4 +4024,26 @@ SEASTAR_TEST_CASE(basic_generator_test_leaseguard) {
                 .epoch = raft::lease_clock::time_point{std::chrono::hours{24 * 365}},
             },
             true /* force_forwarding */);
+}
+
+SEASTAR_TEST_CASE(basic_generator_test_leaseguard_read_only) {
+    // LeaseGuard automatic lease extension (arXiv:2512.15659, Section 5.1) under
+    // a read-only workload. Writes are capped to an initial burst, so most of the
+    // run is read-only for far longer than Δ. Without renewal no-ops the lease
+    // would expire and every read would fall back to a quorum barrier; worse, a
+    // new leader elected during the read-only tail (nemeses still run) would have
+    // no client writes to establish its own read lease. The renewal no-ops keep
+    // leases alive, and the model still checks that no read is ever stale.
+    constexpr auto tick = std::chrono::milliseconds{10};
+    co_await run_basic_generator_test(
+            tests::random::get_int<int32_t>(),
+            20_t /* fd_convict_threshold */,
+            environment_config::leaseguard_config{
+                .delta = 400 * tick,
+                .error = 20 * tick,
+                .tick_duration = tick,
+                .epoch = raft::lease_clock::time_point{std::chrono::hours{24 * 365}},
+            },
+            true /* force_forwarding */,
+            true /* read_only_tail */);
 }

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1669,6 +1669,10 @@ class environment : public seastar::weakly_referencable<environment<M>> {
         // so it survives crash/stop/restart, keeping the reference stored in
         // `_cfg.leaseguard` valid across server instances.
         raft::bounded_clock_mock _clock;
+        // LeaseGuard: when true, the clock-failure nemesis has made this node's
+        // clock unsynchronized; update_lease_clocks() reports nullopt for it
+        // until it is healed.
+        bool _clock_broken = false;
         // LeaseGuard: this node's fixed clock skew, drawn once from
         // [-error, +error]. Node-scoped like the clock itself, so a restart does
         // not silently resynchronize the node.
@@ -1784,8 +1788,27 @@ public:
         const auto ticks = (now - raft::logical_clock::min()).count();
         const auto t = _leaseguard->epoch + ticks * _leaseguard->tick_duration;
         for (auto& [id, r] : _routes) {
-            r._clock.set(t + r._clock_skew, _leaseguard->error);
+            if (r._clock_broken) {
+                // Simulated clock failure: the node cannot bound the current
+                // time. LeaseGuard must fall back to the safe path (defer / no
+                // lease reads / step down).
+                r._clock.set_unsynchronized();
+            } else {
+                r._clock.set(t + r._clock_skew, _leaseguard->error);
+            }
         }
+    }
+
+    // LeaseGuard clock-failure nemesis: make (or restore) a node's simulated
+    // clock unsynchronized. The node's `route` (and thus this flag) persists
+    // across crash/stop/restart, so it is safe to call even if no server is
+    // currently running on the node.
+    void break_clock(raft::server_id id) {
+        _routes.at(id)._clock_broken = true;
+    }
+
+    void heal_clock(raft::server_id id) {
+        _routes.at(id)._clock_broken = false;
     }
 
     // A 'node' is a container for a Raft server, its storage ('persistence') and failure detector.
@@ -2816,6 +2839,95 @@ struct fmt::formatter<network_majority_grudge<M>> : fmt::formatter<string_view> 
     }
 };
 
+// LeaseGuard clock-failure nemesis: make a single node's simulated clock
+// unsynchronized for a while, then restore it. Biases toward the current leader
+// so we exercise a leaseholder losing its clock: while a freshly elected leader
+// is still deferring the deposed lease this forces it to step down (a node with
+// a healthy clock then takes over); a leader that has already committed in its
+// term instead falls back to quorum read barriers. Only one node's clock is
+// broken at a time (the op sleeps for the whole failure and is pinned to a
+// dedicated generator thread), so a healthy-clock quorum always remains and the
+// cluster keeps making progress. `nullopt` bounds only degrade availability, not
+// correctness, so this must never cause a linearizability violation.
+// Distinct (empty) result type so the operation result variant does not collide
+// with other monostate-returning nemeses.
+struct clock_failure_result {};
+
+template <>
+struct fmt::formatter<clock_failure_result> : fmt::formatter<string_view> {
+    auto format(clock_failure_result, fmt::format_context& ctx) const {
+        return ctx.out();
+    }
+};
+
+template <PureStateMachine M>
+class clock_failure {
+    raft::logical_clock::duration _duration;
+
+    friend fmt::formatter<clock_failure>;
+
+public:
+    struct state_type {
+        environment<M>& env;
+        const std::unordered_set<raft::server_id>& known;
+        logical_timer& timer;
+        std::mt19937 rnd;
+    };
+
+    using result_type = clock_failure_result;
+
+    clock_failure(raft::logical_clock::duration d) : _duration(d) {
+        static_assert(operation::Executable<clock_failure<M>>);
+    }
+
+    future<result_type> execute(state_type& s, const operation::context& ctx) {
+        SCYLLA_ASSERT(s.known.size() > 0);
+
+        // Prefer the current leader; otherwise pick a random known node.
+        auto leader_it = std::find_if(s.known.begin(), s.known.end(),
+                [&env = s.env] (raft::server_id id) { return env.is_leader(id); });
+        raft::server_id target;
+        if (leader_it != s.known.end()) {
+            target = *leader_it;
+        } else {
+            auto it = s.known.begin();
+            std::advance(it, std::uniform_int_distribution<size_t>{0, s.known.size() - 1}(s.rnd));
+            target = *it;
+        }
+
+        tlogger.debug("clock_failure start tid {} time {} target {} duration {}",
+                ctx.thread, s.timer.now(), target, _duration);
+        s.env.break_clock(target);
+        // Heal however we leave this scope, not just on the happy path: a throw
+        // from the sleep below (a broken promise if the timer outlives us, say)
+        // would otherwise leave this node permanently unable to bound the current
+        // time, which under LeaseGuard means it steps down whenever it leads and
+        // cannot commit while deferring.
+        //
+        // Today such a throw does not actually leak: generator::invoke() turns it
+        // into an exceptional_result, interpreter::exit() awaits every outstanding
+        // operation, and the consistency checker asserts on any non-value result,
+        // so the run aborts before the leak could matter. That is a coupling to
+        // machinery outside this nemesis, and generator.hh explicitly flags it as
+        // provisional ("consider failing in case of unknown/unexpected exception
+        // instead of storing it"). Cleaning up locally costs one line and does not
+        // depend on it. `heal_clock` cannot throw -- routes are never erased -- so
+        // a noexcept scope guard is safe.
+        auto healer = defer([&env = s.env, target] () noexcept { env.heal_clock(target); });
+        co_await s.timer.sleep(_duration);
+        tlogger.debug("clock_failure end tid {} time {} target {}", ctx.thread, s.timer.now(), target);
+
+        co_return clock_failure_result{};
+    }
+};
+
+template <PureStateMachine M>
+struct fmt::formatter<clock_failure<M>> : fmt::formatter<string_view> {
+    auto format(const clock_failure<M>& c, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "clock_failure{{duration:{}}}", c._duration);
+    }
+};
+
 // Must be executed sequentially.
 template <PureStateMachine M>
 struct reconfiguration {
@@ -3355,7 +3467,8 @@ static future<> run_basic_generator_test(
             raft_read<AppendReg>,
             network_majority_grudge<AppendReg>,
             reconfiguration<AppendReg>,
-            stop_crash<AppendReg>
+            stop_crash<AppendReg>,
+            clock_failure<AppendReg>
         >>;
     using history_t = utils::chunked_vector<std::variant<op_type, operation::completion<op_type>>>;
 
@@ -3405,6 +3518,9 @@ static future<> run_basic_generator_test(
         bool nemesis_partitions = true;
         bool nemesis_reconfigurations = true;
         bool nemesis_crashes = true;
+        // LeaseGuard clock-failure nemesis is only meaningful (and only enabled)
+        // when leases are on.
+        bool nemesis_clock_failures = leaseguard.has_value();
 
         // TODO: randomize the snapshot thresholds between different servers for more chaos.
         const auto max_command_size = 2 * sizeof(raft::log_entry);
@@ -3465,8 +3581,8 @@ static future<> run_basic_generator_test(
             co_await env.reconfigure(leader_id,
                 std::vector<raft::server_id>{known_config.begin(), known_config.end()}, timer.now() + 100_t, timer)));
 
-        auto threads = operation::make_thread_set(all_servers.size() + 3);
-        auto [partition_thread, reconfig_thread, crash_thread] = take<3>(threads);
+        auto threads = operation::make_thread_set(all_servers.size() + 4);
+        auto [partition_thread, reconfig_thread, crash_thread, clock_thread] = take<4>(threads);
 
 
         raft_call<AppendReg>::state_type db_call_state {
@@ -3503,12 +3619,20 @@ static future<> run_basic_generator_test(
             .rnd = std::mt19937{seed}
         };
 
+        clock_failure<AppendReg>::state_type clock_failure_state {
+            .env = env,
+            .known = known_config,
+            .timer = timer,
+            .rnd = std::mt19937{seed}
+        };
+
         auto init_state = op_type::state_type{
             std::move(db_call_state),
             std::move(read_state),
             std::move(network_majority_grudge_state),
             std::move(reconfiguration_state),
-            std::move(crash_state)
+            std::move(crash_state),
+            std::move(clock_failure_state)
         };
 
         using namespace generator;
@@ -3550,18 +3674,40 @@ static future<> run_basic_generator_test(
                                 })
                             )
                         ),
-                        either(
-                            stagger(seed, timer.now(), 0_t, 50_t,
-                                sequence(1, [] (int32_t i) {
-                                    SCYLLA_ASSERT(i > 0);
-                                    return op_type{raft_call<AppendReg>{AppendReg::append{i}, 200_t}};
-                                })
-                            ),
-                            op_limit(forwarding ? num_ops : 0 /* only produce raft_reads in forwarding mode */,
-                                stagger(seed, timer.now(), 0_t, 200_t,
-                                    sequence(1, [] (int32_t i) {
-                                        return op_type{raft_read<AppendReg>{i, 200_t}};
+                        pin(clock_thread,
+                            op_limit(nemesis_clock_failures ? num_ops : 0,
+                                // Space clock failures at least a full failover apart. A newly
+                                // elected leader must defer committing for delta (400_t) before it
+                                // can make progress; if clock failures arrived faster than that
+                                // (and they always target the current leader), every new leader's
+                                // clock would break mid-deferral and it would step down, livelocking
+                                // the group with no progress. With ~1000-1600_t between failures and
+                                // durations <= 300_t, there is a contiguous healthy window well above
+                                // election-timeout + delta for a healthy-clock leader to commit.
+                                stagger(seed, timer.now() + 200_t, 1000_t, 1600_t,
+                                    random(seed, [] (std::mt19937& engine) {
+                                        // Durations span both sides of the step-down threshold
+                                        // (~100_t): short failures cause a brief defer-and-recover
+                                        // on a leaseholder, long ones make a deferring leader step
+                                        // down so a healthy-clock node can take over.
+                                        static std::uniform_int_distribution<raft::logical_clock::rep> dist{0, 300};
+                                        return op_type{clock_failure<AppendReg>{raft::logical_clock::duration{dist(engine)}}};
                                     })
+                                )
+                            ),
+                            either(
+                                stagger(seed, timer.now(), 0_t, 50_t,
+                                    sequence(1, [] (int32_t i) {
+                                        SCYLLA_ASSERT(i > 0);
+                                        return op_type{raft_call<AppendReg>{AppendReg::append{i}, 200_t}};
+                                    })
+                                ),
+                                op_limit(forwarding ? num_ops : 0 /* only produce raft_reads in forwarding mode */,
+                                    stagger(seed, timer.now(), 0_t, 200_t,
+                                        sequence(1, [] (int32_t i) {
+                                            return op_type{raft_read<AppendReg>{i, 200_t}};
+                                        })
+                                    )
                                 )
                             )
                         )

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1626,6 +1626,21 @@ struct environment_config {
     std::mt19937 rnd;
     std::uniform_int_distribution<raft::logical_clock::rep> network_delay;
     raft::logical_clock::duration fd_convict_threshold;
+
+    // LeaseGuard: when set, every node created in this environment is configured
+    // with leader leases, backed by a per-node simulated bounded-uncertainty
+    // clock. The clocks are driven from simulated (logical) time by
+    // environment::update_lease_clocks(), mapping one logical tick to
+    // `tick_duration` of physical time. All nodes report the same interval
+    // [now - error, now + error], so the bounds always contain the true
+    // simulated time and leases are safe.
+    struct leaseguard_config {
+        raft::lease_clock::duration delta;
+        raft::lease_clock::duration error;
+        raft::lease_clock::duration tick_duration;
+        raft::lease_clock::time_point epoch;
+    };
+    std::optional<leaseguard_config> leaseguard;
 };
 
 // A set of `raft_server`s connected by a `network`.
@@ -3279,7 +3294,11 @@ template <> struct fmt::formatter<AppendReg::ret> : fmt::formatter<string_view> 
     }
 };
 
-SEASTAR_TEST_CASE(basic_generator_test) {
+static future<> run_basic_generator_test(
+        int32_t seed,
+        raft::logical_clock::duration fd_convict_threshold,
+        std::optional<environment_config::leaseguard_config> leaseguard,
+        std::optional<bool> force_forwarding) {
     using op_type = operation::invocable<operation::either_of<
             raft_call<AppendReg>,
             raft_read<AppendReg>,
@@ -3291,14 +3310,14 @@ SEASTAR_TEST_CASE(basic_generator_test) {
 
     static_assert(operation::Invocable<op_type>);
 
-    auto seed = tests::random::get_int<int32_t>();
     std::mt19937 random_engine{seed};
 
     logical_timer timer;
     environment_config cfg {
         .rnd{random_engine},
         .network_delay{0, 6},
-        .fd_convict_threshold = 50_t,
+        .fd_convict_threshold = fd_convict_threshold,
+        .leaseguard = leaseguard,
     };
     co_await with_env_and_ticker<AppendReg>(cfg, [&] (environment<AppendReg>& env, ticker& t) -> future<> {
         t.start([&, dist = std::uniform_int_distribution<size_t>(0, 9)] (uint64_t tick) mutable {
@@ -3320,8 +3339,9 @@ SEASTAR_TEST_CASE(basic_generator_test) {
 
         // With probability 1/2 enable forwarding: when we send a command to a follower, it automatically
         // forwards it to the known leader or waits for learning about a leader instead of returning
-        // `not_a_leader`.
-        bool forwarding = bdist(random_engine);
+        // `not_a_leader`. The lease variant forces this on so that `raft_read` operations are generated
+        // (they require forwarding) and thus exercise the lease read path.
+        bool forwarding = force_forwarding.value_or(bdist(random_engine));
 
         // With probability 1/2, run the servers with a configuration which causes frequent snapshotting.
         // Note: with the default configuration we won't observe any snapshots at all, since the default
@@ -3650,4 +3670,12 @@ SEASTAR_TEST_CASE(basic_generator_test) {
         tlogger.error("Failed to obtain a final successful response at the end of the test. Number of attempts: {}", cnt);
         SCYLLA_ASSERT(false);
     });
+}
+
+SEASTAR_TEST_CASE(basic_generator_test) {
+    co_await run_basic_generator_test(
+            tests::random::get_int<int32_t>(),
+            50_t /* fd_convict_threshold */,
+            std::nullopt /* leaseguard */,
+            std::nullopt /* force_forwarding */);
 }


### PR DESCRIPTION
The series implements https://arxiv.org/pdf/2512.15659 paper which describes an elegant way to implement time leases for raft using raft log itself. It is implemented as an optional feature. The paper relies on existence of bounded-uncertainty clock. Some clouds started to provide it natively. This series adds an abstract interface for it and the implementation used for testing.

No need to backport. New feature.

Fixes SCYLLADB-2576