### PR TITLE
test: secondary index: set cassandra_bug on oversized-value tests

### DIFF
--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -195,9 +195,13 @@ def test_create_index_if_not_exists2(cql, test_keyspace, cassandra_bug):
         with pytest.raises(InvalidRequest, match="already exists"):
             cql.execute(f"CREATE INDEX IF NOT EXISTS {index_name} ON {table}(v2)")
 
-# Verify that oversized index names are cleanly rejected  as InvalidRequest
+# Verify that oversized index names are cleanly rejected as InvalidRequest.
+# Cassandra doesn't validate the name's length, so the CREATE INDEX request
+# fails on the filesystem name length limit with an internal server error
+# instead of a clean InvalidRequest. Hence this test is marked
+# "cassandra_bug" - passes on Scylla and xfails on Cassandra.
 # Reproduces issue #20755
-def test_create_index_oversized_name(cql, test_keyspace):
+def test_create_index_oversized_name(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace, 'p int primary key, v int') as table:
         index_name = 'x'*500
         with pytest.raises((InvalidRequest, ConfigurationException)):

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -319,31 +319,18 @@ def test_too_large_indexed_value_build(cql, test_keyspace):
         assert [(30,big)] == list(cql.execute(f'SELECT * FROM {table} WHERE p=30'))
         # Create an index on v as the new key. The background index-building
         # process should start promptly.
-        cql.execute(f"CREATE INDEX ON {table}(v)")
-        # If Scylla's view builder hangs or stops, there is no way to
-        # tell this state apart from a view build that simply hasn't
-        # completed yet (besides looking at the logs, which we don't).
-        # This means, unfortunately, that a failure of this test is slow -
-        # it needs to wait for a timeout.
-        # However, today we are lucky (?) that the cql.execute(read, [big])
-        # test also fails immediately on Scylla, so this test fails quickly.
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        # Wait for the background index building to complete. If the big key
+        # causes the index build to hang, this wait_for_index() will timeout
+        # and the test will fail.
+        wait_for_index(cql, test_keyspace, index_name)
+        # At this point, the index build should have completed. The "big"
+        # key cannot be searched (trying it results in an InvalidRequest), but
+        # all other keys should be searchable:
         read = cql.prepare(f'SELECT * FROM {table} WHERE v = ?')
-        start_time = time.time()
-        while time.time() < start_time + 30:
-            # The oversized "big" cannot be a key in the view, and
-            # cannot be searched. Cassandra reports: "Index expression
-            # values may not be larger than 64K".
-            with pytest.raises(InvalidRequest):
-                cql.execute(read, [big])
-            # All the other keys should eventually be there
-            c = 0
-            for i in range(30):
-                if list(cql.execute(read, [str(i)])):
-                    c += 1
-            if c == 30:
-                break
-            print(c)
-            time.sleep(0.1)
+        with pytest.raises(InvalidRequest):
+            cql.execute(read, [big])
         for i in range(30):
             assert list(cql.execute(read, [str(i)]))
 


### PR DESCRIPTION
Before this patch series, two cqlpy secondary-index tests fail
when the suite is run against Cassandra, even though cqlpy
is expected to pass there:
- `test_create_index_oversized_name` expects a clean InvalidRequest for
 an over-long index name, but Cassandra doesn't validate the length
 and fails with an internal server error when the on-disk structure
 hits the filesystem name-length limit. Mark the test with the
 cassandra_bug fixture so it xfails on Cassandra instead of failing,
 as the suite already does for other deliberate
 Scylla-correct/Cassandra-buggy expectations.
- `test_too_large_indexed_value_build` read through the new index before
 the background index build finished, which Cassandra rejects with a
 ReadFailure, aborting the test. Wait for the build with
 wait_for_index() and drop the ad-hoc retry loop. The test now passes
 against Scylla, Cassandra 4.1, and Cassandra 5.

Refs https://github.com/scylladb/scylladb/issues/11690
Fixes: SCYLLADB-3396

No backport, just test compatibility improvement