### PR TITLE
raft: fix stale config index when truncation overwrites two config entries

### DIFF
--- a/raft/log.cc
+++ b/raft/log.cc
@@ -71,12 +71,16 @@ void log::truncate_uncommitted(index_t idx) {
     _memory_usage -= released_memory;
     stable_to(std::min(_stable_idx, last_idx()));
     if (_last_conf_idx > last_idx()) {
-        // If _prev_conf_idx is 0, this log does not contain any
-        // other configuration changes, since no two uncommitted
-        // configuration changes can be in progress.
-        SCYLLA_ASSERT(_prev_conf_idx < _last_conf_idx);
-        _last_conf_idx = _prev_conf_idx;
-        _prev_conf_idx = index_t{0};
+        // At least the last configuration entry was truncated. A single
+        // rollback to _prev_conf_idx is not always enough: both tracked
+        // configuration entries can be truncated at once. This happens after
+        // crash recovery, where a node may hold an uncommitted configuration
+        // on top of a committed one it has not re-applied yet -- commit_idx is
+        // not persisted, so on restart both look uncommitted -- and a leader
+        // then overwrites both. Re-derive the indices from the entries that
+        // remain in the log (as the constructor does).
+        _last_conf_idx = _prev_conf_idx = index_t{0};
+        init_last_conf_idx();
     }
 }
 

--- a/test/raft/fsm_test.cc
+++ b/test/raft/fsm_test.cc
@@ -1124,6 +1124,54 @@ BOOST_AUTO_TEST_CASE(test_leader_stepdown) {
     /// End test
 }
 
+BOOST_AUTO_TEST_CASE(test_truncate_overwrites_two_config_entries) {
+    // Reproducer for a raft::log bookkeeping bug: when a leader's AppendEntries
+    // overwrites a follower's log across *two* configuration entries at once,
+    // truncate_uncommitted() must not leave _last_conf_idx pointing at a
+    // truncated (and possibly replaced) entry.
+    //
+    // This state is reachable after a crash: commit_idx is not persisted, so on
+    // restart a committed configuration and an uncommitted joint configuration on
+    // top of it both look uncommitted, and the current leader may overwrite both.
+    // The old single-level rollback (_last_conf_idx = _prev_conf_idx) left
+    // _last_conf_idx dangling, so a later get_configuration() did
+    // std::get<configuration> on a non-configuration entry and threw
+    // bad_variant_access. This is a pure log logic bug: it triggers
+    // deterministically here, with no cluster and no task reordering.
+    server_id A = id(), B = id(), C = id(), D = id();
+
+    // Original cluster {A,B,C,D} captured in the snapshot at idx 0.
+    raft::configuration snap_cfg = config_from_ids({A, B, C, D});
+
+    // Persisted log reloaded after a crash:
+    //   idx 1 (term 1): committed config {A,B,C}
+    //   idx 2 (term 2): uncommitted joint config curr={A,B} prev={A,B,C}
+    raft::log_entries entries;
+    entries.push_back(seastar::make_lw_shared<const raft::log_entry>(
+            raft::log_entry{term_t{1}, index_t{1}, config_from_ids({A, B, C})}));
+    entries.push_back(seastar::make_lw_shared<const raft::log_entry>(
+            raft::log_entry{term_t{2}, index_t{2},
+                    raft::configuration{config_set({A, B}), config_set({A, B, C})}}));
+
+    raft::log log(raft::snapshot_descriptor{.idx = index_t{0}, .config = snap_cfg},
+            std::move(entries));
+    BOOST_CHECK_EQUAL(log.last_conf_idx(), index_t{2});
+    BOOST_CHECK(log.get_configuration().is_joint());
+
+    // A new leader (term 3) overwrites the log from idx 1 with a non-configuration
+    // entry, conflicting on term. This truncates both config entries at once.
+    raft::log_entry_ptr_list overwrite;
+    overwrite.push_back(seastar::make_lw_shared<const raft::log_entry>(
+            raft::log_entry{term_t{3}, index_t{1}, raft::log_entry::dummy{}}));
+    log.maybe_append(std::move(overwrite));
+
+    // Both configuration entries are gone: the effective configuration must fall
+    // back to the snapshot config, and get_configuration() must not throw.
+    BOOST_CHECK_EQUAL(log.last_conf_idx(), index_t{0});
+    BOOST_CHECK(!log.get_configuration().is_joint());
+    BOOST_CHECK(log.get_configuration().current == snap_cfg.current);
+}
+
 BOOST_AUTO_TEST_CASE(test_empty_configuration) {
     // When a server is joining an existing cluster, its configuration is empty.
     // The leader sends its configuration over in AppendEntries or


### PR DESCRIPTION

log::get_configuration() could throw std::bad_variant_access ("std::get: wrong index for variant"). It is called from the io fiber via fsm::get_output() on every wakeup, so once the log reaches the bad state the throw repeats indefinitely and the server makes no progress.

log::truncate_uncommitted() did only a single-level rollback of the config indices:

    _last_conf_idx = _prev_conf_idx;
    _prev_conf_idx = index_t{0};

which is correct only when at most the last configuration entry is uncommitted. But both tracked configuration entries can be truncated at once. This is reachable after a crash: commit_idx is not persisted, so on restart a committed configuration and an uncommitted joint configuration stacked on top of it both look uncommitted, and the current leader may overwrite both via AppendEntries. The rollback then leaves _last_conf_idx pointing at a truncated-and-replaced (non-configuration) entry, and the next get_configuration() does std::get<configuration> on it and throws.

Re-derive _last_conf_idx and _prev_conf_idx from the entries that remain in the log (as the constructor does) instead of the single-level rollback.

Add test/raft/fsm_test.cc::test_truncate_overwrites_two_config_entries, a deterministic reproducer that builds the log state directly and truncates both configuration entries with one maybe_append(); it fails without the fix and needs no cluster and no task reordering.

The bug is pre-existing; it was surfaced by replication_test flakiness after the seastar update reseeded the debug task-queue shuffle from std::random_device, which made the cluster reach the overwrite ~1% of runs.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3486

I'm not qualified to determine if this needs backporting (probably yes), so not yet making any backport decision.