### PR TITLE
Support node replacement during vnodes-to-tablets migration

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1691,6 +1691,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/auth_test.cc',
     'test/boost/batchlog_manager_test.cc',
     'test/boost/table_helper_test.cc',
+    'test/boost/table_streaming_reader_test.cc',
     'test/boost/cache_algorithm_test.cc',
     'test/boost/castas_fcts_test.cc',
     'test/boost/cdc_test.cc',

--- a/configure.py
+++ b/configure.py
@@ -1712,6 +1712,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/client_state_test.cc',
     'test/boost/batchlog_manager_test.cc',
     'test/boost/table_helper_test.cc',
+    'test/boost/table_streaming_reader_test.cc',
     'test/boost/cache_algorithm_test.cc',
     'test/boost/castas_fcts_test.cc',
     'test/boost/cdc_test.cc',

--- a/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
+++ b/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
@@ -78,8 +78,9 @@ The current migration procedure has the following limitations:
 * Only **single-DC clusters** are supported.
 * **No schema changes** during the migration. Do not create, alter, or drop
   tables in the migrating keyspace until the migration is finished.
-* **No topology changes** during the migration. Do not add, remove, decommission,
-  replace, or rebuild nodes while a migration is in progress.
+* **No planned topology changes** during the migration. Do not add, remove,
+  decommission, or rebuild nodes while a migration is in progress. Replacing
+  a dead node is supported as an emergency recovery operation.
 * **No repair** operations during the migration. Do not run ``nodetool repair``
   on the migrating keyspace while a migration is in progress.
 * **No TRUNCATE** on tables in the migrating keyspace during the migration.
@@ -445,3 +446,16 @@ To migrate multiple keyspaces simultaneously, follow these steps:
       scylla nodetool migrate-to-tablets finalize <keyspace1>
       scylla nodetool migrate-to-tablets finalize <keyspace2>
       ...
+
+Replacing a Dead Node during Migration
+--------------------------------------
+
+If a node fails during the migration, replace it using the standard procedure
+for :doc:`replacing a dead node </operating-scylla/procedures/cluster-management/replace-dead-node/>`.
+
+The replacing node must have the same shard count as the replaced node. If the
+shard count differs, the replacement will fail.
+
+After replacement completes, you can resume the migration. The replacing node
+always starts in vnode mode and must be upgraded to tablets, regardless of the
+storage mode of node it replaced.

--- a/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
+++ b/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
@@ -83,8 +83,9 @@ The current migration procedure has the following limitations:
 
 * **No schema changes** during the migration. Do not create, alter, or drop
   tables in the migrating keyspace until the migration is finished.
-* **No topology changes** during the migration. Do not add, remove, decommission,
-  replace, or rebuild nodes while a migration is in progress.
+* **No planned topology changes** during the migration. Do not add, remove,
+  decommission, or rebuild nodes while a migration is in progress. Replacing
+  a dead node is supported as an emergency recovery operation.
 * **No repair** operations during the migration. Do not run ``nodetool repair``
   on the migrating keyspace while a migration is in progress.
 * **No TRUNCATE** on tables in the migrating keyspace during the migration.
@@ -450,3 +451,16 @@ To migrate multiple keyspaces simultaneously, follow these steps:
       scylla nodetool migrate-to-tablets finalize <keyspace1>
       scylla nodetool migrate-to-tablets finalize <keyspace2>
       ...
+
+Replacing a Dead Node during Migration
+--------------------------------------
+
+If a node fails during the migration, replace it using the standard procedure
+for :doc:`replacing a dead node </operating-scylla/procedures/cluster-management/replace-dead-node/>`.
+
+The replacing node must have the same shard count as the replaced node. If the
+shard count differs, the replacement will fail.
+
+After replacement completes, you can resume the migration. The replacing node
+always starts in vnode mode and must be upgraded to tablets, regardless of the
+storage mode of node it replaced.

--- a/readers/combined.hh
+++ b/readers/combined.hh
@@ -27,7 +27,12 @@ public:
 
     virtual ~reader_selector() = default;
     // Call only if has_new_readers() returned true.
+    // If a position is provided, it returns only readers that overlap with this position.
+    // An empty vector is returned if the selector reached end-of-stream, or no
+    // readers overlap with the provided position.
     virtual std::vector<mutation_reader> create_new_readers(const std::optional<dht::ring_position_view>& pos) = 0;
+    // Expected to return at least one reader that overlaps with the new range,
+    // if any readers are available within the range.
     virtual std::vector<mutation_reader> fast_forward_to(const dht::partition_range& pr) = 0;
 
     // Can be false-positive but never false-negative!

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -817,6 +817,8 @@ private:
     repair_hasher _repair_hasher;
     gc_clock::time_point _compaction_time;
     bool _is_tablet;
+    bool _explicit_dst_cpu_id;
+    bool _table_is_migrating;
     reader_concurrency_semaphore::inactive_read_handle _fake_inactive_read_handle;
     std::unique_ptr<const locator::token_metadata> _small_table_optimization_tm;
     seastar::semaphore _small_table_optimization_tm_sem{1};
@@ -906,7 +908,8 @@ public:
             gc_clock::time_point compaction_time,
             service::frozen_topology_guard topo_guard,
             std::optional<int64_t> repaired_at,
-            locator::tablet_repair_incremental_mode incremental_mode)
+            locator::tablet_repair_incremental_mode incremental_mode,
+            bool explicit_dst_cpu_id)
             : _rs(rs)
             , _db(rs.get_db())
             , _messaging(rs.get_messaging())
@@ -950,6 +953,8 @@ public:
             , _repair_hasher(_seed, _schema)
             , _compaction_time(compaction_time)
             , _is_tablet(cf.uses_tablets())
+            , _explicit_dst_cpu_id(explicit_dst_cpu_id)
+            , _table_is_migrating(is_table_migrating(_db.local(), *_schema))
             , _frozen_topology_guard(topo_guard)
             , _topology_guard(_frozen_topology_guard)
             , _is_eligible_to_repair_rejection(cf.is_eligible_to_write_rejection_on_critical_disk_utilization())
@@ -997,9 +1002,10 @@ public:
             gc_clock::time_point compaction_time,
             service::frozen_topology_guard topo_guard,
             std::optional<int64_t> repaired_at,
-            locator::tablet_repair_incremental_mode incremental_mode)
+            locator::tablet_repair_incremental_mode incremental_mode,
+            bool explicit_dst_cpu_id)
         : repair_meta(rs, cf, std::move(s), std::move(permit), std::move(range), algo, max_row_buf_size, seed, master, repair_meta_id, reason,
-                std::move(master_node_shard_config), std::move(all_live_peer_nodes), 1, {std::nullopt}, nullptr, compaction_time, topo_guard, repaired_at, incremental_mode)
+                std::move(master_node_shard_config), std::move(all_live_peer_nodes), 1, {std::nullopt}, nullptr, compaction_time, topo_guard, repaired_at, incremental_mode, explicit_dst_cpu_id)
     {
     }
 
@@ -1107,7 +1113,7 @@ private:
 
     future<uint64_t> get_estimated_partitions() {
         auto gate_held = _gate.hold();
-        if (_repair_master || _same_sharding_config || _is_tablet) {
+        if (can_read_locally()) {
             co_return co_await do_estimate_partitions_on_local_shard();
         } else {
             auto sharder = dht::selective_token_range_sharder(_remote_sharder, _range, _master_node_shard_config.shard);
@@ -1144,6 +1150,71 @@ private:
         return sharder.shard_count() == _master_node_shard_config.shard_count
                && sharder.sharding_ignore_msb() == _master_node_shard_config.ignore_msb
                && this_shard_id() == _master_node_shard_config.shard;
+    }
+
+    // Check if a table is undergoing vnodes-to-tablets migration.
+    // True when the keyspace uses vnodes but the table has a tablet map.
+    static bool is_table_migrating(const replica::database& db, const schema& s) {
+        return db.find_keyspace(s.ks_name()).get_replication_strategy().is_vnode_based()
+                && db.get_token_metadata().tablets().has_tablet_map(s.id());
+    }
+
+    // Determine whether this node can use a shard-local reader for the repair
+    // session, or needs a multishard one. Returns true for shard-local.
+    //
+    // The repair master always reads shard-locally: it repairs a range it owns,
+    // on the shard that owns it.
+    //
+    // On follower's side, there are two scenarios:
+    //
+    // 1. (common case) Master and follower have the same sharding flavor, i.e.
+    //    both vnode-based or both tablet-based. In this case, the read is
+    //    shard-local if either:
+    //    - both nodes have the same sharding configuration; or
+    //    - the table uses tablets, in which case the master explicitly selects
+    //      the follower's shard, so the follower is already on the owning
+    //      shard.
+    //
+    // 2. (rare case) Master and follower have different sharding flavors.
+    //    This is a very special use case that aims to support repair-based
+    //    node replacements (RBNO) while a vnodes-to-tablets migration is in
+    //    progress. When the replacing node joins the cluster, it needs to
+    //    stream the migrating table's data from other peers. Since the
+    //    migration switches nodes from vnode to tablet ERMs incrementally, and
+    //    the replacing node always starts on vnodes, the possible combinations
+    //    are (vnode-based master, vnode-based follower) and
+    //    (vnode-based master, tablet-based follower). To support the
+    //    mixed-flavor case, the follower must always do a multishard read.
+    bool can_read_locally() const {
+        if (_repair_master) {
+            return true;
+        }
+
+        // Sharding flavors for master and follower.
+        // Deduce the master's flavor from whether it has specified a destination shard (expected to be true only for tablet-style masters).
+        // Deduce the current follower's flavor from the table's ERM.
+        const bool master_uses_tablets = _explicit_dst_cpu_id;
+        const bool follower_uses_tablets = _is_tablet;
+        const bool same_flavor = master_uses_tablets == follower_uses_tablets;
+
+        if (same_flavor) {
+            return _same_sharding_config || _is_tablet;
+        }
+
+        if (!_table_is_migrating) {
+            on_internal_error(rlogger, format(
+                    "repair_meta[{}]: master and follower have different flavors for table {}.{}, but the table is not undergoing vnodes-to-tablets migration",
+                    _repair_meta_id, _schema->ks_name(), _schema->cf_name()));
+        }
+
+        if (master_uses_tablets && !follower_uses_tablets) {
+            throw std::runtime_error(format(
+                    "repair_meta[{}]: tablet-based master cannot repair vnode-based follower, operation is not supported (table: {}.{} range: {})",
+                    _repair_meta_id, _schema->ks_name(), _schema->cf_name(), _range));
+        }
+
+        // vnode master -> tablet follower : multishard read required
+        return false;
     }
 
     future<size_t> get_repair_rows_size(const std::list<repair_row>& rows) const {
@@ -1290,7 +1361,7 @@ private:
                         return repair_reader::read_strategy::incremental_repair;
                     }
 
-                    if (_repair_master || _same_sharding_config || _is_tablet) {
+                    if (can_read_locally()) {
                         rlogger.debug("repair_reader: meta_id={}, _repair_master={}, _same_sharding_config={},"
                                       "read_strategy {} is chosen",
                            _repair_meta_id, _repair_master, _same_sharding_config,
@@ -1813,14 +1884,15 @@ public:
     repair_row_level_start_handler(repair_service& repair, locator::host_id from_id, uint32_t src_cpu_id, uint32_t repair_meta_id, sstring ks_name, sstring cf_name,
             dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size,
             uint64_t seed, shard_config master_node_shard_config, table_schema_version schema_version, streaming::stream_reason reason,
-            gc_clock::time_point compaction_time, abort_source& as, service::frozen_topology_guard topo_guard, std::optional<int64_t> repaired_at, locator::tablet_repair_incremental_mode incremental_mode) {
+            gc_clock::time_point compaction_time, abort_source& as, service::frozen_topology_guard topo_guard, std::optional<int64_t> repaired_at, locator::tablet_repair_incremental_mode incremental_mode,
+            bool explicit_dst_cpu_id) {
         rlogger.debug(">>> Started Row Level Repair (Follower): local={}, peers={}, repair_meta_id={}, keyspace={}, cf={}, schema_version={}, range={}, seed={}, max_row_buf_siz={}",
                 repair.my_host_id(), from_id, repair_meta_id, ks_name, cf_name, schema_version, range, seed, max_row_buf_size);
         try {
             // Trigger read barrier to ensure that session_id is visible.
             auto& mm = repair.get_migration_manager();
             co_await mm.get_group0_barrier().trigger(mm.get_abort_source());
-            co_await repair.insert_repair_meta(from_id, src_cpu_id, repair_meta_id, std::move(range), algo, max_row_buf_size, seed, std::move(master_node_shard_config), std::move(schema_version), reason, compaction_time, as, topo_guard, repaired_at, incremental_mode);
+            co_await repair.insert_repair_meta(from_id, src_cpu_id, repair_meta_id, std::move(range), algo, max_row_buf_size, seed, std::move(master_node_shard_config), std::move(schema_version), reason, compaction_time, as, topo_guard, repaired_at, incremental_mode, explicit_dst_cpu_id);
             co_return repair_row_level_start_response{repair_row_level_start_status::ok};
         } catch (replica::no_such_column_family&) {
             co_return repair_row_level_start_response{repair_row_level_start_status::no_such_column_family};
@@ -2886,17 +2958,18 @@ future<> repair_service::init_ms_handlers() {
             rpc::optional<service::frozen_topology_guard> topo_guard, rpc::optional<std::optional<int64_t>> repaired_at,
             rpc::optional<locator::tablet_repair_incremental_mode> incremental_mode) {
         auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        bool explicit_dst_cpu_id = bool(dst_cpu_id_opt && *dst_cpu_id_opt != repair_unspecified_shard);
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
         auto from_id = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
         return container().invoke_on(shard, [from_id, src_cpu_id, repair_meta_id, ks_name, cf_name,
                 range, algo, max_row_buf_size, seed, remote_shard, remote_shard_count, remote_ignore_msb, schema_version, reason, compaction_time, this,
-                topo_guard = topo_guard.value_or(service::default_session_id), repaired_at = repaired_at.value_or(std::nullopt), incremental_mode = incremental_mode.value_or(locator::tablet_repair_incremental_mode::disabled)] (repair_service& local_repair) mutable {
+                topo_guard = topo_guard.value_or(service::default_session_id), repaired_at = repaired_at.value_or(std::nullopt), incremental_mode = incremental_mode.value_or(locator::tablet_repair_incremental_mode::disabled), explicit_dst_cpu_id] (repair_service& local_repair) mutable {
             streaming::stream_reason r = reason ? *reason : streaming::stream_reason::repair;
             const gc_clock::time_point ct = compaction_time ? *compaction_time : gc_clock::now();
             return repair_meta::repair_row_level_start_handler(local_repair, from_id, src_cpu_id, repair_meta_id, std::move(ks_name),
                     std::move(cf_name), std::move(range), algo, max_row_buf_size, seed,
                     shard_config{remote_shard, remote_shard_count, remote_ignore_msb},
-                    schema_version, r, ct, _repair_module->abort_source(), topo_guard, repaired_at, incremental_mode);
+                    schema_version, r, ct, _repair_module->abort_source(), topo_guard, repaired_at, incremental_mode, explicit_dst_cpu_id);
         });
     });
     ser::repair_rpc_verbs::register_repair_row_level_stop(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id,
@@ -3588,7 +3661,8 @@ public:
                     compaction_time,
                     _topo_guard,
                     repaired_at,
-                    _shard_task.sched_info.incremental_mode);
+                    _shard_task.sched_info.incremental_mode,
+                    false);
             auto auto_stop_master = defer([&master] noexcept {
                 try {
                     master.stop().get();
@@ -3981,7 +4055,8 @@ repair_service::insert_repair_meta(
         abort_source& as,
         service::frozen_topology_guard topo_guard,
         std::optional<int64_t> repaired_at,
-        locator::tablet_repair_incremental_mode incremental_mode) {
+        locator::tablet_repair_incremental_mode incremental_mode,
+        bool explicit_dst_cpu_id) {
     schema_ptr s = co_await get_migration_manager().get_schema_for_write(schema_version, from_id, src_cpu_id, get_messaging(), as);
     auto& db = get_db();
     reader_permit permit = co_await db.local().obtain_reader_permit(db.local().find_column_family(s->id()), "repair-meta", db::no_timeout, {});
@@ -4002,7 +4077,8 @@ repair_service::insert_repair_meta(
             compaction_time,
             topo_guard,
             repaired_at,
-            incremental_mode);
+            incremental_mode,
+            explicit_dst_cpu_id);
     rm->set_repair_state_for_local_node(repair_state::row_level_start_started);
     bool insertion = repair_meta_map().emplace(id, rm).second;
     if (!insertion) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3439,7 +3439,7 @@ private:
 private:
     // Update system.repair_history table
     future<> update_system_repair_table() {
-        // Update repair_history table only if it is a reguar repair.
+        // Update repair_history table only if it is a regular repair.
         if (_shard_task.reason() != streaming::stream_reason::repair) {
             co_return;
         }
@@ -3881,7 +3881,7 @@ repair_service::update_history(tasks::task_id repair_id, table_id table_id, dht:
                     repair_id, range, table_id, finished_shards);
             co_return rh.repair_time;
         } else {
-            rlogger.debug("repair[{}]: Finished range {} for table {} on all shards, updating system.repair_historytable, finished_shards={}",
+            rlogger.debug("repair[{}]: Finished range {} for table {} on all shards, updating system.repair_history table, finished_shards={}",
                     repair_id, range, table_id, finished_shards);
             co_return std::nullopt;
         }

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -817,6 +817,8 @@ private:
     repair_hasher _repair_hasher;
     gc_clock::time_point _compaction_time;
     bool _is_tablet;
+    bool _explicit_dst_cpu_id;
+    bool _table_is_migrating;
     reader_concurrency_semaphore::inactive_read_handle _fake_inactive_read_handle;
     std::unique_ptr<const locator::token_metadata> _small_table_optimization_tm;
     seastar::semaphore _small_table_optimization_tm_sem{1};
@@ -906,7 +908,8 @@ public:
             gc_clock::time_point compaction_time,
             service::frozen_topology_guard topo_guard,
             std::optional<int64_t> repaired_at,
-            locator::tablet_repair_incremental_mode incremental_mode)
+            locator::tablet_repair_incremental_mode incremental_mode,
+            bool explicit_dst_cpu_id)
             : _rs(rs)
             , _db(rs.get_db())
             , _messaging(rs.get_messaging())
@@ -950,6 +953,8 @@ public:
             , _repair_hasher(_seed, _schema)
             , _compaction_time(compaction_time)
             , _is_tablet(cf.uses_tablets())
+            , _explicit_dst_cpu_id(explicit_dst_cpu_id)
+            , _table_is_migrating(is_table_migrating(_db.local(), *_schema))
             , _frozen_topology_guard(topo_guard)
             , _topology_guard(_frozen_topology_guard)
             , _is_eligible_to_repair_rejection(cf.is_eligible_to_write_rejection_on_critical_disk_utilization())
@@ -997,9 +1002,10 @@ public:
             gc_clock::time_point compaction_time,
             service::frozen_topology_guard topo_guard,
             std::optional<int64_t> repaired_at,
-            locator::tablet_repair_incremental_mode incremental_mode)
+            locator::tablet_repair_incremental_mode incremental_mode,
+            bool explicit_dst_cpu_id)
         : repair_meta(rs, cf, std::move(s), std::move(permit), std::move(range), algo, max_row_buf_size, seed, master, repair_meta_id, reason,
-                std::move(master_node_shard_config), std::move(all_live_peer_nodes), 1, {std::nullopt}, nullptr, compaction_time, topo_guard, repaired_at, incremental_mode)
+                std::move(master_node_shard_config), std::move(all_live_peer_nodes), 1, {std::nullopt}, nullptr, compaction_time, topo_guard, repaired_at, incremental_mode, explicit_dst_cpu_id)
     {
     }
 
@@ -1107,7 +1113,7 @@ private:
 
     future<uint64_t> get_estimated_partitions() {
         auto gate_held = _gate.hold();
-        if (_repair_master || _same_sharding_config || _is_tablet) {
+        if (can_read_locally()) {
             co_return co_await do_estimate_partitions_on_local_shard();
         } else {
             auto sharder = dht::selective_token_range_sharder(_remote_sharder, _range, _master_node_shard_config.shard);
@@ -1144,6 +1150,45 @@ private:
         return sharder.shard_count() == _master_node_shard_config.shard_count
                && sharder.sharding_ignore_msb() == _master_node_shard_config.ignore_msb
                && this_shard_id() == _master_node_shard_config.shard;
+    }
+
+    // Check if a table is undergoing vnodes-to-tablets migration.
+    // True when the keyspace uses vnodes but the table has a tablet map.
+    static bool is_table_migrating(const replica::database& db, const schema& s) {
+        return db.find_keyspace(s.ks_name()).get_replication_strategy().is_vnode_based()
+                && db.get_token_metadata().tablets().has_tablet_map(s.id());
+    }
+
+    bool can_read_locally() const {
+        if (_repair_master) {
+            return true;
+        }
+
+        // Sharding flavors for master and follower.
+        // Deduce the master's flavor from whether it has specified a destination shard (expected to be true only for tablet-style masters).
+        // Deduce the current follower's flavor from the table's ERM.
+        const bool master_uses_tablets = _explicit_dst_cpu_id;
+        const bool follower_uses_tablets = _is_tablet;
+        const bool same_flavor = master_uses_tablets == follower_uses_tablets;
+
+        if (same_flavor) {
+            return _same_sharding_config || _is_tablet;
+        }
+
+        if (!_table_is_migrating) {
+            on_internal_error(rlogger, format(
+                    "repair_meta[{}]: master and follower have different flavors for table {}.{}, but the table is not undergoing vnodes-to-tablets migration",
+                    _repair_meta_id, _schema->ks_name(), _schema->cf_name()));
+        }
+
+        if (master_uses_tablets && !follower_uses_tablets) {
+            throw std::runtime_error(format(
+                    "repair_meta[{}]: tablet-based master cannot repair vnode-based follower, operation is not supported (table: {}.{} range: {})",
+                    _repair_meta_id, _schema->ks_name(), _schema->cf_name(), _range));
+        }
+
+        // vnode master -> tablet follower : multishard read required
+        return false;
     }
 
     future<size_t> get_repair_rows_size(const std::list<repair_row>& rows) const {
@@ -1290,7 +1335,7 @@ private:
                         return repair_reader::read_strategy::incremental_repair;
                     }
 
-                    if (_repair_master || _same_sharding_config || _is_tablet) {
+                    if (can_read_locally()) {
                         rlogger.debug("repair_reader: meta_id={}, _repair_master={}, _same_sharding_config={},"
                                       "read_strategy {} is chosen",
                            _repair_meta_id, _repair_master, _same_sharding_config,
@@ -1813,14 +1858,15 @@ public:
     repair_row_level_start_handler(repair_service& repair, locator::host_id from_id, uint32_t src_cpu_id, uint32_t repair_meta_id, sstring ks_name, sstring cf_name,
             dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size,
             uint64_t seed, shard_config master_node_shard_config, table_schema_version schema_version, streaming::stream_reason reason,
-            gc_clock::time_point compaction_time, abort_source& as, service::frozen_topology_guard topo_guard, std::optional<int64_t> repaired_at, locator::tablet_repair_incremental_mode incremental_mode) {
+            gc_clock::time_point compaction_time, abort_source& as, service::frozen_topology_guard topo_guard, std::optional<int64_t> repaired_at, locator::tablet_repair_incremental_mode incremental_mode,
+            bool explicit_dst_cpu_id) {
         rlogger.debug(">>> Started Row Level Repair (Follower): local={}, peers={}, repair_meta_id={}, keyspace={}, cf={}, schema_version={}, range={}, seed={}, max_row_buf_siz={}",
                 repair.my_host_id(), from_id, repair_meta_id, ks_name, cf_name, schema_version, range, seed, max_row_buf_size);
         try {
             // Trigger read barrier to ensure that session_id is visible.
             auto& mm = repair.get_migration_manager();
             co_await mm.get_group0_barrier().trigger(mm.get_abort_source());
-            co_await repair.insert_repair_meta(from_id, src_cpu_id, repair_meta_id, std::move(range), algo, max_row_buf_size, seed, std::move(master_node_shard_config), std::move(schema_version), reason, compaction_time, as, topo_guard, repaired_at, incremental_mode);
+            co_await repair.insert_repair_meta(from_id, src_cpu_id, repair_meta_id, std::move(range), algo, max_row_buf_size, seed, std::move(master_node_shard_config), std::move(schema_version), reason, compaction_time, as, topo_guard, repaired_at, incremental_mode, explicit_dst_cpu_id);
             co_return repair_row_level_start_response{repair_row_level_start_status::ok};
         } catch (replica::no_such_column_family&) {
             co_return repair_row_level_start_response{repair_row_level_start_status::no_such_column_family};
@@ -2882,17 +2928,18 @@ future<> repair_service::init_ms_handlers() {
             rpc::optional<service::frozen_topology_guard> topo_guard, rpc::optional<std::optional<int64_t>> repaired_at,
             rpc::optional<locator::tablet_repair_incremental_mode> incremental_mode) {
         auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        bool explicit_dst_cpu_id = bool(dst_cpu_id_opt && *dst_cpu_id_opt != repair_unspecified_shard);
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
         auto from_id = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
         return container().invoke_on(shard, [from_id, src_cpu_id, repair_meta_id, ks_name, cf_name,
                 range, algo, max_row_buf_size, seed, remote_shard, remote_shard_count, remote_ignore_msb, schema_version, reason, compaction_time, this,
-                topo_guard = topo_guard.value_or(service::default_session_id), repaired_at = repaired_at.value_or(std::nullopt), incremental_mode = incremental_mode.value_or(locator::tablet_repair_incremental_mode::disabled)] (repair_service& local_repair) mutable {
+                topo_guard = topo_guard.value_or(service::default_session_id), repaired_at = repaired_at.value_or(std::nullopt), incremental_mode = incremental_mode.value_or(locator::tablet_repair_incremental_mode::disabled), explicit_dst_cpu_id] (repair_service& local_repair) mutable {
             streaming::stream_reason r = reason ? *reason : streaming::stream_reason::repair;
             const gc_clock::time_point ct = compaction_time ? *compaction_time : gc_clock::now();
             return repair_meta::repair_row_level_start_handler(local_repair, from_id, src_cpu_id, repair_meta_id, std::move(ks_name),
                     std::move(cf_name), std::move(range), algo, max_row_buf_size, seed,
                     shard_config{remote_shard, remote_shard_count, remote_ignore_msb},
-                    schema_version, r, ct, _repair_module->abort_source(), topo_guard, repaired_at, incremental_mode);
+                    schema_version, r, ct, _repair_module->abort_source(), topo_guard, repaired_at, incremental_mode, explicit_dst_cpu_id);
         });
     });
     ser::repair_rpc_verbs::register_repair_row_level_stop(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id,
@@ -3499,7 +3546,8 @@ public:
                     compaction_time,
                     _topo_guard,
                     repaired_at,
-                    _shard_task.sched_info.incremental_mode);
+                    _shard_task.sched_info.incremental_mode,
+                    false);
             auto auto_stop_master = defer([&master] noexcept {
                 try {
                     master.stop().get();
@@ -3892,7 +3940,8 @@ repair_service::insert_repair_meta(
         abort_source& as,
         service::frozen_topology_guard topo_guard,
         std::optional<int64_t> repaired_at,
-        locator::tablet_repair_incremental_mode incremental_mode) {
+        locator::tablet_repair_incremental_mode incremental_mode,
+        bool explicit_dst_cpu_id) {
     schema_ptr s = co_await get_migration_manager().get_schema_for_write(schema_version, from_id, src_cpu_id, get_messaging(), as);
     auto& db = get_db();
     reader_permit permit = co_await db.local().obtain_reader_permit(db.local().find_column_family(s->id()), "repair-meta", db::no_timeout, {});
@@ -3913,7 +3962,8 @@ repair_service::insert_repair_meta(
             compaction_time,
             topo_guard,
             repaired_at,
-            incremental_mode);
+            incremental_mode,
+            explicit_dst_cpu_id);
     rm->set_repair_state_for_local_node(repair_state::row_level_start_started);
     bool insertion = repair_meta_map().emplace(id, rm).second;
     if (!insertion) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3386,7 +3386,7 @@ private:
 private:
     // Update system.repair_history table
     future<> update_system_repair_table() {
-        // Update repair_history table only if it is a reguar repair.
+        // Update repair_history table only if it is a regular repair.
         if (_shard_task.reason() != streaming::stream_reason::repair) {
             co_return;
         }
@@ -3792,7 +3792,7 @@ repair_service::update_history(tasks::task_id repair_id, table_id table_id, dht:
                     repair_id, range, table_id, finished_shards);
             co_return rh.repair_time;
         } else {
-            rlogger.debug("repair[{}]: Finished range {} for table {} on all shards, updating system.repair_historytable, finished_shards={}",
+            rlogger.debug("repair[{}]: Finished range {} for table {} on all shards, updating system.repair_history table, finished_shards={}",
                     repair_id, range, table_id, finished_shards);
             co_return std::nullopt;
         }

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -320,7 +320,8 @@ public:
             abort_source& as,
             service::frozen_topology_guard topo_guard,
             std::optional<int64_t> repaired_at,
-            locator::tablet_repair_incremental_mode incremental_mode);
+            locator::tablet_repair_incremental_mode incremental_mode,
+            bool explicit_dst_cpu_id);
 
     future<>
     remove_repair_meta(const locator::host_id& from,

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -520,6 +520,8 @@ public:
 
     virtual storage_group& storage_group_for_token(dht::token) const = 0;
     virtual utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const = 0;
+    virtual utils::chunked_vector<storage_group_ptr> storage_groups_for_token_ranges(
+            noncopyable_function<std::optional<dht::token_range>()> next_token_range) const = 0;
 
     virtual locator::combined_load_stats table_load_stats() const = 0;
     virtual bool all_storage_groups_split() = 0;

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -550,6 +550,8 @@ public:
 
     virtual storage_group& storage_group_for_token(dht::token) const = 0;
     virtual utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const = 0;
+    virtual utils::chunked_vector<storage_group_ptr> storage_groups_for_token_ranges(
+            noncopyable_function<std::optional<dht::token_range>()> next_token_range) const = 0;
 
     virtual locator::combined_load_stats table_load_stats() const = 0;
     virtual bool all_storage_groups_split() = 0;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -736,6 +736,11 @@ private:
     // data at any point in time. In short, writes can operate on compaction group level, but reads
     // must operate on storage group level.
     utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const;
+    // Like storage_groups_for_token_range(), but for multiple token ranges.
+    // The token ranges are produced by next_token_range and they are expected
+    // to be sorted and disjoint.
+    utils::chunked_vector<storage_group_ptr> storage_groups_for_token_ranges(
+            noncopyable_function<std::optional<dht::token_range>()> next_token_range) const;
     storage_group& storage_group_for_id(size_t i) const;
 
     std::unique_ptr<storage_group_manager> make_storage_group_manager();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -864,6 +864,20 @@ private:
              streamed_mutation::forwarding fwd,
              mutation_reader::forwarding fwd_mr,
              std::function<void(size_t)> reserve_fn) const;
+    // Multi-range overload for the streaming reader. Creates memtable readers
+    // on all storage groups that overlap with the provided ranges.
+    // The provided ranges must be sorted, disjoint and non-empty.
+    // The created readers are always fast-forwardable, since they are positioned
+    // at the first range and reach the remaining ones only by being fast-forwarded.
+    // Use the single-range overload above if a non-fast-forwardable reader is needed.
+    void add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
+             const schema_ptr& s,
+             const reader_permit& permit,
+             const dht::partition_range_vector& ranges,
+             const query::partition_slice& slice,
+             const tracing::trace_state_ptr& trace_state,
+             streamed_mutation::forwarding fwd,
+             std::function<void(size_t)> reserve_fn) const;
 public:
     const storage_options& get_storage_options() const noexcept { return *_storage_opts; }
     lw_shared_ptr<const storage_options> get_storage_options_ptr() const noexcept { return _storage_opts; }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -869,6 +869,20 @@ private:
              streamed_mutation::forwarding fwd,
              mutation_reader::forwarding fwd_mr,
              std::function<void(size_t)> reserve_fn) const;
+    // Multi-range overload for the streaming reader. Creates memtable readers
+    // on all storage groups that overlap with the provided ranges.
+    // The provided ranges must be sorted, disjoint and non-empty.
+    // The created readers are always fast-forwardable, since they are positioned
+    // at the first range and reach the remaining ones only by being fast-forwarded.
+    // Use the single-range overload above if a non-fast-forwardable reader is needed.
+    void add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
+             const schema_ptr& s,
+             const reader_permit& permit,
+             const dht::partition_range_vector& ranges,
+             const query::partition_slice& slice,
+             const tracing::trace_state_ptr& trace_state,
+             streamed_mutation::forwarding fwd,
+             std::function<void(size_t)> reserve_fn) const;
 public:
     const storage_options& get_storage_options() const noexcept { return *_storage_opts; }
     lw_shared_ptr<const storage_options> get_storage_options_ptr() const noexcept { return _storage_opts; }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -731,6 +731,11 @@ private:
     // data at any point in time. In short, writes can operate on compaction group level, but reads
     // must operate on storage group level.
     utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const;
+    // Like storage_groups_for_token_range(), but for multiple token ranges.
+    // The token ranges are produced by next_token_range and they are expected
+    // to be sorted and disjoint.
+    utils::chunked_vector<storage_group_ptr> storage_groups_for_token_ranges(
+            noncopyable_function<std::optional<dht::token_range>()> next_token_range) const;
     storage_group& storage_group_for_id(size_t i) const;
 
     std::unique_ptr<storage_group_manager> make_storage_group_manager();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -223,6 +223,45 @@ table::add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
     }
 }
 
+void
+table::add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
+        const schema_ptr& s,
+        const reader_permit& permit,
+        const dht::partition_range_vector& ranges,
+        const query::partition_slice& slice,
+        const tracing::trace_state_ptr& trace_state,
+        streamed_mutation::forwarding fwd,
+        std::function<void(size_t)> reserve_fn) const {
+    if (ranges.empty()) {
+        return;
+    }
+    const dht::partition_range& first_range = ranges.front();
+
+    auto add_memtables_from_cg = [&] (compaction_group& cg) mutable {
+        for (auto&& mt: *cg.memtables()) {
+            // Create each reader with first range as its initial range; a reader of
+            // a later storage group yields nothing until fast-forwarded into its own range.
+            if (auto reader_opt = mt->make_mutation_reader_opt(s, permit, first_range, slice, trace_state, fwd, mutation_reader::forwarding::yes)) {
+                readers.emplace_back(std::move(*reader_opt));
+            }
+        }
+    };
+
+    auto next_token_range = [it = ranges.cbegin(), end = ranges.cend()] () mutable -> std::optional<dht::token_range> {
+        if (it == end) {
+            return std::nullopt;
+        }
+        return (it++)->transform(std::mem_fn(&dht::ring_position::token));
+    };
+    auto sgs = storage_groups_for_token_ranges(next_token_range);
+    reserve_fn(std::ranges::fold_left(sgs | std::views::transform(std::mem_fn(&storage_group::memtable_count)), uint64_t(0), std::plus{}));
+    for (auto& sg : sgs) {
+        sg->for_each_compaction_group([&] (const compaction_group_ptr &cg) {
+            add_memtables_from_cg(*cg);
+        });
+    }
+}
+
 mutation_reader
 table::make_mutation_reader(schema_ptr s,
                            reader_permit permit,
@@ -317,10 +356,10 @@ table::make_streaming_reader(schema_ptr s, reader_permit permit,
                            gc_clock::time_point compaction_time) const {
     auto& slice = s->full_slice();
 
-    auto source = mutation_source([this] (schema_ptr s, reader_permit permit, const dht::partition_range& range, const query::partition_slice& slice,
+    auto source = mutation_source([this, &ranges] (schema_ptr s, reader_permit permit, const dht::partition_range& range, const query::partition_slice& slice,
                                       tracing::trace_state_ptr trace_state, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr) {
         std::vector<mutation_reader> readers;
-        add_memtables_to_reader_list(readers, s, permit, range, slice, trace_state, fwd, fwd_mr, [&] (size_t memtable_count) {
+        add_memtables_to_reader_list(readers, s, permit, ranges, slice, trace_state, fwd, [&] (size_t memtable_count) {
             readers.reserve(memtable_count + 1);
         });
         readers.emplace_back(make_sstable_reader(s, permit, _sstables, range, slice,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -224,6 +224,45 @@ table::add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
     }
 }
 
+void
+table::add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
+        const schema_ptr& s,
+        const reader_permit& permit,
+        const dht::partition_range_vector& ranges,
+        const query::partition_slice& slice,
+        const tracing::trace_state_ptr& trace_state,
+        streamed_mutation::forwarding fwd,
+        std::function<void(size_t)> reserve_fn) const {
+    if (ranges.empty()) {
+        return;
+    }
+    const dht::partition_range& first_range = ranges.front();
+
+    auto add_memtables_from_cg = [&] (compaction_group& cg) mutable {
+        for (auto&& mt: *cg.memtables()) {
+            // Create each reader with first range as its initial range; a reader of
+            // a later storage group yields nothing until fast-forwarded into its own range.
+            if (auto reader_opt = mt->make_mutation_reader_opt(s, permit, first_range, slice, trace_state, fwd, mutation_reader::forwarding::yes)) {
+                readers.emplace_back(std::move(*reader_opt));
+            }
+        }
+    };
+
+    auto next_token_range = [it = ranges.cbegin(), end = ranges.cend()] () mutable -> std::optional<dht::token_range> {
+        if (it == end) {
+            return std::nullopt;
+        }
+        return (it++)->transform(std::mem_fn(&dht::ring_position::token));
+    };
+    auto sgs = storage_groups_for_token_ranges(next_token_range);
+    reserve_fn(std::ranges::fold_left(sgs | std::views::transform(std::mem_fn(&storage_group::memtable_count)), uint64_t(0), std::plus{}));
+    for (auto& sg : sgs) {
+        sg->for_each_compaction_group([&] (const compaction_group_ptr &cg) {
+            add_memtables_from_cg(*cg);
+        });
+    }
+}
+
 mutation_reader
 table::make_mutation_reader(schema_ptr s,
                            reader_permit permit,
@@ -318,10 +357,10 @@ table::make_streaming_reader(schema_ptr s, reader_permit permit,
                            gc_clock::time_point compaction_time) const {
     auto& slice = s->full_slice();
 
-    auto source = mutation_source([this] (schema_ptr s, reader_permit permit, const dht::partition_range& range, const query::partition_slice& slice,
+    auto source = mutation_source([this, &ranges] (schema_ptr s, reader_permit permit, const dht::partition_range& range, const query::partition_slice& slice,
                                       tracing::trace_state_ptr trace_state, streamed_mutation::forwarding fwd, mutation_reader::forwarding fwd_mr) {
         std::vector<mutation_reader> readers;
-        add_memtables_to_reader_list(readers, s, permit, range, slice, trace_state, fwd, fwd_mr, [&] (size_t memtable_count) {
+        add_memtables_to_reader_list(readers, s, permit, ranges, slice, trace_state, fwd, [&] (size_t memtable_count) {
             readers.reserve(memtable_count + 1);
         });
         readers.emplace_back(make_sstable_reader(s, permit, _sstables, range, slice,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -747,6 +747,11 @@ public:
         ret.push_back(_single_sg);
         return ret;
     }
+    utils::chunked_vector<storage_group_ptr> storage_groups_for_token_ranges(noncopyable_function<std::optional<dht::token_range>()>) const override {
+        utils::chunked_vector<storage_group_ptr> ret;
+        ret.push_back(_single_sg);
+        return ret;
+    }
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const override {
         return get_compaction_group();
     }
@@ -948,6 +953,7 @@ public:
 
     compaction_group& compaction_group_for_token(dht::token token) const override;
     utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const override;
+    utils::chunked_vector<storage_group_ptr> storage_groups_for_token_ranges(noncopyable_function<std::optional<dht::token_range>()> next_token_range) const override;
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const override;
     compaction_group& compaction_group_for_token_range(sstring desc, dht::token first_token, dht::token last_token) const;
     compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const override;
@@ -1429,6 +1435,27 @@ utils::chunked_vector<storage_group_ptr> tablet_storage_group_manager::storage_g
 
 utils::chunked_vector<storage_group_ptr> table::storage_groups_for_token_range(dht::token_range tr) const {
     return _sg_manager->storage_groups_for_token_range(tr);
+}
+
+utils::chunked_vector<storage_group_ptr>
+tablet_storage_group_manager::storage_groups_for_token_ranges(noncopyable_function<std::optional<dht::token_range>()> next_token_range) const {
+    utils::chunked_vector<storage_group_ptr> sgs;
+    const storage_group* last = nullptr;
+    while (auto tr = next_token_range()) {
+        for (auto& sg : storage_groups_for_token_range(*tr)) {
+            if (sg.get() == last) {
+                continue;
+            }
+            last = sg.get();
+            sgs.push_back(sg);
+        }
+    }
+    return sgs;
+}
+
+utils::chunked_vector<storage_group_ptr>
+table::storage_groups_for_token_ranges(noncopyable_function<std::optional<dht::token_range>()> next_token_range) const {
+    return _sg_manager->storage_groups_for_token_ranges(std::move(next_token_range));
 }
 
 compaction_group& tablet_storage_group_manager::compaction_group_for_key(partition_key_view key, const schema_ptr& s) const {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -749,6 +749,11 @@ public:
         ret.push_back(_single_sg);
         return ret;
     }
+    utils::chunked_vector<storage_group_ptr> storage_groups_for_token_ranges(noncopyable_function<std::optional<dht::token_range>()>) const override {
+        utils::chunked_vector<storage_group_ptr> ret;
+        ret.push_back(_single_sg);
+        return ret;
+    }
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const override {
         return get_compaction_group();
     }
@@ -950,6 +955,7 @@ public:
 
     compaction_group& compaction_group_for_token(dht::token token) const override;
     utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const override;
+    utils::chunked_vector<storage_group_ptr> storage_groups_for_token_ranges(noncopyable_function<std::optional<dht::token_range>()> next_token_range) const override;
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const override;
     compaction_group& compaction_group_for_token_range(sstring desc, dht::token first_token, dht::token last_token) const;
     compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const override;
@@ -1481,6 +1487,27 @@ utils::chunked_vector<storage_group_ptr> tablet_storage_group_manager::storage_g
 
 utils::chunked_vector<storage_group_ptr> table::storage_groups_for_token_range(dht::token_range tr) const {
     return _sg_manager->storage_groups_for_token_range(tr);
+}
+
+utils::chunked_vector<storage_group_ptr>
+tablet_storage_group_manager::storage_groups_for_token_ranges(noncopyable_function<std::optional<dht::token_range>()> next_token_range) const {
+    utils::chunked_vector<storage_group_ptr> sgs;
+    const storage_group* last = nullptr;
+    while (auto tr = next_token_range()) {
+        for (auto& sg : storage_groups_for_token_range(*tr)) {
+            if (sg.get() == last) {
+                continue;
+            }
+            last = sg.get();
+            sgs.push_back(sg);
+        }
+    }
+    return sgs;
+}
+
+utils::chunked_vector<storage_group_ptr>
+table::storage_groups_for_token_ranges(noncopyable_function<std::optional<dht::token_range>()> next_token_range) const {
+    return _sg_manager->storage_groups_for_token_ranges(std::move(next_token_range));
 }
 
 compaction_group& tablet_storage_group_manager::compaction_group_for_key(partition_key_view key, const schema_ptr& s) const {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -647,6 +647,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             used_bytes += table_updates_size;
             updates.emplace_back(std::move(table_mutation));
 
+            if (utils::get_local_injector().enter("topology_coordinator/generate_vnodes_to_tablets_replace_updates/one_table_per_command")) {
+                co_return more_tablet_updates::yes;
+            }
+
             co_await coroutine::maybe_yield();
         }
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -442,6 +442,301 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         return service::topology::parse_replaced_node(req_param);
     }
 
+    bool is_migrating_table(table_id table) const {
+        auto t = _db.get_tables_metadata().get_table_if_exists(table);
+        if (!t) {
+            return false;
+        }
+        const auto& ks = _db.find_keyspace(t->schema()->ks_name());
+        return !ks.get_replication_strategy().uses_tablets();
+    }
+
+    bool has_migrating_tablet_replicas_on_replaced_node(locator::host_id host) const {
+        const auto& tmd = get_token_metadata_ptr()->tablets();
+        for (const auto& group : tmd.all_table_groups()) {
+            auto table = group.first;
+            if (!is_migrating_table(table)) {
+                continue;
+            }
+            const auto& tmap = tmd.get_tablet_map(table);
+            for (auto tablet : tmap.tablet_ids()) {
+                const auto& tinfo = tmap.get_tablet_info(tablet);
+                if (std::ranges::any_of(tinfo.replicas, [host] (const locator::tablet_replica& r) { return r.host == host; })) {
+                    return true;
+                }
+                if (const auto* trinfo = tmap.get_tablet_transition_info(tablet)) {
+                    if (std::ranges::any_of(trinfo->next, [host] (const locator::tablet_replica& r) { return r.host == host; })) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    std::optional<locator::tablet_replica_set> maybe_replace_replica_host(
+            const locator::tablet_replica_set& replicas,
+            locator::host_id old_host,
+            locator::host_id new_host) const {
+        locator::tablet_replica_set result;
+        result.reserve(replicas.size());
+        bool replaced = false;
+        for (auto r : replicas) {
+            if (r.host == old_host) {
+                r.host = new_host;
+                replaced = true;
+            }
+            result.push_back(r);
+        }
+        if (!replaced) {
+            return std::nullopt;
+        }
+        return result;
+    }
+
+    enum class replace_tablets_phase {
+        write_both_read_old,
+        write_both_read_new,
+        finalize,
+        rollback,
+    };
+
+    const char* replace_tablets_phase_name(replace_tablets_phase phase) const {
+        switch (phase) {
+        case replace_tablets_phase::write_both_read_old:
+            return "write_both_read_old";
+        case replace_tablets_phase::write_both_read_new:
+            return "write_both_read_new";
+        case replace_tablets_phase::finalize:
+            return "finalize";
+        case replace_tablets_phase::rollback:
+            return "rollback";
+        }
+        on_internal_error(rtlogger, "unexpected replace_tablets_phase in replace_tablets_phase_name");
+    }
+
+    using more_tablet_updates = bool_class<class more_tablet_updates_tag>;
+
+    // Drives the migrating tablet maps through the phases of the vnode replace flow.
+    //
+    // Stages of the tablet state machine (handle_tablet_migration()) not entered here:
+    //  * allow_write_both_read_old: it lets replicas allocate the storage groups
+    //    before request coordinators start routing requests to them. This is
+    //    redundant for replace because the topology coordinator always enforces
+    //    the replacing node to be vnode-based, so there is nothing to prepare.
+    //    The barrier that follows in transition_state::write_both_read_old
+    //    still ensures all coordinators write to both replica sets before streaming
+    //    starts.
+    //  * use_new, cleanup: they fence writes off the leaving replica and clean
+    //    up its data. The replaced node is dead and is being removed,
+    //    so there is nothing to clean up.
+    future<more_tablet_updates> generate_vnodes_to_tablets_replace_updates(utils::chunked_vector<canonical_mutation>& updates,
+            api::timestamp_type ts,
+            locator::host_id replaced_host,
+            locator::host_id replacing_host,
+            replace_tablets_phase phase,
+            size_t available_bytes) const {
+        static constexpr auto transition_kind = locator::tablet_transition_kind::rebuild;
+
+        // Applies an update for a single tablet onto the given mutation builder,
+        // constructing the builder lazily on first use. Tablets already in the
+        // desired state are left untouched (idempotency).
+        auto apply_tablet_update = [&] (std::optional<replica::tablet_mutation_builder>& builder, table_id table, const locator::tablet_map& tmap, auto tablet) -> void {
+            const auto& tinfo = tmap.get_tablet_info(tablet);
+            auto next = maybe_replace_replica_host(tinfo.replicas, replaced_host, replacing_host);
+            if (!next) {
+                return;
+            }
+            const auto* trinfo = tmap.get_tablet_transition_info(tablet);
+            auto last_token = tmap.get_last_token(tablet);
+            auto fail_unexpected_state = [&] {
+                if (!trinfo) {
+                    throw std::runtime_error(fmt::format(
+                            "replace: tablet {} of table {} is not in a transition while applying phase {}",
+                            tablet, table, replace_tablets_phase_name(phase)));
+                }
+                throw std::runtime_error(fmt::format(
+                        "replace: tablet {} of table {} is in unexpected transition state while applying phase {}: transition={}, stage={}, next={}, session={}",
+                        tablet, table, replace_tablets_phase_name(phase), trinfo->transition, trinfo->stage, trinfo->next, trinfo->session_id));
+            };
+            auto b = [&] () -> replica::tablet_mutation_builder& {
+                if (!builder) {
+                    builder.emplace(ts, table);
+                }
+                return *builder;
+            };
+            switch (phase) {
+            case replace_tablets_phase::write_both_read_old: {
+                if (trinfo && trinfo->transition == transition_kind && trinfo->next == *next && trinfo->stage == locator::tablet_transition_stage::write_both_read_old) {
+                    return;
+                }
+                if (trinfo) {
+                    fail_unexpected_state();
+                }
+                // Note: no session is set on this transition. Sessions guard
+                // tablet-track streaming and repair, but the replace flow
+                // never enters the streaming/repair stages; streaming happens
+                // through vnodes, under the topology session.
+                b().set_new_replicas(last_token, std::move(*next))
+                        .set_stage(last_token, locator::tablet_transition_stage::write_both_read_old)
+                        .set_transition(last_token, transition_kind);
+                return;
+            }
+            case replace_tablets_phase::write_both_read_new: {
+                if (trinfo && trinfo->stage == locator::tablet_transition_stage::write_both_read_new) {
+                    return;
+                }
+                if (!trinfo || trinfo->stage != locator::tablet_transition_stage::write_both_read_old) {
+                    fail_unexpected_state();
+                }
+                b().set_stage(last_token, locator::tablet_transition_stage::write_both_read_new);
+                return;
+            }
+            case replace_tablets_phase::finalize: {
+                if (!trinfo || trinfo->stage != locator::tablet_transition_stage::write_both_read_new) {
+                    fail_unexpected_state();
+                }
+                b().set_replicas(last_token, std::move(*next))
+                        .del_transition(last_token);
+                return;
+            }
+            case replace_tablets_phase::rollback: {
+                if (!trinfo || trinfo->transition != transition_kind || trinfo->next != *next) {
+                    return;
+                }
+                b().del_transition(last_token);
+                return;
+            }
+            default:
+                on_internal_error(rtlogger, "unexpected replace_tablets_phase in generate_vnodes_to_tablets_replace_updates");
+            }
+        };
+
+        size_t used_bytes = 0;
+
+        auto tmptr = get_token_metadata_ptr();
+        const auto& tablet_metadata = tmptr->tablets();
+        for (const auto& [table_id, _] : tablet_metadata.all_table_groups()) {
+            if (!is_migrating_table(table_id)) {
+                continue;
+            }
+
+            std::optional<replica::tablet_mutation_builder> builder;
+
+            const auto& tmap = tablet_metadata.get_tablet_map(table_id);
+            for (auto tablet : tmap.tablet_ids()) {
+                apply_tablet_update(builder, table_id, tmap, tablet);
+            }
+
+            if (!builder) {
+                continue;
+            }
+
+            canonical_mutation table_mutation(builder->build());
+            auto table_updates_size = table_mutation.representation().size();
+
+            if (table_updates_size > available_bytes) {
+                throw std::runtime_error(fmt::format(
+                        "replace: tablet map update in phase {} for table {} is too large for one command: {} bytes exceed limit {}",
+                        replace_tablets_phase_name(phase), table_id, table_updates_size, available_bytes));
+            }
+            if (used_bytes + table_updates_size > available_bytes) {
+                co_return more_tablet_updates::yes;
+            }
+
+            used_bytes += table_updates_size;
+            updates.emplace_back(std::move(table_mutation));
+
+            co_await coroutine::maybe_yield();
+        }
+
+        co_return more_tablet_updates::no;
+    }
+
+    using vnode_topology_updates_fn = noncopyable_function<future<>(node_to_work_on&, utils::chunked_vector<canonical_mutation>&)>;
+
+    // Commits the vnode topology updates of a replace transition (produced
+    // by build_vnode_topology_updates), after driving the migrating tablet
+    // maps through the given phase of the vnode replace flow.
+    //
+    // The tablet updates are committed in batches bounded by the group0
+    // command size limit. The last batch (in the common case, the only one)
+    // is committed together with the vnode topology updates in a single
+    // group0 command when they fit. Otherwise, the tablet updates are
+    // committed first -- we must never complete finalization/rollback with
+    // tablets still in transition -- and the vnode topology updates are then
+    // rebuilt with a fresh guard and committed separately.
+    future<> update_topology_state_with_replace_tablet_updates(
+            node_to_work_on node,
+            raft::server_id replaced_node_id,
+            replace_tablets_phase phase,
+            vnode_topology_updates_fn build_vnode_topology_updates,
+            sstring reason) {
+        const size_t max_command_size = _raft.max_command_size();
+        // leave some room for group0 overhead (e.g., 4-byte length prefix
+        // per serialized canonical mutation, other group0_command fields)
+        const size_t mutation_size_threshold = max_command_size * 0.9;
+
+        const auto replaced_host = locator::host_id(replaced_node_id.uuid());
+        const auto replacing_host = locator::host_id(node.id.uuid());
+
+        auto mutations_size = [] (const utils::chunked_vector<canonical_mutation>& muts) {
+            return std::accumulate(muts.begin(), muts.end(), size_t{0},
+                    [] (size_t sum, const canonical_mutation& m) { return sum + m.representation().size(); });
+        };
+
+        while (true) {
+            utils::chunked_vector<canonical_mutation> updates;
+            auto has_more = co_await generate_vnodes_to_tablets_replace_updates(
+                    updates,
+                    node.guard.write_timestamp(),
+                    replaced_host,
+                    replacing_host,
+                    phase,
+                    mutation_size_threshold);
+
+            if (!has_more) {
+                // Last batch (possibly empty). Compute the vnode topology updates
+                // and commit them together with tablet updates if they all fit
+                // in a single command.
+                utils::chunked_vector<canonical_mutation> vnode_updates;
+                co_await build_vnode_topology_updates(node, vnode_updates);
+
+                bool fits_in_one_command = updates.empty() || mutations_size(updates) + mutations_size(vnode_updates) <= mutation_size_threshold;
+                if (fits_in_one_command) {
+                    std::ranges::move(vnode_updates, std::back_inserter(updates));
+                    co_await update_topology_state(take_guard(std::move(node)), std::move(updates), reason);
+                    co_return;
+                }
+                // They don't fit together. Commit them in two phases, first the
+                // tablet updates, then the vnode updates. Tablet updates must
+                // be committed first because finalization/rollback should not
+                // delete the topology transition state with tablets still in
+                // transition.
+            }
+
+            updates.emplace_back(topology_mutation_builder(node.guard.write_timestamp())
+                    .set_version(_topo_sm._topology.version + 1)
+                    .build());
+
+            auto node_id = node.id;
+            co_await update_topology_state(
+                    take_guard(std::move(node)),
+                    std::move(updates),
+                    fmt::format("replace: apply replacement transitions to migrating tablet maps ({})", replace_tablets_phase_name(phase)));
+            node = retake_node(co_await start_operation(), node_id);
+
+            if (!has_more) {
+                // Rebuild the vnode topology updates with the timestamp of the
+                // recreated guard and commit them in a separate command.
+                utils::chunked_vector<canonical_mutation> vnode_updates;
+                co_await build_vnode_topology_updates(node, vnode_updates);
+                co_await update_topology_state(take_guard(std::move(node)), std::move(vnode_updates), reason);
+                co_return;
+            }
+        }
+    }
+
     future<> exec_direct_command_helper(raft::server_id id, uint64_t cmd_index, raft_topology_cmd cmd) {
         rtlogger.debug("send {} command with term {} and index {} to {}",
             cmd.cmd, _term, cmd_index, id);
@@ -3360,11 +3655,22 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                     format("Node {} being replaced by {} is not in normal state", replaced_id, node.id));
                         }
 
-                        topology_mutation_builder builder(node.guard.write_timestamp());
+                        const bool has_migrating_tablet_replicas = has_migrating_tablet_replicas_on_replaced_node(locator::host_id(replaced_id.uuid()));
+                        if (has_migrating_tablet_replicas) {
+                            const auto& replacing = *node.rs;
+                            const auto& replaced = it->second;
+                            if (replacing.shard_count != replaced.shard_count) {
+                                _rollback = fmt::format(
+                                    "Cannot replace node {} with node {} during vnode-to-tablet migration: shard_count mismatch (replacing={}, replaced={})",
+                                    replaced_id, node.id, replacing.shard_count, replaced.shard_count);
+                                break;
+                            }
+                        }
 
                         // If a zero-token node is replacing another zero-token node,
                         // we can instantly move the new node's state to normal.
                         if (it->second.ring->tokens.empty()) {
+                            topology_mutation_builder builder(node.guard.write_timestamp());
                             node = retake_node(co_await remove_from_group0(std::move(node.guard), replaced_id), node.id);
 
                             topology_request_tracking_mutation_builder rtbuilder(node.rs->request_id);
@@ -3387,14 +3693,30 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             break;
                         }
 
-                        guard = take_guard(std::move(node));
-                        builder.set_transition_state(topology::transition_state::write_both_read_old)
-                               .set_version(_topo_sm._topology.version + 1)
-                               .set_session(session_id(guard.new_group0_state_id()))
-                               .with_node(node.id)
-                               .set("tokens", it->second.ring->tokens);
-                        co_await update_topology_state(std::move(guard), {builder.build()},
-                                "replace: transition to write_both_read_old and take ownership of the replaced node's tokens");
+                        // Copy the tokens out of the topology state: the vnode topology
+                        // updates may be rebuilt after intermediate group0 commits,
+                        // which invalidate iterators into the topology state.
+                        const auto replaced_tokens = it->second.ring->tokens;
+                        auto build_transition_muts = [&, this] (node_to_work_on& n, utils::chunked_vector<canonical_mutation>& muts) -> future<> {
+                            topology_mutation_builder builder(n.guard.write_timestamp());
+                            builder.set_transition_state(topology::transition_state::write_both_read_old)
+                                   .set_version(_topo_sm._topology.version + 1)
+                                   .set_session(session_id(n.guard.new_group0_state_id()))
+                                   .with_node(n.id)
+                                   .set("tokens", replaced_tokens)
+                                   .del("intended_storage_mode");
+                            muts.emplace_back(builder.build());
+                            co_return;
+                        };
+                        const sstring reason = "replace: transition to write_both_read_old and take ownership of the replaced node's tokens";
+                        if (has_migrating_tablet_replicas) {
+                            co_await update_topology_state_with_replace_tablet_updates(std::move(node), replaced_id,
+                                    replace_tablets_phase::write_both_read_old, std::move(build_transition_muts), reason);
+                        } else {
+                            utils::chunked_vector<canonical_mutation> muts;
+                            co_await build_transition_muts(node, muts);
+                            co_await update_topology_state(take_guard(std::move(node)), std::move(muts), reason);
+                        }
                     }
                         break;
                     default:
@@ -3621,13 +3943,28 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     utils::wait_for_message(std::chrono::minutes(5)));
 
                 // Streaming completed. We can now move tokens state to topology::transition_state::write_both_read_new
-                topology_mutation_builder builder(node.guard.write_timestamp());
-                builder
-                    .set_transition_state(topology::transition_state::write_both_read_new)
-                    .del_session()
-                    .set_version(_topo_sm._topology.version + 1);
+                auto build_transition_muts = [&, this] (node_to_work_on& n, utils::chunked_vector<canonical_mutation>& muts) -> future<> {
+                    topology_mutation_builder builder(n.guard.write_timestamp());
+                    builder
+                        .set_transition_state(topology::transition_state::write_both_read_new)
+                        .del_session()
+                        .set_version(_topo_sm._topology.version + 1);
+                    muts.emplace_back(builder.build());
+                    co_return;
+                };
                 auto str = ::format("{}: streaming completed for node {}", node.rs->state, node.id);
-                co_await update_topology_state(take_guard(std::move(node)), {builder.build()}, std::move(str));
+                std::optional<raft::server_id> replaced_node_id;
+                if (node.rs->state == node_state::replacing) {
+                    replaced_node_id = parse_replaced_node(node.req_param);
+                }
+                if (replaced_node_id && has_migrating_tablet_replicas_on_replaced_node(locator::host_id(replaced_node_id->uuid()))) {
+                    co_await update_topology_state_with_replace_tablet_updates(std::move(node), *replaced_node_id,
+                            replace_tablets_phase::write_both_read_new, std::move(build_transition_muts), std::move(str));
+                } else {
+                    utils::chunked_vector<canonical_mutation> muts;
+                    co_await build_transition_muts(node, muts);
+                    co_await update_topology_state(take_guard(std::move(node)), std::move(muts), std::move(str));
+                }
             }
                 break;
             case topology::transition_state::write_both_read_new: {
@@ -3731,31 +4068,41 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     auto replaced_node_id = parse_replaced_node(node.req_param);
                     node = retake_node(co_await remove_from_group0(std::move(node.guard), replaced_node_id), node.id);
 
-                    utils::chunked_vector<canonical_mutation> muts;
-
-                    topology_mutation_builder builder1(node.guard.write_timestamp());
-                    // Move new node to 'normal'
-                    builder1.del_transition_state()
-                            .set_version(_topo_sm._topology.version + 1)
-                            .with_node(node.id)
-                            .set("node_state", node_state::normal);
-                    muts.push_back(builder1.build());
-
-                    // Move old node to 'left'
-                    topology_mutation_builder builder2(node.guard.write_timestamp());
-                    cleanup_ignored_nodes_on_left(builder2, replaced_node_id);
-                    builder2.with_node(replaced_node_id)
-                            .del("tokens")
-                            .set("node_state", node_state::left);
-                    muts.push_back(builder2.build());
-
-                    muts.push_back(rtbuilder.build());
-                    co_await mark_view_build_statuses_on_node_join(muts, node.guard, node.id);
-                    co_await remove_view_build_statuses_on_left_node(muts, node.guard, replaced_node_id);
-                    co_await db::view::view_builder::generate_mutations_on_node_left(_db, _sys_ks, node.guard.write_timestamp(), locator::host_id(replaced_node_id.uuid()), muts);
                     co_await _voter_handler.on_node_added(node.id, _as);
-                    co_await update_topology_state(take_guard(std::move(node)), std::move(muts),
-                                                  "replace: read fence completed");
+
+                    auto build_transition_muts = [&, this] (node_to_work_on& n, utils::chunked_vector<canonical_mutation>& muts) -> future<> {
+                        // Move new node to 'normal'
+                        topology_mutation_builder builder1(n.guard.write_timestamp());
+                        builder1.del_transition_state()
+                                .set_version(_topo_sm._topology.version + 1)
+                                .with_node(n.id)
+                                .set("node_state", node_state::normal);
+                        muts.push_back(builder1.build());
+
+                        // Move old node to 'left'
+                        topology_mutation_builder builder2(n.guard.write_timestamp());
+                        cleanup_ignored_nodes_on_left(builder2, replaced_node_id);
+                        builder2.with_node(replaced_node_id)
+                                .del("tokens")
+                                .set("node_state", node_state::left);
+                        muts.push_back(builder2.build());
+
+                        topology_request_tracking_mutation_builder rtbuilder(n.rs->request_id);
+                        rtbuilder.done();
+                        muts.push_back(rtbuilder.build());
+                        co_await mark_view_build_statuses_on_node_join(muts, n.guard, n.id);
+                        co_await remove_view_build_statuses_on_left_node(muts, n.guard, replaced_node_id);
+                        co_await db::view::view_builder::generate_mutations_on_node_left(_db, _sys_ks, n.guard.write_timestamp(), locator::host_id(replaced_node_id.uuid()), muts);
+                    };
+                    if (has_migrating_tablet_replicas_on_replaced_node(locator::host_id(replaced_node_id.uuid()))) {
+                        co_await update_topology_state_with_replace_tablet_updates(std::move(node), replaced_node_id,
+                                replace_tablets_phase::finalize, std::move(build_transition_muts), "replace: read fence completed");
+                    } else {
+                        utils::chunked_vector<canonical_mutation> muts;
+                        co_await build_transition_muts(node, muts);
+                        co_await update_topology_state(take_guard(std::move(node)), std::move(muts),
+                                                      "replace: read fence completed");
+                    }
                     trigger_load_stats_refresh();
                     }
                     break;
@@ -4964,23 +5311,39 @@ future<> topology_coordinator::rollback_current_topology_op(group0_guard&& guard
             on_internal_error(rtlogger, fmt::format("tried to rollback in unsupported state {}", node.rs->state));
     }
 
-    topology_mutation_builder builder(node.guard.write_timestamp());
-    topology_request_tracking_mutation_builder rtbuilder(node.rs->request_id);
-    builder.set_transition_state(transition_state)
-           .set_version(_topo_sm._topology.version + 1);
-    rtbuilder.set("error", fmt::format("Rolled back: {}", *_rollback));
+    auto build_rollback_muts = [&, this] (node_to_work_on& n, utils::chunked_vector<canonical_mutation>& muts) -> future<> {
+        topology_mutation_builder builder(n.guard.write_timestamp());
+        topology_request_tracking_mutation_builder rtbuilder(n.rs->request_id);
+        builder.set_transition_state(transition_state)
+               .set_version(_topo_sm._topology.version + 1);
+        rtbuilder.set("error", fmt::format("Rolled back: {}", *_rollback));
 
-    utils::chunked_vector<canonical_mutation> muts;
-    // We are in the process of aborting remove or decommission which may have streamed some
-    // ranges to other nodes. Cleanup is needed.
-    muts = mark_nodes_as_cleanup_needed(node, true);
-    muts.emplace_back(builder.build());
-    muts.emplace_back(rtbuilder.build());
+        // We are in the process of aborting remove or decommission which may have streamed some
+        // ranges to other nodes. Cleanup is needed.
+        for (auto&& m : mark_nodes_as_cleanup_needed(n, true)) {
+            muts.emplace_back(std::move(m));
+        }
+        muts.emplace_back(builder.build());
+        muts.emplace_back(rtbuilder.build());
+        co_return;
+    };
 
     std::string str = fmt::format("rollback {} after {} failure, moving transition state to {} and setting cleanup flag",
             node.id, node.rs->state, transition_state);
     rtlogger.info("{}", str);
-    co_await update_topology_state(std::move(node.guard), std::move(muts), str);
+
+    std::optional<raft::server_id> replaced_node_id;
+    if (node.rs->state == node_state::replacing) {
+        replaced_node_id = parse_replaced_node(node.req_param);
+    }
+    if (replaced_node_id && has_migrating_tablet_replicas_on_replaced_node(locator::host_id(replaced_node_id->uuid()))) {
+        co_await update_topology_state_with_replace_tablet_updates(std::move(node), *replaced_node_id,
+                replace_tablets_phase::rollback, std::move(build_rollback_muts), sstring(str));
+    } else {
+        utils::chunked_vector<canonical_mutation> muts;
+        co_await build_rollback_muts(node, muts);
+        co_await update_topology_state(std::move(node.guard), std::move(muts), str);
+    }
 }
 
 bool topology_coordinator::handle_topology_coordinator_error(std::exception_ptr eptr) noexcept {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -442,6 +442,301 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         return service::topology::parse_replaced_node(req_param);
     }
 
+    bool is_migrating_table(table_id table) const {
+        auto t = _db.get_tables_metadata().get_table_if_exists(table);
+        if (!t) {
+            return false;
+        }
+        const auto& ks = _db.find_keyspace(t->schema()->ks_name());
+        return !ks.get_replication_strategy().uses_tablets();
+    }
+
+    bool has_migrating_tablet_replicas_on_replaced_node(locator::host_id host) const {
+        const auto& tmd = get_token_metadata_ptr()->tablets();
+        for (const auto& group : tmd.all_table_groups()) {
+            auto table = group.first;
+            if (!is_migrating_table(table)) {
+                continue;
+            }
+            const auto& tmap = tmd.get_tablet_map(table);
+            for (auto tablet : tmap.tablet_ids()) {
+                const auto& tinfo = tmap.get_tablet_info(tablet);
+                if (std::ranges::any_of(tinfo.replicas, [host] (const locator::tablet_replica& r) { return r.host == host; })) {
+                    return true;
+                }
+                if (const auto* trinfo = tmap.get_tablet_transition_info(tablet)) {
+                    if (std::ranges::any_of(trinfo->next, [host] (const locator::tablet_replica& r) { return r.host == host; })) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    std::optional<locator::tablet_replica_set> maybe_replace_replica_host(
+            const locator::tablet_replica_set& replicas,
+            locator::host_id old_host,
+            locator::host_id new_host) const {
+        locator::tablet_replica_set result;
+        result.reserve(replicas.size());
+        bool replaced = false;
+        for (auto r : replicas) {
+            if (r.host == old_host) {
+                r.host = new_host;
+                replaced = true;
+            }
+            result.push_back(r);
+        }
+        if (!replaced) {
+            return std::nullopt;
+        }
+        return result;
+    }
+
+    enum class replace_tablets_phase {
+        write_both_read_old,
+        write_both_read_new,
+        finalize,
+        rollback,
+    };
+
+    const char* replace_tablets_phase_name(replace_tablets_phase phase) const {
+        switch (phase) {
+        case replace_tablets_phase::write_both_read_old:
+            return "write_both_read_old";
+        case replace_tablets_phase::write_both_read_new:
+            return "write_both_read_new";
+        case replace_tablets_phase::finalize:
+            return "finalize";
+        case replace_tablets_phase::rollback:
+            return "rollback";
+        }
+        on_internal_error(rtlogger, "unexpected replace_tablets_phase in replace_tablets_phase_name");
+    }
+
+    using more_tablet_updates = bool_class<class more_tablet_updates_tag>;
+
+    // Drives the migrating tablet maps through the phases of the vnode replace flow.
+    //
+    // Stages of the tablet state machine (handle_tablet_migration()) not entered here:
+    //  * allow_write_both_read_old: it lets replicas allocate the storage groups
+    //    before request coordinators start routing requests to them. This is
+    //    redundant for replace because the topology coordinator always enforces
+    //    the replacing node to be vnode-based, so there is nothing to prepare.
+    //    The barrier that follows in transition_state::write_both_read_old
+    //    still ensures all coordinators write to both replica sets before streaming
+    //    starts.
+    //  * use_new, cleanup: they fence writes off the leaving replica and clean
+    //    up its data. The replaced node is dead and is being removed,
+    //    so there is nothing to clean up.
+    future<more_tablet_updates> generate_vnodes_to_tablets_replace_updates(utils::chunked_vector<canonical_mutation>& updates,
+            api::timestamp_type ts,
+            locator::host_id replaced_host,
+            locator::host_id replacing_host,
+            replace_tablets_phase phase,
+            size_t available_bytes) const {
+        static constexpr auto transition_kind = locator::tablet_transition_kind::rebuild;
+
+        // Applies an update for a single tablet onto the given mutation builder,
+        // constructing the builder lazily on first use. Tablets already in the
+        // desired state are left untouched (idempotency).
+        auto apply_tablet_update = [&] (std::optional<replica::tablet_mutation_builder>& builder, table_id table, const locator::tablet_map& tmap, auto tablet) -> void {
+            const auto& tinfo = tmap.get_tablet_info(tablet);
+            auto next = maybe_replace_replica_host(tinfo.replicas, replaced_host, replacing_host);
+            if (!next) {
+                return;
+            }
+            const auto* trinfo = tmap.get_tablet_transition_info(tablet);
+            auto last_token = tmap.get_last_token(tablet);
+            auto fail_unexpected_state = [&] {
+                if (!trinfo) {
+                    throw std::runtime_error(fmt::format(
+                            "replace: tablet {} of table {} is not in a transition while applying phase {}",
+                            tablet, table, replace_tablets_phase_name(phase)));
+                }
+                throw std::runtime_error(fmt::format(
+                        "replace: tablet {} of table {} is in unexpected transition state while applying phase {}: transition={}, stage={}, next={}, session={}",
+                        tablet, table, replace_tablets_phase_name(phase), trinfo->transition, trinfo->stage, trinfo->next, trinfo->session_id));
+            };
+            auto b = [&] () -> replica::tablet_mutation_builder& {
+                if (!builder) {
+                    builder.emplace(ts, table);
+                }
+                return *builder;
+            };
+            switch (phase) {
+            case replace_tablets_phase::write_both_read_old: {
+                if (trinfo && trinfo->transition == transition_kind && trinfo->next == *next && trinfo->stage == locator::tablet_transition_stage::write_both_read_old) {
+                    return;
+                }
+                if (trinfo) {
+                    fail_unexpected_state();
+                }
+                // Note: no session is set on this transition. Sessions guard
+                // tablet-track streaming and repair, but the replace flow
+                // never enters the streaming/repair stages; streaming happens
+                // through vnodes, under the topology session.
+                b().set_new_replicas(last_token, std::move(*next))
+                        .set_stage(last_token, locator::tablet_transition_stage::write_both_read_old)
+                        .set_transition(last_token, transition_kind);
+                return;
+            }
+            case replace_tablets_phase::write_both_read_new: {
+                if (trinfo && trinfo->stage == locator::tablet_transition_stage::write_both_read_new) {
+                    return;
+                }
+                if (!trinfo || trinfo->stage != locator::tablet_transition_stage::write_both_read_old) {
+                    fail_unexpected_state();
+                }
+                b().set_stage(last_token, locator::tablet_transition_stage::write_both_read_new);
+                return;
+            }
+            case replace_tablets_phase::finalize: {
+                if (!trinfo || trinfo->stage != locator::tablet_transition_stage::write_both_read_new) {
+                    fail_unexpected_state();
+                }
+                b().set_replicas(last_token, std::move(*next))
+                        .del_transition(last_token);
+                return;
+            }
+            case replace_tablets_phase::rollback: {
+                if (!trinfo || trinfo->transition != transition_kind || trinfo->next != *next) {
+                    return;
+                }
+                b().del_transition(last_token);
+                return;
+            }
+            default:
+                on_internal_error(rtlogger, "unexpected replace_tablets_phase in generate_vnodes_to_tablets_replace_updates");
+            }
+        };
+
+        size_t used_bytes = 0;
+
+        auto tmptr = get_token_metadata_ptr();
+        const auto& tablet_metadata = tmptr->tablets();
+        for (const auto& [table_id, _] : tablet_metadata.all_table_groups()) {
+            if (!is_migrating_table(table_id)) {
+                continue;
+            }
+
+            std::optional<replica::tablet_mutation_builder> builder;
+
+            const auto& tmap = tablet_metadata.get_tablet_map(table_id);
+            for (auto tablet : tmap.tablet_ids()) {
+                apply_tablet_update(builder, table_id, tmap, tablet);
+            }
+
+            if (!builder) {
+                continue;
+            }
+
+            canonical_mutation table_mutation(builder->build());
+            auto table_updates_size = table_mutation.representation().size();
+
+            if (table_updates_size > available_bytes) {
+                throw std::runtime_error(fmt::format(
+                        "replace: tablet map update in phase {} for table {} is too large for one command: {} bytes exceed limit {}",
+                        replace_tablets_phase_name(phase), table_id, table_updates_size, available_bytes));
+            }
+            if (used_bytes + table_updates_size > available_bytes) {
+                co_return more_tablet_updates::yes;
+            }
+
+            used_bytes += table_updates_size;
+            updates.emplace_back(std::move(table_mutation));
+
+            co_await coroutine::maybe_yield();
+        }
+
+        co_return more_tablet_updates::no;
+    }
+
+    using vnode_topology_updates_fn = noncopyable_function<future<>(node_to_work_on&, utils::chunked_vector<canonical_mutation>&)>;
+
+    // Commits the vnode topology updates of a replace transition (produced
+    // by build_vnode_topology_updates), after driving the migrating tablet
+    // maps through the given phase of the vnode replace flow.
+    //
+    // The tablet updates are committed in batches bounded by the group0
+    // command size limit. The last batch (in the common case, the only one)
+    // is committed together with the vnode topology updates in a single
+    // group0 command when they fit. Otherwise, the tablet updates are
+    // committed first -- we must never complete finalization/rollback with
+    // tablets still in transition -- and the vnode topology updates are then
+    // rebuilt with a fresh guard and committed separately.
+    future<> update_topology_state_with_replace_tablet_updates(
+            node_to_work_on node,
+            raft::server_id replaced_node_id,
+            replace_tablets_phase phase,
+            vnode_topology_updates_fn build_vnode_topology_updates,
+            sstring reason) {
+        const size_t max_command_size = _raft.max_command_size();
+        // leave some room for group0 overhead (e.g., 4-byte length prefix
+        // per serialized canonical mutation, other group0_command fields)
+        const size_t mutation_size_threshold = max_command_size * 0.9;
+
+        const auto replaced_host = locator::host_id(replaced_node_id.uuid());
+        const auto replacing_host = locator::host_id(node.id.uuid());
+
+        auto mutations_size = [] (const utils::chunked_vector<canonical_mutation>& muts) {
+            return std::accumulate(muts.begin(), muts.end(), size_t{0},
+                    [] (size_t sum, const canonical_mutation& m) { return sum + m.representation().size(); });
+        };
+
+        while (true) {
+            utils::chunked_vector<canonical_mutation> updates;
+            auto has_more = co_await generate_vnodes_to_tablets_replace_updates(
+                    updates,
+                    node.guard.write_timestamp(),
+                    replaced_host,
+                    replacing_host,
+                    phase,
+                    mutation_size_threshold);
+
+            if (!has_more) {
+                // Last batch (possibly empty). Compute the vnode topology updates
+                // and commit them together with tablet updates if they all fit
+                // in a single command.
+                utils::chunked_vector<canonical_mutation> vnode_updates;
+                co_await build_vnode_topology_updates(node, vnode_updates);
+
+                bool fits_in_one_command = updates.empty() || mutations_size(updates) + mutations_size(vnode_updates) <= mutation_size_threshold;
+                if (fits_in_one_command) {
+                    std::ranges::move(vnode_updates, std::back_inserter(updates));
+                    co_await update_topology_state(take_guard(std::move(node)), std::move(updates), reason);
+                    co_return;
+                }
+                // They don't fit together. Commit them in two phases, first the
+                // tablet updates, then the vnode updates. Tablet updates must
+                // be committed first because finalization/rollback should not
+                // delete the topology transition state with tablets still in
+                // transition.
+            }
+
+            updates.emplace_back(topology_mutation_builder(node.guard.write_timestamp())
+                    .set_version(_topo_sm._topology.version + 1)
+                    .build());
+
+            auto node_id = node.id;
+            co_await update_topology_state(
+                    take_guard(std::move(node)),
+                    std::move(updates),
+                    fmt::format("replace: apply replacement transitions to migrating tablet maps ({})", replace_tablets_phase_name(phase)));
+            node = retake_node(co_await start_operation(), node_id);
+
+            if (!has_more) {
+                // Rebuild the vnode topology updates with the timestamp of the
+                // recreated guard and commit them in a separate command.
+                utils::chunked_vector<canonical_mutation> vnode_updates;
+                co_await build_vnode_topology_updates(node, vnode_updates);
+                co_await update_topology_state(take_guard(std::move(node)), std::move(vnode_updates), reason);
+                co_return;
+            }
+        }
+    }
+
     future<> exec_direct_command_helper(raft::server_id id, uint64_t cmd_index, raft_topology_cmd cmd) {
         rtlogger.debug("send {} command with term {} and index {} to {}",
             cmd.cmd, _term, cmd_index, id);
@@ -3332,11 +3627,22 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                                     format("Node {} being replaced by {} is not in normal state", replaced_id, node.id));
                         }
 
-                        topology_mutation_builder builder(node.guard.write_timestamp());
+                        const bool has_migrating_tablet_replicas = has_migrating_tablet_replicas_on_replaced_node(locator::host_id(replaced_id.uuid()));
+                        if (has_migrating_tablet_replicas) {
+                            const auto& replacing = *node.rs;
+                            const auto& replaced = it->second;
+                            if (replacing.shard_count != replaced.shard_count) {
+                                _rollback = fmt::format(
+                                    "Cannot replace node {} with node {} during vnode-to-tablet migration: shard_count mismatch (replacing={}, replaced={})",
+                                    replaced_id, node.id, replacing.shard_count, replaced.shard_count);
+                                break;
+                            }
+                        }
 
                         // If a zero-token node is replacing another zero-token node,
                         // we can instantly move the new node's state to normal.
                         if (it->second.ring->tokens.empty()) {
+                            topology_mutation_builder builder(node.guard.write_timestamp());
                             node = retake_node(co_await remove_from_group0(std::move(node.guard), replaced_id), node.id);
 
                             topology_request_tracking_mutation_builder rtbuilder(node.rs->request_id);
@@ -3359,14 +3665,30 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                             break;
                         }
 
-                        guard = take_guard(std::move(node));
-                        builder.set_transition_state(topology::transition_state::write_both_read_old)
-                               .set_version(_topo_sm._topology.version + 1)
-                               .set_session(session_id(guard.new_group0_state_id()))
-                               .with_node(node.id)
-                               .set("tokens", it->second.ring->tokens);
-                        co_await update_topology_state(std::move(guard), {builder.build()},
-                                "replace: transition to write_both_read_old and take ownership of the replaced node's tokens");
+                        // Copy the tokens out of the topology state: the vnode topology
+                        // updates may be rebuilt after intermediate group0 commits,
+                        // which invalidate iterators into the topology state.
+                        const auto replaced_tokens = it->second.ring->tokens;
+                        auto build_transition_muts = [&, this] (node_to_work_on& n, utils::chunked_vector<canonical_mutation>& muts) -> future<> {
+                            topology_mutation_builder builder(n.guard.write_timestamp());
+                            builder.set_transition_state(topology::transition_state::write_both_read_old)
+                                   .set_version(_topo_sm._topology.version + 1)
+                                   .set_session(session_id(n.guard.new_group0_state_id()))
+                                   .with_node(n.id)
+                                   .set("tokens", replaced_tokens)
+                                   .del("intended_storage_mode");
+                            muts.emplace_back(builder.build());
+                            co_return;
+                        };
+                        const sstring reason = "replace: transition to write_both_read_old and take ownership of the replaced node's tokens";
+                        if (has_migrating_tablet_replicas) {
+                            co_await update_topology_state_with_replace_tablet_updates(std::move(node), replaced_id,
+                                    replace_tablets_phase::write_both_read_old, std::move(build_transition_muts), reason);
+                        } else {
+                            utils::chunked_vector<canonical_mutation> muts;
+                            co_await build_transition_muts(node, muts);
+                            co_await update_topology_state(take_guard(std::move(node)), std::move(muts), reason);
+                        }
                     }
                         break;
                     default:
@@ -3593,13 +3915,28 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     utils::wait_for_message(std::chrono::minutes(5)));
 
                 // Streaming completed. We can now move tokens state to topology::transition_state::write_both_read_new
-                topology_mutation_builder builder(node.guard.write_timestamp());
-                builder
-                    .set_transition_state(topology::transition_state::write_both_read_new)
-                    .del_session()
-                    .set_version(_topo_sm._topology.version + 1);
+                auto build_transition_muts = [&, this] (node_to_work_on& n, utils::chunked_vector<canonical_mutation>& muts) -> future<> {
+                    topology_mutation_builder builder(n.guard.write_timestamp());
+                    builder
+                        .set_transition_state(topology::transition_state::write_both_read_new)
+                        .del_session()
+                        .set_version(_topo_sm._topology.version + 1);
+                    muts.emplace_back(builder.build());
+                    co_return;
+                };
                 auto str = ::format("{}: streaming completed for node {}", node.rs->state, node.id);
-                co_await update_topology_state(take_guard(std::move(node)), {builder.build()}, std::move(str));
+                std::optional<raft::server_id> replaced_node_id;
+                if (node.rs->state == node_state::replacing) {
+                    replaced_node_id = parse_replaced_node(node.req_param);
+                }
+                if (replaced_node_id && has_migrating_tablet_replicas_on_replaced_node(locator::host_id(replaced_node_id->uuid()))) {
+                    co_await update_topology_state_with_replace_tablet_updates(std::move(node), *replaced_node_id,
+                            replace_tablets_phase::write_both_read_new, std::move(build_transition_muts), std::move(str));
+                } else {
+                    utils::chunked_vector<canonical_mutation> muts;
+                    co_await build_transition_muts(node, muts);
+                    co_await update_topology_state(take_guard(std::move(node)), std::move(muts), std::move(str));
+                }
             }
                 break;
             case topology::transition_state::write_both_read_new: {
@@ -3703,31 +4040,41 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     auto replaced_node_id = parse_replaced_node(node.req_param);
                     node = retake_node(co_await remove_from_group0(std::move(node.guard), replaced_node_id), node.id);
 
-                    utils::chunked_vector<canonical_mutation> muts;
-
-                    topology_mutation_builder builder1(node.guard.write_timestamp());
-                    // Move new node to 'normal'
-                    builder1.del_transition_state()
-                            .set_version(_topo_sm._topology.version + 1)
-                            .with_node(node.id)
-                            .set("node_state", node_state::normal);
-                    muts.push_back(builder1.build());
-
-                    // Move old node to 'left'
-                    topology_mutation_builder builder2(node.guard.write_timestamp());
-                    cleanup_ignored_nodes_on_left(builder2, replaced_node_id);
-                    builder2.with_node(replaced_node_id)
-                            .del("tokens")
-                            .set("node_state", node_state::left);
-                    muts.push_back(builder2.build());
-
-                    muts.push_back(rtbuilder.build());
-                    co_await mark_view_build_statuses_on_node_join(muts, node.guard, node.id);
-                    co_await remove_view_build_statuses_on_left_node(muts, node.guard, replaced_node_id);
-                    co_await db::view::view_builder::generate_mutations_on_node_left(_db, _sys_ks, node.guard.write_timestamp(), locator::host_id(replaced_node_id.uuid()), muts);
                     co_await _voter_handler.on_node_added(node.id, _as);
-                    co_await update_topology_state(take_guard(std::move(node)), std::move(muts),
-                                                  "replace: read fence completed");
+
+                    auto build_transition_muts = [&, this] (node_to_work_on& n, utils::chunked_vector<canonical_mutation>& muts) -> future<> {
+                        // Move new node to 'normal'
+                        topology_mutation_builder builder1(n.guard.write_timestamp());
+                        builder1.del_transition_state()
+                                .set_version(_topo_sm._topology.version + 1)
+                                .with_node(n.id)
+                                .set("node_state", node_state::normal);
+                        muts.push_back(builder1.build());
+
+                        // Move old node to 'left'
+                        topology_mutation_builder builder2(n.guard.write_timestamp());
+                        cleanup_ignored_nodes_on_left(builder2, replaced_node_id);
+                        builder2.with_node(replaced_node_id)
+                                .del("tokens")
+                                .set("node_state", node_state::left);
+                        muts.push_back(builder2.build());
+
+                        topology_request_tracking_mutation_builder rtbuilder(n.rs->request_id);
+                        rtbuilder.done();
+                        muts.push_back(rtbuilder.build());
+                        co_await mark_view_build_statuses_on_node_join(muts, n.guard, n.id);
+                        co_await remove_view_build_statuses_on_left_node(muts, n.guard, replaced_node_id);
+                        co_await db::view::view_builder::generate_mutations_on_node_left(_db, _sys_ks, n.guard.write_timestamp(), locator::host_id(replaced_node_id.uuid()), muts);
+                    };
+                    if (has_migrating_tablet_replicas_on_replaced_node(locator::host_id(replaced_node_id.uuid()))) {
+                        co_await update_topology_state_with_replace_tablet_updates(std::move(node), replaced_node_id,
+                                replace_tablets_phase::finalize, std::move(build_transition_muts), "replace: read fence completed");
+                    } else {
+                        utils::chunked_vector<canonical_mutation> muts;
+                        co_await build_transition_muts(node, muts);
+                        co_await update_topology_state(take_guard(std::move(node)), std::move(muts),
+                                                      "replace: read fence completed");
+                    }
                     trigger_load_stats_refresh();
                     }
                     break;
@@ -4936,23 +5283,39 @@ future<> topology_coordinator::rollback_current_topology_op(group0_guard&& guard
             on_internal_error(rtlogger, fmt::format("tried to rollback in unsupported state {}", node.rs->state));
     }
 
-    topology_mutation_builder builder(node.guard.write_timestamp());
-    topology_request_tracking_mutation_builder rtbuilder(node.rs->request_id);
-    builder.set_transition_state(transition_state)
-           .set_version(_topo_sm._topology.version + 1);
-    rtbuilder.set("error", fmt::format("Rolled back: {}", *_rollback));
+    auto build_rollback_muts = [&, this] (node_to_work_on& n, utils::chunked_vector<canonical_mutation>& muts) -> future<> {
+        topology_mutation_builder builder(n.guard.write_timestamp());
+        topology_request_tracking_mutation_builder rtbuilder(n.rs->request_id);
+        builder.set_transition_state(transition_state)
+               .set_version(_topo_sm._topology.version + 1);
+        rtbuilder.set("error", fmt::format("Rolled back: {}", *_rollback));
 
-    utils::chunked_vector<canonical_mutation> muts;
-    // We are in the process of aborting remove or decommission which may have streamed some
-    // ranges to other nodes. Cleanup is needed.
-    muts = mark_nodes_as_cleanup_needed(node, true);
-    muts.emplace_back(builder.build());
-    muts.emplace_back(rtbuilder.build());
+        // We are in the process of aborting remove or decommission which may have streamed some
+        // ranges to other nodes. Cleanup is needed.
+        for (auto&& m : mark_nodes_as_cleanup_needed(n, true)) {
+            muts.emplace_back(std::move(m));
+        }
+        muts.emplace_back(builder.build());
+        muts.emplace_back(rtbuilder.build());
+        co_return;
+    };
 
     std::string str = fmt::format("rollback {} after {} failure, moving transition state to {} and setting cleanup flag",
             node.id, node.rs->state, transition_state);
     rtlogger.info("{}", str);
-    co_await update_topology_state(std::move(node.guard), std::move(muts), str);
+
+    std::optional<raft::server_id> replaced_node_id;
+    if (node.rs->state == node_state::replacing) {
+        replaced_node_id = parse_replaced_node(node.req_param);
+    }
+    if (replaced_node_id && has_migrating_tablet_replicas_on_replaced_node(locator::host_id(replaced_node_id->uuid()))) {
+        co_await update_topology_state_with_replace_tablet_updates(std::move(node), *replaced_node_id,
+                replace_tablets_phase::rollback, std::move(build_rollback_muts), sstring(str));
+    } else {
+        utils::chunked_vector<canonical_mutation> muts;
+        co_await build_rollback_muts(node, muts);
+        co_await update_topology_state(std::move(node.guard), std::move(muts), str);
+    }
 }
 
 bool topology_coordinator::handle_topology_coordinator_error(std::exception_ptr eptr) noexcept {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -707,6 +707,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 co_await build_vnode_topology_updates(node, vnode_updates);
 
                 bool fits_in_one_command = updates.empty() || mutations_size(updates) + mutations_size(vnode_updates) <= mutation_size_threshold;
+                if (fits_in_one_command && !updates.empty() &&
+                        utils::get_local_injector().enter("topology_coordinator/update_topology_state_with_replace_tablet_updates/force_split")) {
+                    fits_in_one_command = false;
+                }
                 if (fits_in_one_command) {
                     std::ranges::move(vnode_updates, std::back_inserter(updates));
                     co_await update_topology_state(take_guard(std::move(node)), std::move(updates), reason);

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -856,14 +856,14 @@ public:
     virtual std::vector<mutation_reader> fast_forward_to(const dht::partition_range& pr) override {
         _pr = &pr;
 
-        auto pos = dht::ring_position_view::for_range_start(*_pr);
-
-        if (dht::ring_position_tri_compare(*_s, pos, _selector_position) >= 0) {
-            return create_new_readers(pos);
-        }
-        // If selector position Y is contained in new range [X, Z], then we should try selecting new
-        // sstables since it might have sstables that overlap with that range.
-        if (!_selector_position.is_max() && dht::ring_position_tri_compare(*_s, _selector_position, pr_end()) <= 0) {
+        // Select new sstables as long as the selector position Y hasn't
+        // advanced past the new range [X, Z], i.e. Y is either before the new
+        // range or contained in it.
+        //
+        // Select with no position restriction, since the next sstables may
+        // start anywhere within the range, and we must return at least one
+        // reader to the caller if any are available within the range.
+        if (!end_of_stream()) {
             return create_new_readers(std::nullopt);
         }
 

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -863,14 +863,14 @@ public:
     virtual std::vector<mutation_reader> fast_forward_to(const dht::partition_range& pr) override {
         _pr = &pr;
 
-        auto pos = dht::ring_position_view::for_range_start(*_pr);
-
-        if (dht::ring_position_tri_compare(*_s, pos, _selector_position) >= 0) {
-            return create_new_readers(pos);
-        }
-        // If selector position Y is contained in new range [X, Z], then we should try selecting new
-        // sstables since it might have sstables that overlap with that range.
-        if (!_selector_position.is_max() && dht::ring_position_tri_compare(*_s, _selector_position, pr_end()) <= 0) {
+        // Select new sstables as long as the selector position Y hasn't
+        // advanced past the new range [X, Z], i.e. Y is either before the new
+        // range or contained in it.
+        //
+        // Select with no position restriction, since the next sstables may
+        // start anywhere within the range, and we must return at least one
+        // reader to the caller if any are available within the range.
+        if (!end_of_stream()) {
             return create_new_readers(std::nullopt);
         }
 

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -343,6 +343,7 @@ add_scylla_test(combined_tests
     auth_test.cc
     batchlog_manager_test.cc
     table_helper_test.cc
+    table_streaming_reader_test.cc
     cache_algorithm_test.cc
     castas_fcts_test.cc
     cdc_test.cc

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -350,6 +350,7 @@ add_scylla_test(combined_tests
     client_state_test.cc
     batchlog_manager_test.cc
     table_helper_test.cc
+    table_streaming_reader_test.cc
     cache_algorithm_test.cc
     castas_fcts_test.cc
     cdc_test.cc

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -485,6 +485,82 @@ SEASTAR_TEST_CASE(test_tablet_sstable_set_fast_forward_across_tablet_ranges) {
     }, std::move(cfg));
 }
 
+// Reproduces a bug where fast forward returns no sstable readers although the
+// new range has sstables:
+// 1) the test creates a reader on the range of the 1st tablet, which is empty,
+//    so the reader selector returns no sstable readers to the merging reader
+//    and advances the selector position (`incremental_reader_selector::_selector_position`)
+//    to the 1st token of the 2nd tablet (see `tablet_incremental_selector::find_lowest_next_token`),
+//    which is empty too
+// 2) the test then fast forwards the reader to the range of the 3rd tablet,
+//    which has sstables
+// 3) as part of the fast-forward call, the reader selector scans for sstables
+//    from the current selector position, finds none in the 2nd tablet and
+//    advances the selector position to the 1st token of the 3rd tablet
+// `incremental_reader_selector::fast_forward_to` used to restrict `create_new_readers`
+// by the new range's start position. The scan stopped as soon as the selector
+// position moved past it and returned no readers to the merging reader (`mutation_reader_merger`).
+// The merging reader cannot recover from that, as it never creates new readers
+// if it has none in its cache, so it reported end of stream and missed the 3rd
+// tablet's data.
+SEASTAR_TEST_CASE(test_tablet_sstable_set_fast_forward_across_empty_tablet) {
+    // enable tablets, to get access to tablet_storage_group_manager
+    cql_test_config cfg;
+    cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+
+    return do_with_cql_env_thread([&](cql_test_env& env) {
+        guarantee_all_tablet_replicas_on_shard0(env).get();
+
+        env.execute_cql("CREATE KEYSPACE test_tablet_sstable_set_empty_tablet"
+                        " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1} AND TABLETS = {'enabled': true, 'initial': 4};").get();
+        env.execute_cql("CREATE TABLE test_tablet_sstable_set_empty_tablet.test (pk int PRIMARY KEY)").get();
+
+        auto& table = env.local_db().find_column_family("test_tablet_sstable_set_empty_tablet", "test");
+        auto s = table.schema();
+        auto& sgm = column_family_test::get_storage_group_manager(table);
+        auto erm = table.get_effective_replication_map();
+        auto& tmap = erm->get_token_metadata().tablets().get_tablet_map(s->id());
+
+        // Populate the third tablet only, leaving the first two empty.
+        const auto populated_tablet = locator::tablet_id(2);
+        std::optional<dht::decorated_key> key;
+        for (int val = 0; !key; val++) {
+            auto dk = dht::decorate_key(*s, partition_key::from_singular(*s, val));
+            if (tmap.get_tablet_id(dk.token()) != populated_tablet) {
+                continue;
+            }
+            env.execute_cql(fmt::format("INSERT INTO test_tablet_sstable_set_empty_tablet.test (pk) VALUES ({})", val)).get();
+            table.flush().get();
+            key = std::move(dk);
+        }
+
+        auto set = replica::make_tablet_sstable_set(s, *sgm.get(), tmap);
+
+        auto empty_tablet_range = dht::to_partition_range(tmap.get_token_range(locator::tablet_id(0)));
+        auto populated_tablet_range = dht::to_partition_range(tmap.get_token_range(populated_tablet));
+
+        auto reader = set->make_range_sstable_reader(s, make_reader_permit(env),
+                                                     empty_tablet_range,
+                                                     s->full_slice(),
+                                                     nullptr,
+                                                     ::streamed_mutation::forwarding::no,
+                                                     ::mutation_reader::forwarding::yes);
+        auto close_r = deferred_close(reader);
+
+        BOOST_REQUIRE_MESSAGE(!read_mutation_from_mutation_reader(reader).get(),
+                "the first tablet is expected to be empty");
+
+        reader.fast_forward_to(populated_tablet_range).get();
+
+        auto mopt = read_mutation_from_mutation_reader(reader).get();
+        BOOST_REQUIRE_MESSAGE(mopt, "no data was read from the fast forwarded tablet");
+        BOOST_REQUIRE_MESSAGE(mopt->decorated_key().equal(*s, *key),
+                format("expected key: {}, got: {}", *key, mopt->decorated_key()));
+        BOOST_REQUIRE_MESSAGE(!read_mutation_from_mutation_reader(reader).get(),
+                "unexpected data past the fast forwarded tablet");
+    }, std::move(cfg));
+}
+
 // Test that tablet_sstable_set respects arbitrary tablet boundaries when selecting sstables
 // overlapping with a given token range.
 SEASTAR_TEST_CASE(test_tablet_sstable_set_preserves_arbitrary_boundaries) {

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -451,6 +451,82 @@ SEASTAR_TEST_CASE(test_tablet_sstable_set_fast_forward_across_tablet_ranges) {
     }, std::move(cfg));
 }
 
+// Reproduces a bug where fast forward returns no sstable readers although the
+// new range has sstables:
+// 1) the test creates a reader on the range of the 1st tablet, which is empty,
+//    so the reader selector returns no sstable readers to the merging reader
+//    and advances the selector position (`incremental_reader_selector::_selector_position`)
+//    to the 1st token of the 2nd tablet (see `tablet_incremental_selector::find_lowest_next_token`),
+//    which is empty too
+// 2) the test then fast forwards the reader to the range of the 3rd tablet,
+//    which has sstables
+// 3) as part of the fast-forward call, the reader selector scans for sstables
+//    from the current selector position, finds none in the 2nd tablet and
+//    advances the selector position to the 1st token of the 3rd tablet
+// `incremental_reader_selector::fast_forward_to` used to restrict `create_new_readers`
+// by the new range's start position. The scan stopped as soon as the selector
+// position moved past it and returned no readers to the merging reader (`mutation_reader_merger`).
+// The merging reader cannot recover from that, as it never creates new readers
+// if it has none in its cache, so it reported end of stream and missed the 3rd
+// tablet's data.
+SEASTAR_TEST_CASE(test_tablet_sstable_set_fast_forward_across_empty_tablet) {
+    // enable tablets, to get access to tablet_storage_group_manager
+    cql_test_config cfg;
+    cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+
+    return do_with_cql_env_thread([&](cql_test_env& env) {
+        guarantee_all_tablet_replicas_on_shard0(env).get();
+
+        env.execute_cql("CREATE KEYSPACE test_tablet_sstable_set_empty_tablet"
+                        " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1} AND TABLETS = {'enabled': true, 'initial': 4};").get();
+        env.execute_cql("CREATE TABLE test_tablet_sstable_set_empty_tablet.test (pk int PRIMARY KEY)").get();
+
+        auto& table = env.local_db().find_column_family("test_tablet_sstable_set_empty_tablet", "test");
+        auto s = table.schema();
+        auto& sgm = column_family_test::get_storage_group_manager(table);
+        auto erm = table.get_effective_replication_map();
+        auto& tmap = erm->get_token_metadata().tablets().get_tablet_map(s->id());
+
+        // Populate the third tablet only, leaving the first two empty.
+        const auto populated_tablet = locator::tablet_id(2);
+        std::optional<dht::decorated_key> key;
+        for (int val = 0; !key; val++) {
+            auto dk = dht::decorate_key(*s, partition_key::from_singular(*s, val));
+            if (tmap.get_tablet_id(dk.token()) != populated_tablet) {
+                continue;
+            }
+            env.execute_cql(fmt::format("INSERT INTO test_tablet_sstable_set_empty_tablet.test (pk) VALUES ({})", val)).get();
+            table.flush().get();
+            key = std::move(dk);
+        }
+
+        auto set = replica::make_tablet_sstable_set(s, *sgm.get(), tmap);
+
+        auto empty_tablet_range = dht::to_partition_range(tmap.get_token_range(locator::tablet_id(0)));
+        auto populated_tablet_range = dht::to_partition_range(tmap.get_token_range(populated_tablet));
+
+        auto reader = set->make_range_sstable_reader(s, make_reader_permit(env),
+                                                     empty_tablet_range,
+                                                     s->full_slice(),
+                                                     nullptr,
+                                                     ::streamed_mutation::forwarding::no,
+                                                     ::mutation_reader::forwarding::yes);
+        auto close_r = deferred_close(reader);
+
+        BOOST_REQUIRE_MESSAGE(!read_mutation_from_mutation_reader(reader).get(),
+                "the first tablet is expected to be empty");
+
+        reader.fast_forward_to(populated_tablet_range).get();
+
+        auto mopt = read_mutation_from_mutation_reader(reader).get();
+        BOOST_REQUIRE_MESSAGE(mopt, "no data was read from the fast forwarded tablet");
+        BOOST_REQUIRE_MESSAGE(mopt->decorated_key().equal(*s, *key),
+                format("expected key: {}, got: {}", *key, mopt->decorated_key()));
+        BOOST_REQUIRE_MESSAGE(!read_mutation_from_mutation_reader(reader).get(),
+                "unexpected data past the fast forwarded tablet");
+    }, std::move(cfg));
+}
+
 // Test that tablet_sstable_set respects arbitrary tablet boundaries when selecting sstables
 // overlapping with a given token range.
 SEASTAR_TEST_CASE(test_tablet_sstable_set_preserves_arbitrary_boundaries) {

--- a/test/boost/table_streaming_reader_test.cc
+++ b/test/boost/table_streaming_reader_test.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#undef SEASTAR_TESTING_MAIN
+#include <seastar/util/closeable.hh>
+#include <seastar/testing/test_case.hh>
+
+#include <map>
+#include <set>
+
+#include "dht/i_partitioner.hh"
+#include "test/lib/cql_test_env.hh"
+#include "test/lib/reader_concurrency_semaphore.hh"
+#include "types/types.hh"
+#include "schema/schema.hh"
+#include "replica/database.hh"
+#include "locator/tablets.hh"
+#include "readers/mutation_reader.hh"
+#include "mutation/mutation.hh"
+
+BOOST_AUTO_TEST_SUITE(table_streaming_reader_test)
+
+// Verifies that the streaming reader can read memtables from multiple tablets
+// (storage groups) on the same shard. The test creates a streaming reader on
+// two token ranges belonging to different tablets and verifies that the
+// memtable data from both tablets is read, while data from other tablets are not.
+SEASTAR_TEST_CASE(test_streaming_reader_reads_all_tablets_memtables) {
+    if (this_smp_shard_count() > 1) {
+        std::cerr << "Cannot run test " << get_name() << " with this_smp_shard_count() > 2" << std::endl;
+        return make_ready_future<>();
+    }
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        auto ks_name = sstring("test_ks");
+        // The test runs on a single shard (see custom_args in test_config.yaml),
+        // so this shard owns all tablets.
+        e.execute_cql(format("CREATE KEYSPACE {} "
+                "WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} "
+                "AND tablets = {{'enabled': true, 'initial': 4}}", ks_name)).get();
+        e.execute_cql(format("CREATE TABLE {}.t (pk int PRIMARY KEY, v int)", ks_name)).get();
+
+        auto& db = e.local_db();
+        auto s = db.find_schema(ks_name, "t");
+        auto uuid = s->id();
+        auto& table = db.find_column_family(uuid);
+
+        auto& stm = db.get_shared_token_metadata();
+        const auto& tmap = stm.get()->tablets().get_tablet_map(uuid);
+
+        // Find one representative partition key per tablet.
+        // Data is applied to the memtable (not flushed) so that the streaming
+        // reader must go through add_memtables_to_reader_list(). The tablet map
+        // is ordered by token, so iterating it in ascending tablet_id order also
+        // yields keys in ascending token order (required for sorted ranges).
+        std::map<locator::tablet_id, dht::decorated_key> keys_by_tablet;
+        for (int32_t i = 0; i < 100000 && keys_by_tablet.size() < 3; ++i) {
+            auto pkey = partition_key::from_single_value(*s, int32_type->decompose(i));
+            auto dk = dht::decorate_key(*s, pkey);
+            auto tid = tmap.get_tablet_id(dk.token());
+            keys_by_tablet.try_emplace(tid, std::move(dk));
+        }
+        BOOST_REQUIRE_MESSAGE(keys_by_tablet.size() >= 3, "Could not find keys in three distinct tablets");
+
+        // Pick three tablets in ascending token order. Insert one key to each
+        // one of them and then stream the outer two (non-adjacent) tablets.
+        auto it = keys_by_tablet.begin();
+        const dht::decorated_key& low_key = (it++)->second;
+        const dht::decorated_key& mid_key = (it++)->second;
+        const dht::decorated_key& high_key = (it++)->second;
+
+        auto apply = [&] (const dht::decorated_key& dk, int32_t v) {
+            mutation m(s, dk);
+            m.set_clustered_cell(clustering_key_prefix::make_empty(), "v", v, api::new_timestamp());
+            db.apply(s, freeze(m), tracing::trace_state_ptr(), db::commitlog::force_sync::no, db::no_timeout).get();
+        };
+        apply(low_key, 1);
+        apply(mid_key, 2);
+        apply(high_key, 3);
+
+        // Two sorted, disjoint singular ranges in non-adjacent tablets. The
+        // middle tablet is not covered by any range.
+        dht::partition_range_vector ranges;
+        ranges.push_back(dht::partition_range::make_singular(low_key));
+        ranges.push_back(dht::partition_range::make_singular(high_key));
+
+        tests::reader_concurrency_semaphore_wrapper semaphore;
+        auto reader = table.make_streaming_reader(s, semaphore.make_permit(), ranges, gc_clock::now());
+        auto close_reader = deferred_close(reader);
+
+        std::set<dht::decorated_key, dht::decorated_key::less_comparator> read_keys{
+                dht::decorated_key::less_comparator(s)};
+        while (auto mutation = read_mutation_from_mutation_reader(reader).get()) {
+            read_keys.insert(mutation->decorated_key());
+        }
+
+        BOOST_REQUIRE_MESSAGE(read_keys.contains(low_key),
+                "Streaming reader missed the partition in the first range's tablet");
+        BOOST_REQUIRE_MESSAGE(read_keys.contains(high_key),
+                "Streaming reader missed the partition in the second range's tablet");
+        BOOST_REQUIRE_MESSAGE(!read_keys.contains(mid_key),
+                "Streaming reader returned a partition from an unrequested tablet");
+    });
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/test_config.yaml
+++ b/test/boost/test_config.yaml
@@ -51,6 +51,8 @@ custom_args:
         - '-c2 -m2G --logger-log-level s3=trace --logger-log-level http=trace --logger-log-level default_http_retry_strategy=trace'
     batchlog_manager_test:
         - '-c2 -m2G --logger-log-level batchlog_manager=trace:debug_error_injection=trace:testlog=trace'
+    table_streaming_reader_test:
+        - '-c1 -m2G'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test
 # Tests skipped in debug/sanitize modes because they use many iterations

--- a/test/boost/test_config.yaml
+++ b/test/boost/test_config.yaml
@@ -56,6 +56,8 @@ custom_args:
     # Purely CPU-bound, single-threaded, and it allocates nothing but its own buffers.
     stream_compressor_test:
         - '-c1 -m512M'
+    table_streaming_reader_test:
+        - '-c1 -m2G'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test
 # Tests skipped in debug/sanitize modes because they use many iterations

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -11,12 +11,14 @@ import pytest
 import asyncio
 import logging
 import subprocess
+from uuid import UUID
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
 from test.pylib.tablets import get_tablet_count, get_all_tablet_replicas
 from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
+from test.pylib.scylla_cluster import ReplaceConfig
 from test.cluster.util import new_test_keyspace, reconnect_driver
 from test.cluster.tasks.task_manager_client import TaskManagerClient
 
@@ -94,10 +96,14 @@ async def get_all_vnode_tokens(cql) -> list[int]:
     return sorted(tokens)
 
 
-async def verify_data_integrity(cql, ks, table, num_keys, cl=ConsistencyLevel.QUORUM):
+async def verify_data_integrity(cql, ks, table, num_keys, cl=ConsistencyLevel.QUORUM, server=None):
     stmt = SimpleStatement(f"SELECT * FROM {ks}.{table}")
     stmt.consistency_level = cl
-    rows = await cql.run_async(stmt)
+    if server:
+        host = cql.cluster.metadata.get_host(server.ip_addr)
+        rows = await cql.run_async(stmt, host=host)
+    else:
+        rows = await cql.run_async(stmt)
     data = {r.pk: r.c for r in rows}
     expected = {k: k for k in range(num_keys)}
     if data != expected:
@@ -1200,3 +1206,153 @@ async def test_pow2_convergence_virtual_task(manager: ManagerClient):
         convergence_tasks = [t for t in tasks if t.type == "pow2_convergence"]
         assert len(convergence_tasks) == 0, \
             f"Expected no convergence tasks after completion, got {len(convergence_tasks)}"
+
+
+@pytest.mark.parametrize("rbno_enabled", [
+    pytest.param(True, id="repair"),
+    pytest.param(False, id="range_streamer"),
+])
+async def test_replace_during_migration(manager: ManagerClient, rbno_enabled: bool):
+    """Replace a dead node when a vnodes-to-tablets migration is in progress.
+
+    The test verifies that replace on a semi-migrated cluster succeeds, the
+    tablet map is updated to reference the new node as replica, and the
+    migration can resume after replace. A 3-node cluster is used so that Raft
+    quorum is preserved with a dead node (required to run the node replacement).
+    """
+    num_nodes = 3
+    num_shards = 2
+    tokens_per_node = 16
+    num_keys = 1000
+
+    logger.info(f"Starting a cluster with {num_nodes} nodes, {num_shards} shards, "
+                f"{tokens_per_node} tokens per node, rbno_enabled={rbno_enabled}")
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        'num_tokens': tokens_per_node,
+        'enable_repair_based_node_ops': rbno_enabled,
+    }
+    cmdline = ['--smp', str(num_shards)]
+    property_file = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, num_nodes + 1)]
+    servers = await manager.servers_add(num_nodes, cmdline=cmdline, config=cfg, property_file=property_file)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async def upgrade_and_restart_node(server: ServerInfo):
+        logger.info(f"Marking node {server.server_id} for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+        logger.info(f"Restarting node {server.server_id} for resharding")
+        await manager.server_restart(server.server_id)
+
+    server_to_host_map = {s.server_id: await manager.get_host_id(s.server_id) for s in servers}
+    host_ids = set(server_to_host_map.values())
+
+    logger.info(f"Creating keyspace and table with RF={num_nodes} using vnodes")
+    async with new_test_keyspace(manager,
+            f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {num_nodes}}} "
+            f"AND tablets = {{'enabled': false}}") as ks:
+        table_name = "test"
+        await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        logger.info(f"Populating table with {num_keys} rows at CL=ALL")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.{table_name} (pk, c) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, [k, k]) for k in range(num_keys)))
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(servers[0].ip_addr, ks)
+
+        logger.info("Partially migrating cluster: upgrading 2 nodes to tablets")
+        upgraded_servers = servers[:2]
+        nonupgraded_servers = servers[2:]
+        for s in upgraded_servers:
+            await upgrade_and_restart_node(s)
+
+        # Pick one of the upgraded servers to replace mid-migration.
+        replaced_server = upgraded_servers[0]
+        replaced_host_id = server_to_host_map[replaced_server.server_id]
+        replaced_tokens = await manager.api.get_tokens(replaced_server.ip_addr)
+
+        logger.info(f"Stopping node {replaced_server.server_id} to replace mid-migration")
+        await manager.server_stop(replaced_server.server_id, convict=True)
+
+        logger.info(f"Adding replacement node (same shard count {num_shards})")
+        replace_cfg = ReplaceConfig(replaced_id=replaced_server.server_id, reuse_ip_addr=False, use_host_id=True)
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=cmdline,
+                                              property_file=replaced_server.property_file(),
+                                              config=cfg)
+        new_host_id = await manager.get_host_id(new_server.server_id)
+        logger.info(f"Replacement node started: server_id={new_server.server_id}, host_id={new_host_id}")
+
+        await reconnect_driver(manager)
+        surviving_servers = [s for s in servers if s.server_id != replaced_server.server_id] + [new_server]
+        cql, _ = await manager.get_ready_cql(surviving_servers)
+
+        logger.info("Verifying node statuses after replacement")
+        rs = await cql.run_async("SELECT host_id, node_state FROM system.topology WHERE key = 'topology'")
+        for row in rs:
+            if row.host_id == UUID(replaced_host_id):
+                assert row.node_state == "left", f"Replaced node {row.host_id} should be left, got {row.node_state}"
+            else:
+                assert row.node_state == "normal", f"Surviving node {row.host_id} should be normal, got {row.node_state}"
+
+        logger.info("Verifying that the new node has the same token ranges as the replaced node")
+        new_tokens = await manager.api.get_tokens(new_server.ip_addr)
+        assert replaced_tokens == new_tokens, \
+            f"Replacement node tokens {new_tokens} do not match replaced node tokens {replaced_tokens}"
+
+        # Due to RF=num_nodes, the new node should be a replica for all tablets.
+        logger.info("Verifying tablet map after replacement")
+        expected_host_ids = (host_ids - {server_to_host_map[replaced_server.server_id]}) | {new_host_id}
+
+        check_server = servers[1]
+        await read_barrier(manager.api, check_server.ip_addr)
+        host = manager.get_cql().cluster.metadata.get_host(check_server.ip_addr)
+        table_id = await manager.get_table_or_view_id(ks, table_name)
+        tablet_rows = await manager.get_cql().run_async(
+            f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}", host=host)
+
+        for row in tablet_rows:
+            replica_hosts = {str(host_id) for host_id, _ in row.replicas}
+            assert replica_hosts == expected_host_ids, f"Tablet at token {row.last_token}: expected replicas {expected_host_ids}, got {replica_hosts}"
+            assert row.new_replicas is None, f"Tablet at token {row.last_token}: expected new_replicas to be empty, got {row.new_replicas}"
+            assert row.stage is None, f"Tablet at token {row.last_token}: expected stage to be None, got {row.stage}"
+            assert row.transition is None, f"Tablet at token {row.last_token}: expected transition to be None, got {row.transition}"
+
+        logger.info("Verifying migration status after replacement (new node should be on vnodes)")
+        upgraded_servers.remove(replaced_server)
+        nonupgraded_servers.append(new_server)
+        server_to_host_map[new_server.server_id] = new_host_id
+        expected_node_statuses = {
+            str(server_to_host_map[s.server_id]): (status, status)
+            for servers, status in ((upgraded_servers, "tablets"), (nonupgraded_servers, "vnodes"))
+            for s in servers
+        }
+        await verify_migration_status(manager, surviving_servers[0], ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses=expected_node_statuses,
+            retries=1,
+            retry_interval=1)
+
+        logger.info("Verifying data set on new node")
+        await verify_data_integrity(cql, ks, table_name, num_keys, cl=ConsistencyLevel.LOCAL_ONE, server=new_server)
+
+        logger.info("Resuming migration: upgrading the two vnode-based nodes")
+        for s in nonupgraded_servers:
+            await upgrade_and_restart_node(s)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(surviving_servers)
+
+        logger.info("Finalizing tablets migration")
+        await manager.api.finalize_vnode_tablet_migration(check_server.ip_addr, ks)
+
+        # Barrier on an arbitrary node to ensure we can observe the latest group0 state from it.
+        await read_barrier(manager.api, check_server.ip_addr)
+        host1 = cql.cluster.metadata.get_host(check_server.ip_addr)
+
+        logger.info("Verifying keyspace uses tablets after finalization")
+        res = await cql.run_async(
+            f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'", host=host1)
+        assert len(res) == 1 and res[0].initial_tablets is not None, \
+            "Keyspace is still using vnodes after migration finalization"

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1358,6 +1358,89 @@ async def test_replace_during_migration(manager: ManagerClient, rbno_enabled: bo
             "Keyspace is still using vnodes after migration finalization"
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_replace_during_migration_chunked_updates(manager: ManagerClient):
+    """Verify that tablet-map updates for migrating tables can be chunked.
+
+    If the number of migrating tables is large, the tablet-map updates for node
+    replacement may be too large to fit in a single group0 command. In this
+    case, it is split into multiple commands. This test verifies that with an
+    injection that forces each tablet map to be updated in a separate command.
+    """
+    num_shards = 2
+    num_tokens = 16
+    injection = 'topology_coordinator/generate_vnodes_to_tablets_replace_updates/one_table_per_command'
+
+    cfg = {'num_tokens': num_tokens}
+    cmdline = ['--smp', str(num_shards)]
+
+    logger.info("Starting a 3-node cluster (one rack per node)")
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+    servers = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=property_files)
+    s0, s1, s2 = servers
+
+    logger.info(f"Pinning raft group0 leader on s0 ({s0.server_id})")
+    await ensure_group0_leader_on(manager, s0)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} "
+            "AND tablets = {'enabled': false}") as ks:
+        table_names = ['t1', 't2']
+        for table_name in table_names:
+            await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        s1_host_id = str(await manager.get_host_id(s1.server_id))
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet maps)")
+        await manager.api.create_vnode_tablet_migration(s0.ip_addr, ks)
+
+        logger.info(f"Enabling injection {injection!r} on s0")
+        await manager.api.enable_injection(s0.ip_addr, injection, one_shot=False)
+
+        logger.info(f"Stopping s1 ({s1.server_id}) to replace it")
+        await manager.server_stop(s1.server_id, convict=True)
+
+        logger.info("Starting replacement of dead node s1")
+        replace_cfg = ReplaceConfig(replaced_id=s1.server_id, reuse_ip_addr=False, use_host_id=True)
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=cmdline,
+                                              property_file=s1.property_file(),
+                                              config=cfg)
+        new_host_id = str(await manager.get_host_id(new_server.server_id))
+        logger.info(f"Replacement node started: server_id={new_server.server_id}, host_id={new_host_id}")
+
+        # The injection should be triggered 6 times, 3 topology transitions * 2 tables.
+        await manager.api.wait_for_injection_enter(s0.ip_addr, injection, threshold=6)
+
+        await reconnect_driver(manager)
+        live_servers = [s0, new_server, s2]
+        cql, _ = await manager.get_ready_cql(live_servers)
+
+        logger.info("Verifying both tablet maps were finalized with the replacement host")
+        await read_barrier(manager.api, s0.ip_addr)
+        host = cql.cluster.metadata.get_host(s0.ip_addr)
+        for table_name in table_names:
+            table_id = await manager.get_table_or_view_id(ks, table_name)
+            tablet_rows = await cql.run_async(
+                f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}",
+                host=host)
+            assert tablet_rows, f"No tablet rows found for {ks}.{table_name} after replace"
+            for row in tablet_rows:
+                replica_hosts = {str(h) for h, _ in row.replicas}
+                assert new_host_id in replica_hosts, \
+                    f"Tablet at {row.last_token} in {table_name}: new node {new_host_id} not in replicas {replica_hosts}"
+                assert s1_host_id not in replica_hosts, \
+                    f"Tablet at {row.last_token} in {table_name}: dead node {s1_host_id} still in replicas {replica_hosts}"
+                assert row.new_replicas is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected new_replicas=None, got {row.new_replicas}"
+                assert row.stage is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected stage=None, got {row.stage}"
+                assert row.transition is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected transition=None, got {row.transition}"
+
+
 async def _check_migrating_tablet_map(manager: ManagerClient, server: ServerInfo, ks: str, table_name: str,
                                       expected_stage: str, expected_replicas_host_ids: set,
                                       expected_new_replicas_host_ids: set) -> None:

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1358,6 +1358,44 @@ async def test_replace_during_migration(manager: ManagerClient, rbno_enabled: bo
             "Keyspace is still using vnodes after migration finalization"
 
 
+async def test_replace_during_migration_rejects_shard_count_mismatch(manager: ManagerClient):
+    """Verify that node replacement during vnodes-to-tablets migration fails if shard counts do not match."""
+    cfg = {'num_tokens': 1}
+    replaced_cmdline = ['--smp', '2']
+    replacing_cmdline = ['--smp', '1']
+
+    logger.info("Starting a 3-node cluster")
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+    servers = await manager.servers_add(3, cmdline=replaced_cmdline, config=cfg, property_file=property_files)
+    s0, s1, _ = servers
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} "
+            "AND tablets = {'enabled': false}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(s0.ip_addr, ks)
+
+        logger.info(f"Stopping s1 ({s1.server_id}) to replace it")
+        await manager.server_stop(s1.server_id, convict=True)
+
+        logger.info("Starting replacement of s1 with a different shard count (expected to fail)")
+        replace_cfg = ReplaceConfig(replaced_id=s1.server_id, reuse_ip_addr=False, use_host_id=True)
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=replacing_cmdline,
+                                              property_file=s1.property_file(),
+                                              config=cfg,
+                                              expected_error="during vnode-to-tablet migration: shard_count mismatch")
+
+        log = await manager.server_open_log(new_server.server_id)
+        rollback_pattern = r"Cannot replace node .* during vnode-to-tablet migration: shard_count mismatch \(replacing=1, replaced=2\)"
+        matches = await log.grep(rollback_pattern)
+        assert len(matches) == 1
+
+
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_replace_during_migration_chunked_updates(manager: ManagerClient):
     """Verify that tablet-map updates for migrating tables can be chunked.

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -895,7 +895,6 @@ async def test_migration_multiple_keyspaces(manager: ManagerClient):
                     f"intended_storage_mode should be cleared for node {row.host_id} after all migrations are done, got '{row.intended_storage_mode}'"
 
 
-@pytest.mark.asyncio
 async def test_migration_multiple_tables(manager: ManagerClient):
     """Verify vnodes-to-tablets migration on keyspace with multiple tables.
 
@@ -949,7 +948,6 @@ async def test_migration_multiple_tables(manager: ManagerClient):
         await wait_for_pow2_convergence(manager, server, ks, 't2')
 
 
-@pytest.mark.asyncio
 async def test_tablet_status_in_migration_api(manager: ManagerClient):
     """"Verify the ?include=tablet_status query parameter in the migration API.
 
@@ -1061,7 +1059,6 @@ async def test_tablet_status_in_migration_api(manager: ManagerClient):
                 f"Tablet count {tablet_count} for table {t['table']} is not a power of two"
 
 
-@pytest.mark.asyncio
 async def test_pow2_convergence_virtual_task(manager: ManagerClient):
     """Verify that pow2 convergence is tracked via a virtual task.
 

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1358,6 +1358,119 @@ async def test_replace_during_migration(manager: ManagerClient, rbno_enabled: bo
             "Keyspace is still using vnodes after migration finalization"
 
 
+@pytest.mark.parametrize("rbno_enabled", [
+    pytest.param(True, id="repair"),
+    pytest.param(False, id="range_streamer"),
+])
+async def test_replace_during_migration_tablet_followers(manager: ManagerClient, rbno_enabled: bool):
+    """Verify that streaming works correctly from tablet-only followers.
+
+    The test creates a 3-node cluster, upgrades two nodes to tablets and then
+    replaces the vnode-based node. The new node is expected to stream the full
+    dataset from the two upgraded nodes.
+
+    The test contains 2 tweaks that trigger problematic edge cases in
+    repair-based and range streaming which are expected to be fixed as part of
+    node replacement support (SCYLLADB-1165):
+
+    * Tweak for repair-based streaming:
+      Followers are created with more shards than the new node. This causes
+      the test to fail if the follower chooses local instead of multishard read
+      strategy. With less or equal shards on the follower, the problem would be
+      masked by the master's multishard writer: a follower's local read would
+      return incomplete data per repair session, but the collection of all
+      repair sessions would return the complete data. The master starts one
+      repair session per master shard.
+
+    * Tweak for range streaming:
+      Data on followers reside on memtables. This causes the test to fail if
+      the follower's streaming reader does not read from all tablets.
+    """
+    num_keys = 1000
+    tokens_per_node = 16
+    replaced_cmdline = ['--smp', '2']
+    follower_cmdline = ['--smp', '3']
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        'num_tokens': tokens_per_node,
+        'enable_repair_based_node_ops': rbno_enabled,
+    }
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+
+    logger.info("Starting replaced node with 2 shards")
+    replaced_server = await manager.server_add(cmdline=replaced_cmdline, config=cfg, property_file=property_files[0])
+
+    logger.info("Starting two follower nodes with 3 shards")
+    follower_servers = [
+        await manager.server_add(cmdline=follower_cmdline, config=cfg, property_file=property_files[1]),
+        await manager.server_add(cmdline=follower_cmdline, config=cfg, property_file=property_files[2]),
+    ]
+    servers = [replaced_server] + follower_servers
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async def upgrade_and_restart_node(server: ServerInfo):
+        logger.info(f"Marking node {server.server_id} for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+        logger.info(f"Restarting node {server.server_id} for resharding")
+        await manager.server_restart(server.server_id)
+
+    logger.info("Creating keyspace and table with RF=3 using vnodes")
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} "
+            "AND tablets = {'enabled': false}") as ks:
+        table_name = "test"
+        await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(replaced_server.ip_addr, ks)
+
+        logger.info("Migrating the two follower nodes to tablets")
+        for s in follower_servers:
+            await upgrade_and_restart_node(s)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        # Inject data after restarts to ensure they will reside on memtables.
+        logger.info(f"Populating table with {num_keys} rows at CL=ALL")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.{table_name} (pk, c) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, [k, k]) for k in range(num_keys)))
+
+        replaced_host_id = await manager.get_host_id(replaced_server.server_id)
+        replaced_tokens = await manager.api.get_tokens(replaced_server.ip_addr)
+
+        logger.info(f"Stopping 2-shard node {replaced_server.server_id} to replace mid-migration")
+        await manager.server_stop(replaced_server.server_id, convict=True)
+
+        logger.info("Adding 2-shard replacement node")
+        replace_cfg = ReplaceConfig(replaced_id=replaced_server.server_id, reuse_ip_addr=False, use_host_id=True)
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=replaced_cmdline,
+                                              property_file=replaced_server.property_file(),
+                                              config=cfg)
+        logger.info(f"Replacement node started: server_id={new_server.server_id}, host_id={await manager.get_host_id(new_server.server_id)}")
+
+        await reconnect_driver(manager)
+        surviving_servers = follower_servers + [new_server]
+        cql, _ = await manager.get_ready_cql(surviving_servers)
+
+        logger.info("Verifying that the new node has the same token ranges as the replaced node")
+        new_tokens = await manager.api.get_tokens(new_server.ip_addr)
+        assert replaced_tokens == new_tokens, \
+            f"Replacement node tokens {new_tokens} do not match replaced node tokens {replaced_tokens}"
+
+        logger.info("Verifying node statuses after replacement")
+        rows = await cql.run_async("SELECT host_id, node_state FROM system.topology WHERE key = 'topology'")
+        for row in rows:
+            if row.host_id == UUID(replaced_host_id):
+                assert row.node_state == "left", f"Replaced node {row.host_id} should be left, got {row.node_state}"
+            else:
+                assert row.node_state == "normal", f"Surviving node {row.host_id} should be normal, got {row.node_state}"
+
+        logger.info("Reading all rows from the replacement node at CL=LOCAL_ONE")
+        await verify_data_integrity(cql, ks, table_name, num_keys, cl=ConsistencyLevel.LOCAL_ONE, server=new_server)
+
+
 async def test_replace_during_migration_rejects_shard_count_mismatch(manager: ManagerClient):
     """Verify that node replacement during vnodes-to-tablets migration fails if shard counts do not match."""
     cfg = {'num_tokens': 1}

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -11,11 +11,13 @@ import pytest
 import asyncio
 import logging
 import subprocess
+from uuid import UUID
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
 from test.pylib.tablets import get_tablet_count, get_all_tablet_replicas
 from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.internal_types import ServerInfo
+from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
 from test.cluster.util import new_test_keyspace, reconnect_driver
 from test.cluster.tasks.task_manager_client import TaskManagerClient
@@ -94,10 +96,14 @@ async def get_all_vnode_tokens(cql) -> list[int]:
     return sorted(tokens)
 
 
-async def verify_data_integrity(cql, ks, table, num_keys, cl=ConsistencyLevel.QUORUM):
+async def verify_data_integrity(cql, ks, table, num_keys, cl=ConsistencyLevel.QUORUM, server=None):
     stmt = SimpleStatement(f"SELECT * FROM {ks}.{table}")
     stmt.consistency_level = cl
-    rows = await cql.run_async(stmt)
+    if server:
+        host = cql.cluster.metadata.get_host(server.ip_addr)
+        rows = await cql.run_async(stmt, host=host)
+    else:
+        rows = await cql.run_async(stmt)
     data = {r.pk: r.c for r in rows}
     expected = {k: k for k in range(num_keys)}
     if data != expected:
@@ -1357,3 +1363,153 @@ async def test_pow2_convergence_virtual_task(manager: ScyllaClusterManager):
         convergence_tasks = [t for t in tasks if t.type == "pow2_convergence"]
         assert len(convergence_tasks) == 0, \
             f"Expected no convergence tasks after completion, got {len(convergence_tasks)}"
+
+
+@pytest.mark.parametrize("rbno_enabled", [
+    pytest.param(True, id="repair"),
+    pytest.param(False, id="range_streamer"),
+])
+async def test_replace_during_migration(manager: ScyllaClusterManager, rbno_enabled: bool):
+    """Replace a dead node when a vnodes-to-tablets migration is in progress.
+
+    The test verifies that replace on a semi-migrated cluster succeeds, the
+    tablet map is updated to reference the new node as replica, and the
+    migration can resume after replace. A 3-node cluster is used so that Raft
+    quorum is preserved with a dead node (required to run the node replacement).
+    """
+    num_nodes = 3
+    num_shards = 2
+    tokens_per_node = 16
+    num_keys = 1000
+
+    logger.info(f"Starting a cluster with {num_nodes} nodes, {num_shards} shards, "
+                f"{tokens_per_node} tokens per node, rbno_enabled={rbno_enabled}")
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        'num_tokens': tokens_per_node,
+        'enable_repair_based_node_ops': rbno_enabled,
+    }
+    cmdline = ['--smp', str(num_shards)]
+    property_file = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, num_nodes + 1)]
+    servers = await manager.servers_add(num_nodes, cmdline=cmdline, config=cfg, property_file=property_file)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async def upgrade_and_restart_node(server: ServerInfo):
+        logger.info(f"Marking node {server.server_id} for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+        logger.info(f"Restarting node {server.server_id} for resharding")
+        await manager.server_restart(server.server_id)
+
+    server_to_host_map = {s.server_id: await manager.get_host_id(s.server_id) for s in servers}
+    host_ids = set(server_to_host_map.values())
+
+    logger.info(f"Creating keyspace and table with RF={num_nodes} using vnodes")
+    async with new_test_keyspace(manager,
+            f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {num_nodes}}} "
+            f"AND tablets = {{'enabled': false}}") as ks:
+        table_name = "test"
+        await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        logger.info(f"Populating table with {num_keys} rows at CL=ALL")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.{table_name} (pk, c) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, [k, k]) for k in range(num_keys)))
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(servers[0].ip_addr, ks)
+
+        logger.info("Partially migrating cluster: upgrading 2 nodes to tablets")
+        upgraded_servers = servers[:2]
+        nonupgraded_servers = servers[2:]
+        for s in upgraded_servers:
+            await upgrade_and_restart_node(s)
+
+        # Pick one of the upgraded servers to replace mid-migration.
+        replaced_server = upgraded_servers[0]
+        replaced_host_id = server_to_host_map[replaced_server.server_id]
+        replaced_tokens = await manager.api.get_tokens(replaced_server.ip_addr)
+
+        logger.info(f"Stopping node {replaced_server.server_id} to replace mid-migration")
+        await manager.server_stop(replaced_server.server_id, convict=True)
+
+        logger.info(f"Adding replacement node (same shard count {num_shards})")
+        replace_cfg = ReplaceConfig(replaced_id=replaced_server.server_id, reuse_ip_addr=False, use_host_id=True)
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=cmdline,
+                                              property_file=replaced_server.property_file(),
+                                              config=cfg)
+        new_host_id = await manager.get_host_id(new_server.server_id)
+        logger.info(f"Replacement node started: server_id={new_server.server_id}, host_id={new_host_id}")
+
+        await reconnect_driver(manager)
+        surviving_servers = [s for s in servers if s.server_id != replaced_server.server_id] + [new_server]
+        cql, _ = await manager.get_ready_cql(surviving_servers)
+
+        logger.info("Verifying node statuses after replacement")
+        rs = await cql.run_async("SELECT host_id, node_state FROM system.topology WHERE key = 'topology'")
+        for row in rs:
+            if row.host_id == UUID(replaced_host_id):
+                assert row.node_state == "left", f"Replaced node {row.host_id} should be left, got {row.node_state}"
+            else:
+                assert row.node_state == "normal", f"Surviving node {row.host_id} should be normal, got {row.node_state}"
+
+        logger.info("Verifying that the new node has the same token ranges as the replaced node")
+        new_tokens = await manager.api.get_tokens(new_server.ip_addr)
+        assert replaced_tokens == new_tokens, \
+            f"Replacement node tokens {new_tokens} do not match replaced node tokens {replaced_tokens}"
+
+        # Due to RF=num_nodes, the new node should be a replica for all tablets.
+        logger.info("Verifying tablet map after replacement")
+        expected_host_ids = (host_ids - {server_to_host_map[replaced_server.server_id]}) | {new_host_id}
+
+        check_server = servers[1]
+        await read_barrier(manager.api, check_server.ip_addr)
+        host = manager.get_cql().cluster.metadata.get_host(check_server.ip_addr)
+        table_id = await manager.get_table_or_view_id(ks, table_name)
+        tablet_rows = await manager.get_cql().run_async(
+            f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}", host=host)
+
+        for row in tablet_rows:
+            replica_hosts = {str(host_id) for host_id, _ in row.replicas}
+            assert replica_hosts == expected_host_ids, f"Tablet at token {row.last_token}: expected replicas {expected_host_ids}, got {replica_hosts}"
+            assert row.new_replicas is None, f"Tablet at token {row.last_token}: expected new_replicas to be empty, got {row.new_replicas}"
+            assert row.stage is None, f"Tablet at token {row.last_token}: expected stage to be None, got {row.stage}"
+            assert row.transition is None, f"Tablet at token {row.last_token}: expected transition to be None, got {row.transition}"
+
+        logger.info("Verifying migration status after replacement (new node should be on vnodes)")
+        upgraded_servers.remove(replaced_server)
+        nonupgraded_servers.append(new_server)
+        server_to_host_map[new_server.server_id] = new_host_id
+        expected_node_statuses = {
+            str(server_to_host_map[s.server_id]): (status, status)
+            for servers, status in ((upgraded_servers, "tablets"), (nonupgraded_servers, "vnodes"))
+            for s in servers
+        }
+        await verify_migration_status(manager, surviving_servers[0], ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses=expected_node_statuses,
+            retries=1,
+            retry_interval=1)
+
+        logger.info("Verifying data set on new node")
+        await verify_data_integrity(cql, ks, table_name, num_keys, cl=ConsistencyLevel.LOCAL_ONE, server=new_server)
+
+        logger.info("Resuming migration: upgrading the two vnode-based nodes")
+        for s in nonupgraded_servers:
+            await upgrade_and_restart_node(s)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(surviving_servers)
+
+        logger.info("Finalizing tablets migration")
+        await manager.api.finalize_vnode_tablet_migration(check_server.ip_addr, ks)
+
+        # Barrier on an arbitrary node to ensure we can observe the latest group0 state from it.
+        await read_barrier(manager.api, check_server.ip_addr)
+        host1 = cql.cluster.metadata.get_host(check_server.ip_addr)
+
+        logger.info("Verifying keyspace uses tablets after finalization")
+        res = await cql.run_async(
+            f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'", host=host1)
+        assert len(res) == 1 and res[0].initial_tablets is not None, \
+            "Keyspace is still using vnodes after migration finalization"

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -19,7 +19,7 @@ from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.internal_types import ServerInfo
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.scylla_cluster_manager import ScyllaClusterManager
-from test.cluster.util import new_test_keyspace, reconnect_driver
+from test.cluster.util import new_test_keyspace, reconnect_driver, ensure_group0_leader_on
 from test.cluster.tasks.task_manager_client import TaskManagerClient
 
 logger = logging.getLogger(__name__)
@@ -1513,3 +1513,238 @@ async def test_replace_during_migration(manager: ScyllaClusterManager, rbno_enab
             f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'", host=host1)
         assert len(res) == 1 and res[0].initial_tablets is not None, \
             "Keyspace is still using vnodes after migration finalization"
+
+
+async def _check_migrating_tablet_map(manager: ScyllaClusterManager, server: ServerInfo, ks: str, table_name: str,
+                                      expected_stage: str, expected_replicas_host_ids: set,
+                                      expected_new_replicas_host_ids: set) -> None:
+    """Read all rows for this table from system.tablets on `server` (after a read barrier) and assert,
+    for every row:
+      - stage == expected_stage
+      - transition == 'rebuild'
+      - {str(host) for (host, _) in replicas} == expected_replicas_host_ids
+      - {str(host) for (host, _) in new_replicas} == expected_new_replicas_host_ids
+    """
+    await read_barrier(manager.api, server.ip_addr)
+    host = manager.get_cql().cluster.metadata.get_host(server.ip_addr)
+    table_id = await manager.get_table_or_view_id(ks, table_name)
+    tablet_rows = await manager.get_cql().run_async(
+        f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}",
+        host=host)
+    assert tablet_rows, f"No tablet rows found for {ks}.{table_name} — tablet map is empty"
+    for row in tablet_rows:
+        replica_hosts = {str(h) for h, _ in row.replicas}
+        new_replica_hosts = {str(h) for h, _ in row.new_replicas} if row.new_replicas is not None else set()
+        assert row.stage == expected_stage, \
+            f"Tablet at {row.last_token}: expected stage={expected_stage!r}, got {row.stage!r}"
+        assert row.transition == 'rebuild', \
+            f"Tablet at {row.last_token}: expected transition='rebuild', got {row.transition!r}"
+        assert replica_hosts == expected_replicas_host_ids, \
+            f"Tablet at {row.last_token}: expected replicas {expected_replicas_host_ids}, got {replica_hosts}"
+        assert new_replica_hosts == expected_new_replicas_host_ids, \
+            f"Tablet at {row.last_token}: expected new_replicas {expected_new_replicas_host_ids}, got {new_replica_hosts}"
+
+
+async def _read_key(cql, ks: str, key: int, host) -> None:
+    """Read a single row at CL=ONE via `host` (a Cassandra driver Host object) and assert the value.
+
+    Verifies that a write that was supposed to reach `host` as a replica is actually readable.
+    """
+    stmt = cql.prepare(f"SELECT c FROM {ks}.test WHERE pk = ?")
+    stmt.consistency_level = ConsistencyLevel.ONE
+    rows = await cql.run_async(stmt, [key], host=host)
+    assert len(rows) == 1 and rows[0].c == key, \
+        f"CL=ONE read via {host} for pk={key} returned {rows}"
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_request_routing_during_replace(manager: ScyllaClusterManager):
+    """Verify that CQL coordinators correctly route reads and writes to the
+    replacing node during the write_both_read_old and write_both_read_new
+    topology states if the table is undergoing vnodes-to-tablets migration.
+
+    The difference between a normal vnode/tablet-based table and a migrating
+    table is that, in the latter case, the cluster is in a mixed state with
+    some nodes using a vnode ERM and others using a tablet ERM. To ensure that
+    the replacement process remains transparent to user queries while the
+    cluster is in this mixed state, the topology coordinator must update both
+    ERMs in lockstep as part of the replacement process.
+
+    Note that this test focuses only on the coordinator-to-replica request
+    routing logic during the topology transitions. The end-to-end correctness
+    of the replacement process is covered by test_replace_during_migration.
+
+    Steps:
+    1. Start a 3-node cluster {s0, s1, s2}, one node per rack.
+    2. Create a vnode-based table, RF=3.
+    3. Start vnodes-to-tablets migration and upgrade node s0 to tablets.
+    4. Ensure the group0 leader runs on s1 and enable error injections for
+       write_both_read_old and write_both_read_new on that node.
+    5. Start replacing s2 with s2'. Wait for the replacement process to pause in write_both_read_old.
+    6. Write keys K1 and K2 to s0 and s1 respectively.
+       In one case the coordinator uses a tablet ERM, in the other it uses a vnode ERM.
+       Read the keys to verify they are readable from both nodes.
+       We also expect the write to be routed to s2', but s2' is not yet ready to serve CQL requests as coordinator, only as replica.
+    7. Progress to write_both_read_new.
+       Again, write and read new keys K3 and K4 to s0 and s1.
+    8. Finish the replacement process and verify that K1..K4 are readable from s2'.
+    """
+    num_shards = 2
+    num_tokens = 16
+    K1, K2, K3, K4 = 1, 2, 3, 4
+    INJECTION_WBRO = 'topology_coordinator/write_both_read_old/before_version_increment'
+    INJECTION_WBRN = 'topology_coordinator/write_both_read_new/after_barrier'
+
+    cfg = {
+        'num_tokens': num_tokens,
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+    }
+    cmdline = ['--smp', str(num_shards)]
+
+    logger.info("Starting a 3-node cluster (one rack per node)")
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+    servers = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=property_files)
+    s0, s1, s2 = servers[0], servers[1], servers[2]
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager,
+            f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}} "
+            f"AND tablets = {{'enabled': false}}") as ks:
+        table_name = 'test'
+        await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        s0_id = str(await manager.get_host_id(s0.server_id))
+        s1_id = str(await manager.get_host_id(s1.server_id))
+        s2_id = str(await manager.get_host_id(s2.server_id))
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(s1.ip_addr, ks)
+
+        logger.info(f"Upgrading s0 ({s0.server_id}) to tablets")
+        await manager.api.upgrade_node_to_tablets(s0.ip_addr)
+        await manager.server_restart(s0.server_id)
+
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info(f"Pinning raft group0 leader on s1 ({s1.server_id})")
+        await ensure_group0_leader_on(manager, s1)
+
+        logger.info(f"Enabling injection {INJECTION_WBRO!r} on s1")
+        await manager.api.enable_injection(s1.ip_addr, INJECTION_WBRO, one_shot=True)
+        logger.info(f"Enabling injection {INJECTION_WBRN!r} on s1")
+        await manager.api.enable_injection(s1.ip_addr, INJECTION_WBRN, one_shot=True)
+
+        logger.info(f"Stopping s2 ({s2.server_id}) — to be replaced")
+        await manager.server_stop(s2.server_id, convict=True)
+
+        logger.info("Starting replacement for s2 in background")
+        replace_cfg = ReplaceConfig(replaced_id=s2.server_id, reuse_ip_addr=False, use_host_id=True)
+        replace_task = asyncio.create_task(manager.server_add(replace_cfg, cmdline=cmdline, property_file=s2.property_file(), config=cfg))
+
+        # PAUSE 1: write_both_read_old
+        # The replacing node s2' must be in the tablet write set.
+        # When this injection is hit, streaming has finished.
+        # The following writes can reach s2' only via the CQL write path.
+        logger.info(f"Waiting for injection {INJECTION_WBRO!r}")
+        await manager.api.wait_for_injection_enter(s1.ip_addr, INJECTION_WBRO)
+
+        # Discover the replacement node's host ID from system.topology.
+        # We cannot use get_host_id() because we don't have the new node's ServerNum yet.
+        await read_barrier(manager.api, s1.ip_addr)
+        s1_cql_host = cql.cluster.metadata.get_host(s1.ip_addr)
+        topology_rows = await cql.run_async(
+            "SELECT host_id FROM system.topology WHERE key = 'topology'",
+            host=s1_cql_host)
+        old_ids = {s0_id, s1_id, s2_id}
+        s2p_candidates = [str(r.host_id) for r in topology_rows if str(r.host_id) not in old_ids]
+        assert len(s2p_candidates) == 1
+        s2p_id = s2p_candidates[0]
+        logger.info(f"Replacement node (s2') host_id: {s2p_id}")
+
+        logger.info("Checking tablet map: stage=write_both_read_old (before K1 write)")
+        await _check_migrating_tablet_map(
+            manager, s0, ks, table_name,
+            expected_stage='write_both_read_old',
+            expected_replicas_host_ids={s0_id, s1_id, s2_id},
+            expected_new_replicas_host_ids={s0_id, s1_id, s2p_id})
+
+        s0_host = cql.cluster.metadata.get_host(s0.ip_addr)
+        s1_host = cql.cluster.metadata.get_host(s1.ip_addr)
+        write_stmt = cql.prepare(f"INSERT INTO {ks}.{table_name} (pk, c) VALUES (?, ?)")
+        write_stmt.consistency_level = ConsistencyLevel.QUORUM
+
+        logger.info(f"Writing K1={K1} via s0 (tablets-based coordinator)")
+        await cql.run_async(write_stmt, [K1, K1], host=s0_host)
+        await _read_key(cql, ks, K1, s0_host)
+        await _read_key(cql, ks, K1, s1_host)
+
+        logger.info(f"Writing K2={K2} via s1 (vnodes-based coordinator)")
+        await cql.run_async(write_stmt, [K2, K2], host=s1_host)
+        await _read_key(cql, ks, K2, s0_host)
+        await _read_key(cql, ks, K2, s1_host)
+
+        logger.info(f"Releasing injection {INJECTION_WBRO!r}")
+        await manager.api.message_injection(s1.ip_addr, INJECTION_WBRO)
+
+        # PAUSE 2: write_both_read_new
+        # The replacing node s2' must be in the tablet read and write set.
+        logger.info(f"Waiting for injection {INJECTION_WBRN!r}")
+        await manager.api.wait_for_injection_enter(s1.ip_addr, INJECTION_WBRN)
+
+        logger.info("Checking tablet map: stage=write_both_read_new (before K3 write)")
+        await _check_migrating_tablet_map(
+            manager, s0, ks, table_name,
+            expected_stage='write_both_read_new',
+            expected_replicas_host_ids={s0_id, s1_id, s2_id},
+            expected_new_replicas_host_ids={s0_id, s1_id, s2p_id})
+
+        logger.info(f"Writing K3={K3} via s0 (tablets-based coordinator)")
+        await cql.run_async(write_stmt, [K3, K3], host=s0_host)
+        await _read_key(cql, ks, K3, s0_host)
+        await _read_key(cql, ks, K3, s1_host)
+
+        logger.info(f"Writing K4={K4} via s1 (vnodes-based coordinator)")
+        await cql.run_async(write_stmt, [K4, K4], host=s1_host)
+        await _read_key(cql, ks, K4, s0_host)
+        await _read_key(cql, ks, K4, s1_host)
+
+        logger.info(f"Releasing injection {INJECTION_WBRN!r}")
+        await manager.api.message_injection(s1.ip_addr, INJECTION_WBRN)
+
+        # REPLACE COMPLETES
+        logger.info("Waiting for replace to complete")
+        new_server = await replace_task
+        logger.info(f"Replacement node started: server_id={new_server.server_id}")
+
+        await reconnect_driver(manager)
+        live_servers = [s0, s1, new_server]
+        cql, _ = await manager.get_ready_cql(live_servers)
+
+        # POST-REPLACE VERIFICATION
+        logger.info("Verifying final tablet map: replicas swapped, no pending transitions")
+        await read_barrier(manager.api, s0.ip_addr)
+        s0_host = cql.cluster.metadata.get_host(s0.ip_addr)
+        table_id = await manager.get_table_or_view_id(ks, table_name)
+        tablet_rows = await cql.run_async(
+            f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}",
+            host=s0_host)
+        assert tablet_rows, f"No tablet rows found for {ks}.{table_name} after replace"
+        for row in tablet_rows:
+            replica_hosts = {str(h) for h, _ in row.replicas}
+            assert s2p_id in replica_hosts, \
+                f"Tablet at {row.last_token}: replacement node {s2p_id} not in replicas {replica_hosts}"
+            assert s2_id not in replica_hosts, \
+                f"Tablet at {row.last_token}: dead node {s2_id} still in replicas {replica_hosts}"
+            assert row.new_replicas is None, \
+                f"Tablet at {row.last_token}: expected new_replicas=None, got {row.new_replicas}"
+            assert row.stage is None, \
+                f"Tablet at {row.last_token}: expected stage=None, got {row.stage}"
+            assert row.transition is None, \
+                f"Tablet at {row.last_token}: expected transition=None, got {row.transition}"
+
+        logger.info("Verifying K1..K4 are present in s2'")
+        new_server_host = cql.cluster.metadata.get_host(new_server.ip_addr)
+        for k in [K1, K2, K3, K4]:
+            await _read_key(cql, ks, k, new_server_host)

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1515,6 +1515,89 @@ async def test_replace_during_migration(manager: ScyllaClusterManager, rbno_enab
             "Keyspace is still using vnodes after migration finalization"
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_replace_during_migration_chunked_updates(manager: ScyllaClusterManager):
+    """Verify that tablet-map updates for migrating tables can be chunked.
+
+    If the number of migrating tables is large, the tablet-map updates for node
+    replacement may be too large to fit in a single group0 command. In this
+    case, it is split into multiple commands. This test verifies that with an
+    injection that forces each tablet map to be updated in a separate command.
+    """
+    num_shards = 2
+    num_tokens = 16
+    injection = 'topology_coordinator/generate_vnodes_to_tablets_replace_updates/one_table_per_command'
+
+    cfg = {'num_tokens': num_tokens}
+    cmdline = ['--smp', str(num_shards)]
+
+    logger.info("Starting a 3-node cluster (one rack per node)")
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+    servers = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=property_files)
+    s0, s1, s2 = servers
+
+    logger.info(f"Pinning raft group0 leader on s0 ({s0.server_id})")
+    await ensure_group0_leader_on(manager, s0)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} "
+            "AND tablets = {'enabled': false}") as ks:
+        table_names = ['t1', 't2']
+        for table_name in table_names:
+            await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        s1_host_id = str(await manager.get_host_id(s1.server_id))
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet maps)")
+        await manager.api.create_vnode_tablet_migration(s0.ip_addr, ks)
+
+        logger.info(f"Enabling injection {injection!r} on s0")
+        await manager.api.enable_injection(s0.ip_addr, injection, one_shot=False)
+
+        logger.info(f"Stopping s1 ({s1.server_id}) to replace it")
+        await manager.server_stop(s1.server_id, convict=True)
+
+        logger.info("Starting replacement of dead node s1")
+        replace_cfg = ReplaceConfig(replaced_id=s1.server_id, reuse_ip_addr=False, use_host_id=True)
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=cmdline,
+                                              property_file=s1.property_file(),
+                                              config=cfg)
+        new_host_id = str(await manager.get_host_id(new_server.server_id))
+        logger.info(f"Replacement node started: server_id={new_server.server_id}, host_id={new_host_id}")
+
+        # The injection should be triggered 6 times, 3 topology transitions * 2 tables.
+        await manager.api.wait_for_injection_enter(s0.ip_addr, injection, threshold=6)
+
+        await reconnect_driver(manager)
+        live_servers = [s0, new_server, s2]
+        cql, _ = await manager.get_ready_cql(live_servers)
+
+        logger.info("Verifying both tablet maps were finalized with the replacement host")
+        await read_barrier(manager.api, s0.ip_addr)
+        host = cql.cluster.metadata.get_host(s0.ip_addr)
+        for table_name in table_names:
+            table_id = await manager.get_table_or_view_id(ks, table_name)
+            tablet_rows = await cql.run_async(
+                f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}",
+                host=host)
+            assert tablet_rows, f"No tablet rows found for {ks}.{table_name} after replace"
+            for row in tablet_rows:
+                replica_hosts = {str(h) for h, _ in row.replicas}
+                assert new_host_id in replica_hosts, \
+                    f"Tablet at {row.last_token} in {table_name}: new node {new_host_id} not in replicas {replica_hosts}"
+                assert s1_host_id not in replica_hosts, \
+                    f"Tablet at {row.last_token} in {table_name}: dead node {s1_host_id} still in replicas {replica_hosts}"
+                assert row.new_replicas is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected new_replicas=None, got {row.new_replicas}"
+                assert row.stage is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected stage=None, got {row.stage}"
+                assert row.transition is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected transition=None, got {row.transition}"
+
+
 async def _check_migrating_tablet_map(manager: ScyllaClusterManager, server: ServerInfo, ks: str, table_name: str,
                                       expected_stage: str, expected_replicas_host_ids: set,
                                       expected_new_replicas_host_ids: set) -> None:

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1598,6 +1598,91 @@ async def test_replace_during_migration_chunked_updates(manager: ScyllaClusterMa
                     f"Tablet at {row.last_token} in {table_name}: expected transition=None, got {row.transition}"
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_replace_during_migration_separate_commands(manager: ScyllaClusterManager):
+    """Verify the two-step commit path when tablet updates don't fit in one command with the vnode updates.
+
+    Each replace transition commits the tablet-map updates for migrating
+    tables together with the vnode topology updates in a single group0
+    command. When they don't fit in one command, the tablet updates are
+    committed first, in separate commands, followed by the vnode topology
+    updates. This test forces that fallback with an error injection.
+    """
+    num_shards = 2
+    num_tokens = 16
+    injection = 'topology_coordinator/update_topology_state_with_replace_tablet_updates/force_split'
+
+    cfg = {'num_tokens': num_tokens}
+    cmdline = ['--smp', str(num_shards)]
+
+    logger.info("Starting a 3-node cluster (one rack per node)")
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+    servers = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=property_files)
+    s0, s1, s2 = servers
+
+    logger.info(f"Pinning raft group0 leader on s0 ({s0.server_id})")
+    await ensure_group0_leader_on(manager, s0)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} "
+            "AND tablets = {'enabled': false}") as ks:
+        table_names = ['t1', 't2']
+        for table_name in table_names:
+            await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        s1_host_id = str(await manager.get_host_id(s1.server_id))
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet maps)")
+        await manager.api.create_vnode_tablet_migration(s0.ip_addr, ks)
+
+        logger.info(f"Enabling injection {injection!r} on s0")
+        await manager.api.enable_injection(s0.ip_addr, injection, one_shot=False)
+
+        logger.info(f"Stopping s1 ({s1.server_id}) to replace it")
+        await manager.server_stop(s1.server_id, convict=True)
+
+        logger.info("Starting replacement of dead node s1")
+        replace_cfg = ReplaceConfig(replaced_id=s1.server_id, reuse_ip_addr=False, use_host_id=True)
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=cmdline,
+                                              property_file=s1.property_file(),
+                                              config=cfg)
+        new_host_id = str(await manager.get_host_id(new_server.server_id))
+        logger.info(f"Replacement node started: server_id={new_server.server_id}, host_id={new_host_id}")
+
+        # The injection should be triggered 3 times, once per topology transition
+        # (write_both_read_old, write_both_read_new, finalize).
+        await manager.api.wait_for_injection_enter(s0.ip_addr, injection, threshold=3)
+
+        await reconnect_driver(manager)
+        live_servers = [s0, new_server, s2]
+        cql, _ = await manager.get_ready_cql(live_servers)
+
+        logger.info("Verifying both tablet maps were finalized with the replacement host")
+        await read_barrier(manager.api, s0.ip_addr)
+        host = cql.cluster.metadata.get_host(s0.ip_addr)
+        for table_name in table_names:
+            table_id = await manager.get_table_or_view_id(ks, table_name)
+            tablet_rows = await cql.run_async(
+                f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}",
+                host=host)
+            assert tablet_rows, f"No tablet rows found for {ks}.{table_name} after replace"
+            for row in tablet_rows:
+                replica_hosts = {str(h) for h, _ in row.replicas}
+                assert new_host_id in replica_hosts, \
+                    f"Tablet at {row.last_token} in {table_name}: new node {new_host_id} not in replicas {replica_hosts}"
+                assert s1_host_id not in replica_hosts, \
+                    f"Tablet at {row.last_token} in {table_name}: dead node {s1_host_id} still in replicas {replica_hosts}"
+                assert row.new_replicas is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected new_replicas=None, got {row.new_replicas}"
+                assert row.stage is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected stage=None, got {row.stage}"
+                assert row.transition is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected transition=None, got {row.transition}"
+
+
 async def _check_migrating_tablet_map(manager: ScyllaClusterManager, server: ServerInfo, ks: str, table_name: str,
                                       expected_stage: str, expected_replicas_host_ids: set,
                                       expected_new_replicas_host_ids: set) -> None:

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -19,7 +19,7 @@ from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.scylla_cluster import ReplaceConfig
-from test.cluster.util import new_test_keyspace, reconnect_driver
+from test.cluster.util import new_test_keyspace, reconnect_driver, ensure_group0_leader_on
 from test.cluster.tasks.task_manager_client import TaskManagerClient
 
 logger = logging.getLogger(__name__)
@@ -1356,3 +1356,238 @@ async def test_replace_during_migration(manager: ManagerClient, rbno_enabled: bo
             f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'", host=host1)
         assert len(res) == 1 and res[0].initial_tablets is not None, \
             "Keyspace is still using vnodes after migration finalization"
+
+
+async def _check_migrating_tablet_map(manager: ManagerClient, server: ServerInfo, ks: str, table_name: str,
+                                      expected_stage: str, expected_replicas_host_ids: set,
+                                      expected_new_replicas_host_ids: set) -> None:
+    """Read all rows for this table from system.tablets on `server` (after a read barrier) and assert,
+    for every row:
+      - stage == expected_stage
+      - transition == 'rebuild'
+      - {str(host) for (host, _) in replicas} == expected_replicas_host_ids
+      - {str(host) for (host, _) in new_replicas} == expected_new_replicas_host_ids
+    """
+    await read_barrier(manager.api, server.ip_addr)
+    host = manager.get_cql().cluster.metadata.get_host(server.ip_addr)
+    table_id = await manager.get_table_or_view_id(ks, table_name)
+    tablet_rows = await manager.get_cql().run_async(
+        f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}",
+        host=host)
+    assert tablet_rows, f"No tablet rows found for {ks}.{table_name} — tablet map is empty"
+    for row in tablet_rows:
+        replica_hosts = {str(h) for h, _ in row.replicas}
+        new_replica_hosts = {str(h) for h, _ in row.new_replicas} if row.new_replicas is not None else set()
+        assert row.stage == expected_stage, \
+            f"Tablet at {row.last_token}: expected stage={expected_stage!r}, got {row.stage!r}"
+        assert row.transition == 'rebuild', \
+            f"Tablet at {row.last_token}: expected transition='rebuild', got {row.transition!r}"
+        assert replica_hosts == expected_replicas_host_ids, \
+            f"Tablet at {row.last_token}: expected replicas {expected_replicas_host_ids}, got {replica_hosts}"
+        assert new_replica_hosts == expected_new_replicas_host_ids, \
+            f"Tablet at {row.last_token}: expected new_replicas {expected_new_replicas_host_ids}, got {new_replica_hosts}"
+
+
+async def _read_key(cql, ks: str, key: int, host) -> None:
+    """Read a single row at CL=ONE via `host` (a Cassandra driver Host object) and assert the value.
+
+    Verifies that a write that was supposed to reach `host` as a replica is actually readable.
+    """
+    stmt = cql.prepare(f"SELECT c FROM {ks}.test WHERE pk = ?")
+    stmt.consistency_level = ConsistencyLevel.ONE
+    rows = await cql.run_async(stmt, [key], host=host)
+    assert len(rows) == 1 and rows[0].c == key, \
+        f"CL=ONE read via {host} for pk={key} returned {rows}"
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_request_routing_during_replace(manager: ManagerClient):
+    """Verify that CQL coordinators correctly route reads and writes to the
+    replacing node during the write_both_read_old and write_both_read_new
+    topology states if the table is undergoing vnodes-to-tablets migration.
+
+    The difference between a normal vnode/tablet-based table and a migrating
+    table is that, in the latter case, the cluster is in a mixed state with
+    some nodes using a vnode ERM and others using a tablet ERM. To ensure that
+    the replacement process remains transparent to user queries while the
+    cluster is in this mixed state, the topology coordinator must update both
+    ERMs in lockstep as part of the replacement process.
+
+    Note that this test focuses only on the coordinator-to-replica request
+    routing logic during the topology transitions. The end-to-end correctness
+    of the replacement process is covered by test_replace_during_migration.
+
+    Steps:
+    1. Start a 3-node cluster {s0, s1, s2}, one node per rack.
+    2. Create a vnode-based table, RF=3.
+    3. Start vnodes-to-tablets migration and upgrade node s0 to tablets.
+    4. Ensure the group0 leader runs on s1 and enable error injections for
+       write_both_read_old and write_both_read_new on that node.
+    5. Start replacing s2 with s2'. Wait for the replacement process to pause in write_both_read_old.
+    6. Write keys K1 and K2 to s0 and s1 respectively.
+       In one case the coordinator uses a tablet ERM, in the other it uses a vnode ERM.
+       Read the keys to verify they are readable from both nodes.
+       We also expect the write to be routed to s2', but s2' is not yet ready to serve CQL requests as coordinator, only as replica.
+    7. Progress to write_both_read_new.
+       Again, write and read new keys K3 and K4 to s0 and s1.
+    8. Finish the replacement process and verify that K1..K4 are readable from s2'.
+    """
+    num_shards = 2
+    num_tokens = 16
+    K1, K2, K3, K4 = 1, 2, 3, 4
+    INJECTION_WBRO = 'topology_coordinator/write_both_read_old/before_version_increment'
+    INJECTION_WBRN = 'topology_coordinator/write_both_read_new/after_barrier'
+
+    cfg = {
+        'num_tokens': num_tokens,
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+    }
+    cmdline = ['--smp', str(num_shards)]
+
+    logger.info("Starting a 3-node cluster (one rack per node)")
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+    servers = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=property_files)
+    s0, s1, s2 = servers[0], servers[1], servers[2]
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager,
+            f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}} "
+            f"AND tablets = {{'enabled': false}}") as ks:
+        table_name = 'test'
+        await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        s0_id = str(await manager.get_host_id(s0.server_id))
+        s1_id = str(await manager.get_host_id(s1.server_id))
+        s2_id = str(await manager.get_host_id(s2.server_id))
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(s1.ip_addr, ks)
+
+        logger.info(f"Upgrading s0 ({s0.server_id}) to tablets")
+        await manager.api.upgrade_node_to_tablets(s0.ip_addr)
+        await manager.server_restart(s0.server_id)
+
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info(f"Pinning raft group0 leader on s1 ({s1.server_id})")
+        await ensure_group0_leader_on(manager, s1)
+
+        logger.info(f"Enabling injection {INJECTION_WBRO!r} on s1")
+        await manager.api.enable_injection(s1.ip_addr, INJECTION_WBRO, one_shot=True)
+        logger.info(f"Enabling injection {INJECTION_WBRN!r} on s1")
+        await manager.api.enable_injection(s1.ip_addr, INJECTION_WBRN, one_shot=True)
+
+        logger.info(f"Stopping s2 ({s2.server_id}) — to be replaced")
+        await manager.server_stop(s2.server_id, convict=True)
+
+        logger.info("Starting replacement for s2 in background")
+        replace_cfg = ReplaceConfig(replaced_id=s2.server_id, reuse_ip_addr=False, use_host_id=True)
+        replace_task = asyncio.create_task(manager.server_add(replace_cfg, cmdline=cmdline, property_file=s2.property_file(), config=cfg))
+
+        # PAUSE 1: write_both_read_old
+        # The replacing node s2' must be in the tablet write set.
+        # When this injection is hit, streaming has finished.
+        # The following writes can reach s2' only via the CQL write path.
+        logger.info(f"Waiting for injection {INJECTION_WBRO!r}")
+        await manager.api.wait_for_injection_enter(s1.ip_addr, INJECTION_WBRO)
+
+        # Discover the replacement node's host ID from system.topology.
+        # We cannot use get_host_id() because we don't have the new node's ServerNum yet.
+        await read_barrier(manager.api, s1.ip_addr)
+        s1_cql_host = cql.cluster.metadata.get_host(s1.ip_addr)
+        topology_rows = await cql.run_async(
+            "SELECT host_id FROM system.topology WHERE key = 'topology'",
+            host=s1_cql_host)
+        old_ids = {s0_id, s1_id, s2_id}
+        s2p_candidates = [str(r.host_id) for r in topology_rows if str(r.host_id) not in old_ids]
+        assert len(s2p_candidates) == 1
+        s2p_id = s2p_candidates[0]
+        logger.info(f"Replacement node (s2') host_id: {s2p_id}")
+
+        logger.info("Checking tablet map: stage=write_both_read_old (before K1 write)")
+        await _check_migrating_tablet_map(
+            manager, s0, ks, table_name,
+            expected_stage='write_both_read_old',
+            expected_replicas_host_ids={s0_id, s1_id, s2_id},
+            expected_new_replicas_host_ids={s0_id, s1_id, s2p_id})
+
+        s0_host = cql.cluster.metadata.get_host(s0.ip_addr)
+        s1_host = cql.cluster.metadata.get_host(s1.ip_addr)
+        write_stmt = cql.prepare(f"INSERT INTO {ks}.{table_name} (pk, c) VALUES (?, ?)")
+        write_stmt.consistency_level = ConsistencyLevel.QUORUM
+
+        logger.info(f"Writing K1={K1} via s0 (tablets-based coordinator)")
+        await cql.run_async(write_stmt, [K1, K1], host=s0_host)
+        await _read_key(cql, ks, K1, s0_host)
+        await _read_key(cql, ks, K1, s1_host)
+
+        logger.info(f"Writing K2={K2} via s1 (vnodes-based coordinator)")
+        await cql.run_async(write_stmt, [K2, K2], host=s1_host)
+        await _read_key(cql, ks, K2, s0_host)
+        await _read_key(cql, ks, K2, s1_host)
+
+        logger.info(f"Releasing injection {INJECTION_WBRO!r}")
+        await manager.api.message_injection(s1.ip_addr, INJECTION_WBRO)
+
+        # PAUSE 2: write_both_read_new
+        # The replacing node s2' must be in the tablet read and write set.
+        logger.info(f"Waiting for injection {INJECTION_WBRN!r}")
+        await manager.api.wait_for_injection_enter(s1.ip_addr, INJECTION_WBRN)
+
+        logger.info("Checking tablet map: stage=write_both_read_new (before K3 write)")
+        await _check_migrating_tablet_map(
+            manager, s0, ks, table_name,
+            expected_stage='write_both_read_new',
+            expected_replicas_host_ids={s0_id, s1_id, s2_id},
+            expected_new_replicas_host_ids={s0_id, s1_id, s2p_id})
+
+        logger.info(f"Writing K3={K3} via s0 (tablets-based coordinator)")
+        await cql.run_async(write_stmt, [K3, K3], host=s0_host)
+        await _read_key(cql, ks, K3, s0_host)
+        await _read_key(cql, ks, K3, s1_host)
+
+        logger.info(f"Writing K4={K4} via s1 (vnodes-based coordinator)")
+        await cql.run_async(write_stmt, [K4, K4], host=s1_host)
+        await _read_key(cql, ks, K4, s0_host)
+        await _read_key(cql, ks, K4, s1_host)
+
+        logger.info(f"Releasing injection {INJECTION_WBRN!r}")
+        await manager.api.message_injection(s1.ip_addr, INJECTION_WBRN)
+
+        # REPLACE COMPLETES
+        logger.info("Waiting for replace to complete")
+        new_server = await replace_task
+        logger.info(f"Replacement node started: server_id={new_server.server_id}")
+
+        await reconnect_driver(manager)
+        live_servers = [s0, s1, new_server]
+        cql, _ = await manager.get_ready_cql(live_servers)
+
+        # POST-REPLACE VERIFICATION
+        logger.info("Verifying final tablet map: replicas swapped, no pending transitions")
+        await read_barrier(manager.api, s0.ip_addr)
+        s0_host = cql.cluster.metadata.get_host(s0.ip_addr)
+        table_id = await manager.get_table_or_view_id(ks, table_name)
+        tablet_rows = await cql.run_async(
+            f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}",
+            host=s0_host)
+        assert tablet_rows, f"No tablet rows found for {ks}.{table_name} after replace"
+        for row in tablet_rows:
+            replica_hosts = {str(h) for h, _ in row.replicas}
+            assert s2p_id in replica_hosts, \
+                f"Tablet at {row.last_token}: replacement node {s2p_id} not in replicas {replica_hosts}"
+            assert s2_id not in replica_hosts, \
+                f"Tablet at {row.last_token}: dead node {s2_id} still in replicas {replica_hosts}"
+            assert row.new_replicas is None, \
+                f"Tablet at {row.last_token}: expected new_replicas=None, got {row.new_replicas}"
+            assert row.stage is None, \
+                f"Tablet at {row.last_token}: expected stage=None, got {row.stage}"
+            assert row.transition is None, \
+                f"Tablet at {row.last_token}: expected transition=None, got {row.transition}"
+
+        logger.info("Verifying K1..K4 are present in s2'")
+        new_server_host = cql.cluster.metadata.get_host(new_server.ip_addr)
+        for k in [K1, K2, K3, K4]:
+            await _read_key(cql, ks, k, new_server_host)

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1441,6 +1441,91 @@ async def test_replace_during_migration_chunked_updates(manager: ManagerClient):
                     f"Tablet at {row.last_token} in {table_name}: expected transition=None, got {row.transition}"
 
 
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_replace_during_migration_separate_commands(manager: ManagerClient):
+    """Verify the two-step commit path when tablet updates don't fit in one command with the vnode updates.
+
+    Each replace transition commits the tablet-map updates for migrating
+    tables together with the vnode topology updates in a single group0
+    command. When they don't fit in one command, the tablet updates are
+    committed first, in separate commands, followed by the vnode topology
+    updates. This test forces that fallback with an error injection.
+    """
+    num_shards = 2
+    num_tokens = 16
+    injection = 'topology_coordinator/update_topology_state_with_replace_tablet_updates/force_split'
+
+    cfg = {'num_tokens': num_tokens}
+    cmdline = ['--smp', str(num_shards)]
+
+    logger.info("Starting a 3-node cluster (one rack per node)")
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+    servers = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=property_files)
+    s0, s1, s2 = servers
+
+    logger.info(f"Pinning raft group0 leader on s0 ({s0.server_id})")
+    await ensure_group0_leader_on(manager, s0)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} "
+            "AND tablets = {'enabled': false}") as ks:
+        table_names = ['t1', 't2']
+        for table_name in table_names:
+            await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        s1_host_id = str(await manager.get_host_id(s1.server_id))
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet maps)")
+        await manager.api.create_vnode_tablet_migration(s0.ip_addr, ks)
+
+        logger.info(f"Enabling injection {injection!r} on s0")
+        await manager.api.enable_injection(s0.ip_addr, injection, one_shot=False)
+
+        logger.info(f"Stopping s1 ({s1.server_id}) to replace it")
+        await manager.server_stop(s1.server_id, convict=True)
+
+        logger.info("Starting replacement of dead node s1")
+        replace_cfg = ReplaceConfig(replaced_id=s1.server_id, reuse_ip_addr=False, use_host_id=True)
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=cmdline,
+                                              property_file=s1.property_file(),
+                                              config=cfg)
+        new_host_id = str(await manager.get_host_id(new_server.server_id))
+        logger.info(f"Replacement node started: server_id={new_server.server_id}, host_id={new_host_id}")
+
+        # The injection should be triggered 3 times, once per topology transition
+        # (write_both_read_old, write_both_read_new, finalize).
+        await manager.api.wait_for_injection_enter(s0.ip_addr, injection, threshold=3)
+
+        await reconnect_driver(manager)
+        live_servers = [s0, new_server, s2]
+        cql, _ = await manager.get_ready_cql(live_servers)
+
+        logger.info("Verifying both tablet maps were finalized with the replacement host")
+        await read_barrier(manager.api, s0.ip_addr)
+        host = cql.cluster.metadata.get_host(s0.ip_addr)
+        for table_name in table_names:
+            table_id = await manager.get_table_or_view_id(ks, table_name)
+            tablet_rows = await cql.run_async(
+                f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}",
+                host=host)
+            assert tablet_rows, f"No tablet rows found for {ks}.{table_name} after replace"
+            for row in tablet_rows:
+                replica_hosts = {str(h) for h, _ in row.replicas}
+                assert new_host_id in replica_hosts, \
+                    f"Tablet at {row.last_token} in {table_name}: new node {new_host_id} not in replicas {replica_hosts}"
+                assert s1_host_id not in replica_hosts, \
+                    f"Tablet at {row.last_token} in {table_name}: dead node {s1_host_id} still in replicas {replica_hosts}"
+                assert row.new_replicas is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected new_replicas=None, got {row.new_replicas}"
+                assert row.stage is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected stage=None, got {row.stage}"
+                assert row.transition is None, \
+                    f"Tablet at {row.last_token} in {table_name}: expected transition=None, got {row.transition}"
+
+
 async def _check_migrating_tablet_map(manager: ManagerClient, server: ServerInfo, ks: str, table_name: str,
                                       expected_stage: str, expected_replicas_host_ids: set,
                                       expected_new_replicas_host_ids: set) -> None:

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1591,3 +1591,110 @@ async def test_request_routing_during_replace(manager: ManagerClient):
         new_server_host = cql.cluster.metadata.get_host(new_server.ip_addr)
         for k in [K1, K2, K3, K4]:
             await _read_key(cql, ks, k, new_server_host)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_replace_rollback_during_migration(manager: ManagerClient):
+    """Verify that the topology coordinator correctly rolls back tablet map changes
+    when a node replacement fails during streaming, and that a subsequent
+    replacement succeeds.
+    """
+    num_shards = 2
+    num_tokens = 16
+
+    cfg = {'num_tokens': num_tokens}
+    cmdline = ['--smp', str(num_shards)]
+
+    logger.info("Starting a 3-node cluster (one rack per node)")
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+    servers = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=property_files)
+    s0, s1, s2 = servers
+    s1_host_id = str(await manager.get_host_id(s1.server_id))
+
+    logger.info(f"Pinning raft group0 leader on s0 ({s0.server_id})")
+    await ensure_group0_leader_on(manager, s0)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager,
+            f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}} "
+            f"AND tablets = {{'enabled': false}}") as ks:
+        table_name = 'test'
+        await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(s0.ip_addr, ks)
+
+        logger.info("Taking log mark on s0 before the failed replace")
+        log = await manager.server_open_log(s0.server_id)
+        mark = await log.mark()
+
+        # --- FAILED REPLACE ---
+        logger.info(f"Stopping s1 ({s1.server_id}) — to be replaced")
+        await manager.server_stop(s1.server_id, convict=True)
+
+        logger.info("Starting replacement of dead node s1 with stream_ranges_fail injection (expected to fail)")
+        replace_cfg = ReplaceConfig(replaced_id=s1.server_id, reuse_ip_addr=False, use_host_id=True)
+        await manager.server_add(replace_cfg,
+                                 cmdline=cmdline,
+                                 property_file=s1.property_file(),
+                                 config={**cfg, 'error_injections_at_startup': ['stream_ranges_fail']},
+                                 expected_error="Replace failed. See earlier errors")
+
+        rollback_pattern = r"raft_topology - rollback.*after replacing failure, moving transition state to left token ring"
+        matches = await log.grep(rollback_pattern, from_mark=mark)
+        assert len(matches) == 1
+
+        logger.info("Verifying tablet map is clean after rollback")
+        table_id = await manager.get_table_or_view_id(ks, table_name)
+        await read_barrier(manager.api, s0.ip_addr)
+        host = manager.get_cql().cluster.metadata.get_host(s0.ip_addr)
+        tablet_rows = await manager.get_cql().run_async(
+            f"SELECT last_token, replicas, new_replicas, stage, transition "
+            f"FROM system.tablets WHERE table_id = {table_id}",
+            host=host)
+        assert tablet_rows, f"No tablet rows found for {ks}.{table_name} after rollback"
+        for row in tablet_rows:
+            replica_hosts = {str(h) for h, _ in row.replicas}
+            assert s1_host_id in replica_hosts, \
+                f"Tablet at {row.last_token}: dead node {s1_host_id} should still be in replicas after rollback, got {replica_hosts}"
+            assert row.new_replicas is None, \
+                f"Tablet at {row.last_token}: expected new_replicas=None after rollback, got {row.new_replicas}"
+            assert row.stage is None, \
+                f"Tablet at {row.last_token}: expected stage=None after rollback, got {row.stage}"
+            assert row.transition is None, \
+                f"Tablet at {row.last_token}: expected transition=None after rollback, got {row.transition}"
+
+        # --- RECOVERY: SECOND REPLACE (SUCCESSFUL) ---
+        logger.info("Starting second replacement of dead node s1 (expected to succeed)")
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=cmdline,
+                                              property_file=s1.property_file(),
+                                              config=cfg)
+        new_host_id = str(await manager.get_host_id(new_server.server_id))
+        logger.info(f"Second replacement node started: server_id={new_server.server_id}, host_id={new_host_id}")
+
+        await reconnect_driver(manager)
+        surviving = [s0, new_server, s2]
+        cql, _ = await manager.get_ready_cql(surviving)
+
+        logger.info("Verifying final tablet map after successful second replace")
+        await read_barrier(manager.api, s0.ip_addr)
+        host = cql.cluster.metadata.get_host(s0.ip_addr)
+        table_id = await manager.get_table_or_view_id(ks, table_name)
+        tablet_rows = await cql.run_async(
+            f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}",
+            host=host)
+        assert tablet_rows, f"No tablet rows found for {ks}.{table_name} after second replace"
+        for row in tablet_rows:
+            replica_hosts = {str(h) for h, _ in row.replicas}
+            assert new_host_id in replica_hosts, \
+                f"Tablet at {row.last_token}: new node {new_host_id} not in replicas {replica_hosts}"
+            assert s1_host_id not in replica_hosts, \
+                f"Tablet at {row.last_token}: dead node {s1_host_id} still in replicas {replica_hosts}"
+            assert row.new_replicas is None, \
+                f"Tablet at {row.last_token}: expected new_replicas=None, got {row.new_replicas}"
+            assert row.stage is None, \
+                f"Tablet at {row.last_token}: expected stage=None, got {row.stage}"
+            assert row.transition is None, \
+                f"Tablet at {row.last_token}: expected transition=None, got {row.transition}"

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1052,7 +1052,6 @@ async def test_migration_multiple_keyspaces(manager: ScyllaClusterManager):
                     f"intended_storage_mode should be cleared for node {row.host_id} after all migrations are done, got '{row.intended_storage_mode}'"
 
 
-@pytest.mark.asyncio
 async def test_migration_multiple_tables(manager: ScyllaClusterManager):
     """Verify vnodes-to-tablets migration on keyspace with multiple tables.
 
@@ -1106,7 +1105,6 @@ async def test_migration_multiple_tables(manager: ScyllaClusterManager):
         await wait_for_pow2_convergence(manager, server, ks, 't2')
 
 
-@pytest.mark.asyncio
 async def test_tablet_status_in_migration_api(manager: ScyllaClusterManager):
     """"Verify the ?include=tablet_status query parameter in the migration API.
 
@@ -1218,7 +1216,6 @@ async def test_tablet_status_in_migration_api(manager: ScyllaClusterManager):
                 f"Tablet count {tablet_count} for table {t['table']} is not a power of two"
 
 
-@pytest.mark.asyncio
 async def test_pow2_convergence_virtual_task(manager: ScyllaClusterManager):
     """Verify that pow2 convergence is tracked via a virtual task.
 

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1515,6 +1515,44 @@ async def test_replace_during_migration(manager: ScyllaClusterManager, rbno_enab
             "Keyspace is still using vnodes after migration finalization"
 
 
+async def test_replace_during_migration_rejects_shard_count_mismatch(manager: ScyllaClusterManager):
+    """Verify that node replacement during vnodes-to-tablets migration fails if shard counts do not match."""
+    cfg = {'num_tokens': 1}
+    replaced_cmdline = ['--smp', '2']
+    replacing_cmdline = ['--smp', '1']
+
+    logger.info("Starting a 3-node cluster")
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+    servers = await manager.servers_add(3, cmdline=replaced_cmdline, config=cfg, property_file=property_files)
+    s0, s1, _ = servers
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} "
+            "AND tablets = {'enabled': false}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(s0.ip_addr, ks)
+
+        logger.info(f"Stopping s1 ({s1.server_id}) to replace it")
+        await manager.server_stop(s1.server_id, convict=True)
+
+        logger.info("Starting replacement of s1 with a different shard count (expected to fail)")
+        replace_cfg = ReplaceConfig(replaced_id=s1.server_id, reuse_ip_addr=False, use_host_id=True)
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=replacing_cmdline,
+                                              property_file=s1.property_file(),
+                                              config=cfg,
+                                              expected_error="during vnode-to-tablet migration: shard_count mismatch")
+
+        log = await manager.server_open_log(new_server.server_id)
+        rollback_pattern = r"Cannot replace node .* during vnode-to-tablet migration: shard_count mismatch \(replacing=1, replaced=2\)"
+        matches = await log.grep(rollback_pattern)
+        assert len(matches) == 1
+
+
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_replace_during_migration_chunked_updates(manager: ScyllaClusterManager):
     """Verify that tablet-map updates for migrating tables can be chunked.

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1748,3 +1748,110 @@ async def test_request_routing_during_replace(manager: ScyllaClusterManager):
         new_server_host = cql.cluster.metadata.get_host(new_server.ip_addr)
         for k in [K1, K2, K3, K4]:
             await _read_key(cql, ks, k, new_server_host)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_replace_rollback_during_migration(manager: ScyllaClusterManager):
+    """Verify that the topology coordinator correctly rolls back tablet map changes
+    when a node replacement fails during streaming, and that a subsequent
+    replacement succeeds.
+    """
+    num_shards = 2
+    num_tokens = 16
+
+    cfg = {'num_tokens': num_tokens}
+    cmdline = ['--smp', str(num_shards)]
+
+    logger.info("Starting a 3-node cluster (one rack per node)")
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+    servers = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=property_files)
+    s0, s1, s2 = servers
+    s1_host_id = str(await manager.get_host_id(s1.server_id))
+
+    logger.info(f"Pinning raft group0 leader on s0 ({s0.server_id})")
+    await ensure_group0_leader_on(manager, s0)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager,
+            f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}} "
+            f"AND tablets = {{'enabled': false}}") as ks:
+        table_name = 'test'
+        await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(s0.ip_addr, ks)
+
+        logger.info("Taking log mark on s0 before the failed replace")
+        log = await manager.server_open_log(s0.server_id)
+        mark = await log.mark()
+
+        # --- FAILED REPLACE ---
+        logger.info(f"Stopping s1 ({s1.server_id}) — to be replaced")
+        await manager.server_stop(s1.server_id, convict=True)
+
+        logger.info("Starting replacement of dead node s1 with stream_ranges_fail injection (expected to fail)")
+        replace_cfg = ReplaceConfig(replaced_id=s1.server_id, reuse_ip_addr=False, use_host_id=True)
+        await manager.server_add(replace_cfg,
+                                 cmdline=cmdline,
+                                 property_file=s1.property_file(),
+                                 config={**cfg, 'error_injections_at_startup': ['stream_ranges_fail']},
+                                 expected_error="Replace failed. See earlier errors")
+
+        rollback_pattern = r"raft_topology - rollback.*after replacing failure, moving transition state to left token ring"
+        matches = await log.grep(rollback_pattern, from_mark=mark)
+        assert len(matches) == 1
+
+        logger.info("Verifying tablet map is clean after rollback")
+        table_id = await manager.get_table_or_view_id(ks, table_name)
+        await read_barrier(manager.api, s0.ip_addr)
+        host = manager.get_cql().cluster.metadata.get_host(s0.ip_addr)
+        tablet_rows = await manager.get_cql().run_async(
+            f"SELECT last_token, replicas, new_replicas, stage, transition "
+            f"FROM system.tablets WHERE table_id = {table_id}",
+            host=host)
+        assert tablet_rows, f"No tablet rows found for {ks}.{table_name} after rollback"
+        for row in tablet_rows:
+            replica_hosts = {str(h) for h, _ in row.replicas}
+            assert s1_host_id in replica_hosts, \
+                f"Tablet at {row.last_token}: dead node {s1_host_id} should still be in replicas after rollback, got {replica_hosts}"
+            assert row.new_replicas is None, \
+                f"Tablet at {row.last_token}: expected new_replicas=None after rollback, got {row.new_replicas}"
+            assert row.stage is None, \
+                f"Tablet at {row.last_token}: expected stage=None after rollback, got {row.stage}"
+            assert row.transition is None, \
+                f"Tablet at {row.last_token}: expected transition=None after rollback, got {row.transition}"
+
+        # --- RECOVERY: SECOND REPLACE (SUCCESSFUL) ---
+        logger.info("Starting second replacement of dead node s1 (expected to succeed)")
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=cmdline,
+                                              property_file=s1.property_file(),
+                                              config=cfg)
+        new_host_id = str(await manager.get_host_id(new_server.server_id))
+        logger.info(f"Second replacement node started: server_id={new_server.server_id}, host_id={new_host_id}")
+
+        await reconnect_driver(manager)
+        surviving = [s0, new_server, s2]
+        cql, _ = await manager.get_ready_cql(surviving)
+
+        logger.info("Verifying final tablet map after successful second replace")
+        await read_barrier(manager.api, s0.ip_addr)
+        host = cql.cluster.metadata.get_host(s0.ip_addr)
+        table_id = await manager.get_table_or_view_id(ks, table_name)
+        tablet_rows = await cql.run_async(
+            f"SELECT last_token, replicas, new_replicas, stage, transition FROM system.tablets WHERE table_id = {table_id}",
+            host=host)
+        assert tablet_rows, f"No tablet rows found for {ks}.{table_name} after second replace"
+        for row in tablet_rows:
+            replica_hosts = {str(h) for h, _ in row.replicas}
+            assert new_host_id in replica_hosts, \
+                f"Tablet at {row.last_token}: new node {new_host_id} not in replicas {replica_hosts}"
+            assert s1_host_id not in replica_hosts, \
+                f"Tablet at {row.last_token}: dead node {s1_host_id} still in replicas {replica_hosts}"
+            assert row.new_replicas is None, \
+                f"Tablet at {row.last_token}: expected new_replicas=None, got {row.new_replicas}"
+            assert row.stage is None, \
+                f"Tablet at {row.last_token}: expected stage=None, got {row.stage}"
+            assert row.transition is None, \
+                f"Tablet at {row.last_token}: expected transition=None, got {row.transition}"

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1515,6 +1515,119 @@ async def test_replace_during_migration(manager: ScyllaClusterManager, rbno_enab
             "Keyspace is still using vnodes after migration finalization"
 
 
+@pytest.mark.parametrize("rbno_enabled", [
+    pytest.param(True, id="repair"),
+    pytest.param(False, id="range_streamer"),
+])
+async def test_replace_during_migration_tablet_followers(manager: ScyllaClusterManager, rbno_enabled: bool):
+    """Verify that streaming works correctly from tablet-only followers.
+
+    The test creates a 3-node cluster, upgrades two nodes to tablets and then
+    replaces the vnode-based node. The new node is expected to stream the full
+    dataset from the two upgraded nodes.
+
+    The test contains 2 tweaks that trigger problematic edge cases in
+    repair-based and range streaming which are expected to be fixed as part of
+    node replacement support (SCYLLADB-1165):
+
+    * Tweak for repair-based streaming:
+      Followers are created with more shards than the new node. This causes
+      the test to fail if the follower chooses local instead of multishard read
+      strategy. With less or equal shards on the follower, the problem would be
+      masked by the master's multishard writer: a follower's local read would
+      return incomplete data per repair session, but the collection of all
+      repair sessions would return the complete data. The master starts one
+      repair session per master shard.
+
+    * Tweak for range streaming:
+      Data on followers reside on memtables. This causes the test to fail if
+      the follower's streaming reader does not read from all tablets.
+    """
+    num_keys = 1000
+    tokens_per_node = 16
+    replaced_cmdline = ['--smp', '2']
+    follower_cmdline = ['--smp', '3']
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        'num_tokens': tokens_per_node,
+        'enable_repair_based_node_ops': rbno_enabled,
+    }
+    property_files = [{"dc": "dc1", "rack": f"rack{i}"} for i in range(1, 4)]
+
+    logger.info("Starting replaced node with 2 shards")
+    replaced_server = await manager.server_add(cmdline=replaced_cmdline, config=cfg, property_file=property_files[0])
+
+    logger.info("Starting two follower nodes with 3 shards")
+    follower_servers = [
+        await manager.server_add(cmdline=follower_cmdline, config=cfg, property_file=property_files[1]),
+        await manager.server_add(cmdline=follower_cmdline, config=cfg, property_file=property_files[2]),
+    ]
+    servers = [replaced_server] + follower_servers
+    cql, _ = await manager.get_ready_cql(servers)
+
+    async def upgrade_and_restart_node(server: ServerInfo):
+        logger.info(f"Marking node {server.server_id} for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+        logger.info(f"Restarting node {server.server_id} for resharding")
+        await manager.server_restart(server.server_id)
+
+    logger.info("Creating keyspace and table with RF=3 using vnodes")
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} "
+            "AND tablets = {'enabled': false}") as ks:
+        table_name = "test"
+        await cql.run_async(f"CREATE TABLE {ks}.{table_name} (pk int PRIMARY KEY, c int)")
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(replaced_server.ip_addr, ks)
+
+        logger.info("Migrating the two follower nodes to tablets")
+        for s in follower_servers:
+            await upgrade_and_restart_node(s)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        # Inject data after restarts to ensure they will reside on memtables.
+        logger.info(f"Populating table with {num_keys} rows at CL=ALL")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.{table_name} (pk, c) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.ALL
+        await asyncio.gather(*(cql.run_async(insert_stmt, [k, k]) for k in range(num_keys)))
+
+        replaced_host_id = await manager.get_host_id(replaced_server.server_id)
+        replaced_tokens = await manager.api.get_tokens(replaced_server.ip_addr)
+
+        logger.info(f"Stopping 2-shard node {replaced_server.server_id} to replace mid-migration")
+        await manager.server_stop(replaced_server.server_id, convict=True)
+
+        logger.info("Adding 2-shard replacement node")
+        replace_cfg = ReplaceConfig(replaced_id=replaced_server.server_id, reuse_ip_addr=False, use_host_id=True)
+        new_server = await manager.server_add(replace_cfg,
+                                              cmdline=replaced_cmdline,
+                                              property_file=replaced_server.property_file(),
+                                              config=cfg)
+        logger.info(f"Replacement node started: server_id={new_server.server_id}, host_id={await manager.get_host_id(new_server.server_id)}")
+
+        await reconnect_driver(manager)
+        surviving_servers = follower_servers + [new_server]
+        cql, _ = await manager.get_ready_cql(surviving_servers)
+
+        logger.info("Verifying that the new node has the same token ranges as the replaced node")
+        new_tokens = await manager.api.get_tokens(new_server.ip_addr)
+        assert replaced_tokens == new_tokens, \
+            f"Replacement node tokens {new_tokens} do not match replaced node tokens {replaced_tokens}"
+
+        logger.info("Verifying node statuses after replacement")
+        rows = await cql.run_async("SELECT host_id, node_state FROM system.topology WHERE key = 'topology'")
+        for row in rows:
+            if row.host_id == UUID(replaced_host_id):
+                assert row.node_state == "left", f"Replaced node {row.host_id} should be left, got {row.node_state}"
+            else:
+                assert row.node_state == "normal", f"Surviving node {row.host_id} should be normal, got {row.node_state}"
+
+        logger.info("Reading all rows from the replacement node at CL=LOCAL_ONE")
+        await verify_data_integrity(cql, ks, table_name, num_keys, cl=ConsistencyLevel.LOCAL_ONE, server=new_server)
+
+
 async def test_replace_during_migration_rejects_shard_count_mismatch(manager: ScyllaClusterManager):
     """Verify that node replacement during vnodes-to-tablets migration fails if shard counts do not match."""
     cfg = {'num_tokens': 1}


### PR DESCRIPTION
Vnodes-to-tablets migration is a long-running process during which a node might die, reducing high availability and blocking the migration (finalization requires every normal node to report load stats for the migrating tables).

This PR adds support for replacing a dead node while a migration is in progress. It is intended as an emergency-recovery operation; other topology changes (add, remove, decommission) remain unsupported.

The replacing node inherits the tokens of the dead node, so the tablet token boundaries do not need to change. However, tablet replicas on the replaced node need to be swapped with replicas on the replacing node. This PR embeds these updates into the vnode replace flow so that vnode and tablet replicas are updated in lockstep: when the topology goes through write_both_read_old and write_both_read_new states, the tablets go through the same phases in the tablet state machine. This way, user queries remain unaffected.

For simplicity, the new node always starts on vnodes, regardless of the storage mode of the node it replaced, and replacement with a different shard count is rejected.

The replacement requires streaming data between a vnode-based node and tablet-based peers, a mixed-flavor combination that neither repair nor range streaming handled correctly before. Two fixes are added:

- Repair followers fall back to the multishard read strategy when they are tablet-based and the master is vnode-based. The reverse case (tablet-based master, vnode-based follower) is explicitly rejected as a safety guard; it cannot occur in practice.
- Range streaming followers read memtables from all storage groups that overlap the requested token ranges. Previously, followers were selecting memtable readers based on the first range only and silently returned partial data for tablets covered by later ranges.

The new feature comes with several tests: the happy path (with both streaming options), rollback on streaming failure, query routing during replacement, streaming from tablet-only followers, chunked mutation behavior, and shard-count-mismatch rejection. These are all Python cluster tests and take ~20 seconds each, primarily because replacement requires at least three nodes to maintain Raft quorum while one node is dead and some tests require some nodes to be upgraded to tablets.

Fixes SCYLLADB-1165.

New feature, no backport is needed.