### PR TITLE
compaction_manager: fix a race between stop() and enable()

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1136,7 +1136,14 @@ void compaction_manager::register_metrics() {
 }
 
 void compaction_manager::enable() {
-    SCYLLA_ASSERT(_state == state::none || _state == state::running);
+    if (_state == state::stopped) {
+        // The manager is being (or has been) stopped, e.g. shutdown started
+        // before enable() was ever called. A late caller (e.g. a
+        // disk_space_monitor callback that fires while the monitor is still
+        // alive during shutdown) must not resurrect the state machine.
+        return;
+    }
+
     cmlog.info("Asked to enable");
 
     if (_state == state::none) {
@@ -1353,6 +1360,11 @@ void compaction_manager::do_stop() noexcept {
         // Possible when the node shuts down before enable() is called,
         // e.g. due to an early startup failure. The task manager module
         // was registered in the constructor and must be unregistered.
+        // Move to state::stopped right away, so that a late enable()/drain()
+        // call (e.g. triggered by a disk_space_monitor callback that is still
+        // alive during shutdown) doesn't resurrect the state machine and
+        // leave it in a non-terminal state forever (see destructor assert).
+        _state = state::stopped;
         _stop_future = _task_manager_module->stop();
         return;
     }

--- a/test/cluster/test_major_compaction.py
+++ b/test/cluster/test_major_compaction.py
@@ -181,7 +181,7 @@ async def test_shutdown_drain_during_compaction(manager: ManagerClient):
         logger.info("Shutdown server")
         stop_task = asyncio.create_task(manager.server_stop_gracefully(server.server_id))
         # wait until the shutdown drain request is sent to compaction_manager
-        await log.wait_for("Asked to drain", from_mark=mark, timeout=30)
+        await log.wait_for("compaction_manager - Asked to drain", from_mark=mark, timeout=30)
         # now resume compaction and let shutdown complete
         await injection_handler.message()
         # wait server to shutdown


### PR DESCRIPTION
If the node shuts down before compaction_manager::enable() is ever called (e.g. early startup failure), do_stop() took a shortcut for state::none that only stopped the task_manager module and left _state at state::none instead of state::stopped.

The disk_space_monitor is stopped after the compaction_manager in main.cc's shutdown sequence, so there is a window during shutdown where a still-alive disk_space_monitor callback can invoke enable()/drain() on a compaction_manager that has already begun stopping. Since _state was still state::none, enable()'s assert passed and flipped _state to state::running, permanently stuck there because do_stop() only runs once. This later tripped the destructor assert:

  SCYLLA_ASSERT(_state == state::none || _state == state::stopped)

Fix by:
- making do_stop()'s state::none branch transition to state::stopped as well, so the terminal state is always consistent
- guarding enable() to no-op when _state == state::stopped, instead of resurrecting the state machine from a late call

Additionally improve the test_shutdown_drain_during_compaction. There are multiple services logging "Asked to drain" but the test wants to wait for the drain request to arrive to the compaction_manager.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3291

No backport required. It's a CI failure on master.