### PR TITLE
repair: defer view-update registration of incremental repair's staging sstables

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -128,6 +128,7 @@ future<> view_update_generator::start() {
             // To ensure we don't race with updates, move the entire content
             // into a local variable.
             auto sstables_with_tables = std::exchange(_sstables_with_tables, {});
+            utils::get_local_injector().inject("view_update_generator_pause_main_loop", utils::wait_for_message(std::chrono::minutes(5))).get();
 
             // If we got here, we will process all tables we know about so far eventually so there
             // is no starvation

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -11,6 +11,7 @@
 #include <seastar/util/defer.hh>
 #include "dht/auto_refreshing_sharder.hh"
 #include "db/view/view_building_worker.hh"
+#include "db/view/view_builder.hh"
 #include "gms/endpoint_state.hh"
 #include "repair/repair.hh"
 #include "message/messaging_service.hh"
@@ -572,9 +573,29 @@ void repair_writer_impl::create_writer(lw_shared_ptr<repair_writer> w) {
         sst->being_repaired = sid;
         sst_list.insert(sst);
     };
+    // Sstables produced by incremental repair are later marked as repaired
+    // (see repair_meta::mark_sstable_as_repaired()), which rewrites them via a
+    // component rewrite and replaces the sstable object. Registering a staging
+    // sstable with the view building machinery before that rewrite happens
+    // would leave it holding a reference invalidated by the rewrite. So defer
+    // the registration until after mark_sstable_as_repaired() has run; see
+    // repair_meta::register_pending_view_update_sstables().
+    streaming::view_update_registration_override_fn defer_view_update_registration;
+    if (mark_as_repaired) {
+        auto& pending_ssts = w->get_pending_view_update_sstables();
+        defer_view_update_registration = [&pending_ssts, shard] (std::vector<sstables::shared_sstable> ssts,
+                db::view::sstable_destination_decision decision, lw_shared_ptr<replica::table> table) mutable {
+            if (shard != this_shard_id()) {
+                return;
+            }
+            for (auto& sst : ssts) {
+                pending_ssts.push_back({std::move(sst), decision, table});
+            }
+        };
+    }
     _writer_done = mutation_writer::distribute_reader_and_consume_on_shards(_schema, sharder.sharder, std::move(_queue_reader),
             streaming::make_streaming_consumer(sstables::repair_origin, _db, _view_builder, _view_building_worker, w->get_estimated_partitions(), _reason, off_str,
-                _topo_guard, inc_repair_handler),
+                _topo_guard, inc_repair_handler, defer_view_update_registration),
     t.stream_in_progress()).then([w] (uint64_t partitions) {
         rlogger.debug("repair_writer: keyspace={}, table={}, managed to write partitions={} to sstable",
             w->schema()->ks_name(), w->schema()->cf_name(), partitions);
@@ -1833,6 +1854,10 @@ public:
             co_await stop();
             if (mark_as_repaired) {
                 co_await mark_sstable_as_repaired();
+            } else {
+                // The repair round didn't succeed, so no rewrite happened;
+                // register the deferred sstables as-is.
+                co_await register_pending_view_update_sstables();
             }
             co_return;
         }
@@ -2192,6 +2217,7 @@ public:
     future<> mark_sstable_as_repaired() {
         auto& sstables = _repair_writer->get_sstable_list_to_mark_as_repaired();
         if (!_incremental_repair_meta.sst_set && sstables.empty()) {
+            co_await register_pending_view_update_sstables();
             co_return;
         }
 
@@ -2234,6 +2260,7 @@ public:
         }
 
         if (repair_set.empty()) {
+            co_await register_pending_view_update_sstables();
             co_return;
         }
 
@@ -2265,6 +2292,55 @@ public:
                     sstables.insert(ss.second);
                 }
             }
+        co_await register_pending_view_update_sstables(rewritten_sstables);
+    }
+
+    // Registers staging sstables produced by this repair round's writer whose
+    // registration with the view building machinery was deferred (see
+    // repair_writer::pending_view_update_sstable) until this repair round
+    // finished trying to mark its output sstables as repaired.
+    //
+    // `rewritten_sstables` maps an original sstable produced by the repair
+    // writer to its replacement, for sstables that underwent a component
+    // rewrite as part of mark_sstable_as_repaired(). A pending sstable found
+    // in this map is registered as its replacement instead of the original,
+    // since the original's on-disk files no longer exist by the time this
+    // runs. When the map is empty (e.g. mark_sstable_as_repaired() was never
+    // called because the repair round failed or was aborted), pending
+    // sstables are registered unchanged, matching the moment they would have
+    // been registered without the deferral.
+    //
+    // Safe to call multiple times: it drains the pending list, so calling it
+    // again after it already ran is a no-op.
+    future<> register_pending_view_update_sstables(
+            const std::unordered_map<sstables::shared_sstable, sstables::shared_sstable>& rewritten_sstables = {}) {
+        auto pending = std::exchange(_repair_writer->get_pending_view_update_sstables(), {});
+        if (pending.empty()) {
+            co_return;
+        }
+
+        std::unordered_map<table_id, std::vector<sstables::shared_sstable>> vbc_tasks;
+        for (auto& p : pending) {
+            auto sst = p.sst;
+            if (auto it = rewritten_sstables.find(sst); it != rewritten_sstables.end()) {
+                sst = it->second;
+            }
+            switch (p.decision) {
+            case db::view::sstable_destination_decision::staging_managed_by_vbc:
+                vbc_tasks[p.table->schema()->id()].push_back(std::move(sst));
+                break;
+            case db::view::sstable_destination_decision::staging_directly_to_generator:
+                co_await _rs.get_view_builder().register_staging_sstable(std::move(sst), p.table);
+                break;
+            case db::view::sstable_destination_decision::normal_directory:
+                // repair_writer_impl::create_writer() never defers registration
+                // with this decision.
+                on_internal_error(rlogger, "register_pending_view_update_sstables(): unexpected normal_directory decision");
+            }
+        }
+        for (auto& [tid, ssts] : vbc_tasks) {
+            co_await _rs.get_view_building_worker().local().register_staging_sstable_tasks(std::move(ssts), tid);
+        }
     }
 };
 
@@ -3503,6 +3579,11 @@ public:
             auto auto_stop_master = defer([&master] noexcept {
                 try {
                     master.stop().get();
+                    // Safety net in case the main loop below never reached the
+                    // point where it calls repair_row_level_stop() for the
+                    // master's own node (e.g. an exception was thrown earlier).
+                    // No-op if already handled there.
+                    master.register_pending_view_update_sstables().get();
                 } catch (...) {
                     std::exception_ptr ep = std::current_exception();
                     rlogger.warn("Failed auto-stopping Row Level Repair (Master): {}. Ignored.", ep);
@@ -3945,7 +4026,11 @@ repair_service::insert_repair_meta(
             // Start stop() in the background. The topology_guard (gate::holder) inside
             // repair_meta is released when stop() completes and the shared_ptr drops,
             // which ensures session drain waits for this cleanup to finish.
-            (void)rm->stop().handle_exception([rm, local_id, local_topo_guard] (auto ep) {
+            (void)rm->stop().then([rm] {
+                // The session was aborted, so mark_sstable_as_repaired() was never
+                // called for this round; register any deferred sstables as-is.
+                return rm->register_pending_view_update_sstables();
+            }).handle_exception([rm, local_id, local_topo_guard] (auto ep) {
                 rlogger.warn("Session {}: failed to stop orphaned repair_meta_id {} for node {}: {}", local_topo_guard, local_id.repair_meta_id, local_id.ip, ep);
             });
         });
@@ -3953,6 +4038,7 @@ repair_service::insert_repair_meta(
             repair_meta_map().erase(id);
             rlogger.info("Session {} already closed, removing late repair_meta_id {} for node {}", topo_guard, id.repair_meta_id, id.ip);
             co_await rm->stop();
+            co_await rm->register_pending_view_update_sstables();
             co_return;
         }
         rm->set_session_abort_subscription(std::move(sub));
@@ -3978,6 +4064,10 @@ repair_service::remove_repair_meta(const locator::host_id& from,
         co_await rm->stop();
         if (mark_as_repaired) {
             co_await rm->mark_sstable_as_repaired();
+        } else {
+            // The repair round didn't succeed, so no rewrite happened;
+            // register the deferred sstables as-is.
+            co_await rm->register_pending_view_update_sstables();
         }
         rlogger.debug("remove_repair_meta: Stop repair_meta_id {} for node {} finished", id.repair_meta_id, id.ip);
     }
@@ -3997,6 +4087,10 @@ repair_service::remove_repair_meta(locator::host_id from) {
     }
     co_await coroutine::parallel_for_each(*repair_metas, [&] (auto& rm) -> future<> {
         co_await rm->stop();
+        // These repair_meta instances are torn down abruptly (e.g. node
+        // removal), so mark_sstable_as_repaired() may never run for them;
+        // register any deferred sstables as-is.
+        co_await rm->register_pending_view_update_sstables();
         rm = {};
     });
     rlogger.debug("Removed all repair_meta for single node {}", from);
@@ -4011,6 +4105,10 @@ repair_service::remove_repair_meta() {
     repair_meta_map().clear();
     co_await coroutine::parallel_for_each(*repair_metas, [&] (auto& rm) -> future<> {
         co_await rm->stop();
+        // These repair_meta instances are torn down abruptly (e.g. service
+        // shutdown), so mark_sstable_as_repaired() may never run for them;
+        // register any deferred sstables as-is.
+        co_await rm->register_pending_view_update_sstables();
         rm = {};
     });
     rlogger.debug("Removed all repair_meta for all nodes");

--- a/repair/writer.hh
+++ b/repair/writer.hh
@@ -9,6 +9,8 @@
 #include "repair/decorated_key_with_hash.hh"
 #include "readers/upgrading_consumer.hh"
 #include "./sstables/shared_sstable.hh"
+#include "db/view/view_update_checks.hh"
+#include "replica/database.hh"
 
 using namespace seastar;
 
@@ -77,6 +79,18 @@ public:
 };
 
 class repair_writer : public enable_lw_shared_from_this<repair_writer> {
+public:
+    // A staging sstable produced by the repair writer whose registration with
+    // the view building machinery (view_building_worker / view_update_generator)
+    // is deferred until after the repair round has finished trying to mark it
+    // as repaired.
+    struct pending_view_update_sstable {
+        sstables::shared_sstable sst;
+        db::view::sstable_destination_decision decision;
+        lw_shared_ptr<replica::table> table;
+    };
+
+private:
     schema_ptr _schema;
     reader_permit _permit;
     // Current partition written to disk
@@ -90,6 +104,7 @@ class repair_writer : public enable_lw_shared_from_this<repair_writer> {
     uint64_t _estimated_partitions = 0;
     // Holds the sstables produced by repair
     sstables::sstable_list _sstables;
+    std::vector<pending_view_update_sstable> _pending_view_update_sstables;
 public:
     class impl {
     public:
@@ -144,6 +159,10 @@ public:
 
     sstables::sstable_list& get_sstable_list_to_mark_as_repaired() {
         return _sstables;
+    }
+
+    std::vector<pending_view_update_sstable>& get_pending_view_update_sstables() {
+        return _pending_view_update_sstables;
     }
 
 private:

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -30,8 +30,10 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
         stream_reason reason,
         sstables::offstrategy offstrategy,
         service::frozen_topology_guard frozen_guard,
-        std::function<void (sstables::shared_sstable sst)> on_sstable_written) {
-    return [&db, &vb = vb.container(), &vbw, estimated_partitions, reason, offstrategy, origin = std::move(origin), frozen_guard, on_sstable_written] (mutation_reader reader) -> future<> {
+        std::function<void (sstables::shared_sstable sst)> on_sstable_written,
+        view_update_registration_override_fn view_update_registration_override) {
+    return [&db, &vb = vb.container(), &vbw, estimated_partitions, reason, offstrategy, origin = std::move(origin), frozen_guard, on_sstable_written,
+            view_update_registration_override = std::move(view_update_registration_override)] (mutation_reader reader) -> future<> {
         std::exception_ptr ex;
         try {
             if (current_scheduling_group() != debug::streaming_scheduling_group) {
@@ -52,7 +54,7 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
             const auto adjusted_estimated_partitions = (offstrategy) ? estimated_partitions : cs.adjust_partition_estimate(metadata, estimated_partitions, cf->schema());
             mutation_reader_consumer consumer =
                     [cf = std::move(cf), adjusted_estimated_partitions, use_view_update_path, &vb, &vbw, origin = std::move(origin),
-                offstrategy, on_sstable_written] (mutation_reader reader) {
+                offstrategy, on_sstable_written, view_update_registration_override] (mutation_reader reader) {
                 sstables::shared_sstable sst;
                 try {
                     sst = use_view_update_path == db::view::sstable_destination_decision::normal_directory ? cf->make_streaming_sstable_for_write() : cf->make_streaming_staging_sstable();
@@ -95,10 +97,19 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
                         cf->enable_off_strategy_trigger();
                     }
                     co_return co_await cf->add_new_sstable_and_update_cache(sst, on_add, offstrategy);
-                }).then([cf, s, sst, use_view_update_path, &vb, &vbw] (std::vector<sstables::shared_sstable> new_sstables) mutable -> future<> {
+                }).then([cf, s, sst, use_view_update_path, &vb, &vbw, view_update_registration_override] (std::vector<sstables::shared_sstable> new_sstables) mutable -> future<> {
                     auto& vb_ = vb;
                     auto new_sstables_ = std::move(new_sstables);
                     auto table = cf;
+
+                    if (use_view_update_path == db::view::sstable_destination_decision::normal_directory) {
+                        co_return;
+                    }
+
+                    if (view_update_registration_override) {
+                        view_update_registration_override(std::move(new_sstables_), use_view_update_path, std::move(table));
+                        co_return;
+                    }
 
                     if (use_view_update_path == db::view::sstable_destination_decision::staging_managed_by_vbc) {
                         co_return co_await vbw.local().register_staging_sstable_tasks(new_sstables_, cf->schema()->id());

--- a/streaming/consumer.hh
+++ b/streaming/consumer.hh
@@ -11,10 +11,12 @@
 #include "sstables/sstable_set.hh"
 #include "streaming/stream_reason.hh"
 #include "service/topology_guard.hh"
+#include "db/view/view_update_checks.hh"
 #include <optional>
 
 namespace replica {
 class database;
+class table;
 }
 
 namespace db {
@@ -26,6 +28,17 @@ class view_building_worker;
 
 namespace streaming {
 
+// Called instead of registering newly written staging sstables with the view
+// building machinery (view_building_worker / view_update_generator) right
+// away. Used by incremental tablet repair to defer registration until after
+// the repair round has finished trying to mark its output sstables as
+// repaired, which may replace them via a component rewrite. Never called with
+// db::view::sstable_destination_decision::normal_directory.
+using view_update_registration_override_fn = std::function<void (
+        std::vector<sstables::shared_sstable> ssts,
+        db::view::sstable_destination_decision decision,
+        lw_shared_ptr<replica::table> table)>;
+
 mutation_reader_consumer make_streaming_consumer(sstring origin,
     sharded<replica::database>& db,
     db::view::view_builder& vb,
@@ -34,6 +47,7 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
     stream_reason reason,
     sstables::offstrategy offstrategy,
     service::frozen_topology_guard,
-    std::function<void (sstables::shared_sstable sst)> on_sstable_written = {});
+    std::function<void (sstables::shared_sstable sst)> on_sstable_written = {},
+    view_update_registration_override_fn view_update_registration_override = {});
 
 }

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -793,6 +793,79 @@ async def test_file_streaming(manager: ManagerClient):
         await assert_row_count_on_host(cql, new_hosts[0], ks, "mv", 1000)
         await manager.server_start(servers[1].server_id)
 
+# Reproduces a race where incremental tablet repair rewrites a staging SSTable
+# after it was registered for view building but before view_update_generator moves
+# it out of staging. The stale registered SSTable reference used to point at files
+# already unlinked by repair's component rewrite, making process_staging retry
+# forever with ENOENT on the staging TOC file.
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_incremental_repair_rewrites_registered_staging_sstable(manager: ManagerClient):
+    node_count = 2
+    smp = 2
+    servers = await manager.servers_add(node_count, cmdline=cmdline_loggers + [f'--smp={smp}'], property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+    ])
+    cql, hosts = await manager.get_ready_cql(servers)
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v int, PRIMARY KEY (key))")
+
+        rows = 1000
+        for i in range(rows):
+            await cql.run_async(f"INSERT INTO {ks}.tab (key, c, v) VALUES ({i}, {i}, 1)")
+
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv AS SELECT * FROM {ks}.tab "
+                        "WHERE key IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c, key)")
+        await wait_for_view(cql, 'mv', node_count)
+
+        await manager.api.keyspace_flush(servers[0].ip_addr, ks, "tab")
+        await manager.api.keyspace_flush(servers[0].ip_addr, ks, "mv")
+        await delete_table_sstables(manager, servers[0], ks, "tab")
+        await delete_table_sstables(manager, servers[0], ks, "mv")
+
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_start(servers[0].server_id)
+        hosts = await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30)
+
+        await manager.server_stop_gracefully(servers[1].server_id)
+        await assert_row_count_on_host(cql, hosts[0], ks, "tab", 0)
+        await assert_row_count_on_host(cql, hosts[0], ks, "mv", 0)
+        await manager.server_start(servers[1].server_id)
+        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+        s0_log = await manager.server_open_log(servers[0].server_id)
+        s0_mark = await s0_log.mark()
+        await manager.api.enable_injection(servers[0].ip_addr, "view_update_generator_pause_main_loop", one_shot=False)
+
+        repair_task = asyncio.create_task(manager.api.tablet_repair(servers[0].ip_addr, ks, "tab", "all", incremental_mode='incremental'))
+        await s0_log.wait_for("view_update_generator_pause_main_loop: waiting", from_mark=s0_mark, timeout=60)
+        await repair_task
+
+        s0_mark = await s0_log.mark()
+        await manager.api.message_injection(servers[0].ip_addr, "view_update_generator_pause_main_loop")
+        await manager.api.disable_injection(servers[0].ip_addr, "view_update_generator_pause_main_loop")
+        await s0_log.wait_for("Moving sstable .* to .*", from_mark=s0_mark, timeout=60)
+        errors = await s0_log.grep("view_update_generator - Moving some sstable from staging failed", from_mark=s0_mark)
+        assert len(errors) == 0
+
+        async def view_updates_drained():
+            local_metrics = await manager.metrics.query(servers[0].ip_addr)
+            for shard in range(smp):
+                backlog = local_metrics.get("scylla_database_view_update_backlog", {'shard': str(shard)})
+                if backlog > 0:
+                    return None
+            return True
+        await wait_for(view_updates_drained, deadline=time.time() + 30)
+
+        hosts = await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30)
+        await manager.server_stop_gracefully(servers[1].server_id)
+        await assert_row_count_on_host(cql, hosts[0], ks, "tab", rows)
+        await assert_row_count_on_host(cql, hosts[0], ks, "mv", rows)
+        await manager.server_start(servers[1].server_id)
+
 # Reproducer for issue scylladb#26244
 # Purpose of this test is to check if staging sstables managed by `view_building_worker`
 # correctly reacts to tablet merge.


### PR DESCRIPTION
Incremental tablet repair marks its output sstables as repaired by rewriting
their `Statistics` component (`mark_sstable_as_repaired()`), which produces a
new sstable object and unlinks the original's on-disk files. Staging sstables
were registered with the view building machinery (`view_building_worker` /
`view_update_generator`) immediately when written, before this rewrite could
happen. If the rewrite occurred after registration, the view building worker
was left holding a `shared_sstable` reference to already-unlinked files,
causing `move_sstables_from_staging()` to fail forever with `ENOENT` on the
staging TOC file and permanently stalling view building for that base table.

This PR defers registration of staging sstables produced by incremental tablet
repair until after the repair round has finished attempting to mark them as
repaired, so registration always uses the sstable's final (possibly
rewritten) identity. A fallback registers pending sstables unchanged on
every path where a repair round can end without reaching that point (e.g.
failure/abort), preserving the previous immediate-registration behavior for
those cases.

Fixes SCYLLADB-3372

This fix needs to be backported to 2026.2 and 2026.3. Previous versions don't rewrite sstable's component to update `repaired_at` property.