### PR TITLE
message: add extra diagnostics for RPC compression checksum errors

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1184,6 +1184,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "If this happens, this option can be used to make the stalls less severe.")
     , internode_compression_checksumming(this, "internode_compression_checksumming", liveness::LiveUpdate, value_status::Used, true,
         "Computes and checks checksums for compressed RPC frames. This is a paranoid precaution against corruption bugs in the compression protocol.")
+    , internode_compression_dump_message_on_checksum_error(this, "internode_compression_dump_message_on_checksum_error", liveness::LiveUpdate, value_status::Used, false,
+        "When internode_compression_checksumming detects a checksum violation, dump the bad message to a file in TMPDIR. For debug usage by Scylla developers.")
     , internode_compression_algorithms(this, "internode_compression_algorithms", liveness::LiveUpdate, value_status::Used,
             { netw::compression_algorithm::type::ZSTD, netw::compression_algorithm::type::LZ4, },
         "Specifies RPC compression algorithms supported by this node. ")

--- a/db/config.cc
+++ b/db/config.cc
@@ -1186,6 +1186,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Computes and checks checksums for compressed RPC frames. This is a paranoid precaution against corruption bugs in the compression protocol.")
     , internode_compression_dump_message_on_checksum_error(this, "internode_compression_dump_message_on_checksum_error", liveness::LiveUpdate, value_status::Used, false,
         "When internode_compression_checksumming detects a checksum violation, dump the bad message to a file in TMPDIR. For debug usage by Scylla developers.")
+    , internode_compression_dump_message_on_fingerprint(this, "internode_compression_dump_message_on_fingerprint", liveness::LiveUpdate, value_status::Used, "",
+        "When a compressed message matches this hash on the sender, dump it to a file in TMPDIR. For debug usage by Scylla developers.")
     , internode_compression_algorithms(this, "internode_compression_algorithms", liveness::LiveUpdate, value_status::Used,
             { netw::compression_algorithm::type::ZSTD, netw::compression_algorithm::type::LZ4, },
         "Specifies RPC compression algorithms supported by this node. ")

--- a/db/config.hh
+++ b/db/config.hh
@@ -340,6 +340,7 @@ public:
     named_value<uint32_t> internode_compression_zstd_min_message_size;
     named_value<uint32_t> internode_compression_zstd_max_message_size;
     named_value<bool> internode_compression_checksumming;
+    named_value<bool> internode_compression_dump_message_on_checksum_error;
     named_value<netw::advanced_rpc_compressor::tracker::algo_config> internode_compression_algorithms;
     named_value<bool> internode_compression_enable_advanced;
     named_value<enum_option<netw::dict_training_loop::when>> rpc_dict_training_when;

--- a/db/config.hh
+++ b/db/config.hh
@@ -341,6 +341,7 @@ public:
     named_value<uint32_t> internode_compression_zstd_max_message_size;
     named_value<bool> internode_compression_checksumming;
     named_value<bool> internode_compression_dump_message_on_checksum_error;
+    named_value<sstring> internode_compression_dump_message_on_fingerprint;
     named_value<netw::advanced_rpc_compressor::tracker::algo_config> internode_compression_algorithms;
     named_value<bool> internode_compression_enable_advanced;
     named_value<enum_option<netw::dict_training_loop::when>> rpc_dict_training_when;

--- a/main.cc
+++ b/main.cc
@@ -1655,6 +1655,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     .register_metrics = cfg->internode_compression_enable_advanced(),
                     .checksumming = cfg->internode_compression_checksumming,
                     .dump_message_on_checksum_error = cfg->internode_compression_dump_message_on_checksum_error,
+                    .dump_message_on_fingerprint = cfg->internode_compression_dump_message_on_fingerprint,
                 };
             };
             static sharded<netw::walltime_compressor_tracker> compressor_tracker;

--- a/main.cc
+++ b/main.cc
@@ -1654,6 +1654,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     .algo_config = cfg->internode_compression_algorithms,
                     .register_metrics = cfg->internode_compression_enable_advanced(),
                     .checksumming = cfg->internode_compression_checksumming,
+                    .dump_message_on_checksum_error = cfg->internode_compression_dump_message_on_checksum_error,
                 };
             };
             static sharded<netw::walltime_compressor_tracker> compressor_tracker;

--- a/message/advanced_rpc_compressor.cc
+++ b/message/advanced_rpc_compressor.cc
@@ -8,8 +8,16 @@
 
 #include <seastar/core/metrics.hh>
 #include <seastar/util/defer.hh>
+#include <filesystem>
+#include <seastar/util/tmp_file.hh>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
 #include <numeric>
+#include <system_error>
 #include "utils/log.hh"
+#include "utils/assert.hh"
+#include "utils/error_injection.hh"
 #include "utils/hashers.hh"
 #include "utils/xx_hasher.hh"
 #include "bytes.hh"
@@ -432,6 +440,80 @@ static rpc_compression_fingerprint get_compression_fingerprint(uint32_t crc, con
     };
 }
 
+static void write_all(int fd, std::span<const std::byte> data) {
+    while (!data.empty()) {
+        const ssize_t n = ::write(fd, data.data(), data.size());
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            throw std::system_error(errno, std::system_category(), "write");
+        }
+        data = data.subspan(n);
+    }
+}
+
+// Dumps a compressed frame together with the dictionary it used to a file in the
+// temporary directory, for offline investigation.
+//
+// This is just a diagnostic aid, so any failure is logged and otherwise ignored.
+// It must never bring the node down.
+template <RpcBuf Buf>
+static void dump_message(
+    std::string_view path_filename,
+    std::string_view description,
+    uint8_t header_byte,
+    uint32_t expected_crc,
+    uint32_t actual_crc,
+    const shared_dict& dict,
+    const Buf& data,
+    size_t payload_offset
+) {
+    const auto path = fmt::format("{}/{}.shard_{}.bin", seastar::default_tmpdir().native(), path_filename, this_shard_id());
+    int fd = -1;
+    auto close_fd = defer([&fd] noexcept {
+        if (fd >= 0) {
+            ::close(fd);
+        }
+    });
+    try {
+        // Recreate the file from scratch, so that we are sure about its permissions.
+        if (::unlink(path.c_str()) < 0 && errno != ENOENT) {
+            throw std::system_error(errno, std::system_category(), "unlink");
+        }
+        fd = ::open(path.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR);
+        if (fd < 0) {
+            throw std::system_error(errno, std::system_category(), "open");
+        }
+
+        // The message can be arbitrarily big, so we stream it out fragment by fragment
+        // instead of gluing it into one contiguous buffer.
+        auto write_be = [&fd] <std::integral T> (T x) {
+            std::array<char, sizeof(T)> buf;
+            seastar::write_be<T>(buf.data(), x);
+            write_all(fd, std::as_bytes(std::span(buf)));
+        };
+
+        write_be(header_byte);
+        write_be(expected_crc);
+        write_be(actual_crc);
+        write_all(fd, dict.id.content_sha256);
+        write_be(uint64_t(dict.data.size()));
+        write_all(fd, dict.data);
+        for_each_rpc_buf_fragment(data, payload_offset, [&] (std::span<const std::byte> fragment) {
+            write_be(uint64_t(fragment.size()));
+            write_all(fd, fragment);
+        });
+
+        if (::close(std::exchange(fd, -1)) < 0) {
+            throw std::system_error(errno, std::system_category(), "close");
+        }
+        arc_logger.warn("Dumped {} to {}", description, path);
+    } catch (...) {
+        arc_logger.error("Failed to dump {} to {}: {}", description, path, std::current_exception());
+    }
+}
+
 rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf data) {
     const size_t checksum_size = _tracker->_cfg.checksumming.get() ? sizeof(uint32_t) + sizeof(std::byte) : 0;
     const uint32_t crc = checksum_size ? crc_impl(data) : -1;
@@ -481,6 +563,28 @@ rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf d
         constexpr size_t out_size = control_protocol_frame::serialized_size;
         auto out = std::span<std::byte, out_size>(out_data, out_size);
         protocol_header->serialize(out);
+    }
+
+    // Emulates a corruption of the message somewhere between the compressor and the
+    // decompressor, to let tests exercise the checksum validation path on the receiver.
+    // An empty message carries no compressed payload, so there is nothing to corrupt in it.
+    if (uncompressed_size > 0) {
+        utils::get_local_injector().inject("advanced_rpc_compressor_corrupt_last_byte", [&] {
+            auto* frags = std::get_if<temporary_buffer<char>>(&compressed.bufs);
+            size_t n_frags = 1;
+            if (!frags) {
+                auto& vec = std::get<std::vector<temporary_buffer<char>>>(compressed.bufs);
+                frags = vec.data();
+                n_frags = vec.size();
+            }
+            // The last fragment can be empty, so we look for the last one which isn't.
+            while (n_frags > 0 && frags[n_frags - 1].empty()) {
+                --n_frags;
+            }
+            SCYLLA_ASSERT(n_frags > 0);
+            auto& last = frags[n_frags - 1];
+            last.get_write()[last.size() - 1] ^= 0xff;
+        });
     }
 
     stats.bytes_sent += uncompressed_size;
@@ -602,6 +706,17 @@ rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
             static thread_local logging::logger::rate_limit dump_rate_limit(std::chrono::minutes(1));
             if (!dump_rate_limit.rate_limited()) {
                 arc_logger.error("sha256 recomputed from the contents of the dictionary used for decompression: {}", fmt_hex(get_sha256(_control.receiver_current_dict().data)));
+                if (_tracker->_cfg.dump_message_on_checksum_error.get()) {
+                    dump_message(
+                        "scylladb_rpc_checksum_error_dump",
+                        "the compressed message which failed checksum validation",
+                        header_byte,
+                        expected_crc,
+                        actual_crc,
+                        _control.receiver_current_dict(),
+                        data,
+                        0);
+                }
             }
             seastar::on_internal_error(arc_logger, fmt::format("RPC compression checksum error (expected: {:x}, got: {:x}). This indicates a bug. Set `internode_compression: none` and restart the nodes to regain stability, then report the bug.", expected_crc, actual_crc));
         }

--- a/message/advanced_rpc_compressor.cc
+++ b/message/advanced_rpc_compressor.cc
@@ -241,7 +241,7 @@ advanced_rpc_compressor::~advanced_rpc_compressor() {
 // Note: whenever a backwards-incompatible change to the compressor protocol/format
 // is made, the COMPRESSOR_NAME has to change.
 //
-const static sstring COMPRESSOR_NAME = "SCYLLA_V3";
+const static sstring COMPRESSOR_NAME = "SCYLLA_V4";
 
 compression_algorithm advanced_rpc_compressor::get_algo_for_next_msg(size_t msgsize) {
     auto algo = _control.sender_current_algorithm();
@@ -433,7 +433,7 @@ static rpc_compression_fingerprint get_compression_fingerprint(uint32_t crc, con
 }
 
 rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf data) {
-    const size_t checksum_size = _tracker->_cfg.checksumming.get() ? sizeof(uint32_t) : 0;
+    const size_t checksum_size = _tracker->_cfg.checksumming.get() ? sizeof(uint32_t) + sizeof(std::byte) : 0;
     const uint32_t crc = checksum_size ? crc_impl(data) : -1;
 
     auto now = _tracker->get_steady_nanos();
@@ -450,6 +450,8 @@ rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf d
 
     auto protocol_header = _control.produce_control_header();
     const size_t protocol_header_size = protocol_header ? control_protocol_frame::serialized_size : 0;
+
+    const std::byte dict_id = _control.sender_current_dict().id.content_sha256[0];
 
     auto uncompressed_size = data.size;
     auto compressed = std::invoke([&] {
@@ -472,6 +474,7 @@ rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf d
     dst->get_write()[head_space] = (algo.idx() & 0x3f) | (protocol_header ? 0x80 : 0x00) | (checksum_size ? 0x40 : 0x00);
     if (checksum_size) {
         write_le<uint32_t>(&dst->get_write()[head_space + 1], crc);
+        dst->get_write()[head_space + 1 + sizeof(uint32_t)] = static_cast<char>(dict_id);
     }
     if (protocol_header) {
         auto out_data = reinterpret_cast<std::byte*>(dst->get_write() + head_space + 1 + checksum_size);
@@ -546,8 +549,10 @@ rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
     const bool has_control_frame = header_byte & 0x80;
 
     uint32_t expected_crc = -1;
+    std::byte expected_dict_id = std::byte(0);
     if (has_checksum) {
         expected_crc = seastar::le_to_cpu(read_from_rcv_buf<uint32_t>(data));
+        expected_dict_id = std::byte(read_from_rcv_buf<uint8_t>(data));
     }
 
     if (has_control_frame) {
@@ -573,6 +578,11 @@ rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
     });
     if (has_checksum) {
         const uint32_t actual_crc = crc_impl(decompressed);
+        const auto& current_dict_id = _control.receiver_current_dict().id;
+        if (expected_dict_id != current_dict_id.content_sha256[0]) [[unlikely]] {
+            static thread_local logging::logger::rate_limit error_rate_limit(std::chrono::minutes(1));
+            arc_logger.log(log_level::error, error_rate_limit, "RPC compression dict ID mismatch: expected={:#04x}, actual={}", static_cast<int>(expected_dict_id), format_dict_id(current_dict_id));
+        }
         if (expected_crc != actual_crc) [[unlikely]] {
             const auto fingerprint = get_compression_fingerprint(expected_crc, data);
             // Gathering the details below (in particular hashing the dictionary) isn't free,

--- a/message/advanced_rpc_compressor.cc
+++ b/message/advanced_rpc_compressor.cc
@@ -61,6 +61,17 @@ std::optional<rpc_compression_fingerprint> rpc_compression_fingerprint::deserial
     }
 }
 
+static std::optional<rpc_compression_fingerprint> parse_dump_message_on_fingerprint(const sstring& value) {
+    if (value.empty()) {
+        return std::nullopt;
+    }
+    auto fingerprint = rpc_compression_fingerprint::deserialize(value);
+    if (!fingerprint) {
+        arc_logger.warn("Ignoring invalid internode_compression_dump_message_on_fingerprint value '{}'", value);
+    }
+    return fingerprint;
+}
+
 control_protocol::control_protocol(condition_variable& cv)
     : _needs_progress(cv)
 {
@@ -291,6 +302,10 @@ advanced_rpc_compressor::tracker::tracker(config cfg)
     , _algo_config_observer(_cfg.algo_config.observe([this] (const auto& x) {
         set_supported_algos(algo_list_to_set(x));
     }))
+    , _dump_message_on_fingerprint(parse_dump_message_on_fingerprint(_cfg.dump_message_on_fingerprint.get()))
+    , _dump_message_on_fingerprint_observer(_cfg.dump_message_on_fingerprint.observe([this] (const auto& x) {
+        _dump_message_on_fingerprint = parse_dump_message_on_fingerprint(x);
+    }))
 {
     if (_cfg.register_metrics) {
         register_metrics();
@@ -440,6 +455,10 @@ static rpc_compression_fingerprint get_compression_fingerprint(uint32_t crc, con
     };
 }
 
+static rpc_compression_fingerprint get_compression_fingerprint(uint32_t crc, const rpc::snd_buf& compressed, size_t offset) noexcept {
+    return get_compression_fingerprint<rpc::snd_buf>(crc, compressed, offset);
+}
+
 static void write_all(int fd, std::span<const std::byte> data) {
     while (!data.empty()) {
         const ssize_t n = ::write(fd, data.data(), data.size());
@@ -538,7 +557,7 @@ rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf d
     auto uncompressed_size = data.size;
     auto compressed = std::invoke([&] {
         try {
-            return compress_impl(head_space + 1 + checksum_size + protocol_header_size, std::move(data), get_compressor(algo), true, rpc::snd_buf::chunk_size);
+            return compress_impl(head_space + 1 + checksum_size + protocol_header_size, data, get_compressor(algo), true, rpc::snd_buf::chunk_size);
         } catch (...) {
             arc_logger.error("Error during compression with algorithm {}: {}. ", algo.name(), std::current_exception());
             throw;
@@ -553,7 +572,8 @@ rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf d
         dst = std::get<std::vector<temporary_buffer<char>>>(compressed.bufs).data();
     }
     static_assert(compression_algorithm::count() <= 0x3f); // We have 6 bits for algorithm ID, 2 bits for flags.
-    dst->get_write()[head_space] = (algo.idx() & 0x3f) | (protocol_header ? 0x80 : 0x00) | (checksum_size ? 0x40 : 0x00);
+    const uint8_t header_byte = (algo.idx() & 0x3f) | (protocol_header ? 0x80 : 0x00) | (checksum_size ? 0x40 : 0x00);
+    dst->get_write()[head_space] = header_byte;
     if (checksum_size) {
         write_le<uint32_t>(&dst->get_write()[head_space + 1], crc);
         dst->get_write()[head_space + 1 + sizeof(uint32_t)] = static_cast<char>(dict_id);
@@ -585,6 +605,29 @@ rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf d
             auto& last = frags[n_frags - 1];
             last.get_write()[last.size() - 1] ^= 0xff;
         });
+    }
+
+    const auto& dump_message_on_fingerprint = _tracker->_dump_message_on_fingerprint;
+    if (checksum_size && dump_message_on_fingerprint) {
+        if (dump_message_on_fingerprint->crc == crc) [[unlikely]] {
+            const size_t payload_offset = head_space + 1 + checksum_size + protocol_header_size;
+            auto fingerprint = get_compression_fingerprint(crc, compressed, payload_offset);
+            if (fingerprint == dump_message_on_fingerprint) {
+                arc_logger.warn("Sender matched fingerprint {}", fmt_hex(fingerprint.serialize()));
+                static thread_local logging::logger::rate_limit dump_rate_limit(std::chrono::minutes(1));
+                if (!dump_rate_limit.rate_limited()) {
+                    dump_message(
+                        "scylladb_rpc_fingerprint_match_dump",
+                        "the pre-compression message matching fingerprint",
+                        header_byte,
+                        crc,
+                        crc,
+                        _control.sender_current_dict(),
+                        data,
+                        0);
+                }
+            }
+        }
     }
 
     stats.bytes_sent += uncompressed_size;

--- a/message/advanced_rpc_compressor.cc
+++ b/message/advanced_rpc_compressor.cc
@@ -377,7 +377,7 @@ rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf d
         try {
             return compress_impl(head_space + 1 + checksum_size + protocol_header_size, std::move(data), get_compressor(algo), true, rpc::snd_buf::chunk_size);
         } catch (...) {
-            arc_logger.error("Error during decompression with algorithm {}: {}. ", algo.name(), std::current_exception());
+            arc_logger.error("Error during compression with algorithm {}: {}. ", algo.name(), std::current_exception());
             throw;
         }
     });
@@ -460,7 +460,7 @@ rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
         try {
             return decompress_impl(data, get_decompressor(algo), true, rpc::snd_buf::chunk_size);
          } catch (...) {
-            arc_logger.error("Error during compression with algorithm {}: {}. ", algo.name(), std::current_exception());
+            arc_logger.error("Error during decompression with algorithm {}: {}. ", algo.name(), std::current_exception());
             throw;
         }
     });

--- a/message/advanced_rpc_compressor.cc
+++ b/message/advanced_rpc_compressor.cc
@@ -10,6 +10,9 @@
 #include <seastar/util/defer.hh>
 #include <numeric>
 #include "utils/log.hh"
+#include "utils/hashers.hh"
+#include "utils/xx_hasher.hh"
+#include "bytes.hh"
 #include "advanced_rpc_compressor.hh"
 #include "advanced_rpc_compressor_protocol.hh"
 #include "stream_compressor.hh"
@@ -21,6 +24,34 @@ namespace netw {
 logging::logger arc_logger("advanced_rpc_compressor");
 
 static const shared_dict null_dict;
+
+std::array<std::byte, rpc_compression_fingerprint::serialized_size> rpc_compression_fingerprint::serialize() const noexcept {
+    std::array<std::byte, serialized_size> out;
+    auto* out_data = reinterpret_cast<char*>(out.data());
+    seastar::write_be<uint32_t>(out_data, crc);
+    seastar::write_be<uint64_t>(out_data + sizeof(uint32_t), compressed_xxh64);
+    return out;
+}
+
+std::optional<rpc_compression_fingerprint> rpc_compression_fingerprint::deserialize(std::span<const std::byte> bytes) noexcept {
+    if (bytes.size() != serialized_size) {
+        return std::nullopt;
+    }
+    const auto* data = reinterpret_cast<const char*>(bytes.data());
+    return rpc_compression_fingerprint{
+        .crc = seastar::read_be<uint32_t>(data),
+        .compressed_xxh64 = seastar::read_be<uint64_t>(data + sizeof(uint32_t)),
+    };
+}
+
+std::optional<rpc_compression_fingerprint> rpc_compression_fingerprint::deserialize(std::string_view hex_string) noexcept {
+    try {
+        auto bytes = from_hex(hex_string);
+        return deserialize(std::span<const std::byte>(reinterpret_cast<const std::byte*>(bytes.data()), bytes.size()));
+    } catch (...) {
+        return std::nullopt;
+    }
+}
 
 control_protocol::control_protocol(condition_variable& cv)
     : _needs_progress(cv)
@@ -353,6 +384,54 @@ stream_decompressor& advanced_rpc_compressor::get_decompressor(compression_algor
     }
 }
 
+template<class T>
+concept RpcBuf = std::same_as<T, rpc::rcv_buf> || std::same_as<T, rpc::snd_buf>;
+
+template <RpcBuf Buf, std::invocable<std::span<const std::byte>> Func>
+static void for_each_rpc_buf_fragment(const Buf& data, size_t offset, Func&& func) {
+    if (offset > data.size) {
+        throw std::invalid_argument("RPC buffer fragment offset is past the end of the buffer");
+    }
+    auto payload_size = data.size - offset;
+    auto it = std::get_if<temporary_buffer<char>>(&data.bufs);
+    if (!it) {
+        it = std::get<std::vector<temporary_buffer<char>>>(data.bufs).data();
+    }
+
+    while (payload_size > 0) {
+        const auto fragment_size = it->size();
+        if (offset > fragment_size) {
+            offset -= fragment_size;
+            ++it;
+            continue;
+        }
+        const auto n = std::min<size_t>(fragment_size - offset, payload_size);
+        std::invoke(func, std::as_bytes(std::span(it->get() + offset, n)));
+        offset = 0;
+        payload_size -= n;
+        ++it;
+    }
+}
+
+template <RpcBuf Buf>
+static uint64_t xxh64_impl(const Buf& data, size_t offset = 0) noexcept {
+    xx_hasher hasher;
+    for_each_rpc_buf_fragment(data, offset, [&hasher] (std::span<const std::byte> fragment) {
+        if (!fragment.empty()) {
+            hasher.update(reinterpret_cast<const char*>(fragment.data()), fragment.size());
+        }
+    });
+    return hasher.finalize_uint64();
+}
+
+template <RpcBuf Buf>
+static rpc_compression_fingerprint get_compression_fingerprint(uint32_t crc, const Buf& compressed, size_t offset = 0) noexcept {
+    return rpc_compression_fingerprint{
+        .crc = crc,
+        .compressed_xxh64 = xxh64_impl(compressed, offset),
+    };
+}
+
 rpc::snd_buf advanced_rpc_compressor::compress(size_t head_space, rpc::snd_buf data) {
     const size_t checksum_size = _tracker->_cfg.checksumming.get() ? sizeof(uint32_t) : 0;
     const uint32_t crc = checksum_size ? crc_impl(data) : -1;
@@ -433,6 +512,34 @@ T read_from_rcv_buf(rpc::rcv_buf& data) {
     return out[0];
 }
 
+static std::string format_dict_id(const shared_dict::dict_id& id) {
+    return fmt::format("{{timestamp={}, origin_node={}, content_sha256={}}}", id.timestamp, id.origin_node, fmt_hex(id.content_sha256));
+}
+
+static std::string format_dict_ptr(const dict_ptr& d) {
+    if (!d) {
+        return "null";
+    }
+    const auto& id = (**d).id;
+    return format_dict_id(id);
+}
+
+static std::string format_control_protocol(const control_protocol& cp) {
+    return fmt::format(
+        "{{sender_protocol_epoch={}, receiver_protocol_epoch={}"
+        ", sender_has_update={}, sender_has_commit={}"
+        ", receiver_has_update={}, receiver_has_commit={}"
+        ", sender_recent_dict={}, sender_committed_dict={}, sender_current_dict={}"
+        ", receiver_recent_dict={}, receiver_committed_dict={}, receiver_current_dict={}"
+        ", sender_current_algo={}, sender_committed_algo={}, algos={:#04x}}}",
+        cp._sender_protocol_epoch, cp._receiver_protocol_epoch,
+        cp._sender_has_update, cp._sender_has_commit,
+        cp._receiver_has_update, cp._receiver_has_commit,
+        format_dict_ptr(cp._sender_recent_dict), format_dict_ptr(cp._sender_committed_dict), format_dict_ptr(cp._sender_current_dict),
+        format_dict_ptr(cp._receiver_recent_dict), format_dict_ptr(cp._receiver_committed_dict), format_dict_ptr(cp._receiver_current_dict),
+        cp._sender_current_algo.name(), cp._sender_committed_algo.name(), cp._algos.value());
+}
+
 rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
     const uint8_t header_byte = read_from_rcv_buf<uint8_t>(data);
     const bool has_checksum = header_byte & 0x40;
@@ -466,7 +573,26 @@ rpc::rcv_buf advanced_rpc_compressor::decompress(rpc::rcv_buf data) {
     });
     if (has_checksum) {
         const uint32_t actual_crc = crc_impl(decompressed);
-        if (expected_crc != actual_crc) {
+        if (expected_crc != actual_crc) [[unlikely]] {
+            const auto fingerprint = get_compression_fingerprint(expected_crc, data);
+            // Gathering the details below (in particular hashing the dictionary) isn't free,
+            // so we query the rate limit ourselves instead of passing it to the logger.
+            arc_logger.error(
+                "RPC compression checksum error details:"
+                " expected_crc={:#010x}, actual_crc={:#010x}"
+                ", header_byte={:#04x}"
+                ", fingerprint={}"
+                ", control_protocol={}"
+                ", compressed_size={}, decompressed_size={}",
+                expected_crc, actual_crc,
+                header_byte,
+                fmt_hex(fingerprint.serialize()),
+                format_control_protocol(_control),
+                compressed_size, decompressed.size);
+            static thread_local logging::logger::rate_limit dump_rate_limit(std::chrono::minutes(1));
+            if (!dump_rate_limit.rate_limited()) {
+                arc_logger.error("sha256 recomputed from the contents of the dictionary used for decompression: {}", fmt_hex(get_sha256(_control.receiver_current_dict().data)));
+            }
             seastar::on_internal_error(arc_logger, fmt::format("RPC compression checksum error (expected: {:x}, got: {:x}). This indicates a bug. Set `internode_compression: none` and restart the nodes to regain stability, then report the bug.", expected_crc, actual_crc));
         }
     }

--- a/message/advanced_rpc_compressor.hh
+++ b/message/advanced_rpc_compressor.hh
@@ -8,8 +8,12 @@
 
 #pragma once
 
+#include <array>
+#include <optional>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/rpc/rpc_types.hh>
+#include <span>
+#include <string_view>
 #include <utility>
 #include "utils/refcounted.hh"
 #include "utils/updateable_value.hh"
@@ -235,6 +239,19 @@ struct per_algorithm_stats {
     uint64_t compressed_bytes_received = 0;
     uint64_t messages_received = 0;
     uint64_t decompression_cpu_nanos = 0;
+};
+
+struct rpc_compression_fingerprint {
+    static constexpr size_t serialized_size = sizeof(uint32_t) + sizeof(uint64_t);
+
+    uint32_t crc;
+    uint64_t compressed_xxh64;
+
+    std::array<std::byte, serialized_size> serialize() const noexcept;
+    static std::optional<rpc_compression_fingerprint> deserialize(std::span<const std::byte> bytes) noexcept;
+    static std::optional<rpc_compression_fingerprint> deserialize(std::string_view hex_string) noexcept;
+
+    bool operator==(const rpc_compression_fingerprint&) const = default;
 };
 
 // The tracker contains everything which is shared between compressor instances:

--- a/message/advanced_rpc_compressor.hh
+++ b/message/advanced_rpc_compressor.hh
@@ -276,6 +276,10 @@ public:
         utils::updateable_value<algo_config> algo_config{{compression_algorithm::type::ZSTD, compression_algorithm::type::LZ4}};
         bool register_metrics = false;
         utils::updateable_value<bool> checksumming{true};
+        // Enables dumping extra diagnostic data to files in the temporary directory,
+        // so that compression bugs can be investigated offline.
+        // Currently, this only covers frames which fail checksum validation.
+        utils::updateable_value<bool> dump_message_on_checksum_error{false};
     };
 private:
     friend advanced_rpc_compressor;

--- a/message/advanced_rpc_compressor.hh
+++ b/message/advanced_rpc_compressor.hh
@@ -280,12 +280,15 @@ public:
         // so that compression bugs can be investigated offline.
         // Currently, this only covers frames which fail checksum validation.
         utils::updateable_value<bool> dump_message_on_checksum_error{false};
+        utils::updateable_value<sstring> dump_message_on_fingerprint{""};
     };
 private:
     friend advanced_rpc_compressor;
     
     config _cfg;
     utils::observer<algo_config> _algo_config_observer;
+    std::optional<rpc_compression_fingerprint> _dump_message_on_fingerprint;
+    utils::observer<sstring> _dump_message_on_fingerprint_observer;
 
     std::array<per_algorithm_stats, compression_algorithm::count()> _stats;
     metrics::metric_groups _metrics;

--- a/test/boost/advanced_rpc_compressor_test.cc
+++ b/test/boost/advanced_rpc_compressor_test.cc
@@ -7,11 +7,19 @@
  */
 
 #include <seastar/core/manual_clock.hh>
+#include <seastar/net/byteorder.hh>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <seastar/util/tmp_file.hh>
 #include <seastar/util/closeable.hh>
 #include "test/lib/random_utils.hh"
 #include "test/lib/scylla_test_case.hh"
 #include "message/advanced_rpc_compressor.hh"
 #include "message/advanced_rpc_compressor_protocol.hh"
+#include "message/stream_compressor.hh"
+#include "utils/crc.hh"
+#include "utils/xx_hasher.hh"
 
 using namespace seastar;
 using namespace std::chrono_literals;
@@ -97,6 +105,144 @@ class tracker_without_clock final : public netw::advanced_rpc_compressor::tracke
 public:
     using tracker::tracker;
 };
+
+static uint32_t crc32(bytes_view data) {
+    utils::crc32 crc;
+    crc.process(reinterpret_cast<const uint8_t*>(data.data()), data.size());
+    return crc.get();
+}
+
+static uint64_t xxh64(bytes_view data) {
+    xx_hasher hasher;
+    hasher.update(reinterpret_cast<const char*>(data.data()), data.size());
+    return hasher.finalize_uint64();
+}
+
+static std::filesystem::path fingerprint_match_dump_path() {
+    return seastar::default_tmpdir() / fmt::format("scylladb_rpc_fingerprint_match_dump.shard_{}.bin", this_shard_id());
+}
+
+static std::vector<std::byte> read_file(std::filesystem::path path) {
+    std::ifstream in(path, std::ios::binary);
+    std::vector<char> data{std::istreambuf_iterator<char>(in), std::istreambuf_iterator<char>()};
+    std::vector<std::byte> out(data.size());
+    std::memcpy(out.data(), data.data(), data.size());
+    return out;
+}
+
+SEASTAR_THREAD_TEST_CASE(test_rpc_compression_fingerprint_serialization) {
+    const auto fingerprint = netw::rpc_compression_fingerprint{
+        .crc = 0x01020304,
+        .compressed_xxh64 = 0x05060708090a0b0c,
+    };
+    const auto serialized = fingerprint.serialize();
+    BOOST_REQUIRE_EQUAL(fmt::format("{}", fmt_hex(serialized)), "0102030405060708090a0b0c");
+
+    auto parsed_from_bytes = netw::rpc_compression_fingerprint::deserialize(serialized);
+    BOOST_REQUIRE(parsed_from_bytes);
+    BOOST_REQUIRE(*parsed_from_bytes == fingerprint);
+
+    auto parsed_from_string = netw::rpc_compression_fingerprint::deserialize("0102030405060708090a0b0c");
+    BOOST_REQUIRE(parsed_from_string);
+    BOOST_REQUIRE(*parsed_from_string == fingerprint);
+
+    BOOST_REQUIRE(!netw::rpc_compression_fingerprint::deserialize(""));
+    BOOST_REQUIRE(!netw::rpc_compression_fingerprint::deserialize("01020304"));
+    BOOST_REQUIRE(!netw::rpc_compression_fingerprint::deserialize("not a fingerprint"));
+}
+
+// Test the effect of the dump_message_on_fingerprint option.
+static void run_dump_message_on_fingerprint_test(bool live_update) {
+    bytes message;
+    for (int i = 0; i < 100; ++i) {
+        const auto chunk = fmt::format("rpc compression fingerprint dump payload {}\n", i);
+        message.append(reinterpret_cast<const int8_t*>(chunk.data()), chunk.size());
+    }
+
+    netw::lz4_cstream cstream;
+    const auto compressed_message = rpc_buf_to_bytes(
+        netw::compress_impl(0, rpc::snd_buf{bytes_view_to_temporary_buffer(message)}, cstream, true, rpc::snd_buf::chunk_size));
+    BOOST_REQUIRE_NE(compressed_message, message);
+
+    const auto fingerprint = netw::rpc_compression_fingerprint{
+        .crc = crc32(bytes_view(message)),
+        .compressed_xxh64 = xxh64(bytes_view(compressed_message)),
+    };
+    const auto fingerprint_string = sstring(fmt::format("{}", fmt_hex(fingerprint.serialize())));
+
+    const auto path = fingerprint_match_dump_path();
+    std::filesystem::remove(path);
+    auto cleanup = defer([&path] {
+        std::filesystem::remove(path);
+    });
+
+    utils::updateable_value_source<sstring> dump_message_on_fingerprint(live_update ? sstring() : fingerprint_string);
+    auto cfg = netw::advanced_rpc_compressor::tracker::config{
+        .algo_config = utils::updateable_value<netw::algo_config>{
+            {netw::compression_algorithm::type::LZ4},
+        },
+        .checksumming = utils::updateable_value<bool>{true},
+        .dump_message_on_fingerprint = utils::updateable_value<sstring>{dump_message_on_fingerprint},
+    };
+    tracker_without_clock tracker{cfg};
+    auto sender = tracker.negotiate(tracker.supported(), true, [] { return make_ready_future<>(); });
+    auto close_sender = deferred_close(*sender);
+    auto receiver = tracker.negotiate(sender->name(), false, [] { return make_ready_future<>(); });
+    auto close_receiver = deferred_close(*receiver);
+
+    // Settle the algorithm negotiation, so that the message below is compressed with LZ4
+    // rather than with the initial RAW.
+    for (int i = 0; i < 5; ++i) {
+        receiver->decompress(convert_rpc_buf<rpc::rcv_buf>(sender->compress(0, rpc::snd_buf{0})));
+        sender->decompress(convert_rpc_buf<rpc::rcv_buf>(receiver->compress(0, rpc::snd_buf{0})));
+    }
+
+    constexpr int head_space = 4;
+
+    if (live_update) {
+        auto compressed = sender->compress(head_space, rpc::snd_buf{bytes_view_to_temporary_buffer(message)});
+        dump_message_on_fingerprint.set(fingerprint_string);
+    }
+
+    BOOST_REQUIRE(!std::filesystem::exists(path));
+    auto compressed = sender->compress(head_space, rpc::snd_buf{bytes_view_to_temporary_buffer(message)});
+    BOOST_REQUIRE(std::filesystem::exists(path));
+
+    auto dump = read_file(path);
+    size_t pos = 0;
+    BOOST_REQUIRE_GT(dump.size(), 1 + sizeof(uint32_t) + sizeof(uint32_t) + 32 + sizeof(uint64_t));
+    BOOST_REQUIRE_EQUAL(uint8_t(dump[pos++]), uint8_t(compressed.front().get()[head_space]));
+    BOOST_REQUIRE_EQUAL(seastar::read_be<uint32_t>(reinterpret_cast<const char*>(dump.data() + pos)), fingerprint.crc);
+    pos += sizeof(uint32_t);
+    BOOST_REQUIRE_EQUAL(seastar::read_be<uint32_t>(reinterpret_cast<const char*>(dump.data() + pos)), fingerprint.crc);
+    pos += sizeof(uint32_t);
+    pos += 32;
+    const auto dict_size = seastar::read_be<uint64_t>(reinterpret_cast<const char*>(dump.data() + pos));
+    pos += sizeof(uint64_t);
+    BOOST_REQUIRE_EQUAL(dict_size, 0);
+
+    bytes dumped_payload;
+    while (pos < dump.size()) {
+        BOOST_REQUIRE_GE(dump.size() - pos, sizeof(uint64_t));
+        const auto fragment_size = seastar::read_be<uint64_t>(reinterpret_cast<const char*>(dump.data() + pos));
+        pos += sizeof(uint64_t);
+        BOOST_REQUIRE_GE(dump.size() - pos, fragment_size);
+        dumped_payload.append(reinterpret_cast<const int8_t*>(dump.data() + pos), fragment_size);
+        pos += fragment_size;
+    }
+    BOOST_REQUIRE_EQUAL(dumped_payload, message);
+}
+
+// Note: the dump is rate-limited to one per minute, so at most one dump can be observed
+// in a single process. Hence the two variants below have to live in separate test cases
+// (the test runner runs each Boost test case in its own process), rather than in a loop.
+SEASTAR_THREAD_TEST_CASE(test_dump_message_on_fingerprint_from_initial_config) {
+    run_dump_message_on_fingerprint_test(false);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_dump_message_on_fingerprint_after_live_update) {
+    run_dump_message_on_fingerprint_test(true);
+}
 
 SEASTAR_THREAD_TEST_CASE(test_tracker_basic_sanity) {
     for (const bool checksumming : {false, true})

--- a/test/cluster/test_rpc_compression.py
+++ b/test/cluster/test_rpc_compression.py
@@ -14,6 +14,10 @@ from test.cluster.util import new_test_keyspace
 
 import pytest
 import asyncio
+import hashlib
+import os
+import re
+import stat
 import time
 import logging
 import random
@@ -254,3 +258,111 @@ async def test_external_dicts_sanity(manager: ManagerClient) -> None:
             assert compressed < expected_ratio * uncompressed
 
         await with_retries(functools.partial(test_algo, "lz4", 0.04), timeout=600)
+
+@pytest.mark.parametrize("use_dict", [False, True], ids=["null_dict", "trained_dict"])
+async def test_checksum_error_diagnostics(manager: ManagerClient, use_dict: bool, tmp_path) -> None:
+    """Tests that a corruption of a compressed message is diagnosed by the receiver.
+
+    Corrupts a single message on the sender (after it's compressed), and checks that
+    the receiver prints the detailed report about the resulting checksum mismatch,
+    and dumps the offending frame to a file.
+    """
+    cfg = {
+        'internode_compression_enable_advanced': True,
+        'internode_compression': "all",
+        'internode_compression_zstd_max_cpu_fraction': 0.0,
+        'internode_compression_dump_message_on_checksum_error': True,
+        'rpc_dict_training_when': 'when_leader' if use_dict else 'never',
+        'rpc_dict_training_min_bytes': 10000000,
+        'rpc_dict_training_min_time_seconds': 0,
+    }
+    cmdline = [
+        '--logger-log-level=advanced_rpc_compressor=debug',
+        # The checksum mismatch is reported via on_internal_error, which would kill
+        # the node if it was configured to abort on those.
+        '--abort-on-internal-error', '0',
+    ]
+    logger.info(f"Booting initial cluster")
+    servers = await manager.servers_add(servers_num=2, config=cfg, cmdline=cmdline, append_env={"TMPDIR": str(tmp_path)}, auto_rack_dc="dc1")
+
+    cql = manager.get_cql()
+
+    replication_factor = 2
+    async with new_test_keyspace(manager, f"with replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {replication_factor}}}") as ks:
+        await cql.run_async(f"create table {ks}.cf (pk int, v blob, primary key (pk))")
+        write_stmt = cql.prepare(f"update {ks}.cf set v = ? where pk = ?")
+        write_stmt.consistency_level = ConsistencyLevel.ALL
+
+        msg = random.randbytes(8192)
+
+        async def write_messages(n_messages: int = 1000) -> None:
+            await asyncio.gather(*[cql.run_async(write_stmt, parameters=[msg, pk]) for pk in range(n_messages)])
+
+        if use_dict:
+            # Wait until a dict is trained and put to use. Since we are spamming the same
+            # message over and over, a compression ratio this good is only achievable with
+            # a dictionary.
+            async def dict_in_use() -> None:
+                metrics_before = await get_metrics(manager, servers)
+                await write_messages()
+                metrics_after = await get_metrics(manager, servers)
+                uncompressed = uncompressed_sent(metrics_after, "lz4") - uncompressed_sent(metrics_before, "lz4")
+                compressed = compressed_sent(metrics_after, "lz4") - compressed_sent(metrics_before, "lz4")
+                assert compressed < 0.04 * uncompressed
+            await with_retries(dict_in_use, timeout=600)
+
+        # The sender is servers[0], so the mismatch is detected and reported by servers[1].
+        receiver_log = await manager.server_open_log(servers[1].server_id)
+        mark = await receiver_log.mark()
+        await manager.api.enable_injection(servers[0].ip_addr, "advanced_rpc_compressor_corrupt_last_byte", one_shot=True)
+
+        write_stmt.consistency_level = ConsistencyLevel.ONE
+        await write_messages(n_messages=1)
+
+        mark, _ = await receiver_log.wait_for("RPC compression checksum error details", from_mark=mark, timeout=120)
+
+        # The dump is written before this message is logged, so by now the file is complete.
+        _, matches = await receiver_log.wait_for(
+            r"Dumped the compressed message which failed checksum validation to (\S+)", from_mark=mark, timeout=120)
+        dump_path = matches[0][1].group(1)
+        tmpdir = str(tmp_path)
+        assert re.fullmatch(re.escape(tmpdir) + r"/scylladb_rpc_checksum_error_dump\.shard_\d+\.bin", dump_path)
+        try:
+            # Only the owner may access the dump. It can contain user data.
+            assert stat.S_IMODE(os.stat(dump_path).st_mode) & 0o077 == 0
+            with open(dump_path, "rb") as f:
+                dump = f.read()
+        finally:
+            os.unlink(dump_path)
+
+        # Parse the dump. See `dump_message()` for the format.
+        pos = 0
+        def take(n: int) -> bytes:
+            nonlocal pos
+            assert pos + n <= len(dump), f"dump truncated at {pos}, wanted {n} more bytes out of {len(dump)}"
+            pos += n
+            return dump[pos - n:pos]
+        def take_be(n: int) -> int:
+            return int.from_bytes(take(n), 'big')
+
+        header_byte = take(1)[0]
+        # Bit 0x40 is the "frame has a checksum" flag. It must be set, or there would
+        # have been no checksum to mismatch.
+        assert header_byte & 0x40
+        expected_crc = take_be(4)
+        actual_crc = take_be(4)
+        assert expected_crc != actual_crc
+        dict_sha256 = take(32)
+        dict_data = take(take_be(8))
+        if use_dict:
+            assert len(dict_data) > 0
+            # The ID stored in the dump must describe the dictionary stored in the dump.
+            assert hashlib.sha256(dict_data).digest() == dict_sha256
+        else:
+            # The null dictionary is empty, and its ID is all zeros.
+            assert len(dict_data) == 0
+            assert dict_sha256 == bytes(32)
+        fragments = []
+        while pos < len(dump):
+            fragments.append(take(take_be(8)))
+        assert sum(len(f) for f in fragments) > 0

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -572,6 +572,7 @@ class ManagerClient:
                                 replace_cfg: Optional[ReplaceConfig],
                                 cmdline: Optional[List[str]],
                                 config: Optional[dict[str, Any]],
+                                append_env: Optional[dict[str, str]],
                                 version: Optional[ScyllaVersionDescription],
                                 property_file: Union[List[dict[str, Any]], dict[str, Any], None],
                                 start: bool,
@@ -586,6 +587,8 @@ class ManagerClient:
             data['cmdline'] = cmdline
         if config:
             data['config'] = config
+        if append_env:
+            data['append_env'] = append_env
         if version:
             data['version'] = version._asdict()
         if property_file:
@@ -604,6 +607,7 @@ class ManagerClient:
                          replace_cfg: Optional[ReplaceConfig] = None,
                          cmdline: Optional[List[str]] = None,
                          config: Optional[dict[str, Any]] = None,
+                         append_env: Optional[dict[str, str]] = None,
                          version: Optional[ScyllaVersionDescription] = None,
                          property_file: Optional[dict[str, Any]] = None,
                          start: bool = True,
@@ -632,6 +636,7 @@ class ManagerClient:
                 replace_cfg,
                 cmdline,
                 config,
+                append_env,
                 version,
                 property_file,
                 start,
@@ -670,6 +675,7 @@ class ManagerClient:
     async def servers_add(self, servers_num: int = 1,
                           cmdline: Optional[List[str]] = None,
                           config: Optional[dict[str, Any]] = None,
+                          append_env: Optional[dict[str, str]] = None,
                           version: Optional[ScyllaVersionDescription] = None,
                           property_file: Union[List[dict[str, Any]], dict[str, Any], None] = None,
                           start: bool = True,
@@ -698,7 +704,7 @@ class ManagerClient:
             property_file = [{"dc":auto_rack_dc, "rack":f"rack{i+1}"} for i in range(servers_num)]
 
         try:
-            data = self._create_server_add_data(None, cmdline, config, version, property_file, start, seeds, expected_error, server_encryption, None)
+            data = self._create_server_add_data(None, cmdline, config, append_env, version, property_file, start, seeds, expected_error, server_encryption, None)
             data['servers_num'] = servers_num
             server_infos = await self.client.put_json("/cluster/addservers", data, response_type="json",
                                                       timeout=ScyllaServer.TOPOLOGY_TIMEOUT * servers_num)

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -837,7 +837,7 @@ def create_suite_pool(suite_config: TestSuiteConfig,
             cmdline_options=cmdline_options,
             config_options=config_options,
             property_file=create_cfg.property_file,
-            append_env=base_env,
+            append_env={**base_env, **(create_cfg.append_env_from_test or {})},
             server_encryption=create_cfg.server_encryption)
 
         return server

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1137,6 +1137,7 @@ class ScyllaCluster:
         property_file: dict[str, Any] | None
         config_from_test: dict[str, Any]
         cmdline_from_test: List[str]
+        append_env_from_test: dict[str, str] | None
         version: Optional[ScyllaVersionDescription]
         server_encryption: str
 
@@ -1242,6 +1243,7 @@ class ScyllaCluster:
     async def add_server(self, replace_cfg: Optional[ReplaceConfig] = None,
                          cmdline: Optional[List[str]] = None,
                          config: Optional[dict[str, Any]] = None,
+                         append_env: Optional[dict[str, str]] = None,
                          version: Optional[ScyllaVersionDescription] = None,
                          property_file: Optional[dict[str, Any]] = None,
                          start: bool = True,
@@ -1300,6 +1302,7 @@ class ScyllaCluster:
             config_from_test = extra_config,
             server_encryption = server_encryption,
             cmdline_from_test = cmdline or [],
+            append_env_from_test = append_env,
             version = version,
         )
 
@@ -1344,6 +1347,7 @@ class ScyllaCluster:
     async def add_servers(self, servers_num: int = 1,
                           cmdline: Optional[List[str]] = None,
                           config: Optional[dict[str, Any]] = None,
+                          append_env: Optional[dict[str, str]] = None,
                           version: Optional[ScyllaVersionDescription] = None,
                           property_file: Union[list[dict[str, Any]], dict[str, Any], None] = None,
                           start: bool = True,
@@ -1362,7 +1366,7 @@ class ScyllaCluster:
                 assert type(property_file) is list and len(property_file) == servers_num
                 return property_file[i]
 
-        return await gather_safely(*(self.add_server(None, cmdline, config, version, get_property_file(i), start, seeds, server_encryption, expected_error)
+        return await gather_safely(*(self.add_server(None, cmdline, config, append_env, version, get_property_file(i), start, seeds, server_encryption, expected_error)
                                       for i in range(servers_num)))
 
     def endpoint(self) -> str:
@@ -2005,6 +2009,7 @@ class ScyllaClusterManager:
             replace_cfg=replace_cfg,
             cmdline=data.get("cmdline"),
             config=data.get("config"),
+            append_env=data.get("append_env"),
             version=version,
             property_file=data.get("property_file"),
             start=data.get("start", True),
@@ -2020,7 +2025,7 @@ class ScyllaClusterManager:
         assert self.cluster
         data = await request.json()
         version = ScyllaVersionDescription(**data["version"]) if "version" in data else None
-        s_infos = await self.cluster.add_servers(data.get('servers_num'), data.get('cmdline'), data.get('config'), version,
+        s_infos = await self.cluster.add_servers(data.get('servers_num'), data.get('cmdline'), data.get('config'), data.get('append_env'), version,
                                                  data.get('property_file'), data.get('start', True),
                                                  data.get('seeds', None), data.get('server_encryption'), data.get('expected_error', None))
         return [s_info.as_dict() for s_info in s_infos]


### PR DESCRIPTION
advanced_rpc_compressor (which exists for the sake of zstd-based compression and dictionary-based compression) has an optional checksum (enabled by default) calculated before compression and checked after compression. I added it to guard against potential bugs in the implementation of compression.

And indeed, we recently saw several (5? 10?) cases of checksum mismatch errors, spread across two clusters over two months. Some notes:
- All known cases happened in repair.
- There were several cases where the repair was retried, and failed again with exactly the same expected checksum and actual checksum as in the prior failure, which suggests that the corruption is either internal to compression logic or caused by the repair, rather than by something external and not causally related to repair.
- In several cases, the repair eventually succeed after several days and several retries. (Possibly due to drift in the repaired dataset or rotations of RPC compression dictionaries).
- The problem recurs (with different checksums). The pattern is: repairs work fine for some weeks, then a repair starts failing fails with checksum errors for several retries, then it works fine again for some time. 
- For one of the clusters, the average daily RPC traffic is 5TB over 6e9 messages, while the average repair sends 6TB over 200e9 messages.

I don't know what the cause of the errors might be. Possibilities:
- Mismatch between dictionaries used by sender and receiver (which would mean a bug in the dictionary control protocol).
- Memory corruption bugs.
- Bug in the basic compression logic.
- Misuse of one of the compression libraries.
- Bug in a compression library. (Extremely unlikely, but maybe our usage is weird enough).

I couldn't find the problem by inspection, so this series adds more data collection points, to narrow it down when the problem happens again.
Refer to individual commits for specifics.