### PR TITLE
test/boost/mutation_test: add digest difference test

### DIFF
--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1622,6 +1622,55 @@ SEASTAR_TEST_CASE(test_query_digest) {
     });
 }
 
+// Positive test verifying that every possible kind of difference between two mutations is detected by digest.
+SEASTAR_THREAD_TEST_CASE(test_query_digest_not_equal) {
+    auto now = gc_clock::now();
+
+    for_each_mutation_pair([&] (const mutation& m1, const mutation& m2, are_equal eq, std::string_view label) {
+        if (eq) {
+            return;
+        }
+
+        testlog.info("Running case {}", label);
+
+        if (m1.empty() || m2.empty()) {
+            testlog.info("Skipping case {}, empty mutations have the same digest", label);
+            return;
+        }
+
+        // range tombstones are not included in the digest
+        if (label == "range tombstone") {
+            testlog.info("Skipping case {}, range tombstone is not included in the digest", label);
+            return;
+        }
+
+        if (label == "row tombstone") {
+            testlog.info("Skipping case {}, row tombstone is not included in the digest", label);
+            return;
+        }
+
+        auto m3 = m1;
+        if (m1.schema()->version() != m2.schema()->version()) {
+            m3.upgrade(m2.schema());
+        }
+        const auto schema = m2.schema();
+
+        if (m2 == m3) {
+            // possible if the only difference is eliminated by the schema upgrade above
+            testlog.info("Skipping case {}, mutations identical after schema upgrade", label);
+            return;
+        }
+
+        auto ps = partition_slice_builder(*schema).build();
+        auto digest2 = *query_mutation(mutation(m2), ps, query::max_rows, now,
+                query::result_options::only_digest(query::digest_algorithm::xxHash)).digest();
+        auto digest3 = *query_mutation(mutation(m3), ps, query::max_rows, now,
+                query::result_options::only_digest(query::digest_algorithm::xxHash)).digest();
+
+        BOOST_CHECK_MESSAGE(digest2 != digest3, fmt::format("Digest should not be the same for:\nm1={}\nm2={}\nCase: {}", m2, m3, label));
+    });
+}
+
 SEASTAR_TEST_CASE(test_mutation_upgrade_of_equal_mutations) {
     return seastar::async([] {
         for_each_mutation_pair([](auto&& m1, auto&& m2, are_equal eq) {

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -1542,7 +1542,7 @@ SEASTAR_TEST_CASE(test_mutation_equality) {
 
 SEASTAR_TEST_CASE(test_mutation_hash) {
     return seastar::async([] {
-        for_each_mutation_pair([] (auto&& m1, auto&& m2, are_equal eq) {
+        for_each_mutation_pair([] (auto&& m1, auto&& m2, are_equal eq, std::string_view label) {
             auto test_with_hasher = [&] (auto hasher) {
                 auto get_hash = [&] (const mutation &m) {
                     auto h = hasher;
@@ -1558,7 +1558,7 @@ SEASTAR_TEST_CASE(test_mutation_hash) {
                 } else {
                     // We're using a strong hasher, collision should be unlikely
                     if (h1 == h2) {
-                        BOOST_FAIL(format("Hash should be different for {} and {}", m1, m2));
+                        BOOST_FAIL(fmt::format("Hash should be different for {} and {}, case {}", m1, m2, label));
                     }
                 }
             };
@@ -1590,7 +1590,7 @@ SEASTAR_TEST_CASE(test_query_digest) {
             }
         };
 
-        for_each_mutation_pair([&] (const mutation& m1, const mutation& m2, are_equal eq) {
+        for_each_mutation_pair([&] (const mutation& m1, const mutation& m2, are_equal eq, std::string_view label) {
             if (m1.schema()->version() != m2.schema()->version()) {
                 return;
             }
@@ -1599,7 +1599,7 @@ SEASTAR_TEST_CASE(test_query_digest) {
                 check_digests_equal(compacted(m1, now), m2);
                 check_digests_equal(m1, compacted(m2, now));
             } else {
-                testlog.info("If not equal, they should become so after applying diffs mutually");
+                testlog.info("If not equal (case {}), they should become so after applying diffs mutually", label);
 
                 mutation_application_stats app_stats;
                 schema_ptr s = m1.schema();

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1776,9 +1776,21 @@ void run_mutation_source_tests_reverse_read_back(populate_fn_ex populate, bool w
     });
 }
 
+struct unequal_mutation_pair {
+    mutation a;
+    mutation b;
+    sstring label;
+
+    unequal_mutation_pair(mutation a, mutation b, std::string_view label)
+        : a(std::move(a))
+        , b(std::move(b))
+        , label(label)
+    { }
+};
+
 struct mutation_sets {
     std::vector<utils::chunked_vector<mutation>> equal;
-    std::vector<utils::chunked_vector<mutation>> unequal;
+    std::vector<unequal_mutation_pair> unequal;
     mutation_sets(){}
 };
 
@@ -1813,10 +1825,11 @@ static mutation_sets generate_mutation_sets() {
         auto& key2 = local_keys[1];
 
         // Differing keys
-        result.unequal.emplace_back(mutations{
+        result.unequal.emplace_back(
             mutation(s1, key1),
-            mutation(s2, key2)
-        });
+            mutation(s2, key2),
+            "differing keys"
+        );
 
         auto m1 = mutation(s1, key1);
         auto m2 = mutation(s2, key1);
@@ -1829,7 +1842,7 @@ static mutation_sets generate_mutation_sets() {
         {
             auto tomb = new_tombstone();
             m1.partition().apply(tomb);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "partition tombstone");
             m2.partition().apply(tomb);
             result.equal.emplace_back(mutations{m1, m2});
         }
@@ -1838,7 +1851,7 @@ static mutation_sets generate_mutation_sets() {
             auto tomb = new_tombstone();
             auto key = clustering_key_prefix::from_deeply_exploded(*s1, {data_value(bytes("ck2_0"))});
             m1.partition().apply_row_tombstone(*s1, key, tomb);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "range tombstone");
             m2.partition().apply_row_tombstone(*s2, key, tomb);
             result.equal.emplace_back(mutations{m1, m2});
         }
@@ -1846,7 +1859,7 @@ static mutation_sets generate_mutation_sets() {
         {
             auto tomb = new_tombstone();
             m1.partition().apply_delete(*s1, ck2, tomb);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "row tombstone");
             m2.partition().apply_delete(*s2, ck2, tomb);
             result.equal.emplace_back(mutations{m1, m2});
         }
@@ -1856,7 +1869,7 @@ static mutation_sets generate_mutation_sets() {
             auto ts = new_timestamp();
             auto key_full = clustering_key_prefix::from_deeply_exploded(*s1, {data_value(bytes("ck2_0")), data_value(bytes("ck1_1")), });
             m1.set_clustered_cell(key_full, "regular_col_2", data_value(bytes("regular_col_value")), ts, ttl);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "update regular_col_2 for key covered by range tombstone");
             m2.set_clustered_cell(key_full, "regular_col_2", data_value(bytes("regular_col_value")), ts, ttl);
             result.equal.emplace_back(mutations{m1, m2});
         }
@@ -1864,7 +1877,7 @@ static mutation_sets generate_mutation_sets() {
         {
             auto ts = new_timestamp();
             m1.set_clustered_cell(ck1, "regular_col_1", data_value(bytes("regular_col_value")), ts, ttl);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "update regular_col_1 for ck1");
             m2.set_clustered_cell(ck1, "regular_col_1", data_value(bytes("regular_col_value")), ts, ttl);
             result.equal.emplace_back(mutations{m1, m2});
         }
@@ -1872,7 +1885,7 @@ static mutation_sets generate_mutation_sets() {
         {
             auto ts = new_timestamp();
             m1.set_clustered_cell(ck1, "regular_col_2", data_value(bytes("regular_col_value")), ts, ttl);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "update regular_col_2 for ck1");
             m2.set_clustered_cell(ck1, "regular_col_2", data_value(bytes("regular_col_value")), ts, ttl);
             result.equal.emplace_back(mutations{m1, m2});
         }
@@ -1880,7 +1893,7 @@ static mutation_sets generate_mutation_sets() {
         {
             auto ts = new_timestamp();
             m1.partition().apply_insert(*s1, ck2, ts);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "empty row");
             m2.partition().apply_insert(*s2, ck2, ts);
             result.equal.emplace_back(mutations{m1, m2});
         }
@@ -1888,7 +1901,7 @@ static mutation_sets generate_mutation_sets() {
         {
             auto ts = new_timestamp();
             m1.set_clustered_cell(ck2, "regular_col_1", data_value(bytes("ck2_regular_col_1_value")), ts);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "update regular_col_1 for ck2");
             m2.set_clustered_cell(ck2, "regular_col_1", data_value(bytes("ck2_regular_col_1_value")), ts);
             result.equal.emplace_back(mutations{m1, m2});
         }
@@ -1896,7 +1909,7 @@ static mutation_sets generate_mutation_sets() {
         {
             auto ts = new_timestamp();
             m1.set_static_cell("static_col_1", data_value(bytes("static_col_value")), ts, ttl);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "update static_col_1");
             m2.set_static_cell("static_col_1", data_value(bytes("static_col_value")), ts, ttl);
             result.equal.emplace_back(mutations{m1, m2});
         }
@@ -1904,7 +1917,7 @@ static mutation_sets generate_mutation_sets() {
         {
             auto ts = new_timestamp();
             m1.set_static_cell("static_col_2", data_value(bytes("static_col_value")), ts);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "update static_col_2");
             m2.set_static_cell("static_col_2", data_value(bytes("static_col_value")), ts);
             result.equal.emplace_back(mutations{m1, m2});
         }
@@ -1920,9 +1933,9 @@ static mutation_sets generate_mutation_sets() {
         {
             auto ts = new_timestamp();
             m1.set_clustered_cell(ck2, "regular_col_1_s1", data_value(bytes("x")), ts);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "update regular_col_1_s1 for ck2");
             m2.set_clustered_cell(ck2, "regular_col_1_s2", data_value(bytes("x")), ts);
-            result.unequal.emplace_back(mutations{m1, m2});
+            result.unequal.emplace_back(m1, m2, "update regular_col_1_s2 for ck2");
         }
     }
 
@@ -1933,7 +1946,7 @@ static mutation_sets generate_mutation_sets() {
                 random_mutation_generator::generate_uncompactable::yes);
         for (int i = 0; i < rmg_iterations; ++i) {
             auto m = gen();
-            result.unequal.emplace_back(mutations{m, gen()}); // collision unlikely
+            result.unequal.emplace_back(m, gen(), "random mutation (no counters)"); // collision unlikely
             result.equal.emplace_back(mutations{m, m});
         }
     }
@@ -1943,7 +1956,7 @@ static mutation_sets generate_mutation_sets() {
                 random_mutation_generator::generate_uncompactable::yes);
         for (int i = 0; i < rmg_iterations; ++i) {
             auto m = gen();
-            result.unequal.emplace_back(mutations{m, gen()}); // collision unlikely
+            result.unequal.emplace_back(m, gen(), "random mutation (with counters)"); // collision unlikely
             result.equal.emplace_back(mutations{m, m});
         }
     }
@@ -1956,26 +1969,26 @@ static const mutation_sets& get_mutation_sets() {
     return ms;
 }
 
-void for_each_mutation_pair(std::function<void(const mutation&, const mutation&, are_equal)> callback) {
+void for_each_mutation_pair(std::function<void(const mutation&, const mutation&, are_equal, std::string_view)> callback) {
     auto&& ms = get_mutation_sets();
     for (auto&& mutations : ms.equal) {
         auto i = mutations.begin();
         SCYLLA_ASSERT(i != mutations.end());
         const mutation& first = *i++;
         while (i != mutations.end()) {
-            callback(first, *i, are_equal::yes);
+            callback(first, *i, are_equal::yes, {});
             ++i;
         }
     }
-    for (auto&& mutations : ms.unequal) {
-        auto i = mutations.begin();
-        SCYLLA_ASSERT(i != mutations.end());
-        const mutation& first = *i++;
-        while (i != mutations.end()) {
-            callback(first, *i, are_equal::no);
-            ++i;
-        }
+    for (auto&& pair : ms.unequal) {
+        callback(pair.a, pair.b, are_equal::no, pair.label);
     }
+}
+
+void for_each_mutation_pair(std::function<void(const mutation&, const mutation&, are_equal)> callback) {
+    for_each_mutation_pair([callback = std::move(callback)] (const mutation& m1, const mutation& m2, are_equal eq, std::string_view) {
+        callback(m1, m2, eq);
+    });
 }
 
 void for_each_mutation(std::function<void(const mutation&)> callback) {
@@ -1985,10 +1998,9 @@ void for_each_mutation(std::function<void(const mutation&)> callback) {
             callback(m);
         }
     }
-    for (auto&& mutations : ms.unequal) {
-        for (auto&& m : mutations) {
-            callback(m);
-        }
+    for (auto&& pair : ms.unequal) {
+        callback(pair.a);
+        callback(pair.b);
     }
 }
 

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -1875,6 +1875,34 @@ static mutation_sets generate_mutation_sets() {
         }
 
         {
+            // Add two identical live rows, with different effective tombstones
+            clustering_key live_ck = clustering_key::from_deeply_exploded(*s1, {data_value(bytes("ck_live_0")), data_value(bytes("ck_live_1"))});
+            clustering_key live_ck_prefix = clustering_key::from_deeply_exploded(*s1, {data_value(bytes("ck_live_0"))});
+            auto tomb1 = new_tombstone();
+            auto tomb2 = new_tombstone();
+            auto tomb3 = new_tombstone();
+            auto ts = new_timestamp();
+
+            m1.set_clustered_cell(live_ck, "regular_col_1", data_value(bytes("live_value1")), ts);
+            m2.set_clustered_cell(live_ck, "regular_col_1", data_value(bytes("live_value1")), ts);
+
+            m1.partition().apply_delete(*s1, live_ck, tomb1);
+            result.unequal.emplace_back(m1, m2, "identical rows, one has row tombstone");
+
+            m2.partition().apply_delete(*s2, live_ck, tomb2);
+            result.unequal.emplace_back(m1, m2, "identical rows with different row tombstone");
+
+            m1.partition().apply_delete(*s1, live_ck, tomb2);
+            result.equal.emplace_back(mutations{m1, m2});
+
+            m1.partition().apply_delete(*s1, live_ck_prefix, tomb3);
+            result.unequal.emplace_back(m1, m2, "identical rows with different effective tombstone");
+
+            m2.partition().apply_delete(*s2, live_ck_prefix, tomb3);
+            result.equal.emplace_back(mutations{m1, m2});
+        }
+
+        {
             auto ts = new_timestamp();
             m1.set_clustered_cell(ck1, "regular_col_1", data_value(bytes("regular_col_value")), ts, ttl);
             result.unequal.emplace_back(m1, m2, "update regular_col_1 for ck1");

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -32,6 +32,8 @@ enum are_equal { no, yes };
 
 // Calls the provided function on mutation pairs, equal and not equal. Is supposed
 // to exercise all potential ways two mutations may differ.
+// The label param is an optional human readable string describing the mutation pair.
+void for_each_mutation_pair(std::function<void(const mutation&, const mutation&, are_equal, std::string_view label)>);
 void for_each_mutation_pair(std::function<void(const mutation&, const mutation&, are_equal)>);
 
 // Calls the provided function on mutations. Is supposed to exercise as many differences as possible.


### PR DESCRIPTION
There is already a test which checks that digests calculated on equal mutations are equal. Add another test which checks that digests calculated on unequal mutations are not equal. This test is even more important than the previous one: digests flagging up differences is more important than not producing false positives.

Backport: new test, no backport