### PR TITLE
cql3: allow naming the IN bind variable to use lowercase 

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -327,7 +327,7 @@ query returns [std::unique_ptr<raw::parsed_statement> stmnt]
     ;
 
 cqlStatement returns [std::unique_ptr<raw::parsed_statement> stmt]
-    @after{ if (stmt) { stmt->set_bound_variables(_bind_variable_names); } }
+    @after{ if (stmt) { stmt->set_bound_variables(_bind_variable_names, _dialect); } }
     : st1= selectStatement             { $stmt = std::move(st1); }
     | st2= insertStatement             { $stmt = std::move(st2); }
     | st3= updateStatement             { $stmt = std::move(st3); }

--- a/cql3/dialect.hh
+++ b/cql3/dialect.hh
@@ -10,6 +10,9 @@ namespace cql3 {
 struct dialect {
     bool duplicate_bind_variable_names_refer_to_same_variable = true;  // if :a is found twice in a query, the two references are to the same variable (see #15559)
     unsigned max_relations_in_where_clause = 100; // maximum number of relations in a WHERE clause
+    // the bind variable of an IN restriction is named "IN(column)" (if false, the
+    // operator is spelled in lowercase, as Cassandra spells it)
+    bool in_bind_variable_name_uses_uppercase_operator = true;
     bool operator==(const dialect&) const = default;
 };
 
@@ -19,6 +22,7 @@ internal_dialect() {
     return dialect{
         .duplicate_bind_variable_names_refer_to_same_variable = true,
         .max_relations_in_where_clause = 100,
+        .in_bind_variable_name_uses_uppercase_operator = true,
     };
 }
 
@@ -30,7 +34,7 @@ struct fmt::formatter<cql3::dialect> {
 
     template <typename FormatContext>
     auto format(const cql3::dialect& d, FormatContext& ctx) const {
-        return fmt::format_to(ctx.out(), "cql3::dialect{{duplicate_bind_variable_names_refer_to_same_variable={}, max_relations_in_where_clause={}}}",
-                d.duplicate_bind_variable_names_refer_to_same_variable, d.max_relations_in_where_clause);
+        return fmt::format_to(ctx.out(), "cql3::dialect{{duplicate_bind_variable_names_refer_to_same_variable={}, max_relations_in_where_clause={}, in_bind_variable_name_uses_uppercase_operator={}}}",
+                d.duplicate_bind_variable_names_refer_to_same_variable, d.max_relations_in_where_clause, d.in_bind_variable_name_uses_uppercase_operator);
     }
 };

--- a/cql3/expr/expr-utils.hh
+++ b/cql3/expr/expr-utils.hh
@@ -10,6 +10,7 @@
 #include "utils/interval.hh"
 #include "cql3/expr/restrictions.hh"
 #include "cql3/assignment_testable.hh"
+#include "cql3/dialect.hh"
 #include "cql3/statements/bound.hh"
 
 namespace cql3 {
@@ -187,12 +188,20 @@ expression adjust_for_collection_as_maps(const expression& e);
 extern expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
 std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default = false);
 
+// Like prepare_expression, but for a position where a relation is allowed, like the IF
+// condition of an LWT statement. A relation is named after the dialect it is prepared
+// under, so the dialect the statement was parsed under has to be passed along, and the
+// functions above, which cannot receive one, reject a relation instead of naming it under
+// a made up dialect. The dialect of a parsed statement is available as
+// prepare_context::get_dialect().
+extern expression prepare_expression_allowing_relations(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, dialect d);
+
 // Check that a prepared expression has no aggregate functions. Throws on error.
 void verify_no_aggregate_functions(const expression& expr, std::string_view context_for_errors);
 
 // Prepares a binary operator received from the parser.
 // Does some basic type checks but no advanced validation.
-extern binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, const schema& table_schema);
+extern binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, const schema& table_schema, const dialect& d);
 
 // Pre-compile any constant LIKE patterns and return equivalent expression
 expression optimize_like(const expression& e);

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -93,9 +93,17 @@ struct prepare_memo {
 // same memo by reference, so it is never global.
 static std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default, prepare_memo& memo, bool allow_unresolved = false);
 static assignment_testable::test_result test_assignment(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo);
-static expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo);
+static expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo, const dialect* d = nullptr);
 static assignment_testable::test_result test_assignment_all(const std::vector<expression>& to_test, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo);
 static ::shared_ptr<assignment_testable> as_assignment_testable(expression e, std::optional<data_type> type_opt, prepare_memo& memo);
+
+// A relation is named after the dialect it is prepared under, so the dialect travels along
+// the expressions that can contain a relation and nowhere else - what a relation is built
+// from is an ordinary expression, which cannot contain one. The dialect is null when
+// preparing an expression that is not allowed to contain a relation, which then refuses one
+// rather than naming it under a dialect nobody chose.
+static std::optional<expression> try_prepare_expression_allowing_relations(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default, prepare_memo& memo, const dialect* d);
+static std::optional<expression> prepare_relation(const binary_operator& binop, data_dictionary::database db, const schema* schema_opt, const lw_shared_ptr<column_specification>& receiver, const dialect* d);
 
 struct inferred_elements {
     data_type element_type;
@@ -1571,7 +1579,8 @@ std::optional<expression> prepare_conjunction(const conjunction& conj,
                                               const sstring& keyspace,
                                               const schema* schema_opt,
                                               lw_shared_ptr<column_specification> receiver,
-                                              prepare_memo& memo) {
+                                              prepare_memo& memo,
+                                              const dialect* d) {
     if (receiver.get() != nullptr && receiver->type->without_reversed().get_kind() != abstract_type::kind::boolean) {
         throw exceptions::invalid_request_exception(
             format("AND conjunction produces a boolean value, which doesn't match the type: {} of {}",
@@ -1597,7 +1606,7 @@ std::optional<expression> prepare_conjunction(const conjunction& conj,
     bool all_terminal = true;
     for (const expression& child : conj.children) {
         std::optional<expression> prepared_child =
-            try_prepare_expression(child, db, keyspace, schema_opt, child_receiver, /*infer_default=*/false, memo);
+            try_prepare_expression_allowing_relations(child, db, keyspace, schema_opt, child_receiver, /*infer_default=*/false, memo, d);
         if (!prepared_child.has_value()) {
             throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", child));
         }
@@ -1681,6 +1690,39 @@ prepare_column_mutation_attribute(
     };
 }
 
+static std::optional<expression>
+prepare_relation(const binary_operator& binop, data_dictionary::database db, const schema* schema_opt, const lw_shared_ptr<column_specification>& receiver, const dialect* d) {
+    if (receiver.get() != nullptr && &receiver->type->without_reversed() != boolean_type.get()) {
+        throw exceptions::invalid_request_exception(
+            format("binary operator produces a boolean value, which doesn't match the type: {} of {}",
+                   receiver->type->name(), receiver->name->text()));
+    }
+
+    if (!d) {
+        on_internal_error(expr_logger, "preparing a relation in an expression that is not allowed to contain one");
+    }
+    binary_operator result = prepare_binary_operator(binop, db, *schema_opt, *d);
+
+    // A binary operator where both sides of the equation are known can be evaluated to a boolean value.
+    // This only applies to operators in the CQL order, operations in the clustering order should only be
+    // of form (clustering_column1, colustering_column2) < SCYLLA_CLUSTERING_BOUND(1, 2).
+    if (is<constant>(result.lhs) && is<constant>(result.rhs) && result.order == comparison_order::cql) {
+        return constant(evaluate(result, query_options::DEFAULT), boolean_type);
+    }
+    return result;
+}
+
+static std::optional<expression>
+try_prepare_expression_allowing_relations(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default, prepare_memo& memo, const dialect* d) {
+    if (auto* conj = as_if<conjunction>(&expr)) {
+        return prepare_conjunction(*conj, db, keyspace, schema_opt, std::move(receiver), memo, d);
+    }
+    if (auto* binop = as_if<binary_operator>(&expr)) {
+        return prepare_relation(*binop, db, schema_opt, receiver, d);
+    }
+    return try_prepare_expression(expr, db, keyspace, schema_opt, std::move(receiver), infer_default, memo);
+}
+
 std::optional<expression>
 try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default) {
     prepare_memo memo;
@@ -1703,21 +1745,7 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             return value;
         },
         [&] (const binary_operator& binop) -> std::optional<expression> {
-            if (receiver.get() != nullptr && &receiver->type->without_reversed() != boolean_type.get()) {
-                throw exceptions::invalid_request_exception(
-                    format("binary operator produces a boolean value, which doesn't match the type: {} of {}",
-                           receiver->type->name(), receiver->name->text()));
-            }
-
-            binary_operator result = prepare_binary_operator(binop, db, *schema_opt);
-
-            // A binary operator where both sides of the equation are known can be evaluated to a boolean value.
-            // This only applies to operators in the CQL order, operations in the clustering order should only be
-            // of form (clustering_column1, colustering_column2) < SCYLLA_CLUSTERING_BOUND(1, 2).
-            if (is<constant>(result.lhs) && is<constant>(result.rhs) && result.order == comparison_order::cql) {
-                return constant(evaluate(result, query_options::DEFAULT), boolean_type);
-            }
-            return result;
+            return prepare_relation(binop, db, schema_opt, receiver, /*d=*/nullptr);
         },
         [&] (const unary_operator& uo) -> std::optional<expression> {
             // Prepare the operand; unary_operator preserves its operand's type.
@@ -1733,7 +1761,7 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             return result;
         },
         [&] (const conjunction& conj) -> std::optional<expression> {
-            return prepare_conjunction(conj, db, keyspace, schema_opt, receiver, memo);
+            return prepare_conjunction(conj, db, keyspace, schema_opt, receiver, memo, /*d=*/nullptr);
         },
         [] (const column_value& cv) -> std::optional<expression> {
             return cv;
@@ -2020,16 +2048,22 @@ prepare_expression(const expression& expr, data_dictionary::database db, const s
     return prepare_expression(expr, db, keyspace, schema_opt, std::move(receiver), memo);
 }
 
+expression
+prepare_expression_allowing_relations(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, dialect d) {
+    prepare_memo memo;
+    return prepare_expression(expr, db, keyspace, schema_opt, std::move(receiver), memo, &d);
+}
+
 static expression
-prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
+prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo, const dialect* d) {
     // Pass 1: contextual typing. Expressions without a type (untyped constants,
     // collection literals) yield nullopt when no receiver constrains them.
-    auto e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, receiver, /*infer_default=*/false, memo);
+    auto e_opt = try_prepare_expression_allowing_relations(expr, db, keyspace, schema_opt, receiver, /*infer_default=*/false, memo, d);
     // Pass 2: default-type inference. The same prepare is retried with infer_default
     // enabled, so untyped constants and collection literals fall back to a default
     // type at the point where no receiver is available.
     if (!e_opt) {
-        e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, receiver, /*infer_default=*/true, memo);
+        e_opt = try_prepare_expression_allowing_relations(expr, db, keyspace, schema_opt, receiver, /*infer_default=*/true, memo, d);
     }
     if (!e_opt) {
         throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", expr));
@@ -2181,12 +2215,22 @@ static lw_shared_ptr<column_specification> get_lhs_receiver(const expression& pr
 
 // Given type of LHS and the operation finds the expected type of RHS.
 // The type will be the same as LHS for simple operations like =, but it will be different for more complex ones like IN or CONTAINS.
-static lw_shared_ptr<column_specification> get_rhs_receiver(lw_shared_ptr<column_specification>& lhs_receiver, oper_t oper) {
+static lw_shared_ptr<column_specification> get_rhs_receiver(lw_shared_ptr<column_specification>& lhs_receiver, oper_t oper, const dialect& d) {
     const data_type lhs_type = lhs_receiver->type->underlying_type();
 
     if (oper == oper_t::IN || oper == oper_t::NOT_IN) {
         data_type rhs_receiver_type = list_type_impl::get_instance(std::move(lhs_type), false);
-        auto in_name = ::make_shared<column_identifier>(format("{}({})", oper, lhs_receiver->name->text()), true);
+        // Cassandra spells the operator in lowercase. Applications bind by this name,
+        // so the case cannot change under them and is part of the dialect. The dialect
+        // is also part of the prepared statement cache key, so statements prepared
+        // under different dialects get separate entries.
+        std::string_view oper_name;
+        if (d.in_bind_variable_name_uses_uppercase_operator) {
+            oper_name = (oper == oper_t::IN) ? "IN" : "NOT IN";
+        } else {
+            oper_name = (oper == oper_t::IN) ? "in" : "not in";
+        }
+        auto in_name = ::make_shared<column_identifier>(fmt::format("{}({})", oper_name, lhs_receiver->name->text()), true);
         return make_lw_shared<column_specification>(lhs_receiver->ks_name,
                                                     lhs_receiver->cf_name,
                                                     in_name,
@@ -2300,7 +2344,7 @@ optimize_like(const expression& e) {
     });
 }
 
-binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, const schema& table_schema) {
+binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::database db, const schema& table_schema, const dialect& d) {
     std::optional<expression> prepared_lhs_opt = try_prepare_expression(binop.lhs, db, table_schema.ks_name(), &table_schema, {});
     if (!prepared_lhs_opt) {
         throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", binop.lhs));
@@ -2312,7 +2356,7 @@ binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::
         throw exceptions::invalid_request_exception(fmt::format("Duration type is unordered for {}", lhs_receiver->name));
     }
 
-    lw_shared_ptr<column_specification> rhs_receiver = get_rhs_receiver(lhs_receiver, binop.op);
+    lw_shared_ptr<column_specification> rhs_receiver = get_rhs_receiver(lhs_receiver, binop.op, d);
     expression prepared_rhs = prepare_expression(binop.rhs, db, table_schema.ks_name(), &table_schema, rhs_receiver);
 
     // IS NOT NULL requires an additional check that the RHS is NULL.

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -215,7 +215,7 @@ binary_operator validate_and_prepare_new_restriction(const binary_operator& rest
     preliminary_binop_vaidation_checks(restriction);
 
     // Prepare the restriction
-    binary_operator prepared_binop = prepare_binary_operator(restriction, db, *schema);
+    binary_operator prepared_binop = prepare_binary_operator(restriction, db, *schema, ctx.get_dialect());
     expr::verify_no_aggregate_functions(prepared_binop, "WHERE clause");
 
     // Fill prepare context

--- a/cql3/prepare_context.cc
+++ b/cql3/prepare_context.cc
@@ -8,12 +8,16 @@
  * SPDX-License-Identifier: (LicenseRef-ScyllaDB-Source-Available-1.1 and Apache-2.0)
  */
 
+#include <seastar/core/on_internal_error.hh>
+
 #include "cql3/prepare_context.hh"
 #include "cql3/column_identifier.hh"
 #include "cql3/column_specification.hh"
 #include "exceptions/exceptions.hh"
 
 namespace cql3 {
+
+static logging::logger prepare_context_logger("prepare_context");
 
 size_t prepare_context::bound_variables_size() const {
     return _variable_names.size();
@@ -65,14 +69,22 @@ void prepare_context::add_variable_specification(int32_t bind_index, lw_shared_p
     _variable_specs[bind_index] = spec;
 }
 
-void prepare_context::set_bound_variables(const std::vector<shared_ptr<column_identifier>>& bind_variable_names) {
+void prepare_context::set_bound_variables(const std::vector<shared_ptr<column_identifier>>& bind_variable_names, dialect d) {
     _variable_names = bind_variable_names;
     _variable_specs.clear();
     _targets.clear();
+    _dialect = d;
 
     const size_t bn_size = bind_variable_names.size();
     _variable_specs.resize(bn_size);
     _targets.resize(bn_size);
+}
+
+const dialect& prepare_context::get_dialect() const {
+    if (!_dialect) {
+        on_internal_error(prepare_context_logger, "the dialect of the prepared statement was never set");
+    }
+    return *_dialect;
 }
 
 void prepare_context::clear_pk_function_calls_cache() {

--- a/cql3/prepare_context.hh
+++ b/cql3/prepare_context.hh
@@ -17,6 +17,7 @@
 #include <vector>
 #include <stddef.h>
 #include "cql3/expr/expression.hh"
+#include "cql3/dialect.hh"
 
 class schema;
 
@@ -56,6 +57,13 @@ private:
     // the function call results.
     bool _processing_pk_restrictions = false;
 
+    // The dialect the statement is parsed and prepared under. Captured when the
+    // request starts being processed, so that everything the prepare step decides
+    // is decided under a single value, even if the node configuration changes
+    // while the statement is being prepared. There is no default: preparing under
+    // a dialect nobody chose is worse than not preparing at all.
+    std::optional<dialect> _dialect;
+
 public:
 
     prepare_context() = default;
@@ -70,7 +78,12 @@ public:
 
     void add_variable_specification(int32_t bind_index, lw_shared_ptr<column_specification> spec);
 
-    void set_bound_variables(const std::vector<shared_ptr<column_identifier>>& bind_variable_names);
+    // Hands over what the parser knows and the prepare step needs. The dialect is
+    // part of it, so that a statement built rather than parsed cannot reach the
+    // prepare step without having said which dialect it is prepared under.
+    void set_bound_variables(const std::vector<shared_ptr<column_identifier>>& bind_variable_names, dialect d);
+
+    const dialect& get_dialect() const;
 
     void clear_pk_function_calls_cache();
 

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -205,7 +205,10 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     auto parameters = make_lw_shared<raw::select_statement::parameters>(raw::select_statement::parameters::orderings_type(), false, true);
     raw::select_statement raw_select(_base_name, std::move(parameters), _select_clause, _where_clause, std::nullopt, std::nullopt, {}, std::make_unique<cql3::attributes::raw>());
     raw_select.prepare_keyspace(keyspace());
-    raw_select.set_bound_variables({});
+    // The view definition is rebuilt from the schema and prepared again on every read,
+    // under the internal dialect, so validating it here under the dialect of the
+    // connection that happens to create the view would validate something else.
+    raw_select.set_bound_variables({}, internal_dialect());
 
     cql_stats ignored;
     auto prepared = raw_select.prepare(db, ignored, default_cql_config, true);

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -680,8 +680,8 @@ update_for_lwt_null_equality_rules(const expr::expression& e) {
 
 static
 expr::expression
-column_condition_prepare(const expr::expression& expr, data_dictionary::database db, const sstring& keyspace, const schema& schema){
-    auto prepared = expr::prepare_expression(expr, db, keyspace, &schema, make_lw_shared<column_specification>("", "", make_shared<column_identifier>("IF condition", true), boolean_type));
+column_condition_prepare(const expr::expression& expr, data_dictionary::database db, const sstring& keyspace, const schema& schema, const dialect& d){
+    auto prepared = expr::prepare_expression_allowing_relations(expr, db, keyspace, &schema, make_lw_shared<column_specification>("", "", make_shared<column_identifier>("IF condition", true), boolean_type), d);
     expr::verify_no_aggregate_functions(prepared, "IF clause");
 
     expr::for_each_expression<expr::column_value>(prepared, [] (const expr::column_value& cval) {
@@ -734,7 +734,7 @@ modification_statement::prepare_conditions(data_dictionary::database db, const s
             throwing_assert(!_if_not_exists);
             stmt.set_if_exist_condition();
         } else {
-            stmt._condition = column_condition_prepare(*_conditions, db, keyspace(), schema);
+            stmt._condition = column_condition_prepare(*_conditions, db, keyspace(), schema, ctx.get_dialect());
             expr::fill_prepare_context(stmt._condition, ctx);
             stmt.analyze_condition(stmt._condition);
         }

--- a/cql3/statements/raw/parsed_statement.cc
+++ b/cql3/statements/raw/parsed_statement.cc
@@ -34,8 +34,8 @@ const prepare_context& parsed_statement::get_prepare_context() const {
 }
 
 // Used by the parser and preparable statement
-void parsed_statement::set_bound_variables(const std::vector<::shared_ptr<column_identifier>>& bound_names) {
-    _prepare_ctx.set_bound_variables(bound_names);
+void parsed_statement::set_bound_variables(const std::vector<::shared_ptr<column_identifier>>& bound_names, dialect d) {
+    _prepare_ctx.set_bound_variables(bound_names, d);
 }
 
 }

--- a/cql3/statements/raw/parsed_statement.hh
+++ b/cql3/statements/raw/parsed_statement.hh
@@ -41,7 +41,7 @@ public:
     prepare_context& get_prepare_context();
     const prepare_context& get_prepare_context() const;
 
-    void set_bound_variables(const std::vector<::shared_ptr<column_identifier>>& bound_names);
+    void set_bound_variables(const std::vector<::shared_ptr<column_identifier>>& bound_names, dialect d);
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) = 0;
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -1601,6 +1601,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Use on a new, parallel algorithm for performing aggregate queries.")
     , cql_duplicate_bind_variable_names_refer_to_same_variable(this, "cql_duplicate_bind_variable_names_refer_to_same_variable", liveness::LiveUpdate, value_status::Used, true,
             "A bind variable that appears twice in a CQL query refers to a single variable (if false, no name matching is performed).")
+    , cql_in_bind_variable_name_uses_uppercase_operator(this, "cql_in_bind_variable_name_uses_uppercase_operator", liveness::LiveUpdate, value_status::Used, true,
+            "Name the bind variable of an IN restriction \"IN(column)\" (if false, the operator is spelled in lowercase, \"in(column)\").")
     , max_relations_in_where_clause(this, "max_relations_in_where_clause", liveness::LiveUpdate, value_status::Used, 100,
             "Maximum number of relations allowed in a WHERE clause. Queries with too many relations can cause quadratic complexity.")
     , select_internal_page_size(this, "select_internal_page_size", liveness::LiveUpdate, value_status::Used, 10000,

--- a/db/config.hh
+++ b/db/config.hh
@@ -508,6 +508,7 @@ public:
     named_value<bool> enable_cql_config_updates;
     named_value<bool> enable_parallelized_aggregation;
     named_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
+    named_value<bool> cql_in_bind_variable_name_uses_uppercase_operator;
     named_value<uint32_t> max_relations_in_where_clause;
     named_value<uint32_t> select_internal_page_size;
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -129,7 +129,7 @@ cql3::statements::select_statement& view_info::select_statement(data_dictionary:
             raw = cql3::util::build_select_statement(base_name(), where_clause(), include_all_columns(), _schema.all_columns());
         }
         raw->prepare_keyspace(_schema.ks_name());
-        raw->set_bound_variables({});
+        raw->set_bound_variables({}, cql3::internal_dialect());
         cql3::cql_stats ignored;
         auto prepared = raw->prepare(db, ignored, cql3::default_cql_config, true);
         _select_statement = static_pointer_cast<cql3::statements::select_statement>(prepared->statement);

--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -385,6 +385,40 @@ is referenced twice), ScyllaDB and Cassandra treat it differently:
 ScyllaDB can revert to the Cassandra treatment by setting the configuration item
 `cql_duplicate_bind_variable_names_refer_to_same_variable` to `false`.
 
+### Name of the bind variable of an IN restriction
+
+The right-hand side of an `IN` restriction (example: `WHERE c IN ?`) is a synthetic bind
+variable whose name is reported to drivers in the prepared statement metadata. Cassandra
+names it `in(column)`, while ScyllaDB names it `IN(column)`.
+
+Applications that bind this variable by name, and want the Cassandra spelling, can get it
+by setting the configuration item `cql_in_bind_variable_name_uses_uppercase_operator` to
+`false`.
+
+The name is chosen when a statement is prepared, and the item is part of the prepared
+statement cache key. Statements prepared after a change on a running node therefore get
+fresh cache entries and report the new name. Executing a statement prepared under the
+previous setting makes the node report it as unknown, upon which drivers prepare it
+again transparently.
+
+To change the item on a live cluster, set it on every node and have applications pick up
+the new name from the refreshed prepared statement metadata. Until every node has been
+switched, different coordinators can report different names for the same query, so
+applications should be able to bind either spelling while the change is being rolled out.
+
+Leaving nodes with different values for longer than that is not supported. Most drivers
+resolve the name to a position when the values are bound, using the metadata of the node the
+statement was prepared against, and then send the values positionally; those are unaffected
+by a coordinator that would have spelled the name differently. A driver that instead sends
+the names together with the values leaves the matching to the coordinator, which compares
+them against its own copy of the prepared statement. A request reaching a node that prepared
+the statement under the other spelling then fails with
+`Missing value for bind marker with name: ...` instead of falling back to the other spelling.
+
+The `NOT IN` restriction is a ScyllaDB extension with no Cassandra counterpart, and its
+bind variable follows the same convention: `NOT IN(column)`, or `not in(column)` when the
+operator is spelled in lowercase.
+
 ### Lists elements for filtering
 
 Subscripting a list in a WHERE clause is supported as are maps.

--- a/idl/forward_cql.idl.hh
+++ b/idl/forward_cql.idl.hh
@@ -17,6 +17,7 @@ namespace cql3 {
 struct dialect {
     bool duplicate_bind_variable_names_refer_to_same_variable;
     unsigned max_relations_in_where_clause;
+    bool in_bind_variable_name_uses_uppercase_operator [[version 2026.4]] = true;
 };
 
 }

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5986,6 +5986,41 @@ SEASTAR_TEST_CASE(test_bind_variable_type_checking_disabled) {
     }, cql_test_config{db_config});
 }
 
+static sstring prepared_variable_names(cql_test_env& e, const sstring& query) {
+    const auto prepared = e.local_qp().get_prepared(e.prepare(query).get());
+    BOOST_REQUIRE(prepared);
+    sstring names;
+    for (const auto& spec : prepared->bound_names) {
+        if (!names.empty()) {
+            names += ", ";
+        }
+        names += spec->name->text();
+    }
+    return names;
+}
+
+SEASTAR_TEST_CASE(test_in_bind_variable_name) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        e.execute_cql("CREATE TABLE tab (p int, c int, v int, PRIMARY KEY (p, c))").get();
+
+        BOOST_REQUIRE_EQUAL(prepared_variable_names(e, "SELECT * FROM tab WHERE p = ? AND c IN ?"), "p, IN(c)");
+        // The IF condition of an LWT statement is prepared as an expression rather than
+        // as a restriction, so the name is reached along a different path.
+        BOOST_REQUIRE_EQUAL(prepared_variable_names(e, "UPDATE tab SET v = 1 WHERE p = 0 AND c = 0 IF v IN ?"), "IN(v)");
+    });
+}
+
+SEASTAR_TEST_CASE(test_in_bind_variable_name_lowercase_operator) {
+    auto db_config = make_shared<db::config>();
+    db_config->cql_in_bind_variable_name_uses_uppercase_operator(false);
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        e.execute_cql("CREATE TABLE tab (p int, c int, v int, PRIMARY KEY (p, c))").get();
+
+        BOOST_REQUIRE_EQUAL(prepared_variable_names(e, "SELECT * FROM tab WHERE p = ? AND c IN ?"), "p, in(c)");
+        BOOST_REQUIRE_EQUAL(prepared_variable_names(e, "UPDATE tab SET v = 1 WHERE p = 0 AND c = 0 IF v IN ?"), "in(v)");
+    }, cql_test_config{db_config});
+}
+
 SEASTAR_TEST_CASE(test_setting_synchronous_updates_property) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         e.execute_cql("create table base (k int, v int, primary key (k));").get();

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -4036,8 +4036,8 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_empty) {
 
     expression expected = make_bool_const(true);
 
-    BOOST_REQUIRE_EQUAL(prepare_expression(conj_empty, db, "test_ks", table_schema.get(), nullptr), expected);
-    BOOST_REQUIRE_EQUAL(prepare_expression(conj_empty, db, "test_ks", table_schema.get(), make_receiver(boolean_type)),
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(conj_empty, db, "test_ks", table_schema.get(), nullptr, internal_dialect()), expected);
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(conj_empty, db, "test_ks", table_schema.get(), make_receiver(boolean_type), internal_dialect()),
                         expected);
 }
 
@@ -4052,7 +4052,7 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_empty_with_int_receiver) {
 
     ::lw_shared_ptr<column_specification> int_receiver = make_receiver(int32_type);
 
-    BOOST_REQUIRE_THROW(prepare_expression(conj_empty, db, "test_ks", table_schema.get(), int_receiver),
+    BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(conj_empty, db, "test_ks", table_schema.get(), int_receiver, internal_dialect()),
                         exceptions::invalid_request_exception);
 }
 
@@ -4066,8 +4066,8 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_one_untyped_const_false) {
 
     expression expected = make_bool_const(false);
 
-    BOOST_REQUIRE_EQUAL(prepare_expression(conj_one, db, "test_ks", table_schema.get(), nullptr), expected);
-    BOOST_REQUIRE_EQUAL(prepare_expression(conj_one, db, "test_ks", table_schema.get(), make_receiver(boolean_type)),
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(conj_one, db, "test_ks", table_schema.get(), nullptr, internal_dialect()), expected);
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(conj_one, db, "test_ks", table_schema.get(), make_receiver(boolean_type), internal_dialect()),
                         expected);
 }
 
@@ -4081,8 +4081,8 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_one_untyped_const_true) {
 
     expression expected = make_bool_const(true);
 
-    BOOST_REQUIRE_EQUAL(prepare_expression(conj_one, db, "test_ks", table_schema.get(), nullptr), expected);
-    BOOST_REQUIRE_EQUAL(prepare_expression(conj_one, db, "test_ks", table_schema.get(), make_receiver(boolean_type)),
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(conj_one, db, "test_ks", table_schema.get(), nullptr, internal_dialect()), expected);
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(conj_one, db, "test_ks", table_schema.get(), make_receiver(boolean_type), internal_dialect()),
                         expected);
 }
 
@@ -4096,8 +4096,8 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_one_untyped_const_null) {
 
     expression expected = constant::make_null(boolean_type);
 
-    BOOST_REQUIRE_EQUAL(prepare_expression(conj_one, db, "test_ks", table_schema.get(), nullptr), expected);
-    BOOST_REQUIRE_EQUAL(prepare_expression(conj_one, db, "test_ks", table_schema.get(), make_receiver(boolean_type)),
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(conj_one, db, "test_ks", table_schema.get(), nullptr, internal_dialect()), expected);
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(conj_one, db, "test_ks", table_schema.get(), make_receiver(boolean_type), internal_dialect()),
                         expected);
 }
 
@@ -4110,9 +4110,9 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_one_int_untyped_const_0) {
     expression conj_one = conjunction{
         .children = {make_int_untyped("0")}};
 
-    BOOST_REQUIRE_THROW(prepare_expression(conj_one, db, "test_ks", table_schema.get(), nullptr),
+    BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(conj_one, db, "test_ks", table_schema.get(), nullptr, internal_dialect()),
                         exceptions::invalid_request_exception);
-    BOOST_REQUIRE_THROW(prepare_expression(conj_one, db, "test_ks", table_schema.get(), make_receiver(boolean_type)),
+    BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(conj_one, db, "test_ks", table_schema.get(), make_receiver(boolean_type), internal_dialect()),
                         exceptions::invalid_request_exception);
 }
 
@@ -4127,9 +4127,9 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_bools_and_one_int_untyped_const_0) {
                      make_int_untyped("1"),
                      make_bool_untyped("true")}};
 
-    BOOST_REQUIRE_THROW(prepare_expression(conj, db, "test_ks", table_schema.get(), nullptr),
+    BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(conj, db, "test_ks", table_schema.get(), nullptr, internal_dialect()),
                         exceptions::invalid_request_exception);
-    BOOST_REQUIRE_THROW(prepare_expression(conj, db, "test_ks", table_schema.get(), make_receiver(boolean_type)),
+    BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(conj, db, "test_ks", table_schema.get(), make_receiver(boolean_type), internal_dialect()),
                         exceptions::invalid_request_exception);
 }
 
@@ -4142,9 +4142,9 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_and_of_ints_is_invalid) {
         .children = {make_int_untyped("0"),
                      make_int_untyped("1")}};
 
-    BOOST_REQUIRE_THROW(prepare_expression(conj_one, db, "test_ks", table_schema.get(), nullptr),
+    BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(conj_one, db, "test_ks", table_schema.get(), nullptr, internal_dialect()),
                         exceptions::invalid_request_exception);
-    BOOST_REQUIRE_THROW(prepare_expression(conj_one, db, "test_ks", table_schema.get(), make_receiver(int32_type)),
+    BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(conj_one, db, "test_ks", table_schema.get(), make_receiver(int32_type), internal_dialect()),
                         exceptions::invalid_request_exception);
 }
 
@@ -4177,12 +4177,12 @@ BOOST_AUTO_TEST_CASE(prepare_conjunction_many_elements) {
                                  conjunction{.children = {make_bool_const(false),
                                                           column_value(table_schema->get_column_definition("b2"))}}}};
 
-    BOOST_REQUIRE_EQUAL(prepare_expression(conj_many, db, "test_ks", table_schema.get(), nullptr), expected);
-    BOOST_REQUIRE_EQUAL(prepare_expression(conj_many, db, "test_ks", table_schema.get(), make_receiver(boolean_type)),
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(conj_many, db, "test_ks", table_schema.get(), nullptr, internal_dialect()), expected);
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(conj_many, db, "test_ks", table_schema.get(), make_receiver(boolean_type), internal_dialect()),
                         expected);
 
     // Integer receiver is rejected
-    BOOST_REQUIRE_THROW(prepare_expression(conj_many, db, "test_ks", table_schema.get(), make_receiver(int32_type)),
+    BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(conj_many, db, "test_ks", table_schema.get(), make_receiver(int32_type), internal_dialect()),
                         exceptions::invalid_request_exception);
 }
 
@@ -4192,17 +4192,17 @@ void test_prepare_good_binary_operator(expression good_binop_unprepared,
                                        data_dictionary::database db,
                                        const schema_ptr& table_schema) {
     // Preparing without a receiver works as expected
-    BOOST_REQUIRE_EQUAL(prepare_expression(good_binop_unprepared, db, "test_ks", table_schema.get(), nullptr),
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(good_binop_unprepared, db, "test_ks", table_schema.get(), nullptr, internal_dialect()),
                         expected_prepared);
 
     // Preparing with boolean receiver works as expected
     BOOST_REQUIRE_EQUAL(
-        prepare_expression(good_binop_unprepared, db, "test_ks", table_schema.get(), make_receiver(boolean_type)),
+        prepare_expression_allowing_relations(good_binop_unprepared, db, "test_ks", table_schema.get(), make_receiver(boolean_type), internal_dialect()),
         expected_prepared);
 
     // reversed boolean type is also accepted
-    BOOST_REQUIRE_EQUAL(prepare_expression(good_binop_unprepared, db, "test_ks", table_schema.get(),
-                                           make_receiver(reversed_type_impl::get_instance(boolean_type))),
+    BOOST_REQUIRE_EQUAL(prepare_expression_allowing_relations(good_binop_unprepared, db, "test_ks", table_schema.get(),
+                                                              make_receiver(reversed_type_impl::get_instance(boolean_type)), internal_dialect()),
                         expected_prepared);
 
     // Receivers with non-bool type are rejected.
@@ -4250,11 +4250,11 @@ void test_prepare_good_binary_operator(expression good_binop_unprepared,
         user_type_impl::get_instance("test_ks", "test_ut", {"field1", "field2"}, {boolean_type, float_type}, true)};
 
     for (const data_type& invalid_receiver_type : invalid_receiver_types) {
-        BOOST_REQUIRE_THROW(prepare_expression(good_binop_unprepared, db, "test_ks", table_schema.get(),
-                                               make_receiver(invalid_receiver_type)),
+        BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(good_binop_unprepared, db, "test_ks", table_schema.get(),
+                                                                  make_receiver(invalid_receiver_type), internal_dialect()),
                             exceptions::invalid_request_exception);
-        BOOST_REQUIRE_THROW(prepare_expression(good_binop_unprepared, db, "test_ks", table_schema.get(),
-                                               make_receiver(reversed_type_impl::get_instance(invalid_receiver_type))),
+        BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(good_binop_unprepared, db, "test_ks", table_schema.get(),
+                                                                  make_receiver(reversed_type_impl::get_instance(invalid_receiver_type)), internal_dialect()),
                             exceptions::invalid_request_exception);
     }
 }
@@ -4388,10 +4388,10 @@ void test_prepare_binary_operator_invalid_rhs_values(const expression& good_bino
         binary_operator invalid_binop = as<binary_operator>(good_binop);
         invalid_binop.rhs = invalid_rhs;
 
-        BOOST_REQUIRE_THROW(prepare_expression(invalid_binop, db, "test_ks", table_schema.get(), nullptr),
+        BOOST_REQUIRE_THROW(prepare_expression_allowing_relations(invalid_binop, db, "test_ks", table_schema.get(), nullptr, internal_dialect()),
                             exceptions::invalid_request_exception);
         BOOST_REQUIRE_THROW(
-            prepare_expression(invalid_binop, db, "test_ks", table_schema.get(), make_receiver(boolean_type)),
+            prepare_expression_allowing_relations(invalid_binop, db, "test_ks", table_schema.get(), make_receiver(boolean_type), internal_dialect()),
             exceptions::invalid_request_exception);
     }
 }
@@ -5254,7 +5254,7 @@ BOOST_AUTO_TEST_CASE(test_aggregation_depth) {
             },
     };
     auto compared = expression(binary_operator(avg_r, oper_t::EQ, avg_sum_r));
-    compared = prepare_expression(compared, db, "test_ks", schema.get(), nullptr);
+    compared = prepare_expression_allowing_relations(compared, db, "test_ks", schema.get(), nullptr, internal_dialect());
  
     BOOST_REQUIRE_EQUAL(aggregation_depth(compared), 2);
 }

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -35,6 +35,7 @@ query::clustering_row_ranges slice(
         const std::vector<expr::expression>& where_clause, cql_test_env& env,
         const sstring& table_name = "t", const sstring& keyspace_name = "ks") {
     prepare_context ctx;
+    ctx.set_bound_variables({}, internal_dialect());
     return restrictions::analyze_statement_restrictions(
             env.data_dictionary(),
             env.local_db().find_schema(keyspace_name, table_name),
@@ -401,6 +402,7 @@ SEASTAR_TEST_CASE(index_selection) {
         // index-selection result.
         auto check = [&](std::string_view where_clause) -> expected {
             prepare_context ctx;
+            ctx.set_bound_variables({}, internal_dialect());
             auto factors = where_clause.empty()
                 ? std::vector<expr::expression>{}
                 : boolean_factors(cql3::util::where_clause_to_relations(where_clause, cql3::dialect{}));
@@ -650,6 +652,7 @@ SEASTAR_TEST_CASE(combinatorial_restrictions) {
             };
 
             prepare_context ctx;
+            ctx.set_bound_variables({}, internal_dialect());
             auto where_expr = where_clause.empty()
                 ? expr::expression(expr::conjunction{})
                 : cql3::util::where_clause_to_relations(where_clause, cql3::dialect{});
@@ -1155,6 +1158,7 @@ static shared_ptr<const restrictions::statement_restrictions> make_restrictions(
         std::string_view where_clause, cql_test_env& env,
         const sstring& table_name = "t", const sstring& keyspace_name = "ks") {
     prepare_context ctx;
+    ctx.set_bound_variables({}, internal_dialect());
     auto factors = where_clause.empty()
             ? std::vector<expr::expression>{}
             : boolean_factors(cql3::util::where_clause_to_relations(where_clause, cql3::dialect{}));

--- a/test/cluster/test_in_bind_variable_name.py
+++ b/test/cluster/test_in_bind_variable_name.py
@@ -1,0 +1,121 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+# Coverage for the name of the IN bind variable, SCYLLADB-3454.
+
+import logging
+
+from cassandra import ConsistencyLevel
+from cassandra.cluster import ExecutionProfile
+from cassandra.policies import WhiteListRoundRobinPolicy
+
+from test.cluster.conftest import cluster_con
+from test.cluster.util import new_test_keyspace, new_test_table
+from test.pylib.async_cql import _wrap_future
+from test.pylib.internal_types import ServerInfo
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+
+async def assert_binding_by_name_works_across_nodes(prepare_on: ServerInfo, execute_on: ServerInfo,
+                                                    query: str, expected_name: str, key: int):
+    """
+    Prepare on one node and let the other node coordinate the request. The
+    statement is bound by name, using the name the preparing node reported, while
+    the coordinator is a node that would have named the variable the other way.
+    """
+    other = 'other_node'
+    cluster = cluster_con([prepare_on.ip_addr],
+                          load_balancing_policy=WhiteListRoundRobinPolicy([prepare_on.ip_addr]))
+    try:
+        cql = cluster.connect()
+        cluster.add_execution_profile(other, ExecutionProfile(
+            load_balancing_policy=WhiteListRoundRobinPolicy([execute_on.ip_addr]),
+            consistency_level=ConsistencyLevel.LOCAL_QUORUM,
+            request_timeout=200))
+
+        prepared = cql.prepare(query)
+        assert [col.name for col in prepared.column_metadata] == ['p', expected_name]
+
+        future = cql.execute_async(prepared, {'p': key, expected_name: [key]}, execution_profile=other)
+        assert [(key, key)] == await _wrap_future(future)
+        assert str(future.coordinator_host.address) == execute_on.ip_addr
+        logger.info(f"the statement prepared on {prepare_on.ip_addr} as {expected_name!r} "
+                    f"was served by {execute_on.ip_addr}")
+    finally:
+        cluster.shutdown()
+
+
+async def test_in_bind_variable_name_mixed_config(manager: ManagerClient):
+    """
+    cql_in_bind_variable_name_uses_uppercase_operator decides whether the
+    synthetic bind variable of an IN restriction is reported as "IN(c)" or
+    "in(c)". The name is picked when the statement is prepared, so in a cluster
+    whose nodes disagree about the item an application gets whichever spelling
+    the node it prepared against uses.
+
+    The name never reaches the coordinator with this driver: it resolves the
+    name to a position when the values are bound, and the values are sent
+    positionally. A request therefore succeeds no matter which node coordinates
+    it, even when that node would have named the variable the other way. Drivers
+    that instead send the names along with the values leave the matching to the
+    coordinator, which rejects a name its own copy of the statement does not
+    have; that case is not covered here.
+    """
+    lowercase_server = await manager.server_add(config={'cql_in_bind_variable_name_uses_uppercase_operator': False})
+    uppercase_server = await manager.server_add(config={'cql_in_bind_variable_name_uses_uppercase_operator': True})
+
+    async with new_test_keyspace(manager,
+            "WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as keyspace:
+        async with new_test_table(manager, keyspace, "p int, c int, PRIMARY KEY (p, c)") as table:
+            query = f"SELECT * FROM {table} WHERE p = ? AND c IN ?"
+
+            cql_lowercase = await manager.get_cql_exclusive(lowercase_server)
+            cql_uppercase = await manager.get_cql_exclusive(uppercase_server)
+            assert [col.name for col in cql_lowercase.prepare(query).column_metadata] == ['p', 'in(c)']
+            assert [col.name for col in cql_uppercase.prepare(query).column_metadata] == ['p', 'IN(c)']
+            logger.info("the two nodes report different names for the same query")
+
+            for p in range(2):
+                await manager.get_cql().run_async(f"INSERT INTO {table} (p,c) VALUES ({p},{p})")
+
+            await assert_binding_by_name_works_across_nodes(lowercase_server, uppercase_server, query, 'in(c)', 0)
+            await assert_binding_by_name_works_across_nodes(uppercase_server, lowercase_server, query, 'IN(c)', 1)
+
+
+async def test_in_bind_variable_name_of_a_cached_statement(manager: ManagerClient):
+    """
+    The name is picked when the statement is prepared, and the item is part of
+    the prepared statement cache key. A statement that is already cached keeps
+    the name it was prepared under, but does not shadow the changed item:
+    preparing the same query again gets a fresh cache entry and reports the
+    new name.
+
+    The cache is per shard, hence the single-shard node: it guarantees the
+    second prepare runs on a shard that still holds the statement cached under
+    the previous setting, so the test would catch that entry being returned.
+    """
+    server = await manager.server_add(cmdline=['--smp', '1'],
+                                      config={'cql_in_bind_variable_name_uses_uppercase_operator': True})
+
+    async with new_test_keyspace(manager,
+            "WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as keyspace:
+        async with new_test_table(manager, keyspace, "p int, c int, PRIMARY KEY (p, c)") as table:
+            cql = await manager.get_cql_exclusive(server)
+            query = f"SELECT * FROM {table} WHERE p = ? AND c IN ?"
+            not_in_query = f"SELECT * FROM {table} WHERE p = ? AND c NOT IN ?"
+            assert [col.name for col in cql.prepare(query).column_metadata] == ['p', 'IN(c)']
+            assert [col.name for col in cql.prepare(not_in_query).column_metadata] == ['p', 'NOT IN(c)']
+            logger.info("the statements are cached under the uppercase names")
+
+            cql.execute("UPDATE system.config SET value='false' "
+                        "WHERE name='cql_in_bind_variable_name_uses_uppercase_operator'")
+            logger.info("the item is false now")
+
+            assert [col.name for col in cql.prepare(query).column_metadata] == ['p', 'in(c)']
+            assert [col.name for col in cql.prepare(not_in_query).column_metadata] == ['p', 'not in(c)']
+            logger.info("preparing the same query strings again reports the new names")

--- a/test/cqlpy/test_prepare.py
+++ b/test/cqlpy/test_prepare.py
@@ -11,7 +11,7 @@
 # https://github.com/apache/cassandra/blob/1959502d8b16212479eecb076c89945c3f0f180c/doc/native_protocol_v4.spec#L675
 
 import pytest
-from .util import new_test_table, unique_key_int, config_value_context
+from .util import new_test_table, unique_key_int, config_value_context, is_scylla
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
@@ -259,3 +259,88 @@ def test_duplicate_named_bind_marker_prepared_cassandra_compatibility_mode(cql, 
         # query's bind markers have the same name :x. Exactly like two different
         # "?" bind markers can also be bound to different values:
         assert [(x,x+1)] == list(cql.execute(stmt, (x,x+1)))
+
+# The tests from here on cover the name of the IN bind variable, SCYLLADB-3454.
+# The bind variable created for the right-hand side of an IN restriction is
+# named "IN(column)" in Scylla. This name is part of the driver-visible
+# metadata and applications bind values by it, so it must not change.
+def test_in_bind_marker_name(cql, table1, scylla_only):
+    prepared = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND c IN ?")
+    assert [col.name for col in prepared.column_metadata] == ['p', 'IN(c)']
+    x = unique_key_int()
+    cql.execute(f'INSERT INTO {table1} (p,c) VALUES ({x},{x})')
+    assert [(x,x)] == list(cql.execute(prepared, {'p': x, 'IN(c)': [x, x+1]}))
+
+# Same as test_in_bind_marker_name, but for the NOT IN restriction, which is a
+# Scylla extension.
+def test_not_in_bind_marker_name(cql, table1, scylla_only):
+    prepared = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND c NOT IN ?")
+    assert [col.name for col in prepared.column_metadata] == ['p', 'NOT IN(c)']
+    x = unique_key_int()
+    cql.execute(f'INSERT INTO {table1} (p,c) VALUES ({x},{x})')
+    cql.execute(f'INSERT INTO {table1} (p,c) VALUES ({x},{x+1})')
+    assert [(x,x)] == list(cql.execute(prepared, {'p': x, 'NOT IN(c)': [x+1]}))
+
+# The IF condition of an LWT statement is prepared as an expression rather than as
+# a restriction, so its bind variable is named along a different path.
+def test_in_bind_marker_name_lwt_condition(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, v int') as table:
+        prepared = cql.prepare(f"UPDATE {table} SET v = 1 WHERE p = ? IF v IN ?")
+        assert [col.name for col in prepared.column_metadata] == ['p', 'IN(v)']
+
+# Cassandra spells the operator in lowercase, "in(column)". Scylla can be asked
+# for that spelling with cql_in_bind_variable_name_uses_uppercase_operator; on
+# Cassandra it is the only spelling, so the fixture is a no-op there and the
+# tests below run against both.
+@pytest.fixture(scope="function")
+def lowercase_in_bind_marker_name(cql):
+    if is_scylla(cql):
+        with config_value_context(cql, 'cql_in_bind_variable_name_uses_uppercase_operator', 'false'):
+            yield
+    else:
+        yield
+
+# The name is chosen when the statement is prepared, and the item is part of
+# the prepared statement cache key. The tests below can therefore reuse the
+# query strings of the tests above: preparing them again gets a fresh cache
+# entry and reports the new spelling instead of returning the statement
+# cached under the old one.
+def test_in_bind_marker_name_lowercase_operator(cql, table1, lowercase_in_bind_marker_name):
+    prepared = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND c IN ?")
+    assert [col.name for col in prepared.column_metadata] == ['p', 'in(c)']
+    x = unique_key_int()
+    cql.execute(f'INSERT INTO {table1} (p,c) VALUES ({x},{x})')
+    assert [(x,x)] == list(cql.execute(prepared, {'p': x, 'in(c)': [x, x+1]}))
+
+# Same as test_in_bind_marker_name_lowercase_operator, but for NOT IN.
+def test_not_in_bind_marker_name_lowercase_operator(cql, table1, scylla_only, lowercase_in_bind_marker_name):
+    prepared = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND c NOT IN ?")
+    assert [col.name for col in prepared.column_metadata] == ['p', 'not in(c)']
+    x = unique_key_int()
+    cql.execute(f'INSERT INTO {table1} (p,c) VALUES ({x},{x})')
+    cql.execute(f'INSERT INTO {table1} (p,c) VALUES ({x},{x+1})')
+    assert [(x,x)] == list(cql.execute(prepared, {'p': x, 'not in(c)': [x+1]}))
+
+# Same as test_in_bind_marker_name_lwt_condition, with the lowercase spelling. Unlike
+# the tests above this one is scylla_only: the name Cassandra gives the variable of a
+# condition has not been checked against Cassandra, and the SELECT tests already pin
+# down the spelling Cassandra produces.
+def test_in_bind_marker_name_lwt_condition_lowercase_operator(cql, test_keyspace, scylla_only, lowercase_in_bind_marker_name):
+    with new_test_table(cql, test_keyspace, 'p int PRIMARY KEY, v int') as table:
+        prepared = cql.prepare(f"UPDATE {table} SET v = 1 WHERE p = ? IF v IN ?")
+        assert [col.name for col in prepared.column_metadata] == ['p', 'in(v)']
+
+# Only the operator part of the name is affected by the spelling - the column
+# name keeps the case it was declared with in either mode. new_test_table hands
+# out a recycled table name, so the two tests below can end up with the same
+# query string; what keeps the second one from being answered from the prepared
+# statement cache is, as above, that the item is part of the cache key.
+def test_in_bind_marker_name_case_sensitive_column(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, 'p int, "C" int, PRIMARY KEY (p, "C")') as table:
+        prepared = cql.prepare(f'SELECT * FROM {table} WHERE p = ? AND "C" IN ?')
+        assert [col.name for col in prepared.column_metadata] == ['p', 'IN(C)']
+
+def test_in_bind_marker_name_case_sensitive_column_lowercase_operator(cql, test_keyspace, lowercase_in_bind_marker_name):
+    with new_test_table(cql, test_keyspace, 'p int, "C" int, PRIMARY KEY (p, "C")') as table:
+        prepared = cql.prepare(f'SELECT * FROM {table} WHERE p = ? AND "C" IN ?')
+        assert [col.name for col in prepared.column_metadata] == ['p', 'in(C)']

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -221,6 +221,7 @@ private:
         return cql3::dialect{
             .duplicate_bind_variable_names_refer_to_same_variable = _db.local().get_config().cql_duplicate_bind_variable_names_refer_to_same_variable(),
             .max_relations_in_where_clause = _db.local().get_config().max_relations_in_where_clause(),
+            .in_bind_variable_name_uses_uppercase_operator = _db.local().get_config().cql_in_bind_variable_name_uses_uppercase_operator(),
         };
     }
 

--- a/test/vector_search/filter_test.cc
+++ b/test/vector_search/filter_test.cc
@@ -38,10 +38,8 @@ shared_ptr<const restrictions::statement_restrictions> make_restrictions(
         has_bind_markers = true;
         max_bind_index = std::max(max_bind_index, static_cast<size_t>(bv.bind_index));
     });
-    if (has_bind_markers) {
-        std::vector<shared_ptr<cql3::column_identifier>> bind_names(max_bind_index + 1);
-        ctx.set_bound_variables(bind_names);
-    }
+    std::vector<shared_ptr<cql3::column_identifier>> bind_names(has_bind_markers ? max_bind_index + 1 : 0);
+    ctx.set_bound_variables(bind_names, cql3::internal_dialect());
 
     return restrictions::analyze_statement_restrictions(env.data_dictionary(), env.local_db().find_schema(keyspace_name, table_name),
             statements::statement_type::SELECT, where_expr,

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -267,6 +267,7 @@ future<> controller::do_start_server() {
               .max_concurrent_requests = cfg.max_concurrent_requests_per_shard,
               .cql_duplicate_bind_variable_names_refer_to_same_variable = cfg.cql_duplicate_bind_variable_names_refer_to_same_variable,
               .max_relations_in_where_clause = cfg.max_relations_in_where_clause,
+              .cql_in_bind_variable_name_uses_uppercase_operator = cfg.cql_in_bind_variable_name_uses_uppercase_operator,
               .uninitialized_connections_semaphore_cpu_concurrency = cfg.uninitialized_connections_semaphore_cpu_concurrency,
               .request_timeout_on_shutdown_in_seconds = cfg.request_timeout_on_shutdown_in_seconds
             };

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2042,6 +2042,7 @@ cql_server::connection::get_dialect() const {
     return cql3::dialect{
         .duplicate_bind_variable_names_refer_to_same_variable = _server._config.cql_duplicate_bind_variable_names_refer_to_same_variable,
         .max_relations_in_where_clause = _server._config.max_relations_in_where_clause,
+        .in_bind_variable_name_uses_uppercase_operator = _server._config.cql_in_bind_variable_name_uses_uppercase_operator,
     };
 }
 

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -129,6 +129,7 @@ struct cql_server_config {
     utils::updateable_value<uint32_t> max_concurrent_requests;
     utils::updateable_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
     utils::updateable_value<uint32_t> max_relations_in_where_clause;
+    utils::updateable_value<bool> cql_in_bind_variable_name_uses_uppercase_operator;
     utils::updateable_value<uint32_t> uninitialized_connections_semaphore_cpu_concurrency;
     utils::updateable_value<uint32_t> request_timeout_on_shutdown_in_seconds;
 };


### PR DESCRIPTION
The right-hand side of an IN restriction gets a synthetic bind variable
whose name drivers report to applications, and it is spelled in
uppercase, unlike the lowercase name Cassandra produces, so applications
binding by name have to special-case Scylla. It used to be lowercase
here as well and most likely turned uppercase by accident, but
applications now bind by the uppercase name, so changing it outright
would break them on upgrade with no way out other than downgrading.

Make the case a CQL dialect item that keeps the current spelling by
default, the same approach already taken for duplicate bind variable
names. The dialect is part of the prepared statement cache key, so a
statement that is already cached keeps the name it was prepared under
and a change takes effect the next time the query is prepared. NOT IN
has no Cassandra counterpart, but follows the same convention for
consistency.

Deciding the name happens deep inside expression preparation, which is
shared with callers that prepare expressions built from a stored schema
and have no dialect to offer. Rather than requiring one from all of
them, the dialect is passed only where a relation is allowed, which is
the WHERE clause and the LWT condition, and preparing a relation
anywhere else is now an internal error instead of a name invented under
a dialect nobody chose.

`scylla perf-cql-raw --workload read` shows at most marginal (+20 insn/op)
change on the regular path.

Before this patch series:
```
227249.88 tps ( 78.3 allocs/op,   0.0 logallocs/op,  23.3 tasks/op,   47751 insns/op,   19755 cycles/op,        0 errors)
throughput:
        mean=   228600.86 standard-deviation=3067.83
        median= 229472.05 median-absolute-deviation=1181.92
        maximum=230851.47 minimum=216397.32
instructions_per_op:
        mean=   47683.09 standard-deviation=15.19
        median= 47683.01 median-absolute-deviation=3.85
        maximum=47750.98 minimum=47656.50
cpu_cycles_per_op:
        mean=   19586.52 standard-deviation=118.13
        median= 19562.62 median-absolute-deviation=60.84
        maximum=20070.85 minimum=19451.20
```

After this patch series:
```
232130.13 tps ( 78.2 allocs/op,   0.0 logallocs/op,  23.3 tasks/op,   47703 insns/op,   19309 cycles/op,        0 errors)
throughput:
        mean=   230760.41 standard-deviation=3677.02
        median= 231901.59 median-absolute-deviation=1370.98
        maximum=232941.69 minimum=217454.37
instructions_per_op:
        mean=   47709.90 standard-deviation=14.87
        median= 47707.54 median-absolute-deviation=5.85
        maximum=47772.15 minimum=47687.12
cpu_cycles_per_op:
        mean=   19361.90 standard-deviation=140.43
        median= 19317.40 median-absolute-deviation=75.86
        maximum=20002.54 minimum=19242.38
```

Fixes: SCYLLADB-3454

Backport to 2025.1, 2026.1, 2026.2, 2026.3 to help clusters with affected versions being upgraded from 2024.1.X