### PR TITLE
test/scylla_gdb: fix GDB auto-load safe-path rejection causing SIGKILL

### DIFF
--- a/test/scylla_gdb/conftest.py
+++ b/test/scylla_gdb/conftest.py
@@ -31,6 +31,8 @@ def gdb_cmd(scylla_server, request):
         "-q",
         "--batch",
         "--nx",
+        "-iex",
+        "set auto-load safe-path /",
         "-se",
         str(scylla_server.exe),
         "-p",


### PR DESCRIPTION
Since the toolchain was updated to Fedora 44 (e62fcc5e7), the release
binary (statically linked against libstdc++, see --static-libstdc++ in
configure.py) carries a `.debug_gdb_scripts` section pulled in from
libstdc++'s object files, pointing GDB to its pretty-printer script
under the toolchain's non-standard install path. That path isn't
covered by GDB's default `auto-load safe-path`, so GDB declines to
load it and warns about the scylla binary itself; parsing the release
binary's debug info without those printers appears to make GDB run
out of memory, and it gets killed with SIGKILL (-9).

Fix by explicitly allowing auto-loading via `-iex "set auto-load
safe-path /"`, applied before the executable is loaded with `-se`.

Fixes SCYLLADB-2678