### PR TITLE
treewide: drop FMT_STRING

### DIFF
--- a/query/query-result-set.cc
+++ b/query/query-result-set.cc
@@ -199,7 +199,7 @@ result_set_builder::deserialize(const result_row_view& row, bool is_static)
         }
         index++;
       } catch (...) {
-            throw deserialization_error(fmt::format(FMT_STRING("failed on column {}.{}#{} (version: {}, id: {}, index: {}, type: {}): {}"),
+            throw deserialization_error(fmt::format("failed on column {}.{}#{} (version: {}, id: {}, index: {}, type: {}): {}",
                 _schema->ks_name(), _schema->cf_name(), col.name_as_text(), _schema->version(), col.id, index, col.type->name(), std::current_exception()));
       }
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1277,7 +1277,7 @@ void sstable::validate_partitioner() {
     validation_metadata& v = *static_cast<validation_metadata *>(p.get());
     if (v.partitioner.value != to_bytes(_schema->get_partitioner().name())) {
         throw std::runtime_error(
-                fmt::format(FMT_STRING("SSTable {} uses {} partitioner which is different than {} partitioner used by the database"),
+                fmt::format("SSTable {} uses {} partitioner which is different than {} partitioner used by the database",
                             get_filename(),
                             sstring(reinterpret_cast<char*>(v.partitioner.value.data()), v.partitioner.value.size()),
                             _schema->get_partitioner().name()));


### PR DESCRIPTION
FMT_STRING enables compile-time format-string checking with the fmt library. It's not needed on the modern toolchain we use, and stands in the way of modularization, since macros are not exported by modules.

Just remove it.

Minor code cleanup, not backporting.