### PR TITLE
compaction: fix stale-snapshot race between split replacer and regular compaction picker

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -423,8 +423,22 @@ future<compaction_result> compaction_task_executor::compact_sstables(compaction_
         return t.make_sstable(sstables::sstable_state::normal);
     };
     descriptor.replacer = [this, &t, &on_replace, offstrategy] (compaction_completion_desc desc) {
+        utils::get_local_injector().inject("split_pause_before_replacer",
+                [this, &t] (auto& handler) -> future<> {
+            if (is_system_keyspace(t.schema()->ks_name()) || _type != compaction_type::Split) {
+                co_return;
+            }
+            cmlog.info("split_pause_before_replacer: waiting");
+            co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
+            cmlog.info("split_pause_before_replacer: released");
+        }).get();
         t.get_compaction_strategy().notify_completion(t, desc.old_sstables, desc.new_sstables);
         _cm.propagate_replacement(t, desc.old_sstables, desc.new_sstables);
+        // Hold sstable_set_lock while mutating the sstable set and deregistering
+        // old sstables.  This serializes with regular compaction's snapshot +
+        // filter + registration, preventing the stale-snapshot race.
+        auto& cs = _cm.get_compaction_state(_compacting_table);
+        auto units = get_units(cs.sstable_set_lock, 1).get();
         // on_replace updates the compacting registration with the old and new
         // sstables. while on_compaction_completion() removes the old sstables
         // from the table's sstable set, and adds the new ones to the sstable
@@ -584,6 +598,9 @@ protected:
             co_return std::nullopt;
         }
 
+        // sstable_set_lock serializes with replacers that mutate sstable sets.
+        auto sstable_set_units = co_await get_units(_compaction_state.sstable_set_lock, 1);
+
         // candidates are sstables that aren't being operated on by other compaction types.
         // those are eligible for major compaction.
         compaction_group_view* t = _compacting_table;
@@ -596,9 +613,9 @@ protected:
 
         cmlog.info0("User initiated compaction started on behalf of {}", *t);
 
-        // Now that the sstables for major compaction are registered
-        // and the user_initiated_backlog_tracker is set up
-        // the exclusive lock can be freed to let regular compaction run in parallel to major
+        // Now that the sstables for major compaction are registered,
+        // release both locks to let regular compaction run in parallel to major.
+        sstable_set_units.return_all();
         lock_holder.return_all();
 
         co_await utils::get_local_injector().inject("major_compaction_wait", [this] (auto& handler) -> future<> {
@@ -835,6 +852,12 @@ future<>
 compaction_manager::run_with_compaction_disabled(compaction_group_view& t, std::function<future<> ()> func, sstring reason) {
     compaction_reenabler cre = co_await stop_and_disable_compaction(std::move(reason), t);
 
+    // Hold sstable_set_lock while running the function (which typically captures
+    // sstables and registers them as compacting).  This serializes with
+    // concurrent replacers that mutate the sstable set, preventing them from
+    // making the captured snapshot stale.
+    auto& cs = get_compaction_state(&t);
+    auto units = co_await get_units(cs.sstable_set_lock, 1);
     co_await func();
 }
 
@@ -1014,6 +1037,21 @@ public:
 
     future<std::vector<sstables::frozen_sstable_run>> candidates_as_runs(compaction_group_view& t) const override {
         auto main_set = co_await t.main_sstable_set();
+        co_await utils::get_local_injector().inject("regular_compaction_pause_after_snapshot",
+                [this, &t, &main_set] (auto& handler) -> future<> {
+            if (is_system_keyspace(t.schema()->ks_name()) || main_set->size() == 0
+                    || !_cm.can_proceed(&t)) {
+                co_return;
+            }
+            bool has_compacting = std::ranges::any_of(main_set->all_sstable_runs(),
+                    [this] (const auto& run) { return !_cm.eligible_for_compaction(run); });
+            if (!has_compacting) {
+                co_return;
+            }
+            cmlog.info("regular_compaction_pause_after_snapshot: waiting");
+            co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
+            cmlog.info("regular_compaction_pause_after_snapshot: released");
+        });
         co_return _cm.get_candidates(t, main_set->all_sstable_runs());
     }
 };
@@ -1414,8 +1452,16 @@ protected:
                 co_return std::nullopt;
             }
             switch_state(state::pending);
-            // Write lock is used to synchronize selection of sstables for compaction and their registration.
-            auto lock_holder = co_await _compaction_state.lock.hold_write_lock();
+            // Read lock serializes with major compaction (which takes write lock).
+            auto lock_holder = co_await _compaction_state.lock.hold_read_lock();
+            if (!can_proceed()) {
+                co_return std::nullopt;
+            }
+
+            // sstable_set_lock protects the atomicity of snapshot + filter + registration,
+            // preventing split's replacer from mutating the sstable set and deregistering
+            // sstables between our snapshot capture and eligibility filter.
+            auto sstable_set_units = co_await get_units(_compaction_state.sstable_set_lock, 1);
             if (!can_proceed()) {
                 co_return std::nullopt;
             }
@@ -1447,9 +1493,10 @@ protected:
             cmlog.debug("Accepted compaction job: task={} ({} sstable(s)) of weight {} for {}",
                 fmt::ptr(this), descriptor.sstables.size(), weight, t);
 
-            // Finished selecting and registering compacting sstables, so write lock can be released.
-            lock_holder.return_all();
-            lock_holder = co_await _compaction_state.lock.hold_read_lock();
+            // Finished selecting and registering compacting sstables.
+            // Release sstable_set_lock (snapshot+filter+registration is complete).
+            // Keep read lock held during compaction execution.
+            sstable_set_units.return_all();
 
             setup_new_compaction(descriptor.run_identifier);
             _compaction_state.last_regular_compaction = gc_clock::now();

--- a/compaction/compaction_state.hh
+++ b/compaction/compaction_state.hh
@@ -10,6 +10,7 @@
 
 #include <seastar/core/gate.hh>
 #include <seastar/core/rwlock.hh>
+#include <seastar/core/semaphore.hh>
 #include <seastar/core/condition-variable.hh>
 #include "seastarx.hh"
 
@@ -22,16 +23,56 @@ namespace compaction {
 // There's 1:1 relationship between compaction_grop_view and compaction_state.
 // Two or more compaction_group_view can be served by the same instance of sstable::sstable_set,
 // so it's not safe to track any sstable state here.
+//
+// Locking
+// =======
+//
+// Two locks govern concurrency for compaction selection and sstable set mutation:
+//
+// 1) lock (rwlock)
+//
+//    Serializes major compaction against regular compaction selection.
+//    Major compaction takes the write lock to ensure no regular compaction
+//    is in the middle of selecting candidates -- so major sees all sstables.
+//    Regular compaction takes the read lock, allowing multiple regular
+//    compactions to select concurrently.
+//
+//    Lock ordering: lock is taken BEFORE sstable_set_lock when both are needed.
+//
+// 2) sstable_set_lock (semaphore, count=1)
+//
+//    Protects the atomicity of:
+//      (a) regular compaction's: snapshot capture + eligibility filter + registration
+//      (b) split/rewrite replacer's: on_compaction_completion (which mutates the
+//          sstable set and deregisters old sstables from _compacting_sstables)
+//
+//    Without this lock, the following race is possible:
+//      - Regular picker captures a snapshot of main_sstables (contains X).
+//      - Split's replacer fires: moves X out of main_sstables AND deregisters
+//        X from _compacting_sstables.
+//      - Regular picker's filter runs on the stale snapshot, finds X eligible
+//        (since it was deregistered), and selects it.
+//      - Regular compaction completes, tries to remove X from main_sstables
+//        where it no longer exists -> on_internal_error.
+//
+//    The sstable_set_lock ensures that (a) and (b) do not interleave.
+//
+// Lock ordering (when both are acquired):
+//    lock -> sstable_set_lock
+//
 struct compaction_state {
     // Used both by compaction tasks that refer to the compaction_state
     // and by any function running under run_with_compaction_disabled().
     seastar::named_gate gate;
 
-    // Used for synchronizing selection of sstable for compaction.
-    // Write lock is held when getting sstable list, feeding them into strategy, and registering compacting sstables.
-    // The lock prevents two concurrent compaction tasks from picking the same sstables. And it also helps major
-    // to synchronize with minor, such that major doesn't miss any sstable.
+    // Serializes major compaction selection against regular compaction selection.
+    // Major takes write lock; regular takes read lock.
     seastar::rwlock lock;
+
+    // Protects the view's sstable set ownership. Serializes sstable set reads
+    // (snapshot + filter + registration) against sstable set mutations
+    // (on_compaction_completion which moves sstables between groups/views).
+    seastar::semaphore sstable_set_lock{1};
 
     // Compations like major need to work on all sstables in the unrepaired
     // set, no matter if the sstable is being repaired or not. The

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1116,6 +1116,15 @@ future<> compaction_group::split(compaction::compaction_type_options::split opt,
         // Waits on sstables produced by repair to be integrated into main set; off-strategy is usually a no-op with tablets.
         co_await cm.perform_offstrategy(*view, tablet_split_task_info);
         co_await cm.perform_split_compaction(*view, opt, tablet_split_task_info);
+        // Injection point: pause after the first view's split compaction
+        // completes (sstables moved and deregistered). This gives a concurrent
+        // regular compaction time to run its completion phase before the next
+        // view's run_with_compaction_disabled kills it.
+        if (!is_repairing_view(view)) {
+            co_await utils::get_local_injector().inject(
+                    "split_pause_after_first_view_compaction",
+                    utils::wait_for_message{std::chrono::minutes{5}});
+        }
     }
 
     if (_t.uses_logstor()) {

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -2338,3 +2338,123 @@ async def test_split_stopped_on_shutdown(manager: ManagerClient):
         await log.wait_for('Detected tablet split for table', from_mark=log_mark)
         tablet_count = await get_tablet_count(manager, server, ks, 'test')
         assert tablet_count >= expected_tablet_count
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode('release', 'error injections are not supported in release mode')
+async def test_split_vs_regular_compaction_stale_snapshot(manager: ManagerClient):
+    """Reproducer for split-vs-regular-compaction stale-snapshot race.
+
+    The race happens when a regular compaction picker captures a snapshot of
+    main_sstables, then split's replacer moves sstables out of main and
+    deregisters them from _compacting_sstables, then the picker's eligibility
+    filter runs on the stale snapshot and selects the moved sstables.  The
+    regular compaction's completion phase then fails because the sstables are
+    no longer in the source compaction group's main set.
+
+    Injection points:
+      - split_pause_before_replacer: pauses split's replacer before it calls
+        on_compaction_completion (which moves sstables).
+      - regular_compaction_pause_after_snapshot: pauses the regular picker
+        after capturing the snapshot but before the eligibility filter.
+
+    Without the fix (selector_lock), the replacer runs freely between the
+    picker's snapshot and filter, triggering the race and aborting the node.
+    With the fix, selector_lock serializes the two, preventing the race.
+    """
+    logger.info("Setting up 2-node cluster (RF=2, 2 racks)")
+    cfg = {'enable_tablets': True}
+    cmdline = ['--smp', '1', '--target-tablet-size-in-bytes', '1000000']
+    servers = []
+    for i in range(2):
+        s = await manager.servers_add(1, cmdline=cmdline, config=cfg,
+                                      property_file={'dc': 'dc1', 'rack': f'r{i}'})
+        servers.extend(s)
+    server = servers[0]
+    cql = manager.get_cql()
+    log = await manager.server_open_log(server.server_id)
+    mark = await log.mark()
+
+    await manager.api.disable_tablet_balancing(server.ip_addr)
+
+    ks = await create_new_test_keyspace(cql,
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} "
+        "AND tablets = {'initial': 1}")
+
+    await cql.run_async(
+        f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) "
+        f"WITH compression = {{'sstable_compression': ''}} "
+        f"AND compaction = {{'class': 'IncrementalCompactionStrategy', "
+        f"                    'min_threshold': '2'}}")
+
+    insert = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+
+    # Disable auto-compaction during sstable creation.
+    for s in servers:
+        await manager.api.disable_autocompaction(s.ip_addr, ks)
+
+    # Create two sstables.
+    for pk in range(200):
+        await cql.run_async(insert, [pk, b'\x00' * 512])
+    for s in servers:
+        await manager.api.flush_keyspace(s.ip_addr, ks)
+    for pk in range(200, 400):
+        await cql.run_async(insert, [pk, b'\x00' * 512])
+    for s in servers:
+        await manager.api.flush_keyspace(s.ip_addr, ks)
+
+    # Enable injections.
+    await manager.api.enable_injection(
+        server.ip_addr, "split_pause_before_replacer", one_shot=False)
+    await manager.api.enable_injection(
+        server.ip_addr, "regular_compaction_pause_after_snapshot", one_shot=False)
+
+    # Trigger split.
+    await cql.run_async(
+        f"ALTER TABLE {ks}.test WITH tablets = {{'min_tablet_count': 2}}")
+    await manager.enable_tablet_balancing()
+    await log.wait_for("Emitting resize decision of type split",
+                       from_mark=mark, timeout=60)
+
+    # Wait for split to pause before its replacer.
+    await log.wait_for("split_pause_before_replacer: waiting",
+                       from_mark=mark, timeout=120)
+
+    # Enable auto-compaction so a regular task is submitted.  It captures
+    # a snapshot containing the sstables (still in main, registered as
+    # compacting by split) and pauses at the injection.
+    await manager.api.enable_autocompaction(server.ip_addr, ks)
+    # Wait for the handler to actually block (not just enter and co_return).
+    await log.wait_for("regular_compaction_pause_after_snapshot: waiting",
+                       from_mark=mark, timeout=120)
+
+    # Release split replacer.  Without the fix it deregisters sstables
+    # immediately; with the fix it blocks on sstable_set_lock.
+    await manager.api.message_injection(
+        server.ip_addr, "split_pause_before_replacer")
+    await asyncio.sleep(2)
+
+    # Release the picker.
+    try:
+        await manager.api.message_injection(
+            server.ip_addr, "regular_compaction_pause_after_snapshot")
+    except Exception:
+        pass
+
+    # Wait for outcome.
+    try:
+        await asyncio.sleep(10)
+    except Exception:
+        pass
+
+    # Disable injections.
+    try:
+        await manager.api.disable_injection(server.ip_addr, "split_pause_before_replacer")
+        await manager.api.disable_injection(server.ip_addr, "regular_compaction_pause_after_snapshot")
+    except Exception:
+        pass
+
+    # Verify no abort.
+    for marker in ("Unable to remove input SSTable", "Aborting on shard"):
+        matches = await log.grep(marker, from_mark=mark)
+        assert not matches, f"Race triggered: '{marker}' found in log"


### PR DESCRIPTION
After sstable set retrieval was futurized (https://github.com/scylladb/scylladb/commit/f4a5dbc48be102a7735c76d19891c1ca5129ace8), the regular
compaction picker's candidate selection became non-atomic: it captures
a snapshot of main_sstables via an async call (main_sstable_set), then
runs the eligibility filter (get_candidates) synchronously.  Between
these two steps, a yield point allows split's replacer to interleave
and mutate the sstable set, leaving the picker working with a stale
snapshot:

  1. Regular picker captures snapshot of source_cg.main (contains X).
  2. Split's replacer fires: on_compaction_completion moves X from
     source_cg to sub_cg; on_removal deregisters X from
     _compacting_sstables.
  3. Picker's eligibility filter runs on the stale snapshot, finds X
     eligible (no longer in _compacting_sstables), and selects it.
  4. Regular compaction compacts X, produces output.
  5. Regular compaction's completion phase tries to remove X from
     source_cg.main where it no longer exists.
  6. on_internal_error fires: "Unable to remove input SSTable ... for
     compaction of type unknown".

Fix: introduce sstable_set_lock (semaphore, count=1) in compaction_state
that protects sstable set ownership by serializing reads (snapshot
capture + eligibility filter + registration) against mutations
(on_compaction_completion which moves sstables between groups/views and
deregisters them from _compacting_sstables).  This ensures that no
reader works with a stale snapshot of the sstable set.

The lock is taken by:
  (a) regular/major compaction's candidate selection
  (b) replacer's sstable set mutation + deregistration
  (c) run_with_compaction_disabled's sstable capture + registration

The existing rwlock is simplified: regular compaction now takes a read
lock (was write lock), since sstable_set_lock handles the atomicity.
Major compaction keeps the write lock to wait for all regular
selections to quiesce.  Lock ordering: lock -> sstable_set_lock.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3124
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3147