### PR TITLE
vint-serialization: fix overread page-crossing check for vint at end of page

### DIFF
--- a/test/boost/vint_serialization_test.cc
+++ b/test/boost/vint_serialization_test.cc
@@ -18,6 +18,9 @@
 #include <cstdint>
 #include <random>
 
+#include <sys/mman.h>
+#include <unistd.h>
+
 using namespace seastar;
 
 namespace {
@@ -136,4 +139,36 @@ BOOST_AUTO_TEST_CASE(sanity_signed_examples) {
 
 BOOST_AUTO_TEST_CASE(sanity_signed_sweep) {
     check_roundtrip_sweep<signed_vint>(100'000, random_engine());
+}
+
+// Regression test for the case where a 1-byte vint sits at the very end of a
+// mapped page and the following page is unmapped (as it would be for the last
+// page of shard memory). deserialize() reads 8 bytes past the first byte as an
+// optimization; the page-crossing guard must be anchored on the first byte (which
+// is guaranteed mapped) rather than on the byte after it. If it is anchored wrong,
+// this reads into the unmapped page and crashes with SIGSEGV.
+BOOST_AUTO_TEST_CASE(deserialize_at_end_of_mapped_page) {
+    const size_t page_size = ::sysconf(_SC_PAGESIZE);
+
+    // Map two pages worth of address space, then unmap the second page so that
+    // any access past the end of the first page faults.
+    void* base = ::mmap(nullptr, 2 * page_size, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    BOOST_REQUIRE(base != MAP_FAILED);
+    auto* bytes_ptr = static_cast<int8_t*>(base);
+
+    BOOST_REQUIRE_EQUAL(::munmap(bytes_ptr + page_size, page_size), 0);
+
+    // Place a 1-byte vint (any value in [0, 127] encodes to a single byte) at the
+    // last byte of the first, still-mapped, page. src+1 then points at the first
+    // byte of the unmapped page.
+    int8_t* last_byte = bytes_ptr + page_size - 1;
+    const uint64_t expected = 0x42;
+    const auto size = unsigned_vint::serialize(expected, last_byte);
+    BOOST_REQUIRE_EQUAL(size, 1u);
+
+    const auto deserialized = unsigned_vint::deserialize(bytes_view(last_byte, size));
+    BOOST_REQUIRE_EQUAL(deserialized, expected);
+
+    BOOST_REQUIRE_EQUAL(::munmap(base, page_size), 0);
 }

--- a/vint-serialization.cc
+++ b/vint-serialization.cc
@@ -107,7 +107,15 @@ uint64_t unsigned_vint::deserialize(bytes_view v) {
     uint64_t value;
     // If we can overread do that. It is cheaper to have a single 64-bit read and
     // then mask out the unneeded part than to do 8x 1 byte reads.
-    bool can_overread = (reinterpret_cast<uintptr_t>(src+1) ^ reinterpret_cast<uintptr_t>(src+1+sizeof(uint64_t))) < 4096;
+    //
+    // The overread reads 8 bytes starting at src+1, i.e. it touches src+1 .. src+8.
+    // Only src itself is guaranteed to point at valid (mapped) memory, so the whole
+    // read is safe only if it stays within src's page. We therefore anchor the page
+    // check on src (not src+1): if the last byte read, src+sizeof(uint64_t), shares a
+    // page with src, then src+1 .. src+8 all lie in src's (mapped) page. Anchoring on
+    // src+1 would be wrong when src is the last byte of its page, since then src+1 lies
+    // in the following page, which may be unmapped (e.g. the last page of shard memory).
+    bool can_overread = (reinterpret_cast<uintptr_t>(src) ^ reinterpret_cast<uintptr_t>(src+sizeof(uint64_t))) < 4096;
 #ifdef SEASTAR_ASAN_ENABLED
     can_overread = false;
 #endif


### PR DESCRIPTION

unsigned_vint::deserialize() reads 8 bytes past the vint's first byte as an optimization, masking off the excess afterwards. Only the first byte (src) is guaranteed to point at mapped memory, so the overread is safe only if it stays within src's page.

The page-crossing guard was anchored on src+1 rather than src. When a 1-byte vint sits at the last byte of a page, src+1 is the first byte of the next page, so src+1 and src+9 trivially share that next page and the guard passes. If that following page is unmapped -- as it is past the last page of shard memory -- the overread faults with SIGSEGV.

Anchor the check on src, the byte known to be mapped, verifying that the last overread byte (src+sizeof(uint64_t)) still lies in src's page.

Add a regression test that mmaps two pages, unmaps the second, places a 1-byte vint at the last byte of the first page and deserializes it. It crashes against the old code and passes with the fix.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3416

The bug is not present in any release branch, so a backport is not needed.