### PR TITLE
Object storage: encode a hash of the sstable_id in the object prefix

### DIFF
--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -14,6 +14,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/core/byteorder.hh>
 #include <fmt/core.h>
 
 #include "utils/log.hh"
@@ -28,6 +29,8 @@
 #include "utils/s3/creds.hh"
 #include "utils/memory_data_sink.hh"
 #include "utils/lister.hh"
+#include "utils/murmur_hash.hh"
+#include "utils/base64.hh"
 
 using namespace seastar;
 using namespace sstables;
@@ -35,13 +38,19 @@ using namespace utils;
 
 static logging::logger osclog("object_storage_client");
 
+static std::string prefix_hash(const sstable_id& sid) {
+    auto hash_bytes = uninitialized_string<bytes>(4);
+    auto hash = utils::murmur_hash::hash32(sid.id.serialize(), 0);
+    write_le(reinterpret_cast<char*>(hash_bytes.data()), hash);
+    return base64url_encode(hash_bytes);
+}
 
 sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, std::string_view type)
     : _name(fmt::format("/{}/{}/{}", bucket, prefix, type))
 {}
 
 sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, const sstable_id& sid, std::string_view type)
-    : _name(fmt::format("/{}/{}/{}/{}", bucket, prefix, sid, type))
+    : _name(fmt::format("/{}/{}/{}/{}/{}", bucket, prefix, prefix_hash(sid), sid, type))
 {
     if (!sid) {
         on_internal_error(sstlog, fmt::format("SSTable identifier is required for object storage: bucket={} prefix={}", bucket, prefix));

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -790,7 +790,8 @@ static future<> collect_lister_entries(abstract_lister& lister, object_storage_r
 future<object_storage_reference_names> list_object_storage_references(object_storage_client& client, sstring bucket, std::string_view prefix, sstable_id sid) {
     object_storage_reference_names refs;
     try {
-        auto refs_prefix = fmt::format("{}/{}/refs/", prefix, sid);
+        auto refs_name = object_name(bucket, prefix, sid, "refs/");
+        auto refs_prefix = std::string(refs_name.object());
         auto lister = client.make_object_lister(std::move(bucket), refs_prefix, [] (const std::filesystem::path&, const directory_entry&) { return true; });
         co_await with_closeable(std::move(lister), [&refs] (abstract_lister& lister) {
             return collect_lister_entries(lister, refs);

--- a/utils/murmur_hash.hh
+++ b/utils/murmur_hash.hh
@@ -28,7 +28,7 @@ namespace utils {
 
 namespace murmur_hash {
 
-uint32_t hash32(bytes_view data, int32_t seed);
+uint32_t hash32(bytes_view data, uint32_t seed);
 uint64_t hash2_64(bytes_view key, uint64_t seed);
 
 template<typename InputIterator>

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1942,9 +1942,13 @@ public:
         if (offset >= _stats->size) {
             co_return temporary_buffer<uint8_t>();
         }
-
+      try {
         auto buf = co_await _client->get_object_contiguous(_object_name, range{ offset, range_size }, _as);
         co_return temporary_buffer<uint8_t>(reinterpret_cast<uint8_t*>(buf.get_write()), buf.size(), buf.release());
+      } catch (...) {
+        s3l.error("Failed to read {} bytes from {} at offset {}: {}", range_size, _object_name, offset, std::current_exception());
+        throw;
+      }
     }
 
     virtual future<> close() override {


### PR DESCRIPTION
As recommended by https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance-design-patterns.html:
    
> Distribute requests across multiple prefixes – Use a randomized or sequential prefix pattern to spread requests across multiple partitions. For example, instead of using sequential object names like log-2024-01-01.txt, use randomized prefixes like a1b2/log-2024-01-01.txt. This helps Amazon S3 distribute the load more effectively.
    
We use the murmur3 hash32 value of the serialized sstable_id, which is a v1 time uuid, to generate a "random" value.
We then encode its little-endian representation using base64url encoding into a 6-character string that has high stochasticity so that sstable_ids that are generated closly in time will be mapped to different common-prefix partitions on S3 in higher probability.
Otherwise, it may take AWS enough time to recognize a hot spot, split the s3 partition, and migrate some of the objects into other partition(s).

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3368