### PR TITLE
test: use topology timeout when waiting on injection entered after replace

### DIFF
--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -8,7 +8,7 @@ from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.scylla_cluster import ReplaceConfig
+from test.pylib.scylla_cluster import ReplaceConfig, ScyllaServer
 from test.pylib.internal_types import HostID
 
 import pytest
@@ -122,7 +122,7 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient, 
             "rack": server_to_replace.rack
         }))
 
-        await manager.api.wait_for_injection_enter(coord_serv.ip_addr, "tablet_transition_updates")
+        await manager.api.wait_for_injection_enter(coord_serv.ip_addr, "tablet_transition_updates", deadline=time.time() + ScyllaServer.TOPOLOGY_TIMEOUT)
 
         await manager.server_stop(server_to_down.server_id, convict=True)
         await manager.others_not_see_server(server_to_down.ip_addr)


### PR DESCRIPTION
In the test_mv_tablets_replace.py::test_tablet_mv_replica_pairing_during_replace case, we start a replace in the background and then we wait until we enter an injection that we enabled earlier, but which will only be entered about when timeout finishes.
Normally, when replacing a node we use a different default timeout than the default timeout for waiting for entering an injection. However, in this case, even though waiting on an injection depends on replace, we use the default timeout for it.
This can cause us to fail the test on waiting for this injection, particularly when running in a slow setup (aarch + debug mode). We fix this by using the timeout used for replace operations as the timeout for the wait on injection enter

Fixes: SCYLLADB-3366