### PR TITLE
selection: reset clustering key for static-only partitions

### DIFF
--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -371,11 +371,15 @@ public:
             auto partition_key = key.explode(_schema);
             _builder.accept_new_partition(partition_key);
             _partition_key = std::move(partition_key);
+            // Stale from the previous partition: a partition with no rows never calls
+            // accept_new_row(), so it must not observe the old clustering key.
+            _clustering_key.clear();
             _row_count = row_count;
             _filter.reset(&key);
         }
 
         void accept_new_partition(uint64_t row_count) {
+            _clustering_key.clear();
             _row_count = row_count;
             _filter.reset();
         }

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -368,6 +368,11 @@ public:
         }
 
         uint64_t accept_partition_end(const query::result_row_view& static_row) {
+            // The clustering key belongs to the last row visited by accept_new_row(), so it is
+            // only meaningful until the partition ends. Clear it here so that a partition with
+            // no rows -- which never calls accept_new_row() and produces a pseudo-row out of
+            // the static row alone below -- cannot report the previous partition's value.
+            _clustering_key.clear();
             if (_row_count == 0) {
                 if (!_filter(_selection, _partition_key, _clustering_key, static_row, nullptr)) {
                     return _filter.get_rows_dropped();

--- a/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_group_by_test.py
@@ -1570,7 +1570,6 @@ def testGroupByWithRangeNamesQueryWithPaging(cql, test_keyspace):
                           row(1, 1, 2, 2, 2),
                           row(2, 1, 3, 2, 3))
 
-@pytest.mark.xfail(reason="Issue #21267")
 def testGroupByWithStaticColumnsWithPaging(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, s int static, d int, primary key (a, b, c))") as table:
         # ------------------------------------

--- a/test/cqlpy/test_group_by.py
+++ b/test/cqlpy/test_group_by.py
@@ -232,7 +232,6 @@ def test_group_by_non_aggregated_mutation_attribute_of_column(cql, table1):
 
 # This test is from cassandra_tests/validation/operations/select_group_by_test.py::testGroupByWithPaging()
 # Reproduces #21267
-@pytest.mark.xfail(reason="issue #21267")
 def test_group_by_static_column(cql, test_keyspace):
 
     with new_test_table(cql, test_keyspace, "a int, b int, c int, s int static, d int, primary key (a, b, c)") as table:
@@ -254,12 +253,16 @@ def test_group_by_static_column(cql, test_keyspace):
         # This is the expected and correct result of the query:
         assert {(3, None, 3, 0, 1)} == set(result)
 
-        # When we remove the WHERE clause, we get all the rows, and b and count(b)
-        # the wrong values (it seems they have leftover values from the previous row)
+        # When we remove the WHERE clause, we get all the rows. Partition a=3
+        # is static-only and must not inherit b/count(b) from the preceding
+        # partition (a=4) in sort order.
         result = cql.execute(f'SELECT a, b, s, count(b), count(s) FROM {table} GROUP BY a')
-        # FIXME: this test reproduces bug #21267
-        # the assert below is the correct result set
         assert {(1, 2, 3, 4, 4), (2, 2, 2, 2, 2), (4, 8, 3, 1, 1), (3, None, 3, 0, 1)} == set(result)
+
+        # Same thing with the grouping column omitted from the selection: the
+        # static-only partition a=3 must still report b as null.
+        result = cql.execute(f'SELECT b, s, count(b), count(s) FROM {table} GROUP BY a')
+        assert {(2, 3, 4, 4), (2, 2, 2, 2), (8, 3, 1, 1), (None, 3, 0, 1)} == set(result)
 
 
 # NOTE: we have tests for the combination of GROUP BY and SELECT DISTINCT


### PR DESCRIPTION
result_set_builder::visitor kept the previous partition's clustering key around in current_clustering_key. A static-only partition never calls accept_new_row() (only accept_partition_end()), so it could report the previous partition's clustering-key value and pull it into GROUP BY/aggregation output.

Clear the clustering key in both accept_new_partition() overloads (with and without the partition key present), immediately after starting the new partition and before any possible static-only accept_partition_end() callback. This is unconditional: a regular row always repopulates the clustering key via accept_new_row(), so the reset cannot lose data for non-static partitions.

Un-xfail tests which already documented and asserted the correct semantics for a GROUP BY query mixing static-only and regular partitions.

Fixes #21267

It doesn't seem like an important bug - I would say no backport.