### PR TITLE
sstables: serialize component rewrite with sstable state changes

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -194,6 +194,13 @@ std::pair<stop_iteration, uint64_t> view_update_generator::generate_updates_from
     schema_ptr s = table->schema();
     uint64_t input_size = 0;
 
+    // Pause before generating (and dispatching) any view update. This is the single
+    // point covering both the legacy generator fiber (which calls this directly) and
+    // the view_building_worker path (via process_staging_sstables), both of which run
+    // us in a seastar thread.
+    utils::get_local_injector().inject("view_update_generator_pause_before_processing",
+            utils::wait_for_message(std::chrono::minutes(5))).get();
+
     // Exploit the fact that sstables in the staging directory
     // are usually non-overlapping and use a partitioned set for
     // the read.
@@ -245,9 +252,6 @@ future<> view_update_generator::process_staging_sstables(lw_shared_ptr<replica::
     auto deregister_sstables = defer([this, &sstables] noexcept {
         _progress_tracker->on_sstables_deregistration(sstables);
     });
-
-    co_await utils::get_local_injector().inject("view_update_generator_pause_before_processing",
-            utils::wait_for_message(std::chrono::minutes(5)));
 
     // Generate view updates from staging sstables
     auto start_time = db_clock::now();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1627,6 +1627,14 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
     }
 
     return seastar::async([this, creator = std::move(sstable_creator), component, modifier = std::move(modifier), update_id] {
+        // Serialize with the other on-disk mutations of this sstable (change_state(),
+        // snapshot(), pick_up_from_upload(), unlink()), which all take _mutate_sem too.
+        // Without this lock a concurrent change_state() -- e.g. the view update generator
+        // moving a staging sstable to the base directory -- can relocate this sstable's
+        // component files while we resolve their paths, hard-link them and read the Scylla
+        // component below, causing a file-not-found abort. See SCYLLADB-3263.
+        auto lock = get_units(_mutate_sem, 1).get();
+
         auto new_sst = creator(shared_from_this());
         auto generation = new_sst->generation();
 


### PR DESCRIPTION
Incremental repair of a materialized-view (or index) base table on tablets could abort a shard with a file-not-found error.

When persisting repaired_at, mark_sstable_as_repaired() rewrites the sstable's Statistics/Scylla components via perform_component_rewrite -> sstable::link_with_rewritten_component(), which resolves the source sstable's component paths, hard-links them and reads the Scylla component from the sstable's current directory. For a base table whose views are already built, repair writes its output to a staging sstable and registers it with the view update generator (VUG). Concurrently the VUG picks up that same staging sstable, generates the view updates and moves it out of staging (staging -> base) via sstable::change_state(), which relocates the component files and updates the sstable's directory.

link_with_rewritten_component() was the only on-disk mutation of an sstable that did not take the per-sstable _mutate_sem, unlike change_state(), snapshot(), pick_up_from_upload() and unlink(). So the rewrite could race the VUG move: if the move won, the rewrite then hard-linked/read the components from the now moved-away staging path and aborted the shard.

Fix it at the source by taking the sstable's _mutate_sem in link_with_rewritten_component() around the operation, the same mutex the other on-disk mutations already hold. This serializes the rewrite's file operations against relocation/removal of the same sstable regardless of the trigger (VUG move, off-strategy, cleanup, migration), so the rewrite always reads from the sstable's current directory. It also keeps repair fully decoupled from view building: no deferral of VUG registration and no waiting for the VUG.

Also move the view_update_generator_pause_before_processing error injection into generate_updates_from_staging_sstables() so it fires on both the legacy generator fiber (which calls it directly) and the view_building_worker path (via process_staging_sstables); previously it sat in process_staging_sstables() which the legacy fiber bypasses, so the injection never fired on that path.

Fixes SCYLLADB-3263.

Backport to 2026.2 / 2026.3.  (2026.1 and older do not have the relevant code)