### PR TITLE
direct_failure_detector: stop logging every failed ping at WARN level

### DIFF
--- a/service/direct_failure_detector/failure_detector.cc
+++ b/service/direct_failure_detector/failure_detector.cc
@@ -564,7 +564,10 @@ future<> endpoint_worker::ping_fiber() noexcept {
                 logger.debug("ping to endpoint {} timed out after {} clock ticks", _id, clock.now() - start);
             } catch (...) {
                 // Unexpected exception, probably from `pinger.ping(...)`. Log and continue.
-                logger.warn("unexpected exception when pinging {}: {}", _id, std::current_exception());
+                // Rate-limited: an unexpected exception may repeat on every ping
+                // (about once a second per endpoint) for as long as its cause persists.
+                static thread_local logging::logger::rate_limit rl{std::chrono::seconds(5)};
+                logger.log(logging::log_level::warn, rl, "unexpected exception when pinging {}: {}", _id, std::current_exception());
             }
         } else {
             // We have a listener which already timed out.

--- a/service/direct_failure_detector/failure_detector.cc
+++ b/service/direct_failure_detector/failure_detector.cc
@@ -85,6 +85,12 @@ struct endpoint_worker {
     future<> notify_fiber() noexcept;
     future<> _notify_fiber = make_ready_future<>();
 
+    // Rate limit for the catch-all warning in `ping_fiber()`. An unexpected exception
+    // repeats on every ping while its cause persists, up to once per ping period if it
+    // is raised without delay. Kept per worker, i.e. per endpoint, so that one endpoint
+    // cannot shadow the warnings about another.
+    logging::logger::rate_limit _ping_error_rate_limit{std::chrono::minutes(1)};
+
     endpoint_worker(failure_detector::impl&, pinger::endpoint_id);
     ~endpoint_worker();
 
@@ -564,7 +570,9 @@ future<> endpoint_worker::ping_fiber() noexcept {
                 logger.debug("ping to endpoint {} timed out after {} clock ticks", _id, clock.now() - start);
             } catch (...) {
                 // Unexpected exception, probably from `pinger.ping(...)`. Log and continue.
-                logger.warn("unexpected exception when pinging {}: {:t}", _id, std::current_exception());
+                // Rate-limited per endpoint, see `_ping_error_rate_limit`.
+                logger.log(logging::log_level::warn, _ping_error_rate_limit,
+                        "unexpected exception when pinging {}: {:t}", _id, std::current_exception());
             }
         } else {
             // We have a listener which already timed out.

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -592,6 +592,20 @@ future<bool> direct_fd_pinger::ping(direct_failure_detector::pinger::endpoint_id
         }
     } catch (seastar::rpc::closed_error&) {
         co_return false;
+    } catch (seastar::rpc::timeout_error&) {
+        // Expected when the pinged node is dead or unreachable.
+        rslog.debug("ping(id = {}): timed out", dst_id);
+        co_return false;
+    } catch (netw::unknown_address&) {
+        // The node has no IP address mapping, e.g. shortly after this node
+        // restarted while the pinged node is still down. Expected to persist
+        // for as long as the node stays down, so warn per endpoint at most
+        // once per 5 minutes (restores the behavior of #12206, which was
+        // lost when the address lookup moved into the messaging layer).
+        auto& rate_limit = _rate_limits.try_get_recent_entry(id, std::chrono::minutes(5));
+        rslog.log(log_level::warn, rate_limit, "ping(id = {}): node has no IP address mapping", dst_id);
+        _rate_limits.remove_least_recent_entries(std::chrono::minutes(30));
+        co_return false;
     }
     co_return true;
 }

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -572,6 +572,12 @@ future<> raft_server_with_timeouts::read_barrier(seastar::abort_source* as, std:
 future<bool> direct_fd_pinger::ping(direct_failure_detector::pinger::endpoint_id id, direct_failure_detector::clock::timepoint_t timeout, abort_source& as, direct_failure_detector::clock& c) {
     auto dst_id = raft::server_id{id};
 
+    // Collect entries left by endpoints that are no longer pinged, e.g. after they
+    // left the configuration. The sweep covers the whole map, so it also collects
+    // what other endpoints left behind.
+    _timeout_rate_limits.remove_least_recent_entries(std::chrono::minutes(30));
+    _unknown_address_rate_limits.remove_least_recent_entries(std::chrono::minutes(30));
+
     try {
         std::chrono::milliseconds timeout_ms = c.to_milliseconds(timeout);
         netw::messaging_service::clock_type::time_point deadline = netw::messaging_service::clock_type::now() + timeout_ms;
@@ -589,6 +595,20 @@ future<bool> direct_fd_pinger::ping(direct_failure_detector::pinger::endpoint_id
             co_return info->group0_alive;
         }
     } catch (seastar::rpc::closed_error&) {
+        co_return false;
+    } catch (seastar::rpc::timeout_error&) {
+        // Log every timeout at DEBUG, and at most once per 5 minutes per endpoint at WARN.
+        rslog.debug("ping(id = {}): timed out", dst_id);
+        auto& rate_limit = _timeout_rate_limits.try_get_recent_entry(id, std::chrono::minutes(5));
+        rslog.log(log_level::warn, rate_limit, "ping(id = {}): timed out", dst_id);
+        co_return false;
+    } catch (netw::unknown_address&) {
+        // The address lookup fails locally, without waiting for the network, so this
+        // repeats on every ping until the mapping shows up. Warn at most once per
+        // 5 minutes per endpoint.
+        auto& rate_limit = _unknown_address_rate_limits.try_get_recent_entry(id, std::chrono::minutes(5));
+        rslog.log(log_level::warn, rate_limit,
+                "ping(id = {}): node has no IP address mapping, should be transient", dst_id);
         co_return false;
     }
     co_return true;

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -209,7 +209,9 @@ class direct_fd_pinger : public seastar::peering_sharded_service<direct_fd_pinge
     netw::messaging_service& _ms;
 
     using rate_limits = utils::recent_entries_map<direct_failure_detector::pinger::endpoint_id, logger::rate_limit>;
-    rate_limits _rate_limits;
+    // Separate per failure kind, so one kind's warnings can't suppress the other's.
+    rate_limits _timeout_rate_limits;
+    rate_limits _unknown_address_rate_limits;
 
 public:
     direct_fd_pinger(netw::messaging_service& ms)

--- a/test/boost/recent_entries_map_test.cc
+++ b/test/boost/recent_entries_map_test.cc
@@ -161,8 +161,8 @@ SEASTAR_THREAD_TEST_CASE(test_update_and_remove_least_recent_entries) {
     // uuid3 10 min old
     // uuid1 20 min old
 
-    // get the uuid1 key and try to pass new key
-    BOOST_CHECK_NE(map.try_get_recent_entry(uuid1, foo), bar);
+    // the key `uuid1` is already present in the map. return `foo`
+    BOOST_CHECK_EQUAL(map.try_get_recent_entry(uuid1, bar), foo);
     BOOST_CHECK_EQUAL(map.size(), 3);
     // uuid1 0  min old
     // uuid2 5  min old
@@ -194,5 +194,73 @@ SEASTAR_THREAD_TEST_CASE(test_update_and_remove_least_recent_entries) {
 
     // remove the entry with the uuid2 key
     map.remove_least_recent_entries(10min);
+    BOOST_CHECK_EQUAL(map.size(), 0);
+}
+
+// The entries to remove are a suffix of the LRU list: a touched entry moves to the
+// front, so it survives a sweep that collects the ones behind it.
+SEASTAR_THREAD_TEST_CASE(test_remove_least_recent_entries_stops_at_first_young_entry) {
+    using namespace std::chrono_literals;
+
+    utils::recent_entries_map<utils::UUID, non_copyable_value, seastar::manual_clock> map;
+
+    const utils::UUID uuid1(0, 1);
+    const utils::UUID uuid2(0, 2);
+    const utils::UUID uuid3(0, 3);
+
+    const std::string foo("foo");
+    const std::string bar("bar");
+    const std::string foobar("foobar");
+
+    map.try_get_recent_entry(uuid1, foo);
+    seastar::manual_clock::advance(10min);
+    map.try_get_recent_entry(uuid2, bar);
+    seastar::manual_clock::advance(10min);
+    map.try_get_recent_entry(uuid3, foobar);
+    BOOST_CHECK_EQUAL(map.size(), 3);
+    // uuid3 0 min old, uuid2 10 min old, uuid1 20 min old
+
+    // touch the oldest entry: it becomes the youngest
+    BOOST_CHECK_EQUAL(map.try_get_recent_entry(uuid1, bar), foo);
+    // uuid1 0 min old, uuid3 0 min old, uuid2 10 min old
+
+    seastar::manual_clock::advance(5min);
+    // uuid1 5 min old, uuid3 5 min old, uuid2 15 min old
+
+    map.remove_least_recent_entries(15min);
+    BOOST_CHECK_EQUAL(map.size(), 2);
+
+    // uuid1 and uuid3 are still there, so they answer with their stored values
+    BOOST_CHECK_EQUAL(map.try_get_recent_entry(uuid1, foobar), foo);
+    BOOST_CHECK_EQUAL(map.try_get_recent_entry(uuid3, bar), foobar);
+    BOOST_CHECK_EQUAL(map.size(), 2);
+
+    // uuid2 was collected, so it is inserted again with the passed value
+    BOOST_CHECK_EQUAL(map.try_get_recent_entry(uuid2, foobar), foobar);
+    BOOST_CHECK_EQUAL(map.size(), 3);
+}
+
+// Sweeping an empty map, or with an interval no entry reaches, is a no-op.
+SEASTAR_THREAD_TEST_CASE(test_remove_least_recent_entries_noop_cases) {
+    using namespace std::chrono_literals;
+
+    utils::recent_entries_map<utils::UUID, non_copyable_value, seastar::manual_clock> map;
+
+    // empty map
+    map.remove_least_recent_entries(1min);
+    BOOST_CHECK_EQUAL(map.size(), 0);
+
+    const utils::UUID uuid1(0, 1);
+    const std::string foo("foo");
+
+    map.try_get_recent_entry(uuid1, foo);
+    seastar::manual_clock::advance(1min);
+
+    // interval not reached
+    map.remove_least_recent_entries(2min);
+    BOOST_CHECK_EQUAL(map.size(), 1);
+
+    // exactly at the interval: the entry is "not younger than" it, so it goes
+    map.remove_least_recent_entries(1min);
     BOOST_CHECK_EQUAL(map.size(), 0);
 }

--- a/test/cluster/test_direct_fd_ping_logging.py
+++ b/test/cluster/test_direct_fd_ping_logging.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Reproducer for SCYLLADB-3432: every failed direct failure detector ping
+produces an unthrottled "unexpected exception when pinging" warning.
+
+Pings towards a dead or unreachable node time out roughly once per second
+per node, and each timeout used to be logged at WARN level through the
+catch-all in the ping fiber. During a real outage this floods the journal
+(hundreds of lines per second on a large cluster) for the whole duration of
+the outage. A timed-out ping to a dead node is expected behavior and belongs
+at DEBUG level; the node-down transition itself is reported separately
+("marking Raft server ... as dead for raft groups", "InetAddress ... is now
+DOWN").
+
+The test pauses one node (SIGSTOP), so that pings to it time out instead of
+being rejected, waits until the failure detector reports the node dead, lets
+failed pings accumulate, and requires that no per-ping warnings were logged.
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+PING_SPAM = "unexpected exception when pinging"
+
+
+@pytest.mark.xfail(reason="SCYLLADB-3432: every failed direct FD ping is logged at WARN level "
+                          "with no rate limiting")
+@pytest.mark.skip_mode(mode='release', reason='the test relies on debug-level absence checks '
+                                              'that are only meaningful with default log levels')
+@pytest.mark.asyncio
+async def test_failed_fd_pings_do_not_spam_warnings(manager: ManagerClient) -> None:
+    servers = await manager.servers_add(3)
+    observer, victim = servers[0], servers[2]
+    observer_log = await manager.server_open_log(server_id=observer.server_id)
+    mark = await observer_log.mark()
+
+    # SIGSTOP the victim: its kernel still accepts TCP, but the process never
+    # answers, so direct FD pings from the observer fail with a timeout —
+    # the same failure mode as a dead host in the field.
+    await manager.server_pause(victim.server_id)
+    try:
+        # The down transition is the intended signal and must be reported.
+        await observer_log.wait_for(
+            "marking Raft server .* as dead for raft groups",
+            from_mark=mark,
+            timeout=120,
+        )
+
+        # Let failed pings accumulate: ~1.3 timed out pings per second on
+        # the observer for the paused node.
+        await asyncio.sleep(20)
+
+        spam = await observer_log.grep(PING_SPAM, from_mark=mark)
+        assert not spam, (
+            f"{len(spam)} unthrottled per-ping warnings were logged for a node "
+            f"that is simply down (SCYLLADB-3432); expected none")
+    finally:
+        await manager.server_unpause(victim.server_id)

--- a/test/cluster/test_direct_fd_ping_logging.py
+++ b/test/cluster/test_direct_fd_ping_logging.py
@@ -34,8 +34,6 @@ logger = logging.getLogger(__name__)
 PING_SPAM = "unexpected exception when pinging"
 
 
-@pytest.mark.xfail(reason="SCYLLADB-3432: every failed direct FD ping is logged at WARN level "
-                          "with no rate limiting")
 @pytest.mark.skip_mode(mode='release', reason='the test relies on debug-level absence checks '
                                               'that are only meaningful with default log levels')
 @pytest.mark.asyncio

--- a/utils/recent_entries_map.hh
+++ b/utils/recent_entries_map.hh
@@ -37,6 +37,9 @@ class recent_entries_map {
     using entries_map = std::unordered_map<Key, typename recent_entries::iterator>;
 
 private:
+    // Ordered by `_last_visit`, newest first: entries are created at the front and
+    // `touch()` splices them back to it, so the least recently visited one is always
+    // at the back. `remove_least_recent_entries()` depends on this.
     recent_entries _recent_entries;
     entries_map _entries_map;
 
@@ -79,16 +82,17 @@ public:
     }
 
     // Removes recent_entries not younger than the specified interval.
+    //
+    // The entries are ordered by `_last_visit` (see the member declaration), so the
+    // ones to remove are a suffix of the list. Costs a single comparison when there
+    // is nothing to collect, and O(removed entries) otherwise.
     void remove_least_recent_entries(std::chrono::milliseconds interval) {
         const auto now = Clock::now();
 
-        auto it = std::find_if(_recent_entries.begin(), _recent_entries.end(), [now, interval](const recent_entry& entry) {
-            return now - entry._last_visit >= interval;
-        });
-
-        for (; it != _recent_entries.end(); ) {
-            _entries_map.erase(it->_key);
-            it = _recent_entries.erase(it);
+        while (!_recent_entries.empty() && now - _recent_entries.back()._last_visit >= interval) {
+            // Erase from the map first: the key it looks up lives in the list node.
+            _entries_map.erase(_recent_entries.back()._key);
+            _recent_entries.pop_back();
         }
     }
 };


### PR DESCRIPTION
## The problem

When a node is unreachable, direct_failure_detector logs a message for every failed ping—once every 100 ms. This generates a large number of unnecessary messages that can hide more important information in the log.
```
[shard N: gms] direct_failure_detector - unexpected exception when pinging <id>: seastar::rpc::timeout_error (rpc call timed out)
```

## The fix
Introduce rate limiting for ping error messages so that the log is not flooded with repetitive messages.

Refs SCYLLADB-4194 - ping interval backoff.
Refs SCYLLADB-4363 - the startup ping race behind the `unknown_address` warning.

Fixes: SCYLLADB-3432

Backport: This issue applies to all currently supporting versions, but it is a cosmetic issue, so no backport requirements.
