### PR TITLE
test.py: Add parametrized configuration for different config types

### DIFF
--- a/test/cluster/test_table_drop.py
+++ b/test/cluster/test_table_drop.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 import shutil
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, FeatureConfig, feature_configs, FeatureConfigurations
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import unique_name
 import pytest
@@ -17,20 +17,29 @@ async def test_drop_table_during_streaming_receiver_side(manager: ManagerClient)
         'tablets_mode_for_new_keyspaces': 'disabled'
     }) for _ in range(2)]
 
-async def test_drop_table_during_flush(manager: ManagerClient):
-    servers = [await manager.server_add() for _ in range(2)]
+
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+    FeatureConfigurations.STRONG_CONSISTENCY, FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY,
+    FeatureConfigurations.LOGSTOR_STRONG_CONSISTENCY))
+async def test_drop_table_during_flush(manager: ManagerClient, feature_config: FeatureConfig):
+    servers = [await manager.server_add(config=feature_config.get_cluster_cfg({})) for _ in range(2)]
 
     await manager.api.enable_injection(servers[0].ip_addr, "flush_tables_on_all_shards_table_drop", True)
+    keyspace_opts = feature_config.get_keyspace_opts(
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
 
     cql = manager.get_cql()
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);"))
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k%3});") for k in range(64)])
         await manager.api.keyspace_flush(servers[0].ip_addr, ks, "test")
 
 
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+    FeatureConfigurations.STRONG_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_drop_table_during_load_and_stream(manager: ManagerClient):
+async def test_drop_table_during_load_and_stream(manager: ManagerClient, feature_config: FeatureConfig):
     """Verify that dropping a table while load_and_stream is in progress
     does not crash.  The stream_in_progress() phaser guard acquired in
     sstables_loader::load_and_stream keeps the table object alive until
@@ -47,17 +56,19 @@ async def test_drop_table_during_load_and_stream(manager: ManagerClient):
     A single node is sufficient: load_and_stream streams SSTables to
     the natural replicas (the local node in this case) via RPC.
     """
-    server = await manager.server_add()
+    server = await manager.server_add(config=feature_config.get_cluster_cfg({}))
 
     cql = manager.get_cql()
 
     ks = unique_name("ks_")
     cf = "test"
-
-    await cql.run_async(
+    keyspace_opts = feature_config.get_keyspace_opts(
         f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
+    table_opts = feature_config.get_table_opts(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY, c int)")
+
+    await cql.run_async(keyspace_opts)
     try:
-        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY, c int)")
+        await cql.run_async(table_opts)
 
         # Insert data and flush to create SSTables on disk
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.{cf} (pk, c) VALUES ({k}, {k})") for k in range(64)])

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -9,7 +9,8 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, read_barrier
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_count
 from test.pylib.util import wait_for
-from test.cluster.util import new_test_keyspace, create_new_test_keyspace
+from test.cluster.util import new_test_keyspace, create_new_test_keyspace, feature_configs, FeatureConfigurations, \
+    FeatureConfig, count_rows
 
 import pytest
 import asyncio
@@ -436,8 +437,11 @@ async def test_tablet_split_merge_with_many_tables(build_mode: str, manager: Man
 
     await check_logs("after merge completion")
 
+
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+    FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_missing_data(manager: ManagerClient):
+async def test_missing_data(manager: ManagerClient, feature_config: FeatureConfig):
 
     # This is a test and reproducer for issue:
     # https://github.com/scylladb/scylladb/issues/23313
@@ -446,6 +450,7 @@ async def test_missing_data(manager: ManagerClient):
     cfg = { 'enable_tablets': True,
             'tablet_load_stats_refresh_interval_in_seconds': 1
     }
+    cfg = feature_config.get_cluster_cfg(cfg)
     cmdline = [
         '--logger-log-level', 'load_balancer=debug',
         '--logger-log-level', 'debug_error_injection=debug',
@@ -459,9 +464,11 @@ async def test_missing_data(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     inital_tablets = 32
+    keyspace_opts = feature_config.get_keyspace_opts(
+        f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {inital_tablets}}}")
 
-    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {inital_tablets}}}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);'))
 
         await manager.api.disable_autocompaction(server.ip_addr, ks, 'test')
 
@@ -492,19 +499,16 @@ async def test_missing_data(manager: ManagerClient):
         logger.info(f'Merged test table; new number of tablets: {expected_tablet_count}')
 
         # assert that the number of records has not changed
-        qry = f'SELECT * FROM {ks}.test'
-        logger.info(f'Running: {qry}')
-        res = cql.execute(qry)
-        missing = set(pks)
-        rec_count = 0
-        for row in res:
-            rec_count += 1
-            missing.discard(row.pk)
+        rec_count = await count_rows(cql, feature_config,
+                                     query_template="SELECT COUNT(*) FROM {ks}.{table}", ks=ks, table='test', keys=pks, partition_key='pk')
+        assert rec_count == len(
+            pks), f"received {rec_count} records instead of {len(pks)} while querying server {server.server_id}"
 
-        assert rec_count == len(pks), f"received {rec_count} records instead of {len(pks)} while querying server {server.server_id}; missing keys: {missing}"
 
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+    FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_merge_with_drop(manager: ManagerClient):
+async def test_merge_with_drop(manager: ManagerClient, feature_config: FeatureConfig):
 
     # This is a test and reproducer for issue:
     # https://github.com/scylladb/scylladb/issues/23313
@@ -513,11 +517,14 @@ async def test_merge_with_drop(manager: ManagerClient):
     cfg = { 'enable_tablets': True,
             'tablet_load_stats_refresh_interval_in_seconds': 1
             }
+    cfg = feature_config.get_cluster_cfg(cfg)
     cmdline = [
         '--logger-log-level', 'load_balancer=debug',
         '--logger-log-level', 'debug_error_injection=debug',
     ]
     server = await manager.server_add(cmdline=cmdline, config=cfg)
+    keyspace_opts = feature_config.get_keyspace_opts(
+        f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
 
     logger.info(f'server_id = {server.server_id}')
 
@@ -527,8 +534,9 @@ async def test_merge_with_drop(manager: ManagerClient):
 
     initial_tablets = 32
 
-    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': {initial_tablets}}};")
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(
+            f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': {initial_tablets}}};"))
 
         await manager.api.disable_autocompaction(server.ip_addr, ks, 'test')
 
@@ -569,8 +577,10 @@ async def test_merge_with_drop(manager: ManagerClient):
         await drop_table_fut
 
 
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+    FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_background_merge_deadlock(manager: ManagerClient):
+async def test_background_merge_deadlock(manager: ManagerClient, feature_config: FeatureConfig):
     """
     Reproducer for https://scylladb.atlassian.net/browse/SCYLLADB-928
 
@@ -609,13 +619,15 @@ async def test_background_merge_deadlock(manager: ManagerClient):
         '--logger-log-level', 'raft_topology=debug',
     ]
 
-    servers = [await manager.server_add(cmdline=cmdline)]
+    servers = [await manager.server_add(cmdline=cmdline, config=feature_config.get_cluster_cfg({}))]
     cql, _ = await manager.get_ready_cql(servers)
 
-    ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+    ks = await create_new_test_keyspace(cql, feature_config.get_keyspace_opts(
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"))
 
     # Create a table which will go through 3 merge cycles.
-    await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) with tablets = {{'min_tablet_count': 8}};")
+    await cql.run_async(feature_config.get_table_opts(
+        f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) with tablets = {{'min_tablet_count': 8}};"))
 
     await manager.api.enable_injection(servers[0].ip_addr, "merge_completion_fiber", one_shot=True)
     log = await manager.server_open_log(servers[0].server_id)

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -15,6 +15,9 @@ from test.pylib.util import start_writes, scale_timeout_by_mode
 from test.cluster.util import (
     wait_for_cql_and_get_hosts, new_test_keyspace, reconnect_driver, wait_for,
     wait_for_no_pending_topology_transition, get_topology_coordinator,
+    FeatureConfig,
+    feature_configs,
+    FeatureConfigurations
 )
 import time
 import pytest
@@ -177,10 +180,13 @@ async def test_bootstrap_starts_while_tablet_migration_is_blocked(manager: Manag
         await wait_for_no_pending_topology_transition(manager, time.time() + scale_timeout(60))
 
 
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+    FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
 @pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new", "cleanup", "cleanup_target", "end_migration", "revert_migration"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage, build_mode):
+async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage, build_mode,
+                                                    feature_config: FeatureConfig):
     if fail_stage == 'cleanup' and fail_replica == 'destination':
         skip_env('Failing destination during cleanup is pointless')
     if fail_stage == 'cleanup_target' and fail_replica == 'source':
@@ -194,6 +200,9 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
         'write_request_timeout_in_ms': request_timeout_ms,
         'read_request_timeout_in_ms': request_timeout_ms,
     }
+    cfg = feature_config.get_cluster_cfg(cfg)
+    keyspace_opts = feature_config.get_keyspace_opts(
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}")
     host_ids = []
     servers = []
 
@@ -210,8 +219,8 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
 
     cql = manager.get_cql()
 
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);"))
 
         keys = range(256)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
@@ -338,9 +347,15 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
         # For dropping the keyspace after the node failure
         await reconnect_driver(manager)
 
-async def test_tablet_back_and_forth_migration(manager: ManagerClient):
+
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+    FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
+async def test_tablet_back_and_forth_migration(manager: ManagerClient, feature_config: FeatureConfig):
     logger.info("Bootstrapping cluster")
-    cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
+    cfg = feature_config.get_cluster_cfg(
+        {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'})
+    keyspace_opts = feature_config.get_keyspace_opts(
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}")
     host_ids = []
     servers = []
 
@@ -356,8 +371,8 @@ async def test_tablet_back_and_forth_migration(manager: ManagerClient):
     await make_server()
     await manager.disable_tablet_balancing()
     cql = manager.get_cql()
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);"))
         await make_server()
 
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({1}, {1});")
@@ -564,21 +579,28 @@ async def test_restart_leaving_replica_during_cleanup(manager: ManagerClient, mi
         await wait_for(tablets_merged, time.time() + 60)
 
 
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+    FeatureConfigurations.STRONG_CONSISTENCY, FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY,
+    FeatureConfigurations.LOGSTOR_STRONG_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_restart_in_cleanup_stage_after_cleanup(manager: ManagerClient):
+async def test_restart_in_cleanup_stage_after_cleanup(manager: ManagerClient, feature_config: FeatureConfig):
     """
     Migrate a tablet from one node to another, and restart the leaving replica during
     the tablet cleanup stage, after tablet cleanup is completed.
     Reproduces issue #24857
     """
-    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1}
+    keyspace_opts = feature_config.get_keyspace_opts(
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}")
+    cfg = feature_config.get_cluster_cfg({'tablet_load_stats_refresh_interval_in_seconds': 1})
+
     servers = await manager.servers_add(2, config=cfg)
 
     await manager.disable_tablet_balancing()
 
     cql = manager.get_cql()
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 8}};")
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(
+            f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 8}};"))
 
         total_keys = 10
         for pk in range(total_keys):

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -8,7 +8,8 @@ from cassandra.protocol import InvalidRequest
 from cassandra.cluster import TruncateError
 from cassandra.policies import FallthroughRetryPolicy
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import get_topology_coordinator, new_test_keyspace
+from test.cluster.util import get_topology_coordinator, new_test_keyspace, FeatureConfig, feature_configs, \
+    FeatureConfigurations, count_rows
 from test.pylib.tablets import get_all_tablet_replicas, get_tablet_count
 from test.pylib.util import wait_for_cql_and_get_hosts, wait_for
 import time
@@ -18,13 +19,19 @@ import asyncio
 
 logger = logging.getLogger(__name__)
 
+
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+                                                           FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_truncate_while_migration(manager: ManagerClient):
+async def test_truncate_while_migration(manager: ManagerClient, feature_config: FeatureConfig):
 
     logger.info('Bootstrapping cluster')
     cfg = { 'tablets_mode_for_new_keyspaces': 'enabled',
             'error_injections_at_startup': ['migration_streaming_wait']
             }
+    cfg = feature_config.get_cluster_cfg(cfg)
+    keyspace_opts = feature_config.get_keyspace_opts(
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}")
 
     servers = []
     servers.append(await manager.server_add(config=cfg))
@@ -32,8 +39,8 @@ async def test_truncate_while_migration(manager: ManagerClient):
     cql = manager.get_cql()
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);'))
 
         keys = range(1024)
         await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
@@ -55,8 +62,8 @@ async def test_truncate_while_migration(manager: ManagerClient):
         await pending_log.wait_for('raft_topology - Streaming for tablet migration of.*successful')
 
         # Check if we have any data
-        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM {ks}.test', consistency_level=ConsistencyLevel.ALL))
-        assert row[0].count == 0
+        assert await count_rows(cql, feature_config,
+                                query_template="SELECT COUNT(*) FROM {ks}.{table}", ks=ks, table='test', keys=keys, partition_key='pk') == 0
 
 
 async def get_raft_leader_and_log(manager: ManagerClient, servers):
@@ -119,11 +126,18 @@ async def test_truncate_with_concurrent_drop(manager: ManagerClient):
             await trunc_future
 
 
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+                                                           FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY,
+                                                           FeatureConfigurations.STRONG_CONSISTENCY,
+                                                           FeatureConfigurations.LOGSTOR_STRONG_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_truncate_while_node_restart(manager: ManagerClient):
+async def test_truncate_while_node_restart(manager: ManagerClient, feature_config: FeatureConfig):
 
     logger.info('Bootstrapping cluster')
     cfg = { 'tablets_mode_for_new_keyspaces': 'enabled' }
+    cfg = feature_config.get_cluster_cfg(cfg)
+    keyspace_opts = feature_config.get_keyspace_opts(
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}")
 
     servers = []
     servers.append(await manager.server_add(config=cfg))
@@ -134,8 +148,8 @@ async def test_truncate_while_node_restart(manager: ManagerClient):
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);'))
 
         keys = range(1024)
         await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
@@ -162,8 +176,8 @@ async def test_truncate_while_node_restart(manager: ManagerClient):
         await trunc_future
 
         # Check if truncate was successful
-        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM {ks}.test', consistency_level=ConsistencyLevel.ALL))
-        assert row[0].count == 0
+        assert await count_rows(cql, feature_config,
+                                query_template="SELECT COUNT(*) FROM {ks}.{table}", ks=ks, table='test', keys=keys, partition_key='pk') == 0
 
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
@@ -211,13 +225,18 @@ async def test_truncate_with_coordinator_crash(manager: ManagerClient):
         assert row[0].count == 0
 
 
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+                                                           FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_truncate_while_truncate_already_waiting(manager: ManagerClient):
+async def test_truncate_while_truncate_already_waiting(manager: ManagerClient, feature_config: FeatureConfig):
 
     logger.info('Bootstrapping cluster')
     cfg = { 'tablets_mode_for_new_keyspaces': 'enabled',
             'error_injections_at_startup': ['migration_streaming_wait']
             }
+    cfg = feature_config.get_cluster_cfg(cfg)
+    keyspace_opts = feature_config.get_keyspace_opts(
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}")
 
     servers = []
     servers.append(await manager.server_add(config=cfg))
@@ -225,8 +244,8 @@ async def test_truncate_while_truncate_already_waiting(manager: ManagerClient):
     cql = manager.get_cql()
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);'))
 
         keys = range(1024)
         await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
@@ -255,21 +274,27 @@ async def test_truncate_while_truncate_already_waiting(manager: ManagerClient):
         await truncate_future
 
         # Check if we have any data
-        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM {ks}.test', consistency_level=ConsistencyLevel.ALL))
-        assert row[0].count == 0
+        assert await count_rows(cql, feature_config,
+                                query_template="SELECT COUNT(*) FROM {ks}.{table}", ks=ks, table='test', keys=keys, partition_key='pk') == 0
 
 # Reproduces https://github.com/scylladb/scylladb/issues/23771.
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+                                                           FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY,
+                                                           FeatureConfigurations.STRONG_CONSISTENCY,
+                                                           FeatureConfigurations.LOGSTOR_STRONG_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_replay_position_check_during_truncate(manager):
+async def test_replay_position_check_during_truncate(manager, feature_config: FeatureConfig):
     logger.info("Bootstrapping cluster")
-    cfg = { 'auto_snapshot': True }
+    cfg = feature_config.get_cluster_cfg({'auto_snapshot': True})
+    keyspace_opts = feature_config.get_keyspace_opts(
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}")
     cmdline = ['--smp=1']
     servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
     server = servers[0]
 
     cql = manager.get_cql()
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);"))
 
         keys = range(10)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
@@ -293,13 +318,17 @@ async def test_replay_position_check_during_truncate(manager):
         await s1_log.wait_for(f"database_truncate_wait: message received", from_mark=s1_mark)
         await truncate_task
 
+
+@pytest.mark.parametrize("feature_config", feature_configs(FeatureConfigurations.EVENTUAL_CONSISTENCY,
+                                                           FeatureConfigurations.LOGSTOR_EVENTUAL_CONSISTENCY))
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_parallel_truncate(manager: ManagerClient):
+async def test_parallel_truncate(manager: ManagerClient, feature_config: FeatureConfig):
 
     logger.info('Bootstrapping cluster')
-    cfg = { 'tablets_mode_for_new_keyspaces': 'enabled',
-            'error_injections_at_startup': ['migration_streaming_wait']
-            }
+    cfg = feature_config.get_cluster_cfg(
+        {'tablets_mode_for_new_keyspaces': 'enabled', 'error_injections_at_startup': ['migration_streaming_wait']})
+    keyspace_opts = feature_config.get_keyspace_opts(
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}")
 
     servers = []
     servers.append(await manager.server_add(config=cfg))
@@ -307,9 +336,9 @@ async def test_parallel_truncate(manager: ManagerClient):
     cql = manager.get_cql()
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
-        await cql.run_async(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);')
-        await cql.run_async(f'CREATE TABLE {ks}.test1 (pk int PRIMARY KEY, c int);')
+    async with new_test_keyspace(manager, keyspace_opts) as ks:
+        await cql.run_async(feature_config.get_table_opts(f'CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);'))
+        await cql.run_async(feature_config.get_table_opts(f'CREATE TABLE {ks}.test1 (pk int PRIMARY KEY, c int);'))
 
         keys = range(1024)
         await asyncio.gather(*[cql.run_async(f'INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});') for k in keys])
@@ -335,10 +364,10 @@ async def test_parallel_truncate(manager: ManagerClient):
         await tf2
 
         # Check if we have any data
-        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM {ks}.test', consistency_level=ConsistencyLevel.ALL))
-        assert row[0].count == 0
-        row = await cql.run_async(SimpleStatement(f'SELECT COUNT(*) FROM {ks}.test1', consistency_level=ConsistencyLevel.ALL))
-        assert row[0].count == 0
+        assert await count_rows(cql, feature_config,
+                                query_template="SELECT COUNT(*) FROM {ks}.{table}", ks=ks, table='test', keys=keys, partition_key='pk') == 0
+        assert await count_rows(cql, feature_config,
+                                query_template="SELECT COUNT(*) FROM {ks}.{table}", ks=ks, table='test1', keys=keys, partition_key='pk') == 0
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_split_emitted_during_truncate(manager: ManagerClient):

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -13,7 +13,11 @@ import operator
 import time
 import re
 from contextlib import asynccontextmanager, contextmanager, suppress
+from copy import deepcopy
+from dataclasses import dataclass, field
+from enum import Enum
 
+import pytest
 from cassandra.cluster import ConnectionException, ConsistencyLevel, NoHostAvailable, Session, SimpleStatement  # type: ignore # pylint: disable=no-name-in-module
 from cassandra.pool import Host                          # type: ignore # pylint: disable=no-name-in-module
 from test.pylib.internal_types import ServerInfo, HostID
@@ -25,6 +29,98 @@ from typing import Optional, List, Union
 logger = logging.getLogger(__name__)
 
 UUID_REGEX = re.compile(r"([0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12})")
+
+
+@dataclass(frozen=True)
+class FeatureConfig:
+    """Describes how a test's keyspace, table and cluster config should be
+    adjusted to run under a particular storage/consistency configuration.
+
+    - ``ks_opts``: appended to the keyspace ``WITH ...`` clause.
+    - ``table_opts``: appended to the ``CREATE TABLE ...`` statement.
+    - ``cluster_cfg``: merged into the per-server config dict passed to
+      ``manager.server_add``.
+    """
+    ks_opts: str = ""
+    table_opts: str = ""
+    cluster_cfg: dict = field(default_factory=dict)
+
+    @property
+    def strongly_consistent(self) -> bool:
+        """True if this configuration creates a strongly-consistent keyspace.
+        NOTE: it checks only global, since local strong consistency is not yet implemented.
+        """
+        return "consistency = 'global'" in ' '.join(self.ks_opts.split())
+
+
+    def get_cluster_cfg(self, base: dict) -> dict:
+        """Merge a FeatureConfig's cluster_cfg into a test's base config dict.
+
+        List-valued keys (e.g. 'experimental_features', 'error_injections_at_startup')
+        are unioned so a configuration can add features without clobbering the ones
+        the test already relies on. Other keys overwrite the base value. The base
+        dict is not modified; a new merged dict is returned.
+        """
+        merged = deepcopy(base)
+        for key, value in self.cluster_cfg.items():
+            if isinstance(value, list) and isinstance(merged.get(key), list):
+                merged[key] = merged[key] + [v for v in value if v not in merged[key]]
+            else:
+                merged[key] = deepcopy(value)
+        return merged
+
+    @staticmethod
+    def _merge_with_clause(stmt: str, opts: str) -> str:
+        """Merge a WITH clause into a CQL statement, preserving validity.
+
+        If the statement already contains a WITH clause, the option is folded in with AND.
+        A trailing ';' is preserved.
+        """
+        if not opts:
+            return stmt
+
+        stmt = stmt.rstrip()
+        has_semicolon = stmt.endswith(";")
+        if has_semicolon:
+            stmt = stmt[:-1].rstrip()
+
+        # A statement can only have one WITH clause, so fold ours in with AND.
+        if "with " in stmt.lower():
+            opts = opts.replace(" WITH ", " AND ", 1)
+
+        return f"{stmt}{opts}{';' if has_semicolon else ''}"
+
+    def get_table_opts(self, create_stmt: str) -> str:
+        """Append a FeatureConfig's table_opts to a CREATE TABLE statement."""
+        return self._merge_with_clause(create_stmt, self.table_opts)
+
+    def get_keyspace_opts(self, create_stmt: str) -> str:
+        """Append a FeatureConfig's ks_opts to a CREATE KEYSPACE statement."""
+        return self._merge_with_clause(create_stmt, self.ks_opts)
+
+
+class FeatureConfigurations(Enum):
+    EVENTUAL_CONSISTENCY = FeatureConfig()
+    STRONG_CONSISTENCY = FeatureConfig(
+        ks_opts=" WITH consistency = 'global'",
+        cluster_cfg={"experimental_features": ["strongly-consistent-tables"]},
+    )
+    LOGSTOR_EVENTUAL_CONSISTENCY = FeatureConfig(
+        table_opts=" WITH storage_engine = 'logstor'",
+        cluster_cfg={"experimental_features": ["logstor"]},
+    )
+    LOGSTOR_STRONG_CONSISTENCY = FeatureConfig(
+        ks_opts=" WITH consistency = 'global'",
+        table_opts=" WITH storage_engine = 'logstor'",
+        cluster_cfg={"experimental_features": ["logstor", "strongly-consistent-tables"]},
+    )
+
+
+def feature_configs(*configs: FeatureConfigurations):
+    """Build pytest.mark.parametrize arguments for the named configurations.
+    The enum name becomes the test id.
+    """
+    return [pytest.param(config.value, id=config.name.lower()) for config in configs]
 
 
 async def reconnect_driver(manager: ManagerClient) -> Session:

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -123,6 +123,44 @@ def feature_configs(*configs: FeatureConfigurations):
     return [pytest.param(config.value, id=config.name.lower()) for config in configs]
 
 
+async def count_rows(cql, feature_config: FeatureConfig, query_template: str, ks: str, table: str, keys, partition_key: str):
+    """Count rows in a table, honoring the feature config's consistency model.
+
+    ``query_template`` must be a ``SELECT COUNT(*)`` aggregate that references
+    the table as ``{ks}.{table}`` (this token is used as the insertion anchor).
+    Post-FROM clauses (e.g. ``BYPASS CACHE``, ``LIMIT``) are allowed.
+
+    Eventual-consistency keyspaces run ``query_template`` once at CL=ALL and
+    return the count.
+
+    Strongly-consistent keyspaces reject that query on two counts: CL=ALL is not
+    allowed ("must use QUORUM/LOCAL_QUORUM or ONE/LOCAL_ONE"), and scans are
+    rejected ("strongly consistent queries can only target a single partition").
+    For those we run the same template scoped to a single partition by inserting
+    ``WHERE {partition_key} = <key>`` after the table token (so clause order
+    stays valid) for each key at LOCAL_QUORUM, and sum the per-partition counts.
+    """
+
+    async def run_query_with_semaphore(sem, head, sep, tail, key):
+        async with sem:
+            return await cql.run_async(SimpleStatement(
+                    f"{head}{sep} WHERE {partition_key} = {key}{tail}",
+                    consistency_level=ConsistencyLevel.LOCAL_QUORUM))
+
+    query = query_template.format(ks=ks, table=table)
+    if feature_config.strongly_consistent:
+        semaphore = asyncio.Semaphore(100)
+        anchor = f"{ks}.{table}"
+        head, sep, tail = query.partition(anchor)
+        rows = await asyncio.gather(*[run_query_with_semaphore(semaphore, head, sep, tail, key) for key in keys])
+        return sum(r[0].count for r in rows)
+    else:
+        row = await cql.run_async(SimpleStatement(
+            query,
+            consistency_level=ConsistencyLevel.ALL))
+        return row[0].count
+
+
 async def reconnect_driver(manager: ManagerClient) -> Session:
     """Can be used as a workaround for scylladb/python-driver#295.
 

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -107,20 +107,30 @@ class FeatureConfigurations(Enum):
     )
     LOGSTOR_EVENTUAL_CONSISTENCY = FeatureConfig(
         table_opts=" WITH storage_engine = 'logstor'",
-        cluster_cfg={"experimental_features": ["logstor"]},
+        cluster_cfg={"experimental_features": ["logstor"], "logstor_disk_size_in_mb":20, "logstor_file_size_in_mb":1},
     )
     LOGSTOR_STRONG_CONSISTENCY = FeatureConfig(
         ks_opts=" WITH consistency = 'global'",
         table_opts=" WITH storage_engine = 'logstor'",
-        cluster_cfg={"experimental_features": ["logstor", "strongly-consistent-tables"]},
+        cluster_cfg={"experimental_features": ["logstor", "strongly-consistent-tables"],  "logstor_disk_size_in_mb":20, "logstor_file_size_in_mb":1},
     )
 
 
 def feature_configs(*configs: FeatureConfigurations):
     """Build pytest.mark.parametrize arguments for the named configurations.
-    The enum name becomes the test id.
+    The enum name becomes the test id. Logstor configurations are skipped until
+    the logstor compaction controller (https://github.com/scylladb/scylladb/pull/30058) lands.
     """
-    return [pytest.param(config.value, id=config.name.lower()) for config in configs]
+    logstor_skip = pytest.mark.skip_bug(
+        link="https://scylladb.atlassian.net/browse/SCYLLADB-3093",
+        reason="logstor storage engine is not yet stable; blocked on the logstor compaction "
+               "controller (https://github.com/scylladb/scylladb/pull/30058)",
+    )
+    return [
+        pytest.param(config.value, id=config.name.lower(),
+                     marks=[logstor_skip] if config.name.startswith("LOGSTOR_") else [])
+        for config in configs
+    ]
 
 
 async def count_rows(cql, feature_config: FeatureConfig, query_template: str, ks: str, table: str, keys, partition_key: str):


### PR DESCRIPTION
This PR allows to use predefined configuration switch for eventual consistency, strong consistency, logstor and logstor strong consistency. With just marking the test parametrized and light test changes in place where the configuration is provided to the cluster manager.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3202

No backport, small enhancement only.