### PR TITLE
test/object_store: Wait on injection enter, not log line, in drop-dur…

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -1518,7 +1518,7 @@ async def test_drop_keyspace_during_tablet_restore(manager: ManagerClient, objec
     manifests = [f'{s.server_id}/{snap_name}/manifest.json' for s in servers]
     tid = await manager.api.restore_tablets(servers[0].ip_addr, ks, cf, snap_name, servers[0].datacenter, object_storage.address, object_storage.bucket_name, manifests)
 
-    await server_log.wait_for("pause_download_sstable: waiting for message", from_mark=log_mark)
+    await manager.api.wait_for_injection_enter(servers[1].ip_addr, "pause_download_sstable")
 
     # Issue DROP concurrently — with the fix stream_in_progress() guard blocks
     # table::stop() until download completes; without the fix the data directory


### PR DESCRIPTION
…ing-restore test

test_drop_keyspace_during_tablet_restore enabled the 'pause_download_sstable' error injection and then waited for it to fire by grepping the server log for the line it emits once entered.

Replace the log-line wait with wait_for_injection_enter(), which polls the injection's own enter count via the API. This removes the dependency on log output entirely and synchronizes directly on the fact we actually care about: that the download has reached and entered the injection.

Refs SCYLLADB-3370

Improving tests, not backporting