### PR TITLE
sstables/trie: gracefully handle failed allocations in trie writer

### DIFF
--- a/sstables/trie/writer_node.hh
+++ b/sstables/trie/writer_node.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <cstdint>
+#include <new>
 #include "common.hh"
 #include "utils/assert.hh"
 
@@ -192,8 +193,11 @@ private:
         if (_spare) {
             _current = std::move(_spare);
         } else {
-            _current = std::unique_ptr<std::byte[], aligned_deleter>(
-                static_cast<std::byte*>(aligned_alloc(_segment_size, _segment_size)));
+            auto p = static_cast<std::byte*>(aligned_alloc(_segment_size, _segment_size));
+            if (!p) {
+                throw std::bad_alloc();
+            }
+            _current = std::unique_ptr<std::byte[], aligned_deleter>(p);
         }
     }
 

--- a/test/boost/trie_writer_test.cc
+++ b/test/boost/trie_writer_test.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/memory.hh>
+#include <seastar/util/alloc_failure_injector.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/testing/test_case.hh>
 #include <xxhash.h>
@@ -311,4 +312,30 @@ SEASTAR_THREAD_TEST_CASE(test_finite_memory_usage) {
         tests::require_greater_equal(seastar::memory::stats().allocated_memory(), memory_usage_before);
         tests::require_less_equal(seastar::memory::stats().allocated_memory(), max_allowed_memory_usage);
     }
+}
+
+// Regression test for an unchecked aligned_alloc() in the trie writer's bump_allocator.
+//
+// When memory runs out, aligned_alloc() returns nullptr. The bump_allocator used
+// to dereference the result without checking, which segfaulted instead of cleanly
+// propagating an allocation failure.
+//
+// with_allocation_failures() reruns the trie-writing code, failing a different
+// allocation on each pass, so it eventually fails the segment allocation. With the
+// bug present this test segfaults; with the fix it must complete, every failed
+// allocation surfacing as a bad_alloc rather than a crash.
+SEASTAR_THREAD_TEST_CASE(test_allocation_failure_safety) {
+    seastar::memory::with_allocation_failures([] {
+        auto out = null_trie_output_stream(4096);
+        auto wr = trie_writer(out);
+        auto dummy_payload = trie_payload(1, std::array<std::byte, 1>{});
+        std::vector<std::byte> prev_key;
+        for (uint32_t i = 0; i < 100; ++i) {
+            std::vector<std::byte> curr_key(std::from_range, object_representation(seastar::cpu_to_be(i)));
+            size_t depth = std::ranges::mismatch(curr_key, prev_key).in1 - curr_key.begin();
+            wr.add(depth, std::span(curr_key).subspan(depth), dummy_payload);
+            prev_key = curr_key;
+        }
+        wr.finish();
+    });
 }


### PR DESCRIPTION
There an unchecked `aligned_alloc` in the trie writer. If it fails, the writer segfaults on the subsequent attempt to write through the returned null pointer.

This failure can only happen when the shard is OOM, at which point it's very likely to crash on something else anyway. So it's rather unimportant in the grand scheme of things. But it still deserves to be fixed.

Fixes: SCYLLADB-3329

Should be backported to all existing releases with tries.