### PR TITLE
compaction: make scrub in validate mode check all digests

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -2202,7 +2202,7 @@ static future<compaction_result> scrub_sstables_validate_mode(compaction_descrip
 
         validation_errors += co_await sst->validate(permit, cdata.abort, [&schema] (sstring what) {
             scrub_compaction::report_validation_error(compaction_type::Scrub, *schema, what);
-        }, monitor_generator(sst), true);
+        }, monitor_generator(sst));
         // Did validation actually finish because aborted?
         if (cdata.is_stop_requested()) {
             // Compaction manager will catch this exception and re-schedule the compaction.

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -611,6 +611,7 @@ validate
 ^^^^^^^^
 
 Validates the content of the sstable on the mutation-fragment level, see `sstable content <scylla-sstable-sstable-content_>`_ for more details.
+Component digests will be validated if present in the scylla-metadata component.
 Any parsing errors will also be detected, but after successful parsing the validation will happen on the fragment level.
 The following things are validated:
 
@@ -645,7 +646,7 @@ Scrub has several modes:
 * **abort** - Aborts the scrub as soon as any error is found (recognized or not). This mode is only included for the sake of completeness. We recommend using the **validate** mode so that all errors are reported.
 * **skip** - Skips over any corruptions found, thus omitting them from the output. Note that this mode can result in omitting more than is strictly necessary, but it guarantees that all detectable corruptions will be omitted.
 * **segregate** - Fixes partition/row/mutation-fragment out-of-order errors by segregating the output into as many SStables as required so that the content of each output SStable is properly ordered.
-* **validate** - Validates the content of the SStable, reporting any corruptions found. Writes no output SStables. In this mode, scrub has the same outcome as the `validate operation <scylla-sstable-validate-operation_>`_ - and the validate operation is recommended over scrub.
+* **validate** - Validates the content of the SStable and component digests, reporting any corruptions found. Writes no output SStables. In this mode, scrub has the same outcome as the `validate operation <scylla-sstable-validate-operation_>`_ - and the validate operation is recommended over scrub.
 
 Output SStables are written to the directory specified via ``--output-dir``. They will be written with the ``BIG`` format and the highest supported SStable format, with random generation.
 

--- a/docs/operating-scylla/nodetool-commands/scrub.rst
+++ b/docs/operating-scylla/nodetool-commands/scrub.rst
@@ -59,6 +59,7 @@ SCRUB MODES
 Scrub mode                                                            Description
 ====================================================================  ==================================================================================================================
 VALIDATE                                                              Read-only mode: report any corruptions found while scrubbing but do not fix them.
+                                                                      Additionally, validate component integrity by verifying the stored digests if available.
                                                                       By default, corrupt SSTables are moved into a "quarantine" subdirectory so they will not be subject to compaction.
                                                                       (default).
 --------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1341,6 +1341,7 @@ future<uint32_t> sstable::compute_component_file_digest(file f, size_t size) con
 void sstable::validate_component_digest(component_type type, uint32_t computed_digest) const {
     auto expected = get_component_digest(type);
     if (expected && *expected != computed_digest) {
+        utils::get_local_injector().enter("sstable_digest_mismatch_found");
         auto msg = fmt::format("{} digest mismatch in {}: expected {}, computed {}",
                                type, get_filename(), *expected, computed_digest);
         if (_ignore_component_digest_mismatch) {
@@ -1372,6 +1373,7 @@ future<> sstable::validate_scylla_digest_value() {
     if (stored_digest != disk_digest) {
         auto msg = fmt::format("{} digest value does not match the on-disk value in {}: expected {}, read {}",
             component_type::Scylla, get_filename(), stored_digest, disk_digest);
+        utils::get_local_injector().enter("sstable_digest_mismatch_found");
         if (_ignore_component_digest_mismatch) {
             sstlog.warn("{}", msg);
         } else {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1390,28 +1390,6 @@ future<> sstable::validate_digests(sstable::skip_data_digest skip_data) {
     }
 }
 
-future<> sstable::validate_index_digest() const {
-    auto validate_component = [this] (component_type type, const file& f, size_t size) -> future<> {
-        auto expected_digest = get_component_digest(type);
-        if (!expected_digest) {
-            co_return;
-        }
-        auto computed_digest = co_await compute_component_file_digest(f, size);
-        if (*expected_digest != computed_digest) {
-            throw_malformed_sstable_exception(
-                fmt::format("{} digest mismatch in {}: expected {}, computed {}",
-                            type, get_filename(), *expected_digest, computed_digest));
-        }
-    };
-
-    if (_index_file) {
-        co_await validate_component(component_type::Index, _index_file, _index_file_size);
-    } else {
-        co_await validate_component(component_type::Partitions, _partitions_file, _partitions_file_size);
-        co_await validate_component(component_type::Rows, _rows_file, _rows_file_size);
-    }
-}
-
 void sstable::validate_min_max_metadata() {
     auto entry = _components->statistics.contents.find(metadata_type::Stats);
     if (entry == _components->statistics.contents.end()) {
@@ -2668,7 +2646,7 @@ sstable_writer sstable::get_writer(const schema& s, uint64_t estimated_partition
 }
 
 future<uint64_t> sstable::validate(reader_permit permit, abort_source& abort,
-        std::function<void(sstring)> error_handler, sstables::read_monitor& monitor, bool validate_index) {
+        std::function<void(sstring)> error_handler, sstables::read_monitor& monitor) {
     auto handle_sstable_exception = [&error_handler](const malformed_sstable_exception& e, uint64_t& errors) -> std::exception_ptr {
         std::exception_ptr ex;
         try {
@@ -2684,11 +2662,9 @@ future<uint64_t> sstable::validate(reader_permit permit, abort_source& abort,
     std::exception_ptr ex;
     lw_shared_ptr<checksum> checksum;
     try {
+        co_await validate_digests(sstables::sstable::skip_data_digest::yes);
         checksum = co_await read_checksum();
         co_await read_digest();
-        if (validate_index) {
-            co_await validate_index_digest();
-        }
     } catch (const malformed_sstable_exception& e) {
         ex = handle_sstable_exception(e, errors);
     }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -337,7 +337,7 @@ public:
         encoding_stats enc_stats,
         shard_id shard = this_shard_id());
 
-    // Validates the content of the sstable.
+    // Validates the content of the sstable and component digests.
     // Reports all errors via the provided error handler.
     // Returns the count of all validation errors found.
     // Can be aborted via the abort-source parameter.
@@ -345,7 +345,7 @@ public:
     // (e.g. parse error), it will return with validation error count seen up to
     // the abort. In the latter case it will call the error-handler before doing so.
     future<uint64_t> validate(reader_permit permit, abort_source& abort,
-            std::function<void(sstring)> error_handler, sstables::read_monitor& monitor = default_read_monitor(), bool validate_index = false);
+            std::function<void(sstring)> error_handler, sstables::read_monitor& monitor = default_read_monitor());
 
     encoding_stats get_encoding_stats_for_compaction() const;
 
@@ -796,7 +796,6 @@ public:
     using skip_data_digest = bool_class<struct skip_data_digest_tag>;
     future<> validate_digests(skip_data_digest skip_data = skip_data_digest::no);
 private:
-    future<> validate_index_digest() const;
     // Read the Scylla component self-digest from file.
     // Should only be called by sstables which have a Scylla file digest.
     future<uint32_t> read_scylla_file_digest() const;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -44,6 +44,7 @@
 #include "test/lib/mutation_reader_assertions.hh"
 #include "test/lib/sstable_run_based_compaction_strategy_for_tests.hh"
 #include "test/lib/random_schema.hh"
+#include "test/lib/error_injection.hh"
 #include "mutation/mutation_compactor.hh"
 #include "db/config.hh"
 #include "mutation_writer/partition_based_splitting_writer.hh"
@@ -8246,5 +8247,63 @@ SEASTAR_TEST_CASE(test_compaction_output_is_not_leaked_when_attach_fails) {
         BOOST_REQUIRE_EQUAL(after, expected);
     });
 }
+
+static void test_scrub_validates_component_digests(test_env& env, sstables::component_type type) {
+    scrub_test_framework<random_schema::yes> test(compress_sstable::no);
+
+    auto schema = test.schema();
+
+    auto muts = tests::generate_random_mutations(test.random_schema()).get();
+
+    test.run(schema, muts, [type] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
+        BOOST_REQUIRE(sstables.size() == 1);
+        auto sst = sstables.front();
+        scoped_error_injection injection{"sstable_digest_mismatch_found"};
+
+        corrupt_sstable(sst, type);
+
+        compaction::compaction_type_options::scrub opts = {
+            .operation_mode = compaction::compaction_type_options::scrub::mode::validate,
+        };
+        auto scrub = table->get_compaction_manager().perform_sstable_scrub(ts, opts, tasks::task_info{}).get();
+        BOOST_REQUIRE(scrub);
+        auto errors = scrub->validation_errors;
+        BOOST_REQUIRE_NE(errors, 0);
+        BOOST_REQUIRE_GT(utils::get_local_injector().enter_count_on_all("sstable_digest_mismatch_found").get(), 0);
+    });
+}
+
+SEASTAR_TEST_CASE(test_scrub_validates_toc_digest) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+    return make_ready_future();
+#endif
+    return test_env::do_with_async([](test_env& env) { test_scrub_validates_component_digests(env, component_type::TOC); });
+}
+
+SEASTAR_TEST_CASE(test_scrub_validates_scylla_digest) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+    return make_ready_future();
+#endif
+    return test_env::do_with_async([](test_env& env) { test_scrub_validates_component_digests(env, component_type::Scylla); });
+}
+
+SEASTAR_TEST_CASE(test_scrub_validates_index_digest) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+    return make_ready_future();
+#endif
+    return test_env::do_with_async([](test_env& env) { test_scrub_validates_component_digests(env, component_type::Index); });
+}
+
+SEASTAR_TEST_CASE(test_scrub_validates_statistics_digest) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    fmt::print("Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n");
+    return make_ready_future();
+#endif
+    return test_env::do_with_async([](test_env& env) { test_scrub_validates_component_digests(env, component_type::Statistics); });
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cqlpy/test_sstable_validation.py
+++ b/test/cqlpy/test_sstable_validation.py
@@ -51,7 +51,8 @@ def large_rows():
 
 
 def find_component(generation, component_type, sst_dir):
-    comps = glob.glob(os.path.join(sst_dir, f"*-{str(generation)}-big-{component_type}.db"))
+    extension = "txt" if component_type == "TOC" else "db"
+    comps = glob.glob(os.path.join(sst_dir, f"*-{str(generation)}-big-{component_type}.{extension}"))
     assert len(comps) == 1
     return comps[0]
 
@@ -65,6 +66,15 @@ def find_partition_index_component(generation, sst_dir):
     assert len(comps) == 1
     return comps[0]
 
+def rewrite_without_scylla(generation, sst_dir):
+    toc = find_component(generation, "TOC", sst_dir)
+    scylla = find_component(generation, "Scylla", sst_dir)
+    os.remove(scylla)
+
+    with open(toc, 'r') as f:
+        new_toc = [line for line in f.read().splitlines(keepends=True) if line.strip() != "Scylla.db"]
+    with open(toc, 'w') as f:
+        f.write(''.join(new_toc))
 
 @pytest.fixture(scope="module")
 def sstable_cache(scylla_path):
@@ -94,6 +104,7 @@ def sstable_cache(scylla_path):
                 f.write(json_str)
             version_arg = ["--sstable-version", version] if version is not None else []
             generation = subprocess.check_output([self._scylla_path, "sstable", "write", *version_arg, "--schema-file", schema_file, "--output-dir", self._store_dir, "--input-file", self._in_json, "--input-format", "json"], text=True).strip()
+            rewrite_without_scylla(generation, self._store_dir)
             self._cache[cache_key] = generation
             return generation
 


### PR DESCRIPTION
Make the scrub compaction verify digests of all components, if a digest is available in the Scylla component.
Add a test to verify that corruption is correctly detected.

Additionally, add digest validation to `sstable validate`. In order not to break `test_sstable_validation` remove the Scylla component from sstables created for it, so that digest validation does not occur.

Closes: https://scylladb.atlassian.net/browse/SCYLLADB-2883

no backport, this is a new improvement