### PR TITLE
Native backup: survive dropping the snapshot's table or keyspace

### DIFF
--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -332,7 +332,7 @@ future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring buck
                 sstables::snapshots_dir /
                 std::string_view(snapshot_name));
     auto task = co_await _task_manager_module->make_and_start_task<::db::snapshot::backup_task_impl>(
-        {}, *this, _storage_manager.container(), std::move(endpoint), std::move(bucket), std::move(prefix), keyspace, dir, global_table->schema()->id(), move_files);
+        {}, *this, _storage_manager.container(), std::move(endpoint), std::move(bucket), std::move(prefix), keyspace, dir, move_files);
     co_return task->id();
 }
 

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -26,7 +26,6 @@
 #include "db/system_distributed_keyspace.hh"
 #include "index/secondary_index_manager.hh"
 #include "replica/database.hh"
-#include "replica/global_table_ptr.hh"
 #include "replica/schema_describe_helper.hh"
 #include "sstables/sstables_manager.hh"
 #include "sstables/object_storage_client.hh"
@@ -303,13 +302,6 @@ future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring buck
 
     co_await coroutine::switch_to(_config.backup_sched_group);
     snap_log.info("Backup sstables from {}({}) to {}", keyspace, snapshot_name, endpoint);
-    auto global_table = co_await get_table_on_all_shards(_db, keyspace, table);
-    auto& storage_options = global_table->get_storage_options();
-    if (!storage_options.is_local_type()) {
-        throw std::invalid_argument("not able to backup a non-local table");
-    }
-    cancel_expiration(snapshot_name, {keyspace}, table);
-    auto& local_storage_options = std::get<data_dictionary::storage_options::local>(storage_options.value);
     //
     // The keyspace data directories and their snapshots are arranged as follows:
     //
@@ -328,11 +320,20 @@ future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring buck
     //  |- <keyspace name2>
     //  |- ...
     //
-    auto dir = (local_storage_options.dir /
-                sstables::snapshots_dir /
-                std::string_view(snapshot_name));
+    // The backup only reads the on-disk snapshot files, so it must succeed even
+    // if the table or keyspace was dropped after the snapshot was created, or
+    // dropped and recreated under the same name, snapshots survive DROP.
+    // Locate the snapshot on disk instead of resolving it through the live
+    // table.
+    auto dir = co_await _db.local().find_snapshot_dir(keyspace, table, snapshot_name);
+    if (!dir) {
+        throw std::invalid_argument(format("snapshot {} not found for table {}.{}", snapshot_name, keyspace, table));
+    }
+
+    cancel_expiration(snapshot_name, {keyspace}, table);
+
     auto task = co_await _task_manager_module->make_and_start_task<::db::snapshot::backup_task_impl>(
-        {}, *this, _storage_manager.container(), std::move(endpoint), std::move(bucket), std::move(prefix), keyspace, dir, move_files);
+        {}, *this, _storage_manager.container(), std::move(endpoint), std::move(bucket), std::move(prefix), keyspace, std::move(*dir), move_files);
     co_return task->id();
 }
 

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -16,7 +16,6 @@
 #include "db/config.hh"
 #include "db/snapshot-ctl.hh"
 #include "db/snapshot/backup_task.hh"
-#include "schema/schema_fwd.hh"
 #include "sstables/sstables.hh"
 #include "sstables/sstable_directory.hh"
 #include "sstables/sstables_manager.hh"

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -36,7 +36,6 @@ backup_task_impl::backup_task_impl(tasks::task_manager::module_ptr module,
                                    sstring prefix,
                                    sstring ks,
                                    std::filesystem::path snapshot_dir,
-                                   table_id tid,
                                    bool move_files) noexcept
     : tasks::task_manager::task::impl(module, tasks::task_id::create_random_id(), 0, "node", ks, "", "", tasks::task_id::create_null_id())
     , _snap_ctl(ctl)
@@ -45,7 +44,6 @@ backup_task_impl::backup_task_impl(tasks::task_manager::module_ptr module,
     , _bucket(std::move(bucket))
     , _prefix(std::move(prefix))
     , _snapshot_dir(std::move(snapshot_dir))
-    , _table_id(tid)
     , _remove_on_uploaded(move_files) {
     _status.progress_units = "bytes";
 }
@@ -122,7 +120,7 @@ future<> backup_task_impl::do_backup() {
     co_await process_snapshot_dir();
 
     _backup_shard = this_shard_id();
-    co_await _sharded_worker.start(std::ref(_snap_ctl.db()), _table_id, std::ref(*this));
+    co_await _sharded_worker.start(std::ref(_snap_ctl.db()), std::ref(*this));
 
     gate abort_gate;
     auto abort_sub = _as.subscribe([&] () noexcept {
@@ -290,8 +288,13 @@ void backup_task_impl::on_sstable_deletion(sstables::generation_type gen) {
     }
 }
 
-backup_task_impl::worker::worker(const replica::database& db, table_id t, backup_task_impl& task)
-    : _manager(db.get_sstables_manager(*db.find_schema(t)))
+backup_task_impl::worker::worker(const replica::database& db, backup_task_impl& task)
+    // Backup only reads snapshot files from disk and never touches the live
+    // table, so it's not mandatory to resolve it (it may have been dropped after the
+    // snapshot was taken). The sstables_manager is only used for its
+    // dir_semaphore() and deletion notifications, and selecting between the
+    // system and the user manager depends only on the keyspace name.
+    : _manager(db.get_sstables_manager(task._status.keyspace))
     , _task(task)
     , _client(task._sstm.local().get_endpoint_client(task._endpoint))
 {

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -119,6 +119,13 @@ future<> backup_task_impl::do_backup() {
     co_await process_snapshot_dir();
 
     _backup_shard = this_shard_id();
+
+    // Pre-worker break point. Lets tests drop the keyspace/table after the
+    // snapshot already exists but before the per-shard worker is constructed,
+    // to reproduce SCYLLADB-3252 (the worker ctor used to call db.find_schema(),
+    // which threw no_such_column_family once the table was gone).
+    co_await utils::get_local_injector().inject("backup_task_before_worker", utils::wait_for_message(std::chrono::minutes(2)));
+
     co_await _sharded_worker.start(std::ref(_snap_ctl.db()), std::ref(*this));
 
     gate abort_gate;

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -49,7 +49,6 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     sstring _bucket;
     sstring _prefix;
     std::filesystem::path _snapshot_dir;
-    table_id _table_id;
     bool _remove_on_uploaded;
     tasks::task_manager::task::progress _total_progress;
 
@@ -70,7 +69,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
         std::exception_ptr _ex;
 
     public:
-        worker(const replica::database& db, table_id t, backup_task_impl& task);
+        worker(const replica::database& db, backup_task_impl& task);
         ~worker();
 
         future<> start_uploading();
@@ -112,7 +111,6 @@ public:
                      sstring prefix,
                      sstring ks,
                      std::filesystem::path snapshot_dir,
-                     table_id tid,
                      bool move_files) noexcept;
 
     virtual std::string type() const override;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1055,14 +1055,21 @@ void database::drop_keyspace(const sstring& name) {
     _keyspaces.erase(name);
 }
 
+static bool is_system_table(std::string_view ks_name) {
+    return ks_name == db::system_keyspace::NAME ||
+        ks_name == db::system_distributed_keyspace::NAME;
+}
+
 static bool is_system_table(const schema& s) {
-    auto& k = s.ks_name();
-    return k == db::system_keyspace::NAME ||
-        k == db::system_distributed_keyspace::NAME;
+    return is_system_table(s.ks_name());
 }
 
 sstables::sstables_manager& database::get_sstables_manager(const schema& s) const {
-    return get_sstables_manager(system_keyspace(is_system_table(s)));
+    return get_sstables_manager(s.ks_name());
+}
+
+sstables::sstables_manager& database::get_sstables_manager(std::string_view ks_name) const {
+    return get_sstables_manager(system_keyspace(is_system_table(ks_name)));
 }
 
 void database::init_schema_commitlog() {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -73,6 +73,7 @@
 #include <seastar/core/shared_ptr_incomplete.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/util/memory_diagnostics.hh>
+#include <seastar/util/closeable.hh>
 #include <seastar/util/file.hh>
 
 #include "locator/abstract_replication_strategy.hh"
@@ -3343,6 +3344,38 @@ future<std::unordered_map<sstring, database::snapshot_details>> database::get_sn
     }
 
     co_return details;
+}
+
+future<std::optional<std::filesystem::path>> database::find_snapshot_dir(sstring ks_name, sstring table_name, sstring tag) {
+    // The table may have been dropped (and possibly recreated) after the
+    // snapshot was taken. Its data directory '<keyspace>/<table>-<uuid>' is kept
+    // on disk as long as it holds snapshots, so scan for a '<table>-<uuid>'
+    // directory that contains 'snapshots/<tag>' and return the first match.
+    auto table_dir_prefix = get_snapshot_table_dir_prefix(table_name);
+    for (const auto& datadir : _cfg.data_file_directories()) {
+        auto ks_dir = fs::path(datadir) / ks_name;
+        if (!co_await file_exists(ks_dir.native())) {
+            continue;
+        }
+        auto table_dir_lister = directory_lister(ks_dir, lister::dir_entry_types::of<directory_entry_type::directory>(),
+                lister::filter_type([&table_dir_prefix] (const fs::path&, const directory_entry& de) {
+                    return de.name.starts_with(table_dir_prefix);
+                }));
+        auto snapshot_dir = co_await with_closeable(std::move(table_dir_lister), [&] (directory_lister& lister) -> future<std::optional<fs::path>> {
+            while (auto table_ent = co_await lister.get()) {
+                auto candidate = ks_dir / table_ent->name / sstables::snapshots_dir / tag;
+                auto file_type_opt = co_await engine().file_type(candidate.native(), follow_symlink::no);
+                if (file_type_opt && *file_type_opt == directory_entry_type::directory) {
+                    co_return candidate;
+                }
+            }
+            co_return std::nullopt;
+        });
+        if (snapshot_dir) {
+            co_return snapshot_dir;
+        }
+    }
+    co_return std::nullopt;
 }
 
 // For the filesystem operations, this code will assume that all keyspaces are visible in all shards

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -2067,6 +2067,8 @@ public:
     using snapshot_details = db::snapshot_ctl::db_snapshot_details;
     future<std::unordered_map<sstring, snapshot_details>> get_snapshot_details();
 
+    future<std::optional<std::filesystem::path>> find_snapshot_dir(sstring ks_name, sstring table_name, sstring tag);
+
     friend std::ostream& operator<<(std::ostream& out, const database& db);
     const flat_hash_map<sstring, keyspace>& get_keyspaces() const {
         return _keyspaces;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -2109,6 +2109,10 @@ public:
 
     sstables::sstables_manager& get_sstables_manager(const schema& s) const;
 
+    // Selects the sstables_manager by keyspace name alone, so it's possible to
+    // get an sstables manager even if the live table doesnt exist anymore (but its snapshots do).
+    sstables::sstables_manager& get_sstables_manager(std::string_view ks_name) const;
+
     // Returns the list of ranges held by this endpoint
     // The returned list is sorted, and its elements are non overlapping and non wrap-around.
     future<dht::token_range_vector> get_keyspace_local_ranges(locator::static_effective_replication_map_ptr erm);

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1536,6 +1536,112 @@ async def test_drop_keyspace_during_tablet_restore(manager: ManagerClient, objec
     await manager.api.message_injection(servers[1].ip_addr, "pause_download_sstable")
 
     await drop_task
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_drop_table_during_backup(manager: ManagerClient, object_storage):
+    """Verify that dropping a table while a native backup is running does not
+    fail the backup.
+    The 'backup_task_before_worker' injection pauses the backup after the
+    snapshot directory has been scanned but before the per-shard worker is
+    constructed. We drop the table while the
+    backup is parked there, then release it and expect the backup to finish.
+    """
+
+    objconf = object_storage.create_endpoint_conf()
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options'],
+           'task_ttl_in_seconds': 300,
+           }
+    cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
+    server = await manager.server_add(config=cfg, cmdline=cmd)
+    cql = manager.get_cql()
+    cf = 'test_cf'
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+        await asyncio.gather(*(cql.run_async(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('{name}', '{value}');") for name, value in [('0', 'zero'), ('1', 'one'), ('2', 'two')]))
+        snap_name, files = await take_snapshot_on_one_server(ks, server, manager, logger)
+        assert len(files) > 0
+
+        # Pause the backup before the per-shard worker runs.
+        await manager.api.enable_injection(server.ip_addr, "backup_task_before_worker", one_shot=True)
+        server_log = await manager.server_open_log(server.server_id)
+        log_mark = await server_log.mark()
+
+        prefix = unique_name('backup_')
+        tid = await manager.api.backup(server.ip_addr, ks, cf, snap_name, object_storage.address, object_storage.bucket_name, prefix)
+
+        await server_log.wait_for("backup_task_before_worker: waiting for message", from_mark=log_mark)
+
+        # Drop the table while the backup is parked. The snapshot files remain on
+        # disk, so the backup should still be able to upload them.
+        await cql.run_async(f"DROP TABLE {ks}.{cf}")
+
+        # Release the backup and let it finish.
+        await manager.api.message_injection(server.ip_addr, "backup_task_before_worker")
+
+        status = await manager.api.wait_task(server.ip_addr, tid)
+        assert status is not None, "Backup task status is missing"
+        assert status['state'] == 'done', f"Backup failed after the table was dropped: {status}"
+
+        # The snapshot's SSTables must have been uploaded to the bucket.
+        objects = set(o.key for o in object_storage.get_resource().Bucket(object_storage.bucket_name).objects.all())
+        for f in files:
+            assert f'{prefix}/{f}' in objects, f"{f} was not uploaded to the backup"
+
+
+@pytest.mark.parametrize("drop", ["table", "keyspace", "table_recreated"])
+async def test_backup_after_schema_dropped(manager: ManagerClient, object_storage, drop):
+    """Verify that a native backup can be started for a snapshot whose table (or
+    whole keyspace) was already dropped before the backup was requested.
+
+    Snapshot files survive DROP TABLE and DROP KEYSPACE: the table's
+    <cf>-<uuid>/snapshots/<name> directory is kept on disk, and the parent
+    keyspace directory is never removed (it stays non-empty because of the
+    surviving snapshot). So the backup should locate the snapshot on disk and
+    complete independent of table existence.
+    """
+
+    objconf = object_storage.create_endpoint_conf()
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options'],
+           'task_ttl_in_seconds': 300,
+           }
+    cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
+    server = await manager.server_add(config=cfg, cmdline=cmd)
+    cql = manager.get_cql()
+    cf = 'test_cf'
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+        await asyncio.gather(*(cql.run_async(f"INSERT INTO {ks}.{cf} ( name, value ) VALUES ('{name}', '{value}');") for name, value in [('0', 'zero'), ('1', 'one'), ('2', 'two')]))
+        snap_name, files = await take_snapshot_on_one_server(ks, server, manager, logger)
+        assert len(files) > 0
+
+        # Drop the table/keyspace BEFORE requesting the backup.
+        # The snapshot files remain on disk under <cf>-<uuid>/snapshots/<snap_name>.
+        if drop == "table":
+            await cql.run_async(f"DROP TABLE {ks}.{cf}")
+        elif drop == "keyspace":
+            await cql.run_async(f"DROP KEYSPACE {ks}")
+        else:
+            await cql.run_async(f"DROP TABLE {ks}.{cf}")
+            await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
+
+        prefix = unique_name('backup_')
+        tid = await manager.api.backup(server.ip_addr, ks, cf, snap_name, object_storage.address, object_storage.bucket_name, prefix)
+
+        status = await manager.api.wait_task(server.ip_addr, tid)
+        assert status is not None, "Backup task status is missing"
+        assert status['state'] == 'done', f"Backup failed for a dropped {drop}'s snapshot: {status}"
+
+        # The snapshot's SSTables must have been uploaded to the bucket.
+        objects = set(o.key for o in object_storage.get_resource().Bucket(object_storage.bucket_name).objects.all())
+        for f in files:
+            assert f'{prefix}/{f}' in objects, f"{f} was not uploaded to the backup"
+
+
 # cluster backup/snapshot
 
 async def prepare_write_workload(cql, table_name, flush=True, n: int = None):

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -18,7 +18,7 @@ from typing import Callable, Awaitable
 from functools import partial
 from test.pylib.manager_client import ManagerClient, ServerInfo
 from test.cluster.util import wait_for_cql_and_get_hosts, get_replication, new_test_keyspace, new_test_table
-from test.pylib.rest_client import read_barrier
+from test.pylib.rest_client import read_barrier, HTTPError
 from test.pylib.util import unique_name, wait_all
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from cassandra.cluster import ConsistencyLevel
@@ -120,8 +120,15 @@ async def test_backup_with_non_existing_parameters(manager: ManagerClient, objec
         assert len(files) > 0
 
         prefix = f'{cf}/backup'
-        tid = await manager.api.backup(server.ip_addr, ks, cf,
-                backup_snap_name if ne_parameter != 'snapshot' else 'no-such-snapshot',
+        if ne_parameter == 'snapshot':
+            # The snapshot's existence on disk is validated synchronously by the
+            # backup API: the request fails and no task is created.
+            with pytest.raises(HTTPError, match='no-such-snapshot not found'):
+                await manager.api.backup(server.ip_addr, ks, cf, 'no-such-snapshot',
+                        object_storage.address, object_storage.bucket_name, prefix)
+            return
+
+        tid = await manager.api.backup(server.ip_addr, ks, cf, backup_snap_name,
                 object_storage.address if ne_parameter != 'endpoint' else 'no-such-endpoint',
                 object_storage.bucket_name if ne_parameter != 'bucket' else 'no-such-bucket',
                 prefix)


### PR DESCRIPTION
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3252

**Problem**

Scylla Manager drives native backup in two steps: it first takes a snapshot,
then calls POST /storage_service/backup to upload the snapshot's SSTables to object storage.
If the keyspace or table is dropped between those steps — or while the upload is still running — the backup fails with `data_dictionary::no_such_column_family`, even though the backup only reads the on-disk snapshot files, 
which survive DROP TABLE and DROP KEYSPACE. There were two failure points:

- `snapshot_ctl::start_backup()` resolved the snapshot directory from the live table's storage options, so the request failed with HTTP 500 if the schema was already gone. It also resolved the wrong directory if the table had been dropped and recreated under the same name, failing the backup with "snapshot does not exist" although the dropped incarnation's snapshot is still on disk.
- The backup task's per-shard worker called `db.find_schema(table_id)` — only to pick the sstables_manager — so a drop landing after the task started killed a backup already in flight.

**Changes**

- The backup worker no longer resolves the table at all. The sstables_manager is now selected by keyspace name (new `database::get_sstables_manager(std::string_view)` overload), which preserves the system/user manager selection for system/system_distributed backups, and table_id is dropped from the backup task.
- `start_backup()` still resolves the snapshot directory from the live table when possible, but falls back to locating the snapshot on disk — via the new database::find_snapshot_dir(), which scans the data directories for` <keyspace>/<table>-<uuid>/snapshots/<tag>` — when the table is gone or its resolved snapshot directory doesn't exist (the dropped-and-recreated case).
 - Regression tests: one uses a new error injection point to drop the table while a backup is paused right before worker; a parametrized one drops the table/the whole keyspace, or drops-and-recreates the table before requesting the backup.
 
 Needs backport up to 2026.1, customer runs 2026.1.5