### PR TITLE
db: make keyspace-storage-options non-experimental

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -279,7 +279,6 @@ batch_size_fail_threshold_in_kb: 1024
 #     - udf
 #     - alternator-streams
 #     - broadcast-tables
-#     - keyspace-storage-options
 
 # The directory where hints files are stored if hinted handoff is enabled.
 # hints_directory: /var/lib/scylla/hints

--- a/db/config.cc
+++ b/db/config.cc
@@ -2062,7 +2062,7 @@ std::map<sstring, db::experimental_features_t::feature> db::experimental_feature
         {"alternator-ttl", feature::UNUSED },
         {"consistent-topology-changes", feature::UNUSED},
         {"broadcast-tables", feature::BROADCAST_TABLES},
-        {"keyspace-storage-options", feature::KEYSPACE_STORAGE_OPTIONS},
+        {"keyspace-storage-options", feature::UNUSED},
         {"tablets", feature::UNUSED},
         {"views-with-tablets", feature::UNUSED},
         {"strongly-consistent-tables", feature::STRONGLY_CONSISTENT_TABLES},

--- a/db/config.hh
+++ b/db/config.hh
@@ -124,7 +124,6 @@ struct experimental_features_t {
         UNUSED,
         UDF,
         BROADCAST_TABLES,
-        KEYSPACE_STORAGE_OPTIONS,
         STRONGLY_CONSISTENT_TABLES,
         LOGSTOR,
     };

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2282,9 +2282,7 @@ std::vector<schema_ptr> system_keyspace::all_tables(const db::config& cfg) {
 
     r.insert(r.end(), {tablets()});
 
-    if (cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
-        r.insert(r.end(), {sstables_registry()});
-    }
+    r.insert(r.end(), {sstables_registry()});
 
     if (cfg.check_experimental(db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES)) {
         r.insert(r.end(), {raft_groups(), raft_groups_snapshots(), raft_groups_snapshot_config()});

--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -103,6 +103,36 @@ and to the TRUNCATE data definition query.
 
 In addition, the timeout parameter can be applied to SELECT queries as well.
 
+(cql-keyspace-storage-options)=
+## Keyspace storage options
+
+To store your keyspaces on Amazon S3 or another S3-compatible object store, you need to configure your storage endpoints.
+See {ref}`Configuring Object Storage <object-storage-configuration>` for instructions.
+
+After your storage endpoints are configured, you can configure your object storage when creating a keyspace:
+
+```cql
+CREATE KEYSPACE with STORAGE = { 'type': 'S3', 'endpoint': '$endpoint_name', 'bucket': '$bucket' } 
+```
+
+**Example**
+
+```cql
+CREATE KEYSPACE ks
+    WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }
+    AND STORAGE = { 'type' : 'S3', 'bucket' : '/tmp/b1', 'endpoint' : 'localhost' } ;
+```
+
+Storage options can be inspected by checking the new system schema table: `system_schema.scylla_keyspaces`:
+
+```cql
+    cassandra@cqlsh> select * from system_schema.scylla_keyspaces;
+    
+     keyspace_name | storage_options                                | storage_type
+    ---------------+------------------------------------------------+--------------
+               ksx | {'bucket': '/tmp/xx', 'endpoint': 'localhost'} |           S3
+```
+
 ## PRUNE MATERIALIZED VIEW statements
 
 A special statement is dedicated for pruning ghost rows from materialized views.

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -310,6 +310,14 @@ Please use :ref:`Per-table tablet options <cql-per-table-tablet-options>` instea
 
 See :doc:`Data Distribution with Tablets </architecture/tablets>` for more information about tablets.
 
+Keyspace storage options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, SStables of a keyspace are stored locally.
+As an alternative, you can configure your keyspace to be stored
+on Amazon S3 or another S3-compatible object store.
+See :ref:`Keyspace storage options <cql-keyspace-storage-options>` for details.
+
 .. _consistency-option:
 
 Keyspace ``consistency`` options :label-caution:`Experimental`

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -4,16 +4,10 @@ On of the ways to use object storage is to keep sstables directly on it as objec
 
 ## Enabling the feature
 
-Currently the object-storage backend works if `keyspace-storage-options` is listed
-in `experimental_features` in `scylla.yaml`. like:
-
-```yaml
-experimental_features:
-  - keyspace-storage-options
-```
-
-It can also be enabled with `--experimental-features=keyspace-storage-options`
-command line option when launchgin scylla.
+Object-storage backed keyspaces are supported out of the box; no experimental
+feature flag is required. Simply configure the object-storage endpoints in
+`scylla.yaml` (see below) and create a keyspace with the desired storage
+options (see `CREATE KEYSPACE` extensions below).
 
 ## Configuring AWS S3 access
 

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -173,7 +173,7 @@ which help gain local access to the data in case there is a need for manual inte
 
 Most of the time it won't be necessary to touch the data on S3 directly, there are transparent REST APIs and Scylla Manager  
 commands for backup and restore and Scylla can operate normally with S3 storage configured in the  
-`CREATE KEYSPACE` cql documented at [ScyllaDB CQL Extensions | ScyllaDB Docs](https://opensource.docs.scylladb.com/stable/cql/cql-extensions.html#keyspace-storage-options).  
+`CREATE KEYSPACE` cql documented at [ScyllaDB CQL Extensions](../cql/cql-extensions.md#keyspace-storage-options).  
 
 However, if for some reason the SSTables become corrupted and need an offline scrub before re-uploading  
 or if a bug investigation leads to the need to analyze the backup data, follow the information below to access  
@@ -191,7 +191,7 @@ When performing a backup with `sctool`, a `backup` prefix is created within the 
 under that prefix, Scylla Manager stores all the backup data of all the backup tasks organized by cluster name,  
 datacenter, keyspace, etc.
 
-Follow [Specification | ScyllaDB Docs](https://manager.docs.scylladb.com/branch-3.3/backup/specification) in the Scylla Manager documentation for the exact layout  
+Follow [Specification | ScyllaDB Docs](https://manager.docs.scylladb.com/stable/backup/specification.html) in the Scylla Manager documentation for the exact layout  
 under the `backup` prefix.
 
 2. `/storage_service/backup` REST API
@@ -421,7 +421,7 @@ aws s3 cp /local/path/for/sstables s3://your-bucket/path-to-sstables/ --exclude 
 
 In case of Scylla Manager backups, if manual scrubbing is needed and SSTables will be re-uploaded,  
 multiple things would need to be changed, same thing if you need to drop some SSTables altogether.  
-As you might’ve seen in the Scylla Manager [Specification Docs](https://manager.docs.scylladb.com/branch-3.3/backup/specification), we keep a JSON manifest per node  
+As you might’ve seen in the Scylla Manager [Specification Docs](https://manager.docs.scylladb.com/stable/backup/specification.html), we keep a JSON manifest per node  
 and that manifest file contains lots of SSTable-dependent information:
 
 * list of SSTables per table owned by node

--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -305,6 +305,19 @@ ScyllaDB uses experimental flags to expose non-production-ready features safely.
 In recent ScyllaDB versions, these features are controlled by the ``experimental_features`` list in scylla.yaml, allowing one to choose which experimental to enable.
 Use ``scylla --help`` to get the list of experimental features.
 
+.. _admin-keyspace-storage-options:
+
+Keyspace storage options
+------------------------
+
+By default, SStables of a keyspace are stored in a local directory.
+As an alternative, you can configure your keyspace to be stored
+on Amazon S3 or another S3-compatible object store.
+
+Before creating keyspaces with object storage, you need to
+:ref:`configure <object-storage-configuration>` the object storage
+credentials and endpoint.
+
 .. _admin-views-with-tablets:
 
 Views with Tablets

--- a/init.cc
+++ b/init.cc
@@ -90,9 +90,6 @@ std::set<sstring> get_disabled_features_from_db_config(const db::config& cfg, st
         }
     }
 
-    if (!cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
-        disabled.insert("KEYSPACE_STORAGE_OPTIONS"s);
-    }
     if (!cfg.check_experimental(db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES)) {
         disabled.insert("STRONGLY_CONSISTENT_TABLES"s);
     }

--- a/test/alternator/test_config.yaml
+++ b/test/alternator/test_config.yaml
@@ -13,8 +13,7 @@ extra_scylla_cmdline_options:
 extra_scylla_config_options:
   {
     experimental_features: [
-                             udf,
-                             keyspace-storage-options
+                             udf
     ],
     alternator_port: 8000,
     query_tombstone_page_limit: 1000,

--- a/test/boost/config_test.cc
+++ b/test/boost/config_test.cc
@@ -876,7 +876,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_cdc) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UNUSED});
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
 
@@ -887,7 +886,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_unused) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UNUSED});
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
 
@@ -898,7 +896,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_udf) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UDF});
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
 
@@ -909,7 +906,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_alternator_streams) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UNUSED});
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
 
@@ -921,7 +917,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_broadcast_tables) {
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
     BOOST_CHECK(cfg.check_experimental(ef::BROADCAST_TABLES));
-    BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
 
@@ -929,10 +924,9 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_keyspace_storage_options) {
     auto cfg_ptr = std::make_unique<config>();
     config& cfg = *cfg_ptr;
     cfg.read_from_yaml("experimental_features:\n    - keyspace-storage-options\n", throw_on_error);
-    BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::KEYSPACE_STORAGE_OPTIONS});
-    BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
+    BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UNUSED});
+    BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
 
@@ -943,7 +937,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_multiple) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), (features{ef::UNUSED, ef::UNUSED, ef::UNUSED}));
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
 
@@ -957,7 +950,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_invalid) {
                            BOOST_REQUIRE_NE(msg.find("line 2, column 7"), msg.npos);
                            BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
                            BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-                           BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
                        });
     return make_ready_future();
 }

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -82,7 +82,6 @@ using namespace streaming;
 static cql_test_config make_object_storage_test_config(const data_dictionary::storage_options& so) {
     cql_test_config cfg;
     cfg.db_config = make_shared<db::config>();
-    cfg.db_config->experimental_features({db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS});
     cfg.db_config->object_storage_endpoints(sstables::make_storage_options_config(so));
     return cfg;
 }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2710,7 +2710,6 @@ SEASTAR_TEST_CASE(sstable_cleanup_correctness_test) {
 // own sharded storage_manager, which would conflict on the same endpoints).
 static future<> run_sstable_cleanup_correctness_with_storage(data_dictionary::storage_options storage) {
     auto db_cfg = make_shared<db::config>();
-    db_cfg->experimental_features({db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS});
     db_cfg->object_storage_endpoints(make_storage_options_config(storage));
 
     cql_test_config cql_cfg;

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -346,7 +346,6 @@ SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_t
 
     auto db_cfg_ptr = make_shared<db::config>();
     db_cfg_ptr->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
-    db_cfg_ptr->experimental_features({db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS});
     auto storage_options = make_test_object_storage_options("S3");
     db_cfg_ptr->object_storage_endpoints(make_storage_options_config(storage_options));
 

--- a/test/cluster/object_store/test_atomic_delete.py
+++ b/test/cluster/object_store/test_atomic_delete.py
@@ -22,7 +22,6 @@ def make_server_config(object_storage):
     return {
         'enable_user_defined_functions': False,
         'object_storage_endpoints': objconf,
-        'experimental_features': ['keyspace-storage-options'],
     }
 
 async def populate_and_flush(cql, manager, server, ks, flushes, rows_per_flush=10):

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -58,7 +58,6 @@ async def test_simple_backup(manager: ManagerClient, object_storage, move_files)
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
            'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options'],
            'task_ttl_in_seconds': 300
            }
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
@@ -104,7 +103,6 @@ async def test_backup_with_non_existing_parameters(manager: ManagerClient, objec
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
            'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options'],
            'task_ttl_in_seconds': 300
            }
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
@@ -135,7 +133,6 @@ async def test_backup_endpoint_config_is_live_updateable(manager: ManagerClient,
        after updating the config, it should succeed'''
 
     cfg = {'enable_user_defined_functions': False,
-           'experimental_features': ['keyspace-storage-options'],
            'task_ttl_in_seconds': 300
            }
     cmd = ['--logger-log-level', 'sstables_manager=debug']
@@ -179,7 +176,6 @@ async def do_test_backup_helper(manager: ManagerClient, object_storage,
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
            'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options'],
            'task_ttl_in_seconds': 300
            }
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
@@ -252,7 +248,6 @@ async def test_simple_backup_and_restore(manager: ManagerClient, object_storage,
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
            'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options'],
            'task_ttl_in_seconds': 300
            }
     if do_encrypt:
@@ -365,7 +360,6 @@ async def do_abort_restore(manager: ManagerClient, object_storage):
     objconf = object_storage.create_endpoint_conf()
     config = {'enable_user_defined_functions': False,
               'object_storage_endpoints': objconf,
-              'experimental_features': ['keyspace-storage-options'],
               'task_ttl_in_seconds': 300,
               }
 
@@ -1191,7 +1185,6 @@ async def test_restore_with_non_existing_sstable(manager: ManagerClient, object_
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
            'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options'],
            'task_ttl_in_seconds': 300
            }
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
@@ -1215,7 +1208,6 @@ async def test_backup_broken_streaming(manager: ManagerClient, s3_storage):
     config = {
         'enable_user_defined_functions': False,
         'object_storage_endpoints': objconf,
-        'experimental_features': ['keyspace-storage-options'],
         'task_ttl_in_seconds': 300,
     }
     cmd = ['--smp', '1', '--logger-log-level', 'sstables_loader=debug:sstable=debug']
@@ -1418,7 +1410,6 @@ async def test_aborted_decommision_reenables_snapshot(manager: ManagerClient, ob
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
            'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options'],
            'task_ttl_in_seconds': 300
            }
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -97,8 +97,7 @@ async def test_basic(manager: ManagerClient, object_storage, tmp_path, mode, rep
 
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
-           'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options']}
+           'object_storage_endpoints': objconf}
     if mode == 'encrypted':
         d = tmp_path / "system_keys"
         d.mkdir()
@@ -174,8 +173,7 @@ async def test_garbage_collect(manager: ManagerClient, object_storage):
 
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
-           'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options']}
+           'object_storage_endpoints': objconf}
     cmd = ['--logger-log-level', 's3=trace:http=debug:gcp_storage=trace']
     server = await manager.server_add(config=cfg, cmdline=cmd)
 
@@ -217,8 +215,7 @@ async def test_populate_from_quarantine(manager: ManagerClient, object_storage):
 
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
-           'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options']}
+           'object_storage_endpoints': objconf}
     server = await manager.server_add(config=cfg)
 
     cql = manager.get_cql()
@@ -255,8 +252,7 @@ async def test_misconfigured_storage(manager: ManagerClient, object_storage):
     # scylladb/scylladb#15074
     objconf = object_storage.create_endpoint_conf()
     cfg = {'enable_user_defined_functions': False,
-           'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options']}
+           'object_storage_endpoints': objconf}
     server = await manager.server_add(config=cfg)
 
     cql = manager.get_cql()
@@ -279,8 +275,7 @@ async def test_memtable_flush_retries(manager: ManagerClient, tmpdir, object_sto
     objconf = object_storage.create_endpoint_conf()
 
     cfg = {'enable_user_defined_functions': False,
-           'object_storage_endpoints': objconf,
-           'experimental_features': ['keyspace-storage-options']}
+           'object_storage_endpoints': objconf}
     server = await manager.server_add(config=cfg)
 
     cql = manager.get_cql()
@@ -427,7 +422,6 @@ async def test_tablet_move_updates_registry(manager: ManagerClient, s3_storage):
     """
     cfg = {
         'object_storage_endpoints': s3_storage.create_endpoint_conf(),
-        'experimental_features': ['keyspace-storage-options']
     }
     servers = await manager.servers_add(2, config=cfg)
     await manager.disable_tablet_balancing()
@@ -516,7 +510,6 @@ async def test_decommission_migrates_registry(manager: ManagerClient, s3_storage
     """
     cfg = {
         'object_storage_endpoints': s3_storage.create_endpoint_conf(),
-        'experimental_features': ['keyspace-storage-options']
     }
     servers = await manager.servers_add(2, config=cfg)
     # Avoid racing with the pre-decommission registry check below.
@@ -612,7 +605,6 @@ async def test_repair_creates_registry_entries(manager: ManagerClient, s3_storag
     """
     cfg = {
         'object_storage_endpoints': s3_storage.create_endpoint_conf(),
-        'experimental_features': ['keyspace-storage-options'],
         'rf_rack_valid_keyspaces': False,
         'hinted_handoff_enabled': False,
     }
@@ -705,7 +697,6 @@ async def test_registry_cleanup_on_all_nodes(manager: ManagerClient, object_stor
     """
     cfg = {
         'object_storage_endpoints': object_storage.create_endpoint_conf(),
-        'experimental_features': ['keyspace-storage-options'],
     }
     servers = await manager.servers_add(2, config=cfg,
                                         property_file=[{"dc": "dc1", "rack": "r0"},
@@ -753,8 +744,7 @@ async def test_stream_sink_abort_on_object_storage(manager: ManagerClient, objec
     is left with no orphaned objects from the aborted attempt.
     """
     cfg = {'enable_user_defined_functions': False,
-           'object_storage_endpoints': object_storage.create_endpoint_conf(),
-           'experimental_features': ['keyspace-storage-options']}
+           'object_storage_endpoints': object_storage.create_endpoint_conf()}
 
     # Two servers are enough to migrate a tablet from one to the other.
     servers = []

--- a/test/cluster/object_store/test_scaling.py
+++ b/test/cluster/object_store/test_scaling.py
@@ -35,7 +35,6 @@ async def test_scaling(manager: ManagerClient, object_storage):
     cfg = {
         'enable_user_defined_functions': False,
         'object_storage_endpoints': objconf,
-        'experimental_features': ['keyspace-storage-options'],
     }
     cmdline = ['--logger-log-level', 'sstable=debug']
 

--- a/test/cluster/test_encryption.py
+++ b/test/cluster/test_encryption.py
@@ -52,7 +52,6 @@ async def test_file_streaming_respects_encryption(manager: ManagerClient, storag
 
     if storage:
         cfg['object_storage_endpoints'] = storage.create_endpoint_conf()
-        cfg['experimental_features'] = ['keyspace-storage-options']
 
     cmdline = ['--smp=1']
     servers = []

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -315,7 +315,6 @@ def run_scylla_cmd(pid, dir):
         # Note that Alternator-specific experimental features are listed in
         # test/alternator/run.
         '--experimental-features=udf',
-        '--experimental-features=keyspace-storage-options',
         '--experimental-features=views-with-tablets',
         '--enable-tablets=true',
         '--enable-user-defined-functions', '1',
@@ -393,8 +392,6 @@ def run_precompiled_scylla_cmd(exe, pid, dir):
         cmd.remove('--auth-superuser-salted-password=$6$x7IFjiX5VCpvNiFk$2IfjTvSyGL7zerpV.wbY7mJjaRCrJ/68dtT3UpT.sSmNYz1bPjtn3mH.kJKFvaZ2T4SbVeBijjmwGjcb83LlV/')
     if major <= [5,1] or (enterprise and major <= [2022,2]):
         cmd.remove('--query-tombstone-page-limit=1000')
-    if major <= [5,0] or (enterprise and major <= [2022,1]):
-        cmd.remove('--experimental-features=keyspace-storage-options')
     if major <= [4,5] or (enterprise and major <= [2021,1]):
         cmd.remove('--kernel-page-cache=1')
         cmd.remove('--flush-schema-tables-after-modification=false')

--- a/test/cqlpy/test_config.yaml
+++ b/test/cqlpy/test_config.yaml
@@ -3,7 +3,6 @@ dirties_cluster:
 extra_scylla_cmdline_options:
   - '--rf-rack-valid-keyspaces=1'
   - '--experimental-features=udf'
-  - '--experimental-features=keyspace-storage-options'
   - '--experimental-features=views-with-tablets'
   - '--enable-tablets=true'
   - '--tablets-initial-scale-factor=1'

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -368,7 +368,6 @@ future<> test_env::do_with_async(noncopyable_function<void (test_env&)> func, te
     tests::adjust_rlimit();
     if (!cfg.storage.is_local_type()) {
         auto db_cfg = make_shared<db::config>();
-        db_cfg->experimental_features({db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS});
         db_cfg->object_storage_endpoints(make_storage_options_config(cfg.storage));
         return seastar::async([func = std::move(func), cfg = std::move(cfg), db_cfg = std::move(db_cfg)] () mutable {
             sharded<sstables::storage_manager> sstm;

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -112,7 +112,6 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
         'enable_user_defined_functions': True,
         'experimental_features': ['udf',
                                   'broadcast-tables',
-                                  'keyspace-storage-options',
                                   'views-with-tablets'],
 
         'skip_wait_for_gossip_to_settle': 0,


### PR DESCRIPTION
### Problem

The `keyspace-storage-options` experimental feature — which enables object-storage-backed keyspaces — has been in use for long enough to graduate to GA. Users still have to opt in via `experimental_features: [keyspace-storage-options]` in `scylla.yaml` (or the equivalent command-line flag), and the local `system.sstables_registry` table is only created when that flag is set.

### Changes

Object-storage keyspaces are now enabled unconditionally:

- `init.cc` no longer force-disables the `KEYSPACE_STORAGE_OPTIONS` cluster feature based on the experimental config option, and `db/system_keyspace.cc` creates `system.sstables_registry` on every node.
- The `keyspace-storage-options` experimental config option is retired: it maps to `feature::UNUSED` in `db/config.cc` (so existing `scylla.yaml` files keep parsing and users see the standard "unused features found in config" warning on startup), and the corresponding `experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS` enum entry is removed from `db/config.hh`.
- All boost/pytest/YAML test configs that used to opt in via `experimental_features({KEYSPACE_STORAGE_OPTIONS})` or `experimental_features: [keyspace-storage-options]` are cleaned up (test helpers, cqlpy runner, alternator/cqlpy test configs, encryption test, and every `test/cluster/object_store/*.py` file).
- `test/boost/config_test.cc` now expects the `keyspace-storage-options` YAML value to parse as `UNUSED`, matching the treatment of previously-graduated experimental flags (`lwt`, `cdc`, `tablets`, …).
- `conf/scylla.yaml` and `docs/dev/object_storage.md` are updated so the shipped example config and the developer docs no longer instruct users to add the retired flag.

The `gms::feature keyspace_storage_options` cluster feature and its consumers (`sstables_manager::validate_new_keyspace_storage_options`, `alter_keyspace_statement`, `stream_blob`) are intentionally left in place — they still guard mixed-version-cluster behavior until all nodes advertise the feature, which is the standard graduation pattern.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3302

Backport to `2026.3` per the Jira ticket, so the feature also graduates in the next release.
