### PR TITLE
test: fix race in test_stop_reshape_aborts_all_compaction_groups

### DIFF
--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -186,12 +186,11 @@ async def test_stop_reshape_aborts_all_compaction_groups(manager: ManagerClient)
 
             logger.info("Restarting server (reshape happens on boot)")
             await manager.server_stop_gracefully(server.server_id)
-            await manager.server_start(server.server_id,
-                                       expected_server_up_state=ServerUpState.HOST_ID_QUERIED)
+            await manager.server_start(server.server_id)
 
             logger.info("Waiting for reshape to hit the injection point")
             await manager.api.wait_for_injection_enter(server.ip_addr, injection,
-                                                       threshold=1, deadline=time.time() + 60)
+                                                       threshold=1, deadline=time.time() + 120)
 
             logger.info("Stopping RESHAPE globally and releasing injection")
             stop_task = asyncio.create_task(manager.api.stop_compaction(server.ip_addr, "RESHAPE"))


### PR DESCRIPTION
Use SERVING instead of HOST_ID_QUERIED in server_start after restart. HOST_ID_QUERIED returns immediately when _host_id is cached from the previous boot, before the restarted scylla process is actually reachable. This caused wait_for_injection_enter to start its deadline before the server even booted, making the test flaky in debug mode where boot takes up to 3 minutes.

SERVING waits for sd_notify('serving'), by which time background reshapes have already entered the injection and are blocked, so wait_for_injection_enter returns immediately.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3279.

