### PR TITLE
mv: don't remove dead cells from the update when generating view update

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -1537,8 +1537,9 @@ void view_update_builder::generate_update(clustering_row&& update, std::optional
         update.apply(*_schema, *existing);
     }
 
-    update.marker().compact_and_expire(update.tomb().tomb(), _now, always_gc, gc_before);
-    update.cells().compact_and_expire(*_schema, column_kind::regular_column, update.tomb(), _now, always_gc, gc_before, update.marker());
+    // Don't remove dead cells from the update - they still affect the base table even if they are immediately eligible for GC
+    update.marker().compact_and_expire(update.tomb().tomb(), _now, never_gc, gc_before);
+    update.cells().compact_and_expire(*_schema, column_kind::regular_column, update.tomb(), _now, never_gc, gc_before, update.marker());
 
     const auto update_row = clustering_or_static_row(std::move(update));
     const auto existing_row = existing
@@ -1565,7 +1566,8 @@ void view_update_builder::generate_update(static_row&& update, const tombstone& 
         update.apply(*_schema, static_row(*_schema, *existing));
     }
 
-    update.cells().compact_and_expire(*_schema, column_kind::static_column, row_tombstone(update_tomb), _now, always_gc, gc_before);
+    // Don't remove dead cells from the update - they still affect the base table even if they are immediately eligible for GC
+    update.cells().compact_and_expire(*_schema, column_kind::static_column, row_tombstone(update_tomb), _now, never_gc, gc_before);
 
     const auto update_row = clustering_or_static_row(std::move(update));
     const auto existing_row = existing

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5522,6 +5522,8 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     m.upgrade(base);
     gc_clock::time_point now = gc_clock::now();
 
+    utils::get_local_injector().inject("delay_view_update_query_time_1s", [&] { now += 1s; });
+
     if (!db::view::should_generate_view_updates_on_this_shard(base, get_effective_replication_map(), m.token())) {
         // This could happen if we are a pending replica.
         // A pending replica may have incomplete data, and building view updates could result

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -12,6 +12,7 @@ from .util import new_test_table, unique_name, new_materialized_view, new_second
 from cassandra.protocol import ConfigurationException, InvalidRequest, SyntaxException
 from cassandra.cluster import ConsistencyLevel
 from cassandra.query import SimpleStatement
+from .rest_api import scylla_inject_error
 
 from . import nodetool
 
@@ -881,6 +882,22 @@ def test_mv_with_only_primary_key_rows(scylla_only, cql, test_keyspace):
             nodetool.flush(cql, view)
             assert(set([row.id for row in cql.execute(f'SELECT id FROM {view}')]) == set([1, 2, 3]))
             # We now believe that empty value serialization/deserialization is correct
+
+# Reproduces https://scylladb.atlassian.net/browse/SCYLLADB-3361
+# When there are no segments in the commitlog, view update generation takes into account current time when
+# deciding whether to compact the dead cells in the update. If this time is higher (by at least 1s) than the
+# time when the dead cell was created, the dead cell will be compacted away and the view update will not be generated.
+# This test reproduces this issue by injecting a 1s delay in time used for view update generation, and by flushing
+# the commitlog just before the DELETE.
+def test_mv_delete_cell_after_commitlog_flush(cql, test_keyspace, scylla_only):
+    with scylla_inject_error(cql, 'delay_view_update_query_time_1s', one_shot=False):
+        with new_test_table(cql, test_keyspace, 'pk int PRIMARY KEY, v int') as base:
+            with new_materialized_view(cql, table=base, select='pk', pk='pk', where='pk IS NOT NULL') as view:
+                # Add a row which is only kept alive by the liveness of v, clear commitlog, and delete v
+                cql.execute(f'UPDATE {base} SET v = 1 WHERE pk = 0')
+                nodetool.flush_all(cql)
+                cql.execute(f'DELETE v FROM {base} WHERE pk = 0')
+                assert(set([row.pk for row in cql.execute(f'SELECT pk FROM {view}')]) == set([]))
 
 # This test is regression testing added after fixing:
 # https://github.com/scylladb/scylladb/issues/16392 - the gist of the issue is that


### PR DESCRIPTION
When we generate view updates from a write/update, we compare the new state of the row to the existing one. However, before that, we compact and expire both existing and update (merged with existing) rows.

This allows us to avoid generating redundant and even resurrecting updates to the view, but in this process we may purge also some information that's needed to generate a correct view update.

If we observe that the deletion time of a cell in the update is lower than the timepoint for garbage-collection, we'll also remove this cell from the update. However, this dead cell can still affect the base table row - we don't reject writes which are immediately eligible for GC.

In particular, when using immediate gc mode (or repair mode with RF=1), the cell in the update may become eligible for GC while processing the write itself - we generate timestamps separately for the dead cell when constructing the statement and when starting generating the view update. It could also happen when generating view updates from mutations not coming directly from user statements, but through hints/repair/streaming. In such cases, the difference between the deletion time of the cell and the timepoint of generating the view update could be even larger and potentially cross the grace period for timeout GC mode or repair timestamp for (non-RF=1) repair GC mode (though in that case we hope to prevent this programatically).

Because of this, it's not safe to remove dead cells from the update row when generating the view update. We need to keep them regardless of the query processing timepoint.

This patch achieves this by using "never_gc" for "compact_and_expire" on the update row. This only affects dead cells coming from the update - we still compact the existing row before merging the update with it. And the dead cells in the update are still later compared with the existing row, avoiding updates if noting was actually to be deleted, and they still preserve their tombstone timestamps, so they still correctly mutate data in the view. This also doesn't affect TTLs and cells covered by row/range tombstones - "never_gc" is only used for deleted cells.

We also shouldn't delete row markers that become dead during the update, so we use "never_gc" for "compact_on_expire" on the update row marker as well.

We also add a test that reproduces this.

Fixes: SCYLLADB-3361