### PR TITLE
api: Unify backup_location schema between backup and restore APIs

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -3348,32 +3348,14 @@
                       },
                       {
                          "name":"backup_location",
-                         "description":"JSON array of backup location objects. Each object must contain: 'datacenter' (string), 'endpoint' (string), 'bucket' (string), and 'prefix' (string).",
+                         "description":"JSON array of backup location objects. Each object must contain: 'datacenter' (string), 'endpoint' (string), 'bucket' (string), and 'prefix' (string). 'manifests' must not be set.",
                          "required":true,
                          "allowMultiple":false,
                          "type":"array",
-                         "paramType":"body",
-                         "items": {
-                            "description":"A backup location entry describing where to place SSTables",
-                            "properties":{
-                                "datacenter":{
-                                   "type":"string",
-                                   "description":"The datacenter name"
-                                },
-                                "endpoint":{
-                                   "type":"string",
-                                   "description":"The object store endpoint name/URL"
-                                },
-                                "bucket":{
-                                   "type":"string",
-                                   "description":"The object store bucket name"
-                                },
-                                "prefix":{
-                                   "type":"string",
-                                   "description":"The object store bucket prefix"
-                                }
-                            }
-                         }
+                         "items":{
+                            "$ref":"backup_location"
+                         },
+                         "paramType":"body"
                       }
                   ]
               }
@@ -4156,7 +4138,7 @@
       },
       "backup_location":{
          "id":"backup_location",
-         "description":"A backup location entry describing where to find SSTables",
+         "description":"A backup location entry describing where to find or place SSTables",
          "properties":{
             "datacenter":{
                "type":"string",
@@ -4170,12 +4152,16 @@
                "type":"string",
                "description":"The object store bucket name"
             },
+            "prefix":{
+               "type":"string",
+               "description":"The object store bucket prefix"
+            },
             "manifests":{
                "type":"array",
                "items":{
                   "type":"string"
                },
-               "description":"List of manifest file paths"
+               "description":"List of manifest file paths, relative to 'prefix'. Only used by tablet-aware restore; must not be set for backup."
             }
          }
       }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -2406,6 +2406,9 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
             if (!location.IsObject()) {
                 throw httpd::bad_param_exception("backup location (in body) must be a JSON object");
             }
+            if (location.HasMember("manifests")) {
+                throw httpd::bad_param_exception("backup location 'manifests' must not be set for backup");
+            }
 
             auto endpoint = rjson::to_string(location["endpoint"]);
             auto bucket = rjson::to_string(location["bucket"]);


### PR DESCRIPTION
Use a single shared 'backup_location' swagger model for both start_global_backup and tablet_aware_restore, referenced via $ref instead of two independently declared (and drifting) schemas. The shared model now declares 'prefix', which was already used by start_global_backup but missing from tablet_aware_restore's model declaration (despite being read from the request by the handler).

Reject requests to start_global_backup that set 'manifests', since that field is only meaningful for tablet-aware restore.

Code de-duplication, not backporting