### PR TITLE
test: fix test_validate_truncate_with_concurrent_writes exceeding 60s threshold

### DIFF
--- a/test/cluster/test_truncate_concurrent_writes.py
+++ b/test/cluster/test_truncate_concurrent_writes.py
@@ -41,8 +41,8 @@ async def test_validate_truncate_with_concurrent_writes(manager: ManagerClient):
     trunc_completed_event = asyncio.Event()
     writer_halfpoint = asyncio.Event()
 
-    cks_to_insert_before_trunc = 5000
-    cks_to_insert_after_trunc = 5000
+    cks_to_insert_before_trunc = 100
+    cks_to_insert_after_trunc = 100
     writer_results = {}
     async def writer(pk, writer_halfpoint, trunc_started_event, trunc_completed_event):
         stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, ck, val) VALUES (?, ?, ?);")


### PR DESCRIPTION
## Motivation

`test_validate_truncate_with_concurrent_writes` takes 185s in dev mode, 3x over
the project's 60s slow-test threshold (tracked under the "Tests take > 1 minute
even in dev mode" epic).

The test spawns 50 concurrent asyncio writer tasks, each sequentially awaiting
one CL=ALL `INSERT` at a time until it has written `cks_to_insert_after_trunc =
5000` rows after a `TRUNCATE` completes, with a separate
`cks_to_insert_before_trunc = 5000` threshold gating when the `TRUNCATE` itself
starts. In total this adds up to roughly 500k sequential per-row CQL round
trips, which is what actually drives the 185s runtime in a dev/debug build.

## Change

Reduce `cks_to_insert_before_trunc` and `cks_to_insert_after_trunc` from 5000
to 100 each. Neither needs to be large:

- `cks_to_insert_before_trunc` only needs to be big enough that, by the time
  any one writer trips the shared `writer_halfpoint` event and triggers
  `TRUNCATE`, the other concurrent writers are still in-flight around the same
  point — preserving the "truncate races against live concurrent writes"
  property the test exists to check.
- `cks_to_insert_after_trunc` only needs enough rows past the truncate
  boundary to validate `min_ck`/`count_after_trunc` per writer.

The writer count (50) and the rest of the test's structure/logic are
unchanged, so the concurrency characteristics are preserved. Each writer's
inserts are also kept strictly sequential (not batched/pipelined), since the
test's correctness depends on each writer's `ck` increasing in the same order
the writes are actually applied, bracketed by `trunc_started_event` /
`trunc_completed_event`.

## Testing

Verified with `dbuild` (`mode=dev`), 4 consecutive runs — all passed,
runtime ~10-12s (down from 185s), no flakiness observed.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-2281