### PR TITLE
[Backport 2026.2] alternator: Mark the returned `api_error` results as errors in audit log

### DIFF
--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -29,6 +29,7 @@
 #include <cctype>
 #include <string_view>
 #include <utility>
+#include <variant>
 #include "service/storage_proxy.hh"
 #include "gms/gossiper.hh"
 #include "utils/overloaded_functor.hh"
@@ -800,7 +801,8 @@ future<executor::request_return_type> server::handle_api_request(std::unique_ptr
             ex = std::current_exception();
         }
         if (audit_info) {
-            co_await audit::inspect(*audit_info, client_state, ex != nullptr);
+            bool error = ex != nullptr || std::holds_alternative<api_error>(ret);
+            co_await audit::inspect(*audit_info, client_state, error);
         }
         if (ex) {
             co_return coroutine::exception(std::move(ex));
@@ -1077,4 +1079,3 @@ const char* api_error::what() const noexcept {
 }
 
 }
-

--- a/test/alternator/test_audit.py
+++ b/test/alternator/test_audit.py
@@ -611,11 +611,12 @@ def test_audit_keyspace_filtering(dynamodb, cql, alternator_audit_enabled):
                 _assert_no_audit_entries_for(new_rows, ks_name=ks_a)  # sanity check
 
 
-# Test that a failed operation (one that throws after audit_info is set) generates
-# an audit entry with error=True.
-# GetItem with an extra bogus key attribute passes table lookup (audit_info is set)
-# but then check_key() throws ValidationException. A normal GetItem follows as the
-# positive canary (error=False). Both entries should be present.
+# Test that failed operations generate audit entries with error=True.
+# Alternator reports errors in two ways: by throwing an exception, and by
+# returning api_error in request_return_type. GetItem with an extra bogus key
+# attribute covers the throwing path after audit_info is set. PutItem with an
+# unmet condition covers the returned api_error path. A normal GetItem follows
+# as the positive canary (error=False). All entries should be present.
 def test_audit_error_entry(dynamodb, cql, alternator_audit_enabled):
     with new_test_table(dynamodb, **HASH_ONLY_SCHEMA) as table:
         ks_name = f"alternator_{table.name}"
@@ -628,13 +629,18 @@ def test_audit_error_entry(dynamodb, cql, alternator_audit_enabled):
         # which throws api_error::validation after audit_info is already set.
         with pytest.raises(ClientError, match='ValidationException'):
             table.get_item(Key={"p": "pk_0", "bogus": "junk"})
+        # Negative operation: PutItem with an unmet condition. Conditional check
+        # failures are returned as api_error in the normal request_return_type path.
+        with pytest.raises(ClientError, match='ConditionalCheckFailedException'):
+            table.put_item(Item={"p": "pk_0", "v": "new"}, ConditionExpression="attribute_not_exists(p)")
         # Positive operation: normal GetItem — should succeed and produce error=False entry.
         table.get_item(Key={"p": "pk_0"})
         expected = [
             ("QUERY", "LOCAL_ONE", True, ks_name, table.name, ["GetItem", "pk_0", "bogus"]),
+            ("DML", "LOCAL_QUORUM", True, ks_name, table.name, ["PutItem", "pk_0", "attribute_not_exists"]),
             ("QUERY", "LOCAL_ONE", False, ks_name, table.name, ["GetItem", "pk_0"]),
         ]
-        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=2)
+        new_rows = _get_new_audit_log_rows(cql, before_rows, expected_new_row_count=3)
         _assert_audit_entries(new_rows, expected, ks_name, table.name)
 
 


### PR DESCRIPTION
This replaces the incomplete automated backport scylladb/scylladb#30758, which carried only the implementation change and missed the regression test added later.

This PR has two cherry-picked commits:

- scylladb/scylladb@c9e7c54084fd4ad51659e7078a8ca437b5e5c660: marks returned `api_error` Alternator audit entries as errors.
- scylladb/scylladb@f78220353b3cb5ad683d71d18b49cfe5d4f8bf5b: adds regression coverage for returned `api_error` results in `test_audit_error_entry`.

Fixes SCYLLADB-3260

No further backport needed, auditing in Alternator does not exist before 2026.2.
