### PR TITLE
utils: cached_file: inherit DMA alignments via seastar::layered_file_impl

### DIFF
--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -19,6 +19,7 @@
 #include "utils/cached_file_stats.hh"
 
 #include <seastar/core/file.hh>
+#include <seastar/core/layered_file.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
 using namespace seastar;
@@ -582,7 +583,7 @@ void cached_file::cached_page::on_evicted() noexcept {
     });
 }
 
-class cached_file_impl : public file_impl {
+class cached_file_impl : public layered_file_impl {
     cached_file& _cf;
     tracing::trace_state_ptr _trace_state;
 private:
@@ -591,7 +592,7 @@ private:
     }
 public:
     cached_file_impl(cached_file& cf, tracing::trace_state_ptr trace_state = {})
-        : file_impl(*get_file_impl(cf.get_file()))
+        : layered_file_impl(cf.get_file())
         , _cf(cf)
         , _trace_state(std::move(trace_state))
     { }


### PR DESCRIPTION


cached_file inherits the DMA alignments via file_impl's copy constructor. This is fragile since typically one does not slice an object by calling its base class' copy constructor. It looks like a bug and invites someone to "fix" it.

Use layered_file_impl which is the recommended way to copy DMA alignments.

Minor cleanup - no backport.