### PR TITLE
Revert "Merge 'Marking long running LWT test as nightly ' from Yauheni Khatsianevich"

### DIFF
--- a/test/cluster/lwt/test_lwt_during_tablets_migration.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_migration.py
@@ -25,16 +25,16 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 # Test constants
-NUM_MIGRATIONS = 20
-WARMUP_LWT_CNT = 100
-POST_LWT_CNT = 100
+NUM_MIGRATIONS = 10
+WARMUP_LWT_CNT = 30
+POST_LWT_CNT = 30
 PHASE_WARMUP = 'warmup'
 PHASE_POST = 'post'
 PHASE_MIGRATING = 'migrating'
 
 
 async def tablet_migration_ops(stop_event: asyncio.Event,
-        manager: ManagerClient, servers, tester, num_ops: int, pause_range=(0.5, 2.0)
+        manager: ManagerClient, servers, tester, num_ops: int, pause_range=(0.1, 0.5)
         ):
 
     """
@@ -96,7 +96,8 @@ async def tablet_migration_ops(stop_event: asyncio.Event,
     logger.info("Completed tablet migration ops: %d/%d", migration_count, num_ops)
 
 
-@pytest.mark.nightly
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.skip_mode(mode='debug', reason='debug mode is too slow for this test')
 async def test_multi_column_lwt_during_migration(manager: ManagerClient, scale_timeout):
     """
     Test scenario:
@@ -115,11 +116,10 @@ async def test_multi_column_lwt_during_migration(manager: ManagerClient, scale_t
         "rf_rack_valid_keyspaces": False,
     }
 
-    servers = await manager.servers_add(6, config=cfg)
+    servers = await manager.servers_add(4, config=cfg)
     await manager.disable_tablet_balancing()
 
-    rf_max = len(servers) - 1
-    rf = random.randint(2, rf_max)
+    rf = 3
     logger.info("Using replication_factor=%d (servers=%d)", rf, len(servers))
 
     async with new_test_keyspace(
@@ -147,7 +147,7 @@ async def test_multi_column_lwt_during_migration(manager: ManagerClient, scale_t
                 NUM_MIGRATIONS,
             )
             await tester.start_workers(stop_event_)
-            # Phase 1: warmup LWT (100 applied CAS)
+            # Phase 1: warmup LWT (30 applied CAS)
             tester.set_phase(PHASE_WARMUP)
             logger.info("LWT warmup: waiting for %d applied CAS", WARMUP_LWT_CNT)
             await tester.wait_for_phase_ops(stop_event_, PHASE_WARMUP, WARMUP_LWT_CNT, timeout=60, poll=1.0)
@@ -161,7 +161,7 @@ async def test_multi_column_lwt_during_migration(manager: ManagerClient, scale_t
             )
             await asyncio.wait_for(
                 migration_task,
-                timeout=scale_timeout(NUM_MIGRATIONS * 2 + 15),  # 20*2+15 = 55s before scaling
+                timeout=scale_timeout(NUM_MIGRATIONS * 2 + 15),  # 10*2+15 = 35s before scaling
             )
             logger.info("LWT during migrating phase: %d ops", tester.get_phase_ops(PHASE_MIGRATING))
 


### PR DESCRIPTION
This reverts commit f7e739e6f4ba1a952957b50361df44c9da8d3930, reversing changes made to 515a6a22cb7bd0931fa5375656b11931692d76a9.

The test failed two times in a row in next.
Fixes SCYLLADB-3365

Backport: problematic commit is on master only, no backport