### PR TITLE
compaction: Apply proper size tiering when tiny sstables are being generated

### DIFF
--- a/compaction/incremental_compaction_strategy.cc
+++ b/compaction/incremental_compaction_strategy.cc
@@ -176,6 +176,10 @@ incremental_compaction_strategy::get_buckets(const std::vector<sstables::frozen_
         return i.second < j.second;
     });
 
+    auto min_sstable_size_check = [&runs, &options] (uint64_t size) {
+        return !tiny_sstables_written_recently(options.min_sstable_size, runs) && size < options.min_sstable_size;
+    };
+
     using bucket_type = std::vector<sstables::frozen_sstable_run>;
     std::vector<bucket_type> bucket_list;
     std::vector<double> bucket_average_size_list;
@@ -190,7 +194,7 @@ incremental_compaction_strategy::get_buckets(const std::vector<sstables::frozen_
             auto& bucket_average_size = bucket_average_size_list.back();
 
             if ((size > (bucket_average_size * options.bucket_low) && size < (bucket_average_size * options.bucket_high)) ||
-                    (size < options.min_sstable_size && bucket_average_size < options.min_sstable_size)) {
+                    (min_sstable_size_check(size) && min_sstable_size_check(bucket_average_size))) {
                 auto& bucket = bucket_list.back();
                 auto total_size = bucket.size() * bucket_average_size;
                 auto new_average_size = (total_size + size) / (bucket.size() + 1);
@@ -200,7 +204,7 @@ incremental_compaction_strategy::get_buckets(const std::vector<sstables::frozen_
                 // average might drift upwards.
                 // Don't let it drift too high, to a point where the smallest
                 // SSTable might fall out of range.
-                if (size < options.min_sstable_size || smallest_run_in_bucket > new_average_size * options.bucket_low) {
+                if (min_sstable_size_check(size) || smallest_run_in_bucket > new_average_size * options.bucket_low) {
                     bucket.push_back(pair.first);
                     bucket_average_size = new_average_size;
                     continue;

--- a/compaction/incremental_compaction_strategy.cc
+++ b/compaction/incremental_compaction_strategy.cc
@@ -29,10 +29,27 @@ static long validate_min_sstable_size(const std::map<sstring, sstring>& options)
     return min_sstable_size;
 }
 
+static std::chrono::seconds validate_min_sstable_age(const std::map<sstring, sstring>& options) {
+    auto min_sstable_age = cql3::statements::property_definitions::to_long(incremental_compaction_strategy_options::MIN_SSTABLE_AGE_KEY,
+        compaction_strategy_impl::get_value(options, incremental_compaction_strategy_options::MIN_SSTABLE_AGE_KEY),
+        incremental_compaction_strategy_options::DEFAULT_MIN_SSTABLE_AGE.count());
+    if (min_sstable_age < 0) {
+        throw exceptions::configuration_exception(fmt::format("{} value ({}) must be non negative",
+            incremental_compaction_strategy_options::MIN_SSTABLE_AGE_KEY, min_sstable_age));
+    }
+    return std::chrono::seconds(min_sstable_age);
+}
+
 static long validate_min_sstable_size(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options) {
     auto min_sstable_size = validate_min_sstable_size(options);
     unchecked_options.erase(incremental_compaction_strategy_options::MIN_SSTABLE_SIZE_KEY);
     return min_sstable_size;
+}
+
+static std::chrono::seconds validate_min_sstable_age(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options) {
+    auto min_sstable_age = validate_min_sstable_age(options);
+    unchecked_options.erase(incremental_compaction_strategy_options::MIN_SSTABLE_AGE_KEY);
+    return min_sstable_age;
 }
 
 static double validate_bucket_low(const std::map<sstring, sstring>& options) {
@@ -111,6 +128,7 @@ static std::optional<double> validate_space_amplification_goal(const std::map<ss
 
 incremental_compaction_strategy_options::incremental_compaction_strategy_options(const std::map<sstring, sstring>& options) {
     min_sstable_size = validate_min_sstable_size(options);
+    min_sstable_age = validate_min_sstable_age(options);
     bucket_low = validate_bucket_low(options);
     bucket_high = validate_bucket_high(options);
 }
@@ -120,6 +138,7 @@ incremental_compaction_strategy_options::incremental_compaction_strategy_options
 // This helps making sure that only allowed options are being set.
 void incremental_compaction_strategy_options::validate(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options) {
     validate_min_sstable_size(options, unchecked_options);
+    validate_min_sstable_age(options, unchecked_options);
     auto bucket_low = validate_bucket_low(options, unchecked_options);
     auto bucket_high = validate_bucket_high(options, unchecked_options);
     if (bucket_high <= bucket_low) {
@@ -177,7 +196,7 @@ incremental_compaction_strategy::get_buckets(const std::vector<sstables::frozen_
     });
 
     auto min_sstable_size_check = [&runs, &options] (uint64_t size) {
-        return !tiny_sstables_written_recently(options.min_sstable_size, runs) && size < options.min_sstable_size;
+        return !tiny_sstables_written_recently(options.min_sstable_size, options.min_sstable_age, runs) && size < options.min_sstable_size;
     };
 
     using bucket_type = std::vector<sstables::frozen_sstable_run>;

--- a/compaction/incremental_compaction_strategy.hh
+++ b/compaction/incremental_compaction_strategy.hh
@@ -8,6 +8,8 @@
 
 #include "compaction_strategy_impl.hh"
 
+#include <chrono>
+
 namespace compaction {
 
 class incremental_backlog_tracker;
@@ -15,14 +17,17 @@ class incremental_backlog_tracker;
 class incremental_compaction_strategy_options {
 public:
     static constexpr uint64_t DEFAULT_MIN_SSTABLE_SIZE = 50L * 1024L * 1024L;
+    static constexpr std::chrono::seconds DEFAULT_MIN_SSTABLE_AGE = std::chrono::hours(1);
     static constexpr double DEFAULT_BUCKET_LOW = 0.7071;
     static constexpr double DEFAULT_BUCKET_HIGH = 1.4142;
 
     static constexpr auto MIN_SSTABLE_SIZE_KEY = "min_sstable_size";
+    static constexpr auto MIN_SSTABLE_AGE_KEY = "min_sstable_age";
     static constexpr auto BUCKET_LOW_KEY = "bucket_low";
     static constexpr auto BUCKET_HIGH_KEY = "bucket_high";
 private:
     uint64_t min_sstable_size = DEFAULT_MIN_SSTABLE_SIZE;
+    std::chrono::seconds min_sstable_age = DEFAULT_MIN_SSTABLE_AGE;
     double bucket_low = DEFAULT_BUCKET_LOW;
     double bucket_high = DEFAULT_BUCKET_HIGH;
 public:
@@ -30,6 +35,7 @@ public:
 
     incremental_compaction_strategy_options() {
         min_sstable_size = DEFAULT_MIN_SSTABLE_SIZE;
+        min_sstable_age = DEFAULT_MIN_SSTABLE_AGE;
         bucket_low = DEFAULT_BUCKET_LOW;
         bucket_high = DEFAULT_BUCKET_HIGH;
     }
@@ -104,12 +110,12 @@ public:
     friend class compaction::incremental_backlog_tracker;
 };
 
-// Returns true whether any tiny sstable run, i.e. a run smaller than option.min_sstable_size, was written in the last hour.
+// Returns true whether any tiny sstable run, i.e. a run smaller than option.min_sstable_size, was written within the last min_sstable_age.
 template <std::ranges::range Range>
 requires std::convertible_to<std::ranges::range_value_t<Range>, sstables::shared_sstable> || std::convertible_to<std::ranges::range_value_t<Range>, sstables::frozen_sstable_run>
-bool tiny_sstables_written_recently(uint64_t min_sstable_size, const Range& sstable_runs) {
-    return std::ranges::any_of(sstable_runs, [min_sstable_size, now = db_clock::now()] (const std::ranges::range_value_t<Range>& r) {
-        return r->data_size() < min_sstable_size && r->data_file_write_time() > (now - db_clock::duration(std::chrono::seconds(3600)));
+bool tiny_sstables_written_recently(uint64_t min_sstable_size, db_clock::duration min_sstable_age, const Range& sstable_runs) {
+    return std::ranges::any_of(sstable_runs, [min_sstable_size, min_sstable_age, now = db_clock::now()] (const std::ranges::range_value_t<Range>& r) {
+        return r->data_size() < min_sstable_size && r->data_file_write_time() > (now - min_sstable_age);
     });
 }
 

--- a/compaction/incremental_compaction_strategy.hh
+++ b/compaction/incremental_compaction_strategy.hh
@@ -55,8 +55,6 @@ private:
     std::optional<double> _space_amplification_goal;
     static std::vector<sstable_run_and_length> create_run_and_length_pairs(const std::vector<sstables::frozen_sstable_run>& runs);
 
-    static std::vector<std::vector<sstables::frozen_sstable_run>> get_buckets(const std::vector<sstables::frozen_sstable_run>& runs, const incremental_compaction_strategy_options& options);
-
     std::vector<std::vector<sstables::frozen_sstable_run>> get_buckets(const std::vector<sstables::frozen_sstable_run>& runs) const {
         return get_buckets(runs, _options);
     }
@@ -82,6 +80,9 @@ public:
 
     static void validate_options(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options);
 
+    // Group runs of similar size into buckets.
+    static std::vector<std::vector<sstables::frozen_sstable_run>> get_buckets(const std::vector<sstables::frozen_sstable_run>& runs, const incremental_compaction_strategy_options& options);
+
     virtual future<compaction_descriptor> get_sstables_for_compaction(compaction_group_view& t, strategy_control& control) override;
 
     virtual std::vector<compaction_descriptor> get_cleanup_compaction_jobs(compaction_group_view& t, std::vector<sstables::shared_sstable> candidates) const override;
@@ -102,5 +103,14 @@ public:
 
     friend class compaction::incremental_backlog_tracker;
 };
+
+// Returns true whether any tiny sstable run, i.e. a run smaller than option.min_sstable_size, was written in the last hour.
+template <std::ranges::range Range>
+requires std::convertible_to<std::ranges::range_value_t<Range>, sstables::shared_sstable> || std::convertible_to<std::ranges::range_value_t<Range>, sstables::frozen_sstable_run>
+bool tiny_sstables_written_recently(uint64_t min_sstable_size, const Range& sstable_runs) {
+    return std::ranges::any_of(sstable_runs, [min_sstable_size, now = db_clock::now()] (const std::ranges::range_value_t<Range>& r) {
+        return r->data_size() < min_sstable_size && r->data_file_write_time() > (now - db_clock::duration(std::chrono::seconds(3600)));
+    });
+}
 
 }

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -23,10 +23,26 @@ static long validate_sstable_size(const std::map<sstring, sstring>& options) {
     return min_sstables_size;
 }
 
+static std::chrono::seconds validate_min_sstable_age(const std::map<sstring, sstring>& options) {
+    auto min_sstable_age = cql3::statements::property_definitions::to_long(size_tiered_compaction_strategy_options::MIN_SSTABLE_AGE_KEY,
+        compaction_strategy_impl::get_value(options, size_tiered_compaction_strategy_options::MIN_SSTABLE_AGE_KEY),
+        size_tiered_compaction_strategy_options::DEFAULT_MIN_SSTABLE_AGE.count());
+    if (min_sstable_age < 0) {
+        throw exceptions::configuration_exception(fmt::format("{} value ({}) must be non negative", size_tiered_compaction_strategy_options::MIN_SSTABLE_AGE_KEY, min_sstable_age));
+    }
+    return std::chrono::seconds(min_sstable_age);
+}
+
 static long validate_sstable_size(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options) {
     auto min_sstables_size = validate_sstable_size(options);
     unchecked_options.erase(size_tiered_compaction_strategy_options::MIN_SSTABLE_SIZE_KEY);
     return min_sstables_size;
+}
+
+static std::chrono::seconds validate_min_sstable_age(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options) {
+    auto min_sstable_age = validate_min_sstable_age(options);
+    unchecked_options.erase(size_tiered_compaction_strategy_options::MIN_SSTABLE_AGE_KEY);
+    return min_sstable_age;
 }
 
 static double validate_bucket_low(const std::map<sstring, sstring>& options) {
@@ -78,6 +94,7 @@ size_tiered_compaction_strategy_options::size_tiered_compaction_strategy_options
     using namespace cql3::statements;
 
     min_sstable_size = validate_sstable_size(options);
+    min_sstable_age = validate_min_sstable_age(options);
     bucket_low = validate_bucket_low(options);
     bucket_high = validate_bucket_high(options);
     cold_reads_to_omit = validate_cold_reads_to_omit(options);
@@ -85,6 +102,7 @@ size_tiered_compaction_strategy_options::size_tiered_compaction_strategy_options
 
 size_tiered_compaction_strategy_options::size_tiered_compaction_strategy_options() {
     min_sstable_size = DEFAULT_MIN_SSTABLE_SIZE;
+    min_sstable_age = DEFAULT_MIN_SSTABLE_AGE;
     bucket_low = DEFAULT_BUCKET_LOW;
     bucket_high = DEFAULT_BUCKET_HIGH;
     cold_reads_to_omit = DEFAULT_COLD_READS_TO_OMIT;
@@ -95,6 +113,7 @@ size_tiered_compaction_strategy_options::size_tiered_compaction_strategy_options
 // This helps making sure that only allowed options are being set.
 void size_tiered_compaction_strategy_options::validate(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options) {
     validate_sstable_size(options, unchecked_options);
+    validate_min_sstable_age(options, unchecked_options);
     auto bucket_low = validate_bucket_low(options, unchecked_options);
     auto bucket_high = validate_bucket_high(options, unchecked_options);
     if (bucket_high <= bucket_low) {
@@ -130,7 +149,7 @@ size_tiered_compaction_strategy::get_buckets(const std::vector<sstables::shared_
     });
 
     auto min_sstable_size_check = [&sstables, &options] (uint64_t size) {
-        return !tiny_sstables_written_recently(options.min_sstable_size, sstables) && size < options.min_sstable_size;
+        return !tiny_sstables_written_recently(options.min_sstable_size, options.min_sstable_age, sstables) && size < options.min_sstable_size;
     };
 
     using bucket_type = std::vector<sstables::shared_sstable>;

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -9,6 +9,7 @@
 #include "utils/assert.hh"
 #include "sstables/sstables.hh"
 #include "size_tiered_compaction_strategy.hh"
+#include "incremental_compaction_strategy.hh"
 #include "cql3/statements/property_definitions.hh"
 
 namespace compaction {
@@ -128,6 +129,10 @@ size_tiered_compaction_strategy::get_buckets(const std::vector<sstables::shared_
         return i.second < j.second;
     });
 
+    auto min_sstable_size_check = [&sstables, &options] (uint64_t size) {
+        return !tiny_sstables_written_recently(options.min_sstable_size, sstables) && size < options.min_sstable_size;
+    };
+
     using bucket_type = std::vector<sstables::shared_sstable>;
     std::vector<bucket_type> bucket_list;
     std::vector<double> bucket_average_size_list;
@@ -142,7 +147,7 @@ size_tiered_compaction_strategy::get_buckets(const std::vector<sstables::shared_
             auto& bucket_average_size = bucket_average_size_list.back();
 
             if ((size > (bucket_average_size * options.bucket_low) && size < (bucket_average_size * options.bucket_high)) ||
-                    (size < options.min_sstable_size && bucket_average_size < options.min_sstable_size)) {
+                    (min_sstable_size_check(size) && min_sstable_size_check(bucket_average_size))) {
                 auto& bucket = bucket_list.back();
                 auto total_size = bucket.size() * bucket_average_size;
                 auto new_average_size = (total_size + size) / (bucket.size() + 1);
@@ -152,7 +157,7 @@ size_tiered_compaction_strategy::get_buckets(const std::vector<sstables::shared_
                 // average might drift upwards.
                 // Don't let it drift too high, to a point where the smallest
                 // SSTable might fall out of range.
-                if (size < options.min_sstable_size || smallest_sstable_in_bucket > new_average_size * options.bucket_low) {
+                if (min_sstable_size_check(size) || smallest_sstable_in_bucket > new_average_size * options.bucket_low) {
                     bucket.push_back(pair.first);
                     bucket_average_size = new_average_size;
                     continue;

--- a/compaction/size_tiered_compaction_strategy.hh
+++ b/compaction/size_tiered_compaction_strategy.hh
@@ -50,9 +50,6 @@ class size_tiered_compaction_strategy : public compaction_strategy_impl {
     // Return a list of pair of shared_sstable and its respective size.
     static std::vector<std::pair<sstables::shared_sstable, uint64_t>> create_sstable_and_length_pairs(const std::vector<sstables::shared_sstable>& sstables);
 
-    // Group files of similar size into buckets.
-    static std::vector<std::vector<sstables::shared_sstable>> get_buckets(const std::vector<sstables::shared_sstable>& sstables, size_tiered_compaction_strategy_options options);
-
     std::vector<std::vector<sstables::shared_sstable>> get_buckets(const std::vector<sstables::shared_sstable>& sstables) const;
 
     // Maybe return a bucket of sstables to compact
@@ -74,6 +71,9 @@ public:
     size_tiered_compaction_strategy(const std::map<sstring, sstring>& options);
     explicit size_tiered_compaction_strategy(const size_tiered_compaction_strategy_options& options);
     static void validate_options(const std::map<sstring, sstring>& options, std::map<sstring, sstring>& unchecked_options);
+
+    // Group files of similar size into buckets.
+    static std::vector<std::vector<sstables::shared_sstable>> get_buckets(const std::vector<sstables::shared_sstable>& sstables, size_tiered_compaction_strategy_options options);
 
     virtual future<compaction_descriptor> get_sstables_for_compaction(compaction_group_view& table_s, strategy_control& control) override;
 

--- a/compaction/size_tiered_compaction_strategy.hh
+++ b/compaction/size_tiered_compaction_strategy.hh
@@ -11,6 +11,8 @@
 #include "compaction_strategy_impl.hh"
 #include "sstables/shared_sstable.hh"
 
+#include <chrono>
+
 namespace compaction {
 
 class size_tiered_backlog_tracker;
@@ -18,15 +20,18 @@ class size_tiered_backlog_tracker;
 class size_tiered_compaction_strategy_options {
 public:
     static constexpr uint64_t DEFAULT_MIN_SSTABLE_SIZE = 50L * 1024L * 1024L;
+    static constexpr std::chrono::seconds DEFAULT_MIN_SSTABLE_AGE = std::chrono::hours(1);
     static constexpr double DEFAULT_BUCKET_LOW = 0.5;
     static constexpr double DEFAULT_BUCKET_HIGH = 1.5;
     static constexpr double DEFAULT_COLD_READS_TO_OMIT = 0.05;
     static constexpr auto MIN_SSTABLE_SIZE_KEY = "min_sstable_size";
+    static constexpr auto MIN_SSTABLE_AGE_KEY = "min_sstable_age";
     static constexpr auto BUCKET_LOW_KEY = "bucket_low";
     static constexpr auto BUCKET_HIGH_KEY = "bucket_high";
     static constexpr auto COLD_READS_TO_OMIT_KEY = "cold_reads_to_omit";
 private:
     uint64_t min_sstable_size = DEFAULT_MIN_SSTABLE_SIZE;
+    std::chrono::seconds min_sstable_age = DEFAULT_MIN_SSTABLE_AGE;
     double bucket_low = DEFAULT_BUCKET_LOW;
     double bucket_high = DEFAULT_BUCKET_HIGH;
     double cold_reads_to_omit =  DEFAULT_COLD_READS_TO_OMIT;

--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -95,6 +95,7 @@ The following options only apply to SizeTieredCompactionStrategy:
      'bucket_high' : factor,
      'bucket_low' : factor, 
      'min_sstable_size' : int,
+     'min_sstable_age' : sec,
      'min_threshold' : num_sstables,
      'max_threshold' : num_sstables}
 
@@ -121,7 +122,14 @@ The following options only apply to SizeTieredCompactionStrategy:
 =====
 
 ``min_sstable_size`` (default: 52,428,800)
-   All SSTables smaller than this number of bytes are put into the same bucket.
+   All SSTables smaller than this number of bytes are eligible to be put into the same bucket, provided they are at least ``min_sstable_age`` old.
+
+=====
+
+``min_sstable_age`` (default: 3600)
+   The minimum age, in seconds, an SSTable must have before it is eligible to be put into the same bucket as other SSTables smaller than ``min_sstable_size``.
+   SSTables smaller than ``min_sstable_size`` that were written more recently than this are kept in their own size tier, so that similarly sized SSTables
+   are compacted together while they are still being actively written, avoiding excessive write amplification.
 
 =====
 
@@ -198,6 +206,7 @@ The following options only apply to IncrementalCompactionStrategy:
      'bucket_high' : factor,
      'bucket_low' : factor,
      'min_sstable_size' : int,
+     'min_sstable_age' : sec,
      'min_threshold' : num_sstables,
      'max_threshold' : num_sstables,
      'sstable_size_in_mb' : int,
@@ -224,10 +233,17 @@ The following options only apply to IncrementalCompactionStrategy:
 =====
 
 ``min_sstable_size`` (default: 50)
-   All SSTables smaller than this number of megabytes are put into the same bucket.
+   All SSTables smaller than this number of megabytes are eligible to be put into the same bucket, provided they are at least ``min_sstable_age`` old.
 
    Unlike Apache Cassandra, scylla uses **uncompressed** size when bucketing similar-sized tiers together.
    Since compaction works on uncompressed data, SSTables containing similar amounts of data should be compacted together, even when they have different compression ratios.
+
+=====
+
+``min_sstable_age`` (default: 3600)
+   The minimum age, in seconds, an SSTable must have before it is eligible to be put into the same bucket as other SSTables smaller than ``min_sstable_size``.
+   SSTables smaller than ``min_sstable_size`` that were written more recently than this are kept in their own size tier, so that similarly sized SSTables
+   are compacted together while they are still being actively written, avoiding excessive write amplification.
 
 =====
 

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -98,6 +98,13 @@ sstables::run_id sstable_run::run_identifier() const {
     return (_all.empty()) ? run_id() : (*_all.begin())->run_identifier();
 }
 
+db_clock::time_point sstable_run::data_file_write_time() const {
+    if (_all.empty()) {
+        return db_clock::time_point();
+    }
+    return std::ranges::max(_all | std::views::transform([](const shared_sstable& s) { return s->data_file_write_time(); }));
+}
+
 std::ostream& operator<<(std::ostream& os, const sstables::sstable_run& run) {
     os << "Run = {\n";
     if (run.all().empty()) {

--- a/sstables/sstable_set.hh
+++ b/sstables/sstable_set.hh
@@ -57,6 +57,9 @@ public:
     const sstable_set& all() const { return _all; }
     double estimate_droppable_tombstone_ratio(const gc_clock::time_point& compaction_time, const tombstone_gc_state& gc_state, const schema_ptr& s) const;
     run_id run_identifier() const;
+    // the sstable with oldest mtime represents the whole run, as it would be
+    // the mtime had the run be composed of a single sstable.
+    db_clock::time_point data_file_write_time() const;
 };
 
 using shared_sstable_run = lw_shared_ptr<sstable_run>;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7932,14 +7932,25 @@ SEASTAR_TEST_CASE(test_size_tiering_for_tiny_sstables) {
         auto tiny_sst = make_sstable(tiny_sstable_size);
         auto medium_sst = make_sstable(medium_sstable_size);
 
-        auto expect_buckets = [&] (unsigned expected_bucket_count, db_clock::time_point write_time) {
+        // Build compaction strategy options with a specific min_sstable_age, keeping all other defaults.
+        auto make_options = [] (std::chrono::seconds min_sstable_age) {
+            std::map<sstring, sstring> options = {
+                { "min_sstable_age", std::to_string(min_sstable_age.count()) },
+            };
+            return std::pair<compaction::size_tiered_compaction_strategy_options,
+                             compaction::incremental_compaction_strategy_options>(options, options);
+        };
+
+        auto expect_buckets = [&] (unsigned expected_bucket_count, db_clock::time_point write_time, std::chrono::seconds min_sstable_age) {
             sstables::test(tiny_sst).set_data_file_write_time(write_time);
             sstables::test(medium_sst).set_data_file_write_time(write_time);
 
+            auto [stcs_options, ics_options] = make_options(min_sstable_age);
+
             // SSTables of 1M and 40M, both smaller than min_sstable_size (50M), must end up
-            // in the same tier only if they were not written recently. Otherwise, they must
-            // stay in distinct tiers so that similarly sized sstables are compacted together.
-            compaction::size_tiered_compaction_strategy_options stcs_options;
+            // in the same tier only if they were not written within the last min_sstable_age.
+            // Otherwise, they must stay in distinct tiers so that similarly sized sstables are
+            // compacted together.
             auto stcs_buckets = compaction::size_tiered_compaction_strategy::get_buckets({ tiny_sst, medium_sst }, stcs_options);
             BOOST_REQUIRE_EQUAL(stcs_buckets.size(), expected_bucket_count);
 
@@ -7947,15 +7958,23 @@ SEASTAR_TEST_CASE(test_size_tiering_for_tiny_sstables) {
                 make_lw_shared<const sstables::sstable_run>(sstables::sstable_run(tiny_sst)),
                 make_lw_shared<const sstables::sstable_run>(sstables::sstable_run(medium_sst)),
             };
-            compaction::incremental_compaction_strategy_options ics_options;
             auto ics_buckets = compaction::incremental_compaction_strategy::get_buckets(runs, ics_options);
             BOOST_REQUIRE_EQUAL(ics_buckets.size(), expected_bucket_count);
         };
 
-        // Tiny sstables written recently must stay in their own tiers.
-        expect_buckets(2, db_clock::now());
-        // Tiny sstables which are no longer actively written can be squashed into the same tier.
-        expect_buckets(1, db_clock::now() - std::chrono::hours(2));
+        constexpr std::chrono::seconds age_1h = std::chrono::hours(1);
+        constexpr std::chrono::seconds age_10h = std::chrono::hours(10);
+        const auto now = db_clock::now();
+
+        // With the default min_sstable_age of 1h, tiny sstables written recently must stay in
+        // their own tiers, while those written more than 1h ago can be squashed into the same tier.
+        expect_buckets(2, now, age_1h);
+        expect_buckets(1, now - std::chrono::hours(2), age_1h);
+
+        // A longer min_sstable_age keeps tiny sstables in their own tiers for longer: 2h-old
+        // sstables are still "recent" under a 10h window, whereas 12h-old ones are squashed.
+        expect_buckets(2, now - std::chrono::hours(2), age_10h);
+        expect_buckets(1, now - std::chrono::hours(12), age_10h);
     });
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2211,6 +2211,10 @@ void time_window_strategy_size_tiered_behavior_correctness_fn(test_env& env) {
         auto key = partition_key::from_exploded(*s, {to_bytes("key" + to_sstring(ts))});
         auto mut = make_insert(std::move(key), ts);
         auto sst = make_sstable_containing(sst_gen, {std::move(mut)}).get();
+        // The size-tiered fallback, used for past windows, only squashes tiny sstables into the same
+        // tier if none of them were recently written. SStables composing a past window are expected
+        // to be old, as they were written before the window expired, so let's fake their write time.
+        sstables::test(sst).set_data_file_write_time(db_clock::now() - std::chrono::hours(2));
         auto bound = compaction::time_window_compaction_strategy::get_window_lower_bound(window_size, window_ts);
         buckets[bound].push_back(std::move(sst));
     };
@@ -2221,6 +2225,8 @@ void time_window_strategy_size_tiered_behavior_correctness_fn(test_env& env) {
         auto bound = compaction::time_window_compaction_strategy::get_window_lower_bound(window_size, window_ts);
         auto ret = compact_sstables(env, compaction::compaction_descriptor(std::move(buckets[bound])), cf, sst_gen).get();
         BOOST_REQUIRE(ret.new_sstables.size() == 1);
+        // Same rationale as above: the compacted sstable represents old data of a past window.
+        sstables::test(ret.new_sstables.front()).set_data_file_write_time(db_clock::now() - std::chrono::hours(2));
         buckets[bound] = std::move(ret.new_sstables);
     };
 
@@ -6299,6 +6305,10 @@ void test_compaction_strategy_cleanup_method_fn(test_env& env, size_t all_files 
         parallel_for_each(std::views::iota(size_t(0), all_files), [&](size_t i) -> future<> {
             auto current_step = duration_cast<microseconds>(step_base) * i;
             auto sst = co_await make_sstable_containing(sst_gen, {make_mutation(i, next_timestamp(current_step))});
+            // Cleanup operates on existing data, so the sstables are not expected to have been
+            // recently written. This is required so that tiny sstables, i.e. those smaller than
+            // min_sstable_size, are placed into the same size tier by the strategy.
+            sstables::test(sst).set_data_file_write_time(db_clock::now() - std::chrono::hours(2));
             sst->set_sstable_level(sstable_level);
             candidates[i] = std::move(sst);
         }).get();
@@ -7897,6 +7907,55 @@ SEASTAR_TEST_CASE(test_last_gc_sstable_is_not_leaked_on_successful_compaction) {
         BOOST_REQUIRE_MESSAGE(extra.empty(),
                 fmt::format("compaction created sstable(s) it never attached nor deleted: [{}]",
                             fmt::join(extra, ", ")));
+    });
+}
+
+SEASTAR_TEST_CASE(test_size_tiering_for_tiny_sstables) {
+    return test_env::do_with_async([] (test_env& env) {
+        auto s = schema_builder(this_smp_shard_count(), "tests", "tiny_sstables")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("value", int32_type)
+                .build();
+
+        auto make_sstable = [&] (uint64_t data_size) {
+            auto sst = env.make_sstable(s, "/nowhere/in/particular", env.new_generation(), sstable_version_types::md, big);
+            auto keys = tests::generate_partition_keys(2, s, local_shard_only::yes);
+            sstables::test(sst).set_values(keys[0].key(), keys[1].key(), stats_metadata{}, data_size);
+            return sst;
+        };
+
+        constexpr uint64_t min_sstable_size = 50 * 1024 * 1024;
+        constexpr uint64_t tiny_sstable_size = 1 * 1024 * 1024;
+        constexpr uint64_t medium_sstable_size = 40 * 1024 * 1024;
+        static_assert(tiny_sstable_size < min_sstable_size && medium_sstable_size < min_sstable_size);
+
+        auto tiny_sst = make_sstable(tiny_sstable_size);
+        auto medium_sst = make_sstable(medium_sstable_size);
+
+        auto expect_buckets = [&] (unsigned expected_bucket_count, db_clock::time_point write_time) {
+            sstables::test(tiny_sst).set_data_file_write_time(write_time);
+            sstables::test(medium_sst).set_data_file_write_time(write_time);
+
+            // SSTables of 1M and 40M, both smaller than min_sstable_size (50M), must end up
+            // in the same tier only if they were not written recently. Otherwise, they must
+            // stay in distinct tiers so that similarly sized sstables are compacted together.
+            compaction::size_tiered_compaction_strategy_options stcs_options;
+            auto stcs_buckets = compaction::size_tiered_compaction_strategy::get_buckets({ tiny_sst, medium_sst }, stcs_options);
+            BOOST_REQUIRE_EQUAL(stcs_buckets.size(), expected_bucket_count);
+
+            std::vector<sstables::frozen_sstable_run> runs = {
+                make_lw_shared<const sstables::sstable_run>(sstables::sstable_run(tiny_sst)),
+                make_lw_shared<const sstables::sstable_run>(sstables::sstable_run(medium_sst)),
+            };
+            compaction::incremental_compaction_strategy_options ics_options;
+            auto ics_buckets = compaction::incremental_compaction_strategy::get_buckets(runs, ics_options);
+            BOOST_REQUIRE_EQUAL(ics_buckets.size(), expected_bucket_count);
+        };
+
+        // Tiny sstables written recently must stay in their own tiers.
+        expect_buckets(2, db_clock::now());
+        // Tiny sstables which are no longer actively written can be squashed into the same tier.
+        expect_buckets(1, db_clock::now() - std::chrono::hours(2));
     });
 }
 


### PR DESCRIPTION
It was noticed that early flushes can cause high write amplification due to the min_sstable_size setting, defaults to 50M. Every sstable smaller than the min_sstable_size will be placed into same size tier. What it means in practice is that sstables with wildly different sizes might be compacted together, e.g. a 50K sstable with a 50M one, leading to an increase in expected write amplification. The idea behind size tiered is that similar sized sstables are compacted together, in order to increase the overall efficiency.

This setting was introduced in C* to prevent tiny sstables from being forgotten in their small tiers, since creation of tiny sstables might be a rare event during a transient memory pressure. The more tiers, the more read amplification you might have due to amount of sstables to serve a key during a read.

This setting worked well until tablets, since each memtable spans a single range. And each replica in a shard will own about 1% of memory devoted for memtables. With 8G per shard, that's 4G for memtables, and about 40M per tablet replica.
Under certain conditions, e.g. commitlog driven flush, each replica's memtable might not even grow to 40M, triggering the write amplification problem. This is worsened with data ingestion and TWCS, where writes happen in token order rather than time order, and memtable flush will lead to segregation of data to ~25 windows, which can result in ~1.5M sstables on level 0.

To fix this, let's only "squash" small tiers together if none of their sstables were recently written. So if tiny sstables are still being actively written, we'll preserve original tiered nature of the strategy, i.e. similar sized sstables being compacted together, to prevent the write amplification from rising to the sky. The effect is that under scenarios where tiny sstables are produced, the strategy will be more efficient to allow the compaction backlog to be cleared.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-3330.

Not backporting since we don't know how things will behave with the change. We might reconsider the decision once we're more confident in the change.