### PR TITLE
Update seastar submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ else()
     set(Seastar_SCHEDULING_GROUPS_COUNT 24 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
     set(Seastar_OPENSSL OFF CACHE BOOL "" FORCE)
+    set(Seastar_LTTNG OFF CACHE BOOL "" FORCE)
     # Match configure.py's build_seastar_shared_libs: Debug and Dev
     # build Seastar as a shared library, others build it static.
     if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Dev")

--- a/configure.py
+++ b/configure.py
@@ -2200,6 +2200,7 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         '-DSeastar_SCHEDULING_GROUPS_COUNT=24',
         '-DSeastar_IO_URING=ON',
         '-DSeastar_OPENSSL=OFF',
+        '-DSeastar_LTTNG=OFF',
     ]
 
     if compiler_cache:

--- a/test/boost/exceptions_test.inc.cc
+++ b/test/boost/exceptions_test.inc.cc
@@ -213,13 +213,13 @@ SEASTAR_TEST_CASE(test_make_nested_exception_ptr) {
         BOOST_REQUIRE_EQUAL(std::string(ex.what()), "outer");
         auto* nested = dynamic_cast<const std::nested_exception*>(&ex);
         BOOST_REQUIRE_NE(nested, nullptr);
-        BOOST_REQUIRE_EQUAL(nested->nested_ptr(), inner);
+        BOOST_REQUIRE(nested->nested_ptr() == inner);
     }
 
     try {
         std::rethrow_exception(outer);
     } catch (const std::nested_exception& ex) {
-        BOOST_REQUIRE_EQUAL(ex.nested_ptr(), inner);
+        BOOST_REQUIRE(ex.nested_ptr() == inner);
     }
 
     // Not a class
@@ -238,7 +238,7 @@ SEASTAR_TEST_CASE(test_make_nested_exception_ptr) {
         try {
             std::rethrow_exception(make_nested_exception_ptr(already_nested_exception(), inner));
         } catch (const already_nested_exception& ex) {
-            BOOST_REQUIRE_EQUAL(ex.nested_ptr(), inner2);
+            BOOST_REQUIRE(ex.nested_ptr() == inner2);
         }
     }
 

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -413,7 +413,7 @@ SEASTAR_TEST_CASE(test_group0_hard_timeout_history_present_is_always_success) {
             // succeed regardless.
             auto gc_dur = rclient.get_history_gc_duration();
             forward_jump_clocks(gc_dur + std::chrono::seconds{1});
-            auto restore_clocks = defer([gc_dur] { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
+            auto restore_clocks = defer([gc_dur] () noexcept { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
             // Row present => success, must not throw.
             co_await std::move(mc).commit(rclient, as, ::service::raft_timeout{});
         }
@@ -509,7 +509,7 @@ SEASTAR_TEST_CASE(test_group0_hard_timeout_history_absent_gc_eligible_is_hard_ti
         // ambiguous => must throw group0_hard_timeout.
         auto gc_dur = rclient.get_history_gc_duration();
         forward_jump_clocks(gc_dur + std::chrono::seconds{1});
-        auto restore_clocks = defer([gc_dur] { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
+        auto restore_clocks = defer([gc_dur] () noexcept { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
         BOOST_CHECK_EXCEPTION(co_await std::move(mc_a).commit(rclient, as, ::service::raft_timeout{}),
                 service::group0_hard_timeout, [] (const service::group0_hard_timeout&) { return true; });
     });
@@ -554,7 +554,7 @@ SEASTAR_TEST_CASE(test_group0_hard_timeout_history_absent_after_real_gc_is_hard_
         // gc_clock::now() includes clocks_offset, so gc_grace_seconds=0 makes
         // tombstones immediately eligible once gc_clock advances.
         forward_jump_clocks(std::chrono::seconds{1});
-        auto restore_clocks = defer([] { forward_jump_clocks(-std::chrono::seconds{1}); });
+        auto restore_clocks = defer([] () noexcept { forward_jump_clocks(-std::chrono::seconds{1}); });
         auto& history_cf = e.local_db().find_column_family("system", db::system_keyspace::GROUP0_HISTORY);
         co_await history_cf.flush();
         co_await history_cf.compact_all_sstables(tasks::task_info{});

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2719,7 +2719,7 @@ static future<> run_sstable_cleanup_correctness_with_storage(data_dictionary::st
     return do_with_cql_env_thread([storage = std::move(storage)] (cql_test_env& e) {
         auto scf = make_sstable_compressor_factory_for_tests_in_thread();
         test_env env(test_env_config{.storage = storage}, *scf, &e.get_sstorage_manager().local());
-        auto close_env = defer([&] { env.stop().get(); });
+        auto close_env = defer([&] () noexcept { env.stop().get(); });
         env.plug_mock_sstables_registry();
         sstable_cleanup_correctness_fn(e, env);
     }, std::move(cql_cfg));

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3497,7 +3497,7 @@ SEASTAR_TEST_CASE(test_stats_metadata_error_includes_filename) {
 SEASTAR_THREAD_TEST_CASE(test_small_sstable_has_reasonable_memory_usage) {
     auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     test_env env({}, *scf);
-    auto stop_env = defer([&env] { env.stop().get(); });
+    auto stop_env = defer([&env] () noexcept { env.stop().get(); });
 
     // Big enough that a few leaked copies
     constexpr size_t dict_size = 110 * 1024;

--- a/tools/json_mutation_stream_parser.cc
+++ b/tools/json_mutation_stream_parser.cc
@@ -193,7 +193,7 @@ private:
             auto raw = from_hex(*_string);
             _pkey.emplace(partition_key::from_bytes(raw));
         } catch (...) {
-            return error("failed to parse partition key from raw string: {}", fmt::streamed(std::current_exception()));
+            return error("failed to parse partition key from raw string: {}", std::current_exception());
         }
         return true;
     }
@@ -203,7 +203,7 @@ private:
             auto raw = from_hex(*_string);
             _ckey.emplace(clustering_key::from_bytes(raw));
         } catch (...) {
-            return error("failed to parse clustering key from raw string: {}", fmt::streamed(std::current_exception()));
+            return error("failed to parse clustering key from raw string: {}", std::current_exception());
         }
         return true;
     }


### PR DESCRIPTION
Fixes an abandoned failed future in tls::session::~session(), observed in
the vector_store_client_https_wrong_hostname test case.
Fixed by https://github.com/scylladb/seastar/commit/ccec5f27 ('net: fix abandoned failed future in TLS session handshake').

* seastar ffeb9a3c...1020cc77 (39):
  > CMakeLists: link URING::uring as PRIVATE, keep include dir PUBLIC
  > Merge 'test,perf: Measure time it takes to traverse a runqueue' from Pavel Emelyanov
    test/perf: Measure time it takes to traverse a runqueue
    test/perf: Add ability to parametrize tests
  > httpd: Remove deprecated connection constructor taking socket_address
  > reactor: Remove deprecated handle_signal() method
  > http: Remove deprecated httpd::request and httpd::reply aliases
  > Merge 'module: export more symbols' from Avi Kivity
    module: export more symbols
    module: sort exported namespaces and symbols alphabetically
  > dns: fix build with c-ares 1.34.7 constified host callback
  > Merge 'file: query DIO alignment via statx regardless of build headers' from Travis Downs
    file: add a unit test for query_statx_mem_align
    file: query DIO alignment via statx regardless of build headers
  > treewide: initialize disk_config_params members
  > tests: fix bandwidth calculation in test_tb_params
  > Merge 'net: fix abandoned failed future in TLS session handshake' from Karol Nowacki
    tests/tls: verify abandoned_failed_futures count in test_output_pending_exception_on_destroy
    net: fix abandoned failed future in tls::session handshake
  > Merge 'Add LTTng-UST tracepoints (and add some IO ones)' from Pavel Emelyanov
    build: Suppress UBSan vla-bound for lttng probe units on aarch64/clang
    build: Remove SystemTap-SDT dependency
    reactor: Add LTTng-UST tracepoints to task scheduling
    io: Remove io_log.trace() calls duplicated by LTTng tracepoints
    io: Add LTTng-UST tracepoints to IO subsystem
    io: Add offset() and fd() accessors to io_request
    tests: Add LTTng-UST dormant tracepoint overhead benchmark
    build: Add LTTng-UST as optional dependency
  > tests/unit: replace hardcoded TLS certificates with build-system certs
  > lazy: move operator<< to the seastar namespace
  > collectd: avoid static template functions in headers
  > http: Allow HTTPS request handler to fetch client's DN and SAN
  > net: validate each device's config independently
  > reactor: Replace indirect_compare struct with a lambda
  > build: export SEASTAR_DEFERRED_ACTION_REQUIRE_NOEXCEPT
  > perf: avoid `using namespace seastar` in header
  > treewide: make variables in headers inline
  > httpd: Remove deprecated set_tls_credentials() method
  > test/iostream: Fix test_move_after_batched_write deprecation usage
  > iostream: Deprecate consumption_result(optional<buffer>) constructor
  > print: Remove deprecated fmt_print()
  > unaligned: Remove deprecated unaligned_cast()
  > metrics: qualify symbols in impl subnamespace
  > http: mark connection::close() and client::close() noexcept
  > doc: Add documentation for reactor_backend_asymmetric_uring
  > iostream: remove redundant local tmp_buf aliases
  > core/loop: include do_with.hh for max_concurrent_for_each()
  > Merge 'net: modernize posix stack connect/accept paths' from Avi Kivity
    net: posix: coroutinize accept()
    net: posix: coroutinize connect()
    net: posix: avoid bare new when creating a posix_connected_socket_impl
    net: posix: restore indentation in connect_unix_domain()
    net: posix: coroutinize connect_unix_domain()
    net: posix: avoid unneeded coroutine::as_future() in connect()
    net: posix: improve indentation in connect()
    net: posix: coroutinize connect()
  > net/tls: fix concurrent put() on the socket in the OpenSSL backend
  > dns: opt out of c-ares RFC 6724 address sorting
  > CMakeLists: link URING::uring as PUBLIC so consumers find liburing.h
  > reactor_backend: include <span>
  > Merge 'treewide: deprecate formatters for standard types' from Avi Kivity
    build: default Seastar_DEPRECATED_OSTREAM_FORMATTERS to off
    log: gate exception ostream operators on Seastar_DEPRECATED_OSTREAM_FORMATTERS
    log: deprecate fmt::formatter<std::exception_ptr>
    log: add seastar::formattable() for std::exception_ptr
    log: use {fmt}'s std::exception/std::system_error formatters
  > tests/loopback: emulate SHUT_WR in shutdown_output()
  > core/fstream: build pipe_data_sink_impl at SEASTAR_API_LEVEL < 9

Fixes SCYLLADB-2906

No backport is required, as this issue was only observed on master.