### PR TITLE
build: use absolute path for seastar -ffile-prefix-map

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2183,7 +2183,12 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
     # to seastar/ exists just so any possible DW_AT_name under build (e.g. if there are some generated
     # sources) is excluded from the first rule.
     seastar_build_dir = os.path.join(build_dir, mode, 'seastar')
-    extra_file_prefix_map = f' -ffile-prefix-map={seastar_build_dir}=. -ffile-prefix-map={seastar_build_dir}/=seastar/'
+    # DW_AT_comp_dir records the compiler's working directory as an absolute
+    # path, so the prefix-map must use the absolute build dir to match it.
+    # (build_dir is relative to curdir by default; os.path.join handles the
+    # case where the user passes an absolute --build-dir too.)
+    abs_seastar_build_dir = os.path.join(curdir, seastar_build_dir)
+    extra_file_prefix_map = f' -ffile-prefix-map={abs_seastar_build_dir}=. -ffile-prefix-map={abs_seastar_build_dir}/=seastar/'
     seastar_cmake_args = [
         '-DCMAKE_BUILD_TYPE={}'.format(mode_config['cmake_build_type']),
         '-DCMAKE_C_COMPILER={}'.format(args.cc),


### PR DESCRIPTION
The seastar-specific -ffile-prefix-map was emitted with a relative build directory (e.g. build/release/seastar), but -ffile-prefix-map matches its OLD prefix literally against the path as stored, and DW_AT_comp_dir is always the compiler's absolute working directory
(/home/user/scylla/build/release/seastar). The relative prefix therefore never matched, so the comp_dir rewrite described in the comment above silently did nothing, leaving gdb unable to locate seastar sources.

Build the map from the absolute build dir, consistent with the global -ffile-prefix-map={curdir}=. map. Verified that both gcc and clang apply an absolute OLD prefix to DW_AT_comp_dir.

We survived without it so far, so not backporting.