### PR TITLE
cql3: remove the result metadata class indirection

### DIFF
--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -116,6 +116,8 @@ public:
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const = 0;
 
+    // Statements which keep their result set metadata elsewhere, e.g. in a
+    // selection, override this instead of setting _metadata.
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const {
         if (_metadata) {
             return _metadata;
@@ -143,14 +145,6 @@ public:
     void set_audit_info(audit::audit_info_ptr&& info) { _audit_info = std::move(info); }
 
     virtual void sanitize_audit_info() {}
-};
-
-class cql_statement_no_metadata : public cql_statement {
-public:
-    using cql_statement::cql_statement;
-    virtual seastar::shared_ptr<const metadata> get_result_metadata() const override {
-        return make_empty_metadata();
-    }
 };
 
 }

--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -48,6 +48,12 @@ using cql_warnings_vec = std::vector<sstring>;
 class cql_statement {
     timeout_config_selector _timeout_config_selector;
     audit::audit_info_ptr _audit_info;
+protected:
+    // Result set metadata, unset for statements which return no result
+    // set. E.g. conditional modification statements and batches return a
+    // result set and have metadata, while the same statements without
+    // conditions do not.
+    seastar::shared_ptr<metadata> _metadata;
 public:
     // CQL statement text
     utils::chunked_string raw_cql_statement;
@@ -59,7 +65,7 @@ public:
 
     explicit cql_statement(timeout_config_selector timeout_selector) : _timeout_config_selector(timeout_selector) {}
     cql_statement(cql_statement&& o) = default;
-    cql_statement(const cql_statement& o) : _timeout_config_selector(o._timeout_config_selector), _audit_info(o._audit_info ? std::make_unique<audit::audit_info>(*o._audit_info) : nullptr) { }
+    cql_statement(const cql_statement& o) : _timeout_config_selector(o._timeout_config_selector), _audit_info(o._audit_info ? std::make_unique<audit::audit_info>(*o._audit_info) : nullptr), _metadata(o._metadata) { }
     virtual ~cql_statement()
     { }
 
@@ -110,7 +116,12 @@ public:
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const = 0;
 
-    virtual seastar::shared_ptr<const metadata> get_result_metadata() const = 0;
+    virtual seastar::shared_ptr<const metadata> get_result_metadata() const {
+        if (_metadata) {
+            return _metadata;
+        }
+        return make_empty_metadata();
+    }
 
     virtual bool is_conditional() const {
         return false;
@@ -138,23 +149,6 @@ class cql_statement_no_metadata : public cql_statement {
 public:
     using cql_statement::cql_statement;
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override {
-        return make_empty_metadata();
-    }
-};
-
-// Conditional modification statements and batches
-// return a result set and have metadata, while same
-// statements without conditions do not.
-class cql_statement_opt_metadata : public cql_statement {
-protected:
-    // Result set metadata, may be empty for simple updates and batches
-    seastar::shared_ptr<metadata> _metadata;
-public:
-    using cql_statement::cql_statement;
-    virtual seastar::shared_ptr<const metadata> get_result_metadata() const override {
-        if (_metadata) {
-            return _metadata;
-        }
         return make_empty_metadata();
     }
 };

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -615,7 +615,7 @@ alter_table_statement::raw_statement::prepare(data_dictionary::database db, cql_
                 _ttl_change
             ),
             ctx,
-            // since alter table is `cql_statement_no_metadata` (it doesn't return any metadata when preparing)
+            // since alter table doesn't return any metadata when preparing
             // and bind markers cannot be a part of partition key,
             // we can pass empty vector as partition_key_bind_indices
             std::vector<uint16_t>()); 

--- a/cql3/statements/authentication_statement.hh
+++ b/cql3/statements/authentication_statement.hh
@@ -17,9 +17,9 @@ namespace cql3 {
 
 namespace statements {
 
-class authentication_statement : public raw::parsed_statement, public cql_statement_no_metadata {
+class authentication_statement : public raw::parsed_statement, public cql_statement {
 public:
-    authentication_statement() : cql_statement_no_metadata(&timeout_config::other_timeout) {}
+    authentication_statement() : cql_statement(&timeout_config::other_timeout) {}
 
     uint32_t get_bound_terms() const override;
 

--- a/cql3/statements/authorization_statement.hh
+++ b/cql3/statements/authorization_statement.hh
@@ -21,9 +21,9 @@ namespace cql3 {
 
 namespace statements {
 
-class authorization_statement : public raw::parsed_statement, public cql_statement_no_metadata {
+class authorization_statement : public raw::parsed_statement, public cql_statement {
 public:
-    authorization_statement() : cql_statement_no_metadata(&timeout_config::other_timeout) {}
+    authorization_statement() : cql_statement(&timeout_config::other_timeout) {}
 
     uint32_t get_bound_terms() const override;
 

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -45,7 +45,7 @@ batch_statement::batch_statement(int bound_terms, type type_,
                                  std::vector<single_statement> statements,
                                  std::unique_ptr<attributes> attrs,
                                  cql_stats& stats)
-    : cql_statement_opt_metadata(timeout_for_type(type_))
+    : cql_statement(timeout_for_type(type_))
     , _bound_terms(bound_terms), _type(type_), _statements(std::move(statements))
     , _attrs(std::move(attrs))
     , _has_conditions(std::ranges::any_of(_statements, [] (auto&& s) { return s.statement->has_conditions(); }))

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -36,7 +36,7 @@ class modification_statement;
  * A <code>BATCH</code> statement parsed from a CQL query.
  *
  */
-class batch_statement : public cql_statement_opt_metadata {
+class batch_statement : public cql_statement {
     static logging::logger _logger;
 public:
     using type = raw::batch_statement::type;

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -57,7 +57,7 @@ db::timeout_clock::duration modification_statement::get_timeout(const service::c
 }
 
 modification_statement::modification_statement(statement_type type_, uint32_t bound_terms, schema_ptr schema_, std::unique_ptr<attributes> attrs_, cql_stats& stats_)
-    : cql_statement_opt_metadata(modification_statement_timeout(*schema_))
+    : cql_statement(modification_statement_timeout(*schema_))
     , type{type_}
     , _bound_terms{bound_terms}
     , _columns_to_read(schema_->all_columns_count())

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -40,7 +40,7 @@ namespace raw { class modification_statement; }
 /*
  * Abstract parent class of individual modifications, i.e. INSERT, UPDATE and DELETE.
  */
-class modification_statement : public cql_statement_opt_metadata {
+class modification_statement : public cql_statement {
 public:
     const statement_type type;
     bool _may_use_token_aware_routing;

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -24,13 +24,13 @@ static logging::logger logger("schema_altering_statement");
 
 schema_altering_statement::schema_altering_statement(timeout_config_selector timeout_selector)
     : cf_statement(cf_name())
-    , cql_statement_no_metadata(timeout_selector)
+    , cql_statement(timeout_selector)
     , _is_column_family_level{false} {
 }
 
 schema_altering_statement::schema_altering_statement(cf_name name, timeout_config_selector timeout_selector)
     : cf_statement{std::move(name)}
-    , cql_statement_no_metadata(timeout_selector)
+    , cql_statement(timeout_selector)
     , _is_column_family_level{true} {
 }
 

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -33,7 +33,7 @@ namespace messages = cql_transport::messages;
 /**
  * Abstract class for statements that alter the schema.
  */
-class schema_altering_statement : public raw::cf_statement, public cql_statement_no_metadata {
+class schema_altering_statement : public raw::cf_statement, public cql_statement {
 private:
     const bool _is_column_family_level;
 

--- a/cql3/statements/service_level_statement.hh
+++ b/cql3/statements/service_level_statement.hh
@@ -39,9 +39,9 @@ public:
 
 
 
-class service_level_statement : public raw::parsed_statement, public cql_statement_no_metadata {
+class service_level_statement : public raw::parsed_statement, public cql_statement {
 public:
-    service_level_statement() : cql_statement_no_metadata(&timeout_config::other_timeout) {}
+    service_level_statement() : cql_statement(&timeout_config::other_timeout) {}
 
     virtual bool needs_guard(query_processor& qp, service::query_state& state) const override;
 

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -22,7 +22,7 @@ namespace cql3::statements::strong_consistency {
 static logging::logger logger("sc_modification_statement");
 
 modification_statement::modification_statement(shared_ptr<base_statement> statement)
-    : cql_statement_opt_metadata(&timeout_config::write_timeout)
+    : cql_statement(&timeout_config::write_timeout)
     , _statement(std::move(statement))
 {
 }

--- a/cql3/statements/strong_consistency/modification_statement.hh
+++ b/cql3/statements/strong_consistency/modification_statement.hh
@@ -14,7 +14,7 @@
 
 namespace cql3::statements::strong_consistency {
 
-class modification_statement : public cql_statement_opt_metadata {
+class modification_statement : public cql_statement {
     using result_message = cql_transport::messages::result_message;
     using base_statement = cql3::statements::modification_statement;
 

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -47,14 +47,14 @@ std::unique_ptr<prepared_statement> truncate_statement::prepare(data_dictionary:
 } // namespace raw
 
 truncate_statement::truncate_statement(schema_ptr schema, std::unique_ptr<attributes> prepared_attrs)
-    : cql_statement_no_metadata(&timeout_config::truncate_timeout)
+    : cql_statement(&timeout_config::truncate_timeout)
     , _schema{std::move(schema)}
     , _attrs(std::move(prepared_attrs))
 {
 }
 
 truncate_statement::truncate_statement(const truncate_statement& ts)
-    : cql_statement_no_metadata(ts)
+    : cql_statement(ts)
     , _schema(ts._schema)
     , _attrs(std::make_unique<attributes>(*ts._attrs))
 { }

--- a/cql3/statements/truncate_statement.hh
+++ b/cql3/statements/truncate_statement.hh
@@ -20,7 +20,7 @@ class query_processor;
 
 namespace statements {
 
-class truncate_statement : public cql_statement_no_metadata {
+class truncate_statement : public cql_statement {
     schema_ptr _schema;
     const std::unique_ptr<attributes> _attrs;
 public:

--- a/cql3/statements/use_statement.cc
+++ b/cql3/statements/use_statement.cc
@@ -19,7 +19,7 @@ namespace cql3 {
 namespace statements {
 
 use_statement::use_statement(sstring keyspace)
-        : cql_statement_no_metadata(&timeout_config::other_timeout)
+        : cql_statement(&timeout_config::other_timeout)
         , _keyspace(keyspace)
 {
 }

--- a/cql3/statements/use_statement.hh
+++ b/cql3/statements/use_statement.hh
@@ -19,7 +19,7 @@ class query_processor;
 
 namespace statements {
 
-class use_statement : public cql_statement_no_metadata {
+class use_statement : public cql_statement {
 private:
     const seastar::sstring _keyspace;
 


### PR DESCRIPTION
cql_statement_no_metadata and cql_statement_opt_metadata both answered
get_result_metadata() and nothing else - one of them with its metadata
member permanently null. They add two names to the hierarchy without
adding behaviour, and mislead: sub-classes of the "no metadata" one do
return metadata, by overriding the accessor.

Move the optional metadata member to cql_statement and drop both
classes. No functional change.

Backport: no, refactor only

Fixes: SCYLLADB-3489