### PR TITLE
test::pylib::dockerized_service: Inlude more info on error

### DIFF
--- a/test/pylib/dockerized_service.py
+++ b/test/pylib/dockerized_service.py
@@ -132,9 +132,18 @@ class DockerizedServer:
                 while True:
                     data = proc.stderr.readline()
                     if not data:
+                        rc = proc.poll()
+                        level = logging.DEBUG
                         if f:
-                            loop.call_soon_threadsafe(f.set_exception, RuntimeError("Log EOF"))
-                        logger.debug("EOF received")
+                            level = logging.ERROR
+                            self.logfile.close()
+                            self.logfile = None
+                            with logfilename.open('r') as lf:
+                                for line in lf:
+                                    logger.error(line)
+                            loop.call_soon_threadsafe(f.set_exception, RuntimeError(f"Log EOF, return code {rc}"))
+
+                        logger.log(level, "EOF received: %s", rc)
                         break
                     line = data.decode()
                     self.logfile.write(data)


### PR DESCRIPTION
Refs SCYLLADB-3404

Includes exit code (if available) in error message + dumps container log to ours at a higher log level to enable determining spurious error sources.

Note: this in itself does not fix anything. It is just to help find causes. 