### PR TITLE
test: deflake test_quorum_lost_during_node_join_response_handler

### DIFF
--- a/test/cluster/test_raft_no_quorum.py
+++ b/test/cluster/test_raft_no_quorum.py
@@ -156,15 +156,39 @@ async def test_quorum_lost_during_node_join_response_handler(manager: ManagerCli
     fourth_node_future = asyncio.create_task(
         manager.server_start(servers[3].server_id,
                              expected_error="raft operation \\[read_barrier\\] timed out, there is no raft quorum",
-                             timeout=60))
+                             # Generous budget: it must cover the graceful stop of two nodes and
+                             # the log waits below, all of which are slow in debug mode on a
+                             # loaded machine.
+                             timeout=120))
 
     logger.info(
         f"waiting for the fourth node {servers[3]} to hit join-node-response_handler-before-read-barrier")
     await manager.api.wait_for_injection_enter(servers[3].ip_addr, "join-node-response_handler-before-read-barrier")
 
+    # The "there is no raft quorum" suffix in the read_barrier timeout error is produced only
+    # if the joining node already knows the group 0 configuration. The configuration arrives
+    # with the group 0 snapshot, which races with stopping the followers below - make sure
+    # the snapshot is applied before we take the quorum away (SCYLLADB-3411).
+    log_file = await manager.server_open_log(servers[3].server_id)
+    await log_file.wait_for("transfer snapshot from .* completed", timeout=60)
+
+    follower_host_ids = [str(await manager.get_host_id(srv.server_id)) for srv in servers[1:3]]
+    # Make sure the joining node's failure detector saw the followers alive before we stop
+    # them: a server that dies before its first successful ping is counted dead implicitly
+    # and never logs the "as dead" transition we wait for below.
+    for host_id in follower_host_ids:
+        await log_file.wait_for(f"marking Raft server {host_id} as alive for raft groups", timeout=60)
+    mark = await log_file.mark()
+
     logger.info("stopping the second and third nodes")
     await asyncio.gather(manager.server_stop_gracefully(servers[1].server_id),
                          manager.server_stop_gracefully(servers[2].server_id))
+
+    # Make sure the joining node's failure detector noticed the quorum loss, so the
+    # read_barrier timeout error deterministically carries the no-quorum message.
+    for host_id in follower_host_ids:
+        await log_file.wait_for(f"marking Raft server {host_id} as dead for raft groups",
+                                from_mark=mark, timeout=60)
 
     # Do it here to prevent unexpected timeouts before quorum loss.
     await update_group0_raft_op_timeout(servers[3].server_id, manager, raft_op_timeout)


### PR DESCRIPTION
## The flake

`cluster.test_raft_no_quorum.test_quorum_lost_during_node_join_response_handler` fails occasionally in debug/x86_64 nightlies (master-nightly #409, #410, scylla-ci #31446): the joining node fails to start as intended, but its log lacks the expected `, there is no raft quorum` suffix:

```
WARN raft_group_registry - group [...] raft operation [read_barrier] timed out; timeout requested at [service/storage_service.cc(6646:104)], original error raft::request_aborted (...)
Expected: raft operation [read_barrier] timed out, there is no raft quorum
```

## Root cause

A race in the test: it stops the followers assuming the joining node has already received the group 0 snapshot, but nothing waits for that.

The "no raft quorum" suffix is computed by the joining node from its *local* group 0 configuration, and a joining node starts with an empty configuration — the member list arrives only with the group 0 snapshot. The test stops the followers right after the `join-node-response_handler-before-read-barrier` injection is hit, which is typically just ~200 ms after the snapshot lands. If the snapshot loses that race, the leader steps down before ever delivering the configuration, the joining node sees zero voters, and the timeout error carries no quorum message.

Confirmed deterministically by blocking snapshot application on the joining node with the existing `block_group0_transfer_snapshot` injection — reproduces the exact nightly signature. It needs a heavily loaded machine to happen naturally (0/50 idle-machine debug runs), hence debug nightlies only. The failure detector was innocent: it marks stopped followers dead ~100 ms after they go down, well within the 10 s timeout.

## The fix

Wait for the preconditions the test was implicitly assuming:

1. before stopping the followers — the joining node has applied the group 0 snapshot and its failure detector has marked both followers alive (a server that dies before its first successful ping is counted dead implicitly and never logs the "as dead" transition waited for next);
2. before releasing the injection — its failure detector has marked both stopped followers dead.

The other tests in this module run the Raft operation on an original cluster member, which always has the full configuration, so they don't need this.

Verified locally: 20/20 repeats in debug and 15/15 in dev pass with the fix.

Fixes SCYLLADB-3411

Backport: this issue can affect CI builds in many branches,and since it a test only fix, there is no risk, so backport to all currently supported braches..
