### PR TITLE
tools/toolchain: prepare nested podman runtime in dbuild

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -156,12 +156,15 @@ docker_common_args+=("${SCYLLADB_DBUILD[@]}")
 
 if [ -z "$is_podman" ]; then
     unset TMP_PASSWD
+    uid="$(id -u)"
+    gid="$(id -g)"
     docker_common_args+=(
-       -u "$(id -u):$(id -g)"
+       -u "$uid:$gid"
        "${group_args[@]}"
        -v /etc/passwd:/etc/passwd:ro
        -v /etc/group:/etc/group:ro
        -v /var/run/docker.sock:/var/run/docker.sock
+       --tmpfs "/run/user/$uid:rw,exec,nosuid,nodev,mode=700,uid=$uid,gid=$gid"
        --pids-limit -1
        )
 fi


### PR DESCRIPTION
The object-store cluster tests start fake GCS through DockerizedServer when running the `gs` object-storage variant. With Docker-backed dbuild, the test still finds `/usr/bin/podman` inside the toolchain container and uses it to start:

    docker.io/fsouza/fake-gcs-server:1.54.0

Without a writable rootless podman runtime directory inside dbuild, the real failure is hidden behind DockerizedServer's generic startup error. For example:

    ./tools/toolchain/dbuild ./test.py --mode dev \
        'test/cluster/object_store/test_backup.py::test_restore_tablets_node_loss_resiliency[gs-api]' -v -s

fails during fixture setup with:

    test/cluster/object_store/conftest.py:40: in make_object_storage
        await server.start()
    test/pylib/object_storage.py:250: in start
        await self.server.start()
    test/pylib/dockerized_service.py:72: in start
        await self._start_attempt(exe, name)
    test/pylib/dockerized_service.py:156: in _start_attempt
        ok = await ready_fut
    E   RuntimeError: Log EOF

The direct failure is visible when running podman manually inside dbuild:

    ./tools/toolchain/dbuild podman info

which reports:

    WARN[0000] RunRoot is pointing to a path (/run/user/1000/containers) which is not writable. Most likely podman will fail.
    Error: creating events dirs: mkdir /run/user/1000: permission denied

Fix this by preparing the nested-podman environment for Docker-backed dbuild: create the host containers storage directory before bind-mounting it, so Docker does not create it as root, and mount a writable tmpfs at `/run/user/$UID` for rootless podman's runtime/event directories.

This lets object-store tests using the fake GCS auxiliary container run under Docker-backed dbuild without requiring users to pass the podman runtime-dir workaround manually.

No backport required. Tool fix only.