### PR TITLE
test/cluster/object_store: fix race in test_scaling S3 namespace verification

### DIFF
--- a/test/cluster/object_store/test_scaling.py
+++ b/test/cluster/object_store/test_scaling.py
@@ -14,8 +14,8 @@ import pytest
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.object_storage import keyspace_options
-from test.cluster.util import new_test_keyspace, wait_for_no_pending_topology_transition
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.cluster.util import new_test_keyspace, wait_for_no_pending_topology_transition, wait_for_no_running_compactions
+from test.pylib.util import wait_for_cql_and_get_hosts
 from test.pylib.tablets import get_all_tablet_replicas
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
@@ -108,6 +108,9 @@ async def test_scaling(manager: ManagerClient, object_storage):
         try:
             for node in live_servers:
                 await manager.api.disable_autocompaction(node.ip_addr, ks, "test")
+
+            await wait_for_no_running_compactions(manager, live_servers, time.time() + 120)
+
             for node in live_servers:
                 await manager.api.flush_keyspace(node.ip_addr, ks)
 

--- a/test/cluster/object_store/test_scaling.py
+++ b/test/cluster/object_store/test_scaling.py
@@ -104,6 +104,7 @@ async def test_scaling(manager: ManagerClient, object_storage):
     async def verify_object_storage_namespace(server, live_servers, ks):
         """Verify object-storage namespace layout and reference counts through REST API."""
         await manager.disable_tablet_balancing()
+        await wait_for_no_pending_topology_transition(manager, time.time() + 120)
         try:
             for node in live_servers:
                 await manager.api.disable_autocompaction(node.ip_addr, ks, "test")

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -149,6 +149,24 @@ async def wait_for_no_pending_topology_transition(manager: ManagerClient, deadli
     await wait_for(no_transition, deadline, period=.5)
 
 
+async def wait_for_no_running_compactions(manager: ManagerClient,
+                                          servers: List[ServerInfo],
+                                          deadline: float) -> None:
+    """Wait until there are no running compactions on any of the given nodes.
+    Assumes autocompaction has already been disabled so no new compactions
+    will be started while we wait for in-flight ones to finish.
+    """
+    async def no_compactions():
+        for srv in servers:
+            compactions = await manager.api.client.get_json(
+                "/compaction_manager/compactions", host=srv.ip_addr)
+            if compactions:
+                return None
+        return True
+
+    await wait_for(no_compactions, deadline)
+
+
 async def wait_for_token_ring_and_group0_consistency(manager: ManagerClient, deadline: float) -> None:
     """
     Weaker version of the above check.


### PR DESCRIPTION
test_scaling[s3] intermittently fails with a mismatch between S3 SSTable references and the system.sstables registry.
The root cause is that verify_object_storage_namespace() can observe S3 references created by operations that haven't yet committed their registry entries.
Two races were identified:
1. Tablet migration race
Between wait_for_no_pending_topology_transition() at the call site and disable_tablet_balancing() inside the function, the topology coordinator can start a new migration. The migration streams an SSTable to S3, but the test checks before end_migration commits the registry entry.
Call wait_for_no_pending_topology_transition() after disabling balancing, so no new migrations can start and any in-flight ones complete before the consistency check.
2. Split compaction race
Split compactions run asynchronously after tablet migration completes. A split compaction creates S3 references before registering the SSTable in system.sstables..
Add a wait loop that drains all in-flight compactions on every node. Since autocompaction is disabled beforehand, no new compactions will start - we just wait for running ones to finish.
A reusable wait_for_no_running_compactions() helper is added to test/cluster/util.py for this purpose.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3284

--

The test is introduced in 2026.3, requires backport