### PR TITLE
test/pylib: bound driver reconnection policy on control-connection Clusters

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -60,6 +60,7 @@ from cassandra.cluster import NoHostAvailable   # type: ignore # pylint: disable
 from cassandra.cluster import Session           # pylint: disable=no-name-in-module
 from cassandra.cluster import ExecutionProfile  # pylint: disable=no-name-in-module
 from cassandra.cluster import EXEC_PROFILE_DEFAULT  # pylint: disable=no-name-in-module
+from cassandra.policies import ExponentialReconnectionPolicy  # type: ignore
 from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
 from cassandra.connection import UnixSocketEndPoint
 
@@ -319,6 +320,13 @@ def stop_event(func):
             self.stop_event.clear()
         return result
     return wrap
+
+
+# The driver's default reconnection policy has an unbounded max_delay (600s) and can take
+# up to ~64 attempts to give up, i.e. hours, to notice a control connection is unreachable.
+# Any Cluster created by this module must bound both individual connection attempts and
+# the overall retry budget.
+_DRIVER_RECONNECTION_POLICY = ExponentialReconnectionPolicy(base_delay=1.0, max_delay=10.0, max_attempts=10)
 
 
 class ScyllaServer:
@@ -713,6 +721,7 @@ class ScyllaServer:
             protocol_version=4,  # This is the latest version Scylla supports
             control_connection_timeout=self.TOPOLOGY_TIMEOUT,
             auth_provider=self.auth_provider,
+            reconnection_policy=_DRIVER_RECONNECTION_POLICY,
         )
         try:
             # In a cluster setup, it's possible that the CQL
@@ -969,6 +978,8 @@ class ScyllaServer:
                      auth_provider=auth,
                      # This is the latest version Scylla supports
                      protocol_version=4,
+                     control_connection_timeout=self.TOPOLOGY_TIMEOUT,
+                     reconnection_policy=_DRIVER_RECONNECTION_POLICY,
                      ) as cluster:
             with cluster.connect() as session:
                 session.execute("CREATE KEYSPACE IF NOT EXISTS k WITH REPLICATION = {" +


### PR DESCRIPTION
a pytest-xdist worker hung 12h+ after a failed server-add left the cluster in a broken state. The teardown/CQL-check path in ScyllaServer builds Cluster objects without overriding the driver's default reconnection_policy (ExponentialReconnectionPolicy(1.0, 600.0), max_attempts=64) or connect_timeout, so once a control connection to an unreachable node breaks, the driver retries in the background for up to ~10 hours before giving up - matching the "Timed out creating connection (5 seconds)" loop and multi-hour hang reported in the ticket.

Apply the same bounded reconnection_policy already used for the main test driver in test/cluster/conftest.py's cluster_con() (added earlier for this exact failure mode) to the remaining Cluster instances created in scylla_cluster.py: the per-server CQL/alternator check and its persistent control_cluster, and the previously-unbounded force_schema_migration() Cluster.

Fixes: SCYLLADB-3224

**Fixes a reproducible CI hang (pytest-xdist workers stuck 12h+ after a failed server-add) via a self-contained, test-only change with no product-code risk, since it's rare, i am not sure we should backport this***