### PR TITLE
alternator: add composite GSI table schema parsing, validation and creation with DescribeTable support

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -57,6 +57,7 @@
 #include <seastar/core/loop.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <boost/range/algorithm/find_end.hpp>
+#include <string_view>
 #include <unordered_set>
 #include "service/storage_proxy.hh"
 #include "gms/feature_service.hh"
@@ -119,16 +120,29 @@ const sstring TABLE_CREATION_TIME_TAG_KEY("system:table_creation_time");
 // configured by UpdateTimeToLive to be the expiration-time attribute for
 // this table.
 extern const sstring TTL_TAG_KEY("system:ttl_attribute");
-// This will be set to 1 in a case, where user DID NOT specify a range key.
-// The way GSI / LSI is implemented by Alternator assumes user specified keys will come first
-// in materialized view's key list. Then, if needed missing keys are added (current implementation
-// of materialized views requires that all base hash / range keys were added to the view as well).
-// Alternator allows only a single range key attribute to be specified by the user. So if
-// the SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY is set the user didn't specify any key and
-// base table's keys were added as range keys. In all other cases either the first key is the user specified key,
-// following ones are base table's keys added as needed or range key list will be empty.
+// This tag is set for GSIs since scylla-2026.4.
+// GSI implementation in Alternator assumes that (currently up to 4)
+// user-specified RANGE keys come first in the underlying materialized view's
+// clustering columns list. Then if not specified by the user as RANGE keys base
+// table HASH and/or RANGE key/keys is/are appended to the materialized view as
+// additional trailing clustering columns. This is required by the materialized
+// view's implementation but should not be reported to the Alternator user.
+// This tag keeps track of the number of RANGE keys the user specified thus
+// allowing for reporting correct user-specified RANGE keys with only a column
+// prefix of the clustering columns of length written in the tag.
+extern const sstring NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY("system:number_of_user_specified_gsi_range_keys");
+// This is a legacy tag since scylla-2026.4, replaced by the tag above.
+// It was set to true when the user did not specify a RANGE key for a single
+// HASH key GSI. In that case base table key column/columns is/are appended to
+// the materialized view's clustering column list so Alternator should report
+// 0 - no user-specified RANGE columns. If this tag is *not* set then only the
+// first clustering key column should be reported as user-specified RANGE key.
+// New GSIs are tagged with NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY
+// instead, and it takes precedence over this tag where both are present. This
+// tag is only still *written* on single key GSIs when
+// ALTERNATOR_COMPOSITE_GSI_KEYS feature is disabled. It is still read to
+// describe tables created long time ago.
 extern const sstring SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY("system:spurious_range_key_added_to_gsi_and_user_didnt_specify_range_key");
-
 // The following tags also have the "system:" prefix but are NOT used
 // by Alternator to store table properties - only the user ever writes to
 // them, as a way to configure the table. As such, these tags are writable
@@ -853,6 +867,76 @@ static std::pair<std::string, std::string> parse_key_schema(const rjson::value& 
     return {hash_key, range_key};
 }
 
+// parse_gsi_composite_key_schema() is like parse_key_schema() above, but for
+// GSIs, which (unlike base tables and LSIs) may have a "composite" (multi-
+// attribute) key: up to 4 HASH attributes forming the partition key, followed
+// by up to 4 RANGE attributes forming the sort key (up to 8 KeySchema entries
+// in total). All HASH entries must appear before all RANGE entries (i.e., the
+// KeySchema array must be a contiguous run of HASH entries followed by a
+// contiguous run of RANGE entries), at least one HASH entry is required, and
+// no attribute name may be used more than once (whether as two HASH entries,
+// two RANGE entries, or as both a HASH and a RANGE entry).
+// The function returns two vectors of column names - the HASH (partition)
+// key attributes in KeySchema order, and the RANGE (sort) key attributes in
+// KeySchema order (which may be empty).
+static std::pair<std::vector<std::string>, std::vector<std::string>> parse_gsi_composite_key_schema(const rjson::value& obj, std::string_view supplementary_context, bool composite_keys_supported) {
+    const size_t max_keys_of_each_type = composite_keys_supported ? 4 : 1;
+    const rjson::value *key_schema;
+    if (!obj.IsObject() || !(key_schema = rjson::find(obj, "KeySchema"))) {
+        throw api_error::validation("Missing KeySchema member");
+    }
+    if (!key_schema->IsArray() || key_schema->Size() < 1 || key_schema->Size() > 2 * max_keys_of_each_type) {
+        throw api_error::validation(fmt::format("KeySchema must list between one and {} key columns",
+                2 * max_keys_of_each_type));
+    }
+    std::vector<std::string> hash_keys;
+    std::vector<std::string> range_keys;
+    std::unordered_set<std::string_view> seen_names;
+    for (size_t i = 0; i < key_schema->Size(); ++i) {
+        if (!(*key_schema)[i].IsObject()) {
+            throw api_error::validation("KeySchema element " + std::to_string(i) + " must be an object");
+        }
+        const rjson::value *v = rjson::find((*key_schema)[i], "KeyType");
+        if (!v || !v->IsString()) {
+            throw api_error::validation("KeySchema element " + std::to_string(i) + " must have a string KeyType");
+        }
+        const std::string_view key_type = rjson::to_string_view(*v);
+        if (key_type != "HASH" && key_type != "RANGE") {
+            throw api_error::validation("KeySchema element " + std::to_string(i) + " KeyType must be HASH or RANGE");
+        }
+        v = rjson::find((*key_schema)[i], "AttributeName");
+        if (!v || !v->IsString()) {
+            throw api_error::validation("KeySchema element " + std::to_string(i) + " must have string AttributeName");
+        }
+        validate_attr_name_length(supplementary_context, v->GetStringLength(), true,
+                key_type == "HASH" ? "HASH key in KeySchema - " : "RANGE key in KeySchema - ");
+        std::string_view attr_name = rjson::to_string_view(*v);
+        if (!seen_names.insert(attr_name).second) {
+            throw api_error::validation("KeySchema cannot have two key elements with the same name ('" + std::string(attr_name) + "')");
+        }
+        if (key_type == "HASH") {
+            if (!range_keys.empty()) {
+                throw api_error::validation("All HASH keys in KeySchema must precede any RANGE key");
+            }
+            if (hash_keys.size() >= max_keys_of_each_type) {
+                throw api_error::validation(fmt::format("KeySchema can have at most {} HASH keys",
+                        max_keys_of_each_type));
+            }
+            hash_keys.emplace_back(attr_name);
+        } else {
+            if (range_keys.size() >= max_keys_of_each_type) {
+                throw api_error::validation(fmt::format("KeySchema can have at most {} RANGE keys",
+                        max_keys_of_each_type));
+            }
+            range_keys.emplace_back(attr_name);
+        }
+    }
+    if (hash_keys.empty()) {
+        throw api_error::validation("KeySchema must have at least one HASH key");
+    }
+    return {std::move(hash_keys), std::move(range_keys)};
+}
+
 arn_parts parse_arn(std::string_view arn, std::string_view arn_field_name, std::string_view type_name, std::string_view expected_postfix) {
     // Expected ARN format arn:partition:service:region:account-id:resource-type/resource-id
     // So (old arn produced by scylla for internal purposes) arn:scylla:alternator:${KEYSPACE_NAME}:scylla:table/${TABLE_NAME}
@@ -1429,6 +1513,28 @@ static std::string get_similarity_function(const rjson::value& vector_index, std
     return sf;
 }
 
+// Record how many of the view's leading clustering columns are genuine,
+// user-specified RANGE key attributes (as opposed to the base table's own
+// key columns, appended as irrelevant to the user clustering columns
+// for materialized view correctness). DescribeTable relies on this tag-writing
+// code via genuine_range_key_count() to know where to stop reporting RANGE
+// keys - if this writer and that reader ever diverge, DescribeTable will report
+// a wrong/stale KeySchema for the GSI.
+static std::map<sstring, sstring> make_gsi_tags(
+    bool composite_gsi_keys_supported,
+    bool spurious_base_key_added_as_range_key,
+    const std::vector<std::string>& view_hash_keys,
+    const std::vector<std::string>& view_range_keys
+) {
+    std::map<sstring, sstring> tags;
+    if (composite_gsi_keys_supported) {
+        tags[NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY] = std::to_string(view_range_keys.size());
+    } else if (view_hash_keys.size() == 1 && view_range_keys.empty() && spurious_base_key_added_as_range_key) {
+        tags[SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY] = "true";
+    }
+    return tags;
+}
+
 future<executor::request_return_type> executor::create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, bool enforce_authorization, bool warn_authorization,
             const db::tablets_mode_t::mode tablets_mode, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     throwing_assert(this_shard_id() == 0);
@@ -1541,6 +1647,7 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
         if (!gsi->IsArray()) {
             co_return api_error::validation("GlobalSecondaryIndexes must be an array.");
         }
+        const bool composite_gsi_keys_supported = _proxy.features().alternator_composite_gsi_keys;
         for (const rjson::value& g : gsi->GetArray()) {
             const rjson::value* index_name_v = rjson::find(g, "IndexName");
             if (!index_name_v || !index_name_v->IsString()) {
@@ -1556,23 +1663,22 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             // FIXME: read and handle "Projection" parameter. This will
             // require the MV code to copy just parts of the attrs map.
             schema_builder view_builder(this_smp_shard_count(), keyspace_name, vname);
-            auto [view_hash_key, view_range_key] = parse_key_schema(g, "GlobalSecondaryIndexes");
+            const auto [view_hash_keys, view_range_keys] = parse_gsi_composite_key_schema(g, "GlobalSecondaryIndexes",
+                    composite_gsi_keys_supported);
 
             // If an attribute is already a real column in the base table
             // (i.e., a key attribute), we can use it directly as a view key.
             // Otherwise, we need to add it as a "computed column", which
             // extracts and deserializes the attribute from the ":attrs" map.
-            bool view_hash_key_real_column = partial_schema->get_column_definition(to_bytes(view_hash_key));
-            add_column(view_builder, view_hash_key, *attribute_definitions, column_kind::partition_key, !view_hash_key_real_column);
-            unused_attribute_definitions.erase(view_hash_key);
-            if (!view_range_key.empty()) {
+            for (const auto& view_hash_key : view_hash_keys) {
+                bool view_hash_key_real_column = partial_schema->get_column_definition(to_bytes(view_hash_key));
+                add_column(view_builder, view_hash_key, *attribute_definitions, column_kind::partition_key, !view_hash_key_real_column);
+                unused_attribute_definitions.erase(view_hash_key);
+            }
+
+            for (const auto& view_range_key : view_range_keys) {
                 bool view_range_key_real_column = partial_schema->get_column_definition(to_bytes(view_range_key));
                 add_column(view_builder, view_range_key, *attribute_definitions, column_kind::clustering_key, !view_range_key_real_column);
-                if (!partial_schema->get_column_definition(to_bytes(view_range_key)) &&
-                    !partial_schema->get_column_definition(to_bytes(view_hash_key))) {
-                    // FIXME: This warning should go away. See issue #6714
-                    elogger.warn("Only 1 regular column from the base table should be used in the GSI key in order to ensure correct liveness management without assumptions");
-                }
                 unused_attribute_definitions.erase(view_range_key);
             }
 
@@ -1581,18 +1687,16 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             // key(s).
             // NOTE: DescribeTable's implementation depends on those keys being added AFTER user specified keys.
             bool spurious_base_key_added_as_range_key = false;
-            if (hash_key != view_hash_key && hash_key != view_range_key) {
+            if (!std::ranges::contains(view_hash_keys, hash_key) && !std::ranges::contains(view_range_keys, hash_key)) {
                 add_column(view_builder, hash_key, *attribute_definitions, column_kind::clustering_key);
                 spurious_base_key_added_as_range_key = true;
             }
-            if (!range_key.empty() && range_key != view_hash_key && range_key != view_range_key) {
+            if (!range_key.empty() && !std::ranges::contains(view_hash_keys, range_key) && !std::ranges::contains(view_range_keys, range_key)) {
                 add_column(view_builder, range_key, *attribute_definitions, column_kind::clustering_key);
                 spurious_base_key_added_as_range_key = true;
             }
-            std::map<sstring, sstring> tags;
-            if (view_range_key.empty() && spurious_base_key_added_as_range_key) {
-                tags[SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY] = "true";
-            }
+
+            auto tags = make_gsi_tags(composite_gsi_keys_supported, spurious_base_key_added_as_range_key, view_hash_keys, view_range_keys);
             view_builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>(std::move(tags)));
             view_builders.emplace_back(std::move(view_builder));
         }
@@ -2198,25 +2302,24 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                         // FIXME: read and handle "Projection" parameter. This will
                         // require the MV code to copy just parts of the attrs map.
                         schema_builder view_builder(this_smp_shard_count(), keyspace_name, vname);
-                        auto [view_hash_key, view_range_key] = parse_key_schema(it->value, "GlobalSecondaryIndexUpdates");
+                        const bool composite_gsi_keys_supported = p.local().features().alternator_composite_gsi_keys;
+                        const auto [view_hash_keys, view_range_keys] = parse_gsi_composite_key_schema(it->value, "GlobalSecondaryIndexUpdates",
+                                composite_gsi_keys_supported);
                         // If an attribute is already a real column in the base
                         // table (i.e., a key attribute in the base table),
                         // we can use it directly as a view key. Otherwise, we
                         // need to add it as a "computed column", which extracts
                         // and deserializes the attribute from the ":attrs" map.
-                        bool view_hash_key_real_column =
-                            schema->get_column_definition(to_bytes(view_hash_key));
-                        add_column(view_builder, view_hash_key, *attribute_definitions, column_kind::partition_key, !view_hash_key_real_column);
-                        unused_attribute_definitions.erase(view_hash_key);
-                        if (!view_range_key.empty()) {
+                        for (const auto& view_hash_key : view_hash_keys) {
+                            bool view_hash_key_real_column =
+                                schema->get_column_definition(to_bytes(view_hash_key));
+                            add_column(view_builder, view_hash_key, *attribute_definitions, column_kind::partition_key, !view_hash_key_real_column);
+                            unused_attribute_definitions.erase(view_hash_key);
+                        }
+                        for (const auto& view_range_key : view_range_keys) {
                             bool view_range_key_real_column =
                                 schema->get_column_definition(to_bytes(view_range_key));
                             add_column(view_builder, view_range_key, *attribute_definitions, column_kind::clustering_key, !view_range_key_real_column);
-                            if (!schema->get_column_definition(to_bytes(view_range_key)) &&
-                                !schema->get_column_definition(to_bytes(view_hash_key))) {
-                                // FIXME: This warning should go away. See issue #6714
-                                elogger.warn("Only 1 regular column from the base table should be used in the GSI key in order to ensure correct liveness management without assumptions");
-                            }
                             unused_attribute_definitions.erase(view_range_key);
                         }
                         // Surprisingly, although DynamoDB checks for unused
@@ -2230,13 +2333,17 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                         // Base key columns which aren't part of the index's key need to
                         // be added to the view nonetheless, as (additional) clustering
                         // key(s).
+                        // NOTE: DescribeTable's implementation depends on those keys being added AFTER user specified keys.
+                        bool spurious_base_key_added_as_range_key = false;
                         for (auto& def : schema->primary_key_columns()) {
-                            if  (def.name_as_text() != view_hash_key && def.name_as_text() != view_range_key) {
+                            std::string_view target_view = def.name_as_text();
+                            if  (!std::ranges::contains(view_hash_keys, target_view) && !std::ranges::contains(view_range_keys, target_view)) {
                                 view_builder.with_column(def.name(), def.type, column_kind::clustering_key);
+                                spurious_base_key_added_as_range_key = true;
                             }
                         }
-                        // GSIs have no tags:
-                        view_builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>());
+                        auto tags = make_gsi_tags(composite_gsi_keys_supported, spurious_base_key_added_as_range_key, view_hash_keys, view_range_keys);
+                        view_builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>(std::move(tags)));
                         // Note below we don't need to add virtual columns, as all
                         // base columns were copied to view. TODO: reconsider the need
                         // for virtual columns when we support Projection.

--- a/alternator/executor_util.cc
+++ b/alternator/executor_util.cc
@@ -130,14 +130,50 @@ bool is_alternator_keyspace(std::string_view ks_name) {
     return ks_name.starts_with(executor::KEYSPACE_NAME_PREFIX);
 }
 
-// This tag is set on a GSI when the user did not specify a range key, causing
-// Alternator to add the base table's range key as a spurious range key. It is
-// used by describe_key_schema() to suppress reporting that key.
+extern const sstring NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY;
 extern const sstring SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY;
+
+uint8_t genuine_range_key_count(const schema& schema, const std::map<sstring, sstring>* tags) {
+    // When a GSI doesn't carry the NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY
+    // tag, to preserve the behavior of legacy tables we translate the presence of
+    // SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY
+    // to "0" in NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY
+    // and absence of the tag to "suppress nothing".
+    if (tags != nullptr) {
+        auto it = tags->find(NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY);
+        if (it != tags->end() && !it->second.empty()) {
+            unsigned long parsed;
+            auto [ptr, ec] = std::from_chars(it->second.data(), it->second.data() + it->second.size(), parsed);
+            if (ec != std::errc{}
+                || ptr != it->second.end()
+                || parsed > 4
+                || parsed > static_cast<unsigned long>(schema.clustering_key_size())) {
+                // This should never happen, because this tag is only ever
+                // written by our own code (as std::to_string() of a size_t),
+                // never user-facing, and validated at GSI creation/update
+                // time. If it does happen anyway (e.g., due to a corrupted
+                // tag), report all of the clustering columns as RANGE keys.
+                elogger.error(
+                        "Unexpected {} tag value '{}' for table {}.{}, falling back to reporting all clustering columns as RANGE keys",
+                        NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY, it->second, schema.ks_name(), schema.cf_name());
+                return static_cast<uint8_t>(schema.clustering_key_size());
+            }
+            return static_cast<uint8_t>(parsed);
+        } else if (tags->contains(SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY)) {
+            return 0;
+        }
+    }
+    // Preserve behavior of reporting at most 1 column when there is no
+    // SPURIOUS_... tag. In test_table_gsi_5 before scylla 2026.4 there *is*
+    // specified RANGE key column thus there is *no* SPURIOUS_... tag, but we
+    // can't report all the mv's clustering keys, there are still base table key
+    // columns appended! Clamping the reporting keys to 1 is correct,
+    // historically if there was a user-specified RANGE key it was at most 1.
+    return std::min(uint8_t{1}, static_cast<uint8_t>(schema.clustering_key_size()));
+}
 
 void describe_key_schema(rjson::value& parent, const schema& schema, std::unordered_map<std::string, std::string>* attribute_types, const std::map<sstring, sstring>* tags) {
     rjson::value key_schema = rjson::empty_array();
-    const bool ignore_range_keys_as_spurious = tags != nullptr && tags->contains(SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY);
 
     for (const column_definition& cdef : schema.partition_key_columns()) {
         rjson::value key = rjson::empty_object();
@@ -148,19 +184,19 @@ void describe_key_schema(rjson::value& parent, const schema& schema, std::unorde
             (*attribute_types)[cdef.name_as_text()] = type_to_string(cdef.type);
         }
     }
-    if (!ignore_range_keys_as_spurious) {
-        // NOTE: user requested key (there can be at most one) will always come first.
-        // There might be more keys following it, which were added, but those were
-        // not requested by the user, so we ignore them.
-        for (const column_definition& cdef : schema.clustering_key_columns()) {
-            rjson::value key = rjson::empty_object();
-            rjson::add(key, "AttributeName", rjson::from_string(cdef.name_as_text()));
-            rjson::add(key, "KeyType", "RANGE");
-            rjson::push_back(key_schema, std::move(key));
-            if (attribute_types) {
-                (*attribute_types)[cdef.name_as_text()] = type_to_string(cdef.type);
-            }
-            break;
+    // NOTE: user requested key will always come first.
+    // There can be at most 1 user-specified key for a non-composite GSI table.
+    // The single key GSIs (before scylla 2026.4) should still report at most 1.
+    // There might be more keys following it, which were added, but those were
+    // not requested by the user, so we ignore them.
+    uint8_t range_keys_to_report = genuine_range_key_count(schema, tags);
+    for (const column_definition& cdef : schema.clustering_key_columns() | std::views::take(range_keys_to_report)) {
+        rjson::value key = rjson::empty_object();
+        rjson::add(key, "AttributeName", rjson::from_string(cdef.name_as_text()));
+        rjson::add(key, "KeyType", "RANGE");
+        rjson::push_back(key_schema, std::move(key));
+        if (attribute_types) {
+            (*attribute_types)[cdef.name_as_text()] = type_to_string(cdef.type);
         }
     }
     rjson::add(parent, "KeySchema", std::move(key_schema));

--- a/alternator/executor_util.hh
+++ b/alternator/executor_util.hh
@@ -196,6 +196,12 @@ future<> verify_create_permission(bool enforce_authorization, bool warn_authoriz
 // attribute_types.
 void describe_key_schema(rjson::value& parent, const schema&, std::unordered_map<std::string, std::string>* attribute_types = nullptr, const std::map<sstring, sstring>* tags = nullptr);
 
+// Returns how many of the *leading* clustering-key columns of the given
+// schema are genuine, user-specified RANGE key attributes. The rest of the
+// clustering columns, if any, were added by Alternator for the materialized
+// view's sake and must not be reported to the user.
+uint8_t genuine_range_key_count(const schema&, const std::map<sstring, sstring>* tags);
+
 /// is_big() checks approximately if the given JSON value is "bigger" than
 /// the given big_size number of bytes. The goal is to *quickly* detect
 /// oversized JSON that, for example, is too large to be serialized to a

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1229,20 +1229,15 @@ void view_updates::generate_update(
         // Note:
         // 1. By reaching here we know that updatable_view_key_cols has at
         //    least one member (in CQL, it's always one, in Alternator it
-        //    may be two).
+        //    may be two or more).
         // 2. Because has_new_row, we know all elements in that array have
         //    after.has_value() true, so we can use after.get_ts() et al.
         api::timestamp_type new_row_ts = updatable_view_key_cols[0].after.get_ts();
-        // This is the Alternator-only support for *two* regular base columns
-        // that become view key columns. The timestamp we use is the *maximum*
-        // of the two key columns, as explained in pull-request #17172.
-        if (updatable_view_key_cols.size() > 1) {
-            auto second_ts = updatable_view_key_cols[1].after.get_ts();
-            new_row_ts = std::max(new_row_ts, second_ts);
-            // Alternator isn't supposed to have more than two updatable view key columns!
-            if (updatable_view_key_cols.size() != 2) [[unlikely]] {
-                utils::on_internal_error(format("Unexpected updatable_view_key_col length {}", updatable_view_key_cols.size()));
-            }
+        // This is the Alternator-only support for *two or more* regular base
+        // columns that become view key columns. The timestamp we use is the
+        // *maximum* of those key columns, as explained in pull-request #17172.
+        for (size_t i = 1; i < updatable_view_key_cols.size(); ++i) {
+            new_row_ts = std::max(new_row_ts, updatable_view_key_cols[i].after.get_ts());
         }
         // We assume that either updatable_view_key_cols has just one column
         // (the only situation allowed in CQL) or if there is more then one
@@ -1254,25 +1249,20 @@ void view_updates::generate_update(
     if (has_old_row) {
         // As explained in #19977, when there is one updatable_view_key_cols
         // (the only case allowed in CQL) the deletion timestamp is before's
-        // timestamp. As explained in #17119, if there are two of them (only
-        // possible in Alternator), we take the maximum.
+        // timestamp. As explained in #17119, if there are two or more of them
+        // (only possible in Alternator), we take the maximum.
         // Note:
         // 1. By reaching here we know that updatable_view_key_cols has at
         //    least one member (in CQL, it's always one, in Alternator it
-        //    may be two).
+        //    may be two or more).
         // 2. Because has_old_row, we know all elements in that array have
         //    before.has_value() true, so we can use before.get_ts().
         auto old_row_ts = updatable_view_key_cols[0].before.get_ts();
-        if (updatable_view_key_cols.size() > 1) {
-            // This is the Alternator-only support for two regular base
-            // columns that become view key columns. See explanation in
-            // view_updates::compute_row_marker().
-            auto second_ts = updatable_view_key_cols[1].before.get_ts();
-            old_row_ts = std::max(old_row_ts, second_ts);
-            // Alternator isn't supposed to have more than two updatable view key columns!
-            if (updatable_view_key_cols.size() != 2) [[unlikely]] {
-                utils::on_internal_error(format("Unexpected updatable_view_key_col length {}", updatable_view_key_cols.size()));
-            }
+        // This is the Alternator-only support for two or more regular base
+        // columns that become view key columns. See explanation in
+        // view_updates::compute_row_marker().
+        for (size_t i = 1; i < updatable_view_key_cols.size(); ++i) {
+            old_row_ts = std::max(old_row_ts, updatable_view_key_cols[i].before.get_ts());
         }
         if (has_new_row) {
             if (same_row) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -196,6 +196,7 @@ public:
     // RPCs (and their warnings) to nodes that do not register the verb during a
     // rolling upgrade.
     gms::feature small_table_optimization_size_probe { *this, "SMALL_TABLE_OPTIMIZATION_SIZE_PROBE"sv };
+    gms::feature alternator_composite_gsi_keys { *this, "ALTERNATOR_COMPOSITE_GSI_KEYS"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -305,6 +305,27 @@ def test_gsi_missing_attribute_definition(dynamodb):
                 }
             ])
 
+# A GSI's KeySchema, just like a base table's, must list the HASH key before
+# the RANGE key.
+def test_gsi_key_schema_wrong_order(dynamodb):
+    with pytest.raises(ClientError, match='ValidationException.*(first.*HASH|HASH.*precede)'):
+        create_test_table(dynamodb,
+            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+            AttributeDefinitions=[
+                { 'AttributeName': 'p', 'AttributeType': 'S' },
+                { 'AttributeName': 'x', 'AttributeType': 'S' },
+                { 'AttributeName': 'y', 'AttributeType': 'S' },
+            ],
+            GlobalSecondaryIndexes=[
+                {   'IndexName': 'hello',
+                    'KeySchema': [
+                        { 'AttributeName': 'y', 'KeyType': 'RANGE' },
+                        { 'AttributeName': 'x', 'KeyType': 'HASH' },
+                    ],
+                    'Projection': { 'ProjectionType': 'ALL' }
+                }
+            ])
+
 # test_table_gsi_1_hash_only is a variant of test_table_gsi_1: It's another
 # case where the index doesn't involve non-key attributes. Again the base
 # table has a hash and sort key, but in this case the index has *only* a

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -1194,6 +1194,30 @@ def test_gsi_2_describe_table_schema(test_table_gsi_2):
     # The list of attribute definitions may be arbitrarily reordered
     assert multiset(got['AttributeDefinitions']) == multiset(expected_all_attribute_definitions)
 
+# A GSI whose key is exactly the base table's only key attribute: the base table
+# has a hash key and no range key, and the GSI has that same hash key and no
+# range key either. This is the one shape where Alternator has an empty clustering
+# key - the base table's only key column is already the view's partition key.
+# So the view has no clustering columns at all. DescribeTable must report just
+# the one HASH key, with no RANGE key invented for it.
+def test_gsi_describe_table_schema_hash_key_only_everywhere(dynamodb):
+    key_schema = [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ]
+    gsi_key_schema = [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ]
+    with new_test_table(dynamodb,
+        KeySchema=key_schema,
+        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ],
+        GlobalSecondaryIndexes=[
+            {   'IndexName': 'hello',
+                'KeySchema': gsi_key_schema,
+                'Projection': { 'ProjectionType': 'ALL' }
+            }
+        ]) as table:
+        got = table.meta.client.describe_table(TableName=table.name)['Table']
+        assert got['KeySchema'] == key_schema
+        gsis = got['GlobalSecondaryIndexes']
+        assert len(gsis) == 1
+        assert gsis[0]['KeySchema'] == gsi_key_schema
+
 # This test is a comprehensive regression test for issue #5320, testing that
 # DescribeTable shows the correct user-requested GSI key even when Alternator
 # had to add to the underlying materialized view an "extra" clustering key

--- a/test/alternator/test_gsi_composite_keys.py
+++ b/test/alternator/test_gsi_composite_keys.py
@@ -160,7 +160,6 @@ def test_table_gsi_1h2r(dynamodb):
 
 
 # Test that creating a GSI with 2 HASH keys and no RANGE keys succeeds.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2620)")
 def test_gsi_composite_create_2h(dynamodb):
     with new_composite_gsi_table(
         dynamodb, "gsi", hash_keys=[("a", "S"), ("b", "S")], range_keys=[]
@@ -174,7 +173,6 @@ def test_gsi_composite_create_2h(dynamodb):
 
 
 # Test that creating a GSI with max 4 HASH + 4 RANGE succeeds.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2620)")
 def test_gsi_composite_create_4h4r(test_table_gsi_4h4r):
     desc = test_table_gsi_4h4r.meta.client.describe_table(
         TableName=test_table_gsi_4h4r.name
@@ -188,7 +186,6 @@ def test_gsi_composite_create_4h4r(test_table_gsi_4h4r):
 # Test that a single HASH attr + composite 2-attribute RANGE key succeeds.
 # This is the AWS doc's PlayerMatchHistoryIndex pattern: single hash
 # key + multi-attribute range key.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2620)")
 def test_gsi_composite_create_1h2r(test_table_gsi_1h2r):
     desc = test_table_gsi_1h2r.meta.client.describe_table(
         TableName=test_table_gsi_1h2r.name
@@ -204,7 +201,6 @@ def test_gsi_composite_create_1h2r(test_table_gsi_1h2r):
 
 
 # 5 HASH attributes exceeds the limit of 4.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2620)")
 def test_gsi_composite_create_5h_rejected(dynamodb):
     with pytest.raises(ClientError, match="ValidationException.*HASH"):
         with new_composite_gsi_table(
@@ -214,7 +210,6 @@ def test_gsi_composite_create_5h_rejected(dynamodb):
 
 
 # 1 HASH + 5 RANGE exceeds the limit of 4 RANGE.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2620)")
 def test_gsi_composite_create_5r_rejected(dynamodb):
     with pytest.raises(ClientError, match="ValidationException.*RANGE"):
         with new_composite_gsi_table(
@@ -227,7 +222,6 @@ def test_gsi_composite_create_5r_rejected(dynamodb):
 
 
 # Interleaved HASH, RANGE, HASH is not allowed.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2620)")
 def test_gsi_composite_interleaved_rejected(dynamodb):
     with pytest.raises(ClientError, match="ValidationException.*HASH.*precede.*RANGE"):
         with new_test_table(
@@ -258,7 +252,6 @@ def test_gsi_composite_interleaved_rejected(dynamodb):
 # whether duplicated within the same role (HASH+HASH) or reused across
 # roles (HASH and RANGE). Both shapes exercise the same "same name"
 # validation rule, so they are parametrized into a single test.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2620)")
 @pytest.mark.parametrize(
     "key_schema",
     [
@@ -301,7 +294,6 @@ def test_gsi_composite_duplicate_attr_rejected(dynamodb, key_schema):
 
 
 # GSI key attribute referenced but not in AttributeDefinitions.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2620)")
 def test_gsi_composite_missing_attribute_definition(dynamodb):
     with pytest.raises(ClientError, match="ValidationException.*AttributeDefinitions"):
         with new_test_table(
@@ -331,7 +323,6 @@ def test_gsi_composite_missing_attribute_definition(dynamodb):
 
 # Verify DescribeTable returns the correct KeySchema and AttributeDefinitions
 # for a 2H+2R composite GSI.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2626)")
 def test_gsi_composite_describe_2h2r(test_table_gsi_2h2r):
     desc = test_table_gsi_2h2r.meta.client.describe_table(
         TableName=test_table_gsi_2h2r.name
@@ -357,7 +348,6 @@ def test_gsi_composite_describe_2h2r(test_table_gsi_2h2r):
 
 # Verify DescribeTable returns the correct KeySchema and AttributeDefinitions
 # for max 4H+4R.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2626)")
 def test_gsi_composite_describe_4h4r(test_table_gsi_4h4r):
     desc = test_table_gsi_4h4r.meta.client.describe_table(
         TableName=test_table_gsi_4h4r.name
@@ -419,7 +409,6 @@ def test_gsi_composite_describe_projection_keys_only(dynamodb):
 # is a different scenario from test_gsi_composite_create_4h4r (one GSI with
 # 4 HASH + 4 RANGE components): here two separate composite GSIs coexist on
 # the same base table and share an attribute ('b') across their key schemas.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2626)")
 def test_gsi_composite_describe_multiple_gsi(dynamodb):
     with new_test_table(
         dynamodb,
@@ -613,7 +602,6 @@ def test_gsi_composite_swapped_hash_range_keys(dynamodb):
 
 
 # Add a composite GSI via UpdateTable and verify it becomes queryable.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2622)")
 def test_gsi_composite_updatetable_create_2h2r(dynamodb):
     with new_test_table(
         dynamodb,
@@ -652,7 +640,6 @@ def test_gsi_composite_updatetable_create_2h2r(dynamodb):
 
 
 # Add a composite GSI to a table with existing data; verify backfill.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2622)")
 def test_gsi_composite_updatetable_backfill(dynamodb):
     with new_test_table(
         dynamodb,
@@ -695,7 +682,6 @@ def test_gsi_composite_updatetable_backfill(dynamodb):
 
 
 # UpdateTable with 5 HASH attrs should be rejected.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2622)")
 def test_gsi_composite_updatetable_5h_rejected(dynamodb):
     with new_test_table(
         dynamodb,
@@ -723,7 +709,6 @@ def test_gsi_composite_updatetable_5h_rejected(dynamodb):
 
 
 # UpdateTable with HASH after RANGE should be rejected.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2622)")
 def test_gsi_composite_updatetable_hash_after_range_rejected(dynamodb):
     with new_test_table(
         dynamodb,
@@ -956,7 +941,6 @@ def test_gsi_composite_delete_item_removes_from_gsi(test_table_gsi_2h2r):
 # keys: type validation must be enforced for every attribute that
 # participates in a HASH or RANGE key, not just a single key attribute
 # as already covered for single-key GSIs in test_gsi.py.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2625)")
 @pytest.mark.parametrize("wrong_type_attr", ["h1", "h2", "r1", "r2"])
 def test_gsi_composite_wrong_type_key_attr(test_table_gsi_2h2r, wrong_type_attr):
     table = test_table_gsi_2h2r
@@ -1001,7 +985,6 @@ def test_gsi_composite_mixed_types_correct(test_table_gsi_mixed_types):
 
 
 # PutItem with empty string for a composite GSI key attr should fail.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2625)")
 def test_gsi_composite_empty_string_key_attr(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
     p = random_string()
@@ -1099,7 +1082,6 @@ def test_gsi_composite_query_4h_all_eq(test_table_gsi_4h4r):
 
 # Query with wrong type for a hash key attr value. h1 is defined as type S, but
 # we pass a Number literal (boto3 serializes it as N).
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2627)")
 def test_gsi_composite_query_hk_wrong_type(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
     with pytest.raises(ClientError, match="ValidationException.*[Tt]ype"):
@@ -1447,7 +1429,6 @@ def test_gsi_composite_query_rk_between(test_table_gsi_2h2r):
 
 # Query with only the hash key attr - every item under that partition, across
 # all range key combinations, is returned.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2629)")
 def test_gsi_composite_query_1h_hash_only(test_table_gsi_1h2r):
     table = test_table_gsi_1h2r
     h_val = random_string()
@@ -2027,7 +2008,6 @@ def test_gsi_composite_query_pagination_roundtrip(test_table_gsi_2h2r, limit):
 
 
 # Scan pagination on composite GSI.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2629)")
 @pytest.mark.parametrize("limit", [1, 2, 5, 8])
 def test_gsi_composite_scan_pagination(dynamodb, limit):
     with new_test_table(
@@ -2155,7 +2135,6 @@ def test_gsi_composite_keyconditions_blocked(test_table_gsi_2h2r):
 # Scan composite GSI returns all indexed items. Uses its own table (rather
 # than a shared fixture) so the item count can be checked exactly, without
 # leftover items from other tests sharing the same fixture/index.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2629)")
 def test_gsi_composite_scan_returns_all(dynamodb):
     with new_test_table(
         dynamodb,
@@ -2201,7 +2180,6 @@ def test_gsi_composite_scan_returns_all(dynamodb):
 
 
 # Scan with FilterExpression on non-key attr.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2629)")
 def test_gsi_composite_scan_with_filter(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
     marker = random_string()
@@ -2338,7 +2316,6 @@ def test_gsi_composite_and_single_key_gsi_with_shared_hash_key_coexist(dynamodb)
         )
 
 # ConsistentRead=True on a composite GSI query - should fail.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2627)")
 def test_gsi_composite_consistent_read_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
     with pytest.raises(ClientError, match="ValidationException.*[cC]onsistent"):
@@ -2507,7 +2484,6 @@ def test_gsi_composite_batchwrite_correct(test_table_gsi_2h2r):
 # BatchWriteItem where one item has a wrong-type composite GSI key attribute
 # rejects the whole batch - none of the items get written, even to the base
 # table.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2625)")
 def test_gsi_composite_batchwrite_wrong_type_rejected(test_table_gsi_2h2r):
     table = test_table_gsi_2h2r
     p1, p2 = random_string(), random_string()
@@ -2596,7 +2572,6 @@ def test_gsi_composite_batchwrite_delete(test_table_gsi_2h2r):
 
 # Test specifically Alternator for correct key reporting when base table keys
 # are appended (or not) by the user as range keys.
-@pytest.mark.xfail(reason="Composite GSI keys not implemented yet (SCYLLADB-2620)")
 @pytest.mark.parametrize("base_table_key_used", ["both", "hash_only", "range_only", "none"])
 def test_gsi_composite_base_pk_ck_as_range(dynamodb, base_table_key_used):
     key_schema = []
@@ -2651,5 +2626,6 @@ def test_gsi_composite_base_pk_ck_as_range(dynamodb, base_table_key_used):
         assert gsi["KeySchema"] == [
             {"AttributeName": "a1", "KeyType": "HASH"},
             {"AttributeName": "a2", "KeyType": "RANGE"},
+            {"AttributeName": "a3", "KeyType": "RANGE"},
             *key_schema
         ]

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -186,6 +186,23 @@ def test_create_table_invalid_schema(dynamodb):
             ],
         )
 
+# A table's KeySchema must list the HASH key before the RANGE key. Listing
+# them the other way around is an error.
+def test_create_table_key_schema_wrong_order(dynamodb):
+    with pytest.raises(ClientError, match='ValidationException.*[Ff]irst.*HASH'):
+        dynamodb.create_table(
+            TableName='name_doesnt_matter',
+            BillingMode='PAY_PER_REQUEST',
+            KeySchema=[
+                { 'AttributeName': 'c', 'KeyType': 'RANGE' },
+                { 'AttributeName': 'p', 'KeyType': 'HASH' }
+            ],
+            AttributeDefinitions=[
+                { 'AttributeName': 'p', 'AttributeType': 'S' },
+                { 'AttributeName': 'c', 'AttributeType': 'S' },
+            ],
+        )
+
 # Another case of an invalid schema is repeating the same AttributeName
 # twice in AttributeDefinitions. DynamoDB has no way of knowing which of
 # the two definitions was intended.

--- a/test/boost/alternator_unit_test.cc
+++ b/test/boost/alternator_unit_test.cc
@@ -17,15 +17,133 @@
 
 #include "cdc/generation.hh"
 #include "alternator/executor.hh"
+#include "alternator/executor_util.hh"
 #include "dht/token-sharding.hh"
 #include "alternator/expressions.hh"
 #include "alternator/streams.hh"
+#include "schema/schema_builder.hh"
+#include "types/types.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/core/sleep.hh>
 
 namespace alternator {
     const cdc::stream_id& find_parent_shard_in_previous_generation(db_clock::time_point prev_timestamp, const utils::chunked_vector<cdc::stream_id>& prev_streams, const cdc::stream_id& child);
+    extern const sstring SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY;
+    extern const sstring NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY;
+}
+
+// Builds a schema_ptr simulating a GSI with an irrelevant to the user
+// "base_range" column appended simulating materialized view's correctness
+// requirement regarding base table HASH and RANGE keys.
+static schema_ptr make_old_style_gsi_schema_without_user_range_key() {
+    schema_builder builder(1, "test_ks", "test_gsi");
+    builder.with_column("gsi_hash", utf8_type, column_kind::partition_key);
+    builder.with_column("base_range", utf8_type, column_kind::clustering_key);
+    return builder.build();
+}
+
+static schema_ptr make_table_schema_without_any_range_key() {
+    schema_builder builder(1, "test_ks", "only_hash_table");
+    builder.with_column("only_hash", utf8_type, column_kind::partition_key);
+    return builder.build();
+}
+
+BOOST_AUTO_TEST_CASE(test_genuine_range_key_count_old_tag_only) {
+    schema_ptr schema = make_old_style_gsi_schema_without_user_range_key();
+    std::map<sstring, sstring> tags{
+        {alternator::SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY, "true"},
+    };
+    // Only the legacy tag is present, simulating a GSI created before the new
+    // tag existed. It must be translated to "0 genuine range keys".
+    BOOST_REQUIRE_EQUAL(alternator::genuine_range_key_count(*schema, &tags), 0);
+
+    // No tags / empty tags should be translated to default 1 range key reported.
+    BOOST_REQUIRE_EQUAL(alternator::genuine_range_key_count(*schema, nullptr), 1);
+    std::map<sstring, sstring> no_tags;
+    BOOST_REQUIRE_EQUAL(alternator::genuine_range_key_count(*schema, &no_tags), 1);
+}
+
+// Reproduces a corrupted/undecodable
+// NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY tag value, which falls back
+// to reporting all of the clustering columns as RANGE keys.
+BOOST_AUTO_TEST_CASE(test_genuine_range_key_count_undecodable_tag_value) {
+    schema_ptr schema = make_old_style_gsi_schema_without_user_range_key();
+    const uint8_t all_clustering_columns = static_cast<uint8_t>(schema->clustering_key_size());
+
+    std::map<sstring, sstring> non_numeric_tag{
+        {alternator::NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY, "not_a_number"},
+    };
+    BOOST_REQUIRE_EQUAL(alternator::genuine_range_key_count(*schema, &non_numeric_tag), all_clustering_columns);
+
+    // Out-of-range values (valid GSIs only ever have 0 to 4 user-specified
+    // range keys) should be treated the same way as non-numeric ones.
+    std::map<sstring, sstring> out_of_range_tag{
+        {alternator::NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY, "5"},
+    };
+    BOOST_REQUIRE_EQUAL(alternator::genuine_range_key_count(*schema, &out_of_range_tag), all_clustering_columns);
+
+    std::map<sstring, sstring> valid_prefix_invalid_tag{
+        {alternator::NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY, "1junk"},
+    };
+    BOOST_REQUIRE_EQUAL(alternator::genuine_range_key_count(*schema, &valid_prefix_invalid_tag), all_clustering_columns);
+
+    std::map<sstring, sstring> not_exact_to_string_tag{
+        {alternator::NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY, " 1"},
+    };
+    BOOST_REQUIRE_EQUAL(alternator::genuine_range_key_count(*schema, &not_exact_to_string_tag), all_clustering_columns);
+}
+
+BOOST_AUTO_TEST_CASE(test_describe_key_schema_old_tag_only) {
+    schema_ptr schema = make_old_style_gsi_schema_without_user_range_key();
+    std::map<sstring, sstring> tags{
+        {alternator::SPURIOUS_RANGE_KEY_ADDED_TO_GSI_AND_USER_DIDNT_SPECIFY_RANGE_KEY_TAG_KEY, "true"},
+    };
+    std::unordered_map<std::string, std::string> attribute_types;
+    rjson::value parent = rjson::empty_object();
+    alternator::describe_key_schema(parent, *schema, &attribute_types, &tags);
+
+    const rjson::value* key_schema = rjson::find(parent, "KeySchema");
+    BOOST_REQUIRE(key_schema);
+    BOOST_REQUIRE(key_schema->IsArray());
+    // Only the HASH key should be reported.
+    BOOST_REQUIRE_EQUAL(key_schema->Size(), 1u);
+    const rjson::value& hash_entry = (*key_schema)[0];
+    BOOST_REQUIRE_EQUAL(rjson::to_string_view(hash_entry["AttributeName"]), "gsi_hash");
+    BOOST_REQUIRE_EQUAL(rjson::to_string_view(hash_entry["KeyType"]), "HASH");
+
+    BOOST_REQUIRE_EQUAL(attribute_types.size(), 1u);
+    BOOST_REQUIRE(attribute_types.contains("gsi_hash"));
+    BOOST_REQUIRE(!attribute_types.contains("base_range"));
+}
+
+BOOST_AUTO_TEST_CASE(test_describe_key_schema_without_old_tag) {
+    schema_ptr schema = make_old_style_gsi_schema_without_user_range_key();
+    std::unordered_map<std::string, std::string> attribute_types;
+    rjson::value parent = rjson::empty_object();
+    alternator::describe_key_schema(parent, *schema, &attribute_types, nullptr);
+
+    const rjson::value* key_schema = rjson::find(parent, "KeySchema");
+    BOOST_REQUIRE(key_schema);
+    BOOST_REQUIRE(key_schema->IsArray());
+    // Both HASH and RANGE keys should be reported (preserved default behavior).
+    BOOST_REQUIRE_EQUAL(key_schema->Size(), 2u);
+    const rjson::value& hash_entry = (*key_schema)[0];
+    BOOST_REQUIRE_EQUAL(rjson::to_string_view(hash_entry["AttributeName"]), "gsi_hash");
+    BOOST_REQUIRE_EQUAL(rjson::to_string_view(hash_entry["KeyType"]), "HASH");
+    const rjson::value& range_entry = (*key_schema)[1];
+    BOOST_REQUIRE_EQUAL(rjson::to_string_view(range_entry["AttributeName"]), "base_range");
+    BOOST_REQUIRE_EQUAL(rjson::to_string_view(range_entry["KeyType"]), "RANGE");
+
+    BOOST_REQUIRE_EQUAL(attribute_types.size(), 2u);
+    BOOST_REQUIRE(attribute_types.contains("gsi_hash"));
+    BOOST_REQUIRE(attribute_types.contains("base_range"));
+}
+
+BOOST_AUTO_TEST_CASE(test_only_hash_table_without_tag) {
+    schema_ptr schema = make_table_schema_without_any_range_key();
+
+    BOOST_REQUIRE_EQUAL(0, alternator::genuine_range_key_count(*schema, nullptr));
 }
 
 BOOST_AUTO_TEST_CASE(test_extract_table_name_from_arn_simple_new_format) {


### PR DESCRIPTION
A GSI's KeySchema may now name up to 4 HASH and up to 4 RANGE attributes.
CreateTable and UpdateTable accept and validate such a schema, build the
underlying materialized view from it, and DescribeTable reports back
exactly the key the user asked for.

The data path is only half done. Writes go to the base table and the index
is updated from them through the normal view-update path. Scan over a
composite GSI works too. Query does not: that path has not been updated
for a composite key, so it still looks only at the first HASH and the first
RANGE column of the index, which means a Query on a composite GSI is
neither answered correctly nor rejected cleanly.
The patch that fixes it: https://github.com/scylladb/scylladb/pull/30818 should be merged before the next release.

Composite GSI creation is behind a new feature,
ALTERNATOR_COMPOSITE_GSI_KEYS.

Extends the reasoning from issues https://github.com/scylladb/scylladb/issues/17119, https://github.com/scylladb/scylladb/issues/5320 and https://github.com/scylladb/scylladb/pull/25978
adding `NUMBER_OF_USER_SPECIFIED_GSI_RANGE_KEYS_TAG_KEY`, which records how many
leading materialized view's clustering columns are genuine user-specified
RANGE attributes vs. irrelevant to the user base-table key columns needed
for materialized view corectness. `describe_key_schema()` and the new
`genuine_range_key_count()` helper use this tag so DescribeTable reports the
correct KeySchema for composite keys, with a backward-compatible fallback
for tables carrying the old tag or none at all.

Generalizes view_updates::generate_update()'s row-marker timestamp
computation in db/view/view.cc (see https://github.com/scylladb/scylladb/issues/17119).

Adds boost tests to verify tag translation.

Adds regression for HASH and RANGE order enforcement on GSI and normal tables verified against DDB.

Updates the `test/alternator/test_gsi_composite_keys.py` to expect relevant parsing, validation and creation tests to pass.


Fixes: SCYLLADB-2620
Fixes: SCYLLADB-2621
Fixes: SCYLLADB-2622
Fixes: SCYLLADB-2624
Fixes: SCYLLADB-2626
Refs: SCYLLADB-393