### PR TITLE
repair: Fix NameError in incremental repair race-window test

### DIFF
--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -1115,7 +1115,7 @@ async def _do_race_window_promotes_unrepaired_data(manager, servers, cql, ks, to
     if new_coord != coord:
         logger.warning(f"Topology coordinator changed from {coord} to {new_coord} after restart")
         coord = new_coord
-        coord_serv = await find_server_by_host_id(manager, servers, coord)
+        coord_serv = await manager.find_server_by_host_id(servers, coord)
         coord_log = await manager.server_open_log(coord_serv.server_id)
         post_marks_pos = await coord_log.mark()
 


### PR DESCRIPTION
The coordinator-change branch in _do_race_window_promotes_unrepaired_data() called the bare find_server_by_host_id(manager, servers, coord), but this free function was removed when it was moved onto ManagerClient. Update the call site to manager.find_server_by_host_id(servers, coord), matching the other call sites in this file.

Fixes the crash 'NameError: name find_server_by_host_id is not defined' that occurs whenever the topology coordinator changes during the test's node restart.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3270

Only in master. No backport is needed.