### PR TITLE
test: fix test_repair_failure_on_split_rejection HTTP timeout

### DIFF
--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -518,7 +518,12 @@ async def test_repair_failure_on_split_rejection(manager: ManagerClient, volumes
                 await manager.api.enable_injection(servers[0].ip_addr, "maybe_split_new_sstable_wait", one_shot=True)
 
                 token = 'all'
-                repair_task = asyncio.create_task(manager.api.tablet_repair(servers[0].ip_addr, ks, table, token))
+                # The repair REST call blocks until the whole repair completes (await_completion).
+                # Under the split/repair serialization (commit 02c639dd93, SCYLLADB-2531) repair can
+                # take well over the 300s default HTTP client timeout to reach the injection point,
+                # and the test itself waits up to 600s for that injection below. Give the call a
+                # timeout comfortably above that deadline so the client does not time out (SCYLLADB-3214).
+                repair_task = asyncio.create_task(manager.api.tablet_repair(servers[0].ip_addr, ks, table, token, timeout=900))
 
                 # Emit split decision during repair.
                 await run_split()


### PR DESCRIPTION
test_repair_failure_on_split_rejection issues a synchronous tablet_repair REST call (await_completion) that blocks until the whole repair finishes. The default HTTP client timeout for that call is 300s.

Since commit 02c639dd93 ("repair, compaction: serialize tablet split bypass with concurrent repair", SCYLLADB-2531), repair rewrites sstables across all views, including the repairing view, under run_with_compaction_disabled while split holds a read lock on the same view. This serialization makes repair take significantly longer to reach the maybe_split_new_sstable_wait injection point when a split is running concurrently.

The prior flakiness fix 45d920b132 (SCYLLADB-2798) already raised the injection-enter wait to 600s but left the tablet_repair REST call at its 300s default, so the call now consistently times out while the test is still correctly waiting up to 600s.

Pass an explicit timeout of 900s to tablet_repair so the client timeout comfortably exceeds the 600s injection deadline plus the disk-fill and critical-utilization detection time.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3214

No backport is needed. Relevant code in master only and now in 2026.3.