### PR TITLE
vector_search: fix handling of HTTP 503 on ann requests

### DIFF
--- a/test/cqlpy/test_vector_search_with_vector_store_mock.py
+++ b/test/cqlpy/test_vector_search_with_vector_store_mock.py
@@ -13,12 +13,32 @@
 from http import HTTPStatus
 from itertools import combinations
 import json
+import time
 
 import pytest
 from cassandra.protocol import InvalidRequest
 from cassandra.query import SimpleStatement
 
 from .util import new_test_table, unique_name
+
+
+def wait_for_vector_store_node_recovery(cql, table, vector_store_mock):
+    vector_store_mock.set_next_status_response(200, '"SERVING"')
+    vector_store_mock.set_next_ann_response(200, json.dumps({
+        "primary_keys": {"pk1": [], "pk2": [], "ck1": [], "ck2": []},
+        "similarity_scores": [],
+    }))
+    timeout_s = 10
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            cql.execute(
+                f"SELECT pk1, pk2, ck1, ck2 FROM {table} WHERE pk1 IN (5, 6) ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 2")
+            return
+        except InvalidRequest:
+            time.sleep(0.5)
+    pytest.fail(
+        "Timed out waiting for vector store node to recover after bootstrapping")
 
 
 # Verify that partition key IN restriction is forwarded to the vector store.
@@ -210,3 +230,54 @@ def test_vector_search_map_subscript_restriction_raises_error(cql, test_keyspace
                 " ORDER BY embedding ANN OF [1.0, 0.0, 0.0]"
                 " LIMIT 10 ALLOW FILTERING"
             )
+
+
+# Reproduces SCYLLADB-3209: the vector store embeds the reason directly in the 503 body:
+#
+# {"reason":"NODE_BOOTSTRAPPING"} - the node has not finished its startup sequence and is
+# not yet ready to serve any traffic. Scylla must treat this as a node-level outage: mark
+# the node down (so future requests are not routed there) and report a service unavailable
+# error if no other nodes are available to failover.
+def test_vector_search_503_from_ann_when_vector_store_is_bootstrapping(cql, test_keyspace, vector_store_mock, skip_without_tablets):
+
+    schema = "pk1 tinyint, pk2 tinyint, ck1 tinyint, ck2 tinyint, embedding vector<float, 3>, PRIMARY KEY ((pk1, pk2), ck1, ck2)"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(
+            f"CREATE CUSTOM INDEX ON {table}(embedding) USING 'vector_index'")
+
+        vector_store_mock.set_next_ann_response(
+            HTTPStatus.SERVICE_UNAVAILABLE, '{"reason":"NODE_BOOTSTRAPPING"}')
+        cql.execute(
+            f"INSERT INTO {table} (pk1, pk2, ck1, ck2, embedding) VALUES (5, 7, 9, 2, [0.1, 0.2, 0.3])")
+
+        try:
+            with pytest.raises(InvalidRequest, match="Vector Store service is unavailable"):
+                cql.execute(
+                    f"SELECT pk1, pk2, ck1, ck2 FROM {table} WHERE pk1 IN (5, 6) ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 2")
+        finally:
+            # Restore the node to a healthy state so subsequent tests are not affected
+            # by the node-down state left behind by this test.
+            wait_for_vector_store_node_recovery(cql, table, vector_store_mock)
+
+
+# Reproduces SCYLLADB-3209 (complement to the BOOTSTRAPPING case above): when /ann returns
+# HTTP 503 with {"reason":"INDEX_BUILDING","message":...} the node itself is healthy - the 503
+# signals an index-specific condition: index is still being built after creation.
+# Scylla must NOT mark the node as down; instead it should forward the "message" field from the
+# 503 body to the CQL caller as an InvalidRequest error.
+def test_vector_search_503_from_ann_when_vector_store_is_serving(cql, test_keyspace, vector_store_mock, skip_without_tablets):
+
+    schema = "pk1 tinyint, pk2 tinyint, ck1 tinyint, ck2 tinyint, embedding vector<float, 3>, PRIMARY KEY ((pk1, pk2), ck1, ck2)"
+
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(
+            f"CREATE CUSTOM INDEX ON {table}(embedding) USING 'vector_index'")
+        cql.execute(
+            f"INSERT INTO {table} (pk1, pk2, ck1, ck2, embedding) VALUES (5, 7, 9, 2, [0.1, 0.2, 0.3])")
+
+        vector_store_mock.set_next_ann_response(
+            HTTPStatus.SERVICE_UNAVAILABLE,
+            '{"reason":"INDEX_BUILDING","message":"Index is not available yet as it is still being constructed, progress: 33.333%"}')
+        with pytest.raises(InvalidRequest, match="503.*still being constructed"):
+            cql.execute(
+                f"SELECT pk1, pk2, ck1, ck2 FROM {table} WHERE pk1 IN (5, 6) ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 2")

--- a/test/cqlpy/vector_store_mock.py
+++ b/test/cqlpy/vector_store_mock.py
@@ -36,9 +36,11 @@ class VectorStoreMock:
     def __init__(self):
         self._ann_requests: list[Request] = []
         self._bm25_requests: list[Request] = []
+        self._status_requests: list[Request] = []
         self._lock = threading.Lock()
         self._next_ann_response = Response()
         self._next_bm25_response = BM25Response()
+        self._next_status_response = Response(status=200, body='"SERVING"')
         self._server: HTTPServer | None = None
         self._thread: threading.Thread | None = None
 
@@ -56,6 +58,11 @@ class VectorStoreMock:
         with self._lock:
             return self._bm25_requests.copy()
 
+    @property
+    def status_requests(self) -> list[Request]:
+        with self._lock:
+            return self._status_requests.copy()
+
     def set_next_ann_response(self, status: int, body: str) -> None:
         with self._lock:
             self._next_ann_response = Response(status=status, body=body)
@@ -64,12 +71,18 @@ class VectorStoreMock:
         with self._lock:
             self._next_bm25_response = BM25Response(status=status, body=body)
 
+    def set_next_status_response(self, status: int, body: str) -> None:
+        with self._lock:
+            self._next_status_response = Response(status=status, body=body)
+
     def reset(self) -> None:
         with self._lock:
             self._ann_requests.clear()
             self._bm25_requests.clear()
+            self._status_requests.clear()
             self._next_ann_response = Response()
             self._next_bm25_response = BM25Response()
+            self._next_status_response = Response(status=200, body='"SERVING"')
 
     def _handle_ann(self, request: Request, send_response: Callable[[Response], None]) -> None:
         with self._lock:
@@ -81,6 +94,12 @@ class VectorStoreMock:
         with self._lock:
             self._bm25_requests.append(request)
             response = self._next_bm25_response
+        send_response(response)
+
+    def _handle_status(self, request: Request, send_response: Callable[[Response], None]) -> None:
+        with self._lock:
+            self._status_requests.append(request)
+            response = self._next_status_response
         send_response(response)
 
     def start(self, host: str):
@@ -98,6 +117,14 @@ class VectorStoreMock:
                     mock._handle_ann(req, self._send_response)
                 elif self.path.endswith("/bm25"):
                     mock._handle_bm25(req, self._send_response)
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+
+            def do_GET(self):
+                if self.path == "/api/v1/status":
+                    req = Request(path=self.path, body="")
+                    mock._handle_status(req, self._send_response)
                 else:
                     self.send_response(404)
                     self.end_headers()

--- a/test/vector_search/client_test.cc
+++ b/test/vector_search/client_test.cc
@@ -119,7 +119,45 @@ SEASTAR_TEST_CASE(is_up_when_server_returned_server_error_status) {
     co_await server->stop();
 }
 
-SEASTAR_TEST_CASE(is_up_when_server_returned_service_unavailable_status) {
+SEASTAR_TEST_CASE(becomes_down_after_service_unavailable_when_body_has_node_bootstrapping_reason) {
+    abort_source_timeout as;
+    auto server = co_await make_vs_mock_server();
+    server->next_ann_response(vs_mock_server::response{seastar::http::reply::status_type::service_unavailable, R"({"reason":"NODE_BOOTSTRAPPING"})"});
+
+    client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
+
+    auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
+
+    BOOST_CHECK(!res);
+    BOOST_CHECK(std::holds_alternative<service_unavailable_error>(res.error()));
+
+    auto became_down = co_await repeat_until([&client]() -> future<bool> {
+        co_return !client.is_up();
+    });
+    BOOST_CHECK(became_down);
+
+    co_await client.close();
+    co_await server->stop();
+}
+
+SEASTAR_TEST_CASE(returns_response_and_stays_up_on_service_unavailable_when_body_has_index_building_reason) {
+    abort_source_timeout as;
+    auto server = co_await make_vs_mock_server();
+    server->next_ann_response(
+            vs_mock_server::response{seastar::http::reply::status_type::service_unavailable, R"({"reason":"INDEX_BUILDING","message":"index is building"})"});
+
+    client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
+
+    auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
+    BOOST_REQUIRE(res);
+    BOOST_CHECK_EQUAL(res.value().status, seastar::http::reply::status_type::service_unavailable);
+    BOOST_CHECK(client.is_up());
+
+    co_await client.close();
+    co_await server->stop();
+}
+
+SEASTAR_TEST_CASE(returns_response_and_stays_up_on_service_unavailable_when_body_is_not_json_object) {
     abort_source_timeout as;
     auto server = co_await make_vs_mock_server();
     server->next_ann_response(vs_mock_server::response{seastar::http::reply::status_type::service_unavailable, "Service Unavailable"});
@@ -127,10 +165,9 @@ SEASTAR_TEST_CASE(is_up_when_server_returned_service_unavailable_status) {
     client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
-
+    BOOST_REQUIRE(res);
+    BOOST_CHECK_EQUAL(res.value().status, seastar::http::reply::status_type::service_unavailable);
     BOOST_CHECK(client.is_up());
-    BOOST_CHECK(res);
-    BOOST_CHECK(res->status == seastar::http::reply::status_type::service_unavailable);
 
     co_await client.close();
     co_await server->stop();

--- a/vector_search/client.cc
+++ b/vector_search/client.cc
@@ -120,6 +120,29 @@ bool is_server_problem(std::exception_ptr& err) {
     return is_server_unavailable(err) || try_catch<tls::verification_error>(err) != nullptr || try_catch<timed_out_error>(err) != nullptr;
 }
 
+bool is_service_unavailable(http::reply::status_type status) {
+    return status == http::reply::status_type::service_unavailable;
+}
+
+enum class service_unavailable_reason { node_bootstrapping, index_building };
+
+std::optional<service_unavailable_reason> parse_service_unavailable_reason(std::string_view body) {
+    auto maybe_json = rjson::try_parse(body);
+    if (maybe_json) {
+        const auto* reason = rjson::find(*maybe_json, "reason");
+        if (reason && reason->IsString()) {
+            auto reason_str = rjson::to_string_view(*reason);
+            if (reason_str == "NODE_BOOTSTRAPPING") {
+                return service_unavailable_reason::node_bootstrapping;
+            }
+            if (reason_str == "INDEX_BUILDING") {
+                return service_unavailable_reason::index_building;
+            }
+        }
+    }
+    return std::nullopt;
+}
+
 future<client::request_error> map_err(std::exception_ptr& err) {
     if (is_server_problem(err)) {
         co_return service_unavailable_error{};
@@ -156,11 +179,20 @@ seastar::future<client::request_result> client::request(
             co_return std::unexpected{aborted_error{}};
         }
         if (is_server_problem(err)) {
-            handle_server_unavailable(err);
+            handle_server_unavailable(fmt::format("{}", err));
         }
         co_return std::unexpected{co_await map_err(err)};
     }
-    co_return co_await std::move(f);
+    auto resp = co_await std::move(f);
+    if (is_service_unavailable(resp.status)) {
+        auto body = response_content_to_sstring(resp.content);
+        auto reason = parse_service_unavailable_reason(body);
+        if (reason == service_unavailable_reason::node_bootstrapping) {
+            handle_server_unavailable(fmt::format("received HTTP status {}: {}", static_cast<int>(resp.status), body));
+            co_return std::unexpected{service_unavailable_error{}};
+        }
+    }
+    co_return resp;
 }
 
 seastar::future<client::response> client::request_impl(seastar::httpd::operation_type method, seastar::sstring path, std::optional<seastar::sstring> content,
@@ -197,9 +229,9 @@ seastar::future<> client::close() {
     co_await _http_client.close();
 }
 
-void client::handle_server_unavailable(std::exception_ptr err) {
+void client::handle_server_unavailable(const seastar::sstring& reason) {
     if (!is_checking_status_in_progress()) {
-        _logger.warn("Request to vector store {} {}:{} failed: {}", _endpoint.host, _endpoint.ip, _endpoint.port, err);
+        _logger.warn("Request to vector store {} {}:{} failed: {}", _endpoint.host, _endpoint.ip, _endpoint.port, reason);
         _checking_status_future = run_checking_status();
     }
 }

--- a/vector_search/client.hh
+++ b/vector_search/client.hh
@@ -12,7 +12,6 @@
 #include "utils/log.hh"
 #include "utils/updateable_value.hh"
 #include <chrono>
-#include <exception>
 #include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/abort_source.hh>
@@ -61,7 +60,7 @@ private:
     seastar::future<response> request_impl(seastar::httpd::operation_type method, seastar::sstring path, std::optional<seastar::sstring> content,
             std::optional<seastar::http::reply::status_type>&& expected, seastar::abort_source& as);
     seastar::future<bool> check_status();
-    void handle_server_unavailable(std::exception_ptr err);
+    void handle_server_unavailable(const seastar::sstring& reason);
     seastar::future<> run_checking_status();
     bool is_checking_status_in_progress() const;
     std::chrono::milliseconds backoff_retry_max() const;

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -88,19 +88,16 @@ auto parse_service_uri(std::string_view uri_) -> std::optional<uri> {
 }
 
 auto decode_error_message(const std::vector<seastar::temporary_buffer<char>>& content) -> sstring {
-    if (content.size() == 1) {
-        auto body = std::string_view(content.front().get(), content.front().size());
-        auto json = rjson::try_parse(body);
-        if (json && json->IsString()) {
-            return sstring(rjson::to_string_view(*json));
-        }
-        return sstring(body);
-    }
-
     auto body = vector_search::response_content_to_sstring(content);
     auto json = rjson::try_parse(body);
-    if (json && json->IsString()) {
-        return sstring(rjson::to_string_view(*json));
+    if (json) {
+        if (json->IsString()) {
+            return sstring(rjson::to_string_view(*json));
+        }
+        auto message = rjson::find(*json, "message");
+        if (message && message->IsString()) {
+            return sstring(rjson::to_string_view(*message));
+        }
     }
     return body;
 }


### PR DESCRIPTION
When the index is being built, the ann request returns HTTP 503.
So far we treated this as a regular response and forward this back
to the client.

However the index may return 503 in two different scenarios:
1. The node is SERVING but the index is still being built after creation.
2. The node is BOOTSTRAPPING and not yet ready to serve requests.

In the first case treating 503 as a regular response is correct.
In the second case we should treat 503 as a failure and retry
the request on another node (high availability failover).
Otherwise we will be permanently trying to send requests to a node
that is not yet ready to serve requests.

In the scope of this task, the vector-store 503 response body has been
changed to a JSON object containing the 'reason' of the 503, and the human
readable message in the 'message' field that was previously the body of
the response.
In this change we parse the 503 body as a JSON object and inspect the 'reason'
field to distinguish between the two scenarios and handle them accordingly.

The vector store 503 response body format is now:
```
  {"reason":"NODE_BOOTSTRAPPING"}              - the node is not ready yet
  {"reason":"INDEX_BUILDING","message":...}    - only this index is building
```

For backward compatibility, if the 503 response body is not a valid JSON object,
we will treat it as a regular response and forward it back to the client.

Fixes SCYLLADB-3209

Backport to 2026.1, 2026.2, 2026.3  as these branches are affected.