### PR TITLE
test/cluster: stabilize tablet merge tests by forcing raw disk capacity

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1814,6 +1814,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Throttles background I/O to the specified total throughput (in MiBs/s) across the entire system. Background I/O includes the one performed by repair and both RBNO and legacy topology operations such as adding or removing a node. Setting the value to 0 disables background IO throttling. It is recommended to set the value for this parameter to be 75% of network bandwidth")
     , backup_io_throughput_mb_per_sec(this, "backup_io_throughput_mb_per_sec", liveness::LiveUpdate, value_status::Used, 0,
         "Throttles backup I/O to the specified total throughput (in MiBs/s) across the entire system")
+    , force_effective_capacity_to_raw_disk_capacity(this, "force_effective_capacity_to_raw_disk_capacity", liveness::LiveUpdate, value_status::Used, false,
+        "Forces effective_capacity used in tablets load balancing to be the equal to the raw disk capacity instead of the sum of tablet "
+        "sizes and available disk space.")
     , default_log_level(this, "default_log_level", value_status::Used, seastar::log_level::info, "Default log level for log messages")
     , logger_log_level(this, "logger_log_level", value_status::Used, {}, "Map of logger name to log level. Valid log levels are 'error', 'warn', 'info', 'debug' and 'trace'")
     , log_to_stdout(this, "log_to_stdout", value_status::Used, true, "Send log output to stdout")

--- a/db/config.hh
+++ b/db/config.hh
@@ -676,6 +676,8 @@ public:
     named_value<uint32_t> maintenance_io_throughput_mb_per_sec;
     named_value<uint32_t> backup_io_throughput_mb_per_sec;
 
+    named_value<bool> force_effective_capacity_to_raw_disk_capacity;
+
     static const sstring default_tls_priority;
 private:
     template<typename T>

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6163,6 +6163,8 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
     const uint64_t config_capacity = _db.local().get_config().data_file_capacity();
     if (config_capacity != 0) {
         tls.effective_capacity = config_capacity;
+    } else if (_db.local().get_config().force_effective_capacity_to_raw_disk_capacity()) {
+        tls.effective_capacity = _disk_space_monitor->space().capacity;
     } else {
         uint64_t sum_tablet_sizes = 0;
         for (const auto& ts : tablet_sizes_per_shard) {

--- a/test/cluster/test_config.yaml
+++ b/test/cluster/test_config.yaml
@@ -9,6 +9,7 @@ extra_scylla_config_options:
     tablets_mode_for_new_keyspaces: enabled
     logstor_disk_size_in_mb: 8
     logstor_file_size_in_mb: 4
+    force_effective_capacity_to_raw_disk_capacity: True
 run_first:
   - test_group0_schema_versioning
   - test_tablets_migration


### PR DESCRIPTION
The tablet load balancer computes each node's load as used_size / effective_capacity, where effective_capacity is reported by the node as `available_disk_space + sum(tablet_sizes)`. Because available_disk_space is sampled from the live filesystem at slightly different moments on each node (and, in CI, all nodes share the same physical disk), `effective_capacity` oscillates from one load-balancer invocation to the next.

When several nodes hold the same number of equally-sized tablets, they are tied on load and the winner is decided purely by these tiny, drifting capacity differences. As a result the balancer keeps flipping which node it considers least loaded and issues compensating migrations, ping-ponging tablets back and forth.

A tablet merge can only be finalized once all sibling tablet replicas are co-located. The constant load-balancing migrations work against achieving tablet sibling co-location, so on slower/loaded CI machines the merge cannot finalize within the test's deadline, whereas on a fast local machine the balancer iterates quickly enough to hit a co-located window by chance and the test passes. This makes `test_tablet_merge_cross_rack_migrations` and `test_tablet_split_merge_with_many_tables` flaky in CI while passing locally.

Add a config option, `force_effective_capacity_to_raw_disk_capacity`, which makes a node report the raw total disk capacity as its `effective_capacity` instead of `available_space + sum(tablet_sizes)`. The raw capacity is constant and identical across nodes sharing a disk, so tied nodes get byte-identical load, the least-loaded target selection becomes deterministic, tablets converge to a stable placement, and the merge finalizes promptly.

This change sets the new config option `force_effective_capacity_to_raw_disk_capacity` to `True` in `test/cluster/test_config.yaml` so that it is enabled for all the tests under `test/cluster`.

Fixes: SCYLLADB-3152
Fixes: SCYLLADB-1717

This is an improvement and does not need to be backported.