### PR TITLE
test: cdc: test_image_deleted_column: fetch log separately for each pk

### DIFF
--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -2119,8 +2119,9 @@ SEASTAR_THREAD_TEST_CASE(test_image_deleted_column) {
             cquery_nofail(e, "insert into tbl(pk, ck, v, v2) values (1, 1, null, 1)");
             cquery_nofail(e, "insert into tbl(pk, ck, v, v2) values (2, 2, null, 2)");
 
-            // These are the queried columns:
-            sstring query_string = "select \"cdc$operation\", pk, ck, v, \"cdc$deleted_v\", \"cdc$deleted_v2\" from tbl_scylla_cdc_log";
+            auto query_pk = [] (int32_t pk_value) -> sstring {
+                return fmt::format("select \"cdc$operation\", pk, ck, v, \"cdc$deleted_v\", \"cdc$deleted_v2\" from tbl_scylla_cdc_log where pk = {} allow filtering", pk_value);
+            };
 
             // Perform an insert that does not affect v column.
             // Pre-image: v=NULL, cdc$deleted_v=NULL
@@ -2133,6 +2134,11 @@ SEASTAR_THREAD_TEST_CASE(test_image_deleted_column) {
             std::vector<data_value> postimage1 = 
                 { oper_ut(cdc::operation::post_image), int32_t(1), int32_t(1), data_value::make_null(int32_type), data_value::make_null(boolean_type), data_value::make_null(boolean_type) };
 
+            auto pk1_result = get_result(e, {oper_type, int32_type, int32_type, int32_type, boolean_type, boolean_type}, query_pk(1));
+            BOOST_REQUIRE_EQUAL(pk1_result.size(), 5);
+            BOOST_REQUIRE_EQUAL(pk1_result[2], preimage1);
+            BOOST_REQUIRE_EQUAL(pk1_result[4], postimage1);
+
             // Perform an insert that affects v column.
             // Pre-image: v=NULL, cdc$deleted_v=true
             // Pre-image ('full' mode): v=NULL, cdc$deleted_v=true
@@ -2143,12 +2149,10 @@ SEASTAR_THREAD_TEST_CASE(test_image_deleted_column) {
             std::vector<data_value> postimage2 = 
                 { oper_ut(cdc::operation::post_image), int32_t(2), int32_t(2), int32_t(2), data_value::make_null(boolean_type), data_value::make_null(boolean_type) };
 
-            auto result = get_result(e, {oper_type, int32_type, int32_type, int32_type, boolean_type, boolean_type}, query_string);
-            BOOST_REQUIRE_EQUAL(result.size(), 10);
-            BOOST_REQUIRE_EQUAL(result[2], preimage1);
-            BOOST_REQUIRE_EQUAL(result[4], postimage1);
-            BOOST_REQUIRE_EQUAL(result[7], preimage2);
-            BOOST_REQUIRE_EQUAL(result[9], postimage2);
+            auto pk2_result = get_result(e, {oper_type, int32_type, int32_type, int32_type, boolean_type, boolean_type}, query_pk(2));
+            BOOST_REQUIRE_EQUAL(pk2_result.size(), 5);
+            BOOST_REQUIRE_EQUAL(pk2_result[2], preimage2);
+            BOOST_REQUIRE_EQUAL(pk2_result[4], postimage2);
 
             auto test_table_with_collection = [&](bool frozen_collection) {
                 // Create a table and insert data with v = NULL
@@ -2163,9 +2167,6 @@ SEASTAR_THREAD_TEST_CASE(test_image_deleted_column) {
                 cquery_nofail(e, "insert into tbl(pk, ck, v, v2) values (1, 1, null, {1})");
                 cquery_nofail(e, "insert into tbl(pk, ck, v, v2) values (2, 2, null, {2})");
 
-                // These are the queried columns:
-                sstring query_string = "select \"cdc$operation\", pk, ck, v, \"cdc$deleted_v\", \"cdc$deleted_v2\" from tbl_scylla_cdc_log";
-
                 // Perform an insert that does not affect v column.
                 // Pre-image: v=NULL, cdc$deleted_v=NULL
                 // Pre-image ('full' mode): v=NULL, cdc$deleted_v=true
@@ -2175,6 +2176,11 @@ SEASTAR_THREAD_TEST_CASE(test_image_deleted_column) {
                     { oper_ut(cdc::operation::pre_image), int32_t(1), int32_t(1), data_value::make_null(int32_set_type), deleted_v, data_value::make_null(boolean_type) };
                 std::vector<data_value> postimage1 = 
                     { oper_ut(cdc::operation::post_image), int32_t(1), int32_t(1), data_value::make_null(int32_set_type), data_value::make_null(boolean_type), data_value::make_null(boolean_type) };
+
+                auto pk1_result = get_result(e, {oper_type, int32_type, int32_type, int32_set_type, boolean_type, boolean_type}, query_pk(1));
+                BOOST_REQUIRE_EQUAL(pk1_result.size(), 5);
+                BOOST_REQUIRE_EQUAL(pk1_result[2], preimage1);
+                BOOST_REQUIRE_EQUAL(pk1_result[4], postimage1);
 
                 // Perform an insert that affects v column.
                 // Pre-image: v=NULL, cdc$deleted_v=true
@@ -2186,12 +2192,10 @@ SEASTAR_THREAD_TEST_CASE(test_image_deleted_column) {
                 std::vector<data_value> postimage2 = 
                     { oper_ut(cdc::operation::post_image), int32_t(2), int32_t(2), make_int32_set(2), data_value::make_null(boolean_type), data_value::make_null(boolean_type) };
 
-                auto result = get_result(e, {oper_type, int32_type, int32_type, int32_set_type, boolean_type, boolean_type}, query_string);
-                BOOST_REQUIRE_EQUAL(result.size(), 10);
-                BOOST_REQUIRE_EQUAL(result[2], preimage1);
-                BOOST_REQUIRE_EQUAL(result[4], postimage1);
-                BOOST_REQUIRE_EQUAL(result[7], preimage2);
-                BOOST_REQUIRE_EQUAL(result[9], postimage2);
+                auto pk2_result = get_result(e, {oper_type, int32_type, int32_type, int32_set_type, boolean_type, boolean_type}, query_pk(2));
+                BOOST_REQUIRE_EQUAL(pk2_result.size(), 5);
+                BOOST_REQUIRE_EQUAL(pk2_result[2], preimage2);
+                BOOST_REQUIRE_EQUAL(pk2_result[4], postimage2);
             };
 
             test_table_with_collection(false);


### PR DESCRIPTION
The test writes data to two partitions in the base table, then does a full scan on the CDC log table and expects them to be present in a particular order. However, due to a combination of factors, the order actually depends on the vnode distribution - which is generated randomly in the beginning of the test - and thus the test can fail in a rare scenario.

CDC for vnodes creates a CDC stream for each vnode x shard pair. The stream ID contains a token, which is the highest token that belongs to the vnode and the shard (if the vnode is small enough that some shard does not have a token with it, this vnode x shard pair is skipped). The token encoded in the stream ID is the actual token of this partition - the CDC partitioner intentionally does this instead of passing the partition key through the usual murmurhash3 algorithm.

Full scans order partitions according to their token order - thus, partitions in a CDC log are returned according to the token in the stream ID. Thus, if two partition keys belong to two different vnodes, their relevant streams in the CDC log will be ordered in the same way as the tokens of the partition keys. However, if two partition keys belong to the same vnode then there are two cases:

- Both partition keys are handled by the same shard. In that case, changes to those partition keys will be recorded in the same CDC stream and the records will be ordered wrt. the write timestamp. This ordering is congruent with the ordering expected in the test.
- The partition keys are handled by two different shards. In that case, their ordering depends on the end tokens of chosen for the CDC stream IDs. With two shards, the chance for one of the two possible orders is basically 50/50.

In the observed failure, the second scenario actually happened:

- There was a vnode (-4121913117070699734, -3185821111993883821],
- The two partition keys were "1" and "2", with tokens -4069959284402364209 and -3248873570005575792, respectively - both contained in the aforementioned vnode,
- Pk "1" belonged to stream with token = -4120793659044003840,
- Pk "2" belonged to stream with token = -4121913117070699733.

Thus, the stream that described changes for partition "2" was reported in the full scan before the stream that described changes for partition "1", and thus the test failed.

The failure is rather unlikely to reproduce because it requires a particularly large vnode to be generated that encompasses both partition keys in the test (the vnode is ~5% of the size of the token space, whereas a random vnode should be roughly 1/256 of the space, so about 0.4%). However, the failure can be reliably reproduced if it is configured to run with the same vnodes as in the failed test.

Fix the test by issuing separate queries for each partition key and doing assertions separately on each result, rather than fetching everything at once and expecting a particular order.

Fixes: SCYLLADB-3176

Not sure if it is backport worthy. This is a very rare failure and only reproduced once so far. On the other hand, the fix is very simple and rather safe.