### PR TITLE
 test: test_stop_reshape_aborts_all_compaction_groups: fix reshape register/stop race

### DIFF
--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -192,6 +192,20 @@ async def test_stop_reshape_aborts_all_compaction_groups(manager: ManagerClient)
             logger.info("Waiting for reshape to hit the injection point")
             await manager.api.wait_for_injection_enter(server.ip_addr, injection,
                                                        threshold=1, deadline=time.time() + 60)
+            async def reshape_tasks_registered():
+                compactions = await manager.api.client.get_json("/compaction_manager/compactions", host=server.ip_addr)
+                reshapes = [
+                    c for c in compactions
+                    if c["task_type"] == "RESHAPE"
+                    and c["ks"] in [ks1, ks2]
+                    and c["cf"] == "test"
+                ]
+                return True if len(reshapes) >= 2 else None
+
+            await wait_for(
+                reshape_tasks_registered,
+                time.time() + 60,
+                label="registered reshape compactions")
 
             logger.info("Stopping RESHAPE globally and releasing injection")
             stop_task = asyncio.create_task(manager.api.stop_compaction(server.ip_addr, "RESHAPE"))


### PR DESCRIPTION
The test wants to test that stop reshape stops all running and queued reshape jobs, not just the currently running one. It creates two tables with two tablets each and checks that stop reshape indeed stops reshape for all. There is however a race between the reshapes being registered and the test issuing stop: the test could issue stop too early, when only one table has reshape jobs created. The other table is reshaped after the stop and thus fails the test's check for no post-stop reshape activity.
Improve the wait condition for when to issue stop: after the error injection for the first reshape job is hit, wait for the reshape job count to reach 2 (number of tables), to ensure all reshape jobs are registered by the time stop is issued.

Fixes: SCYLLADB-3279

Backport: test is present on branch 2026.3, need backport there