### PR TITLE
sstables: Validate STORAGE type matches configured endpoint type

### DIFF
--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -8,6 +8,8 @@
 
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/switch_to.hh>
+#include <cctype>
+#include <ranges>
 #include <unordered_map>
 #include <unordered_set>
 #include "utils/log.hh"
@@ -184,8 +186,9 @@ sstring storage_manager::get_endpoint_type(sstring endpoint) {
     return get_endpoint(endpoint).cfg.type();
 }
 
-bool storage_manager::is_known_endpoint(sstring endpoint) const {
-    return _object_storage_endpoints.contains(endpoint);
+bool storage_manager::is_known_endpoint(sstring endpoint, sstring type) const {
+    auto it = _object_storage_endpoints.find(endpoint);
+    return it != _object_storage_endpoints.end() && (type == "" || it->second.cfg.is_storage_of_type(type));
 }
 
 std::vector<sstring> storage_manager::endpoints(sstring type) const noexcept {
@@ -525,8 +528,10 @@ void sstables_manager::validate_new_keyspace_storage_options(const data_dictiona
                 throw exceptions::invalid_request_exception("Keyspace storage options not supported in the cluster");
             }
             // It's non-system keyspace
-            if (!is_known_endpoint(so.endpoint)) {
-                throw exceptions::configuration_exception(format("Endpoint {} not configured", so.endpoint));
+            // The endpoint must be configured and have the same storage type the keyspace declares
+            auto requested_type = so.type | std::views::transform(&tolower) | std::ranges::to<std::string>();
+            if (!is_known_endpoint(so.endpoint, requested_type)) {
+                throw exceptions::configuration_exception(format("Endpoint {} not configured as {}", so.endpoint, so.type));
             }
         }
     }, so.value);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -118,7 +118,9 @@ public:
 
     storage_manager(const db::config&, config cfg);
     shared_ptr<object_storage_client> get_endpoint_client(sstring endpoint);
-    bool is_known_endpoint(sstring endpoint) const;
+    // With no type (default), just checks that the endpoint is configured at all.
+    // With a type ("s3"/"gs"), also checks that the endpoint is configured as that type.
+    bool is_known_endpoint(sstring endpoint, sstring type = "") const;
     sstring get_endpoint_type(sstring endpoint);
     future<> stop();
     std::vector<sstring> endpoints(sstring type = "") const noexcept;
@@ -245,9 +247,9 @@ public:
         return _storage->get_endpoint_client(std::move(endpoint));
     }
 
-    bool is_known_endpoint(sstring endpoint) const {
+    bool is_known_endpoint(sstring endpoint, sstring type = "") const {
         SCYLLA_ASSERT(_storage != nullptr);
-        return _storage->is_known_endpoint(std::move(endpoint));
+        return _storage->is_known_endpoint(std::move(endpoint), std::move(type));
     }
 
     virtual sstable_writer_config configure_writer(sstring origin) const;

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -57,3 +57,9 @@ async def object_storage(request, pytestconfig, tmpdir):
 async def s3_storage(request, pytestconfig, tmpdir):
     async with make_object_storage('s3', pytestconfig, tmpdir, request.node.name) as server:
         yield server
+
+
+@pytest.fixture(scope="function")
+async def gs_storage(request, pytestconfig, tmpdir):
+    async with make_object_storage('gs', pytestconfig, tmpdir, request.node.name) as server:
+        yield server

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -268,6 +268,33 @@ async def test_misconfigured_storage(manager: ManagerClient, object_storage):
                       f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
 
 
+async def test_storage_type_endpoint_mismatch(manager: ManagerClient, s3_storage, gs_storage):
+    '''creating a keyspace whose STORAGE type doesn't match the configured type of the
+    given endpoint (S3 endpoint used with type GS, or vice versa) must not be allowed,
+    even though the endpoint name itself is known.'''
+    objconf = s3_storage.create_endpoint_conf() + gs_storage.create_endpoint_conf()
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_endpoints': objconf,
+           'experimental_features': ['keyspace-storage-options']}
+    await manager.server_add(config=cfg)
+
+    cql = manager.get_cql()
+    replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
+                                      'replication_factor': '1'})
+
+    print('S3 storage type must not be able to pick a GS-configured endpoint')
+    storage_opts = format_tuples(type='S3', endpoint=gs_storage.address, bucket=s3_storage.bucket_name)
+    with pytest.raises(ConfigurationException):
+        cql.execute((f"CREATE KEYSPACE test_ks_s3_on_gs WITH"
+                      f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
+
+    print('GS storage type must not be able to pick an S3-configured endpoint')
+    storage_opts = format_tuples(type='GS', endpoint=s3_storage.address, bucket=gs_storage.bucket_name)
+    with pytest.raises(ConfigurationException):
+        cql.execute((f"CREATE KEYSPACE test_ks_gs_on_s3 WITH"
+                      f" REPLICATION = {replication_opts} AND STORAGE = {storage_opts};"))
+
+
 async def test_memtable_flush_retries(manager: ManagerClient, tmpdir, object_storage):
     '''verify that memtable flush doesn't crash in case storage access keys are incorrect'''
 


### PR DESCRIPTION
CREATE KEYSPACE ... WITH STORAGE = {'type': ..., 'endpoint': ..., ...} only validated that the given endpoint name was known to object_storage_endpoints, but never verified that the endpoint's configured type (s3/gs) actually matches the STORAGE type (S3/GS) declared for the keyspace. This allowed e.g. STORAGE = {'type': 'S3', 'endpoint': <a gs-configured endpoint>, ...} to be accepted, later misbehaving when the keyspace's sstables are actually written using the gs client.

Extend storage_manager::is_known_endpoint() (and the sstables_manager wrapper around it) with an optional type parameter: with no type it behaves as before (endpoint name lookup only), with a type given it also checks the endpoint is configured as that type. Use it in validate_new_keyspace_storage_options() to reject a CREATE KEYSPACE whose declared STORAGE type doesn't match the configured type of the given endpoint.

Add a gs_storage fixture (mirroring the existing s3_storage one) so that both an S3 and a GS object-storage endpoint can be configured on the same node simultaneously, and add
test_storage_type_endpoint_mismatch, which configures both kinds of endpoints and verifies that CREATE KEYSPACE is rejected with ConfigurationException when the declared STORAGE type doesn't match the type of the given endpoint (S3 type pointed at a GS endpoint, and vice versa).

Enhancement of the feature in development, not backporting