### PR TITLE
node_ops: record the target node of topology requests in system.topology_requests

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -316,6 +316,7 @@ schema_ptr system_keyspace::topology_requests() {
         return schema_builder(this_smp_shard_count(), NAME, TOPOLOGY_REQUESTS, std::optional(id))
             .with_column("id", timeuuid_type, column_kind::partition_key)
             .with_column("initiating_host", uuid_type)
+            .with_column("target_host", uuid_type)
             .with_column("request_type", utf8_type)
             .with_column("start_time", timestamp_type)
             .with_column("done", boolean_type)
@@ -3570,6 +3571,9 @@ system_keyspace::topology_requests_entry system_keyspace::topology_request_row_t
     entry.id = id;
     if (row.has("initiating_host")) {
         entry.initiating_host = row.get_as<utils::UUID>("initiating_host");
+    }
+    if (row.has("target_host")) {
+        entry.target_host = row.get_as<utils::UUID>("target_host");
     }
     if (row.has("request_type")) {
         auto rts = row.get_as<sstring>("request_type");

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -411,6 +411,7 @@ public:
     struct topology_requests_entry {
         utils::UUID id;
         utils::UUID initiating_host;
+        std::optional<utils::UUID> target_host;
         std::variant<std::monostate, service::topology_request, service::global_topology_request> request_type;
         db_clock::time_point start_time;
         bool done;

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -117,6 +117,7 @@ public:
     gms::feature table_digest_insensitive_to_expiry { *this, "TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"sv };
     gms::feature supports_consistent_topology_changes { *this, "SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"sv };
     gms::feature topology_requests_type_column { *this, "TOPOLOGY_REQUESTS_TYPE_COLUMN"sv };
+    gms::feature topology_requests_target_host_column { *this, "TOPOLOGY_REQUESTS_TARGET_HOST_COLUMN"sv };
     gms::feature native_reverse_queries { *this, "NATIVE_REVERSE_QUERIES"sv };
     gms::feature zero_token_nodes { *this, "ZERO_TOKEN_NODES"sv };
     gms::feature views_with_tablets { *this, "VIEWS_WITH_TABLETS"sv };

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -111,18 +111,19 @@ tasks::task_manager::task_group node_ops_virtual_task::get_group() const noexcep
     return tasks::task_manager::task_group::topology_change_group;
 }
 
-static std::map<tasks::task_id, locator::host_id> get_requests(const service::topology& topology) {
-    std::map<tasks::task_id, locator::host_id> result;
-    for (auto& request : topology.requests) {
-        auto* rs = topology.find(request.first);
-        if (rs) {
-            result.emplace(tasks::task_id(rs->second.request_id), locator::host_id(request.first.uuid()));
+static std::optional<locator::host_id> get_request_target(const service::topology& topology, tasks::task_id task_id) {
+    for (auto& [node, request] : topology.requests) {
+        auto* rs = topology.find(node);
+        if (rs && tasks::task_id(rs->second.request_id) == task_id) {
+            return locator::host_id(node.uuid());
         }
     }
     for (auto& [node, rs] : topology.transition_nodes) {
-        result.emplace(tasks::task_id(rs.request_id), locator::host_id(node.uuid()));
+        if (tasks::task_id(rs.request_id) == task_id) {
+            return locator::host_id(node.uuid());
+        }
     }
-    return result;
+    return std::nullopt;
 }
 
 future<std::optional<tasks::virtual_task_hint>> node_ops_virtual_task::contains(tasks::task_id task_id) const {
@@ -131,16 +132,17 @@ future<std::optional<tasks::virtual_task_hint>> node_ops_virtual_task::contains(
         co_return std::nullopt;
     }
 
-    auto hint = std::make_optional<tasks::virtual_task_hint>({});
-    service::topology& topology = _ss._topology_state_machine._topology;
-    auto reqs = get_requests(topology);
-    if (reqs.contains(task_id)) {
-        hint->node_id = reqs.at(task_id);
-        co_return hint;
-    }
-
     auto entry = co_await _ss._sys_ks.local().get_topology_request_entry_opt(task_id.uuid());
-    co_return entry && std::holds_alternative<service::topology_request>(entry->request_type) ? hint : std::nullopt;
+    if (!entry || !std::holds_alternative<service::topology_request>(entry->request_type)) {
+        co_return std::nullopt;
+    }
+    auto hint = std::make_optional<tasks::virtual_task_hint>({});
+    if (entry->target_host) {
+        hint->node_id = locator::host_id(*entry->target_host);
+    } else {
+        hint->node_id = get_request_target(_ss._topology_state_machine._topology, task_id);
+    }
+    co_return hint;
 }
 
 future<tasks::is_abortable> node_ops_virtual_task::is_abortable(tasks::virtual_task_hint hint) const {
@@ -165,12 +167,13 @@ future<> node_ops_virtual_task::abort(tasks::task_id id, tasks::virtual_task_hin
 future<std::vector<tasks::task_stats>> node_ops_virtual_task::get_stats() {
     db::system_keyspace& sys_ks = _ss._sys_ks.local();
     co_return std::ranges::to<std::vector<tasks::task_stats>>(co_await get_entries(sys_ks, get_task_manager().get_user_task_ttl())
-            | std::views::transform([reqs = get_requests(_ss._topology_state_machine._topology)] (const auto& e) {
-        auto id = tasks::task_id{e.first};
+            | std::views::transform([&topology = std::as_const(_ss._topology_state_machine._topology)] (const auto& e) {
         auto& entry = e.second;
         tasks::virtual_task_hint hint;
-        if (reqs.contains(id)) {
-            hint.node_id = reqs.at(id);
+        if (entry.target_host) {
+            hint.node_id = locator::host_id(*entry.target_host);
+        } else {
+            hint.node_id = get_request_target(topology, tasks::task_id{e.first});
         }
         return get_task_stats(entry, hint);
     }));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1255,6 +1255,10 @@ utils::chunked_vector<canonical_mutation> storage_service::build_mutation_from_j
     rtbuilder.set("initiating_host", params.host_id.uuid())
              .set("done", false);
     rtbuilder.set("request_type", params.replaced_id ? topology_request::replace : topology_request::join);
+    if (_feature_service.topology_requests_target_host_column) {
+        auto target = params.replaced_id ? params.replaced_id->uuid() : params.host_id.uuid();
+        rtbuilder.set("target_host", target);
+    }
 
     utils::chunked_vector<canonical_mutation> muts = {builder.build(), rtbuilder.build()};
 
@@ -2713,6 +2717,9 @@ future<> storage_service::raft_decommission() {
         rtbuilder.set("initiating_host",_group0->group0_server().id().uuid())
                  .set("done", false);
         rtbuilder.set("request_type", topology_request::leave);
+        if (_feature_service.topology_requests_target_host_column) {
+            rtbuilder.set("target_host", raft_server.id().uuid());
+        }
         topology_change change{{builder.build(), rtbuilder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, ::format("decommission: request decommission for {}", raft_server.id()));
 
@@ -2861,6 +2868,9 @@ future<> storage_service::raft_removenode(locator::host_id host_id, locator::hos
         rtbuilder.set("initiating_host",_group0->group0_server().id().uuid())
                  .set("done", false);
         rtbuilder.set("request_type", topology_request::remove);
+        if (_feature_service.topology_requests_target_host_column) {
+            rtbuilder.set("target_host", id.uuid());
+        }
         topology_change change{{builder.build(), rtbuilder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, ::format("removenode: request remove for {}", id));
 
@@ -3531,6 +3541,9 @@ future<> storage_service::raft_rebuild(utils::optional_param sdc_param) {
         rtbuilder.set("initiating_host",_group0->group0_server().id().uuid())
                  .set("done", false);
         rtbuilder.set("request_type", topology_request::rebuild);
+        if (_feature_service.topology_requests_target_host_column) {
+            rtbuilder.set("target_host", raft_server.id().uuid());
+        }
         topology_change change{{builder.build(), rtbuilder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, ::format("rebuild: request rebuild for {} ({})", raft_server.id(), source_dc));
 


### PR DESCRIPTION
Adds a target_host column to system.topology_requests, recording which node a topology operation acts on — the joining node for join, the replaced node for replace, and the requesting node for decommission, removenode and rebuild. The column is written only once the whole cluster supports it, gated behind the new TOPOLOGY_REQUESTS_TARGET_HOST_COLUMN cluster feature.

With the target node persisted alongside the request, node_ops_virtual_task no longer has to reconstruct it from in-memory topology state. Both contains() and get_stats() now derive the task hint's node_id straight from the topology_requests entry, which drops the two-phase in-memory-first / table-fallback lookup and its helper, and makes the node id available for completed requests too — not just for those still in flight.

Fixes: SCYLLADB-1678

New feature; no backport