### PR TITLE
qos: wait for replicas before self-healing service levels

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -7,13 +7,19 @@
  */
 
 #include <algorithm>
+#include <exception>
 #include <functional>
+#include <string_view>
+#include <vector>
+#include <ranges>
 #include <fmt/ranges.h>
 
 #include <gnutls/pkcs11.h>
 
 #include <seastar/util/closeable.hh>
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/sstring.hh>
 #include "db/view/view_building_worker.hh"
 #include "exceptions/exceptions.hh"
 #include "gms/inet_address.hh"
@@ -22,10 +28,12 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/signal.hh>
 #include <seastar/core/timer.hh>
+#include "locator/host_id.hh"
 #include "service/client_routes.hh"
 #include "service/qos/raft_service_level_distributed_data_accessor.hh"
 #include "db/view/view_building_state.hh"
 #include "tasks/task_manager.hh"
+#include "types/types.hh"
 #include "utils/assert.hh"
 #include "utils/build_id.hh"
 #include "utils/only_on_shard0.hh"
@@ -228,8 +236,28 @@ read_config(bpo::variables_map& opts, db::config& cfg) {
 }
 
 static void
-self_heal_service_levels_version(db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client, abort_source& as) {
+self_heal_service_levels_version(db::system_keyspace& sys_ks, cql3::query_processor& qp, service::raft_group0_client& group0_client,
+        gms::gossiper& gossiper, abort_source& as) {
     static constexpr unsigned max_attempts = 10;
+    static constexpr auto group0_retry_interval = 1s;
+    static constexpr auto replicas_alive_timeout = 15min;
+    // join_cluster() has completed, so normal token owners remain stable for the rest of startup.
+    auto nodes = qp.db().real_database().get_token_metadata().get_normal_token_owners() | std::ranges::to<std::vector<locator::host_id>>();
+
+    if (std::ranges::any_of(nodes, [&gossiper](locator::host_id& id){return !gossiper.is_alive(id); })) {
+        startlog.info("Cannot self-heal service levels version because not all replicas are alive, waiting for nodes to be alive {}", nodes);
+
+        try {
+            gossiper.wait_alive(nodes, replicas_alive_timeout).get();
+        } catch (std::runtime_error& e){
+            startlog.info("Timeout while waiting for all nodes to become alive {}", e.what());
+            std::throw_with_nested(std::runtime_error(fmt::format("Cannot self-heal service levels version because not all replicas are alive after {} minutes",
+                replicas_alive_timeout.count())));
+        }
+    }
+
+    startlog.info("All nodes are alive continuing with service level self healing");
+
     for (unsigned attempt = 1; attempt <= max_attempts; ++attempt) {
         try {
             auto guard = group0_client.start_operation(as).get();
@@ -240,16 +268,19 @@ self_heal_service_levels_version(db::system_keyspace& sys_ks, cql3::query_proces
                 return;
             }
 
-            auto nodes_count = qp.db().real_database().get_token_metadata().get_normal_token_owners().size();
-            qos::service_level_controller::migrate_to_v2(nodes_count, sys_ks, qp, group0_client, as).get();
+            qos::service_level_controller::migrate_to_v2(nodes.size(),sys_ks, qp, group0_client, as).get();
             group0_client.send_group0_read_barrier_to_live_members().get();
             startlog.info("Self-healed service levels version marker to v2.");
             return;
         } catch (...) {
             if (attempt == max_attempts) {
-                std::throw_with_nested(std::runtime_error(format("Failed to self-heal service levels version marker after {} attempts", max_attempts)));
+                std::throw_with_nested(std::runtime_error(fmt::format("Cannot self-heal service levels version after {} attempts", max_attempts)));
             }
-            startlog.info("Concurrent group0 operation while self-healing service levels version marker, retrying ({}/{}).", attempt, max_attempts);
+
+            startlog.info("Concurrent group0 operation while self-healing service levels version marker, retrying ({}/{}) in {} second(s).",
+                    attempt, max_attempts, group0_retry_interval.count());
+
+            sleep_abortable(group0_retry_interval, as).get();
         }
     }
 }
@@ -2491,7 +2522,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             if (should_self_heal_service_levels_version) {
                 checkpoint(stop_signal, "self-healing service levels version");
-                self_heal_service_levels_version(sys_ks.local(), qp.local(), group0_client, stop_signal.as_local_abort_source());
+                self_heal_service_levels_version(sys_ks.local(), qp.local(), group0_client, gossiper.local(), stop_signal.as_local_abort_source());
             }
 
             // At this point, `locator::topology` should be stable, i.e. we should have complete information

--- a/test/cluster/auth_cluster/test_service_levels_self_healing.py
+++ b/test/cluster/auth_cluster/test_service_levels_self_healing.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 
+import asyncio
 import time
 
 from cassandra import ConsistencyLevel
@@ -14,7 +15,7 @@ import pytest
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 from test.cluster.util import reconnect_driver
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
 
 
 NANOS_PER_SECOND = 1_000_000_000
@@ -22,6 +23,8 @@ NANOS_PER_SECOND = 1_000_000_000
 V1_SERVICE_LEVELS = {
     "sl_v1_interactive": (Duration(0, 0, 30 * NANOS_PER_SECOND), "interactive", 1000),
     "sl_v1_batch": (Duration(0, 0, 60 * NANOS_PER_SECOND), "batch", 500)}
+
+SERVICE_LEVEL_VER_QUERY = "SELECT value FROM system.scylla_local WHERE key = 'service_level_version'"
 
 
 def assert_service_levels(rows, expected):
@@ -35,23 +38,7 @@ def assert_service_levels(rows, expected):
         assert row.shares == shares
 
 
-@pytest.mark.skip_mode(mode="release", reason="error injection is disabled in release mode")
-async def test_self_heals_service_levels_v1_after_restart(manager: ManagerClient, scale_timeout: callable):
-    """Reproduces a raft-topology cluster created before service levels were initialized as v2."""
-
-    service_level_ver_query = "SELECT value FROM system.scylla_local WHERE key = 'service_level_version'"
-    service_level_list_query = "LIST ALL SERVICE LEVELS"
-    service_levels_v1_query = SimpleStatement("SELECT service_level, timeout, workload_type, shares FROM system_distributed.service_levels",
-        consistency_level=ConsistencyLevel.ONE)
-    
-    config = {
-        **auth_config,
-        "error_injections_at_startup": ["skip_service_levels_v2_initialization"]}
-
-    server = await manager.server_add(config=config)
-    cql = manager.get_cql()
-
-    #create the service_levels v1 table because in 2026.2 its removed 
+async def create_system_distributed_service_levels(cql):
     await cql.run_async("""
         CREATE TABLE IF NOT EXISTS system_distributed.service_levels (
             service_level text PRIMARY KEY,
@@ -59,8 +46,26 @@ async def test_self_heals_service_levels_v1_after_restart(manager: ManagerClient
             workload_type text,
             shares int)""")
 
+
+@pytest.mark.skip_mode(mode="release", reason="error injection is disabled in release mode")
+async def test_self_heals_service_levels_v1_after_restart(manager: ManagerClient, scale_timeout: callable):
+    """Reproduces a raft-topology cluster created before service levels were initialized as v2."""
+
+    service_level_list_query = "LIST ALL SERVICE LEVELS"
+    service_levels_v1_query = SimpleStatement("SELECT service_level, timeout, workload_type, shares FROM system_distributed.service_levels",
+        consistency_level=ConsistencyLevel.ONE)
+
+    config = {
+        **auth_config,
+        "error_injections_at_startup": ["skip_service_levels_v2_initialization"]}
+
+    server = await manager.server_add(config=config)
+    cql = manager.get_cql()
+
+    await create_system_distributed_service_levels(cql)
+
     async def service_levels_version_initialized():
-        rows = await cql.run_async(service_level_ver_query)
+        rows = await cql.run_async(SERVICE_LEVEL_VER_QUERY)
         if not rows:
             return None
         return rows
@@ -86,7 +91,7 @@ async def test_self_heals_service_levels_v1_after_restart(manager: ManagerClient
     expected_service_levels = {**V1_SERVICE_LEVELS, "driver": (None, "batch", 200)}
 
     async def service_levels_v2_healed():
-        version_rows = await cql.run_async(service_level_ver_query)
+        version_rows = await cql.run_async(SERVICE_LEVEL_VER_QUERY)
         if not version_rows or version_rows[0].value != "2":
             return None
 
@@ -98,3 +103,50 @@ async def test_self_heals_service_levels_v1_after_restart(manager: ManagerClient
         return True
 
     await wait_for(service_levels_v2_healed, time.time() + scale_timeout(30))
+
+
+async def _validate_host_service_level_ver(hosts, cql, ver):
+    for host in hosts:
+        version_rows = await cql.run_async(SERVICE_LEVEL_VER_QUERY, host=host)
+        if not version_rows:
+            raise RuntimeError("No service level returned from query, aborting!")
+        assert version_rows[0].value == str(ver)
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injection is disabled in release mode")
+async def test_self_heal_waits_for_unavailable_replicas(manager: ManagerClient, scale_timeout: callable):
+    """Verify SCYLLADB-3337: service level migration should wait for all nodes to be available"""
+
+    config = {
+        **auth_config,
+        "error_injections_at_startup": ["skip_service_levels_v2_initialization"]}
+
+    servers = await manager.servers_add(3, config=config)
+    cql = manager.get_cql()
+
+    await create_system_distributed_service_levels(cql)
+
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + scale_timeout(30))
+    await _validate_host_service_level_ver(hosts, cql, 1)
+
+    restarting_server, unavailable_server = servers[:2]
+    await manager.server_stop_gracefully(restarting_server.server_id)
+    await manager.server_stop_gracefully(unavailable_server.server_id)
+    await manager.server_update_config(restarting_server.server_id, "error_injections_at_startup", [])
+
+    restarting_log = await manager.server_open_log(restarting_server.server_id)
+    log_mark = await restarting_log.mark()
+    restart_task = asyncio.create_task(manager.server_start(restarting_server.server_id, timeout=scale_timeout(180)))
+
+    await restarting_log.wait_for(
+        "Cannot self-heal service levels version because not all replicas are alive",
+        from_mark=log_mark,
+        timeout=scale_timeout(60))
+    assert not restart_task.done()
+
+    await manager.server_start(unavailable_server.server_id, timeout=scale_timeout(30))
+    await restart_task
+
+    cql = await reconnect_driver(manager)
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + scale_timeout(30))
+    await _validate_host_service_level_ver(hosts, cql, 2)


### PR DESCRIPTION
Service-level migration reads system_distributed at CL=ALL and can fail during startup when a replica is unavailable. Wait for all replicas to become alive before migrating the service-level state to v2. Also added a cluster test covering recovery after the unavailable node returns.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3337

backport: should be backported to all active branches because of the migration process

