### PR TITLE
storage_proxy: Hold plain ERM for the duration of Paxos requests

### DIFF
--- a/service/cas_shard.hh
+++ b/service/cas_shard.hh
@@ -7,17 +7,21 @@
  */
 #pragma once
 
-#include "locator/tablet_metadata_guard.hh"
+#include <utility>
+#include <seastar/core/shard_id.hh>
+#include "schema/schema.hh"
+#include "locator/abstract_replication_strategy.hh"
+#include "dht/token.hh"
 
 namespace service {
 // A helper class for the storage_proxy::cas API.
 //
 // Represents the correct shard on which cas() must be called.
 // The appropriate shard is selected based on the current topology,
-// and a token_metadata_guard is acquired to ensure that the shard
+// and a pinning an effective_replication_map_ptr is acquired to ensure that the shard
 // decision remains valid while cas_shard instance is alive.
 class cas_shard {
-    locator::token_metadata_guard _token_guard;
+    locator::effective_replication_map_ptr _erm;
     unsigned _shard;
 public:
     cas_shard(const schema& s, dht::token token);
@@ -27,8 +31,9 @@ public:
     bool this_shard() const {
         return _shard == this_shard_id();
     }
-    locator::token_metadata_guard token_guard() && {
-        return std::move(_token_guard);
+
+    decltype(auto) get_erm(this auto&& self) {
+        return std::forward_like<decltype(self)>(self._erm);
     }
 };
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1563,7 +1563,10 @@ public:
 class paxos_response_handler : public enable_shared_from_this<paxos_response_handler> {
 private:
     shared_ptr<storage_proxy> _proxy;
-    locator::token_metadata_guard _token_guard;
+    // Paxos sends topology-version-gated RPCs over several phases, so the ERM must not
+    // refresh between them. Otherwise, a delayed RPC can be rejected as stale after an
+    // unrelated tablet migration advances the topology version (SCYLLADB-1524).
+    locator::effective_replication_map_ptr _effective_replication_map;
     // The schema for the table the operation works upon.
     schema_ptr _schema;
     // Read command used by this CAS request.
@@ -1605,7 +1608,7 @@ public:
     tracing::trace_state_ptr tr_state;
 
 public:
-    paxos_response_handler(shared_ptr<storage_proxy> proxy_arg, locator::token_metadata_guard token_guard_arg,
+    paxos_response_handler(shared_ptr<storage_proxy> proxy_arg, locator::effective_replication_map_ptr effective_replication_map_arg,
         tracing::trace_state_ptr tr_state_arg, service_permit permit_arg,
         dht::decorated_key key_arg, schema_ptr schema_arg, lw_shared_ptr<query::read_command> cmd_arg,
         db::consistency_level cl_for_paxos_arg, db::consistency_level cl_for_learn_arg,
@@ -1647,7 +1650,7 @@ public:
     bool learned(locator::host_id ep);
 
     const locator::effective_replication_map_ptr& get_effective_replication_map() const noexcept {
-        return _token_guard.get_erm();
+        return _effective_replication_map;
     }
 
     fencing_token get_fence() const {
@@ -2209,13 +2212,13 @@ static future<> sleep_approx_50ms() {
     return seastar::sleep(std::chrono::milliseconds(dist(re)));
 }
 
-paxos_response_handler::paxos_response_handler(shared_ptr<storage_proxy> proxy_arg, locator::token_metadata_guard token_guard_arg,
+paxos_response_handler::paxos_response_handler(shared_ptr<storage_proxy> proxy_arg, locator::effective_replication_map_ptr effective_replication_map_arg,
         tracing::trace_state_ptr tr_state_arg, service_permit permit_arg,
         dht::decorated_key key_arg, schema_ptr schema_arg, lw_shared_ptr<query::read_command> cmd_arg,
         db::consistency_level cl_for_paxos_arg, db::consistency_level cl_for_learn_arg,
         storage_proxy::clock_type::time_point timeout_arg, storage_proxy::clock_type::time_point cas_timeout_arg)
         : _proxy(proxy_arg)
-        , _token_guard(std::move(token_guard_arg))
+        , _effective_replication_map(std::move(effective_replication_map_arg))
         , _schema(std::move(schema_arg))
         , _cmd(cmd_arg)
         , _cl_for_paxos(cl_for_paxos_arg)
@@ -6977,12 +6980,15 @@ future<storage_proxy::cas_result> storage_proxy::cas(schema_ptr schema, cas_shar
     db::validate_for_cas(cl_for_paxos);
     db::validate_for_cas_learn(cl_for_learn, schema->ks_name());
 
-    auto token_guard = std::move(cas_shard).token_guard();
     auto key = partition_ranges[0].start()->value().as_decorated_key();
     const auto token = key.token();
-    if (get_cas_shard(*schema, token, *token_guard.get_erm()) != this_shard_id()) {
-        on_internal_error(paxos::paxos_state::logger, "storage_proxy::cas called on a wrong shard");
-    }
+    auto effective_replication_map = [cas_shard = std::move(cas_shard), schema, token] () mutable -> locator::effective_replication_map_ptr {
+        auto token_guard = std::move(cas_shard).token_guard();
+        if (get_cas_shard(*schema, token, *token_guard.get_erm()) != this_shard_id()) {
+            on_internal_error(paxos::paxos_state::logger, "storage_proxy::cas called on a wrong shard");
+        }
+        return token_guard.get_erm();
+    }();
 
     // In case a nullptr is passed to this function (i.e. the caller isn't interested in
     // existing value) we fabricate an "empty"  read_command that does nothing,
@@ -6995,7 +7001,7 @@ future<storage_proxy::cas_result> storage_proxy::cas(schema_ptr schema, cas_shar
     shared_ptr<paxos_response_handler> handler;
     try {
         handler = seastar::make_shared<paxos_response_handler>(shared_from_this(),
-                std::move(token_guard),
+                std::move(effective_replication_map),
                 query_options.trace_state, query_options.permit,
                 std::move(key),
                 schema, cmd, cl_for_paxos, cl_for_learn, write_timeout, cas_timeout);

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1321,8 +1321,8 @@ static unsigned get_cas_shard(const schema& s, dht::token token, const locator::
 }
 
 cas_shard::cas_shard(const schema& s, dht::token token)
-    : _token_guard(s.table(), token)
-    , _shard(get_cas_shard(s, token, *_token_guard.get_erm()))
+    : _erm{s.table().get_effective_replication_map()}
+    , _shard(get_cas_shard(s, token, *_erm))
 {
 }
 
@@ -6982,13 +6982,10 @@ future<storage_proxy::cas_result> storage_proxy::cas(schema_ptr schema, cas_shar
 
     auto key = partition_ranges[0].start()->value().as_decorated_key();
     const auto token = key.token();
-    auto effective_replication_map = [cas_shard = std::move(cas_shard), schema, token] () mutable -> locator::effective_replication_map_ptr {
-        auto token_guard = std::move(cas_shard).token_guard();
-        if (get_cas_shard(*schema, token, *token_guard.get_erm()) != this_shard_id()) {
-            on_internal_error(paxos::paxos_state::logger, "storage_proxy::cas called on a wrong shard");
-        }
-        return token_guard.get_erm();
-    }();
+    
+    if (get_cas_shard(*schema, token, *(cas_shard.get_erm())) != this_shard_id()) {
+        on_internal_error(paxos::paxos_state::logger, "storage_proxy::cas called on a wrong shard");
+    }
 
     // In case a nullptr is passed to this function (i.e. the caller isn't interested in
     // existing value) we fabricate an "empty"  read_command that does nothing,
@@ -7001,7 +6998,7 @@ future<storage_proxy::cas_result> storage_proxy::cas(schema_ptr schema, cas_shar
     shared_ptr<paxos_response_handler> handler;
     try {
         handler = seastar::make_shared<paxos_response_handler>(shared_from_this(),
-                std::move(effective_replication_map),
+                std::move(cas_shard).get_erm(),
                 query_options.trace_state, query_options.permit,
                 std::move(key),
                 schema, cmd, cl_for_paxos, cl_for_learn, write_timeout, cas_timeout);

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -863,15 +863,14 @@ async def test_lwt_shutdown(manager: ManagerClient):
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablets_merge_waits_for_lwt(manager: ManagerClient, scale_timeout):
     """
-    This is a regression test for #26437:
+    This is a regression test for #26437 and SCYLLADB-1524:
     1. A cluster with one node, a table with rf=1 and two tablets on the same shard.
     2. Run an LWT on the second tablet, make it hang on the paxos_accept_proposal_wait injection.
-    The LWT coordinator holds a tablet_metadata_guard with a non-migrating topology erm and global_shard=1.
-    3. Trigger tablets merge with the tablet_force_tablet_count_decrease injection, wait for tablet_count == 1.
-    This step invalidates the global_shard, the tablet_metadata_guard should stop refreshing erms.
-    4. Start tablet migration for the merged tablet, check it hangs on the first global barrier.
-    4. Release the paxos_accept_proposal_wait injection, check the barrier is released, the tablet is
-    migrated and the LWT succeeded.
+    The LWT coordinator holds a plain pointer to the current topology ERM.
+    3. Trigger tablets merge with the tablet_force_tablet_count_decrease injection.
+    The old ERM should block the merge's first topology barrier while the LWT is in progress.
+    4. Release the paxos_accept_proposal_wait injection and wait for the merge to finish.
+    5. Start tablet migration for the merged tablet and check that it finishes and the LWT succeeded.
     """
     logger.info("Bootstrapping cluster")
     cmdline = [
@@ -924,39 +923,30 @@ async def test_tablets_merge_waits_for_lwt(manager: ManagerClient, scale_timeout
 
         m = await log0.mark()
 
+        logger.info("Wait for the merge's global barrier to start draining on shard0")
+        await log0.wait_for("\\[shard 0: gms\\] raft_topology - Got raft_topology_cmd::barrier_and_drain", from_mark=m)
+
+        # The LWT's plain ERM must block the first merge barrier. A tablet_metadata_guard
+        # would refresh its ERM here and allow the merge to make progress while the LWT
+        # is still in flight (SCYLLADB-1524).
+        matches = await log0.grep("\\[shard 0: gms\\] raft_topology - raft_topology_cmd::barrier_and_drain.*done", from_mark=m)
+        assert len(matches) == 0
+
+        logger.info("Trigger 'paxos_accept_proposal_wait'")
+        await manager.api.message_injection(s0.ip_addr, "paxos_accept_proposal_wait")
+
         logger.info("Wait for tablet merge to complete")
         await wait_for_tablet_count(manager, s0, ks, 'test', lambda c: c == 1, 1, scale_timeout=scale_timeout, timeout_s=15)
-
-        logger.info("Ensure the guard decided to retain the erm")
-        m, _ = await log0.wait_for("tablet_metadata_guard::check: retain the erm and abort the guard",
-                            from_mark=m, timeout=10)
 
         tablets = await get_all_tablet_replicas(manager, s0, ks, 'test')
         assert len(tablets) == 1
         tablet = tablets[0]
         assert tablet.replicas == [(s0_host_id, 0)]
 
-        # Since merge now waits for erms before releasing the state machine,
-        # the migration initiated below will not start until paxos released the erm.
-        # The barrier which is blocked is the one in merge finalization.
-        # I keep the tablet movement as a guard against regressions in case the behavior changes.
-
         migration_task = asyncio.create_task(manager.api.move_tablet(s0.ip_addr, ks, "test",
                                                                      s0_host_id, 0,
                                                                      s0_host_id, 1,
                                                                      tablet.last_token))
-        logger.info("Wait for the global barrier to start draining on shard0")
-        await log0.wait_for("\\[shard 0: gms\\] raft_topology - Got raft_topology_cmd::barrier_and_drain", from_mark=m)
-        # Just to confirm that the guard still holds the erm
-        matches = await log0.grep("\\[shard 0: gms\\] raft_topology - raft_topology_cmd::barrier_and_drain.*done", from_mark=m)
-        assert len(matches) == 0
-
-        # Before the fix, the tablet migration global barrier did not wait for the LWT operation.
-        # As a result, the merged tablet could be migrated to another shard while the LWT is still running.
-        # This caused the LWT to crash in paxos_state::prepare/shards_for_writes because of the
-        # unexpected tablet shard change.
-        logger.info("Trigger 'paxos_accept_proposal_wait'")
-        await manager.api.message_injection(s0.ip_addr, "paxos_accept_proposal_wait")
 
         logger.info("Wait for the tablet migration task to finish")
         await migration_task


### PR DESCRIPTION
Paxos_response_handler currently holds a token_metadata_guard. For tablet based tables, this guard can automatically switch to a newer ERM when an unrelated tablet changes.

Paxos sends topology version fenced RPCs over multiple phases. Refreshing
the ERM while a request is in progress can therefore change its fencing token and cause delayed RPCs to be rejected as stale.

Keep the token_metadata_guard only while validating the CAS shard. Capture its current ERM and pass that plain effective_replication_map_ptr to the Paxos response handler, keeping the topology version stable for the whole
request.

Update test_tablets_merge_waits_for_lwt to pause an LWT and verify that its pinned ERM blocks the merge's first topology barrier until the LWT is released.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1524

backport: should be backported to all active branches to eleimenate the possibility of this issue