### PR TITLE
sstables: validate all component checksums in sstables::validate_checksums()

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3432,7 +3432,7 @@ future<lw_shared_ptr<checksum>> sstable::read_checksum() {
     co_return std::move(checksum);
 }
 
-future<validate_checksums_result> validate_checksums(shared_sstable sst, reader_permit permit) {
+future<validate_checksums_result> validate_checksums_and_digests(shared_sstable sst, reader_permit permit) {
     auto valid = true;
     std::exception_ptr ex;
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1285,6 +1285,34 @@ void sstable::validate_partitioner() {
 
 }
 
+future<uint32_t> sstable::read_scylla_file_digest() const {
+    constexpr size_t digest_size = sizeof(uint32_t);
+    auto f = co_await new_sstable_component_file(_read_error_handler, component_type::Scylla, open_flags::ro);
+    auto size = co_await f.size();
+
+    if (size < digest_size) {
+        co_await f.close();
+        throw_malformed_sstable_exception(fmt::format("missing digest in {}", get_filename()));
+    }
+
+    auto reader = file_random_access_reader(std::move(f), size);
+
+    uint32_t digest;
+    std::exception_ptr ex;
+    try {
+        co_await reader.seek(size - digest_size);
+        auto buf = co_await reader.read_exactly(digest_size);
+        digest = seastar::read_be<uint32_t>(buf.get());
+    } catch (...) {
+        ex = std::current_exception();
+    }
+    co_await reader.close();
+
+    maybe_rethrow_exception(std::move(ex));
+
+    co_return digest;
+}
+
 future<uint32_t> sstable::compute_component_file_digest(component_type type) const {
     auto f = co_await new_sstable_component_file(_read_error_handler, type, open_flags::ro);
     auto size = co_await f.size();
@@ -1314,6 +1342,45 @@ void sstable::validate_component_digest(component_type type, uint32_t computed_d
             sstlog.warn("{}", msg);
         } else {
             throw_malformed_sstable_exception(msg);
+        }
+    }
+}
+
+future<> sstable::compute_and_validate_component_digest(component_type type) {
+    auto stored_digest = get_component_digest(type);
+    if (!stored_digest.has_value()) {
+        co_return;
+    }
+
+    auto computed_digest = co_await compute_component_file_digest(type);
+    validate_component_digest(type, computed_digest);
+}
+
+future<> sstable::validate_scylla_digest_value() {
+    auto stored_digest = get_component_digest(component_type::Scylla);
+    
+    if (!stored_digest) {
+        co_return;
+    }
+
+    auto disk_digest = co_await read_scylla_file_digest();
+    if (stored_digest != disk_digest) {
+        auto msg = fmt::format("{} digest value does not match the on-disk value in {}: expected {}, read {}",
+            component_type::Scylla, get_filename(), stored_digest, disk_digest);
+        if (_ignore_component_digest_mismatch) {
+            sstlog.warn("{}", msg);
+        } else {
+            throw_malformed_sstable_exception(msg);
+        }
+    }
+}
+
+future<> sstable::validate_digests(sstable::skip_data_digest skip_data) {
+    co_await validate_scylla_digest_value();
+
+    for (const auto& type : _recognized_components) {
+        if (type != component_type::Data || !skip_data) {
+            co_await compute_and_validate_component_digest(type);
         }
     }
 }
@@ -3366,12 +3433,35 @@ future<lw_shared_ptr<checksum>> sstable::read_checksum() {
 }
 
 future<validate_checksums_result> validate_checksums(shared_sstable sst, reader_permit permit) {
-    const auto digest = co_await sst->read_digest();
+    auto valid = true;
+    std::exception_ptr ex;
+
+    auto has_checksums = sst->has_component(component_type::CRC) || sst->get_compression();
+    auto has_digest = sst->has_component(component_type::Digest);
+
     validate_checksums_result ret = {
         validate_checksums_status::valid,
-        digest.has_value()
+        has_digest,
+        has_checksums
     };
 
+    try {
+        co_await sst->validate_digests(sstable::skip_data_digest::yes);
+    } catch (malformed_sstable_exception& e) {
+        valid = false;
+        sstlog.error("{}", e.what());
+    } catch (...) {
+        ex = std::current_exception();
+    }
+
+    maybe_rethrow_exception(ex);
+
+    if (!valid) {
+        ret.status = validate_checksums_status::invalid;
+        co_return ret;
+    }
+
+    const auto digest = co_await sst->read_digest();
     auto checksum = co_await sst->read_checksum();
     if (!checksum && !sst->get_compression()) {
         sstlog.warn("No checksums available for SSTable: {}", sst->get_filename());
@@ -3389,9 +3479,6 @@ future<validate_checksums_result> validate_checksums(shared_sstable sst, reader_
                     ret.status = validate_checksums_status::invalid;
                 })
         );
-
-    auto valid = true;
-    std::exception_ptr ex;
 
     try {
         if (sst->get_compression()) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1256,7 +1256,7 @@ struct validate_checksums_result {
     bool has_digest;
     bool has_checksum;
 };
-future<validate_checksums_result> validate_checksums(shared_sstable sst, reader_permit permit);
+future<validate_checksums_result> validate_checksums_and_digests(shared_sstable sst, reader_permit permit);
 
 struct index_sampling_state {
     static constexpr size_t default_summary_byte_cost = 2000;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -760,7 +760,17 @@ private:
     void validate_max_local_deletion_time();
     void validate_partitioner();
     void validate_component_digest(component_type type, uint32_t computed_digest) const;
+    // Read component data and validate the digest.
+    future<> compute_and_validate_component_digest(component_type type);
+    future<> validate_scylla_digest_value();
+public:
+    using skip_data_digest = bool_class<struct skip_data_digest_tag>;
+    future<> validate_digests(skip_data_digest skip_data = skip_data_digest::no);
+private:
     future<> validate_index_digest() const;
+    // Read the Scylla component self-digest from file.
+    // Should only be called by sstables which have a Scylla file digest.
+    future<uint32_t> read_scylla_file_digest() const;
     future<uint32_t> compute_component_file_digest(component_type type) const;
     future<uint32_t> compute_component_file_digest(file f, size_t size) const;
 
@@ -1205,6 +1215,8 @@ public:
 //
 // Sstables have two kind of checksums: per-chunk checksums and a
 // full-checksum (digest) calculated over the entire content of Data.db.
+// Other components have a digest, which is stored in the Scylla-metadata
+// component.
 //
 // The full-checksum (digest) is stored in Digest.crc (component_type::Digest).
 //
@@ -1220,12 +1232,19 @@ public:
 // data, on the compressed data.
 //
 // This method validates both the full checksum and the per-chunk checksum
-// for the entire Data.db.
+// for the entire Data.db, as well as the digests of other components.
 //
 // Returns `valid` if all checksums are valid.
-// Returns `invalid` if at least one checksum is invalid.
+// Returns `invalid` if at least one checksum or digest is invalid.
 // Returns `no_checksum` if the sstable is uncompressed and does not have
-// a CRC component (CRC.db is missing from TOC.txt).
+// a CRC component (CRC.db is missing from TOC.txt) and all validated
+// components have a valid digest.
+//
+// `has_digest` is `true` if the data digest is present in the dedicated
+// Digest component.
+// `has_checksum` is `true` if the sstable is compressed or has a CRC
+// component.
+//
 // Validation errors are logged individually.
 enum class validate_checksums_status {
     invalid = 0,
@@ -1235,6 +1254,7 @@ enum class validate_checksums_status {
 struct validate_checksums_result {
     validate_checksums_status status;
     bool has_digest;
+    bool has_checksum;
 };
 future<validate_checksums_result> validate_checksums(shared_sstable sst, reader_permit permit);
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3431,7 +3431,7 @@ void sstable_validate_fn(test_env& env) {
             // Corrupt the data to cause an invalid checksum.
             corrupt_sstable(sst);
 
-            auto res = sstables::validate_checksums(sst, permit).get();
+            auto res = sstables::validate_checksums_and_digests(sst, permit).get();
             BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
             BOOST_REQUIRE(res.has_digest);
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2855,7 +2855,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
 
                 testlog.info("Validating intact {}", sst->get_filename());
 
-                res = sstables::validate_checksums(sst, permit).get();
+                res = sstables::validate_checksums_and_digests(sst, permit).get();
                 BOOST_REQUIRE(res.status == validate_checksums_status::valid);
                 BOOST_REQUIRE(res.has_digest);
 
@@ -2867,7 +2867,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                 BOOST_REQUIRE(valid_digest.has_value());
                 sstables::test(sst).set_digest(valid_digest.value() + 1);
 
-                res = sstables::validate_checksums(sst, permit).get();
+                res = sstables::validate_checksums_and_digests(sst, permit).get();
                 BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
                 BOOST_REQUIRE(res.has_digest);
                 sstables::test(sst).set_digest(valid_digest); // restore it for next test cases
@@ -2881,7 +2881,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                     sst_file.dma_write(sst->ondisk_data_size() / 2, buf.begin(), buf.size()).get();
                 }
 
-                res = sstables::validate_checksums(sst, permit).get();
+                res = sstables::validate_checksums_and_digests(sst, permit).get();
                 BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
                 BOOST_REQUIRE(res.has_digest);
 
@@ -2891,7 +2891,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                     sst_file.truncate(sst->ondisk_data_size() - 1).get();
                 }
 
-                res = sstables::validate_checksums(sst, permit).get();
+                res = sstables::validate_checksums_and_digests(sst, permit).get();
                 BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
                 BOOST_REQUIRE(res.has_digest);
 
@@ -2901,7 +2901,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
                     sst_file.truncate(sst->ondisk_data_size() / 2).get();
                 }
 
-                res = sstables::validate_checksums(sst, permit).get();
+                res = sstables::validate_checksums_and_digests(sst, permit).get();
                 BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
                 BOOST_REQUIRE(res.has_digest);
 
@@ -2909,14 +2909,14 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
 
                 sstables::test(sst).set_digest(std::nullopt);
                 sstables::test(sst).rewrite_toc_without_component(component_type::Digest);
-                res = sstables::validate_checksums(sst, permit).get();
+                res = sstables::validate_checksums_and_digests(sst, permit).get();
                 BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
                 BOOST_REQUIRE(!res.has_digest);
 
                 if (compression_params == no_compression_params) {
                     testlog.info("Validating with no checksums {}", sst->get_filename());
                     sstables::test(sst).rewrite_toc_without_component(component_type::CRC);
-                    auto res = sstables::validate_checksums(sst, permit).get();
+                    auto res = sstables::validate_checksums_and_digests(sst, permit).get();
                     BOOST_REQUIRE(res.status == validate_checksums_status::no_checksum);
                     BOOST_REQUIRE(!res.has_digest);
                 }
@@ -2932,7 +2932,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
 
                     sst->load(sst->get_schema()->get_sharder()).get();
 
-                    res = sstables::validate_checksums(sst, permit).get();
+                    res = sstables::validate_checksums_and_digests(sst, permit).get();
                     BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
                     BOOST_REQUIRE(res.has_digest);
                 }
@@ -2948,7 +2948,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
 
                     sst->load(sst->get_schema()->get_sharder()).get();
 
-                    res = sstables::validate_checksums(sst, permit).get();
+                    res = sstables::validate_checksums_and_digests(sst, permit).get();
                     BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
                     BOOST_REQUIRE(res.has_digest);
                 }
@@ -2969,7 +2969,7 @@ SEASTAR_TEST_CASE(test_validate_checksums) {
 
                     sst->load(sst->get_schema()->get_sharder()).get();
 
-                    res = sstables::validate_checksums(sst, permit).get();
+                    res = sstables::validate_checksums_and_digests(sst, permit).get();
                     BOOST_REQUIRE(res.status == validate_checksums_status::invalid);
                     BOOST_REQUIRE(res.has_digest);
                 }

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -1073,6 +1073,8 @@ static future<> test_component_digest_validation(component_type component, sstab
 
         corrupt_sstable(sst, component);
 
+        BOOST_REQUIRE(sstables::validate_checksums_and_digests(sst, env.make_reader_permit()).get().status == validate_checksums_status::invalid);
+
         // Loading the sstable should detect the digest mismatch
         auto sst_corrupted = env.make_sstable(schema, dir_path, entry_desc.generation, entry_desc.version, entry_desc.format);
         BOOST_REQUIRE_EXCEPTION(sst_corrupted->load(schema->get_sharder()).get(), malformed_sstable_exception,

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -171,12 +171,35 @@ public:
         _sst->_last = last_key;
     }
 
+    void set_component_metadata_digest(component_type type, std::optional<uint32_t> digest) {
+        SCYLLA_ASSERT(_sst->has_scylla_component());
+        if (type == component_type::Scylla) {
+            _sst->_components->scylla_metadata->digest = digest;
+            return;
+        }
+        auto& digests = _sst->_components->scylla_metadata->get_or_create_components_digests();
+        if (digest) {
+            digests.map[type] = *digest;
+        } else {
+            digests.map.erase(type);
+        }
+    }
+
+    future<> recalculate_component_metadata_digest(component_type type) {
+        auto computed = co_await _sst->compute_component_file_digest(type);
+        set_component_metadata_digest(type, computed);
+    }
+
     void rewrite_toc_without_component(component_type component) {
         SCYLLA_ASSERT(component != component_type::TOC);
         _sst->_recognized_components.erase(component);
         remove_file(fmt::to_string(_sst->toc_filename())).get();
         _sst->_storage->open(*_sst);
         _sst->seal_sstable(false).get();
+
+        if (_sst->has_scylla_component() && _sst->_components->scylla_metadata->get_components_digests()) {
+            recalculate_component_metadata_digest(component_type::TOC).get();
+        }
     }
 
     future<> remove_component(component_type c) {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1588,14 +1588,7 @@ void validate_checksums_operation(schema_ptr schema, reader_permit permit, const
         writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartObject();
         writer.Key("has_checksums");
-        switch (res.status) {
-        case validate_checksums_status::valid:
-        case validate_checksums_status::invalid:
-            writer.Bool(true);
-            break;
-        case validate_checksums_status::no_checksum:
-            writer.Bool(false);
-        }
+        writer.Bool(res.has_checksum);
         writer.Key("has_digest");
         writer.Bool(res.has_digest);
         switch (res.status) {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1584,7 +1584,7 @@ void validate_checksums_operation(schema_ptr schema, reader_permit permit, const
     json_writer writer(json_output_stream);
     writer.StartStream();
     for (auto& sst : sstables) {
-        const auto res = sstables::validate_checksums(sst, permit).get();
+        const auto res = sstables::validate_checksums_and_digests(sst, permit).get();
         writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartObject();
         writer.Key("has_checksums");


### PR DESCRIPTION
Add additional validation by checking all components' digests in `validate_checksums()`.

The digest of the `component_type::Scylla` is stored in the last four bytes of the component itself.
The digest is calculated in `compute_component_file_digest` omits the last four bytes and `validate_component_digest` compares to a value stored in memory.
In order not to miss corruption in the last four bytes of the Scylla component, check the digest value in memory against the one on the disk.

Add additional fields to `validate_checksums_result` which contain the results of the additional digest checks. The values of `status` and `has_digest` are not modified

Add a `validate_checksums()` call in `test_component_digest_validation` to test whether it correctly detects corruption in components other than `Data`.

Rename `validate_checksums` to `validate_checksums_and_digests` to reflect the fact that it also checks component digests.

Closes: https://scylladb.atlassian.net/browse/SCYLLADB-2882

No backport; new feature