### PR TITLE
streaming: add missing version tag to sstable_meta

### DIFF
--- a/idl/streaming.idl.hh
+++ b/idl/streaming.idl.hh
@@ -111,7 +111,7 @@ class stream_blob_meta {
     streaming::file_ops fops;
     service::frozen_topology_guard topo_guard;
     std::optional<sstables::sstable_state> sstable_state;
-    std::optional<streaming::stream_sstable_meta> sstable_meta;
+    std::optional<streaming::stream_sstable_meta> sstable_meta [[version 2026.3]];
 };
 
 class node_and_shard {


### PR DESCRIPTION
Commit 9b4c37dcb7 ("streaming: pass sstable metadata in stream_blob_meta and clone_sstable_request") appended a new optional member, `sstable_meta`, to the `stream_blob_meta` IDL class, which is the argument of the `STREAM_BLOB` (verb 71) RPC used by file-stream based tablet migration. The member was added without a [[version]] attribute.

`stream_blob_meta` is a non-final (size-framed) IDL class. During deserialization of such a class, the generated serializer reads a member gracefully -- only consuming it when bytes remain in the frame -- only if the member carries a [[version]] attribute. A member without the attribute is read unconditionally. Note that declaring the member as `std::optional<>` does not help here: it only allows the value to be `nullopt`, it does not make the reader tolerate a truncated buffer.

As a result the field was not rolling-upgrade safe. When an older node that predates 9b4c37dcb7 streams sstables to a newer node during a rolling upgrade, the older sender serializes stream_blob_meta without sstable_meta, and the newer receiver, after reading the known members, unconditionally tries to read sstable_meta from the now-exhausted frame and throws `std::out_of_range (deserialization buffer underflow) on verb 71`. The STREAM_BLOB RPC fails, the tablet migration cannot complete, and the leftover tablet transition keeps the topology coordinator in the `tablet_migration` transition state. While in that state the coordinator never services queued global topology requests, causing subsequent requests to get stuck.

Add the [[version 2026.3]] attribute to `sstable_meta` so that a newer receiver tolerates the shorter payload produced by an older sender, restoring rolling-upgrade compatibility of `STREAM_BLOB`.

Fixes: SCYLLADB-3298

This fix needs to be backported to 2026.3