### PR TITLE
test/audit: wait for audit row visibility in count checks

### DIFF
--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -735,7 +735,17 @@ class CQLAuditTester(AuditTester):
     def assert_exactly_n_audit_entries_were_added(self, session: Session, expected_entries: int):
         counts_before = self.get_audit_entries_count_dict(session)
         yield
-        counts_after = self.get_audit_entries_count_dict(session)
+
+        counts_after: dict[str, int] = {}
+
+        def audit_entry_counts_reached_expected():
+            nonlocal counts_after
+            counts_after = self.get_audit_entries_count_dict(session)
+            assert set(counts_before.keys()) == set(counts_after.keys()), f"audit modes changed (before: {list(counts_before.keys())} after: {list(counts_after.keys())})"
+            return all(counts_after[mode] - count_before >= expected_entries for mode, count_before in counts_before.items())
+
+        wait_for(audit_entry_counts_reached_expected, timeout=60)
+
         assert set(counts_before.keys()) == set(counts_after.keys()), f"audit modes changed (before: {list(counts_before.keys())} after: {list(counts_after.keys())})"
         for mode, count_before in counts_before.items():
             count_after = counts_after[mode]


### PR DESCRIPTION
The table audit backend writes audit rows with CL=ONE, while the multinode audit tests read the audit table with QUORUM. A successful CQL statement can therefore complete before its audit row is visible to the test reader.

Make the count-only audit assertion wait until every audit mode has at least the expected number of new rows, then keep the exact final count assertion so unexpected extra audit rows still fail.

Fixes: SCYLLADB-3221

The test failure occurred in 2026.2, so let's backport there.