### PR TITLE
gossiper: bound the state-apply backlog by coalescing pending states per endpoint

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -702,6 +702,7 @@ scylla_tests = set([
     'test/unit/row_cache_stress_test',
     'test/unit/cross_shard_barrier_test',
     'test/boost/address_map_test',
+    'test/boost/endpoint_state_merge_test',
 ]) | ldap_tests
 
 perf_tests = set([
@@ -1821,6 +1822,7 @@ deps['test/raft/etcd_test'] =  ['test/raft/etcd_test.cc', 'test/raft/helpers.cc'
 deps['test/raft/raft_sys_table_storage_test'] = ['test/raft/raft_sys_table_storage_test.cc'] + \
     scylla_core + alternator + scylla_tests_generic_dependencies
 deps['test/boost/address_map_test'] = ['test/boost/address_map_test.cc'] + scylla_core + alternator
+deps['test/boost/endpoint_state_merge_test'] = ['test/boost/endpoint_state_merge_test.cc'] + scylla_core + alternator
 deps['test/raft/discovery_test'] =  ['test/raft/discovery_test.cc',
                                      'test/raft/helpers.cc',
                                      'test/lib/log.cc',

--- a/configure.py
+++ b/configure.py
@@ -704,6 +704,7 @@ scylla_tests = set([
     'test/unit/row_cache_stress_test',
     'test/unit/cross_shard_barrier_test',
     'test/boost/address_map_test',
+    'test/boost/endpoint_state_merge_test',
 ]) | ldap_tests
 
 perf_tests = set([
@@ -1843,6 +1844,7 @@ deps['test/raft/etcd_test'] =  ['test/raft/etcd_test.cc', 'test/raft/helpers.cc'
 deps['test/raft/raft_sys_table_storage_test'] = ['test/raft/raft_sys_table_storage_test.cc'] + \
     scylla_core + alternator + scylla_tests_generic_dependencies
 deps['test/boost/address_map_test'] = ['test/boost/address_map_test.cc'] + scylla_core + alternator
+deps['test/boost/endpoint_state_merge_test'] = ['test/boost/endpoint_state_merge_test.cc'] + scylla_core + alternator
 deps['test/raft/discovery_test'] =  ['test/raft/discovery_test.cc',
                                      'test/raft/helpers.cc',
                                      'test/lib/log.cc',

--- a/gms/endpoint_state.cc
+++ b/gms/endpoint_state.cc
@@ -9,6 +9,7 @@
  */
 
 #include "gms/endpoint_state.hh"
+#include "utils/assert.hh"
 #include "gms/i_endpoint_state_change_subscriber.hh"
 #include <seastar/core/on_internal_error.hh>
 #include <boost/lexical_cast.hpp>
@@ -82,6 +83,21 @@ future<> i_endpoint_state_change_subscriber::on_application_state_change(inet_ad
         return func(endpoint, id, it->second, pid);
     }
     return make_ready_future<>();
+}
+
+void merge_endpoint_state(endpoint_state& into, const endpoint_state& from) {
+    // Versions are only comparable within one generation; merging across
+    // generations would prefer stale facts from the older incarnation.
+    SCYLLA_ASSERT(into.get_heart_beat_state().get_generation() == from.get_heart_beat_state().get_generation());
+    if (from.get_heart_beat_state().get_heart_beat_version() > into.get_heart_beat_state().get_heart_beat_version()) {
+        into.set_heart_beat_state_and_update_timestamp(from.get_heart_beat_state());
+    }
+    for (const auto& [key, value] : from.get_application_state_map()) {
+        const auto* mine = into.get_application_state_ptr(key);
+        if (!mine || mine->version() < value.version()) {
+            into.add_application_state(key, value);
+        }
+    }
 }
 
 }

--- a/gms/endpoint_state.hh
+++ b/gms/endpoint_state.hh
@@ -155,6 +155,11 @@ inline endpoint_state_ptr make_endpoint_state_ptr(endpoint_state&& eps) {
 using permit_id = utils::tagged_uuid<struct permit_id_tag>;
 constexpr permit_id null_permit_id = permit_id::create_null_id();
 
+// Merges `from` into `into`, both of the same generation, keeping the highest
+// version of every application state and of the heartbeat. Facts present in
+// only one of the two are always kept.
+void merge_endpoint_state(endpoint_state& into, const endpoint_state& from);
+
 } // gms
 
 template <>

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -61,6 +61,15 @@ static logging::logger logger("gossip");
 constexpr std::chrono::milliseconds gossiper::INTERVAL;
 constexpr generation_type::value_type gossiper::MAX_GENERATION_DIFFERENCE;
 
+static version_type get_max_endpoint_state_version(const endpoint_state& state) noexcept {
+    auto max_version = state.get_heart_beat_state().get_heart_beat_version();
+    for (const auto& entry : state.get_application_state_map()) {
+        const auto& value = entry.second;
+        max_version = std::max(max_version, value.version());
+    }
+    return max_version;
+}
+
 const sstring& gossiper::get_cluster_name() const noexcept {
     return _gcfg.cluster_name;
 }
@@ -266,34 +275,22 @@ future<> gossiper::do_send_ack_msg(locator::host_id from, gossip_digest_syn syn_
     co_await ser::gossip_rpc_verbs::send_gossip_digest_ack(&_messaging, from, std::move(ack_msg));
 }
 
-static bool should_count_as_msg_processing(const std::map<inet_address, endpoint_state>& map) {
-    bool count_as_msg_processing  = false;
-    for (const auto& x : map) {
-        const auto& state = x.second;
-        for (const auto& entry : state.get_application_state_map()) {
-            const auto& app_state = entry.first;
-
-            auto is_critical_state = [](application_state state) {
-                switch (state) {
-                case application_state::LOAD:
-                case application_state::VIEW_BACKLOG:
-                case application_state::CACHE_HITRATES:
-                case application_state::GROUP0_STATE_ID:
-                    return false;
-                default:
-                    return true;
-                }
-            };
-
-            if (is_critical_state(app_state)) {
-                count_as_msg_processing = true;
-                logger.debug("node={}, app_state={}, count_as_msg_processing={}",
-                        x.first, app_state, count_as_msg_processing);
-                return count_as_msg_processing;
-            }
+// Whether applying this state is work that gossip must be considered busy
+// with. The excluded states are high-frequency chatter that would otherwise
+// keep gossip from ever looking settled.
+static bool has_critical_application_state(const endpoint_state& state) {
+    const auto is_critical_state = [] (application_state as) {
+        switch (as) {
+        case application_state::LOAD:
+        case application_state::VIEW_BACKLOG:
+        case application_state::CACHE_HITRATES:
+        case application_state::GROUP0_STATE_ID:
+            return false;
+        default:
+            return true;
         }
-    }
-    return count_as_msg_processing;
+    };
+    return std::ranges::any_of(state.get_application_state_map() | std::views::keys, is_critical_state);
 }
 
 // Depends on
@@ -312,19 +309,9 @@ future<> gossiper::handle_ack_msg(locator::host_id id, gossip_digest_ack ack_msg
     auto g_digest_list = ack_msg.get_gossip_digest_list();
     auto& ep_state_map = ack_msg.get_endpoint_state_map();
 
-    bool count_as_msg_processing = should_count_as_msg_processing(ep_state_map);
-    if (count_as_msg_processing) {
-        _msg_processing++;
-    }
-    auto mp = defer([count_as_msg_processing, this] noexcept {
-        if (count_as_msg_processing) {
-            _msg_processing--;
-        }
-    });
-
     if (ep_state_map.size() > 0) {
         update_timestamp_for_nodes(ep_state_map);
-        co_await apply_state_locally(std::move(ep_state_map));
+        queue_state_applies(std::move(ep_state_map));
     }
 
     auto from = id;
@@ -421,17 +408,7 @@ future<> gossiper::handle_ack2_msg(locator::host_id from, gossip_digest_ack2 msg
     auto& remote_ep_state_map = msg.get_endpoint_state_map();
     update_timestamp_for_nodes(remote_ep_state_map);
 
-    bool count_as_msg_processing = should_count_as_msg_processing(remote_ep_state_map);
-    if (count_as_msg_processing) {
-        _msg_processing++;
-    }
-    auto mp = defer([count_as_msg_processing, this] noexcept {
-        if (count_as_msg_processing) {
-            _msg_processing--;
-        }
-    });
-
-    co_await apply_state_locally(std::move(remote_ep_state_map));
+    queue_state_applies(std::move(remote_ep_state_map));
 }
 
 future<> gossiper::handle_echo_msg(locator::host_id from_hid, seastar::rpc::opt_time_point timeout, std::optional<int64_t> generation_number_opt, bool notify_up) {
@@ -673,44 +650,183 @@ future<> gossiper::apply_state_locally_in_shadow_round(std::unordered_map<inet_a
     }
 }
 
-future<> gossiper::apply_state_locally(std::map<inet_address, endpoint_state> map) {
-    auto start = std::chrono::steady_clock::now();
-    // Received states are applied with limited concurrency; the rest queue up
-    // as semaphore waiters. Log the backlog so that a node falling behind on
-    // applying gossip states is observable.
-    logger.debug("gossip state-apply backlog: {}", _apply_state_locally_semaphore.waiters());
+future<> gossiper::apply_pending_states(locator::host_id hid, gate::holder gh) {
+    // The caller inserted hid into _applying_states before creating this
+    // coroutine and handles creation failures itself, so nothing here can
+    // throw before the try block: no exception can end up in the discarded
+    // future. The gate holder lives in the coroutine frame, keeping
+    // _background_msg held for exactly as long as this fiber runs.
+    //
+    // Clear the marker unconditionally: if it were left behind, no applier
+    // would ever be spawned for this endpoint again and its states would
+    // accumulate in the pending slot unapplied.
+    const auto clear_marker = defer([this, hid] noexcept {
+        _applying_states.erase(hid);
+    });
+    try {
+        while (_pending_state_applies.contains(hid)) {
+            const auto units = co_await get_units(_apply_state_locally_semaphore, 1);
+            auto node = _pending_state_applies.extract(hid);
+            if (node.empty()) {
+                break;
+            }
+            auto& pending = node.mapped();
+            // The state has left the pending map but is still outstanding
+            // work until it is applied, so keep it counted until then.
+            const auto counted = defer([this, critical = pending.critical] noexcept {
+                if (critical) {
+                    --_msg_processing;
+                }
+            });
+            co_await do_apply_state_locally(hid, std::move(pending.state), false);
+        }
+    } catch (...) {
+        // Drop any state that was queued while the failed apply was running,
+        // so the entry cannot be retained forever if nothing arrives for this
+        // endpoint anymore (e.g. because it left the cluster). If the state
+        // is still relevant, the next gossip exchange re-delivers it: the
+        // state was never applied, so our digest still advertises a version
+        // below everything it contained.
+        drop_pending_state(hid);
+        const auto ex = std::current_exception();
+        if (_abort_source.abort_requested()) {
+            logger.debug("Failed to apply gossip state for {} during shutdown: {}", hid, ex);
+        } else {
+            logger.warn("Failed to apply gossip state for {}: {}", hid, ex);
+        }
+    }
+}
+
+void gossiper::drop_pending_state(locator::host_id hid) noexcept {
+    if (const auto it = _pending_state_applies.find(hid); it != _pending_state_applies.end()) {
+        if (it->second.critical) {
+            --_msg_processing;
+        }
+        _pending_state_applies.erase(it);
+    }
+}
+
+void gossiper::spawn_state_applier(locator::host_id hid) noexcept {
+    if (_abort_source.abort_requested() || _background_msg.is_closed()) {
+        // Nobody will pick the state up anymore, so do not leave it behind
+        // holding memory and keeping gossip from looking settled.
+        drop_pending_state(hid);
+        return;
+    }
+    try {
+        _applying_states.insert(hid);
+        try {
+            // apply_pending_states() handles all its exceptions; only the
+            // allocation of its coroutine frame can throw, synchronously.
+            (void)apply_pending_states(hid, _background_msg.hold());
+        } catch (...) {
+            _applying_states.erase(hid);
+            throw;
+        }
+    } catch (...) {
+        // Drop the state rather than leave it waiting for an applier that
+        // never spawned: it was never applied, so our digest still advertises
+        // a version below it and the next gossip exchange re-delivers it.
+        drop_pending_state(hid);
+        logger.warn("Failed to spawn a gossip state applier for {}: {}", hid, std::current_exception());
+    }
+}
+
+void gossiper::queue_state_apply(inet_address ep, endpoint_state state) {
+    state.set_ip(ep);
+    locator::host_id hid = state.get_host_id();
+    if (hid == locator::host_id::create_null_id()) {
+        // If there is no host id in the new state there should be one locally
+        hid = get_host_id(ep);
+    }
+    if (hid == my_host_id()) {
+        logger.trace("Ignoring gossip for {} because it maps to local id, but is not local address", ep);
+        return;
+    }
+    if (_topo_sm._topology.left_nodes.contains(raft::server_id(hid.uuid()))) {
+        logger.trace("Ignoring gossip for {} because it left", ep);
+        return;
+    }
+    // Coalesce pending states: keep at most one pending state per endpoint,
+    // merging each arrival into it per key, keeping the highest version of
+    // each. This bounds the apply backlog and its memory consumption at
+    // O(cluster size).
+    //
+    // The per-key merge is defence in depth, not a fix for an observed
+    // problem. Keeping just the state with the highest max version would
+    // also be correct today: colliding states are deltas computed against
+    // our advertised digest, which reflects applied state only, so each one
+    // covers everything between our applied state and its own max, and the
+    // higher-max one is a superset of the other. (The dangerous-looking
+    // heartbeat-only delta — highest max version, no application states — is
+    // only sent to a node that is caught up, and then the slot is empty and
+    // nothing collides.) But that argument rests on every peer's state being
+    // downward-closed in version, a protocol property maintained elsewhere:
+    // add_saved_endpoint() builds a partial state but pins generation 0 so
+    // it is replaced wholesale, and the filtered shadow-round states are
+    // cleared by reset_endpoint_state_map() before gossip starts. A key
+    // dropped here in violation of that assumption would be lost
+    // permanently — a digest advertises a single max version per endpoint,
+    // so no peer would ever re-send a key below it. Merging costs a few
+    // hash lookups on collisions only, and makes the outcome independent of
+    // the assumption: nothing is ever dropped.
+    const bool critical = has_critical_application_state(state);
+    const auto it = _pending_state_applies.find(hid);
+    if (it == _pending_state_applies.end()) {
+        _pending_state_applies.emplace(hid, pending_state{std::move(state), critical});
+        if (critical) {
+            ++_msg_processing;
+        }
+    } else {
+        auto& pending = it->second.state;
+        const auto incoming_gen = state.get_heart_beat_state().get_generation();
+        const auto pending_gen = pending.get_heart_beat_state().get_generation();
+        if (incoming_gen < pending_gen) {
+            // A state from an older incarnation of the node: drop it without
+            // touching the slot — it must not mark the slot critical, nor log
+            // the coalesce line the decommission race test synchronizes on.
+            logger.debug("queue_state_apply: dropping a stale-generation state of {}", hid);
+            return;
+        }
+        if (incoming_gen > pending_gen) {
+            // A newer generation invalidates the older state wholesale.
+            pending = std::move(state);
+        } else {
+            merge_endpoint_state(pending, state);
+        }
+        // The slot's criticality is sticky: whatever it holds still has to be
+        // applied before gossip can be considered settled.
+        if (critical && !std::exchange(it->second.critical, true)) {
+            ++_msg_processing;
+        }
+        logger.debug("queue_state_apply: coalesced a state of {} into the pending one", hid);
+    }
+    if (!_applying_states.contains(hid)) {
+        spawn_state_applier(hid);
+    }
+}
+
+void gossiper::queue_state_applies(std::map<inet_address, endpoint_state> map) {
     auto endpoints = map | std::views::keys | std::ranges::to<utils::chunked_vector<inet_address>>();
     std::shuffle(endpoints.begin(), endpoints.end(), _random_engine);
-    auto node_is_seed = [this] (gms::inet_address ip) { return is_seed(ip); };
+    const auto node_is_seed = [this] (gms::inet_address ip) { return is_seed(ip); };
     boost::partition(endpoints, node_is_seed);
-    logger.debug("apply_state_locally_endpoints={}", endpoints);
+    logger.debug("queue_state_applies endpoints={}", endpoints);
 
-    co_await coroutine::parallel_for_each(endpoints, [this, &map] (auto&& ep) -> future<> {
+    for (const auto& ep : endpoints) {
         if (ep == get_broadcast_address()) {
-            return make_ready_future<>();
+            continue;
         }
-        auto it = map.find(ep);
-        it->second.set_ip(ep);
-        locator::host_id hid = it->second.get_host_id();
-        if (hid == locator::host_id::create_null_id()) {
-            // If there is no host id in the new state there should be one locally
-            hid = get_host_id(ep);
+        try {
+            queue_state_apply(ep, std::move(map.find(ep)->second));
+        } catch (...) {
+            logger.warn("Failed to queue gossip state for {}: {}", ep, std::current_exception());
         }
-        if (hid == my_host_id()) {
-            logger.trace("Ignoring gossip for {} because it maps to local id, but is not local address", ep);
-            return make_ready_future<>();
-        }
-        if (_topo_sm._topology.left_nodes.contains(raft::server_id(hid.uuid()))) {
-            logger.trace("Ignoring gossip for {} because it left", ep);
-            return make_ready_future<>();
-        }
-        return seastar::with_semaphore(_apply_state_locally_semaphore, 1, [this, hid, state = std::move(it->second)] () mutable {
-            return do_apply_state_locally(hid, std::move(state), false);
-        });
-    });
-
-    logger.debug("apply_state_locally() took {} ms", std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now() - start).count());
+    }
+    // The backlog is bounded by the cluster size (one pending state per
+    // endpoint); keep logging it so the reproducer test and support cases can
+    // observe it.
+    logger.debug("gossip state-apply backlog: {}", _pending_state_applies.size());
 }
 
 future<> gossiper::force_remove_endpoint(locator::host_id id, permit_id pid) {
@@ -1232,15 +1348,6 @@ future<> gossiper::convict(locator::host_id endpoint) {
 
 std::set<locator::host_id> gossiper::get_unreachable_members() const {
     return _unreachable_endpoints | std::views::keys | std::ranges::to<std::set>();
-}
-
-version_type gossiper::get_max_endpoint_state_version(const endpoint_state& state) const noexcept {
-    auto max_version = state.get_heart_beat_state().get_heart_beat_version();
-    for (auto& entry : state.get_application_state_map()) {
-        auto& value = entry.second;
-        max_version = std::max(max_version, value.version());
-    }
-    return max_version;
 }
 
 future<> gossiper::evict_from_membership(locator::host_id hid, permit_id pid) {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -587,7 +587,8 @@ future<> gossiper::do_apply_state_locally(locator::host_id node, endpoint_state 
 
     co_await utils::get_local_injector().inject("delay_gossiper_apply", [&node, &remote_state](auto& handler) -> future<> {
         const auto gossip_delay_node = handler.template get<std::string_view>("delay_node");
-        if (gossip_delay_node && !remote_state.get_host_id() && inet_address(sstring(gossip_delay_node.value())) == remote_state.get_ip()) {
+        const bool any_state = handler.template get<std::string_view>("any_state").has_value();
+        if (gossip_delay_node && (any_state || !remote_state.get_host_id()) && inet_address(sstring(gossip_delay_node.value())) == remote_state.get_ip()) {
             logger.debug("delay_gossiper_apply: suspend for node {}", node);
             co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
             logger.debug("delay_gossiper_apply: resume for node {}", node);
@@ -597,6 +598,17 @@ future<> gossiper::do_apply_state_locally(locator::host_id node, endpoint_state 
     // If state does not exist just add it. If it does then add it if the remote generation is greater.
     // If there is a generation tie, attempt to break it by heartbeat version.
     auto permit = co_await lock_endpoint(node, null_permit_id);
+
+    // Re-check under the endpoint lock: the node may have left between the
+    // time the state was queued and now. force_remove_endpoint() runs under
+    // the same lock, so without this a state carrying HOST_ID that was
+    // queued before the removal would re-insert the removed endpoint via
+    // handle_major_state_change().
+    if (!shadow_round && _topo_sm._topology.left_nodes.contains(raft::server_id(node.uuid()))) {
+        logger.debug("do_apply_state_locally: ignoring gossip for {} because it left", node);
+        co_return;
+    }
+
     auto es = get_endpoint_state_ptr(node);
 
     // If remote state update does not contain a host id, check whether the endpoint still

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -603,6 +603,11 @@ future<> gossiper::send_gossip(gossip_digest_syn message, std::set<T> epset) {
 
 future<> gossiper::do_apply_state_locally(locator::host_id node, endpoint_state remote_state, bool shadow_round) {
 
+    // share_messages: a single message_injection() releases every stalled
+    // applier, so the test can unstick them all when it is done.
+    co_await utils::get_local_injector().inject("gossiper_stall_apply_state_locally",
+            utils::wait_for_message(std::chrono::minutes(5)));
+
     co_await utils::get_local_injector().inject("delay_gossiper_apply", [&node, &remote_state](auto& handler) -> future<> {
         const auto gossip_delay_node = handler.template get<std::string_view>("delay_node");
         if (gossip_delay_node && !remote_state.get_host_id() && inet_address(sstring(gossip_delay_node.value())) == remote_state.get_ip()) {
@@ -670,6 +675,10 @@ future<> gossiper::apply_state_locally_in_shadow_round(std::unordered_map<inet_a
 
 future<> gossiper::apply_state_locally(std::map<inet_address, endpoint_state> map) {
     auto start = std::chrono::steady_clock::now();
+    // Received states are applied with limited concurrency; the rest queue up
+    // as semaphore waiters. Log the backlog so that a node falling behind on
+    // applying gossip states is observable.
+    logger.debug("gossip state-apply backlog: {}", _apply_state_locally_semaphore.waiters());
     auto endpoints = map | std::views::keys | std::ranges::to<utils::chunked_vector<inet_address>>();
     std::shuffle(endpoints.begin(), endpoints.end(), _random_engine);
     auto node_is_seed = [this] (gms::inet_address ip) { return is_seed(ip); };

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -61,6 +61,15 @@ static logging::logger logger("gossip");
 constexpr std::chrono::milliseconds gossiper::INTERVAL;
 constexpr generation_type::value_type gossiper::MAX_GENERATION_DIFFERENCE;
 
+static version_type get_max_endpoint_state_version(const endpoint_state& state) noexcept {
+    auto max_version = state.get_heart_beat_state().get_heart_beat_version();
+    for (const auto& entry : state.get_application_state_map()) {
+        const auto& value = entry.second;
+        max_version = std::max(max_version, value.version());
+    }
+    return max_version;
+}
+
 const sstring& gossiper::get_cluster_name() const noexcept {
     return _gcfg.cluster_name;
 }
@@ -266,34 +275,22 @@ future<> gossiper::do_send_ack_msg(locator::host_id from, gossip_digest_syn syn_
     co_await ser::gossip_rpc_verbs::send_gossip_digest_ack(&_messaging, from, std::move(ack_msg));
 }
 
-static bool should_count_as_msg_processing(const std::map<inet_address, endpoint_state>& map) {
-    bool count_as_msg_processing  = false;
-    for (const auto& x : map) {
-        const auto& state = x.second;
-        for (const auto& entry : state.get_application_state_map()) {
-            const auto& app_state = entry.first;
-
-            auto is_critical_state = [](application_state state) {
-                switch (state) {
-                case application_state::LOAD:
-                case application_state::VIEW_BACKLOG:
-                case application_state::CACHE_HITRATES:
-                case application_state::GROUP0_STATE_ID:
-                    return false;
-                default:
-                    return true;
-                }
-            };
-
-            if (is_critical_state(app_state)) {
-                count_as_msg_processing = true;
-                logger.debug("node={}, app_state={}, count_as_msg_processing={}",
-                        x.first, app_state, count_as_msg_processing);
-                return count_as_msg_processing;
-            }
+// Whether applying this state is work that gossip must be considered busy
+// with. The excluded states are high-frequency chatter that would otherwise
+// keep gossip from ever looking settled.
+static bool has_critical_application_state(const endpoint_state& state) {
+    const auto is_critical_state = [] (application_state as) {
+        switch (as) {
+        case application_state::LOAD:
+        case application_state::VIEW_BACKLOG:
+        case application_state::CACHE_HITRATES:
+        case application_state::GROUP0_STATE_ID:
+            return false;
+        default:
+            return true;
         }
-    }
-    return count_as_msg_processing;
+    };
+    return std::ranges::any_of(state.get_application_state_map() | std::views::keys, is_critical_state);
 }
 
 // Depends on
@@ -312,19 +309,9 @@ future<> gossiper::handle_ack_msg(locator::host_id id, gossip_digest_ack ack_msg
     auto g_digest_list = ack_msg.get_gossip_digest_list();
     auto& ep_state_map = ack_msg.get_endpoint_state_map();
 
-    bool count_as_msg_processing = should_count_as_msg_processing(ep_state_map);
-    if (count_as_msg_processing) {
-        _msg_processing++;
-    }
-    auto mp = defer([count_as_msg_processing, this] noexcept {
-        if (count_as_msg_processing) {
-            _msg_processing--;
-        }
-    });
-
     if (ep_state_map.size() > 0) {
         update_timestamp_for_nodes(ep_state_map);
-        co_await apply_state_locally(std::move(ep_state_map));
+        queue_state_applies(std::move(ep_state_map));
     }
 
     auto from = id;
@@ -421,17 +408,7 @@ future<> gossiper::handle_ack2_msg(locator::host_id from, gossip_digest_ack2 msg
     auto& remote_ep_state_map = msg.get_endpoint_state_map();
     update_timestamp_for_nodes(remote_ep_state_map);
 
-    bool count_as_msg_processing = should_count_as_msg_processing(remote_ep_state_map);
-    if (count_as_msg_processing) {
-        _msg_processing++;
-    }
-    auto mp = defer([count_as_msg_processing, this] noexcept {
-        if (count_as_msg_processing) {
-            _msg_processing--;
-        }
-    });
-
-    co_await apply_state_locally(std::move(remote_ep_state_map));
+    queue_state_applies(std::move(remote_ep_state_map));
 }
 
 future<> gossiper::handle_echo_msg(locator::host_id from_hid, seastar::rpc::opt_time_point timeout, std::optional<int64_t> generation_number_opt, bool notify_up) {
@@ -673,44 +650,177 @@ future<> gossiper::apply_state_locally_in_shadow_round(std::unordered_map<inet_a
     }
 }
 
-future<> gossiper::apply_state_locally(std::map<inet_address, endpoint_state> map) {
-    auto start = std::chrono::steady_clock::now();
-    // Received states are applied with limited concurrency; the rest queue up
-    // as semaphore waiters. Log the backlog so that a node falling behind on
-    // applying gossip states is observable.
-    logger.debug("gossip state-apply backlog: {}", _apply_state_locally_semaphore.waiters());
+future<> gossiper::apply_pending_states(locator::host_id hid, gate::holder gh) {
+    // The caller inserted hid into _applying_states before creating this
+    // coroutine and handles creation failures itself, so nothing here can
+    // throw before the try block: no exception can end up in the discarded
+    // future. The gate holder lives in the coroutine frame, keeping
+    // _background_msg held for exactly as long as this fiber runs.
+    try {
+        while (_pending_state_applies.contains(hid)) {
+            const auto units = co_await get_units(_apply_state_locally_semaphore, 1);
+            auto node = _pending_state_applies.extract(hid);
+            if (node.empty()) {
+                break;
+            }
+            auto& pending = node.mapped();
+            // The state has left the pending map but is still outstanding
+            // work until it is applied, so keep it counted until then.
+            const auto counted = defer([this, critical = pending.critical] noexcept {
+                if (critical) {
+                    --_msg_processing;
+                }
+            });
+            co_await do_apply_state_locally(hid, std::move(pending.state), false);
+        }
+    } catch (...) {
+        // Drop any state that was queued while the failed apply was running,
+        // so the entry cannot be retained forever if nothing arrives for this
+        // endpoint anymore (e.g. because it left the cluster). If the state
+        // is still relevant, the next gossip exchange re-delivers it: the
+        // state was never applied, so our digest still advertises a version
+        // below everything it contained.
+        drop_pending_state(hid);
+        const auto ex = std::current_exception();
+        if (_abort_source.abort_requested()) {
+            logger.debug("Failed to apply gossip state for {} during shutdown: {}", hid, ex);
+        } else {
+            logger.warn("Failed to apply gossip state for {}: {}", hid, ex);
+        }
+    }
+    _applying_states.erase(hid);
+}
+
+void gossiper::drop_pending_state(locator::host_id hid) noexcept {
+    if (const auto it = _pending_state_applies.find(hid); it != _pending_state_applies.end()) {
+        if (it->second.critical) {
+            --_msg_processing;
+        }
+        _pending_state_applies.erase(it);
+    }
+}
+
+void gossiper::spawn_state_applier(locator::host_id hid) noexcept {
+    if (_abort_source.abort_requested() || _background_msg.is_closed()) {
+        // Nobody will pick the state up anymore, so do not leave it behind
+        // holding memory and keeping gossip from looking settled.
+        drop_pending_state(hid);
+        return;
+    }
+    try {
+        _applying_states.insert(hid);
+        try {
+            // apply_pending_states() handles all its exceptions; only the
+            // allocation of its coroutine frame can throw, synchronously.
+            (void)apply_pending_states(hid, _background_msg.hold());
+        } catch (...) {
+            _applying_states.erase(hid);
+            throw;
+        }
+    } catch (...) {
+        // Drop the state rather than leave it waiting for an applier that
+        // never spawned: it was never applied, so our digest still advertises
+        // a version below it and the next gossip exchange re-delivers it.
+        drop_pending_state(hid);
+        logger.warn("Failed to spawn a gossip state applier for {}: {}", hid, std::current_exception());
+    }
+}
+
+void gossiper::queue_state_apply(inet_address ep, endpoint_state state) {
+    state.set_ip(ep);
+    locator::host_id hid = state.get_host_id();
+    if (hid == locator::host_id::create_null_id()) {
+        // If there is no host id in the new state there should be one locally
+        hid = get_host_id(ep);
+    }
+    if (hid == my_host_id()) {
+        logger.trace("Ignoring gossip for {} because it maps to local id, but is not local address", ep);
+        return;
+    }
+    if (_topo_sm._topology.left_nodes.contains(raft::server_id(hid.uuid()))) {
+        logger.trace("Ignoring gossip for {} because it left", ep);
+        return;
+    }
+    // Coalesce pending states: keep at most one pending state per endpoint,
+    // merging each arrival into it per key, keeping the highest version of
+    // each. This bounds the apply backlog and its memory consumption at
+    // O(cluster size).
+    //
+    // The per-key merge is defence in depth, not a fix for an observed
+    // problem. Keeping just the state with the highest max version would
+    // also be correct today: colliding states are deltas computed against
+    // our advertised digest, which reflects applied state only, so each one
+    // covers everything between our applied state and its own max, and the
+    // higher-max one is a superset of the other. (The dangerous-looking
+    // heartbeat-only delta — highest max version, no application states — is
+    // only sent to a node that is caught up, and then the slot is empty and
+    // nothing collides.) But that argument rests on every peer's state being
+    // downward-closed in version, a protocol property maintained elsewhere:
+    // add_saved_endpoint() builds a partial state but pins generation 0 so
+    // it is replaced wholesale, and the filtered shadow-round states are
+    // cleared by reset_endpoint_state_map() before gossip starts. A key
+    // dropped here in violation of that assumption would be lost
+    // permanently — a digest advertises a single max version per endpoint,
+    // so no peer would ever re-send a key below it. Merging costs a few
+    // hash lookups on collisions only, and makes the outcome independent of
+    // the assumption: nothing is ever dropped.
+    const bool critical = has_critical_application_state(state);
+    const auto it = _pending_state_applies.find(hid);
+    if (it == _pending_state_applies.end()) {
+        _pending_state_applies.emplace(hid, pending_state{std::move(state), critical});
+        if (critical) {
+            ++_msg_processing;
+        }
+    } else {
+        auto& pending = it->second.state;
+        const auto incoming_gen = state.get_heart_beat_state().get_generation();
+        const auto pending_gen = pending.get_heart_beat_state().get_generation();
+        if (incoming_gen < pending_gen) {
+            // A state from an older incarnation of the node: drop it without
+            // touching the slot — it must not mark the slot critical, nor log
+            // the coalesce line the decommission race test synchronizes on.
+            logger.debug("queue_state_apply: dropping a stale-generation state of {}", hid);
+            return;
+        }
+        if (incoming_gen > pending_gen) {
+            // A newer generation invalidates the older state wholesale.
+            pending = std::move(state);
+        } else {
+            merge_endpoint_state(pending, state);
+        }
+        // The slot's criticality is sticky: whatever it holds still has to be
+        // applied before gossip can be considered settled.
+        if (critical && !std::exchange(it->second.critical, true)) {
+            ++_msg_processing;
+        }
+        logger.debug("queue_state_apply: coalesced a state of {} into the pending one", hid);
+    }
+    if (!_applying_states.contains(hid)) {
+        spawn_state_applier(hid);
+    }
+}
+
+void gossiper::queue_state_applies(std::map<inet_address, endpoint_state> map) {
     auto endpoints = map | std::views::keys | std::ranges::to<utils::chunked_vector<inet_address>>();
     std::shuffle(endpoints.begin(), endpoints.end(), _random_engine);
-    auto node_is_seed = [this] (gms::inet_address ip) { return is_seed(ip); };
+    const auto node_is_seed = [this] (gms::inet_address ip) { return is_seed(ip); };
     boost::partition(endpoints, node_is_seed);
-    logger.debug("apply_state_locally_endpoints={}", endpoints);
+    logger.debug("queue_state_applies endpoints={}", endpoints);
 
-    co_await coroutine::parallel_for_each(endpoints, [this, &map] (auto&& ep) -> future<> {
+    for (const auto& ep : endpoints) {
         if (ep == get_broadcast_address()) {
-            return make_ready_future<>();
+            continue;
         }
-        auto it = map.find(ep);
-        it->second.set_ip(ep);
-        locator::host_id hid = it->second.get_host_id();
-        if (hid == locator::host_id::create_null_id()) {
-            // If there is no host id in the new state there should be one locally
-            hid = get_host_id(ep);
+        try {
+            queue_state_apply(ep, std::move(map.find(ep)->second));
+        } catch (...) {
+            logger.warn("Failed to queue gossip state for {}: {}", ep, std::current_exception());
         }
-        if (hid == my_host_id()) {
-            logger.trace("Ignoring gossip for {} because it maps to local id, but is not local address", ep);
-            return make_ready_future<>();
-        }
-        if (_topo_sm._topology.left_nodes.contains(raft::server_id(hid.uuid()))) {
-            logger.trace("Ignoring gossip for {} because it left", ep);
-            return make_ready_future<>();
-        }
-        return seastar::with_semaphore(_apply_state_locally_semaphore, 1, [this, hid, state = std::move(it->second)] () mutable {
-            return do_apply_state_locally(hid, std::move(state), false);
-        });
-    });
-
-    logger.debug("apply_state_locally() took {} ms", std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::steady_clock::now() - start).count());
+    }
+    // The backlog is bounded by the cluster size (one pending state per
+    // endpoint); keep logging it so the reproducer test and support cases can
+    // observe it.
+    logger.debug("gossip state-apply backlog: {}", _pending_state_applies.size());
 }
 
 future<> gossiper::force_remove_endpoint(locator::host_id id, permit_id pid) {
@@ -1232,15 +1342,6 @@ future<> gossiper::convict(locator::host_id endpoint) {
 
 std::set<locator::host_id> gossiper::get_unreachable_members() const {
     return _unreachable_endpoints | std::views::keys | std::ranges::to<std::set>();
-}
-
-version_type gossiper::get_max_endpoint_state_version(const endpoint_state& state) const noexcept {
-    auto max_version = state.get_heart_beat_state().get_heart_beat_version();
-    for (auto& entry : state.get_application_state_map()) {
-        auto& value = entry.second;
-        max_version = std::max(max_version, value.version());
-    }
-    return max_version;
 }
 
 future<> gossiper::evict_from_membership(locator::host_id hid, permit_id pid) {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -114,6 +114,21 @@ private:
     bool _enabled = false;
     semaphore _callback_running{1};
     semaphore _apply_state_locally_semaphore{100};
+    struct pending_state {
+        endpoint_state state;
+        // Whether the state carries an application state that gossip has to
+        // be considered busy with until it is applied (see _msg_processing).
+        // Sticky: set once, cleared only when the state is applied or dropped.
+        bool critical;
+    };
+    // Pending endpoint states waiting to be applied, coalesced per endpoint:
+    // at most one entry per endpoint is kept, and each arriving state is
+    // merged into it key by key (see queue_state_apply()). This bounds
+    // both the apply backlog and its memory consumption at O(cluster size)
+    // even when application cannot keep up with incoming gossip.
+    std::unordered_map<locator::host_id, pending_state> _pending_state_applies;
+    // Endpoints an apply fiber is currently running for.
+    std::unordered_set<locator::host_id> _applying_states;
     seastar::named_gate _background_msg;
     std::unordered_map<locator::host_id, syn_msg_pending> _syn_handlers;
     std::unordered_map<locator::host_id, ack_msg_pending> _ack_handlers;
@@ -290,14 +305,6 @@ public:
 
     int64_t get_endpoint_downtime(locator::host_id ep) const noexcept;
 
-    /**
-     * Return either: the greatest heartbeat or application state
-     *
-     * @param ep_state
-     * @return
-     */
-    version_type get_max_endpoint_state_version(const endpoint_state& state) const noexcept;
-
 private:
     /**
      * Removes the endpoint from gossip completely
@@ -457,11 +464,21 @@ public:
     // Get live members synchronized to all shards
     future<std::set<inet_address>> get_unreachable_members_synchronized();
 
-    future<> apply_state_locally(std::map<inet_address, endpoint_state> map);
-
 private:
+    // Queues the received endpoint states for application by the per-endpoint
+    // applier fibers. Does not wait for them to be applied.
+    void queue_state_applies(std::map<inet_address, endpoint_state> map);
+    void queue_state_apply(inet_address ep, endpoint_state state);
     future<> do_apply_state_locally(locator::host_id node, endpoint_state remote_state, bool shadow_round);
     future<> apply_state_locally_in_shadow_round(std::unordered_map<inet_address, endpoint_state> map);
+    // Spawns a background fiber applying pending states of the given endpoint
+    // until none remain. At most one such fiber runs per endpoint. On failure
+    // to spawn, the pending state is dropped; gossip re-delivers it.
+    void spawn_state_applier(locator::host_id hid) noexcept;
+    // Discards the pending state of the given endpoint, if any, keeping
+    // _msg_processing in sync.
+    void drop_pending_state(locator::host_id hid) noexcept;
+    future<> apply_pending_states(locator::host_id hid, gate::holder gh);
 
     // Must be called under lock_endpoint.
     future<> apply_new_states(endpoint_state local_state, const endpoint_state& remote_state, permit_id, bool shadow_round);
@@ -578,6 +595,11 @@ public:
     sstring get_gossip_status(const locator::host_id& endpoint) const noexcept;
 private:
     uint64_t _nr_run = 0;
+    // Number of received endpoint states carrying a critical application
+    // state that are queued for or undergoing application. Gossip is not
+    // settled while this is non-zero. Note that it counts the actual work,
+    // not the message handlers: those hand the states over to the per-endpoint
+    // applier fibers and return without waiting for them.
     uint64_t _msg_processing = 0;
 private:
     abort_source& _abort_source;

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -579,8 +579,6 @@ public:
 private:
     uint64_t _nr_run = 0;
     uint64_t _msg_processing = 0;
-
-    class msg_proc_guard;
 private:
     abort_source& _abort_source;
     const locator::shared_token_metadata& _shared_token_metadata;

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -101,6 +101,8 @@ add_scylla_test(http_error_classification_test
   KIND SEASTAR
   LIBRARIES
     encryption)
+add_scylla_test(endpoint_state_merge_test
+  KIND SEASTAR)
 add_scylla_test(enum_option_test
   KIND BOOST)
 add_scylla_test(enum_set_test

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -97,6 +97,8 @@ add_scylla_test(encryption_at_rest_test
   KIND SEASTAR
   LIBRARIES
     encryption)
+add_scylla_test(endpoint_state_merge_test
+  KIND SEASTAR)
 add_scylla_test(enum_option_test
   KIND BOOST)
 add_scylla_test(enum_set_test

--- a/test/boost/endpoint_state_merge_test.cc
+++ b/test/boost/endpoint_state_merge_test.cc
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include <seastar/testing/test_case.hh>
+
+#include "gms/endpoint_state.hh"
+#include "gms/application_state.hh"
+#include "gms/versioned_value.hh"
+
+// Unit tests for gms::merge_endpoint_state(), which the gossiper uses to
+// coalesce pending endpoint states of the same generation: for every
+// application state and for the heartbeat, the highest version must win, and
+// no value present in either input may be lost. The last case is the one
+// that matters: a heartbeat-only state always carries the highest version,
+// so any scheme that picks one whole state over the other by version would
+// discard the other state's application states, and gossip never re-delivers
+// a value below the advertised max version.
+
+using namespace gms;
+
+namespace {
+
+endpoint_state make_state(int32_t hb_version, std::initializer_list<std::pair<application_state, versioned_value>> states) {
+    endpoint_state es{heart_beat_state{generation_type(1), version_type(hb_version)}, inet_address("127.0.0.1")};
+    for (auto& [key, value] : states) {
+        es.add_application_state(key, value);
+    }
+    return es;
+}
+
+versioned_value val(sstring value, int32_t version) {
+    return versioned_value(utils::chunked_string(value), version_type(version));
+}
+
+const versioned_value* get(const endpoint_state& es, application_state key) {
+    return es.get_application_state_ptr(key);
+}
+
+void check(const endpoint_state& es, application_state key, sstring value, int32_t version) {
+    const auto* v = get(es, key);
+    BOOST_REQUIRE(v != nullptr);
+    BOOST_REQUIRE_EQUAL(v->value().linearize(), value);
+    BOOST_REQUIRE_EQUAL(v->version().value(), version);
+}
+
+} // anonymous namespace
+
+// Disjoint application states: the result must carry both.
+SEASTAR_TEST_CASE(test_merge_unions_disjoint_states) {
+    auto into = make_state(10, {{application_state::STATUS, val("NORMAL", 6)}});
+    auto from = make_state(12, {{application_state::LOAD, val("0.5", 11)}});
+
+    merge_endpoint_state(into, from);
+
+    check(into, application_state::STATUS, "NORMAL", 6);
+    check(into, application_state::LOAD, "0.5", 11);
+    BOOST_REQUIRE_EQUAL(into.get_heart_beat_state().get_heart_beat_version().value(), 12);
+    return seastar::make_ready_future<>();
+}
+
+// Overlapping application state: the higher version must win, in both
+// directions, and an equal version must not overwrite.
+SEASTAR_TEST_CASE(test_merge_keeps_highest_version_per_state) {
+    auto into = make_state(10, {{application_state::STATUS, val("BOOT", 4)}});
+    auto from = make_state(12, {{application_state::STATUS, val("NORMAL", 6)}});
+    merge_endpoint_state(into, from);
+    check(into, application_state::STATUS, "NORMAL", 6);
+
+    // Older incoming value must not regress the newer one.
+    auto older = make_state(13, {{application_state::STATUS, val("BOOT", 4)}});
+    merge_endpoint_state(into, older);
+    check(into, application_state::STATUS, "NORMAL", 6);
+
+    // Equal version: keep what we have.
+    auto equal = make_state(14, {{application_state::STATUS, val("SHOULD_NOT_APPEAR", 6)}});
+    merge_endpoint_state(into, equal);
+    check(into, application_state::STATUS, "NORMAL", 6);
+    return seastar::make_ready_future<>();
+}
+
+// The heartbeat: higher version wins, lower does not regress it.
+SEASTAR_TEST_CASE(test_merge_keeps_highest_heartbeat) {
+    auto into = make_state(20, {});
+    auto newer = make_state(30, {});
+    merge_endpoint_state(into, newer);
+    BOOST_REQUIRE_EQUAL(into.get_heart_beat_state().get_heart_beat_version().value(), 30);
+
+    auto older = make_state(25, {});
+    merge_endpoint_state(into, older);
+    BOOST_REQUIRE_EQUAL(into.get_heart_beat_state().get_heart_beat_version().value(), 30);
+    return seastar::make_ready_future<>();
+}
+
+// The case the merge exists for: a heartbeat-only state has the highest
+// version of all, but must not displace the application states of a richer
+// state it is coalesced with — in either arrival order.
+SEASTAR_TEST_CASE(test_merge_heartbeat_only_state_loses_no_facts) {
+    const auto rich = [] {
+        return make_state(43, {
+            {application_state::STATUS, val("NORMAL", 41)},
+            {application_state::TOKENS, val("t1,t2", 3)},
+            {application_state::SCHEMA, val("s1", 21)},
+        });
+    };
+    const auto hb_only = [] {
+        return make_state(80, {});
+    };
+
+    // Rich state pending, heartbeat-only arrives.
+    auto into = rich();
+    merge_endpoint_state(into, hb_only());
+    check(into, application_state::STATUS, "NORMAL", 41);
+    check(into, application_state::TOKENS, "t1,t2", 3);
+    check(into, application_state::SCHEMA, "s1", 21);
+    BOOST_REQUIRE_EQUAL(into.get_heart_beat_state().get_heart_beat_version().value(), 80);
+
+    // Heartbeat-only pending, rich state arrives.
+    auto into2 = hb_only();
+    merge_endpoint_state(into2, rich());
+    check(into2, application_state::STATUS, "NORMAL", 41);
+    check(into2, application_state::TOKENS, "t1,t2", 3);
+    check(into2, application_state::SCHEMA, "s1", 21);
+    BOOST_REQUIRE_EQUAL(into2.get_heart_beat_state().get_heart_beat_version().value(), 80);
+    return seastar::make_ready_future<>();
+}

--- a/test/cluster/test_gossiper_apply_backlog.py
+++ b/test/cluster/test_gossiper_apply_backlog.py
@@ -1,0 +1,108 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Reproducer for the unbounded gossiper apply backlog
+(https://github.com/scylladb/scylladb/issues/10967).
+
+Gossip state application on one node is stalled via error injection while its
+peers keep gossiping: every round carries fresh heartbeat/application state
+versions, and unapplied states never advance the node's digests, so peers keep
+re-sending. Every received endpoint state is queued behind the apply
+concurrency semaphore holding a full endpoint_state copy, so the backlog grows
+without bound for as long as application cannot keep up. In the field this
+takes down nodes: during a zonal outage a node that cannot keep up applying
+gossip states accumulates millions of queued states and dies of OOM.
+
+The backlog size is read from the gossiper's debug log ("gossip state-apply
+backlog: N"), logged whenever received states are queued. The test asserts the
+peak stays bounded. It fails on an unfixed version (the backlog grows
+monotonically for as long as the stall lasts) and passes with per-endpoint
+coalescing, where the backlog is bounded by the number of endpoints in the
+cluster.
+
+Runtime: ~40s (cluster start dominates); the measurement window is 15s.
+"""
+
+import asyncio
+import logging
+import re
+import time
+
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+BACKLOG_RE = re.compile(r"gossip state-apply backlog: (\d+)")
+STALL_INJECTION = "gossiper_stall_apply_state_locally"
+
+# Enough nodes that the victim receives states far faster than the bound below,
+# so an unbounded backlog blows past it within the measurement window: each of
+# the NODES-1 peers gossips once a second carrying up to NODES endpoint states.
+NODES = 5
+# Coalescing bounds the backlog by the number of endpoints. Leave generous
+# headroom so the assertion only trips on unbounded growth, not on jitter.
+BOUND = 4 * NODES
+# ~15 gossip rounds from every peer, i.e. some hundreds of received states.
+MEASURE_SECONDS = 15
+
+
+@pytest.mark.xfail(reason="scylladb/scylladb#10967: the gossiper apply backlog is unbounded; "
+                          "fixed by per-endpoint coalescing of pending states")
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.asyncio
+async def test_gossiper_apply_backlog_is_bounded(manager: ManagerClient) -> None:
+    servers = await manager.servers_add(NODES, cmdline=['--logger-log-level=gossip=debug'])
+    victim = servers[0]
+    victim_log = await manager.server_open_log(server_id=victim.server_id)
+    log_mark = await victim_log.mark()
+
+    async def peak_backlog() -> tuple[int, int]:
+        """Highest backlog logged since log_mark, and the number of samples."""
+        matches = await victim_log.grep(BACKLOG_RE, from_mark=log_mark)
+        values = [int(m.group(1)) for _, m in matches]
+        return (max(values) if values else 0), len(values)
+
+    # Stall all gossip state application on the victim while its peers keep
+    # gossiping. Everything received while application is stalled counts
+    # into the backlog.
+    await manager.api.enable_injection(victim.ip_addr, STALL_INJECTION, one_shot=False)
+    try:
+        # Make sure the stall actually engaged, so the assertion below cannot
+        # pass vacuously with a disconnected injection point.
+        await manager.api.wait_for_injection_enter(victim.ip_addr, STALL_INJECTION)
+
+        # Likewise, make sure states are actually accumulating behind the
+        # stalled application before measuring the bound.
+        async def backlog_nonempty() -> None:
+            while (await peak_backlog())[0] < 1:
+                await asyncio.sleep(0.1)
+
+        await asyncio.wait_for(backlog_nonempty(), timeout=60)
+
+        # A bounded implementation keeps the backlog at O(number of endpoints)
+        # no matter how many states arrive; an unbounded one accumulates every
+        # re-delivery and crosses BOUND within a few seconds.
+        deadline = time.time() + MEASURE_SECONDS
+        peak = 0
+        samples = 0
+        while time.time() < deadline:
+            peak, samples = await peak_backlog()
+            assert peak <= BOUND, (
+                f"gossip apply backlog reached {peak} (> {BOUND}); "
+                f"the backlog is unbounded (scylladb/scylladb#10967)")
+            await asyncio.sleep(0.5)
+        # Guard against the log line being renamed or the logger level not
+        # taking effect: a passing run must have actually observed samples.
+        assert samples > 0, "no backlog samples seen in the victim's log"
+        logger.info("gossip apply backlog peaked at %d over %d samples (bound %d)",
+                    peak, samples, BOUND)
+    finally:
+        # Unstick the stalled appliers so shutdown is clean.
+        await manager.api.message_injection(victim.ip_addr, STALL_INJECTION)
+        await manager.api.disable_injection(victim.ip_addr, STALL_INJECTION)

--- a/test/cluster/test_gossiper_apply_backlog.py
+++ b/test/cluster/test_gossiper_apply_backlog.py
@@ -1,0 +1,108 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Reproducer for the unbounded gossiper apply backlog
+(https://github.com/scylladb/scylladb/issues/10967).
+
+Gossip state application on one node is stalled via error injection while its
+peers keep gossiping: every round carries fresh heartbeat/application state
+versions, and unapplied states never advance the node's digests, so peers keep
+re-sending. Every received endpoint state is queued behind the apply
+concurrency semaphore holding a full endpoint_state copy, so the backlog grows
+without bound for as long as application cannot keep up. In the field this
+takes down nodes: during a zonal outage a node that cannot keep up applying
+gossip states accumulates millions of queued states and dies of OOM.
+
+The backlog size is read from the gossiper's debug log ("gossip state-apply
+backlog: N"), logged whenever received states are queued. The test asserts the
+peak stays bounded. It fails on an unfixed version (the backlog grows
+monotonically for as long as the stall lasts) and passes with per-endpoint
+coalescing, where the backlog is bounded by the number of endpoints in the
+cluster.
+
+Runtime: ~40s (cluster start dominates); the measurement window is 15s.
+"""
+
+import asyncio
+import logging
+import re
+import time
+
+import pytest
+
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+
+logger = logging.getLogger(__name__)
+
+BACKLOG_RE = re.compile(r"gossip state-apply backlog: (\d+)")
+STALL_INJECTION = "gossiper_stall_apply_state_locally"
+
+# Enough nodes that the victim receives states far faster than the bound below,
+# so an unbounded backlog blows past it within the measurement window: each of
+# the NODES-1 peers gossips once a second carrying up to NODES endpoint states.
+NODES = 5
+# Coalescing bounds the backlog by the number of endpoints. Leave generous
+# headroom so the assertion only trips on unbounded growth, not on jitter.
+BOUND = 4 * NODES
+# ~15 gossip rounds from every peer, i.e. some hundreds of received states.
+MEASURE_SECONDS = 15
+
+
+@pytest.mark.xfail(reason="scylladb/scylladb#10967: the gossiper apply backlog is unbounded; "
+                          "fixed by per-endpoint coalescing of pending states")
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.asyncio
+async def test_gossiper_apply_backlog_is_bounded(manager: ScyllaClusterManager) -> None:
+    servers = await manager.servers_add(NODES, cmdline=['--logger-log-level=gossip=debug'])
+    victim = servers[0]
+    victim_log = await manager.server_open_log(server_id=victim.server_id)
+    log_mark = await victim_log.mark()
+
+    async def peak_backlog() -> tuple[int, int]:
+        """Highest backlog logged since log_mark, and the number of samples."""
+        matches = await victim_log.grep(BACKLOG_RE, from_mark=log_mark)
+        values = [int(m.group(1)) for _, m in matches]
+        return (max(values) if values else 0), len(values)
+
+    # Stall all gossip state application on the victim while its peers keep
+    # gossiping. Everything received while application is stalled counts
+    # into the backlog.
+    await manager.api.enable_injection(victim.ip_addr, STALL_INJECTION, one_shot=False)
+    try:
+        # Make sure the stall actually engaged, so the assertion below cannot
+        # pass vacuously with a disconnected injection point.
+        await manager.api.wait_for_injection_enter(victim.ip_addr, STALL_INJECTION)
+
+        # Likewise, make sure states are actually accumulating behind the
+        # stalled application before measuring the bound.
+        async def backlog_nonempty() -> None:
+            while (await peak_backlog())[0] < 1:
+                await asyncio.sleep(0.1)
+
+        await asyncio.wait_for(backlog_nonempty(), timeout=60)
+
+        # A bounded implementation keeps the backlog at O(number of endpoints)
+        # no matter how many states arrive; an unbounded one accumulates every
+        # re-delivery and crosses BOUND within a few seconds.
+        deadline = time.time() + MEASURE_SECONDS
+        peak = 0
+        samples = 0
+        while time.time() < deadline:
+            peak, samples = await peak_backlog()
+            assert peak <= BOUND, (
+                f"gossip apply backlog reached {peak} (> {BOUND}); "
+                f"the backlog is unbounded (scylladb/scylladb#10967)")
+            await asyncio.sleep(0.5)
+        # Guard against the log line being renamed or the logger level not
+        # taking effect: a passing run must have actually observed samples.
+        assert samples > 0, "no backlog samples seen in the victim's log"
+        logger.info("gossip apply backlog peaked at %d over %d samples (bound %d)",
+                    peak, samples, BOUND)
+    finally:
+        # Unstick the stalled appliers so shutdown is clean.
+        await manager.api.message_injection(victim.ip_addr, STALL_INJECTION)
+        await manager.api.disable_injection(victim.ip_addr, STALL_INJECTION)

--- a/test/cluster/test_gossiper_apply_backlog.py
+++ b/test/cluster/test_gossiper_apply_backlog.py
@@ -52,8 +52,6 @@ BOUND = 4 * NODES
 MEASURE_SECONDS = 15
 
 
-@pytest.mark.xfail(reason="scylladb/scylladb#10967: the gossiper apply backlog is unbounded; "
-                          "fixed by per-endpoint coalescing of pending states")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.asyncio
 async def test_gossiper_apply_backlog_is_bounded(manager: ManagerClient) -> None:

--- a/test/cluster/test_gossiper_apply_backlog.py
+++ b/test/cluster/test_gossiper_apply_backlog.py
@@ -52,8 +52,6 @@ BOUND = 4 * NODES
 MEASURE_SECONDS = 15
 
 
-@pytest.mark.xfail(reason="scylladb/scylladb#10967: the gossiper apply backlog is unbounded; "
-                          "fixed by per-endpoint coalescing of pending states")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 @pytest.mark.asyncio
 async def test_gossiper_apply_backlog_is_bounded(manager: ScyllaClusterManager) -> None:

--- a/test/cluster/test_gossiper_race.py
+++ b/test/cluster/test_gossiper_race.py
@@ -102,3 +102,56 @@ async def test_gossiper_race_on_decommission(manager: ManagerClient):
     # secondary test - ensure the coordinator node is still running
     running_servers = await manager.running_servers()
     assert coordinator.server_id in [s.server_id for s in running_servers]
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_gossiper_no_resurrection_on_decommission(manager: ManagerClient):
+    """
+    A state carrying HOST_ID that was queued before the node was removed must
+    not re-add the removed endpoint when it is finally applied: the applier
+    re-checks left_nodes under the endpoint lock. Runtime: ~30s.
+    """
+    cmdline = [
+        '--logger-log-level=gossip=debug',
+        '--logger-log-level=raft_topology=debug'
+    ]
+    servers = await manager.servers_add(3, cmdline=cmdline)
+
+    coordinator = await get_coordinator_host(manager=manager)
+    coordinator_log = await manager.server_open_log(server_id=coordinator.server_id)
+    mark = await coordinator_log.mark()
+
+    decom_node = next(s for s in servers if s.server_id != coordinator.server_id)
+
+    # Suspend application of every state of the decommissioned node —
+    # including the usual ones that carry HOST_ID — so one is still queued
+    # when the node is removed.
+    await manager.api.enable_injection(
+        node_ip=coordinator.ip_addr,
+        injection="delay_gossiper_apply",
+        one_shot=False,
+        parameters={"delay_node": decom_node.ip_addr, "any_state": "1"},
+    )
+    await coordinator_log.wait_for("delay_gossiper_apply: suspend for node", from_mark=mark)
+
+    await manager.decommission_node(decom_node.server_id)
+    await coordinator_log.wait_for("Finished to force remove node", from_mark=mark)
+
+    mark = await coordinator_log.mark()
+    try:
+        await manager.api.message_injection(node_ip=coordinator.ip_addr, injection="delay_gossiper_apply")
+    except ServerDisconnectedError:
+        pass
+
+    # The suspended apply must be discarded by the under-lock re-check ...
+    await coordinator_log.wait_for(
+        "do_apply_state_locally: ignoring gossip for .* because it left",
+        from_mark=mark,
+        timeout=60,
+    )
+
+    # ... and the removed node must not be resurrected in the endpoint map.
+    eps = await manager.api.client.get_json("/failure_detector/endpoints/", host=coordinator.ip_addr)
+    addrs = {e["addrs"] for e in eps}
+    assert decom_node.ip_addr not in addrs, \
+        f"decommissioned node {decom_node.ip_addr} was resurrected in the gossiper endpoint map"

--- a/test/cluster/test_gossiper_race.py
+++ b/test/cluster/test_gossiper_race.py
@@ -42,15 +42,24 @@ async def test_gossiper_race_on_decommission(manager: ManagerClient):
         parameters={"delay_node": decom_node.ip_addr},
     )
 
-    # wait for the "delay_gossiper_apply" error injection to take effect
-    # - wait for multiple occurrences to be batched, so that there is a higher chance of one of them
-    #   failing down in the `gossiper::do_on_change_notifications()`
-    for _ in range(5):
-        log_mark = await coordinator_log.mark()
-        await coordinator_log.wait_for(
-            "delay_gossiper_apply: suspend for node",
-            from_mark=log_mark,
-        )
+    # wait for the "delay_gossiper_apply" error injection to take effect.
+    # Pending state applies are coalesced per endpoint (at most one apply
+    # fiber per endpoint), so only a single suspension can be observed;
+    # newer states of the node arriving while the apply is suspended are
+    # coalesced into the pending slot instead of spawning more fibers.
+    await coordinator_log.wait_for(
+        "delay_gossiper_apply: suspend for node",
+        from_mark=coordinator_log_mark,
+    )
+
+    # wait until newer states of this specific node have queued up behind the
+    # suspended apply, so that the apply resumed after the decommission
+    # races with the node's removal like the batched applies used to
+    decom_host_id = await manager.get_host_id(decom_node.server_id)
+    await coordinator_log.wait_for(
+        f"queue_state_apply: coalesced a state of {decom_host_id} into the pending one",
+        from_mark=coordinator_log_mark,
+    )
 
     coordinator_log_mark = await coordinator_log.mark()
 

--- a/test/cluster/test_gossiper_race.py
+++ b/test/cluster/test_gossiper_race.py
@@ -102,3 +102,56 @@ async def test_gossiper_race_on_decommission(manager: ScyllaClusterManager):
     # secondary test - ensure the coordinator node is still running
     running_servers = await manager.running_servers()
     assert coordinator.server_id in [s.server_id for s in running_servers]
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_gossiper_no_resurrection_on_decommission(manager: ScyllaClusterManager):
+    """
+    A state carrying HOST_ID that was queued before the node was removed must
+    not re-add the removed endpoint when it is finally applied: the applier
+    re-checks left_nodes under the endpoint lock. Runtime: ~30s.
+    """
+    cmdline = [
+        '--logger-log-level=gossip=debug',
+        '--logger-log-level=raft_topology=debug'
+    ]
+    servers = await manager.servers_add(3, cmdline=cmdline)
+
+    coordinator = await get_coordinator_host(manager=manager)
+    coordinator_log = await manager.server_open_log(server_id=coordinator.server_id)
+    mark = await coordinator_log.mark()
+
+    decom_node = next(s for s in servers if s.server_id != coordinator.server_id)
+
+    # Suspend application of every state of the decommissioned node —
+    # including the usual ones that carry HOST_ID — so one is still queued
+    # when the node is removed.
+    await manager.api.enable_injection(
+        node_ip=coordinator.ip_addr,
+        injection="delay_gossiper_apply",
+        one_shot=False,
+        parameters={"delay_node": decom_node.ip_addr, "any_state": "1"},
+    )
+    await coordinator_log.wait_for("delay_gossiper_apply: suspend for node", from_mark=mark)
+
+    await manager.decommission_node(decom_node.server_id)
+    await coordinator_log.wait_for("Finished to force remove node", from_mark=mark)
+
+    mark = await coordinator_log.mark()
+    try:
+        await manager.api.message_injection(node_ip=coordinator.ip_addr, injection="delay_gossiper_apply")
+    except ServerDisconnectedError:
+        pass
+
+    # The suspended apply must be discarded by the under-lock re-check ...
+    await coordinator_log.wait_for(
+        "do_apply_state_locally: ignoring gossip for .* because it left",
+        from_mark=mark,
+        timeout=60,
+    )
+
+    # ... and the removed node must not be resurrected in the endpoint map.
+    eps = await manager.api.client.get_json("/failure_detector/endpoints/", host=coordinator.ip_addr)
+    addrs = {e["addrs"] for e in eps}
+    assert decom_node.ip_addr not in addrs, \
+        f"decommissioned node {decom_node.ip_addr} was resurrected in the gossiper endpoint map"

--- a/test/cluster/test_gossiper_race.py
+++ b/test/cluster/test_gossiper_race.py
@@ -42,15 +42,24 @@ async def test_gossiper_race_on_decommission(manager: ScyllaClusterManager):
         parameters={"delay_node": decom_node.ip_addr},
     )
 
-    # wait for the "delay_gossiper_apply" error injection to take effect
-    # - wait for multiple occurrences to be batched, so that there is a higher chance of one of them
-    #   failing down in the `gossiper::do_on_change_notifications()`
-    for _ in range(5):
-        log_mark = await coordinator_log.mark()
-        await coordinator_log.wait_for(
-            "delay_gossiper_apply: suspend for node",
-            from_mark=log_mark,
-        )
+    # wait for the "delay_gossiper_apply" error injection to take effect.
+    # Pending state applies are coalesced per endpoint (at most one apply
+    # fiber per endpoint), so only a single suspension can be observed;
+    # newer states of the node arriving while the apply is suspended are
+    # coalesced into the pending slot instead of spawning more fibers.
+    await coordinator_log.wait_for(
+        "delay_gossiper_apply: suspend for node",
+        from_mark=coordinator_log_mark,
+    )
+
+    # wait until newer states of this specific node have queued up behind the
+    # suspended apply, so that the apply resumed after the decommission
+    # races with the node's removal like the batched applies used to
+    decom_host_id = await manager.get_host_id(decom_node.server_id)
+    await coordinator_log.wait_for(
+        f"queue_state_apply: coalesced a state of {decom_host_id} into the pending one",
+        from_mark=coordinator_log_mark,
+    )
 
     coordinator_log_mark = await coordinator_log.mark()
 

--- a/test/cluster/test_gossiper_state_coalescing.py
+++ b/test/cluster/test_gossiper_state_coalescing.py
@@ -1,0 +1,118 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Coalescing pending gossip states must not lose application states.
+
+The gossiper keeps at most one pending state per endpoint and merges every
+arrival into it. Merging, rather than keeping whichever arrival has the
+highest version, is what makes that safe: a node summarises everything it
+knows about a peer as a single max version, and asks other nodes only for
+values above it. A value dropped below that mark is therefore never
+re-requested by anyone and is lost for good -- gossip has no re-delivery
+safety net for it.
+
+This test stalls state application on one node so that arrivals pile up and
+coalesce, churns application states meanwhile, and then checks that the node
+still converges on every peer's own view of itself.
+
+Runtime: ~30s (cluster start ~12s, stall 8s, convergence a few seconds).
+"""
+
+import asyncio
+import logging
+import time
+
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+STALL_INJECTION = "gossiper_stall_apply_state_locally"
+
+NODES = 4
+# Long enough for many gossip rounds from every peer to pile up behind the
+# stalled applier, so arrivals actually collide in the pending slot.
+STALL_SECONDS = 8
+CONVERGE_TIMEOUT = 90
+
+
+async def endpoint_states(manager: ManagerClient, node_ip: str) -> dict[str, dict[int, int]]:
+    """What `node_ip` currently knows: {peer ip: {application state: version}}."""
+    raw = await manager.api.client.get_json("/failure_detector/endpoints/", host=node_ip)
+    return {
+        eps["addrs"]: {int(a["application_state"]): int(a["version"])
+                       for a in eps.get("application_state", [])}
+        for eps in raw
+    }
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.asyncio
+async def test_gossiper_coalescing_does_not_lose_application_states(manager: ManagerClient) -> None:
+    # gossip=debug so we can confirm the coalescing path was actually taken.
+    servers = await manager.servers_add(NODES, cmdline=['--logger-log-level=gossip=debug'])
+    victim, peers = servers[0], servers[1:]
+    victim_log = await manager.server_open_log(server_id=victim.server_id)
+    log_mark = await victim_log.mark()
+
+    cql = manager.get_cql()
+
+    await manager.api.enable_injection(victim.ip_addr, STALL_INJECTION, one_shot=False)
+    try:
+        await manager.api.wait_for_injection_enter(victim.ip_addr, STALL_INJECTION)
+
+        # Churn application states while the victim cannot apply anything, so
+        # the states queued behind the stall carry real values rather than
+        # bare heartbeats. A schema change bumps SCHEMA on every node.
+        await cql.run_async("CREATE KEYSPACE IF NOT EXISTS coalesce_ks WITH replication = "
+                            "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+        deadline = time.time() + STALL_SECONDS
+        i = 0
+        while time.time() < deadline:
+            await cql.run_async(f"CREATE TABLE coalesce_ks.t{i} (pk int PRIMARY KEY, v int)")
+            i += 1
+            await asyncio.sleep(1)
+
+        # The whole point of the test is the coalescing path; fail loudly
+        # rather than silently passing if it was never taken.
+        coalesced = await victim_log.grep("queue_state_apply: coalesced a state of",
+                                          from_mark=log_mark)
+        assert coalesced, ("no gossip state was coalesced on the victim; the test did not "
+                           "exercise the path it is meant to cover")
+
+        # Each peer is authoritative about itself, so its own entry is the
+        # truth the victim has to converge on.
+        expected: dict[str, dict[int, int]] = {}
+        for peer in peers:
+            expected[peer.ip_addr] = (await endpoint_states(manager, peer.ip_addr))[peer.ip_addr]
+    finally:
+        await manager.api.message_injection(victim.ip_addr, STALL_INJECTION)
+        await manager.api.disable_injection(victim.ip_addr, STALL_INJECTION)
+
+    async def behind() -> list[str]:
+        """Application states the victim is still missing or stale on."""
+        seen = await endpoint_states(manager, victim.ip_addr)
+        out = []
+        for peer_ip, want in expected.items():
+            got = seen.get(peer_ip, {})
+            for state, version in want.items():
+                if got.get(state, -1) < version:
+                    out.append(f"{peer_ip} state={state} want>={version} got={got.get(state, 'absent')}")
+        return out
+
+    async def converged() -> None:
+        while await behind():
+            await asyncio.sleep(0.5)
+
+    try:
+        await asyncio.wait_for(converged(), timeout=CONVERGE_TIMEOUT)
+    except asyncio.TimeoutError:
+        pytest.fail("the victim never caught up on application states that were coalesced "
+                    "while its applier was stalled; a value dropped below its advertised max "
+                    "version is never re-delivered (scylladb/scylladb#10967): "
+                    + "; ".join(await behind()))

--- a/test/cluster/test_gossiper_state_coalescing.py
+++ b/test/cluster/test_gossiper_state_coalescing.py
@@ -1,0 +1,118 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Coalescing pending gossip states must not lose application states.
+
+The gossiper keeps at most one pending state per endpoint and merges every
+arrival into it. Merging, rather than keeping whichever arrival has the
+highest version, is what makes that safe: a node summarises everything it
+knows about a peer as a single max version, and asks other nodes only for
+values above it. A value dropped below that mark is therefore never
+re-requested by anyone and is lost for good -- gossip has no re-delivery
+safety net for it.
+
+This test stalls state application on one node so that arrivals pile up and
+coalesce, churns application states meanwhile, and then checks that the node
+still converges on every peer's own view of itself.
+
+Runtime: ~30s (cluster start ~12s, stall 8s, convergence a few seconds).
+"""
+
+import asyncio
+import logging
+import time
+
+import pytest
+
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+
+logger = logging.getLogger(__name__)
+
+STALL_INJECTION = "gossiper_stall_apply_state_locally"
+
+NODES = 4
+# Long enough for many gossip rounds from every peer to pile up behind the
+# stalled applier, so arrivals actually collide in the pending slot.
+STALL_SECONDS = 8
+CONVERGE_TIMEOUT = 90
+
+
+async def endpoint_states(manager: ScyllaClusterManager, node_ip: str) -> dict[str, dict[int, int]]:
+    """What `node_ip` currently knows: {peer ip: {application state: version}}."""
+    raw = await manager.api.client.get_json("/failure_detector/endpoints/", host=node_ip)
+    return {
+        eps["addrs"]: {int(a["application_state"]): int(a["version"])
+                       for a in eps.get("application_state", [])}
+        for eps in raw
+    }
+
+
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.asyncio
+async def test_gossiper_coalescing_does_not_lose_application_states(manager: ScyllaClusterManager) -> None:
+    # gossip=debug so we can confirm the coalescing path was actually taken.
+    servers = await manager.servers_add(NODES, cmdline=['--logger-log-level=gossip=debug'])
+    victim, peers = servers[0], servers[1:]
+    victim_log = await manager.server_open_log(server_id=victim.server_id)
+    log_mark = await victim_log.mark()
+
+    cql = manager.get_cql()
+
+    await manager.api.enable_injection(victim.ip_addr, STALL_INJECTION, one_shot=False)
+    try:
+        await manager.api.wait_for_injection_enter(victim.ip_addr, STALL_INJECTION)
+
+        # Churn application states while the victim cannot apply anything, so
+        # the states queued behind the stall carry real values rather than
+        # bare heartbeats. A schema change bumps SCHEMA on every node.
+        await cql.run_async("CREATE KEYSPACE IF NOT EXISTS coalesce_ks WITH replication = "
+                            "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
+        deadline = time.time() + STALL_SECONDS
+        i = 0
+        while time.time() < deadline:
+            await cql.run_async(f"CREATE TABLE coalesce_ks.t{i} (pk int PRIMARY KEY, v int)")
+            i += 1
+            await asyncio.sleep(1)
+
+        # The whole point of the test is the coalescing path; fail loudly
+        # rather than silently passing if it was never taken.
+        coalesced = await victim_log.grep("queue_state_apply: coalesced a state of",
+                                          from_mark=log_mark)
+        assert coalesced, ("no gossip state was coalesced on the victim; the test did not "
+                           "exercise the path it is meant to cover")
+
+        # Each peer is authoritative about itself, so its own entry is the
+        # truth the victim has to converge on.
+        expected: dict[str, dict[int, int]] = {}
+        for peer in peers:
+            expected[peer.ip_addr] = (await endpoint_states(manager, peer.ip_addr))[peer.ip_addr]
+    finally:
+        await manager.api.message_injection(victim.ip_addr, STALL_INJECTION)
+        await manager.api.disable_injection(victim.ip_addr, STALL_INJECTION)
+
+    async def behind() -> list[str]:
+        """Application states the victim is still missing or stale on."""
+        seen = await endpoint_states(manager, victim.ip_addr)
+        out = []
+        for peer_ip, want in expected.items():
+            got = seen.get(peer_ip, {})
+            for state, version in want.items():
+                if got.get(state, -1) < version:
+                    out.append(f"{peer_ip} state={state} want>={version} got={got.get(state, 'absent')}")
+        return out
+
+    async def converged() -> None:
+        while await behind():
+            await asyncio.sleep(0.5)
+
+    try:
+        await asyncio.wait_for(converged(), timeout=CONVERGE_TIMEOUT)
+    except asyncio.TimeoutError:
+        pytest.fail("the victim never caught up on application states that were coalesced "
+                    "while its applier was stalled; a value dropped below its advertised max "
+                    "version is never re-delivered (scylladb/scylladb#10967): "
+                    + "; ".join(await behind()))


### PR DESCRIPTION
## The problem

The gossiper applies endpoint states received in ACK/ACK2 messages with limited concurrency (a 100-unit semaphore), but the wait queue behind that semaphore is unbounded, and every queued entry holds a full `endpoint_state` copy. On top of that, the message handler keeps its whole deserialized message alive until every state in it is applied.

This becomes self-reinforcing when a node falls behind. Gossip digests only advertise applied state, so peers keep re-sending the states that are still sitting in the queue. The gossip verbs are no-wait, so the senders never slow down. The queue fills with duplicates of the same states until the node runs out of memory (#10967).

## The fix

Keep at most one pending state per endpoint, and merge every arrival into it. Per-endpoint applier fibers drain the buffer under the same concurrency limit as before, and message handlers no longer wait for application. The backlog and its memory use are now bounded by the cluster size.

### Why nothing can be lost

The merge is per key, keeping the highest version of each; a higher generation replaces the pending state wholesale (and across a generation change peers send the full state anyway).

The per-key merge is defence in depth, not a fix for an observed problem. Keeping the state with the highest max version would also be correct today: coalescing only happens while a node is behind, and a node that is behind advertises a stale digest, so every delta it receives covers the whole gap — the deltas are nested. (The dangerous-looking heartbeat-only delta, which carries the highest version and no application states, is only ever sent to a node that is caught up — and then the pending slot is empty and nothing collides.) But that argument rests on protocol properties maintained elsewhere, and a key dropped in violation of it would never be re-delivered: a digest carries a single max version per endpoint, so no peer re-sends a key below it (thanks @asias for insisting the safety argument be made airtight here). Merging removes the whole question at the cost of a few hash lookups on collisions: no fact is ever discarded, so there is no invariant to maintain.

Instrumented runs confirm this empirically: 0 lost keys over 296 coalescing collisions on 2026.1 and 131 on master, even with plain replacement. The two paths that build states which are not (boot-time `add_saved_endpoint()`, and the filtered shadow-round states) are kept off the gossip path today by generation-0 pinning and `reset_endpoint_state_map()` respectively; merging makes correctness independent of that staying true.

Listeners see nothing new either: gossip deltas already skip intermediate values of an application state, and merging can only coalesce notifications, never drop a value.

This revisits #10968 and #11030 from 2022. The objection back then — a queued `STATUS=BOOTSTRAP` superseded by `NORMAL` means the bootstrap callback is missed — does not hold: gossip only ever transmits the current value of a key, so a peer that syncs after the transition never sees the intermediate value anyway (nor does one that was down through it), and `handle_state_bootstrap` explicitly documents that missed intermediate states are expected. With merging the value is not even dropped, only its notification coalesced.

### Semantic changes worth flagging

- `apply_state_locally()` is renamed to `queue_state_applies()` and returns `void`. It no longer applies anything by the time it returns, and the signature now says so. Its only two callers, on every live branch, are `handle_ack_msg()` and `handle_ack2_msg()`, both invoked via `background_msg()`, which discards the future and returns `no_wait` — so no caller ever observed "applied and replicated to all shards".
- Shutdown still drains: the applier fibers hold `_background_msg`, so `close()` waits for pending applies as before.
- `_msg_processing` now counts queued and in-flight states rather than handler invocations, keeping the existing critical-state filter (LOAD, VIEW_BACKLOG, CACHE_HITRATES, GROUP0_STATE_ID excluded). Counting handlers would report gossip as idle with a full backlog queued. The counter has no readers on master, but on branches that still support gossiper topology it gates `wait_for_gossip_to_settle()` and `wait_for_range_setup()`, so keeping it truthful keeps this backportable as is.

## Testing

- A new cluster test stalls state application (via a new error injection) while the other nodes keep gossiping, and checks that the backlog (read from the debug log) stays bounded. It comes in the commit before the fix, marked xfail, and the fix commit removes the marker. **Verified both ways**: `1 xfailed` at the reproducer commit, passing at the fix commit. ~25s.
- A new unit test (`endpoint_state_merge_test`, ~1s) covers `merge_endpoint_state()` directly, including the adversarial shape the wire never produces: a heartbeat-only state with the highest version merged with a fact-rich one, in both orders. Verified to fail against a newest-wins replacement.
- A new regression test (`test_gossiper_state_coalescing`) pins the no-loss property: stall applies so arrivals collide and coalesce, churn application states meanwhile, assert the coalescing path was actually taken, then assert the stalled node converges on every peer's own view of itself. **Verified to fail** on a build with a deliberately reintroduced state-losing bug and pass on the fix, on master and 2026.1. ~30s.
- `test_gossiper_race_on_decommission` is adapted: with coalescing at most one apply fiber runs per endpoint, so instead of waiting for five stalled fibers it waits for one and then for the endpoint-specific log line showing a newer state was coalesced behind the suspended apply, keeping the original #25621 race scenario. Runtime unchanged (~30s).
- `test_gossiper_no_resurrection_on_decommission` suspends a HOST_ID state across a decommission, releases it, asserts the resumed apply is discarded by the under-lock re-heck (~5s)

Fixes: SCYLLADB-3400
Fixes: #10967
Fixes: CUSTOMER-574
Backport: this PR addresses a real customer issue. Need backport to all currently supported versions.