### PR TITLE
raft: spread fast-bootstrap initial leadership across nodes

### DIFF
--- a/raft/fsm.cc
+++ b/raft/fsm.cc
@@ -7,7 +7,6 @@
  */
 #include "fsm.hh"
 #include <random>
-#include <ranges>
 #include <seastar/core/coroutine.hh>
 #include "raft/raft.hh"
 #include "utils/assert.hh"
@@ -37,31 +36,44 @@ fsm::fsm(server_id id, sstring tag, term_t current_term, server_id voted_for, lo
     // so that the log can be replayed
     _commit_idx = std::max(_commit_idx, commit_idx);
 
-    // A node that "starts as a candidate" calls an election immediately on
-    // startup instead of waiting for the randomized election timeout. There is
-    // no existing leader to disrupt in these cases, so prevoting is skipped too
-    // -- the extra round-trip would be pure overhead. We start as a candidate:
-    //  - as the (voting) member of a single-node group: it is the only possible
-    //    leader, so it should take over right away;
-    //  - as the smallest-id voting member of a fresh multi-node group (empty
-    //    log, i.e. last_idx() == 0), but only when fast bootstrap is enabled.
-    //    Restricting it to a single, deterministically-chosen node avoids all
-    //    nodes racing to call an election simultaneously (which wastes a term
-    //    and risks split votes). Fast bootstrap is gated by a config flag so
-    //    that a bare fsm (e.g. in unit tests) keeps the classic behaviour of
-    //    starting as a follower; raft::server enables it.
-    // Any node with a non-empty log has already participated in the group and
-    // must go through the normal timeout path.
-    const auto& cfg = _log.get_configuration();
-    const bool start_as_candidate = cfg.can_vote(_my_id) && (
-        cfg.current.size() == 1 || (
-            _config.enable_fast_bootstrap &&
-            _log.last_idx() == index_t{0} &&
-            std::ranges::none_of(cfg.current, [this](const auto& m) {
-                return m.can_vote && m.addr.id < _my_id;
-            })
-        )
-    );
+    // A node "starts as a candidate" -- calls an election immediately instead of
+    // waiting for the randomized election timeout, skipping prevoting since there
+    // is no existing leader to disrupt. This happens for the sole voter of a
+    // single-node group (the only possible leader), and, when fast bootstrap is
+    // enabled (fast_bootstrap_seed is set), for one deterministically chosen voter
+    // of a fresh multi-node group (empty log, last_idx() == 0). Choosing a single
+    // node avoids all nodes racing to call an election at once (wasting a term,
+    // risking split votes). The chosen one is the voter at rank (seed % num_voters)
+    // in ascending server_id order; every node derives the same rank without
+    // coordination. A caller managing many groups can vary the seed per group to
+    // rotate leadership across nodes; seed 0 picks the smallest-id voter. A bare
+    // fsm (e.g. in unit tests) leaves the seed unset and starts as a follower;
+    // raft::server sets it. A multi-node node with a non-empty log has already
+    // participated and takes the normal timeout path.
+    const bool start_as_candidate = std::invoke([&] {
+        const auto& cfg = _log.get_configuration();
+        if (!cfg.can_vote(_my_id)) {
+            return false;
+        }
+        if (cfg.current.size() == 1) {
+            return true;
+        }
+        if (!_config.fast_bootstrap_seed.has_value() || _log.last_idx() != index_t{0}) {
+            return false;
+        }
+        unsigned voters = 0;
+        unsigned rank = 0;
+        for (const auto& m : cfg.current) {
+            if (!m.can_vote) {
+                continue;
+            }
+            if (m.addr.id < _my_id) {
+                ++rank;
+            }
+            ++voters;
+        }
+        return rank == *_config.fast_bootstrap_seed % voters;
+    });
     logger.trace("fsm[{}]: starting, current term {}, log length {}, commit index {}, start_as_candidate {}",
             _tag, _current_term, _log.last_idx(), _commit_idx, start_as_candidate);
 

--- a/raft/fsm.hh
+++ b/raft/fsm.hh
@@ -59,12 +59,17 @@ struct fsm_config {
     size_t max_log_size;
     // If set to true will enable prevoting stage during election
     bool enable_prevoting;
-    // If set to true, on a fresh multi-node group (empty log) the smallest-id
-    // voting member starts an election immediately on construction instead of
-    // waiting for the election timeout, which speeds up the initial leader
-    // election. Disabled by default so that a bare fsm starts as a follower;
-    // raft::server enables it.
-    bool enable_fast_bootstrap = false;
+    // Enables fast bootstrap and selects which voting member becomes the initial
+    // leader on a fresh multi-node group (empty log). When set, that member
+    // starts an election immediately on construction instead of waiting for the
+    // randomized election timeout, which speeds up the initial leader election.
+    // The chosen member is the one at rank (*fast_bootstrap_seed % num_voters) in
+    // ascending server_id order. Callers that manage many groups (e.g. one per
+    // tablet) can derive the seed from the group id so that leadership is spread
+    // across nodes instead of always landing on the smallest-id one; a seed of 0
+    // selects the smallest-id voter. When unset (the default), fast bootstrap is
+    // disabled and a bare fsm starts as a follower; raft::server sets it.
+    std::optional<uint64_t> fast_bootstrap_seed;
 };
 
 class fsm;

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -403,7 +403,7 @@ future<> server_impl::start() {
                                      .append_request_threshold = _config.append_request_threshold,
                                      .max_log_size = _config.max_log_size,
                                      .enable_prevoting = _config.enable_prevoting,
-                                     .enable_fast_bootstrap = true
+                                     .fast_bootstrap_seed = _config.fast_bootstrap_seed
                                  },
                                  _events);
 

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -67,6 +67,15 @@ public:
         // Helps distinguish raft instances when multiple groups share the
         // same server_id. If empty, server_id is used as the default.
         sstring tag;
+        // Selects which voting member fast-bootstraps as the initial leader on
+        // a fresh group: the one at rank (fast_bootstrap_seed % number_of_voters)
+        // in ascending server_id order. Callers that manage many groups (e.g.
+        // one per tablet) can derive this from the group id so that leadership
+        // is spread across nodes instead of always landing on the smallest-id
+        // one. The default of 0 selects the smallest-id voter. raft::server
+        // always enables fast bootstrap (unlike a bare fsm, which disables it
+        // when no seed is provided).
+        uint64_t fast_bootstrap_seed = 0;
     };
 
     virtual ~server() {}

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -194,7 +194,13 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
                 ::format("table {}, tablet {} raft group {} background error {}", 
                     tablet.table, tablet.tablet, group_id, e));
         },
-        .tag = format("sc-{}", group_id)
+        .tag = format("sc-{}", group_id),
+        // Spread initial tablet-group leadership across nodes: derive the
+        // fast-bootstrap leader choice from the group id so that different
+        // groups pick different replicas instead of all electing the
+        // smallest-id node (which would concentrate load on one node when a
+        // table starts with many tablets).
+        .fast_bootstrap_seed = std::hash<raft::group_id>()(group_id)
     };
     auto server = raft::create_server(my_id, std::move(rpc), std::move(state_machine),
             std::move(storage), _raft_gr.failure_detector(), config);

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -2439,7 +2439,7 @@ BOOST_AUTO_TEST_CASE(test_start_as_candidate) {
             raft::config_member{server_addr_from_id(B_id), is_voter::yes}});
 
     raft::fsm_config fcfg{.append_request_threshold = 1, .enable_prevoting = true,
-                          .enable_fast_bootstrap = true};
+                          .fast_bootstrap_seed = 0};
 
     {
         raft::log log(raft::snapshot_descriptor{.config = cfg});
@@ -2480,8 +2480,8 @@ BOOST_AUTO_TEST_CASE(test_start_as_candidate) {
     }
 }
 
-// Test that fast bootstrap is gated by enable_fast_bootstrap: with the flag
-// off (the default), even the smallest-id voter on a fresh group stays a
+// Test that fast bootstrap is gated by fast_bootstrap_seed: when it is unset
+// (the default), even the smallest-id voter on a fresh group stays a
 // follower. This is what keeps the bare fsm usable in tests.
 BOOST_AUTO_TEST_CASE(test_no_start_as_candidate_without_fast_bootstrap) {
     server_id A_id = id(), B_id = id();
@@ -2506,7 +2506,7 @@ BOOST_AUTO_TEST_CASE(test_no_start_as_candidate_with_nonempty_log) {
     // Snapshot at index 1 => non-empty log.
     raft::log log(raft::snapshot_descriptor{.idx = index_t{1}, .config = cfg});
     raft::fsm_config fcfg{.append_request_threshold = 1, .enable_prevoting = true,
-                          .enable_fast_bootstrap = true};
+                          .fast_bootstrap_seed = 0};
     fsm_debug A(A_id, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fcfg);
 
     BOOST_CHECK(A.is_follower());
@@ -2521,7 +2521,7 @@ BOOST_AUTO_TEST_CASE(test_start_as_candidate_resend_on_peer_ping) {
     raft::log log(raft::snapshot_descriptor{.config = cfg});
 
     raft::fsm_config fcfg{.append_request_threshold = 1, .enable_prevoting = true,
-                          .enable_fast_bootstrap = true};
+                          .fast_bootstrap_seed = 0};
     fsm_debug A(A_id, term_t{}, server_id{}, std::move(log), trivial_failure_detector, fcfg);
 
     BOOST_CHECK(A.is_candidate());


### PR DESCRIPTION
Fast bootstrap lets a fresh multi-node group elect a leader without waiting for the randomized election timeout. The member that took over was always the smallest-id voter, selected by the boolean enable_fast_bootstrap flag.

When a table is created with many tablets (via the initial_tablets keyspace config), each tablet gets its own raft group, and every group bootstrapped on the same smallest-id node. That concentrated all initial leaders -- and their load -- on a single node.

Replace the boolean flag with an optional `fast_bootstrap_seed`. The voter that bootstraps is the one at rank (seed % num_voters) in ascending server_id order; every node derives the same rank without coordination. groups_manager derives the seed from the raft group id, so different tablet groups pick different replicas and initial leadership is spread across the cluster. A seed of 0 keeps the old smallest-id behaviour; an unset seed leaves fast bootstrap disabled for a bare fsm, as in unit tests.

backport: no need, strong consistency is currently experimental