### PR TITLE
tools/toolchain/dbuild: fix nested rootless podman in Docker-backed dbuild

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -158,8 +158,8 @@ if [ -z "$is_podman" ]; then
     unset TMP_PASSWD
     uid="$(id -u)"
     gid="$(id -g)"
+    groups_csv="$(id -G | tr ' ' ',')"
     docker_common_args+=(
-       -u "$uid:$gid"
        "${group_args[@]}"
        -v /etc/passwd:/etc/passwd:ro
        -v /etc/group:/etc/group:ro
@@ -167,6 +167,30 @@ if [ -z "$is_podman" ]; then
        --tmpfs "/run/user/$uid:rw,exec,nosuid,nodev,mode=700,uid=$uid,gid=$gid"
        --pids-limit -1
        )
+    # Propagate the host's subuid/subgid ranges so nested rootless podman
+    # (used e.g. by test/pylib/dockerized_service.py to run mock services
+    # such as local-kms) has enough sub-IDs to unpack container images.
+    # Without this, the toolchain image's own (empty) /etc/subuid and
+    # /etc/subgid are used instead, causing failures like:
+    #   "potentially insufficient UIDs or GIDs available in user namespace"
+    if [[ -r /etc/subuid ]]; then
+        docker_common_args+=(-v /etc/subuid:/etc/subuid:ro)
+    fi
+    if [[ -r /etc/subgid ]]; then
+        docker_common_args+=(-v /etc/subgid:/etc/subgid:ro)
+    fi
+    # We used to start the container directly as the host uid:gid via
+    # "docker run -u uid:gid". However, the toolchain image ships
+    # newuidmap/newgidmap without the setuid bit, so a nested rootless
+    # podman (spawned e.g. by test/pylib/dockerized_service.py to run mock
+    # services such as local-kms) fails with:
+    #   "should have setuid or have filecaps setuid"
+    # Fixing that up requires root, so instead we start the container as
+    # root, grant the setuid bit on newuidmap/newgidmap, and then drop
+    # privileges to the host uid/gid/groups with setpriv before exec'ing
+    # the real command.
+    privdrop_prelude='for f in /usr/bin/newuidmap /usr/bin/newgidmap /usr/sbin/newuidmap /usr/sbin/newgidmap; do [ -e "$f" ] && chmod u+s "$f" 2>/dev/null; done'
+    args=(/bin/bash -c "$privdrop_prelude"'; exec setpriv --reuid='"$uid"' --regid='"$gid"' --groups='"$groups_csv"' -- "$@"' -- "${args[@]}")
 fi
 
 # --pids-limit is not supported on podman with cgroupsv1


### PR DESCRIPTION
When running:
```
./tools/toolchain/dbuild ./test.py --mode dev \
      test/boost/encryption_at_rest_test.cc
```
the test spawns a local-kms mock service via a nested rootless podman (start_docker_service in test/lib/proc_utils.cc).  With Docker as the outer tool the podman pull fails with:
```
  "should have setuid or have filecaps setuid"
  "potentially insufficient UIDs or GIDs available in user namespace"
```
Root cause 1 — missing subuid/subgid ranges: 
dbuild mounts /etc/passwd and /etc/group so the container sees the host user's identity, but never /etc/subuid and /etc/subgid.  The toolchain image ships empty files for these, so nested rootless podman finds no allocated ranges for the host user and cannot set up its own user namespace.

Root cause 2 — newuidmap/newgidmap lack setuid bit:
Modern shadow-utils uses file capabilities (cap_setuid) for these helpers rather than the traditional setuid permission bit.  File capabilities require CAP_SETFCAP at install time, which container builds (whether docker, podman, or buildah) do not grant by default.  The RPM installs the capabilities declaratively but they are silently dropped, leaving the binaries without any privilege-escalation mechanism.  An unprivileged process (started via "docker run -u $uid") thus cannot invoke newuidmap to create a nested user namespace.

Fix:
  - Bind-mount the host's /etc/subuid and /etc/subgid (guarded by [[ -r .. ]]) so nested podman sees the real allocated ranges.

  - Instead of starting the container directly as the host uid via "-u $uid:$gid", start as root, chmod u+s newuidmap/newgidmap (a fallback the kernel supports regardless of file-capability plumbing), then drop privileges to the host uid/gid/groups via setpriv before exec'ing the real command.

This has no effect on the podman-backed CI path, where the equivalent block is skipped and the outer podman already provides "root-in-namespace" semantics with native CAP_SETUID.

No backport required. Tool fix only.