### PR TITLE
build: wire compile-time dep on generated AWS error header

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2840,6 +2840,10 @@ def write_build_file(f,
         gen_headers += list(ragels.keys())
         gen_headers += list(rust_headers.keys())
         gen_headers.append('$builddir/{}/gen/rust/cxx.h'.format(mode))
+        # The AWS error definitions header is included (transitively) by
+        # anything that touches utils/s3/aws_error.hh, so it must exist on
+        # disk before any translation unit is compiled.
+        gen_headers.append(aws_errors_gen_hh)
         gen_headers_dep = ' '.join(gen_headers)
 
         for hh in rust_headers:

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -224,12 +224,13 @@ add_scylla_test(rust_test
   LIBRARIES inc)
 add_scylla_test(s3_test
   KIND SEASTAR
-  LIBRARIES scylla_encryption)
+  LIBRARIES scylla_encryption utils)
 add_scylla_test(gcp_object_storage_test
   KIND SEASTAR
   LIBRARIES scylla_encryption)
 add_scylla_test(aws_errors_test
-  KIND BOOST)
+  KIND BOOST
+  LIBRARIES utils)
 add_scylla_test(aws_error_injection_test
   KIND SEASTAR)
 add_scylla_test(schema_changes_test


### PR DESCRIPTION
### Problem

Every translation unit that transitively includes `utils/s3/aws_error.hh` pulls in the generated `utils/s3/aws_error_definitions_generated.hh`, produced by the `aws_service_errors` code-gen rule. The initial wiring only added the generated `.o` to binaries that link `utils/s3/aws_error.cc`, so unrelated targets (e.g. `test/boost/aws_errors_test`) could race the code-gen step and fail with:

```
fatal error: 'aws_error_definitions_generated.hh' file not found
```

This was hit on Jenkins (`scylla-master/scylla-ci #31232`) and reported as SCYLLADB-3277.

### Changes

Both build systems are wired to the generated header explicitly:

- **configure.py**: append the generated `.hh` to `gen_headers` so it becomes an implicit input of every `cxx.<mode>` compile edge — mirroring how IDL `.dist.hh`, swagger, ragel and rust `cxx.h` headers are handled.

- **CMake**: add `LIBRARIES utils` to `test/boost/s3_test` and `test/boost/aws_errors_test`. Both include `utils/s3/aws_error.hh` but only link `test-lib`, which links `utils` PRIVATELY — so `utils`' `PUBLIC` include dirs (which contain the gen dir) did not propagate, and the code-gen ordering dependency was not established.

Verified by removing the generated files and all downstream `.o`s, then rebuilding: the code-gen step now runs before every affected TU.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3277

No backport needed — the underlying feature (AWS error code-gen) has not been released.

