### PR TITLE
paxos/paxos_state: optimize internal paxos state requests

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1726,6 +1726,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/mutation_reader_test.cc',
     'test/boost/mutation_writer_test.cc',
     'test/boost/network_topology_strategy_test.cc',
+    'test/boost/paxos_state_test.cc',
     'test/boost/per_partition_rate_limit_test.cc',
     'test/boost/pluggable_test.cc',
     'test/boost/querier_cache_test.cc',

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -461,7 +461,8 @@ std::optional<std::string_view> paxos_store::try_get_base_table(std::string_view
     return cf_name.substr(0, cf_name.size() - paxos_state_table_suffix.size());
 }
 
-future<cql3::untyped_result_set> paxos_store::do_execute_cql_with_timeout(sstring req,
+future<cql3::untyped_result_set> paxos_store::do_execute_cql_with_timeout(const schema& s,
+        noncopyable_function<sstring(const schema&, const schema&)> make_query,
         db::timeout_clock::time_point timeout,
         std::vector<data_value_or_unset> values)
 {
@@ -474,6 +475,8 @@ future<cql3::untyped_result_set> paxos_store::do_execute_cql_with_timeout(sstrin
         timeout_config{d, d, d, d, d, d, d});
     service::query_state qs(client_state, empty_service_permit());
 
+    const auto state_schema = co_await get_paxos_state_schema(s, timeout);
+    const auto req = make_query(s, *state_schema);
     const auto cache_key = qp.compute_id(req, client_state.get_raw_keyspace(), cql3::internal_dialect());
     auto ps_ptr = qp.get_prepared(cache_key);
     shared_ptr<cql_transport::messages::result_message::prepared> prepared_msg;
@@ -497,10 +500,12 @@ future<cql3::untyped_result_set> paxos_store::do_execute_cql_with_timeout(sstrin
 }
 
 template <typename... Args>
-future<cql3::untyped_result_set> paxos_store::execute_cql_with_timeout(sstring req,
+future<cql3::untyped_result_set> paxos_store::execute_cql_with_timeout(const schema& s,
+        noncopyable_function<sstring(const schema&, const schema&)> make_query,
         db::timeout_clock::time_point timeout,
         Args&&... args) {
-    return do_execute_cql_with_timeout(std::move(req),
+    return do_execute_cql_with_timeout(s,
+        std::move(make_query),
         timeout,
         { data_value(std::forward<Args>(args))... }
     );
@@ -595,14 +600,16 @@ future<paxos_state> paxos_store::load_paxos_state(partition_key_view key, schema
 {
     co_await utils::get_local_injector().inject("load_paxos_state-enter", utils::wait_for_message(60s));
 
-    const auto state_schema = co_await get_paxos_state_schema(*s, timeout);
     // FIXME: we need execute_cql_with_now()
     (void)now;
     const auto results = co_await execute_cql_with_timeout(
-        format("SELECT * FROM \"{}\".\"{}\" WHERE row_key = ?{} LIMIT 1", 
-            state_schema->ks_name(), state_schema->cf_name(), 
-            paxos_state_cf_filter(*s, *state_schema)
-        ),
+        *s,
+        [] (const schema& s, const schema& state_s) {
+            return format("SELECT * FROM \"{}\".\"{}\" WHERE row_key = ?{} LIMIT 1",
+                state_s.ks_name(), state_s.cf_name(),
+                paxos_state_cf_filter(s, state_s)
+            );
+        },
         timeout,
         to_legacy(*key.get_compound_type(*s), key.representation())
     );
@@ -634,12 +641,14 @@ future<paxos_state> paxos_store::load_paxos_state(partition_key_view key, schema
 }
 
 future<> paxos_store::save_paxos_promise(const schema& s, const partition_key& key, const utils::UUID& ballot, db::timeout_clock::time_point timeout) {
-    const auto state_schema = co_await get_paxos_state_schema(s, timeout);
     co_await execute_cql_with_timeout(
-            format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET promise = ? WHERE row_key = ?{}",
-                state_schema->ks_name(), state_schema->cf_name(), 
-                paxos_state_cf_filter(s, *state_schema)
-            ),
+            s,
+            [] (const schema& s, const schema& state_s) {
+                return format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET promise = ? WHERE row_key = ?{}",
+                    state_s.ks_name(), state_s.cf_name(),
+                    paxos_state_cf_filter(s, state_s)
+                );
+            },
             timeout,
             utils::UUID_gen::micros_timestamp(ballot),
             paxos_ttl_sec(s),
@@ -649,13 +658,15 @@ future<> paxos_store::save_paxos_promise(const schema& s, const partition_key& k
 }
 
 future<> paxos_store::save_paxos_proposal(const schema& s, const proposal& proposal, db::timeout_clock::time_point timeout) {
-    const auto state_schema = co_await get_paxos_state_schema(s, timeout);
     partition_key_view key = proposal.update.key();
     co_await execute_cql_with_timeout(
-            format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET promise = ?, proposal_ballot = ?, proposal = ? WHERE row_key = ?{}", 
-                state_schema->ks_name(), state_schema->cf_name(), 
-                paxos_state_cf_filter(s, *state_schema)
-            ),
+            s,
+            [] (const schema& s, const schema& state_s) {
+                return format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET promise = ?, proposal_ballot = ?, proposal = ? WHERE row_key = ?{}",
+                    state_s.ks_name(), state_s.cf_name(),
+                    paxos_state_cf_filter(s, state_s)
+                );
+            },
             timeout,
             utils::UUID_gen::micros_timestamp(proposal.ballot),
             paxos_ttl_sec(s),
@@ -667,8 +678,6 @@ future<> paxos_store::save_paxos_proposal(const schema& s, const proposal& propo
 }
 
 future<> paxos_store::save_paxos_decision(const schema& s, const proposal& decision, db::timeout_clock::time_point timeout) {
-    const auto state_schema = co_await get_paxos_state_schema(s, timeout);
-
     // We always erase the last proposal when we learn about a new Paxos decision. The ballot
     // timestamp of the decision is used for entire mutation, so if the "erased" proposal is more
     // recent it will naturally stay on top.
@@ -677,11 +686,14 @@ future<> paxos_store::save_paxos_decision(const schema& s, const proposal& decis
     // recent commit.
     partition_key_view key = decision.update.key();
     co_await execute_cql_with_timeout(
-            format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET proposal_ballot = null, proposal = null, "
-                   "most_recent_commit_at = ?, most_recent_commit = ? WHERE row_key = ?{}",
-                state_schema->ks_name(), state_schema->cf_name(), 
-                paxos_state_cf_filter(s, *state_schema)
-            ),
+            s,
+            [] (const schema& s, const schema& state_s) {
+                return format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET proposal_ballot = null, proposal = null, "
+                       "most_recent_commit_at = ?, most_recent_commit = ? WHERE row_key = ?{}",
+                    state_s.ks_name(), state_s.cf_name(),
+                    paxos_state_cf_filter(s, state_s)
+                );
+            },
             timeout,
             utils::UUID_gen::micros_timestamp(decision.ballot),
             paxos_ttl_sec(s),
@@ -692,17 +704,18 @@ future<> paxos_store::save_paxos_decision(const schema& s, const proposal& decis
 }
 
 future<> paxos_store::delete_paxos_decision(const schema& s, const partition_key& key, utils::UUID ballot, db::timeout_clock::time_point timeout) {
-    const auto state_schema = co_await get_paxos_state_schema(s, timeout);
-
     // This should be called only if a learn stage succeeded on all replicas.
     // In this case we can remove learned paxos value using ballot's timestamp which
     // guarantees that if there is more recent round it will not be affected.
 
     co_await execute_cql_with_timeout(
-            format("DELETE most_recent_commit FROM \"{}\".\"{}\" USING TIMESTAMP ? WHERE row_key = ?{}",
-                state_schema->ks_name(), state_schema->cf_name(), 
-                paxos_state_cf_filter(s, *state_schema)
-            ),
+            s,
+            [] (const schema& s, const schema& state_s) {
+                return format("DELETE most_recent_commit FROM \"{}\".\"{}\" USING TIMESTAMP ? WHERE row_key = ?{}",
+                    state_s.ks_name(), state_s.cf_name(),
+                    paxos_state_cf_filter(s, state_s)
+                );
+            },
             timeout,
             utils::UUID_gen::micros_timestamp(ballot),
             to_legacy(*key.get_compound_type(s), key.representation())

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -474,7 +474,7 @@ static future<cql3::untyped_result_set> do_execute_cql_with_timeout(sstring req,
         timeout_config{d, d, d, d, d, d, d});
     service::query_state qs(client_state, empty_service_permit());
 
-    const auto cache_key = qp.compute_id(req, "", cql3::internal_dialect());
+    const auto cache_key = qp.compute_id(req, client_state.get_raw_keyspace(), cql3::internal_dialect());
     auto ps_ptr = qp.get_prepared(cache_key);
     shared_ptr<cql_transport::messages::result_message::prepared> prepared_msg;
     if (!ps_ptr) {

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -461,11 +461,17 @@ std::optional<std::string_view> paxos_store::try_get_base_table(std::string_view
     return cf_name.substr(0, cf_name.size() - paxos_state_table_suffix.size());
 }
 
-future<cql3::untyped_result_set> paxos_store::do_execute_cql_with_timeout(const schema& s,
+future<cql3::untyped_result_set> paxos_store::do_execute_cql_with_timeout(const schema& s, paxos_state_query query,
         noncopyable_function<sstring(const schema&, const schema&)> make_query,
         db::timeout_clock::time_point timeout,
         std::vector<data_value_or_unset> values)
 {
+    auto paxos_cache_key = prepared_statement_cache_key{s.id(), query};
+    const auto it = _prepared_statements.find(paxos_cache_key);
+    auto ps_ptr = it != _prepared_statements.end()
+        ? it->second
+        : prepared_statement_ptr();
+
     auto& qp = _sys_ks.query_processor();
     const auto now = db::timeout_clock::now();
     const auto d = now < timeout
@@ -475,17 +481,16 @@ future<cql3::untyped_result_set> paxos_store::do_execute_cql_with_timeout(const 
         timeout_config{d, d, d, d, d, d, d});
     service::query_state qs(client_state, empty_service_permit());
 
-    const auto state_schema = co_await get_paxos_state_schema(s, timeout);
-    const auto req = make_query(s, *state_schema);
-    const auto cache_key = qp.compute_id(req, client_state.get_raw_keyspace(), cql3::internal_dialect());
-    auto ps_ptr = qp.get_prepared(cache_key);
     shared_ptr<cql_transport::messages::result_message::prepared> prepared_msg;
     if (!ps_ptr) {
+        const auto state_schema = co_await get_paxos_state_schema(s, timeout);
+        const auto req = make_query(s, *state_schema);
         prepared_msg = co_await qp.prepare(req, qs, cql3::internal_dialect());
         ps_ptr = prepared_msg->get_prepared();
         if (!ps_ptr) {
             on_internal_error(paxos_state::logger, "prepared statement is null");
         }
+        _prepared_statements.insert_or_assign(std::move(paxos_cache_key), ps_ptr);
     }
     // Use an explicit page size to avoid inflating the non-paged reads metric.
     // Each paxos state query returns at most one row, so paging never kicks in.
@@ -500,11 +505,12 @@ future<cql3::untyped_result_set> paxos_store::do_execute_cql_with_timeout(const 
 }
 
 template <typename... Args>
-future<cql3::untyped_result_set> paxos_store::execute_cql_with_timeout(const schema& s,
+future<cql3::untyped_result_set> paxos_store::execute_cql_with_timeout(const schema& s, paxos_state_query query,
         noncopyable_function<sstring(const schema&, const schema&)> make_query,
         db::timeout_clock::time_point timeout,
         Args&&... args) {
     return do_execute_cql_with_timeout(s,
+        query,
         std::move(make_query),
         timeout,
         { data_value(std::forward<Args>(args))... }
@@ -604,6 +610,7 @@ future<paxos_state> paxos_store::load_paxos_state(partition_key_view key, schema
     (void)now;
     const auto results = co_await execute_cql_with_timeout(
         *s,
+        paxos_state_query::load,
         [] (const schema& s, const schema& state_s) {
             return format("SELECT * FROM \"{}\".\"{}\" WHERE row_key = ?{} LIMIT 1",
                 state_s.ks_name(), state_s.cf_name(),
@@ -643,6 +650,7 @@ future<paxos_state> paxos_store::load_paxos_state(partition_key_view key, schema
 future<> paxos_store::save_paxos_promise(const schema& s, const partition_key& key, const utils::UUID& ballot, db::timeout_clock::time_point timeout) {
     co_await execute_cql_with_timeout(
             s,
+            paxos_state_query::save_promise,
             [] (const schema& s, const schema& state_s) {
                 return format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET promise = ? WHERE row_key = ?{}",
                     state_s.ks_name(), state_s.cf_name(),
@@ -661,6 +669,7 @@ future<> paxos_store::save_paxos_proposal(const schema& s, const proposal& propo
     partition_key_view key = proposal.update.key();
     co_await execute_cql_with_timeout(
             s,
+            paxos_state_query::save_proposal,
             [] (const schema& s, const schema& state_s) {
                 return format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET promise = ?, proposal_ballot = ?, proposal = ? WHERE row_key = ?{}",
                     state_s.ks_name(), state_s.cf_name(),
@@ -687,6 +696,7 @@ future<> paxos_store::save_paxos_decision(const schema& s, const proposal& decis
     partition_key_view key = decision.update.key();
     co_await execute_cql_with_timeout(
             s,
+            paxos_state_query::save_decision,
             [] (const schema& s, const schema& state_s) {
                 return format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET proposal_ballot = null, proposal = null, "
                        "most_recent_commit_at = ?, most_recent_commit = ? WHERE row_key = ?{}",
@@ -710,6 +720,7 @@ future<> paxos_store::delete_paxos_decision(const schema& s, const partition_key
 
     co_await execute_cql_with_timeout(
             s,
+            paxos_state_query::delete_decision,
             [] (const schema& s, const schema& state_s) {
                 return format("DELETE most_recent_commit FROM \"{}\".\"{}\" USING TIMESTAMP ? WHERE row_key = ?{}",
                     state_s.ks_name(), state_s.cf_name(),

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -346,10 +346,12 @@ paxos_store::paxos_store(db::system_keyspace& sys_ks, gms::feature_service& feat
     , _features(features)
     , _db(db)
     , _mm(mm)
+    , _prepared_statements_prune_timer([this] { prune_invalid_prepared_statements(); })
 {
     if (this_shard_id() == 0) {
         _mm.get_notifier().register_listener(this);
     }
+    _prepared_statements_prune_timer.arm_periodic(prepared_statements_prune_period);
 }
 
 paxos_store::~paxos_store() {
@@ -357,10 +359,17 @@ paxos_store::~paxos_store() {
 }
 
 future<> paxos_store::stop() {
+    _prepared_statements_prune_timer.cancel();
     auto stopped = this_shard_id() == 0 
         ? _mm.get_notifier().unregister_listener(this) 
         : make_ready_future<>();
     return stopped.then([this] { _stopped = true; });
+}
+
+void paxos_store::prune_invalid_prepared_statements() {
+    std::erase_if(_prepared_statements, [] (const auto& entry) {
+        return !entry.second;
+    });
 }
 
 schema_ptr paxos_store::create_paxos_state_schema(const schema& s) {

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -372,6 +372,15 @@ void paxos_store::prune_invalid_prepared_statements() {
     });
 }
 
+const paxos_store::prepared_statement_cache& paxos_store::get_prepared_statements_cache() const {
+    return _prepared_statements;
+}
+
+void paxos_store::set_prepared_statements_prune_period(seastar::lowres_clock::duration period) {
+    SCYLLA_ASSERT(_prepared_statements_prune_timer.armed());
+    _prepared_statements_prune_timer.rearm_periodic(period);
+}
+
 schema_ptr paxos_store::create_paxos_state_schema(const schema& s) {
     schema_builder builder(this_smp_shard_count(), std::nullopt, s.ks_name(), paxos_state_table_name(s.cf_name()),
         // partition key

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -461,11 +461,11 @@ std::optional<std::string_view> paxos_store::try_get_base_table(std::string_view
     return cf_name.substr(0, cf_name.size() - paxos_state_table_suffix.size());
 }
 
-static future<cql3::untyped_result_set> do_execute_cql_with_timeout(sstring req,
+future<cql3::untyped_result_set> paxos_store::do_execute_cql_with_timeout(sstring req,
         db::timeout_clock::time_point timeout,
-        std::vector<data_value_or_unset> values,
-        cql3::query_processor& qp)
+        std::vector<data_value_or_unset> values)
 {
+    auto& qp = _sys_ks.query_processor();
     const auto now = db::timeout_clock::now();
     const auto d = now < timeout
         ? timeout - now
@@ -502,8 +502,7 @@ future<cql3::untyped_result_set> paxos_store::execute_cql_with_timeout(sstring r
         Args&&... args) {
     return do_execute_cql_with_timeout(std::move(req),
         timeout,
-        { data_value(std::forward<Args>(args))... },
-        _sys_ks.query_processor()
+        { data_value(std::forward<Args>(args))... }
     );
 }
 

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -7,7 +7,10 @@
  * SPDX-License-Identifier: (LicenseRef-ScyllaDB-Source-Available-1.1 and Apache-2.0)
  */
 #pragma once
+#include <chrono>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/core/timer.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include "service/paxos/proposal.hh"
 #include "utils/log.hh"
@@ -141,6 +144,8 @@ class paxos_store:
     using prepared_statement_cache = std::unordered_map<prepared_statement_cache_key, prepared_statement_ptr, utils::tuple_hash>;
 
     prepared_statement_cache _prepared_statements;
+    static constexpr auto prepared_statements_prune_period = std::chrono::minutes(1);
+    seastar::timer<seastar::lowres_clock> _prepared_statements_prune_timer;
 
     template <typename... Args>
     future<cql3::untyped_result_set> execute_cql_with_timeout(const schema& s, paxos_state_query query,
@@ -153,6 +158,7 @@ class paxos_store:
     future<> create_paxos_state_table(const schema& s, db::timeout_clock::time_point timeout);
     static schema_ptr create_paxos_state_schema(const schema& s);
     schema_ptr try_get_paxos_state_schema(const schema& s) const;
+    void prune_invalid_prepared_statements();
 public:
     explicit paxos_store(db::system_keyspace& sys_ks, gms::feature_service& features, replica::database& db, migration_manager& mm);
     ~paxos_store();

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -127,6 +127,8 @@ class paxos_store:
 
     template <typename... Args>
     future<cql3::untyped_result_set> execute_cql_with_timeout(sstring req, db::timeout_clock::time_point timeout, Args&&... args);
+    future<cql3::untyped_result_set> do_execute_cql_with_timeout(sstring req, db::timeout_clock::time_point timeout,
+            std::vector<data_value_or_unset> values);
     future<schema_ptr> get_paxos_state_schema(const schema& s, db::timeout_clock::time_point timeout) const;
     future<> create_paxos_state_table(const schema& s, db::timeout_clock::time_point timeout);
     static schema_ptr create_paxos_state_schema(const schema& s);

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -8,6 +8,7 @@
  */
 #pragma once
 #include <seastar/core/semaphore.hh>
+#include <seastar/util/noncopyable_function.hh>
 #include "service/paxos/proposal.hh"
 #include "utils/log.hh"
 #include "utils/digest_algorithm.hh"
@@ -126,8 +127,11 @@ class paxos_store:
     key_lock_map<table_id> _table_lock_map{false};
 
     template <typename... Args>
-    future<cql3::untyped_result_set> execute_cql_with_timeout(sstring req, db::timeout_clock::time_point timeout, Args&&... args);
-    future<cql3::untyped_result_set> do_execute_cql_with_timeout(sstring req, db::timeout_clock::time_point timeout,
+    future<cql3::untyped_result_set> execute_cql_with_timeout(const schema& s,
+            noncopyable_function<sstring(const schema&, const schema&)> make_query, db::timeout_clock::time_point timeout,
+            Args&&... args);
+    future<cql3::untyped_result_set> do_execute_cql_with_timeout(const schema& s,
+            noncopyable_function<sstring(const schema&, const schema&)> make_query, db::timeout_clock::time_point timeout,
             std::vector<data_value_or_unset> values);
     future<schema_ptr> get_paxos_state_schema(const schema& s, db::timeout_clock::time_point timeout) const;
     future<> create_paxos_state_table(const schema& s, db::timeout_clock::time_point timeout);

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -176,6 +176,10 @@ public:
     future<> delete_paxos_decision(const schema& s, const partition_key& key, utils::UUID ballot, db::timeout_clock::time_point timeout);
 
     void on_before_drop_column_family(const schema& schema, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp) override;
+
+    // For testing only
+    const prepared_statement_cache& get_prepared_statements_cache() const;
+    void set_prepared_statements_prune_period(seastar::lowres_clock::duration period);
 };
 
 } // end of namespace "service::paxos"

--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -12,11 +12,13 @@
 #include "service/paxos/proposal.hh"
 #include "utils/log.hh"
 #include "utils/digest_algorithm.hh"
+#include "utils/hash.hh"
 #include "db/timeout_clock.hh"
 #include <unordered_map>
 #include "utils/UUID_gen.hh"
 #include "service/paxos/prepare_response.hh"
 #include "service/migration_listener.hh"
+#include "cql3/statements/prepared_statement.hh"
 
 namespace cql3 {
     class query_processor;
@@ -126,11 +128,25 @@ class paxos_store:
     bool _stopped = false;
     key_lock_map<table_id> _table_lock_map{false};
 
+    enum class paxos_state_query {
+        load,
+        save_promise,
+        save_proposal,
+        save_decision,
+        delete_decision,
+    };
+
+    using prepared_statement_cache_key = std::pair<table_id, paxos_state_query>;
+    using prepared_statement_ptr = cql3::statements::prepared_statement::checked_weak_ptr;
+    using prepared_statement_cache = std::unordered_map<prepared_statement_cache_key, prepared_statement_ptr, utils::tuple_hash>;
+
+    prepared_statement_cache _prepared_statements;
+
     template <typename... Args>
-    future<cql3::untyped_result_set> execute_cql_with_timeout(const schema& s,
+    future<cql3::untyped_result_set> execute_cql_with_timeout(const schema& s, paxos_state_query query,
             noncopyable_function<sstring(const schema&, const schema&)> make_query, db::timeout_clock::time_point timeout,
             Args&&... args);
-    future<cql3::untyped_result_set> do_execute_cql_with_timeout(const schema& s,
+    future<cql3::untyped_result_set> do_execute_cql_with_timeout(const schema& s, paxos_state_query query,
             noncopyable_function<sstring(const schema&, const schema&)> make_query, db::timeout_clock::time_point timeout,
             std::vector<data_value_or_unset> values);
     future<schema_ptr> get_paxos_state_schema(const schema& s, db::timeout_clock::time_point timeout) const;

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -377,6 +377,7 @@ add_scylla_test(combined_tests
     mutation_reader_test.cc
     mutation_writer_test.cc
     network_topology_strategy_test.cc
+    paxos_state_test.cc
     per_partition_rate_limit_test.cc
     pluggable_test.cc
     querier_cache_test.cc

--- a/test/boost/paxos_state_test.cc
+++ b/test/boost/paxos_state_test.cc
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include <boost/test/unit_test.hpp>
+
+#undef SEASTAR_TESTING_MAIN
+#include <seastar/testing/test_case.hh>
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sleep.hh>
+
+#include <string_view>
+#include <utility>
+
+#include "test/lib/cql_test_env.hh"
+
+#include "service/paxos/paxos_state.hh"
+
+using namespace std::chrono_literals;
+
+BOOST_AUTO_TEST_SUITE(paxos_state_test)
+
+SEASTAR_TEST_CASE(test_prepared_statement_cache_prunes_after_table_drop) {
+    return seastar::async([] {
+        auto check = [] (std::string_view name, std::string_view drop_statement) {
+            BOOST_TEST_CONTEXT(name) {
+                cql_test_config cfg;
+                // With vnodes, system.paxos is never dropped, so the weak pointers aren't invalidated immediately after
+                // dropping the base table. Hence, we run the test only with tablets.
+                cfg.initial_tablets = 1;
+                cfg.need_remote_proxy = true;
+
+                do_with_cql_env_thread([drop_statement] (cql_test_env& env) {
+                    auto paxos_prepared_statements_cache_size = [&env] {
+                        return env.get_paxos_store().local().get_prepared_statements_cache().size();
+                    };
+
+                    env.get_paxos_store().local().set_prepared_statements_prune_period(1ms);
+                    BOOST_REQUIRE_EQUAL(paxos_prepared_statements_cache_size(), 0);
+
+                    env.execute_cql("CREATE TABLE t (pk int PRIMARY KEY, v int)").get();
+                    env.execute_cql("INSERT INTO t (pk, v) VALUES (0, 0) IF NOT EXISTS").get();
+
+                    BOOST_REQUIRE_GT(paxos_prepared_statements_cache_size(), 0);
+
+                    env.execute_cql(drop_statement).get();
+
+                    const auto deadline = seastar::lowres_clock::now() + 10s;
+                    while (paxos_prepared_statements_cache_size() != 0 && seastar::lowres_clock::now() < deadline) {
+                        seastar::sleep(2ms).get();
+                    }
+
+                    BOOST_REQUIRE_EQUAL(paxos_prepared_statements_cache_size(), 0);
+                }, std::move(cfg)).get();
+            }
+        };
+
+        check("drop table", "DROP TABLE t");
+        check("drop keyspace", "DROP KEYSPACE ks");
+    });
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -422,6 +422,10 @@ public:
         return _proxy;
     }
 
+    virtual sharded<service::paxos::paxos_store>& get_paxos_store() override {
+        return _paxos_store;
+    }
+
     virtual sharded<gms::feature_service>& get_feature_service() override {
         return _feature_service;
     }

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -65,6 +65,10 @@ class migration_manager;
 class raft_group0_client;
 class raft_group_registry;
 
+namespace paxos {
+class paxos_store;
+}
+
 }
 
 class not_prepared_exception : public std::runtime_error {
@@ -197,6 +201,8 @@ public:
     virtual sharded<service::tablet_allocator>& get_tablet_allocator() = 0;
 
     virtual sharded<service::storage_proxy>& get_storage_proxy() = 0;
+
+    virtual sharded<service::paxos::paxos_store>& get_paxos_store() = 0;
 
     virtual sharded<gms::feature_service>& get_feature_service() = 0;
 


### PR DESCRIPTION
This PR contains two improvements for the internal paxos state requests:
- Change 1 (commit 1) fixes a bug that caused paxos_store to always miss the
prepared statement cache.
- Change 2 (commits 2+) introduces a cache that stores weak pointers to the
prepared statements to avoid wastefully recomputing the cache key every time.

Regarding Change 1, note that the statement wasn't re-prepared and the
cache was simply hit deeper in `qp.prepare(...)` (see
`_prepared_cache.get_pinned`). So the code was "correct", but very inefficient.

Change 2 deletes the code changed in Change 1, so commit 1 is only for
reference. In particular, performance results with only Change 1 justify the more
complicated Change 2.

Below are the average results of the perf tests I did. I ran perf_alternator as it
allows using LWT. I did 30 5s runs for each binary. These runs were interleaved
to minimize the impact of the changing machine load. "median tps" is the only
metric that varies significantly between runs.

| binary | median tps | allocs/op | logallocs/op | tasks/op | insns/op | cycles/op |
|---|---:|---:|---:|---:|---:|---:|
| this PR | 7576.33 | 807.87 | 46.13 | 149.52 | 616863.39 | 540947.56 |
| only Change 1 | 7182.10 | 842.15 | 46.02 | 149.07 | 653057.63 | 562772.75 |
| master | 7099.77 | 896.35 | 46.02 | 149.21 | 679826.40 | 585080.36 |

Fixes: SCYLLADB-2963

No backport, IMO the gains/risk ratio is too low.