### PR TITLE
dist/docker: allow --nobest on microdnf update for ubi9-minimal base

### DIFF
--- a/dist/docker/redhat/build_docker.sh
+++ b/dist/docker/redhat/build_docker.sh
@@ -67,7 +67,7 @@ if [ -f build/build.ninja ]; then
 fi
 
 bcp() { buildah copy "$container" "$@"; }
-run() { buildah run "$container" "$@"; }
+run() { buildah run "$container" -- "$@"; }
 bconfig() { buildah config "$@" "$container"; }
 
 container="$(buildah from --pull=always docker.io/redhat/ubi9-minimal:latest)"
@@ -94,7 +94,7 @@ bcp dist/docker/scylla_bashrc /scylla_bashrc
 bcp LICENSE-ScyllaDB-Source-Available.md /licenses/
 
 run microdnf clean all
-run microdnf --setopt=tsflags=nodocs -y update
+run microdnf --setopt=tsflags=nodocs -y --nobest update
 run microdnf --setopt=tsflags=nodocs -y install hostname kmod procps-ng python3 python3-pip systemd
 run curl -L --output /etc/yum.repos.d/scylla.repo ${repo_file_url}
 run pip3 install --no-cache-dir --prefix /usr supervisor


### PR DESCRIPTION
The UBI9 base image can carry a glibc/glibc-common/glibc-minimal-langpack trio that lags behind the live ubi-9-baseos-rpms mirror. microdnf's solver then fails to reconcile the atomic 3-package glibc swap with a depsolve conflict, deterministically breaking the release container build.

`--nobest` relaxes the best-candidate selection, letting the solver route around the glibc trio conflict instead of aborting the transaction.

Fixes RELENG-755

**2026.1 and above carry the identical vulnerable `microdnf --setopt=tsflags=nodocs -y update` call in `dist/docker/redhat/build_docker.sh`, so all are equally exposed to this deterministic glibc depsolve conflict when building the redhat/UBI9 container image**