### PR TITLE
 cql3: add zero-copy blob deserialization helpers and use them

### DIFF
--- a/cql3/untyped_result_set_idl_utils.hh
+++ b/cql3/untyped_result_set_idl_utils.hh
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <string_view>
+#include <type_traits>
+
+#include "cql3/untyped_result_set.hh"
+#include "serializer_impl.hh"
+
+namespace cql3::ser {
+
+inline auto blob_as_input_stream(const untyped_result_set_row& row, std::string_view name) {
+    return ::ser::as_input_stream(row.get_view(name));
+}
+
+template<typename T>
+T deserialize_blob_as(const untyped_result_set_row& row, std::string_view name) {
+    auto in = blob_as_input_stream(row, name);
+    return ::ser::deserialize(in, std::type_identity<T>());
+}
+
+} // namespace cql3::ser

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -36,6 +36,7 @@
 #include "db/schema_tables.hh"
 #include "message/messaging_service.hh"
 #include "cql3/untyped_result_set.hh"
+#include "cql3/untyped_result_set_idl_utils.hh"
 #include "service_permit.hh"
 #include "cql3/query_processor.hh"
 
@@ -357,8 +358,6 @@ static future<db::all_batches_replayed> process_batch(
         co_return db::all_batches_replayed::no;
     }
 
-    auto data = row.get_blob_unfragmented("data");
-
     blogger.debug("Replaying batch {} from stage {} and batch shard {}", id, int32_t(stage), batch_shard);
 
     utils::chunked_vector<mutation> mutations;
@@ -368,7 +367,8 @@ static future<db::all_batches_replayed> process_batch(
 
     try {
         utils::chunked_vector<std::pair<canonical_mutation, schema_ptr>> fms;
-        auto in = ser::as_input_stream(data);
+        auto in = cql3::ser::blob_as_input_stream(row, "data");
+        auto size = in.size();
         while (in.size()) {
             auto fm = ser::deserialize(in, std::type_identity<canonical_mutation>());
             const auto tbl = qp.db().try_find_table(fm.column_family_id());
@@ -392,8 +392,6 @@ static future<db::all_batches_replayed> process_batch(
 
             co_return db::all_batches_replayed::no;
         }
-
-        auto size = data.size();
 
         for (const auto& [fm, s] : fms) {
             mutations.emplace_back(fm.to_mutation(s));

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -17,6 +17,7 @@
 #include "service/query_state.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
+#include "cql3/untyped_result_set_idl_utils.hh"
 #include "db/system_keyspace.hh"
 #include "replica/database.hh"
 #include "schema/schema_builder.hh"
@@ -558,7 +559,7 @@ future<paxos_state> paxos_store::load_paxos_state(partition_key_view key, schema
     std::optional<service::paxos::proposal> accepted;
     if (row.has("proposal")) {
         accepted = service::paxos::proposal(row.get_as<utils::UUID>("proposal_ballot"),
-                ser::deserialize_from_buffer<>(row.get_blob_unfragmented("proposal"),  std::type_identity<frozen_mutation>(), 0));
+                cql3::ser::deserialize_blob_as<frozen_mutation>(row, "proposal"));
     }
 
     std::optional<service::paxos::proposal> most_recent;
@@ -566,7 +567,7 @@ future<paxos_state> paxos_store::load_paxos_state(partition_key_view key, schema
         // the value can be missing if it was pruned, supply empty one since
         // it will not going to be used anyway
         auto fm = row.has("most_recent_commit") ?
-                    ser::deserialize_from_buffer<>(row.get_blob_unfragmented("most_recent_commit"), std::type_identity<frozen_mutation>(), 0) :
+                    cql3::ser::deserialize_blob_as<frozen_mutation>(row, "most_recent_commit") :
                     freeze(mutation(s, key));
         most_recent = service::paxos::proposal(row.get_as<utils::UUID>("most_recent_commit_at"),
                 std::move(fm));

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -8,6 +8,7 @@
 #include "service/raft/raft_sys_table_storage.hh"
 
 #include "cql3/untyped_result_set.hh"
+#include "cql3/untyped_result_set_idl_utils.hh"
 #include "db/config.hh"
 #include "db/system_keyspace.hh"
 #include "raft/raft.hh"
@@ -102,10 +103,8 @@ future<raft::log_entries> raft_sys_table_storage::load_log() {
         }
         raft::term_t term = raft::term_t(row.get_as<int64_t>("term"));
         raft::index_t idx = raft::index_t(row.get_as<int64_t>("index"));
-        auto raw_data = row.get_view("data");
-        auto in = ser::as_input_stream(raw_data);
         using data_variant_type = decltype(raft::log_entry::data);
-        data_variant_type data = ser::deserialize(in, std::type_identity<data_variant_type>());
+        data_variant_type data = cql3::ser::deserialize_blob_as<data_variant_type>(row, "data");
 
         log.emplace_back(make_lw_shared<const raft::log_entry>(
             raft::log_entry{.term = term, .idx = idx, .data = std::move(data)}));


### PR DESCRIPTION
Several places deserialize IDL-encoded blob columns from untyped_result_set_row by first linearizing the fragmented managed_bytes_view into a contiguous bytes buffer (get_blob_unfragmented()), then feeding that to the deserializer. This is wasteful and can hit the Seastar per-allocation size limit (~130K) on large values.

Add cql3/untyped_result_set_utils.hh with two helpers that deserialize directly from the fragmented view — zero copy, no intermediate allocation:
- blob_as_input_stream() for multi-record streaming (batchlog)
- deserialize_blob_as<T>() for single-object deserialization
Convert three call sites:
- raft_sys_table_storage::load_log() — refactor only, was already zero-copy
- paxos_store::load_paxos_state() — eliminates linearization of proposal and most_recent_commit
- batchlog_manager::process_batch() — eliminates linearization of batch data

backport: no need, small optimization