### PR TITLE
sstables/mx/writer: discard compression dictionary from compression::options after deduplicating it

### DIFF
--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -220,6 +220,7 @@ void compression::segmented_offsets::push_back(uint64_t offset, compression::seg
 }
 
 void compression::set_compressor(compressor_ptr c) {
+    options.elements.clear();
     if (c) {
         unqualified_name uqn(compression_parameters::name_prefix, c->name());
         const sstring& cn = uqn;

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1844,6 +1844,7 @@ void writer::consume_end_of_stream() {
     // context after the write is over, because it hogs memory).
     auto decompressor = _sst.manager().get_compressor_factory().make_compressor_for_reading(_sst._components->compression).get();
     _sst._components->compression.set_compressor(std::move(decompressor));
+    _sst._components->compression.discard_hidden_options();
     run_identifier identifier{_run_identifier};
     std::optional<scylla_metadata::large_data_stats> ld_stats(scylla_metadata::large_data_stats{
         .map = {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -10,6 +10,7 @@
 #include <fmt/ranges.h>
 
 #include <seastar/core/sstring.hh>
+#include <seastar/core/memory.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/align.hh>
 #include <seastar/core/aligned_buffer.hh>
@@ -18,6 +19,8 @@
 
 #include "sstables/sstables.hh"
 #include "sstables/compress.hh"
+#include "sstables/compressor.hh"
+#include "sstables/sstable_compressor_factory.hh"
 #include "sstables/metadata_collector.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include "schema/schema.hh"
@@ -3486,4 +3489,66 @@ SEASTAR_TEST_CASE(test_stats_metadata_error_includes_filename) {
                 exception_predicate::message_contains(filename));
         }
     });
+}
+
+// Reproducer for a bug which inflated per-sstable memory usage
+// by leaving a compression dictionary attached to every freshly-written
+// sstable object.
+SEASTAR_THREAD_TEST_CASE(test_small_sstable_has_reasonable_memory_usage) {
+    auto scf = make_sstable_compressor_factory_for_tests_in_thread();
+    test_env env({}, *scf);
+    auto stop_env = defer([&env] { env.stop().get(); });
+
+    // Big enough that a few leaked copies
+    constexpr size_t dict_size = 110 * 1024;
+    constexpr int num_sstables = 8;
+    // At the time of this writing, the measured memory usage without involving dictionaries was 25 kiB. 
+    constexpr size_t per_sstable_allowance = 32 * 1024;
+
+    auto dict = tests::random::get_bytes(dict_size);
+
+    // Build a schema that uses dictionary compression.
+    auto s = schema_builder(this_smp_shard_count(), "ks", "cf")
+        .with_column("pk", utf8_type, column_kind::partition_key)
+        .set_compressor_params(compression_parameters(compressor::algorithm::zstd_with_dicts))
+        .build();
+    scf->set_recommended_dict(s->id(), std::as_bytes(std::span(dict))).get();
+
+    auto write_one = [&] {
+        auto pk = tests::generate_partition_keys(1, s).front();
+        auto m = mutation(s, pk);
+        m.partition().apply(tombstone(1, gc_clock::now()));
+        return make_sstable_containing(env.make_sst_factory(s), {std::move(m)}).get();
+    };
+
+    // Warm up: write and discard one sstable, so that any lazily-initialized,
+    // one-off allocations on the write path (and the single shared, deduplicated
+    // dictionary copy) are already accounted for before we start measuring.
+    auto warmup = write_one();
+    BOOST_REQUIRE(warmup->get_compression().get_compressor().get_algorithm() == compressor::algorithm::zstd_with_dicts);
+
+    // Now measure the live-memory growth by holding onto N freshly written
+    // sstables with the same dict.
+    auto allocated_before = memory::stats().allocated_memory();
+    std::vector<shared_sstable> ssts;
+    for (int i = 0; i < num_sstables; ++i) {
+        ssts.push_back(write_one());
+    }
+    auto allocated_after = memory::stats().allocated_memory();
+    auto growth = allocated_after - allocated_before;
+
+    // The single shared dictionary copy was already allocated during warm-up, so
+    // the growth should be bounded by just the per-sstable overhead.
+    const size_t upper_bound = num_sstables * per_sstable_allowance;
+    const size_t lower_bound = num_sstables * sizeof(sstable);
+    testlog.info("live-memory growth from holding {} dict-compressed sstables: {} bytes "
+            "(lower_bound: {} bytes, upper_bound: {} bytes, dict_size: {} bytes)",
+            num_sstables, growth, lower_bound, upper_bound, dict_size);
+
+#ifndef SEASTAR_DEFAULT_ALLOCATOR
+    // memory::stats() only reflects real usage with the seastar allocator; under
+    // the default allocator (e.g. sanitizer builds) the numbers are meaningless.
+    BOOST_REQUIRE_LT(growth, upper_bound);
+    BOOST_REQUIRE_GE(growth, lower_bound);
+#endif
 }


### PR DESCRIPTION
To keep sstables self-sufficient, every dict-compressed sstable stores the
dictionary in it’s “compression options” map present in the header of CompressionInfo.db.

But since a dictionary is likely to be shared across many sstables,
we don’t want to avoid a keeping in RAM a separate copy of a dictionary for every sstable.
(For two reasons: memory consumption and cache pressure).
We only need one copy per NUMA node.
So when a sstable is being opened for reading, its dictionary gets deduplicated on load:
it gets compared against a registry of dictionaries already present in RAM,
and the sstable’s compressor gets pointed at canonical copy of the dictionary.

On the “open sstables for reading on startup” path, the pre-deduplication copy is then discarded.
But on the “open sstables for reading after sealing” path, it’s not discarded.
It stays, unused, in sstables::compression::options and hogs memory.

The main problem with this it heavily exacerbates OOM problems
if the number of sstables goes out of control for whatever reason.

Fix that.

Fixes: SCYLLADB-3212

The problem is serious enough to warrant a backport (to all supported releases since 2025.2).