### PR TITLE
Remove ctx.db usage from api/tasks.cc handlers

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -368,13 +368,13 @@ future<> set_server_service_levels(http_context &ctx, cql_transport::controller&
     });
 }
 
-future<> set_server_tasks_compaction_module(http_context& ctx, sharded<service::storage_service>& ss, sharded<db::snapshot_ctl>& snap_ctl) {
+future<> set_server_tasks_compaction_module(http_context& ctx, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 
-    return ctx.http_server.set_routes([rb, &ctx, &ss, &snap_ctl](routes& r) {
+    return ctx.http_server.set_routes([rb, &ctx, &db, &snap_ctl](routes& r) {
         rb->register_function(r, "tasks",
                 "The tasks API");
-        set_tasks_compaction_module(ctx, r, ss, snap_ctl);
+        set_tasks_compaction_module(ctx, r, db, snap_ctl);
     });
 }
 

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -137,7 +137,7 @@ future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>
 future<> unset_server_task_manager(http_context& ctx);
 future<> set_server_task_manager_test(http_context& ctx, sharded<tasks::task_manager>& tm);
 future<> unset_server_task_manager_test(http_context& ctx);
-future<> set_server_tasks_compaction_module(http_context& ctx, sharded<service::storage_service>& ss, sharded<db::snapshot_ctl>& snap_ctl);
+future<> set_server_tasks_compaction_module(http_context& ctx, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl);
 future<> unset_server_tasks_compaction_module(http_context& ctx);
 future<> set_server_raft(http_context&, sharded<service::raft_group_registry>&);
 future<> unset_server_raft(http_context&);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -11,6 +11,7 @@
 #include "api/api-doc/column_family.json.hh"
 #include "api/api-doc/storage_service.json.hh"
 #include "api/api-doc/storage_proxy.json.hh"
+#include "api/api-doc/tasks.json.hh"
 #include "api/scrub_status.hh"
 #include "db/config.hh"
 #include "db/schema_tables.hh"
@@ -77,6 +78,7 @@ namespace api {
 
 namespace ss = httpd::storage_service_json;
 namespace sp = httpd::storage_proxy_json;
+namespace t = httpd::tasks_json;
 namespace cf = httpd::column_family_json;
 using namespace json;
 
@@ -799,6 +801,27 @@ rest_cleanup_all(http_context& ctx, sharded<service::storage_service>& ss, std::
         });
 
         co_return json::json_return_type(0);
+}
+
+static future<shared_ptr<compaction::cleanup_keyspace_compaction_task_impl>> force_keyspace_cleanup(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
+        auto& db = ctx.db;
+        auto [keyspace, table_infos] = parse_table_infos(ctx, *req);
+        const auto& rs = db.local().find_keyspace(keyspace).get_replication_strategy();
+        if (rs.is_local() || !rs.is_vnode_based()) {
+            auto reason = rs.is_local() ? "require" : "support";
+            apilog.info("Keyspace {} does not {} cleanup", keyspace, reason);
+            co_return nullptr;
+        }
+        apilog.info("force_keyspace_cleanup: keyspace={} tables={}", keyspace, table_infos);
+        if (!co_await ss.local().is_vnodes_cleanup_allowed(keyspace)) {
+            auto msg = "Can not perform cleanup operation when topology changes";
+            apilog.warn("force_keyspace_cleanup: keyspace={} tables={}: {}", keyspace, table_infos, msg);
+            co_await coroutine::return_exception(std::runtime_error(msg));
+        }
+
+        auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
+        co_return co_await compaction_module.make_and_start_task<compaction::cleanup_keyspace_compaction_task_impl>(
+            {}, std::move(keyspace), db, table_infos, compaction::flush_mode::all_tables, tasks::is_user_task::yes);
 }
 
 static
@@ -2043,6 +2066,21 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::cdc_streams_check_and_repair.set(r, gated(ss, rest_bind(rest_cdc_streams_check_and_repair, ss)));
     ss::cleanup_all.set(r, gated(ss, rest_bind(rest_cleanup_all, ctx, ss)));
     ss::reset_cleanup_needed.set(r, gated(ss, rest_bind(rest_reset_cleanup_needed, ctx, ss)));
+    t::force_keyspace_cleanup_async.set(r, [&ctx, &ss](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        tasks::task_id id = tasks::task_id::create_null_id();
+        auto task = co_await force_keyspace_cleanup(ctx, ss, std::move(req));
+        if (task) {
+            id = task->get_status().id;
+        }
+        co_return json::json_return_type(id.to_sstring());
+    });
+    ss::force_keyspace_cleanup.set(r, [&ctx, &ss](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto task = co_await force_keyspace_cleanup(ctx, ss, std::move(req));
+        if (task) {
+            co_await task->done();
+        }
+        co_return json::json_return_type(0);
+    });
     ss::force_flush.set(r, gated(ss, rest_bind(rest_force_flush, ctx)));
     ss::force_keyspace_flush.set(r, gated(ss, rest_bind(rest_force_keyspace_flush, ctx)));
     ss::decommission.set(r, gated(ss, rest_bind(rest_decommission, ss, ssc)));
@@ -2129,6 +2167,8 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::cdc_streams_check_and_repair.unset(r);
     ss::cleanup_all.unset(r);
     ss::reset_cleanup_needed.unset(r);
+    t::force_keyspace_cleanup_async.unset(r);
+    ss::force_keyspace_cleanup.unset(r);
     ss::force_flush.unset(r);
     ss::force_keyspace_flush.unset(r);
     ss::logstor_compaction.unset(r);

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -38,8 +38,7 @@ static auto wrap_ks_cf(http_context &ctx, ks_cf_func f) {
     };
 }
 
-static future<shared_ptr<compaction::major_keyspace_compaction_task_impl>> force_keyspace_compaction(http_context& ctx, std::unique_ptr<http::request> req) {
-    auto& db = ctx.db;
+static future<shared_ptr<compaction::major_keyspace_compaction_task_impl>> force_keyspace_compaction(http_context& ctx, sharded<replica::database>& db, std::unique_ptr<http::request> req) {
     auto [ keyspace, table_infos ] = parse_table_infos(ctx, *req, "cf");
     auto flush = validate_bool_x(req->get_query_param("flush_memtables"), true);
     auto consider_only_existing_data = validate_bool_x(req->get_query_param("consider_only_existing_data"), false);
@@ -53,8 +52,7 @@ static future<shared_ptr<compaction::major_keyspace_compaction_task_impl>> force
     return compaction_module.make_and_start_task<compaction::major_keyspace_compaction_task_impl>({}, std::move(keyspace), tasks::task_id::create_null_id(), db, table_infos, fmopt, consider_only_existing_data);
 }
 
-static future<shared_ptr<compaction::upgrade_sstables_compaction_task_impl>> upgrade_sstables(http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) {
-    auto& db = ctx.db;
+static future<shared_ptr<compaction::upgrade_sstables_compaction_task_impl>> upgrade_sstables(sharded<replica::database>& db, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) {
     bool exclude_current_version = req_param<bool>(*req, "exclude_current_version", false);
 
     apilog.info("upgrade_sstables: keyspace={} tables={} exclude_current_version={}", keyspace, table_infos, exclude_current_version);
@@ -63,14 +61,14 @@ static future<shared_ptr<compaction::upgrade_sstables_compaction_task_impl>> upg
     return compaction_module.make_and_start_task<compaction::upgrade_sstables_compaction_task_impl>({}, std::move(keyspace), db, table_infos, exclude_current_version);
 }
 
-void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<service::storage_service>& ss, sharded<db::snapshot_ctl>& snap_ctl) {
+void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl) {
     t::force_keyspace_compaction_async.set(r, [&ctx](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto task = co_await force_keyspace_compaction(ctx, std::move(req));
+        auto task = co_await force_keyspace_compaction(ctx, ctx.db, std::move(req));
         co_return json::json_return_type(task->get_status().id.to_sstring());
     });
 
     ss::force_keyspace_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto task = co_await force_keyspace_compaction(ctx, std::move(req));
+        auto task = co_await force_keyspace_compaction(ctx, ctx.db, std::move(req));
         co_await task->done();
         co_return json_void();
     });
@@ -93,12 +91,12 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<service::
     }));
 
     t::upgrade_sstables_async.set(r, wrap_ks_cf(ctx, [] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
-        auto task = co_await upgrade_sstables(ctx, std::move(req), std::move(keyspace), std::move(table_infos));
+        auto task = co_await upgrade_sstables(ctx.db, std::move(req), std::move(keyspace), std::move(table_infos));
         co_return json::json_return_type(task->get_status().id.to_sstring());
     }));
 
     ss::upgrade_sstables.set(r, wrap_ks_cf(ctx, [] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
-        auto task = co_await upgrade_sstables(ctx, std::move(req), std::move(keyspace), std::move(table_infos));
+        auto task = co_await upgrade_sstables(ctx.db, std::move(req), std::move(keyspace), std::move(table_infos));
         co_await task->done();
         co_return json::json_return_type(0);
     }));

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -62,47 +62,46 @@ static future<shared_ptr<compaction::upgrade_sstables_compaction_task_impl>> upg
 }
 
 void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl) {
-    t::force_keyspace_compaction_async.set(r, [&ctx](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto task = co_await force_keyspace_compaction(ctx, ctx.db, std::move(req));
+    t::force_keyspace_compaction_async.set(r, [&ctx, &db](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto task = co_await force_keyspace_compaction(ctx, db, std::move(req));
         co_return json::json_return_type(task->get_status().id.to_sstring());
     });
 
-    ss::force_keyspace_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto task = co_await force_keyspace_compaction(ctx, ctx.db, std::move(req));
+    ss::force_keyspace_compaction.set(r, [&ctx, &db](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto task = co_await force_keyspace_compaction(ctx, db, std::move(req));
         co_await task->done();
         co_return json_void();
     });
 
-    t::perform_keyspace_offstrategy_compaction_async.set(r, wrap_ks_cf(ctx, [] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
+    t::perform_keyspace_offstrategy_compaction_async.set(r, wrap_ks_cf(ctx, [&db] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
         apilog.info("perform_keyspace_offstrategy_compaction: keyspace={} tables={}", keyspace, table_infos);
-        auto& compaction_module = ctx.db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<compaction::offstrategy_keyspace_compaction_task_impl>({}, std::move(keyspace), ctx.db, table_infos, nullptr);
+        auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
+        auto task = co_await compaction_module.make_and_start_task<compaction::offstrategy_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos, nullptr);
 
         co_return json::json_return_type(task->get_status().id.to_sstring());
     }));
 
-    ss::perform_keyspace_offstrategy_compaction.set(r, wrap_ks_cf(ctx, [] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
+    ss::perform_keyspace_offstrategy_compaction.set(r, wrap_ks_cf(ctx, [&db] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
         apilog.info("perform_keyspace_offstrategy_compaction: keyspace={} tables={}", keyspace, table_infos);
         bool res = false;
-        auto& compaction_module = ctx.db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<compaction::offstrategy_keyspace_compaction_task_impl>({}, std::move(keyspace), ctx.db, table_infos, &res);
+        auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
+        auto task = co_await compaction_module.make_and_start_task<compaction::offstrategy_keyspace_compaction_task_impl>({}, std::move(keyspace), db, table_infos, &res);
         co_await task->done();
         co_return json::json_return_type(res);
     }));
 
-    t::upgrade_sstables_async.set(r, wrap_ks_cf(ctx, [] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
-        auto task = co_await upgrade_sstables(ctx.db, std::move(req), std::move(keyspace), std::move(table_infos));
+    t::upgrade_sstables_async.set(r, wrap_ks_cf(ctx, [&db] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
+        auto task = co_await upgrade_sstables(db, std::move(req), std::move(keyspace), std::move(table_infos));
         co_return json::json_return_type(task->get_status().id.to_sstring());
     }));
 
-    ss::upgrade_sstables.set(r, wrap_ks_cf(ctx, [] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
-        auto task = co_await upgrade_sstables(ctx.db, std::move(req), std::move(keyspace), std::move(table_infos));
+    ss::upgrade_sstables.set(r, wrap_ks_cf(ctx, [&db] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
+        auto task = co_await upgrade_sstables(db, std::move(req), std::move(keyspace), std::move(table_infos));
         co_await task->done();
         co_return json::json_return_type(0);
     }));
 
-    t::scrub_async.set(r, [&ctx, &snap_ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto& db = ctx.db;
+    t::scrub_async.set(r, [&ctx, &db, &snap_ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto info = parse_scrub_options(ctx, std::move(req));
 
         if (!info.snapshot_tag.empty()) {
@@ -116,8 +115,7 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<replica::
         co_return json::json_return_type(task->get_status().id.to_sstring());
     });
 
-    ss::force_compaction.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto& db = ctx.db;
+    ss::force_compaction.set(r, [&db] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto flush = validate_bool_x(req->get_query_param("flush_memtables"), true);
         auto consider_only_existing_data = validate_bool_x(req->get_query_param("consider_only_existing_data"), false);
         apilog.info("force_compaction: flush={} consider_only_existing_data={}", flush, consider_only_existing_data);

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -16,7 +16,6 @@
 #include "api/api-doc/storage_service.json.hh"
 #include "compaction/compaction_manager.hh"
 #include "compaction/task_manager_module.hh"
-#include "service/storage_service.hh"
 #include "tasks/task_manager.hh"
 #include "replica/database.hh"
 
@@ -64,27 +63,6 @@ static future<shared_ptr<compaction::upgrade_sstables_compaction_task_impl>> upg
     return compaction_module.make_and_start_task<compaction::upgrade_sstables_compaction_task_impl>({}, std::move(keyspace), db, table_infos, exclude_current_version);
 }
 
-static future<shared_ptr<compaction::cleanup_keyspace_compaction_task_impl>> force_keyspace_cleanup(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
-    auto& db = ctx.db;
-    auto [keyspace, table_infos] = parse_table_infos(ctx, *req);
-    const auto& rs = db.local().find_keyspace(keyspace).get_replication_strategy();
-    if (rs.is_local() || !rs.is_vnode_based()) {
-        auto reason = rs.is_local() ? "require" : "support";
-        apilog.info("Keyspace {} does not {} cleanup", keyspace, reason);
-        co_return nullptr;
-    }
-    apilog.info("force_keyspace_cleanup: keyspace={} tables={}", keyspace, table_infos);
-    if (!co_await ss.local().is_vnodes_cleanup_allowed(keyspace)) {
-        auto msg = "Can not perform cleanup operation when topology changes";
-        apilog.warn("force_keyspace_cleanup: keyspace={} tables={}: {}", keyspace, table_infos, msg);
-        co_await coroutine::return_exception(std::runtime_error(msg));
-    }
-
-    auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-    co_return co_await compaction_module.make_and_start_task<compaction::cleanup_keyspace_compaction_task_impl>(
-        {}, std::move(keyspace), db, table_infos, compaction::flush_mode::all_tables, tasks::is_user_task::yes);
-}
-
 void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<service::storage_service>& ss, sharded<db::snapshot_ctl>& snap_ctl) {
     t::force_keyspace_compaction_async.set(r, [&ctx](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto task = co_await force_keyspace_compaction(ctx, std::move(req));
@@ -95,23 +73,6 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<service::
         auto task = co_await force_keyspace_compaction(ctx, std::move(req));
         co_await task->done();
         co_return json_void();
-    });
-
-    t::force_keyspace_cleanup_async.set(r, [&ctx, &ss](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        tasks::task_id id = tasks::task_id::create_null_id();
-        auto task = co_await force_keyspace_cleanup(ctx, ss, std::move(req));
-        if (task) {
-            id = task->get_status().id;
-        }
-        co_return json::json_return_type(id.to_sstring());
-    });
-
-    ss::force_keyspace_cleanup.set(r, [&ctx, &ss](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto task = co_await force_keyspace_cleanup(ctx, ss, std::move(req));
-        if (task) {
-            co_await task->done();
-        }
-        co_return json::json_return_type(0);
     });
 
     t::perform_keyspace_offstrategy_compaction_async.set(r, wrap_ks_cf(ctx, [] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
@@ -177,8 +138,6 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<service::
 void unset_tasks_compaction_module(http_context& ctx, httpd::routes& r) {
     t::force_keyspace_compaction_async.unset(r);
     ss::force_keyspace_compaction.unset(r);
-    t::force_keyspace_cleanup_async.unset(r);
-    ss::force_keyspace_cleanup.unset(r);
     t::perform_keyspace_offstrategy_compaction_async.unset(r);
     ss::perform_keyspace_offstrategy_compaction.unset(r);
     t::upgrade_sstables_async.unset(r);

--- a/api/tasks.hh
+++ b/api/tasks.hh
@@ -15,14 +15,14 @@ namespace seastar::httpd {
 class routes;
 }
 
-namespace service {
-class storage_service;
+namespace replica {
+class database;
 }
 
 namespace api {
 
 struct http_context;
-void set_tasks_compaction_module(http_context& ctx, httpd::routes& r, sharded<service::storage_service>& ss, sharded<db::snapshot_ctl>& snap_ctl);
+void set_tasks_compaction_module(http_context& ctx, httpd::routes& r, sharded<replica::database>& db, sharded<db::snapshot_ctl>& snap_ctl);
 void unset_tasks_compaction_module(http_context& ctx, httpd::routes& r);
 
 }

--- a/main.cc
+++ b/main.cc
@@ -2378,7 +2378,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 api::unset_server_snapshot(ctx).get();
             });
 
-            api::set_server_tasks_compaction_module(ctx, ss, snapshot_ctl).get();
+            api::set_server_tasks_compaction_module(ctx, db, snapshot_ctl).get();
             auto stop_tasks_api = defer_verbose_shutdown("tasks API", [&ctx] {
                 api::unset_server_tasks_compaction_module(ctx).get();
             });


### PR DESCRIPTION
The handlers in question are compaction_manager async ones. They need replica::database to get compaction manager from and to pass it to compaction manager async tasks. To provide the database the PR follows the approach accepted by other "modules" -- passes the sharded<database> reference from main down to registering handlers, and captures it where needed.

While at it, stop passing the storage_service into those handlers and move the "keyspace cleanup" endpoints to storage_service.cc, as cleanup is nowadays a storage_service operation, not database one.

refs: #2737

Improving components inter-dependencies, not backporting