### PR TITLE
repair: avoid node abort from too-short repair injection timeout

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1178,7 +1178,14 @@ future<> repair::shard_repair_task_impl::do_repair_ranges() {
             auto user_permit = _user_ranges_parallelism ? co_await seastar::get_units(*_user_ranges_parallelism, 1) : semaphore_units<>();
             co_await repair_range(range, table_info);
             if (2 * (_ranges_complete + 1) > ranges_size()) {
-                co_await utils::get_local_injector().inject("repair_shard_repair_task_impl_do_repair_ranges", utils::wait_for_message(10s));
+                // The test that arms this injection releases it only after a
+                // concurrent tablet migration (move_tablet, a raft topology
+                // operation) completes. Under CI load that can take much longer
+                // than 10s; a short timeout here would make wait_for_message
+                // time out and escalate to on_internal_error, aborting the node.
+                // Use the generous timeout convention used for topology-gated
+                // injection sync points.
+                co_await utils::get_local_injector().inject("repair_shard_repair_task_impl_do_repair_ranges", utils::wait_for_message(5min));
             }
             ++_ranges_complete;
             if (_reason == streaming::stream_reason::bootstrap) {


### PR DESCRIPTION
The one-shot error injection repair_shard_repair_task_impl_do_repair_ranges pauses do_repair_ranges() with wait_for_message(10s). The test that arms it (test_two_tablets_concurrent_repair_and_migration) only releases the pause after a concurrent move_tablet (a raft topology operation) completes. Under CI load that migration can take longer than 10s, so wait_for_message times out. The injection framework treats such a timeout as on_internal_error, which aborts the process in test mode, killing the node and cascading into a client-side TimeoutError on the await_completion tablet repair call.

Increase the timeout to 5min, matching the convention used elsewhere for topology-gated injection sync points, so the pause is released by the migration rather than tripping the internal-error abort.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3395

Backport to all active branch. 