### PR TITLE
test: collect and link failed-test server logs

### DIFF
--- a/test.py
+++ b/test.py
@@ -343,6 +343,8 @@ def run_pytest(options: argparse.Namespace) -> int:
         args.append(f'--random-seed={options.random_seed}')
     if options.gather_metrics:
         args.append('--gather-metrics')
+    if options.artifacts_dir_url:
+        args.append(f'--artifacts_dir_url={options.artifacts_dir_url}')
     if options.timeout:
         args.append(f'--timeout={options.timeout}')
     if options.session_timeout:

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -11,13 +11,12 @@ from __future__ import annotations
 import asyncio
 import ssl
 import tempfile
-import urllib.parse
 from concurrent.futures.thread import ThreadPoolExecutor
 from multiprocessing import Event
 from pathlib import Path
 from typing import TYPE_CHECKING
 from test import TOP_SRC_DIR, MODES_TIMEOUT_FACTOR, path_to
-from test.pylib.runner import PHASE_REPORT_KEY
+from test.pylib.runner import PHASE_REPORT_KEY, MANAGER_LOGS_KEY, make_failed_test_dir
 from test.cluster.object_store.conftest import make_object_storage
 from test.pylib.random_tables import RandomTables
 from test.pylib.skip_types import skip_env
@@ -79,9 +78,6 @@ def pytest_addoption(parser):
     add_s3_options(parser)
     parser.addoption('--skip-internet-dependent-tests', action='store_true', default=False,
                      help='Skip tests which depend on artifacts from the internet')
-    parser.addoption('--artifacts_dir_url', action='store', type=str, default=None, dest='artifacts_dir_url',
-                     help='Provide the URL to artifacts directory to generate the link to failed tests directory '
-                          'with logs')
 
 
 conn_logger = logging.getLogger("conn_messages")
@@ -218,7 +214,6 @@ async def manager_internal(request: pytest.FixtureRequest, manager_api_sock_path
 @pytest.fixture(scope="function")
 async def manager(request: pytest.FixtureRequest,
                   manager_internal: Callable[[], ManagerClient],
-                  record_property: Callable[[str, object], None],
                   suite_log_dir: Path,
                   testpy_uname: str,
                   build_mode: str) -> AsyncGenerator[ManagerClient]:
@@ -232,6 +227,12 @@ async def manager(request: pytest.FixtureRequest,
 
     manager_client = manager_internal()  # set up client object in fixture with scope function
     await manager_client.before_test(test_case_name, test_log)
+    # Publish what pytest_runtest_makereport needs to attach this test's logs on
+    # failure (single source of truth), so it doesn't re-derive these paths.
+    request.node.stash[MANAGER_LOGS_KEY] = {
+        "client": manager_client,
+        "logs": {"pytest.log": test_log, "test_py.log": test_py_log_test},
+    }
     yield manager_client
     # `request.node.stash` contains reports stored per phase in `pytest_runtest_makereport`
     # from where we can retrieve test failure.
@@ -248,29 +249,15 @@ async def manager(request: pytest.FixtureRequest,
         found_errors = await manager_client.check_all_errors(check_all_errors=(request.node.get_closest_marker("check_nodes_for_errors") is not None))
 
         if failed or found_errors:
-            # Save scylladb logs for failed tests in a separate directory and copy XML report to the same directory to have
-            # all related logs in one dir.
-            # Then add property to the XML report with the path to the directory, so it can be visible in Jenkins
-            failed_test_dir_path = suite_log_dir / "failed_test" / test_case_name.translate(
-                str.maketrans('[]', '()'))
-            failed_test_dir_path.mkdir(parents=True, exist_ok=True)
-
-        if failed:
-            await manager_client.gather_related_logs(
-                failed_test_dir_path,
-                {'pytest.log': test_log, 'test_py.log': test_py_log_test}
-            )
-            with open(failed_test_dir_path / "stacktrace.txt", "w") as f:
-                f.write(call_report.longreprtext)
-            if request.config.getoption('artifacts_dir_url') is not None:
-                # get the relative path to the tmpdir for the failed directory
-                dir_path_relative = f"{failed_test_dir_path.as_posix()[failed_test_dir_path.as_posix().find('testlog'):]}"
-                full_url = urllib.parse.urljoin(request.config.getoption('artifacts_dir_url') + '/',
-                                                urllib.parse.quote(dir_path_relative))
-                record_property("TEST_LOGS", full_url)
+            # Server logs / traceback / links are attached by pytest_runtest_makereport;
+            # here we only need the dir for the manager-specific found_errors files below.
+            failed_test_dir_path = make_failed_test_dir(request.config, build_mode, test_case_name)
 
         cluster_status = await manager_client.after_test(test_case_name, not failed)
     finally:
+        # Drop the stash entry before closing the client so a teardown-phase
+        # failure report doesn't gather logs through a stopped client.
+        request.node.stash[MANAGER_LOGS_KEY] = None
         await manager_client.stop()  # Stop client session and close driver after each test
 
     if cluster_status is not None and cluster_status["server_broken"] and not failed:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -34,6 +34,12 @@ else:
     pytest_plugins.append("test.pylib.runner")
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    # In the root conftest so it is registered in every pytest session (incl. runpy).
+    parser.addoption('--artifacts_dir_url', action='store', type=str, default=None, dest='artifacts_dir_url',
+                     help='URL to the artifacts directory, used to generate links to failed tests log folders')
+
+
 def pytest_configure(config: pytest.Config) -> None:
     config.pluginmanager.register(ReportPlugin())
 

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -15,6 +15,7 @@ import random
 import shutil
 import sys
 import time
+import urllib.parse
 from argparse import BooleanOptionalAction
 from collections import defaultdict
 from itertools import chain, count
@@ -129,6 +130,55 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 # Stores the per-phase test reports so that fixtures and hooks can inspect the
 # outcome of each phase (setup / call / teardown) independently.
 PHASE_REPORT_KEY = pytest.StashKey[dict[str, pytest.CollectReport]]()
+
+# Set by the `manager` fixture so the log collector in pytest_runtest_makereport
+# can gather manager-owned logs: {"client": ManagerClient, "logs": {name: path}}.
+MANAGER_LOGS_KEY = pytest.StashKey[dict[str, object]]()
+
+FAILED_TEST_DIR = "failed_test"
+
+
+def make_failed_test_dir(config: pytest.Config, build_mode: str, test_name: str) -> pathlib.Path:
+    """Create and return `<mode>/failed_test/<test>` (uploaded on failure).
+
+    The test name is translated so `[]` don't confuse the artifact upload.
+    """
+    path = (pathlib.Path(config.getoption("--tmpdir")).absolute()
+            / build_mode / FAILED_TEST_DIR
+            / test_name.translate(str.maketrans('[]', '()')))
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def record_failed_test_artifacts(config: pytest.Config,
+                                 properties: list[tuple[str, object]],
+                                 failed_test_dir_path: pathlib.Path,
+                                 longreprtext: str,
+                                 when: str) -> None:
+    """Common failed-test bookkeeping: append the phase traceback to
+    stacktrace.txt and record the clickable TEST_LOGS / PYTEST_LOG links.
+
+    Fires once per failed phase, so the traceback is always appended while the
+    links are recorded only once (idempotent).
+    """
+    with open(failed_test_dir_path / "stacktrace.txt", "a") as f:
+        f.write(f"----- {when} -----\n{longreprtext}\n")
+
+    artifacts_dir_url = config.getoption("artifacts_dir_url", None)
+    if artifacts_dir_url is None or any(name == "TEST_LOGS" for name, _ in properties):
+        return
+
+    def _artifact_link(path: pathlib.Path | str) -> str:
+        # URL-encoded so test names with ::/[]/() don't 404; the junit plugin
+        # linkifies http(s) values.
+        posix = pathlib.Path(path).as_posix()
+        return urllib.parse.urljoin(artifacts_dir_url + "/", urllib.parse.quote(posix[posix.find("testlog"):]))
+
+    # TEST_LOGS -> failed_test folder (server logs + traceback);
+    # PYTEST_LOG -> this worker's session log.
+    properties.append(("TEST_LOGS", _artifact_link(failed_test_dir_path) + "/"))
+    if PYTEST_LOG_FILE in config.stash:
+        properties.append(("PYTEST_LOG", _artifact_link(config.stash[PYTEST_LOG_FILE])))
 
 
 def _build_test_mock(item: pytest.Item) -> SimpleNamespace:
@@ -584,6 +634,42 @@ def pytest_runtest_makereport(item, call):
                     f.write(section[0] + "\n")
                     f.write(section[1] + "\n")
 
+        # Single source of truth for attaching failed-test logs. cqlpy/alternator
+        # expose a pooled `scylla_cluster`; topology suites publish MANAGER_LOGS_KEY.
+        if report.failed:
+            # C++ items (and early setup failures) lack `funcargs`; nothing to collect.
+            funcargs = getattr(item, "funcargs", {})
+            build_mode = funcargs.get("build_mode")
+            cluster = funcargs.get("scylla_cluster")
+            # Published by the manager fixture (even when pulled in indirectly),
+            # so we don't re-derive its log paths or re-resolve the fixture here.
+            manager_logs = item.stash.get(MANAGER_LOGS_KEY, None)
+            if build_mode is not None and (cluster is not None or manager_logs is not None):
+                try:
+                    failed_test_dir_path = make_failed_test_dir(item.config, build_mode, item.name)
+
+                    if cluster is not None:
+                        # Copy the pooled server log before the cluster is recycled (unlinks it).
+                        server_log = cluster.server_log_filename()
+                        if server_log is not None and pathlib.Path(server_log).is_file():
+                            shutil.copyfile(server_log, failed_test_dir_path / pathlib.Path(server_log).name)
+
+                    if manager_logs is not None:
+                        # Manager owns the servers; gather via ManagerClient (sync-callable
+                        # since ManagerClient is universalasync-wrapped).
+                        manager_logs["client"].gather_related_logs(failed_test_dir_path, manager_logs["logs"])
+
+                    record_failed_test_artifacts(
+                        config=item.config,
+                        properties=item.user_properties,
+                        failed_test_dir_path=failed_test_dir_path,
+                        longreprtext=report.longreprtext,
+                        when=report.when,
+                    )
+                except Exception:
+                    logger.warning("Failed to collect logs for failed test %s", item.name, exc_info=True)
+
+
 class TestSuiteConfig:
     def __init__(self, config_file: pathlib.Path):
         self.path = config_file.parent
@@ -709,7 +795,7 @@ def prepare_dirs(tempdir_base: pathlib.Path,
         prepare_dir(tempdir_base / mode, "*.log", save_log_on_success)
         prepare_dir(tempdir_base / mode, "*.reject", save_log_on_success)
         prepare_dir(tempdir_base / mode / "xml", "*.xml", save_log_on_success)
-        prepare_dir(tempdir_base / mode / "failed_test", "*", save_log_on_success)
+        prepare_dir(tempdir_base / mode / FAILED_TEST_DIR, "*", save_log_on_success)
         prepare_dir(tempdir_base / mode / "allure", "*.xml", save_log_on_success)
 
 


### PR DESCRIPTION
fix for scylla server logs that are missing, also added direct clickable links

1. **Collects logs for failed cqlpy/alternator tests.** On failure, the leased Scylla server log (`<mode>/scylla-gwN-M.log`) and the traceback are copied into `<mode>/failed_test/<test>/` before the pooled cluster is recycled (which used to delete the log). Adds clickable `TEST_LOGS` and `PYTEST_LOG` links to the junit report.

2. **One shared implementation, no duplication.** The common bookkeeping (failed-test dir, `stacktrace.txt`, report links) now lives in two helpers in `test/pylib/runner.py`, used by both the cqlpy/alternator hook and the cluster/manager fixture.

3. **Fixes dead report links for `test.py` runs.** `--artifacts_dir_url` was parsed but never forwarded to the pytest session; now it is, and the option is registered in the root `test/conftest.py`.




 Backport is not required, the change is test-infrastructure only — it adds failed-test server-log links to the CI report and doesn't fix any product/user-facing behavior.