### PR TITLE
keys: remove partition_key::tri_compare

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1189,7 +1189,7 @@ lw_shared_ptr<const service::pager::paging_state> view_indexed_table_select_stat
     }
 
     auto index_ck = clustering_key::from_range(std::move(exploded_index_ck));
-    if (partition_key::tri_compare(*_view_schema)(paging_state->get_partition_key(), index_pk) == 0
+    if (paging_state->get_partition_key().equal(*_view_schema, index_pk)
             && (!paging_state->get_clustering_key() || clustering_key::prefix_equal_tri_compare(*_view_schema)(*paging_state->get_clustering_key(), index_ck) == 0)) {
         return paging_state;
     }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1177,7 +1177,7 @@ lw_shared_ptr<const service::pager::paging_state> view_indexed_table_select_stat
     }
 
     auto index_ck = clustering_key::from_range(std::move(exploded_index_ck));
-    if (partition_key::tri_compare(*_view_schema)(paging_state->get_partition_key(), index_pk) == 0
+    if (paging_state->get_partition_key().equal(*_view_schema, index_pk)
             && (!paging_state->get_clustering_key() || clustering_key::prefix_equal_tri_compare(*_view_schema)(*paging_state->get_clustering_key(), index_ck) == 0)) {
         return paging_state;
     }

--- a/cql3/update_parameters.cc
+++ b/cql3/update_parameters.cc
@@ -59,7 +59,7 @@ update_parameters::get_prefetched_list(const partition_key& pkey, const clusteri
 }
 
 update_parameters::prefetch_data::prefetch_data(schema_ptr schema)
-    : rows(key_less{*schema})
+    : rows(0, key_hash{*schema}, key_equal{*schema})
     , schema(schema)
 { }
 

--- a/cql3/update_parameters.hh
+++ b/cql3/update_parameters.hh
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <unordered_map>
+
 #include "gc_clock.hh"
 #include "mutation/timestamp.hh"
 #include "schema/schema_fwd.hh"
@@ -20,6 +22,7 @@
 #include "cql3/selection/selection.hh"
 #include "query/query-request.hh"
 #include "query/query-result.hh"
+#include "utils/hash.hh"
 
 namespace cql3 {
 
@@ -40,26 +43,28 @@ public:
     // 3) rows of CAS result set.
     struct prefetch_data {
         using key = std::pair<partition_key, clustering_key>;
-        using key_view = std::pair<const partition_key&, const clustering_key&>;
-        struct key_less {
-            partition_key::tri_compare pk_cmp;
-            clustering_key::tri_compare ck_cmp;
+        struct key_hash {
+            partition_key::hashing pk_hash;
+            clustering_key::hashing ck_hash;
 
-            key_less(const schema& s)
-                : pk_cmp(s)
-                , ck_cmp(s)
+            key_hash(const schema& s)
+                : pk_hash(s)
+                , ck_hash(s)
             { }
-            std::strong_ordering tri_compare(const partition_key& pk1, const clustering_key& ck1,
-                    const partition_key& pk2, const clustering_key& ck2) const {
-
-                std::strong_ordering rc = pk_cmp(pk1, pk2);
-                return rc != 0 ? rc : ck_cmp(ck1, ck2);
+            size_t operator()(const key& k) const {
+                return utils::hash_combine(pk_hash(k.first), ck_hash(k.second));
             }
-            // Allow mixing std::pair<partition_key, clustering_key> and
-            // std::pair<const partition_key&, const clustering_key&> during lookup
-            template <typename Pair1, typename Pair2>
-            bool operator()(const Pair1& k1, const Pair2& k2) const {
-                return  tri_compare(k1.first, k1.second, k2.first, k2.second) < 0;
+        };
+        struct key_equal {
+            partition_key::equality pk_eq;
+            clustering_key::equality ck_eq;
+
+            key_equal(const schema& s)
+                : pk_eq(s)
+                , ck_eq(s)
+            { }
+            bool operator()(const key& k1, const key& k2) const {
+                return pk_eq(k1.first, k2.first) && ck_eq(k1.second, k2.second);
             }
         };
     public:
@@ -72,9 +77,11 @@ public:
                 return has_static;
             }
         };
-        // Use an ordered map since CAS result set must be naturally ordered
-        // when returned to the client.
-        std::map<key, row, key_less> rows;
+        // Rows are only ever looked up by their exact full primary key
+        // (see find_row()), the container is never iterated, so an unordered
+        // map is enough. Note that the CAS result set is ordered by iterating
+        // the statements of the CAS request, not this map.
+        std::unordered_map<key, row, key_hash, key_equal> rows;
         schema_ptr schema;
         shared_ptr<cql3::selection::selection> selection;
     public:

--- a/cql3/update_parameters.hh
+++ b/cql3/update_parameters.hh
@@ -42,17 +42,17 @@ public:
         using key = std::pair<partition_key, clustering_key>;
         using key_view = std::pair<const partition_key&, const clustering_key&>;
         struct key_less {
-            partition_key::tri_compare pk_cmp;
+            partition_key::compound pk_type;
             clustering_key::tri_compare ck_cmp;
 
             key_less(const schema& s)
-                : pk_cmp(s)
+                : pk_type(partition_key::get_compound_type(s))
                 , ck_cmp(s)
             { }
             std::strong_ordering tri_compare(const partition_key& pk1, const clustering_key& ck1,
                     const partition_key& pk2, const clustering_key& ck2) const {
 
-                std::strong_ordering rc = pk_cmp(pk1, pk2);
+                std::strong_ordering rc = pk_type->compare(pk1.representation(), pk2.representation());
                 return rc != 0 ? rc : ck_cmp(ck1, ck2);
             }
             // Allow mixing std::pair<partition_key, clustering_key> and

--- a/keys/full_position.hh
+++ b/keys/full_position.hh
@@ -36,7 +36,7 @@ struct full_position {
 
     static std::strong_ordering cmp(const schema& s, const full_position& a, const full_position& b) {
         // Use ring order (token first, then legacy raw-byte compare) to match the physical
-        // SSTable ordering. Using the type-aware partition_key::tri_compare here would give
+        // SSTable ordering. Using a type-aware value comparison here would give
         // wrong results for key types (e.g. timeuuid) where semantic order differs from the
         // raw-byte order used on disk, potentially causing paging cursors to be advanced past
         // partitions that haven't been returned yet.

--- a/keys/keys.hh
+++ b/keys/keys.hh
@@ -533,6 +533,10 @@ public:
     const legacy_compound_view<c_type> legacy_form(const schema& s) const;
 
     // A trichotomic comparator for ordering compatible with Origin.
+    //
+    // This does not produce ring order! Ring order first compares the key's
+    // tokens and only falls back to legacy-tri-compare if the tokens are equal.
+    // Only use this for partitions which map to the same token.
     std::strong_ordering legacy_tri_compare(const schema& s, partition_key_view o) const;
 
     // Checks if keys are equal in a way which is compatible with Origin.
@@ -627,6 +631,10 @@ public:
     }
 
     // A trichotomic comparator for ordering compatible with Origin.
+    //
+    // This does not produce ring order! Ring order first compares the key's
+    // tokens and only falls back to legacy-tri-compare if the tokens are equal.
+    // Only use this for partitions which map to the same token.
     std::strong_ordering legacy_tri_compare(const schema& s, const partition_key& o) const {
         return view().legacy_tri_compare(s, o);
     }

--- a/keys/keys.hh
+++ b/keys/keys.hh
@@ -25,15 +25,13 @@
 // We distinguish partition keys and clustering keys. API-wise they are almost
 // the same, but they're separate type hierarchies.
 //
-// Clustering keys are further divided into prefixed and non-prefixed (full).
-// Non-prefixed keys always have full component set, as defined by schema.
-// Prefixed ones can have any number of trailing components missing. They may
-// differ in underlying representation.
+// Clustering keys can have any number of trailing components missing (prefix).
+// A full key has all components as defined by the schema.
 //
 // The main classes are:
 //
 //   partition_key           - full partition key
-//   clustering_key          - full clustering key
+//   clustering_key          - full clustering key (alias for clustering_key_prefix)
 //   clustering_key_prefix   - clustering key prefix
 //
 // These classes wrap only the minimum information required to store the key
@@ -386,53 +384,6 @@ public:
     }
 };
 
-template <typename TopLevel, typename PrefixTopLevel>
-class prefix_view_on_full_compound {
-public:
-    using iterator = typename compound_type<allow_prefixes::no>::iterator;
-private:
-    bytes_view _b;
-    unsigned _prefix_len;
-    iterator _begin;
-    iterator _end;
-public:
-    prefix_view_on_full_compound(const schema& s, bytes_view b, unsigned prefix_len)
-        : _b(b)
-        , _prefix_len(prefix_len)
-        , _begin(TopLevel::get_compound_type(s)->begin(_b))
-        , _end(_begin)
-    {
-        std::advance(_end, prefix_len);
-    }
-
-    iterator begin() const { return _begin; }
-    iterator end() const { return _end; }
-
-    struct less_compare_with_prefix {
-        typename PrefixTopLevel::compound prefix_type;
-
-        less_compare_with_prefix(const schema& s)
-            : prefix_type(PrefixTopLevel::get_compound_type(s))
-        { }
-
-        bool operator()(const prefix_view_on_full_compound& k1, const PrefixTopLevel& k2) const {
-            return lexicographical_tri_compare(
-                prefix_type->types().begin(), prefix_type->types().end(),
-                k1.begin(), k1.end(),
-                prefix_type->begin(k2), prefix_type->end(k2),
-                tri_compare) < 0;
-        }
-
-        bool operator()(const PrefixTopLevel& k1, const prefix_view_on_full_compound& k2) const {
-            return lexicographical_tri_compare(
-                prefix_type->types().begin(), prefix_type->types().end(),
-                prefix_type->begin(k1), prefix_type->end(k1),
-                k2.begin(), k2.end(),
-                tri_compare) < 0;
-        }
-    };
-};
-
 template <typename TopLevel>
 class prefix_view_on_prefix_compound {
 public:
@@ -478,82 +429,6 @@ public:
                 tri_compare) < 0;
         }
     };
-};
-
-template <typename TopLevel, typename TopLevelView, typename PrefixTopLevel>
-class prefixable_full_compound : public compound_wrapper<TopLevel, TopLevelView> {
-    using base = compound_wrapper<TopLevel, TopLevelView>;
-protected:
-    prefixable_full_compound(bytes&& b) : base(std::move(b)) {}
-public:
-    using prefix_view_type = prefix_view_on_full_compound<TopLevel, PrefixTopLevel>;
-
-    bool is_prefixed_by(const schema& s, const PrefixTopLevel& prefix) const {
-        const auto& t = base::get_compound_type(s);
-        const auto& prefix_type = PrefixTopLevel::get_compound_type(s);
-        return ::is_prefixed_by(t->types().begin(),
-            t->begin(*this), t->end(*this),
-            prefix_type->begin(prefix), prefix_type->end(prefix),
-            ::equal);
-    }
-
-    struct less_compare_with_prefix {
-        typename PrefixTopLevel::compound prefix_type;
-        typename TopLevel::compound full_type;
-
-        less_compare_with_prefix(const schema& s)
-            : prefix_type(PrefixTopLevel::get_compound_type(s))
-            , full_type(TopLevel::get_compound_type(s))
-        { }
-
-        bool operator()(const TopLevel& k1, const PrefixTopLevel& k2) const {
-            return lexicographical_tri_compare(
-                prefix_type->types().begin(), prefix_type->types().end(),
-                full_type->begin(k1), full_type->end(k1),
-                prefix_type->begin(k2), prefix_type->end(k2),
-                tri_compare) < 0;
-        }
-
-        bool operator()(const PrefixTopLevel& k1, const TopLevel& k2) const {
-            return lexicographical_tri_compare(
-                prefix_type->types().begin(), prefix_type->types().end(),
-                prefix_type->begin(k1), prefix_type->end(k1),
-                full_type->begin(k2), full_type->end(k2),
-                tri_compare) < 0;
-        }
-    };
-
-    // In prefix equality two sequences are equal if any of them is a prefix
-    // of the other. Otherwise lexicographical ordering is applied.
-    // Note: full compounds sorted according to lexicographical ordering are also
-    // sorted according to prefix equality ordering.
-    struct prefix_equality_less_compare {
-        typename PrefixTopLevel::compound prefix_type;
-        typename TopLevel::compound full_type;
-
-        prefix_equality_less_compare(const schema& s)
-            : prefix_type(PrefixTopLevel::get_compound_type(s))
-            , full_type(TopLevel::get_compound_type(s))
-        { }
-
-        bool operator()(const TopLevel& k1, const PrefixTopLevel& k2) const {
-            return prefix_equality_tri_compare(prefix_type->types().begin(),
-                full_type->begin(k1), full_type->end(k1),
-                prefix_type->begin(k2), prefix_type->end(k2),
-                tri_compare) < 0;
-        }
-
-        bool operator()(const PrefixTopLevel& k1, const TopLevel& k2) const {
-            return prefix_equality_tri_compare(prefix_type->types().begin(),
-                prefix_type->begin(k1), prefix_type->end(k1),
-                full_type->begin(k2), full_type->end(k2),
-                tri_compare) < 0;
-        }
-    };
-
-    prefix_view_type prefix_view(const schema& s, unsigned prefix_len) const {
-        return { s, this->representation(), prefix_len };
-    }
 };
 
 template <typename TopLevel, typename FullTopLevel>

--- a/keys/keys.hh
+++ b/keys/keys.hh
@@ -540,12 +540,12 @@ public:
         return legacy_tri_compare(s, o) == 0;
     }
 
+    // A trichotomic comparator which orders keys according to their ordering on the ring.
+    std::strong_ordering ring_order_tri_compare(const schema& s, partition_key_view o) const;
+
     void validate(const schema& s) const {
         return s.partition_key_type()->validate(representation());
     }
-
-    // A trichotomic comparator which orders keys according to their ordering on the ring.
-    std::strong_ordering ring_order_tri_compare(const schema& s, partition_key_view o) const;
 };
 
 template <>
@@ -634,6 +634,11 @@ public:
     // Checks if keys are equal in a way which is compatible with Origin.
     bool legacy_equal(const schema& s, const partition_key& o) const {
         return view().legacy_equal(s, o);
+    }
+
+    // A trichotomic comparator which orders keys according to their ordering on the ring.
+    std::strong_ordering ring_order_tri_compare(const schema& s, const partition_key& o) const {
+        return view().ring_order_tri_compare(s, o.view());
     }
 
     void validate(const schema& s) const {

--- a/keys/keys.hh
+++ b/keys/keys.hh
@@ -61,22 +61,6 @@ public:
         return _bytes;
     }
 
-    struct less_compare {
-        typename TopLevelView::compound _t;
-        less_compare(const schema& s) : _t(get_compound_type(s)) {}
-        bool operator()(const TopLevelView& k1, const TopLevelView& k2) const {
-            return _t->less(k1.representation(), k2.representation());
-        }
-    };
-
-    struct tri_compare {
-        typename TopLevelView::compound _t;
-        tri_compare(const schema &s) : _t(get_compound_type(s)) {}
-        std::strong_ordering operator()(const TopLevelView& k1, const TopLevelView& k2) const {
-            return _t->compare(k1.representation(), k2.representation());
-        }
-    };
-
     struct hashing {
         typename TopLevelView::compound _t;
         hashing(const schema& s) : _t(get_compound_type(s)) {}
@@ -256,34 +240,6 @@ public:
         return result;
     }
 
-    struct tri_compare {
-        typename TopLevel::compound _t;
-        tri_compare(const schema& s) : _t(get_compound_type(s)) {}
-        std::strong_ordering operator()(const TopLevel& k1, const TopLevel& k2) const {
-            return _t->compare(k1.representation(), k2.representation());
-        }
-        std::strong_ordering operator()(const TopLevelView& k1, const TopLevel& k2) const {
-            return _t->compare(k1.representation(), k2.representation());
-        }
-        std::strong_ordering operator()(const TopLevel& k1, const TopLevelView& k2) const {
-            return _t->compare(k1.representation(), k2.representation());
-        }
-    };
-
-    struct less_compare {
-        typename TopLevel::compound _t;
-        less_compare(const schema& s) : _t(get_compound_type(s)) {}
-        bool operator()(const TopLevel& k1, const TopLevel& k2) const {
-            return _t->less(k1.representation(), k2.representation());
-        }
-        bool operator()(const TopLevelView& k1, const TopLevel& k2) const {
-            return _t->less(k1.representation(), k2.representation());
-        }
-        bool operator()(const TopLevel& k1, const TopLevelView& k2) const {
-            return _t->less(k1.representation(), k2.representation());
-        }
-    };
-
     struct hashing {
         typename TopLevel::compound _t;
         hashing(const schema& s) : _t(get_compound_type(s)) {}
@@ -440,6 +396,22 @@ protected:
     { }
 
 public:
+    struct less_compare {
+        typename TopLevel::compound _t;
+        less_compare(const schema& s) : _t(TopLevel::get_compound_type(s)) {}
+        bool operator()(const TopLevel& k1, const TopLevel& k2) const {
+            return _t->less(k1.representation(), k2.representation());
+        }
+    };
+
+    struct tri_compare {
+        typename TopLevel::compound _t;
+        tri_compare(const schema& s) : _t(TopLevel::get_compound_type(s)) {}
+        std::strong_ordering operator()(const TopLevel& k1, const TopLevel& k2) const {
+            return _t->compare(k1.representation(), k2.representation());
+        }
+    };
+
     bool is_full(const schema& s) const {
         return TopLevel::get_compound_type(s)->is_full(base::_bytes);
     }
@@ -489,7 +461,35 @@ public:
             return prefix_equality_tri_compare(prefix_type->types().begin(),
                 prefix_type->begin(k1.representation()), prefix_type->end(k1.representation()),
                 prefix_type->begin(k2.representation()), prefix_type->end(k2.representation()),
-                tri_compare) < 0;
+                ::tri_compare) < 0;
+        }
+    };
+
+    struct less_compare {
+        typename TopLevel::compound _t;
+        less_compare(const schema& s) : _t(base::get_compound_type(s)) {}
+        bool operator()(const TopLevel& k1, const TopLevel& k2) const {
+            return _t->less(k1.representation(), k2.representation());
+        }
+        bool operator()(const TopLevelView& k1, const TopLevel& k2) const {
+            return _t->less(k1.representation(), k2.representation());
+        }
+        bool operator()(const TopLevel& k1, const TopLevelView& k2) const {
+            return _t->less(k1.representation(), k2.representation());
+        }
+    };
+
+    struct tri_compare {
+        typename TopLevel::compound _t;
+        tri_compare(const schema& s) : _t(base::get_compound_type(s)) {}
+        std::strong_ordering operator()(const TopLevel& k1, const TopLevel& k2) const {
+            return _t->compare(k1.representation(), k2.representation());
+        }
+        std::strong_ordering operator()(const TopLevelView& k1, const TopLevel& k2) const {
+            return _t->compare(k1.representation(), k2.representation());
+        }
+        std::strong_ordering operator()(const TopLevel& k1, const TopLevelView& k2) const {
+            return _t->compare(k1.representation(), k2.representation());
         }
     };
 
@@ -505,7 +505,7 @@ public:
             return prefix_equality_tri_compare(prefix_type->types().begin(),
                 prefix_type->begin(k1.representation()), prefix_type->end(k1.representation()),
                 prefix_type->begin(k2.representation()), prefix_type->end(k2.representation()),
-                tri_compare);
+                ::tri_compare);
         }
     };
 };

--- a/test/boost/bti_key_translation_test.cc
+++ b/test/boost/bti_key_translation_test.cc
@@ -75,14 +75,14 @@ static std::generator<dht::ring_position_view> generate_rpvs(
     }
     if (sst_ver == sstables::sstable_version_types::ms) {
         // ms encodes the partition key component-wise, so for two same-token
-        // rpvs the expected order is given by partition_key::tri_compare
+        // rpvs the expected order is the type-aware component-wise order
         // (NOT the ring comparator, which compares pks by their legacy form).
-        partition_key::tri_compare pk_cmp(string_pair_pk_schema);
-        std::ranges::sort(rpvs, [&pk_cmp] (const dht::ring_position_view& a, const dht::ring_position_view& b) {
+        const auto& pk_type = partition_key::get_compound_type(string_pair_pk_schema);
+        std::ranges::sort(rpvs, [&pk_type] (const dht::ring_position_view& a, const dht::ring_position_view& b) {
             if (auto cmp = a.token() <=> b.token(); cmp != 0) {
                 return cmp < 0;
             }
-            if (auto cmp = pk_cmp(*a.key(), *b.key()); cmp != 0) {
+            if (auto cmp = pk_type->compare(a.key()->representation(), b.key()->representation()); cmp != 0) {
                 return cmp < 0;
             }
             return a.weight() < b.weight();

--- a/test/boost/bti_key_translation_test.cc
+++ b/test/boost/bti_key_translation_test.cc
@@ -64,14 +64,14 @@ static std::generator<dht::ring_position_view> generate_rpvs(
     }
     if (sst_ver == sstables::sstable_version_types::ms) {
         // ms encodes the partition key component-wise, so for two same-token
-        // rpvs the expected order is given by partition_key::tri_compare
+        // rpvs the expected order is the type-aware component-wise order
         // (NOT the ring comparator, which compares pks by their legacy form).
-        partition_key::tri_compare pk_cmp(string_pair_pk_schema);
-        std::ranges::sort(rpvs, [&pk_cmp] (const dht::ring_position_view& a, const dht::ring_position_view& b) {
+        const auto& pk_type = partition_key::get_compound_type(string_pair_pk_schema);
+        std::ranges::sort(rpvs, [&pk_type] (const dht::ring_position_view& a, const dht::ring_position_view& b) {
             if (auto cmp = a.token() <=> b.token(); cmp != 0) {
                 return cmp < 0;
             }
-            if (auto cmp = pk_cmp(*a.key(), *b.key()); cmp != 0) {
+            if (auto cmp = pk_type->compare(a.key()->representation(), b.key()->representation()); cmp != 0) {
                 return cmp < 0;
             }
             return a.weight() < b.weight();

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -709,7 +709,7 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_fragment_stream_validator_validation_leve
 }
 
 // Verify that mutation_fragment_stream_validator uses ring (legacy raw-byte) order
-// for same-token partition keys, not the type-aware partition_key::tri_compare order.
+// for same-token partition keys, not a type-aware value comparison.
 //
 // Two keys that share a token must be ordered by their raw serialized bytes
 // (legacy_tri_compare), which is what SSTables use on disk.  Using the

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -1144,8 +1144,11 @@ SEASTAR_TEST_CASE(test_update_failure) {
         int partition_count = 1000;
 
         // populate cache with some partitions
-        using partitions_type = std::map<partition_key, mutation_partition, partition_key::less_compare>;
-        auto original_partitions = partitions_type(partition_key::less_compare(*s));
+        auto pk_less = [&s] (const partition_key& a, const partition_key& b) {
+            return a.view().ring_order_tri_compare(*s, b) < 0;
+        };
+        using partitions_type = std::map<partition_key, mutation_partition, decltype(pk_less)>;
+        auto original_partitions = partitions_type(pk_less);
         for (int i = 0; i < partition_count / 2; i++) {
             auto m = make_new_mutation(s, i + partition_count / 2);
             original_partitions.emplace(m.key(), mutation_partition(*s, m.partition()));
@@ -1154,7 +1157,7 @@ SEASTAR_TEST_CASE(test_update_failure) {
 
         // populate memtable with more updated partitions
         auto mt = make_lw_shared<replica::memtable>(s);
-        auto updated_partitions = partitions_type(partition_key::less_compare(*s));
+        auto updated_partitions = partitions_type(pk_less);
         for (int i = 0; i < partition_count; i++) {
             auto m = make_new_large_mutation(s, i);
             updated_partitions.emplace(m.key(), mutation_partition(*s, m.partition()));

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -486,7 +486,9 @@ static future<> check_compacted_sstables(test_env& env, compact_sstables_result 
         // keys from compacted sstable aren't ordered lexographically,
         // thus we must read all keys into a vector, sort the vector
         // lexographically, then proceed with the comparison.
-        std::sort(keys.begin(), keys.end(), partition_key::less_compare(*s));
+        std::sort(keys.begin(), keys.end(), [pkey_type = s->partition_key_type()] (const partition_key& a, const partition_key& b) {
+            return pkey_type->compare(a.representation(), b.representation()) < 0;
+        });
         BOOST_REQUIRE_EQUAL(keys.size(), res.input_sstables.size());
 
         auto generations = res.input_sstables

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -496,7 +496,9 @@ static future<> check_compacted_sstables(test_env& env, compact_sstables_result 
         // keys from compacted sstable aren't ordered lexographically,
         // thus we must read all keys into a vector, sort the vector
         // lexographically, then proceed with the comparison.
-        std::sort(keys.begin(), keys.end(), partition_key::less_compare(*s));
+        std::sort(keys.begin(), keys.end(), [pkey_type = s->partition_key_type()] (const partition_key& a, const partition_key& b) {
+            return pkey_type->compare(a.representation(), b.representation()) < 0;
+        });
         BOOST_REQUIRE_EQUAL(keys.size(), res.input_sstables.size());
 
         auto generations = res.input_sstables


### PR DESCRIPTION
Partitions in ScyllaDB are ordered by token. If two partitions keys have the same token, the tie is broken by falling back to comparing the values. This ordering is implemented by dht::ring_position_tri_compare() and friends.
partition_key::tri_compare() is dangerous because it is easy to mistake it for the appropriate way to compare partitions, but it compares only the types. We recently had two bugs related to this, code using partition_key::tri_compare() instead of dht::ring_position_tri_compare() to compare partitions keys positions on the ring. See 2caea9ba56b8a28a90b8346ca493ff28a36a28e3 and 944f1115fea9df22807e06c63b2af79a7c9b528f.
This PR removes the partition_key::tri_compare(). The tri_compare is moved to prefix_compound, which is used to implement clustering_key[_prefix], for which this is the correct ordering method. Users are migrated to other comparison methods.

Backport: code safety improvement, no backport