### PR TITLE
sstables_loader: Support 'prefix' in tablet-aware-restore API

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -556,12 +556,6 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
         auto dc = rjson::to_string_view(location["datacenter"]);
         auto prefix = location.HasMember("prefix") ? rjson::to_string_view(location["prefix"]) : std::string_view{};
 
-        // FIXME: once manifest_prefix handling is reworked to combine with
-        // the location prefix, this restriction can be lifted.
-        if (!prefix.empty()) {
-            throw httpd::bad_param_exception("backup location 'prefix' must be empty for now");
-        }
-
         if (!location.HasMember("manifests") || !location["manifests"].IsArray()) {
             throw httpd::bad_param_exception("backup location entry must have 'manifests' array");
         }
@@ -574,8 +568,8 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
             throw httpd::bad_param_exception("backup location 'manifests' array must not be empty");
         }
 
-        apilog.info("Tablet restore for {}:{} called. Parameters: snapshot={} datacenter={} endpoint={} bucket={} manifests_count={}",
-                    keyspace, table, snapshot, dc, endpoint, bucket, manifests.size());
+        apilog.info("Tablet restore for {}:{} called. Parameters: snapshot={} datacenter={} endpoint={} bucket={} prefix={} manifests_count={}",
+                    keyspace, table, snapshot, dc, endpoint, bucket, prefix, manifests.size());
 
         auto table_id = validate_table(ctx.db.local(), keyspace, table);
         auto task_id = co_await sst_loader.local().restore_tablets(table_id, keyspace, table, snapshot, sstring(endpoint), sstring(bucket), sstring(prefix), std::move(manifests));

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -956,6 +956,15 @@ future<sstables::shared_sstable> sstables_loader::attach_sstable(table_id tid, c
     co_return sst;
 }
 
+// Joins a backup location's prefix with a path that is relative to it, the same
+// way cluster-wide backup composes its object keys (db/snapshot/cluster_backup.cc).
+static sstring join_path(std::string_view prefix, std::string_view relative_path) {
+    if (prefix.empty()) {
+        return sstring(relative_path);
+    }
+    return fmt::format("{}/{}", prefix, relative_path);
+}
+
 future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid, locator::tablet_metadata_guard& guard) {
     auto& tmap = guard.get_tablet_map();
 
@@ -1016,7 +1025,8 @@ future<> sstables_loader::download_tablet_sstables(locator::global_tablet_id tid
 
     std::unordered_map<sstring, std::vector<sstring>> toc_names_by_prefix;
     for (const auto& e : fully) {
-        toc_names_by_prefix[e.prefix].emplace_back(e.toc_name);
+        // e.prefix is relative to the backup location's own prefix (snapshot_remote_locations.prefix).
+        toc_names_by_prefix[join_path(snapshot_info.prefix, e.prefix)].emplace_back(e.toc_name);
     }
 
     auto ep_type = _storage_manager.get_endpoint_type(snapshot_info.endpoint);
@@ -1202,7 +1212,7 @@ static future<manifest_summary> process_manifest(input_stream<char>& is, sstring
     co_return manifest_summary{tablet_count, sstables->Size()};
 }
 
-future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl) {
+future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring prefix, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl) {
     if (manifest_prefixes.empty()) {
         throw std::invalid_argument("manifest prefixes list must not be empty");
     }
@@ -1216,8 +1226,8 @@ future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::sto
     size_t nr_sstables = 0;
 
     co_await seastar::max_concurrent_for_each(manifest_prefixes, 16, [&] (const sstring& manifest_prefix) {
-        // Download the manifest JSON file
-        sstables::object_name name(bucket, manifest_prefix);
+        // Manifest entries are relative to the backup location's prefix, same as start_restore.
+        sstables::object_name name(bucket, join_path(prefix, manifest_prefix));
         auto source = client->make_download_source(name);
         return seastar::with_closeable(input_stream<char>(std::move(source)), [&] (input_stream<char>& is) {
             return process_manifest(is, keyspace, table, expected_snapshot_name, manifest_prefix, sys_dist_ks, cl).then([&](manifest_summary ms) {
@@ -1364,7 +1374,7 @@ protected:
 };
 
 future<tasks::task_id> sstables_loader::restore_tablets(table_id tid, sstring keyspace, sstring table, sstring snap_name, sstring endpoint, sstring bucket, sstring prefix, utils::chunked_vector<sstring> manifests) {
-    auto summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, snap_name, std::move(manifests));
+    auto summary = co_await populate_snapshot_sstables_from_manifests(_storage_manager, _sys_dist_ks, keyspace, table, endpoint, bucket, prefix, snap_name, std::move(manifests));
 
     auto datacenter = _db.local().get_token_metadata().get_topology().get_datacenter();
 

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -200,4 +200,4 @@ struct manifest_summary {
     size_t nr_sstables;
 };
 
-future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl = db::consistency_level::EACH_QUORUM);
+future<manifest_summary> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring keyspace, sstring table, sstring endpoint, sstring bucket, sstring prefix, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl = db::consistency_level::EACH_QUORUM);

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -364,10 +364,10 @@ SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_t
             auto prefix = backup(env, ep, bucket).get();
             auto manifest_path = prefix + "/manifest.json";
 
-            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "unexpected_snapshot", {manifest_path}, db::consistency_level::ONE).get(), std::runtime_error);;
+            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "", "unexpected_snapshot", {manifest_path}, db::consistency_level::ONE).get(), std::runtime_error);;
 
             // populate system_distributed.snapshot_sstables with the content of the snapshot manifest
-            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "snapshot", {manifest_path}, db::consistency_level::ONE).get();
+            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), "ks", "cf", ep, bucket, "", "snapshot", {manifest_path}, db::consistency_level::ONE).get();
 
             check_snapshot_sstables(env).get();
     }, false, db_cfg_ptr, 10);

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -764,7 +764,11 @@ async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_s
 
         snap_name, _ = await take_snapshot(ks, servers, manager, logger)
 
-        await asyncio.gather(*(do_backup(s, snap_name, f'{s.server_id}/{snap_name}/{cf}', ks, cf, object_storage, manager, logger) for cf in tables for s in servers))
+        # Use a common prefix across all backup locations so the tablet-aware-restore
+        # API's own 'prefix' parameter (relative to which manifests are resolved) is
+        # exercised, not just the degenerate empty-prefix case.
+        restore_prefix = f'restore-prefix/{snap_name}'
+        await asyncio.gather(*(do_backup(s, snap_name, f'{restore_prefix}/{s.server_id}/{cf}', ks, cf, object_storage, manager, logger) for cf in tables for s in servers))
 
     # Restore all tables into a fresh keyspace, distributing restore calls
     # round-robin across num_restore_nodes nodes.
@@ -776,8 +780,8 @@ async def test_restore_tablets(build_mode: str, manager: ManagerClient, object_s
         async def restore_table(idx, cf):
             node = restore_nodes[idx % len(restore_nodes)]
             logger.info(f'Restore table {cf} via {node.ip_addr}')
-            manifests = [f'{s.server_id}/{snap_name}/{cf}/manifest.json' for s in servers]
-            tid = await manager.api.restore_tablets(node.ip_addr, ks, cf, snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
+            manifests = [f'{s.server_id}/{cf}/manifest.json' for s in servers]
+            tid = await manager.api.restore_tablets(node.ip_addr, ks, cf, snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests, restore_prefix)
             status = await manager.api.wait_task(node.ip_addr, tid)
             assert (status is not None) and (status['state'] == 'done'), f"Restore of {cf} via {node.ip_addr} failed: {status}"
             assert status['progress_total'] > 0

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -444,7 +444,7 @@ class ScyllaRESTAPIClient:
             params['scope'] = scope
         return await self.client.post_json(f"/storage_service/restore", host=node_ip, params=params, json=sstables)
 
-    async def restore_tablets(self, node_ip: str, ks: str, cf: str, snap: str, datacenter: str, endpoint: str, bucket: str, manifests) -> str:
+    async def restore_tablets(self, node_ip: str, ks: str, cf: str, snap: str, datacenter: str, endpoint: str, bucket: str, manifests, prefix: str = '') -> str:
         """Restore tablets from a backup location"""
         params = {
             "keyspace": ks,
@@ -456,6 +456,7 @@ class ScyllaRESTAPIClient:
                 "datacenter": datacenter,
                 "endpoint": endpoint,
                 "bucket": bucket,
+                "prefix": prefix,
                 "manifests": manifests
             }
         ]


### PR DESCRIPTION
The tablet_aware_restore handler used to reject any request with a non-empty backup_location 'prefix', always assuming manifest entries were absolute object keys under the bucket root.

Thread 'prefix' from restore_tablets() into
populate_snapshot_sstables_from_manifests(), joining it with each manifest entry the same way start_restore already does, so manifests are resolved relative to the backup location's prefix.

Fix download_tablet_sstables() to actually combine snapshot_remote_locations.prefix with each row's own snapshot_sstables.prefix instead of silently discarding the former, closing the last gap that made a non-empty prefix unusable end to end.

API sugar for the recently added tablet-aware-restore, not backporting

The corresponding swagger update is in #30942