### PR TITLE
mutation: add missing include

### DIFF
--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/closeable.hh>
 
 #include "mutation.hh"


### PR DESCRIPTION
In the commit fcabc3927e02 seastars coroutine::maybe_yield() was added without the corresponding include and errors when compiled with --disable-precompiled-header flag. It compiles in CI and without the flag due to project wide precompiled header stdafx.hh.

Backport to all branches where the offending commit will be present.

Fixes: SCYLLADB-3491