### PR TITLE
messaging: fail sends on a connection whose CLIENT_ID handshake failed

### DIFF
--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -19,6 +19,7 @@
 #include <seastar/coroutine/all.hh>
 
 #include "message/messaging_service.hh"
+#include <seastar/core/shared_future.hh>
 #include <seastar/core/sharded.hh>
 #include "gms/gossiper.hh"
 #include "service/storage_service.hh"
@@ -1091,7 +1092,10 @@ shared_ptr<messaging_service::rpc_protocol_client_wrapper> messaging_service::ge
 
         if (it != clients[idx].end()) {
             auto c = it->second.rpc_client;
-            if (!c->error()) {
+            // A client whose CLIENT_ID handshake failed is unusable (the peer
+            // never learned who we are); treat it like an errored one so a
+            // fresh connection is created right away.
+            if (!c->error() && !c->client_id_sent().failed()) {
                 return c;
             }
             // The 'dead_only' it should be true, because we're interested in
@@ -1231,8 +1235,13 @@ shared_ptr<messaging_service::rpc_protocol_client_wrapper> messaging_service::ge
         client = it->second.rpc_client;
     }
     uint32_t src_cpu_id = this_shard_id();
-    // No reply is received, nothing to wait for.
-    (void)[&] () -> future<> {
+    // The CLIENT_ID handshake must reach the peer before any other verb on
+    // this connection: its handler attaches the sender identity (host_id etc.)
+    // that handlers of subsequent verbs rely on. Publish the send future on
+    // the client so senders can detect a synchronously failed handshake and
+    // refuse to use the connection (see
+    // rpc_protocol_client_wrapper::client_id_sent()).
+    shared_future<> client_id_sent = [&] () -> future<> {
         if (utils::get_local_injector().enter("fail_outgoing_client_id")) {
             return make_exception_future<>(std::bad_alloc());
         }
@@ -1240,8 +1249,19 @@ shared_ptr<messaging_service::rpc_protocol_client_wrapper> messaging_service::ge
                 rpc::no_wait_type(gms::inet_address, uint32_t, uint64_t, utils::UUID, std::optional<utils::UUID>, gms::generation_type)>(messaging_verb::CLIENT_ID)(
                     *client, broadcast_address, src_cpu_id,
                     query::result_memory_limiter::maximum_result_size, my_host_id.uuid(), host_id ? std::optional{host_id->uuid()} : std::nullopt, _current_generation);
-    }().handle_exception([ms = shared_from_this(), remote_addr, verb] (std::exception_ptr ep) {
-        mlogger.debug("Failed to send client id to {} for verb {}: {}", remote_addr, std::underlying_type_t<messaging_verb>(verb), ep);
+    }();
+    client->set_client_id_sent(client_id_sent);
+    // If the send failed (e.g. bad_alloc under memory pressure), the
+    // connection is unidentified and hence unusable - drop it, so that the
+    // next send creates a fresh one and re-sends CLIENT_ID.
+    (void)client_id_sent.get_future().handle_exception([ms = shared_from_this(), client, idx, id, host_id, remote_addr, verb] (std::exception_ptr ep) {
+        mlogger.warn("Failed to send CLIENT_ID to {} for verb {}: {}; dropping the connection", remote_addr, std::underlying_type_t<messaging_verb>(verb), ep);
+        auto same_client = [&] (const shard_info& si) { return si.rpc_client == client; };
+        if (host_id) {
+            ms->find_and_remove_client(ms->_clients_with_host_id[idx], *host_id, same_client);
+        } else {
+            ms->find_and_remove_client(ms->_clients[idx], id, same_client);
+        }
     });
     return client;
 }

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -1232,11 +1232,15 @@ shared_ptr<messaging_service::rpc_protocol_client_wrapper> messaging_service::ge
     }
     uint32_t src_cpu_id = this_shard_id();
     // No reply is received, nothing to wait for.
-    (void)_rpc->make_client<
-            rpc::no_wait_type(gms::inet_address, uint32_t, uint64_t, utils::UUID, std::optional<utils::UUID>, gms::generation_type)>(messaging_verb::CLIENT_ID)(
-                *client, broadcast_address, src_cpu_id,
-                query::result_memory_limiter::maximum_result_size, my_host_id.uuid(), host_id ? std::optional{host_id->uuid()} : std::nullopt, _current_generation)
-            .handle_exception([ms = shared_from_this(), remote_addr, verb] (std::exception_ptr ep) {
+    (void)[&] () -> future<> {
+        if (utils::get_local_injector().enter("fail_outgoing_client_id")) {
+            return make_exception_future<>(std::bad_alloc());
+        }
+        return _rpc->make_client<
+                rpc::no_wait_type(gms::inet_address, uint32_t, uint64_t, utils::UUID, std::optional<utils::UUID>, gms::generation_type)>(messaging_verb::CLIENT_ID)(
+                    *client, broadcast_address, src_cpu_id,
+                    query::result_memory_limiter::maximum_result_size, my_host_id.uuid(), host_id ? std::optional{host_id->uuid()} : std::nullopt, _current_generation);
+    }().handle_exception([ms = shared_from_this(), remote_addr, verb] (std::exception_ptr ep) {
         mlogger.debug("Failed to send client id to {} for verb {}: {}", remote_addr, std::underlying_type_t<messaging_verb>(verb), ep);
     });
     return client;

--- a/message/rpc_protocol_impl.hh
+++ b/message/rpc_protocol_impl.hh
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <seastar/core/shared_future.hh>
 #include <seastar/rpc/rpc.hh>
 #include "messaging_service.hh"
 #include "serializer.hh"
@@ -79,6 +80,21 @@ public:
 class messaging_service::rpc_protocol_client_wrapper {
     std::unique_ptr<rpc_protocol::client> _p;
     ::shared_ptr<seastar::tls::server_credentials> _credentials;
+    // The future of the one-shot CLIENT_ID handshake send. The CLIENT_ID
+    // handler on the peer attaches the sender identity (host_id etc.) that
+    // handlers of subsequent verbs rely on, so no verb may reach the peer on
+    // a connection whose CLIENT_ID it did not see first. Once CLIENT_ID is
+    // enqueued, the connection's ordered pipeline guarantees that: any verb
+    // sent later is behind it, and a failure to write it out kills the whole
+    // connection, taking the later verbs with it. The only dangerous failure
+    // is a synchronous one (e.g. bad_alloc while marshalling), which leaves
+    // the connection alive but unidentified - it makes this future available
+    // and failed before the connection is ever handed out to senders, and
+    // senders must check for that (and must not wait otherwise: a send may
+    // not outlive its verb's timeout just because the handshake is stuck
+    // together with the rest of a slow connection).
+    // Starts ready and is set right after the connection is created.
+    shared_future<> _client_id_sent = shared_future<>(make_ready_future<>());
 public:
     rpc_protocol_client_wrapper(rpc_protocol &proto, rpc::client_options opts, socket_address addr,
                                 socket_address local = {})
@@ -99,6 +115,10 @@ public:
         return _p->error();
     }
 
+    const shared_future<>& client_id_sent() const { return _client_id_sent; }
+
+    void set_client_id_sent(shared_future<> f) { _client_id_sent = std::move(f); }
+
     operator rpc_protocol::client &() { return *_p; }
 
     /**
@@ -108,6 +128,11 @@ public:
      */
     template<typename Serializer, typename... Out>
     future<rpc::sink<Out...>> make_stream_sink() {
+        // Refuse to use a connection whose CLIENT_ID handshake failed
+        // synchronously (see client_id_sent()).
+        if (_client_id_sent.available() && _client_id_sent.failed()) {
+            return make_exception_future<rpc::sink<Out...>>(_client_id_sent.get_future().get_exception());
+        }
         if (_credentials) {
             return _p->make_stream_sink<Serializer, Out...>(seastar::tls::socket(_credentials));
         }
@@ -130,6 +155,13 @@ auto send_message(messaging_service* ms, messaging_verb verb, std::optional<loca
         return futurator::make_exception_future(rpc::closed_error("local node is shutting down"));
     }
     auto rpc_client_ptr = ms->get_rpc_client(verb, id, host_id);
+    const auto& client_id_sent = rpc_client_ptr->client_id_sent();
+    if (client_id_sent.available() && client_id_sent.failed()) {
+        // The CLIENT_ID handshake failed synchronously, leaving the connection
+        // alive but unidentified and hence unusable (see client_id_sent()).
+        ms->increment_dropped_messages(verb);
+        return futurator::make_exception_future(client_id_sent.get_future().get_exception());
+    }
     auto& rpc_client = *rpc_client_ptr;
     return rpc_handler(rpc_client, std::forward<MsgOut>(msg)...).handle_exception([ms = ms->shared_from_this(), id, host_id, verb, rpc_client_ptr = std::move(rpc_client_ptr)] (std::exception_ptr&& eptr) {
         ms->increment_dropped_messages(verb);
@@ -169,6 +201,13 @@ auto send_message_timeout(messaging_service* ms, messaging_verb verb, std::optio
         return futurator::make_exception_future(rpc::closed_error("local node is shutting down"));
     }
     auto rpc_client_ptr = ms->get_rpc_client(verb, id, host_id);
+    const auto& client_id_sent = rpc_client_ptr->client_id_sent();
+    if (client_id_sent.available() && client_id_sent.failed()) {
+        // The CLIENT_ID handshake failed synchronously, leaving the connection
+        // alive but unidentified and hence unusable (see client_id_sent()).
+        ms->increment_dropped_messages(verb);
+        return futurator::make_exception_future(client_id_sent.get_future().get_exception());
+    }
     auto& rpc_client = *rpc_client_ptr;
     return rpc_handler(rpc_client, timeout, std::forward<MsgOut>(msg)...).handle_exception([ms = ms->shared_from_this(), id, host_id, verb, rpc_client_ptr = std::move(rpc_client_ptr)] (std::exception_ptr&& eptr) {
         ms->increment_dropped_messages(verb);
@@ -211,6 +250,13 @@ auto send_message_cancellable(messaging_service* ms, messaging_verb verb, std::o
         return futurator::make_exception_future(rpc::closed_error("local node is shutting down"));
     }
     auto rpc_client_ptr = ms->get_rpc_client(verb, id, host_id);
+    const auto& client_id_sent = rpc_client_ptr->client_id_sent();
+    if (client_id_sent.available() && client_id_sent.failed()) {
+        // The CLIENT_ID handshake failed synchronously, leaving the connection
+        // alive but unidentified and hence unusable (see client_id_sent()).
+        ms->increment_dropped_messages(verb);
+        return futurator::make_exception_future(client_id_sent.get_future().get_exception());
+    }
     auto& rpc_client = *rpc_client_ptr;
 
     auto c = std::make_unique<seastar::rpc::cancellable>();
@@ -262,6 +308,13 @@ auto send_message_timeout_cancellable(messaging_service* ms, messaging_verb verb
     }
     auto address = ms->addr_for_host_id(host_id);
     auto rpc_client_ptr = ms->get_rpc_client(verb, address, host_id);
+    const auto& client_id_sent = rpc_client_ptr->client_id_sent();
+    if (client_id_sent.available() && client_id_sent.failed()) {
+        // The CLIENT_ID handshake failed synchronously, leaving the connection
+        // alive but unidentified and hence unusable (see client_id_sent()).
+        ms->increment_dropped_messages(verb);
+        return futurator::make_exception_future(client_id_sent.get_future().get_exception());
+    }
     auto& rpc_client = *rpc_client_ptr;
 
     auto c = std::make_unique<seastar::rpc::cancellable>();

--- a/test/cluster/test_client_id_send_failure.py
+++ b/test/cluster/test_client_id_send_failure.py
@@ -1,0 +1,111 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+# Regression test for CUSTOMER-573 / SCYLLADB-3348: a failed one-shot
+# CLIENT_ID handshake (e.g. bad_alloc under memory pressure) must not leave
+# a usable-but-unidentified RPC connection behind. The sender must drop the
+# connection and recover with a fresh one; no verb may be sent on a
+# connection whose CLIENT_ID never reached the wire (the peer would abort,
+# or crash on unpatched versions, when handlers retrieve the missing
+# host_id auxiliary data).
+
+import logging
+import time
+
+import pytest
+from cassandra import ConsistencyLevel
+from cassandra.query import SimpleStatement
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.xfail(reason="SCYLLADB-3348: a failed CLIENT_ID send leaves a cached unidentified "
+                          "connection behind; the next commit fixes this and removes this mark")
+@pytest.mark.asyncio
+async def test_client_id_send_failure(manager: ManagerClient):
+    """A CLIENT_ID send failure on a newly created RPC connection must:
+    1. produce the "dropping the connection" warning on the sender,
+    2. not be followed by any verb sent on the unidentified connection,
+    3. recover automatically: the poisoned connection is evicted and the
+       next send creates a fresh one which re-sends CLIENT_ID.
+
+    The scenario mirrors the field incident: node 0's connections to node 1
+    are torn down (here: by restarting node 1; in the field: by bad_alloc),
+    and the CLIENT_ID send on a re-created connection fails locally (here:
+    via the fail_outgoing_client_id error injection; in the field: bad_alloc
+    during marshalling). Without the fix the connection stayed cached and
+    node 0's next verb on it crashed node 1 with an assertion failure in
+    rpc::client_info::retrieve_auxiliary.
+    """
+
+    logger.info("Starting a 2-node cluster")
+    cfg = {"rf_rack_valid_keyspaces": False}
+    servers = await manager.servers_add(1, config=cfg)
+    servers += await manager.servers_add(1, seeds=[servers[0].ip_addr], config=cfg)
+
+    cql = manager.get_cql()
+    host0 = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 60))[0]
+
+    ks = unique_name()
+    await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = "
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
+    await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int)")
+
+    write = SimpleStatement(f"INSERT INTO {ks}.t (pk, v) VALUES (1, 1)",
+                            consistency_level=ConsistencyLevel.ALL)
+    # Baseline: a CL=ALL write coordinated by node 0 works.
+    await cql.run_async(write, host=host0)
+
+    log0 = await manager.server_open_log(servers[0].server_id)
+    mark = await log0.mark()
+
+    # Tear down node 0's connections to node 1 and make the CLIENT_ID send
+    # on the first re-created connection fail. The injection is one-shot:
+    # exactly one new connection gets a poisoned handshake, later ones
+    # succeed, so the cluster must converge back on its own.
+    logger.info("Stopping node 1")
+    await manager.server_stop_gracefully(servers[1].server_id)
+
+    logger.info("Enabling one-shot fail_outgoing_client_id injection on node 0")
+    await manager.api.enable_injection(servers[0].ip_addr, "fail_outgoing_client_id",
+                                       one_shot=True)
+
+    logger.info("Starting node 1")
+    await manager.server_start(servers[1].server_id)
+
+    # The failed handshake must be detected and the connection dropped.
+    logger.info("Waiting for node 0 to report the dropped connection")
+    await log0.wait_for("Failed to send CLIENT_ID .* dropping the connection",
+                        from_mark=mark, timeout=60)
+
+    # Recovery: node 0 must re-establish connectivity to node 1 on a fresh
+    # connection. Without the eviction, the poisoned connection would stay
+    # cached and this would never converge.
+    logger.info("Waiting for node 0 to see node 1 as alive")
+    await manager.server_sees_other_server(servers[0].ip_addr, servers[1].ip_addr,
+                                           interval=60)
+
+    # one_shot injections are armed per shard; disarm the remaining shards so
+    # the verification write below cannot consume a leftover shot when it
+    # creates its own (statement-class, per-shard) connections.
+    await manager.api.disable_injection(servers[0].ip_addr, "fail_outgoing_client_id")
+
+    # And internode writes work again: CL=ALL requires node 1's replica to
+    # receive the mutation from coordinator node 0 and acknowledge it over
+    # node 1's own (also freshly re-created) connection.
+    logger.info("Verifying a CL=ALL write coordinated by node 0 succeeds")
+    await cql.run_async(write, host=host0)
+
+    # The peer must not have seen a verb on an unidentified connection.
+    # On a patched receiver that would be reported before aborting the
+    # connection; on an unpatched one it would crash the node (which the
+    # test harness reports on its own).
+    log1 = await manager.server_open_log(servers[1].server_id)
+    matches = await log1.grep("missing CLIENT_ID aux data")
+    assert not matches, f"peer received a verb on an unidentified connection: {matches}"

--- a/test/cluster/test_client_id_send_failure.py
+++ b/test/cluster/test_client_id_send_failure.py
@@ -25,8 +25,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-@pytest.mark.xfail(reason="SCYLLADB-3348: a failed CLIENT_ID send leaves a cached unidentified "
-                          "connection behind; the next commit fixes this and removes this mark")
 @pytest.mark.asyncio
 async def test_client_id_send_failure(manager: ManagerClient):
     """A CLIENT_ID send failure on a newly created RPC connection must:


### PR DESCRIPTION
## Background

Internode RPC connections in Scylla carry the sender's identity out-of-band. Whenever a node creates a new RPC connection to a peer (lazily, on the first verb sent on a given connection class), the very first thing it sends on it is a one-shot `CLIENT_ID` message carrying the sender's `host_id`, broadcast address, source shard and max result size. The receiver's `CLIENT_ID` handler stores these values in the connection's `rpc::client_info` auxiliary map (`attach_auxiliary()`), local to that connection. From that point on, handlers of all verbs arriving on the connection learn who is talking to them by reading that map back (`retrieve_auxiliary()`) — the identity is sent once per connection instead of in every message. This works because TCP ordering guarantees the peer processes `CLIENT_ID` before anything sent after it.

## Problem

`CLIENT_ID` is sent fire-and-forget: if the send fails synchronously (e.g. `bad_alloc` while marshalling under memory pressure, as observed in the field — see SCYLLADB-3348), the failure is logged at debug level, the connection stays cached and usable, and the next verb sent on it reaches the peer on a connection whose auxiliary map was never filled. The peer then hits `SCYLLA_ASSERT` in `rpc::client_info::retrieve_auxiliary` and aborts — a sick node takes down healthy peers.

Note that only the synchronous failure is dangerous: once `CLIENT_ID` is enqueued, the connection's ordered pipeline guarantees no verb can overtake it, and a failure to write it out kills the whole connection, taking the later verbs with it. That is why senders don't need to wait for the handshake — waiting would also break verb timeouts on slow/blackholed connections (caught by `test_direct_fd_recovers_after_ip_change` during development).

## Fix

The fix publishes the `CLIENT_ID` send future on the cached client:

- all `send_message*` variants and `make_stream_sink` fail fast when the handshake already failed, instead of sending on the unidentified connection; established connections only pay an `available()` check;
- when the send fails, a warning is logged and the poisoned client is evicted, so the next send creates a fresh connection and re-sends `CLIENT_ID`.

A new cluster test uses the added `fail_outgoing_client_id` error injection to fail the handshake exactly like the field incident (`std::bad_alloc`), and asserts: the sender detects the failure and drops the connection, connectivity recovers automatically on a fresh connection, CL=ALL writes work end-to-end afterwards, and no verb ever reaches the peer on an unidentified connection.

This is the sender-side complement to the receiver-side hotfix #30837 (which remains valuable as protection from unpatched peers). Possible follow-up hardening, out of scope here: a receiver-side dispatch gate that treats any non-CLIENT_ID verb arriving on a connection with no auxiliary data as ill-formed and aborts the connection, covering all ~70 handlers that call `retrieve_auxiliary` unconditionally.

## Testing

- `test/cluster/test_client_id_send_failure.py` (new) passes in dev mode, runs in ~6.5s.
- Messaging-adjacent cluster tests pass in dev mode: `test_stale_rpc_connection_on_ip_change`, `test_ip_mappings`, `test_remove_rpc_client_with_pending_requests`, `test_rpc_compression`, `test_gossiper`, `test_change_rpc_address`.
- During test development, a leftover per-shard injection shot poisoned the handshake of a statement-class connection during a live CL=ALL write: the write failed fast and cleanly with `WriteFailure` on the coordinator (warning logged, connection dropped, peer unaffected) — the exact field scenario shape, handled gracefully.
- Full dev build passes.

Fixes: SCYLLADB-3348

