### PR TITLE
topology: finalize tablet resize on base table

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2684,16 +2684,20 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
         auto tm = get_token_metadata_ptr();
         auto plan = co_await _tablet_allocator.balance_tablets(tm, &_topo_sm._topology, &_sys_ks, {}, get_dead_nodes());
+        std::unordered_set<table_id> finalized_base_tables;
+        for (auto resized_table_id : plan.resize_plan().finalize_resize) {
+            finalized_base_tables.insert(tm->tablets().get_base_table(resized_table_id));
+        }
 
         utils::chunked_vector<canonical_mutation> updates;
         updates.reserve(plan.resize_plan().finalize_resize.size() * 2 + 1);
 
-        for (auto& table_id : plan.resize_plan().finalize_resize) {
-            auto s = _db.find_schema(table_id);
-            auto new_tablet_map = co_await _tablet_allocator.resize_tablets(tm, table_id);
+        for (auto base_table_id : finalized_base_tables) {
+            auto s = _db.find_schema(base_table_id);
+            auto new_tablet_map = co_await _tablet_allocator.resize_tablets(tm, base_table_id);
             co_await replica::tablet_map_to_mutations(
                 new_tablet_map,
-                table_id,
+                base_table_id,
                 s->ks_name(),
                 s->cf_name(),
                 guard.write_timestamp(),
@@ -2703,14 +2707,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 });
 
             // Clears the resize decision for a table.
-            generate_resize_update(updates, guard, table_id, locator::resize_decision{});
-            _vb_coordinator->generate_tablet_resize_updates(updates, guard, table_id, tm->tablets().get_tablet_map(table_id), new_tablet_map);
+            generate_resize_update(updates, guard, base_table_id, locator::resize_decision{});
+            _vb_coordinator->generate_tablet_resize_updates(updates, guard, base_table_id, tm->tablets().get_tablet_map(base_table_id), new_tablet_map);
 
-            for (auto table_id : tm->tablets().all_table_groups().at(table_id)) {
-                co_await _cdc_gens.generate_tablet_resize_update(updates, table_id, new_tablet_map, guard.write_timestamp());
+            for (auto colocated_table_id : tm->tablets().all_table_groups().at(base_table_id)) {
+                co_await _cdc_gens.generate_tablet_resize_update(updates, colocated_table_id, new_tablet_map, guard.write_timestamp());
             }
 
-            const auto& tmap = get_token_metadata_ptr()->tablets().get_tablet_map(table_id);
+            const auto& tmap = get_token_metadata_ptr()->tablets().get_tablet_map(base_table_id);
             auto old_cnt = tmap.tablet_count();
             auto new_cnt = new_tablet_map.tablet_count();
             if (old_cnt > new_cnt) {
@@ -2723,13 +2727,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     }
                 }
                 if (_feature_service.tablet_incremental_repair) {
-                    rtlogger.info("Send rpc verb repair_update_repaired_at_for_merge table={} replicas={} old_cnt={} new_cnt={}", table_id, replicas, old_cnt, new_cnt);
+                    rtlogger.info("Send rpc verb repair_update_repaired_at_for_merge table={} replicas={} old_cnt={} new_cnt={}", base_table_id, replicas, old_cnt, new_cnt);
                     if (utils::get_local_injector().enter("handle_tablet_resize_finalization_for_merge_error")) {
                         rtlogger.info("Got handle_tablet_resize_finalization_for_merge_error old_cnt={} new_cnt={}", old_cnt, new_cnt);
                         co_await sleep_abortable(std::chrono::minutes(1), _as);
                     }
-                    co_await coroutine::parallel_for_each(replicas, [ms = &_messaging, table_id] (const locator::host_id& h) -> future<> {
-                        co_await ser::repair_rpc_verbs::send_repair_update_repaired_at_for_merge(ms, h, table_id);
+                    co_await coroutine::parallel_for_each(replicas, [ms = &_messaging, base_table_id] (const locator::host_id& h) -> future<> {
+                        co_await ser::repair_rpc_verbs::send_repair_update_repaired_at_for_merge(ms, h, base_table_id);
                     });
                 }
             }
@@ -2745,7 +2749,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         if (auto old_load_stats = _tablet_allocator.get_load_stats()) {
             guard = co_await start_operation();
             auto new_tm = get_token_metadata_ptr();
-            auto reconciled_stats = old_load_stats->reconcile_tablets_resize(plan.resize_plan().finalize_resize, *tm, *new_tm);
+            auto reconciled_stats = old_load_stats->reconcile_tablets_resize(finalized_base_tables, *tm, *new_tm);
             if (reconciled_stats) {
                 _tablet_allocator.set_load_stats(reconciled_stats);
             }


### PR DESCRIPTION
Tablet resize finalization operates on a tablet map shared by an entire co-location group. That map is keyed by the group's base table, while co-located tables such as Alternator CDC log tables only point at that base table.

`test_get_records_with_alternating_tablets_count` changes the tablet count by altering the CDC log table directly. In that case the resize plan may refer to the CDC log table id even though the actual tablet-map resize and resize-state clearing must be done through the group's base table id. The old code used the finalized table id directly for `resize_tablets()`, tablet-map mutations, resize-decision clearing, view-building updates, load-stat reconciliation, and lookup in `all_table_groups()`, which is keyed by base table ids.

This normalizes finalized resize entries through `get_base_table()` first, processes each base table once, and uses the normalized set consistently for resize finalization and load-stat reconciliation. CDC stream metadata is still regenerated per co-located table in the group, so the CDC log table continues to get its stream update from the new shared tablet map.

For ordinary base tables this is unchanged because `get_base_table(table) == table`. For non-CDC co-located tables, this follows the same tablet-group ownership model: the signal applies to the group base table, not to an independent tablet map for the co-located table.

Fixes SCYLLADB-3180

The test which triggers the problem came to live with 2026.2, so let's backport there. Other than that, I don't think one would ever explicitly modify tablet count for _auxiliary_ tables (like the CDC table), so let's not backport further.