### PR TITLE
topology_coordinator: skip RF change rebuild retry when tablet balancing is disabled

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -4623,6 +4623,12 @@ future<bool> topology_coordinator::maybe_retry_failed_rf_change_tablet_rebuilds(
     }
 
     auto tmptr = get_token_metadata_ptr();
+
+    if (!tmptr->tablets().balancing_enabled()) {
+        rtlogger.debug("Skipping retrying failed rebuilds because tablet balancing is disabled");
+        co_return false;
+    }
+
     utils::chunked_vector<canonical_mutation> updates;
     for (auto& ks_name : _db.get_tablets_keyspaces()) {
         auto& ks = _db.find_keyspace(ks_name);


### PR DESCRIPTION
maybe_retry_failed_rf_change_tablet_rebuilds() runs unconditionally in the topology coordinator loop and re-adds replicas to under-replicated tablets. This races with del_tablet_replica: after successfully removing a replica, the function immediately starts a new migration to re-add one, undoing the user's explicit operation.

This causes test_tablet_transition_sanity(del_replica) to be flaky: the second migration streams data back to the cleaned node before the test's assertion runs.

Fix by checking balancing_enabled() at the top of the function, consistent with maybe_start_tablet_migration() which already respects this flag. Both are background maintenance operations that should be inhibited when tablet balancing is disabled.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3137

Backport is required