### PR TITLE
messaging: add get_auxiliary() helper and use it for all inbound aux lookups

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -541,29 +541,29 @@ future<rpc::no_wait_type> gossiper::background_msg(sstring type, noncopyable_fun
 
 void gossiper::init_messaging_service_handler() {
     ser::gossip_rpc_verbs::register_gossip_digest_syn(&_messaging, [this] (const rpc::client_info& cinfo, gossip_digest_syn syn_msg) {
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return background_msg("GOSSIP_DIGEST_SYN", [from, syn_msg = std::move(syn_msg)] (gms::gossiper& gossiper) mutable {
             return gossiper.handle_syn_msg(from, std::move(syn_msg));
         });
     });
      ser::gossip_rpc_verbs::register_gossip_digest_ack(&_messaging, [this] (const rpc::client_info& cinfo, gossip_digest_ack msg) {
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return background_msg("GOSSIP_DIGEST_ACK", [from, msg = std::move(msg)] (gms::gossiper& gossiper) mutable {
             return gossiper.handle_ack_msg(from, std::move(msg));
         });
     });
     ser::gossip_rpc_verbs::register_gossip_digest_ack2(&_messaging, [this] (const rpc::client_info& cinfo, gossip_digest_ack2 msg) {
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return background_msg("GOSSIP_DIGEST_ACK2", [from, msg = std::move(msg)] (gms::gossiper& gossiper) mutable {
             return gossiper.handle_ack2_msg(from, std::move(msg));
         });
     });
     ser::gossip_rpc_verbs::register_gossip_echo(&_messaging, [this] (const rpc::client_info& cinfo, seastar::rpc::opt_time_point timeout, rpc::optional<int64_t> generation_number_opt, rpc::optional<bool> notify_up_opt) {
-        auto from_hid = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from_hid = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return handle_echo_msg(from_hid, timeout, generation_number_opt, notify_up_opt.value_or(false));
     });
     ser::gossip_rpc_verbs::register_gossip_shutdown(&_messaging, [this] (const rpc::client_info& cinfo, inet_address from, rpc::optional<int64_t> generation_number_opt) {
-        auto from_hid = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from_hid = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return background_msg("GOSSIP_SHUTDOWN", [from_hid, generation_number_opt] (gms::gossiper& gossiper) {
             return gossiper.handle_shutdown_msg(from_hid, generation_number_opt);
         });

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -604,6 +604,16 @@ messaging_service::messaging_service(config cfg, scheduling_config scfg, std::sh
     init_feature_listeners();
 }
 
+[[noreturn]] void handle_missing_client_id_aux(const rpc::client_info& cinfo, const sstring& key) {
+    static thread_local logger::rate_limit rate_limit(std::chrono::seconds(10));
+    mlogger.log(log_level::warn, rate_limit,
+            "Connection from {} is missing CLIENT_ID auxiliary data \"{}\"; the peer's CLIENT_ID"
+            " message likely failed. Aborting the connection; the RPC will fail and the sender"
+            " will reconnect.", cinfo.addr, key);
+    cinfo.server.abort_connection(cinfo.conn_id);
+    throw missing_client_id_error(key);
+}
+
 messaging_service::~messaging_service() = default;
 
 static future<> do_with_servers(std::string_view what, std::array<std::unique_ptr<messaging_service::rpc_protocol_server_wrapper>, 2>& servers, auto method) {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -604,13 +604,6 @@ messaging_service::messaging_service(config cfg, scheduling_config scfg, std::sh
     init_feature_listeners();
 }
 
-msg_addr messaging_service::get_source(const rpc::client_info& cinfo) {
-    return msg_addr{
-        cinfo.retrieve_auxiliary<gms::inet_address>("baddr"),
-        cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id")
-    };
-}
-
 messaging_service::~messaging_service() = default;
 
 static future<> do_with_servers(std::string_view what, std::array<std::unique_ptr<messaging_service::rpc_protocol_server_wrapper>, 2>& servers, auto method) {

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -486,7 +486,6 @@ public:
         return _connection_dropped.connect(slot);
     }
     std::unique_ptr<rpc_protocol_wrapper>& rpc();
-    static msg_addr get_source(const rpc::client_info& client);
     scheduling_group scheduling_group_for_verb(messaging_verb verb) const;
     future<scheduling_group> scheduling_group_for_isolation_cookie(const sstring& isolation_cookie) const;
     std::vector<messaging_service::scheduling_info_for_connection_index> initial_scheduling_info() const;

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -253,6 +253,31 @@ struct unknown_address : public std::runtime_error {
     unknown_address(locator::host_id id) : std::runtime_error(fmt::format("no ip address mapping for {}", id)) {}
 };
 
+// Thrown by get_auxiliary() when a connection is missing CLIENT_ID
+// auxiliary data (the peer's CLIENT_ID handler failed before
+// attach_auxiliary, e.g. under memory pressure). The connection is
+// aborted before this is thrown; the RPC fails and the sender
+// re-establishes the connection, which resends CLIENT_ID.
+struct missing_client_id_error : public std::runtime_error {
+    explicit missing_client_id_error(std::string_view key)
+        : std::runtime_error(fmt::format("connection missing CLIENT_ID auxiliary data \"{}\"", key)) {}
+};
+
+// Out-of-line: rate-limited warn + abort_connection + throw. Defined in messaging_service.cc.
+[[noreturn]] void handle_missing_client_id_aux(const rpc::client_info& cinfo, const seastar::sstring& key);
+
+// Replacement for rpc::client_info::retrieve_auxiliary(), which SEASTAR_ASSERTs
+// (aborts the node) when the key is absent. Missing aux data means the peer's
+// CLIENT_ID exchange failed on this connection; the connection is unusable,
+// so abort it and fail the RPC instead of crashing.
+template <typename T>
+const T& get_auxiliary(const rpc::client_info& cinfo, const seastar::sstring& key) {
+    if (const T* value = cinfo.retrieve_auxiliary_opt<T>(key)) {
+        return *value;
+    }
+    handle_missing_client_id_aux(cinfo, key);
+}
+
 class messaging_service : public seastar::async_sharded_service<messaging_service>, public peering_sharded_service<messaging_service> {
 public:
     struct rpc_protocol_wrapper;

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2752,8 +2752,8 @@ future<> repair_service::init_ms_handlers() {
     auto& ms = this->_messaging;
 
     ms.register_repair_get_row_diff_with_rpc_stream([this, &ms] (const rpc::client_info& cinfo, uint64_t repair_meta_id, rpc::source<repair_hash_with_cmd> source, rpc::optional<shard_id> dst_cpu_id_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         auto sink = ms.make_sink_for_repair_get_row_diff_with_rpc_stream(source);
         // Start a new fiber.
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
@@ -2764,8 +2764,8 @@ future<> repair_service::init_ms_handlers() {
         return make_ready_future<rpc::sink<repair_row_on_wire_with_cmd>>(sink);
     });
     ms.register_repair_put_row_diff_with_rpc_stream([this, &ms] (const rpc::client_info& cinfo, uint64_t repair_meta_id, rpc::source<repair_row_on_wire_with_cmd> source, rpc::optional<shard_id> dst_cpu_id_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         auto sink = ms.make_sink_for_repair_put_row_diff_with_rpc_stream(source);
         // Start a new fiber.
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
@@ -2776,8 +2776,8 @@ future<> repair_service::init_ms_handlers() {
         return make_ready_future<rpc::sink<repair_stream_cmd>>(sink);
     });
     ms.register_repair_get_full_row_hashes_with_rpc_stream([this, &ms] (const rpc::client_info& cinfo, uint64_t repair_meta_id, rpc::source<repair_stream_cmd> source, rpc::optional<shard_id> dst_cpu_id_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         auto sink = ms.make_sink_for_repair_get_full_row_hashes_with_rpc_stream(source);
         // Start a new fiber.
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
@@ -2788,8 +2788,8 @@ future<> repair_service::init_ms_handlers() {
         return make_ready_future<rpc::sink<repair_hash_with_cmd>>(sink);
     });
     ser::repair_rpc_verbs::register_repair_get_full_row_hashes(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::optional<shard_id> dst_cpu_id_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
         return container().invoke_on(shard, [from, repair_meta_id] (repair_service& local_repair) {
             auto rm = local_repair.get_repair_meta(from, repair_meta_id);
@@ -2803,9 +2803,9 @@ future<> repair_service::init_ms_handlers() {
     });
     ser::repair_rpc_verbs::register_repair_get_combined_row_hash(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id,
             std::optional<repair_sync_boundary> common_sync_boundary, rpc::optional<shard_id> dst_cpu_id_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return container().invoke_on(shard, [from, repair_meta_id,
                 common_sync_boundary = std::move(common_sync_boundary)] (repair_service& local_repair) mutable {
             auto rm = local_repair.get_repair_meta(from, repair_meta_id);
@@ -2819,8 +2819,8 @@ future<> repair_service::init_ms_handlers() {
     });
     ser::repair_rpc_verbs::register_repair_get_sync_boundary(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id,
             std::optional<repair_sync_boundary> skipped_sync_boundary, rpc::optional<shard_id> dst_cpu_id_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
         return container().invoke_on(shard, [from, repair_meta_id,
                 skipped_sync_boundary = std::move(skipped_sync_boundary)] (repair_service& local_repair) mutable {
@@ -2834,9 +2834,9 @@ future<> repair_service::init_ms_handlers() {
     });
     ser::repair_rpc_verbs::register_repair_get_row_diff(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id,
             repair_hash_set set_diff, bool needs_all_rows, rpc::optional<shard_id> dst_cpu_id_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         _metrics.rx_hashes_nr += set_diff.size();
         auto fp = make_foreign(std::make_unique<repair_hash_set>(std::move(set_diff)));
         return container().invoke_on(shard, [from, repair_meta_id, fp = std::move(fp), needs_all_rows] (repair_service& local_repair) mutable {
@@ -2857,9 +2857,9 @@ future<> repair_service::init_ms_handlers() {
     });
     ser::repair_rpc_verbs::register_repair_put_row_diff(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id,
             repair_rows_on_wire row_diff, rpc::optional<shard_id> dst_cpu_id_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         auto fp = make_foreign(std::make_unique<repair_rows_on_wire>(std::move(row_diff)));
         return container().invoke_on(shard, [from, repair_meta_id, fp = std::move(fp)] (repair_service& local_repair) mutable {
             auto rm = local_repair.get_repair_meta(from, repair_meta_id);
@@ -2881,9 +2881,9 @@ future<> repair_service::init_ms_handlers() {
             rpc::optional<streaming::stream_reason> reason, rpc::optional<gc_clock::time_point> compaction_time, rpc::optional<shard_id> dst_cpu_id_opt,
             rpc::optional<service::frozen_topology_guard> topo_guard, rpc::optional<std::optional<int64_t>> repaired_at,
             rpc::optional<locator::tablet_repair_incremental_mode> incremental_mode) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
-        auto from_id = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from_id = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return container().invoke_on(shard, [from_id, src_cpu_id, repair_meta_id, ks_name, cf_name,
                 range, algo, max_row_buf_size, seed, remote_shard, remote_shard_count, remote_ignore_msb, schema_version, reason, compaction_time, this,
                 topo_guard = topo_guard.value_or(service::default_session_id), repaired_at = repaired_at.value_or(std::nullopt), incremental_mode = incremental_mode.value_or(locator::tablet_repair_incremental_mode::disabled)] (repair_service& local_repair) mutable {
@@ -2897,9 +2897,9 @@ future<> repair_service::init_ms_handlers() {
     });
     ser::repair_rpc_verbs::register_repair_row_level_stop(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id,
             sstring ks_name, sstring cf_name, dht::token_range range, rpc::optional<shard_id> dst_cpu_id_opt, rpc::optional<bool> mark_as_repaired_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         bool mark_as_repaired = mark_as_repaired_opt.value_or(false);
         return container().invoke_on(shard, [from, repair_meta_id, ks_name, cf_name, range, mark_as_repaired] (repair_service& local_repair) mutable {
             return repair_meta::repair_row_level_stop_handler(local_repair, from, repair_meta_id,
@@ -2907,18 +2907,18 @@ future<> repair_service::init_ms_handlers() {
         });
     });
     ser::repair_rpc_verbs::register_repair_get_estimated_partitions(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::optional<shard_id> dst_cpu_id_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return container().invoke_on(shard, [from, repair_meta_id] (repair_service& local_repair) mutable {
             return repair_meta::repair_get_estimated_partitions_handler(local_repair, from, repair_meta_id);
         });
     });
     ser::repair_rpc_verbs::register_repair_set_estimated_partitions(&ms, [this] (const rpc::client_info& cinfo, uint32_t repair_meta_id,
             uint64_t estimated_partitions, rpc::optional<shard_id> dst_cpu_id_opt) {
-        auto src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
         auto shard = get_dst_shard_id(src_cpu_id, dst_cpu_id_opt);
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return container().invoke_on(shard, [from, repair_meta_id, estimated_partitions] (repair_service& local_repair) mutable {
             return repair_meta::repair_set_estimated_partitions_handler(local_repair, from, repair_meta_id, estimated_partitions);
         });
@@ -2927,11 +2927,11 @@ future<> repair_service::init_ms_handlers() {
         return make_ready_future<std::vector<row_level_diff_detect_algorithm>>(suportted_diff_detect_algorithms());
     });
     ser::repair_rpc_verbs::register_repair_update_system_table(&ms, [this] (const rpc::client_info& cinfo, repair_update_system_table_request req) {
-        auto from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
+        auto from = netw::get_auxiliary<gms::inet_address>(cinfo, "baddr");
         return repair_update_system_table_handler(from, std::move(req));
     });
     ser::repair_rpc_verbs::register_repair_flush_hints_batchlog(&ms, [this] (const rpc::client_info& cinfo, repair_flush_hints_batchlog_request req) {
-        auto from = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
+        auto from = netw::get_auxiliary<gms::inet_address>(cinfo, "baddr");
         return repair_flush_hints_batchlog_handler(from, std::move(req));
     });
 

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -150,7 +150,7 @@ void migration_manager::init_messaging_service()
             }
 
             co_return rpc::tuple(utils::chunked_vector<frozen_mutation>{}, std::move(cm));
-        }, cinfo.retrieve_auxiliary<locator::host_id>("host_id"), std::move(options)));
+        }, netw::get_auxiliary<locator::host_id>(cinfo, "host_id"), std::move(options)));
     });
     ser::migration_manager_rpc_verbs::register_schema_check(&_messaging, [this] {
         return make_ready_future<table_schema_version>(_storage_proxy.get_db().local().get_version());

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -92,7 +92,7 @@ raft_group_registry::raft_group_registry(
 
 void raft_group_registry::init_rpc_verbs() {
     auto handle_raft_rpc = [this] (
-            const rpc::client_info& cinfo,
+            const rpc::client_info&,
             const raft::group_id& gid, raft::server_id from, raft::server_id dst, auto handler) {
         constexpr bool is_one_way = std::is_void_v<std::invoke_result_t<decltype(handler), raft_rpc&>>;
         if (_my_id != dst) {
@@ -105,7 +105,7 @@ void raft_group_registry::init_rpc_verbs() {
         }
 
         return container().invoke_on(shard_for_group(gid),
-                [addr = netw::messaging_service::get_source(cinfo).addr, gid, handler] (raft_group_registry& self) mutable {
+                [gid, handler] (raft_group_registry& self) mutable {
             auto& rpc = self.get_rpc(gid);
             // Execute the actual message handling code
             if constexpr (is_one_way) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -538,8 +538,8 @@ private:
             const rpc::client_info& cinfo, rpc::opt_time_point t,
             utils::chunked_vector<frozen_mutation> fms, db::consistency_level cl, std::optional<tracing::trace_info> trace_info,
             rpc::optional<service::fencing_token> fence_opt) {
-        auto src_addr = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-         auto src_shard = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_addr = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
+         auto src_shard = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
 
         tracing::trace_state_ptr trace_state_ptr;
         if (trace_info) {
@@ -707,7 +707,7 @@ private:
             rpc::optional<host_id_vector_replica_set> forward_id, rpc::optional<locator::host_id> reply_to_id,
             rpc::optional<bool> skip_large_data_guardrails_opt) {
         tracing::trace_state_ptr trace_state_ptr;
-        auto src_addr = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto src_addr = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         auto rate_limit_info = rate_limit_info_opt.value_or(std::monostate());
         auto skip_large_data_guardrails = skip_large_data_guardrails_opt.value_or(false);
 
@@ -748,7 +748,7 @@ private:
             rpc::optional<host_id_vector_replica_set> forward_id, rpc::optional<locator::host_id> reply_to_id,
             rpc::optional<fencing_token> fence) {
         tracing::trace_state_ptr trace_state_ptr;
-        auto src_addr = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto src_addr = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
 
         auto schema_version = decision.update.schema_version();
         return handle_write(src_addr, t, schema_version, std::move(decision), std::move(forward), reply_to, std::move(forward_id),reply_to_id, shard,
@@ -771,12 +771,12 @@ private:
             const rpc::client_info& cinfo,
             unsigned shard, storage_proxy::response_id_type response_id, rpc::optional<db::view::update_backlog> backlog,
             rpc::optional<uint8_t> large_data_violations_opt) {
-        auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         auto violations = static_cast<db::large_data_violation_type>(large_data_violations_opt.value_or(0));
         _sp.get_stats().replica_cross_shard_ops += shard != this_shard_id();
         return _sp.container().invoke_on(shard, _sp._write_ack_smp_service_group,
-                [from, response_id, backlog = std::move(backlog), violations] (storage_proxy& sp) mutable {
-            sp.got_response(response_id, from, std::move(backlog), violations);
+                [from_id = from, response_id, backlog = std::move(backlog), violations] (storage_proxy& sp) mutable {
+            sp.got_response(response_id, from_id, std::move(backlog), violations);
             return netw::messaging_service::no_wait();
         });
     }
@@ -785,10 +785,10 @@ private:
             const rpc::client_info& cinfo,
             unsigned shard, storage_proxy::response_id_type response_id, size_t num_failed,
             rpc::optional<db::view::update_backlog> backlog, rpc::optional<replica::exception_variant> exception) {
-        auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         _sp.get_stats().replica_cross_shard_ops += shard != this_shard_id();
         return _sp.container().invoke_on(shard, _sp._write_ack_smp_service_group,
-                [from, response_id, num_failed, backlog = std::move(backlog), exception = std::move(exception)] (storage_proxy& sp) mutable {
+                [from_id = from, response_id, num_failed, backlog = std::move(backlog), exception = std::move(exception)] (storage_proxy& sp) mutable {
             error err = error::FAILURE;
             std::optional<sstring> msg;
             if (exception) {
@@ -812,7 +812,7 @@ private:
                     }
                 }, exception->reason);
             }
-            sp.got_failure_response(response_id, from, num_failed, std::move(backlog), err, std::move(msg));
+            sp.got_failure_response(response_id, from_id, num_failed, std::move(backlog), err, std::move(msg));
             return netw::messaging_service::no_wait();
         });
     }
@@ -827,8 +827,8 @@ private:
         rpc::optional<service::fencing_token> fence_opt)
     {
         tracing::trace_state_ptr trace_state_ptr;
-        auto src_addr = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-        auto src_shard = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_addr = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
+        auto src_shard = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
 
         if (cmd1.trace_info) {
             trace_state_ptr = tracing::tracing::get_local_tracing_instance().create_session(*cmd1.trace_info);
@@ -847,7 +847,7 @@ private:
                 auto& cfg = _sp.local_db().get_config();
                 cmd1.max_result_size.emplace(cfg.max_memory_for_unlimited_query_soft_limit(), cfg.max_memory_for_unlimited_query_hard_limit());
             } else {
-                cmd1.max_result_size.emplace(cinfo.retrieve_auxiliary<uint64_t>("max_result_size"));
+                cmd1.max_result_size.emplace(netw::get_auxiliary<uint64_t>(cinfo, "max_result_size"));
             }
         }
         shared_ptr<storage_proxy> p = _sp.shared_from_this();
@@ -1022,8 +1022,8 @@ private:
             query::read_command cmd, partition_key key, utils::UUID ballot,
             bool only_digest, query::digest_algorithm da, std::optional<tracing::trace_info> trace_info,
             rpc::optional<fencing_token> fence_opt) {
-        auto src_addr = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-        auto src_shard = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_addr = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
+        auto src_shard = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
 
         tracing::trace_state_ptr tr_state;
         if (trace_info) {
@@ -1035,7 +1035,7 @@ private:
         co_await _sp.apply_fence(fence_opt, src_addr);
 
         if (!cmd.max_result_size) {
-            cmd.max_result_size.emplace(cinfo.retrieve_auxiliary<uint64_t>("max_result_size"));
+            cmd.max_result_size.emplace(netw::get_auxiliary<uint64_t>(cinfo, "max_result_size"));
         }
 
         auto schema = co_await get_schema_for_read(cmd.schema_version, src_addr, src_shard, *timeout);
@@ -1067,8 +1067,8 @@ private:
             const rpc::client_info& cinfo, rpc::opt_time_point timeout,
             paxos::proposal proposal, std::optional<tracing::trace_info> trace_info,
             rpc::optional<fencing_token> fence_opt) {
-        auto src_addr = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-        auto src_shard = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_addr = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
+        auto src_shard = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
 
         tracing::trace_state_ptr tr_state;
         if (trace_info) {
@@ -1111,8 +1111,8 @@ private:
             rpc::optional<fencing_token> fence_opt) {
         static thread_local uint16_t pruning = 0;
         static constexpr uint16_t pruning_limit = 1000; // since PRUNE verb is one way replica side has its own queue limit
-        auto src_addr = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-        auto src_shard = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto src_addr = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
+        auto src_shard = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
 
         tracing::trace_state_ptr tr_state;
         if (trace_info) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6734,7 +6734,7 @@ void storage_service::check_raft_rpc(raft::server_id dst_id) {
 
 void storage_service::init_messaging_service() {
     ser::node_ops_rpc_verbs::register_node_ops_cmd(&_messaging.local(), [this] (const rpc::client_info& cinfo, node_ops_cmd_request req) {
-        auto coordinator = cinfo.retrieve_auxiliary<gms::inet_address>("baddr");
+        auto coordinator = netw::get_auxiliary<gms::inet_address>(cinfo, "baddr");
         std::optional<locator::host_id> coordinator_host_id;
         if (const auto* id = cinfo.retrieve_auxiliary_opt<locator::host_id>("host_id")) {
             coordinator_host_id = *id;
@@ -6927,7 +6927,7 @@ void storage_service::init_messaging_service() {
         });
     });
     ser::join_node_rpc_verbs::register_notify_banned(&_messaging.local(), [this] (const rpc::client_info& cinfo, raft::server_id dst_id) {
-        auto src_id = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto src_id = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return container().invoke_on(0, [src_id, dst_id] (auto& ss) -> future<rpc::no_wait_type> {
             if (ss.my_host_id() != locator::host_id{dst_id.uuid()}) {
                 rtlogger.warn("received notify_banned from {} for {}, but my id is {}, ignoring", src_id, dst_id, ss.my_host_id());

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -95,8 +95,8 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
     auto& ms = _ms.local();
 
     ser::streaming_rpc_verbs::register_prepare_message(&ms, [this] (const rpc::client_info& cinfo, prepare_message msg, streaming::plan_id plan_id, sstring description, rpc::optional<stream_reason> reason_opt, rpc::optional<service::session_id> session) {
-        const auto& src_cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
-        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        const auto& src_cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
+        const auto& from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         auto dst_cpu_id = this_shard_id();
         auto reason = reason_opt ? *reason_opt : stream_reason::unspecified;
         auto topo_guard = service::frozen_topology_guard(session.value_or(service::default_session_id));
@@ -111,7 +111,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
         });
     });
     ser::streaming_rpc_verbs::register_prepare_done_message(&ms, [this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id) {
-        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        const auto& from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return container().invoke_on(dst_cpu_id, [plan_id, from] (auto& sm) mutable {
             auto session = sm.get_session(plan_id, from, "PREPARE_DONE_MESSAGE");
             session->follower_start_sent();
@@ -122,10 +122,10 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
             rpc::optional<stream_reason> reason_opt,
             rpc::source<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>> source,
             rpc::optional<service::session_id> session) {
-        auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
-        auto cpu_id = cinfo.retrieve_auxiliary<uint32_t>("src_cpu_id");
+        auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
+        auto cpu_id = netw::get_auxiliary<uint32_t>(cinfo, "src_cpu_id");
 
-        auto src = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        auto src = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
 
         auto reason = reason_opt ? *reason_opt: stream_reason::unspecified;
         service::frozen_topology_guard topo_guard = session.value_or(service::default_session_id);
@@ -287,14 +287,14 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
       });
     });
     ser::streaming_rpc_verbs::register_stream_mutation_done(&ms, [this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, dht::token_range_vector ranges, table_id cf_id, unsigned dst_cpu_id) {
-        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        const auto& from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         return container().invoke_on(dst_cpu_id, [ranges = std::move(ranges), plan_id, cf_id, from] (auto& sm) mutable {
             auto session = sm.get_session(plan_id, from, "STREAM_MUTATION_DONE", cf_id);
             session->receive_task_completed(cf_id);
         });
     });
     ser::streaming_rpc_verbs::register_complete_message(&ms, [this] (const rpc::client_info& cinfo, streaming::plan_id plan_id, unsigned dst_cpu_id, rpc::optional<bool> failed) {
-        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        const auto& from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         if (failed && *failed) {
             return container().invoke_on(dst_cpu_id, [plan_id, from, dst_cpu_id] (auto& sm) {
                 auto session = sm.get_session(plan_id, from, "COMPLETE_MESSAGE");
@@ -309,7 +309,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
         }
     });
     ms.register_stream_blob([this] (const rpc::client_info& cinfo, streaming::stream_blob_meta meta, rpc::source<streaming::stream_blob_cmd_data> source) {
-        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+        const auto& from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
         auto sink = _ms.local().make_sink_for_stream_blob(source);
         (void)stream_blob_handler(_db.local(), _view_building_worker.local(), _ms.local(), from, meta, sink, source).handle_exception([ms = _ms.local().shared_from_this()] (std::exception_ptr eptr) {
             sslog.warn("Failed to run stream blob handler: {}", eptr);

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -107,7 +107,7 @@ do_test_file_stream(replica::database& db, netw::messaging_service& ms, std::vec
             if (!verb_register) {
                 co_await smp::invoke_on_all([&] {
                     return global_ms.local().register_stream_blob([&](const rpc::client_info& cinfo, streaming::stream_blob_meta meta, rpc::source<streaming::stream_blob_cmd_data> source) {
-                        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+                        const auto& from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
                         auto sink = global_ms.local().make_sink_for_stream_blob(source);
                         (void)stream_blob_handler(global_db.local(), global_ms.local(), from, meta, sink, source, [&suffix](auto&, const streaming::stream_blob_meta& meta) -> future<output_result> {
                             auto path = meta.filename + suffix;
@@ -206,7 +206,7 @@ do_test_sstable_stream(cql_test_env& env, compress_sstable compress, std::functi
             if (!verb_register) {
                 co_await smp::invoke_on_all([&global_db, &global_ms] {
                     return global_ms.local().register_stream_blob([&global_db, &global_ms](const rpc::client_info& cinfo, streaming::stream_blob_meta meta, rpc::source<streaming::stream_blob_cmd_data> source) {
-                        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+                        const auto& from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
                         auto sink = global_ms.local().make_sink_for_stream_blob(source);
                         (void)stream_blob_handler(global_db.local(), global_ms.local(), from, meta, sink, source, [](auto&, const streaming::stream_blob_meta& meta) -> future<output_result> {
                             auto path = meta.filename;

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -67,7 +67,7 @@ public:
         ser::gossip_rpc_verbs::register_gossip_digest_syn(&ms, [this] (const rpc::client_info& cinfo, gms::gossip_digest_syn msg) {
             test_logger.info("Server got syn msg = {}", msg);
 
-            auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+            auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
             auto ep1 = inet_address("1.1.1.1");
             auto ep2 = inet_address("2.2.2.2");
             gms::generation_type gen(800);
@@ -89,7 +89,7 @@ public:
 
         ser::gossip_rpc_verbs::register_gossip_digest_ack(&ms, [this] (const rpc::client_info& cinfo, gms::gossip_digest_ack msg) {
             test_logger.info("Server got ack msg = {}", msg);
-            auto from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+            auto from = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
             // Prepare gossip_digest_ack2 message
             auto ep1 = inet_address("3.3.3.3");
             std::map<inet_address, endpoint_state> eps{

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -421,7 +421,7 @@ future<> cql_server::stop() {
 void cql_server::init_messaging_service() {
     ser::forward_cql_rpc_verbs::register_forward_cql_execute(&_ms,
         [this](const rpc::client_info& cinfo, rpc::opt_time_point timeout, unsigned shard, forward_cql_execute_request req) -> future<forward_cql_execute_response> {
-            auto src_host = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+            auto src_host = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
             clogger.trace("Handling forwarded CQL request from {} on shard {}", src_host, shard);
 
             co_await utils::get_local_injector().inject("wait_before_handling_forwarded_request", utils::wait_for_message(60s));
@@ -469,7 +469,7 @@ void cql_server::init_messaging_service() {
 
     ser::forward_cql_rpc_verbs::register_forward_cql_prepare(&_ms,
         [this](const rpc::client_info& cinfo, rpc::opt_time_point timeout, forward_cql_prepare_request req) -> future<bytes> {
-            auto src_host = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
+            auto src_host = netw::get_auxiliary<locator::host_id>(cinfo, "host_id");
             clogger.trace("Handling forward prepare request from {}", src_host);
 
             service::client_state cs(_auth_service, &_sl_controller, std::move(req.client_state));


### PR DESCRIPTION
When a CLIENT_ID message fails before attach_auxiliary (e.g. bad_alloc under memory pressure), the receiving connection's aux map stays empty. Subsequent verbs calling retrieve_auxiliary() on that connection unconditionally assert and abort the node.

Add netw::get_auxiliary<T>(cinfo, key): retrieve_auxiliary_opt(), and on miss, rate-limited warn + abort_connection(cinfo.conn_id) + throw missing_client_id_error. Convert all 65 call sites (production and test) from cinfo.retrieve_auxiliary<T>("k") to netw::get_auxiliary<T>(cinfo, "k").

Throwing is safe everywhere: every site is at the top of its handler lambda, before any co_await/invoke_on/sink creation, reached via futurize::apply, so the throw becomes an exceptional future rather than escaping to terminate. One-way (no_wait) handlers: seastar logs and swallows it. Wait handlers: abort_connection() sets the connection's error flag first, so the reply path sends nothing and the sender observes a plain rpc::closed_error, same as any dropped connection. Aux attachment is all-or-nothing per connection, so a connection that fails one lookup fails every subsequent one identically.

Also removed the unused get_source():
get_source()'s sole caller, raft_group_registry.cc's handle_raft_rpc, captured its .addr and never used it in the lambda body. Drop the dead capture (cinfo becomes unused there too, so drop its name) and delete get_source() itself.

Complementary sender-side fix: #30865.

Fixes: SCYLLADB-3348
Fixes: CUSTOMER-573

Backport: This fix needs to be backported to active branches, as the problem has been observed in production cluster running 2026.1.