### PR TITLE
sstables_loader: refresh effective_replication_map between streaming batches

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -187,6 +187,14 @@ public:
 protected:
     virtual host_id_vector_replica_set get_primary_endpoints(const dht::token& token, std::function<bool(const locator::host_id&)> filter) const;
     future<> stream_sstables(const dht::partition_range&, std::vector<sstables::shared_sstable>, shared_ptr<stream_progress> progress, defer_unlinking defer);
+    // Re-fetches _erm between streaming batches so a topology version
+    // superseded mid-operation is released promptly, instead of being held
+    // for the whole (potentially hours-long) operation.
+    //
+    // Synchronous by design: must not suspend before dropping the old _erm,
+    // or a topology change waiting via barrier_and_drain for that erm to be
+    // released could deadlock against it.
+    virtual void refresh_erm();
 private:
     host_id_vector_replica_set get_all_endpoints(const dht::token& token) const;
 };
@@ -204,6 +212,14 @@ public:
 
     virtual future<> stream(shared_ptr<stream_progress> on_streamed) override;
     virtual host_id_vector_replica_set get_primary_endpoints(const dht::token& token, std::function<bool(const locator::host_id&)> filter) const override;
+
+protected:
+    // No-op for now: _tablet_map is a reference into the erm acquired at
+    // construction, so swapping _erm here would leave it dangling. A
+    // follow-up commit converts _tablet_map to a repointable pointer and
+    // implements this properly; until then tablets keep holding their erm
+    // for the whole operation, same as before this change.
+    void refresh_erm() override {}
 
 private:
     host_id_vector_replica_set to_replica_set(const locator::tablet_replica_set& replicas) const {
@@ -316,6 +332,23 @@ host_id_vector_replica_set sstable_streamer::get_all_endpoints(const dht::token&
     auto pending = _erm->get_pending_replicas(token);
     std::move(pending.begin(), pending.end(), std::back_inserter(current_targets));
     return current_targets;
+}
+
+void sstable_streamer::refresh_erm() {
+    auto erm = _table.get_effective_replication_map();
+    if (erm == _erm) {
+        return; // unchanged since the last refresh (the common case)
+    }
+    if (!erm) {
+        // Shouldn't happen for a live table; guard defensively rather than
+        // crash on the next dereference of a null erm.
+        llog.debug("sstable_streamer: table {}.{} has no effective_replication_map; "
+                   "deferring refresh", _table.schema()->ks_name(), _table.schema()->cf_name());
+        return;
+    }
+    _erm = std::move(erm);
+    llog.debug("sstable_streamer: refreshed effective_replication_map for table {}.{} to topology version {}",
+               _table.schema()->ks_name(), _table.schema()->cf_name(), _erm->get_token_metadata().get_version());
 }
 
 host_id_vector_replica_set sstable_streamer::get_primary_endpoints(const dht::token& token, std::function<bool(const locator::host_id&)> filter) const {
@@ -477,6 +510,9 @@ future<> sstable_streamer::stream_sstables(const dht::partition_range& pr, std::
     while (!sstables.empty()) {
         co_await utils::get_local_injector().inject("load_and_stream_before_streaming_batch",
             utils::wait_for_message(60s));
+
+        // See refresh_erm()'s declaration for why this is needed.
+        refresh_erm();
 
         const size_t batch_sst_nr = std::min(16uz, sstables.size());
         auto sst_processed = sstables
@@ -642,8 +678,10 @@ future<locator::effective_replication_map_ptr> sstables_loader::await_topology_q
 future<> sstables_loader::load_and_stream(sstring ks_name, sstring cf_name,
         ::table_id table_id, std::vector<sstables::shared_sstable> sstables, primary_replica_only primary, bool unlink, stream_scope scope,
         shared_ptr<stream_progress> progress) {
-    // streamer guarantees topology stability, for correctness, by holding effective_replication_map
-    // throughout its lifetime.
+    // For vnode-based tables, refresh_erm() (see its declaration) re-fetches
+    // this erm between streaming batches, so a superseded topology version
+    // is released promptly. tablet_sstable_streamer is still a no-op
+    // override for now and holds its erm for the whole operation.
     auto erm = co_await await_topology_quiesced_and_get_erm(table_id);
 
     // Obtain a phaser guard to prevent the table from being destroyed

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -201,25 +201,22 @@ private:
 
 class tablet_sstable_streamer : public sstable_streamer {
     sharded<replica::database>& _db;
-    const locator::tablet_map& _tablet_map;
+    // Pointer, not reference, so refresh_erm() can repoint it together with
+    // _erm, whose token_metadata_ptr keeps the pointee alive.
+    const locator::tablet_map* _tablet_map;
 public:
     tablet_sstable_streamer(netw::messaging_service& ms, sharded<replica::database>& db, ::table_id table_id, locator::effective_replication_map_ptr erm,
                             std::vector<sstables::shared_sstable> sstables, primary_replica_only primary, unlink_sstables unlink, stream_scope scope)
         : sstable_streamer(ms, db.local(), table_id, std::move(erm), std::move(sstables), primary, unlink, scope)
         , _db(db)
-        , _tablet_map(_erm->get_token_metadata().tablets().get_tablet_map(table_id)) {
+        , _tablet_map(&_erm->get_token_metadata().tablets().get_tablet_map(table_id)) {
     }
 
     virtual future<> stream(shared_ptr<stream_progress> on_streamed) override;
     virtual host_id_vector_replica_set get_primary_endpoints(const dht::token& token, std::function<bool(const locator::host_id&)> filter) const override;
 
 protected:
-    // No-op for now: _tablet_map is a reference into the erm acquired at
-    // construction, so swapping _erm here would leave it dangling. A
-    // follow-up commit converts _tablet_map to a repointable pointer and
-    // implements this properly; until then tablets keep holding their erm
-    // for the whole operation, same as before this change.
-    void refresh_erm() override {}
+    void refresh_erm() override;
 
 private:
     host_id_vector_replica_set to_replica_set(const locator::tablet_replica_set& replicas) const {
@@ -358,11 +355,52 @@ host_id_vector_replica_set sstable_streamer::get_primary_endpoints(const dht::to
 }
 
 host_id_vector_replica_set tablet_sstable_streamer::get_primary_endpoints(const dht::token& token, std::function<bool(const locator::host_id&)> filter) const {
-    auto tid = _tablet_map.get_tablet_id(token);
-    auto replicas = locator::get_primary_replicas(_tablet_map, tid, _erm->get_topology(), [filter = std::move(filter)] (const locator::tablet_replica& replica) {
+    auto tid = _tablet_map->get_tablet_id(token);
+    auto replicas = locator::get_primary_replicas(*_tablet_map, tid, _erm->get_topology(), [filter = std::move(filter)] (const locator::tablet_replica& replica) {
         return filter(replica.host);
     });
     return to_replica_set(replicas);
+}
+
+void tablet_sstable_streamer::refresh_erm() {
+    auto erm = _table.get_effective_replication_map();
+    if (erm == _erm) {
+        return; // unchanged since the last refresh (the common case)
+    }
+    if (!erm) {
+        // See sstable_streamer::refresh_erm(): shouldn't happen, guard anyway.
+        llog.debug("tablet_sstable_streamer: table {}.{} has no effective_replication_map; "
+                   "deferring refresh", _table.schema()->ks_name(), _table.schema()->cf_name());
+        return;
+    }
+    const locator::tablet_map* new_tablet_map = nullptr;
+    try {
+        new_tablet_map = &erm->get_token_metadata().tablets().get_tablet_map(_table.schema()->id());
+    } catch (const locator::no_such_tablet_map&) {
+        // Table's tablet metadata is gone from this snapshot (e.g. concurrent
+        // drop); nothing valid to refresh to, so keep the current pair.
+        llog.debug("tablet_sstable_streamer: no tablet map for table {}.{} in the latest topology; "
+                   "deferring effective_replication_map refresh",
+                   _table.schema()->ks_name(), _table.schema()->cf_name());
+        return;
+    }
+    // Compare boundaries, not just tablet_count(): pow2-convergence merges
+    // (tablet_allocator.cc) can restore a previous count with different
+    // boundaries, which stream()'s up-front sstable-to-tablet classification
+    // depends on.
+    if (new_tablet_map->get_sorted_raw_tokens() != _tablet_map->get_sorted_raw_tokens()) {
+        // Keep the current, self-consistent pair and retry next batch. Worst
+        // case: held for the whole operation, same as before this change.
+        llog.debug("tablet_sstable_streamer: tablet boundaries changed (tablet_count {} -> {}) for table {}.{} "
+                   "while streaming is in progress; deferring effective_replication_map refresh",
+                   _tablet_map->tablet_count(), new_tablet_map->tablet_count(),
+                   _table.schema()->ks_name(), _table.schema()->cf_name());
+        return;
+    }
+    _erm = std::move(erm);
+    _tablet_map = new_tablet_map;
+    llog.debug("tablet_sstable_streamer: refreshed effective_replication_map for table {}.{} to topology version {}, tablet_count={}",
+               _table.schema()->ks_name(), _table.schema()->cf_name(), _erm->get_token_metadata().get_version(), _tablet_map->tablet_count());
 }
 
 future<> sstable_streamer::stream(shared_ptr<stream_progress> progress) {
@@ -380,7 +418,7 @@ bool tablet_sstable_streamer::tablet_in_scope(locator::tablet_id tid) const {
     }
 
     const auto& topo = _erm->get_topology();
-    for (const auto& r : _tablet_map.get_tablet_info(tid).replicas) {
+    for (const auto& r : _tablet_map->get_tablet_info(tid).replicas) {
         switch (_stream_scope) {
         case stream_scope::node:
             if (topo.is_me(r.host)) {
@@ -477,12 +515,12 @@ future<std::vector<tablet_sstable_collection>> tablet_sstable_streamer::get_ssta
 
 future<> tablet_sstable_streamer::stream(shared_ptr<stream_progress> progress) {
     if (progress) {
-        progress->start(_tablet_map.tablet_count());
+        progress->start(_tablet_map->tablet_count());
     }
 
     auto classified_sstables = co_await get_sstables_for_tablets(
-        _sstables, _tablet_map.tablet_ids() | std::views::filter([this](auto tid) { return tablet_in_scope(tid); }) | std::views::transform([this](auto tid) {
-                       return _tablet_map.get_token_range(tid);
+        _sstables, _tablet_map->tablet_ids() | std::views::filter([this](auto tid) { return tablet_in_scope(tid); }) | std::views::transform([this](auto tid) {
+                       return _tablet_map->get_token_range(tid);
                    }) | std::ranges::to<std::vector>());
 
     for (auto& [tablet_range, sstables_fully_contained, sstables_partially_contained] : classified_sstables) {
@@ -678,10 +716,9 @@ future<locator::effective_replication_map_ptr> sstables_loader::await_topology_q
 future<> sstables_loader::load_and_stream(sstring ks_name, sstring cf_name,
         ::table_id table_id, std::vector<sstables::shared_sstable> sstables, primary_replica_only primary, bool unlink, stream_scope scope,
         shared_ptr<stream_progress> progress) {
-    // For vnode-based tables, refresh_erm() (see its declaration) re-fetches
-    // this erm between streaming batches, so a superseded topology version
-    // is released promptly. tablet_sstable_streamer is still a no-op
-    // override for now and holds its erm for the whole operation.
+    // refresh_erm() re-fetches this erm between streaming batches (see its
+    // declaration), so a superseded topology version is released promptly
+    // instead of being held for the whole operation.
     auto erm = co_await await_topology_quiesced_and_get_erm(table_id);
 
     // Obtain a phaser guard to prevent the table from being destroyed

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -21,9 +21,9 @@ from test.pylib.minio_server import MinioServer
 from test.pylib.manager_client import ManagerClient
 from test.pylib.object_storage import format_tuples
 from test.cluster.object_store.test_backup import topo, take_snapshot, do_test_streaming_scopes
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, get_topology_version
 from test.pylib.rest_client import read_barrier
-from test.pylib.util import unique_name, wait_for
+from test.pylib.util import unique_name, wait_for, wait_for_cql_and_get_hosts
 
 logger = logging.getLogger(__name__)
 
@@ -172,3 +172,102 @@ async def test_refresh_deletes_uploaded_sstables(manager: ManagerClient):
             await wait_for_upload_dir_empty(upload_dir)
 
         shutil.rmtree(tmpbackup)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_refresh_load_and_stream_releases_stale_topology_version(manager: ManagerClient):
+    """
+    Regression test for SCYLLADB-3336: load_and_stream() held a single erm
+    (pinning its topology version) for the whole streaming operation,
+    blocking concurrent topology changes' barrier_and_drain until streaming
+    finished -- hours, for large data sets. Fixed by
+    sstable_streamer::refresh_erm(), which re-fetches the erm between
+    batches.
+
+    Creates enough sstables for >1 batch, pauses load_and_stream right after
+    it acquires its erm, bootstraps a node concurrently (its
+    barrier_and_drain reports our erm's version as stale), then resumes
+    load_and_stream and checks the erm is refreshed and the barrier
+    completes promptly -- not only after every batch finishes streaming.
+    """
+    cmdline = ['--logger-log-level', 'sstables_loader=debug']
+    server = await manager.server_add(cmdline=cmdline)
+
+    cql = manager.get_cql()
+    ks = unique_name("ks_")
+    cf = "test"
+
+    await cql.run_async(
+        f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} "
+        f"AND tablets = {{'enabled': false}}")
+    try:
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY, c int)")
+
+        # One sstable per row: with num_sstables=20 > batch size (16), we get
+        # more than one streaming batch.
+        num_sstables = 20
+        for pk in range(num_sstables):
+            await cql.run_async(f"INSERT INTO {ks}.{cf} (pk, c) VALUES ({pk}, {pk})")
+            await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        snap_name = unique_name("snap_")
+        await manager.api.take_snapshot(server.ip_addr, ks, snap_name)
+
+        workdir = await manager.server_get_workdir(server.server_id)
+        cf_dir = os.listdir(f"{workdir}/data/{ks}")[0]
+        cf_path = os.path.join(f"{workdir}/data/{ks}", cf_dir)
+        upload_dir = os.path.join(cf_path, "upload")
+        os.makedirs(upload_dir, exist_ok=True)
+        snapshots_dir = os.path.join(cf_path, "snapshots", snap_name)
+        exclude_list = ["manifest.json", "schema.cql"]
+        for item in os.listdir(snapshots_dir):
+            if item not in exclude_list:
+                shutil.copy2(os.path.join(snapshots_dir, item), os.path.join(upload_dir, item))
+
+        hosts = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+        version_before = await get_topology_version(cql, hosts[0])
+
+        await manager.api.enable_injection(server.ip_addr, "load_and_stream_before_streaming_batch", one_shot=True)
+        server_log = await manager.server_open_log(server.server_id)
+        log_mark = await server_log.mark()
+
+        refresh_task = asyncio.create_task(
+            manager.api.load_new_sstables(server.ip_addr, ks, cf, load_and_stream=True))
+        await manager.api.wait_for_injection_enter(server.ip_addr, "load_and_stream_before_streaming_batch")
+        logger.info("load_and_stream paused before its first batch, holding erm at topology version %d", version_before)
+
+        # Bootstrapping bumps the topology version and triggers a
+        # barrier_and_drain that must wait for our paused load_and_stream's
+        # stale erm.
+        bootstrap_task = asyncio.create_task(manager.server_add())
+
+        await server_log.wait_for(
+            r"Got raft_topology_cmd::barrier_and_drain,.*stale versions \(version: use_count\):.*"
+            rf"\b{version_before}\b",
+            from_mark=log_mark, timeout=60)
+        logger.info("bootstrap's barrier_and_drain reported our erm's topology version %d as stale", version_before)
+
+        # Resume load_and_stream; refresh_erm() runs first and releases the
+        # stale erm.
+        await manager.api.message_injection(server.ip_addr, "load_and_stream_before_streaming_batch")
+
+        _, matches = await server_log.wait_for(
+            r"refreshed effective_replication_map for table .* to topology version (\d+)",
+            from_mark=log_mark, timeout=30)
+        refreshed_version = int(matches[0][1].group(1))
+        assert refreshed_version > version_before, \
+            f"expected refresh_erm() to move past the stale version {version_before}, got {refreshed_version}"
+
+        # Must complete promptly, not after load_and_stream streams every
+        # remaining batch.
+        await server_log.wait_for(r"raft_topology_cmd::barrier_and_drain version \d+: done",
+                                   from_mark=log_mark, timeout=30)
+        await asyncio.wait_for(bootstrap_task, timeout=60)
+        logger.info("bootstrap completed")
+
+        await asyncio.wait_for(refresh_task, timeout=60)
+        logger.info("load_and_stream completed")
+
+        assert {row.pk for row in cql.execute(f"SELECT pk FROM {ks}.{cf}")} == set(range(num_sstables))
+    finally:
+        await cql.run_async(f"DROP KEYSPACE IF EXISTS {ks}")

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -22,6 +22,7 @@ import time
 import random
 import os
 import glob
+import shutil
 from collections import defaultdict
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
@@ -1093,6 +1094,107 @@ async def test_tablet_load_and_stream(manager: ManagerClient, primary_replica_on
     logger.info("All SSTable files successfully deleted after streaming")
 
     await asyncio.gather(*[cql.run_async(f"drop keyspace {i}") for i in [ks, ks2]])
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_tablet_load_and_stream_releases_stale_topology_version(manager: ManagerClient):
+    """
+    Tablet variant of test_refresh_load_and_stream_releases_stale_topology_version
+    (see its docstring for SCYLLADB-3336 background). Exercises
+    tablet_sstable_streamer::refresh_erm()'s common "compatible" case: a
+    plain migration, which changes the topology version but not tablet
+    boundaries. The incompatible (split/merge) case is covered by
+    test_tablet_load_and_stream_and_split_synchronization.
+    """
+    cmdline = ['--logger-log-level', 'sstables_loader=debug']
+    servers = await manager.servers_add(2, cmdline=cmdline)
+    await manager.disable_tablet_balancing()
+
+    cql = manager.get_cql()
+    ks = unique_name("ks_")
+    cf = "test"
+    await cql.run_async(
+        f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} "
+        f"AND tablets = {{'initial': 1}}")
+    try:
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY, c int)")
+
+        tablet_token = 0  # single tablet, so any token maps to it
+        src_host, src_shard = await get_tablet_replica(manager, servers[0], ks, cf, tablet_token)
+        host_ids = {await manager.get_host_id(s.server_id): s for s in servers}
+        server = host_ids[src_host]
+        dst_host = next(hid for hid in host_ids if hid != src_host)
+
+        # One sstable per row: with num_sstables=20 > batch size (16), we get
+        # more than one streaming batch.
+        num_sstables = 20
+        for pk in range(num_sstables):
+            await cql.run_async(f"INSERT INTO {ks}.{cf} (pk, c) VALUES ({pk}, {pk})")
+            await manager.api.flush_keyspace(server.ip_addr, ks)
+
+        snap_name = unique_name("snap_")
+        await manager.api.take_snapshot(server.ip_addr, ks, snap_name)
+
+        workdir = await manager.server_get_workdir(server.server_id)
+        cf_dir = os.listdir(f"{workdir}/data/{ks}")[0]
+        cf_path = os.path.join(f"{workdir}/data/{ks}", cf_dir)
+        upload_dir = os.path.join(cf_path, "upload")
+        os.makedirs(upload_dir, exist_ok=True)
+        snapshots_dir = os.path.join(cf_path, "snapshots", snap_name)
+        exclude_list = ["manifest.json", "schema.cql"]
+        for item in os.listdir(snapshots_dir):
+            if item not in exclude_list:
+                shutil.copy2(os.path.join(snapshots_dir, item), os.path.join(upload_dir, item))
+
+        hosts = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+        version_before = await get_topology_version(cql, hosts[0])
+
+        await manager.api.enable_injection(server.ip_addr, "load_and_stream_before_streaming_batch", one_shot=True)
+        server_log = await manager.server_open_log(server.server_id)
+        log_mark = await server_log.mark()
+
+        refresh_task = asyncio.create_task(
+            manager.api.load_new_sstables(server.ip_addr, ks, cf, load_and_stream=True))
+        await manager.api.wait_for_injection_enter(server.ip_addr, "load_and_stream_before_streaming_batch")
+        logger.info("load_and_stream paused before its first batch, holding erm at topology version %d", version_before)
+
+        # Same tablet_count, ownership change only -- the "compatible"
+        # refresh path. move_tablet() blocks until committed, so run it as a
+        # background task.
+        migration_task = asyncio.create_task(
+            manager.api.move_tablet(server.ip_addr, ks, cf, src_host, src_shard, dst_host, 0, tablet_token))
+
+        await server_log.wait_for(
+            r"Got raft_topology_cmd::barrier_and_drain,.*stale versions \(version: use_count\):.*"
+            rf"\b{version_before}\b",
+            from_mark=log_mark, timeout=60)
+        logger.info("tablet migration's barrier_and_drain reported our erm's topology version %d as stale", version_before)
+
+        # Resume load_and_stream; refresh_erm() runs first and releases the
+        # stale erm/tablet_map.
+        await manager.api.message_injection(server.ip_addr, "load_and_stream_before_streaming_batch")
+
+        _, matches = await server_log.wait_for(
+            r"tablet_sstable_streamer: refreshed effective_replication_map for table .* "
+            r"to topology version (\d+), tablet_count=1",
+            from_mark=log_mark, timeout=30)
+        refreshed_version = int(matches[0][1].group(1))
+        assert refreshed_version > version_before, \
+            f"expected refresh_erm() to move past the stale version {version_before}, got {refreshed_version}"
+
+        # Must complete promptly, not after load_and_stream streams every
+        # remaining batch.
+        await asyncio.wait_for(migration_task, timeout=60)
+        logger.info("tablet migration completed")
+
+        await asyncio.wait_for(refresh_task, timeout=60)
+        logger.info("load_and_stream completed")
+
+        new_replica = await get_tablet_replica(manager, servers[0], ks, cf, tablet_token)
+        assert new_replica[0] == dst_host
+        assert {row.pk for row in cql.execute(f"SELECT pk FROM {ks}.{cf}")} == set(range(num_sstables))
+    finally:
+        await cql.run_async(f"DROP KEYSPACE IF EXISTS {ks}")
 
 async def test_storage_service_api_uneven_ownership_keyspace_and_table_params_used(manager: ManagerClient):
     # Given two running servers


### PR DESCRIPTION
## Motivation

`nodetool refresh` with load-and-stream (`sstables_loader::load_and_stream()`) acquired an `effective_replication_map` (ERM) once at the start and held it in `sstable_streamer::_erm` for the whole streaming operation - potentially hours for large data sets.
Since the ERM pins the corresponding `token_metadata` alive via its `version_tracker`, a topology version superseded *while streaming is in progress* could not be released until the whole operation completed.
This blocked concurrent topology changes' `barrier_and_drain` step (`shared_token_metadata::stale_versions_in_use()`) for the entire streaming duration, and is what produces `token_metadata`'s

```
topology version <N> held for <seconds> [s] past expiry, released at: ...
```

warnings seen in production (observed held for ~6.7 hours in one report, with a backtrace pointing at the `sstables_loader` `invoke_on_all` streaming path).

## Changes

Refresh the ERM at streaming-batch boundaries instead of holding a single ERM for the whole operation, so a superseded topology version is released within one batch's processing time.

**Commit 1 (vnode):**
- Add `sstable_streamer::refresh_erm()`, called at the top of each batch in `stream_sstables()` (batches are capped at 16 sstables).
- Early-out when the ERM is unchanged (the common case) to avoid `shared_ptr` churn; defensive null-check.
- `tablet_sstable_streamer` keeps a no-op override in this commit (its `_tablet_map` was still a reference, so it stays bisectable / behavior unchanged for tablets).

**Commit 2 (tablets):**
- Convert `tablet_sstable_streamer::_tablet_map` from a reference to a pointer so it can be repointed alongside `_erm`.
- Implement `tablet_sstable_streamer::refresh_erm()`: refresh ERM + tablet_map together, but only adopt the new pair when it is safe to do so. It defers the refresh (keeping the current, self-consistent pair) when:
  - the table's tablet metadata is missing from the new snapshot (`no_such_tablet_map`, e.g. concurrent drop), or
  - the tablet **boundaries** changed (compared via `get_sorted_raw_tokens()`, not just `tablet_count()`), because the up-front sstable-to-tablet classification in `stream()` was computed against the previous boundaries.
    Comparing boundaries rather than count is necessary: selective/arbitrary-layout merges (pow2 convergence after vnode-to-tablets migration) can return to a previous `tablet_count()` with different boundaries.

Endpoint routing stays correct across a refresh because `effective_replication_map` already accounts for in-progress topology transitions (natural + pending replicas).
Common tablet migrations (replica-only moves) preserve boundaries and so are adopted normally.

## Tests

Two new regression tests, each verified to **fail (time out) without the fix and pass with it**, run via `dbuild`:

- `test/cluster/test_refresh.py::test_refresh_load_and_stream_releases_stale_topology_version`
  (vnode): pauses load-and-stream after it has acquired its ERM, bootstraps a node concurrently, confirms the bootstrap's `barrier_and_drain` reports the held ERM's topology version as stale, then releases the pause and asserts the ERM is refreshed to a newer version and the barrier completes promptly -
  rather than only after the whole (multi-batch) streaming finishes.
- `test/cluster/test_tablets2.py::test_tablet_load_and_stream_releases_stale_topology_version` (tablets): same shape, using an explicit `move_tablet()` migration (same tablet_count -- the compatible refresh path).

Existing regressions run green via `dbuild` (repeated for stability):
`test/boost/sstable_tablet_streaming_test.cc`, all of `test/cluster/test_refresh.py`, all of `test/cluster/test_table_drop.py` (DROP-TABLE-during-streaming race), `test_tablet_load_and_stream` (both params), and `test_tablet_load_and_stream_and_split_synchronization` (both params 
- exercises the incompatible-boundaries deferral path under a real concurrent split).

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3336

Backport: unsure - I think it should be backported all the way to 2026.1
