### PR TITLE
[Backport 2025.4] test/pylib: check expected up state progressively in ScyllaServer.start()

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -787,6 +787,16 @@ class ScyllaServer:
                                          f"{logpath}\n"
                                          f"{self.log_filename}")
 
+        async def is_expected_state_reached() -> bool:
+            if server_up_state >= expected_server_up_state:
+                if expected_error is not None:
+                    await report_error(
+                        f"the node has reached {server_up_state} state,"
+                        f" but was expected to fail with the expected error"
+                    )
+                return True
+            return False
+
         while time.time() < self.start_time + self.TOPOLOGY_TIMEOUT and not self.stop_event.is_set():
             assert self.cmd is not None
             if self.cmd.returncode:
@@ -802,13 +812,11 @@ class ScyllaServer:
             if await self.try_get_host_id(api):
                 if server_up_state == ServerUpState.PROCESS_STARTED:
                     server_up_state = ServerUpState.HOST_ID_QUERIED
+                if await is_expected_state_reached():
+                    return
                 server_up_state = await self.get_cql_up_state() or server_up_state
-                if server_up_state == expected_server_up_state:
-                    if expected_error is not None:
-                        await report_error(
-                            f"the node has reached {server_up_state} state,"
-                            f" but was expected to fail with the expected error"
-                        )
+                if await is_expected_state_reached():
+                    return
                     return
 
             # Sleep and retry


### PR DESCRIPTION
During server startup inside the test cluster, when connect_driver is False the requested expected_server_up_state is capped at HOST_ID_QUERIED. However, the original loop only checked whether the requested state was reached at the very end of each iteration, so it always also called get_cql_alternator_up_state() even when HOST_ID_QUERIED was already enough.

On Scylla 2025.1 and 2025.4 branches when the CQL port is connectable, that call overwrites the state with CQL_CONNECTED/CQL_QUERIED — higher than HOST_ID_QUERIED. Since return condition was exact equality and the expected state was capped at HOST_ID_QUERIED (the connect_driver=False path), it can never match after overshooting, so the loop spins until TOPOLOGY_TIMEOUT (1000s). Most of the time port is not connectable fast enough because host_id is cached so the check fires quickly and test passes.

State equality check was improved as a side effect of ebac810c4e  but it's better to backport this change as it's more targeted and avoids the entire CQL check.

Fix by checking return condition after each state transition. This is skipping the CQL connection checks entirely when they are not required (connect_driver=False).

Fixes SCYLLADB-2866
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2977

Backport: 2025.1 and 2025.4

- (cherry picked from commit bedc66d068f4b0761374d1534cf00e358696e546)

Parent PR: #30528