### PR TITLE
docs: document GCP user data and Tier 1 networking option

### DIFF
--- a/docs/getting-started/install-scylla/launch-on-gcp.rst
+++ b/docs/getting-started/install-scylla/launch-on-gcp.rst
@@ -47,6 +47,9 @@ Launching ScyllaDB on GCP
    
    For more information about GCP image `create` see the `Google Cloud SDK documentation <https://cloud.google.com/sdk/gcloud/reference/compute/images/create>`_.
 
+   To customize the ScyllaDB configuration at launch (cluster name, seeds, networking, and more),
+   pass cloud-init user data as described in `Configuring ScyllaDB with User Data`_.
+
 #. (Optional) Configure firewall rules.
 
    Ensure that all :ref:`ScyllaDB ports <networking-ports>` are open.
@@ -66,8 +69,109 @@ Launching ScyllaDB on GCP
    To check that the ScyllaDB server is running, run:
 
      .. code-block:: console
-      
+
         nodetool status
+
+Configuring ScyllaDB with User Data
+--------------------------------------
+
+You can customize the ScyllaDB configuration at launch time by passing cloud-init
+user data to the instance. On GCP, user data is provided through the instance
+``user-data`` metadata key, for example with ``--metadata-from-file``:
+
+.. code-block:: console
+
+   gcloud compute instances create scylla-node1 --image scylladb-5-2-1 --image-project scylla-images \
+       --local-ssd interface=nvme --machine-type=n2-standard-8 \
+       --metadata-from-file user-data=./user-data.yaml
+
+The user data is a JSON or YAML document. The most commonly used options are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 12 15 48
+
+   * - Option
+     - Type
+     - Default
+     - Description
+   * - ``scylla_yaml``
+     - object
+     - ``{}``
+     - Settings passed directly to ``scylla.yaml`` (for example ``cluster_name`` and ``seed_provider``). See :ref:`scylla.yaml <admin-scylla.yaml>`.
+   * - ``developer_mode``
+     - boolean
+     - ``false``
+     - Enable developer mode (relaxes production checks; not recommended for production).
+   * - ``post_configuration_script``
+     - string
+     - ``""``
+     - A bash script (optionally base64-encoded) executed after ScyllaDB configuration completes.
+   * - ``post_configuration_script_timeout``
+     - integer
+     - ``600``
+     - Timeout, in seconds, for ``post_configuration_script``.
+   * - ``start_scylla_on_first_boot``
+     - boolean
+     - ``true``
+     - Start ``scylla-server`` automatically on the first boot.
+   * - ``tier1_networking``
+     - boolean
+     - auto-detect
+     - **GCP only.** Force the network bandwidth tier ScyllaDB assumes when tuning I/O and streaming throughput. When omitted, it is auto-detected. See `GCP Tier 1 networking`_.
+   * - ``device_wait_seconds``
+     - integer
+     - ``0``
+     - Maximum number of seconds to wait for storage devices to appear before configuring them (``300`` is recommended).
+
+For the full list of supported user-data options, see the
+`ScyllaDB Machine Image documentation <https://github.com/scylladb/scylla-machine-image>`_.
+
+Example ``user-data.yaml``:
+
+.. code-block:: yaml
+
+   scylla_yaml:
+     cluster_name: my-cluster
+     seed_provider:
+       - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+         parameters:
+           - seeds: 10.0.1.1,10.0.1.2
+   start_scylla_on_first_boot: true
+   device_wait_seconds: 300
+
+GCP Tier 1 networking
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Tier 1 networking <https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration>`_
+provides higher egress bandwidth on supported GCP machine types — up to 100 Gbps
+on N2 and N2D instances with 48 or more vCPUs, and up to 200 Gbps on Z3 instances.
+ScyllaDB uses the assumed network bandwidth to tune internal I/O and streaming
+throughput, so it needs to know whether the instance runs with Tier 1 bandwidth.
+
+By default ScyllaDB detects this automatically, in the following order of precedence:
+
+#. The ``tier1_networking`` user-data option (``true`` / ``false``), when set.
+#. The ``scylla_tier1_networking`` instance metadata attribute, when set at VM creation time.
+#. The NIC link speed reported by the kernel (``/sys/class/net/<iface>/speed``).
+
+Auto-detection requires no additional GCP API permissions and works out of the box.
+Set ``tier1_networking`` explicitly only when you want to override the detected
+value — for example, to force the Tier 1 bandwidth assumption on an instance where
+detection is not reliable:
+
+.. code-block:: yaml
+
+   tier1_networking: true
+
+.. note::
+
+   The ``tier1_networking`` option only controls the bandwidth ScyllaDB *assumes*
+   when tuning itself. To actually obtain Tier 1 bandwidth, the instance must be
+   created with Tier 1 networking enabled — a supported machine type, a gVNIC
+   network interface, and
+   ``--network-performance-configs=total-egress-bandwidth-tier=TIER_1``. See the
+   `GCP high-bandwidth configuration documentation <https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration>`_.
 
 Next Steps
 ---------------

--- a/docs/getting-started/install-scylla/launch-on-gcp.rst
+++ b/docs/getting-started/install-scylla/launch-on-gcp.rst
@@ -36,16 +36,20 @@ Launching ScyllaDB on GCP
 
    .. code-block:: console
    
-        gcloud compute instances create scylla-node1 --image scylladb-5-2-1 --image-project scylla-images --local-ssd interface=nvme --machine-type=n1-highmem-8
+        gcloud compute instances create scylla-node1 --image scylladb-2026-1-11 --image-project scylla-images --local-ssd interface=nvme --machine-type=n1-highmem-8
    
    To add more storage to the VM, add multiple ``--local-ssd interface=nvme`` options to the command. For example, the following 
    command will launch a VM with 4 SSD, and 1.5TB of data (4 * `375 GB <https://cloud.google.com/compute/docs/disks/local-ssd>`_):
 
    .. code-block:: console
       
-        gcloud compute instances create scylla-node1 --image scylladb-5-2-1 --image-project scylla-images --local-ssd interface=nvme --local-ssd interface=nvme --local-ssd interface=nvme --local-ssd interface=nvme --machine-type=n1-highmem-8
+        gcloud compute instances create scylla-node1 --image scylladb-2026-1-11 --image-project scylla-images --local-ssd interface=nvme --local-ssd interface=nvme --local-ssd interface=nvme --local-ssd interface=nvme --machine-type=n1-highmem-8
    
    For more information about GCP image `create` see the `Google Cloud SDK documentation <https://cloud.google.com/sdk/gcloud/reference/compute/images/create>`_.
+
+   To customize the ScyllaDB configuration at launch (cluster name, seeds, networking, and more),
+   pass cloud-init user data as described in
+   :ref:`Configuring ScyllaDB with User Data <launch-on-gcp-user-data>`.
 
 #. (Optional) Configure firewall rules.
 
@@ -66,8 +70,124 @@ Launching ScyllaDB on GCP
    To check that the ScyllaDB server is running, run:
 
      .. code-block:: console
-      
+
         nodetool status
+
+.. _launch-on-gcp-user-data:
+
+Configuring ScyllaDB with User Data
+--------------------------------------
+
+You can customize the ScyllaDB configuration at launch time by passing cloud-init
+user data to the instance. On GCP, user data is provided through the instance
+``user-data`` metadata key, for example with ``--metadata-from-file``
+(replace the image name and machine type with your actual version and instance):
+
+.. code-block:: console
+
+   gcloud compute instances create scylla-node1 --image scylladb-2026-1-11 --image-project scylla-images \
+       --local-ssd interface=nvme --machine-type=n2-standard-8 \
+       --metadata-from-file user-data=./user-data.yaml
+
+The user data is a JSON or YAML document. The most commonly used options are:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 12 15 48
+
+   * - Option
+     - Type
+     - Default
+     - Description
+   * - ``scylla_yaml``
+     - object
+     - ``{}``
+     - Settings passed directly to ``scylla.yaml`` (for example ``cluster_name`` and ``seed_provider``). See :ref:`scylla.yaml <admin-scylla.yaml>`.
+   * - ``developer_mode``
+     - boolean
+     - ``false``
+     - Enable developer mode (relaxes production checks; not recommended for production).
+   * - ``post_configuration_script``
+     - string
+     - ``""``
+     - A bash script (optionally base64-encoded) executed after ScyllaDB configuration completes.
+   * - ``post_configuration_script_timeout``
+     - integer
+     - ``600``
+     - Timeout, in seconds, for ``post_configuration_script``.
+   * - ``start_scylla_on_first_boot``
+     - boolean
+     - ``true``
+     - Start ``scylla-server`` automatically on the first boot.
+   * - ``tier1_networking``
+     - boolean
+     - auto-detect
+     - **GCP only.** Override the network bandwidth tier ScyllaDB assumes when tuning streaming throughput. When omitted, it is auto-detected. Only has an effect on machine types that support Tier 1 networking (N2/N2D with 48 or more vCPUs, and Z3); it is ignored on all other types. See :ref:`GCP Tier 1 networking <launch-on-gcp-tier1-networking>`.
+   * - ``device_wait_seconds``
+     - integer
+     - ``0``
+     - Maximum number of seconds to wait for storage devices to appear before configuring them (``300`` is recommended).
+
+For the full list of supported user-data options, see the
+`ScyllaDB Machine Image documentation <https://github.com/scylladb/scylla-machine-image>`_.
+
+Example ``user-data.yaml``:
+
+.. code-block:: yaml
+
+   scylla_yaml:
+     cluster_name: my-cluster
+     seed_provider:
+       - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+         parameters:
+           - seeds: 10.0.1.1,10.0.1.2
+   start_scylla_on_first_boot: true
+   device_wait_seconds: 300
+
+.. _launch-on-gcp-tier1-networking:
+
+GCP Tier 1 networking
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Tier 1 networking <https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration>`_
+provides higher egress bandwidth on supported GCP machine types — up to 100 Gbps
+on N2 and N2D instances with 48 or more vCPUs, and up to 200 Gbps on Z3 instances.
+ScyllaDB uses the assumed network bandwidth to tune streaming throughput
+(``stream_io_throughput_mb_per_sec``), so it needs to know whether the instance
+runs with Tier 1 bandwidth.
+
+By default ScyllaDB detects this automatically, in the following order of precedence:
+
+#. The ``tier1_networking`` user-data option (``true`` / ``false``), when set.
+#. The ``scylla_tier1_networking`` instance metadata attribute, when set at VM creation time.
+#. The NIC link speed reported by the kernel (``/sys/class/net/<iface>/speed``).
+#. The Compute Engine API, as a last resort: ScyllaDB reads
+   ``networkPerformanceConfig.totalEgressBandwidthTier`` from the instance
+   resource. This query requires the ``compute.readonly`` scope on the VM
+   service account; without it the check is skipped and the default bandwidth
+   is assumed.
+
+The first three checks require no additional GCP API permissions and work out of
+the box. Set ``tier1_networking`` explicitly only when you want to override the
+detected value — for example, to assume Tier 1 bandwidth on an instance where
+detection is not reliable:
+
+.. code-block:: yaml
+
+   tier1_networking: true
+
+The override applies only to machine types that support Tier 1 networking. On any
+other type — such as the ``n2-standard-8`` instance used in the examples above —
+``tier1_networking`` is ignored and the default bandwidth is used.
+
+.. note::
+
+   The ``tier1_networking`` option only controls the bandwidth ScyllaDB *assumes*
+   when tuning itself. To actually obtain Tier 1 bandwidth, the instance must be
+   created with Tier 1 networking enabled — a supported machine type, a gVNIC
+   network interface, and
+   ``--network-performance-configs=total-egress-bandwidth-tier=TIER_1``. See the
+   `GCP high-bandwidth configuration documentation <https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration>`_.
 
 Next Steps
 ---------------


### PR DESCRIPTION
## What

Documents GCP cloud-init user data in the ScyllaDB GCP launch guide, and adds documentation for the new `tier1_networking` user-data option introduced in [scylla-machine-image#933](https://github.com/scylladb/scylla-machine-image/pull/933).

The GCP launch guide previously had no user-data documentation at all (it only linked out to the SMI repo). This PR adds a **"Configuring ScyllaDB with User Data"** section to `docs/getting-started/install-scylla/launch-on-gcp.rst` covering:

1. **How to pass user data on GCP** — via the instance `user-data` metadata key (`--metadata-from-file user-data=...`).
2. **User-data options table** — the common options, including a `tier1_networking` row.
3. **GCP Tier 1 networking subsection** — what it provides (up to 100 Gbps on N2/N2D ≥48 vCPUs, 200 Gbps on Z3), the auto-detection precedence, and when to set it explicitly.
4. **Cloud-init examples** — a `user-data.yaml` example and a `tier1_networking: true` snippet.

A cross-reference from the launch procedure points readers to the new section.

## The `tier1_networking` option

- Auto-detection precedence: `tier1_networking` user data → `scylla_tier1_networking` instance metadata attribute → NIC link speed (`/sys/class/net/<iface>/speed`). No extra GCP API scope required.
- A `.. note::` clarifies the important caveat: the option only controls the bandwidth ScyllaDB *assumes* when tuning I/O and streaming throughput — it does **not** enable GCP-side Tier 1 networking, which still requires a gVNIC interface and `--network-performance-configs=total-egress-bandwidth-tier=TIER_1` at VM creation.

## Refs

- Jira: SMI-293
- SMI PR: scylladb/scylla-machine-image#933

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport reason

This is documentation for the feature merged to 2026.3.0-rc0, so it should be backported to branch-2026.3.
Reference: https://github.com/scylladb/scylla-machine-image/pull/933
