### PR TITLE
cql: paging: record query plan identity in paging state

### DIFF
--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -648,7 +648,7 @@ static future<executor::request_return_type> do_query(service::storage_proxy& pr
         if (table_schema->clustering_key_size() > 0) {
             pos = pos_from_json(*exclusive_start_key, table_schema);
         }
-        old_paging_state = make_lw_shared<service::pager::paging_state>(pk, pos, query::max_partitions, query_id::create_null_id(), service::pager::paging_state::replicas_per_token_range{}, std::nullopt, 0);
+        old_paging_state = make_lw_shared<service::pager::paging_state>(pk, pos, query::max_partitions, query_id::create_null_id(), service::pager::paging_state::replicas_per_token_range{}, std::nullopt, 0, std::nullopt);
     }
 
     co_await verify_permission(enforce_authorization, warn_authorization, client_state, table_schema, auth::permission::SELECT, stats);
@@ -678,7 +678,9 @@ static future<executor::request_return_type> do_query(service::storage_proxy& pr
 
     std::unique_ptr<cql3::result_set> rs = co_await p->fetch_page(limit, gc_clock::now(), executor::default_timeout());
     if (!p->is_exhausted()) {
-        rs->get_metadata().set_paging_state(p->state());
+        // No plan to record: this pager was pointed at the table or index to scan
+        // here, rather than by a CQL plan a resumed page could pick differently.
+        rs->get_metadata().set_paging_state(p->state(std::nullopt));
     }
     auto paging_state = rs->get_metadata().paging_state();
     bool has_filter = filter;

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -625,7 +625,7 @@ static future<executor::request_return_type> do_query(service::storage_proxy& pr
         service_permit permit,
         bool enforce_authorization,
         bool warn_authorization) {
-    lw_shared_ptr<service::pager::paging_state> old_paging_state = nullptr;
+    lw_shared_ptr<const service::pager::paging_state> old_paging_state = nullptr;
 
     tracing::trace(trace_state, "Performing a database query");
 

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -526,7 +526,7 @@ struct scan_ranges_context {
         // member we may be forced to read the entire map - but it would
         // be good if we can read only the single item of the map - it
         // should be possible (and a must for issue #7751!).
-        lw_shared_ptr<service::pager::paging_state> paging_state = nullptr;
+        lw_shared_ptr<const service::pager::paging_state> paging_state = nullptr;
         auto regular_columns =
             s->regular_columns() | std::views::transform(&column_definition::id)
             | std::ranges::to<query::column_id_vector>();

--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -11,9 +11,13 @@
 #pragma once
 
 #include "timeout_config.hh"
+#include "schema/schema_fwd.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "audit/audit.hh"
 #include "utils/chunked_string.hh"
+
+#include <optional>
+#include <string_view>
 
 namespace service {
 
@@ -115,6 +119,17 @@ public:
     }
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const = 0;
+
+    // What re-deriving this statement with the same plan pinned needs.
+    // Disengaged for statements that are never paged. See #18992.
+    struct query_plan {
+        table_id id;
+        // Borrowed from the statement, so only valid while it lives.
+        std::string_view keyspace;
+    };
+    virtual std::optional<query_plan> query_plan_for_paging() const {
+        return std::nullopt;
+    }
 
     // Statements which keep their result set metadata elsewhere, e.g. in a
     // selection, override this instead of setting _metadata.

--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -10,7 +10,11 @@
 
 #pragma once
 
+#include <optional>
+#include <string_view>
+
 #include "timeout_config.hh"
+#include "service/pager/query_plan.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "audit/audit.hh"
 #include "utils/chunked_string.hh"
@@ -115,6 +119,19 @@ public:
     }
 
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const = 0;
+
+    // The plan this statement scans, to be checked against the one a paging state
+    // pins. Disengaged for statements that are never paged. See #18992.
+    virtual std::optional<service::pager::query_plan> query_plan_for_paging() const {
+        return std::nullopt;
+    }
+
+    // The keyspace this statement's table lives in, which re-parsing it has to
+    // resolve an unqualified table name against rather than the connection's own.
+    // Borrowed from the statement, so only valid while it lives.
+    virtual std::optional<std::string_view> keyspace_for_reparse() const {
+        return std::nullopt;
+    }
 
     // Statements which keep their result set metadata elsewhere, e.g. in a
     // selection, override this instead of setting _metadata.

--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -94,7 +94,7 @@ query_options::query_options(db::consistency_level cl, cql3::raw_value_vector_wi
 {
 }
 
-query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<service::pager::paging_state> paging_state)
+query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<const service::pager::paging_state> paging_state)
         : query_options(qo->_cql_config,
         qo->_consistency,
         std::move(qo->_names),
@@ -106,7 +106,7 @@ query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<se
 
 }
 
-query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<service::pager::paging_state> paging_state, int32_t page_size)
+query_options::query_options(std::unique_ptr<query_options> qo, lw_shared_ptr<const service::pager::paging_state> paging_state, int32_t page_size)
         : query_options(qo->_cql_config,
         qo->_consistency,
         std::move(qo->_names),

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -74,7 +74,7 @@ public:
         static thread_local const specific_options DEFAULT;
 
         const int32_t page_size;
-        const lw_shared_ptr<service::pager::paging_state> state;
+        const lw_shared_ptr<const service::pager::paging_state> state;
         const std::optional<db::consistency_level> serial_consistency;
         const api::timestamp_type timestamp;
         const service::node_local_only node_local_only;
@@ -166,8 +166,8 @@ public:
     // forInternalUse
     explicit query_options(raw_value_vector_with_unset values);
     explicit query_options(db::consistency_level, raw_value_vector_with_unset values, specific_options options = specific_options::DEFAULT);
-    explicit query_options(std::unique_ptr<query_options>, lw_shared_ptr<service::pager::paging_state> paging_state);
-    explicit query_options(std::unique_ptr<query_options>, lw_shared_ptr<service::pager::paging_state> paging_state, int32_t page_size);
+    explicit query_options(std::unique_ptr<query_options>, lw_shared_ptr<const service::pager::paging_state> paging_state);
+    explicit query_options(std::unique_ptr<query_options>, lw_shared_ptr<const service::pager::paging_state> paging_state, int32_t page_size);
 
     db::consistency_level get_consistency() const {
         return _consistency;
@@ -197,7 +197,7 @@ public:
     }
 
     /** The paging state for this query, or null if not relevant. */
-    lw_shared_ptr<service::pager::paging_state> get_paging_state() const {
+    lw_shared_ptr<const service::pager::paging_state> get_paging_state() const {
         return get_specific_options().state;
     }
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -635,6 +635,11 @@ std::optional<service::pager::query_plan> query_processor::pinned_plan_from_pagi
     if (!paging_state) {
         return std::nullopt;
     }
+    // Pretend an older Scylla version wrote this state, to test resuming from
+    // one during a rolling upgrade.
+    if (utils::get_local_injector().enter("paging_state_without_query_plan")) {
+        return std::nullopt;
+    }
     return paging_state->get_query_plan();
 }
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -635,6 +635,11 @@ std::optional<table_id> query_processor::forced_plan_id_from_paging_state(
     if (!paging_state) {
         return std::nullopt;
     }
+    // Pretend an older Scylla version wrote this state, to test resuming from
+    // one during a rolling upgrade.
+    if (utils::get_local_injector().enter("paging_state_without_query_plan")) {
+        return std::nullopt;
+    }
     return paging_state->get_query_plan_id();
 }
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -625,6 +625,14 @@ query_processor::execute_maybe_with_guard(service::query_state& query_state, ::s
     return execute_with_guard(std::bind_front(exec, std::ref(*this), std::forward<Args>(args)...), std::move(statement), query_state, options);
 }
 
+std::optional<service::pager::query_plan> query_processor::pinned_plan_from_paging_state(
+        const lw_shared_ptr<const service::pager::paging_state>& paging_state) {
+    if (!paging_state) {
+        return std::nullopt;
+    }
+    return paging_state->get_query_plan();
+}
+
 future<::shared_ptr<result_message>>
 query_processor::execute_direct_without_checking_exception_message(utils::chunked_string_view query_string, service::query_state& query_state, dialect d, query_options& options) {
     log.trace("execute_direct: \"{}\"", query_string);
@@ -788,7 +796,7 @@ prepared_cache_key_type query_processor::compute_id(
 }
 
 std::unique_ptr<prepared_statement>
-query_processor::get_statement(utils::chunked_string_view query, const service::client_state& client_state, dialect d) {
+query_processor::get_statement(utils::chunked_string_view query, const service::client_state& client_state, dialect d, std::optional<service::pager::query_plan> pinned_plan) {
     // Measuring allocation cost requires that no yield points exist
     // between bytes_before and bytes_after. It needs fixing if this
     // function is ever futurized.
@@ -799,6 +807,9 @@ query_processor::get_statement(utils::chunked_string_view query, const service::
     auto cf_stmt = dynamic_cast<raw::cf_statement*>(statement.get());
     if (cf_stmt) {
         cf_stmt->prepare_keyspace(client_state);
+        if (pinned_plan) {
+            cf_stmt->set_pinned_plan(std::move(pinned_plan));
+        }
     }
     ++_stats.prepare_invocations;
     auto p = statement->prepare(_db, _cql_stats, _cql_config);

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -434,6 +434,11 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                             sm::description("Counts the number of parallelized aggregation SELECT query executions.")).set_skip_when_empty(),
 
                     sm::make_counter(
+                            "select_paging_plan_rederivations",
+                            _cql_stats.select_paging_plan_rederivations,
+                            sm::description("Counts the pages of a prepared SELECT re-derived, each paying a re-parse, because the paging state pinned another query plan.")).set_skip_when_empty(),
+
+                    sm::make_counter(
                             "authorized_prepared_statements_cache_evictions",
                             [] { return authorized_prepared_statements_cache::shard_stats().authorized_prepared_statements_cache_evictions; },
                             sm::description("Counts the number of authenticated prepared statements cache entries evictions."))(basic_level).set_skip_when_empty(),
@@ -637,7 +642,7 @@ future<::shared_ptr<result_message>>
 query_processor::execute_direct_without_checking_exception_message(utils::chunked_string_view query_string, service::query_state& query_state, dialect d, query_options& options) {
     log.trace("execute_direct: \"{}\"", query_string);
     tracing::trace(query_state.get_trace_state(), "Parsing a statement");
-    auto p = get_statement(query_string, query_state.get_client_state(), d);
+    auto p = get_statement(query_string, query_state.get_client_state(), d, forced_plan_id_from_paging_state(options.get_paging_state()));
     return execute_direct_statement_without_checking_exception_message(std::move(p), query_state, options);
 }
 
@@ -796,7 +801,7 @@ prepared_cache_key_type query_processor::compute_id(
 }
 
 std::unique_ptr<prepared_statement>
-query_processor::get_statement(utils::chunked_string_view query, const service::client_state& client_state, dialect d, std::optional<table_id> forced_plan_id) {
+query_processor::get_statement(utils::chunked_string_view query, const service::client_state& client_state, dialect d, std::optional<table_id> forced_plan_id, std::optional<std::string_view> forced_keyspace) {
     // Measuring allocation cost requires that no yield points exist
     // between bytes_before and bytes_after. It needs fixing if this
     // function is ever futurized.
@@ -806,7 +811,13 @@ query_processor::get_statement(utils::chunked_string_view query, const service::
     // Set keyspace for statement that require login
     auto cf_stmt = dynamic_cast<raw::cf_statement*>(statement.get());
     if (cf_stmt) {
-        cf_stmt->prepare_keyspace(client_state);
+        // A re-derived statement keeps the keyspace it was prepared with; the
+        // connection's own may have changed since PREPARE.
+        if (forced_keyspace) {
+            cf_stmt->prepare_keyspace(*forced_keyspace);
+        } else {
+            cf_stmt->prepare_keyspace(client_state);
+        }
         if (forced_plan_id) {
             cf_stmt->set_forced_plan_id(std::move(forced_plan_id));
         }
@@ -996,6 +1007,8 @@ query_processor::execute_paged_internal(internal_query_state& state) {
                     _state.more_results = false;
                 } else {
                     _state.opts = std::make_unique<query_options>(std::move(_state.opts), rs.get_metadata().paging_state());
+                    // Carries a recorded plan forward without pinning it, safe
+                    // only because the cache hands back the same statement.
                     _state.p = _qp.prepare_internal(_state.query_string);
                 }
             } else {

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -984,9 +984,7 @@ query_processor::execute_paged_internal(internal_query_state& state) {
                 if (done) {
                     _state.more_results = false;
                 } else {
-                    const service::pager::paging_state& st = *rs.get_metadata().paging_state();
-                    lw_shared_ptr<service::pager::paging_state> shrd = make_lw_shared<service::pager::paging_state>(st);
-                    _state.opts = std::make_unique<query_options>(std::move(_state.opts), shrd);
+                    _state.opts = std::make_unique<query_options>(std::move(_state.opts), rs.get_metadata().paging_state());
                     _state.p = _qp.prepare_internal(_state.query_string);
                 }
             } else {

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -625,6 +625,14 @@ query_processor::execute_maybe_with_guard(service::query_state& query_state, ::s
     return execute_with_guard(std::bind_front(exec, std::ref(*this), std::forward<Args>(args)...), std::move(statement), query_state, options);
 }
 
+std::optional<table_id> query_processor::forced_plan_id_from_paging_state(
+        const lw_shared_ptr<const service::pager::paging_state>& paging_state) {
+    if (!paging_state) {
+        return std::nullopt;
+    }
+    return paging_state->get_query_plan_id();
+}
+
 future<::shared_ptr<result_message>>
 query_processor::execute_direct_without_checking_exception_message(utils::chunked_string_view query_string, service::query_state& query_state, dialect d, query_options& options) {
     log.trace("execute_direct: \"{}\"", query_string);
@@ -788,7 +796,7 @@ prepared_cache_key_type query_processor::compute_id(
 }
 
 std::unique_ptr<prepared_statement>
-query_processor::get_statement(utils::chunked_string_view query, const service::client_state& client_state, dialect d) {
+query_processor::get_statement(utils::chunked_string_view query, const service::client_state& client_state, dialect d, std::optional<table_id> forced_plan_id) {
     // Measuring allocation cost requires that no yield points exist
     // between bytes_before and bytes_after. It needs fixing if this
     // function is ever futurized.
@@ -799,6 +807,9 @@ query_processor::get_statement(utils::chunked_string_view query, const service::
     auto cf_stmt = dynamic_cast<raw::cf_statement*>(statement.get());
     if (cf_stmt) {
         cf_stmt->prepare_keyspace(client_state);
+        if (forced_plan_id) {
+            cf_stmt->set_forced_plan_id(std::move(forced_plan_id));
+        }
     }
     ++_stats.prepare_invocations;
     auto p = statement->prepare(_db, _cql_stats, _cql_config);

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -434,6 +434,11 @@ query_processor::query_processor(service::storage_proxy& proxy, data_dictionary:
                             sm::description("Counts the number of parallelized aggregation SELECT query executions.")).set_skip_when_empty(),
 
                     sm::make_counter(
+                            "select_paging_plan_rederivations",
+                            _cql_stats.select_paging_plan_rederivations,
+                            sm::description("Counts the pages of a prepared SELECT re-derived, each paying a re-parse, because the paging state pinned another query plan.")).set_skip_when_empty(),
+
+                    sm::make_counter(
                             "authorized_prepared_statements_cache_evictions",
                             [] { return authorized_prepared_statements_cache::shard_stats().authorized_prepared_statements_cache_evictions; },
                             sm::description("Counts the number of authenticated prepared statements cache entries evictions."))(basic_level).set_skip_when_empty(),
@@ -637,7 +642,7 @@ future<::shared_ptr<result_message>>
 query_processor::execute_direct_without_checking_exception_message(utils::chunked_string_view query_string, service::query_state& query_state, dialect d, query_options& options) {
     log.trace("execute_direct: \"{}\"", query_string);
     tracing::trace(query_state.get_trace_state(), "Parsing a statement");
-    auto p = get_statement(query_string, query_state.get_client_state(), d);
+    auto p = get_statement(query_string, query_state.get_client_state(), d, pinned_plan_from_paging_state(options.get_paging_state()));
     return execute_direct_statement_without_checking_exception_message(std::move(p), query_state, options);
 }
 
@@ -796,7 +801,7 @@ prepared_cache_key_type query_processor::compute_id(
 }
 
 std::unique_ptr<prepared_statement>
-query_processor::get_statement(utils::chunked_string_view query, const service::client_state& client_state, dialect d, std::optional<service::pager::query_plan> pinned_plan) {
+query_processor::get_statement(utils::chunked_string_view query, const service::client_state& client_state, dialect d, std::optional<service::pager::query_plan> pinned_plan, std::optional<std::string_view> forced_keyspace) {
     // Measuring allocation cost requires that no yield points exist
     // between bytes_before and bytes_after. It needs fixing if this
     // function is ever futurized.
@@ -806,7 +811,13 @@ query_processor::get_statement(utils::chunked_string_view query, const service::
     // Set keyspace for statement that require login
     auto cf_stmt = dynamic_cast<raw::cf_statement*>(statement.get());
     if (cf_stmt) {
-        cf_stmt->prepare_keyspace(client_state);
+        // A re-derived statement keeps the keyspace it was prepared with; the
+        // connection's own may have changed since PREPARE.
+        if (forced_keyspace) {
+            cf_stmt->prepare_keyspace(*forced_keyspace);
+        } else {
+            cf_stmt->prepare_keyspace(client_state);
+        }
         if (pinned_plan) {
             cf_stmt->set_pinned_plan(std::move(pinned_plan));
         }
@@ -996,6 +1007,8 @@ query_processor::execute_paged_internal(internal_query_state& state) {
                     _state.more_results = false;
                 } else {
                     _state.opts = std::make_unique<query_options>(std::move(_state.opts), rs.get_metadata().paging_state());
+                    // Carries a recorded plan forward without pinning it, safe
+                    // only because the cache hands back the same statement.
                     _state.p = _qp.prepare_internal(_state.query_string);
                 }
             } else {

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -519,11 +519,14 @@ public:
     // For the local node, waits directly without an RPC.
     future<> wait_for_table_raft_groups_on_all_hosts(table_id table, lowres_clock::time_point timeout);
 
+    // forced_plan_id and forced_keyspace re-derive a statement continuing a
+    // paged query: same plan, same keyspace it was prepared against.
     std::unique_ptr<statements::prepared_statement> get_statement(
             utils::chunked_string_view query,
             const service::client_state& client_state,
             dialect d,
-            std::optional<table_id> forced_plan_id = std::nullopt);
+            std::optional<table_id> forced_plan_id = std::nullopt,
+            std::optional<std::string_view> forced_keyspace = std::nullopt);
 
     // The plan to pin when continuing a paged query, read from the previous
     // page's state. See restrictions::forced_plan_id_opt.

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -37,6 +37,7 @@
 #include "db/config.hh"
 #include "utils/enum_option.hh"
 #include "service/storage_proxy_fwd.hh"
+#include "service/pager/query_plan.hh"
 
 namespace utils {
 class chunked_string;
@@ -48,6 +49,10 @@ class migration_manager;
 class query_state;
 class mapreduce_service;
 class raft_group0_client;
+
+namespace pager {
+class paging_state;
+}
 
 namespace strong_consistency {
 class coordinator;
@@ -518,7 +523,11 @@ public:
     std::unique_ptr<statements::prepared_statement> get_statement(
             utils::chunked_string_view query,
             const service::client_state& client_state,
-            dialect d);
+            dialect d,
+            std::optional<service::pager::query_plan> pinned_plan = std::nullopt);
+
+    static std::optional<service::pager::query_plan> pinned_plan_from_paging_state(
+            const lw_shared_ptr<const service::pager::paging_state>& paging_state);
 
     friend class migration_subscriber;
 

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -49,6 +49,10 @@ class query_state;
 class mapreduce_service;
 class raft_group0_client;
 
+namespace pager {
+class paging_state;
+}
+
 namespace strong_consistency {
 class coordinator;
 }
@@ -518,7 +522,13 @@ public:
     std::unique_ptr<statements::prepared_statement> get_statement(
             utils::chunked_string_view query,
             const service::client_state& client_state,
-            dialect d);
+            dialect d,
+            std::optional<table_id> forced_plan_id = std::nullopt);
+
+    // The plan to pin when continuing a paged query, read from the previous
+    // page's state. See restrictions::forced_plan_id_opt.
+    static std::optional<table_id> forced_plan_id_from_paging_state(
+            const lw_shared_ptr<const service::pager::paging_state>& paging_state);
 
     friend class migration_subscriber;
 

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -520,11 +520,14 @@ public:
     // For the local node, waits directly without an RPC.
     future<> wait_for_table_raft_groups_on_all_hosts(table_id table, lowres_clock::time_point timeout);
 
+    // pinned_plan and forced_keyspace re-derive a statement continuing a
+    // paged query: same plan, same keyspace it was prepared against.
     std::unique_ptr<statements::prepared_statement> get_statement(
             utils::chunked_string_view query,
             const service::client_state& client_state,
             dialect d,
-            std::optional<service::pager::query_plan> pinned_plan = std::nullopt);
+            std::optional<service::pager::query_plan> pinned_plan = std::nullopt,
+            std::optional<std::string_view> forced_keyspace = std::nullopt);
 
     static std::optional<service::pager::query_plan> pinned_plan_from_paging_state(
             const lw_shared_ptr<const service::pager::paging_state>& paging_state);

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -815,7 +815,8 @@ statement_restrictions::statement_restrictions(private_tag,
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering,
-        check_indexes do_check_indexes)
+        check_indexes do_check_indexes,
+        pinned_plan_opt)
     : statement_restrictions(private_tag{}, schema, allow_filtering)
 {
     _check_indexes = do_check_indexes;
@@ -2764,8 +2765,9 @@ analyze_statement_restrictions(
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering,
-        check_indexes do_check_indexes) {
-    return make_shared<statement_restrictions>(statement_restrictions::private_tag{}, db, std::move(schema), type, where_clause, ctx, selects_only_static_columns, for_view, allow_filtering, do_check_indexes);
+        check_indexes do_check_indexes,
+        pinned_plan_opt pinned_plan) {
+    return seastar::make_shared<statement_restrictions>(statement_restrictions::private_tag{}, db, std::move(schema), type, where_clause, ctx, selects_only_static_columns, for_view, allow_filtering, do_check_indexes, std::move(pinned_plan));
 }
 
 shared_ptr<const statement_restrictions>

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -707,14 +707,19 @@ struct index_search_group {
 
 // Like index_supports_some_column, but operates on per-column predicate vectors
 // instead of walking per-column expression trees.
+// pinned_index_name, when set, hides every other index. See #18992.
 static bool index_supports_some_column(
         const single_column_predicate_vectors& per_column_predicates,
         const secondary_index::secondary_index_manager& index_manager,
-        allow_local_index allow_local) {
+        allow_local_index allow_local,
+        const std::optional<sstring>& pinned_index_name) {
     using namespace secondary_index;
     for (auto& [col, preds] : per_column_predicates) {
         for (const auto& idx : index_manager.list_indexes()) {
             if (!allow_local && idx.metadata().local()) {
+                continue;
+            }
+            if (pinned_index_name && idx.metadata().name() != *pinned_index_name) {
                 continue;
             }
             if (preds.empty()) {
@@ -742,9 +747,13 @@ static bool index_supports_some_column(
 static bool multi_column_predicates_have_supporting_index(
         const std::vector<predicate>& mc_preds,
         const secondary_index::secondary_index_manager& index_manager,
-        allow_local_index allow_local) {
+        allow_local_index allow_local,
+        const std::optional<sstring>& pinned_index_name) {
     for (const auto& idx : index_manager.list_indexes()) {
         if (!allow_local && idx.metadata().local()) {
+            continue;
+        }
+        if (pinned_index_name && idx.metadata().name() != *pinned_index_name) {
             continue;
         }
         for (const auto& pred : mc_preds) {
@@ -790,7 +799,46 @@ static do_find_idx_result do_find_idx(
         bool uses_secondary_indexing,
         const secondary_index::secondary_index_manager& sim,
         std::span<const index_search_group> search_groups,
-        allow_local_index allow_local);
+        allow_local_index allow_local,
+        std::optional<sstring> pinned_index_name);
+
+// The pinned plan is a view id naming no index of this table: it was dropped or
+// recreated, this node has not learned of it yet, or the state belongs to
+// another query. A view id has no name left to report either way. See #18992.
+[[noreturn]] static void throw_pinned_plan_gone() {
+    throw exceptions::invalid_request_exception(
+            "Cannot continue paged query: the secondary index used by this "
+            "query is no longer available - it was dropped or recreated, or "
+            "this node does not know it yet. Please retry the query from the "
+            "beginning.");
+}
+
+// The pinned plan is still available - the base table, or an index that is still
+// there - it just cannot serve the query it was handed to, which is not
+// something retrying could fix. See #18992.
+[[noreturn]] static void throw_pinned_plan_foreign() {
+    throw exceptions::invalid_request_exception(
+            "Cannot continue paged query: the paging state was produced by a "
+            "query plan that cannot serve this one. Paging state can only be "
+            "used to continue the query that produced it.");
+}
+
+// Id of the view backing an index - what identifies it across DROP/CREATE.
+// std::nullopt for indexes with no view, which are never pinned this way.
+static std::optional<table_id> index_view_id(
+        data_dictionary::database db,
+        const schema& base_schema,
+        const secondary_index::index& idx) {
+    const auto& im = idx.metadata();
+    if (!db::schema_tables::view_should_exist(im)) {
+        return std::nullopt;
+    }
+    auto view = db.try_find_table(base_schema.ks_name(), secondary_index::index_table_name(im.name()));
+    if (!view) {
+        return std::nullopt;
+    }
+    return view->schema()->id();
+}
 
 
 bool is_empty_restriction(const expression& e) {
@@ -816,7 +864,7 @@ statement_restrictions::statement_restrictions(private_tag,
         bool for_view,
         bool allow_filtering,
         check_indexes do_check_indexes,
-        pinned_plan_opt)
+        pinned_plan_opt pinned_plan)
     : statement_restrictions(private_tag{}, schema, allow_filtering)
 {
     _check_indexes = do_check_indexes;
@@ -1115,25 +1163,75 @@ statement_restrictions::statement_restrictions(private_tag,
     _ck_is_all_eq = ck_is_all_eq;
     _pk_is_all_eq = pk_is_all_eq;
     _pk_has_slice_or_needs_filtering = pk_has_slice_or_needs_filtering;
+    std::optional<sstring> pinned_index_name;
+    bool force_base_plan = false;
+    std::optional<table_id> pinned_view_id;
+    if (pinned_plan) {
+        std::visit(overloaded_functor{
+                [&] (const service::pager::primary_index_plan&) { force_base_plan = true; },
+                [&] (const service::pager::index_plan& plan) { pinned_view_id = plan.view_id; },
+        }, *pinned_plan);
+    }
     if (_check_indexes) {
         auto cf = db.find_column_family(schema);
         auto& sim = cf.get_index_manager();
         const expr::allow_local_index allow_local(
                 !has_partition_key_unrestricted_components()
                 && partition_key_restrictions_is_all_eq());
-        if (!_has_multi_column) {
-            _has_queriable_ck_index = index_supports_some_column(sc_ck_pred_vectors, sim, allow_local)
-                    && !type.is_delete();
+        // Resolve the pinned view id to the index it names, so the plan search
+        // below can filter by it. An id naming no live index means it is gone.
+        if (pinned_view_id) {
+            for (const auto& idx : sim.list_indexes()) {
+                if (index_view_id(db, *schema, idx) == *pinned_view_id) {
+                    pinned_index_name = idx.metadata().name();
+                    break;
+                }
+            }
+            if (!pinned_index_name) {
+                throw_pinned_plan_gone();
+            }
+        }
+        // Hide every index the pinned plan did not use, so the analysis below
+        // reaches the conclusions the page that saved the position reached.
+        if (force_base_plan) {
+            _has_queriable_ck_index = false;
+            _has_queriable_pk_index = false;
+            _has_queriable_regular_index = false;
+            // A query needing an index cannot have saved a base-table position,
+            // so the state came from another query. Mirrors the check below.
+            // Only regular-column restrictions are looked at: a query needing an
+            // index on a key column is rejected a few steps down by the ordinary
+            // filtering validation instead, and reported as that.
+            if (!allow_filtering && !type.is_delete() && !type.is_update()
+                    && !is_empty_restriction(_nonprimary_key_restrictions)) {
+                throw_pinned_plan_foreign();
+            }
         } else {
-            _has_queriable_ck_index = multi_column_predicates_have_supporting_index(mc_ck_preds, sim, allow_local)
+            if (!_has_multi_column) {
+                _has_queriable_ck_index = index_supports_some_column(sc_ck_pred_vectors, sim, allow_local, pinned_index_name)
+                        && !type.is_delete();
+            } else {
+                _has_queriable_ck_index = multi_column_predicates_have_supporting_index(mc_ck_preds, sim, allow_local, pinned_index_name)
+                        && !type.is_delete();
+            }
+            _has_queriable_pk_index = !has_token
+                    && index_supports_some_column(sc_pk_pred_vectors, sim, allow_local, pinned_index_name)
+                    && !type.is_delete();
+            _has_queriable_regular_index = index_supports_some_column(sc_nonpk_pred_vectors, sim, allow_local, pinned_index_name)
                     && !type.is_delete();
         }
-        _has_queriable_pk_index = !has_token
-                && index_supports_some_column(sc_pk_pred_vectors, sim, allow_local)
-                && !type.is_delete();
-        _has_queriable_regular_index = index_supports_some_column(sc_nonpk_pred_vectors, sim, allow_local)
-                && !type.is_delete();
+        // The pinned index cannot serve this query, so the state came from
+        // another one. Caught here, before ALLOW FILTERING is complained about.
+        if (pinned_index_name
+                && !_has_queriable_ck_index && !_has_queriable_pk_index && !_has_queriable_regular_index) {
+            throw_pinned_plan_foreign();
+        }
     } else {
+        // No index manager here, so a pin on an index view cannot be honoured -
+        // and must not be ignored, or its position is read against the base.
+        if (pinned_view_id) {
+            throw_pinned_plan_foreign();
+        }
         _has_queriable_ck_index = false;
         _has_queriable_pk_index = false;
         _has_queriable_regular_index = false;
@@ -1208,7 +1306,7 @@ statement_restrictions::statement_restrictions(private_tag,
                 !has_partition_key_unrestricted_components()
                 && partition_key_restrictions_is_all_eq());
         auto idx_result = do_find_idx(
-                _uses_secondary_indexing, sim, search_groups, allow_local_for_idx);
+                _uses_secondary_indexing, sim, search_groups, allow_local_for_idx, std::move(pinned_index_name));
         if (idx_result.index) {
             _idx_opt = std::make_unique<secondary_index::index>(std::move(*idx_result.index));
         }
@@ -1371,8 +1469,18 @@ static do_find_idx_result do_find_idx(
         bool uses_secondary_indexing,
         const secondary_index::secondary_index_manager& sim,
         std::span<const index_search_group> search_groups,
-        allow_local_index allow_local) {
+        allow_local_index allow_local,
+        std::optional<sstring> pinned_index_name) {
+    // The caller resolved the pinned plan's table id to this name, so matching
+    // by name here can't pick up an index recreated under the same name.
+    const bool has_pinned_index = pinned_index_name.has_value();
+
     if (!uses_secondary_indexing) {
+        // The pinned index is there but yields no plan for this query; refuse
+        // rather than fall back to the base table and misread the saved position.
+        if (has_pinned_index) {
+            throw_pinned_plan_foreign();
+        }
         return {std::nullopt, expr::conjunction({}), {}};
     }
 
@@ -1412,6 +1520,9 @@ static do_find_idx_result do_find_idx(
             }
             const auto& [col, preds] = *it;
             for (const auto& index : sim.list_indexes()) {
+                if (has_pinned_index && index.metadata().name() != *pinned_index_name) {
+                    continue;
+                }
                 if (col->name_as_text() == index.target_column() &&
                         are_predicates_supported_by(preds, index) &&
                         index_score(index) > chosen_index_score) {
@@ -1422,6 +1533,9 @@ static do_find_idx_result do_find_idx(
                 }
             }
         });
+    }
+    if (has_pinned_index && !chosen_index) {
+        throw_pinned_plan_foreign();
     }
     return {chosen_index, chosen_index_restrictions, std::move(chosen_index_predicates)};
 }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -707,14 +707,19 @@ struct index_search_group {
 
 // Like index_supports_some_column, but operates on per-column predicate vectors
 // instead of walking per-column expression trees.
+// pinned_index_name, when set, hides every other index. See #18992.
 static bool index_supports_some_column(
         const single_column_predicate_vectors& per_column_predicates,
         const secondary_index::secondary_index_manager& index_manager,
-        allow_local_index allow_local) {
+        allow_local_index allow_local,
+        const std::optional<sstring>& pinned_index_name) {
     using namespace secondary_index;
     for (auto& [col, preds] : per_column_predicates) {
         for (const auto& idx : index_manager.list_indexes()) {
             if (!allow_local && idx.metadata().local()) {
+                continue;
+            }
+            if (pinned_index_name && idx.metadata().name() != *pinned_index_name) {
                 continue;
             }
             if (preds.empty()) {
@@ -742,9 +747,13 @@ static bool index_supports_some_column(
 static bool multi_column_predicates_have_supporting_index(
         const std::vector<predicate>& mc_preds,
         const secondary_index::secondary_index_manager& index_manager,
-        allow_local_index allow_local) {
+        allow_local_index allow_local,
+        const std::optional<sstring>& pinned_index_name) {
     for (const auto& idx : index_manager.list_indexes()) {
         if (!allow_local && idx.metadata().local()) {
+            continue;
+        }
+        if (pinned_index_name && idx.metadata().name() != *pinned_index_name) {
             continue;
         }
         for (const auto& pred : mc_preds) {
@@ -790,7 +799,46 @@ static do_find_idx_result do_find_idx(
         bool uses_secondary_indexing,
         const secondary_index::secondary_index_manager& sim,
         std::span<const index_search_group> search_groups,
-        allow_local_index allow_local);
+        allow_local_index allow_local,
+        std::optional<sstring> pinned_index_name);
+
+// The pinned plan is a view id naming no index of this table: it was dropped or
+// recreated, this node has not learned of it yet, or the state belongs to
+// another query. A view id has no name left to report either way. See #18992.
+[[noreturn]] static void throw_pinned_plan_gone() {
+    throw exceptions::invalid_request_exception(
+            "Cannot continue paged query: the secondary index used by this "
+            "query is no longer available - it was dropped or recreated, or "
+            "this node does not know it yet. Please retry the query from the "
+            "beginning.");
+}
+
+// The pinned plan is still available - the base table, or an index that is still
+// there - it just cannot serve the query it was handed to, which is not
+// something retrying could fix. See #18992.
+[[noreturn]] static void throw_pinned_plan_foreign() {
+    throw exceptions::invalid_request_exception(
+            "Cannot continue paged query: the paging state was produced by a "
+            "query plan that cannot serve this one. Paging state can only be "
+            "used to continue the query that produced it.");
+}
+
+// Id of the view backing an index - what identifies it across DROP/CREATE.
+// std::nullopt for indexes with no view, which are never pinned this way.
+static std::optional<table_id> index_view_id(
+        data_dictionary::database db,
+        const schema& base_schema,
+        const secondary_index::index& idx) {
+    const auto& im = idx.metadata();
+    if (!db::schema_tables::view_should_exist(im)) {
+        return std::nullopt;
+    }
+    auto view = db.try_find_table(base_schema.ks_name(), secondary_index::index_table_name(im.name()));
+    if (!view) {
+        return std::nullopt;
+    }
+    return view->schema()->id();
+}
 
 
 bool is_empty_restriction(const expression& e) {
@@ -816,7 +864,7 @@ statement_restrictions::statement_restrictions(private_tag,
         bool for_view,
         bool allow_filtering,
         check_indexes do_check_indexes,
-        forced_plan_id_opt)
+        forced_plan_id_opt forced_plan_id)
     : statement_restrictions(private_tag{}, schema, allow_filtering)
 {
     _check_indexes = do_check_indexes;
@@ -1115,25 +1163,68 @@ statement_restrictions::statement_restrictions(private_tag,
     _ck_is_all_eq = ck_is_all_eq;
     _pk_is_all_eq = pk_is_all_eq;
     _pk_has_slice_or_needs_filtering = pk_has_slice_or_needs_filtering;
+    std::optional<sstring> pinned_index_name;
+    // A pinned plan is either a null id, standing for the base table, or the id
+    // of the index view to keep scanning.
+    const bool force_base_plan = forced_plan_id && !*forced_plan_id;
+    const bool force_index_plan = forced_plan_id && !force_base_plan;
     if (_check_indexes) {
         auto cf = db.find_column_family(schema);
         auto& sim = cf.get_index_manager();
         const expr::allow_local_index allow_local(
                 !has_partition_key_unrestricted_components()
                 && partition_key_restrictions_is_all_eq());
-        if (!_has_multi_column) {
-            _has_queriable_ck_index = index_supports_some_column(sc_ck_pred_vectors, sim, allow_local)
-                    && !type.is_delete();
+        // Resolve the pinned id to the index it names, so the plan search below
+        // can filter by it. An id that names no live index means that index is gone.
+        if (force_index_plan) {
+            for (const auto& idx : sim.list_indexes()) {
+                if (index_view_id(db, *schema, idx) == *forced_plan_id) {
+                    pinned_index_name = idx.metadata().name();
+                    break;
+                }
+            }
+            if (!pinned_index_name) {
+                throw_pinned_plan_gone();
+            }
+        }
+        // Hide every index the pinned plan did not use, so the analysis below
+        // reaches the conclusions the page that saved the position reached.
+        if (force_base_plan) {
+            _has_queriable_ck_index = false;
+            _has_queriable_pk_index = false;
+            _has_queriable_regular_index = false;
+            // A query needing an index cannot have saved a base-table position,
+            // so the state came from another query. Mirrors the check below.
+            if (!allow_filtering && !type.is_delete() && !type.is_update()
+                    && !is_empty_restriction(_nonprimary_key_restrictions)) {
+                throw_pinned_plan_foreign();
+            }
         } else {
-            _has_queriable_ck_index = multi_column_predicates_have_supporting_index(mc_ck_preds, sim, allow_local)
+            if (!_has_multi_column) {
+                _has_queriable_ck_index = index_supports_some_column(sc_ck_pred_vectors, sim, allow_local, pinned_index_name)
+                        && !type.is_delete();
+            } else {
+                _has_queriable_ck_index = multi_column_predicates_have_supporting_index(mc_ck_preds, sim, allow_local, pinned_index_name)
+                        && !type.is_delete();
+            }
+            _has_queriable_pk_index = !has_token
+                    && index_supports_some_column(sc_pk_pred_vectors, sim, allow_local, pinned_index_name)
+                    && !type.is_delete();
+            _has_queriable_regular_index = index_supports_some_column(sc_nonpk_pred_vectors, sim, allow_local, pinned_index_name)
                     && !type.is_delete();
         }
-        _has_queriable_pk_index = !has_token
-                && index_supports_some_column(sc_pk_pred_vectors, sim, allow_local)
-                && !type.is_delete();
-        _has_queriable_regular_index = index_supports_some_column(sc_nonpk_pred_vectors, sim, allow_local)
-                && !type.is_delete();
+        // The pinned index cannot serve this query, so the state came from
+        // another one. Caught here, before ALLOW FILTERING is complained about.
+        if (pinned_index_name
+                && !_has_queriable_ck_index && !_has_queriable_pk_index && !_has_queriable_regular_index) {
+            throw_pinned_plan_foreign();
+        }
     } else {
+        // No index manager here, so a pin on an index view cannot be honoured -
+        // and must not be ignored, or its position is read against the base.
+        if (force_index_plan) {
+            throw_pinned_plan_foreign();
+        }
         _has_queriable_ck_index = false;
         _has_queriable_pk_index = false;
         _has_queriable_regular_index = false;
@@ -1208,7 +1299,7 @@ statement_restrictions::statement_restrictions(private_tag,
                 !has_partition_key_unrestricted_components()
                 && partition_key_restrictions_is_all_eq());
         auto idx_result = do_find_idx(
-                _uses_secondary_indexing, sim, search_groups, allow_local_for_idx);
+                _uses_secondary_indexing, sim, search_groups, allow_local_for_idx, std::move(pinned_index_name));
         if (idx_result.index) {
             _idx_opt = std::make_unique<secondary_index::index>(std::move(*idx_result.index));
         }
@@ -1371,8 +1462,18 @@ static do_find_idx_result do_find_idx(
         bool uses_secondary_indexing,
         const secondary_index::secondary_index_manager& sim,
         std::span<const index_search_group> search_groups,
-        allow_local_index allow_local) {
+        allow_local_index allow_local,
+        std::optional<sstring> pinned_index_name) {
+    // The caller resolved the pinned plan's table id to this name, so matching
+    // by name here can't pick up an index recreated under the same name.
+    const bool has_pinned_index = pinned_index_name.has_value();
+
     if (!uses_secondary_indexing) {
+        // The pinned index is there but yields no plan for this query; refuse
+        // rather than fall back to the base table and misread the saved position.
+        if (has_pinned_index) {
+            throw_pinned_plan_foreign();
+        }
         return {std::nullopt, expr::conjunction({}), {}};
     }
 
@@ -1412,6 +1513,9 @@ static do_find_idx_result do_find_idx(
             }
             const auto& [col, preds] = *it;
             for (const auto& index : sim.list_indexes()) {
+                if (has_pinned_index && index.metadata().name() != *pinned_index_name) {
+                    continue;
+                }
                 if (col->name_as_text() == index.target_column() &&
                         are_predicates_supported_by(preds, index) &&
                         index_score(index) > chosen_index_score) {
@@ -1422,6 +1526,9 @@ static do_find_idx_result do_find_idx(
                 }
             }
         });
+    }
+    if (has_pinned_index && !chosen_index) {
+        throw_pinned_plan_foreign();
     }
     return {chosen_index, chosen_index_restrictions, std::move(chosen_index_predicates)};
 }

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -815,7 +815,8 @@ statement_restrictions::statement_restrictions(private_tag,
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering,
-        check_indexes do_check_indexes)
+        check_indexes do_check_indexes,
+        forced_plan_id_opt)
     : statement_restrictions(private_tag{}, schema, allow_filtering)
 {
     _check_indexes = do_check_indexes;
@@ -2764,8 +2765,11 @@ analyze_statement_restrictions(
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering,
-        check_indexes do_check_indexes) {
-    return make_shared<statement_restrictions>(statement_restrictions::private_tag{}, db, std::move(schema), type, where_clause, ctx, selects_only_static_columns, for_view, allow_filtering, do_check_indexes);
+        check_indexes do_check_indexes,
+        forced_plan_id_opt forced_plan_id) {
+    // seastar::make_shared has to be qualified: the std::optional argument drags
+    // namespace std into the overload set, making the unqualified call ambiguous.
+    return seastar::make_shared<statement_restrictions>(statement_restrictions::private_tag{}, db, std::move(schema), type, where_clause, ctx, selects_only_static_columns, for_view, allow_filtering, do_check_indexes, std::move(forced_plan_id));
 }
 
 shared_ptr<const statement_restrictions>

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -95,6 +95,10 @@ struct predicate {
 ///have an index-manager, or even a table object.
 using check_indexes = bool_class<class check_indexes_tag>;
 
+/// Table a continued paged query must keep scanning - base table or index view.
+/// The query fails if it is gone; std::nullopt plans normally. See #18992.
+using forced_plan_id_opt = std::optional<table_id>;
+
 // A function that returns the partition key ranges for a query. It is the solver of
 // WHERE clause fragments such as WHERE token(pk) > 1 or WHERE pk1 IN :list1 AND pk2 IN :list2.
 using get_partition_key_ranges_fn_t = std::function<dht::partition_range_vector (const query_options&)>;
@@ -262,7 +266,8 @@ public:
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering,
-        check_indexes do_check_indexes);
+        check_indexes do_check_indexes,
+        forced_plan_id_opt forced_plan_id);
     friend shared_ptr<const statement_restrictions> make_trivial_statement_restrictions(
         schema_ptr schema,
         bool allow_filtering);
@@ -279,7 +284,8 @@ public:
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering,
-        check_indexes do_check_indexes);
+        check_indexes do_check_indexes,
+        forced_plan_id_opt forced_plan_id);
 public:
 
     const std::vector<expr::expression>& index_restrictions() const;
@@ -543,7 +549,8 @@ shared_ptr<const statement_restrictions> analyze_statement_restrictions(
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering,
-        check_indexes do_check_indexes);
+        check_indexes do_check_indexes,
+        forced_plan_id_opt forced_plan_id = std::nullopt);
 
 shared_ptr<const statement_restrictions> make_trivial_statement_restrictions(
         schema_ptr schema,

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -18,6 +18,7 @@
 #include "cql3/prepare_context.hh"
 #include "cql3/statements/statement_type.hh"
 #include "query/query-request.hh"
+#include "service/pager/query_plan.hh"
 
 namespace cql3 {
 
@@ -94,6 +95,11 @@ struct predicate {
 ///impossible, because e.g. the query runs on a pseudo-table, which does not
 ///have an index-manager, or even a table object.
 using check_indexes = bool_class<class check_indexes_tag>;
+
+/// The plan a continued paged query must keep scanning - the base table, or an
+/// index view. The query fails if that plan is gone or cannot serve the query;
+/// std::nullopt plans normally. See #18992.
+using pinned_plan_opt = std::optional<service::pager::query_plan>;
 
 // A function that returns the partition key ranges for a query. It is the solver of
 // WHERE clause fragments such as WHERE token(pk) > 1 or WHERE pk1 IN :list1 AND pk2 IN :list2.
@@ -262,7 +268,8 @@ public:
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering,
-        check_indexes do_check_indexes);
+        check_indexes do_check_indexes,
+        pinned_plan_opt pinned_plan);
     friend shared_ptr<const statement_restrictions> make_trivial_statement_restrictions(
         schema_ptr schema,
         bool allow_filtering);
@@ -279,7 +286,8 @@ public:
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering,
-        check_indexes do_check_indexes);
+        check_indexes do_check_indexes,
+        pinned_plan_opt pinned_plan);
 public:
 
     const std::vector<expr::expression>& index_restrictions() const;
@@ -543,7 +551,8 @@ shared_ptr<const statement_restrictions> analyze_statement_restrictions(
         bool selects_only_static_columns,
         bool for_view,
         bool allow_filtering,
-        check_indexes do_check_indexes);
+        check_indexes do_check_indexes,
+        pinned_plan_opt pinned_plan = std::nullopt);
 
 shared_ptr<const statement_restrictions> make_trivial_statement_restrictions(
         schema_ptr schema,

--- a/cql3/statements/raw/cf_statement.hh
+++ b/cql3/statements/raw/cf_statement.hh
@@ -37,7 +37,7 @@ public:
     virtual void prepare_keyspace(const service::client_state& state);
 
     // Only for internal calls, use the version with ClientState for user queries
-    void prepare_keyspace(std::string_view keyspace);
+    virtual void prepare_keyspace(std::string_view keyspace);
 
     // Only SELECT is ever paged, so only SELECT overrides this. See #18992.
     virtual void set_forced_plan_id(std::optional<table_id>) {}

--- a/cql3/statements/raw/cf_statement.hh
+++ b/cql3/statements/raw/cf_statement.hh
@@ -37,7 +37,7 @@ public:
     virtual void prepare_keyspace(const service::client_state& state);
 
     // Only for internal calls, use the version with ClientState for user queries
-    void prepare_keyspace(std::string_view keyspace);
+    virtual void prepare_keyspace(std::string_view keyspace);
 
     // Only SELECT is ever paged, so only SELECT overrides this. See #18992.
     virtual void set_pinned_plan(std::optional<service::pager::query_plan>) {}

--- a/cql3/statements/raw/cf_statement.hh
+++ b/cql3/statements/raw/cf_statement.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cql3/cf_name.hh"
+#include "service/pager/query_plan.hh"
 
 #include <optional>
 
@@ -37,6 +38,9 @@ public:
 
     // Only for internal calls, use the version with ClientState for user queries
     void prepare_keyspace(std::string_view keyspace);
+
+    // Only SELECT is ever paged, so only SELECT overrides this. See #18992.
+    virtual void set_pinned_plan(std::optional<service::pager::query_plan>) {}
 
     virtual bool has_keyspace() const;
 

--- a/cql3/statements/raw/cf_statement.hh
+++ b/cql3/statements/raw/cf_statement.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cql3/cf_name.hh"
+#include "schema/schema_fwd.hh"
 
 #include <optional>
 
@@ -37,6 +38,9 @@ public:
 
     // Only for internal calls, use the version with ClientState for user queries
     void prepare_keyspace(std::string_view keyspace);
+
+    // Only SELECT is ever paged, so only SELECT overrides this. See #18992.
+    virtual void set_forced_plan_id(std::optional<table_id>) {}
 
     virtual bool has_keyspace() const;
 

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -103,6 +103,7 @@ private:
     // captured in prepare_keyspace().
     bool _no_from = false;
     sstring _session_keyspace;
+    restrictions::forced_plan_id_opt _forced_plan_id;
 public:
     select_statement(std::optional<cf_name> cf_name,
             lw_shared_ptr<const parameters> parameters,
@@ -120,6 +121,10 @@ public:
         return prepare(db, stats, cfg, false);
     }
     std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg, bool for_view);
+
+    virtual void set_forced_plan_id(restrictions::forced_plan_id_opt forced_plan_id) override {
+        _forced_plan_id = std::move(forced_plan_id);
+    }
 private:
     std::vector<selection::prepared_selector> maybe_jsonize_select_clause(std::vector<selection::prepared_selector> select, data_dictionary::database db, schema_ptr schema);
     ::shared_ptr<const restrictions::statement_restrictions> prepare_restrictions(
@@ -129,7 +134,8 @@ private:
         ::shared_ptr<selection::selection> selection,
         bool for_view = false,
         bool allow_filtering = false,
-        restrictions::check_indexes do_check_indexes = restrictions::check_indexes::yes);
+        restrictions::check_indexes do_check_indexes = restrictions::check_indexes::yes,
+        restrictions::forced_plan_id_opt forced_plan_id = std::nullopt);
 
     /** Returns an expression for the limit or nullopt if no limit is set */
     std::optional<expr::expression> prepare_limit(data_dictionary::database db, prepare_context& ctx, const std::optional<expr::expression>& limit);

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -115,7 +115,7 @@ public:
             std::unique_ptr<cql3::attributes::raw> attrs);
 
     virtual void prepare_keyspace(const service::client_state& state) override;
-    using cf_statement::prepare_keyspace;
+    virtual void prepare_keyspace(std::string_view keyspace) override;
 
     virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override {
         return prepare(db, stats, cfg, false);

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -103,6 +103,7 @@ private:
     // captured in prepare_keyspace().
     bool _no_from = false;
     sstring _session_keyspace;
+    restrictions::pinned_plan_opt _pinned_plan;
 public:
     select_statement(std::optional<cf_name> cf_name,
             lw_shared_ptr<const parameters> parameters,
@@ -120,6 +121,10 @@ public:
         return prepare(db, stats, cfg, false);
     }
     std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg, bool for_view);
+
+    virtual void set_pinned_plan(restrictions::pinned_plan_opt pinned_plan) override {
+        _pinned_plan = std::move(pinned_plan);
+    }
 private:
     std::vector<selection::prepared_selector> maybe_jsonize_select_clause(std::vector<selection::prepared_selector> select, data_dictionary::database db, schema_ptr schema);
     ::shared_ptr<const restrictions::statement_restrictions> prepare_restrictions(
@@ -129,7 +134,8 @@ private:
         ::shared_ptr<selection::selection> selection,
         bool for_view = false,
         bool allow_filtering = false,
-        restrictions::check_indexes do_check_indexes = restrictions::check_indexes::yes);
+        restrictions::check_indexes do_check_indexes = restrictions::check_indexes::yes,
+        restrictions::pinned_plan_opt pinned_plan = std::nullopt);
 
     /** Returns an expression for the limit or nullopt if no limit is set */
     std::optional<expr::expression> prepare_limit(data_dictionary::database db, prepare_context& ctx, const std::optional<expr::expression>& limit);

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -601,7 +601,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
         auto meta = [&] () -> shared_ptr<const cql3::metadata> {
             if (!p->is_exhausted()) {
                 auto meta = make_shared<metadata>(*_selection->get_result_metadata());
-                meta->set_paging_state(p->state());
+                meta->set_paging_state(p->state(scanned_plan()));
                 return meta;
             } else {
                 return _selection->get_result_metadata();
@@ -619,7 +619,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
     }
     std::unique_ptr<cql3::result_set>&& rs = std::move(result_rs).assume_value();
     if (!p->is_exhausted()) {
-        rs->get_metadata().set_paging_state(p->state());
+        rs->get_metadata().set_paging_state(p->state(scanned_plan()));
     }
 
     if (needs_post_filtering()) {
@@ -954,6 +954,8 @@ view_indexed_table_select_statement::process_base_query_results(
         uint32_t internal_page_size) const
 {
     if (paging_state) {
+        // The plan was recorded where the state was built, by the scan of the
+        // index view, and survives the rewriting below. See #18992.
         paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options, internal_page_size);
         _selection->get_result_metadata()->maybe_set_paging_state(std::move(paging_state));
     }
@@ -1011,6 +1013,10 @@ select_statement::process_results_complex(foreign_ptr<lw_shared_ptr<query::resul
 
 const ::shared_ptr<const restrictions::statement_restrictions> select_statement::get_restrictions() const {
     return _restrictions;
+}
+
+service::pager::query_plan select_statement::scanned_plan() const {
+    return service::pager::primary_index_plan{};
 }
 
 primary_key_select_statement::primary_key_select_statement(schema_ptr schema, uint32_t bound_terms,
@@ -1109,6 +1115,10 @@ view_indexed_table_select_statement::view_indexed_table_select_statement(schema_
         _get_partition_ranges_for_posting_list = [this] (const query_options& options) { return get_partition_ranges_for_global_index_posting_list(options); };
         _get_partition_slice_for_posting_list = [this] (const query_options& options) { return get_partition_slice_for_global_index_posting_list(options); };
     }
+}
+
+service::pager::query_plan view_indexed_table_select_statement::scanned_plan() const {
+    return service::pager::index_plan{_view_schema->id()};
 }
 
 template<typename KeyType>
@@ -1456,9 +1466,11 @@ view_indexed_table_select_statement::read_posting_list(query_processor& qp,
 
     auto p = service::pager::query_pagers::pager(qp.proxy(), _view_schema, selection,
             state, options, cmd, std::move(partition_ranges), nullptr);
-    return p->fetch_page_result(options.get_page_size(), now, timeout).then(utils::result_wrap([p = std::move(p)] (std::unique_ptr<cql3::result_set> rs)
+    return p->fetch_page_result(options.get_page_size(), now, timeout).then(utils::result_wrap([plan = scanned_plan(), p = std::move(p)] (std::unique_ptr<cql3::result_set> rs)
             -> coordinator_result<::shared_ptr<cql_transport::messages::result_message::rows>> {
-        rs->get_metadata().set_paging_state(p->state());
+        // This pager scans the index view, which is the plan a page of this query
+        // is served by, so record it here rather than stamping it on later. #18992
+        rs->get_metadata().set_paging_state(p->state(plan));
         return ::make_shared<cql_transport::messages::result_message::rows>(result(std::move(rs)));
     }));
 }
@@ -1943,7 +1955,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
             auto meta = [&] () -> shared_ptr<const cql3::metadata> {
                 if (!p->is_exhausted()) {
                     auto meta = make_shared<metadata>(*_selection->get_result_metadata());
-                    meta->set_paging_state(p->state());
+                    meta->set_paging_state(p->state(scanned_plan()));
                     return meta;
                 } else {
                     return _selection->get_result_metadata();
@@ -1959,7 +1971,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
     return p->fetch_page_result(page_size, now, timeout).then(wrap_result_to_error_message(
             [this, p = std::move(p)](std::unique_ptr<cql3::result_set>&& rs) {
                 if (!p->is_exhausted()) {
-                    rs->get_metadata().set_paging_state(p->state());
+                    rs->get_metadata().set_paging_state(p->state(scanned_plan()));
                 }
 
                 if (needs_post_filtering()) {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2152,7 +2152,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     }
 
     auto restrictions = prepare_restrictions(db, schema, ctx, selection, for_view, _parameters->allow_filtering() || is_ann_query || has_bm25_ordering,
-            restrictions::check_indexes(!_parameters->is_mutation_fragments()));
+            restrictions::check_indexes(!_parameters->is_mutation_fragments()), _pinned_plan);
 
     const auto& scoring_restrictions = restrictions->get_scoring_function_restrictions();
 
@@ -2365,11 +2365,12 @@ select_statement::prepare_restrictions(data_dictionary::database db,
                                        ::shared_ptr<selection::selection> selection,
                                        bool for_view,
                                        bool allow_filtering,
-                                       restrictions::check_indexes do_check_indexes)
+                                       restrictions::check_indexes do_check_indexes,
+                                       restrictions::pinned_plan_opt pinned_plan)
 {
     try {
         return restrictions::analyze_statement_restrictions(db, schema, statement_type::SELECT, _where_clause, ctx,
-            selection->contains_only_static_columns(), for_view, allow_filtering, do_check_indexes);
+            selection->contains_only_static_columns(), for_view, allow_filtering, do_check_indexes, std::move(pinned_plan));
     } catch (const exceptions::unrecognized_entity_exception& e) {
         if (contains_alias(e.entity)) {
             throw exceptions::invalid_request_exception(format("Aliases aren't allowed in the WHERE clause (name: '{}')", e.entity));

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1280,7 +1280,7 @@ view_indexed_table_select_statement::actually_do_execute(query_processor& qp,
                 if (paging_state) {
                     paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options, internal_page_size);
                 }
-                internal_options.reset(new cql3::query_options(std::move(internal_options), paging_state ? make_lw_shared<service::pager::paging_state>(*paging_state) : nullptr));
+                internal_options.reset(new cql3::query_options(std::move(internal_options), paging_state));
                 if (needs_post_filtering()) {
                     _stats.filtered_rows_read_total += *results->row_count();
                     query::result_view::consume(*results, cmd->slice, cql3::selection::result_set_builder::visitor(builder, *_schema, *_selection,

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2029,6 +2029,13 @@ void select_statement::prepare_keyspace(const service::client_state& state) {
     }
 }
 
+void select_statement::prepare_keyspace(std::string_view keyspace) {
+    cf_statement::prepare_keyspace(keyspace);
+    if (_no_from) {
+        _session_keyspace = sstring(keyspace);
+    }
+}
+
 std::vector<selection::prepared_selector>
 select_statement::maybe_jsonize_select_clause(std::vector<selection::prepared_selector> prepared_selectors, data_dictionary::database db, schema_ptr schema) {
     // Fill wildcard clause with explicit column identifiers for as_json function

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -601,7 +601,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
         auto meta = [&] () -> shared_ptr<const cql3::metadata> {
             if (!p->is_exhausted()) {
                 auto meta = make_shared<metadata>(*_selection->get_result_metadata());
-                meta->set_paging_state(p->state());
+                meta->set_paging_state(p->state(query_plan_id()));
                 return meta;
             } else {
                 return _selection->get_result_metadata();
@@ -619,7 +619,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
     }
     std::unique_ptr<cql3::result_set>&& rs = std::move(result_rs).assume_value();
     if (!p->is_exhausted()) {
-        rs->get_metadata().set_paging_state(p->state());
+        rs->get_metadata().set_paging_state(p->state(query_plan_id()));
     }
 
     if (needs_post_filtering()) {
@@ -954,6 +954,8 @@ view_indexed_table_select_statement::process_base_query_results(
         uint32_t internal_page_size) const
 {
     if (paging_state) {
+        // The plan was recorded where the state was built, by the scan of the
+        // index view, and survives the rewriting below. See #18992.
         paging_state = generate_view_paging_state_from_base_query_results(paging_state, results, state, options, internal_page_size);
         _selection->get_result_metadata()->maybe_set_paging_state(std::move(paging_state));
     }
@@ -1011,6 +1013,10 @@ select_statement::process_results_complex(foreign_ptr<lw_shared_ptr<query::resul
 
 const ::shared_ptr<const restrictions::statement_restrictions> select_statement::get_restrictions() const {
     return _restrictions;
+}
+
+table_id select_statement::query_plan_id() const {
+    return table_id::create_null_id();
 }
 
 primary_key_select_statement::primary_key_select_statement(schema_ptr schema, uint32_t bound_terms,
@@ -1109,6 +1115,10 @@ view_indexed_table_select_statement::view_indexed_table_select_statement(schema_
         _get_partition_ranges_for_posting_list = [this] (const query_options& options) { return get_partition_ranges_for_global_index_posting_list(options); };
         _get_partition_slice_for_posting_list = [this] (const query_options& options) { return get_partition_slice_for_global_index_posting_list(options); };
     }
+}
+
+table_id view_indexed_table_select_statement::query_plan_id() const {
+    return _view_schema->id();
 }
 
 template<typename KeyType>
@@ -1456,9 +1466,11 @@ view_indexed_table_select_statement::read_posting_list(query_processor& qp,
 
     auto p = service::pager::query_pagers::pager(qp.proxy(), _view_schema, selection,
             state, options, cmd, std::move(partition_ranges), nullptr);
-    return p->fetch_page_result(options.get_page_size(), now, timeout).then(utils::result_wrap([p = std::move(p)] (std::unique_ptr<cql3::result_set> rs)
+    return p->fetch_page_result(options.get_page_size(), now, timeout).then(utils::result_wrap([this, p = std::move(p)] (std::unique_ptr<cql3::result_set> rs)
             -> coordinator_result<::shared_ptr<cql_transport::messages::result_message::rows>> {
-        rs->get_metadata().set_paging_state(p->state());
+        // This pager scans the index view, which is the plan a page of this query
+        // is served by, so record it here rather than stamping it on later. #18992
+        rs->get_metadata().set_paging_state(p->state(query_plan_id()));
         return ::make_shared<cql_transport::messages::result_message::rows>(result(std::move(rs)));
     }));
 }
@@ -1943,7 +1955,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
             auto meta = [&] () -> shared_ptr<const cql3::metadata> {
                 if (!p->is_exhausted()) {
                     auto meta = make_shared<metadata>(*_selection->get_result_metadata());
-                    meta->set_paging_state(p->state());
+                    meta->set_paging_state(p->state(query_plan_id()));
                     return meta;
                 } else {
                     return _selection->get_result_metadata();
@@ -1959,7 +1971,7 @@ mutation_fragments_select_statement::do_execute(query_processor& qp, service::qu
     return p->fetch_page_result(page_size, now, timeout).then(wrap_result_to_error_message(
             [this, p = std::move(p)](std::unique_ptr<cql3::result_set>&& rs) {
                 if (!p->is_exhausted()) {
-                    rs->get_metadata().set_paging_state(p->state());
+                    rs->get_metadata().set_paging_state(p->state(query_plan_id()));
                 }
 
                 if (needs_post_filtering()) {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2152,7 +2152,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     }
 
     auto restrictions = prepare_restrictions(db, schema, ctx, selection, for_view, _parameters->allow_filtering() || is_ann_query || has_bm25_ordering,
-            restrictions::check_indexes(!_parameters->is_mutation_fragments()));
+            restrictions::check_indexes(!_parameters->is_mutation_fragments()), _forced_plan_id);
 
     const auto& scoring_restrictions = restrictions->get_scoring_function_restrictions();
 
@@ -2365,11 +2365,12 @@ select_statement::prepare_restrictions(data_dictionary::database db,
                                        ::shared_ptr<selection::selection> selection,
                                        bool for_view,
                                        bool allow_filtering,
-                                       restrictions::check_indexes do_check_indexes)
+                                       restrictions::check_indexes do_check_indexes,
+                                       restrictions::forced_plan_id_opt forced_plan_id)
 {
     try {
         return restrictions::analyze_statement_restrictions(db, schema, statement_type::SELECT, _where_clause, ctx,
-            selection->contains_only_static_columns(), for_view, allow_filtering, do_check_indexes);
+            selection->contains_only_static_columns(), for_view, allow_filtering, do_check_indexes, std::move(forced_plan_id));
     } catch (const exceptions::unrecognized_entity_exception& e) {
         if (contains_alias(e.entity)) {
             throw exceptions::invalid_request_exception(format("Aliases aren't allowed in the WHERE clause (name: '{}')", e.entity));

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -125,6 +125,14 @@ public:
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
+    virtual std::optional<service::pager::query_plan> query_plan_for_paging() const override {
+        return scanned_plan();
+    }
+
+    virtual std::optional<std::string_view> keyspace_for_reparse() const override {
+        return keyspace();
+    }
+
     virtual bool should_reclassify_control_connection() const override;
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor& qp,

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -125,6 +125,10 @@ public:
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
+    virtual std::optional<query_plan> query_plan_for_paging() const override {
+        return query_plan{query_plan_id(), keyspace()};
+    }
+
     virtual bool should_reclassify_control_connection() const override;
 
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor& qp,

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -163,6 +163,10 @@ public:
     db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
 
 protected:
+    // The plan this statement scans, recorded in the paging state it hands out
+    // so that a later page keeps reading the same thing. See #18992.
+    virtual service::pager::query_plan scanned_plan() const;
+
     uint64_t get_limit(const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit = false) const;
     static uint64_t get_inner_loop_limit(uint64_t limit, bool is_aggregate);
 
@@ -228,6 +232,9 @@ public:
                                    const secondary_index::index& index,
                                    schema_ptr view_schema,
                                    std::unique_ptr<cql3::attributes> attrs);
+
+protected:
+    virtual service::pager::query_plan scanned_plan() const override;
 
 private:
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(query_processor& qp,

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -163,6 +163,10 @@ public:
     db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
 
 protected:
+    // Id of the index view this statement scans, or a null id for the base
+    // table, whose identity a resumed read is not tied to. See #18992.
+    virtual table_id query_plan_id() const;
+
     uint64_t get_limit(const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit = false) const;
     static uint64_t get_inner_loop_limit(uint64_t limit, bool is_aggregate);
 
@@ -228,6 +232,9 @@ public:
                                    const secondary_index::index& index,
                                    schema_ptr view_schema,
                                    std::unique_ptr<cql3::attributes> attrs);
+
+protected:
+    virtual table_id query_plan_id() const override;
 
 private:
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(query_processor& qp,

--- a/cql3/stats.hh
+++ b/cql3/stats.hh
@@ -80,6 +80,7 @@ struct cql_stats {
     int64_t select_partition_range_scan = 0;
     int64_t select_partition_range_scan_no_bypass_cache = 0;
     int64_t select_parallelized = 0;
+    int64_t select_paging_plan_rederivations = 0;
 
     uint64_t minimum_replication_factor_fail_violations = 0;
     uint64_t minimum_replication_factor_warn_violations = 0;

--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -397,6 +397,30 @@ the system stops the build process and cleans up any partially built data associ
 .. If the index does not exists, the statement will return an error, unless ``IF EXISTS`` is used in which case the
 .. operation is a no-op.
 
+Changing Indexes During a Paged Read
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A paged read keeps using the query plan it started with. The paging state
+returned to the client records whether the read scans the base table or uses a
+particular secondary index, and every subsequent page is served by that same
+plan, so creating an index that could serve the query affects only new queries.
+Because a new index takes a moment to become known cluster-wide, a read that
+already uses one may be resumed by a node that does not know it yet, and then
+fails as described below.
+
+Dropping the index a paged read uses is different: the position saved in the
+paging state belongs to that index's scan, and no other plan can interpret it.
+Requesting the next page fails with an ``InvalidRequest`` error stating that the
+index is no longer available, and the query has to be retried from the
+beginning. Creating another index under the same name does not help, because the
+read is tied to the specific index it started with; and if the query cannot be
+prepared without the index - for example, one lacking ``ALLOW FILTERING`` -
+re-preparing it after the ``DROP`` is what fails instead. A read scanning the
+base table, in contrast, is not tied to that table's identity: dropping and
+re-creating the base table does not change the plan, and the next page is served
+from the new table - resuming where the old table's scan stopped, so whatever
+the new table holds before that position is skipped without an error.
+
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/cql/secondary-indexes.rst
+++ b/docs/cql/secondary-indexes.rst
@@ -397,6 +397,31 @@ the system stops the build process and cleans up any partially built data associ
 .. If the index does not exists, the statement will return an error, unless ``IF EXISTS`` is used in which case the
 .. operation is a no-op.
 
+Changing Indexes During a Paged Read
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A paged read keeps using the query plan it started with. The paging state
+returned to the client records whether the read scans the base table or uses a
+particular secondary index, and every subsequent page is served by that same
+plan, so creating an index that could serve the query affects only new queries.
+Because a new index takes a moment to become known cluster-wide, a read that
+already uses one may be resumed by a node that does not know it yet, and then
+fails as described below.
+
+Dropping the index a paged read uses is different: the position saved in the
+paging state belongs to that index's scan, and no other plan can interpret it.
+Requesting the next page fails with an ``InvalidRequest`` error stating that the
+index is no longer available, and the query has to be retried from the
+beginning. Creating another index under the same name does not help, because the
+read is tied to the specific index it started with. A prepared statement fails
+one step earlier: the ``DROP`` invalidates it, the driver re-prepares it before
+resuming, and a query that is not valid without the index - one lacking
+``ALLOW FILTERING``, for example - fails that re-preparation. A read scanning the
+base table, in contrast, is not tied to that table's identity: dropping and
+re-creating the base table does not change the plan, and the next page is served
+from the new table - resuming where the old table's scan stopped, so whatever
+the new table holds before that position is skipped without an error.
+
 Additional Information
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/idl/paging_state.idl.hh
+++ b/idl/paging_state.idl.hh
@@ -25,6 +25,16 @@ enum class read_repair_decision : uint8_t {
 
 namespace service {
 namespace pager {
+
+// Arms of query_plan. Their order is the order they are written in, so it may
+// not change; see service/pager/query_plan.hh.
+struct primary_index_plan {
+};
+
+struct index_plan {
+    table_id view_id;
+};
+
 class paging_state {
     partition_key get_partition_key();
     std::optional<clustering_key> get_clustering_key();
@@ -37,6 +47,8 @@ class paging_state {
     uint32_t get_rows_fetched_for_last_partition_high_bits() [[version 4.3]] = 0;
     bound_weight get_clustering_key_weight() [[version 5.1]] = bound_weight::equal;
     partition_region get_partition_region() [[version 5.1]] = partition_region::clustered;
+    // The plan that produced this state, disengaged when none was recorded.
+    std::optional<std::variant<service::pager::primary_index_plan, service::pager::index_plan>> get_query_plan() [[version 2026.4]] = std::nullopt;
 };
 }
 }

--- a/idl/paging_state.idl.hh
+++ b/idl/paging_state.idl.hh
@@ -37,6 +37,8 @@ class paging_state {
     uint32_t get_rows_fetched_for_last_partition_high_bits() [[version 4.3]] = 0;
     bound_weight get_clustering_key_weight() [[version 5.1]] = bound_weight::equal;
     partition_region get_partition_region() [[version 5.1]] = partition_region::clustered;
+    // Null id when the base table was scanned, the index view's id otherwise.
+    std::optional<table_id> get_query_plan_id() [[version 2026.4]] = std::nullopt;
 };
 }
 }

--- a/service/pager/paging_state.cc
+++ b/service/pager/paging_state.cc
@@ -56,7 +56,7 @@ service::pager::paging_state::paging_state(partition_key pk,
             pos.region())
 { }
 
-lw_shared_ptr<service::pager::paging_state> service::pager::paging_state::deserialize(
+lw_shared_ptr<const service::pager::paging_state> service::pager::paging_state::deserialize(
         bytes_opt data) {
     if (!data) {
         return nullptr;

--- a/service/pager/paging_state.cc
+++ b/service/pager/paging_state.cc
@@ -50,13 +50,14 @@ service::pager::paging_state::paging_state(partition_key pk,
         query_id query_uuid,
         replicas_per_token_range last_replicas,
         std::optional<db::read_repair_decision> query_read_repair_decision,
-        uint64_t rows_fetched_for_last_partition)
+        uint64_t rows_fetched_for_last_partition,
+        std::optional<table_id> query_plan_id)
     : paging_state(std::move(pk), pos.has_key() ? std::optional(pos.key()) : std::nullopt, static_cast<uint32_t>(rem), query_uuid, std::move(last_replicas), query_read_repair_decision,
             static_cast<uint32_t>(rows_fetched_for_last_partition), static_cast<uint32_t>(rem >> 32),
             static_cast<uint32_t>(rows_fetched_for_last_partition >> 32),
             pos.get_bound_weight(),
             pos.region(),
-            std::nullopt)
+            std::move(query_plan_id))
 { }
 
 lw_shared_ptr<const service::pager::paging_state> service::pager::paging_state::deserialize(

--- a/service/pager/paging_state.cc
+++ b/service/pager/paging_state.cc
@@ -50,12 +50,14 @@ service::pager::paging_state::paging_state(partition_key pk,
         query_id query_uuid,
         replicas_per_token_range last_replicas,
         std::optional<db::read_repair_decision> query_read_repair_decision,
-        uint64_t rows_fetched_for_last_partition)
+        uint64_t rows_fetched_for_last_partition,
+        std::optional<query_plan> plan)
     : paging_state(std::move(pk), pos.has_key() ? std::optional(pos.key()) : std::nullopt, static_cast<uint32_t>(rem), query_uuid, std::move(last_replicas), query_read_repair_decision,
             static_cast<uint32_t>(rows_fetched_for_last_partition), static_cast<uint32_t>(rem >> 32),
             static_cast<uint32_t>(rows_fetched_for_last_partition >> 32),
             pos.get_bound_weight(),
-            pos.region())
+            pos.region(),
+            std::move(plan))
 { }
 
 lw_shared_ptr<const service::pager::paging_state> service::pager::paging_state::deserialize(

--- a/service/pager/paging_state.cc
+++ b/service/pager/paging_state.cc
@@ -28,7 +28,8 @@ service::pager::paging_state::paging_state(partition_key pk,
         uint32_t rem_high_bits,
         uint32_t rows_fetched_for_last_partition_high_bits,
         bound_weight ck_weight,
-        partition_region region)
+        partition_region region,
+        std::optional<table_id> query_plan_id)
     : _partition_key(std::move(pk))
     , _clustering_key(std::move(ck))
     , _remaining_low_bits(rem_low_bits)
@@ -40,6 +41,7 @@ service::pager::paging_state::paging_state(partition_key pk,
     , _rows_fetched_for_last_partition_high_bits(rows_fetched_for_last_partition_high_bits)
     , _ck_weight(ck_weight)
     , _region(region)
+    , _query_plan_id(std::move(query_plan_id))
 { }
 
 service::pager::paging_state::paging_state(partition_key pk,
@@ -53,7 +55,8 @@ service::pager::paging_state::paging_state(partition_key pk,
             static_cast<uint32_t>(rows_fetched_for_last_partition), static_cast<uint32_t>(rem >> 32),
             static_cast<uint32_t>(rows_fetched_for_last_partition >> 32),
             pos.get_bound_weight(),
-            pos.region())
+            pos.region(),
+            std::nullopt)
 { }
 
 lw_shared_ptr<const service::pager::paging_state> service::pager::paging_state::deserialize(

--- a/service/pager/paging_state.cc
+++ b/service/pager/paging_state.cc
@@ -28,7 +28,8 @@ service::pager::paging_state::paging_state(partition_key pk,
         uint32_t rem_high_bits,
         uint32_t rows_fetched_for_last_partition_high_bits,
         bound_weight ck_weight,
-        partition_region region)
+        partition_region region,
+        std::optional<query_plan> plan)
     : _partition_key(std::move(pk))
     , _clustering_key(std::move(ck))
     , _remaining_low_bits(rem_low_bits)
@@ -40,6 +41,7 @@ service::pager::paging_state::paging_state(partition_key pk,
     , _rows_fetched_for_last_partition_high_bits(rows_fetched_for_last_partition_high_bits)
     , _ck_weight(ck_weight)
     , _region(region)
+    , _query_plan(std::move(plan))
 { }
 
 service::pager::paging_state::paging_state(partition_key pk,

--- a/service/pager/paging_state.hh
+++ b/service/pager/paging_state.hh
@@ -179,7 +179,7 @@ public:
         return _query_read_repair_decision;
     }
 
-    static lw_shared_ptr<paging_state> deserialize(bytes_opt bytes);
+    static lw_shared_ptr<const paging_state> deserialize(bytes_opt bytes);
     bytes_opt serialize() const;
 };
 

--- a/service/pager/paging_state.hh
+++ b/service/pager/paging_state.hh
@@ -18,6 +18,8 @@
 #include "db/read_repair_decision.hh"
 #include "mutation/position_in_partition.hh"
 #include "locator/host_id.hh"
+#include "schema/schema_fwd.hh"
+#include "seastarx.hh"
 
 namespace service {
 
@@ -40,6 +42,11 @@ private:
     bound_weight _ck_weight = bound_weight::equal;
     partition_region _region = partition_region::partition_start;
 
+    // Id of the index view scanned, or a null id for the base table. std::nullopt
+    // when no plan was recorded - by a version predating this field, or by a
+    // producer with no CQL plan to pin - and then nothing is pinned. #18992
+    std::optional<table_id> _query_plan_id;
+
 public:
     // IDL ctor
     paging_state(partition_key pk,
@@ -52,7 +59,8 @@ public:
             uint32_t remaining_ext,
             uint32_t rows_fetched_for_last_partition_high_bits,
             bound_weight ck_weight,
-            partition_region region);
+            partition_region region,
+            std::optional<table_id> query_plan_id);
 
     paging_state(partition_key pk,
             position_in_partition_view pos,
@@ -76,6 +84,10 @@ public:
     void set_remaining(uint64_t remaining) {
         _remaining_low_bits = static_cast<uint32_t>(remaining);
         _remaining_high_bits = static_cast<uint32_t>(remaining >> 32);
+    }
+
+    const std::optional<table_id>& get_query_plan_id() const {
+        return _query_plan_id;
     }
 
     /**

--- a/service/pager/paging_state.hh
+++ b/service/pager/paging_state.hh
@@ -60,7 +60,7 @@ public:
             uint32_t rows_fetched_for_last_partition_high_bits,
             bound_weight ck_weight,
             partition_region region,
-            std::optional<query_plan> plan = std::nullopt);
+            std::optional<query_plan> plan);
 
     paging_state(partition_key pk,
             position_in_partition_view pos,
@@ -68,7 +68,8 @@ public:
             query_id reader_recall_uuid,
             replicas_per_token_range last_replicas,
             std::optional<db::read_repair_decision> query_read_repair_decision,
-            uint64_t rows_fetched_for_last_partition);
+            uint64_t rows_fetched_for_last_partition,
+            std::optional<query_plan> plan);
 
     void set_partition_key(partition_key pk) {
         _partition_key = std::move(pk);

--- a/service/pager/paging_state.hh
+++ b/service/pager/paging_state.hh
@@ -18,6 +18,8 @@
 #include "db/read_repair_decision.hh"
 #include "mutation/position_in_partition.hh"
 #include "locator/host_id.hh"
+#include "service/pager/query_plan.hh"
+#include "seastarx.hh"
 
 namespace service {
 
@@ -40,6 +42,11 @@ private:
     bound_weight _ck_weight = bound_weight::equal;
     partition_region _region = partition_region::partition_start;
 
+    // The plan that produced this state, std::nullopt when none was recorded -
+    // by a version predating this field, or by a producer with no CQL plan to
+    // pin - and then nothing is pinned. See query_plan.hh and #18992.
+    std::optional<query_plan> _query_plan;
+
 public:
     // IDL ctor
     paging_state(partition_key pk,
@@ -52,7 +59,8 @@ public:
             uint32_t remaining_ext,
             uint32_t rows_fetched_for_last_partition_high_bits,
             bound_weight ck_weight,
-            partition_region region);
+            partition_region region,
+            std::optional<query_plan> plan = std::nullopt);
 
     paging_state(partition_key pk,
             position_in_partition_view pos,
@@ -76,6 +84,10 @@ public:
     void set_remaining(uint64_t remaining) {
         _remaining_low_bits = static_cast<uint32_t>(remaining);
         _remaining_high_bits = static_cast<uint32_t>(remaining >> 32);
+    }
+
+    const std::optional<query_plan>& get_query_plan() const {
+        return _query_plan;
     }
 
     /**

--- a/service/pager/paging_state.hh
+++ b/service/pager/paging_state.hh
@@ -68,7 +68,8 @@ public:
             query_id reader_recall_uuid,
             replicas_per_token_range last_replicas,
             std::optional<db::read_repair_decision> query_read_repair_decision,
-            uint64_t rows_fetched_for_last_partition);
+            uint64_t rows_fetched_for_last_partition,
+            std::optional<table_id> query_plan_id);
 
     void set_partition_key(partition_key pk) {
         _partition_key = std::move(pk);

--- a/service/pager/query_pager.hh
+++ b/service/pager/query_pager.hh
@@ -143,8 +143,11 @@ public:
      *
      * @return the current paging state. If the pager is exhausted, the result is a valid pointer
      * to a paging_state instance which will return 0 on calling get_remaining() on it.
+     *
+     * @param query_plan_id the plan this pager scans, recorded so a later page keeps
+     * it. No default: std::nullopt pins nothing, and must stay distinct. See #18992.
      */
-    lw_shared_ptr<const paging_state> state() const;
+    lw_shared_ptr<const paging_state> state(std::optional<table_id> query_plan_id) const;
 
     const stats& stats() const {
         return _stats;

--- a/service/pager/query_pager.hh
+++ b/service/pager/query_pager.hh
@@ -143,8 +143,11 @@ public:
      *
      * @return the current paging state. If the pager is exhausted, the result is a valid pointer
      * to a paging_state instance which will return 0 on calling get_remaining() on it.
+     *
+     * @param plan the plan this pager scans, recorded so a later page keeps it.
+     * No default: std::nullopt pins nothing, and must stay distinct. See #18992.
      */
-    lw_shared_ptr<const paging_state> state() const;
+    lw_shared_ptr<const paging_state> state(std::optional<query_plan> plan) const;
 
     const stats& stats() const {
         return _stats;

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -445,8 +445,8 @@ void query_pager::handle_result(
     }
 }
 
-lw_shared_ptr<const paging_state> query_pager::state() const {
-    return make_lw_shared<paging_state>(_last_pkey.value_or(partition_key::make_empty()), _last_pos, _exhausted ? 0 : _max, _cmd->query_uuid, _last_replicas, _query_read_repair_decision, _rows_fetched_for_last_partition);
+lw_shared_ptr<const paging_state> query_pager::state(std::optional<query_plan> plan) const {
+    return make_lw_shared<paging_state>(_last_pkey.value_or(partition_key::make_empty()), _last_pos, _exhausted ? 0 : _max, _cmd->query_uuid, _last_replicas, _query_read_repair_decision, _rows_fetched_for_last_partition, std::move(plan));
 }
 
 }

--- a/service/pager/query_pagers.cc
+++ b/service/pager/query_pagers.cc
@@ -445,8 +445,8 @@ void query_pager::handle_result(
     }
 }
 
-lw_shared_ptr<const paging_state> query_pager::state() const {
-    return make_lw_shared<paging_state>(_last_pkey.value_or(partition_key::make_empty()), _last_pos, _exhausted ? 0 : _max, _cmd->query_uuid, _last_replicas, _query_read_repair_decision, _rows_fetched_for_last_partition);
+lw_shared_ptr<const paging_state> query_pager::state(std::optional<table_id> query_plan_id) const {
+    return make_lw_shared<paging_state>(_last_pkey.value_or(partition_key::make_empty()), _last_pos, _exhausted ? 0 : _max, _cmd->query_uuid, _last_replicas, _query_read_repair_decision, _rows_fetched_for_last_partition, std::move(query_plan_id));
 }
 
 }

--- a/service/pager/query_plan.hh
+++ b/service/pager/query_plan.hh
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <variant>
+
+#include "schema/schema_fwd.hh"
+
+namespace service {
+
+namespace pager {
+
+// The plan a paged read scans, recorded in the paging state so that a later
+// page keeps reading whatever the saved position belongs to. See #18992.
+
+// The base table, read in primary index order.
+struct primary_index_plan {
+    bool operator==(const primary_index_plan&) const = default;
+};
+
+// A secondary index, named by the view backing it so that an index re-created
+// under the same name is not mistaken for the original.
+struct index_plan {
+    table_id view_id;
+    bool operator==(const index_plan&) const = default;
+};
+
+// Arm positions are wire positions: arms may only be appended, and a new arm
+// must not be written until every coordinator in the cluster can read it - gate
+// it on a cluster feature.
+//
+// A disengaged std::optional<query_plan> is different: it says no plan was
+// recorded at all - by a version predating the field, or by a producer with no
+// CQL plan to keep - and then nothing is pinned.
+using query_plan = std::variant<primary_index_plan, index_plan>;
+
+}
+
+}

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5004,14 +5004,10 @@ static size_t count_rows_fetched(::shared_ptr<cql_transport::messages::result_me
     return rows->rs().result_set().size();
 };
 
-static lw_shared_ptr<service::pager::paging_state> extract_paging_state(::shared_ptr<cql_transport::messages::result_message> res) {
+static lw_shared_ptr<const service::pager::paging_state> extract_paging_state(::shared_ptr<cql_transport::messages::result_message> res) {
     auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(res);
     BOOST_REQUIRE(rows);
-    auto paging_state = rows->rs().get_metadata().paging_state();
-    if (!paging_state) {
-        return nullptr;
-    }
-    return make_lw_shared<service::pager::paging_state>(*paging_state);
+    return rows->rs().get_metadata().paging_state();
 };
 
 namespace cql_query_test {
@@ -5065,7 +5061,7 @@ SEASTAR_THREAD_TEST_CASE(test_query_limit) {
 
                     try {
                         bool has_more_pages = true;
-                        lw_shared_ptr<service::pager::paging_state> paging_state = nullptr;
+                        lw_shared_ptr<const service::pager::paging_state> paging_state = nullptr;
                         size_t next_expected_row_idx = 0;
                         while (has_more_pages) {
                             // FIXME: even though we chose a large page size, for reversed queries we may still obtain multiple pages.

--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -775,13 +775,9 @@ SEASTAR_TEST_CASE(test_allow_filtering_with_secondary_index) {
     });
 }
 
-static lw_shared_ptr<service::pager::paging_state> extract_paging_state(::shared_ptr<cql_transport::messages::result_message> res) {
+static lw_shared_ptr<const service::pager::paging_state> extract_paging_state(::shared_ptr<cql_transport::messages::result_message> res) {
     auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(res);
-    auto paging_state = rows->rs().get_metadata().paging_state();
-    if (!paging_state) {
-        return nullptr;
-    }
-    return make_lw_shared<service::pager::paging_state>(*paging_state);
+    return rows->rs().get_metadata().paging_state();
 };
 
 static size_t count_rows_fetched(::shared_ptr<cql_transport::messages::result_message> res) {
@@ -966,7 +962,7 @@ SEASTAR_TEST_CASE(test_allow_filtering_per_partition_limit) {
             { int32_type->decompose(1), boolean_type->decompose(false)},
         });
 
-        lw_shared_ptr<service::pager::paging_state> paging_state = nullptr;
+        lw_shared_ptr<const service::pager::paging_state> paging_state = nullptr;
         // Some pages might be empty and in such case we should continue querying
         size_t rows_fetched = 0;
         while (rows_fetched == 0) {

--- a/test/boost/index_with_paging_test.cc
+++ b/test/boost/index_with_paging_test.cc
@@ -13,7 +13,10 @@
 #include "test/lib/eventually.hh"
 #include "cql3/untyped_result_set.hh"
 #include "cql3/query_processor.hh"
+#include "schema/schema_builder.hh"
+#include "service/pager/paging_state.hh"
 #include "transport/messages/result_message.hh"
+#include "utils/UUID_gen.hh"
 
 BOOST_AUTO_TEST_SUITE(index_with_paging_test)
 
@@ -104,6 +107,31 @@ SEASTAR_TEST_CASE(test_index_with_paging_with_base_short_read_no_ck) {
             BOOST_REQUIRE_EQUAL(count, row_count);
         });
     });
+}
+
+// Every plan must survive the round trip as itself rather than as no plan at
+// all, which means nothing was recorded and pins nothing. See #18992.
+SEASTAR_TEST_CASE(test_query_plan_survives_paging_state_serialization) {
+    using namespace service::pager;
+
+    auto schema = schema_builder(this_smp_shard_count(), "ks", "tab")
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("v", int32_type)
+            .build();
+    auto pk = partition_key::from_single_value(*schema, int32_type->decompose(data_value(0)));
+
+    auto round_trip = [&] (std::optional<query_plan> plan) {
+        auto state = paging_state(pk, std::nullopt, 0, query_id::create_null_id(),
+                paging_state::replicas_per_token_range{}, std::nullopt, 0, 0, 0,
+                bound_weight::equal, partition_region::partition_start, std::move(plan));
+        return paging_state::deserialize(state.serialize())->get_query_plan();
+    };
+
+    const auto view_id = table_id(utils::UUID_gen::get_time_UUID());
+    BOOST_REQUIRE(round_trip(std::nullopt) == std::nullopt);
+    BOOST_REQUIRE(round_trip(primary_index_plan{}) == std::optional<query_plan>(primary_index_plan{}));
+    BOOST_REQUIRE(round_trip(index_plan{view_id}) == std::optional<query_plan>(index_plan{view_id}));
+    return make_ready_future<>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/index_with_paging_test.cc
+++ b/test/boost/index_with_paging_test.cc
@@ -13,7 +13,10 @@
 #include "test/lib/eventually.hh"
 #include "cql3/untyped_result_set.hh"
 #include "cql3/query_processor.hh"
+#include "schema/schema_builder.hh"
+#include "service/pager/paging_state.hh"
 #include "transport/messages/result_message.hh"
+#include "utils/UUID_gen.hh"
 
 BOOST_AUTO_TEST_SUITE(index_with_paging_test)
 
@@ -104,6 +107,29 @@ SEASTAR_TEST_CASE(test_index_with_paging_with_base_short_read_no_ck) {
             BOOST_REQUIRE_EQUAL(count, row_count);
         });
     });
+}
+
+// A null id must survive the round trip as a null id rather than as no id at
+// all, which means no plan was recorded and pins nothing. See #18992.
+SEASTAR_TEST_CASE(test_query_plan_id_survives_paging_state_serialization) {
+    auto schema = schema_builder(this_smp_shard_count(), "ks", "tab")
+            .with_column("pk", int32_type, column_kind::partition_key)
+            .with_column("v", int32_type)
+            .build();
+    auto pk = partition_key::from_single_value(*schema, int32_type->decompose(data_value(0)));
+
+    auto round_trip = [&] (std::optional<table_id> plan_id) {
+        auto state = service::pager::paging_state(pk, std::nullopt, 0, query_id::create_null_id(),
+                service::pager::paging_state::replicas_per_token_range{}, std::nullopt, 0, 0, 0,
+                bound_weight::equal, partition_region::partition_start, std::move(plan_id));
+        return service::pager::paging_state::deserialize(state.serialize())->get_query_plan_id();
+    };
+
+    const auto plan_id = table_id(utils::UUID_gen::get_time_UUID());
+    BOOST_REQUIRE(round_trip(std::nullopt) == std::nullopt);
+    BOOST_REQUIRE(round_trip(plan_id) == std::optional<table_id>(plan_id));
+    BOOST_REQUIRE(round_trip(table_id::create_null_id()) == std::optional<table_id>(table_id::create_null_id()));
+    return make_ready_future<>();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -467,7 +467,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
             auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(res);
             auto paging_state = rows->rs().get_metadata().paging_state();
             SCYLLA_ASSERT(paging_state);
-            return make_lw_shared<service::pager::paging_state>(*paging_state);
+            return paging_state;
         };
 
         auto expect_more_pages = [] (::shared_ptr<cql_transport::messages::result_message> res, bool more_pages_expected) {
@@ -846,7 +846,7 @@ SEASTAR_TEST_CASE(test_local_index_paging) {
             auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(res);
             auto paging_state = rows->rs().get_metadata().paging_state();
             SCYLLA_ASSERT(paging_state);
-            return make_lw_shared<service::pager::paging_state>(*paging_state);
+            return paging_state;
         };
 
         eventually([&] {

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -558,7 +558,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
                     position_in_partition_view::for_partition_start(),
                     paging_state->get_remaining(), paging_state->get_query_uuid(),
                     paging_state->get_last_replicas(), paging_state->get_query_read_repair_decision(),
-                    paging_state->get_rows_fetched_for_last_partition());
+                    paging_state->get_rows_fetched_for_last_partition(), std::nullopt);
 
             qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
@@ -572,7 +572,7 @@ SEASTAR_TEST_CASE(test_simple_index_paging) {
             // not to return rows (since no row matches an empty partition key)
             auto paging_state = make_lw_shared<service::pager::paging_state>(partition_key::make_empty(),
                     position_in_partition_view::for_partition_start(),
-                    1, query_id::create_random_id(), service::pager::paging_state::replicas_per_token_range{}, std::nullopt, 1);
+                    1, query_id::create_random_id(), service::pager::paging_state::replicas_per_token_range{}, std::nullopt, 1, std::nullopt);
             auto qo = std::make_unique<cql3::query_options>(db::consistency_level::LOCAL_ONE, std::vector<cql3::raw_value>{},
                     cql3::query_options::specific_options{1, paging_state, {}, api::new_timestamp()});
             auto res = e.execute_cql("SELECT * FROM tab WHERE v = 1", std::move(qo)).get();

--- a/test/boost/statement_restrictions_test.cc
+++ b/test/boost/statement_restrictions_test.cc
@@ -506,6 +506,32 @@ SEASTAR_TEST_CASE(index_selection) {
     });
 }
 
+// Illegal combinations are reported by throwing. Where clang brackets a call
+// with its own stack adjustment instead of reserving the argument space in the
+// prologue - as it does for the loop below in debug builds - the instruction
+// that gives that space back runs only on the normal return path, so a throw
+// leaves the stack pointer lowered until the frame returns. Catching in the
+// loop would lose that space on every rejection, megabytes over 32768
+// combinations; do not inline this into the loop.
+[[gnu::noinline]]
+static shared_ptr<const restrictions::statement_restrictions> try_analyze_restrictions(
+        cql_test_env& e, schema_ptr schema, const expr::expression& where_expr, prepare_context& ctx) {
+    try {
+        return restrictions::analyze_statement_restrictions(
+                e.data_dictionary(),
+                schema,
+                statements::statement_type::SELECT,
+                where_expr,
+                ctx,
+                /*contains_only_static_columns=*/false,
+                /*for_view=*/false,
+                /*allow_filtering=*/true,
+                restrictions::check_indexes::yes);
+    } catch (const exceptions::invalid_request_exception&) {
+        return nullptr;
+    }
+}
+
 // Exhaustive combinatorial test: iterates over all 2^N subsets of N restriction
 // fragments and, for each subset, verifies a broad set of statement_restrictions
 // public APIs. This catches any refactoring that accidentally changes observable
@@ -528,12 +554,6 @@ SEASTAR_TEST_CASE(index_selection) {
 //   bit 13: m3[19] = 'beta'      (global index comb_m3_entries, target: keys_and_values)
 //   bit 14: fs = {20, 21}        (global index comb_fs, target: full — frozen collection)
 SEASTAR_TEST_CASE(combinatorial_restrictions) {
-    // ASAN's fake-stack shadow buffer for the large lambda below is ~248 KiB;
-    // bump the thread stack so it doesn't overflow under sanitized builds.
-    seastar::thread_attributes tattr;
-#if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer)
-    tattr.stack_size = 2 * 1024 * 1024;
-#endif
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "CREATE TABLE ks.comb ("
                          "    pk1 int, pk2 int,"
@@ -657,20 +677,7 @@ SEASTAR_TEST_CASE(combinatorial_restrictions) {
                 ? expr::expression(expr::conjunction{})
                 : cql3::util::where_clause_to_relations(where_clause, cql3::dialect{});
 
-            shared_ptr<const restrictions::statement_restrictions> sr;
-            try {
-                sr = restrictions::analyze_statement_restrictions(
-                        e.data_dictionary(),
-                        schema,
-                        statements::statement_type::SELECT,
-                        where_expr,
-                        ctx,
-                        /*contains_only_static_columns=*/false,
-                        /*for_view=*/false,
-                        /*allow_filtering=*/true,
-                        restrictions::check_indexes::yes);
-            } catch (const exceptions::invalid_request_exception&) {
-            }
+            auto sr = try_analyze_restrictions(e, schema, where_expr, ctx);
 
             if (is_illegal) {
                 BOOST_CHECK_MESSAGE(!sr,
@@ -1150,7 +1157,7 @@ SEASTAR_TEST_CASE(combinatorial_restrictions) {
 
         BOOST_TEST_MESSAGE(fmt::format("Tested {} restriction combinations ({} legal, {} illegal, 2^{} = {} total)",
                                        total_tested, total_tested - total_illegal, total_illegal, N_FRAG, FRAG_TOTAL));
-    }, {}, tattr);
+    });
 }
 
 /// Helper to get statement_restrictions from a parsed WHERE clause string.

--- a/test/cluster/test_secondary_index_paging.py
+++ b/test/cluster/test_secondary_index_paging.py
@@ -1,0 +1,108 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+# The pinned plan reaches a later page only through the paging state, so these
+# tests page alternately through two coordinators. Refs #18992
+
+import logging
+import time
+
+import pytest
+from cassandra.protocol import InvalidRequest  # type: ignore
+from cassandra.query import SimpleStatement  # type: ignore
+
+from test.cluster.util import new_test_keyspace
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, wait_for_view
+
+logger = logging.getLogger(__name__)
+
+RF2 = "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}"
+
+
+async def wait_until_index_visible(cql, hosts, keyspace, table, index_name, present):
+    """Waits until every node agrees on whether the index exists, so that a node
+    resolving the pinned plan against a stale index set cannot be raced with."""
+    async def agreed():
+        for host in hosts:
+            rows = await cql.run_async(
+                    f"SELECT index_name FROM system_schema.indexes WHERE keyspace_name = '{keyspace}'"
+                    f" AND table_name = '{table}' AND index_name = '{index_name}'", host=host)
+            if bool(rows) != present:
+                return None
+        return True
+    await wait_for(agreed, time.time() + 60, label=f"index {index_name} present={present} everywhere")
+
+
+async def fill(cql, table, rows):
+    insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+    for p, v in rows:
+        await cql.run_async(insert, [p, v])
+
+
+async def test_resumed_page_keeps_its_plan_on_another_coordinator(manager: ManagerClient) -> None:
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    async with new_test_keyspace(manager, RF2) as ks:
+        table = f"{ks}.tbl"
+        await cql.run_async(f"CREATE TABLE {table} (p int PRIMARY KEY, v int)")
+        # A sparse match, so a page served by the wrong plan shows up as a wrong
+        # row set rather than as the right one by accident.
+        await fill(cql, table, [(i, 17 if i % 4 == 0 else 23) for i in range(40)])
+
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v = 17 ALLOW FILTERING", fetch_size=3)
+        expected = sorted(row.p for row in cql.execute(stmt))
+        assert len(expected) > 3
+
+        page = cql.execute(stmt, host=hosts[0])
+        assert page.has_more_pages
+        got = list(page.current_rows)
+        logger.info("first page: %d rows, base table scanned, coordinator %s", len(got), hosts[0])
+
+        await cql.run_async(f"CREATE INDEX idx ON {table}(v)")
+        await wait_for_view(cql, "idx_index", len(servers))
+        await wait_until_index_visible(cql, hosts, ks, "tbl", "idx", present=True)
+        logger.info("an index that could serve this query now exists on every node")
+
+        node = 1
+        while page.has_more_pages:
+            host = hosts[node % len(hosts)]
+            page = cql.execute(stmt, host=host, paging_state=page.paging_state)
+            logger.info("resumed page: %d rows, coordinator %s", len(page.current_rows), host)
+            got.extend(page.current_rows)
+            node += 1
+
+        assert expected == sorted(row.p for row in got)
+
+
+async def test_resuming_a_dropped_index_is_refused_on_another_coordinator(manager: ManagerClient) -> None:
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    async with new_test_keyspace(manager, RF2) as ks:
+        table = f"{ks}.tbl"
+        await cql.run_async(f"CREATE TABLE {table} (p int PRIMARY KEY, v int)")
+        await fill(cql, table, [(i, 17) for i in range(40)])
+        await cql.run_async(f"CREATE INDEX idx ON {table}(v)")
+        await wait_for_view(cql, "idx_index", len(servers))
+        await wait_until_index_visible(cql, hosts, ks, "tbl", "idx", present=True)
+
+        # ALLOW FILTERING, so a node that re-planned rather than keeping the
+        # pinned plan would carry on off a base-table scan instead of failing.
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v = 17 ALLOW FILTERING", fetch_size=7)
+        page = cql.execute(stmt, host=hosts[0])
+        assert page.has_more_pages
+        logger.info("first page: %d rows, index scanned, coordinator %s", len(page.current_rows), hosts[0])
+
+        await cql.run_async(f"DROP INDEX {ks}.idx")
+        await wait_until_index_visible(cql, hosts, ks, "tbl", "idx", present=False)
+        logger.info("index dropped everywhere; the saved position belongs to a view that is gone")
+
+        with pytest.raises(InvalidRequest, match="no longer available"):
+            cql.execute(stmt, host=hosts[1], paging_state=page.paging_state)

--- a/test/cluster/test_secondary_index_paging.py
+++ b/test/cluster/test_secondary_index_paging.py
@@ -1,0 +1,200 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+# The pinned plan reaches a later page only through the paging state, so these
+# tests page alternately through two coordinators. Refs #18992
+
+import logging
+import time
+
+import pytest
+from cassandra.protocol import InvalidRequest  # type: ignore
+from cassandra.query import SimpleStatement  # type: ignore
+
+from test.cluster.util import new_test_keyspace
+from test.pylib.manager_client import ManagerClient
+from test.pylib.scylla_cluster import ScyllaVersionDescription
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, wait_for_view
+
+logger = logging.getLogger(__name__)
+
+RF2 = "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}"
+
+
+async def wait_until_index_visible(cql, hosts, keyspace, index_name, present):
+    """Waits until every node agrees on whether the index exists, so that a node
+    resolving the pinned plan against a stale index set cannot be raced with.
+    Asks system."IndexInfo", which each node filters through its live schema and
+    index manager - the state the pinned plan is resolved against - rather than
+    system_schema.indexes, whose row is written before that state is updated."""
+    async def agreed():
+        for host in hosts:
+            rows = await cql.run_async(
+                    f"SELECT index_name FROM system.\"IndexInfo\" WHERE table_name = '{keyspace}'"
+                    f" AND index_name = '{index_name}'", host=host)
+            if bool(rows) != present:
+                return None
+        return True
+    await wait_for(agreed, time.time() + 60, label=f"index {index_name} present={present} everywhere")
+
+
+async def fill(cql, table, rows):
+    insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+    for p, v in rows:
+        await cql.run_async(insert, [p, v])
+
+
+async def test_resumed_page_keeps_its_plan_on_another_coordinator(manager: ManagerClient) -> None:
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    async with new_test_keyspace(manager, RF2) as ks:
+        table = f"{ks}.tbl"
+        await cql.run_async(f"CREATE TABLE {table} (p int PRIMARY KEY, v int)")
+        # A sparse match, so a page served by the wrong plan shows up as a wrong
+        # row set rather than as the right one by accident.
+        await fill(cql, table, [(i, 17 if i % 4 == 0 else 23) for i in range(40)])
+
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v = 17 ALLOW FILTERING", fetch_size=3)
+        expected = sorted(row.p for row in cql.execute(stmt))
+        assert len(expected) > 3
+
+        page = cql.execute(stmt, host=hosts[0])
+        assert page.has_more_pages
+        got = list(page.current_rows)
+        logger.info("first page: %d rows, base table scanned, coordinator %s", len(got), hosts[0])
+
+        await cql.run_async(f"CREATE INDEX idx ON {table}(v)")
+        await wait_for_view(cql, "idx_index", len(servers))
+        await wait_until_index_visible(cql, hosts, ks, "idx", present=True)
+        logger.info("an index that could serve this query now exists on every node")
+
+        node = 1
+        while page.has_more_pages:
+            host = hosts[node % len(hosts)]
+            page = cql.execute(stmt, host=host, paging_state=page.paging_state)
+            logger.info("resumed page: %d rows, coordinator %s", len(page.current_rows), host)
+            got.extend(page.current_rows)
+            node += 1
+
+        assert expected == sorted(row.p for row in got)
+
+
+async def test_resuming_a_dropped_index_is_refused_on_another_coordinator(manager: ManagerClient) -> None:
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    async with new_test_keyspace(manager, RF2) as ks:
+        table = f"{ks}.tbl"
+        await cql.run_async(f"CREATE TABLE {table} (p int PRIMARY KEY, v int)")
+        await fill(cql, table, [(i, 17) for i in range(40)])
+        await cql.run_async(f"CREATE INDEX idx ON {table}(v)")
+        await wait_for_view(cql, "idx_index", len(servers))
+        await wait_until_index_visible(cql, hosts, ks, "idx", present=True)
+
+        # ALLOW FILTERING, so a node that re-planned rather than keeping the
+        # pinned plan would carry on off a base-table scan instead of failing.
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v = 17 ALLOW FILTERING", fetch_size=7)
+        page = cql.execute(stmt, host=hosts[0])
+        assert page.has_more_pages
+        logger.info("first page: %d rows, index scanned, coordinator %s", len(page.current_rows), hosts[0])
+
+        await cql.run_async(f"DROP INDEX {ks}.idx")
+        await wait_until_index_visible(cql, hosts, ks, "idx", present=False)
+        logger.info("index dropped everywhere; the saved position belongs to a view that is gone")
+
+        with pytest.raises(InvalidRequest, match="no longer available"):
+            cql.execute(stmt, host=hosts[1], paging_state=page.paging_state)
+
+
+async def mixed_version_cluster(manager: ManagerClient, old_version: ScyllaVersionDescription,
+        new_binary: str):
+    """Brings up two nodes on a version that records no plan in the paging state
+    and upgrades one of them, so that a page can cross from a coordinator which
+    records a plan to one that does not know the field, and back."""
+    servers = await manager.servers_add(2, config={'tablets_mode_for_new_keyspaces': 'disabled'},
+                                       auto_rack_dc="dc1", version=old_version)
+    logger.info("cluster up on %s", old_version.path)
+    await manager.server_change_version(servers[1].server_id, new_binary)
+    await manager.server_sees_others(servers[1].server_id, 1, interval=60.0)
+    cql, hosts = await manager.get_ready_cql(servers)
+    old_host = next(h for h in hosts if h.address == servers[0].ip_addr)
+    new_host = next(h for h in hosts if h.address == servers[1].ip_addr)
+    logger.info("upgraded %s: old coordinator %s, new coordinator %s",
+                servers[1].server_id, old_host, new_host)
+    return cql, old_host, new_host
+
+
+async def indexed_table(cql, hosts, ks):
+    table = f"{ks}.tbl"
+    await cql.run_async(f"CREATE TABLE {table} (p int PRIMARY KEY, v int)")
+    # A sparse match, so a page served by the wrong plan shows up as a wrong row
+    # set rather than as the right one by accident.
+    await fill(cql, table, [(i, 17 if i % 4 == 0 else 23) for i in range(40)])
+    await cql.run_async(f"CREATE INDEX idx ON {table}(v)")
+    await wait_for_view(cql, "idx_index", len(hosts))
+    await wait_until_index_visible(cql, hosts, ks, "idx", present=True)
+    return table
+
+
+@pytest.mark.skip_mode(mode='release', reason='dev mode is enough for this test')
+@pytest.mark.skip_mode(mode='debug', reason='dev mode is enough for this test')
+async def test_paged_read_crosses_versions(manager: ManagerClient,
+        scylla_2025_1: ScyllaVersionDescription, scylla_binary: str) -> None:
+    """A paged read has to survive a rolling upgrade in both directions: a state
+    naming no plan cannot be refused, and a state naming one has to be read
+    without complaint by a version that does not know the field. Refs #18992"""
+    cql, old_host, new_host = await mixed_version_cluster(
+            manager, scylla_2025_1, str(scylla_binary))
+
+    async with new_test_keyspace(manager, RF2) as ks:
+        table = await indexed_table(cql, [old_host, new_host], ks)
+
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v = 17", fetch_size=3)
+        expected = sorted(row.p for row in cql.execute(stmt))
+        assert len(expected) > 3
+
+        for first, second in [(old_host, new_host), (new_host, old_host)]:
+            logger.info("indexed read started on %s, resumed on %s", first, second)
+            page = cql.execute(stmt, host=first)
+            assert page.has_more_pages
+            got = list(page.current_rows)
+            while page.has_more_pages:
+                page = cql.execute(stmt, host=second, paging_state=page.paging_state)
+                got.extend(page.current_rows)
+            assert expected == sorted(row.p for row in got)
+
+
+@pytest.mark.skip_mode(mode='release', reason='dev mode is enough for this test')
+@pytest.mark.skip_mode(mode='debug', reason='dev mode is enough for this test')
+async def test_resuming_a_pre_plan_paging_state_is_not_refused(manager: ManagerClient,
+        scylla_2025_1: ScyllaVersionDescription, scylla_binary: str) -> None:
+    """A state that records no plan has nothing to pin, so dropping the index it
+    was reading must not make the new coordinator refuse it - what such a resume
+    returns is #18992, which a rolling upgrade cannot fix."""
+    cql, old_host, new_host = await mixed_version_cluster(
+            manager, scylla_2025_1, str(scylla_binary))
+
+    async with new_test_keyspace(manager, RF2) as ks:
+        table = await indexed_table(cql, [old_host, new_host], ks)
+
+        # ALLOW FILTERING, so a base-table scan is still a legal fallback.
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v = 17 ALLOW FILTERING", fetch_size=3)
+        page = cql.execute(stmt, host=old_host)
+        assert page.has_more_pages
+        logger.info("first page from %s, which records no plan", old_host)
+
+        await cql.run_async(f"DROP INDEX {ks}.idx")
+        await wait_until_index_visible(cql, [old_host, new_host], ks, "idx", present=False)
+
+        try:
+            cql.execute(stmt, host=new_host, paging_state=page.paging_state)
+            logger.info("the new coordinator served the page")
+        except InvalidRequest as e:
+            logger.info("the new coordinator refused the page: %s", e)
+            assert "no longer available" not in str(e)

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -1992,8 +1992,8 @@ def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
             got.extend(r.current_rows)
         assert expected == got
 
-# As above but *without* ALLOW FILTERING, so both engines currently raise the
-# usual error about ALLOW FILTERING when the next page follows a DROP INDEX.
+# As above but without ALLOW FILTERING, so neither engine can resume: Scylla's
+# saved position belongs to the dropped index, Cassandra needs the filtering.
 def test_paging_and_drop_index_no_allow_filtering(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -2007,24 +2007,19 @@ def test_paging_and_drop_index_no_allow_filtering(cql, test_keyspace):
 
         page_size = 7
         stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v=17", fetch_size=page_size)
-        expected = list(cql.execute(stmt))
+        # The index serves the whole query while it exists.
+        assert len(list(cql.execute(stmt))) == count
         # Run the same paged query again but this time use the page-by-page
         # API, and do a DROP INDEX between the first and second page.
-        got = []
         r = cql.execute(stmt)
         assert len(r.current_rows) == page_size
-        got.extend(r.current_rows)
         cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
-        # Because the query does not have "ALLOW FILTERING", even if we
-        # could resume this query it would be inefficient without the
-        # index, so the resumed query should fail with an error about
-        # ALLOW FILTERING being needed.
-        with pytest.raises(InvalidRequest, match="ALLOW FILTERING"):
-            while r.has_more_pages:
-                r = cql.execute(stmt, paging_state=r.paging_state)
-                assert len(r.current_rows) <= page_size
-                got.extend(r.current_rows)
-            assert expected == got
+        expected_error = "no longer available" if is_scylla(cql) else "ALLOW FILTERING"
+        # On the first resumed page, so a regression that returns wrong rows and
+        # only raises later cannot pass.
+        assert r.has_more_pages
+        with pytest.raises(InvalidRequest, match=expected_error):
+            cql.execute(stmt, paging_state=r.paging_state)
 
 # A base-table read is not tied to the table's identity, so a table dropped and
 # recreated between pages is read on - the same way on Cassandra and on Scylla.

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -1837,9 +1837,6 @@ def test_paging_and_create_index(cql, test_keyspace):
         # We wait for the index to be built, since we don't want to reproduce
         # #7963 again here (an index getting used before actually built).
         wait_for_index(cql, test_keyspace, index_name)
-        # Stop here on Scylla, so the resume below is enforced on Cassandra.
-        if is_scylla(cql):
-            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(stmt, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size # sanity check
@@ -1879,9 +1876,6 @@ def test_paging_and_create_index2(cql, test_keyspace):
         index_name1 = unique_name()
         cql.execute(f"CREATE INDEX {index_name1} ON {table}(v1)")
         wait_for_index(cql, test_keyspace, index_name1)
-        # Stop here on Scylla, so the resume below is enforced on Cassandra.
-        if is_scylla(cql):
-            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(stmt, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
@@ -1889,7 +1883,7 @@ def test_paging_and_create_index2(cql, test_keyspace):
         assert expected == got
 
 # The two tests above re-parse the query on every page. These two repeat them
-# with a prepared statement, whose plan is derived once. Reproduces #18992.
+# with a prepared statement, whose plan is derived once and must be re-derived.
 def test_paging_and_create_index_prepared(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1908,9 +1902,6 @@ def test_paging_and_create_index_prepared(cql, test_keyspace):
         index_name = unique_name()
         cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
         wait_for_index(cql, test_keyspace, index_name)
-        # Stop here on Scylla, so the resume below is enforced on Cassandra.
-        if is_scylla(cql):
-            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(select, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
@@ -1940,22 +1931,30 @@ def test_paging_and_create_index2_prepared(cql, test_keyspace):
         index_name1 = unique_name()
         cql.execute(f"CREATE INDEX {index_name1} ON {table}(v1)")
         wait_for_index(cql, test_keyspace, index_name1)
-        # Stop here on Scylla, so the resume below is enforced on Cassandra.
-        if is_scylla(cql):
-            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(select, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
             got.extend(r.current_rows)
         assert expected == got
 
-# Similar to the previous tests, but here a secondary index which is used
-# for the original request is suddenly deleted between pages. In this test,
-# the query has "ALLOW FILTERING" so the query can continue to work -
-# inefficiently - after the index is deleted. In the following test, we
-# will do the same without ALLOW FILTERING in the query - and we'll see the
-# query can't be resumed after the index is dropped.
-# Reproduces #18992.
+# The tests from here on read pages while the set of indexes that could serve
+# the query changes underneath them, which is where Scylla deliberately stops
+# being compatible with Cassandra: Cassandra re-plans and keeps paging, Scylla
+# keeps the plan the first page used and refuses the resume once that plan is
+# gone. Each such test asserts per engine and says which behaviour is whose.
+#
+# Re-planning is not something to reproduce here, which is not to say it is
+# wrong on Cassandra: it needs one plan to resume from where another stopped,
+# and Scylla would rather not depend on that; an index created between pages may
+# still be building, so switching to it would return part of the rows; and
+# refusing is not new in kind, since a query that would need ALLOW FILTERING
+# once its index is dropped has to fail on either engine anyway. The error is an
+# InvalidRequest so that no driver retries it on its own, which would not help:
+# the same paging state fails the same way, and the query has to be restarted.
+# Refs #18992
+#
+# The index the request uses is deleted between pages. With "ALLOW FILTERING"
+# Cassandra re-plans to a base-table scan; Scylla refuses.
 def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1976,21 +1975,24 @@ def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
         assert expected == list(cql.execute(stmt))
         # Finally, run the same paged query again but this time use the page-
         # by-page API, and do a DROP INDEX between the first and second page.
-        # The query still has ALLOW FILTERING to prevent Scylla from rejecting
-        # the query because now (without the index) it needs ALLOW FILTERING.
         got = []
         r = cql.execute(stmt)
         assert len(r.current_rows) == page_size  # sanity check
         got.extend(r.current_rows)
         cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
-        # Stop here on Scylla, so the resume below is enforced on Cassandra.
         if is_scylla(cql):
-            pytest.xfail("issue #18992")
-        while r.has_more_pages:
-            r = cql.execute(stmt, paging_state=r.paging_state)
-            assert len(r.current_rows) <= page_size # sanity check
-            got.extend(r.current_rows)
-        assert expected == got
+            # On the first resumed page, so a regression that returns wrong rows
+            # and only raises later cannot pass.
+            assert r.has_more_pages
+            with pytest.raises(InvalidRequest, match="no longer available"):
+                cql.execute(stmt, paging_state=r.paging_state)
+        else:
+            # Cassandra re-plans to a base-table scan and resumes correctly.
+            while r.has_more_pages:
+                r = cql.execute(stmt, paging_state=r.paging_state)
+                assert len(r.current_rows) <= page_size  # sanity check
+                got.extend(r.current_rows)
+            assert expected == got
 
 # As above but without ALLOW FILTERING, so neither engine can resume: Scylla's
 # saved position belongs to the dropped index, Cassandra needs the filtering.

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -17,7 +17,7 @@ from cassandra.protocol import InvalidRequest, ConfigurationException, ReadFailu
 from cassandra.query import SimpleStatement
 from .cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order
 
-from .util import new_test_table, unique_name, unique_key_int, is_scylla, ScyllaMetrics, config_value_context
+from .util import new_test_table, new_test_keyspace, new_cql, unique_name, unique_key_int, is_scylla, ScyllaMetrics, config_value_context
 
 # A reproducer for issue #7443: Normally, when the entire table is SELECTed,
 # the partitions are returned sorted by the partitions' token. When there
@@ -1807,6 +1807,24 @@ def wait_for_index(cql, keyspace, index_name, timeout_sec=60):
         time.sleep(0.1)
     pytest.fail(f"Timeout ({timeout_sec} seconds) waiting for index {keyspace}.{index_name}")
 
+# Utility function waiting for the given index to disappear from "IndexInfo",
+# so a later wait_for_index() isn't satisfied by the dropped index's entry.
+def wait_for_index_gone(cql, keyspace, index_name, timeout_sec=60):
+    start_time = time.time()
+    while time.time() < start_time + timeout_sec:
+        if not list(cql.execute(f"SELECT index_name FROM system.\"IndexInfo\" WHERE table_name = '{keyspace}' and index_name = '{index_name}'")):
+            return
+        time.sleep(0.1)
+    pytest.fail(f"Timeout ({timeout_sec} seconds) waiting for index {keyspace}.{index_name} to be gone")
+
+# Pages so far that re-derived their query plan, watched by the prepared tests
+# to tell a real exercise of the fix from a vacuous pass. 0 on Cassandra.
+def paging_plan_rederivations(cql):
+    if not is_scylla(cql):
+        return 0
+    count = ScyllaMetrics.query(cql).get('scylla_cql_select_paging_plan_rederivations')
+    return count if count is not None else 0
+
 # The following test starts a filtering request (with ALLOW FILTERING),
 # pages through the results, and between two pages adds a secondary-index
 # that could be used - or not - for continuing the request, but certainly
@@ -1842,6 +1860,32 @@ def test_paging_and_create_index(cql, test_keyspace):
             assert len(r.current_rows) <= page_size # sanity check
             got.extend(r.current_rows)
         assert expected == got
+
+# Like test_paging_and_create_index, but with a sparse filter, where a fallback
+# that skips or duplicates rows cannot return the right set by accident.
+def test_paging_and_create_index_sparse(cql, test_keyspace, driver_bug_1):
+    count = 40
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17 if i % 4 == 0 else 23])
+        page_size = 3
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING", fetch_size=page_size)
+        expected = sorted(row.p for row in cql.execute(stmt))
+        got = []
+        r = cql.execute(stmt)
+        # A sparse scan may return fewer than page_size rows, but must page.
+        assert r.has_more_pages
+        got.extend(r.current_rows)
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        while r.has_more_pages:
+            r = cql.execute(stmt, paging_state=r.paging_state)
+            assert len(r.current_rows) <= page_size
+            got.extend(r.current_rows)
+        assert expected == sorted(row.p for row in got)
 
 # This test is the same as the previous one, but in this test the request
 # filters on both v1 and v2 is already using an index for column v2, and
@@ -1882,6 +1926,42 @@ def test_paging_and_create_index2(cql, test_keyspace):
             got.extend(r.current_rows)
         assert expected == got
 
+# Re-deriving costs a re-parse, so a paged prepared read that nobody changed the
+# indexes under has to reach its last page without one - for a base-table plan,
+# whose recorded id is null, as much as for an index plan naming a view.
+def test_paging_prepared_without_index_change_does_not_rederive(cql, test_keyspace, scylla_only):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        page_size = 7
+        def page_through(select):
+            got = []
+            r = cql.execute(select)
+            assert r.has_more_pages
+            got.extend(r.current_rows)
+            while r.has_more_pages:
+                r = cql.execute(select, paging_state=r.paging_state)
+                got.extend(r.current_rows)
+            return got
+        base = cql.prepare(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING")
+        base.fetch_size = page_size
+        expected = list(cql.execute(base))
+        rederivations = paging_plan_rederivations(cql)
+        assert expected == page_through(base)
+        assert paging_plan_rederivations(cql) == rederivations
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        indexed = cql.prepare(f"SELECT p FROM {table} WHERE v=17")
+        indexed.fetch_size = page_size
+        expected = list(cql.execute(indexed))
+        rederivations = paging_plan_rederivations(cql)
+        assert expected == page_through(indexed)
+        assert paging_plan_rederivations(cql) == rederivations
+
 # The two tests above re-parse the query on every page. These two repeat them
 # with a prepared statement, whose plan is derived once and must be re-derived.
 def test_paging_and_create_index_prepared(cql, test_keyspace):
@@ -1902,11 +1982,14 @@ def test_paging_and_create_index_prepared(cql, test_keyspace):
         index_name = unique_name()
         cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
         wait_for_index(cql, test_keyspace, index_name)
+        rederivations = paging_plan_rederivations(cql)
         while r.has_more_pages:
             r = cql.execute(select, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
             got.extend(r.current_rows)
         assert expected == got
+        if is_scylla(cql):
+            assert paging_plan_rederivations(cql) > rederivations
 
 # Prepared-statement version of test_paging_and_create_index2: the query is
 # already using an index for v2, and we add an index for v1 between pages.
@@ -1931,11 +2014,56 @@ def test_paging_and_create_index2_prepared(cql, test_keyspace):
         index_name1 = unique_name()
         cql.execute(f"CREATE INDEX {index_name1} ON {table}(v1)")
         wait_for_index(cql, test_keyspace, index_name1)
+        rederivations = paging_plan_rederivations(cql)
         while r.has_more_pages:
             r = cql.execute(select, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
             got.extend(r.current_rows)
         assert expected == got
+        if is_scylla(cql):
+            assert paging_plan_rederivations(cql) > rederivations
+
+# A re-derived statement naming its table without a keyspace must keep resolving
+# it against the keyspace it was prepared with, not the connection's current one.
+def test_paging_and_create_index_prepared_use_keyspace(cql, test_keyspace, this_dc):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        table_name = table.split(".")[1]
+        with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace2:
+            cql.execute(f"CREATE TABLE {keyspace2}.{table_name} (p int, v int, PRIMARY KEY (p))")
+            with new_cql(cql) as session:
+                session.set_keyspace(test_keyspace)
+                page_size = 7
+                select = session.prepare(f"SELECT p FROM {table_name} WHERE v=17 ALLOW FILTERING")
+                select.fetch_size = page_size
+                expected = list(session.execute(select))
+                got = []
+                r = session.execute(select)
+                assert len(r.current_rows) == page_size
+                got.extend(r.current_rows)
+                index_name = unique_name()
+                cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+                wait_for_index(cql, test_keyspace, index_name)
+                # The index must be able to serve this query, or the plan never
+                # changes and the re-derivation below is never exercised.
+                cql.execute(f"SELECT p FROM {table} WHERE v=17")
+                rederivations = paging_plan_rederivations(cql)
+                # Re-derivation happens here, while the original keyspace is set.
+                assert r.has_more_pages
+                r = session.execute(select, paging_state=r.paging_state)
+                got.extend(r.current_rows)
+                assert r.has_more_pages
+                session.set_keyspace(keyspace2)
+                while r.has_more_pages:
+                    r = session.execute(select, paging_state=r.paging_state)
+                    got.extend(r.current_rows)
+                assert expected == got
+                if is_scylla(cql):
+                    assert paging_plan_rederivations(cql) > rederivations
 
 # The index the request uses is deleted between pages. With "ALLOW FILTERING"
 # Cassandra re-plans to a base-table scan; Scylla refuses. Refs #18992.
@@ -2007,6 +2135,43 @@ def test_paging_and_drop_index_no_allow_filtering(cql, test_keyspace):
         with pytest.raises(InvalidRequest, match=expected_error):
             cql.execute(stmt, paging_state=r.paging_state)
 
+# The read is tied to the index it started with, not to its name. The recreated
+# index here can serve the query, so only comparing view ids rejects it.
+def test_paging_and_recreate_index_same_name_other_column(cql, test_keyspace, driver_bug_1):
+    count = 40
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, w int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v, w) VALUES (?, ?, ?)")
+        # A sparse subset, so a wrong plan shows up as a wrong row set.
+        for i in range(count):
+            cql.execute(insert, [i, 17 if i % 2 == 0 else 23, 3 if i % 3 == 0 else 5])
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        page_size = 2
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v=17 AND w=3 ALLOW FILTERING",
+                fetch_size=page_size)
+        expected = sorted(row.p for row in cql.execute(stmt))
+        assert len(expected) > page_size
+
+        r = cql.execute(stmt)
+        assert r.has_more_pages
+        got = list(r.current_rows)
+        # The new index is over w, which the query also restricts, so it can serve.
+        cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
+        wait_for_index_gone(cql, test_keyspace, index_name)
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(w)")
+        wait_for_index(cql, test_keyspace, index_name)
+        if is_scylla(cql):
+            with pytest.raises(InvalidRequest, match="no longer available"):
+                cql.execute(stmt, paging_state=r.paging_state)
+        else:
+            while r.has_more_pages:
+                r = cql.execute(stmt, paging_state=r.paging_state)
+                assert len(r.current_rows) <= page_size
+                got.extend(r.current_rows)
+            assert expected == sorted(row.p for row in got)
+
 # A base-table read is not tied to the table's identity, so a table dropped and
 # recreated between pages is read on - the same way on Cassandra and on Scylla.
 def test_paging_and_recreate_table(cql, test_keyspace):
@@ -2044,6 +2209,138 @@ def test_paging_and_recreate_table(cql, test_keyspace):
             r = cql.execute(stmt, paging_state=r.paging_state)
             got.update(row.p for row in r.current_rows)
         assert got == set(fresh) - skipped
+
+# A paging state from another query can pin an index that exists but cannot
+# serve this one, and the refusal has to name that rather than a missing index.
+def test_paging_and_paging_state_from_other_query(cql, test_keyspace, scylla_only):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, w int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v, w) VALUES (?, ?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17, 3])
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(w)")
+        wait_for_index(cql, test_keyspace, index_name)
+        page_size = 7
+        indexed = SimpleStatement(f"SELECT p FROM {table} WHERE w=3", fetch_size=page_size)
+        r = cql.execute(indexed)
+        assert len(r.current_rows) == page_size
+        # No index on v, while the pinned one is still there. Without ALLOW
+        # FILTERING, so a pin noticed too late would be reported as needing it.
+        unindexed = SimpleStatement(f"SELECT p FROM {table} WHERE v=17", fetch_size=page_size)
+        with pytest.raises(InvalidRequest, match="cannot serve this one"):
+            cql.execute(unindexed, paging_state=r.paging_state)
+
+# The mirror of the test above for a state that pins the base table: a query that
+# an index has to serve cannot continue from a position the base-table scan left.
+def test_paging_and_paging_state_from_base_table_query(cql, test_keyspace, scylla_only):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, w int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v, w) VALUES (?, ?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17, 3])
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(w)")
+        wait_for_index(cql, test_keyspace, index_name)
+        page_size = 7
+        # Filters on v, which the only index does not cover, so this scans the
+        # base table and its paging state pins the base table.
+        unindexed = SimpleStatement(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING",
+                fetch_size=page_size)
+        r = cql.execute(unindexed)
+        assert len(r.current_rows) == page_size
+        # Without ALLOW FILTERING, so a pin noticed too late would be reported as
+        # needing it rather than as a state this query cannot continue from.
+        indexed = SimpleStatement(f"SELECT p FROM {table} WHERE w=3", fetch_size=page_size)
+        with pytest.raises(InvalidRequest, match="cannot serve this one"):
+            cql.execute(indexed, paging_state=r.paging_state)
+
+# Prepared-statement version of test_paging_and_drop_index_allow_filtering. The
+# driver re-prepares after the DROP, and ALLOW FILTERING lets that succeed.
+def test_paging_and_drop_index_allow_filtering_prepared(cql, test_keyspace):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        page_size = 7
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        select = cql.prepare(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING")
+        select.fetch_size = page_size
+        expected = list(cql.execute(select))
+        got = []
+        r = cql.execute(select)
+        assert len(r.current_rows) == page_size
+        got.extend(r.current_rows)
+        cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
+        if is_scylla(cql):
+            with pytest.raises(InvalidRequest, match="no longer available"):
+                cql.execute(select, paging_state=r.paging_state)
+        else:
+            while r.has_more_pages:
+                r = cql.execute(select, paging_state=r.paging_state)
+                assert len(r.current_rows) <= page_size
+                got.extend(r.current_rows)
+            assert expected == got
+
+# A paging state recording no plan, as an older node writes during a rolling
+# upgrade, has nothing to pin and must not be refused. Refs #18992
+def test_paging_resume_from_pre_plan_paging_state_drop_index(cql, test_keyspace):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        page_size = 7
+        # ALLOW FILTERING, so a base-table scan is still a legal fallback.
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING", fetch_size=page_size)
+        with rest_api.scylla_inject_error(cql, "paging_state_without_query_plan"):
+            r = cql.execute(stmt)
+            assert len(r.current_rows) == page_size
+            assert r.has_more_pages
+            cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
+            # What the fallback returns is #18992 and not asserted, but it must
+            # not be the refusal a recorded plan produces.
+            try:
+                cql.execute(stmt, paging_state=r.paging_state)
+            except Exception as e:
+                assert "no longer available" not in str(e)
+
+# The same state reaching a prepared statement, the only path that re-derives:
+# with nothing to pin it must be neither refused nor charged for a re-parse.
+def test_paging_resume_from_pre_plan_paging_state_prepared(cql, test_keyspace):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        page_size = 7
+        select = cql.prepare(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING")
+        select.fetch_size = page_size
+        with rest_api.scylla_inject_error(cql, "paging_state_without_query_plan"):
+            r = cql.execute(select)
+            assert len(r.current_rows) == page_size
+            assert r.has_more_pages
+            index_name = unique_name()
+            cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+            wait_for_index(cql, test_keyspace, index_name)
+            rederivations = paging_plan_rederivations(cql)
+            try:
+                cql.execute(select, paging_state=r.paging_state)
+            except Exception as e:
+                assert "no longer available" not in str(e)
+                assert "cannot serve this one" not in str(e)
+            assert paging_plan_rederivations(cql) == rederivations
 
 
 # Test index representation in system.* tables

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -17,7 +17,7 @@ from cassandra.protocol import InvalidRequest, ConfigurationException, ReadFailu
 from cassandra.query import SimpleStatement
 from .cassandra_tests.porting import assert_rows, assert_row_count, assert_rows_ignoring_order
 
-from .util import new_test_table, unique_name, unique_key_int, is_scylla, ScyllaMetrics, config_value_context
+from .util import new_test_table, new_test_keyspace, new_cql, unique_name, unique_key_int, is_scylla, ScyllaMetrics, config_value_context
 
 # A reproducer for issue #7443: Normally, when the entire table is SELECTed,
 # the partitions are returned sorted by the partitions' token. When there
@@ -1807,6 +1807,24 @@ def wait_for_index(cql, keyspace, index_name, timeout_sec=60):
         time.sleep(0.1)
     pytest.fail(f"Timeout ({timeout_sec} seconds) waiting for index {keyspace}.{index_name}")
 
+# Utility function waiting for the given index to disappear from "IndexInfo",
+# so a later wait_for_index() isn't satisfied by the dropped index's entry.
+def wait_for_index_gone(cql, keyspace, index_name, timeout_sec=60):
+    start_time = time.time()
+    while time.time() < start_time + timeout_sec:
+        if not list(cql.execute(f"SELECT index_name FROM system.\"IndexInfo\" WHERE table_name = '{keyspace}' and index_name = '{index_name}'")):
+            return
+        time.sleep(0.1)
+    pytest.fail(f"Timeout ({timeout_sec} seconds) waiting for index {keyspace}.{index_name} to be gone")
+
+# Pages so far that re-derived their query plan, watched by the prepared tests
+# to tell a real exercise of the fix from a vacuous pass. 0 on Cassandra.
+def paging_plan_rederivations(cql):
+    if not is_scylla(cql):
+        return 0
+    count = ScyllaMetrics.query(cql).get('scylla_cql_select_paging_plan_rederivations')
+    return count if count is not None else 0
+
 # The following test starts a filtering request (with ALLOW FILTERING),
 # pages through the results, and between two pages adds a secondary-index
 # that could be used - or not - for continuing the request, but certainly
@@ -1842,6 +1860,32 @@ def test_paging_and_create_index(cql, test_keyspace):
             assert len(r.current_rows) <= page_size # sanity check
             got.extend(r.current_rows)
         assert expected == got
+
+# Like test_paging_and_create_index, but with a sparse filter, where a fallback
+# that skips or duplicates rows cannot return the right set by accident.
+def test_paging_and_create_index_sparse(cql, test_keyspace, driver_bug_1):
+    count = 40
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17 if i % 4 == 0 else 23])
+        page_size = 3
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING", fetch_size=page_size)
+        expected = sorted(row.p for row in cql.execute(stmt))
+        got = []
+        r = cql.execute(stmt)
+        # A sparse scan may return fewer than page_size rows, but must page.
+        assert r.has_more_pages
+        got.extend(r.current_rows)
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        while r.has_more_pages:
+            r = cql.execute(stmt, paging_state=r.paging_state)
+            assert len(r.current_rows) <= page_size
+            got.extend(r.current_rows)
+        assert expected == sorted(row.p for row in got)
 
 # This test is the same as the previous one, but in this test the request
 # filters on both v1 and v2 is already using an index for column v2, and
@@ -1882,6 +1926,42 @@ def test_paging_and_create_index2(cql, test_keyspace):
             got.extend(r.current_rows)
         assert expected == got
 
+# Re-deriving costs a re-parse, so a paged prepared read that nobody changed the
+# indexes under has to reach its last page without one - for a base-table plan,
+# whose recorded id is null, as much as for an index plan naming a view.
+def test_paging_prepared_without_index_change_does_not_rederive(cql, test_keyspace, scylla_only):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        page_size = 7
+        def page_through(select):
+            got = []
+            r = cql.execute(select)
+            assert r.has_more_pages
+            got.extend(r.current_rows)
+            while r.has_more_pages:
+                r = cql.execute(select, paging_state=r.paging_state)
+                got.extend(r.current_rows)
+            return got
+        base = cql.prepare(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING")
+        base.fetch_size = page_size
+        expected = list(cql.execute(base))
+        rederivations = paging_plan_rederivations(cql)
+        assert expected == page_through(base)
+        assert paging_plan_rederivations(cql) == rederivations
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        indexed = cql.prepare(f"SELECT p FROM {table} WHERE v=17")
+        indexed.fetch_size = page_size
+        expected = list(cql.execute(indexed))
+        rederivations = paging_plan_rederivations(cql)
+        assert expected == page_through(indexed)
+        assert paging_plan_rederivations(cql) == rederivations
+
 # The two tests above re-parse the query on every page. These two repeat them
 # with a prepared statement, whose plan is derived once and must be re-derived.
 def test_paging_and_create_index_prepared(cql, test_keyspace):
@@ -1902,11 +1982,14 @@ def test_paging_and_create_index_prepared(cql, test_keyspace):
         index_name = unique_name()
         cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
         wait_for_index(cql, test_keyspace, index_name)
+        rederivations = paging_plan_rederivations(cql)
         while r.has_more_pages:
             r = cql.execute(select, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
             got.extend(r.current_rows)
         assert expected == got
+        if is_scylla(cql):
+            assert paging_plan_rederivations(cql) > rederivations
 
 # Prepared-statement version of test_paging_and_create_index2: the query is
 # already using an index for v2, and we add an index for v1 between pages.
@@ -1931,11 +2014,95 @@ def test_paging_and_create_index2_prepared(cql, test_keyspace):
         index_name1 = unique_name()
         cql.execute(f"CREATE INDEX {index_name1} ON {table}(v1)")
         wait_for_index(cql, test_keyspace, index_name1)
+        rederivations = paging_plan_rederivations(cql)
         while r.has_more_pages:
             r = cql.execute(select, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
             got.extend(r.current_rows)
         assert expected == got
+        if is_scylla(cql):
+            assert paging_plan_rederivations(cql) > rederivations
+
+# The prepared tests above filter on literals. Re-deriving a statement builds a
+# second one from the same text, with its own bind markers, so repeat with the
+# filtered values bound instead: a resumed page has to bind the values the
+# client sent. The two markers match nothing when transposed, so a page binding
+# them in the wrong order could not return the expected rows.
+def test_paging_and_create_index_prepared_bind_markers(cql, test_keyspace, driver_bug_1):
+    count = 40
+    with new_test_table(cql, test_keyspace,
+            "p int, v1 int, v2 int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v1, v2) VALUES (?, ?, ?)")
+        # A sparse match on v1, so a page served by the wrong plan shows up as a
+        # wrong row set rather than as the right one by accident.
+        for i in range(count):
+            cql.execute(insert, [i, 17 if i % 4 == 0 else 23, 1])
+        page_size = 3
+        select = cql.prepare(f"SELECT p FROM {table} WHERE v1=? AND v2=? ALLOW FILTERING")
+        select.fetch_size = page_size
+        expected = sorted(row.p for row in cql.execute(select, [17, 1]))
+        assert len(expected) > page_size
+        # Nothing has v1=1, so the rows collected below cannot have come from the
+        # values bound the other way round.
+        assert list(cql.execute(select, [1, 17])) == []
+        got = []
+        r = cql.execute(select, [17, 1])
+        # A sparse scan may return fewer than page_size rows, but must page.
+        assert r.has_more_pages
+        got.extend(r.current_rows)
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v1)")
+        wait_for_index(cql, test_keyspace, index_name)
+        rederivations = paging_plan_rederivations(cql)
+        while r.has_more_pages:
+            r = cql.execute(select, [17, 1], paging_state=r.paging_state)
+            assert len(r.current_rows) <= page_size
+            got.extend(r.current_rows)
+        assert expected == sorted(row.p for row in got)
+        if is_scylla(cql):
+            assert paging_plan_rederivations(cql) > rederivations
+
+# A re-derived statement naming its table without a keyspace must keep resolving
+# it against the keyspace it was prepared with, not the connection's current one.
+def test_paging_and_create_index_prepared_use_keyspace(cql, test_keyspace, this_dc):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        table_name = table.split(".")[1]
+        with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace2:
+            cql.execute(f"CREATE TABLE {keyspace2}.{table_name} (p int, v int, PRIMARY KEY (p))")
+            with new_cql(cql) as session:
+                session.set_keyspace(test_keyspace)
+                page_size = 7
+                select = session.prepare(f"SELECT p FROM {table_name} WHERE v=17 ALLOW FILTERING")
+                select.fetch_size = page_size
+                expected = list(session.execute(select))
+                got = []
+                r = session.execute(select)
+                assert len(r.current_rows) == page_size
+                got.extend(r.current_rows)
+                index_name = unique_name()
+                cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+                wait_for_index(cql, test_keyspace, index_name)
+                # The index must be able to serve this query, or the plan never
+                # changes and the re-derivation below is never exercised.
+                cql.execute(f"SELECT p FROM {table} WHERE v=17")
+                rederivations = paging_plan_rederivations(cql)
+                # Re-derivation happens here, while the original keyspace is set.
+                assert r.has_more_pages
+                r = session.execute(select, paging_state=r.paging_state)
+                got.extend(r.current_rows)
+                assert r.has_more_pages
+                session.set_keyspace(keyspace2)
+                while r.has_more_pages:
+                    r = session.execute(select, paging_state=r.paging_state)
+                    got.extend(r.current_rows)
+                assert expected == got
+                if is_scylla(cql):
+                    assert paging_plan_rederivations(cql) > rederivations
 
 # The tests from here on read pages while the set of indexes that could serve
 # the query changes underneath them, which is where Scylla deliberately stops
@@ -2023,6 +2190,43 @@ def test_paging_and_drop_index_no_allow_filtering(cql, test_keyspace):
         with pytest.raises(InvalidRequest, match=expected_error):
             cql.execute(stmt, paging_state=r.paging_state)
 
+# The read is tied to the index it started with, not to its name. The recreated
+# index here can serve the query, so only comparing view ids rejects it.
+def test_paging_and_recreate_index_same_name_other_column(cql, test_keyspace, driver_bug_1):
+    count = 40
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, w int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v, w) VALUES (?, ?, ?)")
+        # A sparse subset, so a wrong plan shows up as a wrong row set.
+        for i in range(count):
+            cql.execute(insert, [i, 17 if i % 2 == 0 else 23, 3 if i % 3 == 0 else 5])
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        page_size = 2
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v=17 AND w=3 ALLOW FILTERING",
+                fetch_size=page_size)
+        expected = sorted(row.p for row in cql.execute(stmt))
+        assert len(expected) > page_size
+
+        r = cql.execute(stmt)
+        assert r.has_more_pages
+        got = list(r.current_rows)
+        # The new index is over w, which the query also restricts, so it can serve.
+        cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
+        wait_for_index_gone(cql, test_keyspace, index_name)
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(w)")
+        wait_for_index(cql, test_keyspace, index_name)
+        if is_scylla(cql):
+            with pytest.raises(InvalidRequest, match="no longer available"):
+                cql.execute(stmt, paging_state=r.paging_state)
+        else:
+            while r.has_more_pages:
+                r = cql.execute(stmt, paging_state=r.paging_state)
+                assert len(r.current_rows) <= page_size
+                got.extend(r.current_rows)
+            assert expected == sorted(row.p for row in got)
+
 # A base-table read is not tied to the table's identity, so a table dropped and
 # recreated between pages is read on - the same way on Cassandra and on Scylla.
 def test_paging_and_recreate_table(cql, test_keyspace):
@@ -2060,6 +2264,168 @@ def test_paging_and_recreate_table(cql, test_keyspace):
             r = cql.execute(stmt, paging_state=r.paging_state)
             got.update(row.p for row in r.current_rows)
         assert got == set(fresh) - skipped
+
+# A paging state from another query can pin an index that exists but cannot
+# serve this one, and the refusal has to name that rather than a missing index.
+def test_paging_and_paging_state_from_other_query(cql, test_keyspace, scylla_only):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, w int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v, w) VALUES (?, ?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17, 3])
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(w)")
+        wait_for_index(cql, test_keyspace, index_name)
+        page_size = 7
+        indexed = SimpleStatement(f"SELECT p FROM {table} WHERE w=3", fetch_size=page_size)
+        r = cql.execute(indexed)
+        assert len(r.current_rows) == page_size
+        # No index on v, while the pinned one is still there. Without ALLOW
+        # FILTERING, so a pin noticed too late would be reported as needing it.
+        unindexed = SimpleStatement(f"SELECT p FROM {table} WHERE v=17", fetch_size=page_size)
+        with pytest.raises(InvalidRequest, match="cannot serve this one"):
+            cql.execute(unindexed, paging_state=r.paging_state)
+
+# The mirror of the test above for a state that pins the base table: a query that
+# an index has to serve cannot continue from a position the base-table scan left.
+def test_paging_and_paging_state_from_base_table_query(cql, test_keyspace, scylla_only):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, w int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v, w) VALUES (?, ?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17, 3])
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(w)")
+        wait_for_index(cql, test_keyspace, index_name)
+        page_size = 7
+        # Filters on v, which the only index does not cover, so this scans the
+        # base table and its paging state pins the base table.
+        unindexed = SimpleStatement(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING",
+                fetch_size=page_size)
+        r = cql.execute(unindexed)
+        assert len(r.current_rows) == page_size
+        # Without ALLOW FILTERING, so a pin noticed too late would be reported as
+        # needing it rather than as a state this query cannot continue from.
+        indexed = SimpleStatement(f"SELECT p FROM {table} WHERE w=3", fetch_size=page_size)
+        with pytest.raises(InvalidRequest, match="cannot serve this one"):
+            cql.execute(indexed, paging_state=r.paging_state)
+
+# The same for a query an index on a key column has to serve, where the pin is
+# noticed only after the ordinary filtering validation has rejected the query,
+# so the error is that one. Only the refusal is asserted and not its wording, so
+# extending the pin's own error to these queries would keep this passing.
+@pytest.mark.parametrize("schema,insert,indexed_column,restriction", [
+        ("p1 int, p2 int, c int, v int, PRIMARY KEY ((p1,p2),c)",
+                "(p1, p2, c, v) VALUES (7, {i}, 42, 1)", "p1", "p1=7"),
+        ("p int, c1 int, c2 int, v int, PRIMARY KEY (p, c1, c2)",
+                "(p, c1, c2, v) VALUES ({i}, 1, 3, 1)", "c2", "c2=3")])
+def test_paging_and_paging_state_from_base_table_query_key_columns(cql, test_keyspace,
+        schema, insert, indexed_column, restriction, scylla_only):
+    count = 20
+    with new_test_table(cql, test_keyspace, schema) as table:
+        for i in range(count):
+            cql.execute(f"INSERT INTO {table} {insert.format(i=i)}")
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}({indexed_column})")
+        wait_for_index(cql, test_keyspace, index_name)
+        page_size = 7
+        # Filters on v, which the only index does not cover, so this scans the
+        # base table and its paging state pins the base table.
+        unindexed = SimpleStatement(f"SELECT v FROM {table} WHERE v=1 ALLOW FILTERING",
+                fetch_size=page_size)
+        r = cql.execute(unindexed)
+        assert len(r.current_rows) == page_size
+        indexed = SimpleStatement(f"SELECT v FROM {table} WHERE {restriction}",
+                fetch_size=page_size)
+        with pytest.raises(InvalidRequest):
+            cql.execute(indexed, paging_state=r.paging_state)
+
+# Prepared-statement version of test_paging_and_drop_index_allow_filtering. The
+# driver re-prepares after the DROP, and ALLOW FILTERING lets that succeed.
+def test_paging_and_drop_index_allow_filtering_prepared(cql, test_keyspace):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        page_size = 7
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        select = cql.prepare(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING")
+        select.fetch_size = page_size
+        expected = list(cql.execute(select))
+        got = []
+        r = cql.execute(select)
+        assert len(r.current_rows) == page_size
+        got.extend(r.current_rows)
+        cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
+        if is_scylla(cql):
+            with pytest.raises(InvalidRequest, match="no longer available"):
+                cql.execute(select, paging_state=r.paging_state)
+        else:
+            while r.has_more_pages:
+                r = cql.execute(select, paging_state=r.paging_state)
+                assert len(r.current_rows) <= page_size
+                got.extend(r.current_rows)
+            assert expected == got
+
+# A paging state recording no plan, as an older node writes during a rolling
+# upgrade, has nothing to pin and must not be refused. Refs #18992
+def test_paging_resume_from_pre_plan_paging_state_drop_index(cql, test_keyspace, scylla_only):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        page_size = 7
+        # ALLOW FILTERING, so a base-table scan is still a legal fallback.
+        stmt = SimpleStatement(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING", fetch_size=page_size)
+        with rest_api.scylla_inject_error(cql, "paging_state_without_query_plan"):
+            r = cql.execute(stmt)
+            assert len(r.current_rows) == page_size
+            assert r.has_more_pages
+            cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
+            # What the fallback returns is #18992 and not asserted, but it must
+            # not be the refusal a recorded plan produces.
+            try:
+                cql.execute(stmt, paging_state=r.paging_state)
+            except InvalidRequest as e:
+                assert "no longer available" not in str(e)
+
+# The same state reaching a prepared statement, the only path that re-derives:
+# with nothing to pin it must be neither refused nor charged for a re-parse.
+def test_paging_resume_from_pre_plan_paging_state_prepared(cql, test_keyspace, scylla_only):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        page_size = 7
+        select = cql.prepare(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING")
+        select.fetch_size = page_size
+        with rest_api.scylla_inject_error(cql, "paging_state_without_query_plan"):
+            r = cql.execute(select)
+            assert len(r.current_rows) == page_size
+            assert r.has_more_pages
+            index_name = unique_name()
+            cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+            wait_for_index(cql, test_keyspace, index_name)
+            rederivations = paging_plan_rederivations(cql)
+            try:
+                cql.execute(select, paging_state=r.paging_state)
+            except InvalidRequest as e:
+                assert "no longer available" not in str(e)
+                assert "cannot serve this one" not in str(e)
+            assert paging_plan_rederivations(cql) == rederivations
 
 
 # Test index representation in system.* tables

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -1961,6 +1961,44 @@ def test_paging_and_drop_index_no_allow_filtering(cql, test_keyspace):
                 got.extend(r.current_rows)
             assert expected == got
 
+# A base-table read is not tied to the table's identity, so a table dropped and
+# recreated between pages is read on - the same way on Cassandra and on Scylla.
+def test_paging_and_recreate_table(cql, test_keyspace):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        page_size = 7
+        stmt = SimpleStatement(f"SELECT p, token(p) FROM {table} WHERE v=17 ALLOW FILTERING",
+                fetch_size=page_size)
+        r = cql.execute(stmt)
+        assert len(r.current_rows) == page_size
+        assert r.has_more_pages
+        # Where the read stopped. The scan visits partitions in token order, so
+        # this is the position the new table is read from.
+        stale_token = max(row.system_token_p for row in r.current_rows)
+        cql.execute(f"DROP TABLE {table}")
+        cql.execute(f"CREATE TABLE {table} (p text, v int, PRIMARY KEY (p))")
+        # Fill the new table, so a resume that decodes the old position returns
+        # rows instead of an empty page indistinguishable from a finished read.
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [str(i), 17])
+        fresh = {row.p: row.system_token_p for row in
+                cql.execute(f"SELECT p, token(p) FROM {table} WHERE v=17 ALLOW FILTERING")}
+        skipped = {p for p, token in fresh.items() if token <= stale_token}
+        # The stale position has to fall inside the new table's tokens, or there
+        # would be nothing for the resumed read to skip and nothing left to return.
+        assert skipped
+        assert set(fresh) - skipped
+        got = set()
+        while r.has_more_pages:
+            r = cql.execute(stmt, paging_state=r.paging_state)
+            got.update(row.p for row in r.current_rows)
+        assert got == set(fresh) - skipped
+
 
 # Test index representation in system.* tables
 def test_index_in_system_tables(cql, test_keyspace):

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -1837,9 +1837,6 @@ def test_paging_and_create_index(cql, test_keyspace):
         # We wait for the index to be built, since we don't want to reproduce
         # #7963 again here (an index getting used before actually built).
         wait_for_index(cql, test_keyspace, index_name)
-        # Stop here on Scylla, so the resume below is enforced on Cassandra.
-        if is_scylla(cql):
-            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(stmt, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size # sanity check
@@ -1879,9 +1876,6 @@ def test_paging_and_create_index2(cql, test_keyspace):
         index_name1 = unique_name()
         cql.execute(f"CREATE INDEX {index_name1} ON {table}(v1)")
         wait_for_index(cql, test_keyspace, index_name1)
-        # Stop here on Scylla, so the resume below is enforced on Cassandra.
-        if is_scylla(cql):
-            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(stmt, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
@@ -1889,7 +1883,7 @@ def test_paging_and_create_index2(cql, test_keyspace):
         assert expected == got
 
 # The two tests above re-parse the query on every page. These two repeat them
-# with a prepared statement, whose plan is derived once. Reproduces #18992.
+# with a prepared statement, whose plan is derived once and must be re-derived.
 def test_paging_and_create_index_prepared(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1908,9 +1902,6 @@ def test_paging_and_create_index_prepared(cql, test_keyspace):
         index_name = unique_name()
         cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
         wait_for_index(cql, test_keyspace, index_name)
-        # Stop here on Scylla, so the resume below is enforced on Cassandra.
-        if is_scylla(cql):
-            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(select, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
@@ -1940,22 +1931,14 @@ def test_paging_and_create_index2_prepared(cql, test_keyspace):
         index_name1 = unique_name()
         cql.execute(f"CREATE INDEX {index_name1} ON {table}(v1)")
         wait_for_index(cql, test_keyspace, index_name1)
-        # Stop here on Scylla, so the resume below is enforced on Cassandra.
-        if is_scylla(cql):
-            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(select, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
             got.extend(r.current_rows)
         assert expected == got
 
-# Similar to the previous tests, but here a secondary index which is used
-# for the original request is suddenly deleted between pages. In this test,
-# the query has "ALLOW FILTERING" so the query can continue to work -
-# inefficiently - after the index is deleted. In the following test, we
-# will do the same without ALLOW FILTERING in the query - and we'll see the
-# query can't be resumed after the index is dropped.
-# Reproduces #18992.
+# The index the request uses is deleted between pages. With "ALLOW FILTERING"
+# Cassandra re-plans to a base-table scan; Scylla refuses. Refs #18992.
 def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1976,21 +1959,24 @@ def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
         assert expected == list(cql.execute(stmt))
         # Finally, run the same paged query again but this time use the page-
         # by-page API, and do a DROP INDEX between the first and second page.
-        # The query still has ALLOW FILTERING to prevent Scylla from rejecting
-        # the query because now (without the index) it needs ALLOW FILTERING.
         got = []
         r = cql.execute(stmt)
         assert len(r.current_rows) == page_size  # sanity check
         got.extend(r.current_rows)
         cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
-        # Stop here on Scylla, so the resume below is enforced on Cassandra.
         if is_scylla(cql):
-            pytest.xfail("issue #18992")
-        while r.has_more_pages:
-            r = cql.execute(stmt, paging_state=r.paging_state)
-            assert len(r.current_rows) <= page_size # sanity check
-            got.extend(r.current_rows)
-        assert expected == got
+            # On the first resumed page, so a regression that returns wrong rows
+            # and only raises later cannot pass.
+            assert r.has_more_pages
+            with pytest.raises(InvalidRequest, match="no longer available"):
+                cql.execute(stmt, paging_state=r.paging_state)
+        else:
+            # Cassandra re-plans to a base-table scan and resumes correctly.
+            while r.has_more_pages:
+                r = cql.execute(stmt, paging_state=r.paging_state)
+                assert len(r.current_rows) <= page_size  # sanity check
+                got.extend(r.current_rows)
+            assert expected == got
 
 # As above but without ALLOW FILTERING, so neither engine can resume: Scylla's
 # saved position belongs to the dropped index, Cassandra needs the filtering.

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -1811,7 +1811,6 @@ def wait_for_index(cql, keyspace, index_name, timeout_sec=60):
 # pages through the results, and between two pages adds a secondary-index
 # that could be used - or not - for continuing the request, but certainly
 # shouldn't break the request. Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
 def test_paging_and_create_index(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1838,6 +1837,9 @@ def test_paging_and_create_index(cql, test_keyspace):
         # We wait for the index to be built, since we don't want to reproduce
         # #7963 again here (an index getting used before actually built).
         wait_for_index(cql, test_keyspace, index_name)
+        # Stop here on Scylla, so the resume below is enforced on Cassandra.
+        if is_scylla(cql):
+            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(stmt, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size # sanity check
@@ -1847,7 +1849,6 @@ def test_paging_and_create_index(cql, test_keyspace):
 # This test is the same as the previous one, but in this test the request
 # filters on both v1 and v2 is already using an index for column v2, and
 # now between the pages we add an index for v1. Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
 def test_paging_and_create_index2(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1878,8 +1879,72 @@ def test_paging_and_create_index2(cql, test_keyspace):
         index_name1 = unique_name()
         cql.execute(f"CREATE INDEX {index_name1} ON {table}(v1)")
         wait_for_index(cql, test_keyspace, index_name1)
+        # Stop here on Scylla, so the resume below is enforced on Cassandra.
+        if is_scylla(cql):
+            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(stmt, paging_state=r.paging_state)
+            assert len(r.current_rows) <= page_size
+            got.extend(r.current_rows)
+        assert expected == got
+
+# The two tests above re-parse the query on every page. These two repeat them
+# with a prepared statement, whose plan is derived once. Reproduces #18992.
+def test_paging_and_create_index_prepared(cql, test_keyspace):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, 17])
+        page_size = 7
+        select = cql.prepare(f"SELECT p FROM {table} WHERE v=17 ALLOW FILTERING")
+        select.fetch_size = page_size
+        expected = list(cql.execute(select))
+        got = []
+        r = cql.execute(select)
+        assert len(r.current_rows) == page_size
+        got.extend(r.current_rows)
+        index_name = unique_name()
+        cql.execute(f"CREATE INDEX {index_name} ON {table}(v)")
+        wait_for_index(cql, test_keyspace, index_name)
+        # Stop here on Scylla, so the resume below is enforced on Cassandra.
+        if is_scylla(cql):
+            pytest.xfail("issue #18992")
+        while r.has_more_pages:
+            r = cql.execute(select, paging_state=r.paging_state)
+            assert len(r.current_rows) <= page_size
+            got.extend(r.current_rows)
+        assert expected == got
+
+# Prepared-statement version of test_paging_and_create_index2: the query is
+# already using an index for v2, and we add an index for v1 between pages.
+def test_paging_and_create_index2_prepared(cql, test_keyspace):
+    count = 20
+    with new_test_table(cql, test_keyspace,
+            "p int, v1 text, v2 int, PRIMARY KEY (p)") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (p, v1, v2) VALUES (?, ?, ?)")
+        for i in range(count):
+            cql.execute(insert, [i, "dog", 3])
+        page_size = 7
+        index_name2 = unique_name()
+        cql.execute(f"CREATE INDEX {index_name2} ON {table}(v2)")
+        wait_for_index(cql, test_keyspace, index_name2)
+        select = cql.prepare(f"SELECT p FROM {table} WHERE v1='dog' AND v2=3 ALLOW FILTERING")
+        select.fetch_size = page_size
+        expected = list(cql.execute(select))
+        got = []
+        r = cql.execute(select)
+        assert len(r.current_rows) == page_size
+        got.extend(r.current_rows)
+        index_name1 = unique_name()
+        cql.execute(f"CREATE INDEX {index_name1} ON {table}(v1)")
+        wait_for_index(cql, test_keyspace, index_name1)
+        # Stop here on Scylla, so the resume below is enforced on Cassandra.
+        if is_scylla(cql):
+            pytest.xfail("issue #18992")
+        while r.has_more_pages:
+            r = cql.execute(select, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size
             got.extend(r.current_rows)
         assert expected == got
@@ -1891,7 +1956,6 @@ def test_paging_and_create_index2(cql, test_keyspace):
 # will do the same without ALLOW FILTERING in the query - and we'll see the
 # query can't be resumed after the index is dropped.
 # Reproduces #18992.
-@pytest.mark.xfail(reason="issue #18992")
 def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,
@@ -1919,16 +1983,17 @@ def test_paging_and_drop_index_allow_filtering(cql, test_keyspace):
         assert len(r.current_rows) == page_size  # sanity check
         got.extend(r.current_rows)
         cql.execute(f"DROP INDEX {test_keyspace}.{index_name}")
+        # Stop here on Scylla, so the resume below is enforced on Cassandra.
+        if is_scylla(cql):
+            pytest.xfail("issue #18992")
         while r.has_more_pages:
             r = cql.execute(stmt, paging_state=r.paging_state)
             assert len(r.current_rows) <= page_size # sanity check
             got.extend(r.current_rows)
         assert expected == got
 
-# This test is the same as the previous one, except that it uses a query
-# *without* ALLOW FILTERING while an index existed, and when it attempts
-# to get the next page after a DROP INDEX, we expect the usual error
-# message about ALLOW FILTERING being necessary.
+# As above but *without* ALLOW FILTERING, so both engines currently raise the
+# usual error about ALLOW FILTERING when the next page follows a DROP INDEX.
 def test_paging_and_drop_index_no_allow_filtering(cql, test_keyspace):
     count = 20
     with new_test_table(cql, test_keyspace,

--- a/test/manual/enormous_table_scan_test.cc
+++ b/test/manual/enormous_table_scan_test.cc
@@ -173,13 +173,9 @@ struct enormous_virtual_reader {
 };
 
 
-static lw_shared_ptr<service::pager::paging_state> extract_paging_state(::shared_ptr<cql_transport::messages::result_message> res) {
+static lw_shared_ptr<const service::pager::paging_state> extract_paging_state(::shared_ptr<cql_transport::messages::result_message> res) {
     auto rows = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(res);
-    auto paging_state = rows->rs().get_metadata().paging_state();
-    if (!paging_state) {
-        return nullptr;
-    }
-    return make_lw_shared<service::pager::paging_state>(*paging_state);
+    return rows->rs().get_metadata().paging_state();
 };
 
 static size_t count_rows_fetched(::shared_ptr<cql_transport::messages::result_message> res) {
@@ -206,7 +202,7 @@ SEASTAR_TEST_CASE(scan_enormous_table_test) {
 
         uint64_t rows_fetched = 0;
         shared_ptr<cql_transport::messages::result_message> msg;
-        lw_shared_ptr<service::pager::paging_state> paging_state;
+        lw_shared_ptr<const service::pager::paging_state> paging_state;
         std::unique_ptr<cql3::query_options> qo;
         uint64_t fetched_rows_log_counter = 1e7;
         do {

--- a/transport/request.hh
+++ b/transport/request.hh
@@ -413,7 +413,7 @@ public:
 
         std::unique_ptr<cql3::query_options> options;
         if (flags) {
-            lw_shared_ptr<service::pager::paging_state> paging_state;
+            lw_shared_ptr<const service::pager::paging_state> paging_state;
             int32_t page_size = -1;
             if (flags.contains<options_flag::PAGE_SIZE>()) {
                 utils::result_with_exception_ptr<int32_t> v = read_int();

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1624,7 +1624,10 @@ static future<cql_server::process_fn_return_type>
 process_query_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls,
-        cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp) {
+        cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp,
+        // Only EXECUTE takes memory here; a QUERY is already charged for parsing
+        // up front. Taken to share one signature across the process_fn's.
+        semaphore&) {
     utils::result_with_exception_ptr<utils::chunked_string> query = in.read_long_chunked_string();
     if (!query) {
         return make_exception_future<cql_server::process_fn_return_type>(std::move(query).assume_error());
@@ -1653,7 +1656,8 @@ process_query_internal(service::client_state& client_state, sharded<cql3::query_
     }
 
     tracing::trace(trace_state, "Parsing a statement");
-    auto prepared = qp.local().get_statement(query.assume_value(), client_state, dialect);
+    auto prepared = qp.local().get_statement(query.assume_value(), client_state, dialect,
+            cql3::query_processor::pinned_plan_from_paging_state(options.get_paging_state()));
     auto& statement = *prepared->statement;
     auto execute_fut = reclassifying_control_connection_needs_user_service_level(statement, query_state)
             ? query_state.get_service_level_controller().with_user_service_level(query_state.get_client_state().user(),
@@ -1703,11 +1707,56 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
     });
 }
 
+// A statement re-derived with its query plan pinned. The parsing charge is
+// declared first so that it outlives what it accounts for.
+struct pinned_plan {
+    semaphore_units<> parsing_units;
+    std::unique_ptr<cql3::statements::prepared_statement> statement;
+};
+
+// A prepared SELECT derives its plan once; re-derive it when the paging state
+// pins another. Returns an empty plan when there is nothing to re-derive.
+static pinned_plan
+maybe_rederive_with_pinned_plan(cql3::query_processor& qp, const service::client_state& client_state,
+        cql3::dialect dialect, const lw_shared_ptr<const service::pager::paging_state>& paging_state,
+        const cql3::cql_statement& stmt, semaphore& memory_available,
+        const tracing::trace_state_ptr& trace_state) {
+    auto pinned = cql3::query_processor::pinned_plan_from_paging_state(paging_state);
+    if (!pinned) {
+        return {};
+    }
+    auto stmt_plan = stmt.query_plan_for_paging();
+    if (!stmt_plan || *stmt_plan == *pinned) {
+        return {};
+    }
+    auto keyspace = stmt.keyspace_for_reparse();
+    if (stmt.raw_cql_statement.empty() || !keyspace) {
+        // Unreachable: get_statement() records the query string, and a statement
+        // reporting a plan reports the keyspace of its table. Refuse rather than
+        // run the page against the wrong plan.
+        throw exceptions::invalid_request_exception(
+                "Cannot continue paged query: this statement cannot be re-prepared with "
+                "its query plan pinned. Please retry the query from the beginning.");
+    }
+    // An EXECUTE is not charged for parsing up front, so charge it here rather
+    // than tax the hot path. consume_units() does not wait, so cannot deadlock.
+    pinned_plan rederived{.parsing_units = consume_units(memory_available, qp.parsing_cost_estimate())};
+    tracing::trace(trace_state,
+            "Paging state pins another query plan; re-deriving the statement with that plan pinned");
+    rederived.statement = qp.get_statement(stmt.raw_cql_statement, client_state, dialect,
+            std::move(pinned), keyspace);
+    // Counts the pages that got a statement back. A refusal pays the re-parse
+    // too - it is thrown while preparing what was parsed - but serves no page.
+    ++qp.get_cql_stats().select_paging_plan_rederivations;
+    return rederived;
+}
+
 static future<cql_server::process_fn_return_type>
 process_execute_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls,
-        cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp) {
+        cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp,
+        semaphore& memory_available) {
     utils::result_with_exception_ptr<bytes> cache_key_bytes = in.read_short_bytes();
     if (!cache_key_bytes) {
         return make_exception_future<cql_server::process_fn_return_type>(std::move(cache_key_bytes).assume_error());
@@ -1782,7 +1831,17 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
         throw exceptions::invalid_request_exception(msg);
     }
 
-    options.prepare(prepared->bound_names);
+    // A paging state can pin a query plan this prepared statement did not
+    // derive; continuing that page takes re-deriving the statement. See #18992.
+    pinned_plan pinned = maybe_rederive_with_pinned_plan(qp.local(), client_state, dialect,
+            options.get_specific_options().state, *stmt, memory_available, query_state.get_trace_state());
+    if (pinned.statement) {
+        stmt = pinned.statement->statement;
+    }
+
+    // The bound names must come from the statement being executed: they order the
+    // values a client sent by name, and only its own prepare_context numbered them.
+    options.prepare(pinned.statement ? pinned.statement->bound_names : prepared->bound_names);
 
     if (init_trace && trace_state) {
         tracing::add_prepared_query_options(trace_state, options);
@@ -1796,7 +1855,8 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
                 return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
             })
             : qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
-    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id)] (auto msg) mutable {
+    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id),
+            pinned = std::move(pinned)] (auto msg) mutable {
         if (msg->as_bounce()) {
             return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {
@@ -1811,7 +1871,9 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
 static future<cql_server::process_fn_return_type>
 process_batch_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
-        service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls, cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp) {
+        service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls, cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp,
+        // Never paged, so nothing here re-derives a statement. See above.
+        semaphore&) {
     const utils::result_with_exception_ptr<int8_t> type = in.read_byte();
     if (!type) {
         return make_exception_future<cql_server::process_fn_return_type>(std::move(type).assume_error());
@@ -1993,7 +2055,7 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
     bool init_trace = (bool)!bounced; // If the request was bounced, we already started the trace in the handler
     auto& sg_stats = get_cql_sg_stats();
     auto msg = co_await coroutine::try_future(process_fn(client_state, _query_processor, in, stream,
-        version, permit, trace_state, init_trace, {}, dialect, sg_stats, request_start_timestamp));
+        version, permit, trace_state, init_trace, {}, dialect, sg_stats, request_start_timestamp, _memory_available));
     while (auto* bounce_msg = std::get_if<cql_server::result_with_bounce>(&msg)) {
         auto shard = (*bounce_msg)->target_shard();
         auto&& cached_vals = (*bounce_msg)->take_cached_pk_function_calls();
@@ -2011,7 +2073,8 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
                 auto local_trace_state = gt.get();
                 auto& local_sg_stats = server.get_cql_sg_stats();
                 co_return co_await process_fn(local_client_state, server._query_processor, in, stream, version,
-                        /* FIXME */empty_service_permit(), std::move(local_trace_state), false, cached_vals, dialect, local_sg_stats, request_start_timestamp);
+                        /* FIXME */empty_service_permit(), std::move(local_trace_state), false, cached_vals, dialect, local_sg_stats, request_start_timestamp,
+                        server._memory_available);
             });
         } else {
             // Node bounce

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1624,7 +1624,10 @@ static future<cql_server::process_fn_return_type>
 process_query_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls,
-        cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp) {
+        cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp,
+        // Only EXECUTE takes memory here; a QUERY is already charged for parsing
+        // up front. Taken to share one signature across the process_fn's.
+        semaphore&) {
     utils::result_with_exception_ptr<utils::chunked_string> query = in.read_long_chunked_string();
     if (!query) {
         return make_exception_future<cql_server::process_fn_return_type>(std::move(query).assume_error());
@@ -1653,7 +1656,8 @@ process_query_internal(service::client_state& client_state, sharded<cql3::query_
     }
 
     tracing::trace(trace_state, "Parsing a statement");
-    auto prepared = qp.local().get_statement(query.assume_value(), client_state, dialect);
+    auto prepared = qp.local().get_statement(query.assume_value(), client_state, dialect,
+            cql3::query_processor::forced_plan_id_from_paging_state(options.get_paging_state()));
     auto& statement = *prepared->statement;
     auto execute_fut = reclassifying_control_connection_needs_user_service_level(statement, query_state)
             ? query_state.get_service_level_controller().with_user_service_level(query_state.get_client_state().user(),
@@ -1703,11 +1707,54 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_pr
     });
 }
 
+// A statement re-derived with its query plan pinned. The parsing charge is
+// declared first so that it outlives what it accounts for.
+struct pinned_plan {
+    semaphore_units<> parsing_units;
+    std::unique_ptr<cql3::statements::prepared_statement> statement;
+};
+
+// A prepared SELECT derives its plan once; re-derive it when the paging state
+// pins another. Returns an empty plan when there is nothing to re-derive.
+static pinned_plan
+maybe_rederive_with_pinned_plan(cql3::query_processor& qp, const service::client_state& client_state,
+        cql3::dialect dialect, const lw_shared_ptr<const service::pager::paging_state>& paging_state,
+        const cql3::cql_statement& stmt, semaphore& memory_available,
+        const tracing::trace_state_ptr& trace_state) {
+    auto forced_plan_id = cql3::query_processor::forced_plan_id_from_paging_state(paging_state);
+    if (!forced_plan_id) {
+        return {};
+    }
+    auto plan = stmt.query_plan_for_paging();
+    if (!plan || plan->id == *forced_plan_id) {
+        return {};
+    }
+    if (stmt.raw_cql_statement.empty()) {
+        // Unreachable: get_statement() records the query string. Refuse rather
+        // than run the page against the wrong plan.
+        throw exceptions::invalid_request_exception(
+                "Cannot continue paged query: this statement cannot be re-prepared with "
+                "its query plan pinned. Please retry the query from the beginning.");
+    }
+    // An EXECUTE is not charged for parsing up front, so charge it here rather
+    // than tax the hot path. consume_units() does not wait, so cannot deadlock.
+    pinned_plan pinned{.parsing_units = consume_units(memory_available, qp.parsing_cost_estimate())};
+    tracing::trace(trace_state,
+            "Paging state pins another query plan; re-deriving the statement with that plan pinned");
+    pinned.statement = qp.get_statement(stmt.raw_cql_statement, client_state, dialect,
+            std::move(forced_plan_id), plan->keyspace);
+    // Counts the pages that got a statement back. A refusal pays the re-parse
+    // too - it is thrown while preparing what was parsed - but serves no page.
+    ++qp.get_cql_stats().select_paging_plan_rederivations;
+    return pinned;
+}
+
 static future<cql_server::process_fn_return_type>
 process_execute_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls,
-        cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp) {
+        cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp,
+        semaphore& memory_available) {
     utils::result_with_exception_ptr<bytes> cache_key_bytes = in.read_short_bytes();
     if (!cache_key_bytes) {
         return make_exception_future<cql_server::process_fn_return_type>(std::move(cache_key_bytes).assume_error());
@@ -1782,7 +1829,17 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
         throw exceptions::invalid_request_exception(msg);
     }
 
-    options.prepare(prepared->bound_names);
+    // A paging state can pin a query plan this prepared statement did not
+    // derive; continuing that page takes re-deriving the statement. See #18992.
+    pinned_plan pinned = maybe_rederive_with_pinned_plan(qp.local(), client_state, dialect,
+            options.get_specific_options().state, *stmt, memory_available, query_state.get_trace_state());
+    if (pinned.statement) {
+        stmt = pinned.statement->statement;
+    }
+
+    // The bound names must come from the statement being executed: they order the
+    // values a client sent by name, and only its own prepare_context numbered them.
+    options.prepare(pinned.statement ? pinned.statement->bound_names : prepared->bound_names);
 
     if (init_trace && trace_state) {
         tracing::add_prepared_query_options(trace_state, options);
@@ -1796,7 +1853,8 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
                 return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
             })
             : qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
-    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id)] (auto msg) mutable {
+    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id),
+            pinned = std::move(pinned)] (auto msg) mutable {
         if (msg->as_bounce()) {
             return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {
@@ -1811,7 +1869,9 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
 static future<cql_server::process_fn_return_type>
 process_batch_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
-        service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls, cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp) {
+        service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls, cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp,
+        // Never paged, so nothing here re-derives a statement. See above.
+        semaphore&) {
     const utils::result_with_exception_ptr<int8_t> type = in.read_byte();
     if (!type) {
         return make_exception_future<cql_server::process_fn_return_type>(std::move(type).assume_error());
@@ -1993,7 +2053,7 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
     bool init_trace = (bool)!bounced; // If the request was bounced, we already started the trace in the handler
     auto& sg_stats = get_cql_sg_stats();
     auto msg = co_await coroutine::try_future(process_fn(client_state, _query_processor, in, stream,
-        version, permit, trace_state, init_trace, {}, dialect, sg_stats, request_start_timestamp));
+        version, permit, trace_state, init_trace, {}, dialect, sg_stats, request_start_timestamp, _memory_available));
     while (auto* bounce_msg = std::get_if<cql_server::result_with_bounce>(&msg)) {
         auto shard = (*bounce_msg)->target_shard();
         auto&& cached_vals = (*bounce_msg)->take_cached_pk_function_calls();
@@ -2011,7 +2071,8 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
                 auto local_trace_state = gt.get();
                 auto& local_sg_stats = server.get_cql_sg_stats();
                 co_return co_await process_fn(local_client_state, server._query_processor, in, stream, version,
-                        /* FIXME */empty_service_permit(), std::move(local_trace_state), false, cached_vals, dialect, local_sg_stats, request_start_timestamp);
+                        /* FIXME */empty_service_permit(), std::move(local_trace_state), false, cached_vals, dialect, local_sg_stats, request_start_timestamp,
+                        server._memory_available);
             });
         } else {
             // Node bounce

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1749,6 +1749,54 @@ maybe_rederive_with_pinned_plan(cql3::query_processor& qp, const service::client
     return pinned;
 }
 
+// Kept apart from process_execute_internal so a paged EXECUTE costs the common
+// path nothing; the tail is duplicated on purpose - keep the two in step.
+static future<cql_server::process_fn_return_type>
+execute_prepared_with_paging_state(service::client_state& client_state, sharded<cql3::query_processor>& qp,
+        uint16_t stream, cql_protocol_version_type version, cql3::dialect dialect,
+        std::unique_ptr<cql_query_state> q_state, cql3::statements::prepared_statement::checked_weak_ptr prepared,
+        cql3::prepared_cache_key_type cache_key, bool needs_authorization,
+        cql_metadata_id_wrapper metadata_id, bool skip_metadata, bool init_trace,
+        tracing::trace_state_ptr trace_state, semaphore& memory_available) {
+    auto& query_state = q_state->query_state;
+    auto& options = *q_state->options;
+    auto stmt = prepared->statement;
+
+    pinned_plan pinned = maybe_rederive_with_pinned_plan(qp.local(), client_state, dialect,
+            options.get_specific_options().state, *stmt, memory_available, query_state.get_trace_state());
+    if (pinned.statement) {
+        stmt = pinned.statement->statement;
+    }
+
+    // The bound names must come from the statement being executed: they order the
+    // values a client sent by name, and only its own prepare_context numbered them.
+    options.prepare(pinned.statement ? pinned.statement->bound_names : prepared->bound_names);
+
+    if (init_trace && trace_state) {
+        tracing::add_prepared_query_options(trace_state, options);
+    }
+
+    tracing::trace(trace_state, "Processing a statement");
+    auto& statement = *stmt;
+    auto execute_fut = reclassifying_control_connection_needs_user_service_level(statement, query_state)
+            ? query_state.get_service_level_controller().with_user_service_level(query_state.get_client_state().user(),
+                    [&qp, &query_state, &options, stmt = std::move(stmt), prepared = std::move(prepared), cache_key = std::move(cache_key), needs_authorization] () mutable {
+                return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
+            })
+            : qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
+    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id),
+            pinned = std::move(pinned)] (auto msg) mutable {
+        if (msg->as_bounce()) {
+            return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
+        } else if (msg->is_exception()) {
+            return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
+        } else {
+            tracing::trace(q_state->query_state.get_trace_state(), "Done processing - preparing a result");
+            return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, q_state->query_state.get_trace_state(), version, std::move(metadata_id), skip_metadata)));
+        }
+    });
+}
+
 static future<cql_server::process_fn_return_type>
 process_execute_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
@@ -1829,17 +1877,15 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
         throw exceptions::invalid_request_exception(msg);
     }
 
-    // A paging state can pin a query plan this prepared statement did not
-    // derive; continuing that page takes re-deriving the statement. See #18992.
-    pinned_plan pinned = maybe_rederive_with_pinned_plan(qp.local(), client_state, dialect,
-            options.get_specific_options().state, *stmt, memory_available, query_state.get_trace_state());
-    if (pinned.statement) {
-        stmt = pinned.statement->statement;
+    // A paging state can pin a query plan this statement did not derive, which
+    // takes re-deriving it - all out of line, so this path pays only a branch.
+    if (options.get_specific_options().state) {
+        return execute_prepared_with_paging_state(client_state, qp, stream, version, dialect,
+                std::move(q_state), std::move(prepared), std::move(cache_key), needs_authorization,
+                std::move(metadata_id), skip_metadata, init_trace, trace_state, memory_available);
     }
 
-    // The bound names must come from the statement being executed: they order the
-    // values a client sent by name, and only its own prepare_context numbered them.
-    options.prepare(pinned.statement ? pinned.statement->bound_names : prepared->bound_names);
+    options.prepare(prepared->bound_names);
 
     if (init_trace && trace_state) {
         tracing::add_prepared_query_options(trace_state, options);
@@ -1853,8 +1899,7 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
                 return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
             })
             : qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
-    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id),
-            pinned = std::move(pinned)] (auto msg) mutable {
+    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id)] (auto msg) mutable {
         if (msg->as_bounce()) {
             return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1751,6 +1751,54 @@ maybe_rederive_with_pinned_plan(cql3::query_processor& qp, const service::client
     return rederived;
 }
 
+// Kept apart from process_execute_internal so a paged EXECUTE costs the common
+// path nothing; the tail is duplicated on purpose - keep the two in step.
+static future<cql_server::process_fn_return_type>
+execute_prepared_with_paging_state(service::client_state& client_state, sharded<cql3::query_processor>& qp,
+        uint16_t stream, cql_protocol_version_type version, cql3::dialect dialect,
+        std::unique_ptr<cql_query_state> q_state, cql3::statements::prepared_statement::checked_weak_ptr prepared,
+        cql3::prepared_cache_key_type cache_key, bool needs_authorization,
+        cql_metadata_id_wrapper metadata_id, bool skip_metadata, bool init_trace,
+        tracing::trace_state_ptr trace_state, semaphore& memory_available) {
+    auto& query_state = q_state->query_state;
+    auto& options = *q_state->options;
+    auto stmt = prepared->statement;
+
+    pinned_plan pinned = maybe_rederive_with_pinned_plan(qp.local(), client_state, dialect,
+            options.get_specific_options().state, *stmt, memory_available, query_state.get_trace_state());
+    if (pinned.statement) {
+        stmt = pinned.statement->statement;
+    }
+
+    // The bound names must come from the statement being executed: they order the
+    // values a client sent by name, and only its own prepare_context numbered them.
+    options.prepare(pinned.statement ? pinned.statement->bound_names : prepared->bound_names);
+
+    if (init_trace && trace_state) {
+        tracing::add_prepared_query_options(trace_state, options);
+    }
+
+    tracing::trace(trace_state, "Processing a statement");
+    auto& statement = *stmt;
+    auto execute_fut = reclassifying_control_connection_needs_user_service_level(statement, query_state)
+            ? query_state.get_service_level_controller().with_user_service_level(query_state.get_client_state().user(),
+                    [&qp, &query_state, &options, stmt = std::move(stmt), prepared = std::move(prepared), cache_key = std::move(cache_key), needs_authorization] () mutable {
+                return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
+            })
+            : qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
+    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id),
+            pinned = std::move(pinned)] (auto msg) mutable {
+        if (msg->as_bounce()) {
+            return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
+        } else if (msg->is_exception()) {
+            return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
+        } else {
+            tracing::trace(q_state->query_state.get_trace_state(), "Done processing - preparing a result");
+            return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, q_state->query_state.get_trace_state(), version, std::move(metadata_id), skip_metadata)));
+        }
+    });
+}
+
 static future<cql_server::process_fn_return_type>
 process_execute_internal(service::client_state& client_state, sharded<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
@@ -1831,17 +1879,15 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
         throw exceptions::invalid_request_exception(msg);
     }
 
-    // A paging state can pin a query plan this prepared statement did not
-    // derive; continuing that page takes re-deriving the statement. See #18992.
-    pinned_plan pinned = maybe_rederive_with_pinned_plan(qp.local(), client_state, dialect,
-            options.get_specific_options().state, *stmt, memory_available, query_state.get_trace_state());
-    if (pinned.statement) {
-        stmt = pinned.statement->statement;
+    // A paging state can pin a query plan this statement did not derive, which
+    // takes re-deriving it - all out of line, so this path pays only a branch.
+    if (options.get_specific_options().state) {
+        return execute_prepared_with_paging_state(client_state, qp, stream, version, dialect,
+                std::move(q_state), std::move(prepared), std::move(cache_key), needs_authorization,
+                std::move(metadata_id), skip_metadata, init_trace, trace_state, memory_available);
     }
 
-    // The bound names must come from the statement being executed: they order the
-    // values a client sent by name, and only its own prepare_context numbered them.
-    options.prepare(pinned.statement ? pinned.statement->bound_names : prepared->bound_names);
+    options.prepare(prepared->bound_names);
 
     if (init_trace && trace_state) {
         tracing::add_prepared_query_options(trace_state, options);
@@ -1855,8 +1901,7 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
                 return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
             })
             : qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
-    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id),
-            pinned = std::move(pinned)] (auto msg) mutable {
+    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id)] (auto msg) mutable {
         if (msg->as_bounce()) {
             return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1796,7 +1796,7 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
                 return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
             })
             : qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization);
-    return std::move(execute_fut).then([trace_state = query_state.get_trace_state(), skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id)] (auto msg) mutable {
+    return std::move(execute_fut).then([skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id)] (auto msg) mutable {
         if (msg->as_bounce()) {
             return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {


### PR DESCRIPTION
Before this patch series, a paged SELECT saved its scan position in the
paging state, but nothing about which plan produced that position. When
the set of secondary indexes changes between pages - one created, or the
one being read dropped - a later page can be served by a different plan
that reads the saved position as its own. The read then returns wrong
rows, or fails with a marshalling error that says nothing about what
happened. The tests covering this were blanket-xfailed, so their resume
assertions never ran anywhere, which also hid that the same reads are
correct on Cassandra.

The series has the paging state name the plan that produced it, and pins
that plan when a later page resumes. The plan is a variant, so that each
kind of scan is an arm of its own: an index is identified by the id of
its view rather than by its name, so an index re-created under the same
name is not mistaken for the original, and a base-table scan is a plan
in its own right rather than a missing index id. Recording no plan at
all stays distinct - that is what a node predating the field leaves
behind, and what a rolling upgrade has to tolerate. A kind of plan added
later may only be appended to the variant, and must not be written
before the whole cluster can read it. Pinning is enforced by hiding
every index the pinned plan did not use, because which indexes exist
also decides how much of the query is filtered after the scan, so
choosing the same plan at the end would not be enough.

Two consequences reach clients, and are documented: resuming after the
pinned index was dropped now fails and asks the client to restart the
query, where it used to return (incorrect) rows, and a paging state
pinning a plan the query cannot be served by is refused outright instead
of being reported as the query needing ALLOW FILTERING. Failing there is
a deliberate deviation from Cassandra, which re-plans and keeps going.

Pinning a plan takes re-deriving the statement, which can parse a query
string, so it happens only where it is needed: on a page whose paging
state pins a plan the prepared statement did not derive, which takes DDL
between pages. A paged read over a table nobody changed compares the two
plans, finds them equal and re-derives nothing, and an unprepared query
parses its string every page regardless. The check itself is kept off
the path every prepared statement takes, and two unrelated costs on that
path - a paging state copied per internal page only to satisfy a mutable
pointer, and a dead trace state capture in the execute reply - are
removed ahead of it, leaving throughput slightly above where the series
started.

The tests lose their xfails, and where Scylla now refuses a resume the
expectation is split per engine to record that Cassandra instead re-
plans and keeps going. Each refusal is asserted on the first resumed
page, so a regression that returns wrong rows there and only raises
later cannot pass, and a counter of re-derived pages is watched in both
directions: a re-derived page cannot be told from one that never re-
derived by looking at rows, and a paged read nobody changed an index
under has to reach its last page without re-deriving once. Beyond the
create-index and drop-index reproducers, the new cases cover a sparse
filter, a plan derived once at prepare time, an index re-created under
the same name, an unqualified table name resumed after the connection
switched keyspaces, a paging state from an unrelated query, and a state
recording no plan as an older node would during a rolling upgrade, faked
by an error injection. The cases where a page is resumed by a
coordinator other than the one that chose the plan need two nodes, so
they live with the cluster tests, and two of those run a real mixed-
version cluster.

Mixed-version cluster
---------------------

test/cluster/test_secondary_index_paging.py brings up two nodes on
2025.1, which records no plan, upgrades one of them to this branch, and
pages through both coordinators:

- test_paged_read_crosses_versions - an indexed read started on the old
  coordinator and resumed on the new one returns every row, and so does
  the same read started on the new coordinator and resumed on the old
  one, which is the case where the old node has to read a paging state
  carrying a field it does not know.
- test_resuming_a_pre_plan_paging_state_is_not_refused - a state written
  by the old coordinator, whose index is then dropped, must not be
  refused by the new one: there is no plan to pin, so the resume behaves
  as it did before the series.

Fixes: #18992
Fixes: SCYLLADB-3345

Backport: no backport, a new feature.