### PR TITLE
compaction: preserve ICS run structure during split

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1552,6 +1552,9 @@ public:
         auto monitor = std::make_unique<compaction_write_monitor>(sst, _table_s, maximum_timestamp(), _sstable_level);
         sstables::sstable_writer_config cfg = make_sstable_writer_config(_type);
         cfg.monitor = monitor.get();
+        if (auto it = _options.run_identifier_for_token_group.find(_options.classifier(dk.token())); it != _options.run_identifier_for_token_group.end()) {
+            cfg.run_identifier = it->second;
+        }
 
         return compaction_writer{std::move(monitor), sst->get_writer(*_schema, estimated_keys, cfg, get_encoding_stats()), sst};
     }

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -94,6 +94,7 @@ public:
     };
     struct split {
         mutation_writer::classify_by_token_group classifier;
+        std::unordered_map<mutation_writer::token_group_id, sstables::run_id> run_identifier_for_token_group;
     };
     struct component_rewrite {
         sstables::component_type component_to_rewrite;
@@ -144,8 +145,9 @@ public:
         return compaction_type_options(component_rewrite{.component_to_rewrite = component, .modifier = std::move(modifier), .update_id = update_id});
     }
 
-    static compaction_type_options make_split(mutation_writer::classify_by_token_group classifier) {
-        return compaction_type_options(split{std::move(classifier)});
+    static compaction_type_options make_split(mutation_writer::classify_by_token_group classifier,
+            std::unordered_map<mutation_writer::token_group_id, sstables::run_id> run_identifier_for_token_group = {}) {
+        return compaction_type_options(split{std::move(classifier), std::move(run_identifier_for_token_group)});
     }
 
     template <typename... Visitor>

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1758,7 +1758,9 @@ future<bool> compaction_manager::perform_offstrategy(compaction_group_view& t, t
 class rewrite_sstables_compaction_task_executor : public sstables_task_executor {
     compaction_type_options _options;
     owned_ranges_ptr _owned_ranges_ptr;
+protected:
     compacting_sstable_registration _compacting;
+private:
     compaction_manager::can_purge_tombstones _can_purge;
 
 public:
@@ -1876,6 +1878,12 @@ protected:
 
 class split_compaction_task_executor final : public rewrite_sstables_compaction_task_executor {
     compaction_type_options::split _opt;
+    // For each SSTable whose original run is split across token groups,
+    // _split_run_info stores token-group-specific run IDs used by split writers.
+    // output_run_id_group is reserved as a sentinel key for the run ID assigned to
+    // this SSTable itself when it is moved with component rewrite instead of split.
+    static constexpr auto output_run_id_group = std::numeric_limits<mutation_writer::token_group_id>::max();
+    std::unordered_map<sstables::shared_sstable, std::unordered_map<mutation_writer::token_group_id, sstables::run_id>> _split_run_info;
 public:
     split_compaction_task_executor(compaction_manager& mgr,
                                        throw_if_stopping do_throw_if_stopping,
@@ -1892,6 +1900,33 @@ public:
         if (utils::get_local_injector().is_enabled("split_sstable_rewrite")) {
             _do_throw_if_stopping = throw_if_stopping::yes;
         }
+        std::unordered_map<sstables::run_id, std::unordered_set<mutation_writer::token_group_id>> run_token_groups;
+        std::unordered_map<sstables::run_id, std::unordered_map<mutation_writer::token_group_id, sstables::run_id>> split_run_ids;
+        for (const auto& sst : _sstables) {
+            auto& token_groups = run_token_groups[sst->run_identifier()];
+            auto first_group = _opt.classifier(sst->get_first_decorated_key().token());
+            auto last_group = _opt.classifier(sst->get_last_decorated_key().token());
+            throwing_assert(last_group != output_run_id_group);
+            for (auto group = first_group; group <= last_group; ++group) {
+                token_groups.insert(group);
+            }
+        }
+        for (const auto& [run_id, token_groups] : run_token_groups) {
+            if (token_groups.size() < 2) {
+                continue;
+            }
+            auto& run_split_run_ids = split_run_ids[run_id];
+            for (auto token_group : token_groups) {
+                run_split_run_ids.emplace(token_group, split_run_identifier(run_id, token_group));
+            }
+        }
+        for (const auto& sst : _sstables) {
+            if (auto run_it = split_run_ids.find(sst->run_identifier()); run_it != split_run_ids.end()) {
+                auto [info_it, inserted] = _split_run_info.emplace(sst, run_it->second);
+                info_it->second.emplace(output_run_id_group,
+                        run_it->second.at(_opt.classifier(sst->get_first_decorated_key().token())));
+            }
+        }
     }
 
     static bool sstable_needs_split(const sstables::shared_sstable& sst, const compaction_type_options::split& opt) {
@@ -1900,21 +1935,80 @@ public:
 
     static compaction_descriptor
     make_descriptor(const sstables::shared_sstable& sst, const compaction_type_options::split& split_opt) {
-        auto opt = compaction_type_options::make_split(split_opt.classifier);
+        auto opt = compaction_type_options::make_split(split_opt.classifier, split_opt.run_identifier_for_token_group);
         return rewrite_sstables_compaction_task_executor::make_descriptor(sst, std::move(opt));
     }
 private:
+    static sstables::run_id split_run_identifier(sstables::run_id original_run_id, mutation_writer::token_group_id token_group) {
+        return sstables::run_id(utils::UUID_gen::get_name_UUID(fmt::format("split-run:{}:{}", original_run_id, token_group)));
+    }
+
     bool sstable_needs_split(const sstables::shared_sstable& sst) const {
         return sstable_needs_split(sst, _opt);
     }
+
+    sstables::run_id output_run_identifier(const sstables::shared_sstable& sst) const {
+        auto info_it = _split_run_info.find(sst);
+        if (info_it == _split_run_info.end()) {
+            return sst->run_identifier();
+        }
+        return info_it->second.at(output_run_id_group);
+    }
+
+    compaction_type_options::split make_split_options(const sstables::shared_sstable& sst) const {
+        std::unordered_map<mutation_writer::token_group_id, sstables::run_id> run_identifier_for_token_group;
+        if (auto info_it = _split_run_info.find(sst); info_it != _split_run_info.end()) {
+            run_identifier_for_token_group = info_it->second;
+            run_identifier_for_token_group.erase(output_run_id_group);
+        }
+        return compaction_type_options::split{
+            .classifier = _opt.classifier,
+            .run_identifier_for_token_group = std::move(run_identifier_for_token_group),
+        };
+    }
+
+    future<compaction_result> rewrite_sstable_run_identifier(sstables::shared_sstable sst) {
+        co_await coroutine::switch_to(_cm.maintenance_sg());
+
+        for (;;) {
+            auto output_run_id = output_run_identifier(sst);
+            auto opt = compaction_type_options::make_component_rewrite(sstables::component_type::Scylla,
+                    [output_run_id] (sstables::sstable& new_sst) {
+                new_sst.mutate_sstable_run_identifier(output_run_id);
+            });
+            auto descriptor = rewrite_sstables_compaction_task_executor::make_descriptor(sst, std::move(opt));
+            auto on_replace = _compacting.update_on_sstable_replacement();
+            setup_new_compaction(output_run_id);
+
+            std::exception_ptr ex;
+            try {
+                compaction_result res = co_await compact_sstables(std::move(descriptor), _compaction_data, on_replace, compaction_manager::can_purge_tombstones::no);
+                finish_compaction();
+                _cm.reevaluate_postponed_compactions();
+                co_return res;
+            } catch (...) {
+                ex = std::current_exception();
+            }
+
+            finish_compaction(state::failed);
+            if ((co_await maybe_retry(std::move(ex), true)) == stop_iteration::yes) {
+                co_return compaction_result{};
+            }
+        }
+    }
 protected:
     compaction_descriptor make_descriptor(const sstables::shared_sstable& sst) const override {
-        return make_descriptor(sst, _opt);
+        auto split_options = make_split_options(sst);
+        auto opt = compaction_type_options::make_split(std::move(split_options.classifier), std::move(split_options.run_identifier_for_token_group));
+        return rewrite_sstables_compaction_task_executor::make_descriptor(sst, std::move(opt), {});
     }
 
     future<compaction_result> do_rewrite_sstable(const sstables::shared_sstable sst) {
         if (sstable_needs_split(sst)) {
             co_return co_await rewrite_sstables_compaction_task_executor::rewrite_sstable(std::move(sst));
+        }
+        if (sst->run_identifier() != output_run_identifier(sst)) {
+            co_return co_await rewrite_sstable_run_identifier(std::move(sst));
         }
         // SSTable that doesn't require split can bypass compaction and the table will be able to place
         // it into the correct compaction group. Similar approach is done in off-strategy compaction for
@@ -2431,7 +2525,7 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_spl
         return get_candidates(t);
     };
     owned_ranges_ptr owned_ranges_ptr = {};
-    auto options = compaction_type_options::make_split(std::move(opt.classifier));
+    auto options = compaction_type_options::make_split(std::move(opt.classifier), std::move(opt.run_identifier_for_token_group));
 
     return perform_task_on_all_files<split_compaction_task_executor>("split", info, t, std::move(options), std::move(owned_ranges_ptr), std::move(get_sstables), throw_if_stopping::no);
 }

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -461,7 +461,7 @@ storage_options make_object_storage_options(const std::string& endpoint, const s
     return make_object_storage_options(endpoint, type, bucket, object, as);
 }
 
-storage_options make_object_storage_options(const std::string& endpoint, const std::string& type, const std::string& bucket, const std::string& prefix, abort_source* as) {
+static storage_options make_object_storage_options(const std::string& endpoint, const std::string& type, const std::string& bucket, std::optional<sstring> prefix, abort_source* as) {
     storage_options so;
     storage_options::object_storage os{
         .bucket = std::move(bucket), .endpoint = endpoint, .location = std::move(prefix),
@@ -470,6 +470,14 @@ storage_options make_object_storage_options(const std::string& endpoint, const s
     };
     so.value = std::move(os);
     return so;
+}
+
+storage_options make_live_object_storage_options(const std::string& endpoint, const std::string& type, const std::string& bucket, abort_source* as) {
+    return make_object_storage_options(endpoint, type, bucket, std::nullopt, as);
+}
+
+storage_options make_object_storage_options(const std::string& endpoint, const std::string& type, const std::string& bucket, const std::string& prefix, abort_source* as) {
+    return make_object_storage_options(endpoint, type, bucket, std::optional<sstring>(prefix), as);
 }
 
 namespace fs = std::filesystem;

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -71,6 +71,7 @@ struct storage_options {
 
 storage_options make_local_options(std::filesystem::path dir);
 storage_options make_object_storage_options(const std::string& endpoint, const std::string& fqn, abort_source* = nullptr);
+storage_options make_live_object_storage_options(const std::string& endpoint, const std::string& type, const std::string& bucket, abort_source* = nullptr);
 storage_options make_object_storage_options(const std::string& endpoint, const std::string& type, const std::string& bucket, const std::string& prefix, abort_source* = nullptr);
 
 bool is_object_storage_fqn(const std::filesystem::path& fqn, std::string_view type);

--- a/docs/dev/object_storage.md
+++ b/docs/dev/object_storage.md
@@ -350,7 +350,12 @@ Each SSTable lives under:
 sstables/{sstable_id}/
 ```
 
-SSTable component object names are the component suffixes used by the local SSTable format, for example `Data.db`, `Index.db`, `Summary.db`, `Scylla.db`, and `TOC.txt`.
+SSTable component object names are the component suffixes used by the local SSTable format, for example `Data.db`, `Index.db`, `Summary.db`, `Scylla.db`, and `TOC.txt`. Since these object names do not include the SSTable version or format, Scylla stores them as object attributes on the `TOC.txt` object:
+
+- `version` - the SSTable version, for example `me` or `mt`.
+- `format` - the SSTable format, for example `big`.
+
+These attributes are written when the TOC is uploaded and preserved when the TOC is copied as part of SSTable clone/component-rewrite flows. Tools that read live object-storage SSTables directly, such as `scylla sstable`, use these attributes to identify the SSTable descriptor before opening the component set.
 
 Reference objects under `refs/nodes/` record which nodes still own a reference to the SSTable data:
 

--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -23,14 +23,47 @@ The command syntax is as follows:
 
 You can specify more than one SSTable.
 
-Additionally, the path to SSTable can point to an S3 fully qualified path in
-the form of s3://bucket-name/prefix/of/your/sstable/sstable-TOC.txt. To use
-this feature, you need to have AWS credentials set up in your environment.
-For more information, see :ref:`Configuring Object Storage <object-storage-configuration>`.
+Additionally, the path to SSTable can point to an object storage fully qualified
+path in the form of ``s3://bucket-name/prefix/of/your/sstable/sstable-TOC.txt``
+or ``gs://bucket-name/prefix/of/your/sstable/sstable-TOC.txt``. This also
+supports live object-storage SSTables; see `SSTables on Object Storage`_.
+To use this feature, you need to have object-storage credentials set up in your
+environment. For more information, see :ref:`Configuring Object Storage <object-storage-configuration>`.
 
 Additionally, you must ensure the tool is able to load the correct scylla.yaml
 file, which can be done using the ``--scylla-yaml-file`` parameter or by
 placing the YAML file in one of the default locations the tool checks.
+
+SSTables on Object Storage
+--------------------------
+
+``scylla sstable`` can read SSTables from S3 and Google Cloud Storage using
+fully qualified paths with the ``s3://`` or ``gs://`` scheme.
+
+Snapshot and backup layouts use regular SSTable component names that include
+the SSTable version, generation, and format, for example
+``me-3gqe_1lnj_4sbpc2ezoscu9hhtor-big-Data.db``. For these layouts, point the
+tool at any component path in that SSTable.
+
+Live object-storage keyspaces use a different layout. SSTable components are
+stored under ``sstables/<sstable-id>/`` and the component object names do not
+include the version, generation, or format:
+
+.. code-block:: text
+
+   s3://bucket/sstables/<sstable-id>/Data.db
+   s3://bucket/sstables/<sstable-id>/Index.db
+   s3://bucket/sstables/<sstable-id>/TOC.txt
+
+The same layout is used with ``gs://`` paths. In this layout, Scylla stores the
+SSTable version and format as object attributes named ``version`` and
+``format`` on the ``TOC.txt`` object. ``scylla sstable`` uses these attributes
+to open the SSTable because the component name itself only contains the
+component suffix.
+
+The tool reads live object-storage SSTables in place; it does not download the
+full SSTable first. The ``--scylla-yaml-file`` configuration must contain a
+matching object-storage endpoint for the path scheme.
 
 .. _scylla-sstable-schema:
 

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -28,12 +28,31 @@
 #include "utils/s3/creds.hh"
 #include "utils/memory_data_sink.hh"
 #include "utils/lister.hh"
+#include "utils/rjson.hh"
 
 using namespace seastar;
 using namespace sstables;
 using namespace utils;
 
 static logging::logger osclog("object_storage_client");
+
+static rjson::value make_gcs_object_metadata(const object_storage_attributes& attributes) {
+    rjson::value metadata = rjson::empty_object();
+    for (const auto& [key, value] : attributes) {
+        rjson::add_with_string_name(metadata, key, rjson::from_string(value));
+    }
+    rjson::value object_metadata = rjson::empty_object();
+    rjson::add(object_metadata, "metadata", std::move(metadata));
+    return object_metadata;
+}
+
+static object_storage_attributes make_attributes(std::unordered_map<std::string, std::string>&& attributes) {
+    object_storage_attributes ret;
+    for (auto& [key, value] : attributes) {
+        ret.emplace(sstring(key), sstring(value));
+    }
+    return ret;
+}
 
 
 sstables::object_name::object_name(std::string_view bucket, std::string_view prefix, std::string_view type)
@@ -87,11 +106,11 @@ public:
         return lc ? dynamic_pointer_cast<s3_client_wrapper>(lc)->_client : shared_ptr<s3::client>{};
     }
 
-    future<> put_object(object_name name, ::memory_data_sink_buffers bufs, abort_source* as) override {
-        return _client->put_object(name.str(), std::move(bufs), as);
+    future<> put_object(object_name name, ::memory_data_sink_buffers bufs, object_storage_attributes attributes, abort_source* as) override {
+        return _client->put_object(name.str(), std::move(bufs), std::move(attributes), as);
     }
-    future<> copy_object(object_name src, object_name dst, abort_source* as) override {
-        return _client->copy_object(src.str(), dst.str(), std::nullopt, std::nullopt, as);
+    future<> copy_object(object_name src, object_name dst, object_storage_attributes attributes, abort_source* as) override {
+        return _client->copy_object(src.str(), dst.str(), std::move(attributes), std::nullopt, std::nullopt, as);
     }
     future<> delete_object(object_name name, abort_source* as) override {
         return _client->delete_object(name.str(), as);
@@ -99,17 +118,21 @@ public:
     file make_readable_file(object_name name, abort_source* as) override {
         return _client->make_readable_file(name.str(), as);
     }
-    data_sink make_data_upload_sink(object_name name, std::optional<unsigned> max_parts_per_piece, abort_source* as) override {
-        return _client->make_upload_jumbo_sink(name.str(), max_parts_per_piece, as);
+    data_sink make_data_upload_sink(object_name name, std::optional<unsigned> max_parts_per_piece, object_storage_attributes attributes, abort_source* as) override {
+        return _client->make_upload_jumbo_sink(name.str(), max_parts_per_piece, std::move(attributes), as);
     }
-    data_sink make_upload_sink(object_name name, abort_source* as) override {
-        return _client->make_upload_sink(name.str(), as);
+    data_sink make_upload_sink(object_name name, object_storage_attributes attributes, abort_source* as) override {
+        return _client->make_upload_sink(name.str(), std::move(attributes), as);
     }
     data_source make_download_source(object_name name, abort_source* as) override {
         return _client->make_chunked_download_source(name.str(), s3::full_range, as);
     }
     future<bool> object_exists(object_name name, abort_source* as) override {
         return _client->object_exists(name.str(), as);
+    }
+    future<object_storage_metadata> get_object_metadata(object_name name, abort_source* as) override {
+        auto info = co_await _client->get_object_info(name.str(), as);
+        co_return object_storage_metadata{ .attributes = std::move(info.metadata) };
     }
     abstract_lister make_object_lister(std::string bucket, std::string prefix, lister::filter_type filter) override {
         return abstract_lister::make<s3::client::bucket_lister>(_client, std::move(bucket), std::move(prefix), std::move(filter));
@@ -163,16 +186,16 @@ public:
         })
     {}
 
-    future<> put_object(object_name name, ::memory_data_sink_buffers bufs, abort_source* as) override {
-        auto sink = _client->create_upload_sink(name.bucket(), name.object(), {}, as);
+    future<> put_object(object_name name, ::memory_data_sink_buffers bufs, object_storage_attributes attributes, abort_source* as) override {
+        auto sink = _client->create_upload_sink(name.bucket(), name.object(), make_gcs_object_metadata(attributes), as);
         for (auto&& buf : bufs.buffers()) {
             co_await sink.put(std::move(buf));
         }
         co_await sink.flush();
         co_await sink.close();
     }
-    future<> copy_object(object_name src, object_name dst, abort_source* as) override {
-        return _client->copy_object(src.bucket(), src.object(), dst.bucket(), dst.object(), as);
+    future<> copy_object(object_name src, object_name dst, object_storage_attributes attributes, abort_source* as) override {
+        return _client->copy_object(src.bucket(), src.object(), dst.bucket(), dst.object(), make_gcs_object_metadata(attributes), as);
     }
     future<> delete_object(object_name name, abort_source* as) override {
         return _client->delete_object(name.bucket(), name.object(), as);
@@ -183,17 +206,21 @@ public:
                     return scf();
                 }, as);
     }
-    data_sink make_data_upload_sink(object_name name, std::optional<unsigned> max_parts_per_piece, abort_source* as) override {
-        return make_upload_sink(std::move(name), as);
+    data_sink make_data_upload_sink(object_name name, std::optional<unsigned> max_parts_per_piece, object_storage_attributes attributes, abort_source* as) override {
+        return make_upload_sink(std::move(name), std::move(attributes), as);
     }
-    data_sink make_upload_sink(object_name name, abort_source* as) override {
-        return _client->create_upload_sink(name.bucket(), name.object(), {}, as);
+    data_sink make_upload_sink(object_name name, object_storage_attributes attributes, abort_source* as) override {
+        return _client->create_upload_sink(name.bucket(), name.object(), make_gcs_object_metadata(attributes), as);
     }
     data_source make_download_source(object_name name, abort_source* as) override {
         return _client->create_download_source(name.bucket(), name.object(), as);
     }
     future<bool> object_exists(object_name name, abort_source* as) override {
         return _client->object_exists(name.bucket(), name.object(), as);
+    }
+    future<object_storage_metadata> get_object_metadata(object_name name, abort_source* as) override {
+        auto info = co_await _client->get_object_info(name.bucket(), name.object(), as);
+        co_return object_storage_metadata{ .attributes = make_attributes(std::move(info.metadata)) };
     }
     abstract_lister make_object_lister(std::string bucket, std::string prefix, lister::filter_type filter) override {
         class list_impl : public abstract_lister::impl {
@@ -250,7 +277,7 @@ public:
 
         auto upload_one = [this, as, &up, &f](object_name name, uint64_t offset, uint64_t size) -> future<> {
             uint64_t pos = offset;
-            auto sink = make_upload_sink(std::move(name), as);
+            auto sink = make_upload_sink(std::move(name), {}, as);
             while (size > 0) {
                 auto rem = std::min(size, size_t(64*1024));
                 auto buf = co_await f.dma_read_bulk<char>(pos, rem);

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -11,6 +11,7 @@
 #include <string>
 #include <optional>
 #include <filesystem>
+#include <unordered_map>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/semaphore.hh>
@@ -44,6 +45,15 @@ class abstract_lister;
 
 namespace sstables {
 
+using object_storage_attributes = std::unordered_map<sstring, sstring>;
+
+inline constexpr std::string_view object_storage_sstable_version_attribute = "version";
+inline constexpr std::string_view object_storage_sstable_format_attribute = "format";
+
+struct object_storage_metadata {
+    object_storage_attributes attributes;
+};
+
 class object_name {
     std::string _name;
 public:
@@ -73,14 +83,15 @@ class object_storage_client {
 public:
     virtual ~object_storage_client() = default;
 
-    virtual future<> put_object(object_name, ::memory_data_sink_buffers bufs, abort_source* = nullptr) = 0;
-    virtual future<> copy_object(object_name src, object_name dst, abort_source* = nullptr) = 0;
+    virtual future<> put_object(object_name, ::memory_data_sink_buffers bufs, object_storage_attributes = {}, abort_source* = nullptr) = 0;
+    virtual future<> copy_object(object_name src, object_name dst, object_storage_attributes = {}, abort_source* = nullptr) = 0;
     virtual future<> delete_object(object_name, abort_source* = nullptr) = 0;
     virtual file make_readable_file(object_name, abort_source* = nullptr) = 0;
-    virtual data_sink make_data_upload_sink(object_name, std::optional<unsigned> max_parts_per_piece, abort_source* = nullptr) = 0;
-    virtual data_sink make_upload_sink(object_name, abort_source* = nullptr) = 0;
+    virtual data_sink make_data_upload_sink(object_name, std::optional<unsigned> max_parts_per_piece, object_storage_attributes = {}, abort_source* = nullptr) = 0;
+    virtual data_sink make_upload_sink(object_name, object_storage_attributes = {}, abort_source* = nullptr) = 0;
     virtual data_source make_download_source(object_name, abort_source* = nullptr) = 0;
     virtual future<bool> object_exists(object_name name, abort_source* as = nullptr) = 0;
+    virtual future<object_storage_metadata> get_object_metadata(object_name name, abort_source* as = nullptr) = 0;
 
     virtual abstract_lister make_object_lister(std::string bucket, std::string prefix, lister::filter_type) = 0;
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1707,7 +1707,11 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         scylla_metadata metadata;
         read_simple<component_type::Scylla>(metadata).get();
         if (update_id) {
-            metadata.set_sstable_identifier();
+            if (auto sid = new_sst->sstable_identifier()) {
+                metadata.set_sstable_identifier(*sid);
+            } else {
+                metadata.set_sstable_identifier();
+            }
         }
 
         new_sst->write_component_with_metadata(component, std::move(metadata));
@@ -1742,6 +1746,7 @@ void sstable::write_component_with_metadata(component_type type, scylla_metadata
     write_simple<component_type::Scylla>(metadata);
 
     _components->scylla_metadata = std::move(metadata);
+    _sstable_identifier = _components->scylla_metadata->get_optional_sstable_identifier();
     // Keep the cached _features in sync with the metadata we just wrote,
     // mirroring read_scylla_metadata(). Otherwise a rewritten sstable would
     // report zeroed features (e.g. losing ShadowableTombstones).

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1678,7 +1678,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         std::function<void(sstable&)> modifier,
         update_sstable_id update_id) {
     if (!is_component_rewrite_supported(component)) {
-        on_internal_error(sstlog, "Only Statistics component can be rewritten.");
+        on_internal_error(sstlog, fmt::format("{} component cannot be rewritten.", component_name(*this, component)));
     }
 
     if (!has_component(component)) {
@@ -1686,7 +1686,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
     }
 
     if (!has_scylla_component()) {
-        on_internal_error(sstlog, "SSTable must have Scylla component to rewrite Statistics component.");
+        on_internal_error(sstlog, fmt::format("SSTable must have Scylla component to rewrite {} component.", component_name(*this, component)));
     }
 
     if (_storage->is_object_storage() && !update_id) {
@@ -1696,16 +1696,26 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
     return seastar::async([this, creator = std::move(sstable_creator), component, modifier = std::move(modifier), update_id] {
         auto new_sst = creator(shared_from_this());
         auto generation = new_sst->generation();
+        new_sst->generate_toc();
+        new_sst->_storage->open_for_component_rewrite(*new_sst);
 
-        _storage->link_with_excluded_components(*this, generation, {component, component_type::Scylla}).get();
+        std::unordered_set<component_type> excluded_components{component_type::Scylla};
+        if (component != component_type::Scylla) {
+            excluded_components.insert(component);
+        }
+        _storage->link_with_excluded_components(*this, generation, excluded_components).get();
         new_sst->copy_components(*this).get();
 
         modifier(*new_sst);
 
-        // FIXME: Optimize by re-reading metadata only if _components->scylla_metadata was modified after loading.
-        // If unchanged, reuse the existing _components->scylla_metadata instead.
         scylla_metadata metadata;
-        read_simple<component_type::Scylla>(metadata).get();
+        if (component == component_type::Scylla) {
+            metadata = *new_sst->_components->scylla_metadata;
+        } else {
+            // FIXME: Optimize by re-reading metadata only if _components->scylla_metadata was modified after loading.
+            // If unchanged, reuse the existing _components->scylla_metadata instead.
+            read_simple<component_type::Scylla>(metadata).get();
+        }
         if (update_id) {
             if (auto sid = new_sst->sstable_identifier()) {
                 metadata.set_sstable_identifier(*sid);
@@ -1735,12 +1745,13 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
 // 5. Set the in-memory Scylla metadata to the new metadata
 void sstable::write_component_with_metadata(component_type type, scylla_metadata metadata) {
     if (!is_component_rewrite_supported(type)) {
-        on_internal_error(sstlog, "Only Statistics component can be rewritten.");
+        on_internal_error(sstlog, fmt::format("{} component cannot be rewritten.", component_name(*this, type)));
     }
 
-    write_component(type);
-
-    metadata.get_or_create_components_digests().map[type] = _components_digests.map[type];
+    if (type != component_type::Scylla) {
+        write_component(type);
+        metadata.get_or_create_components_digests().map[type] = _components_digests.map[type];
+    }
     metadata.digest = serialized_checksum(_version, metadata.data);
 
     write_simple<component_type::Scylla>(metadata);
@@ -2134,6 +2145,7 @@ void sstable::disable_component_memory_reload() {
 bool sstable::is_component_rewrite_supported(component_type type) {
     switch (type) {
     case component_type::Statistics:
+    case component_type::Scylla:
         return true;
     default:
         return false;
@@ -2144,6 +2156,8 @@ void sstable::write_component(component_type type) {
     switch (type) {
     case component_type::Statistics:
         write_statistics();
+        break;
+    case component_type::Scylla:
         break;
     default:
         on_internal_error(sstlog, fmt::format("Writing component {} is not supported.", component_name(*this, type)));
@@ -3609,6 +3623,15 @@ void sstable::mutate_sstable_level(uint32_t new_level) {
     }
 
     s.sstable_level = new_level;
+}
+
+void sstable::mutate_sstable_run_identifier(run_id new_run_id) {
+    if (!_components->scylla_metadata) {
+        on_internal_error(sstlog, fmt::format("SSTable {} does not have Scylla metadata to rewrite run identifier.", get_filename()));
+    }
+
+    _components->scylla_metadata->data.set<scylla_metadata_type::RunIdentifier>(sstables::run_identifier{new_run_id});
+    _run_identifier = new_run_id;
 }
 
 bool sstable::should_mutate_sstable_level(uint32_t new_level) const {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1060,6 +1060,8 @@ public:
         _run_identifier = run_id::create_random_id();
     }
 
+    void mutate_sstable_run_identifier(run_id);
+
     double get_compression_ratio() const;
 
     const sstables::compression& get_compression() const {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -1088,6 +1088,14 @@ future<> object_storage_base::link_with_excluded_components(const sstable& sst, 
         const std::unordered_set<component_type>& excluded_components,
         optimized_optional<sstable_id> new_sid) const {
     auto sid = new_sid ? *new_sid : sstable_id(new_gen.as_uuid());
+    entry_descriptor desc(new_gen, sid, sst.get_version(), sst.get_format(), component_type::TOC);
+    desc.state = sst.state();
+    auto node_owner = sst.manager().get_local_host_id();
+    co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
+
+    auto ref_name = make_ref_object_name(sid, new_gen, node_owner);
+    co_await put_object(ref_name, memory_data_sink_buffers());
+
     auto prefix = this->prefix();
     co_await coroutine::parallel_for_each(sst.all_components(), [this, &sst, sid, &excluded_components, &prefix] (const std::pair<component_type, sstring>& p) -> future<> {
         if (excluded_components.contains(p.first)) {
@@ -1106,12 +1114,6 @@ future<entry_descriptor> object_storage_base::clone(sstable& sst, generation_typ
     entry_descriptor desc(gen, sid, sst.get_version(), sst.get_format(), component_type::TOC);
     desc.state = sst.state();
     auto node_owner = sst.manager().get_local_host_id();
-    co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
-
-    auto ref_name = make_ref_object_name(sid, gen, node_owner);
-    co_await _client->put_object(ref_name, memory_data_sink_buffers(), abort_source());
-    auto refs = co_await num_references(sid);
-    sstlog.debug("Cloned {} reference {} num_references={}", sst.get_filename(), ref_name, refs);
 
     if (!may_use_reference_sharing) {
         co_await link_with_excluded_components(sst, gen, {component_type::Scylla}, sid);
@@ -1119,7 +1121,14 @@ future<entry_descriptor> object_storage_base::clone(sstable& sst, generation_typ
         scylla_metadata->set_sstable_identifier(sid);
         auto scylla_metadata_bufs = co_await sst.serialize_scylla_metadata(std::move(*scylla_metadata));
         co_await put_object(object_name(_bucket, prefix(), sid, sstable_version_constants::get_component_map(sst.get_version()).at(component_type::Scylla)), std::move(*scylla_metadata_bufs));
+    } else {
+        auto ref_name = make_ref_object_name(sid, gen, node_owner);
+        co_await _client->put_object(ref_name, memory_data_sink_buffers(), abort_source());
+        co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
     }
+
+    auto refs = co_await num_references(sid);
+    sstlog.debug("Cloned {} sstable_id={} num_references={}", sst.get_filename(), sid, refs);
 
     if (!leave_unsealed) {
         // Mark the cloned sstable as sealed in the registry

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -692,6 +692,7 @@ public:
     future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     void open(sstable& sst) override;
+    void open_for_component_rewrite(sstable&) override;
     future<> wipe(sstable& sst, const atomic_delete_context* ctx = nullptr) noexcept override;
     future<file> open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) override;
     future<data_sink> make_data_or_index_sink(sstable& sst, component_type type) override;
@@ -866,6 +867,10 @@ void object_storage_base::open(sstable& sst) {
     sst.write_toc(std::move(w));
     put_object(make_object_name(sst, component_type::TOC), std::move(bufs), make_sstable_object_attributes(sst)).get();
     sstlog.debug("Created reference {}: {}", sst.get_filename(), ref_name);
+}
+
+void object_storage_base::open_for_component_rewrite(sstable& sst) {
+    open(sst);
 }
 
 future<file> object_storage_base::open_component(const sstable& sst, component_type type, open_flags flags, file_open_options options, bool check_integrity) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -735,10 +735,16 @@ public:
     bool is_object_storage() const override { return true; }
 
     future<> put_object(object_name name, ::memory_data_sink_buffers bufs) const {
-        return _client->put_object(std::move(name), std::move(bufs), abort_source());
+        return _client->put_object(std::move(name), std::move(bufs), {}, abort_source());
+    }
+    future<> put_object(object_name name, ::memory_data_sink_buffers bufs, object_storage_attributes attributes) const {
+        return _client->put_object(std::move(name), std::move(bufs), std::move(attributes), abort_source());
     }
     future<> copy_object(object_name src, object_name dst) const {
-        return _client->copy_object(std::move(src), std::move(dst), abort_source());
+        return _client->copy_object(std::move(src), std::move(dst), {}, abort_source());
+    }
+    future<> copy_object(object_name src, object_name dst, object_storage_attributes attributes) const {
+        return _client->copy_object(std::move(src), std::move(dst), std::move(attributes), abort_source());
     }
     future<> delete_object(object_name name) const {
         return _client->delete_object(std::move(name), abort_source());
@@ -747,12 +753,19 @@ public:
         return _client->make_readable_file(std::move(name), abort_source());
     }
     data_sink make_data_upload_sink(object_name name, std::optional<unsigned> max_parts_per_piece) {
-        return _client->make_data_upload_sink(std::move(name), max_parts_per_piece, abort_source());
+        return _client->make_data_upload_sink(std::move(name), max_parts_per_piece, {}, abort_source());
     }
-    data_sink make_upload_sink(object_name name) {
-        return _client->make_upload_sink(std::move(name), abort_source());
+    data_sink make_upload_sink(object_name name, object_storage_attributes attributes = {}) {
+        return _client->make_upload_sink(std::move(name), std::move(attributes), abort_source());
     }
 };
+
+static object_storage_attributes make_sstable_object_attributes(const sstable& sst) {
+    return {
+        {sstring(object_storage_sstable_version_attribute), fmt::format("{}", sst.get_version())},
+        {sstring(object_storage_sstable_format_attribute), fmt::format("{}", sst.get_format())},
+    };
+}
 
 class s3_storage : public object_storage_base {
 public:
@@ -844,14 +857,14 @@ void object_storage_base::open(sstable& sst) {
     sst.manager().sstables_registry().create_entry(owner(), host_id, status_creating, sst._state, std::move(desc)).get();
 
     auto ref_name = make_ref_object_name(sid, sst.generation(), host_id);
-    put_object(ref_name, memory_data_sink_buffers()).get();
+    _client->put_object(ref_name, memory_data_sink_buffers(), {}, abort_source()).get();
 
     memory_data_sink_buffers bufs;
     auto out = data_sink(std::make_unique<memory_data_sink>(bufs));
     auto w = std::make_unique<crc32_digest_file_writer>(std::move(out), sst.sstable_buffer_size, component_name(sst, component_type::TOC));
 
     sst.write_toc(std::move(w));
-    put_object(make_object_name(sst, component_type::TOC), std::move(bufs)).get();
+    put_object(make_object_name(sst, component_type::TOC), std::move(bufs), make_sstable_object_attributes(sst)).get();
     sstlog.debug("Created reference {}: {}", sst.get_filename(), ref_name);
 }
 
@@ -938,7 +951,7 @@ s3_storage::make_source(sstable& sst, component_type type, file f, uint64_t offs
 }
 
 future<data_sink> object_storage_base::make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) {
-    return maybe_wrap_sink(sst, type, make_upload_sink(make_object_name(sst, type)));
+    return maybe_wrap_sink(sst, type, make_upload_sink(make_object_name(sst, type), type == component_type::TOC ? make_sstable_object_attributes(sst) : object_storage_attributes{}));
 }
 
 future<> object_storage_base::seal(const sstable& sst) {
@@ -1094,14 +1107,15 @@ future<> object_storage_base::link_with_excluded_components(const sstable& sst, 
     co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
 
     auto ref_name = make_ref_object_name(sid, new_gen, node_owner);
-    co_await put_object(ref_name, memory_data_sink_buffers());
+    co_await _client->put_object(ref_name, memory_data_sink_buffers(), {}, abort_source());
 
     auto prefix = this->prefix();
     co_await coroutine::parallel_for_each(sst.all_components(), [this, &sst, sid, &excluded_components, &prefix] (const std::pair<component_type, sstring>& p) -> future<> {
         if (excluded_components.contains(p.first)) {
             co_return;
         }
-        co_await copy_object(make_object_name(sst, p.second, sst.generation()), object_name(_bucket, prefix, sid, p.second));
+        co_await copy_object(make_object_name(sst, p.second, sst.generation()), object_name(_bucket, prefix, sid, p.second),
+                p.first == component_type::TOC ? make_sstable_object_attributes(sst) : object_storage_attributes{});
     });
 }
 
@@ -1120,10 +1134,11 @@ future<entry_descriptor> object_storage_base::clone(sstable& sst, generation_typ
         auto scylla_metadata = co_await sst.copy_scylla_metadata();
         scylla_metadata->set_sstable_identifier(sid);
         auto scylla_metadata_bufs = co_await sst.serialize_scylla_metadata(std::move(*scylla_metadata));
-        co_await put_object(object_name(_bucket, prefix(), sid, sstable_version_constants::get_component_map(sst.get_version()).at(component_type::Scylla)), std::move(*scylla_metadata_bufs));
+        co_await put_object(object_name(_bucket, prefix(), sid, sstable_version_constants::get_component_map(sst.get_version()).at(component_type::Scylla)),
+                std::move(*scylla_metadata_bufs));
     } else {
         auto ref_name = make_ref_object_name(sid, gen, node_owner);
-        co_await _client->put_object(ref_name, memory_data_sink_buffers(), abort_source());
+        co_await _client->put_object(ref_name, memory_data_sink_buffers(), {}, abort_source());
         co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
     }
 

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -104,6 +104,7 @@ public:
     virtual future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
             const std::unordered_set<component_type>& excluded_components,
             optimized_optional<sstable_id> new_sid = {}) const = 0;
+    virtual void open_for_component_rewrite(sstable&) {}
     virtual ~storage() {}
 
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage

--- a/test/boost/object_storage_upload_test.cc
+++ b/test/boost/object_storage_upload_test.cc
@@ -18,11 +18,15 @@
 #include "db/config.hh"
 #include "sstables/object_storage_client.hh"
 #include "sstables/storage.hh"
+#include "sstables/sstable_version.hh"
 #include "utils/upload_progress.hh"
 
 #include "test/lib/test_utils.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/sstable_test_env.hh"
+#include "test/lib/sstable_utils.hh"
+#include "test/lib/simple_schema.hh"
+#include "test/lib/key_utils.hh"
 #include "test/lib/gcs_fixture.hh"
 
 namespace fs = std::filesystem;
@@ -94,12 +98,44 @@ future<> test_file_upload(test_env_config cfg, size_t size) {
     }, std::move(cfg));
 }
 
+future<> test_sstable_attributes(test_env_config cfg) {
+    auto bucket = cfg.storage.to_map()["bucket"];
+    auto cfg_map = cfg.storage.to_map();
+    auto prefix = cfg_map.contains("prefix") ? cfg_map["prefix"] : "sstables";
+
+    return test_env::do_with_async([bucket, prefix] (test_env& env) {
+        auto ep = env.db_config().object_storage_endpoints().front().key();
+        auto client = env.manager().get_endpoint_client(ep);
+        simple_schema ss;
+        auto schema = ss.schema();
+        auto pk = tests::generate_partition_key(schema).key();
+        auto mut = mutation(schema, pk);
+        mut.partition().apply_insert(*schema, ss.make_ckey(0), ss.new_timestamp());
+
+        auto sst = make_sstable_containing(env.make_sstable(schema), {std::move(mut)}).get();
+        auto sid = sst->sstable_identifier();
+        BOOST_REQUIRE(sid);
+        auto object = sstables::object_name(bucket, prefix, *sid, sstable_version_constants::TOC_SUFFIX);
+        auto metadata = client->get_object_metadata(object).get();
+        BOOST_REQUIRE_EQUAL(metadata.attributes.at(sstring(object_storage_sstable_version_attribute)), fmt::format("{}", sst->get_version()));
+        BOOST_REQUIRE_EQUAL(metadata.attributes.at(sstring(object_storage_sstable_format_attribute)), fmt::format("{}", sst->get_format()));
+    }, std::move(cfg));
+}
+
 constexpr auto large_size = 256 * 1024 * 1024 + 351;
 
 SEASTAR_TEST_CASE(test_large_file_upload_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
     return test_file_upload(test_env_config{ .storage = make_test_object_storage_options("S3") }, large_size);
 }
 
+SEASTAR_TEST_CASE(test_sstable_object_attributes_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    return test_sstable_attributes(test_env_config{ .storage = make_test_object_storage_options("S3") });
+}
+
 SEASTAR_FIXTURE_TEST_CASE(test_large_file_upload_gs, gcs_fixture, *check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
     return test_file_upload(test_env_config{ .storage = make_test_object_storage_options("GS") }, large_size);
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_sstable_object_attributes_gs, gcs_fixture, *check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
+    return test_sstable_attributes(test_env_config{ .storage = make_test_object_storage_options("GS") });
 }

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -761,7 +761,7 @@ void test_object_copy(const client_maker_function& client_maker, size_t chunk_si
 
     out.flush().get();
     out.close().get();
-    cln->copy_object(name, name_copy, 5_MiB).get();
+    cln->copy_object(name, name_copy, {}, 5_MiB).get();
 
     auto sz = cln->get_object_size(name_copy).get();
     BOOST_REQUIRE_EQUAL(sz, chunk_size * chunks);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -71,6 +71,8 @@
 #include "utils/assert.hh"
 #include "utils/pretty_printers.hh"
 #include "sstables/exceptions.hh"
+#include "sstables/object_storage_client.hh"
+#include "sstables/sstable_version.hh"
 
 BOOST_AUTO_TEST_SUITE(sstable_compaction_test)
 
@@ -7608,6 +7610,18 @@ static future<> test_perform_component_rewrite_single_sstable(sstables::update_s
     });
 }
 
+static void require_sstable_toc_object_attributes(test_env& env, const sstables::shared_sstable& sst) {
+    auto storage_map = env.get_storage_options().to_map();
+    auto client = env.manager().get_endpoint_client(env.db_config().object_storage_endpoints().front().key());
+    auto sid = sst->sstable_identifier();
+    BOOST_REQUIRE(sid);
+    auto prefix = storage_map.contains("prefix") ? storage_map["prefix"] : "sstables";
+    auto object = sstables::object_name(storage_map["bucket"], prefix, *sid, sstable_version_constants::TOC_SUFFIX);
+    auto metadata = client->get_object_metadata(object).get();
+    BOOST_REQUIRE_EQUAL(metadata.attributes.at(sstring(object_storage_sstable_version_attribute)), fmt::format("{}", sst->get_version()));
+    BOOST_REQUIRE_EQUAL(metadata.attributes.at(sstring(object_storage_sstable_format_attribute)), fmt::format("{}", sst->get_format()));
+}
+
 SEASTAR_TEST_CASE(test_perform_component_rewrite_single_sstable_with_backup) {
     return test_perform_component_rewrite_single_sstable(sstables::update_sstable_id::yes);
 }
@@ -7623,8 +7637,8 @@ static void object_storage_perform_component_rewrite_single_sstable_fn(test_env&
 
     auto mut1 = mutation(s, pk);
     mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-    auto original_sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
-    BOOST_REQUIRE(original_sst->sstable_identifier());
+    auto original_sst = make_sstable_containing(env.make_sstable(s), {mut1}).get();
+    require_sstable_toc_object_attributes(env, original_sst);
 
     uint32_t new_level = 5;
     auto modifier = [new_level] (sstable& sst) {
@@ -7642,7 +7656,7 @@ static void object_storage_perform_component_rewrite_single_sstable_fn(test_env&
     BOOST_REQUIRE(new_sst->sstable_identifier());
     BOOST_REQUIRE(new_sst->sstable_identifier() != original_sst->sstable_identifier());
     BOOST_REQUIRE(new_sst->get_sstable_level() == new_level);
-    BOOST_REQUIRE(new_sst->generation() != original_sst->generation());
+    require_sstable_toc_object_attributes(env, new_sst);
 }
 
 SEASTAR_TEST_CASE(test_object_storage_perform_component_rewrite_single_sstable_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7669,6 +7669,49 @@ SEASTAR_FIXTURE_TEST_CASE(test_object_storage_perform_component_rewrite_single_s
             test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
+SEASTAR_TEST_CASE(test_perform_component_rewrite_sstable_run_identifier) {
+    return test_env::do_with_async([] (test_env& env) {
+        simple_schema ss;
+        auto s = ss.schema();
+        auto pk = ss.make_pkey();
+
+        auto mut = mutation(s, pk);
+        mut.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
+        auto original_sst = make_sstable_containing(env.make_sstable(s), {mut}).get();
+        auto original_run_id = original_sst->run_identifier();
+        auto new_run_id = run_id::create_random_id();
+
+        auto table = env.make_table_for_tests(s);
+        auto close_table = deferred_stop(table);
+        table->add_sstable_and_update_cache(original_sst).get();
+
+        auto& cm = table->get_compaction_manager();
+        auto& compaction_group_view = table->compaction_group_view_for_sstable(original_sst);
+        auto rewritten_map = cm.perform_component_rewrite(compaction_group_view,
+                                                          tasks::task_info{},
+                                                          [original_sst] (const sstables::shared_sstable& sst) {
+                                                              return sst == original_sst;
+                                                          },
+                                                          component_type::Scylla,
+                                                          [new_run_id] (sstable& sst) {
+                                                              sst.mutate_sstable_run_identifier(new_run_id);
+                                                          },
+                                                          sstables::update_sstable_id::yes).get();
+
+        BOOST_REQUIRE_EQUAL(rewritten_map.size(), 1);
+        auto new_sst = rewritten_map.at(original_sst);
+        BOOST_REQUIRE(new_sst->run_identifier() == new_run_id);
+        BOOST_REQUIRE(new_sst->run_identifier() != original_run_id);
+        BOOST_REQUIRE(new_sst->generation() != original_sst->generation());
+        BOOST_REQUIRE(new_sst->sstable_identifier() != original_sst->sstable_identifier());
+
+        auto all_sstables = table->get_sstables();
+        BOOST_REQUIRE_EQUAL(all_sstables->size(), 1);
+        BOOST_REQUIRE(!all_sstables->contains(original_sst));
+        BOOST_REQUIRE(all_sstables->contains(new_sst));
+    });
+}
+
 SEASTAR_TEST_CASE(test_perform_component_rewrite_multiple_sstables) {
     return test_env::do_with_async([] (test_env& env) {
         simple_schema ss;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -6941,6 +6941,116 @@ SEASTAR_FIXTURE_TEST_CASE(offstrategy_incremental_compaction_gcs_test, gcs_fixtu
         test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
+SEASTAR_TEST_CASE(split_compaction_preserves_incremental_run_sides_test) {
+    return test_env::do_with_async([] (test_env& env) {
+        struct test_case {
+            sstring name;
+            std::vector<unsigned> mutations_per_sstable;
+            size_t split_sstable_idx;
+            size_t expected_left_sstables;
+            size_t expected_right_sstables;
+        };
+
+        auto run_test_case = [&env] (const test_case& tc) {
+            auto builder = schema_builder(this_smp_shard_count(), "tests", format("split_compaction_{}", tc.name))
+                    .with_column("id", utf8_type, column_kind::partition_key)
+                    .with_column("value", int32_type);
+            builder.set_compaction_strategy(compaction::compaction_strategy_type::incremental);
+            builder.set_compaction_strategy_options({{"sstable_size_in_mb", "0"}});
+            auto s = builder.build();
+            auto sst_gen = env.make_sst_factory(s);
+
+            auto make_insert = [&] (partition_key key) {
+                mutation m(s, key);
+                m.set_clustered_cell(clustering_key::make_empty(), bytes("value"), data_value(int32_t(1)), api::new_timestamp());
+                return m;
+            };
+
+            auto mutation_count = std::accumulate(tc.mutations_per_sstable.begin(), tc.mutations_per_sstable.end(), 0u);
+            std::set<mutation, mutation_decorated_key_less_comparator> mutations;
+            for (unsigned i = 0; i < mutation_count; i++) {
+                mutations.insert(make_insert(partition_key::from_exploded(*s, {to_bytes(to_sstring(i))})));
+            }
+
+            std::vector<shared_sstable> ssts;
+            ssts.reserve(tc.mutations_per_sstable.size());
+            auto run_identifier = run_id::create_random_id();
+            auto it = mutations.begin();
+            for (auto mutations_in_sstable : tc.mutations_per_sstable) {
+                utils::chunked_vector<mutation> sst_mutations;
+                for (unsigned i = 0; i < mutations_in_sstable; i++) {
+                    sst_mutations.push_back(std::move(*it++));
+                }
+                auto sst = make_sstable_containing(sst_gen, std::move(sst_mutations)).get();
+                sstables::test(sst).set_run_identifier(run_identifier);
+                ssts.push_back(std::move(sst));
+            }
+
+            std::ranges::sort(ssts, [&s] (const shared_sstable& a, const shared_sstable& b) {
+                return a->get_first_decorated_key().tri_compare(*s, b->get_first_decorated_key()) < 0;
+            });
+
+            BOOST_REQUIRE_LT(tc.split_sstable_idx, ssts.size());
+            auto split_sst = ssts[tc.split_sstable_idx];
+            BOOST_REQUIRE(split_sst->get_first_decorated_key().tri_compare(*s, split_sst->get_last_decorated_key()) < 0);
+            auto split_token = split_sst->get_first_decorated_key().token();
+            auto classifier = [split_token] (dht::token token) -> mutation_writer::token_group_id {
+                return token <= split_token ? 0 : 1;
+            };
+
+            auto table = env.make_table_for_tests(s);
+            auto close_table = deferred_stop(table);
+            table->disable_auto_compaction().get();
+            for (auto& sst : ssts) {
+                table->add_sstable_and_update_cache(sst).get();
+            }
+
+            auto& cm = table->get_compaction_manager();
+            auto& cg_view = table->try_get_compaction_group_view_with_static_sharding();
+            auto ret = cm.perform_split_compaction(cg_view, compaction::compaction_type_options::split{classifier}, tasks::task_info{}).get();
+            BOOST_REQUIRE(ret);
+
+            auto main_set = cg_view.main_sstable_set().get();
+            BOOST_REQUIRE_EQUAL(main_set->size(), tc.mutations_per_sstable.size() + 1);
+
+            std::unordered_map<mutation_writer::token_group_id, frozen_sstable_run> runs_by_side;
+            auto runs = main_set->all_sstable_runs();
+            BOOST_REQUIRE_EQUAL(runs.size(), 2);
+            for (const auto& run : runs) {
+                BOOST_REQUIRE(!run->all().empty());
+                std::optional<mutation_writer::token_group_id> side;
+                for (const auto& sst : run->all()) {
+                    auto first_side = classifier(sst->get_first_decorated_key().token());
+                    auto last_side = classifier(sst->get_last_decorated_key().token());
+                    BOOST_REQUIRE_EQUAL(first_side, last_side);
+                    if (!side) {
+                        side = first_side;
+                    } else {
+                        BOOST_REQUIRE_EQUAL(*side, first_side);
+                    }
+                }
+                BOOST_REQUIRE(side);
+                BOOST_REQUIRE(runs_by_side.emplace(*side, run).second);
+            }
+
+            BOOST_REQUIRE(runs_by_side.contains(0));
+            BOOST_REQUIRE(runs_by_side.contains(1));
+            BOOST_REQUIRE_EQUAL(runs_by_side.at(0)->all().size(), tc.expected_left_sstables);
+            BOOST_REQUIRE_EQUAL(runs_by_side.at(1)->all().size(), tc.expected_right_sstables);
+            BOOST_REQUIRE(runs_by_side.at(0)->run_identifier() != runs_by_side.at(1)->run_identifier());
+        };
+
+        for (const auto& tc : std::vector<test_case>{
+                {"single_sstable", {2}, 0, 1, 1},
+                {"first_sstable_split", {2, 2}, 0, 1, 2},
+                {"last_sstable_split", {2, 2}, 1, 2, 1},
+                {"middle_sstable_split", {2, 2, 2, 2, 2}, 2, 3, 3},
+        }) {
+            run_test_case(tc);
+        }
+    });
+}
+
 void cleanup_during_offstrategy_incremental_compaction_fn(test_env& env) {
     auto builder = schema_builder(this_smp_shard_count(), "tests", "test")
             .with_column("id", utf8_type, column_kind::partition_key)

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7616,6 +7616,45 @@ SEASTAR_TEST_CASE(test_perform_component_rewrite_single_sstable_without_backup) 
     return test_perform_component_rewrite_single_sstable(sstables::update_sstable_id::no);
 }
 
+static void object_storage_perform_component_rewrite_single_sstable_fn(test_env& env) {
+    simple_schema ss;
+    auto s = ss.schema();
+    auto pk = tests::generate_partition_key(s).key();
+
+    auto mut1 = mutation(s, pk);
+    mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
+    auto original_sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
+    BOOST_REQUIRE(original_sst->sstable_identifier());
+
+    uint32_t new_level = 5;
+    auto modifier = [new_level] (sstable& sst) {
+        sst.mutate_sstable_level(new_level);
+    };
+
+    auto creator = [&env] (shared_sstable sst) {
+        return env.make_sstable(sst->get_schema());
+    };
+    auto new_sst = original_sst->link_with_rewritten_component(std::move(creator),
+            component_type::Statistics,
+            std::move(modifier),
+            sstables::update_sstable_id::yes).get();
+
+    BOOST_REQUIRE(new_sst->sstable_identifier());
+    BOOST_REQUIRE(new_sst->sstable_identifier() != original_sst->sstable_identifier());
+    BOOST_REQUIRE(new_sst->get_sstable_level() == new_level);
+    BOOST_REQUIRE(new_sst->generation() != original_sst->generation());
+}
+
+SEASTAR_TEST_CASE(test_object_storage_perform_component_rewrite_single_sstable_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    return test_env::do_with_async([] (test_env& env) { object_storage_perform_component_rewrite_single_sstable_fn(env); },
+            test_env_config{.storage = make_test_object_storage_options("S3")});
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_object_storage_perform_component_rewrite_single_sstable_gcs, gcs_fixture, *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
+    return test_env::do_with_async([] (test_env& env) { object_storage_perform_component_rewrite_single_sstable_fn(env); },
+            test_env_config{.storage = make_test_object_storage_options("GS")});
+}
+
 SEASTAR_TEST_CASE(test_perform_component_rewrite_multiple_sstables) {
     return test_env::do_with_async([] (test_env& env) {
         simple_schema ss;

--- a/test/cluster/object_store/test_scaling.py
+++ b/test/cluster/object_store/test_scaling.py
@@ -8,14 +8,11 @@
 import asyncio
 import time
 import logging
-import re
-import uuid
-import pytest
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.object_storage import keyspace_options
-from test.cluster.util import new_test_keyspace, wait_for_no_pending_topology_transition, wait_for_no_running_compactions
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.cluster.util import new_test_keyspace, wait_for_no_pending_topology_transition
+from test.cluster.object_store.utils import verify_object_storage_namespace
 from test.pylib.tablets import get_all_tablet_replicas
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
@@ -66,109 +63,6 @@ async def test_scaling(manager: ManagerClient, object_storage):
             assert i in rows, f"Missing row with pk={i}"
             assert rows[i] == i * 10, f"Wrong value for pk={i}: expected {i * 10}, got {rows[i]}"
 
-    def verify_uuid_sstable_generation(generation):
-        match = re.fullmatch(r"([0-9a-z]{4})_([0-9a-z]{4})_([0-9a-z]{5})([0-9a-z]{13})", generation)
-        assert match is not None
-        assert int(match.group(2), 36) < 24 * 60 * 60
-        assert int(match.group(3), 36) < 10_000_000
-        assert int(match.group(4), 36) < 1 << 64
-
-    def encode_base36(value):
-        digits = "0123456789abcdefghijklmnopqrstuvwxyz"
-        if value == 0:
-            return "0"
-        result = ""
-        while value:
-            value, digit = divmod(value, 36)
-            result = digits[digit] + result
-        return result
-
-    def encode_uuid_sstable_generation(generation_uuid):
-        seconds, decimicroseconds = divmod(generation_uuid.time, 10_000_000)
-        days, seconds = divmod(seconds, 24 * 60 * 60)
-        lsb = generation_uuid.int & ((1 << 64) - 1)
-        generation = f"{encode_base36(days):0>4}_{encode_base36(seconds):0>4}_{encode_base36(decimicroseconds):0>5}{encode_base36(lsb):0>13}"
-        verify_uuid_sstable_generation(generation)
-        return generation
-
-    def parse_node_reference(reference):
-        parts = reference.split("/")
-        assert len(parts) == 3
-        assert parts[0] == "nodes"
-        host_id = str(uuid.UUID(parts[1]))
-        generation = parts[2]
-        verify_uuid_sstable_generation(generation)
-        return host_id, generation
-
-    async def verify_object_storage_namespace(server, live_servers, ks):
-        """Verify object-storage namespace layout and reference counts through REST API."""
-        await manager.disable_tablet_balancing()
-        await wait_for_no_pending_topology_transition(manager, time.time() + 120)
-        try:
-            for node in live_servers:
-                await manager.api.disable_autocompaction(node.ip_addr, ks, "test")
-
-            await wait_for_no_running_compactions(manager, live_servers, time.time() + 120)
-
-            for node in live_servers:
-                await manager.api.flush_keyspace(node.ip_addr, ks)
-
-            params = {
-                "endpoint": object_storage.address,
-                "bucket": object_storage.bucket_name,
-            }
-            table_id = str(await manager.get_table_id(ks, "test"))
-
-            live_hosts = await wait_for_cql_and_get_hosts(cql, live_servers, time.time() + 30)
-
-            async def get_object_storage_refs():
-                sstables = await manager.api.client.get_json("/storage_service/object_storage/sstables", host=server.ip_addr, params=params)
-                assert sstables
-                refs = {}
-                for sstable in sstables:
-                    sstable_id = str(uuid.UUID(sstable["sstable_id"]))
-                    references = sstable.get("references", [])
-                    assert sstable["num_references"] == len(references)
-                    assert references, f"SSTable {sstable_id} has no object-storage references"
-                    for reference in references:
-                        host_id, generation = parse_node_reference(reference)
-                        key = (sstable_id, host_id, generation)
-                        assert key not in refs
-                        refs[key] = reference
-                return sstables, refs
-
-            async def get_node_registry_refs(host):
-                rows = await cql.run_async("SELECT table_id, node_owner, generation, sstable_id, status FROM system.sstables", host=host)
-                refs = {}
-                for row in rows:
-                    if str(row.table_id) != table_id:
-                        continue
-                    if row.status != "sealed":
-                        continue
-                    sstable_id = str(row.sstable_id if row.sstable_id is not None else row.generation)
-                    generation = encode_uuid_sstable_generation(row.generation)
-                    key = (sstable_id, str(row.node_owner), generation)
-                    assert key not in refs
-                    refs[key] = row.status
-                return refs
-
-            async def get_registry_refs():
-                registry_refs = {}
-                for refs in await asyncio.gather(*(get_node_registry_refs(host) for host in live_hosts)):
-                    for key, status in refs.items():
-                        assert key not in registry_refs
-                        registry_refs[key] = status
-                return registry_refs
-
-            sstables, object_storage_refs = await get_object_storage_refs()
-            registry_refs = await get_registry_refs()
-            assert object_storage_refs.keys() == registry_refs.keys(), f"Only in object_storage: {object_storage_refs.keys() - registry_refs.keys()}\nOnly in registry: {registry_refs.keys() - object_storage_refs.keys()}"
-            logger.info("Verified %d object-storage SSTables and %d references", len(sstables), len(object_storage_refs))
-        finally:
-            for node in live_servers:
-                await manager.api.enable_autocompaction(node.ip_addr, ks, "test")
-            await manager.enable_tablet_balancing()
-
     async with new_test_keyspace(manager, keyspace_options(object_storage, rf=rf)) as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, value int);")
 
@@ -181,7 +75,7 @@ async def test_scaling(manager: ManagerClient, object_storage):
         # Verify initial data
         logger.info("Verifying initial data")
         await verify_data(cql, ks, NUM_ROWS)
-        await verify_object_storage_namespace(servers[0], servers, ks)
+        await verify_object_storage_namespace(manager, object_storage, cql, servers[0], servers, ks)
 
         # Add one node to each rack
         logger.info("Adding 3 new nodes (one per rack)")
@@ -198,7 +92,7 @@ async def test_scaling(manager: ManagerClient, object_storage):
         # Verify data after scale-up
         logger.info("Verifying data after adding nodes")
         await verify_data(cql, ks, NUM_ROWS)
-        await verify_object_storage_namespace(servers[0], servers + new_servers, ks)
+        await verify_object_storage_namespace(manager, object_storage, cql, servers[0], servers + new_servers, ks)
 
         # Verify tablets are distributed across all 6 nodes
         tablet_replicas = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
@@ -226,4 +120,4 @@ async def test_scaling(manager: ManagerClient, object_storage):
         # Verify data after scale-down
         logger.info("Verifying data after decommissioning nodes")
         await verify_data(cql, ks, NUM_ROWS)
-        await verify_object_storage_namespace(new_servers[0], new_servers, ks)
+        await verify_object_storage_namespace(manager, object_storage, cql, new_servers[0], new_servers, ks)

--- a/test/cluster/object_store/test_tablet_split.py
+++ b/test/cluster/object_store/test_tablet_split.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import json
+import logging
+import time
+
+import pytest
+from cassandra.query import SimpleStatement, ConsistencyLevel
+
+from test.cluster.util import new_test_keyspace, wait_for_cql_and_get_hosts, wait_for_no_pending_topology_transition, wait_for_no_running_compactions
+from test.cluster.object_store.utils import dump_object_storage_sstable_metadata, get_sealed_sstable_registry_rows
+from test.pylib.manager_client import ManagerClient
+from test.pylib.object_storage import keyspace_options
+from test.pylib.tablets import get_tablet_count
+from test.pylib.util import wait_for
+
+
+logger = logging.getLogger(__name__)
+
+
+async def dump_object_storage_sstable_run_ids(manager: ManagerClient, object_storage, server, ks: str, table: str, rows) -> list[str]:
+    metadata = await dump_object_storage_sstable_metadata(
+        manager, object_storage, server, ks, table, rows,
+        f"CREATE TABLE {ks}.{table} (pk int PRIMARY KEY, v blob)")
+    run_ids = [entry["run_identifier"] for entry in metadata.values() if "run_identifier" in entry]
+    assert len(run_ids) == len(metadata), f"Missing run_identifier in dump output: {json.dumps(metadata, indent=2)}"
+    return run_ids
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_split_compaction_preserves_incremental_run_ids_on_object_storage(manager: ManagerClient, object_storage):
+    """Verify split compaction updates persisted run IDs when component rewrite uses object-storage clone()."""
+    async def dump_run_ids(ks, table, cql, host, table_id):
+        rows = await get_sealed_sstable_registry_rows(cql, host, table_id)
+        return await dump_object_storage_sstable_run_ids(manager, object_storage, server, ks, table, rows)
+
+    objconf = object_storage.create_endpoint_conf()
+    cfg = {
+        "enable_user_defined_functions": False,
+        "object_storage_endpoints": objconf,
+        "experimental_features": ["keyspace-storage-options"],
+        "tablet_load_stats_refresh_interval_in_seconds": 1,
+    }
+    cmdline = [
+        "--smp", "1",
+        "--logger-log-level", "compaction=debug",
+        "--logger-log-level", "sstable=debug",
+        "--logger-log-level", "table=debug",
+    ]
+    logger.info("Starting server for object-storage split-compaction test")
+    server = await manager.server_add(config=cfg, cmdline=cmdline)
+    cql = manager.get_cql()
+
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, keyspace_options(object_storage, rf=1) + " AND tablets = {'enabled': true}") as ks:
+        await cql.run_async(f"""
+            CREATE TABLE {ks}.test (
+                pk int PRIMARY KEY,
+                v blob
+            ) WITH compaction = {{
+                'class': 'IncrementalCompactionStrategy',
+                'sstable_size_in_mb': '0'
+            }} AND tablets = {{
+                'min_tablet_count': 1
+            }}
+        """)
+        await manager.api.disable_autocompaction(server.ip_addr, ks, "test")
+
+        payload = bytes([1]) * 1024
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, v) VALUES (?, ?)")
+        keys = list(range(96))
+        logger.info("Writing rows for object-storage split-compaction test")
+        await asyncio.gather(*[
+            cql.run_async(insert_stmt, [key, payload])
+            for key in keys
+        ])
+
+        logger.info("Flushing and compacting rows before split")
+        await manager.api.flush_keyspace(server.ip_addr, ks)
+        await manager.api.keyspace_compaction(server.ip_addr, ks)
+        assert await get_tablet_count(manager, server, ks, "test") == 1
+
+        table_id = await manager.get_table_id(ks, "test")
+        host = (await wait_for_cql_and_get_hosts(cql, [server], time.time() + 30))[0]
+        logger.info("Dumping object-storage SSTable run ids before split")
+        before_run_ids = await dump_run_ids(ks, "test", cql, host, table_id)
+        assert len(set(before_run_ids)) == 1
+        assert len(before_run_ids) > 1
+
+        log = await manager.server_open_log(server.server_id)
+        mark = await log.mark()
+        await manager.api.enable_injection(server.ip_addr, "split_sstable_rewrite", one_shot=True)
+
+        logger.info("Triggering tablet split")
+        await cql.run_async(f"ALTER TABLE {ks}.test WITH tablets = {{'min_tablet_count': 2}}")
+        await manager.enable_tablet_balancing()
+
+        await manager.api.wait_for_injection_enter(server.ip_addr, "split_sstable_rewrite")
+        logger.info("Releasing split SSTable rewrite injection")
+        await manager.api.message_injection(server.ip_addr, "split_sstable_rewrite")
+        await log.wait_for("split_sstable_rewrite: released", from_mark=mark)
+
+        async def split_finished():
+            tablet_count = await get_tablet_count(manager, server, ks, "test")
+            return tablet_count if tablet_count >= 2 else None
+
+        logger.info("Waiting for split to finish")
+        await wait_for(split_finished, time.time() + 120)
+        await log.wait_for("Detected tablet split for table", from_mark=mark)
+        await wait_for_no_pending_topology_transition(manager, time.time() + 120)
+        await wait_for_no_running_compactions(manager, [server], time.time() + 120)
+
+        logger.info("Dumping object-storage SSTable run ids after split")
+        after_run_ids = await dump_run_ids(ks, "test", cql, host, table_id)
+        assert len(set(after_run_ids)) == 2
+
+        logger.info("Reading rows after split")
+        rows = await cql.run_async(SimpleStatement(f"SELECT pk, v FROM {ks}.test", consistency_level=ConsistencyLevel.ONE))
+        assert {row.pk for row in rows} == set(keys)
+        assert all(bytes(row.v) == payload for row in rows)

--- a/test/cluster/object_store/utils.py
+++ b/test/cluster/object_store/utils.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import json
+import logging
+import os
+import re
+import subprocess
+import tempfile
+import time
+import uuid
+
+from cassandra.query import SimpleStatement, ConsistencyLevel
+
+from test.cluster.util import wait_for_cql_and_get_hosts, wait_for_no_pending_topology_transition, wait_for_no_running_compactions
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+
+def verify_uuid_sstable_generation(generation: str) -> None:
+    match = re.fullmatch(r"([0-9a-z]{4})_([0-9a-z]{4})_([0-9a-z]{5})([0-9a-z]{13})", generation)
+    assert match is not None
+    assert int(match.group(2), 36) < 24 * 60 * 60
+    assert int(match.group(3), 36) < 10_000_000
+    assert int(match.group(4), 36) < 1 << 64
+
+
+def encode_base36(value: int) -> str:
+    digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+    if value == 0:
+        return "0"
+    result = ""
+    while value:
+        value, digit = divmod(value, 36)
+        result = digits[digit] + result
+    return result
+
+
+def encode_uuid_sstable_generation(generation_uuid: uuid.UUID) -> str:
+    seconds, decimicroseconds = divmod(generation_uuid.time, 10_000_000)
+    days, seconds = divmod(seconds, 24 * 60 * 60)
+    lsb = generation_uuid.int & ((1 << 64) - 1)
+    generation = f"{encode_base36(days):0>4}_{encode_base36(seconds):0>4}_{encode_base36(decimicroseconds):0>5}{encode_base36(lsb):0>13}"
+    verify_uuid_sstable_generation(generation)
+    return generation
+
+
+def parse_node_reference(reference: str) -> tuple[str, str]:
+    parts = reference.split("/")
+    assert len(parts) == 3
+    assert parts[0] == "nodes"
+    host_id = str(uuid.UUID(parts[1]))
+    generation = parts[2]
+    verify_uuid_sstable_generation(generation)
+    return host_id, generation
+
+
+async def get_object_storage_refs(manager: ManagerClient, object_storage, server):
+    params = {
+        "endpoint": object_storage.address,
+        "bucket": object_storage.bucket_name,
+    }
+    sstables = await manager.api.client.get_json("/storage_service/object_storage/sstables", host=server.ip_addr, params=params)
+    assert sstables
+    refs = {}
+    for sstable in sstables:
+        sstable_id = str(uuid.UUID(sstable["sstable_id"]))
+        references = sstable.get("references", [])
+        assert sstable["num_references"] == len(references)
+        if not references:
+            logger.info("Ignoring object-storage SSTable %s with no references", sstable_id)
+            continue
+        for reference in references:
+            host_id, generation = parse_node_reference(reference)
+            key = (sstable_id, host_id, generation)
+            assert key not in refs
+            refs[key] = reference
+    return sstables, refs
+
+
+async def get_node_registry_refs(cql, host, table_id: str):
+    rows = await cql.run_async("SELECT table_id, node_owner, generation, sstable_id, status FROM system.sstables", host=host)
+    refs = {}
+    for row in rows:
+        if str(row.table_id) != table_id:
+            continue
+        if row.status != "sealed":
+            continue
+        sstable_id = str(row.sstable_id if row.sstable_id is not None else row.generation)
+        generation = encode_uuid_sstable_generation(row.generation)
+        key = (sstable_id, str(row.node_owner), generation)
+        assert key not in refs
+        refs[key] = row.status
+    return refs
+
+
+async def verify_object_storage_namespace(manager: ManagerClient, object_storage, cql, server, live_servers, ks: str, table: str = "test") -> None:
+    """Verify object-storage namespace layout and reference counts through REST API and system.sstables."""
+    await manager.disable_tablet_balancing()
+    await wait_for_no_pending_topology_transition(manager, time.time() + 120)
+    try:
+        for node in live_servers:
+            await manager.api.disable_autocompaction(node.ip_addr, ks, table)
+
+        await wait_for_no_running_compactions(manager, live_servers, time.time() + 120)
+
+        for node in live_servers:
+            await manager.api.flush_keyspace(node.ip_addr, ks)
+
+        table_id = str(await manager.get_table_id(ks, table))
+        live_hosts = await wait_for_cql_and_get_hosts(cql, live_servers, time.time() + 30)
+
+        async def get_registry_refs():
+            registry_refs = {}
+            for refs in await asyncio.gather(*(get_node_registry_refs(cql, host, table_id) for host in live_hosts)):
+                for key, status in refs.items():
+                    assert key not in registry_refs
+                    registry_refs[key] = status
+            return registry_refs
+
+        sstables, object_storage_refs = await get_object_storage_refs(manager, object_storage, server)
+        registry_refs = await get_registry_refs()
+        assert object_storage_refs.keys() == registry_refs.keys(), f"Only in object_storage: {object_storage_refs.keys() - registry_refs.keys()}\nOnly in registry: {registry_refs.keys() - object_storage_refs.keys()}"
+        logger.info("Verified %d object-storage SSTables and %d references", len(sstables), len(object_storage_refs))
+    finally:
+        for node in live_servers:
+            await manager.api.enable_autocompaction(node.ip_addr, ks, table)
+        await manager.enable_tablet_balancing()
+
+
+async def get_sealed_sstable_registry_rows(cql, host, table_id):
+    rows = await cql.run_async(
+        SimpleStatement(
+            "SELECT generation, sstable_id, version, format, status FROM system.sstables WHERE table_id = %s ALLOW FILTERING",
+            consistency_level=ConsistencyLevel.ONE),
+        parameters=[table_id], host=host)
+    return [row for row in rows if row.status == "sealed"]
+
+
+async def dump_object_storage_sstable_metadata(manager: ManagerClient, object_storage, server, ks: str, table: str, rows, schema_cql: str):
+    """Dump Scylla metadata for object-storage SSTables through scylla-sstable."""
+    scylla_path = await manager.server_get_exe(server.server_id)
+    workdir = await manager.server_get_workdir(server.server_id)
+    scylla_yaml = os.path.join(workdir, "conf", "scylla.yaml")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        schema_file = os.path.join(tmpdir, "schema.cql")
+        with open(schema_file, "w") as f:
+            f.write(schema_cql)
+
+        data_fqns = [
+            f"{object_storage.type.lower()}://{object_storage.bucket_name}/sstables/{row.sstable_id}/Data.db"
+            for row in rows
+        ]
+        out = subprocess.check_output([
+            scylla_path,
+            "sstable",
+            "dump-scylla-metadata",
+            "--scylla-yaml-file", scylla_yaml,
+            "--schema-file", schema_file,
+            *data_fqns,
+        ])
+        metadata = json.loads(out)["sstables"]
+
+    return metadata

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -43,6 +43,7 @@
 #include "sstables/sstables_manager.hh"
 #include "sstables/sstable_directory.hh"
 #include "sstables/open_info.hh"
+#include "sstables/object_storage_client.hh"
 #include "release.hh"
 #include "replica/schema_describe_helper.hh"
 #include "test/lib/cql_test_env.hh"
@@ -342,16 +343,12 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
         }
 
 
-        data_dictionary::storage_options options;
-        auto ed_result = sstables::parse_path(sst_path, schema->ks_name(), schema->cf_name());
-        if (!ed_result) {
-            sstables::throw_malformed_sstable_exception(ed_result.error());
-        }
-        auto ed = std::move(*ed_result);
-
         using osp = db::object_storage_endpoint_param;
         static const auto os_types = { osp::s3_type, osp::gs_type };
         auto is_fqn = os_types | std::views::filter(std::bind_front(&data_dictionary::is_object_storage_fqn, sst_path));
+
+        data_dictionary::storage_options options;
+        std::optional<sstables::entry_descriptor> ed;
 
         if (!is_fqn.empty()) {
             auto type = is_fqn.front();
@@ -364,13 +361,54 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
                 ));
             }
             auto endpoint = endpoints.front();
-            options = data_dictionary::make_object_storage_options(endpoint, sst_path);
+
+            auto ed_result = sstables::parse_path(sst_path, schema->ks_name(), schema->cf_name());
+            if (ed_result) {
+                options = data_dictionary::make_object_storage_options(endpoint, sst_path);
+                ed = std::move(*ed_result);
+            } else {
+                std::string bucket;
+                std::string object;
+                if (!data_dictionary::object_storage_fqn_to_parts(sst_path, type, bucket, object)) {
+                    sstables::throw_malformed_sstable_exception(ed_result.error());
+                }
+                auto object_path = std::filesystem::path(object).lexically_normal();
+                auto component = object_path.filename().string();
+                auto parent = object_path.parent_path();
+                auto sid_str = parent.filename().string();
+                if (parent.parent_path().filename() != "sstables") {
+                    sstables::throw_malformed_sstable_exception(ed_result.error());
+                }
+                options = data_dictionary::make_live_object_storage_options(endpoint, type, bucket);
+
+                auto toc_object = parent / "TOC.txt";
+                auto metadata = co_await sstm.get_endpoint_client(endpoint)->get_object_metadata(sstables::object_name(bucket, toc_object.string()));
+                auto version_it = metadata.attributes.find(sstring(sstables::object_storage_sstable_version_attribute));
+                auto format_it = metadata.attributes.find(sstring(sstables::object_storage_sstable_format_attribute));
+                if (version_it == metadata.attributes.end() || format_it == metadata.attributes.end()) {
+                    throw std::invalid_argument(fmt::format(
+                        "Unable to open live object-storage SSTable component {}: missing {} or {} object attribute on TOC.txt",
+                        sst_name,
+                        sstables::object_storage_sstable_version_attribute,
+                        sstables::object_storage_sstable_format_attribute));
+                }
+                auto version = sstables::version_from_string(version_it->second);
+                auto format = sstables::format_from_string(format_it->second);
+                auto sid_uuid = utils::UUID(std::string_view(sid_str));
+                ed = sstables::entry_descriptor(sstables::generation_type(sid_uuid), sstables::sstable_id(sid_uuid),
+                        version, format, sstables::sstable::component_from_sstring(version, component));
+            }
         } else {
+            auto ed_result = sstables::parse_path(sst_path, schema->ks_name(), schema->cf_name());
+            if (!ed_result) {
+                sstables::throw_malformed_sstable_exception(ed_result.error());
+            }
+            ed = std::move(*ed_result);
             sst_path = std::filesystem::canonical(std::filesystem::path(sst_name));
             const auto dir_path = sst_path.parent_path();
             options = data_dictionary::make_local_options(dir_path);
         }
-        auto sst = sst_man.make_sstable(schema, options, ed.generation, ed.sid, sstables::sstable_state::normal, ed.version, ed.format);
+        auto sst = sst_man.make_sstable(schema, options, ed->generation, ed->sid, sstables::sstable_state::normal, ed->version, ed->format);
 
         try {
             auto open_cfg = sstables::sstable_open_config{

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -1156,6 +1156,14 @@ static utils::gcp::storage::object_info create_info(const rjson::value& item) {
     info.size = std::stoull(rjson::get<std::string>(item, "size"));
     info.generation = std::stoull(rjson::get<std::string>(item, "generation"));
     info.modified = parse_rfc3339(rjson::get<std::string>(item, "updated"));
+    if (auto metadata = rjson::find(item, "metadata")) {
+        if (!metadata->IsObject()) {
+            throw utils::gcp::storage::failed_operation("Malformed object metadata");
+        }
+        for (const auto& member : metadata->GetObject()) {
+            info.metadata.emplace(member.name.GetString(), rjson::to_string(member.value));
+        }
+    }
 
     return info;
 }
@@ -1275,7 +1283,7 @@ future<> utils::gcp::storage::client::delete_object(std::string_view bucket_in, 
 // See https://cloud.google.com/storage/docs/copying-renaming-moving-objects
 // GCP does not support moveTo across buckets.
 future<> utils::gcp::storage::client::rename_object(std::string_view bucket, std::string_view object_name, std::string_view new_bucket, std::string_view new_name, seastar::abort_source* as) {
-    co_await copy_object(bucket, object_name, new_bucket, new_name, as);
+    co_await copy_object(bucket, object_name, new_bucket, new_name, {}, as);
     co_await delete_object(bucket, object_name, as);
 }
 
@@ -1314,7 +1322,7 @@ future<> utils::gcp::storage::client::rename_object(std::string_view bucket_in, 
 // See https://cloud.google.com/storage/docs/copying-renaming-moving-objects
 // Copying an object in GCP can only process a certain amount of data in one call
 // Must keep doing it until all data is copied, and check response.
-future<> utils::gcp::storage::client::copy_object(std::string_view bucket_in, std::string_view object_name_in, std::string_view new_bucket_in, std::string_view to_name_in, seastar::abort_source* as) {
+future<> utils::gcp::storage::client::copy_object(std::string_view bucket_in, std::string_view object_name_in, std::string_view new_bucket_in, std::string_view to_name_in, rjson::value metadata, seastar::abort_source* as) {
     std::string bucket(bucket_in), object_name(object_name_in), new_bucket(new_bucket_in), to_name(to_name_in);
 
     auto path = fmt::format("/storage/v1/b/{}/o/{}/rewriteTo/b/{}/o/{}"
@@ -1323,7 +1331,7 @@ future<> utils::gcp::storage::client::copy_object(std::string_view bucket_in, st
         , new_bucket
         , seastar::http::internal::url_encode(to_name)
     );
-    std::string body = "{}";
+    std::string body = metadata.IsObject() ? rjson::print(metadata) : "{}";
 
     for (;;) {
         auto res = co_await _impl->send_with_retry(path
@@ -1352,7 +1360,9 @@ future<> utils::gcp::storage::client::copy_object(std::string_view bucket_in, st
         auto size = rjson::get<uint64_t>(resp, "objectSize");
 
         // Call 2+ must include the rewriteToken
-        body = fmt::format("{{\"rewriteToken\": \"{}\"}}", token);
+        rjson::value rewrite_request = metadata.IsObject() ? rjson::copy(metadata) : rjson::empty_object();
+        rjson::add(rewrite_request, "rewriteToken", token);
+        body = rjson::print(rewrite_request);
 
         gcp_storage.debug("Partial copy of {}:{} to {}:{} ({}/{})", bucket, object_name, new_bucket, to_name, written, size);
     }
@@ -1398,8 +1408,8 @@ future<utils::gcp::storage::object_info> utils::gcp::storage::client::merge_obje
     co_return create_info(resp);
 }
 
-future<> utils::gcp::storage::client::copy_object(std::string_view bucket, std::string_view object_name, std::string_view to_name, seastar::abort_source* as) {
-    co_await copy_object(bucket, object_name, bucket, to_name, as);
+future<> utils::gcp::storage::client::copy_object(std::string_view bucket, std::string_view object_name, std::string_view to_name, rjson::value metadata, seastar::abort_source* as) {
+    co_await copy_object(bucket, object_name, bucket, to_name, std::move(metadata), as);
 }
 
 seastar::data_sink utils::gcp::storage::client::create_upload_sink(std::string_view bucket, std::string_view object_name, rjson::value metadata, seastar::abort_source* as) const {
@@ -1432,6 +1442,19 @@ future<bool> storage::client::object_exists(std::string_view bucket, std::string
         throw;
     }
     co_return true;
+}
+
+future<utils::gcp::storage::object_info> storage::client::get_object_info(std::string_view bucket_in, std::string_view object_name_in, seastar::abort_source* as) const {
+    std::string bucket(bucket_in), object_name(object_name_in);
+    gcp_storage.debug("Get object metadata {}:{}", bucket, object_name);
+
+    auto path = fmt::format("/storage/v1/b/{}/o/{}", bucket, seastar::http::internal::url_encode(object_name));
+    auto res = co_await _impl->send_with_retry(path, GCP_OBJECT_SCOPE_READ_ONLY, ""s, ""s, httpclient::method_type::GET, {}, as);
+    if (res.result() != status_type::ok) {
+        throw failed_operation(
+            fmt::format("Could not retrieve object metadata {}:{}: {} ({})", bucket, object_name, res.result(), get_gcp_error_message(res.body())));
+    }
+    co_return create_info(rjson::parse(res.body()));
 }
 
 future<> utils::gcp::storage::client::close() {

--- a/utils/gcp/object_storage.hh
+++ b/utils/gcp/object_storage.hh
@@ -12,6 +12,7 @@
 #include <string>
 #include <chrono>
 #include <functional>
+#include <unordered_map>
 
 #include <seastar/core/file.hh>
 #include <seastar/core/future.hh>
@@ -42,6 +43,7 @@ namespace utils::gcp::storage {
         uint64_t size;
         uint64_t generation;
         std::chrono::system_clock::time_point modified;
+        std::unordered_map<std::string, std::string> metadata;
         // TODO: what info do we need?
     };
 
@@ -134,11 +136,11 @@ namespace utils::gcp::storage {
         /**
          * Copies a named object to @new_name
          */
-        future<> copy_object(std::string_view bucket, std::string_view object_name, std::string_view to_name, seastar::abort_source* = nullptr);
+        future<> copy_object(std::string_view bucket, std::string_view object_name, std::string_view to_name, rjson::value metadata = {}, seastar::abort_source* = nullptr);
         /**
          * Copies a named object to @new_bucket and @new_name
          */
-        future<> copy_object(std::string_view bucket, std::string_view object_name, std::string_view new_bucket, std::string_view to_name, seastar::abort_source* = nullptr);
+        future<> copy_object(std::string_view bucket, std::string_view object_name, std::string_view new_bucket, std::string_view to_name, rjson::value metadata = {}, seastar::abort_source* = nullptr);
 
         /**
          * Merges sub-objects into a new destination. Actual file will be composed in order of subobject in `source_object`.
@@ -172,6 +174,10 @@ namespace utils::gcp::storage {
          * Checks if an object exists.
          */
         future<bool> object_exists(std::string_view bucket, std::string_view object_name, seastar::abort_source* as = nullptr) const;
+        /**
+         * Retrieves object metadata.
+         */
+        future<object_info> get_object_info(std::string_view bucket, std::string_view object_name, seastar::abort_source* as = nullptr) const;
         /**
          * Destroys resources. Must be called before releasing object
          */

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -8,6 +8,7 @@
 
 #include <fmt/format.h>
 #include <exception>
+#include <cctype>
 #include <initializer_list>
 #include <memory>
 #include <numeric>
@@ -566,6 +567,36 @@ future<stats> client::get_object_stats(sstring object_name, seastar::abort_sourc
     co_return st;
 }
 
+static constexpr std::string_view object_metadata_header_prefix = "x-amz-meta-";
+
+static void add_object_metadata_headers(http::request& req, const object_metadata& metadata) {
+    for (const auto& [key, value] : metadata) {
+        req._headers[fmt::format("{}{}", object_metadata_header_prefix, key)] = value;
+    }
+}
+
+static bool has_object_metadata_header_prefix(std::string_view name) {
+    return name.size() >= object_metadata_header_prefix.size()
+            && std::equal(object_metadata_header_prefix.begin(), object_metadata_header_prefix.end(), name.begin(), [] (char lhs, char rhs) {
+                return std::tolower(lhs) == std::tolower(rhs);
+            });
+}
+
+future<object_info> client::get_object_info(sstring object_name, seastar::abort_source* as) {
+    object_info info;
+    co_await get_object_header(std::move(object_name), [&info] (const http::reply& rep, input_stream<char>&& in_) mutable -> future<> {
+        for (const auto& [name, value] : rep._headers) {
+            if (has_object_metadata_header_prefix(name)) {
+                auto key = name.substr(object_metadata_header_prefix.size());
+                std::ranges::transform(key, key.begin(), [] (unsigned char c) { return std::tolower(c); });
+                info.metadata.emplace(std::move(key), value);
+            }
+        }
+        return make_ready_future<>();
+    }, as);
+    co_return info;
+}
+
 future<bool> client::object_exists(sstring object_name, seastar::abort_source* as) {
     try {
         co_await get_object_header(object_name, ignore_reply, as);
@@ -713,9 +744,10 @@ future<temporary_buffer<char>> client::get_object_contiguous(sstring object_name
     co_return std::move(*ret);
 }
 
-future<> client::put_object(sstring object_name, temporary_buffer<char> buf, seastar::abort_source* as) {
+future<> client::put_object(sstring object_name, temporary_buffer<char> buf, object_metadata metadata, seastar::abort_source* as) {
     s3l.trace("PUT {}", object_name);
     auto req = http::request::make("PUT", _host, object_name);
+    add_object_metadata_headers(req, metadata);
     auto len = buf.size();
     req.write_body("bin", len, [buf = std::move(buf)] (output_stream<char>&& out_) -> future<> {
         auto out = std::move(out_);
@@ -737,9 +769,10 @@ future<> client::put_object(sstring object_name, temporary_buffer<char> buf, sea
     }, http::reply::status_type::ok, as);
 }
 
-future<> client::put_object(sstring object_name, ::memory_data_sink_buffers bufs, seastar::abort_source* as) {
+future<> client::put_object(sstring object_name, ::memory_data_sink_buffers bufs, object_metadata metadata, seastar::abort_source* as) {
     s3l.trace("PUT {} (buffers)", object_name);
     auto req = http::request::make("PUT", _host, object_name);
+    add_object_metadata_headers(req, metadata);
     auto len = bufs.size();
     req.write_body("bin", len, [bufs = std::move(bufs)] (output_stream<char>&& out_) -> future<> {
         auto out = std::move(out_);
@@ -858,6 +891,7 @@ protected:
     utils::chunked_vector<sstring> _part_etags;
     named_gate _bg_flushes;
     std::optional<tag> _tag;
+    object_metadata _metadata;
     seastar::abort_source* _as;
 
     future<> start_upload();
@@ -870,11 +904,12 @@ protected:
         return !_upload_id.empty();
     }
 
-    multipart_upload(shared_ptr<client> cln, sstring object_name, std::optional<tag> tag, seastar::abort_source* as)
+    multipart_upload(shared_ptr<client> cln, sstring object_name, std::optional<tag> tag, object_metadata metadata, seastar::abort_source* as)
         : _client(std::move(cln))
         , _object_name(std::move(object_name))
         , _bg_flushes("s3::client::multipart_upload::bg_flushes")
         , _tag(std::move(tag))
+        , _metadata(std::move(metadata))
         , _as(as)
     {
     }
@@ -885,15 +920,15 @@ public:
 
 class client::copy_s3_object final : multipart_upload {
 public:
-    copy_s3_object(shared_ptr<client> cln, sstring source_object, sstring target_object, size_t part_size, std::optional<tag> tag, abort_source* as)
-        : multipart_upload(std::move(cln), std::move(target_object), std::move(tag), as)
+    copy_s3_object(shared_ptr<client> cln, sstring source_object, sstring target_object, object_metadata metadata, size_t part_size, std::optional<tag> tag, abort_source* as)
+        : multipart_upload(std::move(cln), std::move(target_object), std::move(tag), std::move(metadata), as)
         , _max_copy_part_size(part_size)
         , _source_object(std::move(source_object)) {
         assert(_max_copy_part_size > 0 && _max_copy_part_size <= _default_copy_part_size);
     }
 
-    copy_s3_object(shared_ptr<client> cln, sstring source_object, sstring target_object, std::optional<tag> tag, abort_source* as)
-        : copy_s3_object(std::move(cln), std::move(source_object), std::move(target_object), _default_copy_part_size, std::move(tag), as) {}
+    copy_s3_object(shared_ptr<client> cln, sstring source_object, sstring target_object, object_metadata metadata, std::optional<tag> tag, abort_source* as)
+        : copy_s3_object(std::move(cln), std::move(source_object), std::move(target_object), std::move(metadata), _default_copy_part_size, std::move(tag), as) {}
 
     future<> copy() {
         auto source_size = co_await _client->get_object_size(_source_object);
@@ -911,6 +946,10 @@ private:
             req._headers["x-amz-tagging"] = seastar::format("{}={}", _tag->key, _tag->value);
         }
         req._headers["x-amz-copy-source"] = _source_object;
+        if (!_metadata.empty()) {
+            req._headers["x-amz-metadata-directive"] = "REPLACE";
+            add_object_metadata_headers(req, _metadata);
+        }
 
         co_await _client->make_request(std::move(req), ignore_reply, http::reply::status_type::ok, _as);
     }
@@ -978,16 +1017,16 @@ private:
     sstring _source_object;
 };
 
-future<> client::copy_object(sstring source_object, sstring target_object, std::optional<size_t> part_size, std::optional<tag> tag, seastar::abort_source* as) {
+future<> client::copy_object(sstring source_object, sstring target_object, object_metadata metadata, std::optional<size_t> part_size, std::optional<tag> tag, seastar::abort_source* as) {
     if (!part_size)
-        co_return co_await copy_s3_object(shared_from_this(), std::move(source_object), std::move(target_object), tag, as).copy();
-    co_return co_await copy_s3_object(shared_from_this(), std::move(source_object), std::move(target_object), part_size.value(), tag, as).copy();
+        co_return co_await copy_s3_object(shared_from_this(), std::move(source_object), std::move(target_object), std::move(metadata), tag, as).copy();
+    co_return co_await copy_s3_object(shared_from_this(), std::move(source_object), std::move(target_object), std::move(metadata), part_size.value(), tag, as).copy();
 }
 
 class client::upload_sink_base : public multipart_upload, public data_sink_impl {
 public:
-    upload_sink_base(shared_ptr<client> cln, sstring object_name, std::optional<tag> tag, seastar::abort_source* as)
-        : multipart_upload(std::move(cln), std::move(object_name), std::move(tag), as)
+    upload_sink_base(shared_ptr<client> cln, sstring object_name, std::optional<tag> tag, object_metadata metadata, seastar::abort_source* as)
+        : multipart_upload(std::move(cln), std::move(object_name), std::move(tag), std::move(metadata), as)
     {
     }
 
@@ -1071,6 +1110,7 @@ future<> client::multipart_upload::start_upload() {
     if (_tag) {
         rep._headers["x-amz-tagging"] = seastar::format("{}={}", _tag->key, _tag->value);
     }
+    add_object_metadata_headers(rep, _metadata);
     co_await _client->make_request(std::move(rep), [this] (const http::reply& rep, input_stream<char>&& in_) -> future<> {
         auto in = std::move(in_);
         auto body = co_await util::read_entire_stream_contiguous(in);
@@ -1218,8 +1258,8 @@ class client::upload_sink final : public client::upload_sink_base {
     }
 
 public:
-    upload_sink(shared_ptr<client> cln, sstring object_name, std::optional<tag> tag = {}, seastar::abort_source* as = nullptr)
-        : upload_sink_base(std::move(cln), std::move(object_name), std::move(tag), as)
+    upload_sink(shared_ptr<client> cln, sstring object_name, std::optional<tag> tag = {}, object_metadata metadata = {}, seastar::abort_source* as = nullptr)
+        : upload_sink_base(std::move(cln), std::move(object_name), std::move(tag), std::move(metadata), as)
     {}
 
     virtual future<> put(std::span<temporary_buffer<char>> data) override {
@@ -1233,7 +1273,7 @@ public:
             // upload happen in one REST call, instead of three (create + PUT + wrap-up)
             if (!upload_started()) {
                 s3l.trace("Sink fallback to plain PUT for {}", _object_name);
-                co_return co_await _client->put_object(_object_name, std::move(_bufs));
+                co_return co_await _client->put_object(_object_name, std::move(_bufs), std::move(_metadata));
             }
 
             co_await upload_part(std::move(_bufs));
@@ -1318,8 +1358,8 @@ class client::upload_jumbo_sink final : public upload_sink_base {
     }
 
 public:
-    upload_jumbo_sink(shared_ptr<client> cln, sstring object_name, std::optional<unsigned> max_parts_per_piece, seastar::abort_source* as)
-        : upload_sink_base(std::move(cln), std::move(object_name), std::nullopt, as)
+    upload_jumbo_sink(shared_ptr<client> cln, sstring object_name, std::optional<unsigned> max_parts_per_piece, object_metadata metadata, seastar::abort_source* as)
+        : upload_sink_base(std::move(cln), std::move(object_name), std::nullopt, std::move(metadata), as)
         , _maximum_parts_in_piece(max_parts_per_piece.value_or(maximum_parts_in_piece))
         , _current(std::make_unique<upload_sink>(_client, format("{}_{}", _object_name, parts_count()), piece_tag))
     {}
@@ -1356,12 +1396,12 @@ public:
     }
 };
 
-data_sink client::make_upload_sink(sstring object_name, seastar::abort_source* as) {
-    return data_sink(std::make_unique<upload_sink>(shared_from_this(), std::move(object_name), std::nullopt, as));
+data_sink client::make_upload_sink(sstring object_name, object_metadata metadata, seastar::abort_source* as) {
+    return data_sink(std::make_unique<upload_sink>(shared_from_this(), std::move(object_name), std::nullopt, std::move(metadata), as));
 }
 
-data_sink client::make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece, seastar::abort_source* as) {
-    return data_sink(std::make_unique<upload_jumbo_sink>(shared_from_this(), std::move(object_name), max_parts_per_piece, as));
+data_sink client::make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece, object_metadata metadata, seastar::abort_source* as) {
+    return data_sink(std::make_unique<upload_jumbo_sink>(shared_from_this(), std::move(object_name), max_parts_per_piece, std::move(metadata), as));
 }
 
 class client::chunked_download_source final : public seastar::data_source_impl {
@@ -1786,7 +1826,7 @@ public:
                    size_t part_size,
                    upload_progress& up,
                    seastar::abort_source* as)
-        : multipart_upload(std::move(cln), std::move(object_name), std::move(tag), as)
+        : multipart_upload(std::move(cln), std::move(object_name), std::move(tag), {}, as)
         , _path{std::move(path)}
         , _part_size(part_size)
         , _progress(up)

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -17,6 +17,7 @@
 #include <seastar/core/units.hh>
 #include <seastar/http/client.hh>
 #include <filesystem>
+#include <unordered_map>
 #include "utils/lister.hh"
 #include "utils/s3/creds.hh"
 #include "credentials_providers/aws_credentials_provider_chain.hh"
@@ -83,6 +84,12 @@ public:
 private:
     uint64_t _offset;
     uint64_t _length{maximum_object_size};
+};
+
+using object_metadata = std::unordered_map<sstring, sstring>;
+
+struct object_info {
+    object_metadata metadata;
 };
 static constexpr range full_range{0};
 
@@ -184,22 +191,23 @@ public:
 
     future<uint64_t> get_object_size(sstring object_name, seastar::abort_source* = nullptr);
     future<stats> get_object_stats(sstring object_name, seastar::abort_source* = nullptr);
+    future<object_info> get_object_info(sstring object_name, seastar::abort_source* = nullptr);
     future<bool> object_exists(sstring object_name, seastar::abort_source* = nullptr);
     future<tag_set> get_object_tagging(sstring object_name, seastar::abort_source* = nullptr);
     future<> put_object_tagging(sstring object_name, tag_set tagging, seastar::abort_source* = nullptr);
     future<> delete_object_tagging(sstring object_name, seastar::abort_source* = nullptr);
     future<temporary_buffer<char>> get_object_contiguous(sstring object_name, range download_range = s3::full_range, seastar::abort_source* = nullptr);
-    future<> put_object(sstring object_name, temporary_buffer<char> buf, seastar::abort_source* = nullptr);
-    future<> put_object(sstring object_name, ::memory_data_sink_buffers bufs, seastar::abort_source* = nullptr);
-    future<> copy_object(sstring source_object, sstring target_object, std::optional<size_t> part_size = {}, std::optional<tag> tag = {}, seastar::abort_source* = nullptr);
+    future<> put_object(sstring object_name, temporary_buffer<char> buf, object_metadata = {}, seastar::abort_source* = nullptr);
+    future<> put_object(sstring object_name, ::memory_data_sink_buffers bufs, object_metadata = {}, seastar::abort_source* = nullptr);
+    future<> copy_object(sstring source_object, sstring target_object, object_metadata = {}, std::optional<size_t> part_size = {}, std::optional<tag> tag = {}, seastar::abort_source* = nullptr);
     future<> delete_object(sstring object_name, seastar::abort_source* = nullptr);
     future<> create_bucket(sstring bucket_name, seastar::abort_source* = nullptr);
     future<> delete_bucket(sstring bucket_name, seastar::abort_source* = nullptr);
     future<> delete_bucket_with_objects(sstring bucket_name, seastar::abort_source* = nullptr);
 
     file make_readable_file(sstring object_name, seastar::abort_source* = nullptr);
-    data_sink make_upload_sink(sstring object_name, seastar::abort_source* = nullptr);
-    data_sink make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece = {}, seastar::abort_source* = nullptr);
+    data_sink make_upload_sink(sstring object_name, object_metadata = {}, seastar::abort_source* = nullptr);
+    data_sink make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece = {}, object_metadata = {}, seastar::abort_source* = nullptr);
     data_source make_download_source(sstring object_name, range download_range = s3::full_range, seastar::abort_source* = nullptr);
     data_source make_chunked_download_source(sstring object_name, range range = s3::full_range, seastar::abort_source* = nullptr);
     /// upload a file with specified path to s3


### PR DESCRIPTION
Incremental compaction groups SSTables into runs of non-overlapping token ranges. Split compaction used to keep the original run id for SSTables that bypassed data rewrite, while the SSTable that actually crossed the split token was rewritten as a separate output run. That preserves some original run ids, but it breaks the original run structure inside each post-split compaction group.

For example, an input run [A0, A1, A2, A3, A4] split at A2 could produce two runs on the left side, [A0, A1] and [A2.left], and two runs on the right side, [A2.right] and [A3, A4]. This disturbs the size-based tiers in the split compaction groups because the split output SSTable can be mixed with smaller SSTable-runs instead of staying with the fragments from its original run.

Make split compaction preserve the run structure rather than the original run id itself: assign one output run id per input run per split side, rewrite crossing SSTables with the side-specific run id, and use component rewrite to update bypassed fragments. A single split input run now yields at most one run in each resulting compaction group, e.g. [A0, A1, A2.left] on the left and [A2.right, A3, A4] on the right.

The side-specific run ids are derived deterministically from the original run id and split side, so a stopped split compaction can be retried without assigning different run ids to already-rewritten and newly-rewritten fragments of the same side.

The object-storage regression verifies persisted Scylla metadata directly from live object-storage SSTables.

Refs https://scylladb.atlassian.net/browse/SCYLLADB-2560

--

* There is currently no indication that this improvement is required in the field, so no backport needed.