### PR TITLE
view_update_generator: fix drain and destruction order

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -118,7 +118,6 @@ future<> view_update_generator::start() {
                     _sstables_to_move.size(), _sstables_with_tables.size());
             _sstables_to_move.clear();
             _sstables_with_tables.clear();
-            _progress_tracker = {};
         });
         while (!_as.abort_requested()) {
             if (_sstables_with_tables.empty()) {
@@ -302,7 +301,9 @@ future<> view_update_generator::drain() {
 future<> view_update_generator::stop() {
     _db.unplug_view_update_generator();
     do_abort();
+    co_await drain();
     co_await std::exchange(_started, make_ready_future<>());
+    _progress_tracker = {};
     _registration_sem.broken();
 }
 

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -733,9 +733,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_stop_during_process_staging_
             return utils::get_local_injector().waiters(injection) > 0;
         });
 
-        auto stop = view_update_generator.drain().then([&] {
-            return view_update_generator.stop();
-        });
+        auto stop = view_update_generator.stop();
         utils::get_local_injector().receive_message(injection);
 
         stop.get();


### PR DESCRIPTION
In b6323163c4 we fixed an issue in the view_update_generator shutdown procedure where _progress_tracker could be accessed by external callers in process_staging_sstables after it's been destroyed. The admission of external calls and the access to _progress_tracker is now protected by the gate in view_update_generator, which is closed in drain().

This would have fixed the issue under the assumption that shutdown goes as follows:
1. call view_update_generator::drain() - close the gate
2. call view_update_generator::stop() - calls do_abort() to abort the vug fiber and destroy _progress_tracker and wait for the fiber to complete.

Unfortunately, this assumption could break in multiple ways:
* the view_update_generator subscribes to the global stop_signal, and when signaled it calls do_abort() - this aborts the vug fiber and destroys _progress_tracker outside the normal shutdown order. This means it's possible that the gate is not closed yet when _progress_tracker is destroyed.
* if stop() is called without calling drain() first, this will similarly abort the vug fiber and _progress_tracker without waiting for the gate to close.

We fix it by making the view_update_generator shutdown and destruction more robust against misuse:
* We destroy the _progress_tracker only in stop() after the gate is closed. This ensures the access to it is protected by the gate as intended. The vug fiber can still be aborted early, but it should be safe to do.
* in stop() we call drain() to ensure the gate is closed before destroying the _progress_tracker. The intention is to make stop() more robust against misuse, so we don't have to assume the caller has called drain() before calling stop().
* change the unit test that tests this race to call only stop() without drain() - this only makes the test more general, and it reproduces the described issue before this fix, and verifies the fix.

Fixes SCYLLADB-3415

backport - fixes segfault during shutdown.