### PR TITLE
group0: fix voter deadlock on graceful leader shutdown

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2141,6 +2141,17 @@ future<> gossiper::do_stop_gossiping() {
         auto local_generation = my_ep_state->get_heart_beat_state().get_generation();
         logger.info("Announcing shutdown");
         co_await add_local_application_state(application_state::STATUS, versioned_value::shutdown(true));
+
+        // Injection point for SCYLLADB-3026: once STATUS=SHUTDOWN is announced, this
+        // node is excluded from its own gossiper::get_live_members() while it is still
+        // the group0 topology coordinator (the coordinator fiber is aborted only later
+        // in the shutdown sequence). Pausing here holds that window open so that any
+        // voter refresh (e.g. the periodic tablet-load-stats refresher) drives
+        // update_nodes() with self missing from the node list, reproducing the voter
+        // deadlock deterministically.
+        co_await utils::get_local_injector().inject(
+                "gossiper_pause_after_shutdown_announce", utils::wait_for_message(60s));
+
         auto live_endpoints = _live_endpoints;
         co_await coroutine::parallel_for_each(live_endpoints, [this, &local_generation] (locator::host_id id) -> future<> {
             logger.info("Sending a GossipShutdown to {} with generation {}", id, local_generation);

--- a/service/raft/group0_voter_handler.cc
+++ b/service/raft/group0_voter_handler.cc
@@ -491,12 +491,28 @@ future<> group0_voter_handler::update_nodes(
         co_return co_await _group0.modify_voters({}, nodes_removed, as);
     }
 
+    // Nothing to calculate on the bootstrapping discovery leader: it has just written its own join
+    // request, so it sits in `new_nodes` (node_state::none) and gets no replica state below, while
+    // already being a voter from the initial configuration - tripping the voter invariant below.
+    // Checking `normal_nodes` also covers the follow-up window where the leader is in
+    // `transition_nodes`; topology::is_empty() would not, as it counts `transition_nodes` too.
+    if (_topology.normal_nodes.empty()) {
+        co_return;
+    }
+
     auto& raft_server = _group0.group0_server();
 
     const auto& leader_id = raft_server.current_leader();
 
     // Load the current cluster members
     const auto& group0_config = raft_server.get_configuration();
+
+    // The node sets below are derived from the gossiper state, which is only fully populated once gossiping is
+    // running. Bail out early otherwise, so a not-yet-settled gossiper cannot trip the voter invariant below.
+    if (!_gossiper.is_enabled()) {
+        rvlogger.debug("Gossiper is not enabled yet, skipping the voter update");
+        co_return;
+    }
 
     const auto& nodes_alive = _gossiper.get_live_members();
     const auto& nodes_dead = _gossiper.get_unreachable_members();
@@ -571,6 +587,50 @@ future<> group0_voter_handler::update_nodes(
             continue;
         }
         add_node(id, *node, _gossiper.is_alive(locator::host_id{id.uuid()}));
+    }
+
+    // Ensure the current node is present in the nodes list, even if it is not in the gossiper's live or dead
+    // members (e.g., during its own shutdown, when it drops out of its own get_live_members() while still being
+    // the group0 leader driving this calculation). This code runs on the group0 leader, which is a voter and must
+    // be part of the calculation for the quorum math to be correct; add_node() derives votership from the config,
+    // and the leader is effectively alive here (that it is missing from the live members is precisely the bug).
+    //
+    // FIXME(SCYLLADB-86): this relies on the leader still being a member of the group 0 config with topology
+    // state (add_node() ignores non-members, and without a replica state there is nothing to add it with). An
+    // obsolete modify_config initiated by a superseded topology coordinator - though appended and committed by
+    // the current leader, as config changes only go through the leader - can remove the leader from the config,
+    // silently leaving it out of the calculation until the committed change forces it to step down; fixing the
+    // underlying config races is out of scope here.
+    const auto self_id = raft_server.id();
+    if (!nodes.contains(self_id)) {
+        if (const auto* node = get_replica_state(self_id, true)) {
+            add_node(self_id, *node, true);
+        }
+    }
+
+    // Every voting config member is expected to be present in the nodes list (a still-bootstrapping node has no
+    // topology state yet, but must not be a voter before it fully joins).
+    //
+    // Such a voter cannot just be left alone - it still counts towards the raft quorum, while the distribution below is
+    // sized from `nodes` only and would undercount, which is exactly the failure mode of SCYLLADB-3026.
+    //
+    // All the inputs (group 0 configuration, topology and gossiper state) are local and read under the voter lock, so
+    // a voter missing here means the local state is inconsistent rather than merely stale.
+    //
+    // FIXME(SCYLLADB-86): an obsolete modify_config initiated by a superseded topology coordinator - though appended
+    // and committed by the current leader, as config changes only go through the leader - can still grant votership to
+    // a node with no topology state. This should become unreachable once those config races are fixed.
+    for (const auto& member : group0_config.current) {
+        const raft::server_id id = member.addr.id;
+        if (group0_config.can_vote(id) != raft::is_voter::yes) {
+            continue;
+        }
+        if (!nodes.contains(id)) {
+            // The bootstrapping discovery leader is handled by the early return at the top of update_nodes(), and the
+            // leader itself is added by the "self" block above, so reaching this point is unexpected.
+            on_internal_error(rvlogger,
+                    format("group0 voter {} is absent from the node list (no topology state)", id));
+        }
     }
 
     std::unordered_set<raft::server_id> voters_add;

--- a/service/raft/group0_voter_handler.cc
+++ b/service/raft/group0_voter_handler.cc
@@ -606,6 +606,11 @@ future<> group0_voter_handler::update_nodes(
     }
 
     co_await _group0.modify_voters(voters_add, voters_del, as);
+
+    // Marks a fully completed voter recalculation, including any resulting config change. Logged unconditionally
+    // (also when the diff is empty and modify_voters() is a no-op), so that tests can count the occurrences to know
+    // a refresh really ran, instead of guessing with a timeout.
+    rvlogger.debug("Voter update done");
 }
 
 group0_voter_calculator::group0_voter_calculator(std::optional<size_t> voters_max)

--- a/test/cluster/test_raft_voters.py
+++ b/test/cluster/test_raft_voters.py
@@ -164,7 +164,6 @@ async def test_raft_limited_voters_retain_coordinator(manager: ManagerClient):
         f"The coordinator {coordinator_id} should be a voter (but is not)"
 
 
-@pytest.mark.xfail(reason="SCYLLADB-3026: voter deadlock on graceful leader shutdown")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_raft_voters_stop_leader_keeps_quorum(manager: ManagerClient, build_mode: str):
     """

--- a/test/cluster/test_raft_voters.py
+++ b/test/cluster/test_raft_voters.py
@@ -7,6 +7,7 @@
 import asyncio
 import logging
 import random
+import time
 import pytest
 
 from cassandra.policies import WhiteListRoundRobinPolicy
@@ -14,8 +15,10 @@ from cassandra.policies import WhiteListRoundRobinPolicy
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
+from test.pylib.util import scale_timeout_by_mode, wait_for
 from test.cluster.conftest import cluster_con
-from test.cluster.util import get_coordinator_host_ids, get_current_group0_config
+from test.cluster.util import (get_coordinator_host_ids, get_current_group0_config,
+                                ensure_group0_leader_on)
 
 
 GROUP0_VOTERS_LIMIT = 5
@@ -159,3 +162,88 @@ async def test_raft_limited_voters_retain_coordinator(manager: ManagerClient):
     group0_members = await get_current_group0_config(manager, dc_servers[0][0])
     assert any(m[0] == coordinator_id and m[1] for m in group0_members), \
         f"The coordinator {coordinator_id} should be a voter (but is not)"
+
+
+@pytest.mark.xfail(reason="SCYLLADB-3026: voter deadlock on graceful leader shutdown")
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_raft_voters_stop_leader_keeps_quorum(manager: ManagerClient, build_mode: str):
+    """
+    Gracefully stopping the group0 leader must not leave the cluster without
+    quorum (SCYLLADB-3026).
+
+    On shutdown the leader announces STATUS=SHUTDOWN and drops out of its own
+    get_live_members() while staying group0 coordinator. A voter refresh in that
+    window runs update_nodes() with self absent, so calc_voters_max caps voters at
+    1: a healthy node is demoted and the dead leader keeps its vote, leaving
+    voters = {dead_leader, 1 alive} — permanent no-quorum.
+    """
+
+    # 3-node cluster. 1s tablet-load-stats refresh lands the periodic voter refresh inside the short shutdown window
+    # (default 60s is too coarse). It is just a convenient periodic trigger - if that subsystem changes, another way of
+    # triggering the voter refresh in the window is needed.
+    config = {'tablet_load_stats_refresh_interval_in_seconds': 1}
+    servers = await manager.servers_add(3, config=config)
+    assert len(servers) == 3
+
+    # Pin the group0 leader so we know which node drives the refresh.
+    leader = servers[0]
+    await ensure_group0_leader_on(manager, leader)
+
+    leader_host_id = await manager.get_host_id(leader.server_id)
+    survivor = servers[1]
+    logging.info(f"Leader: {leader} (host_id={leader_host_id}), survivor: {survivor}")
+
+    leader_log = await manager.server_open_log(leader.server_id)
+
+    # Sanity: all 3 nodes are voters up front, so a demotion in the window shows up as a drop in the voter count.
+    assert await get_number_of_voters(manager, survivor) == 3
+
+    # Pause the leader right after it announces STATUS=SHUTDOWN (self excluded from
+    # its own live members) but before the topology coordinator fiber is aborted.
+    injection = 'gossiper_pause_after_shutdown_announce'
+    await manager.api.enable_injection(leader.ip_addr, injection, one_shot=True)
+
+    # Drain via REST (mirrors the field incident). Drain commits STATUS=SHUTDOWN
+    # while the node is still alive, so self is excluded from get_live_members() in
+    # the window. (A plain SIGTERM aborts gossip before the STATUS commits, so the
+    # bug does not fire.) Drain blocks in the injection, so run it as a task.
+    drain_task = asyncio.create_task(
+        manager.api.client.post("/storage_service/drain", host=leader.ip_addr))
+
+    try:
+        await manager.api.wait_for_injection_enter(leader.ip_addr, injection)
+        logging.info("Leader paused in the post-shutdown-announce window")
+
+        mark = await leader_log.mark()
+
+        # In-window the tablet-load-stats refresher (1s) wakes the voter refresher; with the bug, update_nodes() runs
+        # with self absent and demotes a healthy node while the dead leader keeps its vote. Wait for two completed
+        # refreshes rather than a fixed timeout: refreshes are serialized by the voter lock, so the second one provably
+        # started - and read the gossiper live members - after the mark, i.e. inside the window, while the first one
+        # might have already been in flight when the window opened.
+        refresh_done = 'group0_voter_handler - Voter update done'
+
+        async def two_refreshes_done() -> bool | None:
+            return len(await leader_log.grep(refresh_done, from_mark=mark)) >= 2 or None
+
+        refresh_timeout = scale_timeout_by_mode(build_mode, 60)
+        await wait_for(two_refreshes_done, deadline=time.time() + refresh_timeout)
+        logging.info("Two voter refreshes completed inside the shutdown window")
+
+        # A voter refresh provably ran inside the window, so with the bug the demotion is already committed by now.
+        assert await get_number_of_voters(manager, survivor) == 3, \
+            "Healthy node demoted during the leader shutdown window (SCYLLADB-3026 reproduced)"
+    finally:
+        # Release the pause; drain stops gossip and the peers mark the leader dead.
+        await manager.api.message_injection(leader.ip_addr, injection)
+        await drain_task
+
+    # Stop the process so the cluster sees the leader as permanently down.
+    await manager.server_stop_gracefully(leader.server_id)
+
+    # A read barrier on a survivor must succeed. With the bug the config is
+    # {dead_leader (voter), survivor (voter), 1 non-voter} — 2 voters, 1 alive —
+    # and the barrier fails with "there is no raft quorum, total voters count 2,
+    # alive voters count 1". Short timeout so a quorum loss surfaces fast.
+    barrier_timeout = scale_timeout_by_mode(build_mode, 5)
+    await read_barrier(manager.api, survivor.ip_addr, timeout=barrier_timeout)


### PR DESCRIPTION
update_nodes() built the node list from get_live_members() + get_unreachable_members(). During graceful shutdown, the shutting-down node is excluded from get_live_members() (STATUS=SHUTDOWN) and never appears in get_unreachable_members(), so self was absent from the node map entirely.

With only 2 nodes visible, calc_voters_max rounds down to 1 voter. The dead leader keeps votership (never iterated), leaving the cluster with {dead_leader, 1_alive} — permanent quorum loss.

Fix: after building nodes from gossip, add a pass over current group0 config members. Any member absent from nodes is added using per-node gossiper::is_alive(), which is reliable for self during shutdown.

Also add an invariant assertion that all voting config members with topology state appear in nodes, to catch future regressions.

Added a reproduction test for the ticket scenario. The new test expected run time (in dev) is approx. 12 sec.

Fixes: SCYLLADB-3026

Backport to active branches: This is a production issue, which wasn't observed in the field yet, only in test, but it has the potential to render the cluster inoperable (lost Raft quorum) and is possible to be hit, thus backport is justified.