### PR TITLE
test: proc_utils: diagnostics for start_docker_service timeouts

### DIFF
--- a/test/lib/proc_utils.cc
+++ b/test/lib/proc_utils.cc
@@ -183,6 +183,61 @@ fs::path tests::proc::find_file_in_path(std::string_view name,
 using namespace std::chrono_literals;
 using namespace std::string_literals;
 
+// Ensure `image` is present in the local container store, pulling it
+// once with its own generous timeout so that image-download latency
+// cannot compete with `start_docker_service`'s per-attempt ready-line
+// budget
+static future<> ensure_image_available(const std::filesystem::path& exec, std::string_view image) {
+    using tests::proc::process_fixture;
+
+    // Fast path: image already present locally.
+    {
+        auto ps = co_await process_fixture::create(exec,
+            {exec.string(), "image", "inspect", std::string(image)},
+            {} /* env */,
+            {} /* stdout: discard */,
+            {} /* stderr: discard */);
+        auto status = co_await ps.wait();
+        if (auto* exited = std::get_if<process_fixture::wait_exited>(&status);
+            exited && exited->exit_code == 0) {
+            proc_logger.debug("image {} already present locally, skipping pull", image);
+            co_return;
+        }
+    }
+
+    auto log_line = [image = std::string(image)](log_level level) {
+        return [image, level](std::string_view line) -> future<consumption_result<char>> {
+            proc_logger.log(level, "pull {}: {}", image, line);
+            co_return continue_consuming{};
+        };
+    };
+
+    proc_logger.info("pulling image {}", image);
+    auto ps = co_await process_fixture::create(exec,
+        {exec.string(), "pull", std::string(image)},
+        {} /* env */,
+        process_fixture::line_handler(log_line(log_level::info)),
+        process_fixture::line_handler(log_line(log_level::info)));
+
+    // Image pulls can be slow on cold caches and slow networks; give
+    // them a much larger budget than the container ready-wait itself.
+    constexpr auto pull_timeout = 300s;
+    process_fixture::wait_status status;
+    try {
+        status = co_await with_timeout(std::chrono::steady_clock::now() + pull_timeout, ps.wait());
+    } catch (const seastar::timed_out_error&) {
+        proc_logger.error("timed out after {}s pulling image {}", pull_timeout.count(), image);
+        ps.terminate();
+        throw;
+    }
+
+    auto* exited = std::get_if<process_fixture::wait_exited>(&status);
+    if (!exited || exited->exit_code != 0) {
+        throw std::runtime_error(fmt::format("Failed to pull image {}: {}", image,
+            exited ? fmt::format("exit code {}", exited->exit_code) : "terminated by signal"));
+    }
+}
+
 future<std::tuple<tests::proc::process_fixture, int>> tests::proc::start_docker_service(
     std::string_view name,
     std::string_view image,
@@ -201,6 +256,11 @@ future<std::tuple<tests::proc::process_fixture, int>> tests::proc::start_docker_
     if (exec.empty()) {
         throw std::runtime_error("Could not find docker or podman.");
     }
+
+    // Pull the image once, before the retry loop, so that a slow image
+    // download cannot eat into the per-attempt ready-wait budget and
+    // cause every attempt to time out for the wrong reason.
+    co_await ensure_image_available(exec, image);
 
     struct in_use{};
     constexpr auto max_retries = 8;

--- a/test/lib/proc_utils.cc
+++ b/test/lib/proc_utils.cc
@@ -26,6 +26,8 @@
 
 using namespace seastar;
 
+static logger proc_logger("docker_service");
+
 class tests::proc::process_fixture::impl {
 public:
     experimental::process _process;
@@ -231,30 +233,34 @@ future<std::tuple<tests::proc::process_fixture, int>> tests::proc::start_docker_
         promise<> ready_promise;
         auto ready_fut = ready_promise.get_future();
 
-        auto create_handler = [](auto h_in, std::ostream& out) {
-            auto h = process_fixture::create_copy_handler(out);
+        auto create_handler = [](auto h_in) {
             promise<> ready_promise;
             future<> f = ready_promise.get_future();
             if (h_in) {
-                h = [state = service_parse_state::cont, ready_promise = std::move(ready_promise), h = std::move(h), h_in = std::move(h_in)](std::string_view line) mutable -> future<consumption_result<char>> {
+                auto h = [state = service_parse_state::cont, ready_promise = std::move(ready_promise), h_in = std::move(h_in)](std::string_view line) mutable -> future<consumption_result<char>> {
+                    proc_logger.info("{}", line);
                     if (state == service_parse_state::cont) {
                         switch (state = h_in(line)) {
-                            case service_parse_state::success: ready_promise.set_value(); break;
-                            case service_parse_state::failed: ready_promise.set_exception(in_use{}); break;
-                            default: 
-                                break;
+                        case service_parse_state::success: ready_promise.set_value(); break;
+                        case service_parse_state::failed: ready_promise.set_exception(in_use{}); break;
+                        default:
+                            break;
                         }
                     }
-                    return h(line);
+                    co_return continue_consuming{};
                 };
-            } else {
-                ready_promise.set_value();
+                return std::make_tuple(process_fixture::line_handler(std::move(h)), std::move(f));
             }
-            return std::make_tuple(std::move(h), std::move(f));
+            ready_promise.set_value();
+            auto h = [](std::string_view line) -> future<consumption_result<char>> {
+                proc_logger.info("{}", line);
+                co_return continue_consuming{};
+            };
+            return std::make_tuple(process_fixture::line_handler(std::move(h)), std::move(f));
         };
 
-        auto [out_h, out_fut] = create_handler(stdout_parse, std::cout);
-        auto [err_h, err_fut] = create_handler(stderr_parse, std::cerr);
+        auto [out_h, out_fut] = create_handler(stdout_parse);
+        auto [err_h, err_fut] = create_handler(stderr_parse);
 
         auto ps = co_await process_fixture::create(exec
             , params


### PR DESCRIPTION
### Problem

`start_docker_service` occasionally times out in CI (e.g. SCYLLADB-3190, where `compaction_with_fully_expired_table_gcs_test` fails with a `seastar::timed_out_error` from the GCS/object-storage fixture). Two things make these failures hard to diagnose and, in some cases, more likely to happen:

1. Container `stdout`/`stderr` are consumed by internal handlers only and never make it into any log captured by CI, so there is nothing to look at when the ready-wait times out.
2. The image pull happens implicitly as part of `docker run` inside the retry loop, so pull latency competes with the 120s per-attempt ready-wait budget. A slow first-time pull can cause every retry to time out for the wrong reason.

### Changes

**Route container output through the seastar logger.** A dedicated `docker_service` logger is added and every line the container emits on either stream is logged at INFO level, in addition to being fed to the existing parse callback. This gives us usable diagnostics in the standard test log the next time this times out.

**Pre-pull the image with an independent timeout.** A new `ensure_image_available()` helper is called once, before the retry loop:

- fast path: `<exec> image inspect` — if the image is already present locally, the pull step is skipped entirely;
- otherwise: `<exec> pull <image>` runs once with a dedicated 300s timeout, streaming its output through the same `docker_service` logger so a stuck pull is visible rather than silent.

After this the per-attempt 120s ready-wait budget is spent only on actual container startup, not on downloading the image.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3190

Backport to 2026.1 and 2026.2 since these releases may be also affected

UPD: this PR cannot be merged back to 2026.1 since all the needed mechinery does not exist