### PR TITLE
raft: decouple commit acknowledgement from the applier fiber

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -215,10 +215,17 @@ private:
 
     // Entries that have a waiter that needs to be notified when the
     // respective entry is known to be committed.
+    // Waiters are inserted by wait_for_entry() and dropped by io_fiber as soon
+    // as the fsm reports the entry committed, independently of the applier
+    // fiber's progress (abort() fails whatever is left). Dropping the waiters
+    // in a single fiber, in commit order, is what maintains the ordering
+    // invariant asserted in notify_waiters().
     std::map<index_t, op_status> _awaited_commits;
 
     // Entries that have a waiter that needs to be notified after
     // the respective entry is applied.
+    // Waiters are inserted by wait_for_entry() and dropped by the applier
+    // fiber, in apply order (abort() fails whatever is left).
     std::map<index_t, op_status> _awaited_applies;
 
     // Maps each destination to the abort_source of the currently active
@@ -256,12 +263,13 @@ private:
     // Called to commit entries (on a leader or otherwise).
     void notify_waiters(std::map<index_t, op_status>& waiters, const log_entry_ptr_list& entries);
 
-    // Drop waiter that we lost track of, can happen due to a snapshot transfer,
+    // Drop waiters that we lost track of, can happen due to a snapshot transfer,
     // or a leader removed from cluster while some entries added on it are uncommitted.
-    // When `snp` is provided (snapshot transfer case), waiters whose term matches
-    // the snapshot term are resolved successfully, since the snapshot-term match proves
-    // they were committed and included in the snapshot (by the Log Matching Property).
-    void drop_waiters(const snapshot_descriptor* snp = nullptr);
+    // When `snp` is provided (snapshot transfer case), only waiters up to the
+    // snapshot index are dropped, and those whose term matches the snapshot term
+    // are resolved successfully, since the snapshot-term match proves they were
+    // committed and included in the snapshot (by the Log Matching Property).
+    void drop_waiters(std::map<index_t, op_status>& waiters, const snapshot_descriptor* snp = nullptr);
 
     // Wake up all waiter that wait for entries with idx smaller of equal to the one provided
     // to be applied.
@@ -998,28 +1006,24 @@ void server_impl::notify_waiters(std::map<index_t, op_status>& waiters,
     }
 }
 
-void server_impl::drop_waiters(const snapshot_descriptor* snp) {
-    auto drop = [&] (std::map<index_t, op_status>& waiters) {
-        while (waiters.size() != 0) {
-            auto it = waiters.begin();
-            if (snp && it->first > snp->idx) {
-                break;
-            }
-            auto [entry_idx, status] = std::move(*it);
-            waiters.erase(it);
-            if (snp && status.term == snp->term) {
-                // entry_idx <= snapshot index and the entry's term matches the snapshot term.
-                // By the Log Matching Property the entry was committed and included in the snapshot.
-                status.done.set_value();
-                _stats.waiters_awoken++;
-            } else {
-                status.done.set_exception(commit_status_unknown());
-                _stats.waiters_dropped++;
-            }
+void server_impl::drop_waiters(std::map<index_t, op_status>& waiters, const snapshot_descriptor* snp) {
+    while (waiters.size() != 0) {
+        auto it = waiters.begin();
+        if (snp && it->first > snp->idx) {
+            break;
         }
-    };
-    drop(_awaited_commits);
-    drop(_awaited_applies);
+        auto [entry_idx, status] = std::move(*it);
+        waiters.erase(it);
+        if (snp && status.term == snp->term) {
+            // entry_idx <= snapshot index and the entry's term matches the snapshot term.
+            // By the Log Matching Property the entry was committed and included in the snapshot.
+            status.done.set_value();
+            _stats.waiters_awoken++;
+        } else {
+            status.done.set_exception(commit_status_unknown());
+            _stats.waiters_dropped++;
+        }
+    }
 }
 
 void server_impl::signal_applied() {
@@ -1144,6 +1148,14 @@ future<> server_impl::process_fsm_output(index_t& last_stable, fsm_output&& batc
         // If this is locally generated snapshot there is no need to
         // load it.
         if (!is_local) {
+            // A snapshot received from the leader may advance the commit index
+            // past entries this server never saw committed, so some commit
+            // waiters may never get a committed batch covering them. Drop
+            // them here, before the committed entries of this batch (which
+            // start above the snapshot index) are notified below: this keeps
+            // commit waiters dropped in index order, which notify_waiters()
+            // asserts.
+            drop_waiters(_awaited_commits, &snp);
             co_await _apply_entries.push_eventually(std::move(snp));
         }
     }
@@ -1217,6 +1229,12 @@ future<> server_impl::process_fsm_output(index_t& last_stable, fsm_output&& batc
             }
         }
         co_await _persistence->store_commit_idx(batch.committed.back()->idx);
+        // Notify commit waiters here rather than in the applier fiber: an entry
+        // is committed once a quorum of servers has it in their logs, regardless
+        // of how far the local state machine got with applying entries, so the
+        // notification must not depend on the applier fiber's progress (which
+        // may lag behind, e.g. when its queue backs up on a slow state machine).
+        notify_waiters(_awaited_commits, batch.committed);
         _stats.queue_entries_for_apply += batch.committed.size();
         co_await _apply_entries.push_eventually(std::move(batch.committed));
     }
@@ -1232,9 +1250,16 @@ future<> server_impl::process_fsm_output(index_t& last_stable, fsm_output&& batc
             std::exchange(_stepdown_promise, std::nullopt)->set_value();
         }
         if (!_current_rpc_config.contains(_id)) {
-            // - It's important we push this after we pushed committed entries above. It
-            // will cause `applier_fiber` to drop waiters, which should be done after we
-            // notify all waiters for entries committed in this batch.
+            // The node is outside the configuration and not a leader, so it may
+            // never learn the status of entries it submitted. Resolve all commit
+            // waiters with commit_status_unknown. This runs after the waiters for
+            // entries committed in this batch were notified above, so they are
+            // not spuriously dropped.
+            drop_waiters(_awaited_commits);
+            // - Tell the applier fiber to drop the apply waiters as well. It's
+            // important we push this after we pushed committed entries above, so
+            // that waiters for entries applied in this batch are notified before
+            // the rest are dropped.
             // - This may happen multiple times if `io_fiber` gets multiple batches when
             // we're outside the configuration, but it should eventually (and generally
             // quickly) stop happening (we're outside the config after all).
@@ -1384,13 +1409,6 @@ future<> server_impl::applier_fiber() {
                     co_return;
                 }
 
-                // Completion notification code assumes that previous snapshot is applied
-                // before new entries are committed, otherwise it asserts that some
-                // notifications were missing. To prevent a committed entry to
-                // be notified before an earlier snapshot is applied do both
-                // notification and snapshot application in the same fiber
-                notify_waiters(_awaited_commits, batch);
-
                 log_entry_ptr_list commands;
                 commands.reserve(batch.size());
 
@@ -1456,18 +1474,32 @@ future<> server_impl::applier_fiber() {
             },
             [this] (snapshot_descriptor& snp) -> future<> {
                 SCYLLA_ASSERT(snp.idx >= _applied_idx);
+                // Lets a test hold the applier fiber here, so that io_fiber
+                // keeps processing fsm output (in particular, notifying commit
+                // waiters) while a remote snapshot is still not applied.
+                co_await utils::get_local_injector().inject("block_raft_applier_fiber_before_load_snapshot",
+                        utils::wait_for_message(std::chrono::minutes(5)));
                 // Apply snapshot it to the state machine
                 logger.trace("[{}] apply_fiber applying snapshot {}", _tag, snp.id);
                 co_await _state_machine->load_snapshot(snp.id);
-                drop_waiters(&snp);
+                // Drop apply waiters covered by the snapshot only now, after
+                // load_snapshot(): a resolved "applied" waiter promises that the
+                // local state machine already contains the entry's effect.
+                // The commit waiters were already dropped by io_fiber when it
+                // received this snapshot, commitment does not depend on the
+                // local apply progress.
+                drop_waiters(_awaited_applies, &snp);
                 _applied_idx = snp.idx;
                 _applied_index_changed.broadcast();
                 _stats.sm_load_snapshot++;
             },
             [this] (const removed_from_config&) -> future<> {
                 // If the node is no longer part of a config and no longer the leader
-                // it may never know the status of entries it submitted.
-                drop_waiters();
+                // it may never know the status of entries it submitted. The commit
+                // waiters were already dropped by io_fiber; drop the apply waiters
+                // here, after all batches queued before this message were applied
+                // and their waiters notified.
+                drop_waiters(_awaited_applies);
                 co_return;
             },
             [this] (const trigger_snapshot_msg&) -> future<> {

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1231,13 +1231,18 @@ future<> server_impl::process_fsm_output(index_t& last_stable, fsm_output&& batc
                 }
             }
         }
-        co_await _persistence->store_commit_idx(batch.committed.back()->idx);
         // Notify commit waiters here rather than in the applier fiber: an entry
         // is committed once a quorum of servers has it in their logs, regardless
         // of how far the local state machine got with applying entries, so the
         // notification must not depend on the applier fiber's progress (which
         // may lag behind, e.g. when its queue backs up on a slow state machine).
         notify_waiters(_awaited_commits, batch.committed);
+        // Persisting the commit index is optional (see
+        // persistence::store_commit_idx): a restarted server re-learns it from
+        // the leader or, after a full cluster restart, the new leader recomputes
+        // it from a quorum. So the commit notification above does not need to
+        // wait for this write.
+        co_await _persistence->store_commit_idx(batch.committed.back()->idx);
         _stats.queue_entries_for_apply += batch.committed.size();
         co_await _apply_entries.push_eventually(std::move(batch.committed));
     }

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -213,6 +213,9 @@ private:
         optimized_optional<seastar::abort_source::subscription> abort; // abort subscription
     };
 
+    // Waiters for entry commit/apply status, keyed by entry index.
+    using waiters_map = std::map<index_t, op_status>;
+
     // Entries that have a waiter that needs to be notified when the
     // respective entry is known to be committed.
     // Waiters are inserted by wait_for_entry() and dropped by io_fiber as soon
@@ -220,13 +223,13 @@ private:
     // fiber's progress (abort() fails whatever is left). Dropping the waiters
     // in a single fiber, in commit order, is what maintains the ordering
     // invariant asserted in notify_waiters().
-    std::map<index_t, op_status> _awaited_commits;
+    waiters_map _awaited_commits;
 
     // Entries that have a waiter that needs to be notified after
     // the respective entry is applied.
     // Waiters are inserted by wait_for_entry() and dropped by the applier
     // fiber, in apply order (abort() fails whatever is left).
-    std::map<index_t, op_status> _awaited_applies;
+    waiters_map _awaited_applies;
 
     // Maps each destination to the abort_source of the currently active
     // snapshot transfer.  The abort_source itself lives on the coroutine
@@ -261,7 +264,7 @@ private:
     server_requests _new_server_requests;
 
     // Called to commit entries (on a leader or otherwise).
-    void notify_waiters(std::map<index_t, op_status>& waiters, const log_entry_ptr_list& entries);
+    void notify_waiters(waiters_map& waiters, const log_entry_ptr_list& entries);
 
     // Drop waiters that we lost track of, can happen due to a snapshot transfer,
     // or a leader removed from cluster while some entries added on it are uncommitted.
@@ -269,7 +272,7 @@ private:
     // snapshot index are dropped, and those whose term matches the snapshot term
     // are resolved successfully, since the snapshot-term match proves they were
     // committed and included in the snapshot (by the Log Matching Property).
-    void drop_waiters(std::map<index_t, op_status>& waiters, const snapshot_descriptor* snp = nullptr);
+    void drop_waiters(waiters_map& waiters, const snapshot_descriptor* snp = nullptr);
 
     // Wake up all waiter that wait for entries with idx smaller of equal to the one provided
     // to be applied.
@@ -963,7 +966,7 @@ void server_impl::read_quorum_reply(server_id from, struct read_quorum_reply rea
     _fsm->step(from, std::move(read_quorum_reply));
 }
 
-void server_impl::notify_waiters(std::map<index_t, op_status>& waiters,
+void server_impl::notify_waiters(waiters_map& waiters,
         const log_entry_ptr_list& entries) {
     index_t commit_idx = entries.back()->idx;
     index_t first_idx = entries.front()->idx;
@@ -1006,7 +1009,7 @@ void server_impl::notify_waiters(std::map<index_t, op_status>& waiters,
     }
 }
 
-void server_impl::drop_waiters(std::map<index_t, op_status>& waiters, const snapshot_descriptor* snp) {
+void server_impl::drop_waiters(waiters_map& waiters, const snapshot_descriptor* snp) {
     while (waiters.size() != 0) {
         auto it = waiters.begin();
         if (snp && it->first > snp->idx) {

--- a/test/lib/error_injection.hh
+++ b/test/lib/error_injection.hh
@@ -8,15 +8,28 @@
 
 #pragma once
 
+#include <chrono>
+#include <stdexcept>
+#include <fmt/format.h>
 #include <seastar/core/future.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include "utils/error_injection.hh"
 
 // Waits until enter_count for the named injection reaches the given threshold.
-// A replacement for busy-loop polling in unit tests.
-inline future<> wait_for_injection_enter(std::string_view injection_name, size_t threshold = 1) {
+// A replacement for busy-loop polling in unit tests. Throws if the threshold
+// is not reached within the timeout, so a test that would otherwise hang
+// forever fails with a clear error instead.
+inline future<> wait_for_injection_enter(std::string_view injection_name, size_t threshold = 1,
+        std::chrono::steady_clock::duration timeout = std::chrono::seconds(30)) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (utils::get_local_injector().enter_count(injection_name) < threshold) {
+        if (std::chrono::steady_clock::now() > deadline) {
+            throw std::runtime_error(fmt::format(
+                    "wait_for_injection_enter(\"{}\"): enter_count did not reach {} within {}s",
+                    injection_name, threshold,
+                    std::chrono::duration_cast<std::chrono::seconds>(timeout).count()));
+        }
         co_await coroutine::maybe_yield();
     }
 }

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -360,12 +360,15 @@ static void test_add_entry_wait_resolved_via_drop_waiters_aux(raft::wait_type ty
         .nodes = 3,
         .config = std::vector<raft::server::configuration>({srv_config, srv_config, srv_config})
     };
+    // Resolved when node 0 (the leader) applies the entry with command 42
+    // added below.
+    seastar::promise<> leader_applied_42;
     // apply_entries must be greater than the number of entries added
     // during the test, otherwise the state machine's done promise fires
     // prematurely.
     auto cluster = raft_cluster<std::chrono::steady_clock>{
         std::move(test_config),
-        ::apply_changes,
+        signal_when_leader_applies(42, leader_applied_42),
         100,  // apply_entries
         0,
         0, false, tick_delay, rpc_config{}
@@ -386,8 +389,20 @@ static void test_add_entry_wait_resolved_via_drop_waiters_aux(raft::wait_type ty
     auto& follower = cluster.get_server(1);
     auto fut = follower.add_entry(create_command(42), type, nullptr);
 
-    // Wait for the leader to commit, apply, and snapshot the entry.
+    // The snapshot must cover the entry, otherwise node 1, once reconnected,
+    // catches up by append entries and drop_waiters() is never exercised.
+    //
+    // The signal fires inside apply(), before the applied index the snapshot is
+    // taken at is assigned, so the barrier is what puts the entry under that
+    // index. The barrier alone wouldn't do: it only waits for entries committed
+    // when it registers, and the forwarded entry may not have reached the
+    // leader yet.
+    //
+    // trigger_snapshot() waits for a persisted snapshot at or above the applied
+    // index; false means automatic snapshotting (snapshot_threshold = 1 above)
+    // already took it.
     auto& leader = cluster.get_server(0);
+    leader_applied_42.get_future().get();
     leader.read_barrier(nullptr).get();
     leader.trigger_snapshot(nullptr).get();
 

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -24,6 +24,31 @@ static raft_cluster<clock_type> get_default_cluster(test_case test_config) {
     };
 }
 
+// Builds a state machine apply function which resolves `applied` as soon as
+// node 0 (the leader in the tests using this) applies the entry carrying
+// `value`. Entries added on a follower are forwarded to the leader
+// asynchronously, so a test that must act only after the leader applied such
+// an entry needs an explicit signal like this one.
+//
+// The value is expected to be added exactly once, so seeing it applied more
+// than once means the test does something it didn't intend to and the check
+// below fails it.
+static auto signal_when_leader_applies(int value, seastar::promise<>& applied) {
+    return [value, &applied, signalled = false] (raft::server_id id, const raft::log_entry_ptr_list& commands,
+            lw_shared_ptr<hasher_int> hasher) mutable {
+        if (id == to_raft_id(0)) {
+            for (auto& entry : commands) {
+                auto is = ser::as_input_stream(std::get<raft::command>(entry->data));
+                if (ser::deserialize(is, std::type_identity<int>()) == value) {
+                    BOOST_REQUIRE(!std::exchange(signalled, true));
+                    applied.set_value();
+                }
+            }
+        }
+        return apply_changes(id, commands, hasher);
+    };
+}
+
 SEASTAR_THREAD_TEST_CASE(test_check_abort_on_client_api) {
     raft_cluster<std::chrono::steady_clock> cluster(
             test_case { .nodes = 1 },
@@ -381,4 +406,109 @@ SEASTAR_THREAD_TEST_CASE(test_add_entry_applied_wait_resolved_via_drop_waiters) 
 
 SEASTAR_THREAD_TEST_CASE(test_add_entry_committed_wait_resolved_via_drop_waiters) {
     test_add_entry_wait_resolved_via_drop_waiters_aux(raft::wait_type::committed);
+}
+
+// Reproducer of the race originally fixed by 88a6e2446d: commit waiters must be
+// resolved in index order, otherwise the ordering assert in notify_waiters()
+// (entry_idx >= first_idx) trips. A waiter covered by a snapshot received from
+// the leader must therefore be dropped before the entries committed above that
+// snapshot's index are notified.
+//
+// Setup: 3-node cluster. Node 1 (follower) is blocked from receiving messages
+// from the leader (node 0), but can still send to it, so its add_entry is
+// forwarded to the leader and a commit waiter is registered locally, while the
+// entry itself never arrives via append entries. The leader commits the entry
+// (with node 2), applies it and takes a snapshot; trigger_snapshot leaves no
+// trailing entries, so once node 1 is reconnected the only way for it to catch
+// up is a snapshot transfer.
+//
+// Node 1's applier fiber is then held before load_snapshot() and another entry,
+// whose index is above the snapshot index, is committed. Node 1's io_fiber
+// notifies the commit waiters for that entry while the snapshot is still not
+// applied. If the waiter for the first entry were dropped only by the applier
+// fiber (as it used to be, when the snapshot was processed), it would still sit
+// in _awaited_commits below the first index of the committed batch and trip the
+// assert. io_fiber drops it when it processes the snapshot, so the order holds.
+SEASTAR_THREAD_TEST_CASE(test_commit_waiter_dropped_before_notifying_above_snapshot) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    std::cerr << "Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n";
+    return;
+#else
+    // The default snapshot thresholds are high enough that no snapshot is taken
+    // automatically during the test: the only snapshot is the one triggered
+    // explicitly below.
+    // Resolved when node 0 (the leader) applies the entry with command 42
+    // added below.
+    seastar::promise<> leader_applied_42;
+    // apply_entries must be greater than the number of entries added during the
+    // test, otherwise the state machine's done promise fires prematurely.
+    auto cluster = raft_cluster<std::chrono::steady_clock>{
+        test_case { .nodes = 3 },
+        signal_when_leader_applies(42, leader_applied_42),
+        100,  // apply_entries
+        0,
+        0, false, tick_delay, rpc_config{}
+    };
+    cluster.start_all().get();
+    auto stop = defer([&cluster] noexcept { cluster.stop_all().get(); });
+
+    auto& leader = cluster.get_server(0);
+    auto& follower = cluster.get_server(1);
+
+    // A server learns who the leader is from the messages the leader sends it,
+    // so node 1 must observe the leader before it stops receiving from node 0.
+    // Otherwise the forwarding below has nowhere to forward the entry to and
+    // blocks until node 1 is reconnected.
+    follower.wait_for_leader(nullptr).get();
+
+    // Block node 1 from receiving messages from node 0 (leader).
+    // Node 1 can still send to node 0 (forwarding works).
+    cluster.block_receive(1, 0);
+
+    // Node 1 forwards the entry to node 0, which commits it with node 2.
+    // Node 1 registers a commit waiter but never receives the entry via
+    // append entries.
+    auto fut = follower.add_entry(create_command(42), raft::wait_type::committed, nullptr);
+
+    // The snapshot must cover the entry, otherwise node 1, once reconnected,
+    // catches up by append entries instead of a snapshot transfer. As in
+    // test_add_entry_wait_resolved_via_drop_waiters_aux, the signal fires inside
+    // apply(), before the applied index the snapshot is taken at is assigned, so
+    // the barrier is what puts the entry under that index. The thresholds here
+    // are the default ones, so nothing snapshots automatically and
+    // trigger_snapshot() must take the snapshot itself.
+    leader_applied_42.get_future().get();
+    leader.read_barrier(nullptr).get();
+    BOOST_REQUIRE(leader.trigger_snapshot(nullptr).get());
+
+    // Hold the applier fiber before it loads the snapshot node 1 is about to
+    // receive. Node 1 is the only server that can reach this injection point:
+    // it only fires for snapshots received from the leader, node 0 is the
+    // leader and node 2 is up to date. The injection is not one-shot, so it is
+    // not consumed by a single server: whoever reaches it waits for the message
+    // sent below. It is disabled when this scope ends, which both releases
+    // anything still waiting and keeps a later snapshot transfer, if any,
+    // from stalling the cluster shutdown.
+    constexpr auto block_applier = "block_raft_applier_fiber_before_load_snapshot";
+    scoped_error_injection blocked_applier{block_applier};
+
+    // Reconnect node 1. The leader sends a snapshot since the entry is no
+    // longer in its log.
+    cluster.connect_all();
+    wait_for_injection_enter(block_applier).get();
+
+    // Commit an entry above the snapshot index while node 1 still hasn't
+    // applied the snapshot. Waiting for it on node 1 guarantees that node 1's
+    // io_fiber notified the commit waiters for a batch starting above the
+    // snapshot index, which is the notification that used to trip the assert.
+    follower.add_entry(create_command(43), raft::wait_type::committed, nullptr).get();
+
+    // Let the applier fiber load the snapshot.
+    utils::get_local_injector().receive_message(block_applier);
+
+    // The waiter for the first entry is resolved successfully: the snapshot's
+    // term matches the entry's term, which proves the entry was committed and
+    // included in the snapshot.
+    BOOST_CHECK_NO_THROW(fut.get());
+#endif
 }


### PR DESCRIPTION
Resolving `wait_type::committed` waiters was tied to the applier fiber -- commit notification ran there (since 88a6e2446d), so acking a committed entry depended on state machine apply progress. This coupling is accidental — 88a6e2446d serialized commit notification with snapshot application only to keep waiter retirement ordered, and db2a3deda1 then had to move the removed_from_config drop there too.

This PR retires commit waiters entirely in io_fiber, in commit order: notify on committed batches, drop on remote snapshots and on removal from config. Ordering is preserved because io_fiber consumes fsm outputs in order and committed batches never overlap a snapshot (fsm::get_output starts them above the snapshot index). Apply waiters (wait_type::applied) stay in the applier fiber — a resolved "applied" waiter promises the local state machine already contains the entry's effect.

Also, commit waiters are now notified before store_commit_idx rather than after: persisting the commit index is optional (see persistence::store_commit_idx, 579dcf187a) — a restarted server re-learns it from the leader or a quorum — so the ack path saves a storage write of latency.

Motivation: strongly consistent tablet split. During split finalization, writes are redirected to the child raft groups while the child applier fibers stay suspended until the parent group applies its final entry (to keep parent/child linearization). Redirected writes must still be acknowledged on commit, so commit acks cannot depend on the applier fiber.

No behavior change for wait_type::applied; commit acks now resolve as soon as the commit is known, independent of apply progress.

backport: no need -- a new feature/optimization