### PR TITLE
qos: use infinite timeout for service level cache load at startup

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2625,7 +2625,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             // update the service level cache after the SL data accessor and auth service are initialized.
-            sl_controller.local().update_cache(qos::update_both_cache_levels::yes).get();
+            // This is a local read of system tables (service levels and roles) that seeds the cache once
+            // at boot, independently of group0 log replay. Use the startup query context so it isn't bound
+            // by the short user-facing timeout, which would otherwise abort startup on a spurious timeout.
+            sl_controller.local().update_cache(qos::update_both_cache_levels::yes, qos::query_context::startup).get();
 
             sl_controller.invoke_on_all([&lifecycle_notifier] (qos::service_level_controller& controller) {
                 lifecycle_notifier.local().register_subscriber(&controller);

--- a/service/qos/qos_common.cc
+++ b/service/qos/qos_common.cc
@@ -191,7 +191,7 @@ service::query_state& qos_query_state(qos::query_context ctx) {
     static thread_local service::client_state cs(service::client_state::internal_tag{}, tc);
     static thread_local service::query_state qs_default(cs, empty_service_permit());
     static thread_local service::query_state qs_internal(service::client_state::for_internal_calls(), empty_service_permit());
-    return ctx == qos::query_context::group0 ? qs_internal : qs_default;
+    return (ctx == qos::query_context::group0 || ctx == qos::query_context::startup) ? qs_internal : qs_default;
 };
 
 static service_level_options::timeout_type get_duration(const cql3::untyped_result_set_row&row, std::string_view col_name) {

--- a/service/qos/qos_common.hh
+++ b/service/qos/qos_common.hh
@@ -37,11 +37,12 @@ enum class include_effective_names { yes, no };
  * the query with internal client_state with an 'infinite' timeout, or a default
  * state with short timeout.
  * for queries that are executed in context of group0 operations it is important to have
- * a long timeout so the query doesn't fail the group0 client spuriously. in the context
- * of user commands, however, a shorter timeout is preferred. in other cases, the default
- * unspecified behavior may be sufficient.
+ * a long timeout so the query doesn't fail the group0 client spuriously. The same applies
+ * to the initial cache load done during node startup, where a spurious timeout would abort
+ * the whole boot. In the context of user commands, however, a shorter timeout is preferred.
+ * in other cases, the default unspecified behavior may be sufficient.
  */
-enum class query_context { group0, user, unspecified };
+enum class query_context { group0, startup, user, unspecified };
 
 /**
  *  a structure that holds the configuration for


### PR DESCRIPTION
The initial service level cache load performed during node startup issued its reads with the short user-facing timeout. On an overloaded node, where a shard can be starved of CPU for several seconds during boot, this read could time out and abort the whole startup with a read_timeout_exception.

This mirrors the same problem that was already fixed for group0 operations, where a spurious timeout must not fail an otherwise healthy operation. The startup cache load is a local read that seeds the cache once at boot and should not be bound by a timeout meant for interactive user commands.

Route the startup cache load through a dedicated query context so it uses the internal client state with an infinite timeout, matching the treatment of group0 reads.

Fixes: SCYLLADB-3113

No backport, the CI failed only once on `master`.