### PR TITLE
replica/table: expose sstables-per-read as a Prometheus metric

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2274,6 +2274,7 @@ void table::set_metrics() {
                     ms::make_summary("cas_commit_latency_summary", ms::description("CAS learn round latency summary"), [this] {return to_metrics_summary(_stats.cas_learn.summary());})(cf)(ks).set_skip_when_empty(),
 
                     ms::make_histogram("read_latency", ms::description("Read latency histogram"), [this] {return to_metrics_histogram(_stats.reads.histogram());})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
+                    ms::make_histogram("sstables_per_read", ms::description("Number of sstables accessed to serve a single-partition read."), [this] {return _stats.estimated_sstable_per_read.get_histogram();})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
                     ms::make_histogram("write_latency", ms::description("Write latency histogram"), [this] {return to_metrics_histogram(_stats.writes.histogram());})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
                     ms::make_histogram("cas_prepare_latency", ms::description("CAS prepare round latency histogram"), [this] {return to_metrics_histogram(_stats.cas_prepare.histogram());})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
                     ms::make_histogram("cas_propose_latency", ms::description("CAS accept round latency histogram"), [this] {return to_metrics_histogram(_stats.cas_accept.histogram());})(cf)(ks).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),


### PR DESCRIPTION
`cf_stats::estimated_sstable_per_read` already tracks, per single- partition read, how many sstables were combined to serve it, but this histogram was only reachable through the internal REST admin API, giving no visibility via Prometheus/Grafana.

Register it as a standard per-column-family histogram metric, `scylla_column_family_sstables_per_read`, so read amplification caused by sstable proliferation can be observed and alerted on like any other latency/throughput metric.

Range scans are intentionally not covered: they are expected to touch all sstables in the range by design, so per-read sstable counts are not a meaningful signal there.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3339

Improvement in visibility. No backport required.