### PR TITLE
dht/range_streamer: fix log message for finished range

### DIFF
--- a/dht/range_streamer.cc
+++ b/dht/range_streamer.cc
@@ -287,8 +287,7 @@ future<> range_streamer::stream_async() {
                     _nr_ranges_remaining -= ranges_streamed;
                     float percentage = _nr_total_ranges == 0 ? 1 : (_nr_total_ranges - _nr_ranges_remaining) / (float)_nr_total_ranges;
                     _stream_manager.local().update_finished_percentage(_reason, percentage);
-                    logger.info("Finished {} out of {} ranges for {}, finished percentage={}",
-                            _nr_total_ranges - _nr_ranges_remaining, _nr_total_ranges, _reason, percentage);
+                    logger.info("Finished {} out of {} ranges ({:.1f}%) for {}", _nr_total_ranges - _nr_ranges_remaining, _nr_total_ranges, percentage * 100, _reason);
                 };
                 dht::token_range_vector ranges_to_stream;
                 try {


### PR DESCRIPTION
The log says "finished percentage", but then logs a value between 0 and 1.
Make the value a true percentage (* 100) and also update the log message to make it easier to read.
Before:

    [shard 0:strm] range_streamer - Finished 3095 out of 13725 ranges for bootstrap, finished percentage=0.22550091

After:

    [shard 0:strm] range_streamer - Finished 3095 out of 13725 ranges (22%) for bootstrap

Backport: minor log message improvement, no backport