### PR TITLE
auth: add `TEXT_SEARCH_INDEXING` permission

### DIFF
--- a/auth/permission.cc
+++ b/auth/permission.cc
@@ -37,7 +37,8 @@ static const std::unordered_map<sstring, auth::permission> permission_names({
         {"AUTHORIZE", auth::permission::AUTHORIZE},
         {"DESCRIBE", auth::permission::DESCRIBE},
         {"EXECUTE", auth::permission::EXECUTE},
-        {"VECTOR_SEARCH_INDEXING", auth::permission::VECTOR_SEARCH_INDEXING}});
+        {"VECTOR_SEARCH_INDEXING", auth::permission::VECTOR_SEARCH_INDEXING},
+        {"TEXT_SEARCH_INDEXING", auth::permission::TEXT_SEARCH_INDEXING}});
 
 const sstring& auth::permissions::to_string(permission p) {
     for (auto& v : permission_names) {

--- a/auth/permission.hh
+++ b/auth/permission.hh
@@ -34,6 +34,7 @@ enum class permission {
     SELECT, // required for SELECT.
     MODIFY, // required for INSERT, UPDATE, DELETE, TRUNCATE.
     VECTOR_SEARCH_INDEXING, // required for SELECT from tables with vector indexes if SELECT permission is not granted.
+    TEXT_SEARCH_INDEXING, // required for SELECT from tables with fulltext indexes if SELECT permission is not granted.
 
     // permission management
     AUTHORIZE, // required for GRANT and REVOKE.
@@ -56,7 +57,8 @@ typedef enum_set<
                 permission::AUTHORIZE,
                 permission::DESCRIBE,
                 permission::EXECUTE,
-                permission::VECTOR_SEARCH_INDEXING>> permission_set;
+                permission::VECTOR_SEARCH_INDEXING,
+                permission::TEXT_SEARCH_INDEXING>> permission_set;
 
 bool operator<(const permission_set&, const permission_set&);
 

--- a/auth/resource.cc
+++ b/auth/resource.cc
@@ -41,8 +41,8 @@ static const std::unordered_map<resource_kind, std::size_t> max_parts{
         {resource_kind::functions, 2}};
 
 static permission_set applicable_permissions(const data_resource_view& dv) {
-    
-    // We only support VECTOR_SEARCH_INDEXING permission for ALL KEYSPACES.
+
+    // We only support VECTOR_SEARCH_INDEXING and TEXT_SEARCH_INDEXING permissions for ALL KEYSPACES.
 
     auto set = permission_set::of<
                 permission::ALTER,
@@ -56,11 +56,11 @@ static permission_set applicable_permissions(const data_resource_view& dv) {
     }
 
     if (!dv.table() && !dv.keyspace()) {
-        set.add(permission_set::of<permission::VECTOR_SEARCH_INDEXING>());
+        set.add(permission_set::of<permission::VECTOR_SEARCH_INDEXING, permission::TEXT_SEARCH_INDEXING>());
     }
 
     return set;
-        
+
 }
 
 static permission_set applicable_permissions(const role_resource_view& rv) {

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1259,7 +1259,7 @@ listPermissionsStatement returns [std::unique_ptr<list_permissions_statement> st
     ;
 
 permission returns [auth::permission perm = auth::permission{}]
-    : p=(K_CREATE | K_ALTER | K_DROP | K_SELECT | K_MODIFY | K_AUTHORIZE | K_DESCRIBE | K_EXECUTE | K_VECTOR_SEARCH_INDEXING)
+    : p=(K_CREATE | K_ALTER | K_DROP | K_SELECT | K_MODIFY | K_AUTHORIZE | K_DESCRIBE | K_EXECUTE | K_VECTOR_SEARCH_INDEXING | K_TEXT_SEARCH_INDEXING)
     { $perm = auth::permissions::from_string($p.text); }
     ;
 
@@ -2471,6 +2471,8 @@ K_EXECUTE:     E X E C U T E;
 K_MUTATION_FRAGMENTS:    M U T A T I O N '_' F R A G M E N T S;
 
 K_VECTOR_SEARCH_INDEXING: V E C T O R '_' S E A R C H '_' I N D E X I N G;
+
+K_TEXT_SEARCH_INDEXING: T E X T '_' S E A R C H '_' I N D E X I N G;
 
 // Case-insensitive alpha characters
 fragment A: ('a'|'A');

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -267,8 +267,13 @@ future<> select_statement::check_access(query_processor& qp, const service::clie
             ? _schema->view_info()->base_name()
             : (cdc ? cdc->cf_name() : column_family());
         const schema_ptr& base_schema = cdc ? cdc : _schema;
-        bool is_vector_indexed = secondary_index::vector_index::has_index(*base_schema);
-        co_await state.has_column_family_access(keyspace(), cf_name, auth::permission::SELECT, auth::command_desc::type::OTHER, is_vector_indexed);
+        // A table's VECTOR_SEARCH_INDEXING permission also authorizes SELECT on it, so a user
+        // holding it can read the table without a full SELECT grant.
+        auth::permission_set additional_permissions;
+        if (secondary_index::vector_index::has_index(*base_schema)) {
+            additional_permissions.set<auth::permission::VECTOR_SEARCH_INDEXING>();
+        }
+        co_await state.has_column_family_access(keyspace(), cf_name, auth::permission::SELECT, auth::command_desc::type::OTHER, additional_permissions);
     } catch (const data_dictionary::no_such_column_family& e) {
         // Will be validated afterwards.
         co_return;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -27,6 +27,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/coroutine/exception.hh>
 #include "index/vector_index.hh"
+#include "index/fulltext_index.hh"
 #include "locator/tablets.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
 #include "service/qos/qos_common.hh"
@@ -267,11 +268,14 @@ future<> select_statement::check_access(query_processor& qp, const service::clie
             ? _schema->view_info()->base_name()
             : (cdc ? cdc->cf_name() : column_family());
         const schema_ptr& base_schema = cdc ? cdc : _schema;
-        // A table's VECTOR_SEARCH_INDEXING permission also authorizes SELECT on it, so a user
-        // holding it can read the table without a full SELECT grant.
+        // A table's external index permissions also authorize SELECT on it, so a user holding
+        // one of them can read the table without a full SELECT grant.
         auth::permission_set additional_permissions;
         if (secondary_index::vector_index::has_index(*base_schema)) {
             additional_permissions.set<auth::permission::VECTOR_SEARCH_INDEXING>();
+        }
+        if (secondary_index::fulltext_index::has_index(*base_schema)) {
+            additional_permissions.set<auth::permission::TEXT_SEARCH_INDEXING>();
         }
         co_await state.has_column_family_access(keyspace(), cf_name, auth::permission::SELECT, auth::command_desc::type::OTHER, additional_permissions);
     } catch (const data_dictionary::no_such_column_family& e) {

--- a/docs/dev/fulltext_search.md
+++ b/docs/dev/fulltext_search.md
@@ -26,6 +26,14 @@ table or column silently does nothing (issue VECTOR-641).
 
 ## Implementation overview
 
+### Authorization
+
+To support least-privilege authorization, ScyllaDB supports the `TEXT_SEARCH_INDEXING`
+permission as an alternative to the `SELECT` permission for full-text-indexed reads.
+It is grantable only on `ALL KEYSPACES`. A role with this permission can read fulltext-indexed base
+tables, their CDC log tables, and the system tables needed by Vector Store; it cannot read
+unrelated non-fulltext tables unless it also has the `SELECT` permission.
+
 ### Query routing and prepare
 
 An FTS query is identified at prepare time by the presence of a `BM25(column, term)` call

--- a/docs/operating-scylla/security/authorization.rst
+++ b/docs/operating-scylla/security/authorization.rst
@@ -395,6 +395,7 @@ The full set of available permissions is:
 - ``AUTHORIZE``
 - ``DESCRIBE``
 - ``VECTOR_SEARCH_INDEXING``
+- ``TEXT_SEARCH_INDEXING``
 
 .. 
    - ``EXECUTE``
@@ -468,8 +469,23 @@ permissions can be granted on which types of resources, and which statements are
      - ``LIST ROLES`` on all roles or only roles granted to another specified role
    * - ``VECTOR_SEARCH_INDEXING``
      - ``ALL KEYSPACES``
-     - ``SELECT`` on all tables with vector search indexes
-  
+     - ``SELECT`` on all tables with vector search indexes, and on some :ref:`system tables <external-index-system-tables>`
+   * - ``TEXT_SEARCH_INDEXING``
+     - ``ALL KEYSPACES``
+     - ``SELECT`` on all tables with full-text search indexes, and on some :ref:`system tables <external-index-system-tables>`
+
+.. _external-index-system-tables:
+
+Both the ``VECTOR_SEARCH_INDEXING`` and ``TEXT_SEARCH_INDEXING`` permissions also grant ``SELECT`` on the following
+system tables, which the external Vector Store engine reads to track schema changes, tablet placement, and CDC
+streams for the tables it indexes:
+
+- ``system.group0_history``
+- ``system.versions``
+- ``system.cdc_streams``
+- ``system.cdc_timestamps``
+- ``system.tablets``
+
 .. _grant-permission-statement:
 
 GRANT PERMISSION
@@ -481,7 +497,7 @@ Granting permission uses the ``GRANT PERMISSION`` statement:
    
    grant_permission_statement: GRANT `permissions` ON `resource` TO `user_name`
    permissions: ALL [ PERMISSIONS ] | `permission` [ PERMISSION ]
-   permission: CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESCRIBE 
+   permission: CREATE | ALTER | DROP | SELECT | MODIFY | AUTHORIZE | DESCRIBE | VECTOR_SEARCH_INDEXING | TEXT_SEARCH_INDEXING
    resource: ALL KEYSPACES
            :| KEYSPACE `keyspace_name`
            :| [ TABLE ] `table_name`

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -87,7 +87,7 @@ future<> service::client_state::has_all_keyspaces_access(
 
 future<> service::client_state::has_keyspace_access(const sstring& ks, auth::permission p) const {
     auth::resource r = auth::make_data_resource(ks);
-    co_return co_await has_access(ks, {p, r});
+    co_return co_await has_access(ks, p, r);
 }
 
 future<> service::client_state::has_functions_access(auth::permission p) const {
@@ -97,21 +97,22 @@ future<> service::client_state::has_functions_access(auth::permission p) const {
 
 future<> service::client_state::has_functions_access(const sstring& ks, auth::permission p) const {
     auth::resource r = auth::make_functions_resource(ks);
-    co_return co_await has_access(ks, {p, r});
+    co_return co_await has_access(ks, p, r);
 }
 
 future<> service::client_state::has_function_access(const sstring& ks, const sstring& function_signature, auth::permission p) const {
     auth::resource r = auth::make_functions_resource(ks, function_signature);
-    co_return co_await has_access(ks, {p, r});
+    co_return co_await has_access(ks, p, r);
 }
 
 future<> service::client_state::has_column_family_access(const sstring& ks,
-                const sstring& cf, auth::permission p, auth::command_desc::type t, std::optional<bool> is_vector_indexed) const {
+                const sstring& cf, auth::permission p, auth::command_desc::type t, auth::permission_set additional_permissions) const {
     auto r = auth::make_data_resource(ks, cf);
-    co_return co_await has_access(ks, {p, r, t}, is_vector_indexed);
+    co_return co_await has_access(ks, p, r, t, additional_permissions);
 }
 
-future<> service::client_state::check_internal_table_permissions(std::string_view ks, std::string_view table_name, const auth::command_desc& cmd) const {
+future<> service::client_state::check_internal_table_permissions(std::string_view ks, std::string_view table_name,
+                    auth::permission permission, const auth::resource& resource) const {
     // 1. CDC and $paxos tables are managed internally by Scylla. Users are prohibited
     //    from running ALTER or DROP commands on them.
     // 2. Non-superusers are not allowed to access $paxos tables, even if explicit
@@ -121,53 +122,47 @@ future<> service::client_state::check_internal_table_permissions(std::string_vie
     static constexpr auto forbidden_permissions = auth::permission_set::of<
                     auth::permission::ALTER, auth::permission::DROP>();
 
-    if (forbidden_permissions.contains(cmd.permission)) {
+    if (forbidden_permissions.contains(permission)) {
         if (ks == db::system_distributed_keyspace::NAME
                 && (table_name == db::system_distributed_keyspace::CDC_DESC_V2
                 || table_name == db::system_distributed_keyspace::CDC_TIMESTAMPS)) {
             return make_exception_future(exceptions::unauthorized_exception(
-                    format("Cannot {} {}", auth::permissions::to_string(cmd.permission), cmd.resource)));
+                    format("Cannot {} {}", auth::permissions::to_string(permission), resource)));
         }
     }
 
     if (service::paxos::paxos_store::try_get_base_table(table_name)) {
-        if (forbidden_permissions.contains(cmd.permission)) {
+        if (forbidden_permissions.contains(permission)) {
             return make_exception_future(exceptions::unauthorized_exception(
-                    format("Cannot {} {}", auth::permissions::to_string(cmd.permission), cmd.resource)));
+                    format("Cannot {} {}", auth::permissions::to_string(permission), resource)));
         }
 
         return _auth_service->underlying_role_manager().is_superuser(*_user->name)
-            .then([&cmd](bool is_superuser) {
+            .then([permission, &resource](bool is_superuser) {
                 return is_superuser
                     ? make_ready_future<>()
                     : make_exception_future(exceptions::unauthorized_exception(
-                        format("Only superusers are allowed to {} {}", 
-                            auth::permissions::to_string(cmd.permission), cmd.resource)));
+                        format("Only superusers are allowed to {} {}",
+                            auth::permissions::to_string(permission), resource)));
             });
     }
 
     return make_ready_future<>();
 }
 
-future<> service::client_state::has_access(const sstring& ks, auth::command_desc cmd, std::optional<bool> is_vector_indexed) const {
-    if (ks.empty()) {
-        throw exceptions::invalid_request_exception("You have not set a keyspace for this session");
-    }
-    if (_bypass_auth_checks) {
-        co_return;
-    }
+static const auto alteration_permissions = auth::permission_set::of<
+        auth::permission::CREATE, auth::permission::ALTER, auth::permission::DROP>();
 
-    validate_login();
-
-    static const auto alteration_permissions = auth::permission_set::of<
-            auth::permission::CREATE, auth::permission::ALTER, auth::permission::DROP>();
+future<> service::client_state::check_access_rules(const sstring& ks, auth::permission permission,
+                const auth::resource& resource, auth::command_desc::type type, auth::permission_set additional_permissions) const {
+    const bool alter_system_with_allowed_opts = (type == auth::command_desc::type::ALTER_SYSTEM_WITH_ALLOWED_OPTS);
 
     // we only care about schema modification.
-    if (alteration_permissions.contains(cmd.permission)) {
+    if (alteration_permissions.contains(permission)) {
         // prevent system keyspace modification
         auto name = ks;
         std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-        if (is_system_keyspace(name) && cmd.type_ != auth::command_desc::type::ALTER_SYSTEM_WITH_ALLOWED_OPTS) {
+        if (is_system_keyspace(name) && !alter_system_with_allowed_opts) {
             throw exceptions::unauthorized_exception(ks + " keyspace is not user-modifiable.");
         }
 
@@ -177,14 +172,14 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
         //
 
         const bool dropping_anything_in_tracing = (name == tracing::trace_keyspace_helper::KEYSPACE_NAME)
-                && (cmd.permission == auth::permission::DROP);
+                && (permission == auth::permission::DROP);
 
-        const bool dropping_auth_keyspace = (cmd.resource == auth::make_data_resource(auth::meta::legacy::AUTH_KS))
-                && (cmd.permission == auth::permission::DROP);
+        const bool dropping_auth_keyspace = (resource == auth::make_data_resource(auth::meta::legacy::AUTH_KS))
+                && (permission == auth::permission::DROP);
 
         if (dropping_anything_in_tracing || dropping_auth_keyspace) {
             throw exceptions::unauthorized_exception(
-                    format("Cannot {} {}", auth::permissions::to_string(cmd.permission), cmd.resource));
+                    format("Cannot {} {}", auth::permissions::to_string(permission), resource));
         }
     }
 
@@ -199,24 +194,24 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
         return tmp;
     }();
 
-    if (cmd.permission == auth::permission::SELECT && readable_system_resources.contains(cmd.resource)) {
+    if (permission == auth::permission::SELECT && readable_system_resources.contains(resource)) {
         co_return;
     }
-    if (alteration_permissions.contains(cmd.permission)) {
-        if (auth::is_protected(*_auth_service, cmd)) {
-            throw exceptions::unauthorized_exception(format("{} is protected", cmd.resource));
+    if (alteration_permissions.contains(permission)) {
+        if (auth::is_protected(*_auth_service, auth::command_desc{permission, resource, type})) {
+            throw exceptions::unauthorized_exception(format("{} is protected", resource));
         }
     }
 
-    if (cmd.resource.kind() == auth::resource_kind::data) {
-        const auto resource_view = auth::data_resource_view(cmd.resource);
+    if (resource.kind() == auth::resource_kind::data) {
+        const auto resource_view = auth::data_resource_view(resource);
         if (resource_view.table()) {
-            co_await check_internal_table_permissions(ks, *resource_view.table(), cmd);
+            co_await check_internal_table_permissions(ks, *resource_view.table(), permission, resource);
         }
     }
 
-    if (cmd.resource.kind() == auth::resource_kind::data
-            && !(cmd.permission == auth::permission::SELECT || cmd.permission == auth::permission::DESCRIBE)
+    if (resource.kind() == auth::resource_kind::data
+            && !(permission == auth::permission::SELECT || permission == auth::permission::DESCRIBE)
             && is_system_keyspace(ks)
             && _user
             && !auth::is_anonymous(*_user)
@@ -225,22 +220,43 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
                 ks + " can be granted only SELECT or DESCRIBE permissions to a non-superuser.");
     }
 
-    static const std::unordered_set<auth::resource> vector_search_system_resources = {
+    if (additional_permissions.mask() == 0) {
+        co_return co_await ensure_has_permission(auth::command_desc{permission, resource, type});
+    }
+    additional_permissions.set(permission);
+    co_return co_await ensure_has_permission<auth::command_desc_with_permission_set>({additional_permissions, resource});
+}
+
+future<> service::client_state::has_access(const sstring& ks, auth::permission permission, const auth::resource& resource,
+                auth::command_desc::type type, auth::permission_set additional_permissions) const {
+    if (ks.empty()) {
+        throw exceptions::invalid_request_exception("You have not set a keyspace for this session");
+    }
+    if (_bypass_auth_checks) {
+        co_return;
+    }
+
+    validate_login();
+
+    // `additional_permissions` only ever widens a SELECT check with other read-authorizing
+    // permissions (e.g. VECTOR_SEARCH_INDEXING), never anything else.
+    SCYLLA_ASSERT(additional_permissions.mask() == 0 || permission == auth::permission::SELECT);
+
+    // System tables read by an external Vector Store engine.
+    // A user holding VECTOR_SEARCH_INDEXING may SELECT from them without holding full SELECT, so
+    // that permission also authorizes the read.
+    static const std::unordered_set<auth::resource> external_index_system_resources = {
         auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::GROUP0_HISTORY),
         auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::VERSIONS),
         auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::CDC_STREAMS),
         auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::CDC_TIMESTAMPS),
         auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::TABLETS),
     };
-
-    if ((cmd.resource.kind() == auth::resource_kind::data && cmd.permission == auth::permission::SELECT && is_vector_indexed.has_value() && is_vector_indexed.value()) ||
-        (cmd.permission == auth::permission::SELECT && vector_search_system_resources.contains(cmd.resource))) {
-
-        co_return co_await ensure_has_permission<auth::command_desc_with_permission_set>({auth::permission_set::of<auth::permission::SELECT, auth::permission::VECTOR_SEARCH_INDEXING>(), cmd.resource});
-
+    if (permission == auth::permission::SELECT && external_index_system_resources.contains(resource)) {
+        additional_permissions.set(auth::permission::VECTOR_SEARCH_INDEXING);
     }
 
-    co_return co_await ensure_has_permission(cmd);
+    co_return co_await check_access_rules(ks, permission, resource, type, additional_permissions);
 }
 
 static bool intersects_permissions(const auth::permission_set& permissions, const auth::command_desc_with_permission_set& cmd) {
@@ -259,7 +275,14 @@ sstring service::client_state::generate_authorization_error_msg(const auth::comm
 }
 
 sstring service::client_state::generate_authorization_error_msg(const auth::command_desc_with_permission_set& cmd) const {
-    sstring perm_names = fmt::format("{}", fmt::join(auth::permissions::to_strings(cmd.permission), ", "));
+    auto permission = cmd.permission.begin();
+    if (std::next(permission) == cmd.permission.end()) {
+        return generate_authorization_error_msg(auth::command_desc{*permission, cmd.resource});
+    }
+    auto names = auth::permissions::to_strings(cmd.permission);
+    std::vector<sstring> sorted_names(names.begin(), names.end());
+    std::sort(sorted_names.begin(), sorted_names.end());
+    sstring perm_names = fmt::format("{}", fmt::join(sorted_names, ", "));
     return format("User {} has none of the permissions ({}) on {} or any of its parents",
             *_user,
             perm_names,

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -239,12 +239,12 @@ future<> service::client_state::has_access(const sstring& ks, auth::permission p
     validate_login();
 
     // `additional_permissions` only ever widens a SELECT check with other read-authorizing
-    // permissions (e.g. VECTOR_SEARCH_INDEXING), never anything else.
+    // permissions (e.g. VECTOR_SEARCH_INDEXING/TEXT_SEARCH_INDEXING), never anything else.
     SCYLLA_ASSERT(additional_permissions.mask() == 0 || permission == auth::permission::SELECT);
 
     // System tables read by an external Vector Store engine.
-    // A user holding VECTOR_SEARCH_INDEXING may SELECT from them without holding full SELECT, so
-    // that permission also authorizes the read.
+    // A user holding VECTOR_SEARCH_INDEXING or TEXT_SEARCH_INDEXING may SELECT from them without
+    // holding full SELECT, so those permissions also authorize the read.
     static const std::unordered_set<auth::resource> external_index_system_resources = {
         auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::GROUP0_HISTORY),
         auth::make_data_resource(db::system_keyspace::NAME, db::system_keyspace::VERSIONS),
@@ -254,6 +254,7 @@ future<> service::client_state::has_access(const sstring& ks, auth::permission p
     };
     if (permission == auth::permission::SELECT && external_index_system_resources.contains(resource)) {
         additional_permissions.set(auth::permission::VECTOR_SEARCH_INDEXING);
+        additional_permissions.set(auth::permission::TEXT_SEARCH_INDEXING);
     }
 
     co_return co_await check_access_rules(ks, permission, resource, type, additional_permissions);

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -448,14 +448,17 @@ public:
     future<> has_all_keyspaces_access(auth::permission) const;
     future<> has_keyspace_access(const sstring&, auth::permission) const;
     future<> has_column_family_access(const sstring&, const sstring&, auth::permission,
-                                      auth::command_desc::type = auth::command_desc::type::OTHER, std::optional<bool> is_vector_indexed = std::nullopt) const;
+                                      auth::command_desc::type = auth::command_desc::type::OTHER, auth::permission_set additional_permissions = {}) const;
 
     future<> has_functions_access(auth::permission p) const;
     future<> has_functions_access(const sstring& ks, auth::permission p) const;
     future<> has_function_access(const sstring& ks, const sstring& function_signature, auth::permission p) const;
 private:
-    future<> check_internal_table_permissions(std::string_view ks, std::string_view table_name, const auth::command_desc& cmd) const;
-    future<> has_access(const sstring& keyspace, auth::command_desc, std::optional<bool> is_vector_indexed = std::nullopt) const;
+    future<> check_internal_table_permissions(std::string_view ks, std::string_view table_name, auth::permission permission, const auth::resource& resource) const;
+    future<> check_access_rules(const sstring& ks, auth::permission permission, const auth::resource& resource,
+                                auth::command_desc::type type, auth::permission_set additional_permissions) const;
+    future<> has_access(const sstring& keyspace, auth::permission permission, const auth::resource& resource,
+                        auth::command_desc::type type = auth::command_desc::type::OTHER, auth::permission_set additional_permissions = {}) const;
     sstring generate_authorization_error_msg(const auth::command_desc&) const;
     sstring generate_authorization_error_msg(const auth::command_desc_with_permission_set&) const;
 

--- a/test/boost/cql_auth_query_test.cc
+++ b/test/boost/cql_auth_query_test.cc
@@ -373,7 +373,7 @@ SEASTAR_TEST_CASE(select_from_vector_indexed_table) {
                 create_user_if_not_exists(env, bob);
                 with_user(env, bob, [&env] {
                     BOOST_REQUIRE_EXCEPTION(env.execute_cql("SELECT * FROM ks.t").get(), exceptions::unauthorized_exception,
-                            exception_predicate::message_contains("User bob has none of the permissions (VECTOR_SEARCH_INDEXING, SELECT) on"));
+                            exception_predicate::message_contains("User bob has none of the permissions (SELECT, VECTOR_SEARCH_INDEXING) on"));
                 });
                 cquery_nofail(env, "GRANT VECTOR_SEARCH_INDEXING ON ALL KEYSPACES TO bob");
                 with_user(env, bob, [&env] {
@@ -387,31 +387,42 @@ SEASTAR_TEST_CASE(select_from_vector_indexed_table) {
             enable_tablets(db_config_with_auth()));
 }
 
-SEASTAR_TEST_CASE(select_from_vector_search_system_table) {
+SEASTAR_TEST_CASE(select_from_external_index_system_tables) {
     return do_with_cql_env_thread(
             [](auto&& env) {
                 create_user_if_not_exists(env, bob);
 
-                // All tables in vector_search_system_resources from client_state.cc
-                const std::vector<sstring> vector_search_system_tables = {
+                // All tables in external_index_system_resources from client_state.cc.
+                const std::vector<sstring> external_index_system_tables = {
                     "system.group0_history",
                     "system.versions",
                     "system.cdc_streams",
                     "system.cdc_timestamps",
+                    "system.tablets",
                 };
 
-                // Without VECTOR_SEARCH_INDEXING permission, bob cannot select from these tables
-                for (const auto& table : vector_search_system_tables) {
+                // Without VECTOR_SEARCH_INDEXING or TEXT_SEARCH_INDEXING permission, bob cannot select from these tables
+                for (const auto& table : external_index_system_tables) {
                     with_user(env, bob, [&env, &table] {
                         BOOST_REQUIRE_EXCEPTION(env.execute_cql(format("SELECT * FROM {}", table)).get(), exceptions::unauthorized_exception,
-                                exception_predicate::message_contains("User bob has none of the permissions (VECTOR_SEARCH_INDEXING, SELECT) on"));
+                                exception_predicate::message_contains("User bob has none of the permissions (SELECT, TEXT_SEARCH_INDEXING, VECTOR_SEARCH_INDEXING) on"));
                     });
                 }
 
                 cquery_nofail(env, "GRANT VECTOR_SEARCH_INDEXING ON ALL KEYSPACES TO bob");
 
                 // With VECTOR_SEARCH_INDEXING permission, bob can select from these tables
-                for (const auto& table : vector_search_system_tables) {
+                for (const auto& table : external_index_system_tables) {
+                    with_user(env, bob, [&env, &table] {
+                        cquery_nofail(env, format("SELECT * FROM {}", table));
+                    });
+                }
+
+                cquery_nofail(env, "REVOKE VECTOR_SEARCH_INDEXING ON ALL KEYSPACES FROM bob");
+                cquery_nofail(env, "GRANT TEXT_SEARCH_INDEXING ON ALL KEYSPACES TO bob");
+
+                // With TEXT_SEARCH_INDEXING permission, bob can also select from these tables
+                for (const auto& table : external_index_system_tables) {
                     with_user(env, bob, [&env, &table] {
                         cquery_nofail(env, format("SELECT * FROM {}", table));
                     });
@@ -436,7 +447,7 @@ SEASTAR_TEST_CASE(select_from_cdc_log_of_vector_indexed_table) {
                 // Without permissions, bob cannot select from the CDC log table
                 with_user(env, bob, [&env] {
                     BOOST_REQUIRE_EXCEPTION(env.execute_cql("SELECT * FROM ks.t_scylla_cdc_log").get(), exceptions::unauthorized_exception,
-                            exception_predicate::message_contains("User bob has none of the permissions (VECTOR_SEARCH_INDEXING, SELECT) on"));
+                            exception_predicate::message_contains("User bob has none of the permissions (SELECT, VECTOR_SEARCH_INDEXING) on"));
                 });
 
                 // Grant VECTOR_SEARCH_INDEXING permission
@@ -445,6 +456,108 @@ SEASTAR_TEST_CASE(select_from_cdc_log_of_vector_indexed_table) {
                 // Now bob can select from the CDC log table
                 with_user(env, bob, [&env] {
                     cquery_nofail(env, "SELECT * FROM ks.t_scylla_cdc_log");
+                });
+            },
+            enable_tablets(db_config_with_auth()));
+}
+
+SEASTAR_TEST_CASE(grant_text_search_indexing) {
+    return do_with_cql_env_thread(
+            [](auto&& env) {
+                create_user_if_not_exists(env, bob);
+                cquery_nofail(env, "CREATE TABLE ks.t (id int PRIMARY KEY, v text)");
+                BOOST_REQUIRE_EXCEPTION(env.execute_cql("GRANT TEXT_SEARCH_INDEXING ON ks.t TO bob").get(), exceptions::syntax_exception,
+                        exception_predicate::message_contains("does not support any of the requested permissions"));
+                BOOST_REQUIRE_EXCEPTION(env.execute_cql("GRANT TEXT_SEARCH_INDEXING ON KEYSPACE ks TO bob").get(), exceptions::syntax_exception,
+                        exception_predicate::message_contains("does not support any of the requested permissions"));
+                cquery_nofail(env, "GRANT TEXT_SEARCH_INDEXING ON ALL KEYSPACES TO bob");
+            },
+            db_config_with_auth());
+}
+
+SEASTAR_TEST_CASE(select_from_fulltext_indexed_table) {
+    return do_with_cql_env_thread(
+            [](auto&& env) {
+                cquery_nofail(env, "CREATE TABLE ks.t (id int PRIMARY KEY, v text)");
+                cquery_nofail(env, "CREATE TABLE ks.t2 (id int PRIMARY KEY, v text)");
+                cquery_nofail(env, "CREATE CUSTOM INDEX ON ks.t(v) USING 'fulltext_index'");
+                create_user_if_not_exists(env, bob);
+                with_user(env, bob, [&env] {
+                    BOOST_REQUIRE_EXCEPTION(env.execute_cql("SELECT * FROM ks.t").get(), exceptions::unauthorized_exception,
+                            exception_predicate::message_contains("User bob has none of the permissions (SELECT, TEXT_SEARCH_INDEXING) on"));
+                });
+                cquery_nofail(env, "GRANT TEXT_SEARCH_INDEXING ON ALL KEYSPACES TO bob");
+                with_user(env, bob, [&env] {
+                    cquery_nofail(env, "SELECT * FROM ks.t");
+                });
+                with_user(env, bob, [&env] {
+                    BOOST_REQUIRE_EXCEPTION(env.execute_cql("SELECT * FROM ks.t2").get(), exceptions::unauthorized_exception,
+                            exception_predicate::message_contains("User bob has no SELECT permission"));
+                });
+            },
+            enable_tablets(db_config_with_auth()));
+}
+
+SEASTAR_TEST_CASE(select_from_cdc_log_of_fulltext_indexed_table) {
+    return do_with_cql_env_thread(
+            [](auto&& env) {
+                // Create a table with a text column and a fulltext index (which enables CDC)
+                cquery_nofail(env, "CREATE TABLE ks.t (id int PRIMARY KEY, v text)");
+                cquery_nofail(env, "CREATE CUSTOM INDEX ON ks.t(v) USING 'fulltext_index'");
+
+                create_user_if_not_exists(env, bob);
+
+                // Without permissions, bob cannot select from the CDC log table
+                with_user(env, bob, [&env] {
+                    BOOST_REQUIRE_EXCEPTION(env.execute_cql("SELECT * FROM ks.t_scylla_cdc_log").get(), exceptions::unauthorized_exception,
+                            exception_predicate::message_contains("User bob has none of the permissions (SELECT, TEXT_SEARCH_INDEXING) on"));
+                });
+
+                // Grant TEXT_SEARCH_INDEXING permission
+                cquery_nofail(env, "GRANT TEXT_SEARCH_INDEXING ON ALL KEYSPACES TO bob");
+
+                // Now bob can select from the CDC log table
+                with_user(env, bob, [&env] {
+                    cquery_nofail(env, "SELECT * FROM ks.t_scylla_cdc_log");
+                });
+            },
+            enable_tablets(db_config_with_auth()));
+}
+
+// TEXT_SEARCH_INDEXING and VECTOR_SEARCH_INDEXING are independent permissions.
+// Neither grants SELECT on a table indexed only with the other index type.
+SEASTAR_TEST_CASE(vector_and_text_search_indexing_permissions_are_isolated) {
+    return do_with_cql_env_thread(
+            [](auto&& env) {
+                cquery_nofail(env, "CREATE TABLE ks.vec_t (id int PRIMARY KEY, v vector<float, 4>)");
+                cquery_nofail(env, "CREATE CUSTOM INDEX ON ks.vec_t(v) USING 'vector_index'");
+                cquery_nofail(env, "CREATE TABLE ks.fts_t (id int PRIMARY KEY, v text)");
+                cquery_nofail(env, "CREATE CUSTOM INDEX ON ks.fts_t(v) USING 'fulltext_index'");
+
+                create_user_if_not_exists(env, bob);
+                cquery_nofail(env, "GRANT TEXT_SEARCH_INDEXING ON ALL KEYSPACES TO bob");
+
+                // TEXT_SEARCH_INDEXING alone does not grant access to a vector-only-indexed table.
+                with_user(env, bob, [&env] {
+                    BOOST_REQUIRE_EXCEPTION(env.execute_cql("SELECT * FROM ks.vec_t").get(), exceptions::unauthorized_exception,
+                            exception_predicate::message_contains("User bob has none of the permissions (SELECT, VECTOR_SEARCH_INDEXING) on"));
+                });
+                // It does grant access to the fulltext-indexed table.
+                with_user(env, bob, [&env] {
+                    cquery_nofail(env, "SELECT * FROM ks.fts_t");
+                });
+
+                cquery_nofail(env, "REVOKE TEXT_SEARCH_INDEXING ON ALL KEYSPACES FROM bob");
+                cquery_nofail(env, "GRANT VECTOR_SEARCH_INDEXING ON ALL KEYSPACES TO bob");
+
+                // VECTOR_SEARCH_INDEXING alone does not grant access to a fulltext-only-indexed table.
+                with_user(env, bob, [&env] {
+                    BOOST_REQUIRE_EXCEPTION(env.execute_cql("SELECT * FROM ks.fts_t").get(), exceptions::unauthorized_exception,
+                            exception_predicate::message_contains("User bob has none of the permissions (SELECT, TEXT_SEARCH_INDEXING) on"));
+                });
+                // It does grant access to the vector-indexed table.
+                with_user(env, bob, [&env] {
+                    cquery_nofail(env, "SELECT * FROM ks.vec_t");
                 });
             },
             enable_tablets(db_config_with_auth()));


### PR DESCRIPTION
`VECTOR_SEARCH_INDEXING` allows a least-privilege role to `SELECT` from vector-indexed tables without granting full `SELECT`. However, it only relaxes access for tables with a vector index, since the check relies on a `dynamic_cast` to `vector_index`, which never matches `fulltext_index` (a sibling subclass of `external_index`). As a result, a role restricted to `VECTOR_SEARCH_INDEXING` cannot read tables that only have a Full-Text Search index, causing FTS indexing to fail in a Cloud deployment where the Vector Store connects with this reduced-privilege role.

This PR adds a new, independent `TEXT_SEARCH_INDEXING` permission that mirrors `VECTOR_SEARCH_INDEXING` but relaxes `SELECT` for tables with a fulltext index instead.

Fixes: [SCYLLADB-3308](https://scylladb.atlassian.net/browse/SCYLLADB-3308)
Refs: [Vector Store Authentication And Authorization](https://scylladb.atlassian.net/wiki/spaces/RND/pages/107085899/Vector+Store+Authentication+And+Authorization+To+ScyllaDB)

Backport to 2026.3: without this change, the Full-Text Search feature will not work in Scylla Cloud, since the `VECTOR_SEARCH_INDEXING` permission does not cover tables indexed only with Full-Text Search.

[SCYLLADB-3308]: https://scylladb.atlassian.net/browse/SCYLLADB-3308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ