### PR TITLE
build(deps): bump sphinx-scylladb-theme from 1.9.2 to 1.9.3 in /docs

### DIFF
--- a/docs/_ext/scylladb_cc_properties.py
+++ b/docs/_ext/scylladb_cc_properties.py
@@ -12,7 +12,7 @@ from docutils import nodes
 from docutils.parsers.rst import directives
 from docutils.statemachine import StringList
 
-from utils import maybe_add_filters
+from utils import get_templates_or_fallback, maybe_add_filters
 
 logger = logging.getLogger(__name__)
 
@@ -195,7 +195,7 @@ class ConfigOption(ObjectDescription):
             raise self.error(f'Option "{name}" not found!')
         builder = self.env.app.builder
         template = self.config.scylladb_cc_properties_option_tmpl
-        return builder.templates.render(template, item)
+        return get_templates_or_fallback(builder).render(template, item)
 
     def transform_content(self,
                           contentnode: addnodes.desc_content) -> None:
@@ -246,7 +246,7 @@ class ConfigOptionList(SphinxDirective):
         template = self.options.get('template')
         if template is None:
             self.error(f'Option "template" not specified!')
-        return builder.templates.render(template, context)
+        return get_templates_or_fallback(builder).render(template, context)
 
     def _make_context(self) -> Dict[str, Any]:
         header = self._resolve_src_path(self.arguments[0])

--- a/docs/_ext/scylladb_metrics.py
+++ b/docs/_ext/scylladb_metrics.py
@@ -10,7 +10,7 @@ from sphinx.util import logging, ws_re
 from docutils.parsers.rst import Directive, directives
 from docutils.statemachine import StringList
 from sphinxcontrib.datatemplates.directive import DataTemplateJSON
-from utils import maybe_add_filters
+from utils import get_templates_or_fallback, maybe_add_filters
 
 sys.path.insert(0, os.path.abspath("../../scripts"))
 import scripts.get_description as metrics
@@ -117,7 +117,7 @@ class MetricsOption(ObjectDescription):
     def _render(self, name, option_type, component, key, source):
         item = {'name': name, 'type': option_type, 'component': component, 'key': key, 'source': source }
         template = self.config.scylladb_metrics_option_template
-        return self.env.app.builder.templates.render(template, item)
+        return get_templates_or_fallback(self.env.app.builder).render(template, item)
 
     def transform_content(self, contentnode: addnodes.desc_content) -> None:
         name = self.arguments[0]

--- a/docs/_ext/scylladb_swagger.py
+++ b/docs/_ext/scylladb_swagger.py
@@ -7,6 +7,8 @@ from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import unchanged
 from sphinx.util import logging, relative_uri
 
+from utils import get_templates
+
 LOGGER = logging.getLogger(__name__)
 
 class SwaggerIncDirective(Directive):
@@ -20,7 +22,10 @@ class SwaggerIncDirective(Directive):
         app = self.state.document.settings.env.app
         env = self.state.document.settings.env
         app = env.app
-        template_env = app.builder.templates.environment        
+        templates = get_templates(app.builder)
+        if templates is None:
+            return []
+        template_env = templates.environment
         try:
             template = template_env.get_template(template_file)
         except Exception as e:
@@ -41,12 +46,15 @@ class SwaggerDirective(Directive):
         env = self.state.document.settings.env
         config = self.state.document.settings.env.config
         app = self.state.document.settings.env.app
-        template_env = app.builder.templates.environment
+        templates = get_templates(app.builder)
+        if templates is None:
+            return []
+        template_env = templates.environment
 
         spec_file = self.options.get('spec')
         spec_file_path = "_static/" + spec_file
         template_file = self.options.get('template', config.scylladb_swagger_template)
-        
+
         try:
             template = template_env.get_template(template_file)
         except Exception as e:
@@ -55,20 +63,23 @@ class SwaggerDirective(Directive):
         swagger_file_name = os.path.splitext(os.path.basename(spec_file))[0]
         rendered_html = template.render(swagger_file_path= spec_file_path, swagger_file_name=swagger_file_name)
         raw_node = nodes.raw('', rendered_html, format='html')
-        
+
         return [raw_node]
 
 
 class SwaggerProcessor():
 
     def run(self, app, exception=None):
+        if get_templates(app.builder) is None:
+            # Non-HTML builder: nothing references these static assets.
+            return
         config = app.config
         folder_name = 'api-doc'
         source_dir = source_dir = os.path.join(app.srcdir, config.scylladb_swagger_origin_api)
         source_folder = os.path.join(source_dir, folder_name)
         dest_dir = os.path.join(app.builder.outdir, '_static/api')
         dest_folder = os.path.join(dest_dir, folder_name)
-        
+
         if os.path.exists(dest_folder):
             LOGGER.info(f"{folder_name} directory already exists in {dest_folder}. Skipping copy.")
         elif os.path.exists(source_folder):
@@ -82,7 +93,7 @@ def custom_pathto(app, docname, typ=None, anchor=None):
     current_doc = app.env.docname
     current_version = os.environ.get('SPHINX_MULTIVERSION_NAME', '')
     flag = os.environ.get('FLAG', 'manual')
-    
+
     if current_version:
         prefix = "/manual/" if flag == 'manual' else "/"
         return f"{prefix}{current_version}/{docname}"
@@ -104,10 +115,16 @@ def setup(app):
         default="swagger_inc.tmpl",
         rebuild="html",
     )
+    def add_template_globals(app):
+        templates = get_templates(app.builder)
+        if templates is None:
+            return
+        templates.environment.globals.update(
+            custom_pathto=lambda docname, typ=None, anchor=None: custom_pathto(app, docname, typ, anchor)
+        )
+
     app.connect("builder-inited",  SwaggerProcessor().run)
-    app.connect('builder-inited', lambda app: app.builder.templates.environment.globals.update(
-        custom_pathto=lambda docname, typ=None, anchor=None: custom_pathto(app, docname, typ, anchor)
-    ))
+    app.connect('builder-inited', add_template_globals)
 
     app.add_directive("scylladb_swagger_inc", SwaggerIncDirective)
     app.add_directive("scylladb_swagger", SwaggerDirective)

--- a/docs/_ext/utils.py
+++ b/docs/_ext/utils.py
@@ -1,3 +1,6 @@
+import os
+
+
 def readable_desc(description: str) -> str:
     """
     This function is deprecated and maintained only for backward compatibility 
@@ -17,29 +20,59 @@ def readable_desc_rst(description):
     indent = ' ' * 3
     lines = description.split('\n')
     cleaned_lines = []
-    
+
     for line in lines:
 
         cleaned_line = line.replace('\\n', '\n')
 
         cleaned_line = cleaned_line.replace('\\t', '\n' + indent * 2)
-        
+
         if line.endswith('"'):
             cleaned_line = cleaned_line[:-1] + ' '
 
         cleaned_line = cleaned_line.lstrip()
         cleaned_line = cleaned_line.replace('"', '')
         cleaned_line = cleaned_line.replace('`', '\\`')
-        
+
         if cleaned_line != '':
             cleaned_line = indent + cleaned_line
             cleaned_lines.append(cleaned_line)
-    
+
     return ''.join(cleaned_lines)
 
 
+def get_templates(builder):
+    """Return the builder's template bridge, or ``None`` if it has none.
+    """
+    return getattr(builder, 'templates', None)
+
+
+class _FallbackTemplates:
+    """Stand-in template bridge that loads ``templates_path`` directly."""
+
+    def __init__(self, builder):
+        from jinja2 import Environment, FileSystemLoader
+
+        search_path = [os.path.join(builder.srcdir, path)
+                       for path in builder.config.templates_path]
+        self.environment = Environment(loader=FileSystemLoader(search_path))
+
+    def render(self, template, context):
+        return self.environment.get_template(template).render(context)
+
+
+def get_templates_or_fallback(builder):
+    """Like get_templates, but never None: use it when the output is content."""
+    templates = get_templates(builder)
+    if templates is not None:
+        return templates
+    if not hasattr(builder, '_scylladb_fallback_templates'):
+        builder._scylladb_fallback_templates = _FallbackTemplates(builder)
+    return builder._scylladb_fallback_templates
+
+
 def maybe_add_filters(builder):
-    env = builder.templates.environment
+    env = get_templates_or_fallback(builder).environment
     if 'readable_desc' not in env.filters:
         env.filters['readable_desc'] = readable_desc
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ author = u"ScyllaDB Project Contributors"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'lib', 'lib64','**/_common/*', 'README.md', 'README-metrics.md', 'index.md', '.git', '.github', '_utils', 'rst_include', 'venv', '.venv', 'dev', '_data/**']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'lib', 'lib64','**/_common/*', 'README.md', 'README-metrics.md', 'index.md', '.git', '.github', '_utils', 'rst_include', 'venv', '.venv', 'dev', '_data/**', '**/README.md']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"

--- a/docs/features/workload-prioritization.rst
+++ b/docs/features/workload-prioritization.rst
@@ -19,9 +19,8 @@ For example, consider the following two workloads:
   - In essence - Latency agnostic
 
 Using Service Level CQL commands, database administrators (working on ScyllaDB) can set different workload prioritization levels (levels of service) for each workload without sacrificing latency or throughput.
-By assigning each service level to the different roles within your organization, DBAs ensure that each role_ receives the level of service the role requires.
+By assigning each service level to the different roles within your organization, DBAs ensure that each :doc:`role </operating-scylla/security/rbac-usecase>` receives the level of service the role requires.
 
-.. _`role` : /operating-scylla/security/rbac_usecase/
 
 Initially ScyllaDB has two service levels:
  * ``'default'`` - Receives all load unassigned to any other service level.

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -904,7 +904,7 @@ Similar to ``scylla sstable dump-data --partition|--partition-file``, with some 
 * Also supports negative filters (keep all partitions except the those specified).
 
 The partition list can be provided either via the ``--partition`` command line argument, or via a file path passed to the the ``--partitions-file`` argument. The file should contain one partition key per line.
-Partition keys should be provided in the hex format, as produced by `scylla types serialize </operating-scylla/admin-tools/scylla-types/>`_.
+Partition keys should be provided in the hex format, as produced by :doc:`scylla types serialize </operating-scylla/admin-tools/scylla-types>`.
 
 With ``--include``, only the specified partitions are kept from the input SSTable(s). With ``--exclude``, the specified partitions are discarded and won't be written to the output SSTable(s).
 It is possible that certain input SSTable(s) won't have any content left after the filtering. These input SSTable(s) will not have a matching output SSTable.

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "pygments>=2.18.0",
     "redirects_cli>=0.1.3",
-    "sphinx-scylladb-theme>=1.9.2",
+    "sphinx-scylladb-theme>=1.9.3",
     "sphinx-sitemap>=2.9.0",
     "sphinx-autobuild>=2025.08.25",
     "sphinx>=9.0",

--- a/docs/troubleshooting/error-messages/schema-mismatch.rst
+++ b/docs/troubleshooting/error-messages/schema-mismatch.rst
@@ -44,7 +44,7 @@ Solution
 
 1. Wait for five minutes and run ``nodetool describecluster`` to verify that the schema is synced.
 
-2. If there is still a mismatch error message execute a `rolling restart`_.
+2. If there is still a mismatch error message execute a :doc:`rolling restart </operating-scylla/procedures/config-change/rolling-restart>`.
 
 3. Verify schema is synced
 
@@ -60,4 +60,3 @@ For example:
 	   Schema versions:
 		   1fd57629-6bae-3f23-97d1-ffa4208cc372: [172.17.0.1, 172.17.0.2, 172.17.0.3]
 
-..  _`rolling restart`: /operating-scylla/procedures/config-change/rolling_restart/

--- a/docs/troubleshooting/failed-decommission.rst
+++ b/docs/troubleshooting/failed-decommission.rst
@@ -20,9 +20,8 @@ Check the node status from the other nodes in the cluster to verify that the sta
 .. note::
   The ``nodetool netstats`` command does not show ongoing streaming. 
 
-The following error message will appear in the logs_:
+The following error message will appear in the :doc:`logs </getting-started/logging>`:
 
-.. _logs: /getting-started/logging/ 
 
 .. code-block:: shell
 

--- a/docs/upgrade/upgrade-guides/upgrade-guide-from-2026.1-to-2026.2/upgrade-guide-from-2026.1-to-2026.2.rst
+++ b/docs/upgrade/upgrade-guides/upgrade-guide-from-2026.1-to-2026.2/upgrade-guide-from-2026.1-to-2026.2.rst
@@ -3,9 +3,6 @@
 .. |SRC_VERSION| replace:: 2026.1
 .. |NEW_VERSION| replace:: 2026.2
 
-.. |ROLLBACK| replace:: rollback
-.. _ROLLBACK: ./#rollback-procedure
-
 .. |SCYLLA_METRICS| replace:: ScyllaDB Metrics Update - ScyllaDB 2026.1 to 2026.2
 .. _SCYLLA_METRICS: ../metric-update-2026.1-to-2026.2
 
@@ -140,7 +137,7 @@ Download and install the new release
 ------------------------------------
 
 Before upgrading, check what version you are running now using ``scylla --version``. 
-You should take note of the current version in case you want to |ROLLBACK|_ the upgrade.
+You should take note of the current version in case you want to :ref:`rollback <rollback-2026.1-to-2026.2>` the upgrade.
 
 .. tabs::
 
@@ -219,6 +216,8 @@ Validate
 #. Check again after two minutes to validate no new issues are introduced.
 
 Once you are sure the node upgrade was successful, move to the next node in the cluster.
+
+.. _rollback-2026.1-to-2026.2:
 
 Rollback Procedure
 ==================

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -497,7 +497,7 @@ requires-dist = [
     { name = "sphinx-collapse", specifier = ">=0.1.3" },
     { name = "sphinx-multiversion-scylla", specifier = ">=0.3.8" },
     { name = "sphinx-scylladb-markdown", specifier = ">=0.1.4" },
-    { name = "sphinx-scylladb-theme", specifier = ">=1.9.2" },
+    { name = "sphinx-scylladb-theme", specifier = ">=1.9.3" },
     { name = "sphinx-sitemap", specifier = ">=2.9.0" },
     { name = "sphinxcontrib-datatemplates", specifier = ">=0.9.2" },
 ]
@@ -620,6 +620,33 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-llm"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+    { name = "sphinx-markdown-builder" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/23/fe184bf9c6761c2cd04dc5b5456b717f626143663a3004f628636a2f7b0e/sphinx_llm-0.4.1.tar.gz", hash = "sha256:0789185dcbbecc00b5e25aa3db6342b98dad6a9def96088a9e50fa0203fda090", size = 280250, upload-time = "2026-04-02T09:09:18.881Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/2b/a54c49b42b25a6eb6039daf882f06488812c28e32734e944b2f7b6f82554/sphinx_llm-0.4.1-py3-none-any.whl", hash = "sha256:d7c8ee2a6335636b628ea2b26cd1e1dee1f0cf9c40fe51b20f201af1c05b95f5", size = 28453, upload-time = "2026-04-02T09:09:17.632Z" },
+]
+
+[[package]]
+name = "sphinx-markdown-builder"
+version = "0.6.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "sphinx" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/58/0b7b9a7d071140b3705885d51932e8b62f520388c2772e4952189971727b/sphinx_markdown_builder-0.6.10.tar.gz", hash = "sha256:cd5acf88d52ea0146a712fd557404f10326dff3428a78ba928e59b1727fd4a86", size = 22688, upload-time = "2026-03-11T10:56:57.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/8f/9fecf3d081d5cd49eff83a17b9fef50ed741e6223ab3bb906de4ab0068f9/sphinx_markdown_builder-0.6.10-py3-none-any.whl", hash = "sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e", size = 16700, upload-time = "2026-03-11T10:56:56.135Z" },
+]
+
+[[package]]
 name = "sphinx-markdown-tables"
 version = "0.0.17"
 source = { registry = "https://pypi.org/simple" }
@@ -672,7 +699,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-scylladb-theme"
-version = "1.9.2"
+version = "1.9.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -680,14 +707,15 @@ dependencies = [
     { name = "setuptools" },
     { name = "sphinx-collapse" },
     { name = "sphinx-copybutton" },
+    { name = "sphinx-llm" },
     { name = "sphinx-notfound-page" },
     { name = "sphinx-substitution-extensions" },
     { name = "sphinx-tabs" },
     { name = "sphinxcontrib-mermaid" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/92/e30549be27dfdbfb3a1bf52cbc5496c190230dd2d4e7a41c8bafada8f4a2/sphinx_scylladb_theme-1.9.2.tar.gz", hash = "sha256:f4319deeefcc446779375c2d9cbdd922eaf63da092a50def74247dd2156f1274", size = 1683295, upload-time = "2026-04-14T11:07:30.662Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/43/2c6ca729655d99c69a7970efe56345d4bf345a345511ce4dc247aa5380df/sphinx_scylladb_theme-1.9.3.tar.gz", hash = "sha256:2a80252d6a5bb1ef8b61b6af47db4b7cbdec9c056b339ad4bc2cee97604603ad", size = 1691127, upload-time = "2026-07-16T16:44:51.404Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/ff/9957eef93c1b46dbbccd66cb4766d513c1061961daaa60fcfc1a78b3bc20/sphinx_scylladb_theme-1.9.2-py3-none-any.whl", hash = "sha256:1d75463151693c3b31ef48b2401aa4db18953fc515b4061c6f127182242e0280", size = 1669961, upload-time = "2026-04-14T11:07:28.944Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0e/b79e97434339b4b935535709b5b20491451e5c5de5d4b90c8cafbdcc7c2f/sphinx_scylladb_theme-1.9.3-py3-none-any.whl", hash = "sha256:2b9eb999421711deb7ca0fbd5c287c668cdaee7bd41d19abf75b140e8e6982d4", size = 1674682, upload-time = "2026-07-16T16:44:49.644Z" },
 ]
 
 [[package]]
@@ -837,6 +865,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Replaces #30780

Updates sphinx-scylladb-theme to the latest version (1.9.3) and fixes the build errors raised by #30780.

## Problem

1.9.3 adds `sphinx-llm`, which generates `llms.txt` files from a second Sphinx pass using a markdown builder. 

That pass breaks three assumptions in `docs/_ext/` extensions. Additionally, the release also lints internal docs linked as external URLs.

## Solution

- `templates` attribute: Only HTML builders have one. Swagger is a JS widget, so it renders nothing without it, `cc_properties` and metrics render real content, so they fall back to plain Jinja.
- `_static/api/README.md`:** The markdown builder doesn't skip `html_static_path`, so it read this as a page. Added `**/README.md` to exclude_patterns`.
- **Links**: Converted the five flagged to `:doc:`/`:ref:`.

## How to test

Run `make preview`, check theme version in footer is 1.9.3:

<img width="666" height="59" alt="image" src="https://github.com/user-attachments/assets/c83ed55d-7475-4f3b-a8eb-e166362c016b" />
