### PR TITLE
sstables: keep _features in sync with `_components->scylla_metadata`

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1580,7 +1580,7 @@ int64_t sstable::update_repaired_at(int64_t repaired_at) {
 }
 
 future<> sstable::copy_components(const sstable& src) {
-    _components = co_await src._components.copy();
+    set_components(co_await src._components.copy());
     _recognized_components = src._recognized_components;
 }
 
@@ -1675,6 +1675,10 @@ void sstable::write_component_with_metadata(component_type type, scylla_metadata
     write_simple<component_type::Scylla>(metadata);
 
     _components->scylla_metadata = std::move(metadata);
+    // Keep the cached _features in sync with the metadata we just wrote,
+    // mirroring read_scylla_metadata(). Otherwise a rewritten sstable would
+    // report zeroed features (e.g. losing ShadowableTombstones).
+    _features = _components->scylla_metadata->get_features();
 }
 
 future<> sstable::read_summary() noexcept {
@@ -2108,7 +2112,7 @@ future<> sstable::load(const dht::sharder& sharder, sstable_open_config cfg) noe
 future<> sstable::load(sstables::foreign_sstable_open_info info) noexcept {
     static_assert(std::is_nothrow_move_constructible_v<sstables::foreign_sstable_open_info>);
     co_await read_toc();
-    _components = std::move(info.components);
+    set_components(std::move(info.components));
     _data_file = make_checked_file(_read_error_handler, info.data.to_file());
   if (info.index) {
     _index_file = make_checked_file(_read_error_handler, info.index->to_file());

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -919,6 +919,13 @@ public:
         _features = sef;
     }
 
+    // Use this instead of assigning _components directly, so that you don't desync
+    // _features from _components.
+    void set_components(foreign_ptr<lw_shared_ptr<shareable_components>> components) {
+        _components = std::move(components);
+        _features = _components->scylla_metadata ? _components->scylla_metadata->get_features() : sstable_enabled_features{};
+    }
+
     bool has_feature(sstable_feature f) const {
         return features().is_enabled(f);
     }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7550,6 +7550,12 @@ static future<> test_perform_component_rewrite_single_sstable(sstables::update_s
 
         BOOST_REQUIRE(original_sst->get_sstable_level() == 0);
 
+        // Sanity: a freshly written sstable has its Scylla features set (e.g.
+        // ShadowableTombstones). The rewrite must preserve them.
+        auto original_features = original_sst->features().enabled_features;
+        BOOST_REQUIRE(original_features != 0);
+        BOOST_REQUIRE(original_sst->has_shadowable_tombstones());
+
         auto table = env.make_table_for_tests(s);
         auto close_table = deferred_stop(table);
 
@@ -7584,6 +7590,11 @@ static future<> test_perform_component_rewrite_single_sstable(sstables::update_s
 
         auto new_sst = it->second;
         BOOST_REQUIRE(new_sst->get_sstable_level() == new_level);
+        // The rewritten sstable must keep the Scylla features of the original
+        // (see the _features handling in link_with_rewritten_component /
+        // write_component_with_metadata / copy_components).
+        BOOST_REQUIRE_EQUAL(new_sst->features().enabled_features, original_features);
+        BOOST_REQUIRE(new_sst->has_shadowable_tombstones());
         BOOST_REQUIRE(new_sst->generation() != original_sst->generation());
         if (update_id) {
             BOOST_REQUIRE(new_sst->sstable_identifier() != original_sst->sstable_identifier());

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -562,6 +562,39 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_lock_works) {
     });
 }
 
+// Regression test for the sstable::_features desync that resharding hits on
+// shared sstables.
+//
+// During resharding, process_sstable_dir() snapshots each shared sstable as a
+// foreign_sstable_open_info (via sstable::get_open_info()), and
+// run_resharding_jobs() later rebuilds an sstable object from that snapshot via
+// sstable_directory::load_foreign_sstable() -> sstable::load(open_info).
+//
+// sstable::_features is a cached copy of the Scylla metadata's Features tag that
+// lives outside _components; get_open_info()/load(open_info) neither carry nor
+// set it. If it is left zeroed, the rebuilt sstable reports no features (e.g.
+// losing ShadowableTombstones, which causes readers of materialized views to error out).
+SEASTAR_TEST_CASE(sstable_open_info_preserves_features) {
+    return sstables::test_env::do_with_async([] (test_env& env) {
+        auto s = test_table_schema();
+
+        auto src = make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env), generation_type(1)));
+        BOOST_REQUIRE(src->features().enabled_features != 0);
+
+        // Rebuild the sstable object from an open-info snapshot, exactly like
+        // sstable_directory::load_foreign_sstable() does for a shared sstable
+        // during resharding. The new object reuses the source's on-disk files, so
+        // it must be created with the source's generation.
+        auto info = src->get_open_info().get();
+        auto dst = env.make_sstable(s, src->generation());
+        dst->load(std::move(info)).get();
+
+        // The rebuilt sstable must keep the source's features. Without the fix
+        // _features is zeroed here.
+        BOOST_REQUIRE_EQUAL(dst->features().enabled_features, src->features().enabled_features);
+    });
+}
+
 SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
     if (this_smp_shard_count() == 1) {
         fmt::print("Skipping sstable_directory_shared_sstables_reshard_correctly, smp == 1\n");


### PR DESCRIPTION
_features must be kept consistent with `_components->scylla_metadata`, but there are some code paths where it goes out of sync: incremental repair and reshard, which create new `sstable` objects (through menas other than the regular write path), set `_components->scylla_metadata` there, but don't set `_features` accordingly.

The main observed consequence of this is that materialized view readers fail on those sstable objects due to the missing ShadowableTombstones feature.

This seems to be a regression introduced in 73e4a3c5813237ed13414db1e5d12bac0452584c (part of 2025.2), where `_features` was introduced in order to make features visible in the write path before
`_components->scylla_metadata` is populated.

Fixes: SCYLLADB-1087

Has to be backported to all releases since 2025.2.