### PR TITLE
sstables: fix inconsistent sstable identifier when updating ids on object storage

### DIFF
--- a/docs/dev/sstable-scylla-format.md
+++ b/docs/dev/sstable-scylla-format.md
@@ -64,7 +64,7 @@ about timestamps in the sstable, like: `min_live_timestamp`, and `min_live_row_m
 
 `sstable_identifier` (tag 10): a uuid identifying the sstable for its whole lifetime.
 It is derived from the sstable uuid generation, upon creation (or uniquely generated
-if the sstable has numerical generation).  Yet, unlike the sstable that may
+if the sstable has numerical generation).  Yet, unlike the sstable generation that may
 change if the sstable is migrated to a different shard or node, the sstable
 identifier is stable and copied with the rest of the scylla metadata.
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1713,7 +1713,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         // The rest of the sstable is hard-linked and its scylla_metadata is carried over.
         new_sst->mark_created_by_component_rewrite();
 
-        _storage->link_with_excluded_components(*this, generation, {component, component_type::Scylla}).get();
+        _storage->link_with_excluded_components(*this, generation, {component, component_type::Scylla}, {}).get();
         new_sst->copy_components(*this).get();
 
         modifier(*new_sst);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2461,6 +2461,13 @@ sstable::read_scylla_metadata() noexcept {
 
             auto computed_digest = co_await compute_component_file_digest(component_type::Scylla);
             validate_component_digest(component_type::Scylla, computed_digest);
+
+            // If we already know which identifier this sstable is, the metadata
+            // we just read must say the same.  On object storage the identifier
+            // we opened the sstable by is the one its component objects are
+            // named after, so a mismatch means those objects and this metadata
+            // do not belong to the same sstable.
+            validate_sstable_identifier();
         });
     });
 }
@@ -2572,7 +2579,10 @@ sstable_id sstable::ensure_sstable_identifier() {
     // If the sstable already loaded its scylla_metadata, take the identifier
     // persisted there; that is the one its components were written under.
     if (_components->scylla_metadata) {
-        // FIXME: validate that it is consistent with the `_sstable_identifier` member.
+        // When the identifier is already known, the metadata must not hold a
+        // different one: adopting it below would then leave the sstable
+        // unreachable under the identifier its components are named by.
+        validate_sstable_identifier();
         sid = _components->scylla_metadata->get_optional_sstable_identifier();
     }
 
@@ -2595,6 +2605,19 @@ sstable_id sstable::ensure_sstable_identifier() {
     // into the Scylla metadata is left to whoever is about to write that out.
     _sstable_identifier = sid;
     return *sid;
+}
+
+void sstable::validate_sstable_identifier() const {
+    if (!_sstable_identifier || !_components->scylla_metadata) {
+        return;
+    }
+    // A null identifier means the metadata predates SSTableIdentifier, or has
+    // not been stamped with one yet; there is nothing to disagree with.
+    auto stored_sid = _components->scylla_metadata->get_optional_sstable_identifier();
+    if (stored_sid && stored_sid != *_sstable_identifier) {
+        on_internal_error(sstlog, fmt::format("SSTable {}: scylla_metadata holds sstable identifier {} while the sstable is identified by {}",
+                get_filename(), stored_sid, *_sstable_identifier));
+    }
 }
 
 bool sstable::may_contain_rows(const query::clustering_row_ranges& ranges) const {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1704,6 +1704,15 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
 
         auto new_sst = creator(shared_from_this());
         auto generation = new_sst->generation();
+        auto sid = this->sstable_identifier();
+        if (update_id || !sid) {
+            // It is okay to use a new sstable_id if update_id==false and the current sstable is missing it
+            // since new sstables are expected to always have a sstable_id and we do not want to preserve
+            // the state of a legacy sstable that doesn't have a sstable_identifier
+            sid = new_sst->ensure_sstable_identifier();
+        } else {
+            new_sst->set_sstable_identifier(*sid);
+        }
 
         // Mark the new sstable as a component-rewrite output so that when the
         // component is written below it preserves the parent sstable's original
@@ -1713,7 +1722,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         // The rest of the sstable is hard-linked and its scylla_metadata is carried over.
         new_sst->mark_created_by_component_rewrite();
 
-        _storage->link_with_excluded_components(*this, generation, {component, component_type::Scylla}, {}).get();
+        _storage->link_with_excluded_components(*this, generation, {component, component_type::Scylla}, sid).get();
         new_sst->copy_components(*this).get();
 
         modifier(*new_sst);
@@ -1722,9 +1731,6 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         // If unchanged, reuse the existing _components->scylla_metadata instead.
         scylla_metadata metadata;
         read_simple<component_type::Scylla>(metadata).get();
-        if (update_id) {
-            metadata.set_sstable_identifier();
-        }
 
         new_sst->write_component_with_metadata(component, std::move(metadata));
 
@@ -1753,6 +1759,15 @@ void sstable::write_component_with_metadata(component_type type, scylla_metadata
     write_component(type);
 
     metadata.get_or_create_components_digests().map[type] = _components_digests.map[type];
+    // The sstable's identifier is authoritative: make sure the sstable_identifier
+    // we store in scylla_metadata is the one the sstable is known by.  This must
+    // happen before the digest below is computed over metadata.data.
+    auto sid = sstable_identifier();
+    if (!sid) {
+        on_internal_error(sstlog, fmt::format("SSTable {}: cannot rewrite {} without an sstable identifier",
+                get_filename(), component_name(*this, type)));
+    }
+    metadata.set_sstable_identifier(*sid);
     metadata.digest = serialized_checksum(_version, metadata.data);
 
     write_simple<component_type::Scylla>(metadata);
@@ -2553,6 +2568,10 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
 
 sstable_id sstable::ensure_sstable_identifier() {
     sstable_id sid;
+    // FIXME:
+    // If the sstable already loaded its scylla_metadata, take the identifier
+    // persisted there; that is the one its components were written under.
+    // Validate that it is consistent with the `_sstable_identifier` member.
     if (_sstable_identifier) {
         sid = *_sstable_identifier;
     } else if (generation().is_uuid_based()) {
@@ -2561,6 +2580,9 @@ sstable_id sstable::ensure_sstable_identifier() {
         sid = sstable_id(utils::UUID_gen::get_time_UUID());
         sstlog.info("SSTable {} has numerical generation. SSTable identifier in scylla_metadata set to {}", get_filename(), sid);
     }
+    // Make the sstable carry the identifier its component objects are named
+    // by, rather than depend on whoever created it to have set it.
+    _sstable_identifier = sid;
     return sid;
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1722,7 +1722,7 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         // The rest of the sstable is hard-linked and its scylla_metadata is carried over.
         new_sst->mark_created_by_component_rewrite();
 
-        _storage->link_with_excluded_components(*this, generation, {component, component_type::Scylla}, sid).get();
+        _storage->link_with_excluded_components(*this, generation, {component, component_type::Scylla}, *sid).get();
         new_sst->copy_components(*this).get();
 
         modifier(*new_sst);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2533,16 +2533,7 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
         _components->scylla_metadata->data.set<scylla_metadata_type::ExtTimestampStats>(std::move(*ts_stats));
     }
 
-    sstable_id sid;
-    if (_sstable_identifier) {
-        sid = *_sstable_identifier;
-    } else if (generation().is_uuid_based()) {
-        sid = sstable_id(generation().as_uuid());
-    } else {
-        sid = sstable_id(utils::UUID_gen::get_time_UUID());
-        sstlog.info("SSTable {} has numerical generation. SSTable identifier in scylla_metadata set to {}", get_filename(), sid);
-    }
-    _components->scylla_metadata->set_sstable_identifier(sid);
+    _components->scylla_metadata->set_sstable_identifier(ensure_sstable_identifier());
 
     sstable_schema_type sstable_schema;
     sstable_schema.id = _schema->id();
@@ -2558,6 +2549,19 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
     _components->scylla_metadata->digest = serialized_checksum(_version, _components->scylla_metadata->data);
 
     write_simple<component_type::Scylla>(*_components->scylla_metadata);
+}
+
+sstable_id sstable::ensure_sstable_identifier() {
+    sstable_id sid;
+    if (_sstable_identifier) {
+        sid = *_sstable_identifier;
+    } else if (generation().is_uuid_based()) {
+        sid = sstable_id(generation().as_uuid());
+    } else {
+        sid = sstable_id(utils::UUID_gen::get_time_UUID());
+        sstlog.info("SSTable {} has numerical generation. SSTable identifier in scylla_metadata set to {}", get_filename(), sid);
+    }
+    return sid;
 }
 
 bool sstable::may_contain_rows(const query::clustering_row_ranges& ranges) const {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1911,7 +1911,7 @@ future<> sstable::update_info_for_opened_data(sstable_open_config cfg) {
     this->set_first_and_last_keys();
     _run_identifier = _components->scylla_metadata->get_optional_run_identifier().value_or(run_id::create_random_id());
 
-    _sstable_identifier = _components->scylla_metadata->get_optional_sstable_identifier();
+    ensure_sstable_identifier();
 
     if (cfg.load_first_and_last_position_metadata) {
         co_await load_first_and_last_position_in_partition();
@@ -2567,23 +2567,34 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
 }
 
 sstable_id sstable::ensure_sstable_identifier() {
-    sstable_id sid;
-    // FIXME:
+    optimized_optional<sstable_id> sid;
+
     // If the sstable already loaded its scylla_metadata, take the identifier
     // persisted there; that is the one its components were written under.
-    // Validate that it is consistent with the `_sstable_identifier` member.
-    if (_sstable_identifier) {
-        sid = *_sstable_identifier;
-    } else if (generation().is_uuid_based()) {
-        sid = sstable_id(generation().as_uuid());
-    } else {
-        sid = sstable_id(utils::UUID_gen::get_time_UUID());
-        sstlog.info("SSTable {} has numerical generation. SSTable identifier in scylla_metadata set to {}", get_filename(), sid);
+    if (_components->scylla_metadata) {
+        // FIXME: validate that it is consistent with the `_sstable_identifier` member.
+        sid = _components->scylla_metadata->get_optional_sstable_identifier();
+    }
+
+    // Otherwise, on the write path, _sstable_identifier may have already been set.
+    // If so, use it, else derive the identifier from the generation unless it is
+    // numerical (as might be the case in some legacy unit tests), in which case
+    // generate a new one.
+    if (!sid) {
+        if (_sstable_identifier) {
+            sid = *_sstable_identifier;
+        } else if (generation().is_uuid_based()) {
+            sid = sstable_id(generation().as_uuid());
+        } else {
+            sid = sstable_id(utils::UUID_gen::get_time_UUID());
+            sstlog.info("SSTable {} has numerical generation. SSTable identifier set to {}", get_filename(), sid);
+        }
     }
     // Make the sstable carry the identifier its component objects are named
-    // by, rather than depend on whoever created it to have set it.
+    // by, rather than depend on whoever created it to have set it.  Stamping it
+    // into the Scylla metadata is left to whoever is about to write that out.
     _sstable_identifier = sid;
-    return sid;
+    return *sid;
 }
 
 bool sstable::may_contain_rows(const query::clustering_row_ranges& ranges) const {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -286,6 +286,10 @@ public:
     // put it into the desired destination assigning the given generation
     future<> pick_up_from_upload(sstable_state to, generation_type new_generation);
 
+    // The sstable generation represents the node/shard reference to the sstable.
+    // When the sstable is created, the sstable identifier is equal to the sstable generation,
+    // but over time, e.g. when a sstable is migrated across shards or nodes, its identifier
+    // remains stable, while the generation changes to reflect the new node/shard reference.
     generation_type generation() const {
         return _generation;
     }
@@ -1172,7 +1176,18 @@ public:
         return _unlinked_at;
     }
 
-    // sstable_id is null iff not present in scylla_metadata
+    // The sstable identifier identifies the sstable globally across all nodes, shards, and over time.
+    // When the sstable is created, the sstable identifier is equal to the sstable generation,
+    // but over time, e.g. when a sstable is migrated across shards or nodes, its identifier
+    // remains stable, while the generation changes to reflect the new node/shard reference.
+    //
+    // On object-storage, the sstable identifier comes as part of the sstable prefix,
+    // while the generation is used to identify the node reference to the sstable.
+    // The generation-based references control the sstable lifetime across migrations, sstable sharing,
+    // and across snapshot and backup operations.
+    //
+    // The sstable_identifier is null iff not present in scylla_metadata
+    // It is required to be set for all sstables stored on object storage.
     const optimized_optional<sstable_id>& sstable_identifier() const noexcept {
         return _sstable_identifier;
     }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -907,6 +907,11 @@ private:
     void write_toc(std::unique_ptr<crc32_digest_file_writer> w);
     static future<uint32_t> read_digest_from_file(file f);
     static future<lw_shared_ptr<checksum>> read_checksum_from_file(file f);
+
+    void set_sstable_identifier(sstable_id sid) noexcept {
+        _sstable_identifier = sid;
+    }
+
 public:
 
     shareable_components& get_shared_components() const {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -740,6 +740,7 @@ private:
                                std::optional<scylla_metadata::large_data_stats> ld_stats,
                                std::optional<scylla_metadata::ext_timestamp_stats> ts_stats,
                                std::optional<scylla_metadata::large_data_records> ld_records = std::nullopt);
+    sstable_id ensure_sstable_identifier();
 
     future<> read_filter(sstable_open_config cfg = {});
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -741,6 +741,9 @@ private:
                                std::optional<scylla_metadata::ext_timestamp_stats> ts_stats,
                                std::optional<scylla_metadata::large_data_records> ld_records = std::nullopt);
     sstable_id ensure_sstable_identifier();
+    // Verifies that the sstable identifier persisted in the Scylla metadata
+    // agrees with the one this sstable is known by, when both are known.
+    void validate_sstable_identifier() const;
 
     future<> read_filter(sstable_open_config cfg = {});
 

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -73,7 +73,7 @@ private:
     future<> rename_new_file(const sstable& sst, sstring from_name, sstring to_name) const;
     future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
             const std::unordered_set<component_type>& excluded_components,
-            optimized_optional<sstable_id> new_sid) const override;
+            sstable_id new_sid) const override;
 
     future<> change_dir(sstring new_dir) {
         auto old_dir = std::exchange(_dir, opened_directory(new_dir));
@@ -424,7 +424,7 @@ future<> filesystem_storage::create_links(const sstable& sst, const std::filesys
 
 future<> filesystem_storage::link_with_excluded_components(const sstable& sst, generation_type new_gen,
         const std::unordered_set<component_type>& excluded_components,
-        optimized_optional<sstable_id>) const {
+        sstable_id) const {
     sstlog.trace("link_with_excluded_components: {} -> generation={} excluded={}",
             sst.get_filename(), new_gen, excluded_components);
 
@@ -726,7 +726,7 @@ public:
     }
     future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
             const std::unordered_set<component_type>& excluded_components,
-            optimized_optional<sstable_id> new_sid) const override;
+            sstable_id new_sid) const override;
     future<> copy_components(const sstable& sst, sstable_id sid, const std::unordered_set<component_type>& excluded_components) const;
     future<> unlink_component(const sstable& sst, component_type) noexcept override;
     future<size_t> num_references(const sstable& sst) const override;
@@ -1143,11 +1143,10 @@ future<> object_storage_base::copy_components(const sstable& sst, sstable_id sid
 
 future<> object_storage_base::link_with_excluded_components(const sstable& sst, generation_type new_gen,
         const std::unordered_set<component_type>& excluded_components,
-        optimized_optional<sstable_id> new_sid) const {
-    if (!new_sid) {
+        sstable_id sid) const {
+    if (!sid) {
         on_internal_error(sstlog, "Object-storage link_with_excluded_components requires an sstable id");
     }
-    auto sid = *new_sid;
     entry_descriptor desc(new_gen, sid, sst.get_version(), sst.get_format(), component_type::TOC);
     desc.state = sst.state();
     auto node_owner = sst.manager().get_local_host_id();

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -727,6 +727,7 @@ public:
     future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
             const std::unordered_set<component_type>& excluded_components,
             optimized_optional<sstable_id> new_sid) const override;
+    future<> copy_components(const sstable& sst, sstable_id sid, const std::unordered_set<component_type>& excluded_components) const;
     future<> unlink_component(const sstable& sst, component_type) noexcept override;
     future<size_t> num_references(const sstable& sst) const override;
 
@@ -1130,10 +1131,7 @@ future<> object_storage_base::snapshot(const sstable& sst, sstring name) const {
     co_return;
 }
 
-future<> object_storage_base::link_with_excluded_components(const sstable& sst, generation_type new_gen,
-        const std::unordered_set<component_type>& excluded_components,
-        optimized_optional<sstable_id> new_sid) const {
-    auto sid = new_sid ? *new_sid : sstable_id(new_gen.as_uuid());
+future<> object_storage_base::copy_components(const sstable& sst, sstable_id sid, const std::unordered_set<component_type>& excluded_components) const {
     auto prefix = this->prefix();
     co_await coroutine::parallel_for_each(sst.all_components(), [this, &sst, sid, &excluded_components, &prefix] (const std::pair<component_type, sstring>& p) -> future<> {
         if (excluded_components.contains(p.first)) {
@@ -1141,6 +1139,24 @@ future<> object_storage_base::link_with_excluded_components(const sstable& sst, 
         }
         co_await copy_object(make_object_name(sst, p.second, sst.generation()), object_name(_bucket, prefix, sid, p.second));
     });
+}
+
+future<> object_storage_base::link_with_excluded_components(const sstable& sst, generation_type new_gen,
+        const std::unordered_set<component_type>& excluded_components,
+        optimized_optional<sstable_id> new_sid) const {
+    if (!new_sid) {
+        on_internal_error(sstlog, "Object-storage link_with_excluded_components requires an sstable id");
+    }
+    auto sid = *new_sid;
+    entry_descriptor desc(new_gen, sid, sst.get_version(), sst.get_format(), component_type::TOC);
+    desc.state = sst.state();
+    auto node_owner = sst.manager().get_local_host_id();
+    co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
+
+    auto ref_name = make_ref_object_name(sid, new_gen, node_owner);
+    co_await put_object(ref_name, memory_data_sink_buffers());
+
+    co_await copy_components(sst, sid, excluded_components);
 }
 
 future<entry_descriptor> object_storage_base::clone(sstable& sst, generation_type gen, bool leave_unsealed, bool may_use_reference_sharing) const {
@@ -1157,10 +1173,10 @@ future<entry_descriptor> object_storage_base::clone(sstable& sst, generation_typ
     auto ref_name = make_ref_object_name(sid, gen, node_owner);
     co_await _client->put_object(ref_name, memory_data_sink_buffers(), abort_source());
     auto refs = co_await num_references(sid);
-    sstlog.debug("Cloned {} reference {} num_references={}", sst.get_filename(), ref_name, refs);
+    sstlog.debug("Cloned {} sstable_id={} num_references={}", sst.get_filename(), sid, refs);
 
     if (!may_use_reference_sharing) {
-        co_await link_with_excluded_components(sst, gen, {component_type::Scylla}, sid);
+        co_await copy_components(sst, sid, {component_type::Scylla});
         auto scylla_metadata = co_await sst.copy_scylla_metadata();
         scylla_metadata->set_sstable_identifier(sid);
         auto scylla_metadata_bufs = co_await sst.serialize_scylla_metadata(std::move(*scylla_metadata));

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -73,7 +73,7 @@ private:
     future<> rename_new_file(const sstable& sst, sstring from_name, sstring to_name) const;
     future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
             const std::unordered_set<component_type>& excluded_components,
-            optimized_optional<sstable_id> new_sid = {}) const override;
+            optimized_optional<sstable_id> new_sid) const override;
 
     future<> change_dir(sstring new_dir) {
         auto old_dir = std::exchange(_dir, opened_directory(new_dir));
@@ -726,7 +726,7 @@ public:
     }
     future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
             const std::unordered_set<component_type>& excluded_components,
-            optimized_optional<sstable_id> new_sid = {}) const override;
+            optimized_optional<sstable_id> new_sid) const override;
     future<> unlink_component(const sstable& sst, component_type) noexcept override;
     future<size_t> num_references(const sstable& sst) const override;
 

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -112,7 +112,7 @@ public:
     // Clone an sstable to a new generation, linking or copying all components except those in excluded_components.
     virtual future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
             const std::unordered_set<component_type>& excluded_components,
-            optimized_optional<sstable_id> new_sid = {}) const = 0;
+            optimized_optional<sstable_id> new_sid) const = 0;
     virtual ~storage() {}
 
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -112,7 +112,7 @@ public:
     // Clone an sstable to a new generation, linking or copying all components except those in excluded_components.
     virtual future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
             const std::unordered_set<component_type>& excluded_components,
-            optimized_optional<sstable_id> new_sid) const = 0;
+            sstable_id new_sid) const = 0;
     virtual ~storage() {}
 
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -736,7 +736,7 @@ struct scylla_metadata {
         auto* sid = data.get<scylla_metadata_type::SSTableIdentifier, scylla_metadata::sstable_identifier>();
         return sid ? sid->value : sstable_id::create_null_id();
     }
-    void set_sstable_identifier(sstable_id sid = sstable_id{utils::UUID_gen::get_time_UUID()}) {
+    void set_sstable_identifier(sstable_id sid) {
         data.set<scylla_metadata_type::SSTableIdentifier>(scylla_metadata::sstable_identifier{sid});
     }
     components_digests& get_or_create_components_digests() {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7616,6 +7616,87 @@ SEASTAR_TEST_CASE(test_perform_component_rewrite_single_sstable_without_backup) 
     return test_perform_component_rewrite_single_sstable(sstables::update_sstable_id::no);
 }
 
+static void object_storage_perform_component_rewrite_single_sstable_fn(test_env& env) {
+    // Regression test for SCYLLADB-3420.
+    //
+    // On object storage the component objects of an sstable are keyed by its
+    // sstable_id, and the id persisted in the Scylla component is the one used
+    // to locate them when the sstable is opened again.  Before the fix, the
+    // component rewrite copied the components under the new sstable's id but
+    // stamped the rewritten Scylla metadata with a freshly generated,
+    // unrelated id, and created no registry entry for the new sstable.  The
+    // in-memory id was right all along, so it is the persisted id and the
+    // registry entry that need to be checked here.
+    simple_schema ss;
+    auto s = ss.schema();
+    auto pk = tests::generate_partition_key(s).key();
+
+    auto mut1 = mutation(s, pk);
+    mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
+    auto original_sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
+    BOOST_REQUIRE(original_sst->sstable_identifier());
+
+    uint32_t new_level = 5;
+    auto modifier = [new_level] (sstable& sst) {
+        sst.mutate_sstable_level(new_level);
+    };
+
+    auto creator = [&env] (shared_sstable sst) {
+        return env.make_sstable(sst->get_schema());
+    };
+    auto new_sst = original_sst->link_with_rewritten_component(std::move(creator),
+            component_type::Statistics,
+            std::move(modifier),
+            sstables::update_sstable_id::yes).get();
+
+    BOOST_REQUIRE(new_sst->sstable_identifier());
+    BOOST_REQUIRE(new_sst->sstable_identifier() != original_sst->sstable_identifier());
+    BOOST_REQUIRE(new_sst->get_sstable_level() == new_level);
+    BOOST_REQUIRE(new_sst->generation() != original_sst->generation());
+    // The rewritten sstable is created fresh, so it takes its identifier from
+    // its own generation, and its component objects are keyed by it.
+    BOOST_REQUIRE(new_sst->sstable_identifier() == sstable_id(new_sst->generation().as_uuid()));
+
+    // The rewritten sstable must be registered under its own identifier,
+    // otherwise it cannot be found after restart.
+    std::optional<sstring> registered_status;
+    optimized_optional<sstable_id> registered_sid;
+    env.manager()
+        .sstables_registry()
+        .sstables_registry_list(s->id(), env.manager().get_local_host_id(),
+                                [&registered_status, &registered_sid, new_gen = new_sst->generation()]
+                                        (sstring status, sstable_state, entry_descriptor desc) {
+                                    if (desc.generation == new_gen) {
+                                        registered_status = std::move(status);
+                                        registered_sid = desc.sid;
+                                    }
+                                    return make_ready_future<>();
+                                })
+        .get();
+    BOOST_REQUIRE(registered_status);
+    BOOST_REQUIRE_EQUAL(*registered_status, "sealed");
+    BOOST_REQUIRE(registered_sid == new_sst->sstable_identifier());
+
+    // Re-open the rewritten sstable to verify that the identifier persisted in
+    // its Scylla component - the one its components are looked up by - is the
+    // identifier they were written under.  This used to be an unrelated id.
+    auto reloaded_sst = env.reusable_sst(s, new_sst).get();
+    BOOST_REQUIRE(reloaded_sst->sstable_identifier() == new_sst->sstable_identifier());
+    // The rewritten Statistics component, not the original one, is the one that
+    // was persisted under the new identifier.
+    BOOST_REQUIRE(reloaded_sst->get_sstable_level() == new_level);
+}
+
+SEASTAR_TEST_CASE(test_object_storage_perform_component_rewrite_single_sstable_s3, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    return test_env::do_with_async([] (test_env& env) { object_storage_perform_component_rewrite_single_sstable_fn(env); },
+            test_env_config{.storage = make_test_object_storage_options("S3")});
+}
+
+SEASTAR_FIXTURE_TEST_CASE(test_object_storage_perform_component_rewrite_single_sstable_gcs, gcs_fixture, *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
+    return test_env::do_with_async([] (test_env& env) { object_storage_perform_component_rewrite_single_sstable_fn(env); },
+            test_env_config{.storage = make_test_object_storage_options("GS")});
+}
+
 SEASTAR_TEST_CASE(test_perform_component_rewrite_multiple_sstables) {
     return test_env::do_with_async([] (test_env& env) {
         simple_schema ss;


### PR DESCRIPTION
On object storage an sstable is addressed by two identifiers: its `generation` (gen) and its `sstable_id` (sid). The component objects are keyed by the sid, while the sid persisted in the Scylla component is the one used to locate those objects when the sstable is opened again — so the two have to agree.

A freshly created sstable gets `sid == gen.as_uuid()`. The sid then stays with the sstable for the rest of its life, even as new generations come to refer to it. A component rewrite is one of the events that does mint a new one: the rewritten "version" of the sstable gets `new_sid == new_gen.as_uuid()`.

Object-storage component rewrite copied the existing components under the new sstable's id, which was correct, but stamped the rewritten Scylla metadata with a freshly generated, unrelated id, and created no registry entry or reference object for the destination. The rewritten sstable therefore could not be found after a restart, and once found would look for its components under the wrong object prefix.

Below, gen_s / gen_n are the source / new generation (distinct uuids) and R is a freshly generated, unrelated UUID.

| Artifact (object storage) | Source sstable (before) | New sstable, pre-fix | New sstable, post-fix |
|---|---|---|---|
| `_generation` (RAM, TOC) | gen_s | gen_n | gen_n |
| `_sstable_identifier` (RAM) | gen_s.as_uuid() | gen_n.as_uuid() | gen_n.as_uuid() |
| component object keys `<prefix>/<sid>/<comp>` (Data, Index, ...) | gen_s.as_uuid() | gen_n.as_uuid() | gen_n.as_uuid() |
| `Scylla.db` metadata content: SSTableIdentifier (persisted sid) | gen_s.as_uuid() | R ← **BUG** | gen_n.as_uuid() |
| registry entry `entry_descriptor{gen,sid}` + ref `refs/nodes/{host}/{gen}` | present, sid=gen_s.as_uuid() | not created ← **BUG** | created, sid=gen_n.as_uuid() |
| id used to locate components on RELOAD (= persisted metadata) | gen_s.as_uuid() → matches | R → != gen_n.as_uuid() → miss | gen_n.as_uuid() → matches |

Thanks to @xemul for putting the table together.

The fix passes the destination id explicitly instead of letting it be generated by default, creates the registry entry and reference object for the destination sstable, and keeps the cached in-memory id from drifting from the persisted one.

The last two patches harden the invariant the fix establishes: whenever an sstable's identifier is known and its Scylla metadata is available, the two must be the same.

First, the sstable's own identifier is the authoritative one. `write_component_with_metadata()` writes it *into* the metadata it is about to persist, rather than reading the metadata back into the sstable, and a rewrite destination without an identifier is an internal error at that point. The load path, in turn, goes through `ensure_sstable_identifier()`, which takes the identifier persisted in the metadata when there is one — on load that is the only truth available — and falls back to the one already held, then to one derived from the generation. Previously the member was assigned unconditionally from the metadata, and since metadata carrying no identifier yields a null one, which leaves the optional unengaged, that did not merely change the identifier but forgot it, leaving an object-storage sstable unable to name its own component objects. `ensure_sstable_identifier()` deliberately does not touch the metadata: stamping stays with the callers that are about to write it out, so the in-memory metadata can never claim an identifier that has not reached disk.

Then a mismatch between the two becomes an internal error, checked where the metadata is consulted. That check is ordered after the fix because before the fix the component rewrite violates that very invariant, so a bisect landing in between would abort on the internal error instead of showing the original failure.

Note that this turns an existing on-disk inconsistency into a failure on load: an sstable rewritten by a build carrying the bug has a mismatched persisted identifier, and will now fail to load loudly instead of silently going missing. This is intentional. 2026.3 has not been released — it is at the release-candidate stage — so there is no requirement to stay compatible with on-disk state produced by earlier builds.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3420

--

* Requires backport to 2026.3 as tables on object storage is intended to be GA'ed there


