### PR TITLE
schema: use chunked_vector for column storage to avoid oversized allocations

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -783,7 +783,7 @@ static void add_column(schema_builder& builder, const std::string& name, const r
                 // but rather extracts a single value from the ":attrs" map)
                 alternator_type at = type_info_from_string(type).atype;
                 builder.with_computed_column(to_bytes(name), dt, kind,
-                    std::make_unique<extract_from_attrs_column_computation>(to_bytes(name), at));
+                    seastar::make_shared<extract_from_attrs_column_computation>(to_bytes(name), at));
             } else {
                 builder.with_column(to_bytes(name), dt, kind);
             }
@@ -1231,10 +1231,6 @@ static std::unordered_set<std::string> validate_attribute_definitions(std::strin
 // member from the ":attrs" map instead of a real column in the schema:
 
 const bytes extract_from_attrs_column_computation::MAP_NAME = executor::ATTRS_COLUMN_NAME;
-
-column_computation_ptr extract_from_attrs_column_computation::clone() const {
-    return std::make_unique<extract_from_attrs_column_computation>(*this);
-}
 
 // Serialize the *definition* of this column computation into a JSON
 // string with a unique "type" string - TYPE_NAME - which then causes

--- a/alternator/extract_from_attrs.hh
+++ b/alternator/extract_from_attrs.hh
@@ -38,7 +38,6 @@ class extract_from_attrs_column_computation : public regular_column_transformati
     // therefore in desired_type.
     alternator_type _desired_type;
 public:
-    virtual column_computation_ptr clone() const override;
     // TYPE_NAME is a unique string that distinguishes this class from other
     // column_computation subclasses. column_computation::deserialize() will
     // construct an object of this subclass if it sees a "type" TYPE_NAME.

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -246,7 +246,7 @@ view_ptr create_index_statement::create_view_for_index(const schema_ptr schema, 
             builder.with_column(index_target->name(), index_target->type, column_kind::partition_key);
         } else {
             bytes key_column_name = get_available_computed_collection_column_name(*schema);
-            column_computation_ptr collection_column_computation_ptr = [&name = index_target->name(), target_type] {
+            column_computation_ptr collection_column_computation_ptr = seastar::make_shared<collection_column_computation>([&name = index_target->name(), target_type] {
                 switch (target_type) {
                     case cql3::statements::index_target::target_type::keys:
                         return collection_column_computation::for_keys(name);
@@ -257,14 +257,14 @@ view_ptr create_index_statement::create_view_for_index(const schema_ptr schema, 
                     default:
                         throw std::logic_error(format("create_view_for_index: invalid target_type, received {}", to_sstring(target_type)));
                 }
-            }().clone();
+            }());
 
             data_type t = type_for_computed_column(target_type, *index_target->type);
             builder.with_computed_column(key_column_name, t, column_kind::partition_key, std::move(collection_column_computation_ptr));
         }
         // Additional token column is added to ensure token order on secondary index queries
         bytes token_column_name = get_available_token_column_name(*schema);
-        builder.with_computed_column(token_column_name, long_type, column_kind::clustering_key, std::make_unique<token_column_computation>());
+        builder.with_computed_column(token_column_name, long_type, column_kind::clustering_key, seastar::make_shared<token_column_computation>());
 
         for (auto& col : schema->partition_key_columns()) {
             if (col == *index_target) {
@@ -291,7 +291,7 @@ view_ptr create_index_statement::create_view_for_index(const schema_ptr schema, 
         if (target_type == cql3::statements::index_target::target_type::collection_values) {
             data_type t = type_for_computed_column(cql3::statements::index_target::target_type::keys, *index_target->type);
             bytes column_name = get_available_column_name(*schema, "keys_for_values_idx");
-            builder.with_computed_column(column_name, t, column_kind::clustering_key, collection_column_computation::for_keys(index_target->name()).clone());
+            builder.with_computed_column(column_name, t, column_kind::clustering_key, seastar::make_shared<collection_column_computation>(collection_column_computation::for_keys(index_target->name())));
         }
     }
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -64,9 +64,9 @@ future<> create_table_statement::check_access(query_processor& qp, const service
 }
 
 // Column definitions
-std::vector<column_definition> create_table_statement::get_columns() const
+utils::chunked_vector<column_definition> create_table_statement::get_columns() const
 {
-    std::vector<column_definition> column_defs;
+    utils::chunked_vector<column_definition> column_defs;
     column_defs.reserve(_columns.size());
     for (auto&& col : _columns) {
         column_kind kind = column_kind::regular_column;

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -17,6 +17,8 @@
 
 #include "schema/schema_fwd.hh"
 
+#include "utils/chunked_vector.hh"
+
 #include <seastar/core/shared_ptr.hh>
 
 #include <seastar/util/indirect.hh>
@@ -86,7 +88,7 @@ public:
 
     friend raw_statement;
 private:
-    std::vector<column_definition> get_columns() const;
+    utils::chunked_vector<column_definition> get_columns() const;
 
     void apply_properties_to(schema_builder& builder, const data_dictionary::database) const;
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2733,7 +2733,7 @@ std::unique_ptr<cql3::statements::raw::select_statement> build_select_statement(
             const std::string_view& cf_name,
             const std::string_view& where_clause,
             bool select_all_columns,
-            const std::vector<column_definition>& selected_columns) {
+            const utils::chunked_vector<column_definition>& selected_columns) {
     std::ostringstream out;
     out << "SELECT ";
     if (select_all_columns) {

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -59,7 +59,7 @@ static std::unordered_map<sstring, rjson::value> handle_case_sensitivity(rjson::
 }
 
 std::unordered_map<sstring, bytes_opt>
-parse(const sstring& json_string, const std::vector<column_definition>& expected_receivers) {
+parse(const sstring& json_string, const schema::columns_type& expected_receivers) {
     std::unordered_map<sstring, bytes_opt> json_map;
     auto prepared_map = handle_case_sensitivity(rjson::parse(json_string));
     for (const auto& def : expected_receivers) {

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -20,6 +20,7 @@
 #include "cql3/statements/raw/select_statement.hh"
 #include "cql3/dialect.hh"
 
+#include "utils/chunked_vector.hh"
 #include "utils/mutable_view.hh"
 
 namespace utils {
@@ -56,7 +57,7 @@ std::unique_ptr<cql3::statements::raw::select_statement> build_select_statement(
         const std::string_view& cf_name,
         const std::string_view& where_clause,
         bool select_all_columns,
-        const std::vector<column_definition>& selected_columns);
+        const utils::chunked_vector<column_definition>& selected_columns);
 
 /// maybe_quote() takes an identifier - the name of a column, table or
 /// keyspace name - and transforms it to a string which can be used in CQL

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -127,7 +127,7 @@ const sstring version = "3";
 using computed_columns_map = std::unordered_map<bytes, column_computation_ptr>;
 static computed_columns_map get_computed_columns(const schema_mutations& sm);
 
-static std::vector<column_definition> create_columns_from_column_rows(
+static schema::columns_type create_columns_from_column_rows(
                 const query::result_set& rows, const sstring& keyspace,
                 const sstring& table, bool is_super, column_view_virtual is_view_virtual, const computed_columns_map& computed_columns,
                 const data_dictionary::user_types_storage& user_types);
@@ -2241,7 +2241,7 @@ schema_ptr create_table_from_mutations(const schema_ctxt& ctxt, schema_mutations
     }
 
     auto computed_columns = get_computed_columns(sm);
-    std::vector<column_definition> column_defs = create_columns_from_column_rows(
+    schema::columns_type column_defs = create_columns_from_column_rows(
             query::result_set(sm.columns_mutation()),
             ks_name,
             cf_name,/*,
@@ -2422,7 +2422,7 @@ static computed_columns_map get_computed_columns(const schema_mutations& sm) {
     }) | std::ranges::to<computed_columns_map>();
 }
 
-static std::vector<column_definition> create_columns_from_column_rows(
+static schema::columns_type create_columns_from_column_rows(
                                                                const query::result_set& rows,
                                                                const sstring& keyspace,
                                                                const sstring& table, /*,
@@ -2432,7 +2432,7 @@ static std::vector<column_definition> create_columns_from_column_rows(
                                                                const computed_columns_map& computed_columns,
                                                                const data_dictionary::user_types_storage& user_types)
 {
-    std::vector<column_definition> columns;
+    schema::columns_type columns;
     for (auto&& row : rows.rows()) {
         auto kind = deserialize_kind(row.get_nonnull<sstring>("kind"));
         auto type = cql_type_parser::parse(keyspace, row.get_nonnull<sstring>("type"), user_types);
@@ -2796,7 +2796,7 @@ future<std::optional<column_mapping>> get_column_mapping_if_exists(db::system_ke
     if (results->empty()) {
         co_return std::nullopt;
     }
-    std::vector<column_definition>  static_columns, regular_columns;
+    utils::chunked_vector<column_definition>  static_columns, regular_columns;
     for (const auto& row : *results) {
         auto kind = deserialize_kind(row.get_as<sstring>("kind"));
         auto type = cql_type_parser::parse("" /*unused*/, row.get_as<sstring>("type"), data_dictionary::dummy_user_types_storage());
@@ -2814,7 +2814,7 @@ future<std::optional<column_mapping>> get_column_mapping_if_exists(db::system_ke
             regular_columns.emplace_back(name_bytes, type, kind, position);
         }
     }
-    std::vector<column_mapping_entry> cm_columns;
+    utils::chunked_vector<column_mapping_entry> cm_columns;
     for (const column_definition& def : boost::range::join(static_columns, regular_columns)) {
         cm_columns.emplace_back(column_mapping_entry{def.name(), def.type});
     }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2449,7 +2449,7 @@ static std::vector<column_definition> create_columns_from_column_rows(
         column_computation_ptr computation;
         auto computed_it = computed_columns.find(name_bytes);
         if (computed_it != computed_columns.end()) {
-            computation = computed_it->second->clone();
+            computation = computed_it->second;
         }
 
         columns.emplace_back(name_bytes, type, kind, position, is_view_virtual, std::move(computation));

--- a/idl/mutation.idl.hh
+++ b/idl/mutation.idl.hh
@@ -9,6 +9,8 @@
 #include "mutation/counters.hh"
 #include "mutation/mutation.hh"
 
+#include "utils/chunked_vector.hh"
+
 #include "idl/uuid.idl.hh"
 #include "idl/keys.idl.hh"
 #include "idl/position_in_partition.idl.hh"
@@ -142,7 +144,7 @@ class column_mapping_entry {
 };
 
 class column_mapping {
-    std::vector<column_mapping_entry> columns();
+    utils::chunked_vector<column_mapping_entry> columns();
     uint32_t n_static();
 };
 

--- a/schema/column_computation.hh
+++ b/schema/column_computation.hh
@@ -11,6 +11,7 @@
 #include "bytes.hh"
 #include "utils/managed_bytes.hh"
 #include <memory>
+#include <seastar/core/shared_ptr.hh>
 
 class schema;
 class partition_key;
@@ -23,7 +24,7 @@ struct view_key_and_action;
 }
 
 class column_computation;
-using column_computation_ptr = std::unique_ptr<column_computation>;
+using column_computation_ptr = seastar::shared_ptr<const column_computation>;
 
 /*
  * Column computation represents a computation performed in order to obtain a value for a computed column.
@@ -40,8 +41,6 @@ public:
     virtual ~column_computation() = default;
 
     static column_computation_ptr deserialize(bytes_view raw);
-
-    virtual column_computation_ptr clone() const = 0;
 
     virtual bytes serialize() const = 0;
     virtual bytes compute_value(const schema& schema, const partition_key& key) const = 0;
@@ -70,9 +69,6 @@ public:
  */
 class legacy_token_column_computation : public column_computation {
 public:
-    virtual column_computation_ptr clone() const override {
-        return std::make_unique<legacy_token_column_computation>(*this);
-    }
     virtual bytes serialize() const override;
     virtual bytes compute_value(const schema& schema, const partition_key& key) const override;
 };
@@ -91,9 +87,6 @@ public:
  */
 class token_column_computation : public column_computation {
 public:
-    virtual column_computation_ptr clone() const override {
-        return std::make_unique<token_column_computation>(*this);
-    }
     virtual bytes serialize() const override;
     virtual bytes compute_value(const schema& schema, const partition_key& key) const override;
 };
@@ -136,9 +129,6 @@ public:
 
     virtual bytes serialize() const override;
     virtual bytes compute_value(const schema& schema, const partition_key& key) const override;
-    virtual column_computation_ptr clone() const override {
-        return std::make_unique<collection_column_computation>(*this);
-    }
     virtual bool depends_on_non_primary_key_column() const override {
         return true;
     }

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -2227,10 +2227,10 @@ column_computation_ptr column_computation::deserialize(bytes_view raw) {
     }
     const std::string_view type = rjson::to_string_view(*type_json);
     if (type == "token") {
-        return std::make_unique<legacy_token_column_computation>();
+        return seastar::make_shared<legacy_token_column_computation>();
     }
     if (type == "token_v2") {
-        return std::make_unique<token_column_computation>();
+        return seastar::make_shared<token_column_computation>();
     }
     if (type.starts_with("collection_")) {
         const rjson::value* collection_name = rjson::find(parsed, "collection_name");
@@ -2239,12 +2239,12 @@ column_computation_ptr column_computation::deserialize(bytes_view raw) {
             auto collection = rjson::to_string_view(*collection_name);
             auto collection_as_bytes = bytes(collection.begin(), collection.end());
             if (auto collection = collection_column_computation::for_target_type(type, collection_as_bytes)) {
-                return collection->clone();
+                return collection;
             }
         }
     }
     if (type == alternator::extract_from_attrs_column_computation::TYPE_NAME) {
-        return std::make_unique<alternator::extract_from_attrs_column_computation>(parsed);
+        return seastar::make_shared<alternator::extract_from_attrs_column_computation>(parsed);
     }
     throw std::runtime_error(format("Incorrect column computation type {} found when parsing {}", *type_json, parsed));
 }
@@ -2291,13 +2291,13 @@ bytes collection_column_computation::serialize() const {
 
 column_computation_ptr collection_column_computation::for_target_type(std::string_view type, const bytes& collection_name) {
     if (type == "collection_keys") {
-        return collection_column_computation::for_keys(collection_name).clone();
+        return seastar::make_shared<collection_column_computation>(for_keys(collection_name));
     }
     if (type == "collection_values") {
-        return collection_column_computation::for_values(collection_name).clone();
+        return seastar::make_shared<collection_column_computation>(for_values(collection_name));
     }
     if (type == "collection_entries") {
-        return collection_column_computation::for_entries(collection_name).clone();
+        return seastar::make_shared<collection_column_computation>(for_entries(collection_name));
     }
     return {};
 }

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -271,7 +271,7 @@ schema::make_column_specification(const column_definition& def) const {
     return make_lw_shared<cql3::column_specification>(_raw._ks_name, _raw._cf_name, std::move(id), def.type);
 }
 
-v3_columns::v3_columns(std::vector<column_definition> cols, bool is_dense, bool is_compound)
+v3_columns::v3_columns(utils::chunked_vector<column_definition> cols, bool is_dense, bool is_compound)
     : _is_dense(is_dense)
     , _is_compound(is_compound)
     , _columns(std::move(cols))
@@ -283,7 +283,7 @@ v3_columns::v3_columns(std::vector<column_definition> cols, bool is_dense, bool 
 
 v3_columns v3_columns::from_v2_schema(const schema& s) {
     data_type static_column_name_type = utf8_type;
-    std::vector<column_definition> cols;
+    utils::chunked_vector<column_definition> cols;
 
     if (s.is_static_compact_table()) {
         if (s.has_static_columns()) {
@@ -358,7 +358,7 @@ const std::unordered_map<bytes, const column_definition*>& v3_columns::columns_b
     return _columns_by_name;
 }
 
-const std::vector<column_definition>& v3_columns::all_columns() const {
+const utils::chunked_vector<column_definition>& v3_columns::all_columns() const {
     return _columns;
 }
 
@@ -383,7 +383,7 @@ void schema::rebuild() {
     }
 
     {
-        std::vector<column_mapping_entry> cm_columns;
+        utils::chunked_vector<column_mapping_entry> cm_columns;
         for (const column_definition& def : std::views::join(std::array{static_columns(), regular_columns()})) {
             cm_columns.emplace_back(column_mapping_entry{def.name(), def.type});
         }
@@ -431,15 +431,17 @@ schema::schema(private_tag, const raw_schema& raw, const schema_static_props& pr
 
         auto& cols = _raw._columns;
         std::array<column_count_type, 4> count = { 0, 0, 0, 0 };
-        auto i = cols.begin();
-        auto e = cols.end();
+        columns_type grouped;
+        grouped.reserve(cols.size());
         for (auto k : { column_kind::partition_key, column_kind::clustering_key, column_kind::static_column, column_kind::regular_column }) {
-            auto j = std::stable_partition(i, e, [k](const auto& c) {
-                return c.kind == k;
-            });
-            count[column_count_type(k)] = std::distance(i, j);
-            i = j;
+            for (auto& c : cols) {
+                if (c.kind == k) {
+                    grouped.push_back(std::move(c));
+                    ++count[column_count_type(k)];
+                }
+            }
         }
+        cols = std::move(grouped);
         return std::array<column_count_type, 3> {
                 count[0],
                 count[0] + count[1],

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -10,6 +10,7 @@
 
 #include "cql3/description.hh"
 #include "utils/assert.hh"
+#include "utils/chunked_vector.hh"
 #include <functional>
 #include <optional>
 #include <unordered_map>
@@ -357,15 +358,15 @@ private:
     // Contains _n_static definitions for static columns followed by definitions for regular columns,
     // both ordered by consecutive column_ids.
     // Primary key column sets are not mutable so we don't need to map them.
-    std::vector<column_mapping_entry> _columns;
+    utils::chunked_vector<column_mapping_entry> _columns;
     column_count_type _n_static = 0;
 public:
     column_mapping() {}
-    column_mapping(std::vector<column_mapping_entry> columns, column_count_type n_static)
+    column_mapping(utils::chunked_vector<column_mapping_entry> columns, column_count_type n_static)
             : _columns(std::move(columns))
             , _n_static(n_static)
     { }
-    const std::vector<column_mapping_entry>& columns() const { return _columns; }
+    const utils::chunked_vector<column_mapping_entry>& columns() const { return _columns; }
     column_count_type n_static() const { return _n_static; }
     const column_mapping_entry& column_at(column_kind kind, column_id id) const;
     const column_mapping_entry& static_column_at(column_id id) const;
@@ -420,17 +421,17 @@ class view_info;
 class v3_columns {
     bool _is_dense = false;
     bool _is_compound = false;
-    std::vector<column_definition> _columns;
+    utils::chunked_vector<column_definition> _columns;
     std::unordered_map<bytes, const column_definition*> _columns_by_name;
 public:
-    v3_columns(std::vector<column_definition> columns, bool is_dense, bool is_compound);
+    v3_columns(utils::chunked_vector<column_definition> columns, bool is_dense, bool is_compound);
     v3_columns() = default;
     v3_columns(v3_columns&&) = default;
     v3_columns& operator=(v3_columns&&) = default;
     v3_columns(const v3_columns&) = delete;
     static v3_columns from_v2_schema(const schema&);
 public:
-    const std::vector<column_definition>& all_columns() const;
+    const utils::chunked_vector<column_definition>& all_columns() const;
     const std::unordered_map<bytes, const column_definition*>& columns_by_name() const;
     bool is_static_compact() const;
     bool is_compact() const;
@@ -566,7 +567,7 @@ private:
         sstring _cf_name;
         // regular columns are sorted by name
         // static columns are sorted by name, but present only when there's any clustering column
-        std::vector<column_definition> _columns;
+        utils::chunked_vector<column_definition> _columns;
         data_type _regular_column_name_type;
         data_type _default_validation_class = bytes_type;
         bool _is_dense = false;
@@ -621,7 +622,7 @@ private:
 public:
     using row_column_ids_are_ordered_by_name = std::true_type;
 
-    typedef std::vector<column_definition> columns_type;
+    typedef utils::chunked_vector<column_definition> columns_type;
     typedef typename columns_type::iterator iterator;
     typedef typename columns_type::const_iterator const_iterator;
     typedef std::ranges::subrange<iterator> iterator_range_type;

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -267,35 +267,6 @@ public:
     column_kind kind;
     lw_shared_ptr<cql3::column_specification> column_specification;
 
-    // NOTICE(sarna): This copy constructor is hand-written instead of default,
-    // because it involves deep copying of the computation object.
-    // Computation has a strict ownership policy provided by
-    // unique_ptr, and as such cannot rely on default copying.
-    column_definition(const column_definition& other)
-            : _name(other._name)
-            , _dropped_at(other._dropped_at)
-            , _is_atomic(other._is_atomic)
-            , _is_counter(other._is_counter)
-            , _is_view_virtual(other._is_view_virtual)
-            , _computation(other.get_computation_ptr())
-            , type(other.type)
-            , id(other.id)
-            , ordinal_id(other.ordinal_id)
-            , kind(other.kind)
-            , column_specification(other.column_specification)
-        {}
-
-    column_definition& operator=(const column_definition& other) {
-        if (this == &other) {
-            return *this;
-        }
-        column_definition tmp(other);
-        *this = std::move(tmp);
-        return *this;
-    }
-
-    column_definition& operator=(column_definition&& other) = default;
-
     bool is_static() const { return kind == column_kind::static_column; }
     bool is_regular() const { return kind == column_kind::regular_column; }
     bool is_partition_key() const { return kind == column_kind::partition_key; }
@@ -315,7 +286,7 @@ public:
     bool is_computed() const { return bool(_computation); }
     const column_computation& get_computation() const { return *_computation; }
     column_computation_ptr get_computation_ptr() const {
-        return _computation ? _computation->clone() : nullptr;
+        return _computation;
     }
     void set_computed(column_computation_ptr computation) { _computation = std::move(computation); }
     // Columns hidden from CQL cannot be in any way retrieved by the user,

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -3703,7 +3703,7 @@ class chunked_vector(object):
         self._max_contiguous_allocation = int(list(template_arguments(self.ref.type))[1])
 
     def max_chunk_capacity(self):
-        return max(self._max_contiguous_allocation / self.ref.type.sizeof, 1);
+        return max(self._max_contiguous_allocation // self.ref.type.template_argument(0).sizeof, 1);
 
     def __len__(self):
         return int(self.ref['_size'])
@@ -5679,7 +5679,7 @@ class scylla_schema(gdb.Command):
 
         gdb.write('\n')
         gdb.write("columns:\n")
-        for cdef in std_vector(raw_schema['_columns']):
+        for cdef in chunked_vector(raw_schema['_columns']):
             gdb.write("    {:27} id={} ordinal_id={} {} {} is_atomic={} is_counter={}\n".format(
                     str(cdef['kind']),
                     cdef['id'],

--- a/utils/hashing.hh
+++ b/utils/hashing.hh
@@ -153,6 +153,23 @@ struct appending_hash<std::vector<T>> {
     }
 };
 
+namespace utils {
+template <typename T, size_t max_contiguous_allocation>
+class chunked_vector;
+}
+
+template<typename T, size_t max_contiguous_allocation>
+struct appending_hash<utils::chunked_vector<T, max_contiguous_allocation>> {
+    template<typename H>
+    requires Hasher<H>
+    void operator()(H& h, const utils::chunked_vector<T, max_contiguous_allocation>& value) const noexcept {
+        feed_hash(h, value.size());
+        for (auto&& v : value) {
+            appending_hash<T>()(h, v);
+        }
+    }
+};
+
 template<typename K, typename V>
 struct appending_hash<std::map<K, V>> {
     template<typename H>


### PR DESCRIPTION
Creating a table with a huge number of columns makes seastar warn about oversized allocations: `raw_schema::_columns` and the other copies of the column set (the `schema` object, `v3_columns`, `column_mapping`, the `CREATE TABLE` and schema load paths) all grow contiguously with the column count.

Switch them to `utils::chunked_vector`. Replace `std::stable_partition` in the schema constructor with a gather loop, since it allocates a contiguous temporary buffer.

The first commit restores `column_definition`'s move constructor (suppressed by its hand-written copy constructor), which `chunked_vector` requires. The schema version digest and the `column_mapping` wire format are unchanged.

Fixes: SCYLLADB-548

This is an improvement. No backport needed.