### PR TITLE
sstables_loader: shuffle tablet ranges in load-and-stream

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -7,6 +7,7 @@
  */
 
 #include <fmt/ranges.h>
+#include <random>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/map_reduce.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -451,6 +452,11 @@ future<> tablet_sstable_streamer::stream(shared_ptr<stream_progress> progress) {
         _sstables, _tablet_map.tablet_ids() | std::views::filter([this](auto tid) { return tablet_in_scope(tid); }) | std::views::transform([this](auto tid) {
                        return _tablet_map.get_token_range(tid);
                    }) | std::ranges::to<std::vector>());
+
+    // Shuffle tablet ranges to distribute the load more evenly across tablets
+    // during streaming.
+    static thread_local std::default_random_engine rng{std::random_device{}()};
+    std::ranges::shuffle(classified_sstables, rng);
 
     for (auto& [tablet_range, sstables_fully_contained, sstables_partially_contained] : classified_sstables) {
         auto per_tablet_progress = make_shared<per_tablet_stream_progress>(


### PR DESCRIPTION
Shuffle the order in which tablet ranges are processed during load-and-stream. Previously, ranges were streamed in token ring order, which fills early ranges completely before touching later ones, creating huge size imbalance that triggers unnecessary tablet rebalancing.

By randomizing the processing order, tablets fill up more uniformly.

This is safe because each tablet range is processed independently:
- SSTable classification happens before the shuffle (token-order optimization in get_sstables_for_tablet is preserved)
- Partially-contained sstables are shared_ptr copies across ranges and defer-unlinked only after all ranges complete
- Fully-contained sstables belong to exactly one range
- No state is accumulated between loop iterations
- Progress tracking and topology invariants are order-independent

Fixes: SCYLLADB-3529

Backport is required