### PR TITLE
sstables_loader: report aborted tablet restore as 'aborted'

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -964,7 +964,7 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
         throw std::runtime_error(fmt::format("No transition info for tablet {}", tid));
     }
     if (!trinfo->session_id) {
-        throw std::runtime_error(fmt::format("Restore of tablet {} was cancelled", tid));
+        throw std::runtime_error(fmt::format("Restore of tablet {} was aborted", tid));
     }
     if (trinfo->snapshot_name.empty()) {
         throw std::runtime_error(format("No snapshot name for tablet {} restore transition", tid));


### PR DESCRIPTION
Aborting a restore removes the transition's session, which unwinds in-flight downloads as an abort (abort_requested_exception, message contains "abort"). A download that instead observes the removed session on entry threw "was cancelled", so the task's final error was non-deterministic depending on which per-tablet failure the coordinator recorded. Use consistent "aborted" wording.

Fixes: [SCYLLADB-3367](https://scylladb.atlassian.net/browse/SCYLLADB-3367)

[SCYLLADB-3367]: https://scylladb.atlassian.net/browse/SCYLLADB-3367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ