### PR TITLE
service/qos: index service-level lookup by scheduling_group, not by index

### DIFF
--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -531,9 +531,9 @@ future<>  service_level_controller::notify_service_level_added(sstring name, ser
         });
         auto result= _service_levels_db.emplace(name, sl_data);
         if (result.second) {
-            unsigned sl_idx = internal::scheduling_group_index(sl_data.sg);
-            _sl_lookup[sl_idx].first = &(result.first->first);
-            _sl_lookup[sl_idx].second = &(result.first->second);
+            auto& slot = _sl_lookup[sl_data.sg];
+            slot.first = &(result.first->first);
+            slot.second = &(result.first->second);
             if (name == driver_service_level_name) {
                 _driver_scheduling_group = sl_data.sg;
             }
@@ -579,9 +579,7 @@ future<> service_level_controller::notify_service_level_updated(sstring name, se
 future<> service_level_controller::notify_service_level_removed(sstring name) {
     auto sl_it = _service_levels_db.find(name);
     if (sl_it != _service_levels_db.end()) {
-        unsigned sl_idx = internal::scheduling_group_index(sl_it->second.sg);
-        _sl_lookup[sl_idx].first = nullptr;
-        _sl_lookup[sl_idx].second = nullptr;
+        _sl_lookup.erase(sl_it->second.sg);
         if (this_shard_id() == global_controller) {
             _global_controller_db->deleted_scheduling_groups.emplace_back(sl_it->second.sg);
             co_await rename_scheduling_group(sl_it->second.sg, seastar::format(deleted_scheduling_group_name_pattern, sl_it->first));
@@ -642,9 +640,9 @@ scheduling_group service_level_controller::get_cached_user_scheduling_group(cons
 }
 
 std::optional<sstring> service_level_controller::get_active_service_level() {
-    unsigned sched_idx = internal::scheduling_group_index(current_scheduling_group());
-    if (_sl_lookup[sched_idx].first) {
-        return sstring(*_sl_lookup[sched_idx].first);
+    auto it = _sl_lookup.find(current_scheduling_group());
+    if (it != _sl_lookup.end() && it->second.first) {
+        return sstring(*it->second.first);
     } else {
         return std::nullopt;
     }

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -23,6 +23,7 @@
 #include "auth/service.hh"
 #include "cql3/description.hh"
 #include <map>
+#include <unordered_map>
 #include "qos_common.hh"
 #include "mutation/mutation.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
@@ -207,7 +208,7 @@ private:
 
     // Keeps names of effectively dropped service levels. Those service levels exits in the table but are not present in _service_levels_db cache
     std::set<sstring> _effectively_dropped_sls;
-    std::pair<const sstring*, service_level*> _sl_lookup[max_scheduling_groups()];
+    std::unordered_map<scheduling_group, std::pair<const sstring*, service_level*>> _sl_lookup;
     service_level _default_service_level;
     seastar::metrics::metric_groups _metrics;
     std::optional<scheduling_group> _driver_scheduling_group = std::nullopt;


### PR DESCRIPTION

Drop the use of `seastar::internal::scheduling_group_index` (which is in seastar's internal namespace and therefore should not be used by applications) and switch `service_level_controller::_sl_lookup` from a fixed-size array indexed by group index to an `std::unordered_map` keyed by the `scheduling_group` itself.

Not backporting: this is preparing for modularization, not fixing a bug