### PR TITLE
build: fix dist package lists for removed node_exporter subpackage

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -3056,16 +3056,16 @@ def write_build_file(f,
     for mode in build_modes:
         server_rpms_dir = f'$builddir/dist/{mode}/redhat/RPMS/{arch}'
         server_rpms = [f'{server_rpms_dir}/{scylla_product}{suffix}-{rpm_ver}.{arch}.rpm'
-                       for suffix in ['', '-server', '-server-debuginfo', '-conf', '-kernel-conf', '-node-exporter']]
+                       for suffix in ['', '-server', '-debuginfo', '-conf', '-kernel-conf']]
         cqlsh_rpms = [f'tools/cqlsh/build/redhat/RPMS/{arch}/{scylla_product}-cqlsh-{rpm_ver}.{arch}.rpm']
         python3_rpms = [f'tools/python3/build/redhat/RPMS/{arch}/{scylla_product}-python3-{rpm_ver}.{arch}.rpm']
         all_rpms = server_rpms + cqlsh_rpms + python3_rpms
 
         server_deb_dir = f'$builddir/dist/{mode}/debian'
         server_debs = [f'{server_deb_dir}/{scylla_product}{suffix}_{deb_ver}_{deb_arch}.deb'
-                       for suffix in ['', '-server', '-server-dbg', '-conf', '-kernel-conf', '-node-exporter']]
+                       for suffix in ['', '-server', '-server-dbg', '-conf', '-kernel-conf']]
         server_debs += [f'{server_deb_dir}/scylla-enterprise{suffix}_{deb_ver}_all.deb'
-                        for suffix in ['', '-server', '-conf', '-kernel-conf', '-node-exporter']]
+                        for suffix in ['', '-server', '-conf', '-kernel-conf']]
         cqlsh_debs = [f'tools/cqlsh/build/debian/{scylla_product}-cqlsh_{deb_ver}_{deb_arch}.deb',
                       f'tools/cqlsh/build/debian/scylla-enterprise-cqlsh_{deb_ver}_all.deb']
         python3_debs = [f'tools/python3/build/debian/{scylla_product}-python3_{deb_ver}_{deb_arch}.deb',


### PR DESCRIPTION
Commit 648fa8f5b1e ("dist: remove bundled node_exporter, add dependency on scylla-node-exporter") dropped the *-node-exporter subpackages but left them in configure.py's expected-package lists. The final cp step of the dist/rpm and dist/deb rules then fails trying to copy packages that are no longer produced.

Also correct the debuginfo package name: the spec sets %_debuginfo_subpackages to nil, so a single scylla-debuginfo package is produced, not scylla-server-debuginfo.

While the bug is present in 2026.3, this is just a convenience build target and isn't heavily used, so not backporting.