### PR TITLE
strong_consistency: persist the commit term for an exact post-replay snapshot bump

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -3227,22 +3227,20 @@ db::commitlog::add_entries(utils::chunked_vector<commitlog_mutation_entry_writer
     return _segment_manager->allocate_when_possible(cl_entries_writer(sync, std::move(entry_writers)), timeout);
 }
 future<utils::chunked_vector<db::rp_handle>> db::commitlog::add_raft_entries(
-        const cf_id_type& id, utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers) {
+        utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers) {
     class cl_raft_entries_writer final : public entry_writer {
         utils::chunked_vector<commitlog_raft_log_entry_writer> _writers;
-        cf_id_type _id;
 
     public:
         utils::chunked_vector<rp_handle> res;
 
-        cl_raft_entries_writer(utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers, cf_id_type id)
+        cl_raft_entries_writer(utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers)
             : entry_writer(force_sync::yes, entry_writers.size())
-            , _writers(std::move(entry_writers))
-            , _id(id) {
+            , _writers(std::move(entry_writers)) {
             res.reserve(_writers.size());
         }
-        const cf_id_type& id(size_t) const override {
-            return _id;
+        const cf_id_type& id(size_t i) const override {
+            return _writers.at(i).cf_id();
         }
         size_t size(segment&) override {
             size_t res = 0;
@@ -3275,7 +3273,7 @@ future<utils::chunked_vector<db::rp_handle>> db::commitlog::add_raft_entries(
             return std::move(res);
         }
     };
-    return _segment_manager->allocate_when_possible(cl_raft_entries_writer(std::move(entry_writers), id), db::no_timeout);
+    return _segment_manager->allocate_when_possible(cl_raft_entries_writer(std::move(entry_writers)), db::no_timeout);
 }
 
 db::commitlog::commitlog(config cfg)

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -239,10 +239,13 @@ public:
 
     /**
      * Add N raft log entries to the commit log as a single operation (in a single segment).
-     * Always uses force_sync::yes.
+     * Each entry writer carries its own cf_id, so a single batch can contain
+     * entries destined for different column families (e.g. raft log entries
+     * for the target table and a trailing commit_idx entry attached to
+     * system.raft_groups). Always uses force_sync::yes.
      */
     future<utils::chunked_vector<rp_handle>> add_raft_entries(
-            const cf_id_type& id, utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers);
+            utils::chunked_vector<commitlog_raft_log_entry_writer> entry_writers);
 
     /**
      * Modifies the per-CF dirty cursors of any commit log segments for the column family according to the position

--- a/db/commitlog/commitlog_entry.cc
+++ b/db/commitlog/commitlog_entry.cc
@@ -44,7 +44,16 @@ void commitlog_mutation_entry_writer::compute_size() {
 
 template<typename Output>
 inline void commitlog_raft_log_entry_writer::serialize(Output& out) const {
-    ser::writer_of_commitlog_entry<Output>(out).write_item_raft_commitlog_entry(_item).end_commitlog_entry();
+    auto writer = ser::writer_of_commitlog_entry<Output>(out);
+    std::visit([&] (const auto& item) {
+        using item_type = std::decay_t<decltype(item)>;
+        if constexpr (std::is_same_v<item_type, raft_commitlog_entry>) {
+            std::move(writer).write_item_raft_commitlog_entry(item).end_commitlog_entry();
+        } else {
+            static_assert(std::is_same_v<item_type, raft_commit_idx_entry>);
+            std::move(writer).write_item_raft_commit_idx_entry(item).end_commitlog_entry();
+        }
+    }, _item);
 }
 
 void commitlog_raft_log_entry_writer::write(ostream& out) const {
@@ -80,6 +89,9 @@ auto read_variant_commitlog_entry(const fragmented_temporary_buffer& buffer) {
             },
             [](const ser::mutation_entry_view& entry_view) {
                 return commitlog_entry{.item = mutation_entry(entry_view.mapping(), entry_view.mutation())};
+            },
+            [](raft_commit_idx_entry entry) {
+                return commitlog_entry{.item = std::move(entry)};
             },
             [](ser::unknown_variant_type) -> commitlog_entry {
                 throw std::runtime_error("Unknown variant type in commitlog entry");

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -196,10 +196,15 @@ public:
 // (raft_commitlog_entry) and the per-batch commit-index entry
 // (raft_commit_idx_entry); both are produced by raft_commitlog::
 // store_log_entries as part of a single batched commit_log.add_raft_entries().
+//
+// Each writer carries its own cf_id_type so a single batch can contain
+// entries destined for different column families — used to associate the
+// commit_idx entry with system.raft_groups rather than the raft log's target table.
 class commitlog_raft_log_entry_writer {
 public:
     using item_variant = std::variant<raft_commitlog_entry, raft_commit_idx_entry>;
 protected:
+    db::cf_id_type _cf_id;
     item_variant _item;
     std::size_t _size = std::numeric_limits<std::size_t>::max();
 
@@ -208,10 +213,10 @@ protected:
     void compute_size();
 
 public:
-    explicit commitlog_raft_log_entry_writer(raft_commitlog_entry item)
-        : _item(std::move(item)) { compute_size(); }
-    explicit commitlog_raft_log_entry_writer(raft_commit_idx_entry item)
-        : _item(std::move(item)) { compute_size(); }
+    explicit commitlog_raft_log_entry_writer(db::cf_id_type cf_id, raft_commitlog_entry item)
+        : _cf_id(cf_id), _item(std::move(item)) { compute_size(); }
+    explicit commitlog_raft_log_entry_writer(db::cf_id_type cf_id, raft_commit_idx_entry item)
+        : _cf_id(cf_id), _item(std::move(item)) { compute_size(); }
 
     size_t size() const {
         SCYLLA_ASSERT(_size != std::numeric_limits<size_t>::max());
@@ -221,6 +226,9 @@ public:
     using ostream = typename seastar::memory_output_stream<detail::sector_split_iterator>;
     void write(ostream& out) const;
 
+    const db::cf_id_type& cf_id() const {
+        return _cf_id;
+    }
     raft::group_id group_id() const {
         return std::visit([] (const auto& item) { return item.group_id; }, _item);
     }

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -102,11 +102,24 @@ struct raft_commitlog_entry {
     raft::log_entry_ptr entry;
 };
 
-// The on-disk envelope for variant-format commitlog segments. Each
-// entry contains exactly one of the variant alternatives: a mutation_entry
-// (normal table write) or a raft_commitlog_entry (Raft log entry for
-// strongly-consistent tables).
-using commitlog_entry_variant = std::variant<raft_commitlog_entry, mutation_entry>;
+// Commitlog entry that carries the current commit index of a strongly-consistent
+// raft group. Used to persist the commit index (see raft_commitlog::store_log_entries
+// and raft_groups_storage::store_log_entries).
+struct raft_commit_idx_entry {
+    raft::group_id group_id;
+    raft::index_t commit_idx{0};
+};
+
+// The on-disk envelope for variant-format commitlog segments. Each entry
+// contains exactly one of the variant alternatives: a mutation_entry (normal
+// table write), a raft_commitlog_entry (Raft log entry for a strongly-consistent
+// table), or a raft_commit_idx_entry (per-batch commit_idx entry).
+//
+// NOTE: the variant alternative index is the on-disk discriminator, so new
+// alternatives must only ever be appended at the end. Reordering or inserting
+// in the middle would change the discriminator of existing alternatives and
+// corrupt the reading of previously written segments.
+using commitlog_entry_variant = std::variant<raft_commitlog_entry, mutation_entry, raft_commit_idx_entry>;
 struct commitlog_entry {
     commitlog_entry_variant item;
 };
@@ -178,11 +191,16 @@ public:
     frozen_mutation&& mutation() && { return std::move(_me).mutation(); }
 };
 
-// Writer for Raft log entries to the database commit log using the commitlog_entry format.
+// Writer for Raft-related entries in the database commit log using the
+// commitlog_entry format. Handles both the raft log entry variant
+// (raft_commitlog_entry) and the per-batch commit-index entry
+// (raft_commit_idx_entry); both are produced by raft_commitlog::
+// store_log_entries as part of a single batched commit_log.add_raft_entries().
 class commitlog_raft_log_entry_writer {
 public:
+    using item_variant = std::variant<raft_commitlog_entry, raft_commit_idx_entry>;
 protected:
-    raft_commitlog_entry _item;
+    item_variant _item;
     std::size_t _size = std::numeric_limits<std::size_t>::max();
 
     template<typename Output>
@@ -192,6 +210,8 @@ protected:
 public:
     explicit commitlog_raft_log_entry_writer(raft_commitlog_entry item)
         : _item(std::move(item)) { compute_size(); }
+    explicit commitlog_raft_log_entry_writer(raft_commit_idx_entry item)
+        : _item(std::move(item)) { compute_size(); }
 
     size_t size() const {
         SCYLLA_ASSERT(_size != std::numeric_limits<size_t>::max());
@@ -200,7 +220,19 @@ public:
 
     using ostream = typename seastar::memory_output_stream<detail::sector_split_iterator>;
     void write(ostream& out) const;
-    const raft_commitlog_entry& get_log_entry() const {
+
+    raft::group_id group_id() const {
+        return std::visit([] (const auto& item) { return item.group_id; }, _item);
+    }
+    // Returns the underlying raft_commitlog_entry when this writer holds one.
+    // Guarded by holds_raft_log_entry(); prefer visiting item() instead.
+    const raft_commitlog_entry& get_raft_log_entry() const {
+        return std::get<raft_commitlog_entry>(_item);
+    }
+    bool holds_raft_log_entry() const {
+        return std::holds_alternative<raft_commitlog_entry>(_item);
+    }
+    const item_variant& item() const {
         return _item;
     }
 };

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -108,6 +108,10 @@ struct raft_commitlog_entry {
 struct raft_commit_idx_entry {
     raft::group_id group_id;
     raft::index_t commit_idx{0};
+    // Term of the log entry at commit_idx. Absent in entries written by
+    // binaries predating the field (IDL append); readers treat absence as
+    // "unknown" and fall back to a conservative term (SCYLLADB-3357).
+    std::optional<raft::term_t> term;
 };
 
 // The on-disk envelope for variant-format commitlog segments. Each entry

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -235,6 +235,12 @@ future<> db::commitlog_replayer::impl::process(
             rlogger.debug("Adding raft log entry for group {} at {} to replay buffer", raft_entry.group_id, rp);
             _raft_buffer->local().add(raft_entry.group_id, raft_entry.entry);
             co_return;
+        } else if (std::holds_alternative<raft_commit_idx_entry>(read_entry)) {
+            // Commit index entry for a strongly-consistent raft group.
+            const auto& commit_idx_entry = std::get<raft_commit_idx_entry>(read_entry);
+            rlogger.debug("Skipping commit_idx entry at {} for group {} (commit_idx={})",
+                    rp, commit_idx_entry.group_id, commit_idx_entry.commit_idx);
+            co_return;
         } else if (std::holds_alternative<mutation_entry>(read_entry)) {
             const auto& mut_entry = std::get<mutation_entry>(read_entry);
 

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -236,10 +236,14 @@ future<> db::commitlog_replayer::impl::process(
             _raft_buffer->local().add(raft_entry.group_id, raft_entry.entry);
             co_return;
         } else if (std::holds_alternative<raft_commit_idx_entry>(read_entry)) {
-            // Commit index entry for a strongly-consistent raft group.
+            // Commit index entry for a strongly-consistent raft group. Record it
+            // so process_raft_replayed_items() can restore commit_idx that a
+            // crash dropped from the raft_groups memtable before it flushed.
             const auto& commit_idx_entry = std::get<raft_commit_idx_entry>(read_entry);
-            rlogger.debug("Skipping commit_idx entry at {} for group {} (commit_idx={})",
+            SCYLLA_ASSERT(_raft_buffer);
+            rlogger.debug("Recording commit_idx entry at {} for group {} (commit_idx={})",
                     rp, commit_idx_entry.group_id, commit_idx_entry.commit_idx);
+            _raft_buffer->local().add_commit_idx(commit_idx_entry.group_id, commit_idx_entry.commit_idx);
             co_return;
         } else if (std::holds_alternative<mutation_entry>(read_entry)) {
             const auto& mut_entry = std::get<mutation_entry>(read_entry);

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -241,9 +241,10 @@ future<> db::commitlog_replayer::impl::process(
             // crash dropped from the raft_groups memtable before it flushed.
             const auto& commit_idx_entry = std::get<raft_commit_idx_entry>(read_entry);
             SCYLLA_ASSERT(_raft_buffer);
-            rlogger.debug("Recording commit_idx entry at {} for group {} (commit_idx={})",
-                    rp, commit_idx_entry.group_id, commit_idx_entry.commit_idx);
-            _raft_buffer->local().add_commit_idx(commit_idx_entry.group_id, commit_idx_entry.commit_idx);
+            rlogger.debug("Recording commit_idx entry at {} for group {} (commit_idx={}, term={})",
+                    rp, commit_idx_entry.group_id, commit_idx_entry.commit_idx, commit_idx_entry.term);
+            _raft_buffer->local().add_commit_idx(commit_idx_entry.group_id, commit_idx_entry.commit_idx,
+                    commit_idx_entry.term.value_or(raft::term_t(0)));
             co_return;
         } else if (std::holds_alternative<mutation_entry>(read_entry)) {
             const auto& mut_entry = std::get<mutation_entry>(read_entry);

--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
@@ -170,9 +171,6 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
         uint64_t rewritten = 0;
         auto& group_data = _per_group_data[group_id];
 
-        // Track the term of the last committed entry to update the snapshot descriptor.
-        std::optional<raft::term_t> last_committed_term;
-
         for (auto& entry : filtered.entries) {
             // Apply committed command entries to the memtables. It is safe not to append them
             // to the new commitlog, because the old commitlog (currently being replayed) will
@@ -187,14 +185,10 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
                 ++applied;
             }
 
-            if (entry->idx <= commit_idx) {
-                last_committed_term = entry->term;
-            }
-
             // Rewrite uncommitted entries to the new commitlog to obtain rp_handles
             // that ensure the commitlog segments won't be deleted.
             if (entry->idx > commit_idx) {
-                commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = group_id, .entry = entry});
+                commitlog_raft_log_entry_writer writer(table_id, raft_commitlog_entry{.group_id = group_id, .entry = entry});
                 const auto write_fn = [&writer](auto& out) {
                     return writer.write(out);
                 };
@@ -205,29 +199,14 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
             }
 
             // Only add uncommitted entries to the raft log. Committed entries have
-            // already been applied to memtables above and will be covered by the
-            // updated snapshot descriptor (see below).
+            // already been applied to memtables above and are covered by the
+            // snapshot index that bump_snapshot_indices() advances to commit_idx
+            // after replay (the sole snapshot-index advancer on startup).
             if (entry->idx > commit_idx) {
                 group_data.entries.push_back(std::move(entry));
             }
 
             co_await seastar::coroutine::maybe_yield();
-        }
-
-        // Advance the persisted snapshot index to commit_idx. This tells the raft
-        // server (which sets _applied_idx = snapshot.idx on restart) that all
-        // committed entries have already been applied, preventing double-application
-        // through the state machine.
-        if (last_committed_term) {
-            // Strongly-consistent tablet raft groups don't use real snapshots,
-            // so we generate a random snapshot ID just to satisfy the schema requirement.
-            co_await service::strong_consistency::raft_groups_storage::store_snapshot_index(
-                    qp, group_id, this_shard_id(), raft::snapshot_descriptor{
-                        .idx = commit_idx,
-                        .term = *last_committed_term,
-                        .id = raft::snapshot_id(utils::make_random_uuid()),
-                    });
-            logger.debug("group {}: advanced snapshot to idx={}, term={}", group_id, commit_idx, *last_committed_term);
         }
 
         logger.debug("group {}: discarded_leader_change={}, applied={}, rewritten={}, total_in_log={}", group_id, filtered.discarded_leader_change, applied,
@@ -237,6 +216,45 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
     // The old items are not needed anymore.
     _replayed_commitlog_entries_by_group.clear();
     logger.info("Raft groups commit log replayed data processing complete");
+}
+
+future<> raft_commitlog_replay_buffer::bump_snapshot_indices(replica::database& db, cql3::query_processor& qp) {
+    // See header for rationale. Runs for every known raft group and is the sole
+    // place that advances the persisted snapshot index on startup. store_snapshot_index
+    // has an internal "only advance" guard, so groups whose snapshot is already at or
+    // beyond commit_idx (e.g. from a prior run) are left untouched.
+    const auto token_metadata = db.get_shared_token_metadata().get();
+    const auto group_to_table = build_group_to_table_map(*token_metadata);
+
+    // Process groups concurrently: each does independent CQL reads/writes, and
+    // doing them serially would make startup O(groups) round-trips.
+    co_await seastar::coroutine::parallel_for_each(group_to_table,
+            [&qp] (const auto& entry) -> future<> {
+        const auto group_id = entry.first;
+        const auto commit_idx = co_await service::strong_consistency::raft_groups_storage::load_commit_idx(qp, group_id, this_shard_id());
+        if (commit_idx.value() == 0) {
+            co_return;
+        }
+        auto [snap_idx, snap_term] = co_await service::strong_consistency::raft_groups_storage::load_snapshot_idx_and_term(qp, group_id, this_shard_id());
+        if (snap_idx >= commit_idx) {
+            co_return;
+        }
+        // Reuse the previously-recorded snapshot term (the term of the last real
+        // raft snapshot). It is <= term(commit_idx), so it errs conservative /
+        // too-low, which is safe: the replica looks no more up-to-date than its
+        // data, and any log-matching mismatch is repaired by InstallSnapshot from
+        // a peer. The exact term(commit_idx) is not recoverable here once the
+        // commitlog is empty; persisting it for an exact bump is tracked in
+        // SCYLLADB-3357.
+        co_await service::strong_consistency::raft_groups_storage::store_snapshot_index(
+                qp, group_id, this_shard_id(), raft::snapshot_descriptor{
+                    .idx = commit_idx,
+                    .term = snap_term,
+                    .id = raft::snapshot_id(utils::make_random_uuid()),
+                });
+        logger.debug("group {}: post-replay catch-up, advanced snapshot idx {} -> {} (term={})",
+                group_id, snap_idx, commit_idx, snap_term);
+    });
 }
 namespace raft_buffer_detail {
 entry_ordering_check_result check_entry_ordering(raft_term_and_idx current, raft_term_and_idx last) {

--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -127,7 +127,7 @@ filter_entries_result filter_entries(utils::chunked_vector<raft::log_entry_ptr>&
 } // anonymous namespace
 
 future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::database& db, cql3::query_processor& qp, db::system_keyspace& sys_ks) {
-    if (remaining_groups() == 0) {
+    if (remaining_groups() == 0 && _replayed_commit_idx_by_group.empty()) {
         co_return;
     }
 
@@ -138,6 +138,30 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
     SCYLLA_ASSERT(new_commitlog_ptr);
 
     logger.info("processing {} raft groups with {} total entries from commitlog replay", remaining_groups(), total_entries());
+
+    // Restore commit_idx recovered from the commitlog. On a crash before the
+    // raft_groups memtable flushed, the per-batch commit_idx (applied in memory
+    // via a fake mutation) is lost, but the commitlog's commit_idx entries
+    // survived. Write the highest recovered value per group back to
+    // system.raft_groups so the apply loop below — and bump_snapshot_indices()
+    // afterwards — observe the correct commit_idx and re-apply / snapshot the
+    // committed entries rather than treating them as uncommitted. The per-group
+    // writes are independent, so run them concurrently (as bump_snapshot_indices
+    // does).
+    co_await seastar::coroutine::parallel_for_each(_replayed_commit_idx_by_group,
+            [&qp, &group_to_table] (const auto& entry) -> future<> {
+        const auto group_id = entry.first;
+        const auto recovered_commit_idx = entry.second;
+        if (!group_to_table.contains(group_id)) {
+            // Same rule as the entries loop below: the tablet was moved away or
+            // dropped, so don't resurrect a system.raft_groups row for it.
+            logger.debug("group {} not found in tablet metadata, discarding recovered commit_idx {}",
+                    group_id, recovered_commit_idx);
+            co_return;
+        }
+        co_await service::strong_consistency::raft_groups_storage::store_commit_idx_if_higher(
+                qp, group_id, this_shard_id(), recovered_commit_idx);
+    });
 
     for (auto& [group_id, entries_list] : _replayed_commitlog_entries_by_group) {
         if (entries_list.empty()) {
@@ -215,6 +239,7 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
 
     // The old items are not needed anymore.
     _replayed_commitlog_entries_by_group.clear();
+    _replayed_commit_idx_by_group.clear();
     logger.info("Raft groups commit log replayed data processing complete");
 }
 

--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -151,16 +151,16 @@ future<> raft_commitlog_replay_buffer::process_raft_replayed_items(replica::data
     co_await seastar::coroutine::parallel_for_each(_replayed_commit_idx_by_group,
             [&qp, &group_to_table] (const auto& entry) -> future<> {
         const auto group_id = entry.first;
-        const auto recovered_commit_idx = entry.second;
+        const auto recovered = entry.second;
         if (!group_to_table.contains(group_id)) {
             // Same rule as the entries loop below: the tablet was moved away or
             // dropped, so don't resurrect a system.raft_groups row for it.
             logger.debug("group {} not found in tablet metadata, discarding recovered commit_idx {}",
-                    group_id, recovered_commit_idx);
+                    group_id, recovered.idx);
             co_return;
         }
         co_await service::strong_consistency::raft_groups_storage::store_commit_idx_if_higher(
-                qp, group_id, this_shard_id(), recovered_commit_idx);
+                qp, group_id, this_shard_id(), recovered);
     });
 
     for (auto& [group_id, entries_list] : _replayed_commitlog_entries_by_group) {

--- a/db/commitlog/raft_commitlog_replay_buffer.cc
+++ b/db/commitlog/raft_commitlog_replay_buffer.cc
@@ -256,29 +256,30 @@ future<> raft_commitlog_replay_buffer::bump_snapshot_indices(replica::database& 
     co_await seastar::coroutine::parallel_for_each(group_to_table,
             [&qp] (const auto& entry) -> future<> {
         const auto group_id = entry.first;
-        const auto commit_idx = co_await service::strong_consistency::raft_groups_storage::load_commit_idx(qp, group_id, this_shard_id());
-        if (commit_idx.value() == 0) {
+        const auto commit = co_await service::strong_consistency::raft_groups_storage::load_commit_idx_and_term(qp, group_id, this_shard_id());
+        if (commit.idx.value() == 0) {
             co_return;
         }
         auto [snap_idx, snap_term] = co_await service::strong_consistency::raft_groups_storage::load_snapshot_idx_and_term(qp, group_id, this_shard_id());
-        if (snap_idx >= commit_idx) {
+        if (snap_idx >= commit.idx) {
             co_return;
         }
-        // Reuse the previously-recorded snapshot term (the term of the last real
-        // raft snapshot). It is <= term(commit_idx), so it errs conservative /
-        // too-low, which is safe: the replica looks no more up-to-date than its
-        // data, and any log-matching mismatch is repaired by InstallSnapshot from
-        // a peer. The exact term(commit_idx) is not recoverable here once the
-        // commitlog is empty; persisting it for an exact bump is tracked in
-        // SCYLLADB-3357.
+        // Use the exact term of the entry at commit_idx when it is known.
+        // commit_idx_term == 0 means the row was written before the term was
+        // persisted (an older binary); fall back to the previously-recorded
+        // snapshot term. The fallback is <= term(commit_idx), i.e. errs
+        // conservative / too-low, which is safe — the replica looks no more
+        // up-to-date than its data — but a peer with higher-term entries may
+        // repair it via InstallSnapshot instead of plain log matching.
+        const auto bump_term = commit.term != raft::term_t(0) ? commit.term : snap_term;
         co_await service::strong_consistency::raft_groups_storage::store_snapshot_index(
                 qp, group_id, this_shard_id(), raft::snapshot_descriptor{
-                    .idx = commit_idx,
-                    .term = snap_term,
+                    .idx = commit.idx,
+                    .term = bump_term,
                     .id = raft::snapshot_id(utils::make_random_uuid()),
                 });
         logger.debug("group {}: post-replay catch-up, advanced snapshot idx {} -> {} (term={})",
-                group_id, snap_idx, commit_idx, snap_term);
+                group_id, snap_idx, commit.idx, bump_term);
     });
 }
 namespace raft_buffer_detail {

--- a/db/commitlog/raft_commitlog_replay_buffer.hh
+++ b/db/commitlog/raft_commitlog_replay_buffer.hh
@@ -168,5 +168,24 @@ public:
     //   6. Non-command entries (configuration, dummy) are kept in the raft log but
     //      don't need mutation application or commitlog rewrite.
     future<> process_raft_replayed_items(replica::database& db, cql3::query_processor& qp, db::system_keyspace& sys_ks);
+
+    // For every strongly-consistent raft group known to this shard, ensure that
+    // system.raft_groups_snapshots.idx >= system.raft_groups.commit_idx.
+    //
+    // The fake-mutation apply in raft_groups_storage::store_log_entries writes
+    // commit_idx into system.raft_groups via the raft_groups memtable → sstable
+    // path, without going through store_snapshot_descriptor. On a clean shutdown
+    // the SC tablet memtables flush and their commitlog segments are reclaimed,
+    // so on the next startup the commitlog can be empty (or contain only
+    // uncommitted entries) for a group even though its persisted commit_idx > 0.
+    //
+    // Without this bump, raft::server::start would observe
+    // commit_idx > log.stable_idx (== snapshot.idx for an empty log) and trip
+    // its "committed index cannot be larger then persisted one" assert.
+    //
+    // This is the sole place that advances the persisted snapshot index during
+    // startup; it must be called unconditionally on every startup (independent
+    // of whether there were any commitlog segments to replay).
+    future<> bump_snapshot_indices(replica::database& db, cql3::query_processor& qp);
 };
 } // namespace db

--- a/db/commitlog/raft_commitlog_replay_buffer.hh
+++ b/db/commitlog/raft_commitlog_replay_buffer.hh
@@ -112,10 +112,12 @@ class raft_commitlog_replay_buffer {
     // Populated via add() during replay, then consumed and cleared by process_raft_replayed_items().
     std::unordered_map<raft::group_id, utils::chunked_vector<raft::log_entry_ptr>> _replayed_commitlog_entries_by_group;
 
-    // Highest commit_idx seen per group across the commitlog's commit_idx entries.
-    // Used by process_raft_replayed_items() to restore commit_idx after a crash
-    // that dropped it from the raft_groups memtable before it could flush.
-    std::unordered_map<raft::group_id, raft::index_t> _replayed_commit_idx_by_group;
+    // Highest commit_idx seen per group across the commitlog's commit_idx
+    // entries, with the term of the entry at that index (term 0 = written by a
+    // binary predating the term field). Used by process_raft_replayed_items()
+    // to restore commit_idx after a crash that dropped it from the raft_groups
+    // memtable before it could flush.
+    std::unordered_map<raft::group_id, service::strong_consistency::commit_idx_and_term> _replayed_commit_idx_by_group;
 
     // Resulting entries and rp_handles written to the new (post-crash) commitlog,
     // raft_commitlog instances when tablet Raft groups start.
@@ -129,12 +131,12 @@ public:
         ++_total_entries;
     }
 
-    // Record a commit_idx recovered from a commitlog commit_idx entry during
-    // replay, keeping the highest value seen per group.
-    void add_commit_idx(const raft::group_id group_id, raft::index_t commit_idx) {
+    // Record a (commit_idx, term) recovered from a commitlog commit_idx entry
+    // during replay, keeping the pair with the highest index per group.
+    void add_commit_idx(const raft::group_id group_id, raft::index_t commit_idx, raft::term_t term) {
         auto& slot = _replayed_commit_idx_by_group[group_id];
-        if (commit_idx > slot) {
-            slot = commit_idx;
+        if (commit_idx > slot.idx) {
+            slot = {commit_idx, term};
         }
     }
 

--- a/db/commitlog/raft_commitlog_replay_buffer.hh
+++ b/db/commitlog/raft_commitlog_replay_buffer.hh
@@ -112,6 +112,11 @@ class raft_commitlog_replay_buffer {
     // Populated via add() during replay, then consumed and cleared by process_raft_replayed_items().
     std::unordered_map<raft::group_id, utils::chunked_vector<raft::log_entry_ptr>> _replayed_commitlog_entries_by_group;
 
+    // Highest commit_idx seen per group across the commitlog's commit_idx entries.
+    // Used by process_raft_replayed_items() to restore commit_idx after a crash
+    // that dropped it from the raft_groups memtable before it could flush.
+    std::unordered_map<raft::group_id, raft::index_t> _replayed_commit_idx_by_group;
+
     // Resulting entries and rp_handles written to the new (post-crash) commitlog,
     // raft_commitlog instances when tablet Raft groups start.
     std::unordered_map<raft::group_id, service::strong_consistency::replayed_data_per_group> _per_group_data;
@@ -122,6 +127,15 @@ public:
     void add(const raft::group_id group_id, raft::log_entry_ptr entry) {
         _replayed_commitlog_entries_by_group[group_id].push_back(std::move(entry));
         ++_total_entries;
+    }
+
+    // Record a commit_idx recovered from a commitlog commit_idx entry during
+    // replay, keeping the highest value seen per group.
+    void add_commit_idx(const raft::group_id group_id, raft::index_t commit_idx) {
+        auto& slot = _replayed_commit_idx_by_group[group_id];
+        if (commit_idx > slot) {
+            slot = commit_idx;
+        }
     }
 
     // Get the replayed items for a group. These are removed from the buffer since they are now owned by the caller (raft_commitlog).
@@ -151,7 +165,11 @@ public:
     // Process the raft replay items after commitlog replay completes but before
     // old commitlog segments are deleted and memtables are flushed.
     //
-    // For each raft group in the buffer:
+    // First restores commit_idx values recovered from the commitlog's commit_idx
+    // entries (see add_commit_idx()) into system.raft_groups, only-advance, so
+    // the steps below and bump_snapshot_indices() read the post-crash value.
+    //
+    // Then, for each raft group in the buffer:
     //   1. Reads commit_idx from the raft system tables.
     //   2. Filters entries: detects leader changes (discards replaced uncommitted
     //      entries) and stops at out-of-order tails from older pre-crash segments.

--- a/idl/commitlog.idl.hh
+++ b/idl/commitlog.idl.hh
@@ -21,6 +21,11 @@ struct raft_commitlog_entry [[writable]] {
     raft::log_entry_ptr entry;
 };
 
+struct raft_commit_idx_entry [[writable]] {
+    raft::group_id group_id;
+    raft::index_t commit_idx;
+};
+
 struct commitlog_entry [[writable]] {
-    std::variant<raft_commitlog_entry, mutation_entry> item;
+    std::variant<raft_commitlog_entry, mutation_entry, raft_commit_idx_entry> item;
 };

--- a/idl/commitlog.idl.hh
+++ b/idl/commitlog.idl.hh
@@ -24,6 +24,7 @@ struct raft_commitlog_entry [[writable]] {
 struct raft_commit_idx_entry [[writable]] {
     raft::group_id group_id;
     raft::index_t commit_idx;
+    std::optional<raft::term_t> term [[version 2026.4]];
 };
 
 struct commitlog_entry [[writable]] {

--- a/main.cc
+++ b/main.cc
@@ -2215,10 +2215,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     // uncommitted entries are now in new segments).
                     supervisor::notify("processing raft replay buffer");
                     raft_replay_buffer.invoke_on_all([&db, &qp](db::raft_commitlog_replay_buffer& buffer) mutable {
-                        if (buffer.remaining_groups()) {
-                            return buffer.process_raft_replayed_items(db.local(), qp.local(), sys_ks.local());
-                        }
-                        return make_ready_future<>();
+                        // Called unconditionally — the buffer returns early when it
+                        // holds nothing. A group may have a recovered commit_idx to
+                        // restore even with no replayed log entries (its entries'
+                        // segment was reclaimed while the commit_idx entry's was not).
+                        return buffer.process_raft_replayed_items(db.local(), qp.local(), sys_ks.local());
                     }).get();
 
                     startlog.info("replaying commit log - flushing memtables");

--- a/main.cc
+++ b/main.cc
@@ -2034,6 +2034,13 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_groups_manager = defer_verbose_shutdown("strongly consistent groups manager", [&] {
                 groups_manager.stop().get();
             });
+            // On every shard: each shard's database gets that shard's manager
+            // instance, so the flush hook works wherever a tablet lives.
+            // Registered after the stop deferral so a failure here still stops
+            // the manager.
+            db.invoke_on_all([&groups_manager] (replica::database& local_db) {
+                local_db.set_strong_consistency_groups_manager(groups_manager.local());
+            }).get();
 
             checkpoint(stop_signal, "initializing strongly consistent coordinator");
             sharded<service::strong_consistency::coordinator> sc_coordinator;

--- a/main.cc
+++ b/main.cc
@@ -2228,6 +2228,18 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                         return make_ready_future<>();
                     }).get();
                 }
+
+                // Reconcile system.raft_groups_snapshots.idx with system.raft_groups.commit_idx
+                // for every known strongly-consistent tablet raft group. Must run unconditionally
+                // (independent of whether there were commitlog segments to replay): after a clean
+                // shutdown all SC tablet segments have been reclaimed, yet the persisted
+                // commit_idx may still be ahead of the persisted snapshot idx, which would
+                // otherwise trip the "committed index cannot be larger then persisted one"
+                // assert in raft::server::start.
+                supervisor::notify("bumping raft snapshot indices");
+                raft_replay_buffer.invoke_on_all([&db, &qp](db::raft_commitlog_replay_buffer& buffer) mutable {
+                    return buffer.bump_snapshot_indices(db.local(), qp.local());
+                }).get();
             }
 
             // Once stuff is replayed, we can empty RP:s from truncation records. 

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -733,10 +733,12 @@ public:
     // in parallel with store.
     virtual future<std::pair<term_t, server_id>> load_term_and_vote() = 0;
 
-    // Persist given commit index.
+    // Persist given commit index. `term` is the term of the log entry
+    // at `idx`; implementations that snapshot up to the commit index on
+    // restart can persist it to recover the exact term later.
     // Cannot be called conccurrently with itself.
     // Persisting a commit index is optional.
-    virtual future<> store_commit_idx(index_t idx) = 0;
+    virtual future<> store_commit_idx(index_t idx, term_t term) = 0;
 
     // Load persisted commit index.
     // Called during Raft server initialization only, is not run

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1246,7 +1246,7 @@ future<> server_impl::process_fsm_output(index_t& last_stable, fsm_output&& batc
         // the leader or, after a full cluster restart, the new leader recomputes
         // it from a quorum. So the commit notification above does not need to
         // wait for this write.
-        co_await _persistence->store_commit_idx(batch.committed.back()->idx);
+        co_await _persistence->store_commit_idx(batch.committed.back()->idx, batch.committed.back()->term);
         _stats.queue_entries_for_apply += batch.committed.size();
         co_await _apply_entries.push_eventually(std::move(batch.committed));
     }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1682,6 +1682,14 @@ void database::set_strong_consistency_groups_manager(service::strong_consistency
     }
 }
 
+void database::clear_strong_consistency_groups_manager() {
+    _strong_consistency_groups_manager = nullptr;
+    auto column_families = get_tables_metadata().get_column_families_copy();
+    for (auto&& [_, cf] : column_families) {
+        cf->clear_strong_consistency_groups_manager();
+    }
+}
+
 future<> table::init_storage() {
     _storage_opts = co_await _sstables_manager.init_table_storage(*_schema, *_storage_opts);
 }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1654,6 +1654,7 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     cfg.tombstone_warn_threshold = db_config.tombstone_warn_threshold();
     cfg.view_update_memory_semaphore_limit = _config.view_update_memory_semaphore_limit;
     cfg.data_listeners = &db.data_listeners();
+    cfg.strong_consistency_groups_manager = db.strong_consistency_groups_manager();
     cfg.enable_compacting_data_for_streaming_and_repair = db_config.enable_compacting_data_for_streaming_and_repair;
     cfg.enable_tombstone_gc_for_streaming_and_repair = db_config.enable_tombstone_gc_for_streaming_and_repair;
     cfg.guardrail_config = db::guardrail_config{
@@ -1671,6 +1672,14 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
     };
 
     return cfg;
+}
+
+void database::set_strong_consistency_groups_manager(service::strong_consistency::groups_manager& gm) {
+    _strong_consistency_groups_manager = &gm;
+    auto column_families = get_tables_metadata().get_column_families_copy();
+    for (auto&& [_, cf] : column_families) {
+        cf->set_strong_consistency_groups_manager(gm);
+    }
 }
 
 future<> table::init_storage() {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -109,6 +109,10 @@ class storage_proxy;
 class storage_service;
 class migration_notifier;
 class raft_group_registry;
+
+namespace strong_consistency {
+class groups_manager;
+}
 }
 
 namespace gms {
@@ -481,6 +485,7 @@ public:
         bool enable_node_aggregated_table_metrics = true;
         size_t view_update_memory_semaphore_limit;
         db::data_listeners* data_listeners = nullptr;
+        service::strong_consistency::groups_manager* strong_consistency_groups_manager = nullptr;
         uint32_t tombstone_warn_threshold{0};
         unsigned x_log2_compaction_groups{0};
         utils::updateable_value<bool> enable_compacting_data_for_streaming_and_repair;
@@ -1002,6 +1007,10 @@ public:
     api::timestamp_type min_memtable_live_timestamp() const;
     api::timestamp_type min_memtable_live_row_marker_timestamp() const;
     api::timestamp_type get_max_timestamp_for_tablet(locator::tablet_id) const;
+
+    void set_strong_consistency_groups_manager(service::strong_consistency::groups_manager& gm) {
+        _config.strong_consistency_groups_manager = &gm;
+    }
 
     const row_cache& get_row_cache() const {
         return _cache;
@@ -1795,6 +1804,7 @@ private:
 
     service::migration_notifier& _mnotifier;
     gms::feature_service& _feat;
+    service::strong_consistency::groups_manager* _strong_consistency_groups_manager = nullptr;
     std::vector<std::any> _listeners;
     locator::shared_token_metadata& _shared_token_metadata;
     lang::manager& _lang_manager;
@@ -1826,6 +1836,8 @@ public:
     future<> init_logstor();
     future<> recover_logstor();
     const gms::feature_service& features() const { return _feat; }
+    service::strong_consistency::groups_manager* strong_consistency_groups_manager() const { return _strong_consistency_groups_manager; }
+    void set_strong_consistency_groups_manager(service::strong_consistency::groups_manager& gm);
     future<> apply_in_memory(const frozen_mutation& m, schema_ptr m_schema, db::rp_handle&&,
                                db::timeout_clock::time_point timeout,
                                 shared_ptr<db::large_data_guardrail_base> guardrails, db::large_data_violation_type* large_data_violation_out = nullptr);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1011,6 +1011,9 @@ public:
     void set_strong_consistency_groups_manager(service::strong_consistency::groups_manager& gm) {
         _config.strong_consistency_groups_manager = &gm;
     }
+    void clear_strong_consistency_groups_manager() {
+        _config.strong_consistency_groups_manager = nullptr;
+    }
 
     const row_cache& get_row_cache() const {
         return _cache;
@@ -1838,6 +1841,10 @@ public:
     const gms::feature_service& features() const { return _feat; }
     service::strong_consistency::groups_manager* strong_consistency_groups_manager() const { return _strong_consistency_groups_manager; }
     void set_strong_consistency_groups_manager(service::strong_consistency::groups_manager& gm);
+    // Reset the pointer here and in every table's config copy. Called when the
+    // groups manager stops, so a later memtable flush hook cannot dereference a
+    // dangling manager pointer.
+    void clear_strong_consistency_groups_manager();
     future<> apply_in_memory(const frozen_mutation& m, schema_ptr m_schema, db::rp_handle&&,
                                db::timeout_clock::time_point timeout,
                                 shared_ptr<db::large_data_guardrail_base> guardrails, db::large_data_violation_type* large_data_violation_out = nullptr);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -71,6 +71,7 @@
 #include "readers/compacting.hh"
 #include "replica/schema_describe_helper.hh"
 #include "repair/incremental.hh"
+#include "service/strong_consistency/groups_manager.hh"
 
 namespace replica {
 
@@ -2065,6 +2066,87 @@ table::seal_active_memtable(compaction_group& cg, flush_permit&& flush_permit) n
     });
 
     undo_stats.reset();
+
+    if (_config.strong_consistency_groups_manager && uses_tablets()) {
+        // Resolve this tablet's raft group without throwing: the tablet map or
+        // its raft info can legitimately disappear while a flush is in flight
+        // (DROP TABLE / tablet migration), and then there is no group to
+        // persist for. Only that lookup is tolerant — the persist itself below
+        // must not be dropped (see the comment there).
+        const auto group_id = [&] () -> std::optional<raft::group_id> {
+            const auto& tablets = _erm->get_token_metadata().tablets();
+            if (!tablets.has_tablet_map(_schema->id())) {
+                return std::nullopt;
+            }
+            const auto& tablet_map = tablets.get_tablet_map(_schema->id());
+            if (!tablet_map.has_raft_info()) {
+                return std::nullopt;
+            }
+            const auto tablet = locator::tablet_id(cg.group_id());
+            try {
+                return tablet_map.get_tablet_raft_info(tablet).group_id;
+            } catch (...) {
+                tlogger.info("No raft info for tablet {} of table {} during flush ({}); "
+                        "skipping commit index persist", tablet, _schema->id(), std::current_exception());
+                return std::nullopt;
+            }
+        }();
+        if (group_id) {
+            // Persist the raft commit index here: after the sealed memtable has
+            // been written to an SSTable, and before this memtable's commitlog
+            // segments are discarded just below. `old` was sealed long before
+            // this point and accepts no further writes, so the tracked commit
+            // index already covers every entry that ended up in it (persisting
+            // *before* the seal would race with concurrent applies landing in
+            // `old` and could leave commit_idx behind the flushed data).
+            //
+            // It must not run before try_flush_memtable_to_sstable() either:
+            // seal_active_memtable() is driven by dirty_memory_manager::
+            // flush_when_needed() under dirty-memory pressure, and
+            // system.raft_groups is created with write_in_user_memory (see
+            // maybe_write_in_user_memory()), so the CQL write below waits on the
+            // *user* dirty-memory pool. Issuing it while the sealed memtable is
+            // still unflushed would make it wait for memory that only this very
+            // flush can release.
+            //
+            // This write is the only thing that keeps commit_idx from falling
+            // behind data flushed to SSTables: the commit_idx entries in the
+            // commitlog carry only the value that was known when their batch
+            // was *appended*, so they cannot cover entries that committed and
+            // flushed afterwards. It therefore must not be dropped — retry
+            // transient failures for about half an hour, as the flush steps
+            // below do, and if it still cannot be persisted, take the node down
+            // rather than let the next restart recover a commit_idx behind the
+            // data this flush puts into SSTables (which would leave raft's
+            // applied state inconsistent with the state machine). The commitlog
+            // still holds the raft entries, so replay recovers.
+            auto commit_idx_retry = exponential_backoff_retry(100ms, 10s);
+            for (int attempts_left = default_retries; ; --attempts_left) {
+                std::exception_ptr ex;
+                try {
+                    co_await _config.strong_consistency_groups_manager->save_commit_log_index(_schema->id(), *group_id);
+                    break;
+                } catch (...) {
+                    ex = std::current_exception();
+                }
+                if (_async_gate.is_closed()) {
+                    // Shutting down; propagate like the flush steps below do
+                    // instead of aborting a node that is already going away.
+                    tlogger.warn("Failed to persist raft commit index for table {} raft group {}: {}. Dropped due to shutdown",
+                            _schema->id(), *group_id, ex);
+                    co_await coroutine::return_exception_ptr(std::move(ex));
+                }
+                if (attempts_left <= 0) {
+                    on_fatal_internal_error(tlogger, fmt::format(
+                            "Failed to persist raft commit index for table {} raft group {} during flush: {}",
+                            _schema->id(), *group_id, ex));
+                }
+                tlogger.warn("Failed to persist raft commit index for table {} raft group {}: {}. Will retry in {}ms",
+                        _schema->id(), *group_id, ex, commit_idx_retry.sleep_time().count());
+                co_await commit_idx_retry.retry();
+            }
+        }
+    }
 
     if (_commitlog) {
         _commitlog->discard_completed_segments(_schema->id(), old->get_and_discard_rp_set());

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -127,8 +127,15 @@ schema_ptr make_raft_schema(sstring name, bool is_group0) {
         .with_column("vote", uuid_type, column_kind::static_column)
         // id of the most recent persisted snapshot
         .with_column("snapshot_id", uuid_type, column_kind::static_column)
-        .with_column("commit_idx", long_type, column_kind::static_column)
-
+        .with_column("commit_idx", long_type, column_kind::static_column);
+    if (!is_group0) {
+        // Term of the log entry at commit_idx. Written together with commit_idx
+        // so the post-replay snapshot bump can use the exact term of the
+        // snapshot point (SCYLLADB-3357). Not needed for group0, which never
+        // snapshots via a commit_idx catch-up on restart.
+        builder.with_column("commit_idx_term", long_type, column_kind::static_column);
+    }
+    builder
         .with_hash_version()
         .set_caching_options(caching_options::get_disabled_caching_options());
 

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -69,7 +69,9 @@ future<std::pair<raft::term_t, raft::server_id>> raft_sys_table_storage::load_te
     co_return std::pair(vote_term, vote);
 }
 
-future<> raft_sys_table_storage::store_commit_idx(raft::index_t idx) {
+future<> raft_sys_table_storage::store_commit_idx(raft::index_t idx, raft::term_t) {
+    // The term is not persisted here: group0 snapshots are driven by
+    // state_machine snapshots, not by a commit_idx catch-up on restart.
     return execute_with_linearization_point([this, idx] {
         static const auto store_cql = format("INSERT INTO system.{} (group_id, commit_idx) VALUES (?, ?)",
             db::system_keyspace::RAFT);

--- a/service/raft/raft_sys_table_storage.hh
+++ b/service/raft/raft_sys_table_storage.hh
@@ -57,7 +57,7 @@ public:
 
     future<> store_term_and_vote(raft::term_t term, raft::server_id vote) override;
     future<std::pair<raft::term_t, raft::server_id>> load_term_and_vote() override;
-    future<> store_commit_idx(raft::index_t) override;
+    future<> store_commit_idx(raft::index_t, raft::term_t) override;
     future<raft::index_t> load_commit_idx() override;
     future<raft::log_entries> load_log() override;
     future<raft::snapshot_descriptor> load_snapshot_descriptor() override;

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -580,6 +580,12 @@ void groups_manager::start() {
 }
 
 future<> groups_manager::stop() {
+    // Stop new flush hooks from reaching this manager through the table
+    // configs before teardown begins. The hook's null-check and its call into
+    // save_commit_log_index() run without a preemption point between them, so
+    // after this line no new hook can enter; hooks already inside hold a
+    // per-group gate that the teardown below drains.
+    _db.clear_strong_consistency_groups_manager();
     co_await uninit_messaging_service();
 
     if (!_started) {

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -145,7 +145,7 @@ groups_manager::groups_manager(netw::messaging_service& ms,
     init_messaging_service();
 }
 
-future<> groups_manager::start_raft_group(global_tablet_id tablet,
+future<raft_groups_storage*> groups_manager::start_raft_group(global_tablet_id tablet,
         raft::group_id group_id,
         token_metadata_ptr tm)
 {
@@ -156,6 +156,7 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
     SCYLLA_ASSERT(commitlog);
     auto storage = std::make_unique<raft_groups_storage>(_qp, group_id, my_id, this_shard_id(),
         *commitlog, tablet.table, _raft_replay_buffer.take_replayed_group_entries(group_id));
+    auto* storage_ptr = storage.get();
 
     auto state_machine = make_state_machine(tablet, group_id, _db, _mm, _sys_ks, *storage);
 
@@ -223,6 +224,7 @@ future<> groups_manager::start_raft_group(global_tablet_id tablet,
         .persistence = persistence_ref,
         .state_machine = state_machine_ref
     }, tick_interval);
+    co_return storage_ptr;
 }
 
 void groups_manager::schedule_raft_group_deletion(raft::group_id id, raft_group_state& state) {
@@ -258,6 +260,7 @@ void groups_manager::schedule_raft_group_deletion(raft::group_id id, raft_group_
         co_await std::move(state.leader_info_updater);
 
         _raft_gr.destroy_server(id);
+        state.storage = nullptr;
         logger.info("schedule_raft_group_deletion(): raft server for group id {} is destroyed", id);
 
         // We need to erase the raft group state only if we are still the last operation on it.
@@ -451,7 +454,7 @@ void groups_manager::update(token_metadata_ptr new_tm) {
             _starting_groups.push_back(state);
             state.server_control_op = futurize_invoke([&state, this, tablet, id, new_tm](this auto) -> future<> {
                 co_await state.server_control_op.get_future();
-                co_await start_raft_group(tablet, id, std::move(new_tm));
+                state.storage = co_await start_raft_group(tablet, id, std::move(new_tm));
                 state.server = &_raft_gr.get_server(id);
                 state.leader_info_updater = leader_info_updater(state, tablet, id);
 
@@ -532,6 +535,36 @@ future<raft_server> groups_manager::acquire_server(table_id table_id, raft::grou
     return state.server_control_op.get_future(as).then([&state, h = std::move(*h)] mutable {
         return raft_server(state, std::move(h));
     });
+}
+
+future<> groups_manager::save_commit_log_index(table_id table_id, raft::group_id group_id) {
+    // Called from the SC-tablet memtable flush path (seal_active_memtable). The
+    // group may already be gone or tearing down (tablet migration / DROP TABLE
+    // racing the flush) — skip rather than error: commit_idx is still made
+    // durable by the per-batch fake system.raft_groups mutation, so this hook
+    // only tightens the "commit_idx never behind flushed data" guarantee.
+    const auto it = _raft_groups.find(group_id);
+    if (it == _raft_groups.end()) {
+        logger.info("save_commit_log_index: raft group {} for table {} not found (already deleted); skipping", group_id, table_id);
+        co_return;
+    }
+    auto& state = it->second;
+    auto h = state.gate->try_hold();
+    if (!h) {
+        logger.info("save_commit_log_index: gate closed for group {} table {} (teardown in progress); skipping", group_id, table_id);
+        co_return;
+    }
+    // Wait out any in-flight start/stop rather than skipping: this write is
+    // what keeps commit_idx from falling behind data flushed to SSTables (the
+    // commitlog's commit_idx entries only carry the value known when their
+    // batch was appended), so it must not be dropped. Control operations are
+    // bounded, and if the group is going away the storage check below skips.
+    co_await state.server_control_op.get_future();
+    if (!state.storage) {
+        logger.info("save_commit_log_index: storage missing for group {} table {} (teardown in progress); skipping", group_id, table_id);
+        co_return;
+    }
+    co_await state.storage->persist_commit_idx();
 }
 
 void groups_manager::start() {

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -31,6 +31,7 @@ class migration_manager;
 namespace service::strong_consistency {
 
 class raft_server;
+class raft_groups_storage;
 
 /// A cache of leader locations for raft groups where this node is not a replica.
 /// Populated by the CQL transport layer after a redirect reveals the actual leader.
@@ -116,6 +117,12 @@ class groups_manager : public peering_sharded_service<groups_manager> {
         lw_shared_ptr<gate> gate = nullptr;
         raft::server* server = nullptr;
 
+        // The persistence object for this Raft group. Held as a raw pointer
+        // because the raft::server owns the persistence and destroys it when
+        // stopped; save_commit_log_index() checks this against nullptr and
+        // uses the server_control_op + gate to protect against use-after-free.
+        raft_groups_storage* storage = nullptr;
+
         // Serialized chain of raft::server control operations (start/stop).
         // This serialization handles (rare) cases where a tablet is migrated out
         // before the raft::server has finished initializing, or conversely,
@@ -146,7 +153,7 @@ class groups_manager : public peering_sharded_service<groups_manager> {
     tablet_group_leader_cache _leader_cache;
 
     // Should be called on the shard that hosts the Raft group
-    future<> start_raft_group(locator::global_tablet_id tablet,
+    future<raft_groups_storage*> start_raft_group(locator::global_tablet_id tablet,
         raft::group_id group_id,
         locator::token_metadata_ptr tm);
 
@@ -175,6 +182,18 @@ public:
 
     // The raft_server instance is used to submit write commands and perform read_barrier() before reads.
     future<raft_server> acquire_server(table_id table_id, raft::group_id group_id, abort_source& as);
+
+    // Called from the memtable flush path for strongly consistent tablet tables
+    // (replica::table::seal_active_memtable). Reaches raft_groups_storage for
+    // the given group and asks it to persist its current commit index, so that
+    // system.raft_groups.commit_idx never lags behind data flushed to SSTables.
+    //
+    // Safe to call concurrently with tablet migration and group teardown: guarded
+    // by the group's gate and serialized with start/stop control ops. A no-op if
+    // the group is already gone or being torn down (commit_idx durability does
+    // not depend on this hook — the per-batch fake system.raft_groups mutation
+    // covers it — so nothing is lost).
+    future<> save_commit_log_index(table_id table_id, raft::group_id group_id);
 
     // Called during node boot. Starts all raft::server instances corresponding
     // to the latest group0 state in the background.

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -70,9 +70,9 @@ raft_commitlog::~raft_commitlog() {
             _command_positions.size(), _noncommand_positions.size(), _group_id);
 }
 
-seastar::future<db::rp_handle> raft_commitlog::store_log_entries(const raft::log_entry_ptr_list& entries, raft::index_t commit_idx) {
-    logger.debug("store_log_entries: group_id={}, num_entries={}, commit_idx={}",
-            _group_id, entries.size(), commit_idx);
+seastar::future<db::rp_handle> raft_commitlog::store_log_entries(const raft::log_entry_ptr_list& entries, commit_idx_and_term commit) {
+    logger.debug("store_log_entries: group_id={}, num_entries={}, commit_idx={}, commit_term={}",
+            _group_id, entries.size(), commit.idx, commit.term);
 
     utils::chunked_vector<commitlog_raft_log_entry_writer> writers;
     writers.reserve(entries.size() + 1);
@@ -90,7 +90,7 @@ seastar::future<db::rp_handle> raft_commitlog::store_log_entries(const raft::log
     // with the memtable that ends up holding the handle.
     writers.emplace_back(
             _raft_groups_table_id,
-            raft_commit_idx_entry{.group_id = _group_id, .commit_idx = commit_idx});
+            raft_commit_idx_entry{.group_id = _group_id, .commit_idx = commit.idx, .term = commit.term});
 
     auto replay_handles = co_await _commit_log.add_raft_entries(std::move(writers));
     // We passed N raft entries + 1 commit_idx entry; add_raft_entries preserves order.

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -29,9 +29,11 @@ bool is_command_entry(const raft::log_entry& e) {
 }
 } // namespace
 
-raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog, table_id target_table_id, replayed_data_per_group replayed_data)
+raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog, table_id target_table_id,
+        db::cf_id_type raft_groups_table_id, replayed_data_per_group replayed_data)
     : _group_id(group_id)
     , _table_id(target_table_id)
+    , _raft_groups_table_id(raft_groups_table_id)
     , _commit_log(commitlog)
     , _replayed_entries(std::move(replayed_data.entries)) {
     // Classify each replay position as command / non-command by the entry it
@@ -68,18 +70,31 @@ raft_commitlog::~raft_commitlog() {
             _command_positions.size(), _noncommand_positions.size(), _group_id);
 }
 
-seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_list& entries) {
-    logger.debug("store_log_entries: group_id={}, num_entries={}", _group_id, entries.size());
+seastar::future<db::rp_handle> raft_commitlog::store_log_entries(const raft::log_entry_ptr_list& entries, raft::index_t commit_idx) {
+    logger.debug("store_log_entries: group_id={}, num_entries={}, commit_idx={}",
+            _group_id, entries.size(), commit_idx);
 
     utils::chunked_vector<commitlog_raft_log_entry_writer> writers;
-    writers.reserve(entries.size());
+    writers.reserve(entries.size() + 1);
 
     for (const auto& log_entry_ptr : entries) {
         logger.debug("  storing log entry: idx={}, term={}", log_entry_ptr->idx, log_entry_ptr->term);
-        writers.emplace_back(raft_commitlog_entry{.group_id = _group_id, .entry = log_entry_ptr});
+        writers.emplace_back(_table_id, raft_commitlog_entry{.group_id = _group_id, .entry = log_entry_ptr});
     }
+    // Trailing commit_idx entry. Its rp_handle is returned to the caller so
+    // it can be attached to a fake system.raft_groups mutation applied
+    // in-memory. That lets the raft_groups memtable eventually flush commit_idx
+    // to an SSTable via a normal flush without a synchronous CQL write on the
+    // raft io_fiber. The entry's cf_id is _raft_groups_table_id
+    // (system.raft_groups) so segment dirty-count accounting stays consistent
+    // with the memtable that ends up holding the handle.
+    writers.emplace_back(
+            _raft_groups_table_id,
+            raft_commit_idx_entry{.group_id = _group_id, .commit_idx = commit_idx});
 
-    auto replay_handles = co_await _commit_log.add_raft_entries(_table_id, std::move(writers));
+    auto replay_handles = co_await _commit_log.add_raft_entries(std::move(writers));
+    // We passed N raft entries + 1 commit_idx entry; add_raft_entries preserves order.
+    SCYLLA_ASSERT(replay_handles.size() == entries.size() + 1);
 
     for (size_t i = 0; i < entries.size(); ++i) {
         const auto& log_entry_ptr = entries[i];
@@ -89,6 +104,7 @@ seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_li
     }
     logger.debug("store_log_entries completed: total_command={}, total_noncommand={}",
             _command_positions.size(), _noncommand_positions.size());
+    co_return std::move(replay_handles.back());
 }
 
 raft::log_entries raft_commitlog::load_log() {

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -21,15 +21,36 @@
 namespace service::strong_consistency {
 namespace {
 seastar::logger logger("raft_commitlog");
+
+// Command entries are the ones state_machine::apply() will consume.
+// Everything else (configuration, dummy) is a "non-command" entry.
+bool is_command_entry(const raft::log_entry& e) {
+    return std::holds_alternative<raft::command>(e.data);
 }
+} // namespace
 
 raft_commitlog::raft_commitlog(raft::group_id group_id, db::commitlog& commitlog, table_id target_table_id, replayed_data_per_group replayed_data)
     : _group_id(group_id)
     , _table_id(target_table_id)
     , _commit_log(commitlog)
-    , _replay_positions(std::move(replayed_data.replay_positions))
     , _replayed_entries(std::move(replayed_data.entries)) {
-    logger.debug("starting raft_commitlog group_id={}, table_id={}, replayed_entries={}", _group_id, _table_id, _replayed_entries.size());
+    // Classify each replay position as command / non-command by the entry it
+    // belongs to. Replay positions are a subset of the replayed entries (only
+    // uncommitted entries are rewritten to the new commitlog on replay) and
+    // both are in raft-index order, so we match them by index with a single
+    // forward walk over _replayed_entries.
+    auto entry_it = _replayed_entries.begin();
+    for (auto& pos : replayed_data.replay_positions) {
+        while (entry_it != _replayed_entries.end() && (*entry_it)->idx != pos.index) {
+            ++entry_it;
+        }
+        SCYLLA_ASSERT(entry_it != _replayed_entries.end());
+        const bool cmd = is_command_entry(**entry_it);
+        (cmd ? _command_positions : _noncommand_positions).push_back(std::move(pos));
+    }
+    logger.debug("starting raft_commitlog group_id={}, table_id={}, replayed_entries={}, "
+            "command_positions={}, noncommand_positions={}", _group_id, _table_id,
+            _replayed_entries.size(), _command_positions.size(), _noncommand_positions.size());
 }
 
 raft_commitlog::~raft_commitlog() {
@@ -37,10 +58,14 @@ raft_commitlog::~raft_commitlog() {
     // segment dirty counts. This keeps commitlog segments alive after this
     // object is destroyed, ensuring uncommitted raft entries remain
     // available for replay after restart.
-    for (auto& entry : _replay_positions) {
+    for (auto& entry : _command_positions) {
         entry.replay_position_handle.release();
     }
-    logger.debug("released {} replay position handles for group_id={}", _replay_positions.size(), _group_id);
+    for (auto& entry : _noncommand_positions) {
+        entry.replay_position_handle.release();
+    }
+    logger.debug("released {} command + {} non-command replay position handles for group_id={}",
+            _command_positions.size(), _noncommand_positions.size(), _group_id);
 }
 
 seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_list& entries) {
@@ -58,10 +83,12 @@ seastar::future<> raft_commitlog::store_log_entries(const raft::log_entry_ptr_li
 
     for (size_t i = 0; i < entries.size(); ++i) {
         const auto& log_entry_ptr = entries[i];
-        _replay_positions.push_back(
+        auto& target = is_command_entry(*log_entry_ptr) ? _command_positions : _noncommand_positions;
+        target.push_back(
                 index_and_replay_position{.index = log_entry_ptr->idx, .replay_position_handle = std::move(replay_handles[i])});
     }
-    logger.debug("store_log_entries completed: total_entries_in_map={}", _replay_positions.size());
+    logger.debug("store_log_entries completed: total_command={}, total_noncommand={}",
+            _command_positions.size(), _noncommand_positions.size());
 }
 
 raft::log_entries raft_commitlog::load_log() {
@@ -72,9 +99,13 @@ raft::log_entries raft_commitlog::load_log() {
 void raft_commitlog::truncate_log(const raft::index_t idx) {
     logger.debug("truncate_log: group_id={}, idx={}", _group_id, idx);
     // Remove entries with index >= idx (Raft semantics: truncate from idx onward).
-    // The deque is sorted by index, so binary search finds the cut point.
-    auto it = std::ranges::lower_bound(_replay_positions, idx, {}, &index_and_replay_position::index);
-    _replay_positions.erase(it, _replay_positions.end());
+    // Both deques are sorted by index, so binary search finds the cut point.
+    auto trim = [idx] (replay_position_list& l) {
+        auto it = std::ranges::lower_bound(l, idx, {}, &index_and_replay_position::index);
+        l.erase(it, l.end());
+    };
+    trim(_command_positions);
+    trim(_noncommand_positions);
 }
 
 void raft_commitlog::truncate_log_tail(const raft::index_t index) {
@@ -82,39 +113,52 @@ void raft_commitlog::truncate_log_tail(const raft::index_t index) {
     // Remove entries with index <= the given index. The handles are destructed
     // normally, decrementing segment dirty counts and allowing commitlog
     // segments to be reclaimed once no other references hold them.
-    auto it = std::ranges::upper_bound(_replay_positions, index, {}, &index_and_replay_position::index);
-    _replay_positions.erase(_replay_positions.begin(), it);
-    logger.debug("truncate_log_tail completed: remaining_map_size={}", _replay_positions.size());
+    auto it = std::ranges::upper_bound(_command_positions, index, {}, &index_and_replay_position::index);
+    _command_positions.erase(_command_positions.begin(), it);
+    // Non-command handles are trimmed by the same rule; share the impl.
+    release_noncommand_rp_handles(index);
+    logger.debug("truncate_log_tail completed: command={}, noncommand={}",
+            _command_positions.size(), _noncommand_positions.size());
+}
+
+void raft_commitlog::release_noncommand_rp_handles(const raft::index_t index) {
+    auto it = std::ranges::upper_bound(_noncommand_positions, index, {}, &index_and_replay_position::index);
+    _noncommand_positions.erase(_noncommand_positions.begin(), it);
+    logger.debug("release_noncommand_rp_handles: group_id={}, up_to_idx={}, remaining={}",
+            _group_id, index, _noncommand_positions.size());
 }
 
 std::vector<index_and_replay_position> raft_commitlog::acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries) {
-    logger.debug("acquire_replay_position_handles_for: group_id={}, entries_count={}, current_map_size={}", _group_id, entries.size(),
-            _replay_positions.size());
+    logger.debug("acquire_replay_position_handles_for: group_id={}, entries_count={}, current_command_size={}",
+            _group_id, entries.size(), _command_positions.size());
 
     std::vector<index_and_replay_position> ret;
     ret.reserve(entries.size());
 
-    // Move replay position handles for requested entries. The entries may not be
-    // contiguous in _replay_positions because non-command entries (configuration,
-    // dummy) are also tracked there but are not passed to state_machine::apply().
-    // We scan forward through _replay_positions, skipping non-matching entries
-    // (which are the non-command items). This is O(n) since both sequences are
-    // sorted by index and we only move forward.
-    auto it = _replay_positions.begin();
+    // Command entries are already contiguous in _command_positions: non-command
+    // entries have their own deque and are not passed to apply(). Scan forward.
+    auto it = _command_positions.begin();
     for (const auto& entry : entries) {
-        // Skip non-command entries that have indices below the one we're looking for.
-        while (it != _replay_positions.end() && it->index < entry->idx) {
+        // The raft applier fiber only hands command entries to apply(); a
+        // non-command entry here would indicate a raft bug.
+        if (!is_command_entry(*entry)) {
+            on_internal_error(logger, fmt::format(
+                    "acquire_replay_position_handles_for: unexpected non-command entry for group_id={}, idx={}",
+                    _group_id, entry->idx));
+        }
+        while (it != _command_positions.end() && it->index < entry->idx) {
             ++it;
         }
-        if (it == _replay_positions.end() || it->index != entry->idx) {
+        if (it == _command_positions.end() || it->index != entry->idx) {
             on_internal_error(logger, fmt::format("missing replay position handle for group_id={}, idx={}", _group_id, entry->idx));
         }
         ret.emplace_back(index_and_replay_position{.index = it->index, .replay_position_handle = std::move(it->replay_position_handle)});
-        it = _replay_positions.erase(it);
+        it = _command_positions.erase(it);
     }
 
     logger.debug(
-            "acquire_replay_position_handles_for completed: returned_count={}, remaining_map_size={}", ret.size(), _replay_positions.size());
+            "acquire_replay_position_handles_for completed: returned_count={}, remaining_command_size={}",
+            ret.size(), _command_positions.size());
     return ret;
 }
 } // namespace service::strong_consistency

--- a/service/strong_consistency/raft_commitlog.cc
+++ b/service/strong_consistency/raft_commitlog.cc
@@ -132,29 +132,38 @@ std::vector<index_and_replay_position> raft_commitlog::acquire_replay_position_h
     logger.debug("acquire_replay_position_handles_for: group_id={}, entries_count={}, current_command_size={}",
             _group_id, entries.size(), _command_positions.size());
 
+    if (entries.empty()) {
+        return {};
+    }
+
+    // The raft applier fiber hands us a contiguous, index-ordered prefix of
+    // pending commands. _command_positions holds pending commands in index
+    // order, so the requested range must be _command_positions[0..entries.size()).
+    // Verify every index, not just the endpoints, so a mismatch fails here with
+    // a precise error rather than one frame up in state_machine::apply()'s
+    // per-index assert.
+    if (entries.size() > _command_positions.size()) {
+        on_internal_error(logger, fmt::format(
+                "acquire_replay_position_handles_for: expected contiguous command prefix for group_id={}: "
+                "requested [{}, {}] ({} entries), but only {} pending",
+                _group_id, entries.front()->idx, entries.back()->idx, entries.size(),
+                _command_positions.size()));
+    }
+    for (size_t i = 0; i < entries.size(); ++i) {
+        if (_command_positions[i].index != entries[i]->idx) {
+            on_internal_error(logger, fmt::format(
+                    "acquire_replay_position_handles_for: expected contiguous command prefix for group_id={}: "
+                    "requested idx {} at offset {}, pending idx {}",
+                    _group_id, entries[i]->idx, i, _command_positions[i].index));
+        }
+    }
+
+    // Bulk-move the prefix to the result and drop it from _command_positions.
     std::vector<index_and_replay_position> ret;
     ret.reserve(entries.size());
-
-    // Command entries are already contiguous in _command_positions: non-command
-    // entries have their own deque and are not passed to apply(). Scan forward.
-    auto it = _command_positions.begin();
-    for (const auto& entry : entries) {
-        // The raft applier fiber only hands command entries to apply(); a
-        // non-command entry here would indicate a raft bug.
-        if (!is_command_entry(*entry)) {
-            on_internal_error(logger, fmt::format(
-                    "acquire_replay_position_handles_for: unexpected non-command entry for group_id={}, idx={}",
-                    _group_id, entry->idx));
-        }
-        while (it != _command_positions.end() && it->index < entry->idx) {
-            ++it;
-        }
-        if (it == _command_positions.end() || it->index != entry->idx) {
-            on_internal_error(logger, fmt::format("missing replay position handle for group_id={}, idx={}", _group_id, entry->idx));
-        }
-        ret.emplace_back(index_and_replay_position{.index = it->index, .replay_position_handle = std::move(it->replay_position_handle)});
-        it = _command_positions.erase(it);
-    }
+    auto end = _command_positions.begin() + entries.size();
+    std::move(_command_positions.begin(), end, std::back_inserter(ret));
+    _command_positions.erase(_command_positions.begin(), end);
 
     logger.debug(
             "acquire_replay_position_handles_for completed: returned_count={}, remaining_command_size={}",

--- a/service/strong_consistency/raft_commitlog.hh
+++ b/service/strong_consistency/raft_commitlog.hh
@@ -33,6 +33,11 @@ class raft_commitlog {
 private:
     const raft::group_id _group_id;
     const db::cf_id_type _table_id;
+    // cf_id used for the trailing commit_idx entry written alongside raft log
+    // entries by store_log_entries(). The entry's rp_handle is handed to the
+    // matching column family's memtable, so its cf_id must match to keep
+    // per-cf dirty-count accounting consistent.
+    const db::cf_id_type _raft_groups_table_id;
     // Common commit log.
     db::commitlog& _commit_log;
     // Replay position handles for committed and uncommitted command entries
@@ -48,14 +53,18 @@ private:
     raft::log_entries _replayed_entries;
 
 public:
-    raft_commitlog(raft::group_id group_id, db::commitlog& commit_log, table_id target_table_id, replayed_data_per_group replayed_data);
+    raft_commitlog(raft::group_id group_id, db::commitlog& commit_log, table_id target_table_id,
+            db::cf_id_type raft_groups_table_id, replayed_data_per_group replayed_data);
 
     ~raft_commitlog();
 
-    // Persist the given log entries in the commit log. Each entry's rp_handle
-    // is placed into _command_positions or _noncommand_positions based on the
-    // entry data type.
-    future<> store_log_entries(const raft::log_entry_ptr_list& entries);
+    // Persist the given log entries in the commit log together with a small
+    // commit_idx entry for the current commit index (a raft_commit_idx_entry).
+    // Returns the rp_handle of that commit_idx entry so the caller
+    // (raft_groups_storage) can attach it to a fake system.raft_groups mutation
+    // applied in-memory. The N raft entries' rp_handles are placed into
+    // _command_positions or _noncommand_positions based on entry->data type.
+    future<db::rp_handle> store_log_entries(const raft::log_entry_ptr_list& entries, raft::index_t commit_idx);
 
     // Get the log items that were loaded from database commit log on startup.
     raft::log_entries load_log();

--- a/service/strong_consistency/raft_commitlog.hh
+++ b/service/strong_consistency/raft_commitlog.hh
@@ -35,13 +35,15 @@ private:
     const db::cf_id_type _table_id;
     // Common commit log.
     db::commitlog& _commit_log;
-    // Replay positions in the commit log for each raft log entry.
-    // Contains entries that have been added but not yet removed by either:
-    //  - truncate_log() (leader change discarding uncommitted tail)
-    //  - truncate_log_tail() (snapshot allowing old entries to be reclaimed)
-    // After a snapshot, some entries with index below the snapshot index may
-    // still be present, in accordance with raft trailing log settings.
-    replay_position_list _replay_positions;
+    // Replay position handles for committed and uncommitted command entries
+    // (raft::command). Consumed by
+    // acquire_replay_position_handles_for() when state_machine::apply() hands
+    // the entry to its target memtable, which takes over segment lifetime.
+    replay_position_list _command_positions;
+    // Replay position handles for non-command entries (raft::configuration and
+    // raft::log_entry::dummy). Never consumed by apply(); released only by
+    // truncate_log() / truncate_log_tail() / release_noncommand_rp_handles().
+    replay_position_list _noncommand_positions;
     // The log entries that were loaded from database commit log on startup.
     raft::log_entries _replayed_entries;
 
@@ -50,7 +52,9 @@ public:
 
     ~raft_commitlog();
 
-    // Persist the given log entries in the commit log and get the replay position handles for them.
+    // Persist the given log entries in the commit log. Each entry's rp_handle
+    // is placed into _command_positions or _noncommand_positions based on the
+    // entry data type.
     future<> store_log_entries(const raft::log_entry_ptr_list& entries);
 
     // Get the log items that were loaded from database commit log on startup.
@@ -65,10 +69,16 @@ public:
     // Called from store_snapshot_descriptor after the snapshot is persisted.
     void truncate_log_tail(raft::index_t index);
 
-    // Move replay position handles out of the map for the specified indices.
-    // The handles are handed to memtables in the raft state machine apply(),
-    // and removed from the map since the memtable now owns segment lifetime.
-    // Triggers on_internal_error if an entry is missing from the map.
+    // Release non-command rp_handles with index <= idx. Safe only after
+    // system.raft_groups.commit_idx has been durably persisted at or above
+    // idx: below that watermark raft would need those non-command entries on
+    // restart.
+    void release_noncommand_rp_handles(raft::index_t idx);
+
+    // Move replay position handles out of _command_positions for the specified
+    // entries. The handles are handed to memtables in the raft state machine
+    // apply(), transferring segment ownership. Triggers on_internal_error if a
+    // requested entry is missing.
     std::vector<index_and_replay_position> acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries);
 };
 } // namespace service::strong_consistency

--- a/service/strong_consistency/raft_commitlog.hh
+++ b/service/strong_consistency/raft_commitlog.hh
@@ -72,7 +72,7 @@ public:
     // (raft_groups_storage) can attach it to a fake system.raft_groups mutation
     // applied in-memory. The N raft entries' rp_handles are placed into
     // _command_positions or _noncommand_positions based on entry->data type.
-    future<db::rp_handle> store_log_entries(const raft::log_entry_ptr_list& entries, raft::index_t commit_idx);
+    future<db::rp_handle> store_log_entries(const raft::log_entry_ptr_list& entries, commit_idx_and_term commit);
 
     // Get the log items that were loaded from database commit log on startup.
     raft::log_entries load_log();

--- a/service/strong_consistency/raft_commitlog.hh
+++ b/service/strong_consistency/raft_commitlog.hh
@@ -12,6 +12,14 @@
 #include <deque>
 
 namespace service::strong_consistency {
+// Committed raft position: the commit index and the term of the log entry at
+// that index. The two are always tracked and persisted together so that the
+// post-replay snapshot bump can use the exact term (SCYLLADB-3357).
+struct commit_idx_and_term {
+    raft::index_t idx{0};
+    raft::term_t term{0};
+};
+
 struct index_and_replay_position {
     raft::index_t index;
     db::rp_handle replay_position_handle;

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -65,13 +65,25 @@ future<std::pair<raft::term_t, raft::server_id>> raft_groups_storage::load_term_
 }
 
 future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
+    _last_known_commit_idx = idx;
+    return persist_commit_idx();
+}
+
+future<> raft_groups_storage::persist_commit_idx() {
+    if (_last_known_commit_idx <= _last_persisted_commit_idx) {
+        // Nothing new to persist since the last write.
+        return make_ready_future<>();
+    }
+    auto idx = _last_known_commit_idx;
     return execute_with_linearization_point([this, idx] {
         static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx) VALUES (?, ?, ?)",
             db::system_keyspace::RAFT_GROUPS);
         return _qp.execute_internal(
             store_cql,
             {int16_t(_shard), _group_id.id, int64_t(idx.value())},
-            cql3::query_processor::cache_internal::yes).discard_result();
+            cql3::query_processor::cache_internal::yes).discard_result().then([this, idx] {
+                _last_persisted_commit_idx = idx;
+            });
     });
 }
 

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -83,6 +83,13 @@ future<> raft_groups_storage::persist_commit_idx() {
             {int16_t(_shard), _group_id.id, int64_t(idx.value())},
             cql3::query_processor::cache_internal::yes).discard_result().then([this, idx] {
                 _last_persisted_commit_idx = idx;
+                // Non-command entries (configuration, dummy) at or below commit_idx
+                // are committed and, now that commit_idx is persisted, are covered
+                // by it on restart — raft won't replay them — so release their
+                // rp_handles and let the commitlog segments be reclaimed. (Command
+                // entries are handled by apply(), which hands their rp_handles to
+                // the target memtable.)
+                _raft_commitlog.release_noncommand_rp_handles(idx);
             });
     });
 }

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -72,7 +72,7 @@ future<std::pair<raft::term_t, raft::server_id>> raft_groups_storage::load_term_
     co_return std::pair(vote_term, vote);
 }
 
-future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
+future<> raft_groups_storage::store_commit_idx(raft::index_t idx, raft::term_t) {
     // Update in-memory tracking only. Persistence happens via the fake
     // mutation in store_log_entries (durable once the raft_groups memtable
     // flushes) and via persist_commit_idx() from the SC tablet flush hook

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -73,8 +73,34 @@ future<std::pair<raft::term_t, raft::server_id>> raft_groups_storage::load_term_
 }
 
 future<> raft_groups_storage::store_commit_idx(raft::index_t idx) {
+    // Update in-memory tracking only. Persistence happens via the fake
+    // mutation in store_log_entries (durable once the raft_groups memtable
+    // flushes) and via persist_commit_idx() from the SC tablet flush hook
+    // (groups_manager::save_commit_log_index). Keeping this path IO-free
+    // avoids a per-committed-batch CQL write on the raft io_fiber.
+    //
+    // The io_fiber calls this *before* pushing entries to the applier_fiber,
+    // so _last_known_commit_idx is always >= the raft index of any entry that
+    // has been applied to a memtable.
     _last_known_commit_idx = idx;
-    return persist_commit_idx();
+    return make_ready_future<>();
+}
+
+// Execute the CQL INSERT that persists commit_idx to system.raft_groups.
+// Shared by persist_commit_idx() and store_commit_idx_if_higher().
+//
+// The write timestamp is supplied by the caller: it must be captured in the
+// same task as the commit_idx value (no yield in between), so that a
+// concurrent fake-mutation write of a larger commit_idx (store_log_entries())
+// always carries a larger timestamp and last-write-wins cannot regress the
+// row. api::new_timestamp() is monotonic within a shard.
+static future<> store_commit_idx_cql(cql3::query_processor& qp, raft::group_id gid, shard_id shard, raft::index_t commit_idx, api::timestamp_type ts) {
+    static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx) VALUES (?, ?, ?) USING TIMESTAMP ?",
+        db::system_keyspace::RAFT_GROUPS);
+    return qp.execute_internal(
+        store_cql,
+        {int16_t(shard), gid.id, int64_t(commit_idx.value()), int64_t(ts)},
+        cql3::query_processor::cache_internal::yes).discard_result();
 }
 
 future<> raft_groups_storage::persist_commit_idx() {
@@ -82,14 +108,40 @@ future<> raft_groups_storage::persist_commit_idx() {
         // Nothing new to persist since the last write.
         return make_ready_future<>();
     }
-    auto idx = _last_known_commit_idx;
-    return execute_with_linearization_point([this, idx] {
-        static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx) VALUES (?, ?, ?)",
-            db::system_keyspace::RAFT_GROUPS);
-        return _qp.execute_internal(
-            store_cql,
-            {int16_t(_shard), _group_id.id, int64_t(idx.value())},
-            cql3::query_processor::cache_internal::yes).discard_result().then([this, idx] {
+    if (_aborted) {
+        // The group is being torn down. abort() deliberately does not persist
+        // commit_idx (shutdown may have closed the CQL / storage_proxy gates);
+        // durability is instead provided by the fake system.raft_groups mutation
+        // applied per batch and the raft_groups memtable flush. A flush hook
+        // (groups_manager::save_commit_log_index) racing teardown can still reach
+        // here with unpersisted commit_idx — that is expected and harmless, so
+        // skip quietly rather than starting a CQL write.
+        rgslog.debug("persist_commit_idx skipped after abort for group {}"
+            " (unpersisted commit_idx {}, last persisted {})",
+            _group_id, _last_known_commit_idx, _last_persisted_commit_idx);
+        return make_ready_future<>();
+    }
+    return execute_with_linearization_point([this] () -> future<> {
+        if (_aborted) {
+            // The check above only filters the common case: abort() can set
+            // _aborted while we wait for the linearization point (and then waits
+            // for this very operation via _pending_op_fut). Re-check here so a
+            // group being torn down is not raced by a CQL write against closed
+            // CQL / storage_proxy gates. Skipping is safe for the same reason as
+            // above.
+            rgslog.debug("persist_commit_idx skipped after abort for group {}"
+                " (abort raced the linearization point; unpersisted commit_idx {}, last persisted {})",
+                _group_id, _last_known_commit_idx, _last_persisted_commit_idx);
+            return make_ready_future<>();
+        }
+        // Read the value and capture the write timestamp at execution time, in
+        // one task: waiting for the linearization point may have overlapped a
+        // fake-mutation write of a larger commit_idx (store_log_entries()),
+        // and writing a stale snapshot taken at enqueue time with a fresher
+        // timestamp would win last-write-wins and regress the row.
+        const auto idx = _last_known_commit_idx;
+        const auto ts = api::new_timestamp();
+        return store_commit_idx_cql(_qp, _group_id, _shard, idx, ts).then([this, idx] {
                 // store_log_entries()'s fake mutation may have advanced the
                 // watermark past idx while our CQL write was in flight; keep it
                 // monotonic.
@@ -117,6 +169,16 @@ future<raft::index_t> raft_groups_storage::load_commit_idx(cql3::query_processor
     }
     const auto& static_row = rs->one();
     co_return raft::index_t(static_row.get_or<int64_t>("commit_idx", raft::index_t{}.value()));
+}
+
+future<> raft_groups_storage::store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard, raft::index_t commit_idx) {
+    // Only advance, never regress: a prior flush (or an earlier replay) may
+    // already have persisted a value at or beyond the recovered one.
+    const auto persisted = co_await load_commit_idx(qp, gid, shard);
+    if (commit_idx <= persisted) {
+        co_return;
+    }
+    co_await store_commit_idx_cql(qp, gid, shard, commit_idx, api::new_timestamp());
 }
 
 future<raft::log_entries> raft_groups_storage::load_log() {
@@ -269,8 +331,10 @@ future<> raft_groups_storage::truncate_log(raft::index_t idx) {
 }
 
 future<> raft_groups_storage::abort() {
-    // wait for pending write requests to complete.
-    // TODO: should we wait for all kinds of requests?
+    // Mark aborted so a flush hook (save_commit_log_index -> persist_commit_idx)
+    // racing teardown becomes a no-op instead of running against a group that is
+    // being destroyed.
+    _aborted = true;
     return std::move(_pending_op_fut);
 }
 

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -171,6 +171,20 @@ future<raft::index_t> raft_groups_storage::load_commit_idx(cql3::query_processor
     co_return raft::index_t(static_row.get_or<int64_t>("commit_idx", raft::index_t{}.value()));
 }
 
+future<commit_idx_and_term> raft_groups_storage::load_commit_idx_and_term(cql3::query_processor& qp, raft::group_id gid, shard_id shard) {
+    static const auto load_cql = format("SELECT commit_idx, commit_idx_term FROM system.{} WHERE shard = ? AND group_id = ? LIMIT 1",
+        db::system_keyspace::RAFT_GROUPS);
+    ::shared_ptr<cql3::untyped_result_set> rs = co_await qp.execute_internal(load_cql, {int16_t(shard), gid.id}, cql3::query_processor::cache_internal::yes);
+    if (rs->empty()) {
+        co_return commit_idx_and_term{};
+    }
+    const auto& row = rs->one();
+    co_return commit_idx_and_term{
+        raft::index_t(row.get_or<int64_t>("commit_idx", 0)),
+        raft::term_t(row.get_or<int64_t>("commit_idx_term", 0)),
+    };
+}
+
 future<> raft_groups_storage::store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard, commit_idx_and_term commit) {
     // Only advance, never regress: a prior flush (or an earlier replay) may
     // already have persisted a value at or beyond the recovered one.

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -72,7 +72,7 @@ future<std::pair<raft::term_t, raft::server_id>> raft_groups_storage::load_term_
     co_return std::pair(vote_term, vote);
 }
 
-future<> raft_groups_storage::store_commit_idx(raft::index_t idx, raft::term_t) {
+future<> raft_groups_storage::store_commit_idx(raft::index_t idx, raft::term_t term) {
     // Update in-memory tracking only. Persistence happens via the fake
     // mutation in store_log_entries (durable once the raft_groups memtable
     // flushes) and via persist_commit_idx() from the SC tablet flush hook
@@ -80,9 +80,9 @@ future<> raft_groups_storage::store_commit_idx(raft::index_t idx, raft::term_t) 
     // avoids a per-committed-batch CQL write on the raft io_fiber.
     //
     // The io_fiber calls this *before* pushing entries to the applier_fiber,
-    // so _last_known_commit_idx is always >= the raft index of any entry that
+    // so _last_known_commit.idx is always >= the raft index of any entry that
     // has been applied to a memtable.
-    _last_known_commit_idx = idx;
+    _last_known_commit = {idx, term};
     return make_ready_future<>();
 }
 
@@ -90,21 +90,21 @@ future<> raft_groups_storage::store_commit_idx(raft::index_t idx, raft::term_t) 
 // Shared by persist_commit_idx() and store_commit_idx_if_higher().
 //
 // The write timestamp is supplied by the caller: it must be captured in the
-// same task as the commit_idx value (no yield in between), so that a
+// same task as the (commit_idx, term) value (no yield in between), so that a
 // concurrent fake-mutation write of a larger commit_idx (store_log_entries())
 // always carries a larger timestamp and last-write-wins cannot regress the
 // row. api::new_timestamp() is monotonic within a shard.
-static future<> store_commit_idx_cql(cql3::query_processor& qp, raft::group_id gid, shard_id shard, raft::index_t commit_idx, api::timestamp_type ts) {
-    static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx) VALUES (?, ?, ?) USING TIMESTAMP ?",
+static future<> store_commit_idx_cql(cql3::query_processor& qp, raft::group_id gid, shard_id shard, commit_idx_and_term commit, api::timestamp_type ts) {
+    static const auto store_cql = format("INSERT INTO system.{} (shard, group_id, commit_idx, commit_idx_term) VALUES (?, ?, ?, ?) USING TIMESTAMP ?",
         db::system_keyspace::RAFT_GROUPS);
     return qp.execute_internal(
         store_cql,
-        {int16_t(shard), gid.id, int64_t(commit_idx.value()), int64_t(ts)},
+        {int16_t(shard), gid.id, int64_t(commit.idx.value()), int64_t(commit.term.value()), int64_t(ts)},
         cql3::query_processor::cache_internal::yes).discard_result();
 }
 
 future<> raft_groups_storage::persist_commit_idx() {
-    if (_last_known_commit_idx <= _last_persisted_commit_idx) {
+    if (_last_known_commit.idx <= _last_persisted_commit_idx) {
         // Nothing new to persist since the last write.
         return make_ready_future<>();
     }
@@ -118,7 +118,7 @@ future<> raft_groups_storage::persist_commit_idx() {
         // skip quietly rather than starting a CQL write.
         rgslog.debug("persist_commit_idx skipped after abort for group {}"
             " (unpersisted commit_idx {}, last persisted {})",
-            _group_id, _last_known_commit_idx, _last_persisted_commit_idx);
+            _group_id, _last_known_commit.idx, _last_persisted_commit_idx);
         return make_ready_future<>();
     }
     return execute_with_linearization_point([this] () -> future<> {
@@ -131,7 +131,7 @@ future<> raft_groups_storage::persist_commit_idx() {
             // above.
             rgslog.debug("persist_commit_idx skipped after abort for group {}"
                 " (abort raced the linearization point; unpersisted commit_idx {}, last persisted {})",
-                _group_id, _last_known_commit_idx, _last_persisted_commit_idx);
+                _group_id, _last_known_commit.idx, _last_persisted_commit_idx);
             return make_ready_future<>();
         }
         // Read the value and capture the write timestamp at execution time, in
@@ -139,9 +139,9 @@ future<> raft_groups_storage::persist_commit_idx() {
         // fake-mutation write of a larger commit_idx (store_log_entries()),
         // and writing a stale snapshot taken at enqueue time with a fresher
         // timestamp would win last-write-wins and regress the row.
-        const auto idx = _last_known_commit_idx;
+        const auto known = _last_known_commit;
         const auto ts = api::new_timestamp();
-        return store_commit_idx_cql(_qp, _group_id, _shard, idx, ts).then([this, idx] {
+        return store_commit_idx_cql(_qp, _group_id, _shard, known, ts).then([this, idx = known.idx] {
                 // store_log_entries()'s fake mutation may have advanced the
                 // watermark past idx while our CQL write was in flight; keep it
                 // monotonic.
@@ -178,7 +178,9 @@ future<> raft_groups_storage::store_commit_idx_if_higher(cql3::query_processor& 
     if (commit_idx <= persisted) {
         co_return;
     }
-    co_await store_commit_idx_cql(qp, gid, shard, commit_idx, api::new_timestamp());
+    // The term is threaded through the replay path in a following commit;
+    // until then restored rows record term 0 ("unknown").
+    co_await store_commit_idx_cql(qp, gid, shard, {commit_idx, raft::term_t(0)}, api::new_timestamp());
 }
 
 future<raft::log_entries> raft_groups_storage::load_log() {
@@ -266,32 +268,34 @@ future<> raft_groups_storage::store_snapshot_descriptor(const raft::snapshot_des
 // (shard, group_id) partition. Applied in-memory (see store_log_entries) with
 // the commit_idx entry's rp_handle so it rides the raft_groups memtable flush.
 // The write timestamp is supplied by the caller so it can be captured in the
-// same task as commit_idx (see store_log_entries()).
-static mutation make_commit_idx_mutation(shard_id shard, raft::group_id group_id, raft::index_t commit_idx, api::timestamp_type ts) {
+// same task as the (commit_idx, term) pair (see store_log_entries()).
+static mutation make_commit_idx_mutation(shard_id shard, raft::group_id group_id, commit_idx_and_term commit, api::timestamp_type ts) {
     auto schema = db::system_keyspace::raft_groups();
     auto pk = partition_key::from_exploded(*schema, {
         short_type->decompose(int16_t(shard)),
         timeuuid_type->decompose(group_id.id),
     });
     mutation m(schema, std::move(pk));
-    m.set_static_cell("commit_idx", data_value(int64_t(commit_idx.value())), ts);
+    m.set_static_cell("commit_idx", data_value(int64_t(commit.idx.value())), ts);
+    // Same timestamp: the (idx, term) pair is always written atomically.
+    m.set_static_cell("commit_idx_term", data_value(int64_t(commit.term.value())), ts);
     return m;
 }
 
 future<> raft_groups_storage::store_log_entries(const std::vector<raft::log_entry_ptr>& entries) {
-    const auto commit_idx = _last_known_commit_idx;
+    const auto known = _last_known_commit;
     // Stamp the fake mutation below with a timestamp captured here, together
-    // with commit_idx: persist_commit_idx() writes the same static cell from
-    // the flush path, and last-write-wins resolves the two by timestamp. As
-    // long as both writers capture (value, timestamp) in one task, timestamp
-    // order matches value order and the larger commit_idx always wins.
-    // Generating the timestamp after the append below instead would pair this
-    // (possibly already stale) value with a fresher timestamp and could
-    // regress the row.
+    // with the (commit_idx, term) pair: persist_commit_idx() writes the same
+    // static cells from the flush path, and last-write-wins resolves the two by
+    // timestamp. As long as both writers capture (value, timestamp) in one
+    // task, timestamp order matches value order and the larger commit_idx
+    // always wins. Generating the timestamp after the append below instead
+    // would pair this (possibly already stale) value with a fresher timestamp
+    // and could regress the row.
     const auto commit_idx_ts = api::new_timestamp();
-    auto commit_idx_entry_handle = co_await _raft_commitlog.store_log_entries(entries, commit_idx);
+    auto commit_idx_entry_handle = co_await _raft_commitlog.store_log_entries(entries, known.idx);
 
-    if (commit_idx <= _last_persisted_commit_idx) {
+    if (known.idx <= _last_persisted_commit_idx) {
         // commit_idx has not advanced since it was last recorded to
         // system.raft_groups — by a prior fake mutation here or by
         // persist_commit_idx() — or is 0 before any commit. Nothing new to
@@ -306,14 +310,14 @@ future<> raft_groups_storage::store_log_entries(const std::vector<raft::log_entr
     // attached: this pins the commitlog segment via the raft_groups memtable and
     // lets commit_idx eventually flush to an SSTable without a synchronous CQL
     // write on the raft io_fiber.
-    auto m = make_commit_idx_mutation(_shard, _group_id, commit_idx, commit_idx_ts);
+    auto m = make_commit_idx_mutation(_shard, _group_id, known, commit_idx_ts);
     auto& db = _qp.proxy().local_db();
     auto& cf = db.find_column_family(m.schema()->id());
     co_await db.apply_in_memory(m, cf, std::move(commit_idx_entry_handle), db::no_timeout);
     // Both this path and persist_commit_idx() write commit_idx to the raft_groups
     // memtable; either may run between our co_awaits, so keep the watermark
     // monotonic rather than clobbering a larger value.
-    _last_persisted_commit_idx = std::max(_last_persisted_commit_idx, commit_idx);
+    _last_persisted_commit_idx = std::max(_last_persisted_commit_idx, known.idx);
 
     // Non-command entries (configuration, dummy) are never applied to a memtable
     // — unlike command entries, whose rp_handles apply() hands to the target
@@ -322,7 +326,7 @@ future<> raft_groups_storage::store_log_entries(const std::vector<raft::log_entr
     // that commit_idx is recorded, are covered by it on restart, so raft won't
     // replay them. Release their handles and let the commitlog segments be
     // reclaimed.
-    _raft_commitlog.release_noncommand_rp_handles(commit_idx);
+    _raft_commitlog.release_noncommand_rp_handles(known.idx);
 }
 
 future<> raft_groups_storage::truncate_log(raft::index_t idx) {

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -171,16 +171,14 @@ future<raft::index_t> raft_groups_storage::load_commit_idx(cql3::query_processor
     co_return raft::index_t(static_row.get_or<int64_t>("commit_idx", raft::index_t{}.value()));
 }
 
-future<> raft_groups_storage::store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard, raft::index_t commit_idx) {
+future<> raft_groups_storage::store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard, commit_idx_and_term commit) {
     // Only advance, never regress: a prior flush (or an earlier replay) may
     // already have persisted a value at or beyond the recovered one.
     const auto persisted = co_await load_commit_idx(qp, gid, shard);
-    if (commit_idx <= persisted) {
+    if (commit.idx <= persisted) {
         co_return;
     }
-    // The term is threaded through the replay path in a following commit;
-    // until then restored rows record term 0 ("unknown").
-    co_await store_commit_idx_cql(qp, gid, shard, {commit_idx, raft::term_t(0)}, api::new_timestamp());
+    co_await store_commit_idx_cql(qp, gid, shard, commit, api::new_timestamp());
 }
 
 future<raft::log_entries> raft_groups_storage::load_log() {
@@ -293,7 +291,7 @@ future<> raft_groups_storage::store_log_entries(const std::vector<raft::log_entr
     // would pair this (possibly already stale) value with a fresher timestamp
     // and could regress the row.
     const auto commit_idx_ts = api::new_timestamp();
-    auto commit_idx_entry_handle = co_await _raft_commitlog.store_log_entries(entries, known.idx);
+    auto commit_idx_entry_handle = co_await _raft_commitlog.store_log_entries(entries, known);
 
     if (known.idx <= _last_persisted_commit_idx) {
         // commit_idx has not advanced since it was last recorded to

--- a/service/strong_consistency/raft_groups_storage.cc
+++ b/service/strong_consistency/raft_groups_storage.cc
@@ -19,8 +19,15 @@
 #include "idl/raft_storage.dist.impl.hh"
 
 #include "cql3/query_processor.hh"
+#include "mutation/mutation.hh"
+#include "mutation/timestamp.hh"
+#include "replica/database.hh"
+#include "service/storage_proxy.hh"
+#include "types/types.hh"
 
 #include <seastar/core/coroutine.hh>
+
+#include <algorithm>
 
 namespace service::strong_consistency {
 
@@ -28,7 +35,8 @@ logging::logger rgslog("raft_groups_storage");
 
 raft_groups_storage::raft_groups_storage(cql3::query_processor& qp, raft::group_id gid, raft::server_id server_id, shard_id shard, db::commitlog& commit_log,
         table_id target_table_id, replayed_data_per_group replayed_data)
-    : _raft_commitlog(gid, commit_log, target_table_id, std::move(replayed_data))
+    : _raft_commitlog(gid, commit_log, target_table_id,
+            db::system_keyspace::raft_groups()->id(), std::move(replayed_data))
     , _group_id(std::move(gid))
     , _server_id(std::move(server_id))
     , _qp(qp)
@@ -82,7 +90,10 @@ future<> raft_groups_storage::persist_commit_idx() {
             store_cql,
             {int16_t(_shard), _group_id.id, int64_t(idx.value())},
             cql3::query_processor::cache_internal::yes).discard_result().then([this, idx] {
-                _last_persisted_commit_idx = idx;
+                // store_log_entries()'s fake mutation may have advanced the
+                // watermark past idx while our CQL write was in flight; keep it
+                // monotonic.
+                _last_persisted_commit_idx = std::max(_last_persisted_commit_idx, idx);
                 // Non-command entries (configuration, dummy) at or below commit_idx
                 // are committed and, now that commit_idx is persisted, are covered
                 // by it on restart — raft won't replay them — so release their
@@ -189,8 +200,67 @@ future<> raft_groups_storage::store_snapshot_descriptor(const raft::snapshot_des
     });
 }
 
+// Build a static-only system.raft_groups mutation that sets commit_idx for the
+// (shard, group_id) partition. Applied in-memory (see store_log_entries) with
+// the commit_idx entry's rp_handle so it rides the raft_groups memtable flush.
+// The write timestamp is supplied by the caller so it can be captured in the
+// same task as commit_idx (see store_log_entries()).
+static mutation make_commit_idx_mutation(shard_id shard, raft::group_id group_id, raft::index_t commit_idx, api::timestamp_type ts) {
+    auto schema = db::system_keyspace::raft_groups();
+    auto pk = partition_key::from_exploded(*schema, {
+        short_type->decompose(int16_t(shard)),
+        timeuuid_type->decompose(group_id.id),
+    });
+    mutation m(schema, std::move(pk));
+    m.set_static_cell("commit_idx", data_value(int64_t(commit_idx.value())), ts);
+    return m;
+}
+
 future<> raft_groups_storage::store_log_entries(const std::vector<raft::log_entry_ptr>& entries) {
-    return _raft_commitlog.store_log_entries(entries);
+    const auto commit_idx = _last_known_commit_idx;
+    // Stamp the fake mutation below with a timestamp captured here, together
+    // with commit_idx: persist_commit_idx() writes the same static cell from
+    // the flush path, and last-write-wins resolves the two by timestamp. As
+    // long as both writers capture (value, timestamp) in one task, timestamp
+    // order matches value order and the larger commit_idx always wins.
+    // Generating the timestamp after the append below instead would pair this
+    // (possibly already stale) value with a fresher timestamp and could
+    // regress the row.
+    const auto commit_idx_ts = api::new_timestamp();
+    auto commit_idx_entry_handle = co_await _raft_commitlog.store_log_entries(entries, commit_idx);
+
+    if (commit_idx <= _last_persisted_commit_idx) {
+        // commit_idx has not advanced since it was last recorded to
+        // system.raft_groups — by a prior fake mutation here or by
+        // persist_commit_idx() — or is 0 before any commit. Nothing new to
+        // record; release the commit_idx entry's rp_handle normally — the batch's
+        // raft entries are still pinned via _command/_noncommand_positions.
+        co_return;
+    }
+
+    // raft_commitlog::store_log_entries wrote a small commit_idx entry to the
+    // commitlog and returned its rp_handle. Build a fake system.raft_groups
+    // mutation carrying commit_idx and apply it in-memory with that handle
+    // attached: this pins the commitlog segment via the raft_groups memtable and
+    // lets commit_idx eventually flush to an SSTable without a synchronous CQL
+    // write on the raft io_fiber.
+    auto m = make_commit_idx_mutation(_shard, _group_id, commit_idx, commit_idx_ts);
+    auto& db = _qp.proxy().local_db();
+    auto& cf = db.find_column_family(m.schema()->id());
+    co_await db.apply_in_memory(m, cf, std::move(commit_idx_entry_handle), db::no_timeout);
+    // Both this path and persist_commit_idx() write commit_idx to the raft_groups
+    // memtable; either may run between our co_awaits, so keep the watermark
+    // monotonic rather than clobbering a larger value.
+    _last_persisted_commit_idx = std::max(_last_persisted_commit_idx, commit_idx);
+
+    // Non-command entries (configuration, dummy) are never applied to a memtable
+    // — unlike command entries, whose rp_handles apply() hands to the target
+    // memtable. We keep their rp_handles pinning the commitlog only until they
+    // commit: non-command entries at or below commit_idx are committed and, now
+    // that commit_idx is recorded, are covered by it on restart, so raft won't
+    // replay them. Release their handles and let the commitlog segments be
+    // reclaimed.
+    _raft_commitlog.release_noncommand_rp_handles(commit_idx);
 }
 
 future<> raft_groups_storage::truncate_log(raft::index_t idx) {
@@ -213,6 +283,20 @@ future<> raft_groups_storage::update_snapshot(const raft::snapshot_descriptor &s
         {int16_t(_shard), _group_id.id, snap.id.id},
         cql3::query_processor::cache_internal::yes
     ).discard_result();
+}
+
+future<std::pair<raft::index_t, raft::term_t>>
+raft_groups_storage::load_snapshot_idx_and_term(cql3::query_processor& qp, raft::group_id gid, shard_id shard) {
+    static const auto load_cql = format("SELECT idx, term FROM system.{} WHERE shard = ? AND group_id = ?",
+        db::system_keyspace::RAFT_GROUPS_SNAPSHOTS);
+    auto rs = co_await qp.execute_internal(load_cql, {int16_t(shard), gid.id}, cql3::query_processor::cache_internal::yes);
+    if (rs->empty()) {
+        co_return std::pair(raft::index_t(0), raft::term_t(0));
+    }
+    const auto& row = rs->one();
+    co_return std::pair(
+            raft::index_t(row.get_or<int64_t>("idx", 0)),
+            raft::term_t(row.get_or<int64_t>("term", 0)));
 }
 
 future<> raft_groups_storage::store_snapshot_index(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap) {

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -53,8 +53,10 @@ class raft_groups_storage : public raft::persistence {
     // applier_fiber for apply(), so this value is always >= the raft index
     // of any entry that has been applied to a memtable.
     raft::index_t _last_known_commit_idx{0};
-    // Last commit index actually persisted to system.raft_groups by
-    // persist_commit_idx(). Used to skip redundant writes.
+    // Last commit index recorded to system.raft_groups, by either the flush-hook
+    // CQL write (persist_commit_idx()) or the per-batch fake mutation
+    // (store_log_entries()) — both target the raft_groups memtable. Both paths
+    // skip when commit_idx has not advanced past this watermark.
     raft::index_t _last_persisted_commit_idx{0};
 
 public:
@@ -83,6 +85,10 @@ public:
     // Static version that doesn't require constructing a full raft_groups_storage object.
     // Useful during commitlog replay when only read access to metadata is needed.
     static future<raft::index_t> load_commit_idx(cql3::query_processor& qp, raft::group_id gid, shard_id shard);
+    // Load the current persisted snapshot's (idx, term) for this group.
+    // Returns (0, 0) if no snapshot has been recorded yet.
+    static future<std::pair<raft::index_t, raft::term_t>> load_snapshot_idx_and_term(
+            cql3::query_processor& qp, raft::group_id gid, shard_id shard);
     // Store snapshot idx and term without updating the configuration.
     // Used to advance the persisted snapshot index so that raft does not
     // re-apply already applied entries on restart. Only writes if the new

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -48,6 +48,14 @@ class raft_groups_storage : public raft::persistence {
     // Used to linearize write operations to system.raft_groups table.
     // This is managed by `execute_with_linearization_point` helper function.
     future<> _pending_op_fut;
+    // Last commit index reported by the raft io_fiber via store_commit_idx().
+    // The io_fiber calls store_commit_idx() *before* pushing entries to the
+    // applier_fiber for apply(), so this value is always >= the raft index
+    // of any entry that has been applied to a memtable.
+    raft::index_t _last_known_commit_idx{0};
+    // Last commit index actually persisted to system.raft_groups by
+    // persist_commit_idx(). Used to skip redundant writes.
+    raft::index_t _last_persisted_commit_idx{0};
 
 public:
     explicit raft_groups_storage(cql3::query_processor& qp, raft::group_id gid, raft::server_id server_id, shard_id shard,
@@ -82,6 +90,11 @@ public:
     static future<> store_snapshot_index(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap);
 
     std::vector<index_and_replay_position> acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries);
+
+    // Persist commit index to system.raft_groups. Called by store_commit_idx()
+    // and (in a later commit) from the memtable flush path. Skips the write if
+    // _last_known_commit_idx hasn't advanced since the last persist.
+    future<> persist_commit_idx();
 
 private:
 

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -56,11 +56,12 @@ class raft_groups_storage : public raft::persistence {
     // down. abort() drains any in-flight operation via _pending_op_fut before
     // this object is destroyed.
     bool _aborted = false;
-    // Last commit index reported by the raft io_fiber via store_commit_idx().
-    // The io_fiber calls store_commit_idx() *before* pushing entries to the
-    // applier_fiber for apply(), so this value is always >= the raft index
-    // of any entry that has been applied to a memtable.
-    raft::index_t _last_known_commit_idx{0};
+    // Last commit index (and the term of the entry at it) reported by the raft
+    // io_fiber via store_commit_idx(). The io_fiber calls store_commit_idx()
+    // *before* pushing entries to the applier_fiber for apply(), so the index
+    // is always >= the raft index of any entry that has been applied to a
+    // memtable.
+    commit_idx_and_term _last_known_commit{};
     // Last commit index recorded to system.raft_groups, by either the flush-hook
     // CQL write (persist_commit_idx()) or the per-batch fake mutation
     // (store_log_entries()) — both target the raft_groups memtable. Both paths
@@ -110,8 +111,9 @@ public:
 
     std::vector<index_and_replay_position> acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries);
 
-    // Persist _last_known_commit_idx to system.raft_groups. Skips the write
-    // if it hasn't advanced since the last persist, or if abort() has begun.
+    // Persist _last_known_commit (idx and term) to system.raft_groups. Skips
+    // the write if the index hasn't advanced since the last persist, or if
+    // abort() has begun.
     future<> persist_commit_idx();
 
 private:

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -94,6 +94,9 @@ public:
     // Static version that doesn't require constructing a full raft_groups_storage object.
     // Useful during commitlog replay when only read access to metadata is needed.
     static future<raft::index_t> load_commit_idx(cql3::query_processor& qp, raft::group_id gid, shard_id shard);
+    // Load the persisted (commit_idx, commit_idx_term) pair. Term 0 means the
+    // row predates the commit_idx_term column ("unknown").
+    static future<commit_idx_and_term> load_commit_idx_and_term(cql3::query_processor& qp, raft::group_id gid, shard_id shard);
     // Load the current persisted snapshot's (idx, term) for this group.
     // Returns (0, 0) if no snapshot has been recorded yet.
     static future<std::pair<raft::index_t, raft::term_t>> load_snapshot_idx_and_term(

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -48,6 +48,14 @@ class raft_groups_storage : public raft::persistence {
     // Used to linearize write operations to system.raft_groups table.
     // This is managed by `execute_with_linearization_point` helper function.
     future<> _pending_op_fut;
+    // Set once abort() is called. abort() does not persist commit_idx itself
+    // (shutdown may have closed the CQL / storage_proxy gates); durability is
+    // provided by the per-batch fake system.raft_groups mutation and the
+    // raft_groups memtable flush. After this point persist_commit_idx() becomes
+    // a quiet no-op so no new CQL write starts while the object is being torn
+    // down. abort() drains any in-flight operation via _pending_op_fut before
+    // this object is destroyed.
+    bool _aborted = false;
     // Last commit index reported by the raft io_fiber via store_commit_idx().
     // The io_fiber calls store_commit_idx() *before* pushing entries to the
     // applier_fiber for apply(), so this value is always >= the raft index
@@ -94,12 +102,16 @@ public:
     // re-apply already applied entries on restart. Only writes if the new
     // index is higher than the existing one (safe to call on repeated replays).
     static future<> store_snapshot_index(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap);
+    // Persist commit_idx to system.raft_groups, but only if it advances the
+    // currently persisted value. Used during commitlog replay to restore a
+    // commit_idx that a crash dropped from the raft_groups memtable before it
+    // could flush (the value survives in the commitlog's commit_idx entries).
+    static future<> store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard, raft::index_t commit_idx);
 
     std::vector<index_and_replay_position> acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries);
 
-    // Persist commit index to system.raft_groups. Called by store_commit_idx()
-    // and (in a later commit) from the memtable flush path. Skips the write if
-    // _last_known_commit_idx hasn't advanced since the last persist.
+    // Persist _last_known_commit_idx to system.raft_groups. Skips the write
+    // if it hasn't advanced since the last persist, or if abort() has begun.
     future<> persist_commit_idx();
 
 private:

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -73,7 +73,7 @@ public:
 
     future<> store_term_and_vote(raft::term_t term, raft::server_id vote) override;
     future<std::pair<raft::term_t, raft::server_id>> load_term_and_vote() override;
-    future<> store_commit_idx(raft::index_t) override;
+    future<> store_commit_idx(raft::index_t, raft::term_t) override;
     future<raft::index_t> load_commit_idx() override;
     future<raft::log_entries> load_log() override;
     future<raft::snapshot_descriptor> load_snapshot_descriptor() override;

--- a/service/strong_consistency/raft_groups_storage.hh
+++ b/service/strong_consistency/raft_groups_storage.hh
@@ -103,11 +103,12 @@ public:
     // re-apply already applied entries on restart. Only writes if the new
     // index is higher than the existing one (safe to call on repeated replays).
     static future<> store_snapshot_index(cql3::query_processor& qp, raft::group_id gid, shard_id shard, const raft::snapshot_descriptor& snap);
-    // Persist commit_idx to system.raft_groups, but only if it advances the
-    // currently persisted value. Used during commitlog replay to restore a
-    // commit_idx that a crash dropped from the raft_groups memtable before it
-    // could flush (the value survives in the commitlog's commit_idx entries).
-    static future<> store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard, raft::index_t commit_idx);
+    // Persist (commit_idx, commit_idx_term) to system.raft_groups, but only if
+    // the index advances the currently persisted value. Used during commitlog
+    // replay to restore a commit_idx that a crash dropped from the raft_groups
+    // memtable before it could flush (the pair survives in the commitlog's
+    // commit_idx entries).
+    static future<> store_commit_idx_if_higher(cql3::query_processor& qp, raft::group_id gid, shard_id shard, commit_idx_and_term commit);
 
     std::vector<index_and_replay_position> acquire_replay_position_handles_for(const raft::log_entry_ptr_list& entries);
 

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -116,8 +116,8 @@ SEASTAR_TEST_CASE(test_commitlog_raft_log_entry_writer) {
             // the writer wraps it in a commitlog_entry + raft_commitlog_entry envelope.
             BOOST_REQUIRE_GT(writer.size(), 0u);
             BOOST_REQUIRE_GT(writer.size(), ser::get_sizeof(*entry));
-            BOOST_REQUIRE_EQUAL(writer.get_log_entry().group_id, gid);
-            BOOST_REQUIRE_EQUAL(writer.get_log_entry().entry->idx, entry->idx);
+            BOOST_REQUIRE_EQUAL(writer.get_raft_log_entry().group_id, gid);
+            BOOST_REQUIRE_EQUAL(writer.get_raft_log_entry().entry->idx, entry->idx);
 
             auto handle = co_await write_raft_entry_to_commitlog(log, tid, gid, entry);
             rps.push_back(handle.rp());

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -84,10 +84,10 @@ future<> cl_test(noncopyable_function<future<>(commitlog&)> f) {
 
 // Write a raft log entry to the commitlog and return the rp_handle.
 future<rp_handle> write_raft_entry_to_commitlog(commitlog& cl, table_id tid, raft::group_id gid, raft::log_entry_ptr entry) {
-    commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = gid, .entry = entry});
+    commitlog_raft_log_entry_writer writer(tid, raft_commitlog_entry{.group_id = gid, .entry = entry});
     const auto target_size = writer.size();
-    co_return co_await cl.add(tid, target_size, db::no_timeout, db::commitlog_force_sync::yes, [entry, gid](auto& out) {
-        commitlog_raft_log_entry_writer w(raft_commitlog_entry{.group_id = gid, .entry = entry});
+    co_return co_await cl.add(tid, target_size, db::no_timeout, db::commitlog_force_sync::yes, [entry, gid, tid](auto& out) {
+        commitlog_raft_log_entry_writer w(tid, raft_commitlog_entry{.group_id = gid, .entry = entry});
         w.write(out);
     });
 }
@@ -111,7 +111,7 @@ SEASTAR_TEST_CASE(test_commitlog_raft_log_entry_writer) {
         // Verify size() and accessor for each entry type, then write to commitlog.
         std::vector<replay_position> rps;
         for (const auto& entry : entries) {
-            commitlog_raft_log_entry_writer writer(raft_commitlog_entry{.group_id = gid, .entry = entry});
+            commitlog_raft_log_entry_writer writer(tid, raft_commitlog_entry{.group_id = gid, .entry = entry});
             // size() must exceed the bare raft::log_entry serialization because
             // the writer wraps it in a commitlog_entry + raft_commitlog_entry envelope.
             BOOST_REQUIRE_GT(writer.size(), 0u);
@@ -1545,14 +1545,14 @@ SEASTAR_TEST_CASE(test_raft_commitlog_store_and_truncate_log) {
         auto tid = make_table_id();
 
         service::strong_consistency::replayed_data_per_group replayed_data;
-        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
 
         // Store 10 entries.
         raft::log_entry_ptr_list all_entries;
         for (int i = 1; i <= 10; ++i) {
             all_entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
         }
-        co_await persistence.store_log_entries(all_entries);
+        (void)co_await persistence.store_log_entries(all_entries, raft::index_t(0));
 
         // Truncate at idx 6 — entries 6-10 should be removed.
         persistence.truncate_log(raft::index_t(6));
@@ -1589,13 +1589,13 @@ SEASTAR_TEST_CASE(test_raft_commitlog_truncate_log_tail_releases_handles) {
         auto tid = make_table_id();
 
         service::strong_consistency::replayed_data_per_group replayed_data;
-        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
 
         raft::log_entry_ptr_list all_entries;
         for (int i = 1; i <= 10; ++i) {
             all_entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
         }
-        co_await persistence.store_log_entries(all_entries);
+        (void)co_await persistence.store_log_entries(all_entries, raft::index_t(0));
 
         // Truncate tail at idx 5 — entries 1-5 handles should be released.
         persistence.truncate_log_tail(raft::index_t(5));
@@ -1742,13 +1742,13 @@ SEASTAR_TEST_CASE(test_raft_commitlog_combined_truncation) {
         auto tid = make_table_id();
 
         service::strong_consistency::replayed_data_per_group replayed_data;
-        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
 
         raft::log_entry_ptr_list all_entries;
         for (int i = 1; i <= 10; ++i) {
             all_entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
         }
-        co_await persistence.store_log_entries(all_entries);
+        (void)co_await persistence.store_log_entries(all_entries, raft::index_t(0));
 
         // Truncate tail (entries <= 3) and head (entries >= 8).
         persistence.truncate_log_tail(raft::index_t(3));
@@ -1798,7 +1798,7 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
         replayed_data.replay_positions.push_back({.index = raft::index_t(2), .replay_position_handle = {}});
         replayed_data.replay_positions.push_back({.index = raft::index_t(3), .replay_position_handle = {}});
 
-        service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
 
         // First call should return the entries.
         auto entries = persistence.load_log();

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -1793,6 +1793,10 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
         replayed_data.entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(1)));
         replayed_data.entries.push_back(make_dummy_entry(raft::term_t(1), raft::index_t(2)));
         replayed_data.entries.push_back(make_config_entry(raft::term_t(2), raft::index_t(3)));
+        // replay_positions must be 1:1 with entries (raft_commitlog ctor invariant).
+        replayed_data.replay_positions.push_back({.index = raft::index_t(1), .replay_position_handle = {}});
+        replayed_data.replay_positions.push_back({.index = raft::index_t(2), .replay_position_handle = {}});
+        replayed_data.replay_positions.push_back({.index = raft::index_t(3), .replay_position_handle = {}});
 
         service::strong_consistency::raft_commitlog persistence(gid, log, tid, std::move(replayed_data));
 

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -30,6 +30,7 @@
 #include "idl/commitlog.dist.impl.hh"
 #include "test/lib/mutation_source_test.hh"
 #include "service/strong_consistency/raft_commitlog.hh"
+#include "service/strong_consistency/raft_groups_storage.hh"
 #include "idl/raft_storage.dist.hh"
 #include "idl/raft_storage.dist.impl.hh"
 
@@ -347,6 +348,38 @@ SEASTAR_TEST_CASE(test_raft_replay_buffer_process_discards_unknown_groups) {
                 auto data = buffer.take_replayed_group_entries(gid);
                 BOOST_CHECK(data.entries.empty());
                 BOOST_CHECK(data.replay_positions.empty());
+            },
+            std::move(db_cfg_ptr));
+}
+
+// Test that a group whose only replayed record is a commit_idx entry (no log
+// entries) is still processed: process_raft_replayed_items runs its restore
+// pass even when remaining_groups() == 0, and — since the group is not in
+// tablet metadata — discards the recovered commit_idx instead of resurrecting
+// a system.raft_groups row for a moved-away/dropped tablet.
+SEASTAR_TEST_CASE(test_raft_replay_buffer_commit_idx_only_group) {
+    auto db_cfg_ptr = make_shared<db::config>();
+    db_cfg_ptr->experimental_features({db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES});
+    return do_with_cql_env(
+            [](cql_test_env& env) -> future<> {
+                db::raft_commitlog_replay_buffer buffer;
+
+                auto gid = make_group_id();
+                // Only commit_idx entries survived replay for this group (e.g. the
+                // segment holding its raft log entries was already reclaimed).
+                // The highest value wins.
+                buffer.add_commit_idx(gid, raft::index_t(3));
+                buffer.add_commit_idx(gid, raft::index_t(7));
+                buffer.add_commit_idx(gid, raft::index_t(5));
+
+                BOOST_CHECK_EQUAL(buffer.remaining_groups(), 0);
+
+                co_await buffer.process_raft_replayed_items(env.local_db(), env.local_qp(), env.get_system_keyspace().local());
+
+                // The group has no tablet metadata, so nothing may be written.
+                const auto persisted = co_await service::strong_consistency::raft_groups_storage::load_commit_idx(
+                        env.local_qp(), gid, this_shard_id());
+                BOOST_CHECK_EQUAL(persisted, raft::index_t(0));
             },
             std::move(db_cfg_ptr));
 }
@@ -1813,5 +1846,145 @@ SEASTAR_TEST_CASE(test_raft_commitlog_load_log_one_shot) {
         co_return;
     });
 }
+
+// Test: raft_commitlog::store_log_entries writes a trailing commit_idx entry
+// after the raft log entries and returns that entry's rp_handle. Ensures:
+//   * The batch produces exactly N raft entries + 1 commit_idx entry in the commitlog.
+//   * The commit_idx entry carries the expected group_id and commit_idx.
+//
+// Test for: SCYLLADB-2877
+SEASTAR_TEST_CASE(test_raft_commitlog_store_log_entries_writes_commit_idx_entry) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
+
+        raft::log_entry_ptr_list entries;
+        for (int i = 1; i <= 3; ++i) {
+            entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
+        }
+
+        auto commit_idx = raft::index_t(2);
+        auto commit_idx_entry_handle = co_await persistence.store_log_entries(entries, commit_idx);
+        BOOST_REQUIRE(commit_idx_entry_handle);
+
+        co_await log.sync_all_segments();
+
+        auto segments = log.get_active_segment_names();
+        BOOST_REQUIRE(!segments.empty());
+
+        size_t raft_entries = 0;
+        size_t commit_idx_entries = 0;
+        for (auto& seg : segments) {
+            co_await db::commitlog::read_log_file(
+                    seg, db::commitlog::descriptor::FILENAME_PREFIX,
+                    [&](db::commitlog::buffer_and_replay_position buf_rp) -> future<> {
+                        auto&& [buf, _] = buf_rp;
+                        commitlog_entry_reader reader(buf, detail::commitlog_entry_serialization_format::variant);
+                        auto& entry_var = reader.entry().item;
+
+                        if (std::holds_alternative<raft_commitlog_entry>(entry_var)) {
+                            const auto& rle = std::get<raft_commitlog_entry>(entry_var);
+                            BOOST_REQUIRE_EQUAL(rle.group_id, gid);
+                            ++raft_entries;
+                        } else {
+                            BOOST_REQUIRE(std::holds_alternative<raft_commit_idx_entry>(entry_var));
+                            const auto& commit_idx_entry = std::get<raft_commit_idx_entry>(entry_var);
+                            BOOST_REQUIRE_EQUAL(commit_idx_entry.group_id, gid);
+                            BOOST_REQUIRE_EQUAL(commit_idx_entry.commit_idx, commit_idx);
+                            ++commit_idx_entries;
+                        }
+                        co_return;
+                    });
+        }
+
+        BOOST_REQUIRE_EQUAL(raft_entries, entries.size());
+        BOOST_REQUIRE_EQUAL(commit_idx_entries, 1);
+
+        // Release the commit_idx entry handle so the segment can eventually be reclaimed.
+        commit_idx_entry_handle.release();
+    });
+}
+
+// Test: mixed command / non-command batches are routed into the correct
+// deques. acquire_replay_position_handles_for() must find command entries,
+// non-command entries are pinned by their separate deque until truncation.
+SEASTAR_TEST_CASE(test_raft_commitlog_splits_command_and_noncommand_positions) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
+
+        // 3 command entries interleaved with 10 non-command entries
+        // (commands at idx 1, 7, 13; configuration/dummy fill the rest).
+        auto is_command_idx = [](int i) { return i == 1 || i == 7 || i == 13; };
+        raft::log_entry_ptr_list entries;
+        for (int i = 1; i <= 13; ++i) {
+            if (is_command_idx(i)) {
+                entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
+            } else if (i % 2 == 0) {
+                entries.push_back(make_config_entry(raft::term_t(1), raft::index_t(i)));
+            } else {
+                entries.push_back(make_dummy_entry(raft::term_t(1), raft::index_t(i)));
+            }
+        }
+
+        auto commit_idx_entry_handle = co_await persistence.store_log_entries(entries, raft::index_t(2));
+        commit_idx_entry_handle.release();
+
+        // acquire_* only walks _command_positions; the 10 non-command entries
+        // live in a separate deque and must not appear there. Requesting the 3
+        // commands (the full contiguous command prefix) succeeds.
+        raft::log_entry_ptr_list commands = {entries[0], entries[6], entries[12]};
+        auto handles = persistence.acquire_replay_position_handles_for(commands);
+        BOOST_REQUIRE_EQUAL(handles.size(), 3);
+        BOOST_REQUIRE_EQUAL(handles[0].index, raft::index_t(1));
+        BOOST_REQUIRE_EQUAL(handles[1].index, raft::index_t(7));
+        BOOST_REQUIRE_EQUAL(handles[2].index, raft::index_t(13));
+
+        // Truncate the non-command tail (<= idx 10): non-command entries with
+        // idx <= 10 are released, while those above (11, 12) remain. The command
+        // deque was already drained by the acquire above, so it is unaffected.
+        // This must not crash and the class' destructor must succeed.
+        persistence.truncate_log_tail(raft::index_t(10));
+    });
+}
+
+// Test: release_noncommand_rp_handles drops non-command rp_handles up to and including
+// the given idx and leaves command handles untouched.
+SEASTAR_TEST_CASE(test_raft_commitlog_release_noncommand_rp_handles) {
+    return cl_test([](commitlog& log) -> future<> {
+        auto gid = make_group_id();
+        auto tid = make_table_id();
+
+        service::strong_consistency::replayed_data_per_group replayed_data;
+        service::strong_consistency::raft_commitlog persistence(gid, log, tid, make_table_id(), std::move(replayed_data));
+
+        raft::log_entry_ptr_list entries;
+        entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(1)));
+        entries.push_back(make_config_entry (raft::term_t(1), raft::index_t(2)));
+        entries.push_back(make_dummy_entry  (raft::term_t(1), raft::index_t(3)));
+        entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(4)));
+        entries.push_back(make_dummy_entry  (raft::term_t(1), raft::index_t(5)));
+
+        (void)co_await persistence.store_log_entries(entries, raft::index_t(0));
+
+        // Release non-command handles up to idx 3: covers the config@2 and
+        // dummy@3. dummy@5 must remain (idx > 3). Commands must be untouched.
+        persistence.release_noncommand_rp_handles(raft::index_t(3));
+
+        // Commands can still be acquired at their original indices.
+        raft::log_entry_ptr_list commands = {entries[0], entries[3]};
+        auto handles = persistence.acquire_replay_position_handles_for(commands);
+        BOOST_REQUIRE_EQUAL(handles.size(), 2);
+        BOOST_REQUIRE_EQUAL(handles[0].index, raft::index_t(1));
+        BOOST_REQUIRE_EQUAL(handles[1].index, raft::index_t(4));
+    });
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -1894,6 +1894,8 @@ SEASTAR_TEST_CASE(test_raft_commitlog_store_log_entries_writes_commit_idx_entry)
                             const auto& commit_idx_entry = std::get<raft_commit_idx_entry>(entry_var);
                             BOOST_REQUIRE_EQUAL(commit_idx_entry.group_id, gid);
                             BOOST_REQUIRE_EQUAL(commit_idx_entry.commit_idx, commit.idx);
+                            BOOST_REQUIRE(commit_idx_entry.term);
+                            BOOST_REQUIRE_EQUAL(*commit_idx_entry.term, commit.term);
                             ++commit_idx_entries;
                         }
                         co_return;

--- a/test/boost/commitlog_raft_replay_test.cc
+++ b/test/boost/commitlog_raft_replay_test.cc
@@ -368,9 +368,9 @@ SEASTAR_TEST_CASE(test_raft_replay_buffer_commit_idx_only_group) {
                 // Only commit_idx entries survived replay for this group (e.g. the
                 // segment holding its raft log entries was already reclaimed).
                 // The highest value wins.
-                buffer.add_commit_idx(gid, raft::index_t(3));
-                buffer.add_commit_idx(gid, raft::index_t(7));
-                buffer.add_commit_idx(gid, raft::index_t(5));
+                buffer.add_commit_idx(gid, raft::index_t(3), raft::term_t(1));
+                buffer.add_commit_idx(gid, raft::index_t(7), raft::term_t(2));
+                buffer.add_commit_idx(gid, raft::index_t(5), raft::term_t(1));
 
                 BOOST_CHECK_EQUAL(buffer.remaining_groups(), 0);
 
@@ -1585,7 +1585,7 @@ SEASTAR_TEST_CASE(test_raft_commitlog_store_and_truncate_log) {
         for (int i = 1; i <= 10; ++i) {
             all_entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
         }
-        (void)co_await persistence.store_log_entries(all_entries, raft::index_t(0));
+        (void)co_await persistence.store_log_entries(all_entries, {});
 
         // Truncate at idx 6 — entries 6-10 should be removed.
         persistence.truncate_log(raft::index_t(6));
@@ -1628,7 +1628,7 @@ SEASTAR_TEST_CASE(test_raft_commitlog_truncate_log_tail_releases_handles) {
         for (int i = 1; i <= 10; ++i) {
             all_entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
         }
-        (void)co_await persistence.store_log_entries(all_entries, raft::index_t(0));
+        (void)co_await persistence.store_log_entries(all_entries, {});
 
         // Truncate tail at idx 5 — entries 1-5 handles should be released.
         persistence.truncate_log_tail(raft::index_t(5));
@@ -1781,7 +1781,7 @@ SEASTAR_TEST_CASE(test_raft_commitlog_combined_truncation) {
         for (int i = 1; i <= 10; ++i) {
             all_entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
         }
-        (void)co_await persistence.store_log_entries(all_entries, raft::index_t(0));
+        (void)co_await persistence.store_log_entries(all_entries, {});
 
         // Truncate tail (entries <= 3) and head (entries >= 8).
         persistence.truncate_log_tail(raft::index_t(3));
@@ -1866,8 +1866,8 @@ SEASTAR_TEST_CASE(test_raft_commitlog_store_log_entries_writes_commit_idx_entry)
             entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(i)));
         }
 
-        auto commit_idx = raft::index_t(2);
-        auto commit_idx_entry_handle = co_await persistence.store_log_entries(entries, commit_idx);
+        const service::strong_consistency::commit_idx_and_term commit{raft::index_t(2), raft::term_t(1)};
+        auto commit_idx_entry_handle = co_await persistence.store_log_entries(entries, commit);
         BOOST_REQUIRE(commit_idx_entry_handle);
 
         co_await log.sync_all_segments();
@@ -1893,7 +1893,7 @@ SEASTAR_TEST_CASE(test_raft_commitlog_store_log_entries_writes_commit_idx_entry)
                             BOOST_REQUIRE(std::holds_alternative<raft_commit_idx_entry>(entry_var));
                             const auto& commit_idx_entry = std::get<raft_commit_idx_entry>(entry_var);
                             BOOST_REQUIRE_EQUAL(commit_idx_entry.group_id, gid);
-                            BOOST_REQUIRE_EQUAL(commit_idx_entry.commit_idx, commit_idx);
+                            BOOST_REQUIRE_EQUAL(commit_idx_entry.commit_idx, commit.idx);
                             ++commit_idx_entries;
                         }
                         co_return;
@@ -1933,7 +1933,7 @@ SEASTAR_TEST_CASE(test_raft_commitlog_splits_command_and_noncommand_positions) {
             }
         }
 
-        auto commit_idx_entry_handle = co_await persistence.store_log_entries(entries, raft::index_t(2));
+        auto commit_idx_entry_handle = co_await persistence.store_log_entries(entries, {raft::index_t(2), raft::term_t(1)});
         commit_idx_entry_handle.release();
 
         // acquire_* only walks _command_positions; the 10 non-command entries
@@ -1971,7 +1971,7 @@ SEASTAR_TEST_CASE(test_raft_commitlog_release_noncommand_rp_handles) {
         entries.push_back(make_command_entry(raft::term_t(1), raft::index_t(4)));
         entries.push_back(make_dummy_entry  (raft::term_t(1), raft::index_t(5)));
 
-        (void)co_await persistence.store_log_entries(entries, raft::index_t(0));
+        (void)co_await persistence.store_log_entries(entries, {});
 
         // Release non-command handles up to idx 3: covers the config@2 and
         // dummy@3. dummy@5 must remain (idx > 3). Commands must be untouched.

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -1545,6 +1545,47 @@ async def test_read_forwarding(manager: ManagerClient):
                 assert len(rows) == 1, f"Expected 1 row for pk={100 + i}, got {len(rows)}"
                 assert rows[0].c == i * 10, f"Linearizability violation: pk={100 + i}, expected c={i * 10}, got c={rows[0].c}"
 
+@pytest.mark.asyncio
+async def test_data_survives_crash(manager: ManagerClient):
+    """Verify that SC table data survives a non-graceful crash and is recovered
+    from commitlog replay. After a crash, committed raft entries in the commitlog
+    must be re-applied to memtables even if they were already snapshotted, because
+    the snapshot data may not have been flushed to sstables."""
+    config = {
+        'experimental_features': ['strongly-consistent-tables'],
+        # Prevent automatic memtable flushes so data stays in the commitlog
+        # and is not persisted to sstables before the crash.
+        'commitlog_total_space_in_mb': 10000,
+    }
+    cmdline = [
+        '--logger-log-level', 'sc_groups_manager=debug',
+        '--logger-log-level', 'sc_coordinator=debug',
+    ]
+    server = await manager.server_add(config=config, cmdline=cmdline)
+    (cql, hosts) = await manager.get_ready_cql([server])
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        for pk in range(5):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({pk}, {pk * 10})")
+
+        # Crash the node (non-graceful stop — no flush)
+        await manager.server_stop(server.server_id, convict=False)
+        await manager.server_start(server.server_id)
+        await reconnect_driver(manager)
+        cql = manager.get_cql()
+
+        for pk in range(5):
+            rows = await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = {pk};")
+            assert len(rows) == 1, f"Expected 1 row for pk={pk}, got {len(rows)}"
+            assert rows[0].c == pk * 10, f"pk={pk}: expected c={pk * 10}, got c={rows[0].c}"
+
+        # Note: commit_idx is no longer persisted on every batch (optimization),
+        # so after a crash without flush the raft server may re-commit entries
+        # from the raft log rather than relying on an advanced snapshot index.
+
+    await manager.server_stop_gracefully(server.server_id)
+
 
 async def test_write_from_non_replica_after_leader_down(manager: ManagerClient):
     """

--- a/test/cluster/test_strong_consistency_commitlog.py
+++ b/test/cluster/test_strong_consistency_commitlog.py
@@ -303,3 +303,68 @@ async def test_crash_recovery_after_flush(manager: ManagerClient):
             assert rows[0].c == pk * 10, f"pk={pk}: expected c={pk * 10}, got c={rows[0].c}"
 
     await manager.server_stop_gracefully(server.server_id)
+
+
+@pytest.mark.asyncio
+async def test_commit_idx_persisted_on_graceful_shutdown(manager: ManagerClient):
+    """A graceful shutdown must leave system.raft_groups.commit_idx covering every
+    write that was committed and applied, not just the value that was known when
+    the last raft batch was appended (the commit_idx entries in the commitlog
+    carry only the append-time value, and a clean shutdown discards the
+    commitlog).
+
+    That guarantee comes from the memtable-flush hook: storage_service::do_drain()
+    is registered last, so it runs before groups_manager::stop(), and the drain
+    flush therefore seals the SC tablet's memtable while the group is still alive
+    and wired — firing save_commit_log_index(). This test pins that ordering: if
+    the groups were torn down before the drain flush, the hook would not run and
+    the persisted commit_idx would lag."""
+    config = {
+        'experimental_features': ['strongly-consistent-tables'],
+        'commitlog_total_space_in_mb': 10000,
+    }
+    server = await manager.server_add(config=config)
+    (cql, hosts) = await manager.get_ready_cql([server])
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        for pk in range(10):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({pk}, {pk * 10})")
+
+        table_id = await manager.get_table_id(ks.replace('"', ''), "test")
+        tablet_rows = await cql.run_async(f"SELECT raft_group_id FROM system.tablets WHERE table_id = {table_id}")
+        assert len(tablet_rows) == 1
+        group_id = tablet_rows[0].raft_group_id
+
+        # commit_idx as recorded by the per-batch fake mutation: this is the
+        # append-time value and is expected to lag the last commit.
+        pre_rows = await cql.run_async(f"SELECT commit_idx FROM system.raft_groups WHERE shard = 0 AND group_id = {group_id}")
+        assert len(pre_rows) == 1
+        pre_commit_idx = pre_rows[0].commit_idx
+
+        await manager.server_stop_gracefully(server.server_id)
+        await manager.server_start(server.server_id)
+        await reconnect_driver(manager)
+        cql = manager.get_cql()
+
+        for pk in range(10):
+            rows = await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = {pk};")
+            assert len(rows) == 1, f"Expected 1 row for pk={pk}, got {len(rows)}"
+            assert rows[0].c == pk * 10
+
+        # The startup bump sets raft_groups_snapshots.idx from the commit_idx that
+        # was persisted at shutdown, and nothing after startup moves it (post-restart
+        # commits advance system.raft_groups.commit_idx, not the snapshot index), so
+        # it is a stable witness of what shutdown actually persisted.
+        #
+        # The drain flush fires the hook while the group is still alive, so the
+        # persisted value covers every committed insert and the bump lands strictly
+        # past the append-time value. Were the groups torn down before the drain
+        # flush, the bump could only reach the append-time value itself.
+        snp_rows = await cql.run_async(f"SELECT idx FROM system.raft_groups_snapshots WHERE shard = 0 AND group_id = {group_id}")
+        assert len(snp_rows) == 1
+        assert snp_rows[0].idx > pre_commit_idx, \
+            f"snapshot idx {snp_rows[0].idx} did not advance past the append-time commit_idx {pre_commit_idx} " \
+            f"— was commit_idx persisted on shutdown?"
+
+    await manager.server_stop_gracefully(server.server_id)

--- a/test/cluster/test_strong_consistency_commitlog.py
+++ b/test/cluster/test_strong_consistency_commitlog.py
@@ -34,6 +34,20 @@ async def test_data_survives_crash(manager: ManagerClient):
         for pk in range(5):
             await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({pk}, {pk * 10})")
 
+        # Locate the tablet's raft group and capture the pre-crash commit
+        # position: the fake in-memory system.raft_groups mutation makes
+        # (commit_idx, commit_idx_term) readable before any flush.
+        table_id = await manager.get_table_id(ks.replace('"', ''), "test")
+        tablet_rows = await cql.run_async(f"SELECT raft_group_id FROM system.tablets WHERE table_id = {table_id}")
+        assert len(tablet_rows) == 1
+        group_id = tablet_rows[0].raft_group_id
+        pre_rows = await cql.run_async(f"SELECT commit_idx, commit_idx_term FROM system.raft_groups WHERE shard = 0 AND group_id = {group_id}")
+        assert len(pre_rows) == 1
+        pre_commit_idx = pre_rows[0].commit_idx
+        pre_commit_term = pre_rows[0].commit_idx_term
+        assert pre_commit_idx > 0
+        assert pre_commit_term > 0
+
         # Crash the node (non-graceful stop — no flush)
         await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
@@ -45,16 +59,15 @@ async def test_data_survives_crash(manager: ManagerClient):
             assert len(rows) == 1, f"Expected 1 row for pk={pk}, got {len(rows)}"
             assert rows[0].c == pk * 10, f"pk={pk}: expected c={pk * 10}, got c={rows[0].c}"
 
-        # Verify that the snapshot index was advanced during replay.
-        # After commitlog replay, store_snapshot_index should have bumped
-        # snapshot.idx to commit_idx for the tablet's raft group.
-        table_id = await manager.get_table_id(ks.replace('"', ''), "test")
-        tablet_rows = await cql.run_async(f"SELECT raft_group_id FROM system.tablets WHERE table_id = {table_id}")
-        assert len(tablet_rows) == 1
-        group_id = tablet_rows[0].raft_group_id
-        snp_rows = await cql.run_async(f"SELECT idx FROM system.raft_groups_snapshots WHERE shard = 0 AND group_id = {group_id}")
+        # Verify that the snapshot was advanced during replay, using the exact
+        # term restored from the commitlog's commit_idx entries. No raft
+        # snapshot existed before the crash, so a conservative bump would have
+        # written term 0 — the assertion below catches that regression.
+        snp_rows = await cql.run_async(f"SELECT idx, term FROM system.raft_groups_snapshots WHERE shard = 0 AND group_id = {group_id}")
         assert len(snp_rows) == 1, f"Expected snapshot row for group {group_id}"
-        assert snp_rows[0].idx > 0, f"Expected snapshot idx > 0 after replay, got {snp_rows[0].idx}"
+        assert snp_rows[0].idx >= pre_commit_idx, f"Expected snapshot idx >= {pre_commit_idx} after replay, got {snp_rows[0].idx}"
+        assert snp_rows[0].term >= pre_commit_term, \
+            f"snapshot term {snp_rows[0].term} < persisted commit_idx_term {pre_commit_term} — conservative fallback used?"
 
     await manager.server_stop_gracefully(server.server_id)
 
@@ -301,6 +314,52 @@ async def test_crash_recovery_after_flush(manager: ManagerClient):
             rows = await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = {pk};")
             assert len(rows) == 1, f"Expected 1 row for pk={pk}, got {len(rows)}"
             assert rows[0].c == pk * 10, f"pk={pk}: expected c={pk * 10}, got c={rows[0].c}"
+
+    await manager.server_stop_gracefully(server.server_id)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_term_exact_after_clean_restart(manager: ManagerClient):
+    """After a graceful stop and restart, the startup snapshot bump must use
+    the exact persisted commit_idx_term (flushed together with commit_idx on
+    shutdown), not the conservative last-snapshot term (SCYLLADB-3357)."""
+    config = {
+        'experimental_features': ['strongly-consistent-tables'],
+        'commitlog_total_space_in_mb': 10000,
+    }
+    server = await manager.server_add(config=config)
+    (cql, hosts) = await manager.get_ready_cql([server])
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        for pk in range(5):
+            await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({pk}, {pk * 10})")
+
+        table_id = await manager.get_table_id(ks.replace('"', ''), "test")
+        tablet_rows = await cql.run_async(f"SELECT raft_group_id FROM system.tablets WHERE table_id = {table_id}")
+        assert len(tablet_rows) == 1
+        group_id = tablet_rows[0].raft_group_id
+        pre_rows = await cql.run_async(f"SELECT commit_idx, commit_idx_term FROM system.raft_groups WHERE shard = 0 AND group_id = {group_id}")
+        assert len(pre_rows) == 1
+        assert pre_rows[0].commit_idx > 0
+        assert pre_rows[0].commit_idx_term > 0
+
+        await manager.server_stop_gracefully(server.server_id)
+        await manager.server_start(server.server_id)
+        await reconnect_driver(manager)
+        cql = manager.get_cql()
+
+        for pk in range(5):
+            rows = await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = {pk};")
+            assert len(rows) == 1, f"Expected 1 row for pk={pk}, got {len(rows)}"
+
+        snp_rows = await cql.run_async(f"SELECT idx, term FROM system.raft_groups_snapshots WHERE shard = 0 AND group_id = {group_id}")
+        assert len(snp_rows) == 1, f"Expected snapshot row for group {group_id}"
+        assert snp_rows[0].idx >= pre_rows[0].commit_idx
+        # No raft snapshot existed before shutdown, so a conservative bump
+        # would write term 0; the exact bump writes commit_idx_term.
+        assert snp_rows[0].term >= pre_rows[0].commit_idx_term, \
+            f"snapshot term {snp_rows[0].term} < persisted commit_idx_term {pre_rows[0].commit_idx_term} — conservative fallback used?"
 
     await manager.server_stop_gracefully(server.server_id)
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1004,6 +1004,12 @@ private:
                 std::ref(_db), std::ref(_mm), std::ref(_sys_ks), std::ref(_feature_service), std::ref(_gossiper),
                 std::ref(_raft_replay_buffer)).get();
             auto stop_groups_manager = defer_verbose_shutdown("strongly consistent groups manager", [this] { _groups_manager.stop().get(); });
+            // On every shard, as in production (main.cc): each shard's database
+            // gets that shard's manager instance. Registered after the stop
+            // deferral so a failure here still stops the manager.
+            _db.invoke_on_all([this] (replica::database& db) {
+                db.set_strong_consistency_groups_manager(_groups_manager.local());
+            }).get();
 
             _sc_coordinator.start(std::ref(_groups_manager), std::ref(_db), std::ref(_gossiper)).get();
             auto stop_sc_coordinator = defer_verbose_shutdown("strongly consistent coordinator", [this] {

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -532,7 +532,7 @@ SEASTAR_TEST_CASE(test_groups_storage_shard_isolation) {
         // Commit index. store_commit_idx() only updates in-memory tracking now;
         // persist_commit_idx() writes it through to system.raft_groups, which is
         // what load_commit_idx() reads.
-        co_await storage0.store_commit_idx(raft::index_t(42));
+        co_await storage0.store_commit_idx(raft::index_t(42), raft::term_t(7));
         co_await storage0.persist_commit_idx();
 
         auto idx0 = co_await storage0.load_commit_idx();

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -538,6 +538,11 @@ SEASTAR_TEST_CASE(test_groups_storage_shard_isolation) {
         auto idx0 = co_await storage0.load_commit_idx();
         BOOST_CHECK_EQUAL(raft::index_t(42), idx0);
 
+        // The exact (idx, term) pair round-trips (SCYLLADB-3357).
+        const auto pair0 = co_await raft_groups_storage::load_commit_idx_and_term(qp, iso_gid, 0);
+        BOOST_CHECK_EQUAL(raft::index_t(42), pair0.idx);
+        BOOST_CHECK_EQUAL(raft::term_t(7), pair0.term);
+
         auto idx1 = co_await storage1.load_commit_idx();
         BOOST_CHECK_EQUAL(raft::index_t(0), idx1);
     });

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -135,6 +135,34 @@ static std::vector<raft::log_entry_ptr> create_test_log(size_t min_entries = 0, 
     return entries;
 }
 
+// Like create_test_log() but with command entries only, randomized the same
+// way (length, first index, payloads, non-decreasing terms all derive from
+// tests::random). acquire_replay_position_handles_for() serves command
+// entries only (see state_machine::apply, which is handed only commands), so
+// tests exercising it use an all-command log rather than create_test_log()'s
+// mixed types.
+static std::vector<raft::log_entry_ptr> create_test_command_log(size_t min_entries = 3, size_t max_entries = 20) {
+    SCYLLA_ASSERT(min_entries >= 1 && min_entries <= max_entries);
+
+    uint64_t first_idx = tests::random::get_int<uint64_t>(1, 1000);
+    size_t count = tests::random::get_int(min_entries, max_entries);
+
+    std::vector<raft::log_entry_ptr> entries;
+    entries.reserve(count);
+    uint64_t term = 1;
+    for (size_t i = 0; i < count; ++i) {
+        raft::command cmd;
+        ser::serialize(cmd, tests::random::get_int(0, 100000));
+        term += tests::random::get_int(0, 3);
+        entries.push_back(make_lw_shared(raft::log_entry{
+            .term = raft::term_t(term),
+            .idx  = raft::index_t(first_idx + i),
+            .data = std::move(cmd)}));
+    }
+    testlog.info("create_test_command_log: {} entries, first_idx={}", entries.size(), first_idx);
+    return entries;
+}
+
 // Factory functions to create storage instances with uniform interface
 static service::raft_sys_table_storage make_sys_table_storage(cql_test_env& env, raft::group_id group_id) {
     return service::raft_sys_table_storage(env.local_qp(), group_id, raft::server_id::create_random_id());
@@ -384,7 +412,7 @@ SEASTAR_TEST_CASE(test_groups_truncate_log) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Truncate the last entry from the log (entries with idx >= entries.back()->idx)
@@ -585,7 +613,7 @@ SEASTAR_TEST_CASE(test_groups_store_and_get_replay_positions) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Acquire replay position handles for all entries.
@@ -612,7 +640,7 @@ SEASTAR_TEST_CASE(test_groups_get_partial_replay_positions) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Get handles only for the first half of entries
@@ -697,7 +725,7 @@ SEASTAR_TEST_CASE(test_groups_truncate_log_then_get_handles_for_remaining) {
         raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
                 cl, dummy_table, {});
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Truncate at the second entry's idx — entries with idx >= entries[1]->idx are removed.
@@ -742,7 +770,7 @@ SEASTAR_TEST_CASE(test_groups_store_snapshot_truncate_tail_then_get_handles) {
             }, raft::is_voter::yes};
         co_await storage.bootstrap(raft::configuration({srv}), false);
 
-        std::vector<raft::log_entry_ptr> entries = create_test_log(3, 20);
+        std::vector<raft::log_entry_ptr> entries = create_test_command_log(3, 20);
         co_await storage.store_log_entries(entries);
 
         // Store snapshot at entries[1]->idx with preserve_log_entries=1.

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -529,8 +529,11 @@ SEASTAR_TEST_CASE(test_groups_storage_shard_isolation) {
         auto vote1 = co_await storage1.load_term_and_vote();
         BOOST_CHECK_EQUAL(raft::term_t{}, vote1.first);
 
-        // Commit index
+        // Commit index. store_commit_idx() only updates in-memory tracking now;
+        // persist_commit_idx() writes it through to system.raft_groups, which is
+        // what load_commit_idx() reads.
         co_await storage0.store_commit_idx(raft::index_t(42));
+        co_await storage0.persist_commit_idx();
 
         auto idx0 = co_await storage0.load_commit_idx();
         BOOST_CHECK_EQUAL(raft::index_t(42), idx0);

--- a/test/raft/raft_sys_table_storage_test.cc
+++ b/test/raft/raft_sys_table_storage_test.cc
@@ -716,6 +716,50 @@ SEASTAR_TEST_CASE(test_groups_acquire_handles_skips_non_command_entries) {
     });
 }
 
+// Test that acquire_replay_position_handles_for rejects a request whose
+// endpoints match the pending command prefix but which diverges in the
+// middle. Guards the full-range index validation: an endpoint-only check
+// would wrongly hand out the [1, 2, 6] handles for a [1, 5, 6] request.
+SEASTAR_TEST_CASE(test_groups_acquire_handles_rejects_prefix_gap) {
+    return do_with_cql_env_strongly_consistent([] (cql_test_env& env) -> future<> {
+        cql3::query_processor& qp = env.local_qp();
+        auto& cl = *env.local_db().commitlog();
+        auto dummy_table = table_id(utils::UUID_gen::get_time_UUID());
+
+        raft_groups_storage storage(qp, gid, raft::server_id::create_random_id(), test_shard,
+                cl, dummy_table, {});
+
+        // Store commands at idx 1, 2, 6.
+        raft::command cmd1, cmd2, cmd6;
+        ser::serialize(cmd1, 1);
+        ser::serialize(cmd2, 2);
+        ser::serialize(cmd6, 6);
+        std::vector<raft::log_entry_ptr> entries = {
+            make_lw_shared(raft::log_entry{.term = raft::term_t(1), .idx = raft::index_t(1), .data = std::move(cmd1)}),
+            make_lw_shared(raft::log_entry{.term = raft::term_t(1), .idx = raft::index_t(2), .data = std::move(cmd2)}),
+            make_lw_shared(raft::log_entry{.term = raft::term_t(1), .idx = raft::index_t(6), .data = std::move(cmd6)}),
+        };
+        co_await storage.store_log_entries(entries);
+
+        // Request [1, 5, 6]: same size, same first and last index as the
+        // pending [1, 2, 6] prefix, but a mismatch at offset 1.
+        raft::command cmd5;
+        ser::serialize(cmd5, 5);
+        raft::log_entry_ptr_list mismatched = {
+            entries[0],
+            make_lw_shared(raft::log_entry{.term = raft::term_t(1), .idx = raft::index_t(5), .data = std::move(cmd5)}),
+            entries[2],
+        };
+        seastar::testing::scoped_no_abort_on_internal_error no_abort;
+        try {
+            storage.acquire_replay_position_handles_for(mismatched);
+            BOOST_FAIL("Expected on_internal_error for mid-prefix index mismatch");
+        } catch (...) {
+            // Expected — pending idx 2 != requested idx 5.
+        }
+    });
+}
+
 // Test truncate_log (head truncation) then verify remaining handles.
 // Store N>=3 entries, truncate at the second entry's idx (removes entries with idx >= second idx),
 // verify only the first entry can produce a valid handle, and later entries cannot.

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1035,7 +1035,7 @@ public:
         co_return _persistence->load_term_and_vote();
     }
 
-    virtual future<> store_commit_idx(raft::index_t) override {
+    virtual future<> store_commit_idx(raft::index_t, raft::term_t) override {
         co_return;
     }
 

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -475,7 +475,7 @@ public:
         auto term_and_vote = std::make_pair(_conf.term, _conf.vote);
         return make_ready_future<std::pair<raft::term_t, raft::server_id>>(term_and_vote);
     }
-    future<> store_commit_idx(raft::index_t) override {
+    future<> store_commit_idx(raft::index_t, raft::term_t) override {
         co_return;
     }
     future<raft::index_t> load_commit_idx() override {


### PR DESCRIPTION
## What & why

Follow-up to #30394. That PR defers `commit_idx` persistence for strongly-consistent
tablet raft groups to the commitlog + memtable-flush cycle, and on startup bumps
`system.raft_groups_snapshots.idx` up to the persisted `commit_idx`. The bump, however,
had to reuse the *last raft-snapshot term* because the exact `term(commit_idx)` was not
recoverable — safe (it errs low), but a peer with higher-term entries then repairs the
replica via InstallSnapshot instead of plain log matching.

This PR persists the term of the entry at `commit_idx` end-to-end so the bump can use
the exact term:

* **`raft::persistence::store_commit_idx(index_t, term_t)`** — the io_fiber passes
  `batch.committed.back()->term`; group0's `raft_sys_table_storage` ignores it.
* **`system.raft_groups.commit_idx_term`** — new static column (SC schema variant only),
  written atomically with `commit_idx` by both persistence paths (the per-batch fake
  mutation and the flush-hook CQL write).
* **`raft_commit_idx_entry.term`** — IDL field appended with a version attribute;
  entries written by older binaries deserialize with the term absent. On replay the
  recovered per-group maximum is now the `(commit_idx, term)` pair and both columns are
  restored into `system.raft_groups`. This covers crash-before-flush even when the raft
  log entry at `commit_idx` itself was already flushed away — the commit_idx entry
  carries its own term.
* **`bump_snapshot_indices`** uses the exact term when known; `commit_idx_term == 0`
  (rows/entries from older binaries) falls back to the previous conservative behavior.

Also included: `database::clear_strong_consistency_groups_manager()` called from
`groups_manager::stop()`, so a memtable flush hook can no longer reach a dangling
manager pointer after teardown (previously safety rested on shutdown ordering alone).

## Tests

* `commitlog_raft_replay_test`: commit term round-trips through the commitlog entry.
* `raft_sys_table_storage_test`: `persist_commit_idx()` writes and
  `load_commit_idx_and_term()` reads the exact pair.
* `test_strong_consistency_commitlog.py`:
  * `test_data_survives_crash` now asserts the post-crash snapshot term is the restored
    `commit_idx_term` (a conservative bump would write term 0 here — no raft snapshot
    exists before the crash — so the assertion is discriminating);
  * new `test_snapshot_term_exact_after_clean_restart` covers the clean-shutdown path
    the same way.

## New tests runtime

| Test | Reported | Wall (incl. test.py harness) |
|------|---------:|-----------------------------:|
| `cluster test_snapshot_term_exact_after_clean_restart` | 3.5 s | 4.9 s |

The other test changes only add assertions to tests that already run
(`test_raft_commitlog_store_log_entries_writes_commit_idx_entry`,
`test_groups_storage_shard_isolation`, `test_data_survives_crash`) and do not
measurably change their runtime. No new test binary or cluster fixture is
introduced. Measured on a 16-core/32-thread dev build with `--mode=dev`.

## Notes for reviewers

* **Based on #30394** — review only the last 7 commits.
* Commit mapping to the SCYLLADB-3357 plan: interface (1), schema (2, standalone as
  agreed), tracking+persist (3), commitlog entry + replay catch-up (4), exact bump (5),
  tests (6). The index-level half of the replay catch-up already landed in #30394.
* The last commit (pointer hardening) is independent of SCYLLADB-3357.

Fixes: SCYLLADB-3357