### PR TITLE
doc: fix the links in the DEV docs

### DIFF
--- a/docs/dev/fulltext_search.md
+++ b/docs/dev/fulltext_search.md
@@ -1,8 +1,8 @@
 # Full-Text Search — Developer Notes
 
 For user-facing documentation (index creation, query syntax, constraints), see
-:doc:`Full-Text Search </features/fulltext-search>` and
-:ref:`Fulltext Index <create-fulltext-index-statement>` in the secondary-indexes reference.
+[Full-Text Search](../features/fulltext-search.rst) and
+[Fulltext Index section](../cql/secondary-indexes.rst#create-fulltext-index-statement) in the secondary-indexes reference.
 
 This document covers implementation details and decisions not included in the user documentation.
 


### PR DESCRIPTION
Currently, the docs/dev/fulltext_search.md file includes links that use RST syntax (:doc: and :ref: directives). Using RST links inside a Markdown file is incorrect and breaks the links. 
This PR fixes the links to make them work.

No backport required.