### PR TITLE
cql3: modification_statement: stop passing _selects_a_collection as for_view

### DIFF
--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -543,7 +543,7 @@ void modification_statement::build_cas_result_set_metadata() {
 void
 modification_statement::process_where_clause(data_dictionary::database db, expr::expression where_clause, prepare_context& ctx) {
     _restrictions = restrictions::analyze_statement_restrictions(db, s, type, where_clause, ctx,
-            applies_only_to_static_columns(), _selects_a_collection, false /* allow_filtering */, restrictions::check_indexes::no);
+            applies_only_to_static_columns(), false /* for_view */, false /* allow_filtering */, restrictions::check_indexes::no);
     /*
      * If there's no clustering columns restriction, we may assume that EXISTS
      * check only selects static columns and hence we can use any row from the
@@ -787,7 +787,6 @@ void modification_statement::add_operation(std::unique_ptr<operation> op) {
         _sets_static_columns = true;
     } else {
         _sets_regular_columns = true;
-        _selects_a_collection |= op->column.type->is_collection();
     }
     if (op->requires_read()) {
         _requires_read = true;
@@ -833,7 +832,6 @@ void modification_statement::analyze_condition(expr::expression cond) {
         _has_static_column_conditions = true;
     } else {
         _has_regular_column_conditions = true;
-        _selects_a_collection |=  col.col->type->is_collection();
     }
   });
 }

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -94,9 +94,6 @@ private:
     // columns, respectively.
     bool _sets_static_columns = false;
     bool _sets_regular_columns = false;
-    // True if this statement has column operations or conditions for a column
-    // that stores a collection.
-    bool _selects_a_collection = false;
 
     std::optional<bool> _is_raw_counter_shard_write;
 

--- a/test/cqlpy/test_null.py
+++ b/test/cqlpy/test_null.py
@@ -106,18 +106,28 @@ def test_insert_null_key_in_batch(cql, table1):
     with pytest.raises(InvalidRequest, match='null value'):
         cql.execute(stmt, [None, s])
 
-# INSERT statements must specify all components of the primary key,
-# and the corresponding query parameters, if any, must not be null.
-# If INSERT or DELETE statement is missing a non-last element of
-# the primary key, the error message generated contained
-# an invalid column name (#12046).
-# The problem occurred if the query contains a column with the list type,
-# otherwise statement_restrictions::process_clustering_columns_restrictions
-# checks that all the components of the key are specified.
+# INSERT statements must specify all components of the primary key.
+# When a non-last clustering-key component is missing while a later one is
+# given (here "b" is given but "a" is missing),
+# statement_restrictions::process_clustering_columns_restrictions rejects the
+# statement during restriction analysis with a "preceding column ... is not
+# restricted" error. When only the trailing component is missing (here "b"),
+# the analysis passes and modification_statement instead reports the clearer
+# "Missing mandatory PRIMARY KEY part" error.
+#
+# This error message used to depend, by accident, on whether the statement
+# mentioned a list column: a list column set modification_statement's
+# _selects_a_collection, which was mistakenly passed as the restrictions'
+# for_view flag and relaxed the completeness check - so only statements that
+# happened to mention a list column reached the "Missing mandatory PRIMARY KEY
+# part" message. That misuse has been fixed, so list and non-list statements
+# now behave identically and the gap case surfaces the statement_restrictions
+# error. The "Some clustering keys are missing" alternative is kept for
+# Cassandra compatibility. See also #12046 (the reported column must be real).
 def test_insert_with_list_column_and_missing_clustering_key_part(cql, table2):
     key = unique_key_string()
     with pytest.raises(InvalidRequest,
-                       match='Missing mandatory PRIMARY KEY part a|Some clustering keys are missing: a'):
+                       match='PRIMARY KEY column "b" cannot be restricted as preceding column "a" is not restricted|Some clustering keys are missing: a'):
         cql.execute(cql.prepare(f"INSERT INTO {table2} (id,b,c) VALUES ('{key}',1,null)"))
     with pytest.raises(InvalidRequest,
                        match='Missing mandatory PRIMARY KEY part b|Some clustering keys are missing: b'):
@@ -141,14 +151,20 @@ def test_delete_with_list_column_and_missing_clustering_key_part(cql, table2):
     assert list(cql.execute(f"SELECT c FROM {table2} WHERE id='{key}' AND a=1 AND b=1"))[0][0] is None
 
 # The same as test_insert_with_list_column_and_missing_clustering_key_part but
-# for partition key.
+# for partition key. A partition key has no prefix concept, so any missing
+# component (whether id1 or id2) makes the restrictions incomplete; the
+# analysis then rejects the statement with the generic data-filtering error,
+# rather than modification_statement's "Missing mandatory PRIMARY KEY part".
+# As above, this used to reach the nicer message only by accident (via a list
+# column being misrouted into the for_view flag). The "Some partition key
+# parts are missing" alternative is kept for Cassandra compatibility.
 def test_insert_with_list_column_and_missing_partition_key_part(cql, table3):
     key = unique_key_string()
     with pytest.raises(InvalidRequest,
-                       match='Missing mandatory PRIMARY KEY part id1|Some partition key parts are missing: id1'):
+                       match='use ALLOW FILTERING|Some partition key parts are missing: id1'):
         cql.execute(cql.prepare(f"INSERT INTO {table3} (id2,a,c) VALUES ('{key}',1,[1])"))
     with pytest.raises(InvalidRequest,
-                       match='Missing mandatory PRIMARY KEY part id2|Some partition key parts are missing: id2'):
+                       match='use ALLOW FILTERING|Some partition key parts are missing: id2'):
         cql.execute(cql.prepare(f"INSERT INTO {table3} (id1,a,c) VALUES ('{key}',1,[1])"))
 
 # Tests handling of "key_column in ?" where ? is bound to null.


### PR DESCRIPTION

process_where_clause() has been passing _selects_a_collection into the for_view parameter of the statement_restrictions analysis ever since commit d858c573576 ("cql3: allow SELECTs restricted by \"IN\" to retrieve collections") removed the select_a_collection constructor parameter. That commit updated the select_statement.cc caller but not this one; because the following for_view parameter had a default value (= false), the stale call kept compiling and _selects_a_collection silently slid into the for_view argument slot:

  before: (..., selects_only_static_columns, select_a_collection, for_view=false)
  after:  (..., selects_only_static_columns, for_view=_selects_a_collection, ...)

A modification statement is never a view DDL, so pass false for for_view. With that, _selects_a_collection has no remaining readers, so remove the dead member and its two writers.

This paves the way for eventual removal of for_view and replacing its uses with a dedicated API.

This is not a no-op: for_view=true relaxes the primary-key completeness checks in statement_restrictions. So a modification that mentioned a list column (setting _selects_a_collection) and left a gap in the primary key - a non-last key component missing while a later one is given - would skip those checks and instead reach modification_statement's own, clearer "Missing mandatory PRIMARY KEY part" error. The exact same statement on a table without a list column already got the statement_restrictions error, so the error message accidentally depended on whether a list column was mentioned. With for_view now correct, both behave identically: the gap case consistently surfaces the statement_restrictions error ('preceding column ... is not restricted' for clustering keys, the data-filtering/ALLOW FILTERING error for partition keys). Adjust test_null.py accordingly, keeping the Cassandra-compatible "Some ... keys are missing" alternatives.

Note that these statement_restrictions errors are poor for a modification: an INSERT cannot "use ALLOW FILTERING", nor does it "restrict" columns. This is a pre-existing wart - it already affected tables without collection columns, and this change merely makes it consistent by also applying it to statements that mention a collection. Making modifications consistently reach the clearer "Missing mandatory PRIMARY KEY part" message is left for a later change.

Minor code cleanup (and actually worsens error messages, though not in an important way) so not backporting.