### PR TITLE
db_clock: mark formatted timestamps as UTC

### DIFF
--- a/db_clock.hh
+++ b/db_clock.hh
@@ -60,6 +60,6 @@ struct fmt::formatter<db_clock::time_point> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const db_clock::time_point& tp, FormatContext& ctx) const {
         auto t = db_clock::to_time_t(tp);
-        return fmt::format_to(ctx.out(), "{:%Y/%m/%d %T}", fmt::gmtime(t));
+        return fmt::format_to(ctx.out(), "{:%Y/%m/%d %T}z", fmt::gmtime(t));
     }
 };


### PR DESCRIPTION
## Summary

The seastar logger prints its line prefix with localtime_r, while fmt::formatter<db_clock::time_point> uses fmt::gmtime and emits no timezone marker. On a node whose local time is not UTC, a single log line shows two timestamps for the same instant with nothing to explain the gap, which is misleading when using log timestamps to reconstruct the order of events.

Add a "z" suffix rather than switching to fmt::localtime. These are cluster-wide values that operators copy from logs into CQL queries against system tables, so rendering them per-node would make a multi-DC cluster print different strings for the same event and would break those lookups. This also matches how the sstable dump output renders gmtime-based timestamps in mutation/mutation.cc and tools/lua_sstable_consumer.cc.

Before, on a node whose local time is UTC+05:30:

    INFO  2026-07-31 13:51:16,302 [shard 0: gms] cdc - Started using generation (2026/07/31 08:21:16, cccbc546-8cb8-11f1-a35c-7b9e3f2366ca).

After:

    INFO  2026-08-01 19:46:28,228 [shard 0: gms] cdc - Started using generation (2026/08/01 14:16:28z, 961ad8ba-8db3-11f1-9690-6d24d37d5d7f).

The printed instant is unchanged; only the marker is new.

Fixes: #22571

Backport: cosmetic log formatting change, no backport.