### PR TITLE
alternator: count per-table BatchGetItem operations

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3101,6 +3101,8 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
 
     tracing::add_alternator_table_name(trace_state, op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
+    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
+    per_table_stats->api_operations.put_item++;
 
     co_await verify_permission(_enforce_authorization, _warn_authorization, client_state, op->schema(), auth::permission::MODIFY, _stats);
 
@@ -3108,6 +3110,7 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
 
     if (cas_shard && !cas_shard->this_shard()) {
         _stats.api_operations.put_item--; // uncount on this shard, will be counted in other shard
+        per_table_stats->api_operations.put_item--; // uncount on this shard, will be counted in other shard
         _stats.shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
                 [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit), &audit_info]
@@ -3121,8 +3124,6 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
             });
         });
     }
-    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
-    per_table_stats->api_operations.put_item++;
     uint64_t wcu_total = 0;
     auto res = co_await op->execute(_proxy, std::move(cas_shard), client_state, trace_state, std::move(permit), needs_read_before_write, _stats, *per_table_stats, wcu_total);
     per_table_stats->operation_sizes.put_item_op_size_kb.add(bytes_to_kb_ceil(op->consumed_capacity()._total_bytes));
@@ -3213,6 +3214,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
     }
 
     lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
+    per_table_stats->api_operations.delete_item++;
     tracing::add_alternator_table_name(trace_state, op->schema()->cf_name());
     const bool needs_read_before_write = _proxy.data_dictionary().get_config().alternator_force_read_before_write() || op->needs_read_before_write();
 
@@ -3222,6 +3224,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
 
     if (cas_shard && !cas_shard->this_shard()) {
         _stats.api_operations.delete_item--; // uncount on this shard, will be counted in other shard
+        per_table_stats->api_operations.delete_item--; // uncount on this shard, will be counted in other shard
         _stats.shard_bounce_for_lwt++;
         per_table_stats->shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
@@ -3236,7 +3239,6 @@ future<executor::request_return_type> executor::delete_item(client_state& client
             });
         });
     }
-    per_table_stats->api_operations.delete_item++;
     uint64_t wcu_total = 0;
     auto res = co_await op->execute(_proxy, std::move(cas_shard), client_state, trace_state, std::move(permit), needs_read_before_write, _stats, *per_table_stats, wcu_total);
     if (op->consumed_capacity()._total_bytes > 1) {
@@ -4394,6 +4396,8 @@ future<executor::request_return_type> executor::update_item(client_state& client
 
     tracing::add_alternator_table_name(trace_state, op->schema()->cf_name());
     const bool needs_read_before_write = _proxy.data_dictionary().get_config().alternator_force_read_before_write() || op->needs_read_before_write();
+    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
+    per_table_stats->api_operations.update_item++;
 
     co_await verify_permission(_enforce_authorization, _warn_authorization, client_state, op->schema(), auth::permission::MODIFY, _stats);
 
@@ -4401,6 +4405,7 @@ future<executor::request_return_type> executor::update_item(client_state& client
 
     if (cas_shard && !cas_shard->this_shard()) {
         _stats.api_operations.update_item--; // uncount on this shard, will be counted in other shard
+        per_table_stats->api_operations.update_item--; // uncount on this shard, will be counted in other shard
         _stats.shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
                 [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit), &audit_info]
@@ -4414,8 +4419,6 @@ future<executor::request_return_type> executor::update_item(client_state& client
             });
         });
     }
-    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
-    per_table_stats->api_operations.update_item++;
     uint64_t wcu_total = 0;
     auto res = co_await op->execute(_proxy, std::move(cas_shard), client_state, trace_state, std::move(permit), needs_read_before_write, _stats, *per_table_stats, wcu_total);
     per_table_stats->operation_sizes.update_item_op_size_kb.add(bytes_to_kb_ceil(op->consumed_capacity()._total_bytes));

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3476,8 +3476,13 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
     // WCU calculation is performed at the end of execution.
     // We need to keep track of changes per table, both for internal metrics
     // and to be able to return the values if should_add_wcu is true.
-    // For each table, we need its stats and schema.
-    std::vector<std::pair<lw_shared_ptr<stats>, schema_ptr>> per_table_wcu;
+    // For each table, we need its stats, schema and batch item count.
+    struct table_batch_write_stats {
+        lw_shared_ptr<stats> table_stats;
+        schema_ptr schema;
+        size_t item_count;
+    };
+    std::vector<table_batch_write_stats> per_table_wcu;
 
     audit::audit_table_set audited_table_names;
     bool only_audited_tables = true;
@@ -3488,8 +3493,6 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
         schema_ptr schema = get_table_from_batch_request(_proxy, it);
         lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(schema));
         per_table_stats->api_operations.batch_write_item++;
-        per_table_stats->api_operations.batch_write_item_batch_total += it->value.Size();
-        per_table_stats->api_operations.batch_write_item_histogram.add(it->value.Size());
         tracing::add_alternator_table_name(trace_state, schema->cf_name());
         if (should_audit) {
             if (_audit.local().will_log(audit::statement_category::DML, schema->ks_name(), schema->cf_name())) {
@@ -3531,7 +3534,7 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
                 co_return api_error::validation(fmt::format("Unknown BatchWriteItem request type: {}", r_name));
             }
         }
-        per_table_wcu.emplace_back(std::make_pair(per_table_stats, schema));
+        per_table_wcu.emplace_back(std::move(per_table_stats), std::move(schema), it->value.Size());
     }
     for (const auto& b : mutation_builders) {
         co_await verify_permission(_enforce_authorization, _warn_authorization, client_state, b.first, auth::permission::MODIFY, _stats);
@@ -3576,29 +3579,33 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
     for (const auto& w : per_table_wcu) {
         total_wcu = 0;
         // The following loop goes over all items from the same table
-        while(pos < mutation_builders.size() && w.second->id() == mutation_builders[pos].first->id()) {
+        while(pos < mutation_builders.size() && w.schema->id() == mutation_builders[pos].first->id()) {
             uint64_t item_size = mutation_builders[pos].second.length_in_bytes();
             size_t wcu = wcu_consumed_capacity_counter::get_units(item_size ? item_size : 1);
             total_wcu += wcu;
             if (mutation_builders[pos].second.is_put_item()) {
-                w.first->wcu_total[stats::PUT_ITEM] += wcu;
+                w.table_stats->wcu_total[stats::PUT_ITEM] += wcu;
                 wcu_put_units += wcu;
             } else {
-                w.first->wcu_total[stats::DELETE_ITEM] += wcu;
+                w.table_stats->wcu_total[stats::DELETE_ITEM] += wcu;
                 wcu_delete_units += wcu;
             }
-            w.first->operation_sizes.batch_write_item_op_size_kb.add(bytes_to_kb_ceil(item_size));
+            w.table_stats->operation_sizes.batch_write_item_op_size_kb.add(bytes_to_kb_ceil(item_size));
             pos++;
         }
         if (should_add_wcu) {
             rjson::value entry = rjson::empty_object();
-            rjson::add(entry, "TableName", rjson::from_string(w.second->cf_name()));
+            rjson::add(entry, "TableName", rjson::from_string(w.schema->cf_name()));
             rjson::add(entry, "CapacityUnits", total_wcu);
             rjson::push_back(consumed_capacity, std::move(entry));
         }
     }
     _stats.wcu_total[stats::PUT_ITEM] += wcu_put_units;
     _stats.wcu_total[stats::DELETE_ITEM] += wcu_delete_units;
+    for (const auto& w : per_table_wcu) {
+        w.table_stats->api_operations.batch_write_item_batch_total += w.item_count;
+        w.table_stats->api_operations.batch_write_item_histogram.add(w.item_count);
+    }
     _stats.api_operations.batch_write_item_batch_total += total_items;
     _stats.api_operations.batch_write_item_histogram.add(total_items);
     co_await do_batch_write(std::move(mutation_builders), client_state, trace_state, std::move(permit));
@@ -3613,7 +3620,7 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
     auto duration = std::chrono::steady_clock::now() - start_time;
     _stats.api_operations.batch_write_item_latency.mark(duration);
     for (const auto& w : per_table_wcu) {
-        w.first->api_operations.batch_write_item_latency.mark(duration);
+        w.table_stats->api_operations.batch_write_item_latency.mark(duration);
     }
     if (!audited_table_names.empty()) {
         if (!only_audited_tables) {

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -3112,6 +3112,7 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
         _stats.api_operations.put_item--; // uncount on this shard, will be counted in other shard
         per_table_stats->api_operations.put_item--; // uncount on this shard, will be counted in other shard
         _stats.shard_bounce_for_lwt++;
+        per_table_stats->shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
                 [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit), &audit_info]
                 (executor& e) mutable {
@@ -4407,6 +4408,7 @@ future<executor::request_return_type> executor::update_item(client_state& client
         _stats.api_operations.update_item--; // uncount on this shard, will be counted in other shard
         per_table_stats->api_operations.update_item--; // uncount on this shard, will be counted in other shard
         _stats.shard_bounce_for_lwt++;
+        per_table_stats->shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(cas_shard->shard(), _ssg,
                 [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit), &audit_info]
                 (executor& e) mutable {

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1904,6 +1904,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
         schema_ptr schema;
         db::consistency_level cl;
         ::shared_ptr<const std::optional<alternator::attrs_to_get>> attrs_to_get;
+        uint64_t item_count = 0;
         // clustering_keys keeps a sorted set of clustering keys. It must
         // be sorted for the read below (see #10827). Additionally each
         // clustering key is mapped to the original rjson::value "Key".
@@ -1923,12 +1924,15 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
             if (auto [_, inserted] = it->second.emplace(ck, &key); !inserted) {
                 throw api_error::validation("Provided list of item keys contains duplicates");
             }
+            item_count++;
         }
     };
     std::vector<table_requests> requests;
-    uint batch_size = 0;
+    uint64_t batch_size = 0;
     for (auto it = request_items.MemberBegin(); it != request_items.MemberEnd(); ++it) {
         table_requests rs(get_table_from_batch_request(_proxy, it));
+        lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
+        per_table_stats->api_operations.batch_get_item++;
         tracing::add_alternator_table_name(trace_state, rs.schema->cf_name());
         rs.cl = get_read_consistency(it->value);
         std::unordered_set<std::string> used_attribute_names;
@@ -1940,7 +1944,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
             rs.add(key);
             check_key(key, rs.schema);
         }
-        batch_size += rs.requests.size();
+        batch_size += rs.item_count;
         requests.emplace_back(std::move(rs));
     }
 
@@ -1958,7 +1962,8 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
         const table_requests& rs = requests[i];
         bool is_quorum = rs.cl == db::consistency_level::LOCAL_QUORUM;
         lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
-        per_table_stats->api_operations.batch_get_item_histogram.add(rs.requests.size());
+        per_table_stats->api_operations.batch_get_item_batch_total += rs.item_count;
+        per_table_stats->api_operations.batch_get_item_histogram.add(rs.item_count);
         for (const auto& [pk, cks] : rs.requests) {
             dht::partition_range_vector partition_ranges{dht::partition_range(dht::decorate_key(*rs.schema, pk))};
             std::vector<query::clustering_range> bounds;

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -2210,6 +2210,8 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     uint batch_size = 0;
     for (auto it = request_items.MemberBegin(); it != request_items.MemberEnd(); ++it) {
         table_requests rs(get_table_from_batch_request(_proxy, it));
+        lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
+        per_table_stats->api_operations.batch_get_item++;
         tracing::add_alternator_table_name(trace_state, rs.schema->cf_name());
         rs.cl = get_read_consistency(it->value);
         std::unordered_set<std::string> used_attribute_names;

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -1454,6 +1454,38 @@ def test_reads_before_write_and_write_using_lwt_metrics(dynamodb, test_table_s, 
             with check_increases_metric_exact(metrics, table_lwt, [[1, lwt_cf]]):
                 lwt_table.put_item(Item={'p': p})
 
+def test_put_update_item_table_shard_bounce_for_lwt(dynamodb, metrics):
+    shards = {int(shard) for shard in re.findall(r'(?:\{|,)shard="(\d+)"', get_metrics(metrics))}
+    if len(shards) < 2:
+        skip_env('requires at least two shards')
+
+    global_metric = 'scylla_alternator_shard_bounce_for_lwt'
+    table_metric = 'scylla_alternator_table_shard_bounce_for_lwt'
+    with new_test_table(dynamodb,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            Tags=[{'Key': 'system:write_isolation', 'Value': 'always_use_lwt'}]) as lwt_table:
+        cf = {'cf': lwt_table.name}
+
+        def check_table_bounce(operation_name, operation):
+            before_global = get_metric(metrics, global_metric)
+            before_table = get_metric(metrics, table_metric, cf)
+            for i in range(200):
+                operation(i)
+                if get_metric(metrics, table_metric, cf) > before_table:
+                    return
+            assert get_metric(metrics, global_metric) > before_global, (
+                f'{operation_name} did not exercise an LWT shard bounce')
+            assert get_metric(metrics, table_metric, cf) > before_table, (
+                f'{table_metric} did not increase for {operation_name}')
+
+        check_table_bounce('PutItem',
+            lambda i: lwt_table.put_item(Item={'p': f'put-{i}'}))
+        check_table_bounce('UpdateItem',
+            lambda i: lwt_table.update_item(Key={'p': f'update-{i}'},
+                UpdateExpression='SET a = :a',
+                ExpressionAttributeValues={':a': i}))
+
 # Test that scylla_alternator_conditional_check_failed  is incremented when a
 # conditional write (PutItem, UpdateItem, DeleteItem) fails due to an
 # unsatisfied ConditionExpression. Both the global metric and the per-table
@@ -1689,4 +1721,4 @@ def test_metric_reads_before_write(dynamodb, metrics, write_isolation):
 
 # TODO: there are additional metrics which we don't yet test here. At the
 # time of this writing they are:
-# shard_bounce_for_lwt, requests_blocked_memory, requests_shed
+# requests_blocked_memory, requests_shed

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -304,6 +304,38 @@ def test_batch_get_item(test_table_s, metrics):
         test_table_s.meta.client.batch_get_item(RequestItems = {
             test_table_s.name: {'Keys': [{'p': random_string()}], 'ConsistentRead': True}})
 
+# Reproduces issue #30754:
+def test_table_batch_get_item(test_table_s, metrics):
+    with check_table_increases_operation(metrics, ['BatchGetItem'], test_table_s.name, expected_value=1):
+        test_table_s.meta.client.batch_get_item(RequestItems = {
+            test_table_s.name: {'Keys': [{'p': random_string()}, {'p': random_string()}], 'ConsistentRead': True}})
+
+def test_table_batch_get_item_counted_on_validation_error(test_table_s, metrics):
+    p = random_string()
+    before = get_metric(metrics, 'scylla_alternator_table_operation', {'op': 'BatchGetItem', 'cf': test_table_s.name})
+    with pytest.raises(ClientError):
+        test_table_s.meta.client.batch_get_item(RequestItems = {
+            test_table_s.name: {'Keys': [{'p': p}, {'p': p}], 'ConsistentRead': True}})
+    after = get_metric(metrics, 'scylla_alternator_table_operation', {'op': 'BatchGetItem', 'cf': test_table_s.name})
+    assert after == before + 1
+
+def test_table_batch_get_item_counted_on_authorization_error(dynamodb, cql, test_table_s, metrics):
+    p = random_string()
+    with new_role(cql, superuser=True) as (super_role, super_key):
+        with new_dynamodb(dynamodb, super_role, super_key) as auth_dynamodb:
+            with scylla_config_auth_temporary(auth_dynamodb, True, False):
+                with new_role(cql) as (role, key):
+                    with new_dynamodb(dynamodb, role, key) as d:
+                        before = get_metric(metrics, 'scylla_alternator_table_operation', {'op': 'BatchGetItem', 'cf': test_table_s.name})
+                        with check_increases_metric_exact(
+                                metrics, "scylla_alternator_table_batch_item_count",
+                                [[0, {'op': 'BatchGetItem', 'cf': test_table_s.name}]]):
+                            with pytest.raises(ClientError, match='AccessDeniedException'):
+                                d.meta.client.batch_get_item(RequestItems = {
+                                    test_table_s.name: {'Keys': [{'p': p}], 'ConsistentRead': True}})
+                        after = get_metric(metrics, 'scylla_alternator_table_operation', {'op': 'BatchGetItem', 'cf': test_table_s.name})
+                        assert after == before + 1
+
 def test_batch_write_item_count(test_table_s, metrics):
     with check_increases_operation(metrics, ['BatchWriteItem'], metric_name='scylla_alternator_batch_item_count', expected_value=2):
         test_table_s.meta.client.batch_write_item(RequestItems = {
@@ -313,6 +345,29 @@ def test_batch_get_item_count(test_table_s, metrics):
     with check_increases_operation(metrics, ['BatchGetItem'], metric_name='scylla_alternator_batch_item_count', expected_value=2):
         test_table_s.meta.client.batch_get_item(RequestItems = {
             test_table_s.name: {'Keys': [{'p': random_string()}, {'p': random_string()}], 'ConsistentRead': True}})
+
+# Reproduces issue #30754:
+def test_table_batch_get_item_count(test_table_s, metrics):
+    with check_table_increases_operation(metrics, ['BatchGetItem'], test_table_s.name, metric_name='scylla_alternator_table_batch_item_count', expected_value=2):
+        test_table_s.meta.client.batch_get_item(RequestItems = {
+            test_table_s.name: {'Keys': [{'p': random_string()}, {'p': random_string()}], 'ConsistentRead': True}})
+
+def test_batch_get_item_count_same_partition_key(test_table, metrics):
+    p = random_string()
+    keys = [{'p': p, 'c': random_string()} for i in range(3)]
+    with check_increases_operation(
+            metrics, ['BatchGetItem'], metric_name='scylla_alternator_batch_item_count', expected_value=3):
+        with check_table_increases_operation(
+                metrics, ['BatchGetItem'], test_table.name, metric_name='scylla_alternator_table_batch_item_count', expected_value=3):
+            with check_increases_metric_exact(
+                    metrics, "scylla_alternator_batch_item_count_histogram_bucket",
+                    [[0, {'op': 'BatchGetItem', 'le': '2.000000'}], [1, {'op': 'BatchGetItem', 'le': '3.000000'}]]):
+                with check_increases_metric_exact(
+                        metrics, "scylla_alternator_table_batch_item_count_histogram_bucket",
+                        [[0, {'op': 'BatchGetItem', 'le': '2.000000', 'cf': test_table.name}],
+                         [1, {'op': 'BatchGetItem', 'le': '3.000000', 'cf': test_table.name}]]):
+                    test_table.meta.client.batch_get_item(RequestItems = {
+                        test_table.name: {'Keys': keys, 'ConsistentRead': True}})
 
 KB = 1024
 def test_rcu(test_table_s, metrics):

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -274,6 +274,41 @@ def test_table_batch_write_item_histogram(test_table_s, metrics):
         test_table_s.meta.client.batch_write_item(RequestItems = {
             test_table_s.name: items2})
 
+def test_table_batch_write_item_count_not_updated_on_validation_error(test_table_s, metrics):
+    p = random_string()
+    with check_increases_metric_exact(metrics, "scylla_alternator_table_batch_item_count", [[0, {'op': 'BatchWriteItem', 'cf': test_table_s.name}]]):
+        with check_increases_metric_exact(
+                metrics, "scylla_alternator_table_batch_item_count_histogram_bucket",
+                [[0, {'op': 'BatchWriteItem', 'le': '2.000000', 'cf': test_table_s.name}]]):
+            with pytest.raises(ClientError):
+                test_table_s.meta.client.batch_write_item(RequestItems={
+                    test_table_s.name: [
+                        {'PutRequest': {'Item': {'p': p, 'a': 'hi'}}},
+                        {'PutRequest': {'Item': {'p': p, 'a': 'hi1'}}},
+                    ]})
+
+def test_table_batch_write_item_count_not_updated_on_authorization_error(dynamodb, cql, test_table_s, metrics):
+    p1 = random_string()
+    p2 = random_string()
+    with new_role(cql, superuser=True) as (super_role, super_key):
+        with new_dynamodb(dynamodb, super_role, super_key) as auth_dynamodb:
+            with scylla_config_auth_temporary(auth_dynamodb, True, False):
+                with new_role(cql) as (role, key):
+                    with new_dynamodb(dynamodb, role, key) as d:
+                        before = get_metric(metrics, 'scylla_alternator_table_operation', {'op': 'BatchWriteItem', 'cf': test_table_s.name})
+                        with check_increases_metric_exact(metrics, "scylla_alternator_table_batch_item_count", [[0, {'op': 'BatchWriteItem', 'cf': test_table_s.name}]]):
+                            with check_increases_metric_exact(
+                                    metrics, "scylla_alternator_table_batch_item_count_histogram_bucket",
+                                    [[0, {'op': 'BatchWriteItem', 'le': '2.000000', 'cf': test_table_s.name}]]):
+                                with pytest.raises(ClientError, match='AccessDeniedException'):
+                                    d.meta.client.batch_write_item(RequestItems={
+                                        test_table_s.name: [
+                                            {'PutRequest': {'Item': {'p': p1, 'a': 'hi'}}},
+                                            {'PutRequest': {'Item': {'p': p2, 'a': 'hi1'}}},
+                                        ]})
+                        after = get_metric(metrics, 'scylla_alternator_table_operation', {'op': 'BatchWriteItem', 'cf': test_table_s.name})
+                        assert after == before + 1
+
 def test_batch_get_item_histogram(test_table_s, metrics):
     with check_increases_metric_exact(metrics, "scylla_alternator_batch_item_count_histogram_bucket", [[0, {'op': 'BatchWriteItem', 'le': '2.000000'}], [1, {'op': 'BatchGetItem', 'le': '3.000000'}]]):
         test_table_s.meta.client.batch_get_item(RequestItems = {

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -480,6 +480,26 @@ def test_table_item_operations(test_table_s, metrics):
         test_table_s.delete_item(Key={'p': p})
         test_table_s.update_item(Key={'p': p})
 
+def test_table_write_item_operations_counted_on_authorization_error(dynamodb, cql, test_table_s, metrics):
+    p = random_string()
+    with new_role(cql, superuser=True) as (super_role, super_key):
+        with new_dynamodb(dynamodb, super_role, super_key) as auth_dynamodb:
+            with scylla_config_auth_temporary(auth_dynamodb, True, False):
+                with new_role(cql) as (role, key):
+                    with new_dynamodb(dynamodb, role, key) as d:
+                        table = d.Table(test_table_s.name)
+                        operations = [
+                            ('PutItem', lambda: table.put_item(Item={'p': p, 'a': 'hi'})),
+                            ('DeleteItem', lambda: table.delete_item(Key={'p': p})),
+                            ('UpdateItem', lambda: table.update_item(Key={'p': p}, UpdateExpression='SET a = :a', ExpressionAttributeValues={':a': 'hi'})),
+                        ]
+                        for op, operation in operations:
+                            before = get_metric(metrics, 'scylla_alternator_table_operation', {'op': op, 'cf': test_table_s.name})
+                            with pytest.raises(ClientError, match='AccessDeniedException'):
+                                operation()
+                            after = get_metric(metrics, 'scylla_alternator_table_operation', {'op': op, 'cf': test_table_s.name})
+                            assert after == before + 1
+
 # Test counters for Query and Scan:
 def test_scan_operations(test_table_s, metrics):
     with check_increases_operation(metrics, ['Query', 'Scan']):

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -304,6 +304,35 @@ def test_batch_get_item(test_table_s, metrics):
         test_table_s.meta.client.batch_get_item(RequestItems = {
             test_table_s.name: {'Keys': [{'p': random_string()}], 'ConsistentRead': True}})
 
+# Reproduces issue #30754. A single BatchGetItem operation is counted once
+# for each table, regardless of the number of requested items in that table.
+def test_table_batch_get_item(test_table_s, test_table_s_2, metrics):
+    with (
+        check_table_increases_operation(metrics, ['BatchGetItem'], test_table_s.name, expected_value=1),
+        check_table_increases_operation(metrics, ['BatchGetItem'], test_table_s_2.name, expected_value=1),
+    ):
+        test_table_s.meta.client.batch_get_item(RequestItems = {
+            test_table_s.name: {'Keys': [{'p': random_string()}, {'p': random_string()}], 'ConsistentRead': True},
+            test_table_s_2.name: {'Keys': [{'p': random_string()}, {'p': random_string()}], 'ConsistentRead': True}})
+
+def test_table_batch_get_item_counted_on_validation_error(test_table_s, metrics):
+    p = random_string()
+    with check_table_increases_operation(metrics, ['BatchGetItem'], test_table_s.name, expected_value=1):
+        with pytest.raises(ClientError):
+            test_table_s.meta.client.batch_get_item(RequestItems = {
+                test_table_s.name: {'Keys': [{'p': p}, {'p': p}], 'ConsistentRead': True}})
+
+def test_table_batch_get_item_counted_on_authorization_error(dynamodb, cql, test_table_s, metrics):
+    with new_role(cql, superuser=True) as (super_role, super_key):
+        with new_dynamodb(dynamodb, super_role, super_key) as auth_dynamodb:
+            with scylla_config_auth_temporary(auth_dynamodb, True, False):
+                with new_role(cql) as (role, key):
+                    with new_dynamodb(dynamodb, role, key) as d:
+                        with check_table_increases_operation(metrics, ['BatchGetItem'], test_table_s.name, expected_value=1):
+                            with pytest.raises(ClientError, match='AccessDeniedException'):
+                                d.meta.client.batch_get_item(RequestItems = {
+                                    test_table_s.name: {'Keys': [{'p': random_string()}], 'ConsistentRead': True}})
+
 def test_batch_write_item_count(test_table_s, metrics):
     with check_increases_operation(metrics, ['BatchWriteItem'], metric_name='scylla_alternator_batch_item_count', expected_value=2):
         test_table_s.meta.client.batch_write_item(RequestItems = {


### PR DESCRIPTION
## Problem

`BatchGetItem` increments the global Alternator operation counter at request entry, but never increments the corresponding per-table operation counter. As a result, `scylla_alternator_table_operation{op="BatchGetItem", cf="<table>"}` remains empty even while global traffic and per-table latency metrics increase.

Once a table has been resolved, its per-table counter should record the attempted operation, including requests that later fail validation or authorization.

Fixes #30754.

## Solution

Increment `per_table_stats->api_operations.batch_get_item` immediately after resolving each table in the request, before the remaining request validation and authorization.

Add regression coverage verifying that:

- a successful request with two keys increments the table operation counter once;
- a request rejected by duplicate-key validation is still counted once after table resolution;
- a request rejected by authorization is still counted once after table resolution.

## Testing

- Full dev Scylla build completed successfully.
- `python3 -m py_compile test/alternator/test_metrics.py`
- `git diff --check origin/master...HEAD`
- The three focused Alternator tests passed against a local two-shard dev Scylla.
- Each focused test also passed 100 consecutive repetitions (300 test executions total).

## Backport justification

Backport to 2026.1, 2026.2, and 2026.3 because these branches expose the per-table `BatchGetItem` operation metric but do not increment it, leaving affected monitoring panels empty. The fix is a localized counter update with focused regression coverage.