### PR TITLE
compaction: don't leak compaction output when the replacer fails

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -774,6 +774,36 @@ protected:
 
     // Retrieves all unused garbage collected sstables that will be subsequently added
     // to the SSTable set, and mark them as used.
+    // Hands a completion desc to the replacer, making sure the output sstables do
+    // not survive on disk if the replacer fails.
+    //
+    // On the failure path the outputs are unreachable in every other respect:
+    // _all_new_sstables has already been moved into the compaction_result by
+    // finish(), _new_unused_sstables was moved into `desc` here, and a throw out of
+    // finish() -> on_end_of_compaction() never reaches on_interrupt() at all
+    // because compaction::run() calls finish() outside its try/catch. The outputs
+    // are also sealed, so ~sstable() will not unlink them. Without marking them
+    // here they become complete, unreferenced sstables that sit on disk until the
+    // next restart loads them.
+    //
+    // This assumes the replacer is all-or-nothing with respect to attaching
+    // outputs, which holds today: on_compaction_completion() runs
+    // sstable_list_updater::prepare() (where every failure originates) before
+    // execute() mutates any sstable set.
+    void invoke_replacer(compaction_completion_desc desc) {
+        auto new_sstables = desc.new_sstables;
+        try {
+            _replacer(std::move(desc));
+        } catch (...) {
+            for (auto& sst : new_sstables) {
+                log_debug("Deleting sstable {} of failed sstable replacement for {}.{}",
+                          sst->get_filename(), _schema->ks_name(), _schema->cf_name());
+                sst->mark_for_deletion();
+            }
+            throw;
+        }
+    }
+
     std::vector<sstables::shared_sstable> consume_unused_garbage_collected_sstables() {
         auto unused = std::exchange(_unused_garbage_collected_sstables, {});
         _used_garbage_collected_sstables.insert(_used_garbage_collected_sstables.end(), unused.begin(), unused.end());
@@ -1351,7 +1381,7 @@ private:
             log_debug("Replacing earlier exhausted sstable(s) [{}] by new sstable(s) [{}]",
                 fmt::join(exhausted_ssts | std::views::transform([] (auto sst) { return to_string(sst, false); }), ","),
                 fmt::join(_new_unused_sstables | std::views::transform([] (auto sst) { return to_string(sst, true); }), ","));
-            _replacer(get_compaction_completion_desc(exhausted_ssts, std::move(_new_unused_sstables)));
+            invoke_replacer(get_compaction_completion_desc(exhausted_ssts, std::move(_new_unused_sstables)));
             _sstables.erase(exhausted, _sstables.end());
             dynamic_cast<compaction_read_monitor_generator&>(unwrap_monitor_generator()).remove_exhausted_sstables(exhausted_ssts);
         }
@@ -1381,7 +1411,7 @@ private:
             log_debug("Releasing {} exhausted GC sstable(s) earlier: [{}]",
                 exhausted_gc_ssts.size(),
                 fmt::join(exhausted_gc_ssts | std::views::transform([] (auto sst) { return to_string(sst, true); }), ","));
-            _replacer(get_compaction_completion_desc(std::move(exhausted_gc_ssts), {}));
+            invoke_replacer(get_compaction_completion_desc(std::move(exhausted_gc_ssts), {}));
             _used_garbage_collected_sstables.erase(exhausted, _used_garbage_collected_sstables.end());
         }
     }
@@ -1395,7 +1425,7 @@ private:
             auto& used_gc_sstables = used_garbage_collected_sstables();
             old_sstables.insert(old_sstables.end(), used_gc_sstables.begin(), used_gc_sstables.end());
 
-            _replacer(get_compaction_completion_desc(std::move(old_sstables), std::move(_new_unused_sstables)));
+            invoke_replacer(get_compaction_completion_desc(std::move(old_sstables), std::move(_new_unused_sstables)));
          }
     }
 
@@ -1915,7 +1945,7 @@ public:
             auto& used_gc_sstables = used_garbage_collected_sstables();
             old_sstables.insert(old_sstables.end(), used_gc_sstables.begin(), used_gc_sstables.end());
 
-            _replacer(get_compaction_completion_desc(std::move(old_sstables), {}));
+            invoke_replacer(get_compaction_completion_desc(std::move(old_sstables), {}));
         }
 
         // Mark new sstables for deletion as well

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7695,4 +7695,111 @@ SEASTAR_TEST_CASE(test_perform_component_rewrite_multiple_sstables) {
     });
 }
 
+// Returns the sealed sstables present in `dir`, identified by their TOC file.
+// An sstable whose deletion already started is renamed to
+// "<...>-TemporaryTOC.txt" first and is reclaimed by the sstable directory scan
+// on boot, so it is deliberately not counted here: only fully sealed leftovers
+// -- the ones that survive a restart and get loaded again -- are.
+static std::vector<sstring> list_sealed_sstables(const fs::path& dir) {
+    std::vector<sstring> tocs;
+    for (const auto& de : fs::directory_iterator(dir)) {
+        auto name = de.path().filename().string();
+        if (name.ends_with("-TOC.txt")) {
+            tocs.push_back(sstring(name));
+        }
+    }
+    std::ranges::sort(tocs);
+    return tocs;
+}
+
+// Reproducer for SCYLLADB-3531
+//
+// When the replacer fails, the sealed output sstables are neither attached to
+// the table nor scheduled for deletion, so their files stay on disk forever:
+//
+//   * compaction::run() calls finish() OUTSIDE its try/catch, so a throw out of
+//     finish() -> on_end_of_compaction() -> replace_remaining_exhausted_sstables()
+//     -> _replacer() never reaches on_interrupt(), and therefore never reaches
+//     delete_sstables_for_interrupted_compaction().
+//   * By that point finish() has already moved _all_new_sstables into its
+//     result, and the replacer call moved _new_unused_sstables into the
+//     completion desc, so even if delete_sstables_for_interrupted_compaction()
+//     did run, both containers it scans would be empty.
+//   * The output was sealed by the writer, and seal_sstable() clears
+//     mark_for_deletion::implicit, so ~sstable() does not unlink it either.
+//
+// Nothing is logged on this path, since no deletion is ever attempted.
+//
+// In production the replacer throws from sstable_list_updater::prepare(), most
+// notably out of compaction_group_for_sstable() when an output sstable spans
+// two tablets after a tablet split has been finalized. The leaked file is a
+// complete, loadable sstable, so the directory scan picks it up on the next
+// restart and trips
+//     "Unable to load SSTable ... that belongs to tablets X and Y"
+// hours or days after the compaction that produced it.
+SEASTAR_TEST_CASE(test_compaction_output_is_not_leaked_when_replacer_throws) {
+    return test_env::do_with_async([] (test_env& env) {
+        // Single-shard sharder so the fixed keys below are always owned by the
+        // shard running the test, regardless of --smp.
+        auto builder = schema_builder(1, "tests", "replacer_failure")
+                .with_column("id", utf8_type, column_kind::partition_key)
+                .with_column("value", int32_type);
+        auto s = builder.build();
+
+        auto cf = env.make_table_for_tests(s);
+        auto stop_cf = deferred_stop(cf);
+        auto sst_gen = env.make_sst_factory(s);
+
+        auto make_mut = [&] (std::string_view key, int32_t value) {
+            mutation m(s, partition_key::from_exploded(*s, {to_bytes(sstring(key))}));
+            m.set_clustered_cell(clustering_key::make_empty(), bytes("value"), data_value(value), api::new_timestamp());
+            return m;
+        };
+
+        auto sst1 = make_sstable_containing(sst_gen, {make_mut("a", 1)}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {make_mut("b", 2)}).get();
+        column_family_test(cf).add_sstable(sst1).get();
+        column_family_test(cf).add_sstable(sst2).get();
+
+        const auto dir = tests::table_dir(*cf);
+        const auto before = list_sealed_sstables(dir);
+        BOOST_REQUIRE_EQUAL(before.size(), 2u);
+
+        // Compact the two inputs with a replacer that fails, standing in for
+        // sstable_list_updater::prepare() rejecting the output.
+        // can_purge_tombstones::no keeps the garbage-collected sstable writer
+        // disabled, so the single replacer call happens at end of compaction,
+        // from inside finish() -- the variant where on_interrupt() is skipped
+        // entirely.
+        compaction::compaction_descriptor desc({sst1, sst2});
+        BOOST_REQUIRE_THROW(
+            compact_sstables(env, std::move(desc), cf, sst_gen,
+                             [] (compaction::compaction_completion_desc) {
+                                 throw std::runtime_error("simulated replacer failure");
+                             },
+                             can_purge_tombstones::no).get(),
+            std::runtime_error);
+
+        // The compaction failed, so its output is unreachable and must not be
+        // left behind on disk. An unreferenced sstable is unlinked by a
+        // background task, hence the retry loop.
+        auto leaked = [&] {
+            std::vector<sstring> extra;
+            for (const auto& toc : list_sealed_sstables(dir)) {
+                if (std::ranges::find(before, toc) == before.end()) {
+                    extra.push_back(toc);
+                }
+            }
+            return extra;
+        };
+        (void) eventually_true([&] { return leaked().empty(); });
+
+        // Fails today: the output sstable's "<gen>-big-TOC.txt" is still there.
+        auto extra = leaked();
+        BOOST_REQUIRE_MESSAGE(extra.empty(),
+                fmt::format("compaction output leaked on disk after replacer failure: [{}]",
+                            fmt::join(extra, ", ")));
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
If the sstable replacer throws, the compaction's output sstables are left behind on disk with nothing tracking them.

By the time the replacer runs, the outputs are unreachable through every other channel:

  - finish() has already moved _all_new_sstables into the compaction_result it is building.
  - the replacer call itself moved _new_unused_sstables into the completion desc.
  - a throw out of finish() -> on_end_of_compaction() -> replace_remaining_exhausted_sstables() never reaches on_interrupt() at all, because compaction::run() calls finish() outside its try/catch.
  - even when on_interrupt() does run (a throw from an incremental replacement), delete_sstables_for_interrupted_compaction() only scans _new_partial_sstables and _new_unused_sstables, both of which have already been moved from.

The outputs are also sealed by then, and seal_sstable() clears mark_for_deletion::implicit, so ~sstable() will not unlink them either. The result is a set of complete, unreferenced sstables that stay on disk.

The failure itself is not silent. compaction_manager::perform_task() has a catch-all that logs

    <task>: failed, reason <exception>: stopping

at error level and bumps the compaction error counter, and the on_internal_error() based failures below log an additional error with a backtrace at the throw site. What is missing is any trace of the consequence: nothing reports that output sstables were left behind, and since no deletion is ever attempted there is no "Compacted SSTables deletion failed" and no "Exception when deleting sstable file" either.

The replacer has several reachable failure modes, all of them via on_compaction_completion() ->
update_sstable_sets_on_compaction_completion():

  - compaction_group_for_sstable() rejecting an output that spans two tablets, when a tablet split finalized while the compaction was running,
  - the same function throwing std::out_of_range when the tablet's storage group is gone, e.g. after the tablet migrated away,
  - "INCORRECTLY used sstable ... which doesn't belong to this shard", when intra-node migration moved shard ownership mid-compaction,
  - the "was already unlinked before being added to table" and "Unable to remove input SSTable" guards,
  - std::bad_alloc from build_new_list() or cache.invalidate() under memory pressure, which needs no tablet activity at all.

Note that abort_on_internal_error defaults to false, so on_internal_error() logs and then throws, which is exactly this path.

This is what makes the leak easy to miss: compaction is retried and usually succeeds the second time, so the whole episode reads as one transient error that resolved itself, with nothing pointing at the files left behind. The leaked file keeps
costing disk and read amplification, and on tablet tables it is a latent startup failure: it is loaded by the directory scan on the next restart, and if a split or migration has since touched its token range, compaction_group_for_sstable() rejects it and the node refuses to start.

Fix it by routing every replacer invocation through a small wrapper that marks the desc's output sstables for deletion if the replacer throws, and then rethrows. Marking is the right mechanism here: the outputs were never added to the table, so they cannot be handed back through the replacer's old_sstables path.

The wrapper assumes the replacer is all-or-nothing with respect to attaching outputs, which holds today because
on_compaction_completion() runs sstable_list_updater::prepare(), where every failure originates, before execute() mutates any sstable set.

Also add a reproducer that compacts two sstables with a replacer that throws and asserts no sealed sstable is left behind on disk. It fails on the unfixed tree with

    compaction output leaked on disk after replacer failure:
    [mt-<gen>-big-TOC.txt]

and passes with this change.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-3531

**No backport needed. A replacer failure is already visible, so the condition is detectable when it occurs; the fix hardens cleanup on that path rather than addressing a silent failure.**