### PR TITLE
skip Jenkins trigger when gating job does not exist yet

### DIFF
--- a/.github/workflows/trigger_jenkins.yaml
+++ b/.github/workflows/trigger_jenkins.yaml
@@ -38,6 +38,13 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
+          echo "Checking Existence of Jenkins Job: $JOB_NAME"
+          JOB_URL="$JENKINS_URL/job/$JOB_NAME/api/json"
+          if ! curl --silent --fail --user "$JENKINS_USER:$JENKINS_API_TOKEN" "$JOB_URL" > /dev/null; then
+            echo "Jenkins job $JOB_NAME does not exist yet. Skipping trigger."
+            exit 0
+          fi
+
           echo "Triggering Jenkins Job: $JOB_NAME"
           if ! curl -X POST "$JENKINS_URL/job/$JOB_NAME/buildWithParameters" --fail --user "$JENKINS_USER:$JENKINS_API_TOKEN" -i -v; then
             echo "Error: Jenkins job trigger failed"


### PR DESCRIPTION
When a new release branch is created the corresponding Jenkins folder not exist yet. The trigger_jenkins workflow POSTed Slack alert `Jenkins job failed to be triggered`.

Added condition, if the job does not exist yet, log and exit 0 to skip the trigger cleanly instead of erroring.


Backport is not required. Relevant only for master for the next branch release.