### PR TITLE
estimated_histogram: fix out-of-bounds read in get_histogram()

### DIFF
--- a/test/boost/estimated_histogram_test.cc
+++ b/test/boost/estimated_histogram_test.cc
@@ -282,6 +282,21 @@ BOOST_AUTO_TEST_CASE(test_histogram_min_1_statistics) {
     BOOST_CHECK_EQUAL(hist.mean(), 6);
 }
 
+BOOST_AUTO_TEST_CASE(test_estimated_histogram_get_histogram_small_range) {
+    // Regression test for a heap-buffer-overflow: get_histogram() doubles
+    // last_bound up to max_buckets times, which can exceed the largest
+    // bucket_offsets value well before max_buckets is reached for a
+    // histogram with a small bucket_count (e.g. estimated_sstable_per_read{35}).
+    // pos must not be advanced past bucket_offsets.size().
+    utils::estimated_histogram hist(35);
+    hist.add(1);
+    hist.add(2);
+    hist.add(3);
+    auto res = hist.get_histogram();
+    BOOST_CHECK_EQUAL(res.sample_count, 3);
+    BOOST_CHECK_EQUAL(res.buckets.back().count, 3);
+}
+
 BOOST_AUTO_TEST_CASE(test_histogram_precision_1) {
     // Test with Precision=1, Min=1024, Max=16384 (standard exponential mode)
     utils::approx_exponential_histogram<1024, 16384, 1> hist;

--- a/utils/estimated_histogram.hh
+++ b/utils/estimated_histogram.hh
@@ -501,7 +501,7 @@ struct estimated_histogram {
             auto& v = res.buckets[i];
             v.upper_bound = last_bound;
 
-            while (bucket_offsets[pos] <= last_bound) {
+            while (pos < bucket_offsets.size() && bucket_offsets[pos] <= last_bound) {
                 cummulative_count += buckets[pos];
                 pos++;
             }


### PR DESCRIPTION
get_histogram() advances `pos` through bucket_offsets inside a while
loop keyed only on `bucket_offsets[pos] <= last_bound`, with no check
against bucket_offsets.size(). last_bound doubles on every one of the
max_buckets (default 16) outer iterations, so for a histogram with a
small bucket_count -- e.g. estimated_sstable_per_read{35}, whose
largest offset is ~492 -- last_bound outgrows all offsets well before
the outer loop finishes. Once pos reaches bucket_offsets.size(), the
next outer iteration re-evaluates bucket_offsets[pos], reading one
element past the end of the vector.

This is reachable from the Prometheus /metrics endpoint (the
sstables_per_read histogram), which runs in the "maintenance"
scheduling group. Under ASan this is reported as a heap-buffer-overflow
and aborts the node.

Bound the loop by bucket_offsets.size().

**sstables_per_read was very recently exposed to prometheus, in https://github.com/scylladb/scylladb/commit/7e15d34a399b4046dd86eaa64b5f1344671f37de. currently only in master, no need for backport**

Fixes: SCYLLADB-3436