### PR TITLE
compaction: fix split bypass racing with regular compaction selection

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1936,6 +1936,13 @@ protected:
             }
         }, false);
         compaction_completion_desc desc { .old_sstables = {sst}, .new_sstables = {sst} };
+        // Must hold sstable_set_lock while calling on_compaction_completion, because it
+        // mutates the sstable set (moves sstables between compaction groups). Otherwise
+        // a concurrent regular compaction's snapshot+filter+registration (which IS
+        // protected by this lock) can capture sstables that are about to be moved out
+        // from under it — causing "Unable to remove input SSTable" on completion.
+        auto& cs = _cm.get_compaction_state(_compacting_table);
+        auto units = co_await get_units(cs.sstable_set_lock, 1);
         co_await _compacting_table->on_compaction_completion(std::move(desc), sstables::offstrategy::no);
         // It's fine to return empty results (zeroed stats) as compaction was bypassed.
         co_return compaction_result{};


### PR DESCRIPTION
The fix in 3f9d1c16c7 ("compaction: fix stale-snapshot race between split replacer and regular compaction picker") added sstable_set_lock to serialize regular compaction selection against on_compaction_completion in the replacer path, but missed the split bypass path in split_compaction_task_executor::do_rewrite_sstable().

When an sstable doesn't need rewriting, the bypass calls on_compaction_completion() directly without holding sstable_set_lock. This mutates the sstable set (moves sstables from the main group to a split_ready group) while a concurrent regular compaction may be in the middle of its selection phase on the same view, holding the same lock under the (correct) assumption that the lock serializes selection against sstable set mutations.

The resulting race:

  [strm] split bypass: on_compaction_completion moves X out of
         main group  (NO lock held)
  [comp] regular compaction: acquires sstable_set_lock, snapshots
         main set (finds X), filters, registers X, releases lock
  [comp] regular compaction: completes, replacer fires, tries to
         remove X from main set -> X is gone -> on_internal_error

Fix by acquiring the sstable_set_lock in the bypass path before calling on_compaction_completion, matching the protocol used by the regular replacer path.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3292.

Backport to vulnerable along with 3f9d1c16c7