### PR TITLE
test/cluster/dtest: stabilize compact counter cluster teardown

### DIFF
--- a/test/cluster/dtest/counter_test.py
+++ b/test/cluster/dtest/counter_test.py
@@ -55,6 +55,7 @@ class TestCounters(Tester):
             r"Startup failed: seastar::rpc::closed_error",
             r"raft::transport_error.*connection is closed",
             r"CDC generation publisher fiber got error",
+            r"raft - apply_snapshot\[[0-9a-f-]+\] failed with std::runtime_error \(Snapshot application aborted\)",
         ]
 
     def test_simple_increment(self):
@@ -614,7 +615,7 @@ class TestCounters(Tester):
                 "enable_create_table_with_compact_storage": True,
             }
         )
-        cluster.populate(3).start()
+        cluster.populate(3).start(wait_for_binary_proto=True)
         node1 = cluster.nodelist()[0]
         session = self.patient_cql_connection(node1)
         create_ks(session, "counter_tests", 1)


### PR DESCRIPTION
test_compact_counter_cluster starts three nodes, but previously did not wait for their CQL endpoints to become ready. Since the test completes quickly, some nodes could still be joining the cluster and applying a group 0 snapshot when teardown begins.

Waiting for the binary protocol adds a synchronization point that ensures all three nodes have reached CQL readiness before the test proceeds.

Also allow the expected "Snapshot application aborted" shutdown message for this test file, so a legitimate snapshot abort during teardown does not fail the test.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3402

backport - none test improvment