### PR TITLE
encryption: preserve original encryption parameters when rewriting Statistics.db

### DIFF
--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -744,6 +744,26 @@ public:
     }
 
     future<bool> wrap_writeonly(const sstables::sstable& sst, sstables::component_type type, std::function<void(shared_ptr<symmetric_key>)> apply) {
+        if (sst.created_by_component_rewrite()) {
+            // We are rewriting a single component of an already-sealed sstable
+            // (e.g. Statistics, when updating repaired_at). The rest of the
+            // sstable is hard-linked and its scylla_metadata is carried over,
+            // so the rewritten component must be encrypted (or not)
+            // with exactly the parameters as when the sstable was originally written.
+            // We can't use the current config or schema.
+            //
+            // Resolve the same key the read path would use and do not touch scylla_metadata here.
+            auto [id, esx] = get_encryption_schema_extension(sst, type);
+            if (!esx) {
+                // The original component was not encrypted.
+                logg.debug("Rewrite unencrypted sstable component {} (original sstable was not encrypted)", sst.component_basename(type));
+                co_return false;
+            }
+            logg.debug("Rewrite encrypted sstable component {} using {} (id: {})", sst.component_basename(type), *esx, id);
+            auto k = co_await esx->key_for_read(std::move(id));
+            apply(std::move(k));
+            co_return true;
+        }
         auto s = sst.get_schema();
         shared_ptr<encryption_schema_extension> esx;
         auto e = s->extensions().find(encryption_attribute);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1630,6 +1630,14 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         auto new_sst = creator(shared_from_this());
         auto generation = new_sst->generation();
 
+        // Mark the new sstable as a component-rewrite output so that when the
+        // component is written below it preserves the parent sstable's original
+        // encoding (e.g. encryption, recorded in scylla_metadata) instead of
+        // adopting the current schema (or config), which might be different than
+        // for all other components.
+        // The rest of the sstable is hard-linked and its scylla_metadata is carried over.
+        new_sst->mark_created_by_component_rewrite();
+
         _storage->link_with_excluded_components(*this, generation, {component, component_type::Scylla}).get();
         new_sst->copy_components(*this).get();
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -613,6 +613,27 @@ private:
     } _marked_for_deletion = mark_for_deletion::none;
     bool _active = true;
 
+    // Some sstables are produced by performing a metadata update on another sstable.
+    // For example, at the time of this writing, to update repaired_at,
+    // we create a new sstable which shares (by filesystem hardlinks) all files
+    // with the old sstable, except for a fresh Statistics.db which contains
+    // the new repaired_at.
+    // 
+    // Normally the encryption layer adds encryption settings to components based
+    // on the sstable's _schema (and/or the global per-node config).
+    // This works for normal writes where all components have the same schema,
+    // but it doesn't work for single-component rewrites.
+    //
+    // The schema (and/or config) during the rewrite might be different than during the
+    // original write. Using it could result in an sstable where the rewritten
+    // component has different encryption parameters from other components, which
+    // is illegal.
+    // 
+    // We need some way to tell the encryption layer that it's dealing with
+    // a rewrite, not a fresh write. In this case it should ignore schema/config
+    // and strictly obey scylla_metadata.
+    bool _created_by_component_rewrite = false;
+
     db_clock::time_point _now;
 
     io_error_handler _read_error_handler;
@@ -1188,6 +1209,12 @@ public:
     int64_t update_repaired_at(int64_t repaired_at);
     future<> copy_components(const sstable& src);
     bool should_update_repaired_at(int64_t repaired_at) const;
+
+    // See _created_by_component_rewrite. Consulted by file_io_extensions (e.g.
+    // encryption) so the rewritten component matches the parent sstable's
+    // original on-disk encoding rather than the current schema.
+    void mark_created_by_component_rewrite() noexcept { _created_by_component_rewrite = true; }
+    bool created_by_component_rewrite() const noexcept { return _created_by_component_rewrite; }
 
     // Creates a new sstable by linking all sstable components except for the specified component,
     // which is created by calling the provided sstable_creator function and then written to the disc.

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -47,6 +47,9 @@
 #include "db/commitlog/commitlog_replayer.hh"
 #include "init.hh"
 #include "sstables/sstables.hh"
+#include "sstables/sstables_manager.hh"
+#include "compaction/compaction_manager.hh"
+#include "tasks/types.hh"
 #include "cql3/untyped_result_set.hh"
 #include "utils/rjson.hh"
 #include "utils/http.hh"
@@ -473,6 +476,107 @@ SEASTAR_TEST_CASE(test_local_file_provider) {
     tmpdir tmp;
     auto keyfile = tmp.path() / "secret_key";
     co_await test_provider(fmt::format("'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '{}', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", keyfile.string()), tmp);
+}
+
+static std::string local_key_options(const fs::path& keyfile) {
+    return fmt::format("'key_provider': 'LocalFileSystemKeyProviderFactory', 'secret_key_file': '{}', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", keyfile.string());
+}
+
+// Reproduces a bug where rewriting a single sstable component (as done when
+// updating repaired_at, which rewrites Statistics via a special compaction)
+// re-encodes the component according to the *current* encryption settings,
+// which might be incompatible with the encryption settings used by all other
+// components. When that happens, Statistics.db becomes effectively corrupted.
+//
+// The sstable is first written under `initial_options`, then the table is
+// ALTERed to `altered_options`, then the Statistics component is rewritten and
+// the sstable is reloaded from disk (forcing a fresh parse of Statistics).
+// Before the fix, that would crash or throw an exception.
+static future<> test_statistics_rewrite_encryption_mismatch(const tmpdir& tmp,
+        const std::string& initial_options, const std::string& altered_options) {
+    auto ext = std::make_shared<db::extensions>();
+    auto cfg = seastar::make_shared<db::config>(ext);
+    cfg->data_file_directories({tmp.path().string()});
+    {
+        boost::program_options::options_description desc;
+        boost::program_options::options_description_easy_init init(&desc);
+        configurable::append_all(*cfg, init);
+    }
+
+    co_await do_with_cql_env_thread([&] (cql_test_env& env) {
+        auto with_clause = initial_options.empty()
+            ? std::string()
+            : fmt::format(" WITH scylla_encryption_options={{{}}}", initial_options);
+        env.execute_cql(fmt::format("create table ks.t (pk text primary key, v text){}", with_clause)).get();
+        env.execute_cql("insert into ks.t (pk, v) values ('pk0', 'v0')").get();
+
+        // Produce an sstable, written under the initial encryption settings.
+        env.db().invoke_on_all([] (replica::database& db) {
+            return db.find_column_family("ks", "t").flush();
+        }).get();
+
+        // Diverge the schema's encryption from what the sstable was written with.
+        // The on-disk sstables keep their original encryption, as recorded in
+        // their scylla_metadata.
+        env.execute_cql(fmt::format("alter table ks.t WITH scylla_encryption_options={{{}}}", altered_options)).get();
+
+        env.db().invoke_on_all([] (replica::database& db) -> future<> {
+            auto& cf = db.find_column_family("ks", "t");
+            co_await cf.disable_auto_compaction();
+            auto sstables = cf.get_sstables();
+            for (auto sst : *sstables) {
+                // Rewrite the Statistics component, as a repaired_at update does.
+                auto modifier = [] (sstables::sstable& s) {
+                    s.update_repaired_at(s.get_stats_metadata().repaired_at + 1);
+                };
+                auto filter = [&sst] (const sstables::shared_sstable& candidate) {
+                    return candidate == sst;
+                };
+                auto rewritten = co_await cf.get_compaction_manager().perform_component_rewrite(
+                        cf.compaction_group_view_for_sstable(sst), tasks::task_info{},
+                        filter, sstables::component_type::Statistics, modifier,
+                        sstables::update_sstable_id::no);
+                BOOST_REQUIRE_EQUAL(rewritten.size(), 1);
+                auto new_sst = rewritten.at(sst);
+
+                // Reload the rewritten sstable from disk. This re-parses
+                // Statistics.db, which must be decoded consistently with the
+                // sstable's scylla_metadata. Before the fix this throws.
+                auto reloaded = cf.get_sstables_manager().make_sstable(
+                        cf.schema(), cf.get_storage_options(), new_sst->generation(),
+                        new_sst->state(), new_sst->get_version(), new_sst->get_format());
+                co_await reloaded->load(cf.schema()->get_sharder());
+                BOOST_REQUIRE_EQUAL(reloaded->get_stats_metadata().repaired_at,
+                        new_sst->get_stats_metadata().repaired_at);
+            }
+        }).get();
+
+        // Sanity check.
+        require_rows(env, "select * from ks.t",
+                {{utf8_type->decompose(sstring("pk0")), utf8_type->decompose(sstring("v0"))}});
+    }, cfg, {}, cql_test_init_configurables{ *ext });
+}
+
+// sstable written in the clear, encryption enabled afterwards.
+SEASTAR_TEST_CASE(test_statistics_rewrite_after_enabling_encryption) {
+    tmpdir tmp;
+    auto keyfile = tmp.path() / "secret_key";
+    co_await test_statistics_rewrite_encryption_mismatch(tmp, {}, local_key_options(keyfile));
+}
+
+// sstable written encrypted, encryption disabled afterwards.
+SEASTAR_TEST_CASE(test_statistics_rewrite_after_disabling_encryption) {
+    tmpdir tmp;
+    auto keyfile = tmp.path() / "secret_key";
+    co_await test_statistics_rewrite_encryption_mismatch(tmp, local_key_options(keyfile), "'key_provider': 'none'");
+}
+
+// sstable written encrypted, encryption key changed afterwards.
+SEASTAR_TEST_CASE(test_statistics_rewrite_after_changing_encryption_key) {
+    tmpdir tmp;
+    auto keyfile1 = tmp.path() / "secret_key1";
+    auto keyfile2 = tmp.path() / "secret_key2";
+    co_await test_statistics_rewrite_encryption_mismatch(tmp, local_key_options(keyfile1), local_key_options(keyfile2));
 }
 
 static future<> create_key_file(const fs::path& path, const std::vector<key_info>& key_types) {


### PR DESCRIPTION
Some sstables are produced by performing a metadata update on another sstable. For example, at the time of this writing, to update repaired_at, we create a new sstable which shares (by filesystem hardlinks) all files with the old sstable, except for a fresh Statistics.db which contains the new repaired_at.

Normally the encryption layer adds encryption settings to components based on the sstable's _schema (and/or the global per-node config). This works for normal writes where all components have the same schema, but it doesn't work for single-component rewrites.

The schema (and/or config) during the rewrite might be different than during the original write. Using it could result in an sstable where the rewritten component has different encryption parameters from other components, which is illegal, and would leave the sstable effectively corrupted.

We need some way to tell the encryption layer that it's dealing with a rewrite, not a fresh write. In this case it should ignore schema/config and strictly obey scylla_metadata.

Fixes: SCYLLADB-2400

Should be backported to all releases with incremental repair (IIUC that where the "rewrite one component" way of creating sstables was introduced), but this part changed significantly between 2026.1 and 2026.2, so 2026.1 will need to be checked and patched separately.