### PR TITLE
test/s3_proxy: respond with retryable error when forwarding to minio fails

### DIFF
--- a/test/pylib/s3_proxy.py
+++ b/test/pylib/s3_proxy.py
@@ -185,7 +185,16 @@ class InjectingHandler(BaseHTTPRequestHandler):
             if policy.should_forward:
                 target_url = self.minio_uri + self.path
                 headers = {key: value for key, value in self.headers.items()}
-                response = requests.request(self.command, target_url, headers=headers, data=body)
+                try:
+                    response = requests.request(self.command, target_url, headers=headers, data=body)
+                except requests.exceptions.RequestException as e:
+                    # Forwarding to minio failed (e.g. connection reset while minio is under
+                    # load from concurrent requests). Nothing has been written to the client
+                    # yet, so respond with a well-formed retryable error instead of letting the
+                    # client hang until it eventually observes a bare connection drop.
+                    self.logger.warning("Failed to forward request to %s: %s", target_url, e)
+                    self.respond_with_error(reset_connection=False)
+                    return
 
             if policy.should_fail:
                 policy.error_count += 1


### PR DESCRIPTION
If requests.request() to minio raises (e.g. minio resets/refuses a connection under load from concurrent multipart-upload parts), the exception was only caught by process_request()'s outer bare except, which logs it and sends nothing back. The client then sees a bare EOF while parsing the response instead of a well-formed retryable error, which some code paths don't treat as retryable and can cause the request to fail outright instead of being retried.

Catch the forwarding exception explicitly and respond with the same retryable error used for the proxy's deliberate fault injection, so the client gets a clean, immediate signal to retry.

Fixes: SCYLLADB-3448

**vulnerable code pattern (unguarded requests.request() forwarding call) exists in all active releases, it seems like low risk to backport**