### PR TITLE
tools: fix shard-of for dropped tables

### DIFF
--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -1565,6 +1565,35 @@ def test_scylla_sstable_shard_of_tablets(cql, test_keyspace_tablets, scylla_path
                         assert actual_shard == shard_id
 
 
+def test_scylla_sstable_shard_of_tablets_with_stale_directory(cql, test_keyspace_tablets, scylla_path, scylla_data_dir) -> None:
+    """Regression test for #27006: shard-of must use the table ID from the SSTable path."""
+    key = 0  # mapped to shard 0
+
+    def table_with_stale_directory(cql, keyspace):
+        table = util.unique_name()
+        schema = (f"CREATE TABLE {keyspace}.{table} (pk int PRIMARY KEY, v int) "
+                  "WITH compaction = {'class': 'NullCompactionStrategy'}")
+        stale_table_id = "00000000000000000000000000000000"
+        os.mkdir(os.path.join(scylla_data_dir, keyspace, f"{table}-{stale_table_id}"))
+        cql.execute(schema)
+        cql.execute(f"INSERT INTO {keyspace}.{table} (pk, v) VALUES ({key}, 0)")
+        nodetool.flush(cql, f"{keyspace}.{table}")
+        return table, schema
+
+    with scylla_sstable(table_with_stale_directory, cql, test_keyspace_tablets, scylla_data_dir) as (_, schema_file, sstables):
+        with nodetool.no_autocompaction_context(cql, "system.tablets"):
+            nodetool.flush_keyspace(cql, "system")
+            out = subprocess.check_output([scylla_path,
+                                           "sstable", "shard-of",
+                                           "--tablets",
+                                           "--schema-file", schema_file] +
+                                          sstables)
+            sstables_json = json.loads(out)['sstables']
+            for replica_sets in sstables_json.values():
+                for replica_set in replica_sets:
+                    assert replica_set['shard'] == 0
+
+
 def test_scylla_sstable_no_args(scylla_path):
     res = subprocess.run([scylla_path, "sstable"], capture_output=True, text=True)
 

--- a/tools/load_system_tablets.cc
+++ b/tools/load_system_tablets.cc
@@ -11,10 +11,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/util/closeable.hh>
 
-#include "locator/abstract_replication_strategy.hh"
 #include "utils/log.hh"
-#include "data_dictionary/keyspace_metadata.hh"
-#include "db/cql_type_parser.hh"
 #include "db/system_keyspace.hh"
 #include "mutation/mutation.hh"
 #include "readers/combined.hh"
@@ -27,27 +24,9 @@ namespace {
 
 logging::logger logger{"load_sys_tablets"};
 
-future<utils::UUID> get_table_id(std::filesystem::path scylla_data_path,
-                                 std::string_view keyspace_name,
-                                 std::string_view table_name) {
-    auto path = co_await get_table_directory(scylla_data_path,
-                                             keyspace_name,
-                                             table_name);
-    // the part after "-" is the string representation of the table_id
-    //   "$scylla_data_path/system/tablets-fd4f7a4696bd3e7391bf99eb77e82a5c"
-    auto fn = path.filename().native();
-    auto dash_pos = fn.find_last_of('-');
-    assert(dash_pos != fn.npos);
-    if (dash_pos == fn.size()) {
-        throw std::runtime_error(fmt::format("failed parse system.tablets path {}: bad path", path));
-    }
-    co_return utils::UUID{fn.substr(dash_pos + 1).c_str()};
-}
-
 tools::tablets_t do_load_system_tablets(const db::config& dbcfg,
                                         std::filesystem::path scylla_data_path,
-                                        std::string_view keyspace_name,
-                                        std::string_view table_name,
+                                        table_id table,
                                         reader_permit permit) {
     sharded<sstable_manager_service> sst_man;
     auto scf = make_sstable_compressor_factory_for_tests_in_thread();
@@ -58,23 +37,16 @@ tools::tablets_t do_load_system_tablets(const db::config& dbcfg,
     auto tablets_table_directory = get_table_directory(scylla_data_path,
                                                        db::system_keyspace::NAME,
                                                        schema->cf_name()).get();
-    auto table_id = get_table_id(scylla_data_path, keyspace_name, table_name).get();
     auto mut = read_mutation_from_table_offline(sst_man,
                                                 permit,
                                                 tablets_table_directory,
                                                 db::system_keyspace::NAME,
                                                 db::system_keyspace::tablets,
-                                                data_value(table_id),
+                                                data_value(table.uuid()),
                                                 {});
     if (!mut || mut->partition().row_count() == 0) {
-        throw std::runtime_error(fmt::format("failed to find tablets for {}.{}", keyspace_name, table_name));
+        throw std::runtime_error(fmt::format("failed to find tablets for table {}", table));
     }
-
-    auto ks = make_lw_shared<data_dictionary::keyspace_metadata>(keyspace_name,
-                                                                 "org.apache.cassandra.locator.LocalStrategy",
-                                                                 locator::replication_strategy_config_options{},
-                                                                 std::nullopt, std::nullopt, false);
-    db::cql_type_parser::raw_builder ut_builder(*ks);
 
     tools::tablets_t tablets;
     query::result_set result_set{*mut};
@@ -95,11 +67,10 @@ namespace tools {
 
 future<tablets_t> load_system_tablets(const db::config &dbcfg,
                                       std::filesystem::path scylla_data_path,
-                                      std::string_view keyspace_name,
-                                      std::string_view table_name,
+                                      table_id table,
                                       reader_permit permit) {
     return async([=, &dbcfg] {
-        return do_load_system_tablets(dbcfg, scylla_data_path, keyspace_name, table_name, permit);
+        return do_load_system_tablets(dbcfg, scylla_data_path, table, permit);
     });
 }
 

--- a/tools/load_system_tablets.hh
+++ b/tools/load_system_tablets.hh
@@ -15,6 +15,7 @@
 #include "reader_permit.hh"
 #include "dht/token.hh"
 #include "locator/tablets.hh"
+#include "schema/schema_fwd.hh"
 #include "seastarx.hh"
 
 namespace db {
@@ -27,17 +28,15 @@ using tablets_t = std::map<dht::token, locator::tablet_replica_set>;
 
 /// Load the rows of given table in "system.tablets" from its sstables
 ///
-/// @param cfg the db config
+/// @param dbcfg the db config
 /// @param scylla_data_path path to the scylla data directory, which is usually
 ///        /var/lib/scylla/data
-/// @param keyspace_name the keyspace name of the table
-/// @param table_name the table name of the table
+/// @param table the ID of the table whose tablet rows should be loaded
 /// @param permit the permit for performing read ops
 /// @returns a map from last token to the replica set
 future<tablets_t> load_system_tablets(const db::config& dbcfg,
                                       std::filesystem::path scylla_data_path,
-                                      std::string_view keyspace_name,
-                                      std::string_view tablet_name,
+                                      table_id table,
                                       reader_permit permit);
 
 }

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -44,6 +44,7 @@
 #include "sstables/sstable_directory.hh"
 #include "sstables/open_info.hh"
 #include "release.hh"
+#include "replica/database.hh"
 #include "replica/schema_describe_helper.hh"
 #include "test/lib/cql_test_env.hh"
 #include "tools/json_writer.hh"
@@ -147,6 +148,7 @@ struct sstable_path_info {
     std::filesystem::path data_dir_path;
     sstring keyspace;
     sstring table;
+    table_id id;
 };
 
 sstable_path_info extract_from_sstable_path(const bpo::variables_map& app_config) {
@@ -168,13 +170,16 @@ sstable_path_info extract_from_sstable_path(const bpo::variables_map& app_config
     // Detect whether sstable is in root table directory, or in a sub-directory
     // The last component is "" due to the trailing "/" left by "remove_filename()" above.
     // So we need to go back 2 more, to find the supposed keyspace component.
-    if (keyspace == std::prev(sst_dir_path.end(), 3)->native()) {
+    const bool in_table_directory = keyspace == std::prev(sst_dir_path.end(), 3)->native();
+    if (in_table_directory) {
         data_dir_path = sst_dir_path / ".." / "..";
     } else {
         data_dir_path = sst_dir_path / ".." / ".." / "..";
     }
-
-    return sstable_path_info{std::move(sst_path), std::move(data_dir_path), std::move(keyspace), std::move(table)};
+    const auto table_directory = in_table_directory ? sst_dir_path.parent_path() : sst_dir_path.parent_path().parent_path();
+    auto [table_name_ignored, id] = replica::parse_table_directory_name(table_directory.filename().native());
+    return sstable_path_info{
+            std::move(sst_path), std::move(data_dir_path), std::move(keyspace), std::move(table), id};
 }
 
 std::pair<sstring, sstring> get_keyspace_and_table_options(const bpo::variables_map& app_config) {
@@ -1989,13 +1994,12 @@ void shard_of_with_vnodes(const std::vector<sstables::shared_sstable>& sstables,
     writer.EndStream();
 }
 
-void shard_of_with_tablets(schema_ptr schema,
-                           const std::vector<sstables::shared_sstable>& sstables,
+void shard_of_with_tablets(const std::vector<sstables::shared_sstable>& sstables,
                            std::filesystem::path data_dir_path,
+                           table_id id,
                            const db::config& dbcfg,
                            reader_permit permit) {
-    auto tablets = tools::load_system_tablets(dbcfg, data_dir_path,
-                                              schema->ks_name(), schema->cf_name(),
+    auto tablets = tools::load_system_tablets(dbcfg, data_dir_path, id,
                                               permit).get();
     json_writer writer;
     writer.StartStream();
@@ -2053,7 +2057,7 @@ void shard_of_operation(schema_ptr schema, reader_permit permit,
         shard_of_with_vnodes(sstables, sstable_manager, vm);
     } else {
         auto info = extract_from_sstable_path(vm);
-        shard_of_with_tablets(schema, sstables, info.data_dir_path, dbcfg, permit);
+        shard_of_with_tablets(sstables, info.data_dir_path, info.id, dbcfg, permit);
     }
 }
 


### PR DESCRIPTION
Fixes #27006.

`scylla sstable shard-of --tablets` previously looked up the table ID by selecting a same-named directory from the data directory. If a directory from a previously dropped table remained, the command could select its ID and fail to find the table in `system.tablets`.

This change extracts the table ID from the supplied SSTable path and uses that exact ID when loading tablet information.

A regression test creates a stale same-named table directory and verifies that `shard-of --tablets` still succeeds.

Tests:
- `test_scylla_sstable_shard_of_tablets`
- `test_scylla_sstable_shard_of_tablets --repeat 100`
- `test_scylla_sstable_shard_of_vnodes`
- Development build of `build/dev/scylla`