### PR TITLE
transport,test,ent: replace ostream << exception with fmt::format

### DIFF
--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -571,7 +571,7 @@ public:
                 logg.warn("{}", problems);
             }
         } catch (...) {
-            std::throw_with_nested(exceptions::configuration_exception((std::stringstream{} << "Validation failed:" << std::current_exception()).str()));
+            std::throw_with_nested(exceptions::configuration_exception(fmt::format("Validation failed: {}", std::current_exception())));
         }
     }
 

--- a/test/perf/perf_alternator.cc
+++ b/test/perf/perf_alternator.cc
@@ -535,7 +535,7 @@ std::function<int(int, char**)> alternator(std::function<int(int, char**)> scyll
                 try {
                     workload_main(c, &as);
                 } catch(...) {
-                    std::cerr << "Test failed: " << std::current_exception() << std::endl;
+                    std::cerr << fmt::format("Test failed: {}", std::current_exception()) << std::endl;
                     raise(SIGKILL); // request abnormal shutdown
                 }
                 raise(SIGINT); // request shutdown

--- a/test/perf/perf_cql_raw.cc
+++ b/test/perf/perf_cql_raw.cc
@@ -697,7 +697,7 @@ static void prepopulate(const raw_cql_test_config& cfg) {
         conn->stop().get();
         std::cout << "Pre-populated " << cfg.partitions << " partitions" << std::endl;
     } catch (...) {
-        std::cerr << "Population failed: " << std::current_exception() << std::endl;
+        std::cerr << fmt::format("Population failed: {}", std::current_exception()) << std::endl;
         throw;
     }
 }
@@ -744,7 +744,7 @@ static void workload_main(const raw_cql_test_config& cfg, sharded<abort_source>*
     try {
         wait_for_compactions(cfg);
     } catch (...) {
-        std::cerr << "Compaction wait failed: " << std::current_exception() << std::endl;
+        std::cerr << fmt::format("Compaction wait failed: {}", std::current_exception()) << std::endl;
         throw;
     }
     if (!cfg.connection_per_request && cfg.workload != "connect") {
@@ -755,7 +755,7 @@ static void workload_main(const raw_cql_test_config& cfg, sharded<abort_source>*
                 return prepare_thread_connections(*shared_cfg);
             }).get();
         } catch (...) {
-            std::cerr << "Connection preparation failed: " << std::current_exception() << std::endl;
+            std::cerr << fmt::format("Connection preparation failed: {}", std::current_exception()) << std::endl;
             throw;
         }
     }
@@ -876,7 +876,7 @@ std::function<int(int, char**)> perf_cql_raw(std::function<int(int, char**)> scy
                 try {
                     workload_main(c, &as);
                 } catch (...) {
-                    std::cerr << "Perf test failed: " << std::current_exception() << std::endl;
+                    std::cerr << fmt::format("Perf test failed: {}", std::current_exception()) << std::endl;
                     raise(SIGKILL); // abnormal shutdown to signal test failure
                 }
                 raise(SIGINT); // normal shutdown request after test completion

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -956,9 +956,7 @@ std::unique_ptr<cql_server::response> cql_server::handle_exception(int16_t strea
         try {
             std::rethrow_if_nested(*exp);
         } catch (...) {
-            std::ostringstream ss;
-            ss << msg << ": " << std::current_exception();
-            msg = ss.str();
+            msg = seastar::format("{}: {}", msg, std::current_exception());
         }
         return make_error(stream, exceptions::exception_code::SERVER_ERROR, msg, trace_state);
     } else {


### PR DESCRIPTION
New Seastar defaults to DEPRECATED_OSTREAM_FORMATTERS so it no longer provides operator<< for std::exception_ptr. Replace all remaining usages of the ostream << pattern with fmt::format("{}", ...) which uses Seastar's fmt::formatter specialization for exceptions.

Affected files:
- transport/server.cc: nested exception in handle_exception()
- ent/encryption/encryption.cc: configuration_exception message
- test/perf/perf_cql_raw.cc: error reporting in perf harness
- test/perf/perf_alternator.cc: error reporting in perf harness

No need to backport - this patch is only needed in new branches that wish to update to the latest Seastar.