### PR TITLE
treewide: fix minor incompatibilies with upstream seastar

### DIFF
--- a/test/boost/exceptions_test.inc.cc
+++ b/test/boost/exceptions_test.inc.cc
@@ -79,7 +79,7 @@ static void check_no_catch(Throw&& ex) {
             << " is NOT caught as " << seastar::pretty_type_name(typeid(Capture)));
 
     auto typed_eptr = try_catch<Capture>(eptr);
-    BOOST_CHECK_EQUAL(typed_eptr, nullptr);
+    BOOST_CHECK(typed_eptr == nullptr);
 }
 
 template<typename A, typename B>
@@ -213,13 +213,13 @@ SEASTAR_TEST_CASE(test_make_nested_exception_ptr) {
         BOOST_REQUIRE_EQUAL(std::string(ex.what()), "outer");
         auto* nested = dynamic_cast<const std::nested_exception*>(&ex);
         BOOST_REQUIRE_NE(nested, nullptr);
-        BOOST_REQUIRE_EQUAL(nested->nested_ptr(), inner);
+        BOOST_REQUIRE(nested->nested_ptr() == inner);
     }
 
     try {
         std::rethrow_exception(outer);
     } catch (const std::nested_exception& ex) {
-        BOOST_REQUIRE_EQUAL(ex.nested_ptr(), inner);
+        BOOST_REQUIRE(ex.nested_ptr() == inner);
     }
 
     // Not a class
@@ -238,7 +238,7 @@ SEASTAR_TEST_CASE(test_make_nested_exception_ptr) {
         try {
             std::rethrow_exception(make_nested_exception_ptr(already_nested_exception(), inner));
         } catch (const already_nested_exception& ex) {
-            BOOST_REQUIRE_EQUAL(ex.nested_ptr(), inner2);
+            BOOST_REQUIRE(ex.nested_ptr() == inner2);
         }
     }
 

--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -413,7 +413,7 @@ SEASTAR_TEST_CASE(test_group0_hard_timeout_history_present_is_always_success) {
             // succeed regardless.
             auto gc_dur = rclient.get_history_gc_duration();
             forward_jump_clocks(gc_dur + std::chrono::seconds{1});
-            auto restore_clocks = defer([gc_dur] { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
+            auto restore_clocks = defer([gc_dur] noexcept { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
             // Row present => success, must not throw.
             co_await std::move(mc).commit(rclient, as, ::service::raft_timeout{});
         }
@@ -509,7 +509,7 @@ SEASTAR_TEST_CASE(test_group0_hard_timeout_history_absent_gc_eligible_is_hard_ti
         // ambiguous => must throw group0_hard_timeout.
         auto gc_dur = rclient.get_history_gc_duration();
         forward_jump_clocks(gc_dur + std::chrono::seconds{1});
-        auto restore_clocks = defer([gc_dur] { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
+        auto restore_clocks = defer([gc_dur] noexcept { forward_jump_clocks(-(gc_dur + std::chrono::seconds{1})); });
         BOOST_CHECK_EXCEPTION(co_await std::move(mc_a).commit(rclient, as, ::service::raft_timeout{}),
                 service::group0_hard_timeout, [] (const service::group0_hard_timeout&) { return true; });
     });
@@ -554,7 +554,7 @@ SEASTAR_TEST_CASE(test_group0_hard_timeout_history_absent_after_real_gc_is_hard_
         // gc_clock::now() includes clocks_offset, so gc_grace_seconds=0 makes
         // tombstones immediately eligible once gc_clock advances.
         forward_jump_clocks(std::chrono::seconds{1});
-        auto restore_clocks = defer([] { forward_jump_clocks(-std::chrono::seconds{1}); });
+        auto restore_clocks = defer([] noexcept { forward_jump_clocks(-std::chrono::seconds{1}); });
         auto& history_cf = e.local_db().find_column_family("system", db::system_keyspace::GROUP0_HISTORY);
         co_await history_cf.flush();
         co_await history_cf.compact_all_sstables(tasks::task_info{});

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2719,7 +2719,7 @@ static future<> run_sstable_cleanup_correctness_with_storage(data_dictionary::st
     return do_with_cql_env_thread([storage = std::move(storage)] (cql_test_env& e) {
         auto scf = make_sstable_compressor_factory_for_tests_in_thread();
         test_env env(test_env_config{.storage = storage}, *scf, &e.get_sstorage_manager().local());
-        auto close_env = defer([&] { env.stop().get(); });
+        auto close_env = defer([&] noexcept { env.stop().get(); });
         env.plug_mock_sstables_registry();
         sstable_cleanup_correctness_fn(e, env);
     }, std::move(cql_cfg));

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -3497,7 +3497,7 @@ SEASTAR_TEST_CASE(test_stats_metadata_error_includes_filename) {
 SEASTAR_THREAD_TEST_CASE(test_small_sstable_has_reasonable_memory_usage) {
     auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     test_env env({}, *scf);
-    auto stop_env = defer([&env] { env.stop().get(); });
+    auto stop_env = defer([&env] noexcept { env.stop().get(); });
 
     // Big enough that a few leaked copies
     constexpr size_t dict_size = 110 * 1024;

--- a/tools/json_mutation_stream_parser.cc
+++ b/tools/json_mutation_stream_parser.cc
@@ -193,7 +193,7 @@ private:
             auto raw = from_hex(*_string);
             _pkey.emplace(partition_key::from_bytes(raw));
         } catch (...) {
-            return error("failed to parse partition key from raw string: {}", fmt::streamed(std::current_exception()));
+            return error("failed to parse partition key from raw string: {}", std::current_exception());
         }
         return true;
     }
@@ -203,7 +203,7 @@ private:
             auto raw = from_hex(*_string);
             _ckey.emplace(clustering_key::from_bytes(raw));
         } catch (...) {
-            return error("failed to parse clustering key from raw string: {}", fmt::streamed(std::current_exception()));
+            return error("failed to parse clustering key from raw string: {}", std::current_exception());
         }
         return true;
     }


### PR DESCRIPTION
Seastar started enforcing noexcept on defer, and dropped support for operator<<(.., std::exception_ptr)
(when `SEASTAR_DEPRECATED_OSTREAM_FORMATTERS` is off, which it is for us). Prepare for this.

Preparing for Seastar changes which themselves won't be backported.