### PR TITLE
test.py: move before/after test from cluster manager to fixture

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import asyncio
+import aiohttp
 import ssl
 import tempfile
 from concurrent.futures.thread import ThreadPoolExecutor
@@ -226,7 +227,32 @@ async def manager(request: pytest.FixtureRequest,
     test_py_log_test = suite_log_dir / f"{test_log.stem}_cluster.log"
 
     manager_client = manager_internal()  # set up client object in fixture with scope function
-    await manager_client.before_test(test_case_name, test_log)
+
+    # Add handler to the root logger to intercept all logs produced by pytest process
+    test_logger = logging.getLogger()
+    test_log_fh = logging.FileHandler(test_log, mode='w+')
+    # to have the custom formatter with a timestamp that used in a test.py but for each testcase's log, we need to
+    # extract it from the root logger and apply to the handler
+    test_log_fh.setFormatter(logging.getLogger().handlers[0].formatter)
+    test_log_fh.setLevel(test_logger.getEffectiveLevel())
+    test_logger.addHandler(test_log_fh)
+    # Before a test starts check if cluster needs cycling and update driver connection
+    logger.debug("before_test for %s", test_case_name)
+    dirty = await manager_client.is_dirty()
+    if dirty:
+        manager_client.driver_close()  # Close driver connection to old cluster
+    try:
+        cluster_str = await manager_client.client.put_json(f"/cluster/before-test/{test_case_name}", timeout=600,
+                                                           response_type="json")
+        logger.info(f"Using cluster: {cluster_str} for test {test_case_name}")
+    except aiohttp.ClientError as exc:
+        raise RuntimeError(f"Failed before test check {exc}") from exc
+    servers = await manager_client.running_servers()
+    if manager_client.cql is None and servers:
+        # TODO: if cluster is not up yet due to taking long and HTTP timeout, wait for it
+        # await self._wait_for_cluster()
+        await manager_client.driver_connect()  # Connect driver to new cluster
+
     # Publish what pytest_runtest_makereport needs to attach this test's logs on
     # failure (single source of truth), so it doesn't re-derive these paths.
     request.node.stash[MANAGER_LOGS_KEY] = {
@@ -253,7 +279,15 @@ async def manager(request: pytest.FixtureRequest,
             # here we only need the dir for the manager-specific found_errors files below.
             failed_test_dir_path = make_failed_test_dir(request.config, build_mode, test_case_name)
 
-        cluster_status = await manager_client.after_test(test_case_name, not failed)
+        # Tell harness this test finished
+        manager_client.test_finished_event.set()
+        _client = manager_client.client_for_asyncio_loop.get(asyncio.get_running_loop())
+        logging.getLogger().removeHandler(test_log_fh)
+        Path(test_log_fh.baseFilename).unlink()
+        logger.debug("after_test for %s (success: %s)", test_case_name, not failed)
+        cluster_status = await _client.put_json(f"/cluster/after-test/{not failed}",
+                                                 response_type = "json")
+        logger.info("Cluster after test %s: %s", test_case_name, cluster_status)
     finally:
         # Drop the stash entry before closing the client so a teardown-phase
         # failure report doesn't gather logs through a stopped client.

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -227,19 +227,8 @@ async def manager(request: pytest.FixtureRequest,
     test_py_log_test = suite_log_dir / f"{test_log.stem}_cluster.log"
 
     manager_client = manager_internal()  # set up client object in fixture with scope function
-
-    # Add handler to the root logger to intercept all logs produced by pytest process
-    test_logger = logging.getLogger()
-    test_log_fh = logging.FileHandler(test_log, mode='w+')
-    # to have the custom formatter with a timestamp that used in a test.py but for each testcase's log, we need to
-    # extract it from the root logger and apply to the handler
-    test_log_fh.setFormatter(logging.getLogger().handlers[0].formatter)
-    test_log_fh.setLevel(test_logger.getEffectiveLevel())
-    test_logger.addHandler(test_log_fh)
-    # Before a test starts check if cluster needs cycling and update driver connection
     logger.debug("before_test for %s", test_case_name)
-    dirty = await manager_client.is_dirty()
-    if dirty:
+    if await manager_client.is_dirty():
         manager_client.driver_close()  # Close driver connection to old cluster
     try:
         cluster_str = await manager_client.client.put_json(f"/cluster/before-test/{test_case_name}", timeout=600,
@@ -249,8 +238,6 @@ async def manager(request: pytest.FixtureRequest,
         raise RuntimeError(f"Failed before test check {exc}") from exc
     servers = await manager_client.running_servers()
     if manager_client.cql is None and servers:
-        # TODO: if cluster is not up yet due to taking long and HTTP timeout, wait for it
-        # await self._wait_for_cluster()
         await manager_client.driver_connect()  # Connect driver to new cluster
 
     # Publish what pytest_runtest_makereport needs to attach this test's logs on
@@ -279,15 +266,14 @@ async def manager(request: pytest.FixtureRequest,
             # here we only need the dir for the manager-specific found_errors files below.
             failed_test_dir_path = make_failed_test_dir(request.config, build_mode, test_case_name)
 
-        # Tell harness this test finished
+        # Tear down (after test): notify the Manager server that the test finished
+        # We grab the raw per-loop client here because the `client` property becomes inaccessible
+        # once test_finished_event is set.
         manager_client.test_finished_event.set()
         _client = manager_client.client_for_asyncio_loop.get(asyncio.get_running_loop())
-        logging.getLogger().removeHandler(test_log_fh)
-        Path(test_log_fh.baseFilename).unlink()
         logger.debug("after_test for %s (success: %s)", test_case_name, not failed)
-        cluster_status = await _client.put_json(f"/cluster/after-test/{not failed}",
-                                                 response_type = "json")
-        logger.info("Cluster after test %s: %s", test_case_name, cluster_status)
+        cluster_status = await _client.put_json(f"/cluster/after-test/{not failed}", response_type="json")
+        logger.info("Cluster after test %s (success: %s): %s", test_case_name, not failed, cluster_status)
     finally:
         # Drop the stash entry before closing the client so a teardown-phase
         # failure report doesn't gather logs through a stopped client.

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -72,7 +72,7 @@ class ManagerClient:
     @property
     def client(self):
         if self.test_finished_event.is_set():
-            raise Exception("ManagerClient.after_test method was called, client object is not accessible anymore")
+            raise Exception("ManagerClient client object is not accessible after the test finished")
             # there are still can be issue when some task first obtains the client object,
             # but usually, tests obtains the manager and uses the client as manager.client
             # and there is an actual workaround for this case.

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -28,7 +28,6 @@ from cassandra.cluster import Session as CassandraSession, \
 from cassandra.policies import LoadBalancingPolicy, RoundRobinPolicy, WhiteListRoundRobinPolicy
 from cassandra.cluster import Cluster as CassandraCluster  # type: ignore # pylint: disable=no-name-in-module
 from cassandra.auth import AuthProvider
-import aiohttp
 import asyncio
 import allure
 
@@ -52,7 +51,6 @@ class ManagerClient:
     def __init__(self, sock_path: str, port: int, use_ssl: bool, auth_provider: Any|None,
                  con_gen: Callable[[List[IPAddress], int, bool, Any, LoadBalancingPolicy], CassandraCluster]) \
                          -> None:
-        self.test_log_fh: Optional[logging.FileHandler] = None
         self.port = port
         self.use_ssl = use_ssl
         self.auth_provider = auth_provider
@@ -153,45 +151,6 @@ class ManagerClient:
             logger.debug("refresh driver node list")
             self.ccluster.control_connection.refresh_node_list_and_token_map()
 
-    async def before_test(self, test_case_name: str, test_log: Path) -> None:
-        # Add handler to the root logger to intercept all logs produced by pytest process
-        test_logger = logging.getLogger()
-        self.test_log_fh = logging.FileHandler(test_log, mode='w+')
-        # to have the custom formatter with a timestamp that used in a test.py but for each testcase's log, we need to
-        # extract it from the root logger and apply to the handler
-        self.test_log_fh.setFormatter(logging.getLogger().handlers[0].formatter)
-        self.test_log_fh.setLevel(test_logger.getEffectiveLevel())
-        test_logger.addHandler(self.test_log_fh)
-        # Before a test starts check if cluster needs cycling and update driver connection
-        logger.debug("before_test for %s", test_case_name)
-        dirty = await self.is_dirty()
-        if dirty:
-            self.driver_close()  # Close driver connection to old cluster
-        try:
-            cluster_str = await self.client.put_json(f"/cluster/before-test/{test_case_name}", timeout=600,
-                                                     response_type = "json")
-            logger.info(f"Using cluster: {cluster_str} for test {test_case_name}")
-        except aiohttp.ClientError as exc:
-            raise RuntimeError(f"Failed before test check {exc}") from exc
-        servers = await self.running_servers()
-        if self.cql is None and servers:
-            # TODO: if cluster is not up yet due to taking long and HTTP timeout, wait for it
-            # await self._wait_for_cluster()
-            await self.driver_connect()  # Connect driver to new cluster
-
-    async def after_test(self, test_case_name: str, success: bool) -> None:
-        """Tell harness this test finished"""
-        self.test_finished_event.set()
-        _client = self.client_for_asyncio_loop.get(asyncio.get_running_loop())
-        logging.getLogger().removeHandler(self.test_log_fh)
-        pathlib.Path(self.test_log_fh.baseFilename).unlink()
-        logger.debug("after_test for %s (success: %s)", test_case_name, success)
-        cluster_status = await _client.put_json(f"/cluster/after-test/{success}",
-                                                 response_type = "json")
-        logger.info("Cluster after test %s: %s", test_case_name, cluster_status)
-
-        return cluster_status
-    
     async def check_all_errors(self, check_all_errors=False) -> dict[ServerInfo, dict[str, Union[list[str], list[str], Path, list[str]]]]:
         
         errors = defaultdict(dict)


### PR DESCRIPTION
Move the before_test() and after_test() methods out of ManagerClient and inline them directly into the `manager` pytest fixture in  test/cluster/conftest.py.

The relocated logic includes:
- Installing/removing a per-test FileHandler on the root logger
- Cycling the cluster/driver connection when the cluster is dirty
- Sending /cluster/before-test and /cluster/after-test HTTP requests to the Manager server

This reduces the scope of ManagerClient to connection management and CQL/driver helpers, while the fixture (which already owns the setUp/tearDown lifecycle) becomes the single place responsible for per-test orchestration. The test_log_fh instance variable is removed from ManagerClient as it is no longer needed there. Also the test logs should be managed by the test itself, rathern than rely on another place.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2921

No backport, framework refactoring only.
