### PR TITLE
test: fix test_cas_semaphore exceeding 60s threshold in dev mode

### DIFF
--- a/test/cluster/test_lwt_semaphore.py
+++ b/test/cluster/test_lwt_semaphore.py
@@ -7,7 +7,7 @@
 import asyncio
 import time
 from test.pylib.rest_client import inject_error
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for_cql
 import pytest
 from cassandra.protocol import WriteTimeout
 from test.cluster.util import new_test_keyspace
@@ -18,7 +18,7 @@ async def test_cas_semaphore(manager):
     """ This is a regression test for scylladb/scylladb#19698 """
     servers = await manager.servers_add(1, cmdline=['--smp', '1'])
 
-    host = await wait_for_cql_and_get_hosts(manager.cql, {servers[0]}, time.time() + 60)
+    await wait_for_cql(manager.cql, time.time() + 60)
 
     async with new_test_keyspace(manager, "WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         table = f"{ks}.test"
@@ -27,20 +27,29 @@ async def test_cas_semaphore(manager):
         # Lower write timeout only for the CAS phase, after paxos state table
         # creation (which goes through raft) has had time to complete with the
         # default timeout.
+        #
+        # write_request_timeout_in_ms is only read when a CQL connection is
+        # established (it's snapshotted into that connection's client_state),
+        # so a fresh, exclusive connection is required for the new value to
+        # actually apply: manager.cql's existing connection would keep using
+        # whatever timeout was in effect when it first connected.
         await manager.server_update_config(servers[0].server_id, 'write_request_timeout_in_ms', 500)
+        cql = await manager.get_cql_exclusive(servers[0])
 
         async with inject_error(manager.api, servers[0].ip_addr, 'cas_timeout_after_lock'):
-            res = [manager.cql.run_async(f"INSERT INTO {table} (a) VALUES (0) IF NOT EXISTS", host=host[0]) for r in range(10)]
+            res = [cql.run_async(f"INSERT INTO {table} (a) VALUES (0) IF NOT EXISTS") for r in range(10)]
             try:
                 await asyncio.gather(*res)
             except WriteTimeout:
                 pass
 
         # Restore a generous timeout so the second batch isn't affected by
-        # lingering raft apply latency.
+        # lingering raft apply latency. Again requires a fresh connection to
+        # take effect, for the same reason as above.
         await manager.server_update_config(servers[0].server_id, 'write_request_timeout_in_ms', 10000)
+        cql = await manager.get_cql_exclusive(servers[0])
 
-        res = [manager.cql.run_async(f"INSERT INTO {table} (a) VALUES (0) IF NOT EXISTS", host=host[0]) for r in range(10)]
+        res = [cql.run_async(f"INSERT INTO {table} (a) VALUES (0) IF NOT EXISTS") for r in range(10)]
         await asyncio.gather(*res)
 
         metrics = await manager.metrics.query(servers[0].ip_addr)

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -96,7 +96,7 @@ async def wait_for(
             before_retry()
 
 
-async def wait_for_cql(cql: Session, host: Host, deadline: float) -> None:
+async def wait_for_cql(cql: Session, deadline: float, host: Optional[Host] = None) -> None:
     async def cql_ready():
         try:
             await cql.run_async("select * from system.local", host=host)
@@ -143,7 +143,7 @@ async def wait_for_cql_and_get_hosts(cql: Session, servers: list[ServerInfo], de
     servers_by_ip = {srv.rpc_address: i for i, srv in enumerate(servers)}
     hosts.sort(key=lambda x: servers_by_ip[x.address])
 
-    await asyncio.gather(*(wait_for_cql(cql, h, deadline) for h in hosts))
+    await asyncio.gather(*(wait_for_cql(cql, deadline, h) for h in hosts))
 
     return hosts
 


### PR DESCRIPTION
## Summary

`test_cas_semaphore` (`test/cluster/test_lwt_semaphore.py`) took ~65s in dev mode, exceeding the 60s threshold.

The test lowers `write_request_timeout_in_ms` to 500 via `server_update_config` so the CAS phase fails fast under contention, then restores it to 10000 for the second batch. But `write_request_timeout_in_ms` is only read once, when a CQL connection is established: `transport/server.cc` snapshots it into that connection's `client_state` at construction time, so an already-open connection never observes a later config reload.

`manager.cql`'s connection to the node was already open (from `wait_for_cql_and_get_hosts`), so both `server_update_config` calls were silently ineffective for it. The 9 losing CAS requests in each wave kept using the test framework's dev-mode default of 60000ms (`scale_timeout_by_mode('dev', 30000)`) to wait for the per-partition CAS lock, instead of the intended 500ms — confirmed via trace logging, which showed all 9 losers report `Semaphore timedout` at exactly the 60.04s mark.

Fix: use `manager.get_cql_exclusive()` to open a fresh connection after each config update, so the new timeout actually takes effect.

## Test plan

- [x] Ran `./test.py --mode dev test/cluster/test_lwt_semaphore.py::test_cas_semaphore` 4 consecutive times: runtime dropped from ~65s to ~5-9s, well under the 60s threshold, with no flakiness.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2276