### PR TITLE
test: fix and de-duplicate the sanitizer environment

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -10,7 +10,8 @@ import time
 import os
 from pathlib import Path
 
-__all__ = ["ALL_MODES", "BUILD_DIR", "DEBUG_MODES", "HOST_ID", "TEST_DIR", "TEST_RUNNER", "TOP_SRC_DIR", "path_to"]
+__all__ = ["ALL_MODES", "BUILD_DIR", "DEBUG_MODES", "HOST_ID", "TEST_DIR", "TEST_RUNNER", "TOP_SRC_DIR",
+           "asan_options", "path_to", "ubsan_options"]
 
 
 TEST_RUNNER = os.environ.get("SCYLLA_TEST_RUNNER", "pytest")
@@ -34,6 +35,46 @@ HOST_ID = os.environ.get("SCYLLA_TEST_HOST_ID")
 if HOST_ID is None:
     HOST_ID = hashlib.sha3_224((socket.gethostname() + str(time.time())).encode("utf-8")).hexdigest()[:5]
     os.environ["SCYLLA_TEST_HOST_ID"] = HOST_ID
+
+
+def ubsan_options(inherit: bool = False) -> str:
+    """UBSAN_OPTIONS for running a sanitizer-enabled Scylla or Scylla-based tool.
+
+    With inherit=True, a UBSAN_OPTIONS already present in the environment is
+    appended; sanitizer options are last-wins, so it overrides what is set here.
+    """
+
+    opts = [
+        "halt_on_error=1",
+        "abort_on_error=1",
+        f"suppressions={TOP_SRC_DIR / 'ubsan-suppressions.supp'}",
+    ]
+    if inherit:
+        opts.append(os.getenv("UBSAN_OPTIONS"))
+    return ":".join(filter(None, opts))
+
+
+def asan_options(inherit: bool = False) -> str:
+    """ASAN_OPTIONS for running a sanitizer-enabled Scylla or Scylla-based tool.
+
+    See ubsan_options() for inherit.
+
+    abort_on_error + disable_coredump make a sanitizer failure dump a core, which
+    is the only way to inspect corrupted allocator state after the fact.
+    detect_stack_use_after_return makes ASAN relocate frames onto its own "fake
+    stack" so that a frame touched after it returns is caught; keep in mind that
+    it also means the address of a local no longer identifies the stack the code
+    is running on (see cql3/util.cc).
+    """
+
+    opts = [
+        "disable_coredump=0",
+        "abort_on_error=1",
+        "detect_stack_use_after_return=1",
+    ]
+    if inherit:
+        opts.append(os.getenv("ASAN_OPTIONS"))
+    return ":".join(filter(None, opts))
 
 
 def path_to(mode: str, *components: str) -> str:

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -226,6 +226,7 @@ import ssl
 source_path = os.path.realpath(os.path.join(__file__, '../../..'))
 if source_path not in sys.path:
     sys.path.append(source_path)
+from test import asan_options, ubsan_options
 from test.pylib.driver_utils import safe_driver_shutdown
 
 scylla = None
@@ -267,8 +268,8 @@ def run_scylla_cmd(pid, dir):
     # When running a Scylla build with sanitizers enabled, we should
     # configure them to fail on real errors, and ignore spurious errors.
     env = {
-        'UBSAN_OPTIONS': f'halt_on_error=1:abort_on_error=1:suppressions={source_path}/ubsan-suppressions.supp',
-        'ASAN_OPTIONS': 'disable_coredump=0:abort_on_error=1:detect_stack_use_after_returns=1'
+        'UBSAN_OPTIONS': ubsan_options(),
+        'ASAN_OPTIONS': asan_options(),
     }
     return ([scylla_link,
         '--options-file',  source_path + '/conf/scylla.yaml',

--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -14,7 +14,7 @@ from typing import NamedTuple
 import pytest
 import requests.exceptions
 
-from test import TOP_SRC_DIR, path_to
+from test import TOP_SRC_DIR, asan_options, path_to, ubsan_options
 from test.nodetool.rest_api_mock import set_expected_requests, expected_request, get_expected_requests, \
     get_unexpected_requests, expected_requests_manager
 from test.pylib.host_registry import HostRegistry
@@ -208,9 +208,8 @@ def nodetool(request, jmx, nodetool_path, rest_api_mock_server):
                 jmx_ip, jmx_port = jmx
                 cmd = [nodetool_path, "-h", jmx_ip, "-p", str(jmx_port), method]
                 cmd += list(args)
-            suppressions_path = TOP_SRC_DIR / "ubsan-suppressions.supp"
-            env = {'UBSAN_OPTIONS': f'halt_on_error=1:abort_on_error=1:suppressions={suppressions_path}',
-                   'ASAN_OPTIONS': f'disable_coredump=0:abort_on_error=1:detect_stack_use_after_return=1'}
+            env = {'UBSAN_OPTIONS': ubsan_options(),
+                   'ASAN_OPTIONS': asan_options()}
             res = subprocess.run(cmd, capture_output=True, text=True, env=env)
             sys.stdout.write(res.stdout)
             sys.stderr.write(res.stderr)

--- a/test/pylib/cpp/base.py
+++ b/test/pylib/cpp/base.py
@@ -19,7 +19,7 @@ import pytest
 from _pytest._code.code import ReprFileLocation
 
 from scripts import coverage as coverage_script
-from test import DEBUG_MODES, TEST_DIR, TOP_SRC_DIR, path_to
+from test import DEBUG_MODES, TEST_DIR, TOP_SRC_DIR, asan_options, path_to, ubsan_options
 from test.pylib.runner import BUILD_MODE, RUN_ID, TEST_SUITE
 from test.pylib.scylla_cluster import merge_cmdline_options
 
@@ -31,21 +31,9 @@ if TYPE_CHECKING:
     from _pytest._io import TerminalWriter
 
 
-UBSAN_OPTIONS = [
-    "halt_on_error=1",
-    "abort_on_error=1",
-    f"suppressions={TOP_SRC_DIR / 'ubsan-suppressions.supp'}",
-    os.getenv("UBSAN_OPTIONS"),
-]
-ASAN_OPTIONS = [
-    "disable_coredump=0",
-    "abort_on_error=1",
-    "detect_stack_use_after_return=1",
-    os.getenv("ASAN_OPTIONS"),
-]
 BASE_TEST_ENV = {
-    "UBSAN_OPTIONS": ":".join(filter(None, UBSAN_OPTIONS)),
-    "ASAN_OPTIONS": ":".join(filter(None, ASAN_OPTIONS)),
+    "UBSAN_OPTIONS": ubsan_options(inherit=True),
+    "ASAN_OPTIONS": asan_options(inherit=True),
     "SCYLLA_TEST_ENV": "yes",
 }
 

--- a/test/pylib/cpp/base.py
+++ b/test/pylib/cpp/base.py
@@ -19,7 +19,7 @@ import pytest
 from _pytest._code.code import ReprFileLocation
 
 from scripts import coverage as coverage_script
-from test import DEBUG_MODES, TEST_DIR, TOP_SRC_DIR, path_to
+from test import DEBUG_MODES, TEST_DIR, TOP_SRC_DIR, asan_options, path_to, ubsan_options
 from test.pylib.coverage_utils import coverage_dir
 from test.pylib.runner import BUILD_MODE, RUN_ID, TEST_SUITE
 from test.pylib.scylla_server import merge_cmdline_options
@@ -32,21 +32,9 @@ if TYPE_CHECKING:
     from _pytest._io import TerminalWriter
 
 
-UBSAN_OPTIONS = [
-    "halt_on_error=1",
-    "abort_on_error=1",
-    f"suppressions={TOP_SRC_DIR / 'ubsan-suppressions.supp'}",
-    os.getenv("UBSAN_OPTIONS"),
-]
-ASAN_OPTIONS = [
-    "disable_coredump=0",
-    "abort_on_error=1",
-    "detect_stack_use_after_return=1",
-    os.getenv("ASAN_OPTIONS"),
-]
 BASE_TEST_ENV = {
-    "UBSAN_OPTIONS": ":".join(filter(None, UBSAN_OPTIONS)),
-    "ASAN_OPTIONS": ":".join(filter(None, ASAN_OPTIONS)),
+    "UBSAN_OPTIONS": ubsan_options(inherit=True),
+    "ASAN_OPTIONS": asan_options(inherit=True),
     "SCYLLA_TEST_ENV": "yes",
 }
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -27,7 +27,7 @@ import uuid
 from io import BufferedWriter
 import importlib
 
-from test import TOP_SRC_DIR, TEST_DIR
+from test import TEST_DIR, asan_options, ubsan_options
 from test.pylib.host_registry import Host, HostRegistry
 from test.pylib.pool import Pool
 from test.pylib.rest_client import ScyllaRESTAPIClient, HTTPError
@@ -864,8 +864,8 @@ class ScyllaServer:
         # remove from env to make sure user's SCYLLA_HOME has no impact
         env.pop('SCYLLA_HOME', None)
         env.update(self.append_env if append_env_override is None else append_env_override)
-        env['UBSAN_OPTIONS'] = f'halt_on_error=1:abort_on_error=1:suppressions={TOP_SRC_DIR / "ubsan-suppressions.supp"}'
-        env['ASAN_OPTIONS'] = f'disable_coredump=0:abort_on_error=1:detect_stack_use_after_return=1'
+        env['UBSAN_OPTIONS'] = ubsan_options()
+        env['ASAN_OPTIONS'] = asan_options()
 
         # Set up socket for receiving sd_notify messages from Scylla
         self._setup_notify_socket()

--- a/test/pylib/scylla_server.py
+++ b/test/pylib/scylla_server.py
@@ -42,7 +42,7 @@ from cassandra.connection import UnixSocketEndPoint
 from cassandra.policies import ExponentialReconnectionPolicy  # type: ignore
 from cassandra.policies import WhiteListRoundRobinPolicy  # type: ignore
 
-from test import TOP_SRC_DIR, TEST_DIR
+from test import TOP_SRC_DIR, TEST_DIR, asan_options, ubsan_options
 from test.pylib.driver_utils import safe_driver_shutdown, safe_shutting_down
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from test.pylib.rest_client import ScyllaRESTAPIClient, HTTPError
@@ -849,8 +849,8 @@ class ScyllaServer:
         # remove from env to make sure user's SCYLLA_HOME has no impact
         env.pop('SCYLLA_HOME', None)
         env.update(self.append_env if append_env_override is None else append_env_override)
-        env['UBSAN_OPTIONS'] = f'halt_on_error=1:abort_on_error=1:suppressions={TOP_SRC_DIR / "ubsan-suppressions.supp"}'
-        env['ASAN_OPTIONS'] = f'disable_coredump=0:abort_on_error=1:detect_stack_use_after_return=1'
+        env['UBSAN_OPTIONS'] = ubsan_options()
+        env['ASAN_OPTIONS'] = asan_options()
 
         # Set up socket for receiving sd_notify messages from Scylla
         self._setup_notify_socket()


### PR DESCRIPTION
The UBSAN_OPTIONS/ASAN_OPTIONS strings were hand-written in four places and one had drifted: test/cqlpy/run.py spelled it `detect_stack_use_after_returns=1`. ASAN prints nothing for an unrecognized option at the default verbosity, so that suite has been running without stack-use-after-return detection.

Keep a single definition in test/__init__.py and use it from scylla_cluster.py, cpp/base.py, nodetool/conftest.py and cqlpy/run.py. Only cpp/base.py appended an inherited ASAN_OPTIONS/UBSAN_OPTIONS from the environment, so that stays behind an explicit inherit flag and the other three keep ignoring it. Apart from the typo, every call site produces the same string as before.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3497.

No backport; test fix