### PR TITLE
build: switch x86 microarchitecture level to x86-64-v3

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -27,7 +27,7 @@ add_compile_options(
 function(default_target_arch arch)
   set(x86_instruction_sets i386 i686 x86_64)
   if(CMAKE_SYSTEM_PROCESSOR IN_LIST x86_instruction_sets)
-    set(${arch} "westmere" PARENT_SCOPE)
+    set(${arch} "x86-64-v3" PARENT_SCOPE)
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     # we always use intrinsics like vmull.p64 for speeding up crc32 calculations
     # on the aarch64 architectures, and they require the crypto extension, so
@@ -124,6 +124,11 @@ add_compile_options("-fextend-variable-liveness=none")
 default_target_arch(target_arch)
 if(target_arch)
   add_compile_options("-march=${target_arch}")
+  # Add -mpclmul for x86-64 architectures
+  set(x86_instruction_sets i386 i686 x86_64)
+  if(CMAKE_SYSTEM_PROCESSOR IN_LIST x86_instruction_sets)
+    add_compile_options("-mpclmul")
+  endif()
 endif()
 
 function(maybe_limit_stack_usage_in_KB stack_usage_threshold_in_KB config)

--- a/configure.py
+++ b/configure.py
@@ -206,7 +206,7 @@ class Source(object):
 
 def default_target_arch():
     if platform.machine() in ['i386', 'i686', 'x86_64']:
-        return 'westmere'   # support PCLMUL
+        return 'x86-64-v3'   # support PCLMUL
     elif platform.machine() == 'aarch64':
         return 'armv8-a+crc+crypto'
     else:
@@ -2002,6 +2002,9 @@ user_cflags += ' -fextend-variable-liveness=none'
 if args.target != '':
     user_cflags += ' -march=' + args.target
 
+if platform.machine() == 'x86_64':
+    user_cflags += ' -mpclmul'
+
 if args.time_trace:
     user_cflags += ' -ftime-trace'
 
@@ -2208,7 +2211,7 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
 
     dpdk = args.dpdk
     if dpdk:
-        seastar_cmake_args += ['-DSeastar_DPDK=ON', '-DSeastar_DPDK_MACHINE=westmere']
+        seastar_cmake_args += ['-DSeastar_DPDK=ON', '-DSeastar_DPDK_MACHINE=x86-64-v3']
     if args.split_dwarf:
         seastar_cmake_args += ['-DSeastar_SPLIT_DWARF=ON']
     if args.alloc_failure_injector:

--- a/test/cqlpy/test_vector_similarity.py
+++ b/test/cqlpy/test_vector_similarity.py
@@ -57,7 +57,7 @@ def compute_similarity(similarity_function, v1, v2):
         return (1 + dot_product) / 2
 
 def assert_similarity(actual, expected):
-    assert isclose(actual, expected, abs_tol=1e-5)
+    assert isclose(actual, expected, rel_tol=1e-6)
 
 
 @pytest.mark.parametrize("similarity_function", similarity_functions)


### PR DESCRIPTION
We currently use `westmere` as our x86 architecture level,
for crc32c and pclmul.

Switch to more recent (but still ancient) x86-64-v3. Since
this doens't contain pclmul, add it explicitly.

x86-64-v3 brings us:

 - AVX (with 32-byte registers), primarily useful for data movement
 - BMI: bit manipulation instructions
 - MOVBE: better big-endian support

x86-64-v3 dates to 2013, 13 years ago (2015 for AMD), so we're unlikely
to see incompatibilities in the field due to old hardware.

The vector similarity function tolerance had to be increased, likely
due to fused-multiply-add instructions being used (or perhaps the
compiler treating addition and multiplication as associative, though
it shouldn't). We change the tolerance to be relative (absolute tolerance
won't work when we compare pair of numbers that can be 0.1 or 200). We
choose 1e-6 which lets all tests pass and is way beyond the real-world
accuracy of these vectors.

perf-simple-query results:

Before:

throughput:
	mean=   252278.18 standard-deviation=4051.94
	median= 253714.04 median-absolute-deviation=3707.29
	maximum=257102.96 minimum=247586.18
instructions_per_op:
	mean=   38378.87 standard-deviation=19.32
	median= 38375.71 median-absolute-deviation=4.83
	maximum=38408.01 minimum=38354.38
cpu_cycles_per_op:
	mean=   17887.77 standard-deviation=253.42
	median= 17781.94 median-absolute-deviation=224.53
	maximum=18192.38 minimum=17595.83

After:

throughput:
	mean=   256004.69 standard-deviation=7260.34
	median= 259353.72 median-absolute-deviation=4583.57
	maximum=260678.97 minimum=243483.95
instructions_per_op:
	mean=   38231.62 standard-deviation=32.69
	median= 38226.66 median-absolute-deviation=23.29
	maximum=38281.69 minimum=38198.76
cpu_cycles_per_op:
	mean=   17630.18 standard-deviation=492.51
	median= 17408.10 median-absolute-deviation=293.58
	maximum=18488.95 minimum=17320.03

A small but welcome improvement in instructions_per_op.

Performance improvement, not a fix, so not backporting.