### PR TITLE
Introduce framework for analyzing tablet load balance of scylla clusters

### DIFF
--- a/dist/debian/debian/scylla-server.install
+++ b/dist/debian/debian/scylla-server.install
@@ -9,6 +9,7 @@ usr/lib/systemd/system/*.slice
 usr/bin/scylla
 usr/bin/iotune
 usr/bin/scyllatop
+usr/bin/scylla-tablets
 usr/bin/nodetool
 usr/sbin/scylla*
 usr/sbin/node_health_check
@@ -17,6 +18,7 @@ opt/scylladb/scripts/*
 opt/scylladb/swagger-ui/dist/*
 opt/scylladb/api/api-doc/*
 opt/scylladb/scyllatop/*
+opt/scylladb/lib-python/*
 opt/scylladb/scripts/libexec/*
 opt/scylladb/bin/*
 opt/scylladb/libreloc/*

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -132,6 +132,7 @@ ln -sfT /etc/scylla /var/lib/scylla/conf
 %{_bindir}/scylla
 %{_bindir}/iotune
 %{_bindir}/scyllatop
+%{_bindir}/scylla-tablets
 %{_bindir}/nodetool
 %{_sbindir}/scylla*
 %{_sbindir}/node_health_check
@@ -140,6 +141,7 @@ ln -sfT /etc/scylla /var/lib/scylla/conf
 /opt/scylladb/swagger-ui/dist/*
 /opt/scylladb/api/api-doc/*
 /opt/scylladb/scyllatop/*
+/opt/scylladb/lib-python/*
 /opt/scylladb/bin/*
 /opt/scylladb/libreloc/*
 /opt/scylladb/libreloc/.*.hmac

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -176,6 +176,7 @@ fedora_python3_packages=(
     python3-click
     python3-six
     python3-pyudev
+    python3-tabulate
 )
 
 # an associative array from packages to constrains

--- a/install.sh
+++ b/install.sh
@@ -467,9 +467,12 @@ install -d -m755 -d "$rprefix"/api
 cp -pr api/api-doc "$rprefix"/api
 install -d -m755 -d "$rprefix"/scyllatop
 cp -pr tools/scyllatop/* "$rprefix"/scyllatop
+install -d -m755 -d "$rprefix"/lib-python/tablets
+cp -pr scripts/tablets/*.py "$rprefix"/lib-python/tablets
 install -d -m755 -d "$rprefix"/scripts
 cp -pr dist/common/scripts/* "$rprefix"/scripts
 ln -srf "$rprefix/scyllatop/scyllatop.py" "$rprefix/bin/scyllatop"
+ln -srf "$rprefix/lib-python/scylla-tablets.py" "$rprefix/bin/scylla-tablets"
 if $supervisor; then
     install -d -m755 "$rprefix"/supervisor
     install -m755 dist/common/supervisor/* -Dt "$rprefix"/supervisor
@@ -554,6 +557,7 @@ EOS
     ln -srf "$rprefix/bin/scylla" "$rusr/bin/scylla"
     ln -srf "$rprefix/bin/iotune" "$rusr/bin/iotune"
     ln -srf "$rprefix/bin/scyllatop" "$rusr/bin/scyllatop"
+    ln -srf "$rprefix/bin/scylla-tablets" "$rusr/bin/scylla-tablets"
     ln -srf "$rprefix/bin/nodetool" "$rusr/bin/nodetool"
     install -d -m755 "$rusr"/sbin
     for i in $SBINFILES; do
@@ -597,6 +601,7 @@ for i in seastar/scripts/{perftune.py,addr2line.py,seastar-addr2line}; do
     relocate_python3 "$rprefix"/scripts "$i"
 done
 relocate_python3 "$rprefix"/scyllatop tools/scyllatop/scyllatop.py
+relocate_python3 "$rprefix"/lib-python scripts/tablets/scylla-tablets.py
 relocate_python3 "$rprefix"/scripts fix_system_distributed_tables.py
 
 if $supervisor; then

--- a/scripts/create-relocatable-package.py
+++ b/scripts/create-relocatable-package.py
@@ -233,6 +233,8 @@ ar.reloc_add('licenses')
 ar.reloc_add('swagger-ui')
 ar.reloc_add('api')
 ar.reloc_add('tools/scyllatop')
+ar.reloc_add('scripts/tablets',
+             filter=lambda info: info if info.isdir() or info.name.endswith('.py') or info.name.endswith('.md') else None)
 ar.reloc_add('scylla-gdb.py')
 ar.reloc_add('bin/nodetool')
 ar.reloc_add(args.debian_dir, arcname='debian')

--- a/scripts/tablet-mon.py
+++ b/scripts/tablet-mon.py
@@ -18,6 +18,12 @@
 #
 #   ssh -L *:9042:127.0.0.1:9042 -N <remote-host>
 #
+# Instead of a live cluster, it can also visualize a snapshot directory:
+#
+#   ./tablet-mon.py --snapshot tablet_snap_YYMMDD_HHMMSS
+#
+# See tablets/README.md for how to obtain a snapshot.
+#
 # Key bindings:
 #
 #  t - toggle display of table tags. Each table has a unique color which fills tablets of that table.
@@ -26,14 +32,16 @@
 #        - fixed-size (each tablet has the same displayed size)
 #        - scaled-to-capacity (tablet size is proportional to its utilization of shard's storage capacity)
 #
-
+import argparse
 import math
+import logging
 import threading
 import time
-import logging
+
 import pygame
 
-from cassandra.cluster import Cluster
+from tablets import topology
+from tablets.topology import add_topology_source_args, get_topology_source_from_args
 
 tablet_size_modes = ["fixed size", "scaled to capacity"]
 tablet_size_mode_idx = 1
@@ -438,11 +446,10 @@ table_tag_colors = {}
 # Avoid redrawing if nothing changed
 changed = False
 
-cluster = Cluster(['127.0.0.1'])
-session = cluster.connect()
-topo_query = session.prepare("SELECT host_id, shard_count FROM system.topology")
-tablets_query = session.prepare("SELECT * FROM system.tablets")
-load_per_node_query = session.prepare("SELECT * FROM system.load_per_node")
+parser = argparse.ArgumentParser(description="Tablet topology live monitor")
+add_topology_source_args(parser)
+args = parser.parse_args()
+src = get_topology_source_from_args(args)
 
 data_source_alive = False
 
@@ -457,10 +464,11 @@ def update_from_cql(initial=False):
     global changed
     global data_source_alive
 
-    all_host_ids = set()
-    for host in session.execute(topo_query):
-        id = host.host_id
-        all_host_ids.add(id)
+    topo = src.get_topology()
+    all_host_ids = topo.all_host_ids()
+
+    for host in topo.all_hosts():
+        id = host.id
         if id not in nodes_by_id:
             n = Node(id)
             nodes.append(n)
@@ -471,20 +479,14 @@ def update_from_cql(initial=False):
             n.shards = n.shards[:host.shard_count]
         while len(n.shards) < host.shard_count:
             n.shards.append(Shard())
+        if host.storage_capacity:
+            n.capacity = host.storage_capacity
 
     for id in nodes_by_id:
         if id not in all_host_ids:
             nodes.remove(nodes_by_id[id])
             del nodes_by_id[id]
             changed = True
-
-    for row in session.execute(load_per_node_query):
-        host_id = row.node
-        if host_id in nodes_by_id:
-            n = nodes_by_id[host_id]
-            if row.storage_capacity:
-                n.capacity = int(row.storage_capacity)
-
 
     # Nodes are scaled to the node with smallest capacity.
     # Nodes with more capacity will have smaller tablets (smaller capacity_weight).
@@ -510,7 +512,7 @@ def update_from_cql(initial=False):
         tablet_id_by_table[table_id] += 1
         return ret
 
-    def process_tablet(table_id, tablet, base_id):
+    def process_tablet(table_id, tablet: topology.Tablet, base_id):
         tablet_seq = tablet_id_for_table(table_id)
         id = (table_id, tablet.last_token)
         replicas = set(tablet.replicas)
@@ -568,20 +570,9 @@ def update_from_cql(initial=False):
                 fire_tracer(id, src, dst, light_red, light_green, tablet_h,
                             streaming_trace_decay_ms, streaming_trace_duration_ms)
 
-    all_tablets = {}
-    for tablet in session.execute(tablets_query):
-        if not tablet.table_id in all_tablets:
-            all_tablets[tablet.table_id] = []
-        all_tablets[tablet.table_id].append(tablet)
-
-    for (table_id, tablet) in all_tablets.items():
-        base_id = table_id
-        try:
-            base_id = tablet[0].base_table or table_id
-        except AttributeError:
-            pass
-
-        for t in all_tablets[base_id]:
+    for table_id in topo.iter_table_ids():
+        base_id = topo.get_base_table_id(table_id)
+        for t in topo.get_tablet_map(table_id).tablets:
             process_tablet(table_id, t, base_id)
 
     for n in nodes:
@@ -614,9 +605,10 @@ cassandra_logger.addHandler(console_handler)
 
 update_from_cql(initial=True)
 
-cassandra_thread = threading.Thread(target=cql_updater)
-cassandra_thread.daemon = True
-cassandra_thread.start()
+if src.is_live():
+    cassandra_thread = threading.Thread(target=cql_updater)
+    cassandra_thread.daemon = True
+    cassandra_thread.start()
 
 pygame.init()
 clock = pygame.time.Clock()
@@ -806,7 +798,7 @@ while running:
 
     # Check connectivity with data source
     # and display a pane while reconnecting
-    if data_source_alive:
+    if data_source_alive or not src.is_live():
         last_update = now
         data_source_alive = False
     elif now - last_update > cql_update_timeout_ms:

--- a/scripts/tablets/README.md
+++ b/scripts/tablets/README.md
@@ -1,0 +1,321 @@
+<!--
+Copyright (C) 2026-present ScyllaDB
+SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+Reflow with: pandoc --wrap=auto --columns=100 -f gfm -t gfm README.md -o README.md.tmp; mv README.md.tmp README.md
+-->
+
+# Tablet Scripts
+
+The scripts in this directory help inspect tablet placement, tablet load, and load-balancing state
+in Scylla clusters.
+
+## Design
+
+The scripts are written in Python so they need no recompilation and are quick to extend with new
+scripts. This is important when analyzing production incidents, where the ability to inspect a new
+aspect on short notice is crucial.
+
+### Snapshots
+
+All analysis scripts work with either a **live** cluster or a **snapshot** of the cluster's state.
+
+This supports offline and multi-step analysis where cluster access is limited (for example, during
+production incidents) or where data must stay stable across steps. Because snapshots hold complete
+topology information, they can also seed load-balancing simulations on customer topology.
+
+A snapshot contains the captured state of system tables relevant for topology and load statistics,
+with one CSV file per table. It should be cheap to capture.
+
+`snapshot.py` captures a snapshot either by connecting to a live CQL server or by printing manual
+`cqlsh` commands to run wherever cluster access is available.
+
+### Live monitoring
+
+The model also supports connecting to a live cluster, bypassing storing a snapshot on disk. This is
+useful for quick inspection of the cluster where scripts are used in one-shot mode or as
+live-monitors in a similar manner as `nodetool`.
+
+`../tablet-mon.py` is an example of a live-monitoring use case.
+
+## Tools
+
+At a high level, the tools fall into groups:
+
+- Internal table load tools: focus on the load shape inside a table, or on comparing tables to each
+  other.
+  - `table_load.py`: drill down into one table's token ranges, sizes, imbalance between replicas,
+    and replica placement
+  - `table_summary.py`: one row per table, useful for comparing tables to other tables
+- Load distribution tools: focus on how load is spread across cluster resources.
+  - `cluster_load.py`: datacenter, rack, node, and shard distribution of token load, size load, and
+    utilization
+
+Supporting tools:
+
+- `snapshot.py`: capture a snapshot from a live cluster, or print manual `cqlsh COPY` commands
+
+### Running the tools
+
+Each tool is a command of the `scylla-tablets` launcher, which runs from the source tree:
+
+``` bash
+./scripts/tablets/scylla-tablets.py cluster
+```
+
+Scripts are also shipped with the scylla package and exposed in installs via dispatch wrapper:
+`scylla-tablets <tool> <args...>`. For example, the above command is also:
+
+``` bash
+scylla-tablets cluster
+```
+
+The `scylla-tablets` command aliases in installs to the `scylla-tablets.py` script. Each command is
+also a module that can be run on its own, e.g. `./scripts/tablets/cluster_load.py`.
+
+### Snapshot capture
+
+Use `scylla-tablets snapshot` to capture a snapshot from a live cluster.
+
+It chooses a timestamped name automatically and prints the absolute path to the snapshot on success.
+
+The snapshot is a directory containing CSV files for each system table relevant to topology and load
+statistics:
+
+      tablets_snap_YYMMDD_HHMMSS[_sss]/
+      ├── system_tablets.csv
+      ├── system_topology.csv
+      ├── system_tablet_sizes.csv
+      └── system_load_per_node.csv
+
+You can capture a compressed tarball snapshot with `--gz`:
+
+``` bash
+$ ./scylla-tablets.py snapshot --gz
+/home/tgrabiec/tablets_snap_260807_123456.tar.gz
+```
+
+All scripts accept a compressed tarball snapshot as input, and will decompress it on the fly.
+
+If you don't have direct access to the cluster, you can use `--manual` to print the commands that
+capture a snapshot, to be run by someone who does:
+
+``` bash
+$ ./scylla-tablets.py snapshot --manual --gz -u scylla_admin -p xxxx
+mkdir -p tablet_snap_260807_144540
+cqlsh -u scylla_admin -p xxxx -e 'COPY system.topology TO '"'"'tablet_snap_260807_144540/system_topology.csv'"'"' WITH DELIMITER='"'"';'"'"' AND HEADER=TRUE'
+cqlsh -u scylla_admin -p xxxx -e 'COPY system.tablets TO '"'"'tablet_snap_260807_144540/system_tablets.csv'"'"' WITH DELIMITER='"'"';'"'"' AND HEADER=TRUE'
+cqlsh -u scylla_admin -p xxxx -e 'COPY system.load_per_node TO '"'"'tablet_snap_260807_144540/system_load_per_node.csv'"'"' WITH DELIMITER='"'"';'"'"' AND HEADER=TRUE'
+cqlsh -u scylla_admin -p xxxx -e 'COPY system.tablet_sizes TO '"'"'tablet_snap_260807_144540/system_tablet_sizes.csv'"'"' WITH DELIMITER='"'"';'"'"' AND HEADER=TRUE'
+tar -czf tablet_snap_260807_144540.tar.gz tablet_snap_260807_144540 && rm -r tablet_snap_260807_144540
+```
+
+### Common Interface
+
+#### Data source
+
+Most scripts share the same data-source pattern:
+
+- `--cluster HOST` to read from a live cluster
+- `--snapshot PATH` to read from a captured snapshot
+
+When neither is given, the snapshot path is taken from the `SCYLLA_TABLET_SNAPSHOT` environment
+variable. This avoids repeating `--snapshot` on every command while analyzing one snapshot:
+
+``` bash
+export SCYLLA_TABLET_SNAPSHOT=tablet_snap_YYMMDD_HHMMSS
+./scylla-tablets.py cluster
+```
+
+With no snapshot from either source, the scripts connect to a live cluster on `localhost:9042`.
+
+#### Filtering
+
+Most analysis scripts accept narrowing aggregation based on location in the cluster:
+
+- `--host <host-id|ip>`
+- `--shard <host-id|ip>:<shard>` or `--shard <shard-number>` which selects `*:<shard-number>`
+- `--rack <DC>/<rack>`
+- `--dc <DC>`
+
+Also, filtering by keyspace/table is commonly supported:
+
+- `--table <keyspace.table|table-id|table>`.
+- `--keyspace <keyspace>`
+
+These filters narrow down tablet replicas considered by scripts. Only matching replicas contribute
+data to results.
+
+The convention is that filters accept names in the same formats as scripts may print them. For
+example, you can copy `<keyspace>.<table>` from `table_summary.py` output and pass it to
+`table_load.py`.
+
+#### Presentation options
+
+By default, the scripts present data in a human-friendly form:
+
+- table names are shown as `keyspace.table`
+- hosts are shown as IP addresses when available
+- sizes are shown with binary units such as `Ki`, `Mi`, `Gi`
+- data is shown in a table format
+
+This can be changed with command-line flags:
+
+- `--host-id`: show host ids instead of IPs
+- `--table-id`: show table ids instead of `keyspace.table`
+- `--no-hr`: disable human-readable size formatting
+- `--csv`: output in CSV format instead of a table
+
+You can pass `--anonymize` to anonymize customer-specific names in the snapshot, e.g. keyspace and
+table names. The names will still be consistent for a given snapshot. This is useful when sharing
+output publicly.
+
+## Example Workflow
+
+1.  Capture a snapshot and point the other scripts at it. `snapshot.py` prints the path of the
+    snapshot it captured.
+
+    ``` bash
+    export SCYLLA_TABLET_SNAPSHOT=$(./scylla-tablets.py snapshot)
+    ```
+
+2.  Compare tables at a high level.
+
+    ``` bash
+    ./scylla-tablets.py tables
+    ```
+
+    Use this to find large tables, tables with uneven tablet sizes, or tables worth drilling into.
+
+    By default, shows un-replicated sizes by taking the average tablet replica size for a given
+    tablet. Use `--replicated` to count tablet replicas instead.
+
+3.  Inspect cluster-wide distribution.
+
+    ``` bash
+    ./scylla-tablets.py cluster
+    ```
+
+    Use this to see whether load is concentrated on particular racks, nodes, or shards.
+
+4.  Drill into one table.
+
+    ``` bash
+    ./scylla-tablets.py table ks.tbl
+    ```
+
+    Use this to inspect tablet boundaries, token-space coverage, replica sizes, and per-replica
+    placement.
+
+5.  Inspect distribution of a single table across the cluster:
+
+    ``` bash
+    ./scylla-tablets.py cluster --table ks.tbl
+    ```
+
+    Use this to see if table's data or tablets are spread uniformly across the cluster.
+
+## Load Measures
+
+The scripts use a few related but distinct measures of load.
+
+### Replicated vs unreplicated load
+
+Load can be measured in two ways: before replication (unreplicated) or after replication
+(replicated). It's often context-dependent which one is relevant.
+
+For example, the name "tablet" can refer to two different things:
+
+- a token-range unit before replication
+- a replicated unit of a table, placed on a specific host and shard (tablet replica)
+
+`table_load.py` / `scylla-tablets table` aggregates on both levels.
+
+`cluster_load.py` / `scylla-tablets cluster` focuses on replicated load, so its count-based metrics
+are about tablet replicas: placements of tablets on specific hosts and shards. This is the relevant
+count when comparing nodes or shards for balancing purposes.
+
+`table_summary.py` / `scylla-tablets tables` reports either way: `--un-replicated` (the default)
+takes the average tablet replica size for a given tablet, `--replicated` sums all tablet replicas.
+The report counts what it sizes, so an un-replicated one says how much data a table holds and how
+unevenly it is spread over its tablets, while a replicated one says how much the cluster keeps and
+how unevenly it is spread over replicas, which also shows replicas of one tablet differing in size.
+The "size in token space" histogram is always unreplicated, so that its shape is that of the data
+rather than of its placement.
+
+When there is ambiguity, the scripts should explicitly say "replicated" or "unreplicated" in the
+output, and name the unit they count, as `table_summary.py`'s headers do.
+
+### Token load
+
+Token load is the share of token space owned by an entity. It answers: how much of the ring is
+assigned here?
+
+Token ownership can differ from the actual share of key ownership, if present keys are not spread
+uniformly in the token space.
+
+Like tablet count, tokens can be counted before replication (token load) or after replication
+(replicated token load), and which one is relevant is context-dependent.
+
+For replicated data, token load can exceed `100%` when summed across racks, because the measure
+counts every replica copy.
+
+### Storage utilization
+
+Storage utilization is size load divided by storage capacity.
+
+We distinguish between absolute storage capacity and effective capacity. Effective capacity is the
+part of storage capacity that can be used for storing data by tablets. It's computed by scylla
+server as free space plus the size of tablets currently on the node.
+
+### Overcommit (OVC)
+
+Overcommit is a measure of imbalance.
+
+It answers: how far is a node, shard, rack, or token range from the average of its peers?
+
+Computed as:
+
+    OVC[%] = (value - peer_average) / peer_average * 100%
+
+The scripts present OVC as percentage deviation from the peer average, shown as `[%]`:
+
+- `0%`: exactly at the peer average
+- positive value: above the peer average
+- negative value: below the peer average
+
+Maximum OVC within the group is used as a measure of how imbalanced the whole group is. When scripts
+show aggregated OVC, they show the maximum OVC within the group.
+
+The average OVC within the peer group is always `0%` and maximum OVC is always \>= 0%.
+
+Different tools apply OVC at different levels:
+
+- `table_load.py`: imbalance between tablet or token-range rows within a table
+- `table_summary.py`: imbalance between tablets in token space for a table
+- `cluster_load.py`: imbalance between peer racks, nodes, or shards in the selected section
+
+## Running tests
+
+### Pure python unit tests
+
+The tests live in `test/tablet_scripts/`. They exercise the scripts as Python modules, without a
+Scylla server, so the whole suite runs in a few seconds.
+
+Run it like any other Scylla test suite, from the repository root:
+
+``` bash
+tools/toolchain/dbuild ./test.py --mode dev test/tablet_scripts --no-gather-metrics
+```
+
+`--no-gather-metrics` is needed under `dbuild`, where metrics gathering fails trying to create a
+cgroup directory the container cannot see.
+
+### Cluster tests
+
+`test/cluster/test_tablet_snapshot.py` verifies the topology sources against a real cluster, in
+particular snapshot collection.
+
+``` bash
+tools/toolchain/dbuild ./test.py --mode dev test/cluster/test_tablet_snapshot.py --no-gather-metrics
+```

--- a/scripts/tablets/__init__.py
+++ b/scripts/tablets/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#

--- a/scripts/tablets/cluster_load.py
+++ b/scripts/tablets/cluster_load.py
@@ -624,6 +624,7 @@ def main() -> int:
 
         table_ids = get_selected_table_ids(topo, table_id, get_table_filter(args, topo))
         levels = collect_levels(topo, table_ids, capacity_mode, accepts_tablet, accepts_host)
+        topo.report_missing_tablet_sizes(lambda table: table in table_ids, accepts_host)
 
         requested_levels = set(args.level)
         sections = []

--- a/scripts/tablets/cluster_load.py
+++ b/scripts/tablets/cluster_load.py
@@ -1,0 +1,634 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Prints per- rack/node/shard tablet load information.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Iterable, Iterator
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tablets.filters import HostFilter
+from tablets.filters import TableFilter
+from tablets.filters import TabletFilter
+from tablets.filters import add_cluster_filter_options
+from tablets.filters import add_table_filter_options
+from tablets.filters import get_host_filter
+from tablets.filters import get_table_filter
+from tablets.filters import get_tablet_filter
+from tablets.filters import resolve_table_filter_id
+from tablets.filters import select_all
+from tablets.topology import Host
+from tablets.topology import RackId
+from tablets.topology import Tablet
+from tablets.topology import TableId
+from tablets.render_utils import Column
+from tablets.render_utils import DEFAULT_PRESENTATION
+from tablets.render_utils import PresentationOptions
+from tablets.render_utils import SEPARATING_LINE
+from tablets.render_utils import add_presentation_options
+from tablets.render_utils import format_ovc_pct
+from tablets.render_utils import format_pct
+from tablets.render_utils import format_rack_id
+from tablets.render_utils import format_shard_location
+from tablets.render_utils import format_size
+from tablets.render_utils import format_tablets_per_shard
+from tablets.render_utils import format_util_pct
+from tablets.render_utils import format_host
+from tablets.render_utils import get_presentation_options_from_args
+from tablets.render_utils import print_table
+from tablets.render_utils import render_hbar
+from tablets.stats import StatsAggregator
+from tablets.stats import overcommit
+from tablets.stats import share
+from tablets.topology import add_topology_source_args
+from tablets.topology import iter_token_fractions
+from tablets.topology import get_topology_source_from_args
+
+class CapacityMode(Enum):
+    """
+    Which capacity utilization is measured against. See --capacity.
+    """
+    EFFECTIVE = "effective"
+    ABSOLUTE = "absolute"
+
+
+# The --capacity spellings, each mode's short one first.
+CAPACITY_MODES = {
+    "eff": CapacityMode.EFFECTIVE,
+    "effective": CapacityMode.EFFECTIVE,
+    "abs": CapacityMode.ABSOLUTE,
+    "absolute": CapacityMode.ABSOLUTE,
+}
+
+
+def get_columns(capacity_mode: CapacityMode, options: PresentationOptions = DEFAULT_PRESENTATION) -> list[Column]:
+    """
+    Builds the report's columns.
+
+    The capacity mode only rewords the capacity and utilization columns. CSV adds the
+    leading columns which keep a flat table's rows self-describing, and names the label
+    column, which the rendered table leaves blank because its section says what it is.
+    """
+    effective = capacity_mode == CapacityMode.EFFECTIVE
+    columns = [
+        Column("location" if options.csv else ""),
+        Column("tablets\n/ shard", "right"),
+        Column("shard\ncount", "right"),
+        Column("tokens\n[%]", "right"),
+        Column("token ovc\n[%]", "right"),
+        Column("tokens", "left", csv=False),
+        Column("size\n[B]", "right"),
+        Column("size\n[%]", "right"),
+        Column("size ovc\n[%]", "right"),
+        Column("size", "left", csv=False),
+        Column("eff capacity\n[B]" if effective else "capacity\n[B]", "right"),
+        Column("eff util\n[%]" if effective else "util\n[%]", "right"),
+        Column("util ovc\n[%]", "right"),
+        Column("eff util" if effective else "util", "left", csv=False),
+    ]
+    if options.csv:
+        # CSV is one flat table, so every row has to say which section it came from
+        # and which rack it sits in. See build_location_columns().
+        columns = [Column("level"), Column("rack"), *columns]
+    return columns
+
+
+# Rack header rows span the rendered table, which has no CSV-only columns.
+COLUMN_COUNT = len(get_columns(CapacityMode.EFFECTIVE))
+
+
+def build_location_columns(level: str, rack_id: RackId | None) -> list:
+    """
+    Leading CSV-only columns naming the row's section and rack.
+
+    Replace the rack header rows the rendered table groups by, so every row stays
+    self-describing once the sections are concatenated into one.
+    """
+    return [level, format_rack_id(rack_id) if rack_id is not None else None]
+
+
+def get_host_capacity(host: Host, capacity_mode: CapacityMode) -> int:
+    """
+    Returns the host capacity for the given mode, or 0 when the snapshot does not
+    carry it.
+
+    The modes are never substituted for each other: an effective capacity missing
+    from the snapshot is reported as unknown rather than as the absolute capacity,
+    which would silently label absolute numbers as effective.
+    """
+    if capacity_mode == CapacityMode.EFFECTIVE:
+        return host.effective_capacity or 0
+    return host.storage_capacity or 0
+
+def max_ovc(ovcs: Iterable[float | None]) -> float | None:
+    """
+    The worst overcommit among peers, or None when none of them has one to report.
+    """
+    return max((ovc for ovc in ovcs if ovc is not None), default=None)
+
+
+@dataclass
+class ChildStats:
+    """
+    What the items merged into one measured, counted one apiece.
+
+    An item's overcommit is against these: they are the peers it is shown beside. Note that
+    this is not the item's own aggregate said twice: a node's sizes hold one entry per
+    replica, these hold one per shard. The totals agree, but only the average is read from
+    here, and the average of a shard is not the average of a replica.
+    """
+    sizes: StatsAggregator = field(default_factory=StatsAggregator)
+    tokens: StatsAggregator = field(default_factory=StatsAggregator)
+    utils: StatsAggregator = field(default_factory=StatsAggregator)
+
+    def add(self, child: LevelLoad) -> None:
+        self.sizes.add(child.size)
+        self.tokens.add(child.token_fraction)
+        self.utils.add(child.util)
+
+
+@dataclass
+class LevelLoad:
+    """
+    One row's worth of load: a shard, a node, a rack, or a whole DC.
+
+    Every level is measured the same way, over the replicas it was given: their sizes and
+    the token space they own, counted once each. What differs between levels is only which
+    replicas an item is given, and what the item is called.
+
+    So sizes and tokens are per replica, however far up the level is, and the counts they
+    carry are of replicas. Per-item measures come from `children`.
+    """
+    dc: str
+    rack_id: RackId | None = None
+    host: Host | None = None
+    shard_id: int | None = None
+
+    # Aggregated tablet replica sizes for this item. One sample per tablet replica.
+    sizes: StatsAggregator = field(default_factory=StatsAggregator)
+    # Aggregated tablet replica token fractions for this item. One sample per tablet replica.
+    tokens: StatsAggregator = field(default_factory=StatsAggregator)
+
+    # Structural, so a filter narrowing the replicas above leaves them alone. See collect_levels().
+    shard_count: int = 0
+    capacity: int = 0
+
+    # Aggregated stats for the level below, with one sample per element.
+    # For example, if this level describes a node, children contains samples for that node's shards.
+    children: ChildStats = field(default_factory=ChildStats)
+
+    # Overcommit of size on this item relative to peers at the same level.
+    # For a shard, peers are shards on the same node.
+    # For a node, peers are nodes on the same rack.
+    # For a rack, peers are racks in the same DC.
+    ovc: float | None = None
+    # Overcommit of token fraction on this item relative to peers at the same level.
+    token_ovc: float | None = None
+    # Overcommit of utilization on this item relative to peers at the same level.
+    util_ovc: float | None = None
+
+    def add_replica(self, size: int, token_fraction: float) -> None:
+        self.sizes.add(size)
+        self.tokens.add(token_fraction)
+
+    def merge(self, below: LevelLoad) -> None:
+        """
+        Takes in an item of the level below: everything it holds, the shards it counts, and
+        its measures, which its peers are then compared against.
+
+        Capacity is not merged, because the levels do not agree on which of it to count.
+        See collect_levels().
+        """
+        self.sizes.merge(below.sizes)
+        self.tokens.merge(below.tokens)
+        self.shard_count += below.shard_count
+        self.children.add(below)
+
+    def set_ovc(self, parent: LevelLoad) -> None:
+        """
+        Sets how far this item is from the peers it is shown beside, which are the other
+        items merged into its parent. Only meaningful once the parent has merged them all.
+        """
+        self.ovc = overcommit(self.size, parent.children.sizes.avg())
+        self.token_ovc = overcommit(self.token_fraction, parent.children.tokens.avg())
+        self.util_ovc = overcommit(self.util, parent.children.utils.avg())
+
+    def take_worst_ovc(self, below: LevelLoad) -> None:
+        """
+        Overcommit does not add up, so a level with no peers of its own on the report
+        carries the worst of the items it merged instead.
+        """
+        self.ovc = max_ovc((self.ovc, below.ovc))
+        self.token_ovc = max_ovc((self.token_ovc, below.token_ovc))
+        self.util_ovc = max_ovc((self.util_ovc, below.util_ovc))
+
+    @property
+    def level(self) -> str:
+        if self.shard_id is not None:
+            return "shard"
+        if self.host is not None:
+            return "node"
+        if self.rack_id is not None:
+            return "rack"
+        return "dc"
+
+    @property
+    def size(self) -> int:
+        return self.sizes.total
+
+    @property
+    def token_fraction(self) -> float:
+        return self.tokens.total
+
+    @property
+    def tablet_count(self) -> int:
+        return self.sizes.count
+
+    @property
+    def tablets_per_shard(self) -> float:
+        return self.tablet_count / self.shard_count if self.shard_count else 0
+
+    @property
+    def util(self) -> float:
+        return self.size / self.capacity if self.capacity else 0
+
+
+@dataclass
+class Levels:
+    """
+    The report's items at each level, each in the order its section shows them.
+    """
+    shards: list[LevelLoad]
+    nodes: list[LevelLoad]
+    racks: list[LevelLoad]
+    dcs: list[LevelLoad]
+    # One full ring per selected table, which is what a row's token share is taken of.
+    # A row counts every replica it holds, so with RF=3 a DC's share reaches 300%.
+    total_token_space: float = 0
+
+    @property
+    def total_size(self) -> int:
+        """
+        The replicated size every row's size share is taken of.
+        """
+        return sum(node.size for node in self.nodes)
+
+
+@dataclass(frozen=True)
+class SectionScales:
+    """
+    What a section's bars are drawn against: the largest value it shows.
+    """
+    max_size: int | float
+    max_token_fraction: float
+    max_util: float
+
+
+def get_section_scales(loads: list[LevelLoad]) -> SectionScales:
+    return SectionScales(
+        max_size=max((load.size for load in loads), default=0),
+        max_token_fraction=max((load.token_fraction for load in loads), default=0),
+        max_util=max((load.util for load in loads), default=0),
+    )
+
+
+def iter_tablets_with_token_fraction(topo, table_ids: list[TableId]) -> Iterator[tuple[TableId, Tablet, float]]:
+    for current_table_id in table_ids:
+        tablet_map = topo.get_tablet_map(current_table_id)
+        for tablet, token_fraction in iter_token_fractions(tablet_map.tablets):
+            yield current_table_id, tablet, token_fraction
+
+
+def get_selected_table_ids(topo, table_id: TableId | None,
+                           accepts_table: TableFilter = select_all) -> list[TableId]:
+    if table_id is not None:
+        return [table_id]
+    return [table_id for table_id in topo.iter_table_ids() if accepts_table(table_id)]
+
+
+def collect_levels(topo, table_ids: list[TableId], capacity_mode: CapacityMode,
+                   accepts_tablet: TabletFilter = select_all,
+                   accepts_host: HostFilter = select_all) -> Levels:
+    """
+    Measures every level in one walk of the replicas.
+
+    A replica is counted once, by the shard holding it, and every level above is the merge
+    of the one below: shards into their node, nodes into their rack, racks into their DC.
+    The levels therefore agree by construction rather than by being summed up separately.
+
+    Shard counts and capacity come from the topology instead, since they are properties of
+    the hardware: a node shows all of its shards even under --shard, and a rack shows the
+    capacity of every node in it, including nodes a filter kept off the report. A DC counts
+    only the racks it shows, which is what its summary row is a summary of.
+    """
+    nodes: dict[Any, LevelLoad] = {}
+    shards: dict[Any, LevelLoad] = {}
+    racks: dict[RackId, LevelLoad] = {}
+    dcs: dict[str, LevelLoad] = {}
+
+    for host in topo.all_normal_token_owner_hosts():
+        if not host.dc or not host.rack:
+            continue
+        rack_id = (host.dc, host.rack)
+        shard_count = host.shard_count or 0
+        capacity = get_host_capacity(host, capacity_mode)
+        nodes[host.id] = LevelLoad(dc=host.dc, rack_id=rack_id, host=host,
+                                   shard_count=shard_count, capacity=capacity)
+        for shard_id in range(shard_count):
+            if accepts_tablet((host.id, shard_id)):
+                shards[(host.id, shard_id)] = LevelLoad(dc=host.dc, rack_id=rack_id, host=host,
+                                                        shard_id=shard_id,
+                                                        capacity=capacity // shard_count)
+        racks.setdefault(rack_id, LevelLoad(dc=host.dc, rack_id=rack_id)).capacity += capacity
+        dcs.setdefault(host.dc, LevelLoad(dc=host.dc))
+
+    for table_id, tablet, token_fraction in iter_tablets_with_token_fraction(topo, table_ids):
+        for replica in tablet.replicas:
+            host_id, _ = replica
+            node = nodes.get(host_id)
+            if node is None or not accepts_tablet(replica):
+                continue
+            size = topo.get_tablet_size(table_id, tablet, replica)
+            # A replica on a shard its host does not report having is still the node's.
+            (shards.get(replica) or node).add_replica(size, token_fraction)
+
+    for (host_id, _), shard in shards.items():
+        nodes[host_id].merge(shard)
+    for (host_id, _), shard in shards.items():
+        shard.set_ovc(nodes[host_id])
+
+    # An empty node stays on the report: it is itself the imbalance, and dropping it would
+    # lift the peer averages its rack's OVCs compare against.
+    shown_nodes = sorted((node for node in nodes.values()
+                          if node.tablet_count or accepts_host(node.host)),
+                         key=lambda node: (node.rack_id, node.host.id))
+    for node in shown_nodes:
+        racks[node.rack_id].merge(node)
+    for node in shown_nodes:
+        node.set_ovc(racks[node.rack_id])
+
+    shown_racks = [racks[rack_id] for rack_id in sorted({node.rack_id for node in shown_nodes})]
+    for rack in shown_racks:
+        dcs[rack.dc].merge(rack)
+        dcs[rack.dc].capacity += rack.capacity
+    for rack in shown_racks:
+        rack.set_ovc(dcs[rack.dc])
+        dcs[rack.dc].take_worst_ovc(rack)
+
+    shown_dcs = [dcs[dc] for dc in sorted({rack.dc for rack in shown_racks})]
+    shown_shards = [shards[(node.host.id, shard_id)]
+                    for node in shown_nodes
+                    for shard_id in range(node.shard_count)
+                    if (node.host.id, shard_id) in shards]
+
+    return Levels(shards=shown_shards, nodes=shown_nodes, racks=shown_racks, dcs=shown_dcs,
+                  total_token_space=float(len(table_ids)))
+
+
+def group_by(loads: list[LevelLoad], key: Callable[[LevelLoad], Any]) -> dict[Any, list[LevelLoad]]:
+    groups: dict[Any, list[LevelLoad]] = defaultdict(list)
+    for load in loads:
+        groups[key(load)].append(load)
+    return groups
+
+
+def format_location(load: LevelLoad, options: PresentationOptions) -> str:
+    if load.level == "shard":
+        return format_shard_location(format_host(load.host, options), load.shard_id)
+    if load.level == "node":
+        return format_host(load.host, options)
+    if load.level == "rack":
+        return format_rack_id(load.rack_id)
+    # The rendered table reads the DC off the rack rows above it; a flat CSV cannot.
+    return load.dc if options.csv else "DC total"
+
+
+def format_tablets_cell(load: LevelLoad, options: PresentationOptions):
+    if load.level == "shard":
+        # A shard's own count is its tablets per shard, so it takes the same coloring.
+        return format_tablets_per_shard(load.tablet_count, precision=0, options=options)
+    if load.level == "node" or load.shard_count:
+        return format_tablets_per_shard(load.tablets_per_shard, options=options)
+    return None
+
+
+def build_row(load: LevelLoad, levels: Levels, scales: SectionScales,
+              options: PresentationOptions) -> list:
+    """
+    One row, whichever level it is of.
+
+    A DC summary gets no bars: it is the total the other rows are shares of, so a bar
+    scaled against it would fill every time.
+    """
+    show_bars = load.level != "dc"
+    token_frac = share(load.token_fraction, levels.total_token_space)
+    size_frac = share(load.size, levels.total_size)
+    return [
+        format_location(load, options),
+        format_tablets_cell(load, options),
+        None if load.level == "shard" else load.shard_count,
+        format_pct(token_frac, options=options),
+        format_ovc_pct(load.token_ovc, options),
+        render_hbar(load.token_fraction, scales.max_token_fraction, width=8) if show_bars else None,
+        format_size(load.size, options),
+        format_pct(size_frac, options=options),
+        format_ovc_pct(load.ovc, options),
+        render_hbar(load.size, scales.max_size, width=8) if show_bars else None,
+        format_size(load.capacity, options),
+        format_util_pct(load.util, options),
+        format_ovc_pct(load.util_ovc, options),
+        render_hbar(load.util, scales.max_util, width=8) if show_bars else None,
+    ]
+
+
+def build_section_rows(levels: Levels, loads: list[LevelLoad], options: PresentationOptions,
+                       subgroup_key: Callable[[LevelLoad], Any] | None = None) -> list:
+    """
+    Emits a rack header row and a separator before each rack, one row per load, and a
+    separator between subgroups within a rack when ``subgroup_key`` is given (used to
+    separate hosts in the shard-level section).
+
+    CSV drops that grouping: the rack moves into a column on every row, so the rows
+    stay one flat table.
+    """
+    scales = get_section_scales(loads)
+    if options.csv:
+        return [build_location_columns(load.level, load.rack_id)
+                + build_row(load, levels, scales, options)
+                for load in loads]
+
+    rows: list = []
+    current_rack = None
+    current_subgroup = None
+    for load in loads:
+        if load.rack_id != current_rack:
+            if current_rack is not None:
+                rows.append(SEPARATING_LINE)
+            current_rack = load.rack_id
+            rows.append(build_rack_header_row(load.rack_id, COLUMN_COUNT))
+            rows.append(SEPARATING_LINE)
+            current_subgroup = None
+        if subgroup_key is not None:
+            subgroup = subgroup_key(load)
+            if current_subgroup is not None and subgroup != current_subgroup:
+                rows.append(SEPARATING_LINE)
+            current_subgroup = subgroup
+        rows.append(build_row(load, levels, scales, options))
+    return rows
+
+
+def build_rack_header_row(rack_id: RackId, column_count: int) -> list:
+    return [format_rack_id(rack_id)] + [None] * (column_count - 1)
+
+
+def build_rack_rows(levels: Levels, options: PresentationOptions, show_summary: bool = True) -> list:
+    """
+    The rack section: a row per rack, grouped by DC, each group closed by its summary.
+    """
+    scales = get_section_scales(levels.racks)
+    racks_by_dc = group_by(levels.racks, lambda rack: rack.dc)
+
+    def row_for(load: LevelLoad) -> list:
+        row = build_row(load, levels, scales, options)
+        return build_location_columns(load.level, load.rack_id) + row if options.csv else row
+
+    rows = []
+    for idx, dc in enumerate(levels.dcs):
+        if idx and not options.csv:
+            rows.append(SEPARATING_LINE)
+        for rack in racks_by_dc.get(dc.dc, []):
+            rows.append(row_for(rack))
+        if show_summary:
+            if not options.csv:
+                rows.append(SEPARATING_LINE)
+            rows.append(row_for(dc))
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Print cluster load by rack, node, and shard.\n"
+                    "\n"
+                    "By default shows only per-rack and per-node sections. Use --level to show per-shard information.\n",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Columns:\n"
+            "                 Location label. Depending on section, this is a rack id, node, or shard (node:shard).\n"
+            "  tablets/shard  Number of tablet replicas per shard for the row.\n"
+            "  shard count    Number of shards aggregated by the row. Blank where not applicable.\n"
+            "  tokens [%]     Token-space share owned by the row, counting every replica copy. Because replication is counted, totals across peers can exceed 100.\n"
+            "  token ovc [%]  Percentage deviation from the average peer token share at the current aggregation level:\n"
+            "                 rack rows compare racks within a DC, node rows compare nodes within a rack,\n"
+            "                 and shard rows compare shards within a node.\n"
+            "  tokens         Fixed-width bar for token share, scaled within the current section.\n"
+            "  size [B]       Total replicated tablet size owned by the row.\n"
+            "  size [%]       Percentage of the shown replicated data owned by the row.\n"
+            "  size ovc [%]   Percentage deviation from the average peer size at the current aggregation level:\n"
+            "                 rack rows compare racks within a DC, node rows compare nodes within a rack,\n"
+            "                 and shard rows compare shards within a node.\n"
+            "  size           Fixed-width bar for size, scaled within the current section.\n"
+            "  capacity [B]   Capacity of the kind selected by --capacity. With --capacity effective (the default) the header\n"
+            "                 reads 'eff capacity', and the utilization columns below read 'eff util'.\n"
+            "  util [%]       Utilization relative to the selected capacity.\n"
+            "  util ovc [%]   Percentage deviation from the average peer utilization at the current aggregation level:\n"
+            "                 rack rows compare racks within a DC, node rows compare nodes within a rack,\n"
+            "                 and shard rows compare shards within a node.\n"
+            "  util           Fixed-width bar for utilization, scaled within the current section.\n"
+            "\n"
+            "Filter semantics:\n"
+            "  When --host/--shard/--rack/--dc is used, counts, sizes, token shares, and OVC comparisons are computed only from matching replicas and shown peers.\n"
+            "  size [%] stays relative to the shown replicated total, while tokens [%] stays a token-space share for the shown rows, counting every replica copy.\n"
+            "  Capacity is a property of the hardware, not of the selection, so no filter narrows it. A node row shows the node's whole\n"
+            "  capacity and shard count even under --shard. A rack row shows the capacity of every node in the rack, including nodes\n"
+            "  that --host left out of the report. util [%] therefore reads as the share of that full capacity which the selected\n"
+            "  replicas occupy.\n"
+            "\n"
+            "Sections:\n"
+            "  1. Rack-level rows, with DC summaries.\n"
+            "  2. Node-level rows.\n"
+            "  3. Shard-level rows.\n"
+            "\n"
+            "CSV output:\n"
+            "  --csv emits all sections as one table with a single header, since separate sections and the\n"
+            "  rack header rows that group nodes within them do not survive a CSV reader. Two columns lead:\n"
+            "    level     Section the row came from: dc, rack, node, or shard.\n"
+            "    rack      Rack the row belongs to, repeated on every row. Empty on dc rows.\n"
+            "  The label column is named 'location', and a DC summary is labelled with the DC name rather\n"
+            "  than 'DC total'.\n"
+        ),
+    )
+    source_group = parser.add_argument_group("Source options")
+    add_topology_source_args(source_group)
+
+    filtering_group = parser.add_argument_group("Filtering options")
+    add_table_filter_options(filtering_group)
+    add_cluster_filter_options(filtering_group)
+
+    report_group = parser.add_argument_group("Report options")
+    report_group.add_argument("--level", nargs="+", choices=["rack", "node", "shard"], default=["rack", "node"],
+                              help="Aggregation levels to display (default: rack node)")
+    report_group.add_argument("--no-summary", action="store_true",
+                              help="Skip the per-DC total rows")
+    report_group.add_argument("--capacity", choices=list(CAPACITY_MODES), default="effective",
+                              help="Display effective or absolute storage capacity/utilization (default: effective)")
+
+    presentation_group = parser.add_argument_group("Presentation options")
+    add_presentation_options(presentation_group, has_hosts=True)
+
+    args = parser.parse_args()
+    capacity_mode = CAPACITY_MODES[args.capacity]
+    options = get_presentation_options_from_args(args)
+
+    with get_topology_source_from_args(args) as src:
+        topo = src.get_topology()
+        table_id = resolve_table_filter_id(args, topo)
+        accepts_tablet = get_tablet_filter(args, topo)
+        accepts_host = get_host_filter(args, topo)
+
+        table_ids = get_selected_table_ids(topo, table_id, get_table_filter(args, topo))
+        levels = collect_levels(topo, table_ids, capacity_mode, accepts_tablet, accepts_host)
+
+        requested_levels = set(args.level)
+        sections = []
+
+        if "rack" in requested_levels:
+            sections.append(build_rack_rows(levels, options, show_summary=not args.no_summary))
+
+        if "node" in requested_levels:
+            sections.append(build_section_rows(levels, levels.nodes, options))
+
+        if "shard" in requested_levels:
+            sections.append(build_section_rows(levels, levels.shards, options,
+                                               subgroup_key=lambda shard: shard.host.id))
+
+        columns = get_columns(capacity_mode, options)
+        if options.csv:
+            # One header, one table: the level and rack columns keep the sections apart.
+            print_table([row for rows in sections for row in rows], columns, options)
+            return 0
+
+        for idx, rows in enumerate(sections):
+            if idx:
+                print()
+            if not print_table(rows, columns, options):
+                return 0
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tablets/cluster_load.py
+++ b/scripts/tablets/cluster_load.py
@@ -42,6 +42,7 @@ from tablets.render_utils import PresentationOptions
 from tablets.render_utils import SEPARATING_LINE
 from tablets.render_utils import add_presentation_options
 from tablets.render_utils import format_ovc_pct
+from tablets.render_utils import format_host_status
 from tablets.render_utils import format_pct
 from tablets.render_utils import format_rack_id
 from tablets.render_utils import format_shard_location
@@ -51,6 +52,7 @@ from tablets.render_utils import format_util_pct
 from tablets.render_utils import format_host
 from tablets.render_utils import get_presentation_options_from_args
 from tablets.render_utils import print_table
+from tablets.render_utils import red
 from tablets.render_utils import render_hbar
 from tablets.stats import StatsAggregator
 from tablets.stats import overcommit
@@ -83,10 +85,14 @@ def get_columns(capacity_mode: CapacityMode, options: PresentationOptions = DEFA
     The capacity mode only rewords the capacity and utilization columns. CSV adds the
     leading columns which keep a flat table's rows self-describing, and names the label
     column, which the rendered table leaves blank because its section says what it is.
+
+    A node's status is a column of its own in CSV, which is read by column, and part of the
+    location label otherwise.
     """
     effective = capacity_mode == CapacityMode.EFFECTIVE
     columns = [
         Column("location" if options.csv else ""),
+        *([Column("status")] if options.csv else []),
         Column("tablets\n/ shard", "right"),
         Column("shard\ncount", "right"),
         Column("tokens\n[%]", "right"),
@@ -418,6 +424,18 @@ def format_location(load: LevelLoad, options: PresentationOptions) -> str:
     return load.dc if options.csv else "DC total"
 
 
+def build_location_cells(load: LevelLoad, options: PresentationOptions) -> list:
+    """
+    What the row is of, and what is worth knowing about the host it is on. See
+    format_host_status().
+    """
+    location = format_location(load, options)
+    status = format_host_status(load.host)
+    if options.csv:
+        return [location, status or None]
+    return [red(f"{location} ({status})", options) if status else location]
+
+
 def format_tablets_cell(load: LevelLoad, options: PresentationOptions):
     if load.level == "shard":
         # A shard's own count is its tablets per shard, so it takes the same coloring.
@@ -439,7 +457,7 @@ def build_row(load: LevelLoad, levels: Levels, scales: SectionScales,
     token_frac = share(load.token_fraction, levels.total_token_space)
     size_frac = share(load.size, levels.total_size)
     return [
-        format_location(load, options),
+        *build_location_cells(load, options),
         format_tablets_cell(load, options),
         None if load.level == "shard" else load.shard_count,
         format_pct(token_frac, options=options),
@@ -529,6 +547,8 @@ def main() -> int:
         epilog=(
             "Columns:\n"
             "                 Location label. Depending on section, this is a rack id, node, or shard (node:shard).\n"
+            "                 A node which is down is marked '(D)', excluded as '(DX).\n"
+            "  status         Shown only in CSV output. Contains 'D' for down nodes, 'DX' for excluded nodes.\n"
             "  tablets/shard  Number of tablet replicas per shard for the row.\n"
             "  shard count    Number of shards aggregated by the row. Blank where not applicable.\n"
             "  tokens [%]     Token-space share owned by the row, counting every replica copy. Because replication is counted, totals across peers can exceed 100.\n"
@@ -568,6 +588,8 @@ def main() -> int:
             "  rack header rows that group nodes within them do not survive a CSV reader. Two columns lead:\n"
             "    level     Section the row came from: dc, rack, node, or shard.\n"
             "    rack      Rack the row belongs to, repeated on every row. Empty on dc rows.\n"
+            "  A 'status' column follows the location, holding D, X or DX for a node which is down, excluded, or\n"
+            "  both, and empty otherwise.\n"
             "  The label column is named 'location', and a DC summary is labelled with the DC name rather\n"
             "  than 'DC total'.\n"
         ),

--- a/scripts/tablets/filters.py
+++ b/scripts/tablets/filters.py
@@ -1,0 +1,229 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Shared filtering helpers for tablet-analysis scripts.
+
+Usage:
+
+- Pair `add_cluster_filter_options()` with `get_tablet_filter()` or `get_host_filter()`
+  when a script iterates or aggregates tablet replicas.
+- Pair `add_table_filter_options()` with `get_table_filter()` when a script iterates or
+  aggregates tables.
+
+A builder resolves what the arguments name against the topology once and returns a
+predicate. Scripts pass the predicate down instead of the arguments, so nothing below
+the entry point has to know which flags exist.
+
+Every builder assumes its options were added to the parser, so the attributes are there;
+an option left out on the command line is None and selects everything.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Callable
+
+from tablets.topology import Host
+from tablets.topology import parse_uuid
+from tablets.topology import RackId
+from tablets.topology import resolve_table_id
+from tablets.topology import TabletReplica
+from tablets.topology import TableId
+from tablets.topology import Topology
+
+
+HostFilter = Callable[[Host], bool]
+TabletFilter = Callable[[TabletReplica], bool]
+TableFilter = Callable[[TableId], bool]
+
+
+def add_cluster_filter_options(parser: argparse.ArgumentParser) -> None:
+    """
+    Adds replica-level cluster filter options.
+
+    Pair this with `get_tablet_filter()` or `get_host_filter()`.
+    """
+    parser.add_argument("--host", help="Restrict to replicas on the given host IP or host UUID")
+    parser.add_argument("--shard", type=parse_shard_location_arg,
+                        help="Restrict to replicas on the given shard, either as <host>:<shard> or as a bare shard number on any host")
+    parser.add_argument("--rack", type=parse_rack_arg, help="Restrict to replicas in the given rack, in the form <DC>/<rack>")
+    parser.add_argument("--dc", help="Restrict to replicas in the given datacenter")
+
+
+def add_table_filter_options(parser: argparse.ArgumentParser) -> None:
+    """
+    Adds table-level filter options.
+
+    Pair this with `get_table_filter()`.
+    """
+    parser.add_argument("--table", help="Table selector: exact ks.table, unique bare table name, or table UUID")
+    parser.add_argument("--keyspace", help="Restrict to tables in the given keyspace")
+
+
+def filter_args(**overrides) -> argparse.Namespace:
+    """
+    The arguments the filter options define, selecting everything except what the caller
+    narrows.
+
+    The names are exactly what add_cluster_filter_options() and add_table_filter_options()
+    add, and what every builder below assumes is present.
+    """
+    return argparse.Namespace(**{"host": None, "shard": None, "rack": None, "dc": None,
+                                 "table": None, "keyspace": None, **overrides})
+
+
+def parse_shard_location_arg(value: str) -> int | tuple[str, int]:
+    if ":" not in value:
+        try:
+            return int(value)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError("Shard must be an integer or have the form <host>:<shard>") from exc
+
+    host_arg, sep, shard_arg = value.rpartition(":")
+    if not sep or not host_arg or not shard_arg:
+        raise argparse.ArgumentTypeError("Shard location must have the form <host>:<shard>")
+    try:
+        shard_id = int(shard_arg)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("Shard number must be an integer") from exc
+    return host_arg, shard_id
+
+
+def parse_rack_arg(value: str) -> RackId:
+    dc, sep, rack = value.partition("/")
+    if not sep or not dc or not rack:
+        raise argparse.ArgumentTypeError("Rack must have the form <DC>/<rack>")
+    return dc, rack
+
+
+def resolve_host_id(topo: Topology, host_arg: str):
+    matching_hosts = [host.id for host in topo.all_hosts() if host.ip == host_arg]
+    if len(matching_hosts) > 1:
+        raise Exception(f"Ambiguous host ip: {host_arg}")
+    if matching_hosts:
+        return matching_hosts[0]
+
+    try:
+        host_id = parse_uuid(host_arg)
+    except ValueError as exc:
+        raise Exception(f"Unknown host: {host_arg}") from exc
+    if topo.get_host(host_id) is None:
+        raise Exception(f"Unknown host: {host_arg}")
+    return host_id
+
+
+def _resolve_shard(args, topo: Topology) -> int | TabletReplica | None:
+    """
+    Resolves --shard to a bare shard number, or to the replica it names.
+    """
+    if args.shard is None:
+        return None
+    if isinstance(args.shard, int):
+        return args.shard
+    host_arg, shard_id = args.shard
+    return resolve_host_id(topo, host_arg), shard_id
+
+
+def select_all(_) -> bool:
+    """
+    A filter selecting everything, for a caller with nothing to narrow by.
+    """
+    return True
+
+
+def get_host_filter(args, topo: Topology) -> HostFilter:
+    """
+    Builds the predicate for the location filters which select a whole host.
+
+    Only --host, --shard, --rack and --dc can reject a host; --table and --keyspace select
+    tables, so they never do. Lets a caller keep a host holding no matching replica, which
+    the tablet filter alone cannot decide.
+    """
+    host_id = resolve_host_id(topo, args.host) if args.host is not None else None
+    shard = _resolve_shard(args, topo)
+    # A bare --shard number selects that shard on every host, so it excludes no host.
+    shard_host_id = shard[0] if isinstance(shard, tuple) else None
+    rack, dc = args.rack, args.dc
+
+    def accepts(host: Host) -> bool:
+        if host_id is not None and host.id != host_id:
+            return False
+        if shard_host_id is not None and host.id != shard_host_id:
+            return False
+        if rack is not None and (host.dc, host.rack) != rack:
+            return False
+        if dc is not None and host.dc != dc:
+            return False
+        return True
+
+    return accepts
+
+
+def get_tablet_filter(args, topo: Topology) -> TabletFilter:
+    """
+    Builds the predicate selecting tablet replicas.
+
+    A replica is selected when --shard admits it and its host passes the host filter.
+    """
+    accepts_host = get_host_filter(args, topo)
+    shard = _resolve_shard(args, topo)
+    host_id = resolve_host_id(topo, args.host) if args.host is not None else None
+    has_location_filter = args.rack is not None or args.dc is not None
+
+    def accepts(replica: TabletReplica) -> bool:
+        host_id_of, shard_id = replica
+
+        if shard is not None:
+            if isinstance(shard, int):
+                if shard_id != shard:
+                    return False
+            elif replica != shard:
+                return False
+
+        host = topo.get_host(host_id_of)
+        if host is not None:
+            return accepts_host(host)
+
+        # An unknown host has no location, so only the filters not needing one can judge it.
+        if has_location_filter:
+            return False
+        return host_id is None or host_id_of == host_id
+
+    return accepts
+
+
+def resolve_table_filter_id(args, topo: Topology) -> TableId | None:
+    """
+    Resolves --table to the one table it names, or None when it was not given.
+    """
+    if args.table is None:
+        return None
+
+    if "." not in args.table and args.keyspace is not None:
+        return resolve_table_id(topo, f"{args.keyspace}.{args.table}")
+
+    table_id = resolve_table_id(topo, args.table)
+    if args.keyspace is not None and topo.get_keyspace_name(table_id) != args.keyspace:
+        raise Exception(f"Table {args.table} is not in keyspace {args.keyspace}")
+    return table_id
+
+
+def get_table_filter(args, topo: Topology) -> TableFilter:
+    """
+    Builds the predicate selecting tables by --table and --keyspace.
+    """
+    selected_table_id = resolve_table_filter_id(args, topo)
+    keyspace = args.keyspace
+
+    def accepts(table_id: TableId) -> bool:
+        if selected_table_id is not None and table_id != selected_table_id:
+            return False
+        if keyspace is not None and topo.get_keyspace_name(table_id) != keyspace:
+            return False
+        return True
+
+    return accepts

--- a/scripts/tablets/render_utils.py
+++ b/scripts/tablets/render_utils.py
@@ -292,6 +292,18 @@ def format_size(size: int | float, options: PresentationOptions = DEFAULT_PRESEN
         value /= 1024.0
 
 
+def format_count(value: float, precision: int = 2,
+                 options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Formats an averaged count, dimming the fraction as every other number does.
+
+    Examples:
+        >>> format_count(1.5)
+        '1.50'
+    """
+    return dim_fraction(f"{value:.{precision}f}", options)
+
+
 def format_pct(fraction: float | None, precision: int = 2,
                options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
     """

--- a/scripts/tablets/render_utils.py
+++ b/scripts/tablets/render_utils.py
@@ -16,7 +16,7 @@ import csv
 import io
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 from tablets.stats import overcommit
 from tablets.topology import Host
@@ -85,6 +85,29 @@ def format_host(host: Host, options: PresentationOptions = DEFAULT_PRESENTATION)
     if options.host_id or not host.ip:
         return str(host.id)
     return host.ip
+
+
+def format_host_status(host: Host | None) -> str:
+    """
+    What a report has to say about a node beyond its load: D when the cluster cannot reach
+    it, X when it is left out of load balancing, DX when both.
+
+    Empty for a working node, for a row which is of no one node, such as a rack, and for a
+    snapshot taken before system.load_per_node carried the columns, which leaves both
+    unknown rather than false.
+
+    Examples:
+        >>> host = Host(id="e1a4", shard_count=1)
+        >>> format_host_status(replace(host, up=False, excluded=True))
+        'DX'
+        >>> format_host_status(replace(host, up=True, excluded=False))
+        ''
+        >>> format_host_status(host), format_host_status(None)
+        ('', '')
+    """
+    if host is None:
+        return ""
+    return ("D" if host.up is False else "") + ("X" if host.excluded else "")
 
 
 def positive_int(value: str) -> int:
@@ -345,6 +368,17 @@ def color_replica_histogram(bar: str, replica_idx: int | None,
     if replica_idx == 1:
         return f"{ANSI_BLUE}{bar}{ANSI_RESET}"
     return f"{ANSI_GREEN}{bar}{ANSI_RESET}"
+
+
+def red(text: str, options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Marks text as something wrong, such as a node the cluster cannot reach.
+
+    Returns the text unchanged when color is off, so CSV and pipes stay clean.
+    """
+    if not options.colors:
+        return text
+    return f"{ANSI_RED}{text}{ANSI_RESET}"
 
 
 def color_zero_glyph(glyph: str, options: PresentationOptions = DEFAULT_PRESENTATION) -> str:

--- a/scripts/tablets/render_utils.py
+++ b/scripts/tablets/render_utils.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Shared terminal rendering helpers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import re
+import sys
+from dataclasses import dataclass
+from typing import Any
+from tablets.stats import overcommit
+from tablets.topology import Host
+from tablets.topology import RackId
+
+import tabulate as tabulate_module
+from tabulate import SEPARATING_LINE
+from tabulate import tabulate
+
+TABLE_FORMAT = "rounded_outline"
+
+# tabulate only splits embedded newlines for formats it lists as multiline, and no *_outline
+# format is listed, so a two-line header would be emitted raw and break the row. The rendering
+# path itself is format-agnostic, so registering the format is enough.
+tabulate_module.multiline_formats.setdefault(TABLE_FORMAT, TABLE_FORMAT)
+
+HISTOGRAM_WIDTH = 16
+PARTIAL_BLOCKS = ["", "▏", "▎", "▍", "▌", "▋", "▊", "▉"]
+
+# Do not use whitespace as the zero-height glyph: tabulate trims leading
+# whitespace in cells, which distorts the histogram.
+# Keep the tallest glyph at ▇ to leave one line of headroom.
+SPARKLINE_BLOCKS = "▁▁▂▃▄▅▆▇"
+ZERO_GLYPH = SPARKLINE_BLOCKS[0]
+
+ANSI_BLUE = "\033[34m"
+ANSI_GREEN = "\033[32m"
+ANSI_YELLOW = "\033[33m"
+ANSI_RED = "\033[31m"
+ANSI_DARK_GRAY = "\033[90m"
+ANSI_RESET = "\033[0m"
+ANSI_ESCAPE_RE = re.compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+
+# The Box Drawing block, which the table frame is built from. It stops short of the Block
+# Elements the bars and sparklines use, so cell content is never matched.
+BOX_DRAWING_RE = re.compile(r"[─-╿]+")
+
+
+@dataclass(frozen=True)
+class PresentationOptions:
+    """
+    What the shared presentation flags selected. See add_presentation_options().
+    """
+
+    # Render as CSV rather than a table, dropping bar columns.
+    csv: bool = False
+    # Format sizes with binary units instead of raw bytes.
+    human_readable: bool = True
+    # Identify a host by its id rather than its ip.
+    host_id: bool = False
+    # Identify a table by its id rather than keyspace.table.
+    table_id: bool = False
+    # Emit ANSI coloring. Off by default so that a caller which does not pass options,
+    # such as a doctest, gets plain text.
+    colors: bool = False
+
+
+DEFAULT_PRESENTATION = PresentationOptions()
+
+
+def format_host(host: Host, options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Renders a host the way a report identifies one: its ip, or its id when asked for or when
+    the host has no ip.
+    """
+    if options.host_id or not host.ip:
+        return str(host.id)
+    return host.ip
+
+
+def positive_int(value: str) -> int:
+    """
+    An argparse type for counts which have to be at least one.
+    """
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def add_presentation_options(parser: argparse.ArgumentParser, *,
+                             has_hosts: bool = False, has_tables: bool = False) -> None:
+    parser.add_argument("--csv", action="store_true", help="Render tabular output as CSV")
+    parser.add_argument("--hr", action=argparse.BooleanOptionalAction, default=True,
+                        help="Format sizes with binary units (default: enabled)")
+    # Defaults to None rather than to the detected value so that --colors can force coloring
+    # on for a pipe, which "auto plus an override" could not express.
+    parser.add_argument("--colors", action=argparse.BooleanOptionalAction, default=None,
+                        help="Colorize output (default: only when stdout is a terminal)")
+    if has_hosts:
+        parser.add_argument("--host-id", action="store_true", help="Show host id instead of ip")
+    if has_tables:
+        parser.add_argument("--table-id", action="store_true", help="Print table id instead of keyspace.table in the first column")
+
+
+def get_presentation_options_from_args(args: argparse.Namespace) -> PresentationOptions:
+    """
+    Reads the presentation flags a parser was given, defaulting the ones it left out.
+
+    --colors/--no-colors overrides coloring; left out, it follows whether stdout is a terminal.
+    """
+    colors = getattr(args, "colors", None)
+    return PresentationOptions(
+        csv=getattr(args, "csv", DEFAULT_PRESENTATION.csv),
+        human_readable=getattr(args, "hr", DEFAULT_PRESENTATION.human_readable),
+        host_id=getattr(args, "host_id", DEFAULT_PRESENTATION.host_id),
+        table_id=getattr(args, "table_id", DEFAULT_PRESENTATION.table_id),
+        colors=colors if colors is not None else sys.stdout.isatty(),
+    )
+
+
+def strip_ansi(value: str) -> str:
+    return ANSI_ESCAPE_RE.sub("", value)
+
+
+def normalize_csv_cell(value: Any) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return strip_ansi(value)
+    return value
+
+
+def normalize_csv_header(value: Any) -> str:
+    return strip_ansi(str(value)).replace("\n", " ")
+
+
+def color_frame(text: str, options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Dims a rendered table's frame to dark gray, leaving cell content as it was.
+
+    Colors whole runs of frame characters, so a row costs a handful of escapes rather
+    than one per character.
+    """
+    if not options.colors:
+        return text
+    return BOX_DRAWING_RE.sub(lambda m: f"{ANSI_DARK_GRAY}{m.group()}{ANSI_RESET}", text)
+
+
+def render_table(rows: list[Any], headers: list[Any], *, csv_output: bool = False,
+                 colalign: list[str] | None = None,
+                 options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    # Number parsing is always disabled: cells arrive pre-formatted, and letting
+    # tabulate re-parse them drops the OVC sign and trailing zeros ("+1.60" -> "1.6").
+    if not csv_output:
+        # tabulate sizes its alignment list from the rows, so passing colalign for a
+        # table a filter emptied would index past it. Headers alone still render.
+        return color_frame(tabulate(rows, headers, tablefmt=TABLE_FORMAT,
+                                    colalign=colalign if rows else None, disable_numparse=True), options)
+
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow([normalize_csv_header(header) for header in headers])
+    for row in rows:
+        if row == SEPARATING_LINE:
+            continue
+        writer.writerow([normalize_csv_cell(cell) for cell in row])
+    return output.getvalue().rstrip("\r\n")
+
+
+@dataclass(frozen=True)
+class Column:
+    """
+    Describes one table column: its header, alignment, and whether it appears in CSV output.
+
+    Bar/histogram columns set ``csv=False`` so they are dropped from CSV output,
+    where their sibling numeric columns carry the same information.
+    """
+    header: str = ""
+    align: str = "left"
+    csv: bool = True
+
+
+def print_table(rows: list[Any], columns: list[Column],
+                options: PresentationOptions = DEFAULT_PRESENTATION) -> bool:
+    """
+    Renders ``rows`` using column metadata, deriving headers, alignment, and CSV
+    column filtering from a single list of :class:`Column` descriptors.
+
+    A cell with no value is None, which renders blank in a table and as an empty field in
+    CSV. The format_*() helpers return "" for a value they were given as None, so a caller
+    can hand them one rather than testing first.
+
+    Columns with ``csv=False`` (typically bar/histogram columns) are dropped from
+    CSV output, where their sibling numeric columns carry the same information.
+    """
+    if options.csv:
+        kept = [idx for idx, col in enumerate(columns) if col.csv]
+        columns = [columns[idx] for idx in kept]
+        rows = [row if row == SEPARATING_LINE else [row[idx] for idx in kept] for row in rows]
+
+    try:
+        print(render_table(
+            rows,
+            [col.header for col in columns],
+            csv_output=options.csv,
+            colalign=[col.align for col in columns],
+            options=options,
+        ))
+    except BrokenPipeError:
+        return False
+    return True
+
+
+def render_hbar(value: float, max_value: float, width: int = HISTOGRAM_WIDTH) -> str:
+    """
+    Renders a fixed-width horizontal bar.
+
+    Args:
+        value: Value to render.
+        max_value: Reference value that fills the whole bar.
+        width: Bar width in terminal cells.
+
+    Returns:
+        A left-aligned Unicode block bar padded to ``width``.
+
+    Examples:
+        >>> render_hbar(0.5, 1.0, width=4)
+        '██  '
+    """
+    cells = (float(value) * width / max_value) if max_value else 0
+    full = int(cells)
+    partial = int((cells - full) * len(PARTIAL_BLOCKS))
+    bar = "█" * full
+    if partial > 0 and full < width:
+        bar += PARTIAL_BLOCKS[partial]
+    return bar.ljust(width)
+
+
+def dim_fraction(text: str, options: PresentationOptions = DEFAULT_PRESENTATION, color: str = "") -> str:
+    """
+    Dims a formatted number down to what is worth reading: the decimal point and the digits
+    after it go dark gray, while the significant digits and any unit keep ``color``, or the
+    default color when a caller passes none.
+
+    ``color`` is how a formatter which judges its value, such as format_util_pct(), keeps
+    that judgement on the digits that carry it. A number with no fraction is just colored.
+
+    Returns the text unchanged when color is off, so CSV and pipes stay clean.
+    """
+    if not options.colors:
+        return text
+    number, sep, unit = text.partition(" ")
+    whole, point, fraction = number.partition(".")
+    if color:
+        whole = f"{color}{whole}{ANSI_RESET}"
+    number = f"{whole}{ANSI_DARK_GRAY}{point}{fraction}{ANSI_RESET}" if point else whole
+    return f"{number}{sep}{unit}"
+
+
+def format_size(size: int | float, options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Formats a size in bytes, with binary units unless the report asked for raw ones.
+
+    Examples:
+        >>> format_size(1536)
+        '1.500 Ki'
+        >>> format_size(1536, PresentationOptions(human_readable=False))
+        '1536'
+    """
+    if not options.human_readable:
+        if isinstance(size, int) or (isinstance(size, float) and size.is_integer()):
+            return str(int(size))
+        return dim_fraction(f"{size:.3f}", options)
+
+    value = float(size)
+    for unit in ["B", "Ki", "Mi", "Gi", "Ti"]:
+        if value < 1024.0 or unit == "Ti":
+            padded_unit = f"{unit:>2}"
+            if unit == "B":
+                return dim_fraction(f"{int(value)} {padded_unit}", options)
+            return dim_fraction(f"{value:.3f} {padded_unit}", options)
+        value /= 1024.0
+
+
+def format_pct(fraction: float | None, precision: int = 2,
+               options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Formats a share of a total as a percentage, dimming the fraction the way a size is dimmed.
+
+    Takes the share itself, in [0, 1], so a caller never scales one by hand.
+
+    For the columns whose value is a share of a total, such as size [%] and tokens [%].
+    The columns carrying a judgement, ovc [%] and util [%], have their own coloring.
+
+    Examples:
+        >>> format_pct(0.123456)
+        '12.35'
+        >>> format_pct(None)
+        ''
+    """
+    if fraction is None:
+        return ""
+    return dim_fraction(f"{fraction * 100:.{precision}f}", options)
+
+
+def format_rack_id(rack_id: RackId) -> str:
+    return f"{rack_id[0]}/{rack_id[1]}"
+
+
+def color_replica_histogram(bar: str, replica_idx: int | None,
+                            options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Applies replica-specific ANSI coloring to a rendered bar fragment.
+
+    Replica 0 keeps the default color, replica 1 is light blue, and higher
+    replica indexes are light green. A bar standing for no single replica, such as one
+    of a whole range, keeps the default color too.
+    """
+    if not options.colors or replica_idx is None:
+        return bar
+    if replica_idx == 0:
+        return bar
+    if replica_idx == 1:
+        return f"{ANSI_BLUE}{bar}{ANSI_RESET}"
+    return f"{ANSI_GREEN}{bar}{ANSI_RESET}"
+
+
+def color_zero_glyph(glyph: str, options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Highlights a zero-height sparkline glyph in dark gray.
+    """
+    if not options.colors:
+        return glyph
+    return f"{ANSI_DARK_GRAY}{glyph}{ANSI_RESET}"
+
+
+def format_ovc_pct(value: float | None, options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Formats overcommit as a percentage deviation from 1.0.
+
+    Coloring is based on absolute deviation:
+    - < 3%: default
+    - < 10%: yellow/orange
+    - >= 10%: red
+
+    Examples:
+        >>> format_ovc_pct(1.05)
+        '+5.00'
+    """
+    if value is None:
+        return ""
+    pct = (value - 1) * 100
+    text = f"{pct:+.2f}"
+    if not options.colors:
+        return text
+    abs_pct = abs(pct)
+    if abs_pct < 3:
+        return text
+    if abs_pct < 10:
+        return f"{ANSI_YELLOW}{text}{ANSI_RESET}"
+    return f"{ANSI_RED}{text}{ANSI_RESET}"
+
+
+def format_ovc_ratio(value: float, average: float,
+                     options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Formats a value's overcommit against an average, as format_ovc_pct() formats the ratio.
+
+    An average of zero leaves nothing to deviate from, so the cell stays empty.
+
+    Examples:
+        >>> format_ovc_ratio(105, 100)
+        '+5.00'
+        >>> format_ovc_ratio(105, 0)
+        ''
+    """
+    return format_ovc_pct(overcommit(value, average), options)
+
+
+def format_util_pct(used: float, options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Formats utilization as a percentage, coloring the significant digits by level and
+    dimming the fraction as every other number does.
+
+    Takes the share of capacity in use, in [0, 1], as format_pct() does.
+
+    Coloring is based on utilization level:
+    - < 75%: default
+    - < 85%: yellow/orange
+    - >= 85%: red
+    """
+    color = ANSI_RED if used >= 0.85 else ANSI_YELLOW if used >= 0.75 else ""
+    return dim_fraction(f"{used * 100:.2f}", options, color)
+
+
+def format_tablets_per_shard(value: float | None, precision: int = 2,
+                             options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Formats tablets-per-shard with threshold-based coloring.
+
+    Coloring is based on the absolute value:
+    - < 200: default
+    - < 500: yellow/orange
+    - >= 500: red
+
+    A shard row counts whole tablets, so it asks for no decimals; rack and node rows
+    average over shards and keep two, dimmed as every other fraction is.
+    """
+    if value is None:
+        return ""
+    color = ANSI_RED if value >= 500 else ANSI_YELLOW if value >= 200 else ""
+    return dim_fraction(f"{value:.{precision}f}", options, color)
+
+
+def format_shard_location(host_part: str, shard_id: int) -> str:
+    """
+    Formats a host/shard location label.
+
+    Examples:
+        >>> format_shard_location('10.0.0.1', 3)
+        '10.0.0.1:3'
+    """
+    return f"{host_part}:{shard_id}"
+
+
+def render_vbar(value: int | float, max_value: int | float, blocks: str = SPARKLINE_BLOCKS,
+                color_zero: bool = True, options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Renders a single vertical bar glyph chosen from ``blocks``.
+
+    Args:
+        value: Value to render.
+        max_value: Reference value that maps to the tallest glyph.
+        blocks: Ordered glyph set from shortest to tallest.
+
+    Returns:
+        A single Unicode character.
+
+    Examples:
+        >>> render_vbar(5, 10, color_zero=False)
+        '▄'
+    """
+    if not max_value:
+        return color_zero_glyph(blocks[0], options) if color_zero else blocks[0]
+
+    # Clamped, so a value above the reference tops the glyph out rather than indexing past it.
+    level = min(max(round((value / max_value) * (len(blocks) - 1)), 0), len(blocks) - 1)
+    glyph = blocks[level]
+    if glyph == ZERO_GLYPH and color_zero:
+        return color_zero_glyph(glyph, options)
+    return glyph
+
+
+def render_sparkline(values: list[int], width: int | None = None,
+                     options: PresentationOptions = DEFAULT_PRESENTATION) -> str:
+    """
+    Renders a compact sparkline for a sequence of values.
+
+    While the value count is even and still above ``width``, adjacent values are
+    merged in pairs to make the sparkline fit. If the count is still above
+    ``width`` afterward, only the first ``width - 1`` values are rendered and
+    the last character is ``>`` to indicate truncation.
+
+    Args:
+        values: Input values.
+        width: Maximum number of glyphs to emit.
+
+    Returns:
+        A Unicode sparkline string.
+
+    Examples:
+        >>> render_sparkline([1, 2, 4, 8], width=4)
+        '▁▂▄▇'
+        >>> render_sparkline([1, 2, 3, 4, 5], width=4)
+        '▁▃▄>'
+    """
+    if not values:
+        return ""
+
+    if width is None:
+        width = len(values)
+
+    if width <= 0:
+        return ""
+
+    while len(values) > width and len(values) % 2 == 0:
+        values = [sum(values[i:i + 2]) / 2 for i in range(0, len(values), 2)]
+
+    # What is left over does not fit, so the last glyph gives way to a mark saying so.
+    truncated = len(values) > width
+    max_value = max(values)
+    chars = [render_vbar(value, max_value, options=options)
+             for value in (values[:width - 1] if truncated else values)]
+    if truncated:
+        chars.append(">")
+    return "".join(chars)

--- a/scripts/tablets/scylla-tablets.py
+++ b/scripts/tablets/scylla-tablets.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Unified entry point for the tablet-analysis scripts.
+
+Usage:
+
+    scylla-tablets <command> [options]
+
+Each command maps to a module in this directory, which can also be run directly
+(e.g. ./cluster_load.py). Run a command with --help for its options:
+
+    scylla-tablets cluster --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tablets import cluster_load
+from tablets import snapshot
+from tablets import table_load
+from tablets import table_summary
+
+# Command name -> the module implementing it. Each exposes a main() reading sys.argv.
+COMMANDS = {
+    "snapshot": snapshot,
+    "tables": table_summary,
+    "table": table_load,
+    "cluster": cluster_load,
+}
+
+# One-line descriptions shown in --help, mirroring each script's own summary.
+COMMAND_HELP = {
+    "snapshot": "Capture a tablet metadata and stats snapshot from a live cluster",
+    "tables": "Print one summary row per table",
+    "table": "Print per-tablet load information for a single table",
+    "cluster": "Print tablet load by datacenter, rack, node, and shard",
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="scylla-tablets",
+        description="Inspect tablet placement, load, and load-balancing state in ScyllaDB clusters.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Run 'scylla-tablets <command> --help' for command-specific options.",
+    )
+    subparsers = parser.add_subparsers(dest="command", metavar="<command>")
+    for name in COMMANDS:
+        subparsers.add_parser(name, help=COMMAND_HELP[name], add_help=False)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    parser = build_parser()
+    if not argv or argv[0] in ("-h", "--help"):
+        parser.print_help()
+        return 0
+
+    command = argv[0]
+    if command not in COMMANDS:
+        parser.error(f"invalid command: {command!r} (choose from {', '.join(COMMANDS)})")
+
+    # Hand the remaining arguments to the command's own argparse-based main(), which
+    # reads sys.argv. Rewrite argv[0] so its usage/error messages name the command.
+    sys.argv = [f"scylla-tablets {command}"] + argv[1:]
+    return COMMANDS[command].main()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tablets/snapshot.py
+++ b/scripts/tablets/snapshot.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Capture a tablet metadata and stats snapshot from a live cluster.
+
+By default, the script will create a directory with a name of the format tablet_snap_YYMMDD_HHMMSS with CSV files
+containing contents of system tables which contain relevant metadata, statistics and topology information.
+
+Use --gz to pack that directory into a tar.gz archive, which is easier to pass around. The analysis
+scripts accept such an archive directly via --snapshot, without unpacking it.
+
+Use --manual for a dry run which prints cqlsh instructions instead of taking the snapshot.
+"""
+
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import os.path
+import shutil
+import tarfile
+from datetime import datetime
+import shlex
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Generator, Sequence
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tablets.topology import CSV_DELIMITER
+from tablets.topology import Column
+from tablets.topology import SNAPSHOT_TABLES
+from tablets.topology import SnapshotTable
+from tablets.topology import add_topology_source_args
+from tablets.topology import get_live_topology_source_from_args
+
+
+def _format_field(value: Any, format_value: Callable[[Any], str]) -> str:
+    """
+    Renders one field; a null becomes the empty field reading takes for one.
+    """
+    if value is None:
+        return ""
+    return format_value(value)
+
+
+def _write_query_rows(path: str, rows, columns: Sequence[Column]) -> None:
+    """
+    Writes driver rows of a system table to a CSV dump.
+
+    Every column is written, not only the ones read back. Columns needing more than str() to
+    render say so in their Column.format.
+    """
+    formats = {column.name: column.format for column in columns}
+    with open(path, "w", newline="") as f:
+        writer = csv.writer(f, delimiter=CSV_DELIMITER)
+        if not rows:
+            return
+        fields = list(rows[0]._fields)
+        writer.writerow(fields)
+        for row in rows:
+            writer.writerow([
+                _format_field(getattr(row, field), formats.get(field, str))
+                for field in fields
+            ])
+
+
+def write_snapshot(snapshot_dir: str, src) -> None:
+    """
+    Writes a snapshot in a CSV format compatible with cqlsh COPY when used with
+    DELIMITER=';' and HEADER=TRUE.
+
+    ``snapshot_dir`` must already exist; the caller creates it atomically to claim
+    the name (see :func:`create_snapshot_dir`).
+
+    Read back by the csv module with the same quoting, so a field containing the delimiter
+    survives instead of splitting its row.
+    """
+    # All issued before any is awaited, so they run concurrently.
+    pending = {table: src.session.execute_async(src.queries[table]) for table in SNAPSHOT_TABLES}
+
+    for table, result in pending.items():
+        rows = list(result.result())
+        _write_query_rows(os.path.join(snapshot_dir, table.file), rows, table.columns)
+
+
+def print_manual_snapshot_instructions(args: argparse.Namespace, snapshot_dir: str) -> None:
+    """
+    Prints cqlsh commands that can be used to create a compatible snapshot manually.
+    """
+
+    cqlsh_args = []
+    if args.user:
+        cqlsh_args.extend(["-u", args.user])
+    if args.password:
+        cqlsh_args.extend(["-p", args.password])
+    # cqlsh takes host then port positionally, so a port needs a host ahead of it.
+    if args.cluster or args.port:
+        cqlsh_args.append(args.cluster or "127.0.0.1")
+    if args.port:
+        cqlsh_args.append(str(args.port))
+
+    cqlsh_prefix = " ".join(["cqlsh"] + [shlex.quote(arg) for arg in cqlsh_args])
+
+    def copy_cmd(table: SnapshotTable) -> str:
+        query = (f"COPY {table.name} TO '{snapshot_dir}/{table.file}'"
+                 f" WITH DELIMITER='{CSV_DELIMITER}' AND HEADER=TRUE")
+        return f"{cqlsh_prefix} -e {shlex.quote(query)}"
+
+    print(f"mkdir -p {shlex.quote(snapshot_dir)}")
+    for table in SNAPSHOT_TABLES:
+        print(copy_cmd(table))
+    if getattr(args, "gz", False):
+        quoted_dir = shlex.quote(snapshot_dir)
+        print(f"tar -czf {shlex.quote(archive_path_for(snapshot_dir))} {quoted_dir} && rm -r {quoted_dir}")
+
+
+def archive_path_for(snapshot_dir: str) -> str:
+    return f"{snapshot_dir}.tar.gz"
+
+
+def snapshot_dir_candidates(output_dir: str | None) -> Generator[str, None, None]:
+    """
+    Yields candidate snapshot directory names.
+
+    A requested name is the only candidate, so the caller gets that name or an error.
+    A timestamped one is followed by millisecond suffixes, endlessly, recomputing the
+    timestamp each time so a fresh second can be taken plain.
+
+    Never checks whether a name is free: the caller claims one by creating it, keeping
+    check and creation a single atomic step so concurrent runs cannot pick the same name.
+    """
+    if output_dir is not None:
+        yield output_dir
+        return
+
+    def base() -> str:
+        return datetime.now().strftime("tablet_snap_%y%m%d_%H%M%S")
+
+    yield base()
+    while True:
+        yield f"{base()}_{int(time.time_ns() / 1_000_000) % 1000:03d}"
+        time.sleep(0.001)
+
+
+def create_snapshot_dir(output_dir: str | None, gz: bool = False, workdir: Path = Path(".")) -> str:
+    """
+    Creates a snapshot directory under ``workdir`` and returns its path.
+
+    Never overwrites: the directory is claimed with ``os.mkdir``, which fails atomically
+    if taken, and with ``gz`` the archive name must be free too.
+
+    When output_dir is set, snapshot will be created with that name and function raises if it already exists.
+    Otherwise, name is generated based on current timestamp and function will keep trying until it finds a free name.
+    """
+    for candidate in snapshot_dir_candidates(output_dir):
+        path = str(workdir / candidate)
+        archive = archive_path_for(path)
+        if gz and os.path.exists(archive):
+            conflict = archive
+            continue
+        try:
+            os.mkdir(path)
+        except FileExistsError:
+            conflict = path
+            continue
+        return path
+    # Reachable only for a requested name; a timestamped one never runs out.
+    raise Exception(f"Snapshot already exists: {conflict}")
+
+
+def choose_manual_snapshot_dir(output_dir: str | None, gz: bool = False) -> str:
+    """
+    Chooses a snapshot directory name for the manual workflow without creating it.
+
+    The printed commands create it, so the name is only checked, not claimed: unlike
+    :func:`create_snapshot_dir` this cannot be atomic, and is best-effort.
+    """
+    def is_taken(name: str) -> bool:
+        return os.path.exists(name) or (gz and os.path.exists(archive_path_for(name)))
+
+    for candidate in snapshot_dir_candidates(output_dir):
+        if not is_taken(candidate):
+            return candidate
+    # Only a requested name runs out of candidates; a timestamped one keeps trying.
+    raise Exception(f"Snapshot already exists: {candidate}")
+
+
+def pack_snapshot(snapshot_dir: str) -> str:
+    """
+    Packs a snapshot directory into a tar.gz archive next to it and removes the
+    directory, returning the archive path.
+
+    The snapshot directory is the single top-level entry of the archive, so
+    unpacking it recreates the directory layout the analysis scripts expect.
+    """
+    archive_path = archive_path_for(snapshot_dir)
+    with tarfile.open(archive_path, "w:gz") as tar:
+        tar.add(snapshot_dir, arcname=os.path.basename(os.path.normpath(snapshot_dir)))
+    shutil.rmtree(snapshot_dir)
+    return archive_path
+
+
+def take_snapshot(args: argparse.Namespace, workdir: Path = Path(".")) -> Path:
+    """
+    Captures a snapshot from the cluster ``args`` names, returning the directory it wrote,
+    or the archive when ``--gz`` is set.
+
+    Writes only under ``workdir``, and leaves the working directory alone: it is
+    process-global, so moving it would be seen by everything else in the process.
+    """
+    snapshot_dir = create_snapshot_dir(args.output_dir, gz=args.gz, workdir=workdir)
+    with get_live_topology_source_from_args(args) as src:
+        write_snapshot(snapshot_dir, src)
+    return Path(pack_snapshot(snapshot_dir) if args.gz else snapshot_dir)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Capture tablet layout snapshot from a live cluster")
+    add_topology_source_args(parser)
+    parser.add_argument("--output-dir", metavar="DIR", help="Output snapshot directory (default: tablet_snap_YYMMDD_HHMMSS)")
+    parser.add_argument("--gz", action="store_true",
+                        help="Pack the snapshot directory into a <name>.tar.gz archive and remove the directory. "
+                             "--snapshot reads such an archive directly, without unpacking")
+    parser.add_argument("--manual", action="store_true",
+                        help="Print cqlsh COPY commands that create the snapshot instead of capturing it directly")
+
+    args = parser.parse_args()
+
+    if args.manual:
+        snapshot_dir = choose_manual_snapshot_dir(args.output_dir, gz=args.gz)
+        print_manual_snapshot_instructions(args, snapshot_dir)
+        return 0
+
+    print(os.path.abspath(take_snapshot(args)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tablets/stats.py
+++ b/scripts/tablets/stats.py
@@ -1,0 +1,94 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Accumulators for the measures the reports take over their rows.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+
+def share(value: float, total: float) -> float:
+    """
+    What part of a total a value takes, or 0 when the total is nothing to take a part of.
+    """
+    return value / total if total else 0
+
+
+def overcommit(value: float | None, average: float) -> float | None:
+    """
+    How far a value is from an average, as a ratio.
+
+    Peers which all hold nothing are evenly spread, not unmeasurable: an empty table sits at
+    the average on every shard it is on, so it reports as balanced rather than as a blank.
+    None when there is nothing to compare at all: no value, or one above an average of zero,
+    which peers holding nothing cannot produce.
+    """
+    if average:
+        return value / average if value is not None else None
+    return 1.0 if value == 0 else None
+
+
+@dataclass
+class StatsAggregator:
+    """
+    Accumulates values as they are seen, so a caller measuring a set does not have to keep
+    it, nor walk it once per measure.
+
+    An aggregator which was given nothing has no min or max, an average of 0, and no
+    overcommit to speak of.
+    """
+    count: int = 0
+    total: float = 0
+    min: float | None = None
+    max: float | None = None
+
+    @classmethod
+    def of(cls, values: Iterable[float]) -> StatsAggregator:
+        """
+        An aggregator of values a caller already holds.
+        """
+        stats = cls()
+        for value in values:
+            stats.add(value)
+        return stats
+
+    def add(self, value: float) -> None:
+        self.count += 1
+        self.total += value
+        self.min = value if self.min is None else min(self.min, value)
+        self.max = value if self.max is None else max(self.max, value)
+
+    def merge(self, other: StatsAggregator) -> None:
+        """
+        Takes in everything another aggregator was given, as if it had been added here.
+        """
+        self.count += other.count
+        self.total += other.total
+        if other.min is not None:
+            self.min = other.min if self.min is None else min(self.min, other.min)
+        if other.max is not None:
+            self.max = other.max if self.max is None else max(self.max, other.max)
+
+    def avg(self) -> float:
+        return self.total / self.count if self.count else 0
+
+    def max_frac(self) -> float:
+        """
+        The share of the total the largest value takes, which is what a bar scaled against
+        the values is drawn to. 0 when nothing was added.
+        """
+        return share(self.max, self.total)
+
+    def ovc(self) -> float | None:
+        """
+        Overcommit.
+        How far the largest value overcommits the average of them all.
+        """
+        return overcommit(self.max, self.avg())

--- a/scripts/tablets/table_load.py
+++ b/scripts/tablets/table_load.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Presents table's internal load distribution across tablets / token space.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from itertools import zip_longest
+from pathlib import Path
+from statistics import mean
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tablets.filters import add_cluster_filter_options
+from tablets.filters import TabletFilter
+from tablets.filters import get_tablet_filter
+from tablets.filters import select_all
+from tablets.render_utils import Column
+from tablets.render_utils import PresentationOptions
+from tablets.render_utils import SEPARATING_LINE
+from tablets.render_utils import add_presentation_options
+from tablets.render_utils import color_replica_histogram
+from tablets.render_utils import format_count
+from tablets.render_utils import format_ovc_ratio
+from tablets.render_utils import format_pct
+from tablets.render_utils import format_rack_id
+from tablets.render_utils import format_shard_location
+from tablets.render_utils import format_size
+from tablets.render_utils import get_presentation_options_from_args
+from tablets.render_utils import format_host
+from tablets.render_utils import positive_int
+from tablets.render_utils import print_table
+from tablets.render_utils import render_hbar
+from tablets.render_utils import render_sparkline
+from tablets.stats import StatsAggregator
+from tablets.stats import share
+from tablets.topology import HostId
+from tablets.topology import TableId
+from tablets.topology import TabletMap
+from tablets.topology import TabletReplica
+from tablets.topology import Token
+from tablets.topology import Topology
+from tablets.topology import add_topology_source_args
+from tablets.topology import get_topology_source_from_args
+from tablets.topology import iter_token_fractions
+from tablets.topology import resolve_table_id
+
+
+
+@dataclass
+class TabletLoadRange:
+    last_token: Token
+    tablet_count: int
+    # Replicated size of the range, or of one replica once split. See build_ranges().
+    size: int
+    token_frac: float
+    # Sizes of every replica of the range, in replica order, which a split range keeps so
+    # that the ALL row can add them up replica by replica.
+    replica_sizes: list[int]
+    replicas: list[TabletReplica]
+
+    # Sizes of every replica of the range, taken once when it is built. A split range keeps
+    # them, so the measures below describe the whole range whichever row carries them.
+    replica_stats: StatsAggregator
+    # Set when --per-replica is used, and None otherwise.
+    # Indexes into self.replicas.
+    replica_idx: int | None = None
+
+    @property
+    def avg_replica_size(self) -> float:
+        return self.replica_stats.avg()
+
+    @property
+    def replica_ovc(self) -> float | None:
+        return self.replica_stats.ovc()
+
+    def size_frac(self, total_size: int) -> float:
+        return share(self.size, total_size)
+
+
+def make_load_range(last_token: Token, tablet_count: int, token_frac: float,
+                    replica_sizes: list[int], replicas: list[TabletReplica]) -> TabletLoadRange:
+    """
+    A range over the given replicas, whose size is theirs summed.
+    """
+    replica_stats = StatsAggregator()
+    for replica_size in replica_sizes:
+        replica_stats.add(replica_size)
+    return TabletLoadRange(
+        last_token=last_token,
+        tablet_count=tablet_count,
+        size=replica_stats.total,
+        token_frac=token_frac,
+        replica_sizes=replica_sizes,
+        replicas=replicas,
+        replica_stats=replica_stats,
+    )
+
+
+def sum_replica_sizes_by_index(ranges: list[TabletLoadRange]) -> list[int]:
+    """
+    The ranges' sizes added up replica by replica, so the n-th total is what every n-th
+    replica holds together. Ranges with fewer replicas contribute nothing to the rest.
+    """
+    return [sum(sizes) for sizes in zip_longest(*(r.replica_sizes for r in ranges), fillvalue=0)]
+
+
+def format_avg_size(values: list[float], options: PresentationOptions) -> str:
+    return format_size(mean(values), options) if values else ""
+
+
+def merge_adjacent_ranges(ranges: list[TabletLoadRange], max_ranges: int | None) -> list[TabletLoadRange]:
+    if not max_ranges or len(ranges) <= max_ranges:
+        return ranges
+
+    group_count = min(max_ranges, len(ranges))
+    base_group_size = len(ranges) // group_count
+    extra = len(ranges) % group_count
+
+    merged = []
+    idx = 0
+    for group_idx in range(group_count):
+        current_group_size = base_group_size + (1 if group_idx < extra else 0)
+        group = ranges[idx:idx + current_group_size]
+        idx += current_group_size
+        merged.append(make_load_range(
+            last_token=group[-1].last_token,
+            tablet_count=sum(r.tablet_count for r in group),
+            token_frac=sum(r.token_frac for r in group),
+            replica_sizes=sum_replica_sizes_by_index(group),
+            replicas=[],
+        ))
+
+    return merged
+
+
+# Ranges arrive in token order, which "token" therefore leaves alone; every other key
+# sorts worst-first.
+SORT_KEYS = {
+    "token": None,
+    "tokens": lambda load_range: load_range.token_frac,
+    "size": lambda load_range: load_range.size,
+    "ovc.rep": lambda load_range: load_range.replica_ovc or 0,
+}
+
+
+def sort_ranges(ranges: list[TabletLoadRange], sort_key: str) -> list[TabletLoadRange]:
+    key = SORT_KEYS[sort_key]
+    return ranges if key is None else sorted(ranges, key=key, reverse=True)
+
+
+def build_ranges(table_id: TableId, tmap: TabletMap, topo: Topology,
+                 accepts_tablet: TabletFilter = select_all,
+                 per_replica: bool = False) -> list[TabletLoadRange]:
+    ranges = []
+    for tablet, token_frac in iter_token_fractions(tmap.tablets):
+        replicas = [replica for replica in tablet.replicas if accepts_tablet(replica)]
+        replica_sizes = [topo.get_tablet_size(table_id, tablet, replica) for replica in replicas]
+        if not replica_sizes:
+            continue
+        load_range = make_load_range(
+            last_token=tablet.last_token,
+            tablet_count=1,
+            token_frac=token_frac,
+            replica_sizes=replica_sizes,
+            replicas=replicas,
+        )
+        if not per_replica:
+            ranges.append(load_range)
+            continue
+
+        # One range per replica, sized as that replica. The measures of the whole range
+        # are the ones taken above, so every one of its rows reports the same.
+        for idx, size in enumerate(replica_sizes):
+            ranges.append(TabletLoadRange(
+                last_token=load_range.last_token,
+                tablet_count=load_range.tablet_count,
+                size=size,
+                token_frac=load_range.token_frac,
+                replica_sizes=replica_sizes,
+                replicas=replicas,
+                replica_stats=load_range.replica_stats,
+                replica_idx=idx,
+            ))
+    return ranges
+
+
+@dataclass
+class ReportShape:
+    """
+    Which columns the report has.
+
+    Whether a row stands for one replica or for a whole range decides most of them: a
+    replica row says where it sits, and cannot carry measures of the range it is part of.
+    """
+    per_replica: bool
+    show_tablet_count: bool
+    show_token_hist: bool
+
+
+def build_shape(args: argparse.Namespace, tablet_count: int) -> ReportShape:
+    show_tablet_count = args.max_ranges is not None and tablet_count > args.max_ranges
+    return ReportShape(
+        per_replica=args.per_replica,
+        show_tablet_count=show_tablet_count,
+        show_token_hist=args.tokens_hist,
+    )
+
+
+def format_replica_rack(topo: Topology, host_id: HostId) -> str:
+    host = topo.get_host(host_id)
+    if host is None:
+        return ""
+    if host.dc and host.rack:
+        return format_rack_id((host.dc, host.rack))
+    return ""
+
+
+def format_replica_shard(topo: Topology, host_id: HostId, shard_id: int,
+                         options: PresentationOptions) -> str:
+    host = topo.get_host(host_id)
+    host_part = str(host_id) if host is None else format_host(host, options)
+    return format_shard_location(host_part, shard_id)
+
+
+def build_summary_row(label: str, shape: ReportShape, *, tablets, tokens, size, avg_replica_size,
+                      ovc, size_frac, size_bar, replicas) -> list:
+    """
+    A summary row, laid out like every other row so that the two stay in step.
+
+    The token histogram is left blank: a summary spans the whole token space, so a bar of
+    it would say nothing. So are the location columns, since a summary sits nowhere.
+    """
+    row = [label]
+    if shape.show_tablet_count:
+        row.append(tablets)
+    row.append(tokens)
+    if shape.show_token_hist:
+        row.append(None)
+    row.append(size)
+    if not shape.per_replica:
+        row.append(avg_replica_size)
+    row.extend([ovc, size_frac, size_bar])
+    if not shape.per_replica:
+        row.append(replicas)
+    if shape.per_replica:
+        row.extend([None, None])
+    return row
+
+
+def build_summary_rows(rows: list[TabletLoadRange], shape: ReportShape,
+                       options: PresentationOptions, summary: RowsSummary) -> list[list]:
+    sizes = summary.sizes
+    # Per-tablet measures average over tablets, not over the rows they take: ranges split
+    # per replica would otherwise weigh a tablet by its replica count.
+    tablets = list({r.last_token: r for r in rows}.values())
+    total_replica_sizes = sum_replica_sizes_by_index(tablets)
+    # Every row shown takes an equal share of the total, which is what an average row holds.
+    avg_frac = share(1, sizes.count)
+
+    total_row = build_summary_row(
+        "ALL", shape,
+        tablets=sum(r.tablet_count for r in tablets),
+        tokens=None,
+        size=format_size(sizes.total, options),
+        avg_replica_size=format_avg_size(total_replica_sizes, options),
+        # The widest row, as its overcommit against the average row.
+        ovc=format_ovc_ratio(sizes.max or 0, sizes.avg(), options),
+        size_frac=None,
+        size_bar=None,
+        replicas=render_sparkline(total_replica_sizes, options=options),
+    )
+    avg_row = build_summary_row(
+        "Average", shape,
+        tablets=format_count(mean(r.tablet_count for r in tablets), 3, options) if tablets else None,
+        tokens=format_pct(mean(r.token_frac for r in tablets), 4, options) if tablets else None,
+        size=format_size(sizes.avg(), options) if sizes.count else None,
+        avg_replica_size=format_avg_size([r.avg_replica_size for r in tablets], options),
+        ovc=None,
+        size_frac=format_pct(avg_frac, 4, options) if avg_frac else None,
+        size_bar=render_hbar(avg_frac, sizes.max_frac()) if avg_frac else None,
+        replicas=None,
+    )
+    return [total_row, avg_row, SEPARATING_LINE]
+
+
+def build_columns(shape: ReportShape, options: PresentationOptions) -> list[Column]:
+    columns = [Column("last token")]
+    if shape.show_tablet_count:
+        columns.append(Column("tablets", "right"))
+    columns.append(Column("tokens\n[%]", "right"))
+    if shape.show_token_hist:
+        columns.append(Column("tokens", "left", csv=False))
+    columns.append(Column("replicated\nsize [B]", "right"))
+    if not shape.per_replica:
+        columns.append(Column("size\n/ replica [B]", "right"))
+    columns.extend([Column("ovc\n[%]", "right"), Column("size\n[%]", "right"), Column("size", "left", csv=False)])
+    if not shape.per_replica:
+        columns.append(Column("rep", "left", csv=False))
+    if shape.per_replica:
+        columns.extend([Column("rack"), Column("shard")])
+    return columns
+
+
+def build_rows(rows: list[TabletLoadRange], shape: ReportShape, options: PresentationOptions,
+                topo: Topology, summary: RowsSummary) -> list[list]:
+    """
+    One table row per row of the report: whether it shows a replica or a whole range is the
+    row's own business, so nothing here has to be told which report this is.
+    """
+    total_size, avg_size = summary.sizes.total, summary.sizes.avg()
+    max_frac, max_token_frac = summary.sizes.max_frac(), summary.max_token_frac()
+    formatted = []
+    prev_last_token = None
+    for load_range in rows:
+        idx = load_range.replica_idx
+        frac = load_range.size_frac(total_size)
+        # A tablet's measures show once, on the first of the rows it takes. Sorting can put
+        # a tablet's replicas apart, so what counts is the row above, not the replica index.
+        # A row of the rendered table reads them off the row above it; a csv row has to stand
+        # on its own, so they repeat: summing the token share then counts every replica copy,
+        # as cluster_load.py does, and RF=3 totals 300%. An unsplit range is its own tablet,
+        # so it always shows them.
+        show_tablet = load_range.last_token != prev_last_token or options.csv
+        prev_last_token = load_range.last_token
+
+        columns = [load_range.last_token if show_tablet else None]
+        if shape.show_tablet_count:
+            columns.append(load_range.tablet_count if show_tablet else None)
+        columns.append(format_pct(load_range.token_frac, 4, options) if show_tablet else None)
+        if shape.show_token_hist:
+            columns.append(render_hbar(load_range.token_frac, max_token_frac) if show_tablet else None)
+        columns.append(format_size(load_range.size, options))
+        if not shape.per_replica:
+            columns.append(format_size(load_range.avg_replica_size, options))
+        columns.extend([
+            format_ovc_ratio(load_range.size, avg_size, options),
+            format_pct(frac, 4, options),
+            color_replica_histogram(render_hbar(frac, max_frac), idx, options),
+        ])
+        if not shape.per_replica:
+            columns.append(render_sparkline(load_range.replica_sizes, options=options) if load_range.replica_sizes else None)
+        if shape.per_replica:
+            host_id, shard_id = load_range.replicas[idx]
+            columns.append(format_replica_rack(topo, host_id))
+            columns.append(format_replica_shard(topo, host_id, shard_id, options))
+        formatted.append(columns)
+
+    return formatted
+
+
+@dataclass(frozen=True)
+class RowsSummary:
+    """
+    What the rows about to be printed are measured and scaled against.
+    """
+    # Replicated size of every row shown, whose total the shares are taken of.
+    sizes: StatsAggregator
+    # Token share of every row shown.
+    token_fracs: StatsAggregator
+
+    def max_token_frac(self) -> float:
+        """
+        The largest token share of any range shown, which scales the token bars.
+        """
+        return self.token_fracs.max or 0
+
+
+def summarize_rows(rows: list[TabletLoadRange]) -> RowsSummary:
+    sizes = StatsAggregator()
+    token_fracs = StatsAggregator()
+    for row in rows:
+        sizes.add(row.size)
+        token_fracs.add(row.token_frac)
+    return RowsSummary(sizes=sizes, token_fracs=token_fracs)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Presents per-tablet load information for a single table\n"
+                    "\n"
+                    "By default shows one row per tablet, aggregating all replicas. Use --per-replica to show one row per tablet replica.\n"
+                    "\n"
+                    "You can aggregate tablet ranges using --max-ranges. This will merge adjacent tablets until the printed range count\n"
+                    "is at most the specified value. It's a way to simulate table-level tablet merge events.\n",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Columns:\n"
+            "  last token           Ending token of the tablet, or token range if aggregated.\n"
+            "  tablets              Number of shown tablets in the row's token range (shown only when coalescing with --max-ranges).\n"
+            "  tokens [%]           Fraction of the table's token space covered by the row.\n"
+            "  tokens               Optional bar for token-space coverage (shown with --tokens-hist).\n"
+            "  replicated size [B]  Total replicated size of shown replicas in the token range.\n"
+            "  size / replica [B]   Replicated size of the row divided by its replica count (shown only without --per-replica).\n"
+            "                       For a single-tablet row this is the average replica size. For rows that aggregate\n"
+            "                       several tablets (--max-ranges) and for the ALL row, the replica count is the number of\n"
+            "                       replicas per tablet, so the value is the size carried by one replica of the whole range.\n"
+            "  rep                  Per-replica size histogram, one vertical bar per replica, scaled to the largest replica in the current row.\n"
+            "  ovc [%]              Size overcommit, shown as percentage deviation from the average row size.\n"
+            "                       In the ALL row, it's the maximal overcommit among the rows, and is a measure of imbalance between tablets.\n"
+            "  size [%]             Fraction this row's size takes of the shown replicated size of the table.\n"
+            "  rack                 Replica rack location (shown only with --per-replica).\n"
+            "  shard                Replica host:shard location (shown only with --per-replica).\n"
+            "\n"
+            "Filter semantics:\n"
+            "  When --host/--shard/--rack/--dc is used, size and size [%] are computed only from matching replicas.\n"
+            "  tokens [%] still refers to the table's token space, not to a filtered token-space total.\n"
+            "\n"
+            "--per-replica rows:\n"
+            "  A tablet's own columns show once, on the first of its rows, since a rendered table reads them off the row above.\n"
+            "  In csv they repeat on every row, so a row stands on its own: summing tokens [%] then counts every replica copy,\n"
+            "  as cluster-load does, and an RF=3 table totals 300%.\n"
+            "  Tablets with no matching replicas are omitted from the output.\n"
+        ),
+    )
+    source_group = parser.add_argument_group("Source options")
+    add_topology_source_args(source_group)
+
+    filtering_group = parser.add_argument_group("Filtering options")
+    add_cluster_filter_options(filtering_group)
+
+    parser.add_argument("table", help="Table selector: exact ks.table, unique bare table name, or table UUID")
+
+    report_group = parser.add_argument_group("Report options")
+    report_group.add_argument("--max-ranges", type=positive_int,
+                              help="Merge adjacent tablets until the printed range count is at most this value")
+    report_group.add_argument("--per-replica", action="store_true",
+                              help="Print one row per tablet replica instead of one row per tablet")
+    report_group.add_argument("--tokens-hist", action="store_true",
+                              help="Show a token-space histogram column")
+    report_group.add_argument("--no-summary", action="store_true",
+                              help="Skip the ALL and Average rows")
+    report_group.add_argument("--sort", choices=list(SORT_KEYS), default="token",
+                              help="Sort rows by the selected key (default: token). ovc.rep is overcommit between row's replicas (the 'rep' column)")
+
+    presentation_group = parser.add_argument_group("Presentation options")
+    add_presentation_options(presentation_group, has_hosts=True)
+
+    args = parser.parse_args()
+    if args.per_replica and args.max_ranges is not None:
+        parser.error("--per-replica is incompatible with --max-ranges")
+    options = get_presentation_options_from_args(args)
+
+    with get_topology_source_from_args(args) as src:
+        topo = src.get_topology()
+        table_id = resolve_table_id(topo, args.table)
+        if "." not in args.table and not options.csv:
+            print(f"Table: {topo.get_table_name(table_id)}")
+
+        tablet_map = topo.get_tablet_map(table_id)
+        tablet_ranges = build_ranges(table_id, tablet_map, topo, get_tablet_filter(args, topo), args.per_replica)
+        ranges = merge_adjacent_ranges(tablet_ranges, args.max_ranges)
+        ranges = sort_ranges(ranges, args.sort)
+        shape = build_shape(args, len(tablet_ranges))
+        summary = summarize_rows(ranges)
+
+        table_rows = [] if args.no_summary else build_summary_rows(ranges, shape, options, summary)
+        table_rows += build_rows(ranges, shape, options, topo, summary)
+        if not print_table(table_rows, build_columns(shape, options), options):
+            return 0
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tablets/table_load.py
+++ b/scripts/tablets/table_load.py
@@ -23,6 +23,7 @@ if __package__ in (None, ""):
 
 from tablets.filters import add_cluster_filter_options
 from tablets.filters import TabletFilter
+from tablets.filters import get_host_filter
 from tablets.filters import get_tablet_filter
 from tablets.filters import select_all
 from tablets.render_utils import Column
@@ -456,6 +457,9 @@ def main() -> int:
         table_id = resolve_table_id(topo, args.table)
         if "." not in args.table and not options.csv:
             print(f"Table: {topo.get_table_name(table_id)}")
+
+        topo.report_missing_tablet_sizes(lambda table: table == table_id,
+                                         get_host_filter(args, topo))
 
         tablet_map = topo.get_tablet_map(table_id)
         tablet_ranges = build_ranges(table_id, tablet_map, topo, get_tablet_filter(args, topo), args.per_replica)

--- a/scripts/tablets/table_summary.py
+++ b/scripts/tablets/table_summary.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Shows per-table summary of size and internal tablet imbalance.
+
+This is a high-level table-oriented view of size and tablet-size distribution.
+It is useful for comparing tables to each other and spotting tables with uneven
+tablet sizes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from statistics import mean
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tablets.filters import add_cluster_filter_options
+from tablets.filters import add_table_filter_options
+from tablets.filters import get_table_filter
+from tablets.filters import TabletFilter
+from tablets.filters import get_tablet_filter
+from tablets.render_utils import Column
+from tablets.render_utils import PresentationOptions
+from tablets.render_utils import SEPARATING_LINE
+from tablets.render_utils import add_presentation_options
+from tablets.render_utils import format_ovc_pct
+from tablets.render_utils import format_pct
+from tablets.render_utils import format_size
+from tablets.render_utils import get_presentation_options_from_args
+from tablets.render_utils import positive_int
+from tablets.render_utils import print_table
+from tablets.render_utils import render_hbar
+from tablets.render_utils import render_sparkline
+from tablets.stats import StatsAggregator
+from tablets.stats import share
+from tablets.topology import TableId
+from tablets.topology import TableName
+from tablets.topology import add_topology_source_args, get_topology_source_from_args
+
+
+class SizeMode(Enum):
+    """
+    What the sizes are of. See --un-replicated.
+
+    An un-replicated report takes the average tablet replica size for a given tablet; a
+    replicated one sums all tablet replicas. Either way the report counts what it sizes:
+    tablets, or replicas.
+    """
+    REPLICATED = "replicated"
+    UNREPLICATED = "un-replicated"
+
+    @property
+    def unit(self) -> str:
+        """
+        What the headers call it. A row is one table's, so a replica of one of its tablets
+        needs no further naming.
+        """
+        return "replica" if self is SizeMode.REPLICATED else "tablet"
+
+
+def measure_tablet(replica_sizes: list[int], size_mode: SizeMode) -> list[float]:
+    """
+    The sizes a tablet contributes to its table: all of its replicas, or their average.
+
+    Only shown replicas are measured, so under a filter a tablet counts for what the
+    selection holds of it rather than for what the cluster holds.
+    """
+    if size_mode is SizeMode.REPLICATED:
+        return list(replica_sizes)
+    return [mean(replica_sizes)]
+
+
+def get_columns(size_mode: SizeMode) -> list[Column]:
+    """
+    Builds the report's columns.
+
+    The size mode names the sizes, and names the unit the report counts and sizes.
+    """
+    return [
+        Column("name"),
+        Column(f"{size_mode.value}\nsize [B]", "right"),
+        Column(f"{size_mode.value}\nsize [%]", "right"),
+        Column("", "left", csv=False),  # size hbar
+        Column(f"{size_mode.unit}\ncount", "right"),
+        Column(f"{size_mode.unit}\nsize ovc [%]", "right"),
+        Column(f"{size_mode.unit}\navg size [B]", "right"),
+        Column(f"{size_mode.unit}\nmax size [B]", "right"),
+        Column("size\nin token space", "left", csv=False),
+    ]
+
+
+@dataclass
+class TableRow:
+    """
+    A table the report has a row for, once a filter has been applied: what it is called, the
+    size of every unit the report measures, and the size of its whole token space in token
+    order, which is always un-replicated so that its shape is that of the data rather than
+    of its placement.
+
+    A tablet with no replica left contributes zero to the token space and nothing at all to
+    the sizes: it takes up token space without being something the report counts.
+    """
+    name: TableName
+    table_id: TableId
+    sizes: StatsAggregator
+    token_space: list[float]
+
+
+# Tables read best listed by name, and worst-first by every other key.
+SORT_KEYS = {
+    "name": lambda row: row.name,
+    "size": lambda row: row.sizes.total,
+    # Overcommit is never below 1, so a table with none to report sorts last.
+    "tablet.ovc": lambda row: row.sizes.ovc() or 0,
+    "tablet.avg": lambda row: row.sizes.avg(),
+}
+
+
+def sort_table_rows(rows: list[TableRow], sort_key: str) -> list[TableRow]:
+    return sorted(rows, key=SORT_KEYS[sort_key], reverse=sort_key != "name")
+
+
+def measure_table(topo, table_id: TableId, name: TableName, accepts_tablet: TabletFilter,
+                  size_mode: SizeMode) -> TableRow | None:
+    """
+    A table's row, or None when the filter left nothing of it to show.
+    """
+    row = TableRow(name=name, table_id=table_id, sizes=StatsAggregator(), token_space=[])
+    for tablet in topo.get_tablet_map(table_id).tablets:
+        replica_sizes = [topo.get_tablet_size(table_id, tablet, replica)
+                         for replica in tablet.replicas
+                         if accepts_tablet(replica)]
+        if not replica_sizes:
+            row.token_space.append(0)
+            continue
+        row.token_space.append(mean(replica_sizes))
+        for size in measure_tablet(replica_sizes, size_mode):
+            row.sizes.add(size)
+    return row if row.sizes.count else None
+
+
+def build_all_row(rows: list[TableRow], options: PresentationOptions) -> list | None:
+    if not rows:
+        return None
+
+    # The ALL row measures every shown table's units taken together.
+    sizes = StatsAggregator()
+    for row in rows:
+        sizes.merge(row.sizes)
+    # Overcommit is a table's own measure and does not add up, so ALL reports the worst one.
+    max_ovc = max((ovc for row in rows if (ovc := row.sizes.ovc()) is not None), default=None)
+
+    return [
+        "ALL",
+        format_size(sizes.total, options),
+        "100.00",
+        None,
+        sizes.count,
+        format_ovc_pct(max_ovc, options),
+        format_size(sizes.avg(), options),
+        format_size(sizes.max, options),
+        None,
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Print one summary row per table",
+        epilog=(
+            "Size mode:\n"
+            "  --un-replicated (the default) takes the average tablet replica size for a given tablet;\n"
+            "  --replicated sums all tablet replicas. The report counts what it sizes: tablets, or replicas.\n"
+            "  Every column below follows the mode, and the headers name the unit.\n"
+            "  The \"size in token space\" histogram is always un-replicated, so that its shape is that of\n"
+            "  the data rather than of its placement.\n"
+            "\n"
+            "Columns:\n"
+            "  size [B]             Total size shown for the table.\n"
+            "  size [%]             Fraction this table's shown size takes of the shown total.\n"
+            "  count                Number of units shown for the table.\n"
+            "  ovc [%]              Size overcommit of the shown units, as percentage deviation from their average.\n"
+            "  avg size [B]         Average size of a shown unit.\n"
+            "  max size [B]         Size of the largest shown unit.\n"
+            "  size in token space  Histogram of the whole table's token space in token order, with filtered-out tablets contributing zero.\n"
+            "\n"
+            "ALL row semantics:\n"
+            "  size [%] is always 100.00, the size bar is blank, and ovc [%] is the maximal shown table OVC.\n"
+            "\n"
+            "Filter semantics:\n"
+            "  When --host/--shard/--rack/--dc is used, size is computed only from matching replicas,\n"
+            "  and size [%] is relative to the total post-filtering.\n"
+            "  The \"size in token space\" histogram only shows contribution from matching replicas.\n"
+        ),
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    source_group = parser.add_argument_group("Source options")
+    add_topology_source_args(source_group)
+
+    filtering_group = parser.add_argument_group("Filtering options")
+    add_cluster_filter_options(filtering_group)
+    add_table_filter_options(filtering_group)
+
+    report_group = parser.add_argument_group("Report options")
+    report_group.add_argument("--sort", choices=list(SORT_KEYS), default="size",
+                              help="Sort rows by the selected column (default: size)")
+    report_group.add_argument("--no-summary", action="store_true",
+                              help="Skip the ALL row")
+    report_group.add_argument("-n", type=positive_int, metavar="COUNT",
+                              help="Show only the first COUNT tables, followed by a '...' row when more were left out")
+    size_mode_group = report_group.add_mutually_exclusive_group()
+    size_mode_group.add_argument("--un-replicated", dest="size_mode", action="store_const",
+                                 const=SizeMode.UNREPLICATED, default=SizeMode.UNREPLICATED,
+                                 help="Count tablets, take the average tablet replica size for a given tablet (default)")
+    size_mode_group.add_argument("--replicated", dest="size_mode", action="store_const",
+                                 const=SizeMode.REPLICATED,
+                                 help="Count tablet replicas")
+
+    presentation_group = parser.add_argument_group("Presentation options")
+    add_presentation_options(presentation_group, has_tables=True)
+
+    args = parser.parse_args()
+    options = get_presentation_options_from_args(args)
+
+    with get_topology_source_from_args(args) as src:
+        topo = src.get_topology()
+
+        accepts_table = get_table_filter(args, topo)
+        accepts_tablet = get_tablet_filter(args, topo)
+
+        rows = []
+        for table_id, table_name in topo.iter_tables():
+            if not accepts_table(table_id):
+                continue
+            row = measure_table(topo, table_id, table_name, accepts_tablet, args.size_mode)
+            if row is not None:
+                rows.append(row)
+
+        rows = sort_table_rows(rows, args.sort)
+        table_sizes = StatsAggregator.of(row.sizes.total for row in rows)
+
+        formatted_rows = []
+        all_row = None if args.no_summary else build_all_row(rows, options)
+        if all_row is not None:
+            formatted_rows.extend([all_row, SEPARATING_LINE])
+        # Sizes and shares stay relative to every selected table, so -n only narrows what
+        # is printed, never what the numbers mean.
+        shown_rows = rows[:args.n] if args.n is not None else rows
+        for row in shown_rows:
+            formatted_rows.append([
+                row.table_id if options.table_id else row.name,
+                format_size(row.sizes.total, options),
+                format_pct(share(row.sizes.total, table_sizes.total), options=options),
+                render_hbar(row.sizes.total, table_sizes.max),
+                row.sizes.count,
+                format_ovc_pct(row.sizes.ovc(), options),
+                format_size(row.sizes.avg(), options),
+                format_size(row.sizes.max, options),
+                render_sparkline(row.token_space, width=16, options=options),
+            ])
+
+        columns = get_columns(args.size_mode)
+        # CSV is consumed by other tools, so it carries data rows only; the rendered table
+        # says that -n left something out.
+        if len(shown_rows) < len(rows) and not options.csv:
+            formatted_rows.append(["..."] + [None] * (len(columns) - 1))
+
+        print_table(formatted_rows, columns, options)
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tablets/table_summary.py
+++ b/scripts/tablets/table_summary.py
@@ -27,6 +27,7 @@ if __package__ in (None, ""):
 
 from tablets.filters import add_cluster_filter_options
 from tablets.filters import add_table_filter_options
+from tablets.filters import get_host_filter
 from tablets.filters import get_table_filter
 from tablets.filters import TabletFilter
 from tablets.filters import get_tablet_filter
@@ -237,6 +238,7 @@ def main() -> int:
 
         accepts_table = get_table_filter(args, topo)
         accepts_tablet = get_tablet_filter(args, topo)
+        topo.report_missing_tablet_sizes(accepts_table, get_host_filter(args, topo))
 
         rows = []
         for table_id, table_name in topo.iter_tables():

--- a/scripts/tablets/topology.py
+++ b/scripts/tablets/topology.py
@@ -98,6 +98,8 @@ class Host:
     ip: Optional[str] = None
     node_state: Optional[str] = None # system.topology#node_state
     num_tokens: Optional[int] = None # system.topology#num_tokens
+    up: Optional[bool] = None # system.load_per_node#up
+    excluded: Optional[bool] = None # system.load_per_node#excluded, left out of balancing
 
     def is_normal_token_owner(self) -> bool:
         if self.node_state is None or self.num_tokens is None:
@@ -176,6 +178,13 @@ def iter_token_fractions(tablets: Sequence[Tablet]) -> Iterator[Tuple[Tablet, fl
     for tablet in tablets:
         yield tablet, ((tablet.last_token - prev_last_token) % TOKEN_RING_SIZE) / TOKEN_RING_SIZE
         prev_last_token = tablet.last_token
+
+
+def parse_bool(value: str | bool) -> bool:
+    """
+    Parses a boolean column, which the CQL driver yields as a bool and a dump as its text.
+    """
+    return value if isinstance(value, bool) else str(value).strip().lower() == "true"
 
 
 def parse_uuid(value: str | uuid.UUID | None) -> UUID | None:
@@ -273,6 +282,10 @@ LOAD_PER_NODE_COLUMNS = (
     Column("dc", str, required=False),
     Column("rack", str, required=False),
     Column("ip", str, required=False),
+    # Whether the cluster can reach the node, and whether it takes part in balancing.
+    # Optional, so a snapshot taken before the columns existed still reads.
+    Column("up", parse_bool, required=False),
+    Column("excluded", parse_bool, required=False),
 )
 
 TABLET_SIZES_COLUMNS = (
@@ -603,6 +616,10 @@ class Topology:
                 host.storage_capacity = row.storage_capacity
             if row.effective_capacity is not None:
                 host.effective_capacity = row.effective_capacity
+            if row.up is not None:
+                host.up = row.up
+            if row.excluded is not None:
+                host.excluded = row.excluded
 
     def _build_topology(self, rows: Iterable[Row]) -> None:
         """

--- a/scripts/tablets/topology.py
+++ b/scripts/tablets/topology.py
@@ -18,6 +18,11 @@ All scripts can then use the snapshot directory as a topology source, e.g.:
 
   $ ./scylla-tablets.py cluster --snapshot ./tablet_snap_260714_123456/
 
+Or by picking it up from the environment variable:
+
+  $ export SCYLLA_TABLET_SNAPSHOT=./tablet_snap_260714_123456/
+  $ ./scylla-tablets.py cluster
+
 Scripts integrate with topology source abstraction by:
 
  1) Adding topology source arguments to the script's argument parser:
@@ -862,7 +867,8 @@ def add_topology_source_args(parser: argparse.ArgumentParser):
     source_group.add_argument(
         "--snapshot",
         metavar="PATH",
-        help="Read topology from a snapshot directory, or from a tar archive holding one (as created by snapshot.py --gz)."
+        help="Read topology from a snapshot directory, or from a tar archive holding one (as created by snapshot.py --gz). "
+             "If omitted, the snapshot path may be picked up from the SCYLLA_TABLET_SNAPSHOT environment variable when --cluster is also omitted"
     )
     source_group.add_argument(
         "--cluster",
@@ -902,8 +908,14 @@ def add_topology_source_args(parser: argparse.ArgumentParser):
 
 
 def get_topology_source_from_args(args: argparse.Namespace) -> TopologySource:
-    if args.snapshot:
-        src = TopologyFromSnapshot(args.snapshot)
+    """
+    Builds a topology source from args produced by a parser add_topology_source_args() set up.
+    """
+    snapshot_dir = args.snapshot
+    if snapshot_dir is None and args.cluster is None:
+        snapshot_dir = os.getenv("SCYLLA_TABLET_SNAPSHOT")
+    if snapshot_dir:
+        src = TopologyFromSnapshot(snapshot_dir)
     else:
         src = get_live_topology_source_from_args(args)
 

--- a/scripts/tablets/topology.py
+++ b/scripts/tablets/topology.py
@@ -45,16 +45,17 @@ import argparse
 import csv
 import io
 import os
+import sys
 import re
 import tarfile
 import uuid
 from abc import ABC, abstractmethod
-from collections import defaultdict
+from collections import Counter, defaultdict
 from contextlib import AbstractContextManager, ExitStack, nullcontext
 from dataclasses import dataclass, field
 from functools import partial
 from types import SimpleNamespace
-from typing import Callable, Dict, Iterable, Iterator, List, NewType, Optional, Sequence, Tuple
+from typing import Callable, Dict, Iterable, Iterator, List, NewType, Optional, Sequence, Set, Tuple
 
 UUID = uuid.UUID
 TableId = NewType("TableId", UUID)
@@ -159,6 +160,8 @@ def _parse_id(text: str) -> UUID:
 
 TOKEN_RING_SIZE = 1 << 64
 
+_MISSING_SIZES_SHOWN = 3
+
 
 def iter_token_fractions(tablets: Sequence[Tablet]) -> Iterator[Tuple[Tablet, float]]:
     """
@@ -203,6 +206,7 @@ def parse_uuid(value: str | uuid.UUID | None) -> UUID | None:
 # One pattern for both. Brackets are not matched, so cqlsh COPY's [] and snapshot.py's {} both
 # read. Matching the id by width beat every other form tried by ~25%.
 _REPLICA_PAIR_RE = re.compile(r'([0-9a-fA-F-]{36})[,:]\s*(\d+)')
+_UUID_RE = re.compile(r'[0-9a-fA-F-]{36}')
 
 
 def parse_replica_list(value: str) -> ReplicaList:
@@ -221,12 +225,28 @@ def parse_replica_size_map(value: str) -> Dict[HostId, int]:
     return {_parse_id(host): int(number) for host, number in _REPLICA_PAIR_RE.findall(value)}
 
 
+def parse_host_set(value: str) -> List[HostId]:
+    """
+    Parses a set of host ids, e.g.
+    "{35d5e1a4-a3e8-4d33-84c9-2b6f1a0c9e77}" to [UUID('35d5e1a4-...')].
+    """
+    return [_parse_id(host) for host in _UUID_RE.findall(value or "")]
+
+
 def format_replica_list(replicas: ReplicaList) -> str:
     """
     Renders tablet replicas back to the form parse_replica_list() reads, e.g.
     [(UUID('35d5e1a4-...'), 2)] to "{(35d5e1a4-a3e8-4d33-84c9-2b6f1a0c9e77, 2)}".
     """
     return "{" + ", ".join(f"({host}, {shard})" for host, shard in replicas) + "}"
+
+
+def format_host_set(hosts: Iterable[HostId]) -> str:
+    """
+    Renders host ids back to the form parse_host_set() reads, e.g.
+    [UUID('35d5e1a4-...')] to "{35d5e1a4-a3e8-4d33-84c9-2b6f1a0c9e77}".
+    """
+    return "{" + ", ".join(str(host) for host in hosts) + "}"
 
 
 def format_replica_size_map(sizes: Dict[HostId, int]) -> str:
@@ -292,6 +312,9 @@ TABLET_SIZES_COLUMNS = (
     Column("table_id", parse_uuid),
     Column("last_token", int),
     Column("replicas", parse_replica_size_map, format_replica_size_map),
+    # Replicas the server has no size for yet, e.g. one which has just been migrated to.
+    # Optional, so a snapshot taken before the column existed still reads.
+    Column("missing_replicas", parse_host_set, format_host_set, required=False),
 )
 
 
@@ -407,6 +430,8 @@ class Topology:
     _tables: Dict[TableId, Tuple[KeyspaceName, TableName]] = field(default_factory=dict)
     # Per-replica tablet sizes in bytes, keyed by (table_id, last_token) -> {host_id: size}.
     _tablet_sizes: Dict[Tuple[TableId, Token], Dict[HostId, int]] = field(default_factory=dict)
+    # Replicas system.tablet_sizes reports no size for, as (table_id, last_token, host_id).
+    _missing_tablet_sizes: Set[Tuple[TableId, Token, HostId]] = field(default_factory=set)
     # Lower bound applied to every reported tablet size, in bytes.
     _min_tablet_size: int = 0
     _anonymizer: Optional[Anonymizer] = None
@@ -645,10 +670,73 @@ class Topology:
     def _build_tablet_sizes(self, rows: Iterable[Row]) -> None:
         """
         Populates per-replica tablet sizes from system.tablet_sizes.
+
+        A replica the server lists as missing has no size yet, having just been migrated to,
+        and is recorded as such: it counts for nothing rather than stopping the report.
+        See report_missing_tablet_sizes(), which a report calls to say so.
         """
         for row in rows:
             # dict() because the driver's own map type would not compare equal to a dump's.
             self._tablet_sizes[(row.table_id, row.last_token)] = dict(row.replicas or {})
+            for host_id in row.missing_replicas or ():
+                self._missing_tablet_sizes.add((row.table_id, row.last_token, host_id))
+
+    def _reports_no_sizes(self, host_id: HostId) -> bool:
+        """
+        Whether a node is expected to report no size for what it holds: the cluster excludes
+        it from load balancing, or it no longer owns tokens.
+        """
+        host = self._hosts.get(host_id)
+        if host is None:
+            return False
+        return bool(host.excluded) or not host.is_normal_token_owner()
+
+    def _name_host(self, host_id: HostId) -> str:
+        host = self._hosts.get(host_id)
+        return host.ip if host is not None and host.ip else str(host_id)
+
+    def _name_table(self, table: TableId) -> str:
+        return self.get_table_name(table) if table in self._tables else str(table)
+
+    def report_missing_tablet_sizes(self,
+                                    accepts_table: Callable[[TableId], bool] = None,
+                                    accepts_host: Callable[[Host], bool] = None) -> None:
+        """
+        Prints how many replicas the server reports no size for, grouped by host and by table.
+
+        Counts only replicas the caller's report shows, so it takes the same filters. There
+        is no shard filter: system.tablet_sizes names a missing replica by host only.
+
+        Skips replicas on nodes the cluster excludes from load balancing, and on nodes which
+        no longer own tokens. Those report no size for anything they hold, which is expected
+        rather than a problem.
+
+        The report calls this, rather than the loader, because it needs the report's filters
+        and the options which decide how a table is named and what a sizeless replica counts
+        as. Prints to stderr so that --csv output stays machine-readable.
+        """
+        def shown(table: TableId, host_id: HostId) -> bool:
+            if self._reports_no_sizes(host_id):
+                return False
+            if accepts_table is not None and not accepts_table(table):
+                return False
+            host = self._hosts.get(host_id)
+            return accepts_host is None or host is None or accepts_host(host)
+
+        unexpected = [(table, host_id) for table, _, host_id in self._missing_tablet_sizes
+                      if shown(table, host_id)]
+        if not unexpected:
+            return
+
+        print(f"Note: {len(unexpected)} replicas have no size, counted as {self._min_tablet_size}",
+              file=sys.stderr)
+        for label, counts in (("hosts", Counter(self._name_host(h) for _, h in unexpected)),
+                              ("tables", Counter(self._name_table(t) for t, _ in unexpected))):
+            ranked = sorted(counts.items(), key=lambda pair: (-pair[1], pair[0]))
+            named = [f"{name} ({count})" for name, count in ranked[:_MISSING_SIZES_SHOWN]]
+            if len(ranked) > _MISSING_SIZES_SHOWN:
+                named.append(f"+{len(ranked) - _MISSING_SIZES_SHOWN}")
+            print(f"  {label}: {', '.join(named)}", file=sys.stderr)
 
     def get_tablet_size(self, table: TableId, tablet: Tablet, replica: TabletReplica) -> int:
         """
@@ -661,6 +749,10 @@ class Topology:
             raise Exception(f"Tablet size not available for tablet {tablet_id}. ")
         host_id = replica[0]
         if host_id not in sizes:
+            # The server says it has no size for this replica yet, so it holds nothing the
+            # report can measure. Anything else is a snapshot which does not add up.
+            if (table, tablet.last_token, host_id) in self._missing_tablet_sizes:
+                return self._min_tablet_size
             raise Exception(f"Tablet size not available for tablet {tablet_id} on host {host_id}")
         return max(sizes[host_id], self._min_tablet_size)
 

--- a/scripts/tablets/topology.py
+++ b/scripts/tablets/topology.py
@@ -1,0 +1,927 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""
+Provides a model for tablet metadata, topology and related statistics.
+Primarily intended to be used for analyzing and visualizing information relevant for load balancing.
+
+Provides a framework for obtaining topology information from either a live cluster or a snapshot.
+
+To obtain a snapshot from a live cluster, use snapshot.py:
+
+  $ ./snapshot.py --cluster <host>
+  ./tablet_snap_260714_123456/
+
+All scripts can then use the snapshot directory as a topology source, e.g.:
+
+  $ ./scylla-tablets.py cluster --snapshot ./tablet_snap_260714_123456/
+
+Scripts integrate with topology source abstraction by:
+
+ 1) Adding topology source arguments to the script's argument parser:
+
+    add_topology_source_args(parser)
+
+ 2) Creating a topology source from the parsed arguments:
+
+    topo_src = get_topology_source_from_args(args)
+
+ 3) Using the topology source to obtain a snapshot of topology:
+
+    topo = topo_src.get_topology()
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import os
+import re
+import tarfile
+import uuid
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from contextlib import AbstractContextManager, ExitStack, nullcontext
+from dataclasses import dataclass, field
+from functools import partial
+from types import SimpleNamespace
+from typing import Callable, Dict, Iterable, Iterator, List, NewType, Optional, Sequence, Tuple
+
+UUID = uuid.UUID
+TableId = NewType("TableId", UUID)
+TableName = NewType("TableName", str)
+KeyspaceName = NewType("KeyspaceName", str)
+DatacenterName = NewType("DatacenterName", str)
+RackName = NewType("RackName", str)
+RackId = Tuple[DatacenterName, RackName] # Unique within cluster
+Token = NewType("Token", int)
+HostId = NewType("HostId", UUID)
+ShardNumber = NewType("ShardNumber", int)
+ShardId = Tuple[HostId, ShardNumber] # Unique within cluster
+TabletReplica = ShardId
+ReplicaList = List[TabletReplica]
+
+
+@dataclass
+class Tablet:
+    last_token : Token
+    replicas : ReplicaList
+    new_replicas : Optional[ReplicaList] = None
+    stage : Optional[str] = None
+
+
+@dataclass
+class TabletMap:
+    table : TableId
+    base_table : Optional[TableId] = None
+    # Ordered by last_token. Colocated tables share the base table's list.
+    tablets : list[Tablet] = field(default_factory=list)
+
+
+@dataclass
+class Host:
+    id : HostId
+    shard_count : int
+    storage_capacity: Optional[int] = None
+    effective_capacity: Optional[int] = None
+    dc: Optional[DatacenterName] = None
+    rack: Optional[RackName] = None
+    ip: Optional[str] = None
+    node_state: Optional[str] = None # system.topology#node_state
+    num_tokens: Optional[int] = None # system.topology#num_tokens
+
+    def is_normal_token_owner(self) -> bool:
+        if self.node_state is None or self.num_tokens is None:
+            # Snapshot is missing system.topology, assume a member
+            return True
+        if self.node_state != "normal" or self.num_tokens == 0:
+            return False
+        return True
+
+
+@dataclass
+class Anonymizer:
+    keyspaces: Dict[KeyspaceName, KeyspaceName] = field(default_factory=dict)
+    tables: Dict[TableId, Tuple[KeyspaceName, TableName]] = field(default_factory=dict)
+    next_keyspace_idx: int = 1
+    next_table_idx_by_keyspace: Dict[KeyspaceName, int] = field(default_factory=lambda: defaultdict(lambda: 1))
+
+    def get_table_name(self, table_id: TableId, keyspace_name: KeyspaceName) -> str:
+        """
+        Returns a deterministic anonymized name for a table.
+
+        New tables extend the mapping while existing aliases remain stable.
+        """
+        if table_id not in self.tables:
+            if keyspace_name not in self.keyspaces:
+                self.keyspaces[keyspace_name] = f"ks{self.next_keyspace_idx}"
+                self.next_keyspace_idx += 1
+            anonymized_keyspace = self.keyspaces[keyspace_name]
+            table_idx = self.next_table_idx_by_keyspace[anonymized_keyspace]
+            self.tables[table_id] = (anonymized_keyspace, f"table{table_idx}")
+            self.next_table_idx_by_keyspace[anonymized_keyspace] += 1
+        anonymized_keyspace, anonymized_table = self.tables[table_id]
+        return f"{anonymized_keyspace}.{anonymized_table}"
+
+    def get_keyspace_name(self, table_id: TableId, keyspace_name: KeyspaceName) -> KeyspaceName:
+        """
+        Returns the anonymized keyspace name for a table, registering it if needed.
+        """
+        self.get_table_name(table_id, keyspace_name)
+        return self.tables[table_id][0]
+
+
+# A dump names the same few ids once per replica, and uuid.UUID() is the priciest part of
+# loading. Bounded by the cluster's hosts and tables.
+_PARSED_UUIDS: Dict[str, UUID] = {}
+
+
+def _parse_id(text: str) -> UUID:
+    """
+    Parses an id known to be text, caching it.
+    """
+    parsed = _PARSED_UUIDS.get(text)
+    if parsed is None:
+        parsed = _PARSED_UUIDS[text] = uuid.UUID(text)
+    return parsed
+
+
+TOKEN_RING_SIZE = 1 << 64
+
+
+def iter_token_fractions(tablets: Sequence[Tablet]) -> Iterator[Tuple[Tablet, float]]:
+    """
+    Pairs each tablet with the fraction of the token ring it owns.
+
+    A tablet spans from the previous tablet's last token to its own, the first wrapping
+    around from the last. A lone tablet owns the whole ring: it wraps to itself, which
+    the span arithmetic would otherwise read as owning nothing.
+    """
+    if not tablets:
+        return
+    if len(tablets) == 1:
+        yield tablets[0], 1.0
+        return
+
+    prev_last_token = tablets[-1].last_token
+    for tablet in tablets:
+        yield tablet, ((tablet.last_token - prev_last_token) % TOKEN_RING_SIZE) / TOKEN_RING_SIZE
+        prev_last_token = tablet.last_token
+
+
+def parse_uuid(value: str | uuid.UUID | None) -> UUID | None:
+    if value is None or isinstance(value, uuid.UUID):
+        return value
+    return _parse_id(value)
+
+
+# Both replica columns are (host id, number) pairs, differing only in how a pair is spelled:
+#
+#   system.tablets#replicas, list<frozen<tuple<uuid, int>>>, number is a shard:
+#     [(35d5e1a4-a3e8-4d33-84c9-2b6f1a0c9e77, 2), (7c4b8f10-1d94-4a52-9d0e-3f8a5c2b7e61, 0)]
+#   system.tablet_sizes#replicas, map<uuid, bigint>, number is a size in bytes:
+#     {35d5e1a4-a3e8-4d33-84c9-2b6f1a0c9e77: 18006543, 7c4b8f10-1d94-4a52-9d0e-3f8a5c2b7e61: 90}
+#
+# One pattern for both. Brackets are not matched, so cqlsh COPY's [] and snapshot.py's {} both
+# read. Matching the id by width beat every other form tried by ~25%.
+_REPLICA_PAIR_RE = re.compile(r'([0-9a-fA-F-]{36})[,:]\s*(\d+)')
+
+
+def parse_replica_list(value: str) -> ReplicaList:
+    """
+    Parses tablet replicas, e.g.
+    "[(35d5e1a4-a3e8-4d33-84c9-2b6f1a0c9e77, 2)]" to [(UUID('35d5e1a4-...'), 2)].
+    """
+    return [(_parse_id(host), int(number)) for host, number in _REPLICA_PAIR_RE.findall(value)]
+
+
+def parse_replica_size_map(value: str) -> Dict[HostId, int]:
+    """
+    Parses per-replica tablet sizes in bytes, e.g.
+    "{35d5e1a4-a3e8-4d33-84c9-2b6f1a0c9e77: 18006543}" to {UUID('35d5e1a4-...'): 18006543}.
+    """
+    return {_parse_id(host): int(number) for host, number in _REPLICA_PAIR_RE.findall(value)}
+
+
+def format_replica_list(replicas: ReplicaList) -> str:
+    """
+    Renders tablet replicas back to the form parse_replica_list() reads, e.g.
+    [(UUID('35d5e1a4-...'), 2)] to "{(35d5e1a4-a3e8-4d33-84c9-2b6f1a0c9e77, 2)}".
+    """
+    return "{" + ", ".join(f"({host}, {shard})" for host, shard in replicas) + "}"
+
+
+def format_replica_size_map(sizes: Dict[HostId, int]) -> str:
+    """
+    Renders per-replica tablet sizes back to the form parse_replica_size_map() reads, e.g.
+    {UUID('35d5e1a4-...'): 18006543} to "{35d5e1a4-a3e8-4d33-84c9-2b6f1a0c9e77: 18006543}".
+    """
+    return "{" + ", ".join(f"{host}: {size}" for host, size in sizes.items()) + "}"
+
+
+@dataclass(frozen=True)
+class Column:
+    """
+    A column of a system table which Topology is built from.
+    """
+
+    name: str
+    # Text form to the value type the CQL driver yields. Never called with a null value.
+    parse: Callable[[str], object]
+    # Inverse of parse(), for snapshot.py to dump. Never called with a null value.
+    format: Callable[[object], str] = str
+    # A missing required column fails the build; a missing optional one reads as None.
+    required: bool = True
+
+
+TABLETS_COLUMNS = (
+    Column("table_id", parse_uuid),
+    Column("keyspace_name", str),
+    Column("table_name", str),
+    Column("last_token", int),
+    Column("replicas", parse_replica_list, format_replica_list),
+    Column("new_replicas", parse_replica_list, format_replica_list),
+    Column("stage", str),
+    Column("base_table", parse_uuid, required=False),
+)
+
+TOPOLOGY_COLUMNS = (
+    Column("version", int),
+    Column("host_id", parse_uuid),
+    Column("shard_count", int),
+    Column("node_state", str, required=False),
+    Column("num_tokens", int, required=False),
+    # Where the node sits. system.load_per_node says the same of the nodes it lists, and
+    # drops a node which has left, so this is what still places one.
+    Column("datacenter", str, required=False),
+    Column("rack", str, required=False),
+)
+
+LOAD_PER_NODE_COLUMNS = (
+    Column("node", parse_uuid),
+    Column("storage_capacity", int),
+    Column("effective_capacity", int, required=False),
+    Column("dc", str, required=False),
+    Column("rack", str, required=False),
+    Column("ip", str, required=False),
+)
+
+TABLET_SIZES_COLUMNS = (
+    Column("table_id", parse_uuid),
+    Column("last_token", int),
+    Column("replicas", parse_replica_size_map, format_replica_size_map),
+)
+
+
+@dataclass(frozen=True)
+class SnapshotTable:
+    """
+    A system table which Topology is derived from, and which a snapshot therefore holds.
+    """
+
+    # The CQL table to read, e.g. "system.tablets".
+    name: str
+    # The file holding its dump inside a snapshot, e.g. "system_tablets.csv".
+    file: str
+    # Columns read from it. A dump holds all of them, being a "SELECT *".
+    columns: Sequence[Column]
+
+
+TOPOLOGY_TABLE = SnapshotTable("system.topology", "system_topology.csv", TOPOLOGY_COLUMNS)
+TABLETS_TABLE = SnapshotTable("system.tablets", "system_tablets.csv", TABLETS_COLUMNS)
+LOAD_PER_NODE_TABLE = SnapshotTable("system.load_per_node", "system_load_per_node.csv", LOAD_PER_NODE_COLUMNS)
+TABLET_SIZES_TABLE = SnapshotTable("system.tablet_sizes", "system_tablet_sizes.csv", TABLET_SIZES_COLUMNS)
+
+# What snapshot.py captures and a snapshot is read for. Adding one here covers both ends; only
+# Topology._build() needs teaching what its rows mean. Order is the dump order.
+SNAPSHOT_TABLES = (TOPOLOGY_TABLE, TABLETS_TABLE, LOAD_PER_NODE_TABLE, TABLET_SIZES_TABLE)
+
+
+# A row with column values as attributes, as the CQL driver returns them. Columns the source
+# does not have read as None.
+Row = SimpleNamespace
+
+# Dumps are CSV with a header, as snapshot.py and "cqlsh COPY ... WITH DELIMITER=';' AND
+# HEADER=TRUE" write them. Not a comma: collection values are full of those.
+CSV_DELIMITER = ";"
+
+# How a dump may spell a null.
+CSV_NULLS = ("", "null")
+
+
+def _csv_column_indexes(header: Sequence[str], columns: Sequence[Column]) -> List[Tuple[Optional[int], Column]]:
+    """
+    Locates the columns in a dump's header by name, None for the ones it does not have.
+
+    Raises:
+        Exception: a required column is missing, or the header names none of them.
+    """
+    index_by_name = {name: idx for idx, name in enumerate(header)}
+    if not any(column.name in index_by_name for column in columns):
+        raise Exception(f"Dump is not CSV with a '{CSV_DELIMITER}' delimiter and a header row,"
+                        f" its first line names none of the expected columns: {header[0][:60]!r}")
+
+    indexes = []
+    for column in columns:
+        idx = index_by_name.get(column.name)
+        if idx is None and column.required:
+            raise Exception(f"Required column '{column.name}' is missing")
+        indexes.append((idx, column))
+    return indexes
+
+
+def rows_from_csv(lines: Iterable[str], columns: Sequence[Column]) -> Iterator[Row]:
+    """
+    Converts a dump of a system table into rows in CQL shape, lazily, a row at a time.
+
+    Values are parsed into the types the driver would have yielded, columns located by name,
+    quoting the csv module's, matching snapshot.py's writer.
+
+    Raises:
+        Exception: see _csv_column_indexes().
+    """
+    reader = csv.reader(lines, delimiter=CSV_DELIMITER)
+    # A blank line, e.g. a trailing one, holds no fields at all and is not a row.
+    header = next((row for row in reader if row), None)
+    if header is None:
+        return
+    fields = _csv_column_indexes(header, columns)
+
+    for row in reader:
+        if not row:
+            continue
+        values = {}
+        for idx, column in fields:
+            if idx is not None and idx >= len(row):
+                raise Exception(
+                    f"Truncated row in dump: column '{column.name}' is at index {idx} "
+                    f"but the row has {len(row)} fields: {row}")
+            # A column the dump lacks reads as null; a row too short is corruption.
+            value = row[idx] if idx is not None else ""
+            values[column.name] = None if value in CSV_NULLS else column.parse(value)
+        yield Row(**values)
+
+
+def rows_from_cql(rows: Iterable, columns: Sequence[Column]) -> Iterator[Row]:
+    """
+    Adapts driver rows to the row shape Topology is built from, filling in columns the cluster
+    does not have, as a snapshot's missing ones are filled in.
+    """
+    for row in rows:
+        yield Row(**{column.name: getattr(row, column.name, None) for column in columns})
+
+
+@dataclass
+class Topology:
+    """
+    Snapshot of tablet topology and related metadata.
+    """
+
+    # topology version obtained from system.topology#version.
+    # Note: size stats may change without "version" changing.
+    _version: int | None = None
+    _hosts: Dict[HostId, Host] = field(default_factory=dict)
+    _tablet_maps: Dict[TableId, TabletMap] = field(default_factory=dict)
+    _tables: Dict[TableId, Tuple[KeyspaceName, TableName]] = field(default_factory=dict)
+    # Per-replica tablet sizes in bytes, keyed by (table_id, last_token) -> {host_id: size}.
+    _tablet_sizes: Dict[Tuple[TableId, Token], Dict[HostId, int]] = field(default_factory=dict)
+    # Lower bound applied to every reported tablet size, in bytes.
+    _min_tablet_size: int = 0
+    _anonymizer: Optional[Anonymizer] = None
+
+    def has_table(self, table: TableId) -> bool:
+        """
+        Returns whether a table id is present in the topology.
+        """
+        return table in self._tables
+
+    def host_count(self) -> int:
+        """
+        Returns the number of known hosts.
+        """
+        return len(self._hosts)
+
+    def all_host_ids(self):
+        """
+        Returns an iterable over HostIds of all known hosts.
+        """
+        return self._hosts.keys()
+
+    def all_hosts(self):
+        """
+        Returns an iterable over Host objects representing all known hosts.
+        """
+        return self._hosts.values()
+
+    def get_host(self, host_id: HostId) -> Host | None:
+        """
+        Returns a host by id, or None when it is not known.
+        """
+        return self._hosts.get(host_id)
+
+    def require_host(self, host_id: HostId) -> Host:
+        """
+        Returns a host by id, raising if it is not known.
+        """
+        host = self.get_host(host_id)
+        if host is None:
+            raise Exception(f"Unknown host: {host_id}")
+        return host
+
+    def all_normal_token_owner_hosts(self):
+        """
+        Returns normal topology members that own tokens.
+        This is the set of nodes which is supposed to be balanced.
+        Other nodes should be ignored when calculating imbalance.
+        """
+        return (host for host in self._hosts.values() if host.is_normal_token_owner())
+
+    def iter_table_ids(self, include_colocated: bool = True) -> Iterator[TableId]:
+        """
+        Returns known table ids.
+
+        When include_colocated is false, only base tables are returned.
+        """
+        for table_id, tablet_map in self._tablet_maps.items():
+            if include_colocated or not tablet_map.base_table:
+                yield table_id
+
+    def iter_tables(self, include_colocated: bool = True) -> Iterator[tuple[TableId, str]]:
+        """
+        Returns known tables as ``(table_id, "keyspace.table")`` pairs.
+
+        When include_colocated is false, only base tables are returned.
+        """
+        for table_id in self.iter_table_ids(include_colocated=include_colocated):
+            yield table_id, self.get_table_name(table_id)
+
+    def all_tablets(self) -> Iterator[tuple[TableId, Tablet]]:
+        """
+        Returns all physical tablets as (base_table_id, tablet) pairs.
+        """
+        for table_id in self.iter_table_ids(include_colocated=False):
+            tablet_map = self._tablet_maps[table_id]
+            for tablet in tablet_map.tablets:
+                yield table_id, tablet
+
+    def get_table_name(self, table: TableId) -> str:
+        ks_name, table_name = self._tables[table]
+        if self._anonymizer is not None:
+            return self._anonymizer.get_table_name(table, ks_name)
+        return f"{ks_name}.{table_name}"
+
+    def get_keyspace_name(self, table: TableId) -> str:
+        """
+        Returns the keyspace name for a table id.
+        """
+        ks_name, _ = self._tables[table]
+        if self._anonymizer is not None:
+            return self._anonymizer.get_keyspace_name(table, ks_name)
+        return ks_name
+
+    def set_anonymizer(self, anonymizer: Optional[Anonymizer]) -> None:
+        """
+        Configures name anonymization for this topology snapshot.
+        """
+        self._anonymizer = anonymizer
+
+    def get_base_table_id(self, table: TableId) -> TableId:
+        """
+        Returns the base table id for a table, or the table itself if it is not colocated.
+        """
+        tablet_map = self._tablet_maps[table]
+        return tablet_map.base_table or table
+
+    def get_tablet_map(self, table: TableId) -> TabletMap:
+        """
+        Returns the tablet map for a table.
+
+        For colocated tables, the returned map is the table's own TabletMap,
+        but its tablets list is shared with the base table.
+        """
+        return self._tablet_maps[table]
+
+    def _link_colocated_tablets(self) -> None:
+        """
+        Makes colocated table maps share the base table's tablet list.
+        """
+        for table_id, tablet_map in self._tablet_maps.items():
+            if not tablet_map.base_table:
+                continue
+            if tablet_map.base_table not in self._tablet_maps:
+                raise Exception(f"Base table {tablet_map.base_table} for colocated table {table_id} is missing")
+            tablet_map.tablets = self._tablet_maps[tablet_map.base_table].tablets
+
+    def _build(self, rows_by_table: Dict[str, Iterable[Row]]) -> None:
+        """
+        Builds this topology from rows of the system tables, keyed by table name, as
+        rows_from_cql() and rows_from_csv() yield them. A table left out contributes nothing.
+        Each is consumed in a single forward pass, so a source may stream it.
+        """
+        # Nodes first, so the tablets pass has nothing left to work out about them.
+        self._build_topology(rows_by_table.get(TOPOLOGY_TABLE.name, ()))
+        self._build_load_per_node(rows_by_table.get(LOAD_PER_NODE_TABLE.name, ()))
+        self._build_tablets(rows_by_table.get(TABLETS_TABLE.name, ()))
+        self._build_tablet_sizes(rows_by_table.get(TABLET_SIZES_TABLE.name, ()))
+        self._link_colocated_tablets()
+
+    def _get_or_add_host(self, host_id: HostId, shard_count: Optional[int] = None) -> Host:
+        """
+        Returns the host with the given id, registering it if it is not known yet.
+        """
+        host = self._hosts.get(host_id)
+        if host is None:
+            host = Host(host_id, shard_count)
+            self._hosts[host_id] = host
+        return host
+
+    def _build_tablets(self, rows: Iterable[Row]) -> None:
+        """
+        Populates tables and their tablet maps from system.tablets.
+
+        A host system.topology missed is registered from its replicas, shard count inferred as
+        the highest shard seen plus one. That costs a lookup per replica, so it is skipped when
+        every known host already has one.
+        """
+        infer_hosts_from_replicas = not self._hosts or any(host.shard_count is None
+                                                           for host in self._hosts.values())
+        max_shard_per_host: Dict[HostId, int] = {}
+
+        for row in rows:
+            table_id = row.table_id
+            if table_id not in self._tablet_maps:
+                self._tables[table_id] = (row.keyspace_name, row.table_name)
+                self._tablet_maps[table_id] = TabletMap(table_id, base_table=row.base_table)
+
+            if row.base_table:
+                # It shares its base table's tablets. See _link_colocated_tablets().
+                continue
+
+            replicas = row.replicas or []
+            # An empty new_replicas means no migration is in progress, same as a missing one.
+            new_replicas = row.new_replicas or None
+            if infer_hosts_from_replicas:
+                for replica_list in (replicas, new_replicas or ()):
+                    for host_id, shard in replica_list:
+                        # Writes are a handful per cluster, lookups are per replica.
+                        if shard > max_shard_per_host.get(host_id, -1):
+                            max_shard_per_host[host_id] = shard
+
+            self._tablet_maps[table_id].tablets.append(
+                Tablet(last_token=row.last_token,
+                       replicas=replicas,
+                       new_replicas=new_replicas,
+                       stage=row.stage))
+
+        for host_id, max_shard in max_shard_per_host.items():
+            host = self._get_or_add_host(host_id)
+            if host.shard_count is None:
+                host.shard_count = max_shard + 1
+
+    def _build_load_per_node(self, rows: Iterable[Row]) -> None:
+        """
+        Augments hosts with storage capacity and location from system.load_per_node.
+        """
+        for row in rows:
+            host = self._get_or_add_host(row.node)
+            if row.dc is not None:
+                host.dc = row.dc
+            if row.rack is not None:
+                host.rack = row.rack
+            if row.ip is not None:
+                host.ip = str(row.ip)  # an inet is an ipaddress object over CQL
+            if row.storage_capacity is not None:
+                host.storage_capacity = row.storage_capacity
+            if row.effective_capacity is not None:
+                host.effective_capacity = row.effective_capacity
+
+    def _build_topology(self, rows: Iterable[Row]) -> None:
+        """
+        Augments hosts with authoritative shard counts, membership state and location from
+        system.topology, and records the topology version.
+
+        Read before system.load_per_node, which repeats the location of every node it lists.
+        The two agree; this one also covers the nodes that table has dropped.
+        """
+        for row in rows:
+            if row.version is not None:
+                self._version = row.version
+            host = self._get_or_add_host(row.host_id)
+            if row.shard_count is not None:
+                host.shard_count = row.shard_count
+            host.node_state = row.node_state
+            host.num_tokens = row.num_tokens
+            if row.datacenter is not None:
+                host.dc = row.datacenter
+            if row.rack is not None:
+                host.rack = row.rack
+
+    def _build_tablet_sizes(self, rows: Iterable[Row]) -> None:
+        """
+        Populates per-replica tablet sizes from system.tablet_sizes.
+        """
+        for row in rows:
+            # dict() because the driver's own map type would not compare equal to a dump's.
+            self._tablet_sizes[(row.table_id, row.last_token)] = dict(row.replicas or {})
+
+    def get_tablet_size(self, table: TableId, tablet: Tablet, replica: TabletReplica) -> int:
+        """
+        Returns the size in bytes of a given tablet replica.
+        Raises an exception if the size is not available (e.g. when tablet sizes were not loaded).
+        """
+        tablet_id = (table, tablet.last_token)
+        sizes = self._tablet_sizes.get(tablet_id)
+        if sizes is None:
+            raise Exception(f"Tablet size not available for tablet {tablet_id}. ")
+        host_id = replica[0]
+        if host_id not in sizes:
+            raise Exception(f"Tablet size not available for tablet {tablet_id} on host {host_id}")
+        return max(sizes[host_id], self._min_tablet_size)
+
+    def get_host_effective_capacity(self, host: Host) -> int:
+        """
+        Returns the effective storage capacity in bytes of a given host.
+
+        Does not fall back to storage_capacity, which would present absolute
+        capacity as if it were effective.
+        """
+        if host.effective_capacity is None:
+            raise Exception(f"Effective capacity of host {host.id} is missing.")
+        return host.effective_capacity
+
+
+class TopologySource(ABC):
+    # Setting this will affect reported size stats for tablets, making this a lower-bound on reported size.
+    # Load balancer treats tablets smaller than 50 MiB as having 50 MiB size for balancing purposes,
+    # so when displaying balance reporting, it may make sense to treat the size the same way as load balancer
+    # does.
+    min_tablet_size: Optional[int] = None
+    anonymizer: Optional[Anonymizer] = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    @abstractmethod
+    def is_live(self) -> bool:
+        """
+        is_live() == true indicates that topology in this source can change in real time and subsequent calls
+        to get_topology() may return different results.
+        The object returned by get_topology() is not modified by this source, and consumers should not modify it either.
+        It may be reused by the source for subsequent calls to get_topology().
+
+        is_live() == false indicates that topology is static and subsequent calls to get_topology()
+        will return the same result.
+        """
+        pass
+
+    @abstractmethod
+    def get_topology(self) -> Topology:
+        """
+        Returns a snapshot of Topology.
+        The returned Topology object is not updated by the source, even if the topology source is live.
+        """
+        pass
+
+    def close(self) -> None:
+        """
+        Releases any underlying resources owned by this topology source.
+        """
+        pass
+
+    def _with_shared_options(self, topo: Topology) -> Topology:
+        """
+        Applies the options which do not depend on where the topology came from.
+        """
+        topo._min_tablet_size = self.min_tablet_size or 0
+        topo.set_anonymizer(self.anonymizer)
+        return topo
+
+
+def resolve_table_id(topo: Topology, table_arg: str) -> TableId:
+    """
+    Resolves a user-provided table selector to a table id.
+
+    The selector may be either:
+    - an exact table id string, in which case UUID parsing errors propagate, or
+    - an exact ``keyspace.table`` name.
+    - a bare table name, when it is unique within the cluster.
+
+    Raises:
+        Exception: if the table does not exist or the name is ambiguous.
+    """
+    if "." not in table_arg:
+        matches = [table_id for table_id, name in topo.iter_tables() if name.split(".", 1)[1] == table_arg]
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise Exception(f"Ambiguous table name: {table_arg}")
+
+        try:
+            table_id = parse_uuid(table_arg)
+        except ValueError as exc:
+            raise Exception(f"Unknown table or table id: {table_arg}") from exc
+        if not topo.has_table(table_id):
+            raise Exception(f"Unknown table or table id: {table_arg}")
+        return table_id
+
+    matches = [table_id for table_id, name in topo.iter_tables() if name == table_arg]
+    if not matches:
+        raise Exception(f"Unknown table: {table_arg}")
+    if len(matches) > 1:
+        raise Exception(f"Ambiguous table name: {table_arg}")
+    return matches[0]
+
+
+# A snapshot file, opened by calling it, yielding a context manager over its lines.
+LineSource = Callable[[], AbstractContextManager[Iterable[str]]]
+
+
+def open_snapshot_files(snapshot_path: str) -> Dict[SnapshotTable, LineSource]:
+    """
+    Returns ``{table: line source}`` for the tables a snapshot holds, given its directory or a
+    tar archive of one. Files are matched by base name, so the archive layout does not matter.
+
+    A directory's files are read on the fly. Archive members are read up front: gzip has no
+    member index, so getmembers() already decompressed everything.
+    """
+    sources: Dict[SnapshotTable, LineSource] = {}
+
+    if os.path.isdir(snapshot_path):
+        for table in SNAPSHOT_TABLES:
+            path = os.path.join(snapshot_path, table.file)
+            if os.path.exists(path):
+                # newline="" leaves line endings to the csv module, so a newline inside a
+                # quoted value does not end its row.
+                sources[table] = partial(open, path, newline="")
+        return sources
+
+    if not os.path.exists(snapshot_path):
+        raise Exception(f"Snapshot does not exist: {snapshot_path}")
+    if not tarfile.is_tarfile(snapshot_path):
+        raise Exception(f"Snapshot is neither a directory nor a tar archive: {snapshot_path}")
+
+    table_by_file = {table.file: table for table in SNAPSHOT_TABLES}
+    with tarfile.open(snapshot_path, "r:*") as tar:
+        for member in tar.getmembers():
+            table = table_by_file.get(os.path.basename(member.name))
+            if table is None or not member.isfile():
+                continue
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                continue
+            with io.TextIOWrapper(extracted, encoding="utf-8", newline="") as text_lines:
+                sources[table] = partial(nullcontext, list(text_lines))
+    return sources
+
+
+class TopologyFromSnapshot(TopologySource):
+    """
+    Topology is constructed from a snapshot directory or from a tar archive holding one.
+
+    system_tablets.csv is required. Other files are optional and augment the base
+    topology when present.
+    """
+
+    def __init__(self, snapshot_dir: str):
+        self.snapshot_dir = snapshot_dir
+
+        files = open_snapshot_files(snapshot_dir)
+        if TABLETS_TABLE not in files:
+            raise Exception(f"Snapshot is missing required file: {TABLETS_TABLE.file} in {snapshot_dir}")
+
+        topo = Topology()
+        # Files stay open for the whole build, so rows are read as _build() walks them.
+        with ExitStack() as open_files:
+            def rows(table: SnapshotTable) -> Iterator[Row]:
+                source = files.get(table)
+                if source is None:
+                    return iter(())
+                return rows_from_csv(open_files.enter_context(source()), table.columns)
+
+            topo._build({table.name: rows(table) for table in SNAPSHOT_TABLES})
+
+        self.topo = topo
+
+    def get_topology(self) -> Topology:
+        return self._with_shared_options(self.topo)
+
+    def is_live(self):
+        return False
+
+
+class LiveClusterTopologySource(TopologySource):
+    """
+    Topology is constructed by querying system tables from a live cluster.
+    """
+
+    def __init__(self, cluster, session):
+        self.cluster = cluster
+        self.session = session
+        self.queries = {table: session.prepare(f"SELECT * FROM {table.name}")
+                        for table in SNAPSHOT_TABLES}
+
+    def get_topology(self) -> Topology:
+        pending = {table: self.session.execute_async(query) for table, query in self.queries.items()}
+
+        topo = Topology()
+        topo._build({table.name: rows_from_cql(result.result(), table.columns)
+                     for table, result in pending.items()})
+
+        return self._with_shared_options(topo)
+
+    def is_live(self):
+        return True
+
+    def close(self) -> None:
+        self.cluster.shutdown()
+
+
+def parse_size(s: str) -> int:
+    """
+    Parses a size in bytes, optionally with a binary unit suffix (e.g. "1GiB", "512MiB", "1024").
+    """
+    m = re.fullmatch(r'\s*(\d+(?:\.\d+)?)\s*([KMGTP]i?B?)?\s*', s, re.IGNORECASE)
+    if not m:
+        raise argparse.ArgumentTypeError(f"Invalid size: '{s}'")
+    value = float(m.group(1))
+    unit = (m.group(2) or "").rstrip("bB").rstrip("iI").upper()
+    factor = {"": 1, "K": 1 << 10, "M": 1 << 20, "G": 1 << 30, "T": 1 << 40, "P": 1 << 50}[unit]
+    return int(value * factor)
+
+
+def add_topology_source_args(parser: argparse.ArgumentParser):
+    # Options for selecting topology source
+    source_group = parser.add_mutually_exclusive_group(required=False)
+    source_group.add_argument(
+        "--snapshot",
+        metavar="PATH",
+        help="Read topology from a snapshot directory, or from a tar archive holding one (as created by snapshot.py --gz)."
+    )
+    source_group.add_argument(
+        "--cluster",
+        metavar="URL",
+        help="Read data from a live cluster, connecting to a given host"
+    )
+
+    # Live topology source options
+    parser.add_argument(
+        "--port",
+        metavar="port",
+        help="Port number to use when connecting to a cluster"
+    )
+    # -u and -p spelled as cqlsh spells them.
+    parser.add_argument(
+        "-u", "--user",
+        metavar="user",
+        help="Username to use when connecting to a cluster"
+    )
+    parser.add_argument(
+        "-p", "--password",
+        metavar="password",
+        help="Password to use when connecting to a cluster"
+    )
+
+    # Options independent of the topology source
+    parser.add_argument(
+        "--min-tablet-size",
+        type=parse_size,
+        help="Lower bound applied to every tablet size, e.g. '1GiB' or in bytes"
+    )
+    parser.add_argument(
+        "--anonymize",
+        action="store_true",
+        help="Replace keyspace and table names with deterministic ksN.tableM aliases"
+    )
+
+
+def get_topology_source_from_args(args: argparse.Namespace) -> TopologySource:
+    if args.snapshot:
+        src = TopologyFromSnapshot(args.snapshot)
+    else:
+        src = get_live_topology_source_from_args(args)
+
+    src.min_tablet_size = args.min_tablet_size
+    src.anonymizer = Anonymizer() if args.anonymize else None
+
+    return src
+
+
+def get_live_topology_source_from_args(args: argparse.Namespace) -> TopologySource:
+    from cassandra.auth import PlainTextAuthProvider
+    from cassandra.cluster import Cluster
+
+    auth = None
+    if args.user is not None or args.password is not None:
+        auth = PlainTextAuthProvider(username=args.user, password=args.password)
+
+    port = int(args.port) if args.port is not None else 9042
+    cluster = Cluster([args.cluster or "127.0.0.1"], port=port, auth_provider=auth)
+    session = cluster.connect()
+    return LiveClusterTopologySource(cluster, session)

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import threading
+import sys
+import tempfile
 from concurrent.futures.thread import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -32,6 +34,10 @@ from cassandra.cluster import Session                                    # type:
 from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
 from collections.abc import AsyncIterator
+
+SCRIPTS_DIR = str(TOP_SRC_DIR / "scripts")
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator

--- a/test/cluster/test_tablet_snapshot.py
+++ b/test/cluster/test_tablet_snapshot.py
@@ -1,0 +1,203 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from test import TOP_SRC_DIR
+from test.cluster.util import get_topology_coordinator
+from test.cluster.util import new_test_keyspace
+from test.pylib.scylla_cluster import ReplaceConfig
+from test.pylib.util import unique_name
+from test.pylib.util import wait_for_view
+from test.pylib.scylla_cluster_manager import ScyllaClusterManager
+
+from tablets.snapshot import take_snapshot
+from tablets import topology
+
+logger = logging.getLogger(__name__)
+
+
+def take_manual_snapshot(host: str, workdir: Path, output_dir: str = "manual_snapshot") -> Path:
+    """
+    Captures a snapshot by running the cqlsh commands --manual prints, as a user without
+    direct cluster access would, and returns the directory they wrote.
+    """
+    snapshot_script = TOP_SRC_DIR / "scripts" / "tablets" / "snapshot.py"
+    result = subprocess.run(
+        [sys.executable, str(snapshot_script), "--manual", "--cluster", host, "--output-dir", output_dir],
+        cwd=workdir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    for line in result.stdout.strip().splitlines():
+        if line.startswith("cqlsh "):
+            line = line.replace(
+                "cqlsh ",
+                f"{TOP_SRC_DIR / 'bin/cqlsh'} ",
+                1,
+            )
+        subprocess.run(line, cwd=workdir, shell=True, check=True, text=True)
+    return workdir / output_dir
+
+
+def source_args(host: str) -> SimpleNamespace:
+    """
+    What snapshot.py would have parsed for a plain capture from one node.
+    """
+    return SimpleNamespace(
+        cluster=host,
+        port=None,
+        user=None,
+        password=None,
+        output_dir=None,
+        gz=False,
+    )
+
+
+def get_live_topology(host: str) -> topology.LiveClusterTopologySource:
+    """
+    Opens a topology source reading the cluster directly, for comparison against snapshots.
+    """
+    return topology.get_live_topology_source_from_args(source_args(host))
+
+
+@pytest.mark.asyncio
+async def test_tablet_snapshot_matches_live_topology(manager: ScyllaClusterManager, tmp_path: Path):
+    """
+    A snapshot must describe the same topology as the live cluster it was taken from,
+    whether snapshot.py captured it directly or the user ran the --manual cqlsh commands.
+    """
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
+    cql = manager.get_cql()
+
+    # 'initial' pins the tablet count: without it the count follows
+    # tablets_initial_scale_factor, which the test runner sets per mode.
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3}"
+                                          " AND tablets = {'initial': 4}") as ks:
+        mv = unique_name()
+        await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, v int)")
+        await cql.run_async(f"CREATE TABLE {ks}.t2 (pk int PRIMARY KEY, v int)")
+        await cql.run_async(
+            f"CREATE MATERIALIZED VIEW {ks}.{mv} AS SELECT pk, v FROM {ks}.t1 "
+            f"WHERE pk IS NOT NULL AND v IS NOT NULL PRIMARY KEY (v, pk)"
+        )
+        await wait_for_view(cql, mv, len(servers))
+
+        # The snapshots are taken after the live topology is read, so a migration in that
+        # window would move replicas and make the comparison below fail intermittently.
+        await manager.disable_tablet_balancing()
+
+        with get_live_topology(servers[0].ip_addr) as live_src:
+            live_topo = live_src.get_topology()
+
+            table_ids = {live_topo.get_table_name(table_id): table_id for table_id in live_topo.iter_table_ids()}
+            assert {f"{ks}.t1", f"{ks}.t2", f"{ks}.{mv}"} <= table_ids.keys()
+            assert live_topo.host_count() == len(servers)
+
+            t1_id, mv_id = table_ids[f"{ks}.t1"], table_ids[f"{ks}.{mv}"]
+            # A base table is its own base. The view reports t1 only once colocated; until
+            # then it has a tablet map of its own.
+            assert live_topo.get_base_table_id(t1_id) == t1_id
+            assert live_topo.get_base_table_id(mv_id) in (mv_id, t1_id)
+
+            for name in (f"{ks}.t1", f"{ks}.t2", f"{ks}.{mv}"):
+                assert len(live_topo.get_tablet_map(table_ids[name]).tablets) == 4, name
+
+            for host in live_topo.all_hosts():
+                assert host.dc == "dc1"
+                assert host.rack is not None
+
+            # Verify that the snapshot taken from a live node matches the live topology,
+            # and that a manual snapshot also matches.
+            snapshot_dir = take_snapshot(source_args(servers[0].ip_addr), tmp_path)
+            snapshot_topo = topology.TopologyFromSnapshot(str(snapshot_dir)).get_topology()
+
+            manual_snapshot_dir = take_manual_snapshot(servers[0].ip_addr, tmp_path)
+            manual_snapshot_topo = topology.TopologyFromSnapshot(str(manual_snapshot_dir)).get_topology()
+
+            assert live_topo == snapshot_topo
+            assert live_topo == manual_snapshot_topo
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+@pytest.mark.tier2
+async def test_tablet_snapshot_taken_after_replace_before_rebuild(manager: ScyllaClusterManager):
+    """
+    A replace finishes its topology request before the replaced node's replicas are rebuilt.
+    In that window the topology model must still list the replaced node as a replica, while
+    system.topology already has it as left and the joining node as normal.
+    """
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3}"
+                                          " AND tablets = {'initial': 8}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t1 (pk int PRIMARY KEY, v int)")
+
+        # Keeps unrelated migrations away. Does not stop the replace driven rebuild.
+        await manager.disable_tablet_balancing()
+
+        coordinator = await get_topology_coordinator(manager)
+        coordinator_server = await manager.find_server_by_host_id(servers, coordinator)
+        replaced_server = next(s for s in servers if s.server_id != coordinator_server.server_id)
+        replaced_host_id = UUID(str(await manager.get_host_id(replaced_server.server_id)))
+        survivor = next(s for s in servers if s.server_id != replaced_server.server_id)
+
+        logger.info(f"Downing {replaced_server} to replace it")
+        await manager.server_stop(replaced_server.server_id, convict=True)
+        await manager.others_not_see_server(replaced_server.ip_addr)
+
+        # An empty migration plan, so nothing is rebuilt off the replaced node and it stays in
+        # system.tablets as a replica.
+        await manager.api.enable_injection(coordinator_server.ip_addr, "tablet_migration_bypass", one_shot=False)
+
+        logger.info("Replacing the node, which blocks in await_tablets_rebuilt()")
+        replace_cfg = ReplaceConfig(replaced_id=replaced_server.server_id, reuse_ip_addr=False, use_host_id=True)
+        joining_server = await manager.server_add(replace_cfg, start=False,
+                                                  property_file=replaced_server.property_file())
+        joining_log = await manager.server_open_log(joining_server.server_id)
+        replace_task = asyncio.create_task(manager.server_start(joining_server.server_id))
+
+        try:
+            # Logged once the replace itself is done, so system.topology already has the joining
+            # node as normal and the replaced one as left, with the replicas not rebuilt yet.
+            await joining_log.wait_for("Waiting for tablet replicas from the replaced node to be rebuilt",
+                                       timeout=300)
+
+            with get_live_topology(survivor.ip_addr) as live_src:
+                live_topo = live_src.get_topology()
+
+                replaced = live_topo.get_host(replaced_host_id)
+                assert replaced is not None, "replaced node is missing from the topology"
+                assert replaced.node_state == "left", f"node_state is {replaced.node_state}"
+
+                # It is not a peer any imbalance is measured against, but it is still a replica.
+                peers = list(live_topo.all_normal_token_owner_hosts())
+                assert not replaced.is_normal_token_owner(), "counted as a token owner"
+                assert replaced not in peers, "listed as a peer"
+                assert len(peers) == len(servers), f"wrong peer count: {len(peers)}"
+
+                held = [tablet for _, tablet in live_topo.all_tablets()
+                        if any(host_id == replaced_host_id for host_id, _ in tablet.replicas)]
+                assert held, "replaced node holds no tablet replicas"
+
+        finally:
+            # The window is all this test needs. Letting the replace finish would cost most of
+            # the runtime, so the half joined cluster is thrown away instead.
+            replace_task.cancel()
+            await manager.mark_dirty()

--- a/test/tablet_scripts/__init__.py
+++ b/test/tablet_scripts/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#

--- a/test/tablet_scripts/conftest.py
+++ b/test/tablet_scripts/conftest.py
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+import sys
+
+from test import TOP_SRC_DIR
+
+
+# Put scripts/ on the path before the test modules import tablets.<module>.
+SCRIPTS_DIR = str(TOP_SRC_DIR / "scripts")
+if SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, SCRIPTS_DIR)

--- a/test/tablet_scripts/test_cluster_load.py
+++ b/test/tablet_scripts/test_cluster_load.py
@@ -1,0 +1,419 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from tablets import cluster_load
+from tablets.cluster_load import CapacityMode
+from tablets.cluster_load import Levels
+from tablets.filters import filter_args
+from tablets.filters import get_host_filter
+from tablets.filters import get_table_filter
+from tablets.filters import get_tablet_filter
+from tablets.render_utils import PresentationOptions
+from tablets.render_utils import strip_ansi
+from tablets.topology import TabletMap
+from tablets.topology import Topology
+
+from test.tablet_scripts.topology_building import *
+
+
+# The hosts the tests below place, whose capacities every utilization here is measured
+# against: the first two hold the same effective capacity but differ in absolute capacity,
+# and the third sits in a rack of its own, for the tests that want a rack holding nothing.
+HOST1 = HostSpec("10.0.0.1", "dc1", "rack1", storage_capacity=600, effective_capacity=400)
+HOST2 = HostSpec("10.0.0.2", "dc1", "rack1", storage_capacity=800, effective_capacity=400)
+HOST3 = HostSpec("10.0.0.3", "dc1", "rack2", storage_capacity=800, effective_capacity=400)
+
+HOSTS = {HOST1_ID: HOST1, HOST2_ID: HOST2}
+TABLES = {TABLE1_ID: ("ks", "tbl")}
+
+# One tablet on a shard of each host, so a host, a shard and the table all hold something
+# different, and 120 against 280 is an imbalance to measure.
+TABLETS = {TABLE1_ID: [
+    (0, {(HOST1_ID, 0): 120}),
+    (1 << 63, {(HOST2_ID, 1): 280}),
+]}
+
+
+def collect_levels(topo: Topology, table_id=None, capacity_mode: CapacityMode = CapacityMode.EFFECTIVE,
+                   **filters) -> Levels:
+    """
+    Measures every level under the filters the caller narrows by, the way main() does.
+    """
+    args = filter_args(**filters)
+    table_ids = cluster_load.get_selected_table_ids(topo, table_id, get_table_filter(args, topo))
+    return cluster_load.collect_levels(topo, table_ids, capacity_mode,
+                                       get_tablet_filter(args, topo),
+                                       get_host_filter(args, topo))
+
+
+def test_a_colocated_table_counts_towards_the_tablet_count() -> None:
+    """
+    A view shares its base table's tablets, but its tablet is load the shard really
+    serves, so it counts. Keeps tablets/shard comparable with table_summary.py, which
+    reports one row per table.
+    """
+    topology = build_topology(hosts=HOSTS, tables=TABLES, tablets=TABLETS)
+
+    view_id = TABLE2_ID
+    topology._tables[view_id] = ("ks", "tbl_view")
+    topology._tablet_maps[view_id] = TabletMap(view_id, base_table=TABLE1_ID)
+    topology._tablet_sizes.update({(view_id, token): {host: 1}
+                               for (_, token), sizes in list(topology._tablet_sizes.items())
+                               for host in sizes})
+    topology._build({})  # links the colocated map to the base table's tablets
+
+    levels = collect_levels(topology)
+
+    # One tablet each from the base table and the view, on each of the two hosts.
+    assert [node.tablet_count for node in levels.nodes] == [2, 2]
+
+
+def test_a_host_holding_no_replica_is_still_reported() -> None:
+    """
+    An empty node stays on the report: it is itself the imbalance being looked for.
+    """
+    topology = build_topology(hosts={**HOSTS, HOST3_ID: HOST3}, tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology)
+
+    shown = {node.host.id: node for node in levels.nodes}
+    assert HOST3_ID in shown
+    assert shown[HOST3_ID].tablet_count == 0
+    assert shown[HOST3_ID].size == 0
+
+
+def test_a_table_filter_does_not_hide_a_host_without_that_tables_replicas() -> None:
+    topology = build_topology(hosts={**HOSTS, HOST3_ID: HOST3}, tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology, TABLE1_ID, table="ks.tbl")
+
+    assert HOST3_ID in {node.host.id for node in levels.nodes}
+
+
+def test_a_location_filter_does_hide_a_host_it_excludes() -> None:
+    topology = build_topology(hosts={**HOSTS, HOST3_ID: HOST3}, tables=TABLES, tablets=TABLETS)
+
+    for field, value in (("rack", ("dc1", "rack1")), ("host", "10.0.0.1")):
+        levels = collect_levels(topology, **{field: value})
+        assert HOST3_ID not in {node.host.id for node in levels.nodes}, field
+
+
+def test_rack_capacity_does_not_follow_the_filters() -> None:
+    """
+    Capacity belongs to the rack, so a filter narrowing what is shown leaves it alone.
+    Utilization then reads as the share of the rack the selection occupies.
+    """
+    topology = build_topology(hosts=HOSTS, tables=TABLES, tablets=TABLETS)
+
+    def rack1_capacities(**filters) -> list[int]:
+        capacities = []
+        for mode in (CapacityMode.EFFECTIVE, CapacityMode.ABSOLUTE):
+            levels = collect_levels(topology, capacity_mode=mode, **filters)
+            rack1 = next(rack for rack in levels.racks if rack.rack_id == ("dc1", "rack1"))
+            capacities.append(rack1.capacity)
+        return capacities
+
+    unfiltered = rack1_capacities()
+    assert unfiltered == [800, 1400]
+
+    for field, value in (("host", "10.0.0.1"), ("shard", ("10.0.0.1", 0)), ("table", "ks.tbl")):
+        assert rack1_capacities(**{field: value}) == unfiltered, field
+
+
+def test_a_node_shows_all_of_its_shards_under_a_shard_filter() -> None:
+    """
+    Shard count and capacity are the node's own, so --shard narrows which replicas count
+    towards its load without shrinking the node it is measured against.
+    """
+    topology = build_topology(hosts=HOSTS, tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology, TABLE1_ID, shard=("10.0.0.1", 0))
+
+    node = levels.nodes[0]
+    assert (node.host.ip, node.shard_count, node.capacity) == ("10.0.0.1", 2, 400)
+    # Only the selected shard is a row of its own.
+    assert [(shard.host.ip, shard.shard_id) for shard in levels.shards] == [("10.0.0.1", 0)]
+
+
+@pytest.mark.parametrize("shard_count", [1, 0], ids=["shard_out_of_range", "no_shard_count"])
+def test_a_replica_on_an_unreported_shard_still_counts_for_its_node(shard_count: int) -> None:
+    """
+    Levels above the shard are the merge of the shards below, so a replica sitting on a
+    shard its host does not report having would go missing if it were left to that merge.
+    A snapshot that carries no shard count at all is the same case for every replica.
+    """
+    topology = build_topology(hosts={HOST1_ID: HOST1, HOST2_ID: replace(HOST2, shard_count=shard_count)},
+                              tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology, TABLE1_ID)
+
+    node = next(node for node in levels.nodes if node.host.id == HOST2_ID)
+    assert (node.size, node.tablet_count) == (280, 1)
+    assert next(rack for rack in levels.racks if rack.rack_id == ("dc1", "rack1")).size == 400
+    assert levels.dcs[0].size == 400
+    # The replica has no shard of its own to be a row of.
+    assert [(shard.host.ip, shard.shard_id) for shard in levels.shards
+            if shard.host.id == HOST2_ID] == [("10.0.0.2", 0)] * shard_count
+
+
+def test_every_level_measures_the_same_replicas() -> None:
+    """
+    One walk feeds every level, so a shard, its node, its rack and its DC agree on what
+    they hold without being summed from one another.
+    """
+    topology = build_topology(hosts=HOSTS, tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology, TABLE1_ID)
+
+    assert levels.total_token_space == 1.0
+    assert [node.host.ip for node in levels.nodes] == ["10.0.0.1", "10.0.0.2"]
+    assert [node.size for node in levels.nodes] == [120, 280]
+    assert [node.tablet_count for node in levels.nodes] == [1, 1]
+    assert [node.token_fraction for node in levels.nodes] == [0.5, 0.5]
+    assert [(shard.host.ip, shard.shard_id, shard.size, shard.tablet_count) for shard in levels.shards] == [
+        ("10.0.0.1", 0, 120, 1),
+        ("10.0.0.1", 1, 0, 0),
+        ("10.0.0.2", 0, 0, 0),
+        ("10.0.0.2", 1, 280, 1),
+    ]
+
+    assert len(levels.racks) == 1
+    rack = levels.racks[0]
+    assert (rack.rack_id, rack.size, rack.tablet_count, rack.shard_count) == (("dc1", "rack1"), 400, 2, 4)
+    assert rack.token_fraction == 1.0
+    assert rack.tablets_per_shard == pytest.approx(0.5)
+
+    assert len(levels.dcs) == 1
+    dc = levels.dcs[0]
+    assert (dc.dc, dc.size, dc.tablet_count, dc.shard_count) == ("dc1", 400, 2, 4)
+    assert dc.token_fraction == 1.0
+
+
+@pytest.mark.parametrize("capacity_mode, node_capacities, node_utils, node_util_ovcs", [
+    pytest.param(CapacityMode.EFFECTIVE, [400, 400], [0.3, 0.7], [0.6, 1.4], id="effective"),
+    pytest.param(CapacityMode.ABSOLUTE, [600, 800], [0.2, 0.35], [0.7272727273, 1.2727272727], id="absolute"),
+])
+def test_capacity_and_utilization_follow_the_capacity_mode(
+        capacity_mode: CapacityMode, node_capacities: list[int],
+        node_utils: list[float], node_util_ovcs: list[float]) -> None:
+    topology = build_topology(hosts=HOSTS, tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology, TABLE1_ID, capacity_mode=capacity_mode)
+
+    assert [node.capacity for node in levels.nodes] == node_capacities
+    assert [node.util for node in levels.nodes] == pytest.approx(node_utils)
+    assert [node.util_ovc for node in levels.nodes] == pytest.approx(node_util_ovcs)
+    # A shard has the node's capacity divided among its shards.
+    assert [shard.capacity for shard in levels.shards] == [capacity // 2
+                                                           for capacity in node_capacities
+                                                           for _ in range(2)]
+
+
+def test_overcommit_compares_an_item_against_the_peers_it_is_shown_beside() -> None:
+    """
+    Nodes are compared within their rack and shards within their node, so a shard holding
+    everything its node has overcommits its idle sibling however small the node is.
+    """
+    topology = build_topology(hosts=HOSTS, tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology, TABLE1_ID)
+
+    assert [node.ovc for node in levels.nodes] == pytest.approx([0.6, 1.4])
+    assert [node.token_ovc for node in levels.nodes] == pytest.approx([1.0, 1.0])
+    assert [shard.ovc for shard in levels.shards] == pytest.approx([2.0, 0.0, 0.0, 2.0])
+    assert [shard.token_ovc for shard in levels.shards] == pytest.approx([2.0, 0.0, 0.0, 2.0])
+
+
+def build_two_dc_topology() -> Topology:
+    """
+    Two DCs of one rack each, holding one tablet replica per host. dc2's host is twice the
+    size of dc1's and has twice the capacity.
+    """
+    return build_topology(
+        hosts={
+            HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1", shard_count=1,
+                               storage_capacity=1000, effective_capacity=1000),
+            HOST2_ID: HostSpec("10.0.0.2", "dc2", "rack2", shard_count=1,
+                               storage_capacity=2000, effective_capacity=2000),
+        },
+        tables={TABLE1_ID: ("ks", "tbl")},
+        tablets={TABLE1_ID: [(0, {(HOST1_ID, 0): 100, (HOST2_ID, 0): 200})]},
+    )
+
+
+def test_a_dc_summarizes_only_the_racks_it_shows() -> None:
+    """
+    A DC row is the total of its rack rows, so a rack a filter kept off the report takes
+    its capacity with it. Otherwise the summary would be a share of hardware not shown.
+    """
+    topo = build_two_dc_topology()
+
+    levels = collect_levels(topo, TABLE1_ID)
+    assert [(dc.dc, dc.size, dc.capacity) for dc in levels.dcs] == [("dc1", 100, 1000), ("dc2", 200, 2000)]
+
+    levels = collect_levels(topo, TABLE1_ID, dc="dc2")
+    assert [(dc.dc, dc.size, dc.capacity) for dc in levels.dcs] == [("dc2", 200, 2000)]
+
+
+def test_a_dc_row_reports_the_worst_of_its_racks() -> None:
+    """
+    Overcommit does not add up, and a DC has no peer to be compared against on the report,
+    so its summary carries the worst of the racks it shows.
+    """
+    topo = build_two_dc_topology()
+
+    levels = collect_levels(topo, TABLE1_ID)
+
+    # One rack per DC, so each rack is its DC's average and overcommits it by nothing.
+    assert [rack.ovc for rack in levels.racks] == pytest.approx([1.0, 1.0])
+    assert [dc.ovc for dc in levels.dcs] == pytest.approx([1.0, 1.0])
+
+
+def test_coloring_only_adds_escapes() -> None:
+    """
+    Stripping the escapes from a colored report gives the uncolored one, so coloring can
+    never move a cell. Also catches a helper that was never handed the options.
+    """
+    topology = build_topology(hosts=HOSTS, tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology, TABLE1_ID)
+
+    def build(colors: bool) -> list[list[str]]:
+        rows = cluster_load.build_section_rows(levels, levels.nodes,
+                                               PresentationOptions(colors=colors))
+        return [[str(cell) for cell in row] for row in rows]
+
+    colored, plain = build(True), build(False)
+    assert colored != plain
+    assert [[strip_ansi(cell) for cell in row] for row in colored] == plain
+
+
+def test_cluster_load_headers_follow_capacity_mode() -> None:
+    abs_headers = [col.header for col in cluster_load.get_columns(CapacityMode.ABSOLUTE)]
+    eff_headers = [col.header for col in cluster_load.get_columns(CapacityMode.EFFECTIVE)]
+    assert abs_headers[10:12] == ["capacity\n[B]", "util\n[%]"]
+    assert eff_headers[10:12] == ["eff capacity\n[B]", "eff util\n[%]"]
+
+
+def test_csv_rows_name_their_level_and_rack() -> None:
+    """
+    Every CSV row names its section and rack, so the sections concatenate into one table.
+    """
+    topology = build_topology(hosts=HOSTS, tables=TABLES, tablets=TABLETS)
+
+    options = PresentationOptions(csv=True)
+    headers = [col.header for col in cluster_load.get_columns(CapacityMode.EFFECTIVE, options)]
+    assert headers[:3] == ["level", "rack", "location"]
+    levels = collect_levels(topology, TABLE1_ID)
+
+    rows = cluster_load.build_section_rows(levels, levels.nodes, options)
+
+    # No header or separator rows survive: every row is data, and carries its rack.
+    assert all(isinstance(row, list) for row in rows)
+    assert len(rows) == len(levels.nodes)
+    assert {row[0] for row in rows} == {"node"}
+    assert {row[1] for row in rows} == {"dc1/rack1"}
+    assert [row[2] for row in rows] == ["10.0.0.1", "10.0.0.2"]
+    assert all(len(row) == len(headers) for row in rows)
+
+
+def test_csv_dc_row_is_named_after_its_dc() -> None:
+    """
+    A flat CSV row names its DC; only the rendered table can rely on the rows above it.
+    """
+    topology = build_topology(hosts=HOSTS, tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology, TABLE1_ID)
+
+    def summary_row(options):
+        rows = cluster_load.build_rack_rows(levels, options)
+        return [row for row in rows if isinstance(row, list)][-1]
+
+    csv_row = summary_row(PresentationOptions(csv=True))
+    assert csv_row[0] == "dc"
+    assert csv_row[1] is None     # a DC summary belongs to no single rack
+    assert csv_row[2] == "dc1"
+    assert summary_row(PresentationOptions(csv=False))[0] == "DC total"
+
+
+def test_missing_effective_capacity_is_not_replaced_by_absolute() -> None:
+    """
+    Snapshots taken before system.load_per_node had effective_capacity carry only the
+    absolute capacity. Reporting that as effective capacity would label absolute numbers
+    with an "eff" header, so it must be reported as unknown instead.
+    """
+    topology = build_topology(
+        hosts={host_id: replace(host, effective_capacity=None) for host_id, host in HOSTS.items()},
+        tables=TABLES, tablets=TABLETS)
+
+    absolute = collect_levels(topology, TABLE1_ID, capacity_mode=CapacityMode.ABSOLUTE)
+    effective = collect_levels(topology, TABLE1_ID, capacity_mode=CapacityMode.EFFECTIVE)
+
+    assert [node.capacity for node in absolute.nodes] == [600, 800]
+    assert [node.capacity for node in effective.nodes] == [0, 0]
+    assert [node.util for node in effective.nodes] == [0, 0]
+    assert [shard.capacity for shard in absolute.shards] == [300, 300, 400, 400]
+    assert [shard.capacity for shard in effective.shards] == [0, 0, 0, 0]
+
+    with pytest.raises(Exception, match=r"Effective capacity of host .* is missing"):
+        topology.get_host_effective_capacity(effective.nodes[0].host)
+
+
+def test_collect_levels_respects_host_and_shard_filters() -> None:
+    topology = build_topology(hosts=HOSTS, tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology, TABLE1_ID, host="10.0.0.1")
+    assert levels.total_token_space == 1.0
+    assert [node.host.ip for node in levels.nodes] == ["10.0.0.1"]
+    assert [node.size for node in levels.nodes] == [120]
+    assert [node.token_fraction for node in levels.nodes] == [0.5]
+
+    levels = collect_levels(topology, TABLE1_ID, shard=("10.0.0.2", 1))
+    assert [node.host.ip for node in levels.nodes] == ["10.0.0.2"]
+    assert [node.size for node in levels.nodes] == [280]
+    assert [(shard.host.ip, shard.shard_id, shard.size) for shard in levels.shards] == [("10.0.0.2", 1, 280)]
+
+
+def build_two_keyspace_topology() -> Topology:
+    """
+    One rack of two hosts, and a table per keyspace: ks1.t1 lives entirely on host1, ks2.t2
+    entirely on host2, and each spans the whole ring.
+    """
+    return build_topology(
+        hosts=HOSTS,
+        tables={TABLE1_ID: ("ks1", "t1"), TABLE2_ID: ("ks2", "t2")},
+        tablets={
+            TABLE1_ID: [
+                (0, {(HOST1_ID, 0): 100}),
+                (1 << 63, {(HOST1_ID, 1): 100}),
+            ],
+            TABLE2_ID: [
+                (0, {(HOST2_ID, 0): 200}),
+                (1 << 63, {(HOST2_ID, 1): 200}),
+            ],
+        },
+    )
+
+
+def test_collect_levels_applies_keyspace_filter() -> None:
+    topo = build_two_keyspace_topology()
+
+    levels = collect_levels(topo, keyspace="ks1")
+
+    # Numerator and denominator must both be restricted to ks1: only host1 carries
+    # ks1 load, its token fraction sums to the full ring, and the token space counts
+    # a single table (not both keyspaces). host2 stays on the report at zero, since a
+    # keyspace filter selects tables, not hosts.
+    assert levels.total_token_space == 1.0
+    assert [node.host.ip for node in levels.nodes] == ["10.0.0.1", "10.0.0.2"]
+    assert [node.size for node in levels.nodes] == [200, 0]
+    assert [node.token_fraction for node in levels.nodes] == [1.0, 0.0]

--- a/test/tablet_scripts/test_cluster_load.py
+++ b/test/tablet_scripts/test_cluster_load.py
@@ -304,6 +304,58 @@ def test_cluster_load_headers_follow_capacity_mode() -> None:
     assert eff_headers[10:12] == ["eff capacity\n[B]", "eff util\n[%]"]
 
 
+@pytest.mark.parametrize("host,expected", [
+    (replace(HOST1, up=False, excluded=True), "10.0.0.1 (DX)"),
+    (replace(HOST1, up=False), "10.0.0.1 (D)"),
+    (replace(HOST1, excluded=True), "10.0.0.1 (X)"),
+    (replace(HOST1, up=True), "10.0.0.1"),
+    (HOST1, "10.0.0.1"),
+])
+def test_a_node_says_when_it_is_down_or_out_of_balancing(host, expected) -> None:
+    """
+    A row of a node the cluster cannot reach, or one it is not balancing onto, reads as one:
+    its zeros are what the node is not reporting rather than load it does not hold. A
+    snapshot taken before the columns existed says nothing either way.
+    """
+    topology = build_topology(hosts={**HOSTS, HOST1_ID: host}, tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology)
+    row = cluster_load.build_row(levels.nodes[0], levels, cluster_load.get_section_scales(levels.nodes),
+                                 PresentationOptions())
+
+    assert row[0] == expected
+
+
+def test_a_marked_node_is_colored_so_it_is_found_without_reading_the_mark() -> None:
+    topology = build_topology(hosts={**HOSTS, HOST1_ID: replace(HOST1, up=False)},
+                             tables=TABLES, tablets=TABLETS)
+
+    levels = collect_levels(topology)
+    scales = cluster_load.get_section_scales(levels.nodes)
+    colored = cluster_load.build_row(levels.nodes[0], levels, scales, PresentationOptions(colors=True))
+    working = cluster_load.build_row(levels.nodes[1], levels, scales, PresentationOptions(colors=True))
+
+    assert strip_ansi(colored[0]) == "10.0.0.1 (D)" and colored[0] != strip_ansi(colored[0])
+    assert working[0] == "10.0.0.2"
+
+
+def test_csv_names_the_status_in_a_column_of_its_own() -> None:
+    """
+    A flat table is read by column, so a note appended to the location would have to be
+    parsed back out of it.
+    """
+    topology = build_topology(hosts={**HOSTS, HOST1_ID: replace(HOST1, up=False, excluded=True)},
+                             tables=TABLES, tablets=TABLETS)
+    options = PresentationOptions(csv=True)
+
+    levels = collect_levels(topology)
+    columns = [column.header for column in cluster_load.get_columns(CapacityMode.EFFECTIVE, options)]
+    rows = cluster_load.build_section_rows(levels, levels.nodes, options)
+
+    assert columns[:4] == ["level", "rack", "location", "status"]
+    assert [row[2:4] for row in rows] == [["10.0.0.1", "DX"], ["10.0.0.2", None]]
+
+
 def test_csv_rows_name_their_level_and_rack() -> None:
     """
     Every CSV row names its section and rack, so the sections concatenate into one table.

--- a/test/tablet_scripts/test_config.yaml
+++ b/test/tablet_scripts/test_config.yaml
@@ -1,0 +1,5 @@
+# Unit tests for the Python tablet-analysis scripts in scripts/tablets/.
+#
+# They exercise pure Python only: no Scylla server, no instrumented binary and no
+# build artifacts, so there is no coverage data to collect.
+coverage: false

--- a/test/tablet_scripts/test_filters.py
+++ b/test/tablet_scripts/test_filters.py
@@ -1,0 +1,163 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+from tablets.filters import filter_args
+from tablets.filters import get_table_filter
+from tablets.filters import get_tablet_filter
+from tablets.filters import parse_rack_arg
+from tablets.filters import parse_shard_location_arg
+from tablets.filters import resolve_table_filter_id
+from tablets.topology import Topology
+
+from test.tablet_scripts.topology_building import *
+
+
+def test_parse_rack_arg() -> None:
+    assert parse_rack_arg("dc1/rack1") == ("dc1", "rack1")
+
+
+def test_parse_shard_location_arg() -> None:
+    assert parse_shard_location_arg("10.0.0.1:3") == ("10.0.0.1", 3)
+    assert parse_shard_location_arg("3") == 3
+
+
+def accepts_replica(topology: Topology, replica: tuple, **filters) -> bool:
+    return get_tablet_filter(filter_args(**filters), topology)(replica)
+
+
+def test_filter_tablet_matches_host() -> None:
+    topology = build_topology({
+        HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1"),
+        HOST2_ID: HostSpec("10.0.0.2", "dc1", "rack1"),
+    })
+
+    assert accepts_replica(topology, (HOST1_ID, 1), host="10.0.0.1") is True
+    assert accepts_replica(topology, (HOST2_ID, 1), host="10.0.0.1") is False
+
+
+def test_filter_tablet_matches_shard() -> None:
+    topology = build_topology({
+        HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1"),
+        HOST2_ID: HostSpec("10.0.0.2", "dc1", "rack1"),
+    })
+
+    assert accepts_replica(topology, (HOST1_ID, 1), shard=("10.0.0.1", 1)) is True
+    assert accepts_replica(topology, (HOST1_ID, 0), shard=("10.0.0.1", 1)) is False
+    assert accepts_replica(topology, (HOST2_ID, 1), shard=("10.0.0.1", 1)) is False
+
+    # A bare shard number selects that shard on every host.
+    assert accepts_replica(topology, (HOST1_ID, 1), shard=1) is True
+    assert accepts_replica(topology, (HOST2_ID, 1), shard=1) is True
+    assert accepts_replica(topology, (HOST1_ID, 0), shard=1) is False
+
+
+def test_filter_tablet_matches_rack() -> None:
+    topology = build_topology({
+        HOST3_ID: HostSpec("10.0.0.3", "dc3", "rack1"),
+        HOST4_ID: HostSpec("10.0.0.4", "dc3", "rack1"),
+        HOST5_ID: HostSpec("10.0.0.5", "dc3", "rack2"),
+        HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1"),   # the same rack name, in another dc
+    })
+
+    assert accepts_replica(topology, (HOST3_ID, 0), rack=("dc3", "rack1")) is True
+    assert accepts_replica(topology, (HOST4_ID, 0), rack=("dc3", "rack1")) is True
+    assert accepts_replica(topology, (HOST5_ID, 0), rack=("dc3", "rack1")) is False
+    assert accepts_replica(topology, (HOST1_ID, 0), rack=("dc3", "rack1")) is False
+
+
+def test_filter_tablet_matches_dc() -> None:
+    topology = build_topology({
+        HOST3_ID: HostSpec("10.0.0.3", "dc3", "rack1"),
+        HOST5_ID: HostSpec("10.0.0.5", "dc3", "rack2"),
+        HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1"),
+    })
+
+    assert accepts_replica(topology, (HOST3_ID, 0), dc="dc3") is True
+    assert accepts_replica(topology, (HOST5_ID, 0), dc="dc3") is True
+    assert accepts_replica(topology, (HOST1_ID, 0), dc="dc3") is False
+
+
+def test_filter_tablet_narrows_by_every_filter_given() -> None:
+    """
+    Filters intersect: a replica has to satisfy all of them, so a combination selects less
+    than either filter alone.
+    """
+    topology = build_topology({
+        HOST3_ID: HostSpec("10.0.0.3", "dc3", "rack1"),
+        HOST4_ID: HostSpec("10.0.0.4", "dc3", "rack1"),
+        HOST5_ID: HostSpec("10.0.0.5", "dc3", "rack2"),
+        HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1"),
+    })
+
+    # A rack and a bare shard number: that shard, on the hosts of that rack only.
+    assert accepts_replica(topology, (HOST3_ID, 1), rack=("dc3", "rack1"), shard=1) is True
+    assert accepts_replica(topology, (HOST4_ID, 1), rack=("dc3", "rack1"), shard=1) is True
+    assert accepts_replica(topology, (HOST3_ID, 0), rack=("dc3", "rack1"), shard=1) is False
+    assert accepts_replica(topology, (HOST5_ID, 1), rack=("dc3", "rack1"), shard=1) is False
+
+    # A dc and a host: the host, and only while it is in that dc.
+    assert accepts_replica(topology, (HOST3_ID, 0), dc="dc3", host="10.0.0.3") is True
+    assert accepts_replica(topology, (HOST4_ID, 0), dc="dc3", host="10.0.0.3") is False
+    assert accepts_replica(topology, (HOST1_ID, 0), dc="dc3", host="10.0.0.1") is False
+
+
+def test_table_and_replica_filters_come_from_one_args() -> None:
+    """
+    The two builders read the same arguments and neither sees the other's: a table filter
+    selects tables whatever narrows the replicas, and vice versa.
+    """
+    topology = build_topology({
+        HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1"),
+        HOST2_ID: HostSpec("10.0.0.2", "dc1", "rack1"),
+    }, tables={
+        TABLE1_ID: ("ks1", "users"),
+        TABLE3_ID: ("ks1", "orders"),
+    })
+
+    args = filter_args(table="ks1.users", host="10.0.0.1")
+
+    accepts_table = get_table_filter(args, topology)
+    assert accepts_table(TABLE1_ID) is True
+    assert accepts_table(TABLE3_ID) is False
+
+    accepts_tablet = get_tablet_filter(args, topology)
+    assert accepts_tablet((HOST1_ID, 0)) is True
+    assert accepts_tablet((HOST2_ID, 0)) is False
+
+    args = filter_args(table="ks1.users", shard=1)
+
+    assert get_table_filter(args, topology)(TABLE1_ID) is True
+    accepts_tablet = get_tablet_filter(args, topology)
+    assert accepts_tablet((HOST1_ID, 1)) is True
+    assert accepts_tablet((HOST1_ID, 0)) is False
+
+
+def test_resolve_table_filter_id_uses_keyspace_to_disambiguate_bare_table_name() -> None:
+    # Both keyspaces hold a "users", so the bare name needs one of them to resolve.
+    topology = build_topology({HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1")}, tables={
+        TABLE1_ID: ("ks1", "users"),
+        TABLE2_ID: ("ks2", "users"),
+    })
+
+    resolved = resolve_table_filter_id(filter_args(table="users", keyspace="ks1"), topology)
+
+    assert resolved == TABLE1_ID
+
+
+def test_filter_table_id_respects_keyspace() -> None:
+    topology = build_topology({HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1")}, tables={
+        TABLE1_ID: ("ks1", "users"),
+        TABLE2_ID: ("ks2", "users"),
+        TABLE3_ID: ("ks1", "orders"),
+    })
+
+    accepts_table = get_table_filter(filter_args(keyspace="ks1"), topology)
+
+    assert accepts_table(TABLE1_ID) is True
+    assert accepts_table(TABLE2_ID) is False
+    assert accepts_table(TABLE3_ID) is True

--- a/test/tablet_scripts/test_render_utils.py
+++ b/test/tablet_scripts/test_render_utils.py
@@ -1,0 +1,113 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+import argparse
+import builtins
+
+import pytest
+
+from tablets.render_utils import Column
+from tablets.render_utils import PresentationOptions
+from tablets.render_utils import SEPARATING_LINE
+from tablets.render_utils import add_presentation_options
+from tablets.render_utils import print_table
+from tablets.render_utils import render_table
+
+
+@pytest.fixture
+def printed(monkeypatch) -> list[str]:
+    """
+    Collects what print_table() printed, one entry per call.
+    """
+    lines: list[str] = []
+    monkeypatch.setattr(builtins, "print", lines.append)
+    return lines
+
+
+def test_render_table_csv_skips_separators_and_normalizes_headers() -> None:
+    rendered = render_table(
+        rows=[
+            ["foo", "\033[31m1\033[0m"],
+            SEPARATING_LINE,
+            ["bar", None],
+        ],
+        headers=["col\n1", "col2"],
+        csv_output=True,
+    )
+
+    assert rendered.splitlines() == [
+        "col 1,col2",
+        "foo,1",
+        "bar,",
+    ]
+
+
+def test_print_table_keeps_non_csv_columns_in_table_output(printed: list[str]) -> None:
+    columns = [
+        Column("name"),
+        Column("bar", "left", csv=False),
+        Column("size", "right"),
+    ]
+    # Without CSV output, non-csv columns are still rendered.
+    assert print_table([["foo", "████", "1"]], columns) is True
+    assert "bar" in printed[0]
+    assert "████" in printed[0]
+
+
+def test_print_table_does_not_reparse_numbers(printed: list[str]) -> None:
+    """
+    Cells reach print_table already formatted. Letting tabulate re-parse them as
+    numbers drops the OVC sign and trailing zeros ("+1.60" -> "1.6"), so number
+    parsing must stay disabled for every caller.
+    """
+    columns = [Column("name"), Column("ovc\n[%]", "right"), Column("size\n[%]", "right")]
+    assert print_table([["ks.tbl", "+1.60", "100.00"]], columns) is True
+    assert "+1.60" in printed[0]
+    assert "100.00" in printed[0]
+
+
+def test_print_table_renders_a_table_a_filter_emptied(printed: list[str]) -> None:
+    """
+    A filter matching nothing leaves no rows. Alignment is derived from the rows, so
+    the aligned columns must not outlive them.
+    """
+    columns = [Column("name"), Column("bar", "left", csv=False), Column("size", "right")]
+    assert print_table([], columns) is True
+    assert "name" in printed[0]
+    assert print_table([], columns, PresentationOptions(csv=True)) is True
+
+
+def test_add_presentation_options_adds_requested_flags() -> None:
+    parser = argparse.ArgumentParser()
+    add_presentation_options(parser, has_hosts=True, has_tables=True)
+
+    args = parser.parse_args(["--csv", "--host-id", "--table-id", "--no-hr"])
+
+    assert args.csv is True
+    assert args.host_id is True
+    assert args.table_id is True
+    assert args.hr is False
+
+
+def test_print_table_ignores_broken_pipe(monkeypatch) -> None:
+    monkeypatch.setattr(builtins, "print", lambda *args, **kwargs: (_ for _ in ()).throw(BrokenPipeError()))
+
+    assert print_table([["x"]], [Column("h")]) is False
+
+
+def test_print_table_derives_headers_alignment_and_csv_filter(printed: list[str]) -> None:
+    columns = [
+        Column("name"),
+        Column("bar", "left", csv=False),
+        Column("size", "right"),
+    ]
+    assert print_table([["foo", "████", "1"]], columns, PresentationOptions(csv=True)) is True
+    assert printed[0].splitlines() == [
+        "name,size",
+        "foo,1",
+    ]

--- a/test/tablet_scripts/test_snapshot.py
+++ b/test/tablet_scripts/test_snapshot.py
@@ -1,0 +1,323 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+import argparse
+import csv
+import ipaddress
+import os
+import re
+import tarfile
+from datetime import datetime
+from collections import namedtuple
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from tablets import snapshot
+from tablets import topology
+from tablets.topology import TopologyFromSnapshot
+
+
+TABLE = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+HOST1 = UUID("11111111-1111-1111-1111-111111111111")
+
+TABLETS_CSV = (
+    "table_id;keyspace_name;table_name;last_token;replicas;new_replicas;stage\n"
+    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa;ks;tbl;0;"
+    "[(11111111-1111-1111-1111-111111111111, 0)];;none\n"
+)
+
+
+def write_snapshot_dir(path: Path) -> None:
+    path.mkdir()
+    (path / "system_tablets.csv").write_text(TABLETS_CSV)
+
+
+def read_lines(source) -> list[str]:
+    with source() as lines:
+        return list(lines)
+
+
+def driver_rows(name: str, fields: list[str], rows: list[tuple]) -> list:
+    """
+    Builds rows shaped as the CQL driver returns them, i.e. named tuples over every column of
+    the table, since snapshots are dumped from a "SELECT *".
+    """
+    row_type = namedtuple(name, fields)
+    return [row_type(*row) for row in rows]
+
+
+def fake_live_source() -> tuple[SimpleNamespace, dict]:
+    """
+    Stands in for LiveClusterTopologySource, returning it together with the rows it answers
+    with. Its query for a table is the table itself, which is all write_snapshot() needs.
+    """
+    rows = {
+        topology.TOPOLOGY_TABLE: driver_rows(
+            "topology",
+            ["key", "host_id", "shard_count", "node_state", "num_tokens", "version", "datacenter"],
+            [("local", HOST1, 4, "normal", 256, 7, "dc1")]),
+        topology.TABLETS_TABLE: driver_rows(
+            "tablets",
+            ["table_id", "last_token", "base_table", "keyspace_name", "table_name",
+             "replicas", "new_replicas", "stage", "resize_seq_number"],
+            [(TABLE, 0, None, "ks", "tbl", [(HOST1, 0)], None, "none", 0),
+             (TABLE, 100, None, "ks", "tbl", [(HOST1, 3)], [(HOST1, 1)], "streaming", 0)]),
+        topology.LOAD_PER_NODE_TABLE: driver_rows(
+            "load_per_node",
+            ["node", "dc", "rack", "ip", "storage_capacity", "effective_capacity"],
+            [(HOST1, "dc1", "rack1", ipaddress.ip_address("10.0.0.1"), 1000, 800)]),
+        topology.TABLET_SIZES_TABLE: driver_rows(
+            "tablet_sizes",
+            ["table_id", "last_token", "replicas"],
+            [(TABLE, 0, {HOST1: 10}), (TABLE, 100, {HOST1: 30})]),
+    }
+    src = SimpleNamespace(queries={table: table for table in rows},
+                          session=SimpleNamespace(
+                              execute_async=lambda query: SimpleNamespace(result=lambda: rows[query])))
+    return src, rows
+
+
+def test_pack_snapshot_produces_archive_that_unpacks_to_the_snapshot(tmp_path) -> None:
+    snapshot_dir = tmp_path / "tablet_snap_260805_120000"
+    write_snapshot_dir(snapshot_dir)
+
+    archive = snapshot.pack_snapshot(str(snapshot_dir))
+
+    assert archive == f"{snapshot_dir}.tar.gz"
+    # The directory is replaced by the archive.
+    assert not snapshot_dir.exists()
+    assert tarfile.is_tarfile(archive)
+
+    # The snapshot directory is the single top-level entry, so unpacking recreates
+    # a directory the analysis scripts can read.
+    with tarfile.open(archive) as tar:
+        assert sorted(tar.getnames()) == [
+            "tablet_snap_260805_120000",
+            "tablet_snap_260805_120000/system_tablets.csv",
+        ]
+        tar.extractall(tmp_path / "unpacked")
+
+    topo = TopologyFromSnapshot(str(tmp_path / "unpacked" / "tablet_snap_260805_120000")).get_topology()
+    assert topo.host_count() == 1
+
+    # ... and the archive itself is readable without unpacking, yielding the same topology.
+    assert TopologyFromSnapshot(archive).get_topology() == topo
+
+
+def test_pack_snapshot_keeps_nested_output_dir_in_place(tmp_path) -> None:
+    (tmp_path / "out").mkdir()
+    write_snapshot_dir(tmp_path / "out" / "snap")
+
+    archive = snapshot.pack_snapshot(str(tmp_path / "out" / "snap"))
+
+    # The archive sits next to the directory it replaced, and holds the leaf name only.
+    assert archive == f"{tmp_path / 'out' / 'snap'}.tar.gz"
+    with tarfile.open(archive) as tar:
+        assert "snap/system_tablets.csv" in tar.getnames()
+
+
+def test_create_snapshot_dir_creates_the_requested_name(tmp_path) -> None:
+    # The chosen name is created atomically and returned.
+    created = snapshot.create_snapshot_dir("tablet_snap_260805_120000", workdir=tmp_path)
+
+    assert Path(created) == tmp_path / "tablet_snap_260805_120000"
+    assert Path(created).is_dir()
+
+
+def test_create_snapshot_dir_refuses_a_requested_name_already_taken(tmp_path) -> None:
+    """
+    A requested name is honoured exactly or fails; it is never silently redirected.
+    """
+    created = snapshot.create_snapshot_dir("tablet_snap_260805_120000", workdir=tmp_path)
+
+    with pytest.raises(Exception, match=rf"Snapshot already exists: {re.escape(created)}$"):
+        snapshot.create_snapshot_dir("tablet_snap_260805_120000", workdir=tmp_path)
+
+
+def test_create_snapshot_dir_refuses_when_only_the_archive_is_taken(tmp_path) -> None:
+    archive = tmp_path / "tablet_snap_260805_120000.tar.gz"
+    archive.write_bytes(b"")
+
+    # With --gz the archive name has to be free too, even though the directory name is.
+    with pytest.raises(Exception, match=rf"Snapshot already exists: {re.escape(str(archive))}$"):
+        snapshot.create_snapshot_dir("tablet_snap_260805_120000", gz=True, workdir=tmp_path)
+
+
+def test_create_snapshot_dir_suffixes_a_timestamped_name_on_collision(tmp_path, monkeypatch) -> None:
+    """
+    A timestamped name always yields a fresh directory, suffixing past any collision.
+    """
+    class FixedDatetime:
+        """Pins the clock so both calls hit the same base name."""
+        @staticmethod
+        def now():
+            return datetime(2026, 8, 5, 12, 0, 0)
+
+    monkeypatch.setattr(snapshot, "datetime", FixedDatetime)
+
+    first = snapshot.create_snapshot_dir(None, workdir=tmp_path)
+    second = snapshot.create_snapshot_dir(None, workdir=tmp_path)
+
+    assert Path(first) == tmp_path / "tablet_snap_260805_120000"
+    assert Path(second).name.startswith("tablet_snap_260805_120000_")
+    assert Path(second).is_dir()
+
+
+def test_create_snapshot_dir_writes_under_workdir_without_changing_the_cwd(tmp_path) -> None:
+    """
+    Writing elsewhere never moves the process-global working directory.
+    """
+    cwd_before = Path.cwd()
+
+    created = snapshot.create_snapshot_dir("tablet_snap_260805_120000", workdir=tmp_path)
+
+    assert Path(created) == tmp_path / "tablet_snap_260805_120000"
+    assert Path(created).is_dir()
+    assert Path.cwd() == cwd_before
+
+
+def test_choose_manual_snapshot_dir_does_not_create_and_refuses_a_taken_name(tmp_path) -> None:
+    requested = str(tmp_path / "tablet_snap_260805_120000")
+    Path(f"{requested}.tar.gz").write_bytes(b"")
+
+    # The manual workflow only names the directory; it must not create it.
+    assert snapshot.choose_manual_snapshot_dir(requested) == requested
+    assert not Path(requested).exists()
+
+    # With --gz the taken archive name is a conflict the caller has to resolve.
+    with pytest.raises(Exception, match=rf"Snapshot already exists: {re.escape(requested)}$"):
+        snapshot.choose_manual_snapshot_dir(requested, gz=True)
+
+
+def test_open_snapshot_files_reads_archive_with_files_at_root(tmp_path) -> None:
+    """
+    Files are matched by base name, so an archive built without a wrapping directory
+    entry is read too, not only the layout that pack_snapshot produces.
+    """
+    (tmp_path / "system_tablets.csv").write_text(TABLETS_CSV)
+    archive = tmp_path / "flat.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(tmp_path / "system_tablets.csv", arcname="system_tablets.csv")
+
+    files = topology.open_snapshot_files(str(archive))
+
+    assert list(files) == [topology.TABLETS_TABLE]
+    assert read_lines(files[topology.TABLETS_TABLE]) == TABLETS_CSV.splitlines(keepends=True)
+    assert TopologyFromSnapshot(str(archive)).get_topology().host_count() == 1
+
+
+def test_open_snapshot_files_streams_a_directory_snapshot(tmp_path) -> None:
+    """
+    A directory snapshot is read on the fly: opening the source yields a live file object
+    rather than a buffer filled in by open_snapshot_files.
+    """
+    write_snapshot_dir(tmp_path / "snap")
+
+    files = topology.open_snapshot_files(str(tmp_path / "snap"))
+
+    with files[topology.TABLETS_TABLE]() as lines:
+        assert not lines.closed
+        # Reading a single line does not consume the rest of the file.
+        assert next(iter(lines)) == TABLETS_CSV.splitlines(keepends=True)[0]
+    assert lines.closed
+
+    assert read_lines(files[topology.TABLETS_TABLE]) == TABLETS_CSV.splitlines(keepends=True)
+
+
+def test_open_snapshot_files_ignores_unrelated_archive_entries(tmp_path) -> None:
+    write_snapshot_dir(tmp_path / "snap")
+    (tmp_path / "snap" / "notes.txt").write_text("unrelated")
+    archive = snapshot.pack_snapshot(str(tmp_path / "snap"))
+
+    assert list(topology.open_snapshot_files(archive)) == [topology.TABLETS_TABLE]
+
+
+def test_open_snapshot_files_rejects_a_non_archive_file(tmp_path) -> None:
+    (tmp_path / "not_a_snapshot").write_text("hello")
+
+    with pytest.raises(Exception, match="neither a directory nor a tar archive"):
+        topology.open_snapshot_files(str(tmp_path / "not_a_snapshot"))
+
+    with pytest.raises(Exception, match="Snapshot does not exist"):
+        topology.open_snapshot_files(str(tmp_path / "missing"))
+
+
+def test_topology_from_archive_missing_required_file(tmp_path) -> None:
+    (tmp_path / "system_topology.csv").write_text("")
+    archive = tmp_path / "incomplete.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(tmp_path / "system_topology.csv", arcname="system_topology.csv")
+
+    with pytest.raises(Exception, match=r"missing required file: system_tablets\.csv"):
+        TopologyFromSnapshot(str(archive))
+
+
+def test_write_snapshot_dumps_every_table_and_reads_back_the_same_topology(tmp_path) -> None:
+    """
+    A dump has to yield the topology its rows would have built directly, which is what the
+    cluster test asserts against a real cluster.
+    """
+    src, rows = fake_live_source()
+
+    snapshot_dir = tmp_path / "snap"
+    snapshot_dir.mkdir()
+    snapshot.write_snapshot(str(snapshot_dir), src)
+
+    assert sorted(os.listdir(snapshot_dir)) == sorted(table.file for table in topology.SNAPSHOT_TABLES)
+
+    expected = topology.Topology()
+    expected._build({table.name: topology.rows_from_cql(table_rows, table.columns)
+                     for table, table_rows in rows.items()})
+
+    assert TopologyFromSnapshot(str(snapshot_dir)).get_topology() == expected
+
+
+def test_write_snapshot_renders_collections_the_way_they_are_read_back(tmp_path) -> None:
+    snapshot_dir = tmp_path / "snap"
+    snapshot_dir.mkdir()
+    snapshot.write_snapshot(str(snapshot_dir), fake_live_source()[0])
+
+    with open(snapshot_dir / topology.TABLETS_TABLE.file, newline="") as dump:
+        header, first, second = list(csv.reader(dump, delimiter=topology.CSV_DELIMITER))
+
+    # A collection is rendered by its column's Column.format, in the form parsing reads.
+    assert first[header.index("replicas")] == f"{{({HOST1}, 0)}}"
+    assert second[header.index("new_replicas")] == f"{{({HOST1}, 1)}}"
+    # A null becomes the empty field that reading takes for a null.
+    assert first[header.index("new_replicas")] == ""
+    assert first[header.index("base_table")] == ""
+    # Columns a snapshot is not read for are dumped all the same.
+    assert first[header.index("resize_seq_number")] == "0"
+
+    with open(snapshot_dir / topology.TABLET_SIZES_TABLE.file, newline="") as dump:
+        header, first, _ = list(csv.reader(dump, delimiter=topology.CSV_DELIMITER))
+
+    assert first[header.index("replicas")] == f"{{{HOST1}: 10}}"
+
+
+def test_manual_instructions_pack_the_snapshot_with_gz(capsys) -> None:
+    args = argparse.Namespace(cluster="127.0.0.1", port=None, user=None, password=None, gz=True)
+
+    snapshot.print_manual_snapshot_instructions(args, "tablet_snap_260805_120000")
+
+    lines = capsys.readouterr().out.strip().splitlines()
+    assert lines[0] == "mkdir -p tablet_snap_260805_120000"
+    assert lines[-1] == ("tar -czf tablet_snap_260805_120000.tar.gz tablet_snap_260805_120000"
+                         " && rm -r tablet_snap_260805_120000")
+
+
+def test_manual_instructions_omit_packing_without_gz(capsys) -> None:
+    args = argparse.Namespace(cluster="127.0.0.1", port=None, user=None, password=None, gz=False)
+
+    snapshot.print_manual_snapshot_instructions(args, "tablet_snap_260805_120000")
+
+    out = capsys.readouterr().out
+    assert "tar -czf" not in out

--- a/test/tablet_scripts/test_stats.py
+++ b/test/tablet_scripts/test_stats.py
@@ -1,0 +1,91 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+import pytest
+
+from tablets.stats import StatsAggregator
+from tablets.stats import overcommit
+from tablets.stats import share
+
+
+def test_share_of_nothing_is_nothing() -> None:
+    """
+    A report divides by a total it did not choose, so an empty selection has to give a
+    share rather than raise.
+    """
+    assert share(25, 100) == 0.25
+    assert share(0, 0) == 0
+    assert share(25, 0) == 0
+
+
+def test_overcommit_reads_peers_which_all_hold_nothing_as_balanced() -> None:
+    """
+    They are evenly spread, which is what the report is asking about: an empty table sits at
+    the average on every shard it is on. Only a value with nothing to compare it to, or one
+    above an average of zero, is left undefined.
+    """
+    assert overcommit(150, 100) == 1.5
+    assert overcommit(0, 100) == 0
+    assert overcommit(0, 0) == 1.0
+    assert overcommit(150, 0) is None
+    assert overcommit(None, 0) is None
+    assert overcommit(None, 100) is None
+
+
+def test_stats_aggregator_accumulates_as_values_are_added() -> None:
+    sizes = StatsAggregator()
+
+    for size in (100, 300, 200):
+        sizes.add(size)
+
+    assert (sizes.count, sizes.total, sizes.min, sizes.max) == (3, 600, 100, 300)
+    assert sizes.avg() == pytest.approx(200)
+    # The largest value against the average, and against the total.
+    assert sizes.ovc() == pytest.approx(1.5)
+    assert sizes.max_frac() == pytest.approx(300 / 600)
+
+
+def test_stats_aggregator_merges_what_another_was_given() -> None:
+    """
+    Merging says the same as having added every value to one aggregator.
+    """
+    sizes = StatsAggregator.of([100, 300])
+    sizes.merge(StatsAggregator.of([200, 50]))
+
+    assert (sizes.count, sizes.total, sizes.min, sizes.max) == (4, 650, 50, 300)
+
+
+def test_stats_aggregator_merging_nothing_changes_nothing() -> None:
+    sizes = StatsAggregator.of([100])
+    sizes.merge(StatsAggregator())
+
+    assert (sizes.count, sizes.total, sizes.min, sizes.max) == (1, 100, 100, 100)
+
+
+def test_stats_aggregator_of_nothing_has_nothing_to_report() -> None:
+    sizes = StatsAggregator()
+
+    assert (sizes.count, sizes.total, sizes.min, sizes.max) == (0, 0, None, None)
+    assert sizes.avg() == 0
+    assert sizes.ovc() is None
+    assert sizes.max_frac() == 0
+
+
+def test_stats_aggregator_of_zeros_is_balanced() -> None:
+    """
+    Values which are all 0 are all at the average, so they are evenly spread.
+    """
+    sizes = StatsAggregator()
+
+    sizes.add(0)
+    sizes.add(0)
+
+    assert sizes.max == 0
+    assert sizes.avg() == 0
+    assert sizes.ovc() == 1.0
+    assert sizes.max_frac() == 0

--- a/test/tablet_scripts/test_table_load.py
+++ b/test/tablet_scripts/test_table_load.py
@@ -1,0 +1,160 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+from argparse import Namespace
+from dataclasses import replace
+
+import pytest
+
+from tablets import table_load
+from tablets.filters import filter_args
+from tablets.filters import get_tablet_filter
+from tablets.render_utils import PresentationOptions
+
+from test.tablet_scripts.topology_building import *
+
+
+def test_build_ranges_uses_cluster_filters() -> None:
+    topology = build_topology(
+        hosts={
+            HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1"),
+            HOST2_ID: HostSpec("10.0.0.2", "dc1", "rack1"),
+        },
+        tables={TABLE1_ID: ("ks", "tbl")},
+        # The first tablet is replicated on both hosts, the second only on host2.
+        tablets={TABLE1_ID: [
+            (0, {(HOST1_ID, 0): 100, (HOST2_ID, 1): 50}),
+            (1 << 63, {(HOST2_ID, 1): 80}),
+        ]},
+    )
+
+    args = filter_args(host="10.0.0.1")
+    ranges = table_load.build_ranges(TABLE1_ID, topology.get_tablet_map(TABLE1_ID), topology,
+                                     get_tablet_filter(args, topology))
+
+    assert [(load.last_token, load.tablet_count, load.size, load.replica_sizes, load.replicas) for load in ranges] == [
+        (0, 1, 100, [100], [(HOST1_ID, 0)]),
+    ]
+
+
+def test_sort_ranges_supports_requested_keys() -> None:
+    ranges = [
+        table_load.make_load_range(last_token=30, tablet_count=1, token_frac=0.1, replica_sizes=[80, 20], replicas=[]),
+        table_load.make_load_range(last_token=10, tablet_count=1, token_frac=0.3, replica_sizes=[100, 100], replicas=[]),
+        table_load.make_load_range(last_token=20, tablet_count=1, token_frac=0.2, replica_sizes=[50], replicas=[]),
+    ]
+
+    assert [load.last_token for load in table_load.sort_ranges(ranges, "token")] == [30, 10, 20]
+    assert [load.last_token for load in table_load.sort_ranges(ranges, "tokens")] == [10, 20, 30]
+    assert [load.last_token for load in table_load.sort_ranges(ranges, "size")] == [10, 30, 20]
+    assert [load.last_token for load in table_load.sort_ranges(ranges, "ovc.rep")] == [30, 10, 20]
+
+
+def test_summarize_rows_handles_no_rows() -> None:
+    # Regression: per-replica scaling used to call max() on an empty sequence when
+    # every replica was filtered out, raising ValueError.
+    summary = table_load.summarize_rows([])
+
+    assert (summary.sizes.count, summary.sizes.total, summary.sizes.avg(), summary.sizes.max_frac()) == (0, 0, 0, 0)
+
+
+@pytest.mark.parametrize("per_replica, sizes, avg_size, max_frac", [
+    pytest.param(True, [100, 200, 100], 400 / 3, 200 / 400, id="per-replica"),
+    pytest.param(False, [300, 100], 200, 300 / 400, id="per-range"),
+])
+def test_build_ranges_splits_per_replica(per_replica: bool, sizes: list[int],
+                                         avg_size: float, max_frac: float) -> None:
+    """
+    A per-replica report measures each replica's size; a range report the replicated size
+    of the whole range. Either way the shares are of the same total.
+    """
+    topology = build_topology(
+        hosts={
+            HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1"),
+            HOST2_ID: HostSpec("10.0.0.2", "dc1", "rack1"),
+        },
+        tables={TABLE1_ID: ("ks", "tbl")},
+        tablets={TABLE1_ID: [
+            (0, {(HOST1_ID, 0): 100, (HOST2_ID, 1): 200}),
+            (1 << 63, {(HOST2_ID, 1): 100}),
+        ]},
+    )
+
+    ranges = table_load.build_ranges(TABLE1_ID, topology.get_tablet_map(TABLE1_ID), topology,
+                                     per_replica=per_replica)
+    summary = table_load.summarize_rows(ranges)
+
+    assert [row.size for row in ranges] == sizes
+    # A split range says which replica it stands for; an unsplit one stands for them all.
+    assert [row.replica_idx for row in ranges] == ([0, 1, 0] if per_replica else [None, None])
+    assert summary.sizes.total == 400
+    assert summary.sizes.avg() == pytest.approx(avg_size)
+    assert summary.sizes.max_frac() == pytest.approx(max_frac)
+
+
+def test_summarize_rows_scales_token_bars_by_the_widest_range() -> None:
+    """
+    The token bars scale against the widest range shown, however many rows a range takes:
+    splitting it over its replicas must not make it count for more.
+    """
+    wide = table_load.make_load_range(last_token=10, tablet_count=1, token_frac=0.75,
+                                      replica_sizes=[100, 200], replicas=[])
+    narrow = table_load.make_load_range(last_token=20, tablet_count=1, token_frac=0.25,
+                                        replica_sizes=[100], replicas=[])
+
+    summary = table_load.summarize_rows([replace(wide, size=100, replica_idx=0),
+                                         replace(wide, size=200, replica_idx=1),
+                                         narrow])
+
+    assert summary.max_token_frac() == pytest.approx(0.75)
+
+
+def per_replica_rows(csv: bool) -> list[list]:
+    """
+    Detail rows of a two replica tablet, rendered per replica.
+    """
+    # The replicas sit in different racks, which the per-replica rows report.
+    topo = build_topology({
+        HOST1_ID: HostSpec("10.0.0.1", "dc1", "rack1"),
+        HOST2_ID: HostSpec("10.0.0.2", "dc1", "rack2"),
+    })
+
+    load_range = table_load.make_load_range(
+        last_token=1234,
+        tablet_count=1,
+        token_frac=1.0,
+        replica_sizes=[100, 50],
+        replicas=[(HOST1_ID, 0), (HOST2_ID, 1)],
+    )
+    args = Namespace(per_replica=True, max_ranges=None, tokens_hist=False)
+    options = PresentationOptions(csv=csv)
+    shape = table_load.build_shape(args, tablet_count=1)
+
+    # Split per replica, as build_ranges() does under --per-replica.
+    rows = [replace(load_range, size=size, replica_idx=idx)
+            for idx, size in enumerate(load_range.replica_sizes)]
+    summary = table_load.summarize_rows(rows)
+
+    return table_load.build_rows(rows, shape, options, topo, summary)
+
+
+@pytest.mark.parametrize("csv, last_token, token_pct", [
+    pytest.param(True, [1234, 1234], ["100.0000", "100.0000"], id="csv_repeats_the_tablets_columns"),
+    pytest.param(False, [1234, None], ["100.0000", None], id="table_leaves_continuation_rows_blank"),
+])
+def test_per_replica_rows_identify_their_tablet(csv: bool, last_token: list[int | None],
+                                                token_pct: list[str | None]) -> None:
+    """
+    A csv row stands on its own, so it carries the tablet's columns even when the row above
+    named the same tablet; summing the token share then counts every replica copy, as
+    cluster_load.py does. A rendered table reads them off the row above instead.
+    """
+    rows = per_replica_rows(csv=csv)
+
+    assert [row[0] for row in rows] == last_token
+    assert [row[1] for row in rows] == token_pct        # tokens [%]

--- a/test/tablet_scripts/test_table_summary.py
+++ b/test/tablet_scripts/test_table_summary.py
@@ -1,0 +1,137 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from tablets import table_summary
+from tablets.filters import filter_args
+from tablets.filters import get_tablet_filter
+from tablets.filters import select_all
+from tablets.render_utils import PresentationOptions
+from tablets.stats import StatsAggregator
+from tablets.topology import Host
+from tablets.topology import Tablet
+from tablets.topology import TabletMap
+from tablets.topology import Topology
+
+
+TABLE_ID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+HOST1_ID = UUID("11111111-1111-1111-1111-111111111111")
+HOST2_ID = UUID("22222222-2222-2222-2222-222222222222")
+
+
+@pytest.fixture
+def topology() -> Topology:
+    """
+    One table over two tablets: the first replicated on both hosts, the second only on host2.
+    """
+    topo = Topology()
+    topo._tables[TABLE_ID] = ("ks", "tbl")
+    topo._hosts[HOST1_ID] = Host(id=HOST1_ID, shard_count=2, ip="10.0.0.1", dc="dc1", rack="rack1")
+    topo._hosts[HOST2_ID] = Host(id=HOST2_ID, shard_count=2, ip="10.0.0.2", dc="dc1", rack="rack1")
+    topo._tablet_maps[TABLE_ID] = TabletMap(
+        table=TABLE_ID,
+        tablets=[
+            Tablet(last_token=0, replicas=[(HOST1_ID, 0), (HOST2_ID, 1)]),
+            Tablet(last_token=1 << 63, replicas=[(HOST2_ID, 1)]),
+        ],
+    )
+    topo._tablet_sizes[(TABLE_ID, 0)] = {HOST1_ID: 100, HOST2_ID: 50}
+    topo._tablet_sizes[(TABLE_ID, 1 << 63)] = {HOST2_ID: 80}
+    return topo
+
+
+def test_measure_table_uses_cluster_filters(topology: Topology) -> None:
+    args = filter_args(host="10.0.0.1")
+    accepts_tablet = get_tablet_filter(args, topology)
+
+    row = table_summary.measure_table(topology, TABLE_ID, "ks.tbl", accepts_tablet,
+                                      table_summary.SizeMode.REPLICATED)
+
+    # The second tablet has no replica left, so it keeps its place in token space at size 0.
+    assert (row.sizes.count, row.sizes.total) == (1, 100)
+    assert row.token_space == [100, 0]
+
+
+def test_measure_table_skips_a_table_the_filter_left_nothing_of(topology: Topology) -> None:
+    # No replica sits on shard 5, so nothing of the table is shown and it gets no row.
+    accepts_tablet = get_tablet_filter(filter_args(shard=5), topology)
+
+    assert table_summary.measure_table(topology, TABLE_ID, "ks.tbl", accepts_tablet,
+                                       table_summary.SizeMode.REPLICATED) is None
+
+
+def table_row(name: str, sizes: list[int]) -> table_summary.TableRow:
+    return table_summary.TableRow(name=name, table_id=TABLE_ID, sizes=StatsAggregator.of(sizes),
+                                  token_space=[])
+
+
+def test_sort_table_rows_supports_requested_keys() -> None:
+    even = table_row("ks.even", sizes=[40, 40])
+    uneven = table_row("ks.uneven", sizes=[90, 10])
+    empty = table_row("ks.empty", sizes=[0, 0])
+    rows = [even, uneven, empty]
+
+    assert table_summary.sort_table_rows(rows, "name") == [empty, even, uneven]
+    assert table_summary.sort_table_rows(rows, "size") == [uneven, even, empty]
+    assert table_summary.sort_table_rows(rows, "tablet.avg") == [uneven, even, empty]
+    # ks.empty has no overcommit to report, so it sorts below tables that do.
+    assert table_summary.sort_table_rows(rows, "tablet.ovc") == [uneven, even, empty]
+
+
+def test_build_all_row_aggregates_table_summary() -> None:
+    """
+    Sizes and counts add up across the tables; overcommit does not, so the worst table's
+    is the one ALL reports.
+    """
+    all_row = table_summary.build_all_row([
+        table_row("ks.big", sizes=[75, 25]),
+        table_row("ks.small", sizes=[60]),
+        # An empty table has no overcommit to report, which must not stand for the worst.
+        table_row("ks.empty", sizes=[0]),
+    ], PresentationOptions(human_readable=False))
+
+    assert all_row == [
+        "ALL",
+        "160",          # 100 + 60 + 0
+        "100.00",
+        None,
+        4,              # 2 + 1 + 1 tablets
+        "+50.00",       # ks.big's 75 against its average of 50; ks.small has a single tablet
+        "40",           # 160 bytes over 4 tablets
+        "75",
+        None,
+    ]
+
+
+@pytest.mark.parametrize("size_mode, count, total, largest, ovc", [
+    # The first tablet holds 100 and 50 bytes on its two replicas, the second 80 on its one.
+    # Replicated, that is three replicas of 100, 50 and 80; un-replicated, two tablets of 75
+    # and 80, since a tablet's replicas each hold a copy of what it holds once.
+    pytest.param(table_summary.SizeMode.REPLICATED, 3, 230, 100, 100 / (230 / 3), id="replicated"),
+    pytest.param(table_summary.SizeMode.UNREPLICATED, 2, 155, 80, 80 / (155 / 2), id="un-replicated"),
+])
+def test_measure_table_measures_the_size_mode_s_unit(
+        topology: Topology, size_mode: table_summary.SizeMode,
+        count: int, total: float, largest: float, ovc: float) -> None:
+    """
+    A replicated report sums all tablet replicas, an un-replicated one takes the average
+    tablet replica size for a given tablet, and each counts what it sizes. Overcommit
+    follows, so a replicated report also sees replicas of one tablet differing in size.
+    """
+    row = table_summary.measure_table(topology, TABLE_ID, "ks.tbl", select_all, size_mode)
+
+    assert row.sizes.count == count
+    assert row.sizes.total == total
+    assert row.sizes.max == largest
+    assert row.sizes.ovc() == pytest.approx(ovc)
+    # The token space is un-replicated whichever unit the sizes are of, so that its shape is
+    # that of the data rather than of its placement.
+    assert row.token_space == [75, 80]

--- a/test/tablet_scripts/test_topology.py
+++ b/test/tablet_scripts/test_topology.py
@@ -1,0 +1,118 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from tablets.topology import Anonymizer
+from tablets.topology import TOKEN_RING_SIZE
+from tablets.topology import Tablet
+from tablets.topology import TabletMap
+from tablets.topology import Topology
+from tablets.topology import iter_token_fractions
+from tablets.topology import resolve_table_id
+
+
+TABLE1_ID = UUID("11111111-1111-1111-1111-111111111111")
+TABLE2_ID = UUID("22222222-2222-2222-2222-222222222222")
+TABLE3_ID = UUID("33333333-3333-3333-3333-333333333333")
+
+
+def test_anonymize_table_names_replaces_names_with_deterministic_unique_aliases() -> None:
+    topo = Topology()
+    anonymizer = Anonymizer()
+
+    topo._tables[TABLE1_ID] = ("customer_a", "users")
+    topo._tables[TABLE2_ID] = ("customer_a", "orders")
+    topo._tables[TABLE3_ID] = ("customer_b", "users")
+
+    topo.set_anonymizer(anonymizer)
+
+    assert topo.get_table_name(TABLE2_ID) == "ks1.table1"
+    assert topo.get_table_name(TABLE1_ID) == "ks1.table2"
+    assert topo.get_table_name(TABLE3_ID) == "ks2.table1"
+    assert len({topo.get_table_name(TABLE1_ID), topo.get_table_name(TABLE2_ID), topo.get_table_name(TABLE3_ID)}) == 3
+    assert topo._tables[TABLE1_ID] == ("customer_a", "users")
+    assert topo._tables[TABLE2_ID] == ("customer_a", "orders")
+    assert topo._tables[TABLE3_ID] == ("customer_b", "users")
+
+
+def test_anonymize_table_names_is_idempotent() -> None:
+    topo = Topology()
+    anonymizer = Anonymizer()
+    topo._tables[TABLE1_ID] = ("customer_a", "users")
+
+    topo.set_anonymizer(anonymizer)
+    first_name = topo.get_table_name(TABLE1_ID)
+    topo.set_anonymizer(anonymizer)
+
+    assert topo.get_table_name(TABLE1_ID) == first_name
+
+
+def test_anonymize_table_names_only_extends_with_new_tables() -> None:
+    topo = Topology()
+    anonymizer = Anonymizer()
+
+    topo._tables[TABLE1_ID] = ("customer_a", "users")
+    topo.set_anonymizer(anonymizer)
+
+    assert topo.get_table_name(TABLE1_ID) == "ks1.table1"
+
+    topo._tables[TABLE2_ID] = ("customer_a", "orders")
+    topo.set_anonymizer(anonymizer)
+
+    assert topo.get_table_name(TABLE1_ID) == "ks1.table1"
+    assert topo.get_table_name(TABLE2_ID) == "ks1.table2"
+
+
+def test_resolve_table_id_accepts_unique_bare_table_name() -> None:
+    topo = Topology()
+    topo._tables[TABLE1_ID] = ("ks1", "users")
+    topo._tables[TABLE2_ID] = ("ks2", "orders")
+    topo._tablet_maps[TABLE1_ID] = TabletMap(TABLE1_ID)
+    topo._tablet_maps[TABLE2_ID] = TabletMap(TABLE2_ID)
+
+    assert resolve_table_id(topo, "users") == TABLE1_ID
+    assert resolve_table_id(topo, "ks1.users") == TABLE1_ID
+
+
+def test_resolve_table_id_rejects_ambiguous_bare_table_name() -> None:
+    topo = Topology()
+    topo._tables[TABLE1_ID] = ("ks1", "users")
+    topo._tables[TABLE2_ID] = ("ks2", "users")
+    topo._tablet_maps[TABLE1_ID] = TabletMap(TABLE1_ID)
+    topo._tablet_maps[TABLE2_ID] = TabletMap(TABLE2_ID)
+
+    with pytest.raises(Exception, match=r"^Ambiguous table name: users$"):
+        resolve_table_id(topo, "users")
+
+
+def test_a_lone_tablet_owns_the_whole_token_ring() -> None:
+    """
+    A single tablet wraps around to itself, which the span arithmetic reads as owning
+    nothing. Every table of a cluster can look like that, hiding all token load.
+    """
+    tablet = Tablet(last_token=1234, replicas=[])
+
+    assert list(iter_token_fractions([tablet])) == [(tablet, 1.0)]
+
+
+def test_token_fractions_span_the_ring_and_wrap_at_the_last_tablet() -> None:
+    quarter = TOKEN_RING_SIZE // 4
+    # Boundaries are the tablets' last tokens, the first spanning the wrap from the last.
+    tablets = [Tablet(last_token=-(TOKEN_RING_SIZE // 2) + quarter * i, replicas=[]) for i in range(1, 5)]
+
+    fractions = [fraction for _, fraction in iter_token_fractions(tablets)]
+
+    assert fractions == [0.25, 0.25, 0.25, 0.25]
+    assert sum(fractions) == 1.0
+
+
+def test_no_tablets_yields_no_token_fractions() -> None:
+    assert list(iter_token_fractions([])) == []

--- a/test/tablet_scripts/test_topology_build.py
+++ b/test/tablet_scripts/test_topology_build.py
@@ -1,0 +1,362 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+import csv
+import ipaddress
+from types import SimpleNamespace
+from uuid import UUID
+
+import pytest
+
+from tablets.topology import CSV_DELIMITER
+from tablets.topology import LOAD_PER_NODE_COLUMNS
+from tablets.topology import LOAD_PER_NODE_TABLE
+from tablets.topology import TABLETS_COLUMNS
+from tablets.topology import TABLETS_TABLE
+from tablets.topology import TABLET_SIZES_COLUMNS
+from tablets.topology import TABLET_SIZES_TABLE
+from tablets.topology import TOPOLOGY_COLUMNS
+from tablets.topology import TOPOLOGY_TABLE
+from tablets.topology import Topology
+from tablets.topology import TopologyFromSnapshot
+from tablets.topology import parse_replica_list
+from tablets.topology import parse_replica_size_map
+from tablets.topology import rows_from_cql
+from tablets.topology import rows_from_csv
+
+
+TABLE = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+VIEW = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+HOST1 = UUID("11111111-1111-1111-1111-111111111111")
+HOST2 = UUID("22222222-2222-2222-2222-222222222222")
+
+# Dumps of the system tables a snapshot is made of. Columns are in an arbitrary order and
+# include ones the topology does not care about, as real dumps do.
+TABLETS_CSV = f"""\
+table_id;last_token;base_table;keyspace_name;table_name;replicas;new_replicas;stage;resize_seq_number
+{TABLE};0;;ks;tbl;{{({HOST1}, 0), ({HOST2}, 1)}};;none;0
+{TABLE};100;;ks;tbl;{{({HOST1}, 3)}};{{({HOST2}, 0)}};streaming;0
+{VIEW};0;{TABLE};ks;tbl_view;;;none;0
+{VIEW};100;{TABLE};ks;tbl_view;;;none;0
+"""
+
+TOPOLOGY_CSV = f"""\
+key;host_id;shard_count;node_state;num_tokens;version;datacenter
+local;{HOST1};4;normal;256;7;dc1
+local;{HOST2};8;normal;256;7;dc1
+"""
+
+LOAD_PER_NODE_CSV = f"""\
+node;dc;rack;ip;storage_capacity;effective_capacity
+{HOST1};dc1;rack1;10.0.0.1;1000;800
+{HOST2};dc1;rack2;10.0.0.2;2000;1600
+"""
+
+TABLET_SIZES_CSV = f"""\
+table_id;last_token;replicas
+{TABLE};0;{{{HOST1}: 10, {HOST2}: 20}}
+{TABLE};100;{{{HOST1}: 30}}
+"""
+
+
+def build_from_snapshot() -> Topology:
+    """
+    Builds the topology the way TopologyFromSnapshot does, from dumps of the system tables.
+    """
+    topo = Topology()
+    topo._build({
+        TABLETS_TABLE.name: rows_from_csv(TABLETS_CSV.splitlines(), TABLETS_COLUMNS),
+        LOAD_PER_NODE_TABLE.name: rows_from_csv(LOAD_PER_NODE_CSV.splitlines(), LOAD_PER_NODE_COLUMNS),
+        TOPOLOGY_TABLE.name: rows_from_csv(TOPOLOGY_CSV.splitlines(), TOPOLOGY_COLUMNS),
+        TABLET_SIZES_TABLE.name: rows_from_csv(TABLET_SIZES_CSV.splitlines(), TABLET_SIZES_COLUMNS),
+    })
+    return topo
+
+
+def build_from_live_cluster() -> Topology:
+    """
+    Builds the topology the way LiveClusterTopologySource does, from the same data as
+    build_from_snapshot(), but shaped as the CQL driver returns it.
+    """
+    tablets = [
+        SimpleNamespace(table_id=TABLE, last_token=0, base_table=None, keyspace_name="ks",
+                        table_name="tbl", replicas=[(HOST1, 0), (HOST2, 1)], new_replicas=None,
+                        stage="none", resize_seq_number=0),
+        SimpleNamespace(table_id=TABLE, last_token=100, base_table=None, keyspace_name="ks",
+                        table_name="tbl", replicas=[(HOST1, 3)], new_replicas=[(HOST2, 0)],
+                        stage="streaming", resize_seq_number=0),
+        SimpleNamespace(table_id=VIEW, last_token=0, base_table=TABLE, keyspace_name="ks",
+                        table_name="tbl_view", replicas=None, new_replicas=None, stage="none",
+                        resize_seq_number=0),
+        SimpleNamespace(table_id=VIEW, last_token=100, base_table=TABLE, keyspace_name="ks",
+                        table_name="tbl_view", replicas=None, new_replicas=None, stage="none",
+                        resize_seq_number=0),
+    ]
+    topology = [
+        SimpleNamespace(key="local", host_id=HOST1, shard_count=4, node_state="normal",
+                        num_tokens=256, version=7, datacenter="dc1"),
+        SimpleNamespace(key="local", host_id=HOST2, shard_count=8, node_state="normal",
+                        num_tokens=256, version=7, datacenter="dc1"),
+    ]
+    load_per_node = [
+        SimpleNamespace(node=HOST1, dc="dc1", rack="rack1", ip=ipaddress.ip_address("10.0.0.1"),
+                        storage_capacity=1000, effective_capacity=800),
+        SimpleNamespace(node=HOST2, dc="dc1", rack="rack2", ip=ipaddress.ip_address("10.0.0.2"),
+                        storage_capacity=2000, effective_capacity=1600),
+    ]
+    tablet_sizes = [
+        SimpleNamespace(table_id=TABLE, last_token=0, replicas={HOST1: 10, HOST2: 20}),
+        SimpleNamespace(table_id=TABLE, last_token=100, replicas={HOST1: 30}),
+    ]
+
+    topo = Topology()
+    topo._build({
+        TABLETS_TABLE.name: rows_from_cql(tablets, TABLETS_COLUMNS),
+        LOAD_PER_NODE_TABLE.name: rows_from_cql(load_per_node, LOAD_PER_NODE_COLUMNS),
+        TOPOLOGY_TABLE.name: rows_from_cql(topology, TOPOLOGY_COLUMNS),
+        TABLET_SIZES_TABLE.name: rows_from_cql(tablet_sizes, TABLET_SIZES_COLUMNS),
+    })
+    return topo
+
+
+def test_a_snapshot_and_a_live_cluster_build_the_same_topology() -> None:
+    """
+    Both sources feed Topology._build() the same rows, differing only in how they got them,
+    so the same cluster state has to come out identical either way.
+    """
+    assert build_from_snapshot() == build_from_live_cluster()
+
+
+@pytest.mark.parametrize("build", [build_from_snapshot, build_from_live_cluster])
+def test_build_populates_tablets_hosts_and_sizes(build) -> None:
+    topo = build()
+
+    assert topo.host_count() == 2
+    host1 = topo.require_host(HOST1)
+    assert (host1.dc, host1.rack, host1.ip) == ("dc1", "rack1", "10.0.0.1")
+    assert (host1.storage_capacity, host1.effective_capacity) == (1000, 800)
+    assert (host1.node_state, host1.num_tokens) == ("normal", 256)
+    assert host1.is_normal_token_owner()
+    # system.topology is authoritative about shard counts, overriding what tablet replicas
+    # suggested, which is only a lower bound.
+    assert (host1.shard_count, topo.require_host(HOST2).shard_count) == (4, 8)
+    assert topo._version == 7
+
+    tablets = topo.get_tablet_map(TABLE).tablets
+    assert [tablet.last_token for tablet in tablets] == [0, 100]
+    assert tablets[0].replicas == [(HOST1, 0), (HOST2, 1)]
+    assert tablets[0].new_replicas is None
+    assert tablets[0].stage == "none"
+    # A tablet being migrated has its new replicas and the stage it reached.
+    assert tablets[1].replicas == [(HOST1, 3)]
+    assert tablets[1].new_replicas == [(HOST2, 0)]
+    assert tablets[1].stage == "streaming"
+
+    assert topo.get_tablet_size(TABLE, tablets[0], (HOST1, 0)) == 10
+    assert topo.get_tablet_size(TABLE, tablets[0], (HOST2, 1)) == 20
+    assert topo.get_tablet_size(TABLE, tablets[1], (HOST1, 3)) == 30
+
+
+@pytest.mark.parametrize("build", [build_from_snapshot, build_from_live_cluster])
+def test_build_makes_a_colocated_table_share_the_base_tables_tablets(build) -> None:
+    topo = build()
+
+    assert topo.get_table_name(VIEW) == "ks.tbl_view"
+    assert topo.get_base_table_id(VIEW) == TABLE
+    # A colocated table is registered once, however many rows system.tablets has for it,
+    # and has no tablets of its own.
+    assert topo.get_tablet_map(VIEW).tablets is topo.get_tablet_map(TABLE).tablets
+    assert set(topo.iter_table_ids()) == {TABLE, VIEW}
+    assert set(topo.iter_table_ids(include_colocated=False)) == {TABLE}
+    # Physical tablets are counted once, under the base table.
+    assert [table_id for table_id, _ in topo.all_tablets()] == [TABLE, TABLE]
+
+
+def test_build_infers_shard_counts_from_replicas_when_system_topology_is_absent() -> None:
+    topo = Topology()
+    topo._build({TABLETS_TABLE.name: rows_from_csv(TABLETS_CSV.splitlines(), TABLETS_COLUMNS)})
+
+    # The highest shard a replica landed on is a lower bound on the host's shard count.
+    # HOST2 only reaches shard 1 through the tablet migrating onto it.
+    assert topo.require_host(HOST1).shard_count == 4
+    assert topo.require_host(HOST2).shard_count == 2
+    # Hosts are known from tablet replicas alone, but nothing about their capacity is.
+    assert topo.require_host(HOST1).storage_capacity is None
+    # Without system.topology membership is unknown, and a host is then assumed to be a
+    # member, so that a partial snapshot still reports load.
+    assert topo.require_host(HOST1).is_normal_token_owner()
+
+
+def test_build_still_infers_shard_counts_for_a_host_system_topology_missed() -> None:
+    """
+    Watching replicas to infer shard counts is skipped when system.topology accounted for
+    every host, so a host it did not account for has to keep it on.
+    """
+    topology_dump = f"key;host_id;shard_count;node_state;num_tokens;version\nlocal;{HOST1};4;normal;256;7\n"
+    load_dump = f"node;dc;rack;ip;storage_capacity\n{HOST2};dc1;rack2;10.0.0.2;2000\n"
+
+    topo = Topology()
+    topo._build({
+        TOPOLOGY_TABLE.name: rows_from_csv(topology_dump.splitlines(), TOPOLOGY_COLUMNS),
+        LOAD_PER_NODE_TABLE.name: rows_from_csv(load_dump.splitlines(), LOAD_PER_NODE_COLUMNS),
+        TABLETS_TABLE.name: rows_from_csv(TABLETS_CSV.splitlines(), TABLETS_COLUMNS),
+    })
+
+    # HOST1 keeps what system.topology said, HOST2 gets the lower bound its replicas imply.
+    assert topo.require_host(HOST1).shard_count == 4
+    assert topo.require_host(HOST2).shard_count == 2
+
+
+def test_build_keeps_host_location_when_its_capacity_is_unknown() -> None:
+    """
+    A node which has not reported a capacity yet is still placed in its dc and rack, so it
+    is not silently left out of rack level reporting.
+    """
+    dump = f"node;dc;rack;ip;storage_capacity;effective_capacity\n{HOST1};dc1;rack1;10.0.0.1;;\n"
+
+    topo = Topology()
+    topo._build({LOAD_PER_NODE_TABLE.name: rows_from_csv(dump.splitlines(), LOAD_PER_NODE_COLUMNS)})
+
+    host = topo.require_host(HOST1)
+    assert (host.dc, host.rack, host.ip) == ("dc1", "rack1", "10.0.0.1")
+    assert (host.storage_capacity, host.effective_capacity) == (None, None)
+
+
+def test_build_places_a_node_which_system_load_per_node_does_not_know() -> None:
+    """
+    A node which has left the cluster keeps its location in system.topology while dropping
+    out of system.load_per_node, so a report can still say where it was.
+    """
+    topology_dump = (f"version;host_id;shard_count;node_state;num_tokens;datacenter;rack\n"
+                     f"6538;{HOST1};4;left;256;dc1;rack1\n")
+    load_dump = f"node;dc;rack;ip;storage_capacity\n{HOST2};dc1;rack2;10.0.0.2;2000\n"
+
+    topo = Topology()
+    topo._build({TOPOLOGY_TABLE.name: rows_from_csv(topology_dump.splitlines(), TOPOLOGY_COLUMNS),
+                 LOAD_PER_NODE_TABLE.name: rows_from_csv(load_dump.splitlines(), LOAD_PER_NODE_COLUMNS)})
+
+    host = topo.require_host(HOST1)
+    assert (host.dc, host.rack, host.node_state) == ("dc1", "rack1", "left")
+    # It has no address anywhere: system.topology carries no ip column.
+    assert host.ip is None
+
+
+def test_system_load_per_node_has_the_last_word_on_where_a_node_is() -> None:
+    """
+    Both tables carry the location; the one which only knows current members is the more
+    current of the two, and is read second.
+    """
+    topology_dump = (f"version;host_id;shard_count;node_state;num_tokens;datacenter;rack\n"
+                     f"6538;{HOST1};4;normal;256;dc1;old_rack\n")
+    load_dump = f"node;dc;rack;ip;storage_capacity\n{HOST1};dc1;rack1;10.0.0.1;1000\n"
+
+    topo = Topology()
+    topo._build({TOPOLOGY_TABLE.name: rows_from_csv(topology_dump.splitlines(), TOPOLOGY_COLUMNS),
+                 LOAD_PER_NODE_TABLE.name: rows_from_csv(load_dump.splitlines(), LOAD_PER_NODE_COLUMNS)})
+
+    assert topo.require_host(HOST1).rack == "rack1"
+
+
+def test_optional_columns_read_as_none_whichever_source_lacks_them() -> None:
+    """
+    A snapshot or a cluster which predates an optional column is read without it, rather
+    than failing, and both end up with the same row.
+    """
+    dump = f"node;storage_capacity\n{HOST1};1000\n"
+
+    csv_row, = rows_from_csv(dump.splitlines(), LOAD_PER_NODE_COLUMNS)
+    cql_row, = rows_from_cql([SimpleNamespace(node=HOST1, storage_capacity=1000)], LOAD_PER_NODE_COLUMNS)
+
+    assert csv_row == cql_row
+    assert (csv_row.node, csv_row.storage_capacity) == (HOST1, 1000)
+    assert (csv_row.effective_capacity, csv_row.dc, csv_row.rack, csv_row.ip) == (None, None, None, None)
+
+
+@pytest.mark.parametrize("parse, text, expected", [
+    pytest.param(parse_replica_list, f"[({HOST1}, 0), ({HOST2}, 13)]",
+                 [(HOST1, 0), (HOST2, 13)], id="replicas-in-brackets"),
+    pytest.param(parse_replica_list, f"{{({HOST1}, 0), ({HOST2}, 13)}}",
+                 [(HOST1, 0), (HOST2, 13)], id="replicas-in-braces"),
+    pytest.param(parse_replica_size_map, f"{{{HOST1}: 18006543, {HOST2}: 90}}",
+                 {HOST1: 18006543, HOST2: 90}, id="sizes-by-host"),
+    pytest.param(parse_replica_list, "[]", [], id="no-replicas"),
+    pytest.param(parse_replica_size_map, "{}", {}, id="no-sizes"),
+])
+def test_replicas_are_parsed_from_either_spelling(parse, text: str, expected) -> None:
+    """
+    One regex reads every collection these columns come in: a list of pairs, "[(host, shard)]",
+    a set of them, "{(host, shard)}", and a map of host to size, "{host: size}". It matches a
+    pair at a time and never the brackets, so the collection kind cannot matter.
+
+    An empty collection is a tablet whose sizes are not known.
+    """
+    assert parse(text) == expected
+
+
+def test_a_malformed_host_id_is_rejected() -> None:
+    """
+    A host id of the right width but not a valid one is rejected rather than taken on trust.
+    """
+    with pytest.raises(ValueError, match="badly formed hexadecimal UUID string"):
+        parse_replica_list("(-1111111-1111-1111-1111-111111111111, 0)")
+
+
+def test_rows_from_csv_reads_empty_and_null_fields_as_none() -> None:
+    dump = f"node;dc;rack;ip;storage_capacity;effective_capacity\n{HOST1};dc1;null;;1000;null\n"
+
+    row, = rows_from_csv(dump.splitlines(), LOAD_PER_NODE_COLUMNS)
+
+    # A dump spells a null either as an empty field or as "null", depending on what wrote it.
+    assert (row.rack, row.ip, row.effective_capacity) == (None, None, None)
+    assert (row.dc, row.storage_capacity) == ("dc1", 1000)
+
+
+def test_a_snapshot_keeps_values_which_need_quoting(tmp_path) -> None:
+    """
+    A quoted CQL identifier can hold the delimiter, or a newline, and has to survive the dump.
+    """
+    snapshot_dir = tmp_path / "snap"
+    snapshot_dir.mkdir()
+    with open(snapshot_dir / "system_tablets.csv", "w", newline="") as dump:
+        writer = csv.writer(dump, delimiter=CSV_DELIMITER)
+        writer.writerow(["table_id", "last_token", "keyspace_name", "table_name",
+                         "replicas", "new_replicas", "stage"])
+        writer.writerow([TABLE, 0, "odd;name", "wrapped\nname", f"{{({HOST1}, 0)}}", "", "none"])
+
+    topo = TopologyFromSnapshot(str(snapshot_dir)).get_topology()
+
+    assert topo.get_table_name(TABLE) == "odd;name.wrapped\nname"
+    assert topo.get_tablet_map(TABLE).tablets[0].replicas == [(HOST1, 0)]
+
+
+def test_rows_from_csv_rejects_a_dump_missing_a_required_column() -> None:
+    dump = f"table_id;last_token;keyspace_name;replicas;new_replicas;stage\n{TABLE};0;ks;{{}};;none\n"
+
+    with pytest.raises(Exception, match="Required column 'table_name' is missing"):
+        list(rows_from_csv(dump.splitlines(), TABLETS_COLUMNS))
+
+
+def test_rows_from_csv_rejects_a_dump_which_is_not_in_the_expected_format() -> None:
+    """
+    Dumps have to be CSV, so cqlsh's default output, which separates columns with '|' and pads
+    them, is reported as the wrong format rather than as a pile of missing columns.
+    """
+    dump = (" table_id | last_token | keyspace_name | table_name\n"
+            "----------+------------+---------------+-----------\n"
+            f" {TABLE} |          0 |            ks |       tbl\n")
+
+    with pytest.raises(Exception, match="not CSV with a ';' delimiter"):
+        list(rows_from_csv(dump.splitlines(), TABLETS_COLUMNS))
+
+
+def test_build_of_nothing_yields_an_empty_topology() -> None:
+    topo = Topology()
+    topo._build({})
+
+    assert topo.host_count() == 0
+    assert list(topo.iter_table_ids()) == []

--- a/test/tablet_scripts/test_topology_build.py
+++ b/test/tablet_scripts/test_topology_build.py
@@ -177,6 +177,165 @@ def test_build_makes_a_colocated_table_share_the_base_tables_tablets(build) -> N
     assert [table_id for table_id, _ in topo.all_tablets()] == [TABLE, TABLE]
 
 
+def test_a_replica_the_server_has_no_size_for_counts_as_nothing() -> None:
+    """
+    A replica which has just been migrated to has no size yet, and system.tablet_sizes says
+    so in missing_replicas. That is a snapshot of a cluster mid-migration rather than a
+    broken one, so it counts for nothing instead of stopping the whole report.
+    """
+    sizes_dump = (f"table_id;last_token;replicas;missing_replicas\n"
+                  f"{TABLE};0;{{{HOST1}: 10}};{{{HOST2}}}\n"
+                  f"{TABLE};100;{{{HOST1}: 30}};{{}}\n")
+    topo = Topology()
+    topo._build({
+        TABLETS_TABLE.name: rows_from_csv(TABLETS_CSV.splitlines(), TABLETS_COLUMNS),
+        TABLET_SIZES_TABLE.name: rows_from_csv(sizes_dump.splitlines(), TABLET_SIZES_COLUMNS),
+    })
+    tablets = topo.get_tablet_map(TABLE).tablets
+
+    assert topo.get_tablet_size(TABLE, tablets[0], (HOST1, 0)) == 10
+    assert topo.get_tablet_size(TABLE, tablets[0], (HOST2, 1)) == 0
+
+    # A replica with neither a size nor a word about it is a snapshot that does not add up.
+    with pytest.raises(Exception, match="Tablet size not available"):
+        topo.get_tablet_size(TABLE, tablets[1], (HOST2, 0))
+
+
+def test_a_node_the_cluster_left_out_is_not_reported_for_holding_no_sizes(capsys) -> None:
+    """
+    It reports no size for anything it holds, which is what being left out looks like. Saying
+    so would bury the replicas which have no size for a reason worth looking into.
+    """
+    load_dump = (f"node;dc;rack;storage_capacity;up;excluded\n"
+                 f"{HOST1};dc1;rack1;1000;True;False\n"
+                 f"{HOST2};dc1;rack2;2000;False;True\n")
+    sizes_dump = (f"table_id;last_token;replicas;missing_replicas\n"
+                  f"{TABLE};0;{{{HOST1}: 10}};{{{HOST2}}}\n")
+
+    topo = Topology()
+    topo._build({
+        LOAD_PER_NODE_TABLE.name: rows_from_csv(load_dump.splitlines(), LOAD_PER_NODE_COLUMNS),
+        TABLET_SIZES_TABLE.name: rows_from_csv(sizes_dump.splitlines(), TABLET_SIZES_COLUMNS),
+    })
+
+    topo.report_missing_tablet_sizes()
+
+    assert capsys.readouterr().err == ""
+    # It is still recorded, so a replica on it counts for nothing rather than stopping a report.
+    assert (TABLE, 0, HOST2) in topo._missing_tablet_sizes
+
+
+def test_a_replica_of_a_working_node_with_no_size_is_still_reported(capsys) -> None:
+    load_dump = (f"node;dc;rack;storage_capacity;up;excluded\n"
+                 f"{HOST1};dc1;rack1;1000;True;False\n"
+                 f"{HOST2};dc1;rack2;2000;True;False\n")
+    sizes_dump = (f"table_id;last_token;replicas;missing_replicas\n"
+                  f"{TABLE};0;{{{HOST1}: 10}};{{{HOST2}}}\n")
+
+    topo = Topology()
+    topo._build({
+        LOAD_PER_NODE_TABLE.name: rows_from_csv(load_dump.splitlines(), LOAD_PER_NODE_COLUMNS),
+        TABLET_SIZES_TABLE.name: rows_from_csv(sizes_dump.splitlines(), TABLET_SIZES_COLUMNS),
+    })
+
+    topo.report_missing_tablet_sizes()
+
+    assert "1 replicas have no size" in capsys.readouterr().err
+
+
+def test_the_missing_sizes_are_grouped_by_node_and_by_table(capsys) -> None:
+    """
+    A handful of replicas on one node reads differently from a table missing everywhere.
+    """
+    load_dump = f"node;dc;rack;ip;storage_capacity\n{HOST1};dc1;rack1;10.0.0.1;1000\n"
+    sizes_dump = (f"table_id;last_token;replicas;missing_replicas\n"
+                  f"{TABLE};0;{{}};{{{HOST1}, {HOST2}}}\n"
+                  f"{TABLE};100;{{}};{{{HOST1}}}\n")
+
+    topo = Topology()
+    topo._build({
+        TABLETS_TABLE.name: rows_from_csv(TABLETS_CSV.splitlines(), TABLETS_COLUMNS),
+        LOAD_PER_NODE_TABLE.name: rows_from_csv(load_dump.splitlines(), LOAD_PER_NODE_COLUMNS),
+        TABLET_SIZES_TABLE.name: rows_from_csv(sizes_dump.splitlines(), TABLET_SIZES_COLUMNS),
+    })
+    topo.report_missing_tablet_sizes()
+
+    err = capsys.readouterr().err.splitlines()
+    assert err[0].startswith("Note: 3 replicas have no size")
+    # The heaviest first, and a node with no ip is named by its id.
+    assert err[1] == f"  hosts: 10.0.0.1 (2), {HOST2} (1)"
+    assert err[2] == "  tables: ks.tbl (3)"
+
+
+def test_the_missing_sizes_name_only_the_heaviest_few_and_say_so(capsys) -> None:
+    """
+    Enough to say where the weight is without turning a note into a report. What is left out
+    is said, rather than inferred from a total which does not add up.
+    """
+    hosts = [UUID(f"{digit}" * 8 + "-1111-1111-1111-111111111111") for digit in range(1, 6)]
+    sizes_dump = "table_id;last_token;replicas;missing_replicas\n" + "".join(
+        f"{TABLE};{token};{{}};{{{host}}}\n" for token, host in enumerate(hosts))
+
+    topo = Topology()
+    topo._build({TABLET_SIZES_TABLE.name: rows_from_csv(sizes_dump.splitlines(), TABLET_SIZES_COLUMNS)})
+    topo.report_missing_tablet_sizes()
+
+    by_host = capsys.readouterr().err.splitlines()[1]
+    assert by_host.count("(1)") == 3 and by_host.endswith("+2")
+
+
+def test_a_node_which_no_longer_owns_tokens_is_not_reported_for_holding_no_sizes(capsys) -> None:
+    """
+    A node which has left reports no size for what it still holds, same as an excluded one.
+    """
+    topology_dump = (f"version;host_id;shard_count;node_state;num_tokens\n"
+                     f"6538;{HOST1};4;left;256\n")
+    sizes_dump = (f"table_id;last_token;replicas;missing_replicas\n"
+                  f"{TABLE};0;{{}};{{{HOST1}}}\n")
+
+    topo = Topology()
+    topo._build({
+        TOPOLOGY_TABLE.name: rows_from_csv(topology_dump.splitlines(), TOPOLOGY_COLUMNS),
+        TABLET_SIZES_TABLE.name: rows_from_csv(sizes_dump.splitlines(), TABLET_SIZES_COLUMNS),
+    })
+    topo.report_missing_tablet_sizes()
+
+    assert capsys.readouterr().err == ""
+
+
+def test_the_report_of_missing_sizes_says_it_of_what_the_report_shows(capsys) -> None:
+    """
+    A replica of a table nobody asked about is not a hole in the numbers on screen, so the
+    report passes the filters it is drawn under.
+    """
+    other_table = UUID("dddddddd-dddd-dddd-dddd-dddddddddddd")
+    load_dump = (f"node;dc;rack;ip;storage_capacity\n"
+                 f"{HOST1};dc1;rack1;10.0.0.1;1000\n"
+                 f"{HOST2};dc1;rack2;10.0.0.2;2000\n")
+    sizes_dump = (f"table_id;last_token;replicas;missing_replicas\n"
+                  f"{TABLE};0;{{}};{{{HOST1}}}\n"
+                  f"{other_table};0;{{}};{{{HOST2}}}\n")
+
+    topo = Topology()
+    topo._build({
+        TABLETS_TABLE.name: rows_from_csv(TABLETS_CSV.splitlines(), TABLETS_COLUMNS),
+        LOAD_PER_NODE_TABLE.name: rows_from_csv(load_dump.splitlines(), LOAD_PER_NODE_COLUMNS),
+        TABLET_SIZES_TABLE.name: rows_from_csv(sizes_dump.splitlines(), TABLET_SIZES_COLUMNS),
+    })
+
+    topo.report_missing_tablet_sizes(accepts_table=lambda table: table == TABLE)
+    err = capsys.readouterr().err
+    assert "Note: 1 replicas" in err and "10.0.0.1 (1)" in err
+
+    topo.report_missing_tablet_sizes(accepts_host=lambda host: host.ip == "10.0.0.2")
+    err = capsys.readouterr().err
+    assert "Note: 1 replicas" in err and "10.0.0.2 (1)" in err
+
+    # Nothing the report shows is missing a size, so it has nothing to say.
+    topo.report_missing_tablet_sizes(accepts_table=lambda table: False)
+    assert capsys.readouterr().err == ""
+
+
 def test_build_infers_shard_counts_from_replicas_when_system_topology_is_absent() -> None:
     topo = Topology()
     topo._build({TABLETS_TABLE.name: rows_from_csv(TABLETS_CSV.splitlines(), TABLETS_COLUMNS)})

--- a/test/tablet_scripts/test_topology_build.py
+++ b/test/tablet_scripts/test_topology_build.py
@@ -262,6 +262,33 @@ def test_system_load_per_node_has_the_last_word_on_where_a_node_is() -> None:
     assert topo.require_host(HOST1).rack == "rack1"
 
 
+def test_build_reads_whether_a_node_is_up_and_whether_it_is_excluded() -> None:
+    """
+    A node the cluster cannot reach reports no sizes and no capacity, which on its own reads
+    as a node holding nothing. These say which it is.
+    """
+    dump = (f"node;dc;rack;ip;storage_capacity;up;excluded\n"
+            f"{HOST1};dc1;rack1;10.0.0.1;1000;False;True\n"
+            f"{HOST2};dc1;rack2;10.0.0.2;2000;True;False\n")
+
+    topo = Topology()
+    topo._build({LOAD_PER_NODE_TABLE.name: rows_from_csv(dump.splitlines(), LOAD_PER_NODE_COLUMNS)})
+
+    assert (topo.require_host(HOST1).up, topo.require_host(HOST1).excluded) == (False, True)
+    assert (topo.require_host(HOST2).up, topo.require_host(HOST2).excluded) == (True, False)
+
+
+def test_a_snapshot_taken_before_the_status_columns_says_nothing_either_way() -> None:
+    """
+    Neither up nor down, so a report can tell "not reported" from "down".
+    """
+    topo = Topology()
+    topo._build({LOAD_PER_NODE_TABLE.name: rows_from_csv(LOAD_PER_NODE_CSV.splitlines(),
+                                                         LOAD_PER_NODE_COLUMNS)})
+
+    assert (topo.require_host(HOST1).up, topo.require_host(HOST1).excluded) == (None, None)
+
+
 def test_optional_columns_read_as_none_whichever_source_lacks_them() -> None:
     """
     A snapshot or a cluster which predates an optional column is read without it, rather

--- a/test/tablet_scripts/test_topology_snapshot.py
+++ b/test/tablet_scripts/test_topology_snapshot.py
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+from __future__ import annotations
+
+import re
+from argparse import Namespace
+
+import pytest
+
+from tablets import topology
+from tablets.topology import TopologyFromSnapshot
+
+
+def test_snapshot_topology_source_reports_missing_snapshot_clearly(tmp_path) -> None:
+    missing_path = tmp_path / "missing-snapshot"
+
+    # A snapshot is a directory or a tar archive, so the message names neither.
+    with pytest.raises(Exception, match=rf"Snapshot does not exist: {re.escape(str(missing_path))}"):
+        TopologyFromSnapshot(str(missing_path))
+
+
+def test_get_topology_source_from_args_uses_env_snapshot_when_no_option_is_set(tmp_path, monkeypatch) -> None:
+    snapshot_dir = tmp_path / "snapshot"
+    snapshot_dir.mkdir()
+    (snapshot_dir / "system_tablets.csv").write_text("")
+    monkeypatch.setenv("SCYLLA_TABLET_SNAPSHOT", str(snapshot_dir))
+
+    src = topology.get_topology_source_from_args(Namespace(
+        snapshot=None,
+        cluster=None,
+        port=None,
+        user=None,
+        password=None,
+        min_tablet_size=None,
+        anonymize=False,
+    ))
+
+    assert isinstance(src, TopologyFromSnapshot)
+    assert src.snapshot_dir == str(snapshot_dir)
+
+
+def test_get_topology_source_from_args_prefers_explicit_options_over_env_snapshot(tmp_path, monkeypatch) -> None:
+    env_snapshot_dir = tmp_path / "env-snapshot"
+    env_snapshot_dir.mkdir()
+    (env_snapshot_dir / "system_tablets.csv").write_text("")
+    explicit_snapshot_dir = tmp_path / "explicit-snapshot"
+    explicit_snapshot_dir.mkdir()
+    (explicit_snapshot_dir / "system_tablets.csv").write_text("")
+    monkeypatch.setenv("SCYLLA_TABLET_SNAPSHOT", str(env_snapshot_dir))
+
+    src = topology.get_topology_source_from_args(Namespace(
+        snapshot=str(explicit_snapshot_dir),
+        cluster=None,
+        port=None,
+        user=None,
+        password=None,
+        min_tablet_size=None,
+        anonymize=False,
+    ))
+
+    assert isinstance(src, TopologyFromSnapshot)
+    assert src.snapshot_dir == str(explicit_snapshot_dir)
+
+
+def test_get_topology_source_from_args_prefers_cluster_over_env_snapshot(tmp_path, monkeypatch) -> None:
+    env_snapshot_dir = tmp_path / "env-snapshot"
+    env_snapshot_dir.mkdir()
+    (env_snapshot_dir / "system_tablets.csv").write_text("")
+    monkeypatch.setenv("SCYLLA_TABLET_SNAPSHOT", str(env_snapshot_dir))
+
+    live_src = Namespace()
+    monkeypatch.setattr(topology, "get_live_topology_source_from_args", lambda args: live_src)
+
+    src = topology.get_topology_source_from_args(Namespace(
+        snapshot=None,
+        cluster="127.0.0.1",
+        port=None,
+        user=None,
+        password=None,
+        min_tablet_size=None,
+        anonymize=False,
+    ))
+
+    assert src is live_src

--- a/test/tablet_scripts/topology_building.py
+++ b/test/tablet_scripts/topology_building.py
@@ -1,0 +1,88 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Topologies for the unit tests to assert over, and the ids they are built from.
+
+A test names every part of the topology its assertions depend on, so the layout stays next
+to them and nothing they rest on is filled in out of sight.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from tablets.topology import DatacenterName
+from tablets.topology import Host
+from tablets.topology import HostId
+from tablets.topology import KeyspaceName
+from tablets.topology import RackName
+from tablets.topology import TableId
+from tablets.topology import TableName
+from tablets.topology import Tablet
+from tablets.topology import TabletMap
+from tablets.topology import TabletReplica
+from tablets.topology import Token
+from tablets.topology import Topology
+
+
+HOST1_ID = UUID("11111111-1111-1111-1111-111111111111")
+HOST2_ID = UUID("22222222-2222-2222-2222-222222222222")
+HOST3_ID = UUID("33333333-3333-3333-3333-333333333333")
+HOST4_ID = UUID("44444444-4444-4444-4444-444444444444")
+HOST5_ID = UUID("55555555-5555-5555-5555-555555555555")
+
+TABLE1_ID = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+TABLE2_ID = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+TABLE3_ID = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+
+
+@dataclass(frozen=True)
+class HostSpec:
+    """
+    A host to place: where it sits, how many shards it has, and how much it can hold.
+
+    A test states the capacity it measures against, and leaves it out when it measures
+    nothing against it, which is a snapshot that carries no capacity for the node.
+    """
+    ip: str
+    dc: DatacenterName
+    rack: RackName
+    shard_count: int = 2
+    storage_capacity: int | None = None
+    effective_capacity: int | None = None
+
+
+def build_topology(hosts: dict[HostId, HostSpec],
+                   tables: dict[TableId, tuple[KeyspaceName, TableName]] | None = None,
+                   tablets: dict[TableId, list[tuple[Token, dict[TabletReplica, int]]]] | None = None) -> Topology:
+    """
+    A topology of the hosts the caller places, of the tables it names, and of their tablets,
+    each given as its last token and the size of every replica.
+
+    Everything a test can assert on is named by the test; nothing is filled in here.
+    """
+    topo = Topology()
+    for host_id, host in hosts.items():
+        topo._hosts[host_id] = Host(id=host_id, shard_count=host.shard_count, ip=host.ip,
+                                    dc=host.dc, rack=host.rack,
+                                    storage_capacity=host.storage_capacity,
+                                    effective_capacity=host.effective_capacity)
+    for table_id, name in (tables or {}).items():
+        topo._tables[table_id] = name
+        topo._tablet_maps[table_id] = TabletMap(table_id)
+    for table_id, table_tablets in (tablets or {}).items():
+        topo._tablet_maps[table_id] = TabletMap(
+            table=table_id,
+            tablets=[Tablet(last_token=token, replicas=list(sizes)) for token, sizes in table_tablets],
+        )
+        for token, sizes in table_tablets:
+            topo._tablet_sizes[(table_id, token)] = {host_id: size for (host_id, _), size in sizes.items()}
+    # Links colocated tablet maps to the tablets of their base table, as building from rows does.
+    topo._build({})
+    return topo
+

--- a/test/tablet_scripts/topology_building.py
+++ b/test/tablet_scripts/topology_building.py
@@ -55,6 +55,10 @@ class HostSpec:
     shard_count: int = 2
     storage_capacity: int | None = None
     effective_capacity: int | None = None
+    # What system.load_per_node says about the node beyond its load: whether the cluster can
+    # reach it, and whether it takes part in balancing. Left out when a test measures neither.
+    up: bool | None = None
+    excluded: bool | None = None
 
 
 def build_topology(hosts: dict[HostId, HostSpec],
@@ -71,7 +75,8 @@ def build_topology(hosts: dict[HostId, HostSpec],
         topo._hosts[host_id] = Host(id=host_id, shard_count=host.shard_count, ip=host.ip,
                                     dc=host.dc, rack=host.rack,
                                     storage_capacity=host.storage_capacity,
-                                    effective_capacity=host.effective_capacity)
+                                    effective_capacity=host.effective_capacity,
+                                    up=host.up, excluded=host.excluded)
     for table_id, name in (tables or {}).items():
         topo._tables[table_id] = name
         topo._tablet_maps[table_id] = TabletMap(table_id)


### PR DESCRIPTION
We were lacking good tools for evaluating tablet load distribution.

We currently only have coarse metrics in prometheus:
  1) tablet count per shard
  2) load balancer's load metric per host

And very low-level information which is scattered across tables:
  1) system.tablets
  2) system.tablet_sizes
  3) system.load_per_node

Relevant information is spread across different sources, hard to collect, and hard to combine.

This PR introduces tools which solve this problem:
  1) Adds a script for creating snapshots of all metadata relevant for load balancing 
  2) Introduces a python framework for accessing tablet metadata, either from a live cluster or a snapshot
  3) Introduces tools which compile information about load in a clear and meaningful manner

This makes workflow for analysis easier:
  1) take a snapshot from the live cluster
  2) analyze off-line using scripts

We can standardize the process with support and QA, and take snapshots by default as part of log collection. We can take them in SCT around key events for post-mortem analysis.

The snapshot has complete information needed to recreate the tablet setup, so it will allow us to experiment with load balancing algorithms or simulate effects of actions (tablet hint changes) before taking them to production.

The PR comes with some basic scripts which help to understand the load distribution and situation with tablets.

Examples:

1.  Capture a snapshot.

    ``` bash
    $ ./scripts/tablets/scylla-tablets.py snapshot
    /home/tgrabiec/tablet_snap_260728_012050
    ```

    Or `--gz` for a single-file archive, which the other scripts read directly:

    ``` bash
    $ ./scripts/tablets/scylla-tablets.py snapshot --gz
    /home/tgrabiec/tablet_snap_260728_012050.tar.gz
    ```

2.  Comparing table sizes at a high level.

    ```
    $ ./scripts/tablets/scylla-tablets.py table-summary --snapshot tablet_snap_260728_012050
    ╭──────────────┬──────────────┬──────────────┬──────────────────┬──────────┬───────────────┬────────────────┬────────────────┬──────────────────╮
    │ name         │   replicated │   replicated │                  │   tablet │   tablet size │         tablet │         tablet │ size             │
    │              │     size [B] │     size [%] │                  │    count │       ovc [%] │   avg size [B] │   max size [B] │ in token space   │
    ├──────────────┼──────────────┼──────────────┼──────────────────┼──────────┼───────────────┼────────────────┼────────────────┼──────────────────┤
    │ ALL          │     8.278 Ti │       100.00 │                  │     3248 │      +1500.00 │     890.782 Mi │      13.115 Gi │                  │
    ├──────────────┼──────────────┼──────────────┼──────────────────┼──────────┼───────────────┼────────────────┼────────────────┼──────────────────┤
    │ ks5.table26  │     2.369 Ti │        28.62 │ ████████████████ │      128 │        +92.84 │       6.318 Gi │      13.115 Gi │ ▇▅▆▆▆▅▆▅▅▆▆▅▆▆▅▅ │
    │ ks5.table10  │     1.683 Ti │        20.33 │ ███████████▎     │      128 │        +52.36 │       4.489 Gi │       7.361 Gi │ ▇▆▅▅▅▄▆▄▇▅▄▆▆▅▆▅ │
    │ ks5.table12  │     1.521 Ti │        18.37 │ ██████████▎      │      512 │        +89.55 │       1.014 Gi │       2.791 Gi │ ▃▅▆▅▄▄▅▅▅▅▅▇▆▅▅▆ │
    │ ks3.table9   │   787.221 Gi │         9.29 │ █████▏           │       32 │        +19.57 │       8.200 Gi │      10.158 Gi │ ▆▇▆▆▆▆▅▆▅▆▆▆▆▅▆▆ │
    │ ks5.table15  │   380.058 Gi │         4.48 │ ██▌              │       64 │       +140.90 │       1.979 Gi │       5.202 Gi │ ▂▄▂▃▃▂▂▃▂▂▃▆▇▆▇▅ │
    │ ks11.table2  │   274.099 Gi │         3.23 │ █▊               │       32 │        +22.72 │       2.855 Gi │       4.532 Gi │ ▆▆▆▇▇▆▆▆▆▅▆▅▆▆▅▇ │
    │ ks5.table16  │   239.685 Gi │         2.83 │ █▌               │      256 │       +154.24 │     319.579 Mi │       1.052 Gi │ ▃▃▃▅▃▅▃▃▃▄▅▅▇▇▃▃ │
    │ ks8.table2   │   221.369 Gi │         2.61 │ █▍               │       16 │        +12.91 │       4.612 Gi │       5.831 Gi │ ▆▆▆▆▇▆▆▆▆▆▇▆▆▆▆▆ │
    ...
    ```

3.  Inspecting cluster-wide imbalance per rack, per node, per shard:

    ```
    $ ./scripts/tablets/scylla-tablets.py cluster-load --snapshot tablet_snap_260728_012050 --level rack node shard
    ╭────────────────────────┬───────────┬─────────┬──────────┬────────┬────────────┬──────────┬──────────┬─────────────┬──────────┬────────────────┬────────────┬────────────┬────────────╮
    │                        │   tablets │   shard │     size │   size │   size ovc │ size     │   tokens │   token ovc │ tokens   │   eff capacity │   eff util │   util ovc │ eff util   │
    │                        │   / shard │   count │      [B] │    [%] │        [%] │          │      [%] │         [%] │          │            [B] │        [%] │        [%] │            │
    ├────────────────────────┼───────────┼─────────┼──────────┼────────┼────────────┼──────────┼──────────┼─────────────┼──────────┼────────────────┼────────────┼────────────┼────────────┤
    │ AWS_EU_WEST_3/euw3-az1 │   154.667 │      21 │ 2.932 Ti │  35.42 │      +6.26 │ ████████ │   100.00 │       +0.00 │ ████████ │       4.993 Ti │      58.73 │      +6.37 │ ████████   │
    │ AWS_EU_WEST_3/euw3-az2 │   154.667 │      21 │ 2.678 Ti │  32.35 │      -2.94 │ ███████▎ │   100.00 │       +0.00 │ ████████ │       5.004 Ti │      53.52 │      -3.06 │ ███████▎   │
    │ AWS_EU_WEST_3/euw3-az3 │   154.667 │      21 │ 2.668 Ti │  32.23 │      -3.32 │ ███████▎ │   100.00 │       +0.00 │ ████████ │       4.998 Ti │      53.38 │      -3.31 │ ███████▎   │
    ├────────────────────────┼───────────┼─────────┼──────────┼────────┼────────────┼──────────┼──────────┼─────────────┼──────────┼────────────────┼────────────┼────────────┼────────────┤
    │ DC total               │   154.667 │      63 │ 8.278 Ti │ 100.00 │      +6.26 │          │   300.00 │       +0.00 │          │      14.995 Ti │      55.20 │      +6.37 │            │
    ╰────────────────────────┴───────────┴─────────┴──────────┴────────┴────────────┴──────────┴──────────┴─────────────┴──────────┴────────────────┴────────────┴────────────┴────────────╯
    
    ╭────────────────────────┬───────────┬─────────┬────────────┬────────┬────────────┬──────────┬──────────┬─────────────┬──────────┬────────────────┬────────────┬────────────┬────────────╮
    │                        │   tablets │   shard │       size │   size │   size ovc │ size     │   tokens │   token ovc │ tokens   │   eff capacity │   eff util │   util ovc │ eff util   │
    │                        │   / shard │   count │        [B] │    [%] │        [%] │          │      [%] │         [%] │          │            [B] │        [%] │        [%] │            │
    ├────────────────────────┼───────────┼─────────┼────────────┼────────┼────────────┼──────────┼──────────┼─────────────┼──────────┼────────────────┼────────────┼────────────┼────────────┤
    │ AWS_EU_WEST_3/euw3-az1 │           │         │            │        │            │          │          │             │          │                │            │            │            │
    ├────────────────────────┼───────────┼─────────┼────────────┼────────┼────────────┼──────────┼──────────┼─────────────┼──────────┼────────────────┼────────────┼────────────┼────────────┤
    │ 172.20.60.47           │   154.714 │       7 │   1.013 Ti │  12.24 │      +3.69 │ ███████▊ │    33.22 │       -0.33 │ ███████▉ │       1.671 Ti │      60.66 │      +3.32 │ ███████▊   │
    │ 172.20.60.5            │   154.571 │       7 │ 924.603 Gi │  10.91 │      -7.61 │ ███████  │    33.39 │       +0.16 │ ███████▉ │       1.652 Ti │      54.67 │      -6.89 │ ███████    │
    │ 172.20.60.52           │   154.714 │       7 │   1.016 Ti │  12.27 │      +3.92 │ ███████▉ │    33.39 │       +0.17 │ ███████▉ │       1.670 Ti │      60.81 │      +3.57 │ ███████▉   │
    ├────────────────────────┼───────────┼─────────┼────────────┼────────┼────────────┼──────────┼──────────┼─────────────┼──────────┼────────────────┼────────────┼────────────┼────────────┤
    │ AWS_EU_WEST_3/euw3-az2 │           │         │            │        │            │          │          │             │          │                │            │            │            │
    ├────────────────────────┼───────────┼─────────┼────────────┼────────┼────────────┼──────────┼──────────┼─────────────┼──────────┼────────────────┼────────────┼────────────┼────────────┤
    │ 172.20.60.125          │   154.714 │       7 │   1.025 Ti │  12.39 │     +14.85 │ ███████▉ │    33.38 │       +0.15 │ ███████▉ │       1.670 Ti │      61.38 │     +14.74 │ ███████▉   │
    │ 172.20.60.104          │   154.714 │       7 │ 637.495 Gi │   7.52 │     -30.26 │ ████▊    │    33.57 │       +0.71 │ ███████▉ │       1.664 Ti │      37.41 │     -30.07 │ ████▊      │
    │ 172.20.60.111          │   154.571 │       7 │   1.030 Ti │  12.45 │     +15.42 │ ████████ │    33.05 │       -0.86 │ ███████▊ │       1.670 Ti │      61.70 │     +15.33 │ ████████   │
    ├────────────────────────┼───────────┼─────────┼────────────┼────────┼────────────┼──────────┼──────────┼─────────────┼──────────┼────────────────┼────────────┼────────────┼────────────┤
    │ AWS_EU_WEST_3/euw3-az3 │           │         │            │        │            │          │          │             │          │                │            │            │            │
    ├────────────────────────┼───────────┼─────────┼────────────┼────────┼────────────┼──────────┼──────────┼─────────────┼──────────┼────────────────┼────────────┼────────────┼────────────┤
    │ 172.20.60.167          │   154.714 │       7 │ 646.247 Gi │   7.62 │     -29.03 │ ████▉    │    33.30 │       -0.11 │ ███████▉ │       1.657 Ti │      38.08 │     -28.60 │ ████▉      │
    │ 172.20.60.178          │   154.714 │       7 │   1.011 Ti │  12.21 │     +13.64 │ ███████▊ │    33.63 │       +0.88 │ ████████ │       1.670 Ti │      60.50 │     +13.43 │ ███████▊   │
    │ 172.20.60.155          │   154.571 │       7 │   1.026 Ti │  12.39 │     +15.39 │ ███████▉ │    33.08 │       -0.77 │ ███████▊ │       1.670 Ti │      61.43 │     +15.17 │ ███████▉   │
    ╰────────────────────────┴───────────┴─────────┴────────────┴────────┴────────────┴──────────┴──────────┴─────────────┴──────────┴────────────────┴────────────┴────────────┴────────────╯
    
    ╭────────────────────────┬───────────┬─────────┬────────────┬────────┬────────────┬──────────┬──────────┬─────────────┬──────────┬────────────────┬────────────┬────────────┬────────────╮
    │                        │   tablets │   shard │       size │   size │   size ovc │ size     │   tokens │   token ovc │ tokens   │   eff capacity │   eff util │   util ovc │ eff util   │
    │                        │   / shard │   count │        [B] │    [%] │        [%] │          │      [%] │         [%] │          │            [B] │        [%] │        [%] │            │
    ├────────────────────────┼───────────┼─────────┼────────────┼────────┼────────────┼──────────┼──────────┼─────────────┼──────────┼────────────────┼────────────┼────────────┼────────────┤
    │ AWS_EU_WEST_3/euw3-az1 │           │         │            │        │            │          │          │             │          │                │            │            │            │
    ├────────────────────────┼───────────┼─────────┼────────────┼────────┼────────────┼──────────┼──────────┼─────────────┼──────────┼────────────────┼────────────┼────────────┼────────────┤
    │ 172.20.60.47:0         │       155 │         │ 133.919 Gi │   1.58 │      -9.66 │ █████▋   │     4.97 │       +4.80 │ ███████▎ │     244.391 Gi │      54.80 │      -9.66 │ █████▋     │
    │ 172.20.60.47:1         │       155 │         │ 134.675 Gi │   1.59 │      -9.15 │ █████▋   │     4.89 │       +3.06 │ ███████▏ │     244.391 Gi │      55.11 │      -9.15 │ █████▋     │
    │ 172.20.60.47:2         │       155 │         │ 161.989 Gi │   1.91 │      +9.27 │ ██████▉  │     4.57 │       -3.76 │ ██████▋  │     244.391 Gi │      66.28 │      +9.27 │ ██████▉    │
    │ 172.20.60.47:3         │       155 │         │ 133.073 Gi │   1.57 │     -10.23 │ █████▋   │     4.97 │       +4.68 │ ███████▎ │     244.391 Gi │      54.45 │     -10.23 │ █████▋     │
    │ 172.20.60.47:4         │       154 │         │ 143.761 Gi │   1.70 │      -3.02 │ ██████   │     4.67 │       -1.63 │ ██████▉  │     244.391 Gi │      58.82 │      -3.02 │ ██████     │
    │ 172.20.60.47:5         │       155 │         │ 172.324 Gi │   2.03 │     +16.24 │ ███████▎ │     4.52 │       -4.69 │ ██████▋  │     244.391 Gi │      70.51 │     +16.24 │ ███████▎   │
    │ 172.20.60.47:6         │       154 │         │ 157.964 Gi │   1.86 │      +6.56 │ ██████▋  │     4.63 │       -2.47 │ ██████▊  │     244.391 Gi │      64.64 │      +6.56 │ ██████▋    │
    ...
    ```

    Narrow to one rack, node or shard with `--host`, `--shard`, `--rack`, `--dc`,
    or to one table with `--table`. Only matching replicas contribute to the aggregates.

4.  Drill into internal load imbalance across tablets and replicas of a single table:

    ```
    $ ./scripts/tablets/scylla-tablets.py table-load --snapshot tablet_snap_260728_012050 ks5.table12 --max-ranges 32
    ╭──────────────────────┬───────────┬──────────┬──────────────┬─────────────────┬────────┬────────┬──────────────────┬───────╮
    │ last token           │   tablets │   tokens │   replicated │            size │    ovc │   size │ size             │ rep   │
    │                      │           │      [%] │     size [B] │   / replica [B] │    [%] │    [%] │                  │       │
    ├──────────────────────┼───────────┼──────────┼──────────────┼─────────────────┼────────┼────────┼──────────────────┼───────┤
    │ ALL                  │       512 │          │     1.521 Ti │      519.127 Gi │ +44.74 │        │                  │ ▇▇▇   │
    │ Average              │    16.000 │   3.1250 │    48.668 Gi │       16.223 Gi │        │ 3.1250 │ ███████████      │       │
    ├──────────────────────┼───────────┼──────────┼──────────────┼─────────────────┼────────┼────────┼──────────────────┼───────┤
    │ -8646911284551352321 │        16 │   3.1250 │    31.404 Gi │       10.468 Gi │ -35.47 │ 2.0165 │ ███████▏         │ ▇▆▆   │
    │ -8070450532247928833 │        16 │   3.1250 │    35.413 Gi │       11.804 Gi │ -27.24 │ 2.2739 │ ████████         │ ▇▅▅   │
    │ -7493989779944505345 │        16 │   3.1250 │    42.465 Gi │       14.155 Gi │ -12.75 │ 2.7267 │ █████████▋       │ ▆▆▇   │
    │ -6917529027641081857 │        16 │   3.1250 │    46.245 Gi │       15.415 Gi │  -4.98 │ 2.9694 │ ██████████▌      │ ▅▇▆   │
    │ -6341068275337658369 │        16 │   3.1250 │    54.883 Gi │       18.294 Gi │ +12.77 │ 3.5241 │ ████████████▍    │ ▇▅▅   │
    │ -5764607523034234881 │        16 │   3.1250 │    55.559 Gi │       18.520 Gi │ +14.16 │ 3.5675 │ ████████████▌    │ ▇▅▅   │
    │ -5188146770730811393 │        16 │   3.1250 │    50.645 Gi │       16.882 Gi │  +4.06 │ 3.2519 │ ███████████▌     │ ▆▇▇   │
    │ -4611686018427387905 │        16 │   3.1250 │    42.792 Gi │       14.264 Gi │ -12.07 │ 2.7477 │ █████████▋       │ ▇▄▆   │
    │ -4035225266123964417 │        16 │   3.1250 │    40.888 Gi │       13.629 Gi │ -15.99 │ 2.6254 │ █████████▎       │ ▇▆▇   │
    │ -3458764513820540929 │        16 │   3.1250 │    37.254 Gi │       12.418 Gi │ -23.45 │ 2.3921 │ ████████▍        │ ▇▇▇   │
    │ -2882303761517117441 │        16 │   3.1250 │    37.444 Gi │       12.481 Gi │ -23.06 │ 2.4043 │ ████████▌        │ ▆▇▇   │
    │ -2305843009213693953 │        16 │   3.1250 │    36.965 Gi │       12.322 Gi │ -24.05 │ 2.3735 │ ████████▍        │ ▇▆▆   │
    │ -1729382256910270465 │        16 │   3.1250 │    47.751 Gi │       15.917 Gi │  -1.88 │ 3.0661 │ ██████████▊      │ ▇▆▆   │
    │ -1152921504606846977 │        16 │   3.1250 │    56.284 Gi │       18.761 Gi │ +15.65 │ 3.6140 │ ████████████▊    │ ▇▆▇   │
    │ -576460752303423489  │        16 │   3.1250 │    40.823 Gi │       13.608 Gi │ -16.12 │ 2.6212 │ █████████▎       │ ▇▄▆   │
    │ -1                   │        16 │   3.1250 │    55.611 Gi │       18.537 Gi │ +14.27 │ 3.5708 │ ████████████▋    │ ▆▅▇   │
    │ 576460752303423487   │        16 │   3.1250 │    46.976 Gi │       15.659 Gi │  -3.48 │ 3.0163 │ ██████████▋      │ ▇▇▅   │
    │ 1152921504606846975  │        16 │   3.1250 │    46.901 Gi │       15.634 Gi │  -3.63 │ 3.0115 │ ██████████▋      │ ▆▇▅   │
    │ 1729382256910270463  │        16 │   3.1250 │    48.887 Gi │       16.296 Gi │  +0.45 │ 3.1391 │ ███████████      │ ▃▇▇   │
    │ 2305843009213693951  │        16 │   3.1250 │    50.589 Gi │       16.863 Gi │  +3.95 │ 3.2483 │ ███████████▍     │ ▇▇▅   │
    │ 2882303761517117439  │        16 │   3.1250 │    35.376 Gi │       11.792 Gi │ -27.31 │ 2.2715 │ ████████         │ ▆▆▇   │
    │ 3458764513820540927  │        16 │   3.1250 │    60.084 Gi │       20.028 Gi │ +23.46 │ 3.8580 │ █████████████▋   │ ▆▇▅   │
    │ 4035225266123964415  │        16 │   3.1250 │    70.444 Gi │       23.481 Gi │ +44.74 │ 4.5232 │ ████████████████ │ ▅▇▄   │
    │ 4611686018427387903  │        16 │   3.1250 │    65.246 Gi │       21.749 Gi │ +34.06 │ 4.1895 │ ██████████████▊  │ ▇▅▄   │
    │ 5188146770730811391  │        16 │   3.1250 │    61.532 Gi │       20.511 Gi │ +26.43 │ 3.9510 │ █████████████▉   │ ▇▇▅   │
    │ 5764607523034234879  │        16 │   3.1250 │    59.160 Gi │       19.720 Gi │ +21.56 │ 3.7987 │ █████████████▍   │ ▇▄▃   │
    │ 6341068275337658367  │        16 │   3.1250 │    60.143 Gi │       20.048 Gi │ +23.58 │ 3.8618 │ █████████████▋   │ ▄▅▇   │
    │ 6917529027641081855  │        16 │   3.1250 │    35.071 Gi │       11.690 Gi │ -27.94 │ 2.2519 │ ███████▉         │ ▆▇▆   │
    │ 7493989779944505343  │        16 │   3.1250 │    49.103 Gi │       16.368 Gi │  +0.89 │ 3.1529 │ ███████████▏     │ ▆▅▇   │
    │ 8070450532247928831  │        16 │   3.1250 │    44.914 Gi │       14.971 Gi │  -7.71 │ 2.8840 │ ██████████▏      │ ▄▇▆   │
    │ 8646911284551352319  │        16 │   3.1250 │    55.536 Gi │       18.512 Gi │ +14.11 │ 3.5660 │ ████████████▌    │ ▅▇▇   │
    │ 9223372036854775807  │        16 │   3.1250 │    54.994 Gi │       18.331 Gi │ +13.00 │ 3.5312 │ ████████████▍    │ ▄▇▇   │
    ╰──────────────────────┴───────────┴──────────┴──────────────┴─────────────────┴────────┴────────┴──────────────────┴───────╯
    ```

    Add `--per-replica` for one row per replica, with its rack and shard.

5.  Machine-readable output for further processing:

    ```
    $ ./scripts/tablets/scylla-tablets.py cluster-load --snapshot tablet_snap_260728_012050 --csv | head -6
    level,rack,location,tablets / shard,shard count,size [B],size [%],size ovc [%],tokens [%],token ovc [%],eff capacity [B],eff util [%],util ovc [%]
    rack,AWS_EU_WEST_3/euw3-az1,AWS_EU_WEST_3/euw3-az1,154.667,21,2.932 Ti,35.42,+6.26,100.00,+0.00,4.993 Ti,58.73,+6.37
    rack,AWS_EU_WEST_3/euw3-az2,AWS_EU_WEST_3/euw3-az2,154.667,21,2.678 Ti,32.35,-2.94,100.00,+0.00,5.004 Ti,53.52,-3.06
    rack,AWS_EU_WEST_3/euw3-az3,AWS_EU_WEST_3/euw3-az3,154.667,21,2.668 Ti,32.23,-3.32,100.00,+0.00,4.998 Ti,53.38,-3.31
    dc,,AWS_EU_WEST_3,154.667,63,8.278 Ti,100.00,+6.26,300.00,+0.00,14.995 Ti,55.20,+6.37
    node,AWS_EU_WEST_3/euw3-az1,172.20.60.47,154.714,7,1.013 Ti,12.24,+3.69,33.22,-0.33,1.671 Ti,60.66,+3.32
    ```

