### PR TITLE
cdc: refresh tablet streams during resize finalization

### DIFF
--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -202,6 +202,16 @@ group0_state_machine::modules_to_reload group0_state_machine::get_modules_to_rel
 
     for (auto& mut: mutations) {
         modules.entries.push_back({.pk = mut.key(), .table = mut.column_family_id()});
+
+        if (mut.column_family_id() == db::system_keyspace::cdc_streams_state()->id()) {
+            const auto elements = mut.key().explode(*db::system_keyspace::cdc_streams_state());
+            auto cdc_log_table_id = table_id(value_cast<utils::UUID>(uuid_type->deserialize_value(elements.front())));
+            modules.update_cdc_streams.insert(cdc_log_table_id);
+        } else if (mut.column_family_id() == db::system_keyspace::cdc_streams_history()->id()) {
+            const auto elements = mut.key().explode(*db::system_keyspace::cdc_streams_history());
+            auto cdc_log_table_id = table_id(value_cast<utils::UUID>(uuid_type->deserialize_value(elements.front())));
+            modules.update_cdc_streams.insert(cdc_log_table_id);
+        }
     }
 
     return modules;
@@ -222,7 +232,6 @@ future<> group0_state_machine::reload_modules(modules_to_reload modules) {
     bool update_service_levels_cache = false;
     bool update_service_levels_effective_cache = false;
     bool make_view_building_state_transition = false;
-    std::unordered_set<table_id> update_cdc_streams;
     std::unordered_set<auth::cache::role_name_t> update_auth_cache_roles;
 
     for (const auto& m : modules.entries) {
@@ -237,14 +246,6 @@ future<> group0_state_machine::reload_modules(modules_to_reload modules) {
             make_view_building_state_transition = true;
         } else if (m.table == db::system_keyspace::scylla_local()->id()) {
             make_view_building_state_transition = true;
-        } else if (m.table == db::system_keyspace::cdc_streams_state()->id()) {
-            const auto elements = m.pk.explode(*db::system_keyspace::cdc_streams_state());
-            auto cdc_log_table_id = table_id(value_cast<utils::UUID>(uuid_type->deserialize_value(elements.front())));
-            update_cdc_streams.insert(cdc_log_table_id);
-        } else if (m.table == db::system_keyspace::cdc_streams_history()->id()) {
-            const auto elements = m.pk.explode(*db::system_keyspace::cdc_streams_history());
-            auto cdc_log_table_id = table_id(value_cast<utils::UUID>(uuid_type->deserialize_value(elements.front())));
-            update_cdc_streams.insert(cdc_log_table_id);
         } else if (auth::cache::includes_table(m.table)) {
             if (m.table == db::system_keyspace::role_members()->id() ||
                     m.table == db::system_keyspace::role_attributes()->id()) {
@@ -293,8 +294,8 @@ future<> group0_state_machine::reload_modules(modules_to_reload modules) {
     if (make_view_building_state_transition) {
         co_await _ss.view_building_transition();
     }
-    if (update_cdc_streams.size()) {
-        co_await _ss.load_cdc_streams(std::move(update_cdc_streams));
+    if (modules.update_cdc_streams.size()) {
+        co_await _ss.load_cdc_streams(std::move(modules.update_cdc_streams));
     }
 }
 
@@ -330,12 +331,12 @@ future<> group0_state_machine::merge_and_apply(group0_state_machine_merger& merg
     },
     [&] (topology_change& chng) -> future<> {
         modules_to_reload = get_modules_to_reload(chng.mutations);
-        topology_state_change_hint = {.tablets_hint = replica::get_tablet_metadata_change_hint(chng.mutations)};
+        topology_state_change_hint = storage_service::state_change_hint(replica::get_tablet_metadata_change_hint(chng.mutations));
         co_await write_mutations_to_database(_ss, _sp, cmd.creator_addr, std::move(chng.mutations));
     },
     [&] (mixed_change& chng) -> future<> {
         modules_to_reload = get_modules_to_reload(chng.mutations);
-        topology_state_change_hint.emplace();
+        topology_state_change_hint = storage_service::state_change_hint(replica::get_tablet_metadata_change_hint(chng.mutations));
         if (_in_memory_state_machine_enabled) {
             co_await _mm.merge_schema_from(locator::host_id{cmd.creator_id.uuid()}, std::move(chng.mutations));
         } else {
@@ -350,6 +351,15 @@ future<> group0_state_machine::merge_and_apply(group0_state_machine_merger& merg
 
     if (_in_memory_state_machine_enabled) {
         if (topology_state_change_hint) {
+            if (topology_state_change_hint->tablets_hint && modules_to_reload.update_cdc_streams.size()) {
+                // Tablet resize finalization publishes a new tablet map and appends
+                // the matching CDC stream generation in the same group0 change.
+                // Load the stream generation first so local CDC writes cannot see
+                // the finalized tablet map with stale stream metadata.
+                co_await _ss.load_cdc_streams(std::move(modules_to_reload.update_cdc_streams));
+                modules_to_reload.update_cdc_streams.clear();
+                topology_state_change_hint->cdc_streams_reloaded = true;
+            }
             co_await _ss.topology_transition(std::move(*topology_state_change_hint));
         }
         co_await reload_modules(std::move(modules_to_reload));

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -7,6 +7,8 @@
  */
 #pragma once
 
+#include <unordered_set>
+
 #include <seastar/core/gate.hh>
 #include <seastar/core/abort_source.hh>
 
@@ -100,6 +102,7 @@ class group0_state_machine : public raft_state_machine {
             table_id table;
         };
         std::vector<entry> entries;
+        std::unordered_set<table_id> update_cdc_streams;
     };
 
     raft_group0_client& _client;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -664,6 +664,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
     rtlogger.debug("reload raft topology state");
     std::unordered_set<raft::server_id> prev_normal = _topology_state_machine._topology.normal_nodes | std::views::keys | std::ranges::to<std::unordered_set>();
     std::optional<std::unordered_set<locator::host_id>> prev_released;
+    auto previous_tstate = _topology_state_machine._topology.tstate;
     if (!_topology_state_machine._topology.is_empty()) {
         prev_released = get_released_nodes(_topology_state_machine._topology, get_token_metadata());
     }
@@ -686,6 +687,16 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
     co_await _sys_ks.local().save_local_enabled_features(topology.enabled_features, false);
 
     auto saved_tmpr = get_token_metadata_ptr();
+
+    const bool reload_cdc_streams_before_publishing_tablets = previous_tstate == topology::transition_state::tablet_resize_finalization
+            || previous_tstate == topology::transition_state::tablet_split_finalization;
+    if (reload_cdc_streams_before_publishing_tablets && !hint.cdc_streams_reloaded) {
+        // Full topology reload paths do not have mutation context. If we were in
+        // resize/split finalization, refresh CDC streams before publishing the
+        // finalized tablet map locally.
+        co_await load_cdc_streams();
+    }
+
     {
         rtlogger.debug("topology_state_load: waiting for token metadata lock");
         auto tmlock = co_await get_token_metadata_lock();
@@ -743,6 +754,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
             tablets = co_await replica::read_tablet_metadata(_qp);
         }
         tablets->set_balancing_enabled(topology.tablet_balancing_enabled);
+
         tmptr->set_tablets(std::move(*tablets));
 
         if (_feature_service.parallel_tablet_draining) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -923,7 +923,13 @@ private:
     future<> update_topology_with_local_metadata(raft::server&);
 
     struct state_change_hint {
+        state_change_hint(std::optional<locator::tablet_metadata_change_hint> tablets_hint = {}, bool cdc_streams_reloaded = false)
+            : tablets_hint(std::move(tablets_hint))
+            , cdc_streams_reloaded(cdc_streams_reloaded)
+        {}
+
         std::optional<locator::tablet_metadata_change_hint> tablets_hint;
+        bool cdc_streams_reloaded;
     };
 
     // This is called on all nodes for each new command received through raft

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2684,6 +2684,17 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
         auto tm = get_token_metadata_ptr();
         auto plan = co_await _tablet_allocator.balance_tablets(tm, &_topo_sm._topology, &_sys_ks, {}, get_dead_nodes());
+        std::unordered_set<table_id> finalized_tables;
+        for (auto table_id : plan.resize_plan().finalize_resize) {
+            for (auto colocated_table_id : tm->tablets().all_table_groups().at(table_id)) {
+                finalized_tables.insert(colocated_table_id);
+            }
+        }
+        if (!finalized_tables.empty()) {
+            // CDC resize diffs are generated from the latest loaded stream set,
+            // so refresh it before computing mutations for another generation.
+            co_await _cdc_gens.load_cdc_tablet_streams(std::make_optional(std::move(finalized_tables)));
+        }
 
         utils::chunked_vector<canonical_mutation> updates;
         updates.reserve(plan.resize_plan().finalize_resize.size() * 2 + 1);
@@ -2706,8 +2717,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             generate_resize_update(updates, guard, table_id, locator::resize_decision{});
             _vb_coordinator->generate_tablet_resize_updates(updates, guard, table_id, tm->tablets().get_tablet_map(table_id), new_tablet_map);
 
-            for (auto table_id : tm->tablets().all_table_groups().at(table_id)) {
-                co_await _cdc_gens.generate_tablet_resize_update(updates, table_id, new_tablet_map, guard.write_timestamp());
+            for (auto colocated_table_id : tm->tablets().all_table_groups().at(table_id)) {
+                co_await _cdc_gens.generate_tablet_resize_update(updates, colocated_table_id, new_tablet_map, guard.write_timestamp());
             }
 
             const auto& tmap = get_token_metadata_ptr()->tablets().get_tablet_map(table_id);


### PR DESCRIPTION
`test_get_records_with_alternating_tablets_count` repeatedly changes the
tablet count of an Alternator Streams CDC log table. Each resize creates a
new CDC stream generation, and the test later validates stream topology
through `DescribeStream`, `GetShardIterator`, and `GetRecords`.

The suspected failure mode is stale local CDC tablet stream metadata during
tablet resize finalization. The old tablet map remains visible while
finalization is in progress, but once the transition is cleared the
finalized tablet map can become visible before local CDC stream metadata has
caught up. With consecutive resizes, the next CDC stream diff can then be
computed from a stale previous generation.

Fix this in two places:

- Refresh relevant CDC tablet stream metadata before computing CDC resize
  stream diffs during tablet resize finalization.
- During group0 apply, when the same command updates tablet metadata and CDC
  stream metadata, reload the affected CDC stream metadata before publishing
  finalized tablet metadata locally.

Fixes SCYLLADB-3180.

The test which triggers the problem came to live with 2026.2, so let's backport there.