### PR TITLE
docs: remove outdated "TTL not supported" claims for Vector Search

### DIFF
--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -412,7 +412,7 @@ For example::
 .. note::
 
    Vector indexes are supported in ScyllaDB Cloud only in clusters that have the Vector Search feature enabled.
-   Vector indexes do not support all ScyllaDB features (e.g., tracing, TTL, paging, and grouping). More information
+   Vector indexes do not support all ScyllaDB features (e.g., tracing, paging, and grouping). More information
    about Vector Search is available in the
    `ScyllaDB Cloud documentation <https://cloud.docs.scylladb.com/stable/vector-search/>`_.
 

--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -135,7 +135,7 @@ Vector Index :label-note:`ScyllaDB Cloud`
 .. note::
 
    Vector indexes are supported in ScyllaDB Cloud only in clusters that have the Vector Search feature enabled.
-   Vector indexes do not support all ScyllaDB features (e.g., tracing, TTL, paging, and grouping). More information
+   Vector indexes do not support all ScyllaDB features (e.g., tracing, paging, and grouping). More information
    about Vector Search is available in the
    `ScyllaDB Cloud documentation <https://cloud.docs.scylladb.com/stable/vector-search/>`_.
 

--- a/docs/cql/types.rst
+++ b/docs/cql/types.rst
@@ -669,7 +669,7 @@ frozen UDT in a vector, you need to explicitly wrap them using `frozen` keyword.
 
    The main application of vectors is to support vector search capabilities, which
    are supported in ScyllaDB Cloud only in clusters that have the Vector Search feature enabled.
-   Note that Vector Search clusters do not support all ScyllaDB features (e.g., tracing, TTL, paging, and grouping). More information
+   Note that Vector Search clusters do not support all ScyllaDB features (e.g., tracing, paging, and grouping). More information
    about Vector Search is available in the
    `ScyllaDB Cloud documentation <https://cloud.docs.scylladb.com/stable/vector-search/>`_.
 


### PR DESCRIPTION
## What

Per-row TTL is now supported on vector-indexed tables (via the per-row TTL feature, scylladb/scylladb#28320, available from **ScyllaDB 2026.2.0**), and this is being documented for ScyllaDB Cloud in scylladb/scylla-cloud-doc#472.

The main repo docs still list `TTL` among the ScyllaDB features that Vector Search / vector indexes do **not** support. This PR removes those outdated claims.

## Changes

Removed `TTL` from the "unsupported features" list in three CQL doc locations, keeping the remaining unsupported features (tracing, paging, and grouping):

- `docs/cql/dml/select.rst` — vector index note in the `ANN OF` query section
- `docs/cql/secondary-indexes.rst` — Vector Index statement note
- `docs/cql/types.rst` — vector type note

Note: the CDC-options requirement mention of TTL in `docs/dev/vector_search.md` is unrelated and left unchanged.

## Jira

Fixes: SCYLLADB-3285
Backport: backport up to 2026.2 needed as this is the first version that supported TTL.