### PR TITLE
logstor: write buffer improvements

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -973,6 +973,7 @@ database::init_logstor() {
             .max_separator_memory = _cfg.logstor_separator_max_memory_in_mb() * 1024ull * 1024ull,
         },
         .flush_sg = _dbcfg.commitlog_scheduling_group,
+        .max_queued_write_bytes = _dbcfg.available_memory * 1 / 100,
     };
     _logstor = std::make_unique<logstor::logstor>(std::move(cfg), _row_cache_tracker);
 

--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -43,7 +43,12 @@ static api::timestamp_type extract_logstor_record_timestamp(const mutation& m) {
 
 logstor::logstor(logstor_config config, ::cache_tracker& shared_cache_tracker)
     : _segment_manager(config.segment_manager_cfg)
-    , _write_buffer(_segment_manager, config.flush_sg, config.max_queued_write_bytes)
+    , _write_buffer(buffered_writer_config{
+            .buffer_size = _segment_manager.get_segment_size(),
+            .ring_size = config.write_buffer_ring_size,
+            .flush_sg = config.flush_sg,
+            .max_queued_write_bytes = config.max_queued_write_bytes,
+        }, [&sm = _segment_manager] (write_buffer& buf) { return sm.write(buf); })
     , _cache_tracker(shared_cache_tracker) {
 
     namespace sm = seastar::metrics;

--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -45,6 +45,13 @@ logstor::logstor(logstor_config config, ::cache_tracker& shared_cache_tracker)
     : _segment_manager(config.segment_manager_cfg)
     , _write_buffer(_segment_manager, config.flush_sg)
     , _cache_tracker(shared_cache_tracker) {
+
+    namespace sm = seastar::metrics;
+
+    _metrics.add_group("logstor", {
+        sm::make_counter("write_failures", [this] { return _stats.write_failures; },
+                       sm::description("Number of writes that failed to be persisted.")),
+    });
 }
 
 future<> logstor::do_recovery(replica::database& db) {
@@ -113,17 +120,17 @@ future<> logstor::write(const mutation& m, compaction_group& cg, seastar::gate::
         .mut = canonical_mutation(m)
     };
 
-    return _write_buffer.write(std::move(record), timeout, &cg, std::move(cg_holder)).then_unpack([index_ptr = &index, ts, key = std::move(key)]
-            (log_location location, seastar::gate::holder op) {
-        index_entry new_entry {
-            .location = location,
-            .timestamp = ts,
-        };
-        index_ptr->insert(key, std::move(new_entry));
-    }).handle_exception([] (std::exception_ptr ep) {
-        logstor_logger.error("Error writing mutation: {}", ep);
-        return make_exception_future<>(ep);
-    });
+    auto result_f = co_await coroutine::as_future(_write_buffer.write(std::move(record), timeout, &cg, std::move(cg_holder)));
+    if (result_f.failed()){
+        _stats.write_failures++;
+        co_await coroutine::return_exception_ptr(result_f.get_exception());
+    }
+    auto [location, op] = result_f.get();
+    index_entry new_entry {
+        .location = location,
+        .timestamp = ts,
+    };
+    index.insert(key, std::move(new_entry));
 }
 
 future<std::optional<mutation>> logstor::read(const schema& s, const primary_index& index, const dht::decorated_key& dk, const query::partition_slice& slice) {

--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -75,8 +75,12 @@ future<> logstor::start() {
 }
 
 future<> logstor::stop() {
+    if (_async_gate.is_closed()) {
+        co_return;
+    }
     logstor_logger.info("Stopping logstor");
 
+    co_await _async_gate.close();
     co_await _write_buffer.stop();
     co_await _segment_manager.stop();
 
@@ -112,6 +116,8 @@ std::unique_ptr<primary_index> logstor::make_primary_index(schema_ptr schema, bo
 }
 
 future<> logstor::write(const mutation& m, compaction_group& cg, seastar::gate::holder cg_holder, db::timeout_clock::time_point timeout) {
+    auto gate_holder = _async_gate.hold();
+
     primary_index_key key(m.decorated_key());
     table_id table = m.schema()->id();
     auto& index = cg.get_logstor_index();
@@ -143,6 +149,8 @@ future<> logstor::write(const mutation& m, compaction_group& cg, seastar::gate::
 }
 
 future<std::optional<mutation>> logstor::read(const schema& s, const primary_index& index, const dht::decorated_key& dk, const query::partition_slice& slice) {
+    auto gate_holder = _async_gate.hold();
+
     auto op = index.start_read();
 
     const auto bypass_cache = slice.options.contains(query::partition_slice::option::bypass_cache);

--- a/replica/logstor/logstor.cc
+++ b/replica/logstor/logstor.cc
@@ -43,12 +43,14 @@ static api::timestamp_type extract_logstor_record_timestamp(const mutation& m) {
 
 logstor::logstor(logstor_config config, ::cache_tracker& shared_cache_tracker)
     : _segment_manager(config.segment_manager_cfg)
-    , _write_buffer(_segment_manager, config.flush_sg)
+    , _write_buffer(_segment_manager, config.flush_sg, config.max_queued_write_bytes)
     , _cache_tracker(shared_cache_tracker) {
 
     namespace sm = seastar::metrics;
 
     _metrics.add_group("logstor", {
+        sm::make_gauge("queued_write_count", [this] { return _write_buffer.queued_write_count(); },
+                       sm::description("Number of writes currently queued in the write buffer.")),
         sm::make_counter("write_failures", [this] { return _stats.write_failures; },
                        sm::description("Number of writes that failed to be persisted.")),
     });
@@ -120,7 +122,9 @@ future<> logstor::write(const mutation& m, compaction_group& cg, seastar::gate::
         .mut = canonical_mutation(m)
     };
 
-    auto result_f = co_await coroutine::as_future(_write_buffer.write(std::move(record), timeout, &cg, std::move(cg_holder)));
+    auto writer = log_record_writer(std::move(record));
+
+    auto result_f = co_await coroutine::as_future(_write_buffer.write(std::move(writer), timeout, &cg, std::move(cg_holder)));
     if (result_f.failed()){
         _stats.write_failures++;
         co_await coroutine::return_exception_ptr(result_f.get_exception());

--- a/replica/logstor/logstor.hh
+++ b/replica/logstor/logstor.hh
@@ -35,6 +35,7 @@ struct logstor_config {
     segment_manager_config segment_manager_cfg;
     seastar::scheduling_group flush_sg;
     size_t max_queued_write_bytes{0};
+    size_t write_buffer_ring_size{5};
 };
 
 class logstor {

--- a/replica/logstor/logstor.hh
+++ b/replica/logstor/logstor.hh
@@ -34,6 +34,7 @@ extern seastar::logger logstor_logger;
 struct logstor_config {
     segment_manager_config segment_manager_cfg;
     seastar::scheduling_group flush_sg;
+    size_t max_queued_write_bytes{0};
 };
 
 class logstor {

--- a/replica/logstor/logstor.hh
+++ b/replica/logstor/logstor.hh
@@ -49,6 +49,7 @@ class logstor {
     cache_tracker _cache_tracker;
     seastar::metrics::metric_groups _metrics;
     stats _stats;
+    seastar::gate _async_gate;
 
 public:
 

--- a/replica/logstor/logstor.hh
+++ b/replica/logstor/logstor.hh
@@ -38,9 +38,15 @@ struct logstor_config {
 
 class logstor {
 
+    struct stats {
+        uint64_t write_failures{0};
+    };
+
     segment_manager _segment_manager;
     buffered_writer _write_buffer;
     cache_tracker _cache_tracker;
+    seastar::metrics::metric_groups _metrics;
+    stats _stats;
 
 public:
 

--- a/replica/logstor/segment_manager.cc
+++ b/replica/logstor/segment_manager.cc
@@ -71,12 +71,22 @@ protected:
 
 class writeable_segment : public segment {
     seastar::gate _write_gate;
+    seastar::semaphore _append_sem{1};
     segment_ref _seg_ref;
     segment_sequence _seq_num;
 
     uint32_t _current_offset = 0; // next offset for write
 
+    // Set when a write to this segment failed. The segment is retired: it accepts no
+    // further appends, and reserve() returns nullopt so that the caller switches to a
+    // new segment.
+    bool _failed = false;
+
     future<> do_write(log_location , bytes_view data);
+
+    bool can_fit(size_t data_size) const noexcept {
+        return _current_offset + data_size <= _max_size;
+    }
 
 public:
     using segment::segment;
@@ -85,13 +95,23 @@ public:
 
     future<> stop();
 
-    // write a serialized sequence of records.
-    // must not be called concurrently.
-    future<log_location> append(bytes_view data);
+    struct append_reservation {
+        log_location loc;
+        seastar::semaphore_units<> units;
+    };
 
-    bool can_fit(size_t data_size) const noexcept {
-        return _current_offset + data_size <= _max_size;
-    }
+    // Reserve the next append offset for this segment and keep the permit held
+    // until the DMA write completes.
+    // Returns nullopt if the data doesn't fit in the segment, or if the segment was
+    // retired by a failed write. In both cases nothing was written and the caller is
+    // expected to move on to another segment.
+    future<std::optional<append_reservation>> reserve(size_t data_size);
+
+    future<log_location> write_reserved(append_reservation reservation, bytes_view data);
+
+    // Convenience helper for callers that do not need to split reservation and write.
+    // Fails if the segment cannot fit the write.
+    future<log_location> append(bytes_view data);
 
     size_t bytes_remaining() const noexcept {
         return _max_size - _current_offset;
@@ -140,25 +160,70 @@ future<> writeable_segment::stop() {
     co_await _write_gate.close();
 }
 
-future<log_location> writeable_segment::append(bytes_view data) {
-    auto data_size = data.size();
-
-    if (!can_fit(data_size)) {
-        throw std::runtime_error("Entry too large for remaining segment space");
+future<std::optional<writeable_segment::append_reservation>> writeable_segment::reserve(size_t data_size) {
+    if (_failed) [[unlikely]] {
+        co_return std::nullopt;
     }
 
-    log_location loc {
-        .segment = _id,
-        .offset = _current_offset,
-        .size = static_cast<uint32_t>(data_size)
+    std::optional<seastar::semaphore_units<>> units;
+    try {
+        units = co_await get_units(_append_sem, 1);
+    } catch (...) {
+        // The only way _append_sem breaks is a failed write retiring the segment, which
+        // may have happened while we were waiting for the permit. Nothing was reserved,
+        // so the caller can retry on another segment.
+        co_return std::nullopt;
+    }
+
+    if (!can_fit(data_size)) {
+        co_return std::nullopt;
+    }
+
+    append_reservation reservation {
+        .loc = log_location {
+            .segment = _id,
+            .offset = _current_offset,
+            .size = static_cast<uint32_t>(data_size)
+        },
+        .units = std::move(*units),
     };
 
-    co_await do_write(loc, data);
     _current_offset += data_size;
-    co_return loc;
+
+    co_return std::move(reservation);
+}
+
+future<log_location> writeable_segment::write_reserved(append_reservation reservation, bytes_view data) {
+    auto write_result = co_await coroutine::as_future(do_write(reservation.loc, data));
+    if (write_result.failed()) {
+        auto ex = write_result.get_exception();
+
+        // if a write fails, fail also all later writes to the segment, since we assume no holes in a segment.
+        // the segment is retired, so that callers switch to a new segment instead of failing forever.
+        _failed = true;
+        _append_sem.broken(ex);
+        logstor_logger.warn("Write to segment {} seq {} failed: {}, retiring segment", _id, _seq_num, ex);
+
+        co_await coroutine::return_exception_ptr(std::move(ex));
+    }
+    co_return reservation.loc;
+}
+
+future<log_location> writeable_segment::append(bytes_view data) {
+    auto reservation = co_await reserve(data.size());
+    if (!reservation) {
+        co_return coroutine::return_exception(std::runtime_error(_failed
+                ? fmt::format("Can't append write of size {} to segment {} retired by a failed write", data.size(), _id)
+                : fmt::format("Can't append write of size {} to segment with {} bytes remaining", data.size(), bytes_remaining())));
+    }
+    co_return co_await write_reserved(std::move(*reservation), data);
 }
 
 future<> writeable_segment::do_write(log_location loc, bytes_view data) {
+    utils::get_local_injector().inject("logstor_fail_segment_write", [] {
+        throw std::runtime_error("segment write failed by injection");
+    });
+
     const auto alignment = _file.disk_write_dma_alignment();
     const uint64_t total = data.size();
     auto offset = absolute_offset(loc.offset);
@@ -668,7 +733,6 @@ class segment_manager_impl {
     static constexpr size_t segment_pool_size = 128;
 
     seg_ptr _active_segment;
-    seastar::semaphore _active_segment_write_sem{1};
     segment_pool _segment_pool;
     std::optional<shared_future<>> _switch_segment_fut;
     segment_sequence _next_segment_seq{1};
@@ -1053,25 +1117,35 @@ future<> segment_manager_impl::stop() {
 future<> segment_manager_impl::write(write_buffer& wb) {
     write_source source = write_source::normal_write;
     auto holder = _async_gate.hold();
-
+    auto write_op = _writes_phaser.start();
     const auto sealed_size = wb.sealed_size(block_alignment);
 
     if (sealed_size > _cfg.segment_size) {
         throw std::runtime_error(fmt::format( "Write size {} exceeds segment size {}", sealed_size, _cfg.segment_size));
     }
 
-    {
-        auto sem_units = co_await get_units(_active_segment_write_sem, 1);
-
-        while (!_active_segment || !_active_segment->can_fit(sealed_size)) {
+    while (true) {
+        if (!_active_segment) {
             co_await request_segment_switch();
+            continue;
         }
 
         seg_ptr seg = _active_segment;
         auto seg_holder = seg->hold();
         auto seg_ref = seg->ref();
+
+        auto reservation = co_await seg->reserve(sealed_size);
+        if (!reservation) {
+            if (_active_segment == seg) {
+                co_await request_segment_switch();
+            }
+            continue;
+        }
+
         auto seq_num = seg->seq_num();
-        auto write_op = _writes_phaser.start();
+
+        wb.seal(seq_num, std::nullopt, block_alignment);
+
         // if we wrote a record to the segment but failed to write it to the separator, the segment should not be freed.
         auto write_to_separator_failed = defer([seg_ref] mutable noexcept {
             seg_ref.set_flush_failure();
@@ -1079,11 +1153,8 @@ future<> segment_manager_impl::write(write_buffer& wb) {
 
         logstor_logger.trace("Write active segment {} seq {}", seg->id(), seq_num);
 
-        wb.seal(seq_num, std::nullopt, block_alignment);
         bytes_view data(reinterpret_cast<const int8_t*>(wb.data()), wb.serialized_size());
-
-        auto loc = co_await seg->append(data);
-        sem_units.return_all();
+        auto loc = co_await seg->write_reserved(std::move(*reservation), data);
 
         _stats.bytes_written[static_cast<size_t>(source)] += data.size();
         _stats.data_bytes_written[static_cast<size_t>(source)] += wb.net_data_size();
@@ -1096,6 +1167,7 @@ future<> segment_manager_impl::write(write_buffer& wb) {
             return write_to_separator(wb, std::move(seg_ref), seq_num);
         });
         write_to_separator_failed.cancel();
+        break;
     }
 
     // flow control for separator debt

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -7,7 +7,6 @@
  */
 #include "write_buffer.hh"
 #include "dht/token.hh"
-#include "segment_manager.hh"
 #include "bytes_fwd.hh"
 #include "logstor.hh"
 #include "replica/logstor/types.hh"
@@ -291,14 +290,27 @@ bool ondisk::validate_record_header(const ondisk::record_header& rh) {
 
 // buffered_writer
 
-buffered_writer::buffered_writer(segment_manager& sm, seastar::scheduling_group flush_sg, size_t max_queued_write_bytes)
-        : _sm(sm)
-        , _flush_sg(flush_sg)
+buffered_writer::buffered_writer(buffered_writer_config cfg, seastar::noncopyable_function<future<>(write_buffer&)> flush_func)
+        : _flush_sg(cfg.flush_sg)
+        , _buffer_size(cfg.buffer_size)
+        , _ring_size(cfg.ring_size)
+        , _flush_func(std::move(flush_func))
+        , _ring()
+        , _in_flight(cfg.ring_size)
         , _queued_writes(on_queued_write_expiry{this})
-        , _max_queued_write_bytes(max_queued_write_bytes) {
-    _ring.reserve(ring_size);
-    for (size_t i = 0; i < ring_size; ++i) {
-        _ring.emplace_back(_sm.get_segment_size(), segment_kind::mixed);
+        , _max_queued_write_bytes(cfg.max_queued_write_bytes) {
+
+    if (_ring_size < 2) {
+        on_internal_error(logstor_logger, fmt::format("buffered_writer ring_size must be >= 2 (got {})", _ring_size));
+    }
+
+    if (_buffer_size == 0) {
+        on_internal_error(logstor_logger, "buffered_writer buffer_size must be > 0");
+    }
+
+    _ring.reserve(_ring_size);
+    for (size_t i = 0; i < _ring_size; ++i) {
+        _ring.emplace_back(_buffer_size, segment_kind::mixed);
     }
 }
 
@@ -344,7 +356,7 @@ std::optional<future<log_location_with_holder>> buffered_writer::append_to_head_
 bool buffered_writer::try_dispatch_next_buffer() {
     auto idx = _dispatch_tail;
     auto& state = dispatch_tail_write();
-    auto& buf = _ring[idx % ring_size];
+    auto& buf = _ring[idx % _ring_size];
 
     if (_dispatch_tail >= _head || !state.idle() || !buf.has_data()) {
         return false;
@@ -360,8 +372,8 @@ bool buffered_writer::try_dispatch_next_buffer() {
 }
 
 future<> buffered_writer::run_dispatched_write(size_t idx) {
-    auto& buf = _ring[idx % ring_size];
-    auto f = co_await coroutine::as_future(_sm.write(buf));
+    auto& buf = _ring[idx % _ring_size];
+    auto f = co_await coroutine::as_future(_flush_func(buf));
     _consumer_progress_cv.signal();
     if (f.failed()) {
         co_await coroutine::return_exception_ptr(f.get_exception());

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -355,6 +355,10 @@ void buffered_writer::cancel_head_flush_timer() noexcept {
     _head_deadline_expired = false;
 }
 
+void buffered_writer::on_queued_writes_changed() noexcept {
+    _queued_writes_changed.broadcast();
+}
+
 void buffered_writer::on_queued_write_removed(const queued_write& w) noexcept {
     _queued_write_bytes -= w.write_size;
 }
@@ -438,6 +442,7 @@ future<bool> buffered_writer::reclaim_completed_tails() {
         state.reset();
         ++_tail;
         reclaimed = true;
+        _tail_advanced.broadcast();
 
         co_await coroutine::maybe_yield();
     }
@@ -466,6 +471,10 @@ future<bool> buffered_writer::drain_queued_writes() {
             fail_queued_write(request, std::current_exception());
         }
         co_await coroutine::maybe_yield();
+    }
+
+    if (removed_queued_writes) {
+        on_queued_writes_changed();
     }
 
     co_return removed_queued_writes;
@@ -506,6 +515,54 @@ future<> buffered_writer::stop() {
     logstor_logger.info("Write buffer stopped");
 }
 
+future<> buffered_writer::flush() {
+    auto holder = _async_gate.hold();
+
+    // Snapshot the queue insertion boundary. New writes pushed after this point
+    // get higher ids and are not our responsibility.
+    const uint64_t target_next_id = _next_queued_write_id;
+
+    auto preflush_queued_writes_gone = [this, target_next_id] {
+        return _queued_writes.empty() || _queued_writes.front().id >= target_next_id;
+    };
+
+    // Drain or let expire all writes that were queued when flush() was called.
+    while (!preflush_queued_writes_gone()) {
+        co_await drain_queued_writes();
+        co_await _queued_writes_changed.wait(preflush_queued_writes_gone);
+    }
+
+    // If the current head buffer is non-empty, flush() must first move _head
+    // past it so the consumer can dispatch that buffer. The head slot itself
+    // is always the buffer that writers are still appending to, so as long as
+    // _head stays unchanged that buffer is not yet eligible for dispatch.
+    //
+    // There are two cases:
+    // 1. The head buffer is empty. There is nothing new to seal, so flush()
+    //    only needs to wait for buffers that were already dispatched or are
+    //    already behind _head.
+    // 2. The head buffer is non-empty. flush() must rotate _head to the next
+    //    ring slot. After that rotation, the old head becomes dispatchable and
+    //    the new _head value is the tail boundary that proves the old head was
+    //    fully flushed and reclaimed.
+    auto head_before_forced_rotation = _head;
+    while (_head == head_before_forced_rotation && head_buf().has_data()) {
+        if (maybe_advance_head()) {
+            break;
+        }
+        // Ring is full; wait for tail flush to free a slot.
+        co_await _tail_advanced.wait();
+    }
+
+    // Wait until all buffers that flush() is responsible for are flushed and
+    // reclaimed. If the head was empty, this is just the current _head. If the
+    // head had data, this is the new post-rotation _head, which means the old
+    // head buffer is now behind the tail.
+    co_await _tail_advanced.when([this, flush_tail_goal = _head] {
+        return _tail >= flush_tail_goal;
+    });
+}
+
 future<buffered_write_result> buffered_writer::write_to_buffer(log_record_writer writer, db::timeout_clock::time_point timeout, compaction_group* cg, seastar::gate::holder cg_holder) {
     auto holder = _async_gate.hold();
 
@@ -529,7 +586,7 @@ future<buffered_write_result> buffered_writer::write_to_buffer(log_record_writer
 
     const bool queue_was_empty = _queued_writes.empty();
     const auto write_size = writer.size();
-    queued_write request(std::move(writer), cg, std::move(cg_holder), timeout, write_size);
+    queued_write request(std::move(writer), cg, std::move(cg_holder), timeout, _next_queued_write_id++, write_size);
     auto accepted = request.accepted_pr.get_future();
     _queued_write_bytes += write_size;
     _queued_writes.push_back(std::move(request), timeout);
@@ -577,6 +634,7 @@ future<> buffered_writer::consumer_loop() {
             auto request = std::move(_queued_writes.front());
             _queued_writes.pop_front();
             on_queued_write_removed(request);
+            on_queued_writes_changed();
             fail_queued_write(request, std::make_exception_ptr(seastar::gate_closed_exception()));
             co_await coroutine::maybe_yield();
         }

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -291,9 +291,11 @@ bool ondisk::validate_record_header(const ondisk::record_header& rh) {
 
 // buffered_writer
 
-buffered_writer::buffered_writer(segment_manager& sm, seastar::scheduling_group flush_sg)
+buffered_writer::buffered_writer(segment_manager& sm, seastar::scheduling_group flush_sg, size_t max_queued_write_bytes)
         : _sm(sm)
-        , _flush_sg(flush_sg) {
+        , _flush_sg(flush_sg)
+        , _queued_writes(on_queued_write_expiry{this})
+        , _max_queued_write_bytes(max_queued_write_bytes) {
     _ring.reserve(ring_size);
     for (size_t i = 0; i < ring_size; ++i) {
         _ring.emplace_back(_sm.get_segment_size(), segment_kind::mixed);
@@ -308,14 +310,35 @@ bool buffered_writer::should_rotate_head_for_flush() const noexcept {
     return _dispatch_tail == _head && head_buf().has_data();
 }
 
+void buffered_writer::on_queued_write_removed(const queued_write& w) noexcept {
+    _queued_write_bytes -= w.write_size;
+}
+
+void buffered_writer::fail_queued_write(queued_write& request, std::exception_ptr ep) noexcept {
+    request.accepted_pr.set_exception(ep);
+    request.persisted_pr.set_exception(std::move(ep));
+}
+
 bool buffered_writer::maybe_advance_head() noexcept {
     if (ring_full() || !head_buf().has_data()) {
         return false;
     }
     ++_head;
-    _head_can_advance.broadcast();
     _consumer_progress_cv.signal();
     return true;
+}
+
+std::optional<future<log_location_with_holder>> buffered_writer::append_to_head_buffer(log_record_writer& writer, compaction_group* cg, seastar::gate::holder cg_holder) {
+    if (!head_buf().can_fit(writer) && !maybe_advance_head()) {
+        return std::nullopt;
+    }
+
+    bool was_empty = !head_buf().has_data();
+    auto persisted = head_buf().write(std::move(writer), cg, std::move(cg_holder));
+    if (was_empty) {
+        _consumer_progress_cv.signal();
+    }
+    return persisted;
 }
 
 bool buffered_writer::try_dispatch_next_buffer() {
@@ -368,12 +391,37 @@ future<bool> buffered_writer::reclaim_completed_tails() {
         state.reset();
         ++_tail;
         reclaimed = true;
-        _head_can_advance.broadcast();
 
         co_await coroutine::maybe_yield();
     }
 
     co_return reclaimed;
+}
+
+future<bool> buffered_writer::drain_queued_writes() {
+    bool removed_queued_writes = false;
+    while (!_queued_writes.empty()) {
+        auto& next = _queued_writes.front();
+
+        if (!head_buf().can_fit(next.writer) && !maybe_advance_head()) {
+            break;
+        }
+
+        auto request = std::move(next);
+        _queued_writes.pop_front();
+        on_queued_write_removed(request);
+        removed_queued_writes = true;
+        try {
+            auto persisted = append_to_head_buffer(request.writer, request.cg, std::move(request.cg_holder)).value();
+            request.accepted_pr.set_value(buffered_write_result{request.persisted_pr.get_future()});
+            std::move(persisted).forward_to(std::move(request.persisted_pr));
+        } catch (...) {
+            fail_queued_write(request, std::current_exception());
+        }
+        co_await coroutine::maybe_yield();
+    }
+
+    co_return removed_queued_writes;
 }
 
 future<> buffered_writer::start() {
@@ -393,8 +441,6 @@ future<> buffered_writer::stop() {
     // Wake the consumer so it can observe the closing gate and exit.
     auto close_fut = _async_gate.close();
     _consumer_progress_cv.broadcast();
-    // Wake any writer blocked waiting for a free ring slot.
-    _head_can_advance.broadcast();
     co_await std::move(close_fut);
     co_await std::move(_consumer);
 
@@ -411,41 +457,42 @@ future<> buffered_writer::stop() {
     logstor_logger.info("Write buffer stopped");
 }
 
-future<log_location_with_holder> buffered_writer::write(log_record record, db::timeout_clock::time_point timeout, compaction_group* cg, seastar::gate::holder cg_holder) {
+future<buffered_write_result> buffered_writer::write_to_buffer(log_record_writer writer, db::timeout_clock::time_point timeout, compaction_group* cg, seastar::gate::holder cg_holder) {
     auto holder = _async_gate.hold();
-
-    log_record_writer writer(std::move(record));
-
-    if (timeout != db::no_timeout && timeout <= db::timeout_clock::now()) {
-        co_await coroutine::return_exception(timed_out_error{});
-    }
 
     if (writer.size() > head_buf().max_record_size()) {
         co_await coroutine::return_exception(std::runtime_error(fmt::format("Write size {} exceeds buffer size {}", writer.size(), head_buf().max_record_size())));
     }
 
-    // Wait until the head buffer can fit this write.
-    while (!head_buf().can_fit(writer)) {
-        // Capture the current head before waiting.  Multiple concurrent writers
-        // can all reach this point; only the first one to proceed actually
-        // advances _head — the rest see _head != current_head and simply
-        // re-check the (already advanced) head buffer.
-        auto current_head = _head;
-        while (ring_full() && !_async_gate.is_closed()) {
-            co_await _head_can_advance.wait(timeout);
-        }
-        _async_gate.check();
-        if (_head == current_head) {
-            maybe_advance_head();
+    // fast path - if there are no queued writes and there is space in the current head buffer or the next, advance the
+    // head buffer if needed and write to it.
+    if (_queued_writes.empty()) {
+        if (auto persisted = append_to_head_buffer(writer, cg, std::move(cg_holder))) {
+            co_return buffered_write_result{std::move(*persisted)};
         }
     }
 
-    auto fut = head_buf().write(std::move(writer), cg, std::move(cg_holder));
+    // either there are queued writes or there is no space in the head buffer and ring is full - queue the write.
 
-    // Wake the consumer: there is now data at the head.
-    _consumer_progress_cv.broadcast();
+    if (_max_queued_write_bytes != 0 && _queued_write_bytes + writer.size() > _max_queued_write_bytes) {
+        co_await coroutine::return_exception(replica::rate_limit_exception());
+    }
 
-    co_return co_await std::move(fut);
+    const bool queue_was_empty = _queued_writes.empty();
+    const auto write_size = writer.size();
+    queued_write request(std::move(writer), cg, std::move(cg_holder), timeout, write_size);
+    auto accepted = request.accepted_pr.get_future();
+    _queued_write_bytes += write_size;
+    _queued_writes.push_back(std::move(request), timeout);
+    if (queue_was_empty) {
+        _consumer_progress_cv.signal();
+    }
+    co_return co_await std::move(accepted);
+}
+
+future<log_location_with_holder> buffered_writer::write(log_record_writer writer, db::timeout_clock::time_point timeout, compaction_group* cg, seastar::gate::holder cg_holder) {
+    auto result = co_await write_to_buffer(std::move(writer), timeout, cg, std::move(cg_holder));
+    co_return co_await std::move(result.persisted);
 }
 
 future<> buffered_writer::consumer_loop() {
@@ -454,6 +501,8 @@ future<> buffered_writer::consumer_loop() {
             bool progressed = false;
 
             progressed |= co_await reclaim_completed_tails();
+
+            progressed |= co_await drain_queued_writes();
 
             if (should_rotate_head_for_flush()) {
                 progressed |= maybe_advance_head();
@@ -464,7 +513,7 @@ future<> buffered_writer::consumer_loop() {
                 co_await coroutine::maybe_yield();
             }
 
-            if (_async_gate.is_closed() && !has_pending_buffers()) {
+            if (_async_gate.is_closed() && _queued_writes.empty() && !has_pending_buffers()) {
                 break;
             }
 
@@ -472,6 +521,14 @@ future<> buffered_writer::consumer_loop() {
                 co_await _consumer_progress_cv.wait();
             }
 
+            co_await coroutine::maybe_yield();
+        }
+
+        while (!_queued_writes.empty()) {
+            auto request = std::move(_queued_writes.front());
+            _queued_writes.pop_front();
+            on_queued_write_removed(request);
+            fail_queued_write(request, std::make_exception_ptr(seastar::gate_closed_exception()));
             co_await coroutine::maybe_yield();
         }
     } catch (...) {

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -15,6 +15,7 @@
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/with_scheduling_group.hh>
 #include <seastar/core/on_internal_error.hh>
+#include <seastar/coroutine/as_future.hh>
 #include "serializer_impl.hh"
 #include "idl/logstor.dist.hh"
 #include "idl/logstor.dist.impl.hh"
@@ -299,12 +300,86 @@ buffered_writer::buffered_writer(segment_manager& sm, seastar::scheduling_group 
     }
 }
 
+bool buffered_writer::has_pending_buffers() const noexcept {
+    return _tail < _head || head_buf().has_data();
+}
+
+bool buffered_writer::should_rotate_head_for_flush() const noexcept {
+    return _dispatch_tail == _head && head_buf().has_data();
+}
+
+bool buffered_writer::maybe_advance_head() noexcept {
+    if (ring_full() || !head_buf().has_data()) {
+        return false;
+    }
+    ++_head;
+    _head_can_advance.broadcast();
+    _consumer_progress_cv.signal();
+    return true;
+}
+
+bool buffered_writer::try_dispatch_next_buffer() {
+    auto idx = _dispatch_tail;
+    auto& state = dispatch_tail_write();
+    auto& buf = _ring[idx % ring_size];
+
+    if (_dispatch_tail >= _head || !state.idle() || !buf.has_data()) {
+        return false;
+    }
+
+    try {
+        state.start(run_dispatched_write(idx));
+    } catch (...) {
+        state.start(make_exception_future<>(std::current_exception()));
+    }
+    ++_dispatch_tail;
+    return true;
+}
+
+future<> buffered_writer::run_dispatched_write(size_t idx) {
+    auto& buf = _ring[idx % ring_size];
+    auto f = co_await coroutine::as_future(_sm.write(buf));
+    _consumer_progress_cv.signal();
+    if (f.failed()) {
+        co_await coroutine::return_exception_ptr(f.get_exception());
+    }
+}
+
+future<bool> buffered_writer::reclaim_completed_tails() {
+    bool reclaimed = false;
+    while (_tail < _dispatch_tail) {
+        auto& state = tail_write();
+        if (!state.ready()) {
+            break;
+        }
+
+        auto completion = state.take_completion();
+        auto f = co_await coroutine::as_future(std::move(completion));
+
+        if (f.failed()) {
+            auto ex = f.get_exception();
+            auto abort_f = co_await coroutine::as_future(tail_buf().abort_writes(std::move(ex)));
+            if (abort_f.failed()) {
+                logstor_logger.warn("Failed to abort buffered writes: {}. Ignoring.", abort_f.get_exception());
+            }
+        }
+
+        tail_buf().reset();
+        state.reset();
+        ++_tail;
+        reclaimed = true;
+        _head_can_advance.broadcast();
+
+        co_await coroutine::maybe_yield();
+    }
+
+    co_return reclaimed;
+}
+
 future<> buffered_writer::start() {
     logstor_logger.info("Starting write buffer");
-    _consumer = with_gate(_async_gate, [this] {
-        return with_scheduling_group(_flush_sg, [this] {
-            return consumer_loop();
-        });
+    _consumer = with_scheduling_group(_flush_sg, [this] {
+        return consumer_loop();
     });
     co_return;
 }
@@ -316,12 +391,22 @@ future<> buffered_writer::stop() {
     logstor_logger.info("Stopping write buffer");
 
     // Wake the consumer so it can observe the closing gate and exit.
-    _tail_can_advance.broadcast();
+    auto close_fut = _async_gate.close();
+    _consumer_progress_cv.broadcast();
     // Wake any writer blocked waiting for a free ring slot.
     _head_can_advance.broadcast();
-
-    co_await _async_gate.close();
+    co_await std::move(close_fut);
     co_await std::move(_consumer);
+
+    for (auto& state : _in_flight) {
+        if (state.completion) {
+            auto f = co_await coroutine::as_future(std::move(*state.completion));
+            state.completion.reset();
+            if (f.failed()) {
+                logstor_logger.warn("Buffered write completion failed during stop: {}. Ignoring.", f.get_exception());
+            }
+        }
+    }
 
     logstor_logger.info("Write buffer stopped");
 }
@@ -336,7 +421,7 @@ future<log_location_with_holder> buffered_writer::write(log_record record, db::t
     }
 
     if (writer.size() > head_buf().max_record_size()) {
-        throw std::runtime_error(fmt::format("Write size {} exceeds buffer size {}", writer.size(), head_buf().max_record_size()));
+        co_await coroutine::return_exception(std::runtime_error(fmt::format("Write size {} exceeds buffer size {}", writer.size(), head_buf().max_record_size())));
     }
 
     // Wait until the head buffer can fit this write.
@@ -351,47 +436,46 @@ future<log_location_with_holder> buffered_writer::write(log_record record, db::t
         }
         _async_gate.check();
         if (_head == current_head) {
-            ++_head;
-            // Wake other writers that are also waiting for a new head buffer.
-            _head_can_advance.broadcast();
+            maybe_advance_head();
         }
     }
 
     auto fut = head_buf().write(std::move(writer), cg, std::move(cg_holder));
 
-    // Wake the consumer: there is now data at the tail.
-    _tail_can_advance.broadcast();
+    // Wake the consumer: there is now data at the head.
+    _consumer_progress_cv.broadcast();
 
     co_return co_await std::move(fut);
 }
 
 future<> buffered_writer::consumer_loop() {
-    while (true) {
-        // Wait for something to flush at the tail.
-        while (!_async_gate.is_closed() && !tail_buf().has_data()) {
-            co_await _tail_can_advance.wait();
+    try {
+        while (true) {
+            bool progressed = false;
+
+            progressed |= co_await reclaim_completed_tails();
+
+            if (should_rotate_head_for_flush()) {
+                progressed |= maybe_advance_head();
+            }
+
+            while (try_dispatch_next_buffer()) {
+                progressed = true;
+                co_await coroutine::maybe_yield();
+            }
+
+            if (_async_gate.is_closed() && !has_pending_buffers()) {
+                break;
+            }
+
+            if (!progressed) {
+                co_await _consumer_progress_cv.wait();
+            }
+
+            co_await coroutine::maybe_yield();
         }
-
-        if (!tail_buf().has_data()) {
-            // Gate is closing and tail is empty — we are done.
-            break;
-        }
-
-        // If head == tail, the head buffer is still being written to.  Seal it
-        // by advancing the head to give writers a fresh slot.
-        if (_head == _tail) {
-            ++_head;
-            // Wake writers that may be waiting for a new head slot.
-            _head_can_advance.broadcast();
-        }
-
-        co_await _sm.write(tail_buf());
-
-        tail_buf().reset();
-        ++_tail;
-
-        // A slot has been freed: wake any writer waiting to advance the head.
-        _head_can_advance.broadcast();
+    } catch (...) {
+        on_internal_error(logstor_logger, format("buffered_writer consumer loop aborted unexpectedly: {}", std::current_exception()));
     }
 }
 

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -10,6 +10,7 @@
 #include "bytes_fwd.hh"
 #include "logstor.hh"
 #include "replica/logstor/types.hh"
+#include <chrono>
 #include <seastar/core/simple-stream.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/with_scheduling_group.hh>
@@ -303,11 +304,13 @@ buffered_writer::buffered_writer(buffered_writer_config cfg, seastar::noncopyabl
         : _flush_sg(cfg.flush_sg)
         , _buffer_size(cfg.buffer_size)
         , _ring_size(cfg.ring_size)
+        , _sync_period(cfg.sync_period)
         , _flush_func(std::move(flush_func))
         , _ring()
         , _in_flight(cfg.ring_size)
         , _queued_writes(on_queued_write_expiry{this})
-        , _max_queued_write_bytes(cfg.max_queued_write_bytes) {
+        , _max_queued_write_bytes(cfg.max_queued_write_bytes)
+        , _head_flush_timer([this] { on_head_flush_timer(); }) {
 
     if (_ring_size < 2) {
         on_internal_error(logstor_logger, fmt::format("buffered_writer ring_size must be >= 2 (got {})", _ring_size));
@@ -328,7 +331,28 @@ bool buffered_writer::has_pending_buffers() const noexcept {
 }
 
 bool buffered_writer::should_rotate_head_for_flush() const noexcept {
-    return _dispatch_tail == _head && head_buf().has_data();
+    return _dispatch_tail == _head && head_buf().has_data() && (_async_gate.is_closed() || _head_deadline_expired);
+}
+
+void buffered_writer::arm_head_flush_timer() {
+    if (_head_deadline_expired || _head_flush_timer.armed()) {
+        return;
+    }
+    if (_sync_period <= std::chrono::milliseconds(0)) {
+        on_head_flush_timer();
+        return;
+    }
+    _head_flush_timer.arm(db::timeout_clock::now() + _sync_period);
+}
+
+void buffered_writer::on_head_flush_timer() noexcept {
+    _head_deadline_expired = true;
+    _consumer_progress_cv.signal();
+}
+
+void buffered_writer::cancel_head_flush_timer() noexcept {
+    _head_flush_timer.cancel();
+    _head_deadline_expired = false;
 }
 
 void buffered_writer::on_queued_write_removed(const queued_write& w) noexcept {
@@ -344,6 +368,7 @@ bool buffered_writer::maybe_advance_head() noexcept {
     if (ring_full() || !head_buf().has_data()) {
         return false;
     }
+    cancel_head_flush_timer();
     ++_head;
     _consumer_progress_cv.signal();
     return true;
@@ -357,6 +382,7 @@ std::optional<future<log_location_with_holder>> buffered_writer::append_to_head_
     bool was_empty = !head_buf().has_data();
     auto persisted = head_buf().write(std::move(writer), cg, std::move(cg_holder));
     if (was_empty) {
+        arm_head_flush_timer();
         _consumer_progress_cv.signal();
     }
     return persisted;
@@ -458,6 +484,8 @@ future<> buffered_writer::stop() {
         co_return;
     }
     logstor_logger.info("Stopping write buffer");
+
+    cancel_head_flush_timer();
 
     // Wake the consumer so it can observe the closing gate and exit.
     auto close_fut = _async_gate.close();

--- a/replica/logstor/write_buffer.cc
+++ b/replica/logstor/write_buffer.cc
@@ -178,6 +178,15 @@ future<> write_buffer::abort_writes(std::exception_ptr ex) {
     if (!_written.available()) {
         _written.set_exception(std::move(ex));
     }
+
+    // Mixed buffers keep per-record futures for separator rewriting. When the
+    // flush fails there is no separator pass to consume them, so drain them here
+    // before reset() clears the vector and would otherwise abandon failed futures.
+    for (auto& record : _records_copy) {
+        auto f = co_await coroutine::as_future(std::move(record.loc));
+        f.ignore_ready_future();
+    }
+
     co_await close();
 }
 

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -348,13 +348,15 @@ class buffered_writer {
         compaction_group* cg;
         seastar::gate::holder cg_holder;
         db::timeout_clock::time_point timeout;
+        uint64_t id;
         size_t write_size;
 
-        queued_write(log_record_writer writer, compaction_group* cg, seastar::gate::holder cg_holder, db::timeout_clock::time_point timeout, size_t write_size)
+        queued_write(log_record_writer writer, compaction_group* cg, seastar::gate::holder cg_holder, db::timeout_clock::time_point timeout, uint64_t id, size_t write_size)
             : writer(std::move(writer))
             , cg(cg)
             , cg_holder(std::move(cg_holder))
             , timeout(timeout)
+            , id(id)
             , write_size(write_size) {
         }
 
@@ -371,6 +373,7 @@ class buffered_writer {
         void operator()(queued_write& w) noexcept {
             owner->on_queued_write_removed(w);
             w.fail_timeout();
+            owner->on_queued_writes_changed();
         }
     };
 
@@ -379,12 +382,23 @@ class buffered_writer {
     // advances, a flush completes, a tail is reclaimed, or shutdown begins.
     seastar::condition_variable _consumer_progress_cv;
 
+    // Notified when queued writes are removed or expired, so flush() can wait
+    // for the pre-flush queue boundary to advance.
+    seastar::condition_variable _queued_writes_changed;
+
+    // Notified when the tail is advanced by the consumer.
+    seastar::condition_variable _tail_advanced;
+
     seastar::expiring_fifo<queued_write, on_queued_write_expiry, db::timeout_clock> _queued_writes;
     size_t _queued_write_bytes{0};
     size_t _max_queued_write_bytes{0};
 
     seastar::timer<db::timeout_clock> _head_flush_timer;
     bool _head_deadline_expired = false;
+
+    // Monotonically increasing id assigned to queued writes. flush() snapshots
+    // this counter and waits until all queued writes with lower ids are gone.
+    uint64_t _next_queued_write_id = 0;
 
     seastar::gate _async_gate;
 
@@ -415,6 +429,7 @@ class buffered_writer {
 
     void on_queued_write_removed(const queued_write&) noexcept;
     void fail_queued_write(queued_write&, std::exception_ptr) noexcept;
+    void on_queued_writes_changed() noexcept;
 
     void arm_head_flush_timer();
     void on_head_flush_timer() noexcept;
@@ -431,6 +446,7 @@ public:
 
     future<> start();
     future<> stop();
+    future<> flush();
 
     future<buffered_write_result> write_to_buffer(log_record_writer, db::timeout_clock::time_point timeout, compaction_group* cg = nullptr, seastar::gate::holder cg_holder = {});
     future<log_location_with_holder> write(log_record_writer, db::timeout_clock::time_point timeout, compaction_group* cg = nullptr, seastar::gate::holder cg_holder = {});

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -285,6 +285,7 @@ struct buffered_writer_config {
     size_t ring_size;
     seastar::scheduling_group flush_sg;
     size_t max_queued_write_bytes{0};
+    std::chrono::milliseconds sync_period{0};
 };
 
 // Manages a circular ring of write_buffers.
@@ -297,6 +298,7 @@ class buffered_writer {
     seastar::scheduling_group _flush_sg;
     size_t _buffer_size;
     size_t _ring_size;
+    std::chrono::milliseconds _sync_period;
     seastar::noncopyable_function<future<>(write_buffer&)> _flush_func;
 
     // The ring of buffers, indexed modulo _ring_size.
@@ -381,6 +383,9 @@ class buffered_writer {
     size_t _queued_write_bytes{0};
     size_t _max_queued_write_bytes{0};
 
+    seastar::timer<db::timeout_clock> _head_flush_timer;
+    bool _head_deadline_expired = false;
+
     seastar::gate _async_gate;
 
     // The single flush-consumer fiber, running for the lifetime of the writer.
@@ -410,6 +415,10 @@ class buffered_writer {
 
     void on_queued_write_removed(const queued_write&) noexcept;
     void fail_queued_write(queued_write&, std::exception_ptr) noexcept;
+
+    void arm_head_flush_timer();
+    void on_head_flush_timer() noexcept;
+    void cancel_head_flush_timer() noexcept;
 
     future<> consumer_loop();
 

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -17,7 +17,10 @@
 #include <seastar/core/queue.hh>
 #include <seastar/core/simple-stream.hh>
 #include <seastar/core/shared_future.hh>
+#include <seastar/core/expiring_fifo.hh>
+#include <seastar/core/timed_out_error.hh>
 
+#include "replica/exceptions.hh"
 #include "replica/logstor/ondisk.hh"
 #include "schema/schema_fwd.hh"
 #include "types.hh"
@@ -76,6 +79,10 @@ public:
 };
 
 using log_location_with_holder = std::tuple<log_location, seastar::gate::holder>;
+
+struct buffered_write_result {
+    future<log_location_with_holder> persisted;
+};
 
 // Serializes one in-memory logstor buffer.
 //
@@ -328,14 +335,47 @@ class buffered_writer {
 
     std::array<in_flight_write, ring_size> _in_flight;
 
-    // Notified when _tail advances (a slot becomes free for the head to move into)
-    // or when the head buffer is switched.
-    seastar::condition_variable _head_can_advance;
+    struct queued_write {
+        seastar::promise<buffered_write_result> accepted_pr; // written to buffer
+        seastar::promise<log_location_with_holder> persisted_pr; // written to a segment
+        log_record_writer writer;
+        compaction_group* cg;
+        seastar::gate::holder cg_holder;
+        db::timeout_clock::time_point timeout;
+        size_t write_size;
+
+        queued_write(log_record_writer writer, compaction_group* cg, seastar::gate::holder cg_holder, db::timeout_clock::time_point timeout, size_t write_size)
+            : writer(std::move(writer))
+            , cg(cg)
+            , cg_holder(std::move(cg_holder))
+            , timeout(timeout)
+            , write_size(write_size) {
+        }
+
+        void fail_timeout() noexcept {
+            auto ep = std::make_exception_ptr(seastar::timed_out_error{});
+            accepted_pr.set_exception(ep);
+            persisted_pr.set_exception(ep);
+        }
+    };
+
+    struct on_queued_write_expiry {
+        buffered_writer* owner{};
+
+        void operator()(queued_write& w) noexcept {
+            owner->on_queued_write_removed(w);
+            w.fail_timeout();
+        }
+    };
 
     // Wakes the consumer whenever a state change may let it make forward
     // progress again: queued writes arrive, the head buffer gains data or
     // advances, a flush completes, a tail is reclaimed, or shutdown begins.
     seastar::condition_variable _consumer_progress_cv;
+
+    seastar::expiring_fifo<queued_write, on_queued_write_expiry, db::timeout_clock> _queued_writes;
+    size_t _queued_write_bytes{0};
+    size_t _max_queued_write_bytes{0};
 
     seastar::gate _async_gate;
 
@@ -356,14 +396,21 @@ class buffered_writer {
     bool should_rotate_head_for_flush() const noexcept;
     bool maybe_advance_head() noexcept;
 
+    std::optional<future<log_location_with_holder>> append_to_head_buffer(log_record_writer&, compaction_group*, seastar::gate::holder);
+
     bool try_dispatch_next_buffer();
     future<> run_dispatched_write(size_t idx);
     future<bool> reclaim_completed_tails();
 
+    future<bool> drain_queued_writes();
+
+    void on_queued_write_removed(const queued_write&) noexcept;
+    void fail_queued_write(queued_write&, std::exception_ptr) noexcept;
+
     future<> consumer_loop();
 
 public:
-    explicit buffered_writer(segment_manager& sm, seastar::scheduling_group flush_sg);
+    explicit buffered_writer(segment_manager& sm, seastar::scheduling_group flush_sg, size_t max_queued_write_bytes);
 
     buffered_writer(const buffered_writer&) = delete;
     buffered_writer& operator=(const buffered_writer&) = delete;
@@ -371,7 +418,11 @@ public:
     future<> start();
     future<> stop();
 
-    future<log_location_with_holder> write(log_record, db::timeout_clock::time_point timeout, compaction_group* cg = nullptr, seastar::gate::holder cg_holder = {});
+    future<buffered_write_result> write_to_buffer(log_record_writer, db::timeout_clock::time_point timeout, compaction_group* cg = nullptr, seastar::gate::holder cg_holder = {});
+    future<log_location_with_holder> write(log_record_writer, db::timeout_clock::time_point timeout, compaction_group* cg = nullptr, seastar::gate::holder cg_holder = {});
+
+    size_t queued_write_count() const noexcept { return _queued_writes.size(); }
+
 };
 
 }

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -32,8 +32,6 @@ class compaction_group;
 
 namespace logstor {
 
-class segment_manager;
-
 // Writer for log records that handles serialization and size computation
 class log_record_writer {
 
@@ -281,28 +279,34 @@ private:
     friend class segment_manager_impl;
 };
 
-// Manages a fixed-size circular ring of write_buffers.
+// Configuration passed to buffered_writer constructor (excluding the flush function).
+struct buffered_writer_config {
+    size_t buffer_size;
+    size_t ring_size;
+    seastar::scheduling_group flush_sg;
+    size_t max_queued_write_bytes{0};
+};
+
+// Manages a circular ring of write_buffers.
 //
 // Writers append to the head buffer.  A single consumer coroutine drains the
 // tail.  The head advances when the current head buffer is full (can't fit the
 // next write) or when the consumer seals it.  Writers wait if the ring is full
 // (all buffers are pending flush).
 class buffered_writer {
-    // Number of buffers in the ring.  Must be >= 2 (one head + at least one
-    // that can be in-flight with the consumer).
-    static constexpr size_t ring_size = 5;
-
-    segment_manager& _sm;
     seastar::scheduling_group _flush_sg;
+    size_t _buffer_size;
+    size_t _ring_size;
+    seastar::noncopyable_function<future<>(write_buffer&)> _flush_func;
 
-    // The ring of buffers, indexed modulo ring_size.
+    // The ring of buffers, indexed modulo _ring_size.
     std::vector<write_buffer> _ring;
 
-    // Monotonically increasing indices; the actual slot is idx % ring_size.
+    // Monotonically increasing indices; the actual slot is idx % _ring_size.
     // _head: next slot writers append to.
-    // _dispatch_tail: next slot the consumer will dispatch to segment_manager.
+    // _dispatch_tail: next slot the consumer will dispatch via _flush_func.
     // _tail: oldest slot not yet safe to reuse.
-    // Invariant: _head >= _dispatch_tail >= _tail && _head - _tail < ring_size.
+    // Invariant: _head >= _dispatch_tail >= _tail && _head - _tail < _ring_size.
     size_t _head{0};
     size_t _dispatch_tail{0};
     size_t _tail{0};
@@ -333,7 +337,7 @@ class buffered_writer {
         }
     };
 
-    std::array<in_flight_write, ring_size> _in_flight;
+    std::vector<in_flight_write> _in_flight;
 
     struct queued_write {
         seastar::promise<buffered_write_result> accepted_pr; // written to buffer
@@ -382,15 +386,15 @@ class buffered_writer {
     // The single flush-consumer fiber, running for the lifetime of the writer.
     future<> _consumer{make_ready_future<>()};
 
-    auto&& head_buf(this auto&& self) noexcept { return self._ring[self._head % ring_size]; }
-    auto&& tail_buf(this auto&& self) noexcept { return self._ring[self._tail % ring_size]; }
+    auto&& head_buf(this auto&& self) noexcept { return self._ring[self._head % self._ring_size]; }
+    auto&& tail_buf(this auto&& self) noexcept { return self._ring[self._tail % self._ring_size]; }
 
-    auto&& tail_write(this auto&& self) noexcept { return self._in_flight[self._tail % ring_size]; }
-    auto&& dispatch_tail_write(this auto&& self) noexcept { return self._in_flight[self._dispatch_tail % ring_size]; }
+    auto&& tail_write(this auto&& self) noexcept { return self._in_flight[self._tail % self._ring_size]; }
+    auto&& dispatch_tail_write(this auto&& self) noexcept { return self._in_flight[self._dispatch_tail % self._ring_size]; }
 
-    // The ring is full when all ring_size slots are occupied. Advancing the
+    // The ring is full when all _ring_size slots are occupied. Advancing the
     // head further would make the new head slot collide with the tail slot.
-    bool ring_full() const noexcept { return _head - _tail == ring_size - 1; }
+    bool ring_full() const noexcept { return _head - _tail == _ring_size - 1; }
 
     bool has_pending_buffers() const noexcept;
     bool should_rotate_head_for_flush() const noexcept;
@@ -410,7 +414,8 @@ class buffered_writer {
     future<> consumer_loop();
 
 public:
-    explicit buffered_writer(segment_manager& sm, seastar::scheduling_group flush_sg, size_t max_queued_write_bytes);
+    explicit buffered_writer(buffered_writer_config cfg,
+            seastar::noncopyable_function<future<>(write_buffer&)> flush_func);
 
     buffered_writer(const buffered_writer&) = delete;
     buffered_writer& operator=(const buffered_writer&) = delete;

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -270,6 +270,7 @@ private:
     future<> complete_writes(log_location base_location);
     future<> abort_writes(std::exception_ptr);
 
+    friend class buffered_writer;
     friend class segment_manager_impl;
 };
 
@@ -292,29 +293,74 @@ class buffered_writer {
 
     // Monotonically increasing indices; the actual slot is idx % ring_size.
     // _head: next slot writers append to.
-    // _tail: next slot the consumer will flush.
-    // Invariant: _head >= _tail && _head - _tail < ring_size.
+    // _dispatch_tail: next slot the consumer will dispatch to segment_manager.
+    // _tail: oldest slot not yet safe to reuse.
+    // Invariant: _head >= _dispatch_tail >= _tail && _head - _tail < ring_size.
     size_t _head{0};
+    size_t _dispatch_tail{0};
     size_t _tail{0};
+
+    struct in_flight_write {
+        std::optional<future<>> completion;
+
+        bool idle() const noexcept {
+            return !completion;
+        }
+
+        bool ready() const noexcept {
+            return completion && completion->available();
+        }
+
+        void start(future<> f) {
+            completion.emplace(std::move(f));
+        }
+
+        future<> take_completion() {
+            auto f = std::move(*completion);
+            completion.reset();
+            return f;
+        }
+
+        void reset() noexcept {
+            completion.reset();
+        }
+    };
+
+    std::array<in_flight_write, ring_size> _in_flight;
 
     // Notified when _tail advances (a slot becomes free for the head to move into)
     // or when the head buffer is switched.
     seastar::condition_variable _head_can_advance;
 
-    // Notified when data is written to the head buffer (consumer may wake up).
-    seastar::condition_variable _tail_can_advance;
+    // Wakes the consumer whenever a state change may let it make forward
+    // progress again: queued writes arrive, the head buffer gains data or
+    // advances, a flush completes, a tail is reclaimed, or shutdown begins.
+    seastar::condition_variable _consumer_progress_cv;
 
     seastar::gate _async_gate;
 
     // The single flush-consumer fiber, running for the lifetime of the writer.
     future<> _consumer{make_ready_future<>()};
 
-    write_buffer& head_buf() noexcept { return _ring[_head % ring_size]; }
-    write_buffer& tail_buf() noexcept { return _ring[_tail % ring_size]; }
+    auto&& head_buf(this auto&& self) noexcept { return self._ring[self._head % ring_size]; }
+    auto&& tail_buf(this auto&& self) noexcept { return self._ring[self._tail % ring_size]; }
+
+    auto&& tail_write(this auto&& self) noexcept { return self._in_flight[self._tail % ring_size]; }
+    auto&& dispatch_tail_write(this auto&& self) noexcept { return self._in_flight[self._dispatch_tail % ring_size]; }
 
     // The ring is full when all ring_size slots are occupied. Advancing the
     // head further would make the new head slot collide with the tail slot.
     bool ring_full() const noexcept { return _head - _tail == ring_size - 1; }
+
+    bool has_pending_buffers() const noexcept;
+    bool should_rotate_head_for_flush() const noexcept;
+    bool maybe_advance_head() noexcept;
+
+    bool try_dispatch_next_buffer();
+    future<> run_dispatched_write(size_t idx);
+    future<bool> reclaim_completed_tails();
+
+    future<> consumer_loop();
 
 public:
     explicit buffered_writer(segment_manager& sm, seastar::scheduling_group flush_sg);
@@ -326,10 +372,6 @@ public:
     future<> stop();
 
     future<log_location_with_holder> write(log_record, db::timeout_clock::time_point timeout, compaction_group* cg = nullptr, seastar::gate::holder cg_holder = {});
-
-private:
-    // The flush consumer loop.
-    future<> consumer_loop();
 };
 
 }

--- a/replica/logstor/write_buffer.hh
+++ b/replica/logstor/write_buffer.hh
@@ -264,16 +264,16 @@ public:
         return write(std::move(writer), nullptr, {});
     }
 
+    // Complete all tracked writes with their locations when the buffer is flushed to base_location
+    future<> complete_writes(log_location base_location);
+    future<> abort_writes(std::exception_ptr);
+
 private:
     bool with_record_copy() const noexcept {
         return _raw.kind() == segment_kind::mixed;
     }
 
     std::vector<record_in_buffer>& records_for_separator();
-
-    /// Complete all tracked writes with their locations when the buffer is flushed to base_location
-    future<> complete_writes(log_location base_location);
-    future<> abort_writes(std::exception_ptr);
 
     friend class buffered_writer;
     friend class segment_manager_impl;

--- a/test/boost/logstor_test.cc
+++ b/test/boost/logstor_test.cc
@@ -183,12 +183,13 @@ db::timeout_clock::time_point test_timeout() {
     return db::timeout_clock::now() + std::chrono::minutes(1);
 }
 
-buffered_writer_config make_buffered_writer_config(size_t buffer_size, size_t ring_size, size_t max_queued_write_bytes = 0) {
+buffered_writer_config make_buffered_writer_config(size_t buffer_size, size_t ring_size, size_t max_queued_write_bytes = 0, std::chrono::milliseconds sync_period = std::chrono::milliseconds(0)) {
     return buffered_writer_config{
         .buffer_size = buffer_size,
         .ring_size = ring_size,
         .flush_sg = seastar::default_scheduling_group(),
         .max_queued_write_bytes = max_queued_write_bytes,
+        .sync_period = sync_period,
     };
 }
 

--- a/test/boost/logstor_test.cc
+++ b/test/boost/logstor_test.cc
@@ -1059,6 +1059,56 @@ SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_basic_flushes_records) {
     }
 }
 
+// Checks that flush() seals and writes a partially filled head buffer even when the sync timer has not expired.
+SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_flushes_partial_buffer_with_large_sync_period) {
+    auto schema = make_kv_schema();
+    constexpr size_t buffer_size = 4 * 1024;
+    constexpr auto sync_period = std::chrono::hours(1);
+
+    test_flush_controller flush_ctl;
+    buffered_writer writer(make_buffered_writer_config(buffer_size, 3, 0, sync_period), [&flush_ctl] (write_buffer& wb) {
+        return flush_ctl(wb);
+    });
+
+    writer.start().get();
+    auto stop = defer([&writer] noexcept {
+        writer.stop().get();
+    });
+
+    std::vector<log_record> expected;
+    std::vector<future<log_location_with_holder>> persisted;
+    for (size_t i = 0; i < 3; ++i) {
+        auto record = make_buffered_writer_record(schema, i, sstring(fmt::format("value{}", i)), api::timestamp_type(150 + i));
+        expected.push_back(record);
+        auto accepted = writer.write_to_buffer(log_record_writer(record), test_timeout()).get();
+        persisted.push_back(std::move(accepted.persisted));
+    }
+
+    BOOST_REQUIRE(flush_ctl.flushed_buffers.empty());
+
+    auto flush = writer.flush();
+    flush_ctl.wait_for_flush_starts(1);
+
+    std::vector<log_location> locations;
+    for (auto& fut : persisted) {
+        locations.push_back(wait_for_persisted(fut));
+    }
+
+    flush.get();
+
+    BOOST_REQUIRE_EQUAL(flush_ctl.flushed_buffers.size(), 1u);
+    BOOST_REQUIRE_EQUAL(flush_ctl.flushed_buffers.front().record_count, expected.size());
+
+    const auto actual = flush_ctl.all_records();
+    assert_records_in_order(schema, actual, expected);
+
+    BOOST_REQUIRE_EQUAL(locations.size(), expected.size());
+    for (size_t i = 0; i < locations.size(); ++i) {
+        auto read_back = read_record_at_location(flush_ctl.buffer_for_segment(locations[i].segment), locations[i]);
+        assert_log_record_matches(schema, read_back, expected[i]);
+    }
+}
+
 // Checks that a paused tail flush can fill the ring, queue later writes, and then drain them without losing order.
 SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_paused_flush_fills_ring_then_drains) {
     auto schema = make_kv_schema();

--- a/test/boost/logstor_test.cc
+++ b/test/boost/logstor_test.cc
@@ -7,8 +7,12 @@
  */
 #include <boost/test/unit_test.hpp>
 #include <algorithm>
+#include <chrono>
 #include <functional>
+#include <stdexcept>
 #include <vector>
+#include <fmt/format.h>
+#include <seastar/core/semaphore.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/util/memory-data-source.hh>
 #include <seastar/util/defer.hh>
@@ -60,6 +64,12 @@ log_record make_log_record(schema_ptr schema, sstring pk, sstring value, api::ti
 }
 
 temporary_buffer<char> make_serialized_buffer_copy(const raw_write_buffer& wb) {
+    temporary_buffer<char> buf(wb.serialized_size());
+    std::copy_n(wb.data(), wb.serialized_size(), buf.get_write());
+    return buf;
+}
+
+temporary_buffer<char> make_serialized_buffer_copy(const write_buffer& wb) {
     temporary_buffer<char> buf(wb.serialized_size());
     std::copy_n(wb.data(), wb.serialized_size(), buf.get_write());
     return buf;
@@ -134,6 +144,158 @@ rewritten_stream_result rewrite_streamed_segment(log_segment_id segment_id, segm
     temporary_buffer<char> out(written.size());
     std::copy(written.begin(), written.end(), out.get_write());
     return rewritten_stream_result{.data = std::move(out), .write_count = write_count};
+}
+
+struct scanned_record {
+    log_location location;
+    log_record record;
+};
+
+std::vector<scanned_record> scan_buffer_records(const temporary_buffer<char>& buf, log_segment_id segment_id) {
+    temporary_buffer<char> copy(buf.size());
+    std::copy_n(buf.get(), buf.size(), copy.get_write());
+    auto in = seastar::util::as_input_stream(std::move(copy));
+    std::vector<scanned_record> records;
+
+    scan_segment(in, segment_id, buf.size(),
+        [] (const segment_header&) {
+            return make_ready_future<>();
+        },
+        [] (log_location, const log_record_header&) {
+            return want_data::yes;
+        },
+        [&records] (log_location loc, log_record rec) {
+            records.push_back(scanned_record{.location = loc, .record = std::move(rec)});
+            return make_ready_future<>();
+        }).get();
+    in.close().get();
+
+    return records;
+}
+
+void assert_log_record_matches(schema_ptr schema, const log_record& actual, const log_record& expected) {
+    BOOST_REQUIRE_EQUAL(actual.header.timestamp, expected.header.timestamp);
+    BOOST_REQUIRE_EQUAL(actual.header.table, expected.header.table);
+    assert_that(actual.mut.to_mutation(schema)).is_equal_to(expected.mut.to_mutation(schema));
+}
+
+db::timeout_clock::time_point test_timeout() {
+    return db::timeout_clock::now() + std::chrono::minutes(1);
+}
+
+buffered_writer_config make_buffered_writer_config(size_t buffer_size, size_t ring_size, size_t max_queued_write_bytes = 0) {
+    return buffered_writer_config{
+        .buffer_size = buffer_size,
+        .ring_size = ring_size,
+        .flush_sg = seastar::default_scheduling_group(),
+        .max_queued_write_bytes = max_queued_write_bytes,
+    };
+}
+
+sstring make_single_buffer_value(schema_ptr schema, size_t buffer_size) {
+    sstring value;
+    while (true) {
+        auto next_value = value;
+        next_value += sstring("x");
+        auto next_record = make_log_record(schema, "pk0000", next_value, api::timestamp_type(17));
+        auto next_writer = log_record_writer(next_record);
+        raw_write_buffer wb(buffer_size, segment_kind::mixed);
+
+        BOOST_REQUIRE(wb.can_fit(next_writer));
+        wb.append(next_writer);
+        if (!wb.can_fit(next_writer)) {
+            return next_value;
+        }
+
+        value = std::move(next_value);
+    }
+}
+
+log_record make_buffered_writer_record(schema_ptr schema, size_t idx, const sstring& value, api::timestamp_type ts) {
+    return make_log_record(schema, sstring(fmt::format("pk{:04}", idx)), value, ts);
+}
+
+log_location wait_for_persisted(future<log_location_with_holder>& fut) {
+    auto [loc, op] = fut.get();
+    return loc;
+}
+
+struct test_flush_controller {
+    struct flushed_buffer {
+        temporary_buffer<char> data;
+        log_location base_location;
+        size_t record_count;
+    };
+
+    bool pause_flushes{false};
+    std::optional<size_t> fail_flush_index;
+    seastar::semaphore flush_started{0};
+    seastar::semaphore flush_release{0};
+    std::vector<flushed_buffer> flushed_buffers;
+    size_t started_count{0};
+    uint32_t next_segment_id{100};
+    uint64_t next_sequence{1};
+
+    future<> operator()(write_buffer& wb) {
+        const auto flush_idx = started_count++;
+        flush_started.signal(1);
+
+        if (pause_flushes) {
+            auto units = co_await get_units(flush_release, 1);
+        }
+
+        if (fail_flush_index && *fail_flush_index == flush_idx) {
+            throw std::runtime_error("injected flush failure");
+        }
+
+        wb.seal(segment_sequence{next_sequence++}, std::nullopt, ondisk::block_alignment);
+        auto base_location = log_location{
+            .segment = log_segment_id{next_segment_id++},
+            .offset = 0,
+            .size = static_cast<uint32_t>(wb.serialized_size()),
+        };
+        flushed_buffers.push_back(flushed_buffer{
+            .data = make_serialized_buffer_copy(wb),
+            .base_location = base_location,
+            .record_count = wb.record_count(),
+        });
+        co_await wb.complete_writes(base_location);
+    }
+
+    void wait_for_flush_starts(size_t target_count) {
+        while (started_count < target_count) {
+            flush_started.wait().get();
+        }
+    }
+
+    void release_one_flush() {
+        flush_release.signal(1);
+    }
+
+    const temporary_buffer<char>& buffer_for_segment(log_segment_id segment_id) const {
+        for (const auto& flushed : flushed_buffers) {
+            if (flushed.base_location.segment == segment_id) {
+                return flushed.data;
+            }
+        }
+        throw std::runtime_error(fmt::format("Missing flushed segment {}", segment_id));
+    }
+
+    std::vector<scanned_record> all_records() const {
+        std::vector<scanned_record> records;
+        for (const auto& flushed : flushed_buffers) {
+            auto buffer_records = scan_buffer_records(flushed.data, flushed.base_location.segment);
+            records.insert(records.end(), std::make_move_iterator(buffer_records.begin()), std::make_move_iterator(buffer_records.end()));
+        }
+        return records;
+    }
+};
+
+void assert_records_in_order(schema_ptr schema, const std::vector<scanned_record>& actual, const std::vector<log_record>& expected) {
+    BOOST_REQUIRE_EQUAL(actual.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        assert_log_record_matches(schema, actual[i].record, expected[i]);
+    }
 }
 
 }
@@ -855,4 +1017,352 @@ SEASTAR_THREAD_TEST_CASE(test_logstor_streamed_segment_rewriter_rejects_truncate
     auto truncated = slice_buffer(serialized, 0, ondisk::buffer_header_size - 1);
 
     BOOST_REQUIRE_THROW(rewrite_streamed_segment(log_segment_id{41}, segment_sequence{341}, std::span(&truncated, 1)), std::runtime_error);
+}
+
+// Checks that buffered_writer forwards records to the flush callback and resolves returned locations.
+SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_basic_flushes_records) {
+    auto schema = make_kv_schema();
+    constexpr size_t buffer_size = 4 * 1024;
+
+    test_flush_controller flush_ctl;
+    buffered_writer writer(make_buffered_writer_config(buffer_size, 3), [&flush_ctl] (write_buffer& wb) {
+        return flush_ctl(wb);
+    });
+
+    writer.start().get();
+    auto stop = defer([&writer] noexcept {
+        writer.stop().get();
+    });
+
+    std::vector<log_record> expected;
+    std::vector<future<log_location_with_holder>> persisted;
+    for (size_t i = 0; i < 3; ++i) {
+        auto record = make_buffered_writer_record(schema, i, sstring(fmt::format("value{}", i)), api::timestamp_type(100 + i));
+        expected.push_back(record);
+        auto accepted = writer.write_to_buffer(log_record_writer(record), test_timeout()).get();
+        persisted.push_back(std::move(accepted.persisted));
+    }
+
+    std::vector<log_location> locations;
+    for (auto& fut : persisted) {
+        locations.push_back(wait_for_persisted(fut));
+    }
+
+    const auto actual = flush_ctl.all_records();
+    assert_records_in_order(schema, actual, expected);
+
+    BOOST_REQUIRE_EQUAL(locations.size(), expected.size());
+    for (size_t i = 0; i < locations.size(); ++i) {
+        auto read_back = read_record_at_location(flush_ctl.buffer_for_segment(locations[i].segment), locations[i]);
+        assert_log_record_matches(schema, read_back, expected[i]);
+    }
+}
+
+// Checks that a paused tail flush can fill the ring, queue later writes, and then drain them without losing order.
+SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_paused_flush_fills_ring_then_drains) {
+    auto schema = make_kv_schema();
+    constexpr size_t buffer_size = 4 * 1024;
+    const auto large_value = make_single_buffer_value(schema, buffer_size);
+
+    test_flush_controller flush_ctl{.pause_flushes = true};
+    buffered_writer writer(make_buffered_writer_config(buffer_size, 2), [&flush_ctl] (write_buffer& wb) {
+        return flush_ctl(wb);
+    });
+
+    writer.start().get();
+    auto stop = defer([&writer] noexcept {
+        writer.stop().get();
+    });
+
+    std::vector<log_record> expected;
+    for (size_t i = 0; i < 4; ++i) {
+        expected.push_back(make_buffered_writer_record(schema, i, large_value, api::timestamp_type(200 + i)));
+    }
+
+    auto accepted0 = writer.write_to_buffer(log_record_writer(expected[0]), test_timeout()).get();
+    auto persisted0 = std::move(accepted0.persisted);
+    flush_ctl.wait_for_flush_starts(1);
+    BOOST_REQUIRE(!persisted0.available());
+
+    auto accepted1 = writer.write_to_buffer(log_record_writer(expected[1]), test_timeout()).get();
+    auto persisted1 = std::move(accepted1.persisted);
+
+    auto queued2 = writer.write_to_buffer(log_record_writer(expected[2]), test_timeout());
+    auto queued3 = writer.write_to_buffer(log_record_writer(expected[3]), test_timeout());
+    BOOST_REQUIRE(!queued2.available());
+    BOOST_REQUIRE(!queued3.available());
+    BOOST_REQUIRE_EQUAL(writer.queued_write_count(), 2u);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted0);
+    flush_ctl.wait_for_flush_starts(2);
+
+    auto accepted2 = queued2.get();
+    auto persisted2 = std::move(accepted2.persisted);
+    BOOST_REQUIRE(!queued3.available());
+    BOOST_REQUIRE_EQUAL(writer.queued_write_count(), 1u);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted1);
+    flush_ctl.wait_for_flush_starts(3);
+
+    auto accepted3 = queued3.get();
+    auto persisted3 = std::move(accepted3.persisted);
+    BOOST_REQUIRE_EQUAL(writer.queued_write_count(), 0u);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted2);
+    flush_ctl.wait_for_flush_starts(4);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted3);
+
+    assert_records_in_order(schema, flush_ctl.all_records(), expected);
+}
+
+// Checks that queued writes are accepted and persisted in FIFO order once capacity becomes available.
+SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_queued_writes_preserve_fifo_order) {
+    auto schema = make_kv_schema();
+    constexpr size_t buffer_size = 4 * 1024;
+    const auto large_value = make_single_buffer_value(schema, buffer_size);
+
+    test_flush_controller flush_ctl{.pause_flushes = true};
+    buffered_writer writer(make_buffered_writer_config(buffer_size, 2), [&flush_ctl] (write_buffer& wb) {
+        return flush_ctl(wb);
+    });
+
+    writer.start().get();
+    auto stop = defer([&writer] noexcept {
+        writer.stop().get();
+    });
+
+    std::vector<log_record> expected;
+    for (size_t i = 0; i < 5; ++i) {
+        expected.push_back(make_buffered_writer_record(schema, i, large_value, api::timestamp_type(300 + i)));
+    }
+
+    auto accepted0 = writer.write_to_buffer(log_record_writer(expected[0]), test_timeout()).get();
+    auto persisted0 = std::move(accepted0.persisted);
+    flush_ctl.wait_for_flush_starts(1);
+
+    auto accepted1 = writer.write_to_buffer(log_record_writer(expected[1]), test_timeout()).get();
+    auto persisted1 = std::move(accepted1.persisted);
+
+    auto queued2 = writer.write_to_buffer(log_record_writer(expected[2]), test_timeout());
+    auto queued3 = writer.write_to_buffer(log_record_writer(expected[3]), test_timeout());
+    auto queued4 = writer.write_to_buffer(log_record_writer(expected[4]), test_timeout());
+
+    BOOST_REQUIRE(!queued2.available());
+    BOOST_REQUIRE(!queued3.available());
+    BOOST_REQUIRE(!queued4.available());
+    BOOST_REQUIRE_EQUAL(writer.queued_write_count(), 3u);
+
+    std::vector<size_t> accepted_order;
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted0);
+    flush_ctl.wait_for_flush_starts(2);
+    accepted_order.push_back(2);
+    auto accepted2 = queued2.get();
+    auto persisted2 = std::move(accepted2.persisted);
+    BOOST_REQUIRE(!queued3.available());
+    BOOST_REQUIRE(!queued4.available());
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted1);
+    flush_ctl.wait_for_flush_starts(3);
+    accepted_order.push_back(3);
+    auto accepted3 = queued3.get();
+    auto persisted3 = std::move(accepted3.persisted);
+    BOOST_REQUIRE(!queued4.available());
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted2);
+    flush_ctl.wait_for_flush_starts(4);
+    accepted_order.push_back(4);
+    auto accepted4 = queued4.get();
+    auto persisted4 = std::move(accepted4.persisted);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted3);
+    flush_ctl.wait_for_flush_starts(5);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted4);
+
+    const std::vector<size_t> expected_acceptance_order{2, 3, 4};
+    BOOST_REQUIRE_EQUAL_COLLECTIONS(accepted_order.begin(), accepted_order.end(), expected_acceptance_order.begin(), expected_acceptance_order.end());
+    assert_records_in_order(schema, flush_ctl.all_records(), expected);
+}
+
+// Checks that queued writes are rejected once max_queued_write_bytes would be exceeded.
+SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_rejects_when_max_queued_write_bytes_exceeded) {
+    auto schema = make_kv_schema();
+    constexpr size_t buffer_size = 4 * 1024;
+    const auto large_value = make_single_buffer_value(schema, buffer_size);
+
+    auto record0 = make_buffered_writer_record(schema, 0, large_value, api::timestamp_type(400));
+    const auto queued_write_budget = log_record_writer(record0).size() * 2;
+
+    test_flush_controller flush_ctl{.pause_flushes = true};
+    buffered_writer writer(make_buffered_writer_config(buffer_size, 2, queued_write_budget), [&flush_ctl] (write_buffer& wb) {
+        return flush_ctl(wb);
+    });
+
+    writer.start().get();
+    auto stop = defer([&writer] noexcept {
+        writer.stop().get();
+    });
+
+    std::vector<log_record> expected{record0};
+    for (size_t i = 1; i < 4; ++i) {
+        expected.push_back(make_buffered_writer_record(schema, i, large_value, api::timestamp_type(400 + i)));
+    }
+
+    auto accepted0 = writer.write_to_buffer(log_record_writer(expected[0]), test_timeout()).get();
+    auto persisted0 = std::move(accepted0.persisted);
+    flush_ctl.wait_for_flush_starts(1);
+
+    auto accepted1 = writer.write_to_buffer(log_record_writer(expected[1]), test_timeout()).get();
+    auto persisted1 = std::move(accepted1.persisted);
+
+    auto queued2 = writer.write_to_buffer(log_record_writer(expected[2]), test_timeout());
+    auto queued3 = writer.write_to_buffer(log_record_writer(expected[3]), test_timeout());
+    BOOST_REQUIRE(!queued2.available());
+    BOOST_REQUIRE(!queued3.available());
+    BOOST_REQUIRE_EQUAL(writer.queued_write_count(), 2u);
+
+    auto rejected = make_buffered_writer_record(schema, 4, large_value, api::timestamp_type(404));
+    BOOST_REQUIRE_THROW(writer.write_to_buffer(log_record_writer(rejected), test_timeout()).get(), replica::rate_limit_exception);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted0);
+    flush_ctl.wait_for_flush_starts(2);
+    auto accepted2 = queued2.get();
+    auto persisted2 = std::move(accepted2.persisted);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted1);
+    flush_ctl.wait_for_flush_starts(3);
+    auto accepted3 = queued3.get();
+    auto persisted3 = std::move(accepted3.persisted);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted2);
+    flush_ctl.wait_for_flush_starts(4);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted3);
+
+    assert_records_in_order(schema, flush_ctl.all_records(), expected);
+}
+
+// Checks that write_to_buffer() stays pending while a request is queued and only persistence remains pending once it is accepted.
+SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_acceptance_stays_blocked_while_write_is_queued) {
+    auto schema = make_kv_schema();
+    constexpr size_t buffer_size = 4 * 1024;
+    const auto large_value = make_single_buffer_value(schema, buffer_size);
+
+    test_flush_controller flush_ctl{.pause_flushes = true};
+    buffered_writer writer(make_buffered_writer_config(buffer_size, 2), [&flush_ctl] (write_buffer& wb) {
+        return flush_ctl(wb);
+    });
+
+    writer.start().get();
+    auto stop = defer([&writer] noexcept {
+        writer.stop().get();
+    });
+
+    auto record0 = make_buffered_writer_record(schema, 0, large_value, api::timestamp_type(500));
+    auto record1 = make_buffered_writer_record(schema, 1, large_value, api::timestamp_type(501));
+    auto record2 = make_buffered_writer_record(schema, 2, large_value, api::timestamp_type(502));
+
+    auto accepted0 = writer.write_to_buffer(log_record_writer(record0), test_timeout()).get();
+    auto persisted0 = std::move(accepted0.persisted);
+    flush_ctl.wait_for_flush_starts(1);
+
+    auto accepted1 = writer.write_to_buffer(log_record_writer(record1), test_timeout()).get();
+    auto persisted1 = std::move(accepted1.persisted);
+
+    auto queued2 = writer.write_to_buffer(log_record_writer(record2), test_timeout());
+    BOOST_REQUIRE(!queued2.available());
+    BOOST_REQUIRE_EQUAL(writer.queued_write_count(), 1u);
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted0);
+    flush_ctl.wait_for_flush_starts(2);
+
+    auto accepted2 = queued2.get();
+    BOOST_REQUIRE(!accepted2.persisted.available());
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted1);
+    flush_ctl.wait_for_flush_starts(3);
+    BOOST_REQUIRE(!accepted2.persisted.available());
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(accepted2.persisted);
+
+    const auto actual = flush_ctl.all_records();
+    const std::vector<log_record> expected{record0, record1, record2};
+    assert_records_in_order(schema, actual, expected);
+}
+
+// Checks that stop() waits for a blocked in-flight flush instead of dropping it.
+SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_stop_drains_blocked_in_flight_write) {
+    auto schema = make_kv_schema();
+    constexpr size_t buffer_size = 4 * 1024;
+    const auto record = make_buffered_writer_record(schema, 0, "value", api::timestamp_type(600));
+
+    test_flush_controller flush_ctl{.pause_flushes = true};
+    buffered_writer writer(make_buffered_writer_config(buffer_size, 2), [&flush_ctl] (write_buffer& wb) {
+        return flush_ctl(wb);
+    });
+
+    writer.start().get();
+
+    auto accepted = writer.write_to_buffer(log_record_writer(record), test_timeout()).get();
+    auto persisted = std::move(accepted.persisted);
+    flush_ctl.wait_for_flush_starts(1);
+
+    auto stop_fut = writer.stop();
+    BOOST_REQUIRE(!stop_fut.available());
+
+    flush_ctl.release_one_flush();
+    wait_for_persisted(persisted);
+    stop_fut.get();
+
+    const auto actual = flush_ctl.all_records();
+    BOOST_REQUIRE_EQUAL(actual.size(), 1u);
+    assert_log_record_matches(schema, actual.front().record, record);
+}
+
+// Checks that a flush failure is propagated to every write that was already accepted into that buffer.
+SEASTAR_THREAD_TEST_CASE(test_logstor_buffered_writer_flush_failure_fails_all_writes_in_buffer) {
+    auto schema = make_kv_schema();
+    constexpr size_t buffer_size = 4 * 1024;
+
+    auto record0 = make_buffered_writer_record(schema, 0, "value0", api::timestamp_type(700));
+    auto record1 = make_buffered_writer_record(schema, 1, "value1", api::timestamp_type(701));
+    raw_write_buffer scratch(buffer_size, segment_kind::mixed);
+    BOOST_REQUIRE(scratch.can_fit(log_record_writer(record0)));
+    scratch.append(log_record_writer(record0));
+    BOOST_REQUIRE(scratch.can_fit(log_record_writer(record1)));
+
+    test_flush_controller flush_ctl{.fail_flush_index = 0};
+    buffered_writer writer(make_buffered_writer_config(buffer_size, 3), [&flush_ctl] (write_buffer& wb) {
+        return flush_ctl(wb);
+    });
+
+    writer.start().get();
+    auto stop = defer([&writer] noexcept {
+        writer.stop().get();
+    });
+
+    auto accepted0 = writer.write_to_buffer(log_record_writer(record0), test_timeout()).get();
+    auto accepted1 = writer.write_to_buffer(log_record_writer(record1), test_timeout()).get();
+
+    BOOST_REQUIRE_THROW(accepted0.persisted.get(), std::runtime_error);
+    BOOST_REQUIRE_THROW(accepted1.persisted.get(), std::runtime_error);
+    BOOST_REQUIRE(flush_ctl.flushed_buffers.empty());
 }

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -10,7 +10,8 @@ import time
 from pathlib import Path
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import new_test_keyspace
-from cassandra.protocol import ConfigurationException
+from cassandra import WriteFailure, WriteTimeout
+from cassandra.protocol import ConfigurationException, ServerError
 import pytest
 import logging
 from test.pylib.tablets import get_tablet_count, get_tablet_replica
@@ -82,6 +83,73 @@ async def test_parallel_big_writes(manager: ManagerClient):
             rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test WHERE pk = {i}")
             assert rows[0].pk == i
             assert rows[0].v == f"{i}-{large_value}"
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_write_failure_retires_active_segment(manager: ManagerClient):
+    """
+    A failed segment write breaks the segment's append semaphore, so the segment must be
+    retired and the active segment switched. Otherwise every later write to that segment
+    fails and writes are stuck until restart.
+
+    This test:
+    1. Writes and verifies a few keys, establishing an active segment
+    2. Injects a failure into the segment write path and verifies the write fails
+    3. Verifies the segment was retired
+    4. Verifies that writes after the failure succeed, including to the failed key
+    5. Restarts the server and verifies all data is recovered
+    """
+    inj = 'logstor_fail_segment_write'
+    cmdline = ['--logger-log-level', 'logstor=debug', '--smp=1']
+    cfg = {'experimental_features': ['logstor']}
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql = manager.get_cql()
+
+    server_log = await manager.server_open_log(servers[0].server_id)
+
+    async with new_test_keyspace(manager, "") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
+
+        expected_data = {}
+        for pk in range(5):
+            value = f"before_{pk}"
+            expected_data[pk] = value
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, '{value}')")
+
+        log_mark = await server_log.mark()
+
+        # Fail the next segment write. The injection is not one-shot, so the write is
+        # guaranteed to fail rather than racing with background segment writes, but it
+        # is disabled again immediately to keep the failure window to a single write.
+        await manager.api.enable_injection(servers[0].ip_addr, inj, one_shot=False)
+        try:
+            with pytest.raises((WriteFailure, WriteTimeout, ServerError)):
+                await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES (100, 'failed')")
+        finally:
+            await manager.api.disable_injection(servers[0].ip_addr, inj)
+
+        await server_log.wait_for('retiring segment', from_mark=log_mark, timeout=60)
+
+        # All writes after the failure must succeed. Without retiring the failed segment
+        # they would keep failing on its broken append semaphore.
+        for pk in list(range(5, 10)) + [100]:
+            value = f"after_{pk}"
+            expected_data[pk] = value
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, v) VALUES ({pk}, '{value}')")
+
+        for pk, expected_v in expected_data.items():
+            rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test WHERE pk = {pk}")
+            assert len(rows) == 1, f"Key {pk} not found"
+            assert rows[0].v == expected_v, f"Key {pk} has wrong value"
+
+        # The retired segment has a hole at the failed write. Verify it doesn't break recovery.
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_start(servers[0].server_id)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        for pk, expected_v in expected_data.items():
+            rows = await cql.run_async(f"SELECT pk, v FROM {ks}.test WHERE pk = {pk}")
+            assert len(rows) == 1, f"Key {pk} not found after recovery"
+            assert rows[0].v == expected_v, f"Key {pk} has wrong value after recovery"
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.parametrize("fail_separator_flush", [False, True], ids=["normal", "fail_separator_flush"])


### PR DESCRIPTION
refactoring and improvements to the logstor write path, especially the buffered_writer:
* rewrite the buffered_writer consumer_loop and improve to support dispatching multiple buffers in parallel
* add a write queue in the write buffer. the write queue is limited to a configured size, after that it rejects new write. it also expires writes by timeout.
* add an optional timer parameter for head buffer rotation.
* add admission gate for writes and reads and improve shutdown
* replace global write semaphore in the segment manager with a semaphore per segment that serializes the writes in each segment. writes that are dispatched in parallel from the write buffer can be written in parallel if they are in different active segments. writes in a single segment are serialized using the semaphore, and if a write fails then later writes to the segment fail as well - so no "holes" in a segment.
* make the buffered_writer configurable for testability and add unit tests.
* small fixes

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3441

no backport - logstor is a new feature